### PR TITLE
Migrate tooling from Astro to Next.js architecture

### DIFF
--- a/tooling/lib/rules/frontmatter-schema.mjs
+++ b/tooling/lib/rules/frontmatter-schema.mjs
@@ -86,7 +86,7 @@ export const frontmatterSchemaRule = {
     const issues = [];
     const frontmatter = contentFile.frontmatter;
 
-    // Check for quoted dates (common mistake that Astro rejects)
+    // Check for quoted dates (common mistake that causes schema validation failures)
     // We need to check the raw content for this since YAML parser already parses dates
     const rawContent = contentFile.raw;
 
@@ -115,7 +115,7 @@ export const frontmatterSchemaRule = {
     }
 
     // Check for UNquoted lastEdited dates - these must be quoted strings
-    // YAML parses bare 2026-02-01 as a Date object, but Astro schema expects string
+    // YAML parses bare 2026-02-01 as a Date object, but frontmatter schema expects string
     const unquotedLastEditedMatch = rawContent.match(/lastEdited:\s*(\d{4}-\d{2}-\d{2})(?:\s*$|\s*\n)/m);
     if (unquotedLastEditedMatch) {
       // Verify it's not quoted by checking if there's a quote before the date

--- a/tooling/lib/rules/internal-links.mjs
+++ b/tooling/lib/rules/internal-links.mjs
@@ -3,7 +3,7 @@
  *
  * Validates that internal markdown links resolve to existing content:
  * - [text](/knowledge-base/path/) links point to real files
- * - Links have trailing slashes (Astro/Starlight convention)
+ * - Links have trailing slashes
  * - Links don't include file extensions
  */
 
@@ -11,9 +11,9 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { createRule, Issue, Severity } from '../validation-engine.mjs';
 import { isInCodeBlock } from '../mdx-utils.mjs';
+import { CONTENT_DIR_ABS as CONTENT_DIR } from '../content-types.mjs';
 
-const CONTENT_DIR = join(process.cwd(), 'content/docs');
-const PAGES_DIR = join(process.cwd(), 'src/pages');
+const APP_DIR = join(process.cwd(), 'app/src/app');
 
 /**
  * Check if an internal link resolves to an existing file
@@ -45,8 +45,8 @@ function resolveLink(href, sourceFile) {
     join(CONTENT_DIR, path + '.md'),
     join(CONTENT_DIR, path, 'index.mdx'),
     join(CONTENT_DIR, path, 'index.md'),
-    join(PAGES_DIR, path + '.astro'),
-    join(PAGES_DIR, path, 'index.astro'),
+    join(APP_DIR, path, 'page.tsx'),
+    join(APP_DIR, path, 'page.jsx'),
   ];
 
   for (const p of possiblePaths) {

--- a/tooling/lib/sidebar-utils.mjs
+++ b/tooling/lib/sidebar-utils.mjs
@@ -1,116 +1,51 @@
 /**
  * Sidebar Utilities
  *
- * Shared utilities for parsing and checking sidebar configuration from astro.config.mjs.
- * Used by validation engine and page-creator to ensure content is accessible in navigation.
+ * In the Next.js app, sidebar navigation is managed by app/src/lib/wiki-nav.ts
+ * and the WikiSidebar component. There is no static config file to parse.
+ *
+ * These functions return empty data so that downstream consumers
+ * (validation-engine, sidebar-coverage rule) continue to work without errors.
  */
 
-import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = join(__dirname, '../..');
-
 /**
- * Parse sidebar configuration from astro.config.mjs
+ * Parse sidebar configuration.
+ * Returns empty data — sidebar is now driven by wiki-nav.ts in the Next.js app.
  * @returns {{ entries: string[], directories: Set<string> }}
  */
 export function parseSidebarConfig() {
-  const configPath = join(PROJECT_ROOT, 'astro.config.mjs');
-  if (!existsSync(configPath)) return { entries: [], directories: new Set() };
-
-  try {
-    const content = readFileSync(configPath, 'utf-8');
-    const entries = [];
-    const directories = new Set();
-
-    // Extract slug entries
-    const slugRegex = /slug:\s*['"]([^'"]+)['"]/g;
-    let match;
-    while ((match = slugRegex.exec(content)) !== null) {
-      entries.push(match[1]);
-    }
-
-    // Extract autogenerate directories
-    const autoRegex = /autogenerate:\s*\{\s*directory:\s*['"]([^'"]+)['"]/g;
-    while ((match = autoRegex.exec(content)) !== null) {
-      directories.add(match[1]);
-    }
-
-    // Extract link entries
-    const linkRegex = /link:\s*['"]([^'"]+)['"]/g;
-    while ((match = linkRegex.exec(content)) !== null) {
-      entries.push(match[1].replace(/^\//, '').replace(/\/$/, ''));
-    }
-
-    return { entries, directories };
-  } catch {
-    return { entries: [], directories: new Set() };
-  }
+  return { entries: [], directories: new Set() };
 }
 
 /**
- * Get all autogenerate directory paths from sidebar config
+ * Get all autogenerate directory paths from sidebar config.
+ * Returns empty — not applicable in Next.js.
  * @returns {string[]}
  */
 export function getSidebarAutogeneratePaths() {
-  const config = parseSidebarConfig();
-  return [...config.directories];
+  return [];
 }
 
 /**
- * Check if a content path is covered by sidebar autogenerate
- * @param {string} contentPath - Path like "knowledge-base/people" or "knowledge-base/organizations/labs"
- * @returns {{ covered: boolean, matchedPath?: string, availablePaths?: string[] }}
+ * Check if a content path is covered by sidebar navigation.
+ * Always returns not-covered — sidebar coverage checking is not applicable in Next.js.
+ * @param {string} contentPath
+ * @returns {{ covered: boolean, availablePaths?: string[] }}
  */
 export function checkSidebarCoverage(contentPath) {
-  const config = parseSidebarConfig();
-  const autogeneratePaths = [...config.directories];
-
-  // Normalize the destination path
-  const normalizedPath = contentPath.replace(/^\/+/, '').replace(/\/+$/, '');
-
-  // Check if this path or a parent is in autogenerate
-  for (const autoPath of autogeneratePaths) {
-    if (normalizedPath === autoPath || normalizedPath.startsWith(autoPath + '/')) {
-      return { covered: true, matchedPath: autoPath };
-    }
-  }
-
-  // Also check explicit entries
-  const explicitEntries = config.entries;
-  for (const entry of explicitEntries) {
-    if (normalizedPath === entry || normalizedPath.startsWith(entry + '/') || entry.startsWith(normalizedPath + '/')) {
-      return { covered: true, matchedPath: entry };
-    }
-  }
-
-  return {
-    covered: false,
-    availablePaths: autogeneratePaths.filter(p => p.startsWith('knowledge-base/'))
-  };
+  return { covered: false, availablePaths: [] };
 }
 
 /**
- * Check if a new page at the given path would appear in the sidebar
- * @param {string} destPath - Destination directory path (e.g., "knowledge-base/people")
- * @returns {{ willAppear: boolean, reason: string, suggestions?: string[] }}
+ * Check if a new page at the given path would appear in the sidebar.
+ * Always returns unknown — sidebar visibility is managed by wiki-nav.ts.
+ * @param {string} destPath
+ * @returns {{ willAppear: boolean, reason: string }}
  */
 export function checkNewPageVisibility(destPath) {
-  const coverage = checkSidebarCoverage(destPath);
-
-  if (coverage.covered) {
-    return {
-      willAppear: true,
-      reason: `Covered by sidebar autogenerate: ${coverage.matchedPath}`
-    };
-  }
-
   return {
     willAppear: false,
-    reason: `Path "${destPath}" is not covered by any sidebar autogenerate directive`,
-    suggestions: coverage.availablePaths?.slice(0, 10) || []
+    reason: 'Sidebar visibility is managed by wiki-nav.ts in the Next.js app',
   };
 }
 

--- a/tooling/lib/validation-engine.mjs
+++ b/tooling/lib/validation-engine.mjs
@@ -185,15 +185,15 @@ export class ValidationEngine {
       this.reversePathRegistry[path.replace(/\/$/, '')] = id;
     }
 
-    // Parse sidebar from astro.config.mjs
+    // Parse sidebar config (returns empty data in Next.js — sidebar is in wiki-nav.ts)
     this.sidebarConfig = this._parseSidebarConfig();
 
     this.loaded = true;
   }
 
   /**
-   * Parse sidebar configuration from astro.config.mjs
-   * Uses shared utility from sidebar-utils.mjs
+   * Parse sidebar configuration.
+   * Returns empty data in Next.js — sidebar is managed by wiki-nav.ts.
    */
   _parseSidebarConfig() {
     return parseSidebarConfig();

--- a/tooling/resource-manager.mjs
+++ b/tooling/resource-manager.mjs
@@ -403,7 +403,7 @@ function cmdProcess(opts) {
   }
 
   // Note: In Next.js, <R> is registered globally via mdx-components.tsx,
-  // so no import injection is needed (unlike the old Astro setup).
+  // so no import injection is needed.
 
   // Save changes
   if (!dryRun) {

--- a/tooling/validate/validate-entity-links.mjs
+++ b/tooling/validate/validate-entity-links.mjs
@@ -48,8 +48,8 @@ if (existsSync(PATH_REGISTRY_FILE)) {
   }
 }
 
-// Pages directory for standalone Astro pages
-const PAGES_DIR = join(process.cwd(), 'src/pages');
+// Next.js app directory for standalone pages
+const APP_DIR = join(process.cwd(), 'app/src/app');
 
 /**
  * Extract all markdown links from file content
@@ -145,8 +145,8 @@ function linkExists(href) {
     join(CONTENT_DIR, path + '.md'),
     join(CONTENT_DIR, path, 'index.mdx'),
     join(CONTENT_DIR, path, 'index.md'),
-    join(PAGES_DIR, path + '.astro'),
-    join(PAGES_DIR, path, 'index.astro'),
+    join(APP_DIR, path, 'page.tsx'),
+    join(APP_DIR, path, 'page.jsx'),
   ];
 
   return possiblePaths.some(p => existsSync(p));

--- a/tooling/validate/validate-internal-links.mjs
+++ b/tooling/validate/validate-internal-links.mjs
@@ -6,7 +6,7 @@
  * Scans MDX/MD files for internal links and verifies they resolve to existing content.
  * Checks:
  * - Markdown links: [text](/knowledge-base/path/)
- * - Ensures trailing slashes are present (Astro/Starlight convention)
+ * - Ensures trailing slashes are present
  * - Verifies target files exist
  *
  * Usage:
@@ -88,8 +88,8 @@ function extractInternalLinks(content, filePath) {
   return links;
 }
 
-// Pages directory for standalone Astro pages
-const PAGES_DIR = join(process.cwd(), 'src/pages');
+// Next.js app directory for standalone pages
+const APP_DIR = join(process.cwd(), 'app/src/app');
 
 /**
  * Check if an internal link resolves to an existing file
@@ -133,9 +133,9 @@ function resolveLink(href, sourceFile) {
     join(CONTENT_DIR, path + '.md'),
     join(CONTENT_DIR, path, 'index.mdx'),
     join(CONTENT_DIR, path, 'index.md'),
-    // Standalone Astro pages (src/pages)
-    join(PAGES_DIR, path + '.astro'),
-    join(PAGES_DIR, path, 'index.astro'),
+    // Next.js app routes (app/src/app)
+    join(APP_DIR, path, 'page.tsx'),
+    join(APP_DIR, path, 'page.jsx'),
   ];
 
   for (const p of possiblePaths) {

--- a/tooling/validate/validate-mdx-compile.mjs
+++ b/tooling/validate/validate-mdx-compile.mjs
@@ -2,7 +2,7 @@
 /**
  * MDX Compilation Validator
  *
- * Actually compiles MDX files to catch JSX syntax errors BEFORE the full Astro build.
+ * Actually compiles MDX files to catch JSX syntax errors BEFORE the full Next.js build.
  * This catches errors that regex-based validators miss:
  * - Unescaped < in tables/prose (JSX parsing errors)
  * - Invalid JSX syntax

--- a/tooling/validate/validate-sidebar-labels.mjs
+++ b/tooling/validate/validate-sidebar-labels.mjs
@@ -3,179 +3,35 @@
 /**
  * Sidebar Label Validation Script
  *
- * Validates that all sidebar labels in astro.config.mjs use proper English names,
- * not kebab-case slugs (e.g., "Analysis Models" not "analysis-models").
+ * Previously validated sidebar labels in the legacy static-site config.
+ * In the Next.js app, sidebar navigation is managed by app/src/lib/wiki-nav.ts.
+ * This script is no longer applicable and exits cleanly.
  *
  * Usage: node scripts/validate/validate-sidebar-labels.mjs [--ci]
  *
  * Exit codes:
- *   0 = All checks passed
- *   1 = Errors found
+ *   0 = Always (not applicable for Next.js)
  */
 
-import { readFileSync } from 'fs';
 import { getColors } from '../lib/output.mjs';
 
-const CONFIG_FILE = 'astro.config.mjs';
 const CI_MODE = process.argv.includes('--ci');
 const colors = getColors(CI_MODE);
 
-/**
- * Check if a label appears to be kebab-case (lowercase with dashes)
- * @param {string} label - The label to check
- * @returns {boolean} True if label appears to be kebab-case
- */
-function isKebabCase(label) {
-  // Check if it contains dashes between lowercase letters
-  // This pattern matches: word-word or word-word-word etc.
-  return /^[a-z]+(-[a-z]+)+$/.test(label);
-}
-
-/**
- * Check if a label has improper casing (e.g., "analysis-Models" or "Analysis-models")
- * @param {string} label - The label to check
- * @returns {boolean} True if label has dashes (suggesting slug-like naming)
- */
-function hasDashes(label) {
-  // Labels shouldn't have dashes - proper English names use spaces
-  // Exception list: hyphenated compound modifiers that are correct English
-  const exceptions = ['Self-Regulation', 'Industry Self-Regulation', 'Long-term Lock-in'];
-  return /-/.test(label) && !exceptions.includes(label);
-}
-
-/**
- * Extract all label values from the config file using regex
- * @param {string} content - Config file content
- * @returns {Array<{label: string, line: number}>}
- */
-function extractLabels(content) {
-  const labels = [];
-  const lines = content.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Match: label: 'value' or label: "value"
-    const match = line.match(/label:\s*['"]([^'"]+)['"]/);
-    if (match) {
-      labels.push({
-        label: match[1],
-        line: i + 1,
-        context: line.trim(),
-      });
-    }
-  }
-
-  return labels;
-}
-
-/**
- * Suggest a proper English name for a kebab-case label
- * @param {string} label - The kebab-case label
- * @returns {string} Suggested proper name
- */
-function suggestProperName(label) {
-  return label
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
-
-/**
- * Main function
- */
 function main() {
-  let content;
-  try {
-    content = readFileSync(CONFIG_FILE, 'utf-8');
-  } catch (e) {
-    // astro.config.mjs doesn't exist in the Next.js-based wiki — skip gracefully
-    console.log(`${colors.dim}Skipping sidebar label check: ${CONFIG_FILE} not found (not applicable for Next.js app)${colors.reset}`);
-    process.exit(0);
-  }
-
-  const labels = extractLabels(content);
-  const issues = [];
-
-  for (const { label, line, context } of labels) {
-    if (isKebabCase(label)) {
-      issues.push({
-        label,
-        line,
-        context,
-        severity: 'error',
-        type: 'kebab-case',
-        suggestion: suggestProperName(label),
-      });
-    } else if (hasDashes(label)) {
-      // Check for dashes in labels (might be intentional like "Self-Regulation")
-      // This is a warning, not an error
-      issues.push({
-        label,
-        line,
-        context,
-        severity: 'warning',
-        type: 'contains-dash',
-        suggestion: label.replace(/-/g, ' '),
-      });
-    }
-  }
-
-  // Filter to only errors for exit code
-  const errors = issues.filter(i => i.severity === 'error');
-  const warnings = issues.filter(i => i.severity === 'warning');
-
   if (CI_MODE) {
     console.log(JSON.stringify({
-      file: CONFIG_FILE,
-      labelsChecked: labels.length,
-      errors: errors.length,
-      warnings: warnings.length,
-      issues,
+      skipped: true,
+      reason: 'Sidebar labels are managed by wiki-nav.ts in the Next.js app',
+      labelsChecked: 0,
+      errors: 0,
+      warnings: 0,
+      issues: [],
     }, null, 2));
   } else {
-    console.log(`${colors.blue}Checking sidebar labels in ${CONFIG_FILE}...${colors.reset}\n`);
-    console.log(`${colors.dim}Labels checked: ${labels.length}${colors.reset}\n`);
-
-    if (issues.length === 0) {
-      console.log(`${colors.green}✓ All sidebar labels use proper English names${colors.reset}\n`);
-    } else {
-      if (errors.length > 0) {
-        console.log(`${colors.red}Found ${errors.length} sidebar label error(s):${colors.reset}\n`);
-        for (const issue of errors) {
-          console.log(`  ${colors.red}✗ Line ${issue.line}: "${issue.label}"${colors.reset}`);
-          console.log(`    ${colors.dim}Context: ${issue.context}${colors.reset}`);
-          console.log(`    ${colors.green}Suggestion: "${issue.suggestion}"${colors.reset}`);
-          console.log();
-        }
-      }
-
-      if (warnings.length > 0) {
-        console.log(`${colors.yellow}Found ${warnings.length} sidebar label warning(s):${colors.reset}\n`);
-        for (const issue of warnings) {
-          console.log(`  ${colors.yellow}⚠ Line ${issue.line}: "${issue.label}"${colors.reset}`);
-          console.log(`    ${colors.dim}Context: ${issue.context}${colors.reset}`);
-          console.log(`    ${colors.dim}Note: Label contains dashes. If intentional, add to exceptions.${colors.reset}`);
-          console.log();
-        }
-      }
-
-      console.log(`${colors.bold}Summary:${colors.reset}`);
-      console.log(`  Labels checked: ${labels.length}`);
-      if (errors.length > 0) {
-        console.log(`  ${colors.red}${errors.length} error(s)${colors.reset}`);
-      }
-      if (warnings.length > 0) {
-        console.log(`  ${colors.yellow}${warnings.length} warning(s)${colors.reset}`);
-      }
-      console.log();
-      console.log(`${colors.dim}Sidebar labels should use proper English names (e.g., "Analysis Models")${colors.reset}`);
-      console.log(`${colors.dim}not kebab-case slugs (e.g., "analysis-models")${colors.reset}`);
-      console.log();
-    }
+    console.log(`${colors.dim}Skipping sidebar label check: sidebar is managed by wiki-nav.ts in the Next.js app${colors.reset}`);
   }
-
-  // Only exit with error for actual errors, not warnings
-  process.exit(errors.length > 0 ? 1 : 0);
+  process.exit(0);
 }
 
 main();


### PR DESCRIPTION
## Summary
Updates validation and utility scripts to reflect the migration from an Astro-based static site to a Next.js-based application. This includes updating file path references, removing Astro-specific configuration parsing, and adjusting sidebar navigation handling.

## Key Changes

### Path and Directory Updates
- Updated page directory references from `src/pages/*.astro` to `app/src/app/*/page.tsx|jsx` (Next.js App Router convention)
- Updated content directory imports to use `CONTENT_DIR_ABS` from `content-types.mjs` instead of hardcoded paths
- Renamed `PAGES_DIR` to `APP_DIR` throughout validation scripts for clarity

### Sidebar Navigation Refactoring
- **sidebar-utils.mjs**: Completely refactored to return empty data structures since sidebar navigation is now managed by `app/src/lib/wiki-nav.ts` and the WikiSidebar component
  - `parseSidebarConfig()` now returns empty entries/directories
  - `checkSidebarCoverage()` always returns not-covered
  - `checkNewPageVisibility()` returns unknown status with reference to wiki-nav.ts
- **validate-sidebar-labels.mjs**: Removed all validation logic; script now exits cleanly with a skip message since labels are managed in wiki-nav.ts

### Comment and Documentation Updates
- Removed references to "Astro" from comments where no longer applicable
- Updated comments to reference Next.js build process instead of Astro
- Clarified that sidebar configuration is no longer parsed from a static config file
- Added notes explaining why functions return empty/default data in the Next.js architecture

### Validation Engine
- Updated `_parseSidebarConfig()` comments to reflect that it returns empty data in Next.js
- Sidebar config parsing now gracefully handles the absence of static configuration

## Implementation Details
- All changes maintain backward compatibility by returning appropriate empty/default values
- Downstream consumers (validation-engine, sidebar-coverage rule) continue to work without errors
- The migration preserves the validation framework while adapting it to the new architecture
- No breaking changes to the validation engine API

https://claude.ai/code/session_01QGBoeDWHTWdGh7d96fCA4F