### PR TITLE
Fix table CSS: lighten nav tabs, column chips, and group headers

### DIFF
--- a/app/src/components/tables/shared/ColumnToggleControls.tsx
+++ b/app/src/components/tables/shared/ColumnToggleControls.tsx
@@ -46,7 +46,7 @@ export function ColumnToggleControls<T extends string>({
             className={cn(
               "px-2 py-0.5 text-[10px] font-medium rounded-full transition-colors",
               isActive
-                ? "bg-foreground/80 text-background"
+                ? "bg-muted text-foreground ring-1 ring-border"
                 : "text-muted-foreground hover:text-foreground hover:bg-muted"
             )}
           >

--- a/app/src/components/tables/shared/GroupedCategorySection.tsx
+++ b/app/src/components/tables/shared/GroupedCategorySection.tsx
@@ -84,7 +84,7 @@ function GroupHeader({
   switch (style) {
     case "dark-slate":
       return (
-        <div className="bg-slate-900 text-white px-4 py-2 rounded-t-md font-semibold text-sm uppercase tracking-wide">
+        <div className="bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-200 px-4 py-2 rounded-t-md font-semibold text-sm uppercase tracking-wide">
           {label}
           {description && ` — ${description}`}
         </div>

--- a/app/src/components/tables/shared/TableViewPage.tsx
+++ b/app/src/components/tables/shared/TableViewPage.tsx
@@ -155,7 +155,7 @@ export function TableViewPage<TData, TColumnKey extends string>({
               className={cn(
                 "px-2.5 py-1 text-xs rounded-md transition-colors",
                 link.active
-                  ? "bg-foreground text-background font-medium"
+                  ? "bg-muted text-foreground font-medium"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted"
               )}
             >


### PR DESCRIPTION
The table views had overly dark styling in three places:
- Active nav link used solid black background (bg-foreground)
- Active column toggle chips used near-black (bg-foreground/80)
- Group category headers used bg-slate-900 (near-black)

All three are now light gray with dark text, with dark mode support on the group headers.

https://claude.ai/code/session_01J4cVaAgfwnacj1EbK7Jgyu