### PR TITLE
Add middleware to redirect legacy wiki URLs to new /wiki routes

### DIFF
--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -8,6 +8,7 @@ import type { NextRequest } from "next/server";
  *   /knowledge-base/risks/deceptive-alignment
  *   /knowledge-base/organizations/anthropic
  *   /ai-transition-model/compute
+ *   /ai-transition-model-views/graph
  *
  * New site serves all wiki content through /wiki/:id (numeric E42 or slug).
  * The /wiki/[id] route handles slug → numeric ID resolution internally.
@@ -15,6 +16,27 @@ import type { NextRequest } from "next/server";
 
 // Paths under /ai-transition-model/ that have dedicated routes in the new site
 const ATM_PRESERVED_ROUTES = new Set(["graph"]);
+
+// Knowledge-base category directories that had index pages in the old site.
+// These don't map to individual wiki pages, so we redirect them to /wiki.
+const KB_CATEGORIES = new Set([
+  "capabilities",
+  "cruxes",
+  "debates",
+  "forecasting",
+  "future-projections",
+  "history",
+  "incidents",
+  "intelligence-paradigms",
+  "metrics",
+  "models",
+  "organizations",
+  "people",
+  "reports",
+  "responses",
+  "risks",
+  "worldviews",
+]);
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -27,28 +49,62 @@ export function middleware(request: NextRequest) {
 
   const segments = path.split("/").filter(Boolean);
 
+  // /knowledge-base → /wiki (root index page)
+  // /knowledge-base/risks → /wiki (category index — no standalone page in new site)
   // /knowledge-base/[category/]slug → /wiki/slug
-  if (segments[0] === "knowledge-base" && segments.length >= 2) {
-    const slug = segments[segments.length - 1];
+  if (segments[0] === "knowledge-base") {
     const url = request.nextUrl.clone();
+    if (segments.length <= 1) {
+      // Root: /knowledge-base
+      url.pathname = "/wiki";
+      return NextResponse.redirect(url, 308);
+    }
+    const slug = segments[segments.length - 1];
+    if (segments.length === 2 && KB_CATEGORIES.has(slug)) {
+      // Category index: /knowledge-base/risks
+      url.pathname = "/wiki";
+      return NextResponse.redirect(url, 308);
+    }
     url.pathname = `/wiki/${slug}`;
     return NextResponse.redirect(url, 308);
   }
 
+  // /ai-transition-model-views/* → /ai-transition-model/graph
+  // Old site had /ai-transition-model-views/graph, /data, and index (→ graph)
+  if (segments[0] === "ai-transition-model-views") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/ai-transition-model/graph";
+    return NextResponse.redirect(url, 308);
+  }
+
+  // /ai-transition-model → /ai-transition-model/graph (overview)
   // /ai-transition-model/slug → /wiki/slug
   // Skip paths that have their own routes (e.g. /ai-transition-model/graph)
-  if (segments[0] === "ai-transition-model" && segments.length >= 2) {
-    const slug = segments[segments.length - 1];
-    if (!ATM_PRESERVED_ROUTES.has(slug)) {
-      const url = request.nextUrl.clone();
-      url.pathname = `/wiki/${slug}`;
+  if (segments[0] === "ai-transition-model") {
+    const url = request.nextUrl.clone();
+    if (segments.length <= 1) {
+      // Root: /ai-transition-model
+      url.pathname = "/ai-transition-model/graph";
       return NextResponse.redirect(url, 308);
     }
+    const slug = segments[segments.length - 1];
+    if (ATM_PRESERVED_ROUTES.has(slug)) {
+      return NextResponse.next();
+    }
+    url.pathname = `/wiki/${slug}`;
+    return NextResponse.redirect(url, 308);
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/knowledge-base/:path+", "/ai-transition-model/:path+"],
+  matcher: [
+    "/knowledge-base",
+    "/knowledge-base/:path+",
+    "/ai-transition-model",
+    "/ai-transition-model/:path+",
+    "/ai-transition-model-views",
+    "/ai-transition-model-views/:path+",
+  ],
 };

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Redirects old-style content URLs to the new /wiki/:slug canonical URLs.
+ *
+ * Old site (longtermwiki.com) used paths like:
+ *   /knowledge-base/risks/deceptive-alignment
+ *   /knowledge-base/organizations/anthropic
+ *   /ai-transition-model/compute
+ *
+ * New site serves all wiki content through /wiki/:id (numeric E42 or slug).
+ * The /wiki/[id] route handles slug → numeric ID resolution internally.
+ */
+
+// Paths under /ai-transition-model/ that have dedicated routes in the new site
+const ATM_PRESERVED_ROUTES = new Set(["graph"]);
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Normalize: strip trailing slash
+  const path =
+    pathname.endsWith("/") && pathname.length > 1
+      ? pathname.slice(0, -1)
+      : pathname;
+
+  const segments = path.split("/").filter(Boolean);
+
+  // /knowledge-base/[category/]slug → /wiki/slug
+  if (segments[0] === "knowledge-base" && segments.length >= 2) {
+    const slug = segments[segments.length - 1];
+    const url = request.nextUrl.clone();
+    url.pathname = `/wiki/${slug}`;
+    return NextResponse.redirect(url, 308);
+  }
+
+  // /ai-transition-model/slug → /wiki/slug
+  // Skip paths that have their own routes (e.g. /ai-transition-model/graph)
+  if (segments[0] === "ai-transition-model" && segments.length >= 2) {
+    const slug = segments[segments.length - 1];
+    if (!ATM_PRESERVED_ROUTES.has(slug)) {
+      const url = request.nextUrl.clone();
+      url.pathname = `/wiki/${slug}`;
+      return NextResponse.redirect(url, 308);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/knowledge-base/:path+", "/ai-transition-model/:path+"],
+};


### PR DESCRIPTION
## Summary
This PR adds a Next.js middleware layer to handle URL redirects from the old site's content structure to the new canonical `/wiki/:slug` routes. This ensures backward compatibility for users with bookmarks or external links to the legacy site.

## Key Changes
- **New middleware.ts**: Implements redirect logic for two legacy URL patterns:
  - `/knowledge-base/[category/]slug` → `/wiki/slug` (handles nested category paths)
  - `/ai-transition-model/slug` → `/wiki/slug` (with exceptions for preserved routes like `/ai-transition-model/graph`)
- **Trailing slash normalization**: Strips trailing slashes before processing redirects for consistent URL handling
- **Preserved routes**: Maintains dedicated routes under `/ai-transition-model/` (e.g., `/graph`) by skipping redirect logic for known paths
- **308 permanent redirects**: Uses HTTP 308 status code to preserve request method and indicate permanent redirects

## Implementation Details
- Middleware is configured to match only legacy URL patterns (`/knowledge-base/:path+` and `/ai-transition-model/:path+`) for performance
- Extracts the final slug segment from nested paths to support the old site's category-based organization
- The `/wiki/[id]` route handles slug-to-numeric ID resolution internally, so middleware only needs to normalize the path structure

https://claude.ai/code/session_014gityuiMDXhzwAp3P7iQ98