### PR TITLE
Refactor page-creator.mjs: split into modules, fix security & bugs

### DIFF
--- a/tooling/content/creator/canonical-links.mjs
+++ b/tooling/content/creator/canonical-links.mjs
@@ -1,0 +1,102 @@
+/**
+ * Canonical Links Module
+ *
+ * Finds official reference links (Wikipedia, LessWrong, EA Forum, etc.) for a topic.
+ */
+
+export const CANONICAL_DOMAINS = [
+  { domain: 'en.wikipedia.org', name: 'Wikipedia', priority: 1 },
+  { domain: 'www.wikidata.org', name: 'Wikidata', priority: 2 },
+  { domain: 'lesswrong.com', name: 'LessWrong', priority: 3 },
+  { domain: 'forum.effectivealtruism.org', name: 'EA Forum', priority: 3 },
+  { domain: 'www.britannica.com', name: 'Britannica', priority: 4 },
+  { domain: 'arxiv.org', name: 'arXiv', priority: 5 },
+  { domain: 'scholar.google.com', name: 'Google Scholar', priority: 5 },
+  { domain: 'twitter.com', name: 'Twitter/X', priority: 6 },
+  { domain: 'x.com', name: 'Twitter/X', priority: 6 },
+  { domain: 'github.com', name: 'GitHub', priority: 6 },
+  { domain: 'linkedin.com', name: 'LinkedIn', priority: 7 },
+];
+
+export async function findCanonicalLinks(topic, { log, saveResult }) {
+  log('canonical', 'Searching for canonical reference links...');
+
+  const { perplexityResearch } = await import('../../lib/openrouter.mjs');
+
+  const searchQuery = `Find official and reference pages for "${topic}". Include:
+- Wikipedia page URL (if exists)
+- Wikidata ID and URL (if exists)
+- LessWrong profile or wiki page (if exists)
+- EA Forum profile or posts (if exists)
+- Official website (if organization or person)
+- Twitter/X profile (if exists)
+- GitHub (if relevant)
+
+For each, provide the exact URL. Only include links that actually exist.`;
+
+  try {
+    const result = await perplexityResearch(searchQuery, { maxTokens: 1500 });
+
+    // Extract URLs from response
+    const urlRegex = /https?:\/\/[^\s<>"{}|\\^`\[\]]+/g;
+    const foundUrls = (result.content.match(urlRegex) || []).map(url => {
+      return url.replace(/[.,;:!?]+$/, '').replace(/\)+$/, '');
+    });
+
+    const allUrls = [...new Set([...foundUrls, ...(result.citations || [])])];
+
+    // Categorize by domain
+    const canonicalLinks = [];
+    const seenDomains = new Set();
+
+    for (const url of allUrls) {
+      try {
+        const urlObj = new URL(url);
+        const hostname = urlObj.hostname.replace(/^www\./, '');
+
+        for (const { domain, name, priority } of CANONICAL_DOMAINS) {
+          const domainHost = domain.replace(/^www\./, '');
+          if (hostname === domainHost || hostname.endsWith('.' + domainHost)) {
+            if (!seenDomains.has(name)) {
+              canonicalLinks.push({ name, url, priority, domain: hostname });
+              seenDomains.add(name);
+            }
+            break;
+          }
+        }
+
+        // Check for official/personal website
+        if (!seenDomains.has('Official Website') &&
+            !CANONICAL_DOMAINS.some(d => hostname.includes(d.domain.replace(/^www\./, '')))) {
+          if (hostname.split('.').length <= 3 && !hostname.includes('google') && !hostname.includes('bing')) {
+            canonicalLinks.push({ name: 'Official Website', url, priority: 0, domain: hostname });
+            seenDomains.add('Official Website');
+          }
+        }
+      } catch (e) {
+        // Invalid URL, skip
+      }
+    }
+
+    canonicalLinks.sort((a, b) => a.priority - b.priority);
+
+    log('canonical', `Found ${canonicalLinks.length} canonical links`);
+    canonicalLinks.forEach(link => {
+      log('canonical', `  ${link.name}: ${link.url}`);
+    });
+
+    const data = {
+      topic,
+      links: canonicalLinks,
+      rawContent: result.content,
+      allFoundUrls: allUrls,
+      timestamp: new Date().toISOString(),
+    };
+    saveResult(topic, 'canonical-links.json', data);
+
+    return { success: true, links: canonicalLinks, cost: result.cost || 0 };
+  } catch (error) {
+    log('canonical', `Error finding canonical links: ${error.message}`);
+    return { success: false, error: error.message, links: [] };
+  }
+}

--- a/tooling/content/creator/creator.test.mjs
+++ b/tooling/content/creator/creator.test.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Unit Tests for Page Creator Sub-Modules
+ *
+ * Tests pure-logic functions extracted during the refactoring.
+ * Run: node tooling/content/creator/creator.test.mjs
+ */
+
+import { levenshteinDistance, similarity, toSlug } from './duplicate-detection.mjs';
+import { extractUrls } from './source-fetching.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`✗ ${name}`);
+    console.log(`  ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || 'Assertion failed');
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(message || `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ─── Duplicate Detection Tests ───
+
+console.log('\n=== Duplicate Detection ===\n');
+
+test('levenshteinDistance: identical strings', () => {
+  assertEqual(levenshteinDistance('hello', 'hello'), 0);
+});
+
+test('levenshteinDistance: one substitution', () => {
+  assertEqual(levenshteinDistance('hello', 'hallo'), 1);
+});
+
+test('levenshteinDistance: one insertion', () => {
+  assertEqual(levenshteinDistance('hello', 'helloo'), 1);
+});
+
+test('levenshteinDistance: one deletion', () => {
+  assertEqual(levenshteinDistance('hello', 'helo'), 1);
+});
+
+test('levenshteinDistance: empty strings', () => {
+  assertEqual(levenshteinDistance('', ''), 0);
+  assertEqual(levenshteinDistance('abc', ''), 3);
+  assertEqual(levenshteinDistance('', 'abc'), 3);
+});
+
+test('similarity: identical strings', () => {
+  assertEqual(similarity('hello', 'hello'), 1);
+});
+
+test('similarity: case insensitive', () => {
+  assertEqual(similarity('Hello', 'hello'), 1);
+});
+
+test('similarity: returns 0-1 range', () => {
+  const sim = similarity('abc', 'xyz');
+  assert(sim >= 0 && sim <= 1, `Similarity ${sim} not in [0, 1]`);
+});
+
+test('similarity: similar strings have high score', () => {
+  const sim = similarity('OpenAI', 'OpenAi');
+  assert(sim >= 0.8, `Expected >= 0.8, got ${sim}`);
+});
+
+test('similarity: very different strings have low score', () => {
+  const sim = similarity('apple', 'bicycle');
+  assert(sim < 0.5, `Expected < 0.5, got ${sim}`);
+});
+
+test('toSlug: basic conversion', () => {
+  assertEqual(toSlug('Hello World'), 'hello-world');
+});
+
+test('toSlug: special characters', () => {
+  assertEqual(toSlug("Open Philanthropy's Fund"), 'open-philanthropy-s-fund');
+});
+
+test('toSlug: trims dashes', () => {
+  assertEqual(toSlug('--hello--'), 'hello');
+});
+
+test('toSlug: handles numbers', () => {
+  assertEqual(toSlug('80000 Hours'), '80000-hours');
+});
+
+// ─── URL Extraction Tests ───
+
+console.log('\n=== URL Extraction ===\n');
+
+test('extractUrls: basic URL', () => {
+  const urls = extractUrls('Check out https://example.com for more');
+  assertEqual(urls.length, 1);
+  assertEqual(urls[0], 'https://example.com');
+});
+
+test('extractUrls: multiple URLs', () => {
+  const urls = extractUrls('See https://a.com and http://b.com');
+  assertEqual(urls.length, 2);
+});
+
+test('extractUrls: strips trailing punctuation', () => {
+  const urls = extractUrls('Visit https://example.com.');
+  assertEqual(urls[0], 'https://example.com');
+});
+
+test('extractUrls: handles trailing comma', () => {
+  const urls = extractUrls('Visit https://example.com, for more');
+  assertEqual(urls[0], 'https://example.com');
+});
+
+test('extractUrls: handles unbalanced parens', () => {
+  const urls = extractUrls('(see https://example.com/path)');
+  assertEqual(urls[0], 'https://example.com/path');
+});
+
+test('extractUrls: preserves balanced parens in URL', () => {
+  const urls = extractUrls('https://en.wikipedia.org/wiki/Test_(computing)');
+  assertEqual(urls[0], 'https://en.wikipedia.org/wiki/Test_(computing)');
+});
+
+test('extractUrls: no URLs returns empty', () => {
+  const urls = extractUrls('No links here');
+  assertEqual(urls.length, 0);
+});
+
+// ─── Summary ───
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tooling/content/creator/deployment.mjs
+++ b/tooling/content/creator/deployment.mjs
@@ -1,0 +1,159 @@
+/**
+ * Deployment Module
+ *
+ * Handles deploying generated content to the wiki, cross-link validation, and category creation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Create a new category directory with index.mdx
+ */
+export function createCategoryDirectory(destPath, categoryName, ROOT) {
+  const fullDir = path.join(ROOT, 'content/docs', destPath);
+
+  if (!fs.existsSync(fullDir)) {
+    fs.mkdirSync(fullDir, { recursive: true });
+  }
+
+  const indexPath = path.join(fullDir, 'index.mdx');
+  if (!fs.existsSync(indexPath)) {
+    const indexContent = `---
+title: "${categoryName}"
+description: "${categoryName} - AI Safety Wiki"
+---
+
+# ${categoryName}
+
+Pages in this category:
+`;
+    fs.writeFileSync(indexPath, indexContent);
+  }
+}
+
+/**
+ * Deploy final article to content directory
+ */
+export function deployToDestination(topic, destPath, { ROOT, getTopicDir, ensureDir }) {
+  const topicDir = getTopicDir(topic);
+  const finalPath = path.join(topicDir, 'final.mdx');
+
+  if (!fs.existsSync(finalPath)) {
+    return { success: false, error: 'No final.mdx found to deploy' };
+  }
+
+  const sanitizedTopic = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const fullDestDir = path.join(ROOT, 'content/docs', destPath);
+  const fullDestPath = path.join(fullDestDir, `${sanitizedTopic}.mdx`);
+
+  ensureDir(fullDestDir);
+
+  fs.copyFileSync(finalPath, fullDestPath);
+
+  return {
+    success: true,
+    deployedTo: fullDestPath,
+  };
+}
+
+/**
+ * Validate cross-links in deployed content
+ */
+export function validateCrossLinks(filePath) {
+  const warnings = [];
+
+  if (!fs.existsSync(filePath)) {
+    return { warnings: ['File not found'], outboundCount: 0, outboundIds: [] };
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  // Count EntityLinks
+  const entityLinkPattern = /<EntityLink\s+id="([^"]+)"/g;
+  const outboundIds = [];
+  let match;
+  while ((match = entityLinkPattern.exec(content)) !== null) {
+    outboundIds.push(match[1]);
+  }
+
+  // Check for very few cross-links
+  if (outboundIds.length === 0) {
+    warnings.push('No EntityLinks found - consider adding cross-references to related wiki pages');
+  } else if (outboundIds.length < 3) {
+    warnings.push(`Only ${outboundIds.length} EntityLink(s) - consider adding more cross-references`);
+  }
+
+  // Check for broken footnote references
+  const footnoteRefs = content.match(/\[\^\d+\]/g) || [];
+  const footnoteDefinitions = content.match(/^\[\^\d+\]:/gm) || [];
+  const refCount = new Set(footnoteRefs.map(r => r.match(/\d+/)[0])).size;
+  const defCount = new Set(footnoteDefinitions.map(d => d.match(/\d+/)[0])).size;
+
+  if (refCount > defCount) {
+    warnings.push(`${refCount - defCount} footnote reference(s) without definitions`);
+  }
+
+  return {
+    warnings,
+    outboundCount: outboundIds.length,
+    outboundIds: [...new Set(outboundIds)]
+  };
+}
+
+/**
+ * Review phase — spawns Claude Code to do a critical review
+ */
+export async function runReview(topic, { ROOT, getTopicDir, log }) {
+  log('review', 'Running critical review...');
+
+  const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
+  const reviewPrompt = `# Critical Review: ${topic}
+
+Read the draft article at: ${draftPath}
+
+You are a skeptical editor doing a final quality check. Look specifically for:
+
+## HIGH PRIORITY - Logical Issues
+
+1. **Section-content contradictions**: Does the content within a section contradict its heading?
+2. **Self-contradicting quotes**: Are quotes used in contexts that contradict their meaning?
+3. **Temporal artifacts**: Does the text expose when research was conducted?
+
+## STANDARD CHECKS
+
+4. **Uncited claims** - Major facts without footnote citations
+5. **Missing topics** - Important aspects not covered based on the title
+6. **One-sided framing** - Only positive or negative coverage
+7. **Vague language** - "significant", "many experts" without specifics
+
+## Output
+
+Write findings to: ${path.join(getTopicDir(topic), 'review.json')}
+
+If you find any logicalIssues or temporalArtifacts, also fix them directly in the draft file.`;
+
+  const { spawn } = await import('child_process');
+
+  return new Promise((resolve, reject) => {
+    const claude = spawn('npx', [
+      '@anthropic-ai/claude-code',
+      '-p',
+      '--print',
+      '--dangerously-skip-permissions',
+      '--model', 'sonnet',
+      '--max-budget-usd', '1.0',
+      '--allowedTools', 'Read,Write'
+    ], {
+      cwd: ROOT,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    claude.stdin.write(reviewPrompt);
+    claude.stdin.end();
+
+    claude.on('close', code => {
+      resolve({ success: code === 0 });
+    });
+  });
+}

--- a/tooling/content/creator/duplicate-detection.mjs
+++ b/tooling/content/creator/duplicate-detection.mjs
@@ -1,0 +1,129 @@
+/**
+ * Duplicate Detection Module
+ *
+ * Checks if a similar page already exists in the wiki using fuzzy string matching.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Calculate Levenshtein distance between two strings
+ */
+export function levenshteinDistance(a, b) {
+  const matrix = [];
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1
+        );
+      }
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Calculate similarity ratio (0-1, where 1 is identical)
+ */
+export function similarity(a, b) {
+  const aLower = a.toLowerCase();
+  const bLower = b.toLowerCase();
+  const distance = levenshteinDistance(aLower, bLower);
+  const maxLen = Math.max(aLower.length, bLower.length);
+  return maxLen === 0 ? 1 : 1 - distance / maxLen;
+}
+
+/**
+ * Normalize a string to a slug for comparison
+ */
+export function toSlug(str) {
+  return str.toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Check if a page with similar name already exists
+ * Returns { exists: boolean, matches: Array<{title, path, similarity}> }
+ */
+export async function checkForExistingPage(topic, ROOT) {
+  const registryPath = path.join(ROOT, 'app/src/data/pathRegistry.json');
+  const databasePath = path.join(ROOT, 'app/src/data/database.json');
+
+  const matches = [];
+  const topicSlug = toSlug(topic);
+  const topicLower = topic.toLowerCase();
+
+  // Check pathRegistry for slug matches
+  if (fs.existsSync(registryPath)) {
+    const registry = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+    for (const [id, urlPath] of Object.entries(registry)) {
+      if (id.startsWith('__index__')) continue;
+
+      // Exact slug match
+      if (id === topicSlug) {
+        matches.push({ title: id, path: urlPath, similarity: 1.0, type: 'exact-id' });
+        continue;
+      }
+
+      // Fuzzy slug match
+      const sim = similarity(id, topicSlug);
+      if (sim >= 0.7) {
+        matches.push({ title: id, path: urlPath, similarity: sim, type: 'fuzzy-id' });
+      }
+    }
+  }
+
+  // Check database.json for title matches
+  if (fs.existsSync(databasePath)) {
+    const database = JSON.parse(fs.readFileSync(databasePath, 'utf-8'));
+    const allEntities = Object.values(database).flat();
+
+    for (const entity of allEntities) {
+      if (!entity.path) continue;
+
+      const entityName = entity.title || entity.name;
+      if (!entityName) continue;
+
+      const entityNameLower = entityName.toLowerCase();
+
+      // Exact title match
+      if (entityNameLower === topicLower) {
+        const existingMatch = matches.find(m => m.path === entity.path);
+        if (!existingMatch) {
+          matches.push({ title: entityName, path: entity.path, similarity: 1.0, type: 'exact-title' });
+        }
+        continue;
+      }
+
+      // Fuzzy title match
+      const sim = similarity(entityName, topic);
+      if (sim >= 0.7) {
+        const existingMatch = matches.find(m => m.path === entity.path);
+        if (!existingMatch) {
+          matches.push({ title: entityName, path: entity.path, similarity: sim, type: 'fuzzy-title' });
+        }
+      }
+    }
+  }
+
+  // Sort by similarity descending
+  matches.sort((a, b) => b.similarity - a.similarity);
+
+  return {
+    exists: matches.some(m => m.similarity >= 0.9),
+    matches: matches.slice(0, 5)
+  };
+}

--- a/tooling/content/creator/grading.mjs
+++ b/tooling/content/creator/grading.mjs
@@ -1,0 +1,174 @@
+/**
+ * Grading Module
+ *
+ * Grades generated articles for quality using Claude API.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createClient, parseJsonResponse } from '../../lib/anthropic.mjs';
+
+const GRADING_SYSTEM_PROMPT = `You are an expert evaluator of AI safety content. Score this page on:
+
+- importance (0-100): How significant for understanding AI risk
+- quality dimensions (0-10 each): novelty, rigor, actionability, completeness
+- llmSummary: 1-2 sentence summary with key conclusions
+- balanceFlags: Array of any balance/bias issues detected (see below)
+
+Be harsh but fair. Typical wiki content scores 3-5 on quality dimensions. 7+ is exceptional.
+
+IMPORTANT: This content may describe events after your knowledge cutoff. If the article cites specific sources (URLs, publications, official announcements), assume the described events are real even if you're unfamiliar with them. Do NOT mark well-sourced content as "fictional" or "fabricated" just because you haven't heard of it. Evaluate based on the quality of sourcing, writing, and relevance to AI safety.
+
+BALANCE CHECK - Flag these issues in balanceFlags array:
+- "no-criticism-section": Article lacks a Criticisms, Concerns, or Limitations section
+- "single-source-dominance": >50% of citations come from one source (e.g., company's own blog)
+- "missing-source-incentives": For controversial claims, source's incentives aren't discussed
+- "one-sided-framing": Article presents only positive OR only negative perspective without balance
+- "uncritical-claims": Major claims presented as fact without attribution ("X is..." vs "X claims...")
+
+IMPORTANCE guidelines:
+- 90-100: Essential for prioritization decisions
+- 70-89: High value for practitioners
+- 50-69: Useful context
+- 30-49: Reference material
+- 0-29: Peripheral or stubs
+
+Respond with valid JSON only.`;
+
+export async function runGrading(topic, { log, saveResult, getTopicDir }) {
+  log('grade', 'Running quality grading on temp file...');
+
+  const finalPath = path.join(getTopicDir(topic), 'final.mdx');
+  if (!fs.existsSync(finalPath)) {
+    log('grade', 'No final.mdx found, skipping grading');
+    return { success: false, error: 'No final.mdx found' };
+  }
+
+  const content = fs.readFileSync(finalPath, 'utf-8');
+
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) {
+    log('grade', 'Could not parse frontmatter');
+    return { success: false, error: 'Invalid frontmatter' };
+  }
+
+  const [, fmYaml, body] = fmMatch;
+
+  let frontmatter;
+  try {
+    const { parse: parseYaml } = await import('yaml');
+    frontmatter = parseYaml(fmYaml);
+  } catch (e) {
+    log('grade', `Frontmatter parse error: ${e.message}`);
+    return { success: false, error: 'Frontmatter parse error' };
+  }
+
+  const title = frontmatter.title || topic;
+  const description = frontmatter.description || '';
+
+  log('grade', 'Calling Claude for grading...');
+
+  try {
+    const client = createClient();
+
+    const userPrompt = `Grade this content page:
+
+**Title**: ${title}
+**Description**: ${description}
+
+---
+FULL CONTENT:
+${body.slice(0, 30000)}
+---
+
+Respond with JSON:
+{
+  "importance": <0-100>,
+  "ratings": {
+    "novelty": <0-10>,
+    "rigor": <0-10>,
+    "actionability": <0-10>,
+    "completeness": <0-10>
+  },
+  "llmSummary": "<1-2 sentences with conclusions>",
+  "balanceFlags": ["<flag-id>", ...] or [] if none,
+  "reasoning": "<brief explanation>"
+}`;
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 800,
+      system: GRADING_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }]
+    });
+
+    const text = response.content[0].text;
+    const grades = parseJsonResponse(text);
+
+    if (!grades || !grades.importance) {
+      log('grade', 'Invalid grading response');
+      return { success: false, error: 'Invalid response' };
+    }
+
+    log('grade', `Importance: ${grades.importance}, Quality: ${Math.round((grades.ratings.novelty + grades.ratings.rigor + grades.ratings.actionability + grades.ratings.completeness) * 2.5)}`);
+
+    const balanceFlags = grades.balanceFlags || [];
+    if (balanceFlags.length > 0) {
+      log('grade', `Balance issues detected:`);
+      for (const flag of balanceFlags) {
+        log('grade', `   - ${flag}`);
+      }
+    } else {
+      log('grade', `No balance issues detected`);
+    }
+
+    const quality = Math.round(
+      (grades.ratings.novelty + grades.ratings.rigor +
+       grades.ratings.actionability + grades.ratings.completeness) * 2.5
+    );
+
+    // Update frontmatter
+    frontmatter.importance = grades.importance;
+    frontmatter.ratings = grades.ratings;
+    frontmatter.quality = quality;
+    frontmatter.llmSummary = grades.llmSummary;
+    if (balanceFlags.length > 0) {
+      frontmatter.balanceFlags = balanceFlags;
+    }
+
+    // Count metrics
+    const wordCount = body.split(/\s+/).filter(w => w.length > 0).length;
+    const citations = (body.match(/\[\^\d+\]/g) || []).length;
+    const tables = (body.match(/^\|/gm) || []).length > 0 ? Math.floor((body.match(/^\|/gm) || []).length / 3) : 0;
+    const diagrams = (body.match(/<Mermaid/g) || []).length;
+
+    frontmatter.metrics = {
+      wordCount,
+      citations: new Set((body.match(/\[\^\d+\]/g) || [])).size,
+      tables,
+      diagrams
+    };
+
+    // Write updated file
+    const { stringify: stringifyYaml } = await import('yaml');
+    let yamlStr = stringifyYaml(frontmatter);
+    yamlStr = yamlStr.replace(/^(lastEdited:\s*)(\d{4}-\d{2}-\d{2})$/m, '$1"$2"');
+    const newContent = `---\n${yamlStr}---\n${body}`;
+    fs.writeFileSync(finalPath, newContent);
+
+    log('grade', `Graded: imp=${grades.importance}, qual=${quality}`);
+    log('grade', `  Summary: ${grades.llmSummary?.slice(0, 100)}...`);
+
+    return {
+      success: true,
+      importance: grades.importance,
+      quality,
+      ratings: grades.ratings,
+      llmSummary: grades.llmSummary
+    };
+
+  } catch (error) {
+    log('grade', `Grading API error: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+}

--- a/tooling/content/creator/index.mjs
+++ b/tooling/content/creator/index.mjs
@@ -1,0 +1,15 @@
+/**
+ * Page Creator Module Index
+ *
+ * Re-exports all sub-modules for use by the page-creator CLI entry point.
+ */
+
+export { checkForExistingPage } from './duplicate-detection.mjs';
+export { findCanonicalLinks } from './canonical-links.mjs';
+export { runPerplexityResearch, runScryResearch } from './research.mjs';
+export { registerResearchSources, fetchRegisteredSources, processDirections } from './source-fetching.mjs';
+export { runSynthesis } from './synthesis.mjs';
+export { runSourceVerification } from './verification.mjs';
+export { ensureComponentImports, runValidationLoop, runFullValidation } from './validation.mjs';
+export { runGrading } from './grading.mjs';
+export { createCategoryDirectory, deployToDestination, validateCrossLinks, runReview } from './deployment.mjs';

--- a/tooling/content/creator/research.mjs
+++ b/tooling/content/creator/research.mjs
@@ -1,0 +1,126 @@
+/**
+ * Research Module
+ *
+ * Handles Perplexity and SCRY research phases.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { batchResearch, generateResearchQueries } from '../../lib/openrouter.mjs';
+
+const SCRY_PUBLIC_KEY = process.env.SCRY_API_KEY || 'exopriors_public_readonly_v1_2025';
+
+export async function runPerplexityResearch(topic, depth, { log, saveResult }) {
+  log('research', `Starting Perplexity research (${depth})...`);
+
+  let queries = generateResearchQueries(topic);
+
+  if (depth === 'lite') {
+    queries = queries.slice(0, 6);
+  } else if (depth === 'deep') {
+    queries.push(
+      { query: `${topic} technical details methodology approach`, category: 'technical' },
+      { query: `${topic} comparison alternatives competitors`, category: 'comparison' },
+      { query: `${topic} future plans roadmap strategy`, category: 'future' },
+      { query: `${topic} academic papers research publications citations`, category: 'academic' },
+    );
+  }
+
+  log('research', `Running ${queries.length} Perplexity queries...`);
+
+  const results = await batchResearch(queries, { concurrency: 3 });
+
+  let totalCost = 0;
+  const researchSources = [];
+
+  for (const result of results) {
+    totalCost += result.cost || 0;
+    researchSources.push({
+      category: result.category,
+      query: result.query,
+      content: result.content,
+      citations: result.citations || [],
+      tokens: result.usage?.total_tokens || 0,
+      cost: result.cost || 0,
+    });
+    log('research', `  ${result.category}: ${result.usage?.total_tokens || 0} tokens, $${(result.cost || 0).toFixed(4)}`);
+  }
+
+  log('research', `Total research cost: $${totalCost.toFixed(4)}`);
+
+  const outputPath = saveResult(topic, 'perplexity-research.json', {
+    topic,
+    depth,
+    queryCount: queries.length,
+    totalCost,
+    timestamp: new Date().toISOString(),
+    sources: researchSources,
+  });
+
+  log('research', `Saved to ${outputPath}`);
+
+  return { success: true, cost: totalCost, queryCount: queries.length };
+}
+
+export async function runScryResearch(topic, { log, saveResult }) {
+  log('scry', 'Searching SCRY (EA Forum, LessWrong)...');
+
+  const searches = [
+    { table: 'mv_eaforum_posts', query: topic },
+    { table: 'mv_lesswrong_posts', query: topic },
+    { table: 'mv_eaforum_posts', query: `${topic} criticism` },
+  ];
+
+  const results = [];
+
+  for (const search of searches) {
+    try {
+      const sql = `SELECT title, uri, snippet, original_author, original_timestamp::date as date
+        FROM scry.search('${search.query.replace(/'/g, "''")}', '${search.table}')
+        WHERE title IS NOT NULL AND kind = 'post'
+        LIMIT 10`;
+
+      const response = await fetch('https://api.exopriors.com/v1/scry/query', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${SCRY_PUBLIC_KEY}`,
+          'Content-Type': 'text/plain',
+        },
+        body: sql,
+      });
+
+      const data = await response.json();
+
+      if (data.rows) {
+        const platform = search.table.includes('eaforum') ? 'EA Forum' : 'LessWrong';
+        log('scry', `  ${platform} "${search.query}": ${data.rows.length} results`);
+        results.push(...data.rows.map(row => ({
+          ...row,
+          platform,
+          searchQuery: search.query,
+        })));
+      }
+    } catch (error) {
+      log('scry', `  Error searching ${search.table}: ${error.message}`);
+    }
+  }
+
+  // Deduplicate by URI
+  const seen = new Set();
+  const unique = results.filter(r => {
+    if (seen.has(r.uri)) return false;
+    seen.add(r.uri);
+    return true;
+  });
+
+  saveResult(topic, 'scry-research.json', {
+    topic,
+    resultCount: unique.length,
+    timestamp: new Date().toISOString(),
+    results: unique,
+  });
+
+  log('scry', `Found ${unique.length} unique community posts`);
+
+  return { success: true, resultCount: unique.length };
+}

--- a/tooling/content/creator/source-fetching.mjs
+++ b/tooling/content/creator/source-fetching.mjs
@@ -1,0 +1,315 @@
+/**
+ * Source Fetching Module
+ *
+ * Handles registration and fetching of source URLs from research results.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { sources, hashId, SOURCES_DIR } from '../../lib/knowledge-db.mjs';
+
+/**
+ * Extract URLs from text with cleanup for trailing punctuation
+ */
+export function extractUrls(text) {
+  const urlRegex = /https?:\/\/[^\s<>"{}|\\^`\[\]]+/g;
+  const rawMatches = text.match(urlRegex) || [];
+
+  return rawMatches.map(url => {
+    let cleaned = url;
+
+    // Strip trailing punctuation (but not / or alphanumeric)
+    cleaned = cleaned.replace(/[.,;:!?]+$/, '');
+
+    // Handle unbalanced parentheses
+    const openParens = (cleaned.match(/\(/g) || []).length;
+    const closeParens = (cleaned.match(/\)/g) || []).length;
+    if (closeParens > openParens) {
+      const excess = closeParens - openParens;
+      for (let i = 0; i < excess; i++) {
+        cleaned = cleaned.replace(/\)$/, '');
+      }
+    }
+
+    return cleaned;
+  });
+}
+
+/**
+ * Extract citation URLs from Perplexity research and register them in the knowledge DB
+ */
+export async function registerResearchSources(topic, { log, saveResult, getTopicDir }) {
+  log('register-sources', 'Extracting and registering citation URLs...');
+
+  const researchPath = path.join(getTopicDir(topic), 'perplexity-research.json');
+  if (!fs.existsSync(researchPath)) {
+    log('register-sources', 'No Perplexity research found, skipping');
+    return { success: false, error: 'No research data' };
+  }
+
+  const research = JSON.parse(fs.readFileSync(researchPath, 'utf-8'));
+  const allUrls = new Set();
+
+  for (const source of (research.sources || [])) {
+    if (source.citations && Array.isArray(source.citations)) {
+      for (const url of source.citations) {
+        if (url && typeof url === 'string' && url.startsWith('http')) {
+          allUrls.add(url);
+        }
+      }
+    }
+  }
+
+  log('register-sources', `Found ${allUrls.size} unique citation URLs`);
+
+  const registered = [];
+  const existing = [];
+
+  for (const url of allUrls) {
+    try {
+      const existingSource = sources.getByUrl(url);
+      if (existingSource) {
+        existing.push(url);
+        continue;
+      }
+
+      let sourceType = 'web';
+      if (url.includes('arxiv.org')) sourceType = 'paper';
+      else if (url.includes('scholar.google')) sourceType = 'paper';
+      else if (url.includes('lesswrong.com')) sourceType = 'blog';
+      else if (url.includes('forum.effectivealtruism.org')) sourceType = 'blog';
+      else if (url.includes('substack.com')) sourceType = 'blog';
+      else if (url.includes('medium.com')) sourceType = 'blog';
+
+      const id = hashId(url);
+      sources.upsert({
+        id,
+        url,
+        title: null,
+        sourceType,
+      });
+
+      registered.push(url);
+    } catch (error) {
+      log('register-sources', `  Failed to register ${url}: ${error.message}`);
+    }
+  }
+
+  log('register-sources', `Registered ${registered.length} new sources, ${existing.length} already existed`);
+
+  saveResult(topic, 'registered-sources.json', {
+    topic,
+    totalUrls: allUrls.size,
+    registered: registered.length,
+    existing: existing.length,
+    urls: [...allUrls],
+    timestamp: new Date().toISOString(),
+  });
+
+  return { success: true, registered: registered.length, existing: existing.length, total: allUrls.size };
+}
+
+/**
+ * Fetch content from registered sources using Firecrawl
+ */
+export async function fetchRegisteredSources(topic, options, { log, saveResult, getTopicDir }) {
+  const { maxSources = 10, skipExisting = true } = options;
+
+  log('fetch-sources', 'Fetching source content with Firecrawl...');
+
+  const FIRECRAWL_KEY = process.env.FIRECRAWL_KEY;
+  if (!FIRECRAWL_KEY) {
+    log('fetch-sources', 'FIRECRAWL_KEY not set - skipping source fetching');
+    return { success: false, error: 'No API key', fetched: 0 };
+  }
+
+  const registeredPath = path.join(getTopicDir(topic), 'registered-sources.json');
+  if (!fs.existsSync(registeredPath)) {
+    log('fetch-sources', 'No registered sources found');
+    return { success: false, error: 'No registered sources' };
+  }
+
+  const registration = JSON.parse(fs.readFileSync(registeredPath, 'utf-8'));
+  const urlsToFetch = [];
+
+  for (const url of registration.urls) {
+    const source = sources.getByUrl(url);
+    if (!source) continue;
+
+    if (skipExisting && source.fetch_status === 'fetched' && source.content) {
+      continue;
+    }
+
+    urlsToFetch.push({ id: source.id, url });
+    if (urlsToFetch.length >= maxSources) break;
+  }
+
+  if (urlsToFetch.length === 0) {
+    log('fetch-sources', 'All sources already fetched');
+    return { success: true, fetched: 0, skipped: registration.urls.length };
+  }
+
+  log('fetch-sources', `Fetching ${urlsToFetch.length} sources (max ${maxSources})...`);
+
+  const FirecrawlApp = (await import('@mendable/firecrawl-js')).default;
+  const firecrawl = new FirecrawlApp({ apiKey: FIRECRAWL_KEY });
+
+  let fetched = 0;
+  let failed = 0;
+  const DELAY_MS = 7000;
+
+  for (let i = 0; i < urlsToFetch.length; i++) {
+    const { id, url } = urlsToFetch[i];
+
+    try {
+      log('fetch-sources', `  [${i + 1}/${urlsToFetch.length}] Fetching: ${url.slice(0, 60)}...`);
+
+      const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+
+      if (result.markdown) {
+        const cacheFile = `${id}.txt`;
+        sources.markFetched(id, result.markdown, cacheFile);
+
+        const cachePath = path.join(SOURCES_DIR, `${id}.txt`);
+        fs.writeFileSync(cachePath, result.markdown);
+
+        const metadata = result.metadata || {};
+        if (metadata.publishedTime) {
+          sources.updateMetadata(id, {
+            year: new Date(metadata.publishedTime).getFullYear(),
+          });
+        }
+
+        log('fetch-sources', `     ✓ ${result.markdown.length.toLocaleString()} chars`);
+        fetched++;
+      } else {
+        throw new Error('No markdown content returned');
+      }
+    } catch (error) {
+      log('fetch-sources', `     ✗ ${error.message}`);
+      sources.markFailed(id, error.message);
+      failed++;
+    }
+
+    if (i < urlsToFetch.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, DELAY_MS));
+    }
+  }
+
+  log('fetch-sources', `Fetched ${fetched} sources, ${failed} failed`);
+
+  saveResult(topic, 'fetch-results.json', {
+    topic,
+    fetched,
+    failed,
+    total: urlsToFetch.length,
+    timestamp: new Date().toISOString(),
+  });
+
+  return { success: true, fetched, failed };
+}
+
+/**
+ * Get fetched content for quote verification
+ */
+export function getFetchedSourceContent(topic, { getTopicDir }) {
+  const registeredPath = path.join(getTopicDir(topic), 'registered-sources.json');
+  if (!fs.existsSync(registeredPath)) {
+    return null;
+  }
+
+  const registration = JSON.parse(fs.readFileSync(registeredPath, 'utf-8'));
+  const contents = [];
+
+  for (const url of registration.urls) {
+    const source = sources.getByUrl(url);
+    if (source?.content) {
+      contents.push({ url, content: source.content });
+    }
+  }
+
+  if (contents.length === 0) {
+    return null;
+  }
+
+  return {
+    sourceCount: contents.length,
+    combinedContent: contents.map(c => c.content).join('\n\n---\n\n'),
+    sources: contents.map(c => ({ url: c.url, length: c.content.length })),
+  };
+}
+
+/**
+ * Process user directions — extract URLs and fetch their content
+ */
+export async function processDirections(topic, directions, { log, saveResult }) {
+  if (!directions) return { success: true, hasDirections: false };
+
+  log('directions', 'Processing user directions...');
+
+  const urls = extractUrls(directions);
+  log('directions', `Found ${urls.length} URL(s) in directions`);
+
+  const fetchedContent = [];
+
+  for (const url of urls) {
+    try {
+      log('directions', `Fetching: ${url}`);
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        log('directions', `  Failed to fetch (${response.status})`);
+        continue;
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      let content = '';
+
+      if (contentType.includes('application/pdf')) {
+        try {
+          const pdfParse = (await import('pdf-parse')).default;
+          const buffer = await response.arrayBuffer();
+          const pdfData = await pdfParse(Buffer.from(buffer));
+          content = pdfData.text.replace(/\s+/g, ' ').trim().slice(0, 15000);
+          log('directions', `  Parsed PDF: ${content.length} chars`);
+        } catch (pdfError) {
+          log('directions', `  PDF parse failed: ${pdfError.message}`);
+          continue;
+        }
+      } else {
+        const html = await response.text();
+        content = html
+          .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+          .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+          .replace(/<[^>]+>/g, ' ')
+          .replace(/&nbsp;/g, ' ')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 15000);
+      }
+
+      if (content.length > 100) {
+        fetchedContent.push({ url, content, charCount: content.length });
+        log('directions', `  Fetched ${content.length} chars`);
+      }
+    } catch (error) {
+      log('directions', `  Error fetching ${url}: ${error.message}`);
+    }
+  }
+
+  const directionsData = {
+    originalDirections: directions,
+    extractedUrls: urls,
+    fetchedContent,
+    timestamp: new Date().toISOString()
+  };
+
+  saveResult(topic, 'directions.json', directionsData);
+  log('directions', `Saved directions with ${fetchedContent.length} fetched URL(s)`);
+
+  return { success: true, hasDirections: true, urlCount: urls.length, fetchedCount: fetchedContent.length };
+}

--- a/tooling/content/creator/synthesis.mjs
+++ b/tooling/content/creator/synthesis.mjs
@@ -1,0 +1,231 @@
+/**
+ * Synthesis Module
+ *
+ * Generates wiki articles from research data using Claude Code SDK.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+
+export function getSynthesisPrompt(topic, quality, { loadResult }) {
+  const researchData = loadResult(topic, 'perplexity-research.json');
+  const scryData = loadResult(topic, 'scry-research.json');
+  const directionsData = loadResult(topic, 'directions.json');
+  const canonicalLinksData = loadResult(topic, 'canonical-links.json');
+
+  // Format canonical links for display
+  let canonicalLinksSection = '';
+  if (canonicalLinksData?.links?.length > 0) {
+    const linksTable = canonicalLinksData.links
+      .map(link => `| ${link.name} | [${link.domain || 'Link'}](${link.url}) |`)
+      .join('\n');
+    canonicalLinksSection = `## Canonical Links Found
+
+**IMPORTANT: Include this table near the top of the article (after Quick Assessment):**
+
+| Source | Link |
+|--------|------|
+${linksTable}
+
+`;
+  }
+
+  // Count total available citation URLs
+  let totalCitations = 0;
+
+  const researchContent = researchData?.sources?.map(s => {
+    let section = `### ${s.category.toUpperCase()}\n${s.content}`;
+    if (s.citations && s.citations.length > 0) {
+      totalCitations += s.citations.length;
+      section += `\n\n**Source URLs for [1], [2], etc. citations above:**\n${s.citations.map((url, i) => `[${i + 1}]: ${url}`).join('\n')}`;
+    } else {
+      section += `\n\n**WARNING: No source URLs available for this section. Do not invent URLs.**`;
+    }
+    return section;
+  }).join('\n\n') || 'No Perplexity research available';
+
+  const scryContent = scryData?.results?.slice(0, 10).map(r =>
+    `- [${r.title}](${r.uri}) by ${r.original_author} (${r.platform})\n  ${r.snippet?.slice(0, 200) || ''}`
+  ).join('\n') || 'No SCRY results available';
+
+  const citationWarning = totalCitations > 0
+    ? `✅ ${totalCitations} source URLs available in research data - USE THESE for citations`
+    : `⚠️ NO SOURCE URLs available in research data - use descriptive citations only, NO FAKE URLs`;
+
+  let directionsSection = '';
+  if (directionsData) {
+    const parts = [];
+
+    if (directionsData.originalDirections) {
+      parts.push(`### User Instructions\n${directionsData.originalDirections}`);
+    }
+
+    if (directionsData.fetchedContent && directionsData.fetchedContent.length > 0) {
+      const fetchedParts = directionsData.fetchedContent.map(fc =>
+        `#### Content from ${fc.url}\n${fc.content.slice(0, 8000)}`
+      );
+      parts.push(`### Content from User-Provided URLs\n${fetchedParts.join('\n\n')}`);
+    }
+
+    if (parts.length > 0) {
+      directionsSection = `## User-Provided Directions\n\n**IMPORTANT: Follow these directions carefully. They take precedence over default instructions.**\n\n${parts.join('\n\n')}`;
+    }
+  }
+
+  return `# Write Wiki Article: ${topic}
+
+You are writing a wiki article for LongtermWiki, an AI safety knowledge base.
+
+## Research Data
+
+### WEB RESEARCH (from Perplexity)
+${researchContent}
+
+### COMMUNITY DISCUSSIONS (from EA Forum/LessWrong)
+${scryContent}
+
+## Citation Status
+${citationWarning}
+
+${directionsSection}
+
+${canonicalLinksSection}
+## Requirements
+
+1. **CRITICAL: Use ONLY real URLs from the research data**
+   - Format: claim[^1] with [^1]: [Source Title](actual-url) at bottom
+   - Look for "Source URLs for [1], [2]" sections in the research data
+   - NEVER invent URLs like "example.com", "/posts/example", or "undefined"
+   - NEVER make up plausible-looking URLs - if you don't have a real URL, use text-only citation
+   - If no URL available: [^1]: Source name - description (no link)
+   - **NEVER use vague citations** like "Interview", "Earnings call", "Conference talk", "Reports"
+   - Always specify: exact name, date, and context (e.g., "Tesla Q4 2021 earnings call", "MIT Aeronautics Centennial Symposium (Oct 2014)")
+2. **CRITICAL: NEVER invent quotes**
+   - Only use EXACT text from the research data when using quotation marks
+   - If you want to attribute a view to someone, paraphrase WITHOUT quotation marks
+   - BAD: Ben Pace wrote "this is problematic because..." (if not verbatim in research)
+   - GOOD: Ben Pace argued this approach was problematic (paraphrase without quotes)
+   - GOOD: According to the post, "exact text from research" (verbatim quote)
+   - When attributing quotes to specific people, the quote MUST appear in the research data
+   - This is especially important for EA/rationalist community members whose names you may recognize
+3. **Escape dollar signs** - Write \\$100M not $100M
+4. **Use EntityLink for internal refs** - <EntityLink id="open-philanthropy">Open Philanthropy</EntityLink>
+5. **Include criticism section** if research supports it
+6. **60%+ prose** - Not just tables and bullet points
+7. **Limited info fallback** - If research is sparse, write a shorter article rather than padding with filler
+8. **Present information as current** - NEVER write "as of the research data" or "through late 2024"
+   - BAD: "As of the research data (through late 2024), no ratifications..."
+   - GOOD: "As of early 2026, the convention remains in..." or just "No ratifications have been reported"
+   - Don't reference when sources were gathered - present facts as current knowledge
+9. **Maintain logical consistency** - Ensure claims within each section align with the section's thesis
+   - If a section is titled "Lack of X", don't describe the subject as having X
+   - If discussing limitations, don't use quotes that suggest the opposite
+10. **Maintain critical distance** - Don't take sources at face value
+   - Use attribution phrases: "According to X...", "X claims that...", "X characterized this as..."
+   - Consider source incentives: companies may overstate their achievements, critics may overstate problems
+   - Include skeptical perspectives even if research is mostly positive or negative
+   - For controversial claims, note that significance/interpretation is debated
+
+## EntityLink Usage - CRITICAL
+
+**Format**: \`<EntityLink id="entity-id">Display Text</EntityLink>\`
+
+**IMPORTANT**:
+- IDs are simple slugs like "open-philanthropy", NOT paths like "organizations/funders/open-philanthropy"
+- ONLY use EntityLinks for entities that exist in the wiki
+- If unsure whether an entity exists, use plain text instead of guessing an ID
+- NEVER invent EntityLink IDs - if you're not certain, don't use EntityLink
+
+**PRIORITY CROSS-LINKING** (most important):
+- **Creators/Authors**: If the subject was created by someone in the wiki, ALWAYS EntityLink them
+  - Example: For a tool page, link to its creator: "created by <EntityLink id="vipul-naik">Vipul Naik</EntityLink>"
+  - Example: For a research project, link to the lead researcher
+- **Related Projects**: Link to sibling projects by the same creator
+  - Example: "part of an ecosystem including <EntityLink id="timelines-wiki">Timelines Wiki</EntityLink>"
+- **Funders/Organizations**: Link to funding sources and affiliated organizations
+- **Key People**: Link to researchers, founders, and notable figures mentioned substantively
+
+**Common valid IDs** (partial list - use plain text if entity not listed):
+open-philanthropy, anthropic, openai, deepmind, miri, lesswrong, redwood-research,
+eliezer-yudkowsky, paul-christiano, dario-amodei, scheming, misuse-risks, cea,
+80000-hours, arc-evals, metr, epoch-ai, fhi, cais, sff, ltff, fli,
+vipul-naik, issa-rice, timelines-wiki, donations-list-website, ai-watch, org-watch
+
+## Output Format
+
+Write the complete MDX article to: .claude/temp/page-creator/${topic.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/draft.mdx
+
+Include proper frontmatter:
+---
+title: "${topic}"
+description: "..."
+importance: 50
+lastEdited: "${new Date().toISOString().split('T')[0]}"
+sidebar:
+  order: 50
+ratings:
+  novelty: 5
+  rigor: 6
+  actionability: 5
+  completeness: 6
+---
+import {EntityLink, Backlinks, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Article Sections
+- Quick Assessment (table)
+- Key Links (table with Wikipedia, LessWrong, EA Forum, official site, etc. - if found)
+- Overview (2-3 paragraphs)
+- History
+- [Topic-specific sections]
+- Criticisms/Concerns (if applicable)
+- Key Uncertainties
+- Sources (footnotes)
+- <Backlinks />`;
+}
+
+export async function runSynthesis(topic, quality, { log, ROOT }) {
+  log('synthesis', `Generating article (${quality})...`);
+
+  return new Promise((resolve, reject) => {
+    const model = quality === 'quality' ? 'opus' : 'sonnet';
+    const budget = quality === 'quality' ? 3.0 : 2.0;
+
+    const claude = spawn('npx', [
+      '@anthropic-ai/claude-code',
+      '-p',
+      '--print',
+      '--dangerously-skip-permissions',
+      '--model', model,
+      '--max-budget-usd', String(budget),
+      '--allowedTools', 'Read,Write,Glob'
+    ], {
+      cwd: ROOT,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    const prompt = getSynthesisPrompt(topic, quality, { loadResult: (t, f) => {
+      const filePath = path.join(ROOT, '.claude/temp/page-creator', t.toLowerCase().replace(/[^a-z0-9]+/g, '-'), f);
+      if (!fs.existsSync(filePath)) return null;
+      const content = fs.readFileSync(filePath, 'utf-8');
+      return f.endsWith('.json') ? JSON.parse(content) : content;
+    }});
+
+    claude.stdin.write(prompt);
+    claude.stdin.end();
+
+    let stdout = '';
+    claude.stdout.on('data', data => {
+      stdout += data.toString();
+      process.stdout.write(data);
+    });
+
+    claude.on('close', code => {
+      if (code === 0) {
+        resolve({ success: true, model, budget });
+      } else {
+        reject(new Error(`Synthesis failed with code ${code}`));
+      }
+    });
+  });
+}

--- a/tooling/content/creator/validation.mjs
+++ b/tooling/content/creator/validation.mjs
@@ -1,0 +1,317 @@
+/**
+ * Validation Module
+ *
+ * Handles validation loop, full validation, and component import fixing.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { CRITICAL_RULES, QUALITY_RULES } from '../../lib/content-types.mjs';
+import { componentImportsRule } from '../../lib/rules/component-imports.mjs';
+import { ContentFile } from '../../lib/validation-engine.mjs';
+
+/**
+ * Ensure all used wiki components are properly imported.
+ * Delegates to the shared component-imports validation rule.
+ */
+export function ensureComponentImports(filePath) {
+  if (!fs.existsSync(filePath)) return { fixed: false, added: [] };
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const contentFile = new ContentFile(filePath, content);
+
+  // Use the shared rule to detect missing imports
+  const issues = componentImportsRule.check(contentFile, { content: new Map() });
+
+  if (!issues || issues.length === 0) {
+    return { fixed: false, added: [] };
+  }
+
+  // Apply the fix from the shared rule
+  const issue = issues[0];
+  const fixedContent = componentImportsRule.fix(content, issue);
+
+  if (fixedContent && fixedContent !== content) {
+    fs.writeFileSync(filePath, fixedContent);
+    return { fixed: true, added: issue.fix?.components || [] };
+  }
+
+  return { fixed: false, added: [] };
+}
+
+export async function runValidationLoop(topic, { log, ROOT, getTopicDir }) {
+  log('validate', 'Starting validation loop...');
+
+  const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
+  if (!fs.existsSync(draftPath)) {
+    log('validate', 'No draft found, skipping validation');
+    return { success: false, error: 'No draft found' };
+  }
+
+  const validationPrompt = `# Validate and Fix Wiki Article
+
+Read the draft article at: ${draftPath}
+
+## Validation Tasks - Fix ALL Issues
+
+### Critical Issues (MUST fix - these break the build):
+
+1. **Run precommit validation**:
+   \`node tooling/crux.mjs validate\`
+
+2. **Fix escaping issues**:
+   - Escape unescaped $ signs as \\$
+   - Escape < before numbers as \\< or use &lt;
+   - Use ≈ instead of ~ in table cells (~ renders as strikethrough)
+   - Use ≈\\$ instead of ~\\$ (tilde + escaped dollar causes errors)
+
+3. **Fix EntityLinks** (verify IDs resolve):
+   - Read app/src/data/pathRegistry.json to see which entity IDs exist
+   - For EVERY EntityLink in the draft, verify the id exists as a key in pathRegistry
+   - EntityLink IDs must be simple slugs (e.g., "open-philanthropy"), NOT paths (e.g., "organizations/funders/open-philanthropy")
+   - If an EntityLink id doesn't exist in pathRegistry:
+     - Check for similar IDs (e.g., "center-for-ai-safety" should be "cais")
+     - Or REMOVE the EntityLink entirely and use plain text instead
+   - It's better to use plain text than to use an invalid EntityLink ID
+
+4. **Fix broken citations**:
+   - Ensure all [^N] footnote citations have actual URLs, not "undefined"
+   - NEVER use fake URLs like "example.com", "/posts/example", etc.
+   - If no real URL available, use text-only citation: [^1]: Source name - description
+
+### Quality Issues (MUST fix - these cause rendering problems):
+
+5. **Fix markdown list formatting**:
+   - Numbered lists starting at N>1 need blank line before
+   - Check with: \`node tooling/crux.mjs validate unified --rules=markdown-lists\`
+
+6. **Fix consecutive bold labels**:
+   - Bold lines like "**Label:** text" need blank line between them
+   - Check with: \`node tooling/crux.mjs validate unified --rules=consecutive-bold-labels\`
+
+7. **Remove placeholders**:
+   - No TODO markers or placeholder text like "[insert X here]"
+
+### Final Steps:
+
+8. **Check wiki conventions**:
+   - All factual claims have footnote citations
+   - Proper frontmatter fields present (title, description, importance, lastEdited, ratings)
+   - Import statement: \`import {...} from '@components/wiki';\`
+
+9. **Write the final fixed version** to:
+   ${path.join(getTopicDir(topic), 'final.mdx')}
+
+10. **Report** what was fixed.
+
+Keep iterating until ALL checks pass. Run validation again after each fix.`;
+
+  return new Promise((resolve, reject) => {
+    const claude = spawn('npx', [
+      '@anthropic-ai/claude-code',
+      '-p',
+      '--print',
+      '--dangerously-skip-permissions',
+      '--model', 'sonnet',
+      '--max-budget-usd', '2.0',
+      '--allowedTools', 'Read,Write,Edit,Bash,Glob,Grep'
+    ], {
+      cwd: ROOT,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    claude.stdin.write(validationPrompt);
+    claude.stdin.end();
+
+    let stdout = '';
+    claude.stdout.on('data', data => {
+      stdout += data.toString();
+      process.stdout.write(data);
+    });
+
+    claude.on('close', code => {
+      const finalPath = path.join(getTopicDir(topic), 'final.mdx');
+      const hasOutput = fs.existsSync(finalPath);
+      resolve({
+        success: code === 0 && hasOutput,
+        hasOutput,
+        exitCode: code
+      });
+    });
+  });
+}
+
+export async function runFullValidation(topic, { log, saveResult, ROOT, getTopicDir }) {
+  log('validate-full', 'Running comprehensive validation...');
+
+  const finalPath = path.join(getTopicDir(topic), 'final.mdx');
+  if (!fs.existsSync(finalPath)) {
+    log('validate-full', 'No final.mdx found, skipping');
+    return { success: false, error: 'No final.mdx found' };
+  }
+
+  const results = {
+    critical: { passed: 0, failed: 0, errors: [] },
+    quality: { passed: 0, failed: 0, warnings: [] },
+    compile: { success: false, error: null }
+  };
+
+  // 1. Run MDX compilation check
+  log('validate-full', 'Checking MDX compilation...');
+  try {
+    const { execSync } = await import('child_process');
+    execSync('node tooling/crux.mjs validate compile --quick', {
+      cwd: ROOT,
+      stdio: 'pipe',
+      timeout: 60000
+    });
+    results.compile.success = true;
+    log('validate-full', '  ✓ MDX compiles');
+  } catch (error) {
+    results.compile.error = error.message;
+    log('validate-full', '  ✗ MDX compilation failed');
+  }
+
+  // 1b. Direct frontmatter check
+  try {
+    const tempContent = fs.readFileSync(finalPath, 'utf-8');
+
+    const unquotedDateMatch = tempContent.match(/lastEdited:\s*(\d{4}-\d{2}-\d{2})(?:\s*$|\s*\n)/m);
+    if (unquotedDateMatch) {
+      const lineContent = tempContent.split('\n').find(l => l.includes('lastEdited:')) || '';
+      if (!lineContent.includes('"') && !lineContent.includes("'")) {
+        const fixedContent = tempContent.replace(
+          /lastEdited:\s*(\d{4}-\d{2}-\d{2})/,
+          'lastEdited: "$1"'
+        );
+        fs.writeFileSync(finalPath, fixedContent);
+        log('validate-full', '  ✓ Fixed unquoted lastEdited date');
+      }
+    }
+  } catch (fmError) {
+    log('validate-full', `  Could not check frontmatter: ${fmError.message}`);
+  }
+
+  // 2. Run unified rules
+  log('validate-full', 'Running validation rules...');
+
+  const extractJson = (output) => {
+    const lines = output.split('\n');
+    const jsonStartIdx = lines.findIndex(line => line.trim().startsWith('{'));
+    if (jsonStartIdx === -1) return null;
+    const jsonStr = lines.slice(jsonStartIdx).join('\n');
+    return JSON.parse(jsonStr);
+  };
+
+  const topicSlug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+  for (const rule of CRITICAL_RULES) {
+    try {
+      const { execSync } = await import('child_process');
+      let output;
+      let hasParseError = false;
+
+      try {
+        output = execSync(
+          `node tooling/crux.mjs validate unified --rules=${rule} --ci 2>&1`,
+          { cwd: ROOT, stdio: 'pipe', timeout: 30000, maxBuffer: 10 * 1024 * 1024 }
+        ).toString();
+      } catch (execError) {
+        output = execError.stdout?.toString() || execError.stderr?.toString() || '';
+      }
+
+      let json = null;
+      try {
+        json = extractJson(output);
+      } catch (parseErr) {
+        hasParseError = true;
+      }
+
+      if (json) {
+        const fileIssues = json.issues?.filter(i =>
+          i.file?.includes(topicSlug) &&
+          i.severity === 'error'
+        ) || [];
+
+        if (fileIssues.length > 0) {
+          results.critical.failed++;
+          results.critical.errors.push({ rule, issues: fileIssues });
+          log('validate-full', `  ✗ ${rule}: ${fileIssues.length} error(s)`);
+        } else {
+          results.critical.passed++;
+          log('validate-full', `  ✓ ${rule}`);
+        }
+      } else if (hasParseError) {
+        try {
+          const grepOutput = execSync(
+            `node tooling/crux.mjs validate unified --rules=${rule} 2>&1 | grep -i "${topicSlug}" || true`,
+            { cwd: ROOT, stdio: 'pipe', timeout: 30000, maxBuffer: 10 * 1024 * 1024 }
+          ).toString();
+
+          const errorCount = (grepOutput.match(/error/gi) || []).length;
+          if (errorCount > 0) {
+            results.critical.failed++;
+            results.critical.errors.push({ rule, error: `${errorCount} error(s) found via grep` });
+            log('validate-full', `  ✗ ${rule}: ${errorCount} error(s)`);
+          } else {
+            results.critical.passed++;
+            log('validate-full', `  ✓ ${rule}`);
+          }
+        } catch {
+          results.critical.passed++;
+          log('validate-full', `  ✓ ${rule} (no issues for this file)`);
+        }
+      } else {
+        results.critical.passed++;
+        log('validate-full', `  ✓ ${rule}`);
+      }
+    } catch (error) {
+      results.critical.failed++;
+      results.critical.errors.push({ rule, error: error.message });
+      log('validate-full', `  ✗ ${rule}: check failed`);
+    }
+  }
+
+  // Quality rules (non-blocking)
+  for (const rule of QUALITY_RULES) {
+    try {
+      const { execSync } = await import('child_process');
+      const output = execSync(
+        `node tooling/crux.mjs validate unified --rules=${rule} --ci 2>&1`,
+        { cwd: ROOT, stdio: 'pipe', timeout: 30000 }
+      ).toString();
+
+      const json = extractJson(output);
+      if (!json) {
+        results.quality.passed++;
+        log('validate-full', `  ✓ ${rule}`);
+        continue;
+      }
+
+      const fileIssues = json.issues?.filter(i =>
+        i.file?.includes(topicSlug)
+      ) || [];
+
+      if (fileIssues.length > 0) {
+        results.quality.failed++;
+        results.quality.warnings.push({ rule, issues: fileIssues });
+        log('validate-full', `  ⚠ ${rule}: ${fileIssues.length} warning(s)`);
+      } else {
+        results.quality.passed++;
+        log('validate-full', `  ✓ ${rule}`);
+      }
+    } catch (error) {
+      log('validate-full', `  ? ${rule}: check skipped`);
+    }
+  }
+
+  const success = results.compile.success && results.critical.failed === 0;
+  log('validate-full', `\nValidation summary: ${success ? 'PASSED' : 'FAILED'}`);
+  log('validate-full', `  Critical: ${results.critical.passed}/${results.critical.passed + results.critical.failed} passed`);
+  log('validate-full', `  Quality: ${results.quality.passed}/${results.quality.passed + results.quality.failed} passed`);
+
+  saveResult(topic, 'validation-results.json', results);
+
+  return { success, results };
+}

--- a/tooling/content/creator/verification.mjs
+++ b/tooling/content/creator/verification.mjs
@@ -1,0 +1,177 @@
+/**
+ * Verification Module
+ *
+ * Verifies source attributions, quotes, and URLs in generated content.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { getFetchedSourceContent } from './source-fetching.mjs';
+
+export async function runSourceVerification(topic, { log, saveResult, getTopicDir }) {
+  log('verify-sources', 'Checking content against research sources...');
+
+  const topicDir = getTopicDir(topic);
+  const researchPath = path.join(topicDir, 'perplexity-research.json');
+  const draftPath = path.join(topicDir, 'draft.mdx');
+
+  if (!fs.existsSync(researchPath) || !fs.existsSync(draftPath)) {
+    log('verify-sources', 'Missing research or draft, skipping verification');
+    return { success: true, warnings: [] };
+  }
+
+  const research = JSON.parse(fs.readFileSync(researchPath, 'utf-8'));
+  const draft = fs.readFileSync(draftPath, 'utf-8');
+
+  // Combine all research text for searching
+  const perplexityText = research.sources
+    ?.map(r => r.content || '')
+    .join('\n') || '';
+
+  const fetchedContent = getFetchedSourceContent(topic, { getTopicDir });
+  if (fetchedContent) {
+    log('verify-sources', `Using ${fetchedContent.sourceCount} fetched sources for verification (${Math.round(fetchedContent.combinedContent.length / 1000)}k chars)`);
+  } else {
+    log('verify-sources', 'No fetched source content available, using Perplexity summaries only');
+  }
+
+  const allSourceContent = fetchedContent
+    ? perplexityText + '\n\n' + fetchedContent.combinedContent
+    : perplexityText;
+
+  const researchText = allSourceContent.toLowerCase();
+
+  const warnings = [];
+
+  // Check 1: Verify names exist in research
+  const authorPatterns = [
+    /authored by\s+([^.\n]+)/gi,
+    /written by\s+([^.\n]+)/gi,
+    /paper was authored by\s+([^.\n]+)/gi,
+    /including\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*(?:,\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)*(?:,?\s+and\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)?)/g,
+  ];
+
+  const mentionedNames = new Set();
+  for (const pattern of authorPatterns) {
+    let match;
+    while ((match = pattern.exec(draft)) !== null) {
+      const nameStr = match[1];
+      const names = nameStr
+        .replace(/\s+and\s+/gi, ', ')
+        .split(',')
+        .map(n => n.trim())
+        .filter(n => n.length > 0 && /^[A-Z]/.test(n));
+
+      for (const name of names) {
+        if (name.split(/\s+/).length >= 2) {
+          mentionedNames.add(name);
+        }
+      }
+    }
+  }
+
+  for (const name of mentionedNames) {
+    const nameLower = name.toLowerCase();
+    const lastName = name.split(/\s+/).pop()?.toLowerCase();
+
+    if (!researchText.includes(nameLower) && lastName && !researchText.includes(lastName)) {
+      warnings.push({
+        type: 'unverified-name',
+        name,
+        message: `Name "${name}" not found in research sources - possible hallucination`,
+      });
+    }
+  }
+
+  // Check 2: Verify attributed quotes exist in research
+  const attributedQuotePatterns = [
+    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+(?:said|wrote|argued|stated|noted|observed|commented|claimed|explained|described|characterized|called)\s*(?:it\s+)?[:\s]*["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /[Aa]ccording to\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /(?:[Ii]n\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)(?:'s)?\s+words[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /[Aa]s\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+put it[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+described\s+\w+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+characterized\s+\w+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
+    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+criticized\s+[^"\u201c]+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
+  ];
+
+  const attributedQuotes = [];
+  for (const pattern of attributedQuotePatterns) {
+    let match;
+    while ((match = pattern.exec(draft)) !== null) {
+      const person = match[1].trim();
+      const quote = match[2].trim();
+      if (quote.length >= 15) {
+        attributedQuotes.push({ person, quote, fullMatch: match[0] });
+      }
+    }
+  }
+
+  for (const { person, quote } of attributedQuotes) {
+    const quoteNormalized = quote.toLowerCase().replace(/\s+/g, ' ').trim();
+    const researchNormalized = researchText.replace(/\s+/g, ' ');
+
+    const quoteStart = quoteNormalized.slice(0, 30);
+    const quoteEnd = quoteNormalized.slice(-30);
+
+    const foundInResearch = researchNormalized.includes(quoteNormalized) ||
+      (quoteStart.length >= 20 && researchNormalized.includes(quoteStart)) ||
+      (quoteEnd.length >= 20 && researchNormalized.includes(quoteEnd));
+
+    if (!foundInResearch) {
+      warnings.push({
+        type: 'unverified-quote',
+        person,
+        quote: quote.length > 60 ? quote.slice(0, 60) + '...' : quote,
+        message: `Quote attributed to "${person}" not found in research - possible hallucination: "${quote.slice(0, 50)}..."`,
+      });
+    }
+  }
+
+  // Check 3: Flag all Person + quote patterns for review
+  const allQuoteAttributions = [];
+  const simpleAttributionPattern = /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+(?:said|wrote|argued|stated|noted|called it|described it as)\s*[:\s]*["\u201c][^"\u201d]{10,}["\u201d]/gi;
+  let simpleMatch;
+  while ((simpleMatch = simpleAttributionPattern.exec(draft)) !== null) {
+    allQuoteAttributions.push({
+      person: simpleMatch[1],
+      context: simpleMatch[0].slice(0, 100),
+    });
+  }
+
+  if (allQuoteAttributions.length > 0) {
+    log('verify-sources', `Found ${allQuoteAttributions.length} quote attribution(s) to review:`);
+    for (const attr of allQuoteAttributions.slice(0, 5)) {
+      log('verify-sources', `  - ${attr.person}: "${attr.context.slice(0, 60)}..."`);
+    }
+    if (allQuoteAttributions.length > 5) {
+      log('verify-sources', `  ... and ${allQuoteAttributions.length - 5} more`);
+    }
+  }
+
+  // Check 4: Undefined URLs
+  const undefinedUrlMatches = draft.match(/\]\(undefined\)/g);
+  if (undefinedUrlMatches) {
+    warnings.push({
+      type: 'undefined-urls',
+      count: undefinedUrlMatches.length,
+      message: `${undefinedUrlMatches.length} footnote(s) have undefined URLs`,
+    });
+  }
+
+  // Summary
+  if (warnings.length > 0) {
+    log('verify-sources', `Found ${warnings.length} potential issue(s):`);
+    for (const w of warnings) {
+      log('verify-sources', `  - ${w.message}`);
+    }
+    saveResult(topic, 'source-warnings.json', warnings);
+  } else {
+    log('verify-sources', 'All extracted claims found in research');
+  }
+
+  if (allQuoteAttributions.length > 0) {
+    saveResult(topic, 'quote-attributions.json', allQuoteAttributions);
+  }
+
+  return { success: true, warnings };
+}

--- a/tooling/content/grade-by-template.mjs
+++ b/tooling/content/grade-by-template.mjs
@@ -23,6 +23,7 @@ import path from 'path';
 import matter from 'gray-matter';
 import { findMdxFiles } from '../lib/file-utils.mjs';
 import { CONTENT_DIR } from '../lib/content-types.mjs';
+import { countWords, countTables, countDiagrams, countInternalLinks } from '../lib/metrics-extractor.mjs';
 
 // Import template definitions
 const PAGE_TEMPLATES = {
@@ -232,37 +233,15 @@ function extractHeadings(content) {
   return headings;
 }
 
-function countWords(content) {
-  // Remove MDX components, code blocks, and frontmatter
-  const cleaned = content
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/import\s+.*?from\s+['"][^'"]+['"]/g, '')
-    .replace(/\{[^}]+\}/g, '')
-    .replace(/\|[^|]+\|/g, ' ')
-    .replace(/[#*_`]/g, ' ');
-  return cleaned.split(/\s+/).filter(word => word.length > 0).length;
-}
-
-function countTables(content) {
-  // Count markdown tables (lines with |)
-  const tableRows = content.match(/^\|.+\|$/gm) || [];
-  // A table needs at least 3 rows (header, separator, data)
-  return Math.floor(tableRows.length / 3);
-}
+// countWords, countTables, countDiagrams imported from metrics-extractor
 
 function hasDiagram(content) {
-  return content.includes('Mermaid') ||
-         content.includes('mermaid') ||
-         content.includes('FactorRelationshipDiagram') ||
-         content.includes('PageCauseEffectGraph') ||
-         content.includes('CauseEffectGraph');
+  return countDiagrams(content) > 0;
 }
 
 function countCitations(content) {
-  const rComponents = (content.match(/<R\s+id=/g) || []).length;
-  const markdownLinks = (content.match(/\[.*?\]\(https?:\/\//g) || []).length;
-  return rComponents + markdownLinks;
+  // R components + external markdown links
+  return countInternalLinks(content);
 }
 
 function sectionMatches(heading, section) {

--- a/tooling/content/page-creator.mjs
+++ b/tooling/content/page-creator.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Page Creator - Cost-Optimized Pipeline
+ * Page Creator - Cost-Optimized Pipeline (CLI Entry Point)
  *
  * Uses Perplexity for research (cheap, good at web search)
  * Uses Claude for synthesis and validation iteration
@@ -17,17 +17,34 @@
  * Usage:
  *   node tooling/content/page-creator.mjs "SecureBio" --tier standard
  *   node tooling/content/page-creator.mjs "Community Notes" --tier premium
+ *
+ * Module structure (under creator/):
+ *   duplicate-detection.mjs  — fuzzy page matching
+ *   canonical-links.mjs      — finds Wikipedia, LW, EA Forum links
+ *   research.mjs             — Perplexity + SCRY research
+ *   source-fetching.mjs      — URL registration, Firecrawl, directions
+ *   synthesis.mjs            — Claude article generation
+ *   verification.mjs         — source/quote verification
+ *   validation.mjs           — validation loop + component imports
+ *   grading.mjs              — quality grading
+ *   deployment.mjs           — deploy, cross-links, review
  */
 
 import fs from 'fs';
 import path from 'path';
-import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
-import { batchResearch, generateResearchQueries, callOpenRouter, MODELS } from '../lib/openrouter.mjs';
-import { checkSidebarCoverage } from '../lib/sidebar-utils.mjs';
-import { sources, hashId, SOURCES_DIR } from '../lib/knowledge-db.mjs';
-import { CRITICAL_RULES, QUALITY_RULES } from '../lib/content-types.mjs';
+
+// Sub-modules
+import { checkForExistingPage } from './creator/duplicate-detection.mjs';
+import { findCanonicalLinks } from './creator/canonical-links.mjs';
+import { runPerplexityResearch, runScryResearch } from './creator/research.mjs';
+import { registerResearchSources, fetchRegisteredSources, processDirections } from './creator/source-fetching.mjs';
+import { runSynthesis } from './creator/synthesis.mjs';
+import { runSourceVerification } from './creator/verification.mjs';
+import { ensureComponentImports, runValidationLoop, runFullValidation } from './creator/validation.mjs';
+import { runGrading } from './creator/grading.mjs';
+import { createCategoryDirectory, deployToDestination, validateCrossLinks, runReview } from './creator/deployment.mjs';
 
 dotenv.config();
 
@@ -57,252 +74,6 @@ const TIERS = {
     description: 'Deep research + source fetching + quality synthesis + review'
   }
 };
-
-// ============ Duplicate Detection ============
-
-/**
- * Calculate Levenshtein distance between two strings
- */
-function levenshteinDistance(a, b) {
-  const matrix = [];
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
-  }
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0][j] = j;
-  }
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i][j] = matrix[i - 1][j - 1];
-      } else {
-        matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1,
-          matrix[i][j - 1] + 1,
-          matrix[i - 1][j] + 1
-        );
-      }
-    }
-  }
-  return matrix[b.length][a.length];
-}
-
-/**
- * Calculate similarity ratio (0-1, where 1 is identical)
- */
-function similarity(a, b) {
-  const aLower = a.toLowerCase();
-  const bLower = b.toLowerCase();
-  const distance = levenshteinDistance(aLower, bLower);
-  const maxLen = Math.max(aLower.length, bLower.length);
-  return maxLen === 0 ? 1 : 1 - distance / maxLen;
-}
-
-/**
- * Normalize a string to a slug for comparison
- */
-function toSlug(str) {
-  return str.toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-/**
- * Check if a page with similar name already exists
- * Returns { exists: boolean, matches: Array<{title, path, similarity}> }
- */
-async function checkForExistingPage(topic) {
-  const registryPath = path.join(ROOT, 'app/src/data/pathRegistry.json');
-  const databasePath = path.join(ROOT, 'app/src/data/database.json');
-
-  const matches = [];
-  const topicSlug = toSlug(topic);
-  const topicLower = topic.toLowerCase();
-
-  // Check pathRegistry for slug matches
-  if (fs.existsSync(registryPath)) {
-    const registry = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
-    for (const [id, urlPath] of Object.entries(registry)) {
-      if (id.startsWith('__index__')) continue;
-
-      // Exact slug match
-      if (id === topicSlug) {
-        matches.push({ title: id, path: urlPath, similarity: 1.0, type: 'exact-id' });
-        continue;
-      }
-
-      // Fuzzy slug match
-      const sim = similarity(id, topicSlug);
-      if (sim >= 0.7) {
-        matches.push({ title: id, path: urlPath, similarity: sim, type: 'fuzzy-id' });
-      }
-    }
-  }
-
-  // Check database.json for title matches
-  // database.json is { experts: [...], organizations: [...], ... }
-  if (fs.existsSync(databasePath)) {
-    const database = JSON.parse(fs.readFileSync(databasePath, 'utf-8'));
-    // Flatten all entity arrays into one list
-    const allEntities = Object.values(database).flat();
-
-    for (const entity of allEntities) {
-      // Skip resources (they don't have paths) - only check actual wiki entities
-      if (!entity.path) continue;
-
-      // Check both 'title' and 'name' fields (experts use 'name', others use 'title')
-      const entityName = entity.title || entity.name;
-      if (!entityName) continue;
-
-      const entityNameLower = entityName.toLowerCase();
-
-      // Exact title match
-      if (entityNameLower === topicLower) {
-        const existingMatch = matches.find(m => m.path === entity.path);
-        if (!existingMatch) {
-          matches.push({ title: entityName, path: entity.path, similarity: 1.0, type: 'exact-title' });
-        }
-        continue;
-      }
-
-      // Fuzzy title match
-      const sim = similarity(entityName, topic);
-      if (sim >= 0.7) {
-        const existingMatch = matches.find(m => m.path === entity.path);
-        if (!existingMatch) {
-          matches.push({ title: entityName, path: entity.path, similarity: sim, type: 'fuzzy-title' });
-        }
-      }
-    }
-  }
-
-  // Sort by similarity descending
-  matches.sort((a, b) => b.similarity - a.similarity);
-
-  return {
-    exists: matches.some(m => m.similarity >= 0.9),
-    matches: matches.slice(0, 5) // Return top 5 matches
-  };
-}
-
-// ============ Deployment ============
-
-/**
- * Move final.mdx to destination and check sidebar coverage
- */
-/**
- * Create a new category directory with index.mdx
- * Note: Next.js auto-detects pages from the filesystem, so no sidebar config needed.
- */
-function createCategoryDirectory(destPath, categoryLabel) {
-  const fullDestDir = path.join(ROOT, 'content/docs', destPath);
-
-  // Create directory
-  ensureDir(fullDestDir);
-
-  // Create index.mdx
-  const indexPath = path.join(fullDestDir, 'index.mdx');
-  if (!fs.existsSync(indexPath)) {
-    const indexContent = `---
-title: ${categoryLabel}
-description: Overview of ${categoryLabel.toLowerCase()}.
-sidebar:
-  label: Overview
-  order: 0
----
-
-This section contains pages about ${categoryLabel.toLowerCase()}.
-`;
-    fs.writeFileSync(indexPath, indexContent);
-    console.log(`✓ Created index.mdx for ${categoryLabel}`);
-  } else {
-    console.log(`  index.mdx already exists`);
-  }
-
-  return { success: true, created: true };
-}
-
-function deployToDestination(topic, destPath) {
-  const topicDir = getTopicDir(topic);
-  const finalPath = path.join(topicDir, 'final.mdx');
-
-  if (!fs.existsSync(finalPath)) {
-    return { success: false, error: 'No final.mdx found to deploy' };
-  }
-
-  // Full destination path
-  const sanitizedTopic = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
-  const fullDestDir = path.join(ROOT, 'content/docs', destPath);
-  const fullDestPath = path.join(fullDestDir, `${sanitizedTopic}.mdx`);
-
-  // Ensure destination directory exists
-  ensureDir(fullDestDir);
-
-  // Check sidebar coverage (uses shared utility)
-  const sidebarCheck = checkSidebarCoverage(destPath);
-
-  // Copy file to destination
-  fs.copyFileSync(finalPath, fullDestPath);
-
-  return {
-    success: true,
-    deployedTo: fullDestPath,
-    sidebarCoverage: sidebarCheck
-  };
-}
-
-// ============ Cross-Link Validation ============
-
-/**
- * Check EntityLinks in a deployed file and warn about missing cross-links
- */
-function validateCrossLinks(filePath) {
-  const content = fs.readFileSync(filePath, 'utf-8');
-
-  // Count outbound EntityLinks
-  const entityLinkMatches = content.match(/<EntityLink\s+id="([^"]+)"/g) || [];
-  const uniqueEntityLinks = new Set(
-    entityLinkMatches.map(m => m.match(/id="([^"]+)"/)[1])
-  );
-
-  const result = {
-    outboundCount: uniqueEntityLinks.size,
-    outboundIds: [...uniqueEntityLinks],
-    warnings: []
-  };
-
-  // Check for common missing patterns
-  const contentLower = content.toLowerCase();
-
-  // Check if "created by" or "developed by" exists without EntityLink nearby
-  const creatorPatterns = [
-    /created by\s+([A-Z][a-z]+\s+[A-Z][a-z]+)/g,
-    /developed by\s+([A-Z][a-z]+\s+[A-Z][a-z]+)/g,
-    /built by\s+([A-Z][a-z]+\s+[A-Z][a-z]+)/g,
-    /founded by\s+([A-Z][a-z]+\s+[A-Z][a-z]+)/g,
-  ];
-
-  for (const pattern of creatorPatterns) {
-    let match;
-    while ((match = pattern.exec(content)) !== null) {
-      const name = match[1];
-      // Check if this name appears in an EntityLink
-      const nameSlug = name.toLowerCase().replace(/\s+/g, '-');
-      if (!result.outboundIds.some(id => id.includes(nameSlug) || nameSlug.includes(id))) {
-        result.warnings.push(`Possible unlinked creator: "${name}" - consider adding EntityLink if they exist in wiki`);
-      }
-    }
-  }
-
-  // Warn if no outbound links at all
-  if (result.outboundCount === 0) {
-    result.warnings.push('No outbound EntityLinks found - consider linking to related entities');
-  } else if (result.outboundCount < 2) {
-    result.warnings.push(`Only ${result.outboundCount} outbound EntityLink(s) - consider adding more cross-references`);
-  }
-
-  return result;
-}
 
 // ============ Utility Functions ============
 
@@ -334,1683 +105,12 @@ function saveResult(topic, filename, data) {
   return filePath;
 }
 
-function loadResult(topic, filename) {
-  const filePath = path.join(getTopicDir(topic), filename);
-  if (!fs.existsSync(filePath)) return null;
-  const content = fs.readFileSync(filePath, 'utf-8');
-  if (filename.endsWith('.json')) {
-    return JSON.parse(content);
-  }
-  return content;
-}
-
-// ============ Auto-Import Components ============
-
 /**
- * Wiki components that need to be imported from @components/wiki
+ * Context object passed to sub-modules so they can use shared utilities
+ * without relying on closures over module-scoped variables.
  */
-const WIKI_COMPONENTS = [
-  'EntityLink',
-  'DataInfoBox',
-  'InfoBox',
-  'Backlinks',
-  'Mermaid',
-  'R',
-  'DataExternalLinks',
-  'EstimateBox',
-  'QuoteBox',
-  'Timeline',
-  'ComparisonTable',
-];
-
-/**
- * Ensure all used wiki components are properly imported.
- * Call this after synthesis to fix missing imports before validation.
- */
-function ensureComponentImports(filePath) {
-  if (!fs.existsSync(filePath)) return { fixed: false, added: [] };
-
-  const content = fs.readFileSync(filePath, 'utf-8');
-
-  // Find used components (not in code blocks)
-  const usedComponents = new Set();
-  const componentRegex = /<([A-Z][a-zA-Z0-9]*)/g;
-  let match;
-
-  // Simple code block detection
-  const codeBlockRanges = [];
-  const codeBlockRegex = /```[\s\S]*?```/g;
-  while ((match = codeBlockRegex.exec(content)) !== null) {
-    codeBlockRanges.push([match.index, match.index + match[0].length]);
-  }
-
-  const isInCodeBlock = (pos) => {
-    return codeBlockRanges.some(([start, end]) => pos >= start && pos < end);
-  };
-
-  while ((match = componentRegex.exec(content)) !== null) {
-    if (!isInCodeBlock(match.index)) {
-      const componentName = match[1];
-      if (WIKI_COMPONENTS.includes(componentName)) {
-        usedComponents.add(componentName);
-      }
-    }
-  }
-
-  if (usedComponents.size === 0) {
-    return { fixed: false, added: [] };
-  }
-
-  // Find what's already imported from @components/wiki
-  const wikiImportRegex = /import\s*\{([^}]+)\}\s*from\s*['"]@components\/wiki['"]/;
-  const wikiImportMatch = content.match(wikiImportRegex);
-  const importedComponents = new Set();
-
-  if (wikiImportMatch) {
-    const importList = wikiImportMatch[1];
-    importList.split(',').map(c => c.trim()).filter(Boolean).forEach(c => importedComponents.add(c));
-  }
-
-  // Also check for individual imports
-  for (const comp of usedComponents) {
-    const individualImportRegex = new RegExp(`import.*\\b${comp}\\b.*from`);
-    if (individualImportRegex.test(content)) {
-      importedComponents.add(comp);
-    }
-  }
-
-  // Find missing imports
-  const missing = [...usedComponents].filter(c => !importedComponents.has(c));
-
-  if (missing.length === 0) {
-    return { fixed: false, added: [] };
-  }
-
-  // Fix the imports
-  let fixedContent = content;
-
-  if (wikiImportMatch) {
-    // Add to existing import
-    const existingImports = wikiImportMatch[1].trim();
-    const newImports = `${existingImports}, ${missing.join(', ')}`;
-    const quoteChar = wikiImportMatch[0].includes("'") ? "'" : '"';
-    fixedContent = content.replace(
-      wikiImportRegex,
-      `import {${newImports}} from ${quoteChar}@components/wiki${quoteChar}`
-    );
-  } else {
-    // Add new import after frontmatter
-    const importStatement = `import { ${missing.join(', ')} } from '@components/wiki';`;
-    const lines = content.split('\n');
-
-    // Find end of frontmatter
-    let fmCount = 0;
-    let insertIdx = 0;
-    for (let i = 0; i < lines.length; i++) {
-      if (lines[i] === '---') {
-        fmCount++;
-        if (fmCount === 2) {
-          insertIdx = i + 1;
-          break;
-        }
-      }
-    }
-
-    lines.splice(insertIdx, 0, importStatement);
-    fixedContent = lines.join('\n');
-  }
-
-  fs.writeFileSync(filePath, fixedContent);
-  return { fixed: true, added: missing };
-}
-
-// ============ Phase: Find Canonical Links ============
-
-const CANONICAL_DOMAINS = [
-  { domain: 'en.wikipedia.org', name: 'Wikipedia', priority: 1 },
-  { domain: 'www.wikidata.org', name: 'Wikidata', priority: 2 },
-  { domain: 'lesswrong.com', name: 'LessWrong', priority: 3 },
-  { domain: 'forum.effectivealtruism.org', name: 'EA Forum', priority: 3 },
-  { domain: 'www.britannica.com', name: 'Britannica', priority: 4 },
-  { domain: 'arxiv.org', name: 'arXiv', priority: 5 },
-  { domain: 'scholar.google.com', name: 'Google Scholar', priority: 5 },
-  { domain: 'twitter.com', name: 'Twitter/X', priority: 6 },
-  { domain: 'x.com', name: 'Twitter/X', priority: 6 },
-  { domain: 'github.com', name: 'GitHub', priority: 6 },
-  { domain: 'linkedin.com', name: 'LinkedIn', priority: 7 },
-];
-
-async function findCanonicalLinks(topic) {
-  log('canonical', 'Searching for canonical reference links...');
-
-  const { perplexityResearch } = await import('../lib/openrouter.mjs');
-
-  // Search for canonical pages
-  const searchQuery = `Find official and reference pages for "${topic}". Include:
-- Wikipedia page URL (if exists)
-- Wikidata ID and URL (if exists)
-- LessWrong profile or wiki page (if exists)
-- EA Forum profile or posts (if exists)
-- Official website (if organization or person)
-- Twitter/X profile (if exists)
-- GitHub (if relevant)
-
-For each, provide the exact URL. Only include links that actually exist.`;
-
-  try {
-    const result = await perplexityResearch(searchQuery, { maxTokens: 1500 });
-
-    // Extract URLs from response
-    const urlRegex = /https?:\/\/[^\s<>"{}|\\^`\[\]]+/g;
-    const foundUrls = (result.content.match(urlRegex) || []).map(url => {
-      // Clean trailing punctuation
-      return url.replace(/[.,;:!?]+$/, '').replace(/\)+$/, '');
-    });
-
-    // Also include citations from Perplexity
-    const allUrls = [...new Set([...foundUrls, ...(result.citations || [])])];
-
-    // Categorize by domain
-    const canonicalLinks = [];
-    const seenDomains = new Set();
-
-    for (const url of allUrls) {
-      try {
-        const urlObj = new URL(url);
-        const hostname = urlObj.hostname.replace(/^www\./, '');
-
-        // Check against known canonical domains
-        for (const { domain, name, priority } of CANONICAL_DOMAINS) {
-          const domainHost = domain.replace(/^www\./, '');
-          if (hostname === domainHost || hostname.endsWith('.' + domainHost)) {
-            if (!seenDomains.has(name)) {
-              canonicalLinks.push({ name, url, priority, domain: hostname });
-              seenDomains.add(name);
-            }
-            break;
-          }
-        }
-
-        // Check for official/personal website (not a known platform)
-        if (!seenDomains.has('Official Website') &&
-            !CANONICAL_DOMAINS.some(d => hostname.includes(d.domain.replace(/^www\./, '')))) {
-          // Heuristic: if it looks like a personal/org site
-          if (hostname.split('.').length <= 3 && !hostname.includes('google') && !hostname.includes('bing')) {
-            canonicalLinks.push({ name: 'Official Website', url, priority: 0, domain: hostname });
-            seenDomains.add('Official Website');
-          }
-        }
-      } catch (e) {
-        // Invalid URL, skip
-      }
-    }
-
-    // Sort by priority
-    canonicalLinks.sort((a, b) => a.priority - b.priority);
-
-    log('canonical', `Found ${canonicalLinks.length} canonical links`);
-    canonicalLinks.forEach(link => {
-      log('canonical', `  ${link.name}: ${link.url}`);
-    });
-
-    // Save results
-    const data = {
-      topic,
-      links: canonicalLinks,
-      rawContent: result.content,
-      allFoundUrls: allUrls,
-      timestamp: new Date().toISOString(),
-    };
-    saveResult(topic, 'canonical-links.json', data);
-
-    return { success: true, links: canonicalLinks, cost: result.cost || 0 };
-  } catch (error) {
-    log('canonical', `Error finding canonical links: ${error.message}`);
-    return { success: false, error: error.message, links: [] };
-  }
-}
-
-// ============ Phase: Perplexity Research ============
-
-async function runPerplexityResearch(topic, depth = 'standard') {
-  log('research', `Starting Perplexity research (${depth})...`);
-
-  // Generate queries based on depth
-  let queries = generateResearchQueries(topic);
-
-  if (depth === 'lite') {
-    queries = queries.slice(0, 6); // Just core queries
-  } else if (depth === 'deep') {
-    // Add more specific queries
-    queries.push(
-      { query: `${topic} technical details methodology approach`, category: 'technical' },
-      { query: `${topic} comparison alternatives competitors`, category: 'comparison' },
-      { query: `${topic} future plans roadmap strategy`, category: 'future' },
-      { query: `${topic} academic papers research publications citations`, category: 'academic' },
-    );
-  }
-
-  log('research', `Running ${queries.length} Perplexity queries...`);
-
-  const results = await batchResearch(queries, { concurrency: 3 });
-
-  let totalCost = 0;
-  const researchSources = [];
-
-  for (const result of results) {
-    totalCost += result.cost || 0;
-    researchSources.push({
-      category: result.category,
-      query: result.query,
-      content: result.content,
-      citations: result.citations || [],  // Perplexity source URLs for [1], [2], etc.
-      tokens: result.usage?.total_tokens || 0,
-      cost: result.cost || 0,
-    });
-    log('research', `  ${result.category}: ${result.usage?.total_tokens || 0} tokens, $${(result.cost || 0).toFixed(4)}`);
-  }
-
-  log('research', `Total research cost: $${totalCost.toFixed(4)}`);
-
-  // Save results
-  const outputPath = saveResult(topic, 'perplexity-research.json', {
-    topic,
-    depth,
-    queryCount: queries.length,
-    totalCost,
-    timestamp: new Date().toISOString(),
-    sources: researchSources,
-  });
-
-  log('research', `Saved to ${outputPath}`);
-
-  return { success: true, cost: totalCost, queryCount: queries.length };
-}
-
-// ============ Phase: Register Sources ============
-
-/**
- * Extract citation URLs from Perplexity research and register them in the knowledge DB
- */
-async function registerResearchSources(topic) {
-  log('register-sources', 'Extracting and registering citation URLs...');
-
-  const researchPath = path.join(getTopicDir(topic), 'perplexity-research.json');
-  if (!fs.existsSync(researchPath)) {
-    log('register-sources', 'No Perplexity research found, skipping');
-    return { success: false, error: 'No research data' };
-  }
-
-  const research = JSON.parse(fs.readFileSync(researchPath, 'utf-8'));
-  const allUrls = new Set();
-
-  // Extract citation URLs from all research responses
-  for (const source of (research.sources || [])) {
-    if (source.citations && Array.isArray(source.citations)) {
-      for (const url of source.citations) {
-        if (url && typeof url === 'string' && url.startsWith('http')) {
-          allUrls.add(url);
-        }
-      }
-    }
-  }
-
-  log('register-sources', `Found ${allUrls.size} unique citation URLs`);
-
-  const registered = [];
-  const existing = [];
-
-  for (const url of allUrls) {
-    try {
-      // Check if already in database
-      const existingSource = sources.getByUrl(url);
-      if (existingSource) {
-        existing.push(url);
-        continue;
-      }
-
-      // Determine source type from URL
-      let sourceType = 'web';
-      if (url.includes('arxiv.org')) sourceType = 'paper';
-      else if (url.includes('scholar.google')) sourceType = 'paper';
-      else if (url.includes('lesswrong.com')) sourceType = 'blog';
-      else if (url.includes('forum.effectivealtruism.org')) sourceType = 'blog';
-      else if (url.includes('substack.com')) sourceType = 'blog';
-      else if (url.includes('medium.com')) sourceType = 'blog';
-
-      // Register in database
-      const id = hashId(url);
-      sources.upsert({
-        id,
-        url,
-        title: null, // Will be extracted during fetch
-        sourceType,
-      });
-
-      registered.push(url);
-    } catch (error) {
-      log('register-sources', `  Failed to register ${url}: ${error.message}`);
-    }
-  }
-
-  log('register-sources', `Registered ${registered.length} new sources, ${existing.length} already existed`);
-
-  // Save registration results
-  saveResult(topic, 'registered-sources.json', {
-    topic,
-    totalUrls: allUrls.size,
-    registered: registered.length,
-    existing: existing.length,
-    urls: [...allUrls],
-    timestamp: new Date().toISOString(),
-  });
-
-  return { success: true, registered: registered.length, existing: existing.length, total: allUrls.size };
-}
-
-// ============ Phase: Fetch Sources ============
-
-/**
- * Fetch content from registered sources using Firecrawl
- * Rate limited to avoid API limits (7s between requests)
- */
-async function fetchRegisteredSources(topic, options = {}) {
-  const { maxSources = 10, skipExisting = true } = options;
-
-  log('fetch-sources', 'Fetching source content with Firecrawl...');
-
-  // Check for Firecrawl API key
-  const FIRECRAWL_KEY = process.env.FIRECRAWL_KEY;
-  if (!FIRECRAWL_KEY) {
-    log('fetch-sources', '⚠️  FIRECRAWL_KEY not set - skipping source fetching');
-    log('fetch-sources', '   Add FIRECRAWL_KEY to .env to enable content fetching');
-    return { success: false, error: 'No API key', fetched: 0 };
-  }
-
-  // Load registered sources for this topic
-  const registeredPath = path.join(getTopicDir(topic), 'registered-sources.json');
-  if (!fs.existsSync(registeredPath)) {
-    log('fetch-sources', 'No registered sources found');
-    return { success: false, error: 'No registered sources' };
-  }
-
-  const registration = JSON.parse(fs.readFileSync(registeredPath, 'utf-8'));
-  const urlsToFetch = [];
-
-  // Filter to sources that need fetching
-  for (const url of registration.urls) {
-    const source = sources.getByUrl(url);
-    if (!source) continue;
-
-    if (skipExisting && source.fetch_status === 'fetched' && source.content) {
-      continue; // Already fetched
-    }
-
-    urlsToFetch.push({ id: source.id, url });
-    if (urlsToFetch.length >= maxSources) break;
-  }
-
-  if (urlsToFetch.length === 0) {
-    log('fetch-sources', 'All sources already fetched');
-    return { success: true, fetched: 0, skipped: registration.urls.length };
-  }
-
-  log('fetch-sources', `Fetching ${urlsToFetch.length} sources (max ${maxSources})...`);
-
-  // Initialize Firecrawl
-  const FirecrawlApp = (await import('@mendable/firecrawl-js')).default;
-  const firecrawl = new FirecrawlApp({ apiKey: FIRECRAWL_KEY });
-
-  let fetched = 0;
-  let failed = 0;
-  const DELAY_MS = 7000; // 7 seconds between requests (Firecrawl rate limit)
-
-  for (let i = 0; i < urlsToFetch.length; i++) {
-    const { id, url } = urlsToFetch[i];
-
-    try {
-      log('fetch-sources', `  [${i + 1}/${urlsToFetch.length}] Fetching: ${url.slice(0, 60)}...`);
-
-      const result = await firecrawl.scrape(url, {
-        formats: ['markdown'],
-      });
-
-      if (result.markdown) {
-        // Save content to database
-        const cacheFile = `${id}.txt`;
-        sources.markFetched(id, result.markdown, cacheFile);
-
-        // Also save to cache file for backup
-        const cachePath = path.join(SOURCES_DIR, `${id}.txt`);
-        fs.writeFileSync(cachePath, result.markdown);
-
-        // Update metadata if available
-        const metadata = result.metadata || {};
-        if (metadata.publishedTime) {
-          sources.updateMetadata(id, {
-            year: new Date(metadata.publishedTime).getFullYear(),
-          });
-        }
-
-        log('fetch-sources', `     ✓ ${result.markdown.length.toLocaleString()} chars`);
-        fetched++;
-      } else {
-        throw new Error('No markdown content returned');
-      }
-    } catch (error) {
-      log('fetch-sources', `     ✗ ${error.message}`);
-      sources.markFailed(id, error.message);
-      failed++;
-    }
-
-    // Rate limit delay (except for last item)
-    if (i < urlsToFetch.length - 1) {
-      await new Promise(resolve => setTimeout(resolve, DELAY_MS));
-    }
-  }
-
-  log('fetch-sources', `Fetched ${fetched} sources, ${failed} failed`);
-
-  // Save fetch results
-  saveResult(topic, 'fetch-results.json', {
-    topic,
-    fetched,
-    failed,
-    total: urlsToFetch.length,
-    timestamp: new Date().toISOString(),
-  });
-
-  return { success: true, fetched, failed };
-}
-
-/**
- * Get fetched content for quote verification
- * Returns combined content from all fetched sources for this topic
- */
-function getFetchedSourceContent(topic) {
-  const registeredPath = path.join(getTopicDir(topic), 'registered-sources.json');
-  if (!fs.existsSync(registeredPath)) {
-    return null;
-  }
-
-  const registration = JSON.parse(fs.readFileSync(registeredPath, 'utf-8'));
-  const contents = [];
-
-  for (const url of registration.urls) {
-    const source = sources.getByUrl(url);
-    if (source?.content) {
-      contents.push({
-        url,
-        content: source.content,
-      });
-    }
-  }
-
-  if (contents.length === 0) {
-    return null;
-  }
-
-  return {
-    sourceCount: contents.length,
-    combinedContent: contents.map(c => c.content).join('\n\n---\n\n'),
-    sources: contents.map(c => ({ url: c.url, length: c.content.length })),
-  };
-}
-
-// ============ Phase: SCRY Research ============
-
-async function runScryResearch(topic) {
-  log('scry', 'Searching SCRY (EA Forum, LessWrong)...');
-
-  const SCRY_PUBLIC_KEY = 'exopriors_public_readonly_v1_2025';
-
-  const searches = [
-    { table: 'mv_eaforum_posts', query: topic },
-    { table: 'mv_lesswrong_posts', query: topic },
-    { table: 'mv_eaforum_posts', query: `${topic} criticism` },
-  ];
-
-  const results = [];
-
-  for (const search of searches) {
-    try {
-      const sql = `SELECT title, uri, snippet, original_author, original_timestamp::date as date
-        FROM scry.search('${search.query.replace(/'/g, "''")}', '${search.table}')
-        WHERE title IS NOT NULL AND kind = 'post'
-        LIMIT 10`;
-
-      const response = await fetch('https://api.exopriors.com/v1/scry/query', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${SCRY_PUBLIC_KEY}`,
-          'Content-Type': 'text/plain',
-        },
-        body: sql,
-      });
-
-      const data = await response.json();
-
-      if (data.rows) {
-        const platform = search.table.includes('eaforum') ? 'EA Forum' : 'LessWrong';
-        log('scry', `  ${platform} "${search.query}": ${data.rows.length} results`);
-        results.push(...data.rows.map(row => ({
-          ...row,
-          platform,
-          searchQuery: search.query,
-        })));
-      }
-    } catch (error) {
-      log('scry', `  Error searching ${search.table}: ${error.message}`);
-    }
-  }
-
-  // Deduplicate by URI
-  const seen = new Set();
-  const unique = results.filter(r => {
-    if (seen.has(r.uri)) return false;
-    seen.add(r.uri);
-    return true;
-  });
-
-  saveResult(topic, 'scry-research.json', {
-    topic,
-    resultCount: unique.length,
-    timestamp: new Date().toISOString(),
-    results: unique,
-  });
-
-  log('scry', `Found ${unique.length} unique community posts`);
-
-  return { success: true, resultCount: unique.length };
-}
-
-// ============ Phase: Process Directions ============
-
-/**
- * Extract URLs from directions text and fetch their content
- */
-/**
- * Extract URLs from text with cleanup for trailing punctuation
- */
-function extractUrls(text) {
-  const urlRegex = /https?:\/\/[^\s<>"{}|\\^`\[\]]+/g;
-  const rawMatches = text.match(urlRegex) || [];
-
-  return rawMatches.map(url => {
-    let cleaned = url;
-
-    // Strip trailing punctuation (but not / or alphanumeric)
-    cleaned = cleaned.replace(/[.,;:!?]+$/, '');
-
-    // Handle unbalanced parentheses - strip trailing ) if more ) than (
-    const openParens = (cleaned.match(/\(/g) || []).length;
-    const closeParens = (cleaned.match(/\)/g) || []).length;
-    if (closeParens > openParens) {
-      const excess = closeParens - openParens;
-      for (let i = 0; i < excess; i++) {
-        cleaned = cleaned.replace(/\)$/, '');
-      }
-    }
-
-    return cleaned;
-  });
-}
-
-async function processDirections(topic, directions) {
-  if (!directions) return { success: true, hasDirections: false };
-
-  log('directions', 'Processing user directions...');
-
-  // Extract URLs from the directions text
-  const urls = extractUrls(directions);
-
-  log('directions', `Found ${urls.length} URL(s) in directions`);
-
-  const fetchedContent = [];
-
-  for (const url of urls) {
-    try {
-      log('directions', `Fetching: ${url}`);
-      const response = await fetch(url);
-
-      if (!response.ok) {
-        log('directions', `  ⚠ Failed to fetch (${response.status})`);
-        continue;
-      }
-
-      const contentType = response.headers.get('content-type') || '';
-      let content = '';
-
-      if (contentType.includes('application/pdf')) {
-        // Handle PDF files
-        try {
-          const pdfParse = (await import('pdf-parse')).default;
-          const buffer = await response.arrayBuffer();
-          const pdfData = await pdfParse(Buffer.from(buffer));
-          content = pdfData.text
-            .replace(/\s+/g, ' ')
-            .trim()
-            .slice(0, 15000);
-          log('directions', `  ✓ Parsed PDF: ${content.length} chars`);
-        } catch (pdfError) {
-          log('directions', `  ⚠ PDF parse failed: ${pdfError.message}`);
-          continue;
-        }
-      } else {
-        // Handle HTML
-        const html = await response.text();
-
-        // Simple HTML to text conversion - strip tags, decode entities
-        content = html
-          .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-          .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-          .replace(/<[^>]+>/g, ' ')
-          .replace(/&nbsp;/g, ' ')
-          .replace(/&amp;/g, '&')
-          .replace(/&lt;/g, '<')
-          .replace(/&gt;/g, '>')
-          .replace(/&quot;/g, '"')
-          .replace(/\s+/g, ' ')
-          .trim()
-          .slice(0, 15000); // Limit content size
-      }
-
-      if (content.length > 100) {
-        fetchedContent.push({
-          url,
-          content,
-          charCount: content.length
-        });
-        log('directions', `  ✓ Fetched ${content.length} chars`);
-      }
-    } catch (error) {
-      log('directions', `  ⚠ Error fetching ${url}: ${error.message}`);
-    }
-  }
-
-  // Save directions and fetched content
-  const directionsData = {
-    originalDirections: directions,
-    extractedUrls: urls,
-    fetchedContent,
-    timestamp: new Date().toISOString()
-  };
-
-  saveResult(topic, 'directions.json', directionsData);
-  log('directions', `Saved directions with ${fetchedContent.length} fetched URL(s)`);
-
-  return { success: true, hasDirections: true, urlCount: urls.length, fetchedCount: fetchedContent.length };
-}
-
-// ============ Phase: Synthesis ============
-
-function getSynthesisPrompt(topic, quality = 'standard') {
-  const researchData = loadResult(topic, 'perplexity-research.json');
-  const scryData = loadResult(topic, 'scry-research.json');
-  const directionsData = loadResult(topic, 'directions.json');
-  const canonicalLinksData = loadResult(topic, 'canonical-links.json');
-
-  // Format canonical links for display
-  let canonicalLinksSection = '';
-  if (canonicalLinksData?.links?.length > 0) {
-    const linksTable = canonicalLinksData.links
-      .map(link => `| ${link.name} | [${link.domain || 'Link'}](${link.url}) |`)
-      .join('\n');
-    canonicalLinksSection = `## Canonical Links Found
-
-**IMPORTANT: Include this table near the top of the article (after Quick Assessment):**
-
-| Source | Link |
-|--------|------|
-${linksTable}
-
-`;
-  }
-
-  // Count total available citation URLs
-  let totalCitations = 0;
-
-  // Format research with citation URLs included
-  const researchContent = researchData?.sources?.map(s => {
-    let section = `### ${s.category.toUpperCase()}\n${s.content}`;
-    // If we have citation URLs, append them so the writer can use real links
-    if (s.citations && s.citations.length > 0) {
-      totalCitations += s.citations.length;
-      section += `\n\n**Source URLs for [1], [2], etc. citations above:**\n${s.citations.map((url, i) => `[${i + 1}]: ${url}`).join('\n')}`;
-    } else {
-      section += `\n\n**WARNING: No source URLs available for this section. Do not invent URLs.**`;
-    }
-    return section;
-  }).join('\n\n') || 'No Perplexity research available';
-
-  const scryContent = scryData?.results?.slice(0, 10).map(r =>
-    `- [${r.title}](${r.uri}) by ${r.original_author} (${r.platform})\n  ${r.snippet?.slice(0, 200) || ''}`
-  ).join('\n') || 'No SCRY results available';
-
-  // Add citation availability warning
-  const citationWarning = totalCitations > 0
-    ? `✅ ${totalCitations} source URLs available in research data - USE THESE for citations`
-    : `⚠️ NO SOURCE URLs available in research data - use descriptive citations only, NO FAKE URLs`;
-
-  // Format user directions and fetched URL content
-  let directionsSection = '';
-  if (directionsData) {
-    const parts = [];
-
-    if (directionsData.originalDirections) {
-      parts.push(`### User Instructions\n${directionsData.originalDirections}`);
-    }
-
-    if (directionsData.fetchedContent && directionsData.fetchedContent.length > 0) {
-      const fetchedParts = directionsData.fetchedContent.map(fc =>
-        `#### Content from ${fc.url}\n${fc.content.slice(0, 8000)}`
-      );
-      parts.push(`### Content from User-Provided URLs\n${fetchedParts.join('\n\n')}`);
-    }
-
-    if (parts.length > 0) {
-      directionsSection = `## User-Provided Directions\n\n**IMPORTANT: Follow these directions carefully. They take precedence over default instructions.**\n\n${parts.join('\n\n')}`;
-    }
-  }
-
-  return `# Write Wiki Article: ${topic}
-
-You are writing a wiki article for LongtermWiki, an AI safety knowledge base.
-
-## Research Data
-
-### WEB RESEARCH (from Perplexity)
-${researchContent}
-
-### COMMUNITY DISCUSSIONS (from EA Forum/LessWrong)
-${scryContent}
-
-## Citation Status
-${citationWarning}
-
-${directionsSection}
-
-${canonicalLinksSection}
-## Requirements
-
-1. **CRITICAL: Use ONLY real URLs from the research data**
-   - Format: claim[^1] with [^1]: [Source Title](actual-url) at bottom
-   - Look for "Source URLs for [1], [2]" sections in the research data
-   - NEVER invent URLs like "example.com", "/posts/example", or "undefined"
-   - NEVER make up plausible-looking URLs - if you don't have a real URL, use text-only citation
-   - If no URL available: [^1]: Source name - description (no link)
-   - **NEVER use vague citations** like "Interview", "Earnings call", "Conference talk", "Reports"
-   - Always specify: exact name, date, and context (e.g., "Tesla Q4 2021 earnings call", "MIT Aeronautics Centennial Symposium (Oct 2014)")
-2. **CRITICAL: NEVER invent quotes**
-   - Only use EXACT text from the research data when using quotation marks
-   - If you want to attribute a view to someone, paraphrase WITHOUT quotation marks
-   - BAD: Ben Pace wrote "this is problematic because..." (if not verbatim in research)
-   - GOOD: Ben Pace argued this approach was problematic (paraphrase without quotes)
-   - GOOD: According to the post, "exact text from research" (verbatim quote)
-   - When attributing quotes to specific people, the quote MUST appear in the research data
-   - This is especially important for EA/rationalist community members whose names you may recognize
-3. **Escape dollar signs** - Write \\$100M not $100M
-4. **Use EntityLink for internal refs** - <EntityLink id="open-philanthropy">Open Philanthropy</EntityLink>
-5. **Include criticism section** if research supports it
-6. **60%+ prose** - Not just tables and bullet points
-7. **Limited info fallback** - If research is sparse, write a shorter article rather than padding with filler
-8. **Present information as current** - NEVER write "as of the research data" or "through late 2024"
-   - BAD: "As of the research data (through late 2024), no ratifications..."
-   - GOOD: "As of early 2026, the convention remains in..." or just "No ratifications have been reported"
-   - Don't reference when sources were gathered - present facts as current knowledge
-9. **Maintain logical consistency** - Ensure claims within each section align with the section's thesis
-   - If a section is titled "Lack of X", don't describe the subject as having X
-   - If discussing limitations, don't use quotes that suggest the opposite
-10. **Maintain critical distance** - Don't take sources at face value
-   - Use attribution phrases: "According to X...", "X claims that...", "X characterized this as..."
-   - Consider source incentives: companies may overstate their achievements, critics may overstate problems
-   - Include skeptical perspectives even if research is mostly positive or negative
-   - For controversial claims, note that significance/interpretation is debated
-
-## EntityLink Usage - CRITICAL
-
-**Format**: \`<EntityLink id="entity-id">Display Text</EntityLink>\`
-
-**IMPORTANT**:
-- IDs are simple slugs like "open-philanthropy", NOT paths like "organizations/funders/open-philanthropy"
-- ONLY use EntityLinks for entities that exist in the wiki
-- If unsure whether an entity exists, use plain text instead of guessing an ID
-- NEVER invent EntityLink IDs - if you're not certain, don't use EntityLink
-
-**PRIORITY CROSS-LINKING** (most important):
-- **Creators/Authors**: If the subject was created by someone in the wiki, ALWAYS EntityLink them
-  - Example: For a tool page, link to its creator: "created by <EntityLink id="vipul-naik">Vipul Naik</EntityLink>"
-  - Example: For a research project, link to the lead researcher
-- **Related Projects**: Link to sibling projects by the same creator
-  - Example: "part of an ecosystem including <EntityLink id="timelines-wiki">Timelines Wiki</EntityLink>"
-- **Funders/Organizations**: Link to funding sources and affiliated organizations
-- **Key People**: Link to researchers, founders, and notable figures mentioned substantively
-
-**Common valid IDs** (partial list - use plain text if entity not listed):
-open-philanthropy, anthropic, openai, deepmind, miri, lesswrong, redwood-research,
-eliezer-yudkowsky, paul-christiano, dario-amodei, scheming, misuse-risks, cea,
-80000-hours, arc-evals, metr, epoch-ai, fhi, cais, sff, ltff, fli,
-vipul-naik, issa-rice, timelines-wiki, donations-list-website, ai-watch, org-watch
-
-## Output Format
-
-Write the complete MDX article to: .claude/temp/page-creator/${topic.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/draft.mdx
-
-Include proper frontmatter:
----
-title: "${topic}"
-description: "..."
-importance: 50
-lastEdited: "${new Date().toISOString().split('T')[0]}"
-sidebar:
-  order: 50
-ratings:
-  novelty: 5
-  rigor: 6
-  actionability: 5
-  completeness: 6
----
-import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@components/wiki';
-
-## Article Sections
-- Quick Assessment (table)
-- Key Links (table with Wikipedia, LessWrong, EA Forum, official site, etc. - if found)
-- Overview (2-3 paragraphs)
-- History
-- [Topic-specific sections]
-- Criticisms/Concerns (if applicable)
-- Key Uncertainties
-- Sources (footnotes)
-- <Backlinks />`;
-}
-
-async function runSynthesis(topic, quality = 'standard') {
-  log('synthesis', `Generating article (${quality})...`);
-
-  const prompt = getSynthesisPrompt(topic, quality);
-
-  // Use Claude Code SDK for synthesis
-  return new Promise((resolve, reject) => {
-    const model = quality === 'quality' ? 'opus' : 'sonnet';
-    const budget = quality === 'quality' ? 3.0 : 2.0;
-
-    const claude = spawn('npx', [
-      '@anthropic-ai/claude-code',
-      '-p',
-      '--print',
-      '--dangerously-skip-permissions',
-      '--model', model,
-      '--max-budget-usd', String(budget),
-      '--allowedTools', 'Read,Write,Glob'
-    ], {
-      cwd: ROOT,
-      stdio: ['pipe', 'pipe', 'pipe']
-    });
-
-    claude.stdin.write(prompt);
-    claude.stdin.end();
-
-    let stdout = '';
-    claude.stdout.on('data', data => {
-      stdout += data.toString();
-      process.stdout.write(data);
-    });
-
-    claude.on('close', code => {
-      if (code === 0) {
-        resolve({ success: true, model, budget });
-      } else {
-        reject(new Error(`Synthesis failed with code ${code}`));
-      }
-    });
-  });
-}
-
-// ============ Phase: Source Verification ============
-
-async function runSourceVerification(topic) {
-  log('verify-sources', 'Checking content against research sources...');
-
-  const topicDir = getTopicDir(topic);
-  const researchPath = path.join(topicDir, 'perplexity-research.json');
-  const draftPath = path.join(topicDir, 'draft.mdx');
-
-  if (!fs.existsSync(researchPath) || !fs.existsSync(draftPath)) {
-    log('verify-sources', 'Missing research or draft, skipping verification');
-    return { success: true, warnings: [] };
-  }
-
-  const research = JSON.parse(fs.readFileSync(researchPath, 'utf-8'));
-  const draft = fs.readFileSync(draftPath, 'utf-8');
-
-  // Combine all research text for searching (from Perplexity summaries)
-  const perplexityText = research.sources
-    ?.map(r => r.content || '')
-    .join('\n') || '';
-
-  // Also get fetched source content (actual page content from Firecrawl)
-  const fetchedContent = getFetchedSourceContent(topic);
-  if (fetchedContent) {
-    log('verify-sources', `Using ${fetchedContent.sourceCount} fetched sources for verification (${Math.round(fetchedContent.combinedContent.length / 1000)}k chars)`);
-  } else {
-    log('verify-sources', 'No fetched source content available, using Perplexity summaries only');
-  }
-
-  // Combine Perplexity summaries + fetched content for comprehensive search
-  const allSourceContent = fetchedContent
-    ? perplexityText + '\n\n' + fetchedContent.combinedContent
-    : perplexityText;
-
-  const researchText = allSourceContent.toLowerCase();
-
-  // Also keep original case version for quote matching
-  const researchTextOriginal = allSourceContent;
-
-  const warnings = [];
-
-  // ============ Check 1: Verify names exist in research ============
-  // Pattern to find author attribution statements
-  const authorPatterns = [
-    /authored by\s+([^.\n]+)/gi,
-    /written by\s+([^.\n]+)/gi,
-    /paper was authored by\s+([^.\n]+)/gi,
-    /including\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*(?:,\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)*(?:,?\s+and\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)?)/g,
-  ];
-
-  // Extract names from draft
-  const mentionedNames = new Set();
-  for (const pattern of authorPatterns) {
-    let match;
-    while ((match = pattern.exec(draft)) !== null) {
-      const nameStr = match[1];
-      const names = nameStr
-        .replace(/\s+and\s+/gi, ', ')
-        .split(',')
-        .map(n => n.trim())
-        .filter(n => n.length > 0 && /^[A-Z]/.test(n));
-
-      for (const name of names) {
-        if (name.split(/\s+/).length >= 2) {
-          mentionedNames.add(name);
-        }
-      }
-    }
-  }
-
-  // Check if each name appears in the research
-  for (const name of mentionedNames) {
-    const nameLower = name.toLowerCase();
-    const lastName = name.split(/\s+/).pop()?.toLowerCase();
-
-    if (!researchText.includes(nameLower) && lastName && !researchText.includes(lastName)) {
-      warnings.push({
-        type: 'unverified-name',
-        name,
-        message: `Name "${name}" not found in research sources - possible hallucination`,
-      });
-    }
-  }
-
-  // ============ Check 2: Verify attributed quotes exist in research ============
-  // Patterns to find quotes attributed to specific people
-  // e.g., "X said '...'" or "X wrote '...'" or "X argued '...'" or "According to X, '...'"
-  const attributedQuotePatterns = [
-    // Person said/wrote/argued/stated/noted/observed/commented "quote"
-    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+(?:said|wrote|argued|stated|noted|observed|commented|claimed|explained|described|characterized|called)\s*(?:it\s+)?[:\s]*["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // According to Person, "quote"
-    /[Aa]ccording to\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // Person's words: "quote" or In Person's words, "quote"
-    /(?:[Ii]n\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)(?:'s)?\s+words[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // As Person put it, "quote"
-    /[Aa]s\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+put it[,:\s]+["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // Person described X as "quote"
-    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+described\s+\w+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // Person characterized X as "quote"
-    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+characterized\s+\w+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
-    // Person criticized X as "quote"
-    /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+criticized\s+[^"\u201c]+\s+as\s+["\u201c]([^"\u201d]+)["\u201d]/gi,
-  ];
-
-  const attributedQuotes = [];
-  for (const pattern of attributedQuotePatterns) {
-    let match;
-    while ((match = pattern.exec(draft)) !== null) {
-      const person = match[1].trim();
-      const quote = match[2].trim();
-      // Only check quotes of reasonable length (short phrases might be coincidental)
-      if (quote.length >= 15) {
-        attributedQuotes.push({ person, quote, fullMatch: match[0] });
-      }
-    }
-  }
-
-  // Check if each attributed quote exists in research
-  for (const { person, quote, fullMatch } of attributedQuotes) {
-    // Normalize quote for searching (remove extra spaces, lowercase)
-    const quoteNormalized = quote.toLowerCase().replace(/\s+/g, ' ').trim();
-    const researchNormalized = researchText.replace(/\s+/g, ' ');
-
-    // Check if a substantial portion of the quote appears in research
-    // We check for the first 30 chars and last 30 chars to allow for minor variations
-    const quoteStart = quoteNormalized.slice(0, 30);
-    const quoteEnd = quoteNormalized.slice(-30);
-
-    const foundInResearch = researchNormalized.includes(quoteNormalized) ||
-      (quoteStart.length >= 20 && researchNormalized.includes(quoteStart)) ||
-      (quoteEnd.length >= 20 && researchNormalized.includes(quoteEnd));
-
-    if (!foundInResearch) {
-      warnings.push({
-        type: 'unverified-quote',
-        person,
-        quote: quote.length > 60 ? quote.slice(0, 60) + '...' : quote,
-        message: `Quote attributed to "${person}" not found in research - possible hallucination: "${quote.slice(0, 50)}..."`,
-      });
-    }
-  }
-
-  // ============ Check 3: Flag all Person + quote patterns for review ============
-  // Even if we can't verify, flag these for manual review
-  const allQuoteAttributions = [];
-  const simpleAttributionPattern = /([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+(?:said|wrote|argued|stated|noted|called it|described it as)\s*[:\s]*["\u201c][^"\u201d]{10,}["\u201d]/gi;
-  let simpleMatch;
-  while ((simpleMatch = simpleAttributionPattern.exec(draft)) !== null) {
-    allQuoteAttributions.push({
-      person: simpleMatch[1],
-      context: simpleMatch[0].slice(0, 100),
-    });
-  }
-
-  if (allQuoteAttributions.length > 0) {
-    log('verify-sources', `📋 Found ${allQuoteAttributions.length} quote attribution(s) to review:`);
-    for (const attr of allQuoteAttributions.slice(0, 5)) {
-      log('verify-sources', `  - ${attr.person}: "${attr.context.slice(0, 60)}..."`);
-    }
-    if (allQuoteAttributions.length > 5) {
-      log('verify-sources', `  ... and ${allQuoteAttributions.length - 5} more`);
-    }
-  }
-
-  // ============ Check 4: Undefined URLs ============
-  const undefinedUrlMatches = draft.match(/\]\(undefined\)/g);
-  if (undefinedUrlMatches) {
-    warnings.push({
-      type: 'undefined-urls',
-      count: undefinedUrlMatches.length,
-      message: `${undefinedUrlMatches.length} footnote(s) have undefined URLs`,
-    });
-  }
-
-  // ============ Summary ============
-  if (warnings.length > 0) {
-    log('verify-sources', `⚠️  Found ${warnings.length} potential issue(s):`);
-    for (const w of warnings) {
-      log('verify-sources', `  - ${w.message}`);
-    }
-    // Save warnings to file for review
-    saveResult(topic, 'source-warnings.json', warnings);
-  } else {
-    log('verify-sources', '✓ All extracted claims found in research');
-  }
-
-  // Save all quote attributions for manual review regardless of warnings
-  if (allQuoteAttributions.length > 0) {
-    saveResult(topic, 'quote-attributions.json', allQuoteAttributions);
-  }
-
-  return { success: true, warnings };
-}
-
-// ============ Phase: Validation Loop ============
-
-async function runValidationLoop(topic, maxIterations = 3) {
-  log('validate', 'Starting validation loop...');
-
-  const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
-  if (!fs.existsSync(draftPath)) {
-    log('validate', 'No draft found, skipping validation');
-    return { success: false, error: 'No draft found' };
-  }
-
-  const validationPrompt = `# Validate and Fix Wiki Article
-
-Read the draft article at: ${draftPath}
-
-## Validation Tasks - Fix ALL Issues
-
-### Critical Issues (MUST fix - these break the build):
-
-1. **Run precommit validation**:
-   \`node tooling/crux.mjs validate\`
-
-2. **Fix escaping issues**:
-   - Escape unescaped $ signs as \\$
-   - Escape < before numbers as \\< or use &lt;
-   - Use ≈ instead of ~ in table cells (~ renders as strikethrough)
-   - Use ≈\\$ instead of ~\\$ (tilde + escaped dollar causes errors)
-
-3. **Fix EntityLinks** (verify IDs resolve):
-   - Read app/src/data/pathRegistry.json to see which entity IDs exist
-   - For EVERY EntityLink in the draft, verify the id exists as a key in pathRegistry
-   - EntityLink IDs must be simple slugs (e.g., "open-philanthropy"), NOT paths (e.g., "organizations/funders/open-philanthropy")
-   - If an EntityLink id doesn't exist in pathRegistry:
-     - Check for similar IDs (e.g., "center-for-ai-safety" should be "cais")
-     - Or REMOVE the EntityLink entirely and use plain text instead
-   - It's better to use plain text than to use an invalid EntityLink ID
-
-4. **Fix broken citations**:
-   - Ensure all [^N] footnote citations have actual URLs, not "undefined"
-   - NEVER use fake URLs like "example.com", "/posts/example", etc.
-   - If no real URL available, use text-only citation: [^1]: Source name - description
-
-### Quality Issues (MUST fix - these cause rendering problems):
-
-5. **Fix markdown list formatting**:
-   - Numbered lists starting at N>1 need blank line before
-   - Check with: \`node tooling/crux.mjs validate unified --rules=markdown-lists\`
-
-6. **Fix consecutive bold labels**:
-   - Bold lines like "**Label:** text" need blank line between them
-   - Check with: \`node tooling/crux.mjs validate unified --rules=consecutive-bold-labels\`
-
-7. **Remove placeholders**:
-   - No TODO markers or placeholder text like "[insert X here]"
-
-### Final Steps:
-
-8. **Check wiki conventions**:
-   - All factual claims have footnote citations
-   - Proper frontmatter fields present (title, description, importance, lastEdited, ratings)
-   - Import statement: \`import {...} from '@components/wiki';\`
-
-9. **Write the final fixed version** to:
-   ${path.join(getTopicDir(topic), 'final.mdx')}
-
-10. **Report** what was fixed.
-
-Keep iterating until ALL checks pass. Run validation again after each fix.`;
-
-  return new Promise((resolve, reject) => {
-    const claude = spawn('npx', [
-      '@anthropic-ai/claude-code',
-      '-p',
-      '--print',
-      '--dangerously-skip-permissions',
-      '--model', 'sonnet',
-      '--max-budget-usd', '2.0',
-      '--allowedTools', 'Read,Write,Edit,Bash,Glob,Grep'
-    ], {
-      cwd: ROOT,
-      stdio: ['pipe', 'pipe', 'pipe']
-    });
-
-    claude.stdin.write(validationPrompt);
-    claude.stdin.end();
-
-    let stdout = '';
-    claude.stdout.on('data', data => {
-      stdout += data.toString();
-      process.stdout.write(data);
-    });
-
-    claude.on('close', code => {
-      const finalPath = path.join(getTopicDir(topic), 'final.mdx');
-      const hasOutput = fs.existsSync(finalPath);
-      resolve({
-        success: code === 0 && hasOutput,
-        hasOutput,
-        exitCode: code
-      });
-    });
-  });
-}
-
-// ============ Phase: Full Validation (programmatic) ============
-
-async function runFullValidation(topic) {
-  log('validate-full', 'Running comprehensive validation...');
-
-  const finalPath = path.join(getTopicDir(topic), 'final.mdx');
-  if (!fs.existsSync(finalPath)) {
-    log('validate-full', 'No final.mdx found, skipping');
-    return { success: false, error: 'No final.mdx found' };
-  }
-
-  const results = {
-    critical: { passed: 0, failed: 0, errors: [] },
-    quality: { passed: 0, failed: 0, warnings: [] },
-    compile: { success: false, error: null }
-  };
-
-  // 1. Run MDX compilation check on the single file
-  log('validate-full', 'Checking MDX compilation...');
-  try {
-    const { execSync } = await import('child_process');
-    // Use compile --quick which only checks changed files
-    execSync('node tooling/crux.mjs validate compile --quick', {
-      cwd: ROOT,
-      stdio: 'pipe',
-      timeout: 60000
-    });
-    results.compile.success = true;
-    log('validate-full', '  ✓ MDX compiles');
-  } catch (error) {
-    results.compile.error = error.message;
-    log('validate-full', '  ✗ MDX compilation failed');
-  }
-
-  // 1b. Direct frontmatter check on temp file (catches issues before deployment)
-  try {
-    const tempContent = fs.readFileSync(finalPath, 'utf-8');
-
-    // Check for unquoted lastEdited dates
-    const unquotedDateMatch = tempContent.match(/lastEdited:\s*(\d{4}-\d{2}-\d{2})(?:\s*$|\s*\n)/m);
-    if (unquotedDateMatch) {
-      const lineContent = tempContent.split('\n').find(l => l.includes('lastEdited:')) || '';
-      if (!lineContent.includes('"') && !lineContent.includes("'")) {
-        // Fix it in place
-        const fixedContent = tempContent.replace(
-          /lastEdited:\s*(\d{4}-\d{2}-\d{2})/,
-          'lastEdited: "$1"'
-        );
-        fs.writeFileSync(finalPath, fixedContent);
-        log('validate-full', '  ✓ Fixed unquoted lastEdited date');
-      }
-    }
-
-    // Check for unquoted createdAt dates (should be unquoted YAML date, not string)
-    // This is the opposite - createdAt should NOT be quoted
-  } catch (fmError) {
-    log('validate-full', `  ⚠ Could not check frontmatter: ${fmError.message}`);
-  }
-
-  // 2. Run unified rules on the file
-  log('validate-full', 'Running validation rules...');
-
-  // Helper to extract JSON from npm output (filters out npm log lines)
-  const extractJson = (output) => {
-    const lines = output.split('\n');
-    const jsonStartIdx = lines.findIndex(line => line.trim().startsWith('{'));
-    if (jsonStartIdx === -1) return null;
-    // Join all lines from the JSON start to the end
-    const jsonStr = lines.slice(jsonStartIdx).join('\n');
-    return JSON.parse(jsonStr);
-  };
-
-  // Critical rules (build-breaking)
-  const topicSlug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
-
-  for (const rule of CRITICAL_RULES) {
-    try {
-      const { execSync } = await import('child_process');
-      let output;
-      let hasParseError = false;
-
-      try {
-        output = execSync(
-          `node tooling/crux.mjs validate unified --rules=${rule} --ci 2>&1`,
-          { cwd: ROOT, stdio: 'pipe', timeout: 30000, maxBuffer: 10 * 1024 * 1024 }
-        ).toString();
-      } catch (execError) {
-        // Command may exit non-zero if there are errors in other files
-        // Capture stdout/stderr and check if our file has issues
-        output = execError.stdout?.toString() || execError.stderr?.toString() || '';
-      }
-
-      // Try to parse JSON output
-      let json = null;
-      try {
-        json = extractJson(output);
-      } catch (parseErr) {
-        // JSON truncated - fall back to grep approach
-        hasParseError = true;
-      }
-
-      if (json) {
-        // JSON parsing succeeded - filter for our file
-        const fileIssues = json.issues?.filter(i =>
-          i.file?.includes(topicSlug) &&
-          i.severity === 'error'
-        ) || [];
-
-        if (fileIssues.length > 0) {
-          results.critical.failed++;
-          results.critical.errors.push({ rule, issues: fileIssues });
-          log('validate-full', `  ✗ ${rule}: ${fileIssues.length} error(s)`);
-        } else {
-          results.critical.passed++;
-          log('validate-full', `  ✓ ${rule}`);
-        }
-      } else if (hasParseError) {
-        // JSON truncated - use grep fallback for our file
-        // Run again in non-CI mode and grep for our file
-        try {
-          const grepOutput = execSync(
-            `node tooling/crux.mjs validate unified --rules=${rule} 2>&1 | grep -i "${topicSlug}" || true`,
-            { cwd: ROOT, stdio: 'pipe', timeout: 30000, maxBuffer: 10 * 1024 * 1024 }
-          ).toString();
-
-          const errorCount = (grepOutput.match(/error/gi) || []).length;
-          if (errorCount > 0) {
-            results.critical.failed++;
-            results.critical.errors.push({ rule, error: `${errorCount} error(s) found via grep` });
-            log('validate-full', `  ✗ ${rule}: ${errorCount} error(s)`);
-          } else {
-            results.critical.passed++;
-            log('validate-full', `  ✓ ${rule}`);
-          }
-        } catch {
-          // Grep fallback failed - assume no issues for our file
-          results.critical.passed++;
-          log('validate-full', `  ✓ ${rule} (no issues for this file)`);
-        }
-      } else {
-        // No JSON output - treat as success
-        results.critical.passed++;
-        log('validate-full', `  ✓ ${rule}`);
-      }
-    } catch (error) {
-      // If parsing or other error, mark as failed
-      results.critical.failed++;
-      results.critical.errors.push({ rule, error: error.message });
-      log('validate-full', `  ✗ ${rule}: check failed`);
-    }
-  }
-
-  // Quality rules (non-blocking)
-  for (const rule of QUALITY_RULES) {
-    try {
-      const { execSync } = await import('child_process');
-      const output = execSync(
-        `node tooling/crux.mjs validate unified --rules=${rule} --ci 2>&1`,
-        { cwd: ROOT, stdio: 'pipe', timeout: 30000 }
-      ).toString();
-
-      const json = extractJson(output);
-      if (!json) {
-        results.quality.passed++;
-        log('validate-full', `  ✓ ${rule}`);
-        continue;
-      }
-
-      const fileIssues = json.issues?.filter(i =>
-        i.file?.includes(topic.toLowerCase().replace(/[^a-z0-9]+/g, '-'))
-      ) || [];
-
-      if (fileIssues.length > 0) {
-        results.quality.failed++;
-        results.quality.warnings.push({ rule, issues: fileIssues });
-        log('validate-full', `  ⚠ ${rule}: ${fileIssues.length} warning(s)`);
-      } else {
-        results.quality.passed++;
-        log('validate-full', `  ✓ ${rule}`);
-      }
-    } catch (error) {
-      // Quality rules don't block
-      log('validate-full', `  ? ${rule}: check skipped`);
-    }
-  }
-
-  // Summary
-  const success = results.compile.success && results.critical.failed === 0;
-  log('validate-full', `\nValidation summary: ${success ? 'PASSED' : 'FAILED'}`);
-  log('validate-full', `  Critical: ${results.critical.passed}/${results.critical.passed + results.critical.failed} passed`);
-  log('validate-full', `  Quality: ${results.quality.passed}/${results.quality.passed + results.quality.failed} passed`);
-
-  // Save results
-  saveResult(topic, 'validation-results.json', results);
-
-  return { success, results };
-}
-
-// ============ Phase: Grading ============
-
-const GRADING_SYSTEM_PROMPT = `You are an expert evaluator of AI safety content. Score this page on:
-
-- importance (0-100): How significant for understanding AI risk
-- quality dimensions (0-10 each): novelty, rigor, actionability, completeness
-- llmSummary: 1-2 sentence summary with key conclusions
-- balanceFlags: Array of any balance/bias issues detected (see below)
-
-Be harsh but fair. Typical wiki content scores 3-5 on quality dimensions. 7+ is exceptional.
-
-IMPORTANT: This content may describe events after your knowledge cutoff. If the article cites specific sources (URLs, publications, official announcements), assume the described events are real even if you're unfamiliar with them. Do NOT mark well-sourced content as "fictional" or "fabricated" just because you haven't heard of it. Evaluate based on the quality of sourcing, writing, and relevance to AI safety.
-
-BALANCE CHECK - Flag these issues in balanceFlags array:
-- "no-criticism-section": Article lacks a Criticisms, Concerns, or Limitations section
-- "single-source-dominance": >50% of citations come from one source (e.g., company's own blog)
-- "missing-source-incentives": For controversial claims, source's incentives aren't discussed
-- "one-sided-framing": Article presents only positive OR only negative perspective without balance
-- "uncritical-claims": Major claims presented as fact without attribution ("X is..." vs "X claims...")
-
-IMPORTANCE guidelines:
-- 90-100: Essential for prioritization decisions
-- 70-89: High value for practitioners
-- 50-69: Useful context
-- 30-49: Reference material
-- 0-29: Peripheral or stubs
-
-Respond with valid JSON only.`;
-
-async function runGrading(topic) {
-  log('grade', 'Running quality grading on temp file...');
-
-  const finalPath = path.join(getTopicDir(topic), 'final.mdx');
-  if (!fs.existsSync(finalPath)) {
-    log('grade', 'No final.mdx found, skipping grading');
-    return { success: false, error: 'No final.mdx found' };
-  }
-
-  // Read the file
-  const content = fs.readFileSync(finalPath, 'utf-8');
-
-  // Extract frontmatter and body
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!fmMatch) {
-    log('grade', 'Could not parse frontmatter');
-    return { success: false, error: 'Invalid frontmatter' };
-  }
-
-  const [, fmYaml, body] = fmMatch;
-
-  // Parse existing frontmatter
-  let frontmatter;
-  try {
-    const { parse: parseYaml } = await import('yaml');
-    frontmatter = parseYaml(fmYaml);
-  } catch (e) {
-    log('grade', `Frontmatter parse error: ${e.message}`);
-    return { success: false, error: 'Frontmatter parse error' };
-  }
-
-  const title = frontmatter.title || topic;
-  const description = frontmatter.description || '';
-
-  // Call Claude API for grading
-  log('grade', 'Calling Claude for grading...');
-
-  try {
-    const { createClient, parseJsonResponse } = await import('../lib/anthropic.mjs');
-    const client = createClient();
-
-    const userPrompt = `Grade this content page:
-
-**Title**: ${title}
-**Description**: ${description}
-
----
-FULL CONTENT:
-${body.slice(0, 30000)}
----
-
-Respond with JSON:
-{
-  "importance": <0-100>,
-  "ratings": {
-    "novelty": <0-10>,
-    "rigor": <0-10>,
-    "actionability": <0-10>,
-    "completeness": <0-10>
-  },
-  "llmSummary": "<1-2 sentences with conclusions>",
-  "balanceFlags": ["<flag-id>", ...] or [] if none,
-  "reasoning": "<brief explanation>"
-}`;
-
-    const response = await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 800,
-      system: GRADING_SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userPrompt }]
-    });
-
-    const text = response.content[0].text;
-    const grades = parseJsonResponse(text);
-
-    if (!grades || !grades.importance) {
-      log('grade', 'Invalid grading response');
-      return { success: false, error: 'Invalid response' };
-    }
-
-    log('grade', `Importance: ${grades.importance}, Quality: ${Math.round((grades.ratings.novelty + grades.ratings.rigor + grades.ratings.actionability + grades.ratings.completeness) * 2.5)}`);
-
-    // Log balance flags if any
-    const balanceFlags = grades.balanceFlags || [];
-    if (balanceFlags.length > 0) {
-      log('grade', `⚠️  Balance issues detected:`);
-      for (const flag of balanceFlags) {
-        log('grade', `   - ${flag}`);
-      }
-    } else {
-      log('grade', `✓ No balance issues detected`);
-    }
-
-    // Calculate quality score (same formula as grade-content.mjs)
-    const quality = Math.round(
-      (grades.ratings.novelty + grades.ratings.rigor +
-       grades.ratings.actionability + grades.ratings.completeness) * 2.5
-    );
-
-    // Update frontmatter
-    frontmatter.importance = grades.importance;
-    frontmatter.ratings = grades.ratings;
-    frontmatter.quality = quality;
-    frontmatter.llmSummary = grades.llmSummary;
-    if (balanceFlags.length > 0) {
-      frontmatter.balanceFlags = balanceFlags;
-    }
-
-    // Count metrics
-    const wordCount = body.split(/\s+/).filter(w => w.length > 0).length;
-    const citations = (body.match(/\[\^\d+\]/g) || []).length;
-    const tables = (body.match(/^\|/gm) || []).length > 0 ? Math.floor((body.match(/^\|/gm) || []).length / 3) : 0;
-    const diagrams = (body.match(/<Mermaid/g) || []).length;
-
-    frontmatter.metrics = {
-      wordCount,
-      citations: new Set((body.match(/\[\^\d+\]/g) || [])).size,
-      tables,
-      diagrams
-    };
-
-    // Write updated file
-    const { stringify: stringifyYaml } = await import('yaml');
-    let yamlStr = stringifyYaml(frontmatter);
-    // Fix: Ensure lastEdited is always quoted (YAML stringifier doesn't quote date-like strings)
-    yamlStr = yamlStr.replace(/^(lastEdited:\s*)(\d{4}-\d{2}-\d{2})$/m, '$1"$2"');
-    const newContent = `---\n${yamlStr}---\n${body}`;
-    fs.writeFileSync(finalPath, newContent);
-
-    log('grade', `✓ Graded: imp=${grades.importance}, qual=${quality}`);
-    log('grade', `  Summary: ${grades.llmSummary?.slice(0, 100)}...`);
-
-    return {
-      success: true,
-      importance: grades.importance,
-      quality,
-      ratings: grades.ratings,
-      llmSummary: grades.llmSummary
-    };
-
-  } catch (error) {
-    log('grade', `Grading API error: ${error.message}`);
-    return { success: false, error: error.message };
-  }
-}
-
-// ============ Phase: Review ============
-
-async function runReview(topic) {
-  log('review', 'Running critical review...');
-
-  const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
-  const reviewPrompt = `# Critical Review: ${topic}
-
-Read the draft article at: ${draftPath}
-
-You are a skeptical editor doing a final quality check. Look specifically for:
-
-## HIGH PRIORITY - Logical Issues
-
-1. **Section-content contradictions**: Does the content within a section contradict its heading?
-   - Example: A section titled "Lack of Preventive Mechanisms" that then describes the subject as "preventive"
-   - Example: A "Criticisms" section that only contains praise
-
-2. **Self-contradicting quotes**: Are quotes used in contexts that contradict their meaning?
-   - Example: Calling something "preventive, not punitive" while arguing it lacks prevention
-
-3. **Temporal artifacts**: Does the text expose when research was conducted?
-   - BAD: "As of the research data (through late 2024)..."
-   - BAD: "Based on available sources from 2023..."
-   - BAD: "No information was found in the sources..."
-   - GOOD: "As of early 2026..." or state facts directly without referencing sources
-
-## STANDARD CHECKS
-
-4. **Uncited claims** - Major facts without footnote citations
-5. **Missing topics** - Important aspects not covered based on the title
-6. **One-sided framing** - Only positive or negative coverage
-7. **Vague language** - "significant", "many experts" without specifics
-
-## Output
-
-Write findings to: ${path.join(getTopicDir(topic), 'review.json')}
-
-Format:
-{
-  "overallQuality": 70,
-  "logicalIssues": [
-    {"section": "...", "problem": "...", "suggestion": "..."}
-  ],
-  "temporalArtifacts": ["line containing the artifact..."],
-  "uncitedClaims": [...],
-  "missingTopics": [...],
-  "suggestions": [...]
-}
-
-If you find any logicalIssues or temporalArtifacts, also fix them directly in the draft file.`;
-
-  return new Promise((resolve, reject) => {
-    const claude = spawn('npx', [
-      '@anthropic-ai/claude-code',
-      '-p',
-      '--print',
-      '--dangerously-skip-permissions',
-      '--model', 'sonnet',
-      '--max-budget-usd', '1.0',
-      '--allowedTools', 'Read,Write'
-    ], {
-      cwd: ROOT,
-      stdio: ['pipe', 'pipe', 'pipe']
-    });
-
-    claude.stdin.write(reviewPrompt);
-    claude.stdin.end();
-
-    claude.on('close', code => {
-      resolve({ success: code === 0 });
-    });
-  });
+function createContext() {
+  return { log, saveResult, getTopicDir, ensureDir, ROOT };
 }
 
 // ============ Pipeline Runner ============
@@ -2022,7 +122,6 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
     process.exit(1);
   }
 
-  // Build phases list - add directions processing if provided
   const phases = directions
     ? ['process-directions', ...config.phases]
     : config.phases;
@@ -2038,8 +137,8 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
   console.log(`Phases: ${phases.join(' → ')}`);
   console.log(`${'='.repeat(60)}\n`);
 
-  // Store directions for later use
   const pipelineContext = { directions };
+  const ctx = createContext();
 
   const results = {
     topic,
@@ -2058,61 +157,60 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
 
       switch (phase) {
         case 'process-directions':
-          result = await processDirections(topic, pipelineContext.directions);
+          result = await processDirections(topic, pipelineContext.directions, ctx);
           break;
 
         case 'canonical-links':
-          result = await findCanonicalLinks(topic);
+          result = await findCanonicalLinks(topic, ctx);
           results.totalCost += result.cost || 0;
           break;
 
         case 'research-perplexity':
-          result = await runPerplexityResearch(topic, 'standard');
+          result = await runPerplexityResearch(topic, 'standard', ctx);
           results.totalCost += result.cost || 0;
           break;
 
         case 'research-perplexity-deep':
-          result = await runPerplexityResearch(topic, 'deep');
+          result = await runPerplexityResearch(topic, 'deep', ctx);
           results.totalCost += result.cost || 0;
           break;
 
         case 'research-scry':
-          result = await runScryResearch(topic);
+          result = await runScryResearch(topic, ctx);
           break;
 
         case 'register-sources':
-          result = await registerResearchSources(topic);
+          result = await registerResearchSources(topic, ctx);
           break;
 
         case 'fetch-sources':
-          // Fetch up to 15 sources (balancing coverage vs API costs)
-          result = await fetchRegisteredSources(topic, { maxSources: 15 });
+          result = await fetchRegisteredSources(topic, { maxSources: 15 }, ctx);
           break;
 
         case 'synthesize':
-          result = await runSynthesis(topic, 'standard');
+          result = await runSynthesis(topic, 'standard', ctx);
           results.totalCost += result.budget || 0;
           break;
 
         case 'synthesize-fast':
-          result = await runSynthesis(topic, 'fast');
+          result = await runSynthesis(topic, 'fast', ctx);
           results.totalCost += 1.0;
           break;
 
         case 'synthesize-quality':
-          result = await runSynthesis(topic, 'quality');
+          result = await runSynthesis(topic, 'quality', ctx);
           results.totalCost += result.budget || 0;
           break;
 
         case 'verify-sources':
-          result = await runSourceVerification(topic);
+          result = await runSourceVerification(topic, ctx);
           if (result.warnings?.length > 0) {
-            log(phase, `⚠️  Found ${result.warnings.length} potential hallucination(s) - review recommended`);
+            log(phase, `Found ${result.warnings.length} potential hallucination(s) - review recommended`);
           }
           break;
 
         case 'review':
-          result = await runReview(topic);
+          result = await runReview(topic, ctx);
           results.totalCost += 1.0;
           break;
 
@@ -2125,28 +223,20 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
               log('validate-loop', `Auto-fixed missing imports: ${importResult.added.join(', ')}`);
             }
           }
-          result = await runValidationLoop(topic);
+          result = await runValidationLoop(topic, ctx);
           results.totalCost += 2.0;
           break;
 
-        case 'validate-quick':
-          // Just run validators, don't iterate
-          result = { success: true };
-          results.totalCost += 0.5;
-          break;
-
         case 'validate-full':
-          // Run comprehensive programmatic validation
-          result = await runFullValidation(topic);
+          result = await runFullValidation(topic, ctx);
           if (!result.success) {
-            log(phase, '❌ Critical validation failures - page may break build');
+            log(phase, 'Critical validation failures - page may break build');
           }
           break;
 
         case 'grade':
-          // Run quality grading
-          result = await runGrading(topic);
-          results.totalCost += 0.01; // Grading is very cheap
+          result = await runGrading(topic, ctx);
+          results.totalCost += 0.01;
           break;
 
         default:
@@ -2155,13 +245,12 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
       }
 
       results.phases[phase] = { success: true, ...result };
-      log(phase, '✅ Complete');
+      log(phase, 'Complete');
 
     } catch (error) {
-      log(phase, `❌ Failed: ${error.message}`);
+      log(phase, `Failed: ${error.message}`);
       results.phases[phase] = { success: false, error: error.message };
 
-      // Stop on critical failures
       if (phase.includes('research') || phase.includes('synthesize')) {
         break;
       }
@@ -2170,10 +259,8 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
 
   results.endTime = new Date().toISOString();
 
-  // Save summary
   saveResult(topic, 'pipeline-results.json', results);
 
-  // Print summary
   console.log(`\n${'='.repeat(60)}`);
   console.log('Pipeline Complete');
   console.log(`${'='.repeat(60)}`);
@@ -2183,9 +270,9 @@ async function runPipeline(topic, tier = 'standard', directions = null) {
   const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
 
   if (fs.existsSync(finalPath)) {
-    console.log(`\n📄 Final article: ${finalPath}`);
+    console.log(`\nFinal article: ${finalPath}`);
   } else if (fs.existsSync(draftPath)) {
-    console.log(`\n📄 Draft article: ${draftPath}`);
+    console.log(`\nDraft article: ${draftPath}`);
   }
 
   return results;
@@ -2271,7 +358,7 @@ async function main() {
   const directionsIndex = args.indexOf('--directions');
   const directions = directionsIndex !== -1 ? args[directionsIndex + 1] : null;
   const createCategoryIndex = args.indexOf('--create-category');
-  const createCategory = createCategoryIndex !== -1 ? args[createCategoryIndex + 1] : null;
+  const createCategoryLabel = createCategoryIndex !== -1 ? args[createCategoryIndex + 1] : null;
   const forceCreate = args.includes('--force');
 
   if (!topic) {
@@ -2283,19 +370,19 @@ async function main() {
   // Check for existing pages with similar names (skip for single phases)
   if (!singlePhase && !forceCreate) {
     console.log(`\nChecking for existing pages similar to "${topic}"...`);
-    const { exists, matches } = await checkForExistingPage(topic);
+    const { exists, matches } = await checkForExistingPage(topic, ROOT);
 
     if (matches.length > 0) {
-      console.log('\n⚠️  Found similar existing pages:');
+      console.log('\nFound similar existing pages:');
       for (const match of matches) {
         const simPercent = Math.round(match.similarity * 100);
-        const indicator = match.similarity >= 0.9 ? '🔴' : match.similarity >= 0.8 ? '🟡' : '🟢';
-        console.log(`  ${indicator} ${match.title} (${simPercent}% similar)`);
+        const indicator = match.similarity >= 0.9 ? 'EXACT' : match.similarity >= 0.8 ? 'CLOSE' : 'PARTIAL';
+        console.log(`  [${indicator}] ${match.title} (${simPercent}% similar)`);
         console.log(`     Path: ${match.path}`);
       }
 
       if (exists) {
-        console.log('\n❌ A page with this name likely already exists.');
+        console.log('\nA page with this name likely already exists.');
         console.log('   Use --force to create anyway, or choose a different topic.\n');
         process.exit(1);
       } else {
@@ -2307,6 +394,7 @@ async function main() {
   }
 
   ensureDir(TEMP_DIR);
+  const ctx = createContext();
 
   // If running a single phase, execute just that phase
   if (singlePhase) {
@@ -2318,28 +406,28 @@ async function main() {
           console.error('Error: --directions required for process-directions phase');
           process.exit(1);
         }
-        result = await processDirections(topic, directions);
+        result = await processDirections(topic, directions, ctx);
         break;
       case 'canonical-links':
-        result = await findCanonicalLinks(topic);
+        result = await findCanonicalLinks(topic, ctx);
         break;
       case 'research-perplexity':
-        result = await runPerplexityResearch(topic);
+        result = await runPerplexityResearch(topic, 'standard', ctx);
         break;
       case 'research-scry':
-        result = await runScryResearch(topic);
+        result = await runScryResearch(topic, ctx);
         break;
       case 'register-sources':
-        result = await registerResearchSources(topic);
+        result = await registerResearchSources(topic, ctx);
         break;
       case 'fetch-sources':
-        result = await fetchRegisteredSources(topic, { maxSources: 15 });
+        result = await fetchRegisteredSources(topic, { maxSources: 15 }, ctx);
         break;
       case 'synthesize':
-        result = await runSynthesis(topic, tier === 'premium' ? 'opus' : 'sonnet', 2.0);
+        result = await runSynthesis(topic, tier === 'premium' ? 'quality' : 'standard', ctx);
         break;
       case 'verify-sources':
-        result = await runSourceVerification(topic);
+        result = await runSourceVerification(topic, ctx);
         break;
       case 'validate-loop':
         // Auto-fix missing component imports before validation
@@ -2350,13 +438,13 @@ async function main() {
             log('validate-loop', `Auto-fixed missing imports: ${importResult.added.join(', ')}`);
           }
         }
-        result = await runValidationLoop(topic);
+        result = await runValidationLoop(topic, ctx);
         break;
       case 'validate-full':
-        result = await runFullValidation(topic);
+        result = await runFullValidation(topic, ctx);
         break;
       case 'grade':
-        result = await runGrading(topic);
+        result = await runGrading(topic, ctx);
         break;
       default:
         console.error(`Unknown phase: ${singlePhase}`);
@@ -2373,30 +461,15 @@ async function main() {
     console.log(`\n${'─'.repeat(50)}`);
     console.log('Deploying to content directory...');
 
-    // Create category if requested
-    if (createCategory) {
-      console.log(`Creating category: ${createCategory}`);
-      createCategoryDirectory(destPath, createCategory);
+    if (createCategoryLabel) {
+      console.log(`Creating category: ${createCategoryLabel}`);
+      createCategoryDirectory(destPath, createCategoryLabel, ROOT);
     }
 
-    const deployResult = deployToDestination(topic, destPath);
+    const deployResult = deployToDestination(topic, destPath, ctx);
 
     if (deployResult.success) {
       console.log(`✓ Deployed to: ${deployResult.deployedTo}`);
-
-      // Check sidebar coverage
-      if (deployResult.sidebarCoverage?.covered) {
-        console.log(`✓ Sidebar: Covered by autogenerate (${deployResult.sidebarCoverage.matchedPath})`);
-      } else if (deployResult.sidebarCoverage) {
-        console.log(`\n⚠️  WARNING: Page may not appear in navigation!`);
-        console.log(`   The path "${destPath}" may not be covered by the navigation config.`);
-        if (deployResult.sidebarCoverage.availablePaths) {
-          console.log(`\n   Available paths:`);
-          deployResult.sidebarCoverage.availablePaths.slice(0, 10).forEach(p => {
-            console.log(`     --dest ${p}`);
-          });
-        }
-      }
 
       // Cross-linking validation
       const entitySlug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
@@ -2404,14 +477,14 @@ async function main() {
 
       console.log(`\n${'─'.repeat(50)}`);
       if (crossLinkCheck.warnings.length > 0) {
-        console.log(`${'\x1b[33m'}⚠️  Cross-linking issues detected:${'\x1b[0m'}`);
+        console.log(`${'\x1b[33m'}Cross-linking issues detected:${'\x1b[0m'}`);
         crossLinkCheck.warnings.forEach(w => console.log(`   - ${w}`));
         console.log(`\n   Outbound EntityLinks (${crossLinkCheck.outboundCount}): ${crossLinkCheck.outboundIds.join(', ') || 'none'}`);
       } else {
-        console.log(`${'\x1b[32m'}✓ Cross-linking looks good (${crossLinkCheck.outboundCount} outbound EntityLinks)${'\x1b[0m'}`);
+        console.log(`${'\x1b[32m'}Cross-linking looks good (${crossLinkCheck.outboundCount} outbound EntityLinks)${'\x1b[0m'}`);
       }
 
-      console.log(`\n${'\x1b[33m'}📌 Cross-linking reminder:${'\x1b[0m'}`);
+      console.log(`\n${'\x1b[33m'}Cross-linking reminder:${'\x1b[0m'}`);
       console.log(`   After running 'pnpm build', check cross-links:`);
       console.log(`   ${'\x1b[36m'}node tooling/crux.mjs analyze entity-links ${entitySlug}${'\x1b[0m'}`);
       console.log(`\n   This shows pages that mention this entity but don't link to it.`);
@@ -2420,8 +493,7 @@ async function main() {
       console.log(`✗ Deployment failed: ${deployResult.error}`);
     }
   } else {
-    // No --dest provided, just remind user
-    console.log(`\n💡 Tip: Use --dest <path> to deploy directly to content directory`);
+    console.log(`\nTip: Use --dest <path> to deploy directly to content directory`);
     console.log(`   Example: --dest knowledge-base/people`);
   }
 }

--- a/tooling/lib/metrics-extractor.mjs
+++ b/tooling/lib/metrics-extractor.mjs
@@ -52,7 +52,7 @@ export function extractMetrics(content, filePath = '') {
 /**
  * Count words in content (excluding code blocks and JSX)
  */
-function countWords(content) {
+export function countWords(content) {
   let text = content;
   // Remove code blocks
   text = text.replace(/```[\s\S]*?```/g, '');
@@ -80,7 +80,7 @@ function countWords(content) {
 /**
  * Count markdown tables
  */
-function countTables(content) {
+export function countTables(content) {
   // Match table rows (lines with | at start and end)
   const tableRowPattern = /^\|.+\|$/gm;
   const rows = content.match(tableRowPattern) || [];
@@ -95,7 +95,7 @@ function countTables(content) {
 /**
  * Count Mermaid diagrams
  */
-function countDiagrams(content) {
+export function countDiagrams(content) {
   // Match Mermaid component usage
   const mermaidComponent = /<Mermaid[^>]*>/g;
   const componentMatches = content.match(mermaidComponent) || [];
@@ -110,7 +110,7 @@ function countDiagrams(content) {
 /**
  * Count internal links (links to other pages in the knowledge base)
  */
-function countInternalLinks(content) {
+export function countInternalLinks(content) {
   // Match markdown links to internal paths
   const internalLinkPattern = /\]\(\/[^)]+\)/g;
   const mdLinks = content.match(internalLinkPattern) || [];
@@ -129,7 +129,7 @@ function countInternalLinks(content) {
 /**
  * Count external links (links to outside sources)
  */
-function countExternalLinks(content) {
+export function countExternalLinks(content) {
   // Match markdown links to external URLs
   const externalLinkPattern = /\]\(https?:\/\/[^)]+\)/g;
   const matches = content.match(externalLinkPattern) || [];

--- a/tooling/lib/metrics-extractor.test.mjs
+++ b/tooling/lib/metrics-extractor.test.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Unit Tests for Metrics Extractor
+ *
+ * Tests the newly-exported counting functions.
+ * Run: node tooling/lib/metrics-extractor.test.mjs
+ */
+
+import {
+  extractMetrics,
+  countWords,
+  countTables,
+  countDiagrams,
+  countInternalLinks,
+  countExternalLinks,
+  suggestQuality,
+} from './metrics-extractor.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`✗ ${name}`);
+    console.log(`  ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || 'Assertion failed');
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(message || `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ─── countWords ───
+
+console.log('\n=== countWords ===\n');
+
+test('countWords: basic word count', () => {
+  const count = countWords('Hello world this is a test');
+  assertEqual(count, 6);
+});
+
+test('countWords: excludes code blocks', () => {
+  const count = countWords('Word one\n```\ncode here not counted\n```\nWord two');
+  // Should count 'Word one' and 'Word two' = 4 words, not the code
+  assert(count < 10, `Expected fewer words without code, got ${count}`);
+});
+
+test('countWords: empty content', () => {
+  assertEqual(countWords(''), 0);
+});
+
+test('countWords: handles JSX components', () => {
+  const count = countWords('Before <Mermaid chart={`graph TD`} /> After');
+  // Should count Before and After but not the component
+  assert(count <= 4, `Expected <= 4 words, got ${count}`);
+});
+
+// ─── countTables ───
+
+console.log('\n=== countTables ===\n');
+
+test('countTables: single table', () => {
+  const content = `| Header | Header |
+| --- | --- |
+| Cell | Cell |`;
+  assertEqual(countTables(content), 1);
+});
+
+test('countTables: no tables', () => {
+  assertEqual(countTables('Just some text'), 0);
+});
+
+test('countTables: two tables', () => {
+  const content = `| H1 | H2 |
+| --- | --- |
+| A | B |
+
+Some text
+
+| H3 | H4 |
+| --- | --- |
+| C | D |`;
+  assertEqual(countTables(content), 2);
+});
+
+// ─── countDiagrams ───
+
+console.log('\n=== countDiagrams ===\n');
+
+test('countDiagrams: Mermaid component', () => {
+  const content = '<Mermaid chart={`graph TD`} />';
+  assertEqual(countDiagrams(content), 1);
+});
+
+test('countDiagrams: mermaid code block', () => {
+  const content = '```mermaid\ngraph TD\n```';
+  assertEqual(countDiagrams(content), 1);
+});
+
+test('countDiagrams: no diagrams', () => {
+  assertEqual(countDiagrams('Just text'), 0);
+});
+
+test('countDiagrams: multiple diagrams', () => {
+  const content = '<Mermaid chart={`graph TD`} />\n\n```mermaid\ngraph LR\n```';
+  assertEqual(countDiagrams(content), 2);
+});
+
+// ─── countInternalLinks ───
+
+console.log('\n=== countInternalLinks ===\n');
+
+test('countInternalLinks: markdown link', () => {
+  assertEqual(countInternalLinks('[text](/some-page)'), 1);
+});
+
+test('countInternalLinks: EntityLink', () => {
+  assertEqual(countInternalLinks('<EntityLink id="test">Text</EntityLink>'), 1);
+});
+
+test('countInternalLinks: R component', () => {
+  assertEqual(countInternalLinks('<R id="ref-1" />'), 1);
+});
+
+test('countInternalLinks: mixed', () => {
+  const content = '[link](/page) and <EntityLink id="x">X</EntityLink> and <R id="y" />';
+  assertEqual(countInternalLinks(content), 3);
+});
+
+// ─── countExternalLinks ───
+
+console.log('\n=== countExternalLinks ===\n');
+
+test('countExternalLinks: https link', () => {
+  assertEqual(countExternalLinks('[text](https://example.com)'), 1);
+});
+
+test('countExternalLinks: http link', () => {
+  assertEqual(countExternalLinks('[text](http://example.com)'), 1);
+});
+
+test('countExternalLinks: no links', () => {
+  assertEqual(countExternalLinks('No links'), 0);
+});
+
+// ─── suggestQuality ───
+
+console.log('\n=== suggestQuality ===\n');
+
+test('suggestQuality: score 0 gives quality 0', () => {
+  assertEqual(suggestQuality(0), 0);
+});
+
+test('suggestQuality: score 15 gives quality 100', () => {
+  assertEqual(suggestQuality(15), 100);
+});
+
+test('suggestQuality: caps stub pages at 35', () => {
+  const quality = suggestQuality(10, { pageType: 'stub' });
+  assert(quality <= 35, `Expected <= 35 for stub, got ${quality}`);
+});
+
+test('suggestQuality: mid-range score', () => {
+  const quality = suggestQuality(7);
+  assert(quality >= 40 && quality <= 55, `Expected 40-55, got ${quality}`);
+});
+
+// ─── extractMetrics (integration) ───
+
+console.log('\n=== extractMetrics (integration) ===\n');
+
+test('extractMetrics: full content', () => {
+  const content = `---
+title: Test
+---
+
+## Overview
+
+This is a test article with some content here.
+
+| Header | Value |
+| --- | --- |
+| One | Two |
+
+[Link](/page) and [external](https://example.com)
+
+<EntityLink id="test">Test</EntityLink>
+`;
+  const metrics = extractMetrics(content);
+  assert(metrics.wordCount > 0, `Expected wordCount > 0, got ${metrics.wordCount}`);
+  assertEqual(metrics.tableCount, 1);
+  assert(metrics.hasOverview, 'Expected hasOverview to be true');
+  assert(metrics.structuralScore >= 0, `Expected structuralScore >= 0`);
+});
+
+// ─── Summary ───
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tooling/lib/rules/component-imports.mjs
+++ b/tooling/lib/rules/component-imports.mjs
@@ -11,19 +11,22 @@
 import { createRule, Issue, Severity, FixType } from '../validation-engine.mjs';
 import { isInCodeBlock } from '../mdx-utils.mjs';
 
-// Components from @components/wiki that are commonly used
+// Components from @components/wiki that are commonly used.
+// Must match actual exports from app/src/components/wiki/index.ts
 const WIKI_COMPONENTS = [
   'EntityLink',
-  'DataInfoBox',
-  'InfoBox',
-  'Backlinks',
-  'Mermaid',
+  'MultiEntityLinks',
   'R',
+  'InfoBox',
+  'DataInfoBox',
+  'Backlinks',
   'DataExternalLinks',
-  'EstimateBox',
-  'QuoteBox',
-  'Timeline',
-  'ComparisonTable',
+  'ExternalLinks',
+  'Mermaid',
+  'CredibilityBadge',
+  'ResourceTags',
+  'F',
+  'SquiggleEstimate',
 ];
 
 // Pattern to find JSX component usage: <ComponentName or <ComponentName>


### PR DESCRIPTION
## Summary

Completes the content scripts refactoring documented in `REFACTORING.md`. Splits the monolithic `page-creator.mjs` (~2,400 lines) into focused modules, fixes critical security vulnerabilities and logic bugs, deduplicates code against shared libraries, and adds comprehensive tests.

## Key Changes

### Security Fixes ✅
- **Shell injection in SCRY search**: Replaced `execSync` + `curl` with `fetch()` API in `page-improver.mjs`
- **Unrestricted file read**: Added path validation to `read_file` tool handler — now rejects paths outside project root
- **Hardcoded API keys**: Both `page-creator.mjs` and `page-improver.mjs` now use `process.env.SCRY_API_KEY` with fallback default

### Bug Fixes ✅
- **gap-fill/review phase ordering**: Swapped phases in deep tier so review runs before gap-fill can use its results
- **Validation validates old content**: Now writes improved content to actual file path before validation, restores original via try/finally
- **runSynthesis wrong args**: Changed to `tier === 'premium' ? 'quality' : 'standard'` to match function signature
- **Sidebar coverage dead code**: Removed non-functional `checkSidebarCoverage` checks
- **Stale component references**: Updated synthesis prompt imports to match actual components in `@components/wiki`
- **Dead validate-quick phase**: Deleted unused code block

### Modularization ✅
Split `page-creator.mjs` into 10 focused modules under `tooling/content/creator/`:

| Module | Purpose |
|--------|---------|
| `duplicate-detection.mjs` | Levenshtein distance, slug matching, existing page detection |
| `canonical-links.mjs` | Find official reference links (Wikipedia, LessWrong, EA Forum, etc.) |
| `research.mjs` | Perplexity and SCRY research phases |
| `source-fetching.mjs` | URL extraction, source registration, Firecrawl fetching |
| `synthesis.mjs` | Claude synthesis with component imports |
| `verification.mjs` | Source quote verification |
| `validation.mjs` | MDX validation loop, component import fixing |
| `grading.mjs` | Quality grading with balance checks |
| `deployment.mjs` | File deployment, cross-link validation, review phase |
| `index.mjs` | Re-exports all modules |

`page-creator.mjs` is now a thin CLI entry point (~500 lines) with configuration, utilities, and pipeline orchestration.

### Code Deduplication ✅
- **ensureComponentImports**: Now delegates to shared `componentImportsRule` from `tooling/lib/rules/component-imports.mjs`
- **grade-content.mjs**: Uses `parseFrontmatter()`, `findMdxFiles()`, and `callClaude()` from shared libs
- **grade-by-template.mjs**: Imports metric functions from `tooling/lib/metrics-extractor.mjs` (newly exported)
- **WIKI_COMPONENTS list**: Updated to match actual exports from `app/src/components/wiki/index.ts`

### Tests ✅
Added comprehensive test coverage:
- `tooling/content/creator/creator.test.mjs` — 21 tests for duplicate detection and URL extraction
- `tooling/lib/metrics-extractor.test.mjs` — 23 tests for exported metric functions

All existing tests pass (lib.test.mjs: 24/24, validators.test.mjs: 35/35).

## Implementation Notes

- **Levenshtein distance**: Pure algorithm implementation for fuzzy string matching
- **URL extraction**: Handles trailing punctuation and unbalanced parentheses correctly
- **Path validation**: Uses `path.resolve()` and `startsWith()` check against ROOT
- **Grading system**: Enhanced with balance flags (no-criticism-section, single-source-dominance, etc.)
- **Firec

https://claude.ai/code/session_01M2iYr1YeSjpudjcj69bS3X