### PR TITLE
Refactor search filtering and add MiniSearch-based relevance ranking

### DIFF
--- a/app/src/components/Breadcrumbs.tsx
+++ b/app/src/components/Breadcrumbs.tsx
@@ -25,7 +25,7 @@ export function Breadcrumbs({
   if (category) {
     items.push({
       label: formatCategory(category),
-      href: `/wiki?tag=${encodeURIComponent(category)}`,
+      href: `/wiki?entity=${encodeURIComponent(category)}`,
     });
   }
 


### PR DESCRIPTION
## Summary
This PR refactors the Explore page's filtering and sorting logic to integrate MiniSearch-based relevance scoring, improving search quality and user experience. It also updates URL parameter handling to use a more flexible `entity` parameter instead of `tag`.

## Key Changes

- **Search parameter migration**: Changed breadcrumb and URL parameter from `tag` to `entity` for better semantic clarity and flexibility
- **MiniSearch integration**: Added `searchWikiScores()` function that returns a Map of document IDs to relevance scores, enabling more sophisticated ranking
- **Improved filtering pipeline**: Restructured filter application order so search filtering happens early, with subsequent filters (field, entity, risk category) applied to search-filtered results
- **Entity group resolution**: Added `resolveEntityGroupIndex()` helper to intelligently match URL parameter values (e.g., "organizations", "organization", "People") to entity group indices, supporting multiple input formats
- **Fallback text filter**: Implemented simple text-based filtering as a fallback while MiniSearch loads, ensuring search functionality works immediately
- **Relevance-based sorting**: When MiniSearch scores are available, sort results by search relevance; otherwise fall back to importance-weighted scoring
- **Debounced search**: Added debouncing for MiniSearch queries to avoid excessive API calls during rapid typing

## Implementation Details

- Search scores are stored in state and updated via a debounced effect when the search query changes
- The filtering pipeline now follows: search → field → entity → risk category, with counts computed at each stage
- MiniSearch results include importance-based boost (up to 3x for exact title matches) to surface more relevant documents
- URL parameter handling is now more robust, supporting both singular and plural entity type names

https://claude.ai/code/session_01AjdbAUVcHmjeEuswgjLkhj