### PR TITLE
Add Open Graph tags, Twitter cards, and OG image generation

### DIFF
--- a/app/src/app/internal/layout.tsx
+++ b/app/src/app/internal/layout.tsx
@@ -1,5 +1,10 @@
 import { InternalSidebar } from "@/components/internal/InternalSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function InternalLayout({
   children,

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -5,13 +5,23 @@ import { SearchButton, SearchDialog } from "@/components/SearchDialog";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Longterm Wiki",
+  metadataBase: new URL("https://longtermwiki.org"),
+  title: {
+    default: "Longterm Wiki",
+    template: "%s | Longterm Wiki",
+  },
   description: "AI Safety Knowledge Base",
   openGraph: {
     title: "Longterm Wiki",
     description: "AI Safety Knowledge Base",
     type: "website",
     siteName: "Longterm Wiki",
+    url: "https://longtermwiki.org",
+  },
+  twitter: {
+    card: "summary",
+    title: "Longterm Wiki",
+    description: "AI Safety Knowledge Base",
   },
 };
 

--- a/app/src/app/opengraph-image.tsx
+++ b/app/src/app/opengraph-image.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "nodejs";
+export const alt = "Longterm Wiki — AI Safety Knowledge Base";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            color: "#f8fafc",
+            marginBottom: 16,
+          }}
+        >
+          Longterm Wiki
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            color: "#94a3b8",
+          }}
+        >
+          AI Safety Knowledge Base
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/src/app/wiki/[id]/opengraph-image.tsx
+++ b/app/src/app/wiki/[id]/opengraph-image.tsx
@@ -1,0 +1,91 @@
+import { ImageResponse } from "next/og";
+import { getEntityById, getPageById } from "@/data";
+import { numericIdToSlug } from "@/lib/mdx";
+
+export const runtime = "nodejs";
+export const alt = "Longterm Wiki";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+function isNumericId(id: string): boolean {
+  return /^E\d+$/i.test(id);
+}
+
+export default async function OgImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  let slug: string | null;
+  if (isNumericId(id)) {
+    slug = numericIdToSlug(id.toUpperCase());
+  } else {
+    slug = id;
+  }
+
+  const entity = slug ? getEntityById(slug) : null;
+  const pageData = slug ? getPageById(slug) : null;
+  const title = entity?.title || pageData?.title || slug || id;
+  const description = entity?.description || pageData?.description || null;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px 80px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: title.length > 40 ? 48 : 60,
+            fontWeight: 700,
+            color: "#f8fafc",
+            marginBottom: 20,
+            textAlign: "center",
+            lineHeight: 1.2,
+            maxWidth: "100%",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {title}
+        </div>
+        {description && (
+          <div
+            style={{
+              fontSize: 26,
+              color: "#94a3b8",
+              textAlign: "center",
+              lineHeight: 1.4,
+              maxWidth: "90%",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              display: "-webkit-box",
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: "vertical",
+            }}
+          >
+            {description.length > 200 ? description.slice(0, 200) + "…" : description}
+          </div>
+        )}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 40,
+            fontSize: 22,
+            color: "#64748b",
+          }}
+        >
+          Longterm Wiki
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/src/app/wiki/[id]/page.tsx
+++ b/app/src/app/wiki/[id]/page.tsx
@@ -68,6 +68,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       type: ogType,
       ...(pageData?.lastUpdated && { modifiedTime: pageData.lastUpdated }),
     },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
   };
 }
 


### PR DESCRIPTION
- Add metadataBase (longtermwiki.org) and title template to root layout
- Add Twitter Card metadata (summary) at root level
- Add robots noindex/nofollow to internal pages layout
- Add dynamic OG image generation for wiki pages (title + description)
- Add default site-wide OG image with branding
- Use summary_large_image Twitter card for wiki pages with OG images

https://claude.ai/code/session_013z2THdYmVP2kBuC7UmDFC1