### PR TITLE
Add ATM interactive graph page with DetailsPanel and deep-linking

### DIFF
--- a/app/src/app/ai-transition-model/graph/ATMGraphClient.tsx
+++ b/app/src/app/ai-transition-model/graph/ATMGraphClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import CauseEffectGraph from "@/components/wiki/CauseEffectGraph";
+import { DetailsPanel } from "@/components/wiki/CauseEffectGraph/components";
+import type { CauseEffectNodeData, CauseEffectEdgeData, GraphConfig } from "@/components/wiki/CauseEffectGraph/types";
+import type { Node, Edge } from "@xyflow/react";
+
+const graphConfig: GraphConfig = {
+  layout: {
+    containerWidth: 1600,
+    centerX: 800,
+    layerGap: 60,
+    causeSpacing: 8,
+    intermediateSpacing: 200,
+    effectSpacing: 400,
+  },
+  typeLabels: {
+    cause: "Root Factors",
+    intermediate: "Ultimate Scenarios",
+    effect: "Ultimate Outcomes",
+  },
+  subgroups: {
+    ai: {
+      label: "AI System Factors",
+      bgColor: "rgba(219, 234, 254, 0.2)",
+      borderColor: "transparent",
+    },
+    society: {
+      label: "Societal Factors",
+      bgColor: "rgba(209, 250, 229, 0.2)",
+      borderColor: "transparent",
+    },
+  },
+};
+
+interface ATMGraphClientProps {
+  initialNodes: Node<CauseEffectNodeData>[];
+  initialEdges: Edge<CauseEffectEdgeData>[];
+}
+
+export function ATMGraphClient({ initialNodes, initialEdges }: ATMGraphClientProps) {
+  const searchParams = useSearchParams();
+  const nodeParam = searchParams.get("node");
+
+  const [selectedNode, setSelectedNode] = useState<Node<CauseEffectNodeData> | null>(() => {
+    if (!nodeParam) return null;
+    return initialNodes.find((n) => n.id === nodeParam) ?? null;
+  });
+
+  // Use URL param as selectedNodeId for visual highlighting in the graph
+  const selectedNodeId = selectedNode?.id ?? nodeParam ?? undefined;
+
+  const handleNodeClick = useCallback((node: Node<CauseEffectNodeData>) => {
+    setSelectedNode((prev) => (prev?.id === node.id ? null : node));
+  }, []);
+
+  return (
+    <div style={{ height: "calc(100vh - 57px)", position: "relative" }}>
+      <CauseEffectGraph
+        initialNodes={initialNodes}
+        initialEdges={initialEdges}
+        height="100%"
+        showFullscreenButton={true}
+        enablePathHighlighting={true}
+        showMiniMap={true}
+        graphConfig={graphConfig}
+        onNodeClick={handleNodeClick}
+        selectedNodeId={selectedNodeId}
+      />
+      <DetailsPanel
+        node={selectedNode}
+        onClose={() => setSelectedNode(null)}
+      />
+    </div>
+  );
+}

--- a/app/src/app/ai-transition-model/graph/page.tsx
+++ b/app/src/app/ai-transition-model/graph/page.tsx
@@ -1,0 +1,69 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import { getRawGraphData } from "@/data/parameter-graph-data";
+import type { CauseEffectNodeData, CauseEffectEdgeData } from "@/components/wiki/CauseEffectGraph/types";
+import type { Node, Edge } from "@xyflow/react";
+import { ATMGraphClient } from "./ATMGraphClient";
+
+export const metadata: Metadata = {
+  title: "AI Transition Model — Graph View",
+  description:
+    "Interactive causal diagram showing relationships between factors, scenarios, and outcomes in the AI transition model.",
+};
+
+export default function ATMGraphPage() {
+  const raw = getRawGraphData();
+
+  // Transform to ReactFlow nodes
+  const nodes: Node<CauseEffectNodeData>[] = raw.nodes.map((node) => ({
+    id: node.id,
+    type: "causeEffect" as const,
+    position: { x: 0, y: 0 },
+    data: {
+      label: node.label,
+      description: node.description,
+      type: node.type,
+      order: node.order,
+      subgroup: node.subgroup,
+      href: node.href,
+      suppressNavigation: true,  // Use DetailsPanel + path highlighting instead of direct navigation
+      subItems: node.subItems?.map((item) => ({
+        label: item.label,
+        href: item.href,
+        entityId: item.entityId,
+        description: item.description,
+        scope: item.scope,
+        ratings: item.ratings,
+        keyDebates: item.keyDebates,
+      })),
+      confidence: node.confidence,
+      confidenceLabel: node.confidenceLabel,
+      nodeColors: node.nodeColors,
+    },
+  }));
+
+  // Transform to ReactFlow edges
+  const edges: Edge<CauseEffectEdgeData>[] = raw.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    data: {
+      label: edge.label,
+      strength: edge.strength,
+      effect: edge.effect,
+    },
+  }));
+
+  // Serialize for client component (strips non-serializable values)
+  const serializedNodes = JSON.parse(JSON.stringify(nodes));
+  const serializedEdges = JSON.parse(JSON.stringify(edges));
+
+  return (
+    <Suspense>
+      <ATMGraphClient
+        initialNodes={serializedNodes}
+        initialEdges={serializedEdges}
+      />
+    </Suspense>
+  );
+}

--- a/app/src/components/wiki/ATMPage.tsx
+++ b/app/src/components/wiki/ATMPage.tsx
@@ -71,6 +71,12 @@ export function ATMPage({
   // Extract backlinks ID (strip tmc- prefix for backlinks lookup)
   const backlinksId = entityId.replace(/^tmc-/, '');
 
+  // Determine graph node ID for "View in Graph" link
+  // Sub-items have parentFactor; top-level factors/scenarios use their own ID
+  const tmcEntity = entity as { parentFactor?: string };
+  const graphNodeId = tmcEntity.parentFactor || backlinksId;
+  const graphUrl = `/ai-transition-model/graph/?node=${encodeURIComponent(graphNodeId)}`;
+
   return (
     <div className="flex flex-col gap-6">
       {/* Description as intro prose */}
@@ -79,6 +85,23 @@ export function ATMPage({
           <p className="m-0">{entity.description}</p>
         </div>
       )}
+
+      {/* Graph link */}
+      <div className="text-sm">
+        <a
+          href={graphUrl}
+          className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors no-underline"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="18" cy="5" r="3"/>
+            <circle cx="6" cy="12" r="3"/>
+            <circle cx="18" cy="19" r="3"/>
+            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+            <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+          </svg>
+          View in AI Transition Model Graph
+        </a>
+      </div>
 
       {/* Custom content from MDX children */}
       {children && (

--- a/app/src/components/wiki/CauseEffectGraph/components/DetailsPanel.tsx
+++ b/app/src/components/wiki/CauseEffectGraph/components/DetailsPanel.tsx
@@ -1,0 +1,101 @@
+import type { Node } from '@xyflow/react';
+import type { CauseEffectNodeData } from '../types';
+
+interface DetailsPanelProps {
+  node: Node<CauseEffectNodeData> | null;
+  onClose: () => void;
+}
+
+export function DetailsPanel({ node, onClose }: DetailsPanelProps) {
+  if (!node) return null;
+  const data = node.data;
+  const nodeType = data.type || 'intermediate';
+
+  return (
+    <div className="cause-effect-graph__panel">
+      <div className="cause-effect-graph__panel-header">
+        <div>
+          <span className={`cause-effect-graph__panel-badge cause-effect-graph__panel-badge--${nodeType}`}>
+            {nodeType.charAt(0).toUpperCase() + nodeType.slice(1)}
+          </span>
+          <h3 className="cause-effect-graph__panel-title">{data.label}</h3>
+        </div>
+        <button className="cause-effect-graph__panel-close" onClick={onClose} aria-label="Close panel">
+          ×
+        </button>
+      </div>
+      <div className="cause-effect-graph__panel-content">
+        {data.href && (
+          <div className="cause-effect-graph__panel-section">
+            <a
+              href={data.href}
+              className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 no-underline"
+            >
+              View wiki page →
+            </a>
+          </div>
+        )}
+        {data.confidence !== undefined && (
+          <div className="cause-effect-graph__panel-section">
+            <div className="cause-effect-graph__panel-label">
+              {data.confidenceLabel
+                ? `${data.confidenceLabel.charAt(0).toUpperCase()}${data.confidenceLabel.slice(1)}`
+                : 'Confidence Level'}
+            </div>
+            {data.confidence <= 1 ? (
+              <div className="cause-effect-graph__progress">
+                <div className="cause-effect-graph__progress-bar">
+                  <div
+                    className="cause-effect-graph__progress-fill"
+                    style={{ width: `${data.confidence * 100}%` }}
+                  />
+                </div>
+                <span className="cause-effect-graph__progress-value">
+                  {Math.round(data.confidence * 100)}%
+                </span>
+              </div>
+            ) : (
+              <span className="cause-effect-graph__progress-value">
+                {Math.round(data.confidence)}
+              </span>
+            )}
+          </div>
+        )}
+        {data.description && (
+          <div className="cause-effect-graph__panel-section">
+            <div className="cause-effect-graph__panel-label">Description</div>
+            <p className="cause-effect-graph__panel-text">{data.description}</p>
+          </div>
+        )}
+        {data.details && (
+          <div className="cause-effect-graph__panel-section">
+            <div className="cause-effect-graph__panel-label">Details</div>
+            <p className="cause-effect-graph__panel-text">{data.details}</p>
+          </div>
+        )}
+        {data.relatedConcepts && data.relatedConcepts.length > 0 && (
+          <div className="cause-effect-graph__panel-section">
+            <div className="cause-effect-graph__panel-label">Related Concepts</div>
+            <div className="cause-effect-graph__panel-tags">
+              {data.relatedConcepts.map((concept, i) => (
+                <span key={i} className="cause-effect-graph__panel-tag">
+                  {concept}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        {data.sources && data.sources.length > 0 && (
+          <div className="cause-effect-graph__panel-section">
+            <div className="cause-effect-graph__panel-label">Sources</div>
+            <ul className="ceg-panel-sources">
+              {data.sources.map((source, i) => (
+                <li key={i}>{source}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/wiki/CauseEffectGraph/components/index.ts
+++ b/app/src/components/wiki/CauseEffectGraph/components/index.ts
@@ -1,3 +1,4 @@
 export { Legend } from './Legend';
 export { DataView } from './DataView';
+export { DetailsPanel } from './DetailsPanel';
 export { CopyIcon, CheckIcon, ChevronIcon, ExpandIcon, ShrinkIcon } from './icons';

--- a/app/src/components/wiki/CauseEffectGraph/index.tsx
+++ b/app/src/components/wiki/CauseEffectGraph/index.tsx
@@ -59,6 +59,7 @@ interface CauseEffectGraphProps {
   showScores?: boolean;  // Show score indicators on nodes (default false)
   renderHeaderRight?: () => React.ReactNode;  // Custom content for right side of header
   scoreHighlight?: ScoreHighlightMode;  // Highlight nodes by score dimension (opacity based on score value)
+  onNodeClick?: (node: Node<CauseEffectNodeData>) => void;  // External callback when a node is clicked
 }
 
 // Generate YAML representation of graph data
@@ -279,6 +280,7 @@ function CauseEffectGraphInner({
   showScores = false,
   renderHeaderRight,
   scoreHighlight,
+  onNodeClick: onNodeClickExternal,
 }: CauseEffectGraphProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<CauseEffectNodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<CauseEffectEdgeData>>([]);
@@ -377,14 +379,15 @@ function CauseEffectGraphInner({
 
   const onEdgeMouseLeave = useCallback(() => setHoveredEdgeId(null), []);
 
-  // Node click handler for path highlighting
+  // Node click handler for path highlighting and external callback
   const onNodeClick: NodeMouseHandler<Node<CauseEffectNodeData>> = useCallback(
     (event, node) => {
+      onNodeClickExternal?.(node);
       if (!enablePathHighlighting) return;
       // Toggle: if clicking same node, clear; otherwise set new
       setPathHighlightNodeId((prev) => (prev === node.id ? null : node.id));
     },
-    [enablePathHighlighting]
+    [enablePathHighlighting, onNodeClickExternal]
   );
 
   // Compute path highlight data

--- a/app/src/components/wiki/CauseEffectGraph/nodes/CauseEffectNode.tsx
+++ b/app/src/components/wiki/CauseEffectGraph/nodes/CauseEffectNode.tsx
@@ -240,10 +240,10 @@ export function CauseEffectNode({ data, selected, id }: NodeProps<Node<CauseEffe
   const borderRadius = NODE_BORDER_RADIUS[nodeType] || '12px';
 
   const hasSubItems = data.subItems && data.subItems.length > 0;
-  const isClickable = !!data.href;
+  const isClickable = !!data.href && !data.suppressNavigation;
 
   const handleClick = () => {
-    if (data.href) {
+    if (data.href && !data.suppressNavigation) {
       window.location.href = data.href;
     }
   };

--- a/app/src/components/wiki/CauseEffectGraph/types.ts
+++ b/app/src/components/wiki/CauseEffectGraph/types.ts
@@ -45,6 +45,7 @@ export interface CauseEffectNodeData extends Record<string, unknown> {
   sources?: string[];
   relatedConcepts?: string[];
   href?: string;  // URL to navigate to when node is clicked
+  suppressNavigation?: boolean;  // When true, clicking the node won't navigate (allows path highlighting/details panel to work instead)
   scores?: NodeScores;  // Scoring dimensions for node
   scoreIntensity?: number;  // Computed score intensity (0-1) for highlighting, -1 = no score
   highlightColor?: 'purple' | 'red' | 'green' | 'blue' | 'yellow';  // Color for score highlighting

--- a/app/src/data/link-health.json
+++ b/app/src/data/link-health.json
@@ -5,37 +5,37 @@
     {
       "file": "ai-transition-model/factors-ai-ownership-overview.mdx",
       "line": 16,
-      "href": "/ai-transition-model-views/graph/",
+      "href": "/ai-transition-model/graph/",
       "text": "AI Transition Model Graph"
     },
     {
       "file": "ai-transition-model/factors-ai-ownership-overview.mdx",
       "line": 47,
-      "href": "/ai-transition-model-views/graph/",
+      "href": "/ai-transition-model/graph/",
       "text": "AI Transition Model"
     },
     {
       "file": "ai-transition-model/factors-ai-uses-overview.mdx",
       "line": 16,
-      "href": "/ai-transition-model-views/graph/",
+      "href": "/ai-transition-model/graph/",
       "text": "AI Transition Model Graph"
     },
     {
       "file": "ai-transition-model/factors-ai-uses-overview.mdx",
       "line": 47,
-      "href": "/ai-transition-model-views/graph/",
+      "href": "/ai-transition-model/graph/",
       "text": "AI Transition Model"
     },
     {
       "file": "ai-transition-model/index.mdx",
       "line": 33,
-      "href": "/ai-transition-model-views/graph/",
+      "href": "/ai-transition-model/graph/",
       "text": "Graph View"
     },
     {
       "file": "ai-transition-model/index.mdx",
       "line": 34,
-      "href": "/ai-transition-model-views/data/",
+      "href": "/ai-transition-model/data/",
       "text": "Data View"
     },
     {

--- a/app/src/data/parameter-graph-data.ts
+++ b/app/src/data/parameter-graph-data.ts
@@ -799,6 +799,7 @@ export interface RawGraphDataExport {
     type: 'cause' | 'intermediate' | 'effect';
     order?: number;
     subgroup?: string;
+    href?: string;
     subItems?: SubItem[];
     confidence?: number;
     confidenceLabel?: string;
@@ -830,6 +831,7 @@ export function getRawGraphData(): RawGraphDataExport {
     type: node.type,
     order: node.order,
     subgroup: node.subgroup,
+    href: (node as any).href as string | undefined,
     subItems: node.subItems?.map(item => enrichSubItem(item, node.type, node.id)),
     confidence: node.confidence,
     confidenceLabel: node.confidenceLabel,

--- a/content/docs/ai-transition-model/factors-ai-ownership-overview.mdx
+++ b/content/docs/ai-transition-model/factors-ai-ownership-overview.mdx
@@ -13,7 +13,7 @@ import {DataInfoBox, FactorSubItemsList, PageCauseEffectGraph, Backlinks, Entity
 
 AI Ownership refers to who controls the most powerful AI systems and their outputs. Concentration among a few companies, countries, or individuals creates different risks than broad distribution. Ownership structure shapes incentives, accountability, and the distribution of AI benefits.
 
-**For interactive exploration of how AI Ownership relates to other factors, see the [AI Transition Model Graph](/ai-transition-model-views/graph/).**
+**For interactive exploration of how AI Ownership relates to other factors, see the [AI Transition Model Graph](/ai-transition-model/graph/).**
 
 ## Key Dimensions
 
@@ -44,7 +44,7 @@ Also affects:
 
 - <EntityLink id="scenarios-long-term-lockin-overview">Long-term Lock-in</EntityLink> - Primary outcome affected
 - <EntityLink id="concentration-of-power">Concentration of Power</EntityLink> - Related risk
-- [AI Transition Model](/ai-transition-model-views/graph/) - Interactive graph showing relationships
+- [AI Transition Model](/ai-transition-model/graph/) - Interactive graph showing relationships
 
 <PageCauseEffectGraph slug="ai-ownership" />
 

--- a/content/docs/ai-transition-model/factors-ai-uses-overview.mdx
+++ b/content/docs/ai-transition-model/factors-ai-uses-overview.mdx
@@ -13,7 +13,7 @@ import {DataInfoBox, FactorSubItemsList, PageCauseEffectGraph, Backlinks, Entity
 
 AI Uses refers to where and how AI is actually deployed in the economy and society. Key applications include recursive AI development (AI improving AI), integration into critical industries, government use for surveillance or military, and tools for coordination and decision-making.
 
-**For interactive exploration of how AI Uses relates to other factors, see the [AI Transition Model Graph](/ai-transition-model-views/graph/).**
+**For interactive exploration of how AI Uses relates to other factors, see the [AI Transition Model Graph](/ai-transition-model/graph/).**
 
 ## Key Dimensions
 
@@ -44,7 +44,7 @@ Also affects:
 
 - <EntityLink id="scenarios-long-term-lockin-overview">Long-term Lock-in</EntityLink> - Primary outcome affected
 - <EntityLink id="agentic-ai">Agentic AI</EntityLink> - Related capability
-- [AI Transition Model](/ai-transition-model-views/graph/) - Interactive graph showing relationships
+- [AI Transition Model](/ai-transition-model/graph/) - Interactive graph showing relationships
 
 <PageCauseEffectGraph slug="ai-uses" />
 

--- a/content/docs/ai-transition-model/index.mdx
+++ b/content/docs/ai-transition-model/index.mdx
@@ -30,8 +30,8 @@ Both **risks** and **interventions** connect to root factors:
 
 **Interactive Views:**
 - **<EntityLink id="table">Parameter Table</EntityLink>** - Sortable tables with ratings (changeability, uncertainty, x-risk impact, trajectory)
-- **[Graph View](/ai-transition-model-views/graph/)** - Visual causal diagram showing relationships between factors, scenarios, and outcomes
-- **[Data View](/ai-transition-model-views/data/)** - Raw data exploration interface
+- **[Graph View](/ai-transition-model/graph/)** - Visual causal diagram showing relationships between factors, scenarios, and outcomes
+- **[Data View](/ai-transition-model/data/)** - Raw data exploration interface
 
 ---
 


### PR DESCRIPTION
## Summary
- **New graph page** at `/ai-transition-model/graph/` wrapping the existing CauseEffectGraph with a DetailsPanel for inspecting nodes, path highlighting, and minimap
- **URL deep-linking** via `?node=<id>` query parameter — clicking a node updates selection, and links can pre-select a node on load
- **"View in Graph" links** on all ATMPage entity pages, linking directly to their corresponding graph node
- **Click conflict resolution** — added `suppressNavigation` flag so graph page uses DetailsPanel + path highlighting instead of navigating away on node click; DetailsPanel includes "View wiki page →" link for navigation
- **Route rename** from `/ai-transition-model-views/` to `/ai-transition-model/` with all MDX links updated
- **Build fix** — added missing `column-helpers.tsx` and table-view-styles exports (`getArchRelevanceClass`, `safetyCategorySortOrder`, `safetyCategoryColors`, `getBadgeColorClass`) that were breaking the build

## Test plan
- [ ] Visit `/ai-transition-model/graph/` and verify the interactive graph renders with path highlighting and minimap
- [ ] Click a node and verify the DetailsPanel appears with description, confidence, and "View wiki page →" link
- [ ] Click the same node again to verify it deselects (toggle behavior)
- [ ] Visit `/ai-transition-model/graph/?node=misalignment-potential` and verify the node is pre-selected
- [ ] Visit an ATM entity page and verify the "View in AI Transition Model Graph" link appears and links to the correct graph node
- [ ] Verify sub-item links within nodes still navigate correctly
- [ ] Check that the safety approaches table at `/knowledge-base/responses/safety-approaches/table` renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)