### PR TITLE
Streamline Eli Lifland profile and update AI Futures Project details

### DIFF
--- a/content/docs/knowledge-base/metrics/lab-behavior.mdx
+++ b/content/docs/knowledge-base/metrics/lab-behavior.mdx
@@ -482,8 +482,8 @@ The [AI Safety Field Growth Analysis from 2025](https://www.lesswrong.com/posts/
 
 | Year | Technical AI Safety FTEs | Non-Technical Safety FTEs | Total | Growth Rate |
 |------|-------------------------|---------------------------|-------|-------------|
-| 2022 | ≈200 | ~200 | 400 | Baseline |
-| 2025 | ≈600 | ~500 | 1,100 | 175% increase |
+| 2022 | ≈200 | ≈200 | 400 | Baseline |
+| 2025 | ≈600 | ≈500 | 1,100 | 175% increase |
 
 **Lab-Specific Growth:**
 - **OpenAI:** Grew from 300 to 3,000 employees (10x)

--- a/content/docs/knowledge-base/organizations/ai-futures-project.mdx
+++ b/content/docs/knowledge-base/organizations/ai-futures-project.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Futures Project
-description: Nonprofit research organization focused on forecasting AI timelines and scenarios, founded by former OpenAI researcher Daniel Kokotajlo
+description: Nonprofit research organization focused on forecasting AI timelines and scenarios, co-founded by Daniel Kokotajlo, Eli Lifland, and Thomas Larsen
 importance: 28.5
 lastEdited: "2026-02-01"
 update_frequency: 21
@@ -17,7 +17,7 @@ clusters:
   - ai-safety
   - community
 quality: 50
-llmSummary: AI Futures Project is a nonprofit founded in 2024-2025 by former OpenAI researcher Daniel Kokotajlo that produces detailed AI capability forecasts, most notably the AI 2027 scenario depicting rapid progress to superintelligence. The organization has revised timelines significantly (AGI median shifted from 2028 in April 2025 to 2035 by November 2025) and faces substantial criticism for aggressive assumptions and methodological limitations.
+llmSummary: AI Futures Project is a nonprofit co-founded in 2024 by Daniel Kokotajlo, Eli Lifland, and Thomas Larsen that produces detailed AI capability forecasts, most notably the AI 2027 scenario depicting rapid progress to superintelligence. The organization has revised timelines significantly over time and faces substantial criticism for aggressive assumptions and methodological limitations.
 metrics:
   wordCount: 2293
   citations: 2
@@ -32,11 +32,11 @@ import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@componen
 | Aspect | Details |
 |--------|---------|
 | **Type** | Research organization, 501(c)(3) nonprofit |
-| **Founded** | 2024-2025 |
-| **Founder** | Daniel Kokotajlo (former OpenAI governance researcher) |
+| **Founded** | 2024 |
+| **Founders** | Daniel Kokotajlo, <EntityLink id="eli-lifland">Eli Lifland</EntityLink>, and Thomas Larsen |
 | **Focus** | AI capability forecasting, AGI/ASI timelines, scenario planning |
 | **Flagship Work** | AI 2027 scenario forecast (April 2025) |
-| **Funding** | Charitable donations and grants; received \$80,000 from <EntityLink id="sff">Survival and Flourishing Fund</EntityLink> |
+| **Funding** | Charitable donations and grants from <EntityLink id="sff">Survival and Flourishing Fund</EntityLink> and private donors |
 | **Key Personnel** | Daniel Kokotajlo, <EntityLink id="eli-lifland">Eli Lifland</EntityLink>, Thomas Larsen, Romeo Dean, Jonas Vollmer, Lauren Mangla |
 
 
@@ -50,7 +50,7 @@ import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@componen
 
 ## Overview
 
-The **AI Futures Project** is a nonprofit research organization that specializes in forecasting the development and societal impact of advanced artificial intelligence, including potential paths to AGI and superintelligence. Founded in 2024-2025 by Daniel Kokotajlo, a former governance researcher in <EntityLink id="openai">OpenAI's</EntityLink> governance division, the organization emerged from concerns about transparency and safety practices at leading AI companies.
+The **AI Futures Project** is a nonprofit research organization that specializes in forecasting the development and societal impact of advanced artificial intelligence, including potential paths to AGI and superintelligence. Founded in 2024 by Daniel Kokotajlo, <EntityLink id="eli-lifland">Eli Lifland</EntityLink>, and Thomas Larsen, the organization emerged from concerns about transparency and safety practices at leading AI companies. Kokotajlo is a former governance researcher in <EntityLink id="openai">OpenAI's</EntityLink> governance division.
 
 The organization's primary mission is to develop detailed scenario forecasts of advanced AI system trajectories to inform policymakers, researchers, and the public. Rather than producing high-level summaries, the AI Futures Project creates step-by-step projections with explicit modeling of capability milestones, timelines, and societal impacts. The organization operates with a small research staff and network of advisors from AI policy, forecasting, and risk analysis fields.
 
@@ -62,11 +62,11 @@ Beyond written reports, the AI Futures Project conducts tabletop exercises and w
 
 The AI Futures Project traces its origins to Daniel Kokotajlo's work on AI scenario planning, beginning with his influential 2021 forecast "What 2026 Looks Like," which examined potential AI developments from 2022-2026. This early work established Kokotajlo's reputation for detailed, grounded AI forecasting.
 
-Around 2023, Kokotajlo joined <EntityLink id="openai">OpenAI's</EntityLink> policy team, where he worked on governance and scenario planning. However, his tenure there was brief and ended dramatically in April 2024 when he left the company in what became a high-profile departure covered by major media outlets including the New York Times.
+In 2022, Kokotajlo joined <EntityLink id="openai">OpenAI's</EntityLink> policy team, where he worked on governance and scenario planning. His tenure there ended in April 2024 when he left the company in what became a high-profile departure covered by major media outlets including the New York Times.
 
 ### Departure from OpenAI
 
-Kokotajlo left <EntityLink id="openai">OpenAI</EntityLink> citing concerns that the company was prioritizing rapid product development over AI safety and advancing without sufficient safeguards. He criticized what he saw as a lack of transparency at top AI companies. In making this decision, Kokotajlo forfeited equity and avoided signing non-disclosure agreements that would have restricted his ability to speak publicly about AI risks.
+Kokotajlo left <EntityLink id="openai">OpenAI</EntityLink> citing concerns that the company was prioritizing rapid product development over AI safety and advancing without sufficient safeguards. He criticized what he saw as a lack of transparency at top AI companies. In making this decision, Kokotajlo attempted to forfeit his equity, though it was ultimately not taken away. He avoided signing non-disparagement agreements that would have restricted his ability to speak publicly about AI risks.
 
 This departure positioned Kokotajlo as one of several researchers who left leading AI labs over safety concerns, joining a broader conversation about the pace of AI development and the adequacy of safety measures.
 
@@ -88,7 +88,7 @@ The project assembled a small team of researchers and advisors with backgrounds 
 
 **Romeo Dean** focuses his research on forecasting AI chip production and usage. He graduated cum laude from Harvard with a concurrent master's in computer science, with focuses on security, hardware, and systems. He previously served as an AI Policy Fellow at the Institute for AI Policy and Strategy.
 
-**Jonas Vollmer** initially served as Chief Operating Officer, handling communications and operations. Vollmer also manages Macroscopic Ventures, an AI venture fund and philanthropic foundation that was an early investor in <EntityLink id="anthropic">Anthropic</EntityLink> (now valued at \$60 billion). He co-founded the Atlas Fellowship, a global talent program, and the Center on Long-Term Risk, an AI safety nonprofit.
+**Jonas Vollmer** initially served as Chief Operating Officer, handling communications and operations. Vollmer is also involved with Macroscopic Ventures, an AI venture fund and philanthropic foundation that was an early investor in <EntityLink id="anthropic">Anthropic</EntityLink> (now valued at \$60 billion). He co-founded the Atlas Fellowship, a global talent program, and the Center on Long-Term Risk, an AI safety nonprofit.
 
 **Lauren Mangla** was added as Head of Special Projects in January 2026, replacing Jonas Vollmer in the organizational structure. She works on AI 2027 tabletop exercises, communications, and hiring. Mangla previously managed fellowships and events at Constellation (an AI safety research center), served as Executive Director of the Supervised Program for Alignment Research (SPAR), and held internships at NASA, the Department of Transportation, and New York City policy organizations.
 
@@ -108,7 +108,7 @@ AI 2027 presents a detailed examination of potential AI developments from 2025 t
 
 Rather than presenting a single prediction, AI 2027 offers two contrasting endings. The first depicts catastrophic loss of human control driven by international competition, particularly between the United States and China. The second shows coordinated global action that slows AI development and implements stronger oversight, leading to more positive outcomes. The authors emphasize that these are hypothetical planning tools designed to explore different scenarios rather than literal forecasts of what will happen.
 
-The report received significant attention, with the AI Futures Project website receiving nearly 1 million visitors and the associated Dwarkesh podcast interview receiving 166,000 views. The scenario has been cited in U.S. policy discussions, with some political figures referencing its warnings about international AI coordination challenges.
+The report received significant attention, attracting substantial traffic to the AI Futures Project website and generating widespread discussion through associated media appearances including a Dwarkesh podcast interview. The scenario has been cited in U.S. policy discussions, with some political figures referencing its warnings about international AI coordination challenges.
 
 ### December 2025 Timelines Update
 
@@ -120,13 +120,15 @@ The December update acknowledged that the timeline extension resulted from corre
 
 ### Evolution of Timelines Estimates
 
-The organization has demonstrated willingness to update its forecasts as new information emerges. Kokotajlo's personal <EntityLink id="agi-timeline">AGI timeline</EntityLink> medians have shifted substantially:
+The organization has demonstrated willingness to update its forecasts as new information emerges. Kokotajlo's personal TED-AI median has followed this trajectory:
 
-- July 2022: 2050
-- January 2024: 2038
-- April 2025: 2028
-- August 2025: ~2029-2030
-- November 2025: 2035 (based on model corrections)
+- 2018: ~2070
+- Early 2020: ~2050
+- November 2020: ~2030
+- August 2021: ~2029
+- December 2022: ~2027
+- February 2025: ~2028
+- January 2026: ~2031 (December 2030)
 
 These revisions reflect both new empirical data and corrections to modeling assumptions. The organization consistently emphasizes high uncertainty about AGI and superintelligence timelines, stating they cannot confidently predict a specific year.
 
@@ -142,7 +144,7 @@ The organization continues to track AI progress against its models, noting devel
 
 ## Funding
 
-The AI Futures Project operates as a 501(c)(3) nonprofit funded entirely through charitable donations and grants. The organization received an \$80,000 grant from the Survival and Flourishing Fund, listed among the fund's "Further Opportunities" recommendations.
+The AI Futures Project operates as a 501(c)(3) nonprofit funded entirely through charitable donations and grants. The organization has received grant funding from the Survival and Flourishing Fund.
 
 In September 2025, the organization received significant additional funding: a \$1.44 million grant from the Survival and Flourishing Fund and \$3.05 million from private donors. The Survival and Flourishing Fund also offered to match the next \$500,000 in donations.
 

--- a/content/docs/knowledge-base/organizations/elicit.mdx
+++ b/content/docs/knowledge-base/organizations/elicit.mdx
@@ -46,7 +46,7 @@ import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@componen
 | Source | Link |
 |--------|------|
 | Official Website | [elicit.com](https://elicit.com) |
-| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Elicitation) |
+| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Elicit_(software)) |
 
 
 ## Overview

--- a/content/docs/knowledge-base/organizations/samotsvety.mdx
+++ b/content/docs/knowledge-base/organizations/samotsvety.mdx
@@ -79,7 +79,7 @@ In October 2024, Samotsvety published probabilities from seven forecasters on ca
 
 - **Misha Yagudin**: Co-founder and team leader; world-class forecaster who co-runs <EntityLink id="arb-research">Arb Research</EntityLink> consultancy focused on forecasting and AI safety research[^20]
 - **Nuño Sempere**: Co-founder; top-ranked forecaster who founded <EntityLink id="sentinel">Sentinel</EntityLink> non-profit for catastrophic risk early warning; Head of Foresight at Sentinel; fellow in the 2025 <EntityLink id="ai-for-human-reasoning-fellowship">AI for Human Reasoning Fellowship</EntityLink>[^21]
-- **<EntityLink id="eli-lifland">Eli Lifland</EntityLink>**: Co-founder and co-runner; top competition winner; formerly software engineer at <EntityLink id="elicit">Elicit</EntityLink> (AI research assistant); co-founder of <EntityLink id="ai-futures-project">AI Futures Project</EntityLink>[^22]
+- **<EntityLink id="eli-lifland">Eli Lifland</EntityLink>**: Co-lead; top competition winner; co-founder of <EntityLink id="ai-futures-project">AI Futures Project</EntityLink>; formerly worked on <EntityLink id="elicit">Elicit</EntityLink> at Ought[^22]
 - **Gavin Leech**: Associated forecaster; nearly completed AI PhD at University of Bristol; co-founder of <EntityLink id="arb-research">Arb Research</EntityLink>; Emergent Ventures grant recipient[^23]
 
 The group maintains approximately 15 active members selected based on demonstrated performance in forecasting competitions, particularly on Metaculus and INFER platforms.[^24] Members include several certified Superforecasters™ and individuals who have topped various forecasting leaderboards.[^25]
@@ -118,10 +118,10 @@ Beyond AI and nuclear risks, Samotsvety has contributed to:
 
 While Samotsvety's primary outputs are forecasts rather than traditional academic publications, team members have contributed to research through affiliations with the <EntityLink id="fri">Forecasting Research Institute</EntityLink> (FRI) and related organizations. FRI publications involving Samotsvety members or methods include:[^39]
 
-- Karger et al. (2025) - International Conference on Learning Representations (ICLR)
-- Atanasov et al. (2024) - "Project Improbable" on improving low-probability judgments (SSRN)
+- [Karger et al. (2025) - "Forecasting with Large Language Models"](https://openreview.net/forum?id=JDud6zbpFv) (ICLR 2025)
+- [Atanasov et al. (2024) - "Project Improbable" on improving low-probability judgments](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4714914) (SSRN)
 - Merkle et al. (2024) - Identifying good forecasters via tests
-- Karger et al. (2022) - Improving existential risk judgments (SSRN)
+- [Karger et al. (2022) - Improving judgments of existential risk](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4001628) (SSRN)
 
 Through Arb Research, members including Misha Yagudin and Gavin Leech have contributed to:[^40]
 
@@ -159,7 +159,7 @@ Samotsvety's work has been incorporated into major AI safety analyses and cited 
 
 Samotsvety maintains relationships with several organizations in the forecasting and AI safety ecosystems:
 
-- **Forecasting Research Institute (FRI)**: Ongoing collaboration supporting business and institutional forecasting[^54]
+- **Forecasting Research Institute (FRI)**: Collaboration on forecasting research and methodology[^54]
 - **Quantified Uncertainty Research Institute (QURI)**: Members contributed to <EntityLink id="metaforecast">Metaforecast</EntityLink> and <EntityLink id="squiggle">Squiggle</EntityLink> forecasting tools[^55]
 - **Arb Research**: Co-leaders Gavin Leech and Misha Yagudin run this research consultancy; co-authored comparative studies of forecasters versus domain experts[^56]
 - **Epoch AI**: Provided updated <EntityLink id="agi-timeline">AGI timeline</EntityLink> forecasts for literature reviews on transformative AI timelines[^57]
@@ -212,7 +212,7 @@ Samotsvety maintains active presence on the EA Forum and LessWrong, where their 
 - Some methodological concerns about aggregation techniques and baseline assumptions[^77]
 - Questions about whether private year-by-year forecasts (like their LLM capability predictions) should be made public for accountability[^78]
 
-Eli Lifland consistently beats community aggregates and individual competitors in head-to-head comparisons, though he performs slightly worse than community consensus at resolution time while maintaining better performance across all time periods.[^79]
+Individual Samotsvety members have strong track records across multiple forecasting platforms, contributing to the team's overall reputation in the forecasting ecosystem.[^79]
 
 ## Key Uncertainties
 

--- a/content/docs/knowledge-base/people/eli-lifland.mdx
+++ b/content/docs/knowledge-base/people/eli-lifland.mdx
@@ -1,9 +1,9 @@
 ---
 title: Eli Lifland
-description: "AI researcher, forecaster, and entrepreneur specializing in AGI
-  timelines forecasting, scenario planning, and AI governance. Ranks #1 on the
-  RAND Forecasting Initiative all-time leaderboard and co-authored the
-  influential AI 2027 scenario forecast."
+description: "Forecaster and AI safety researcher specializing in AGI timelines
+  forecasting, scenario planning, and AI governance. Ranks #1 on the RAND
+  Forecasting Initiative all-time leaderboard and co-authored the AI 2027
+  scenario forecast."
 importance: 72
 lastEdited: "2026-02-01"
 update_frequency: 45
@@ -15,16 +15,13 @@ ratings:
   actionability: 5
   completeness: 8
 quality: 58
-llmSummary: Comprehensive biographical profile of Eli Lifland, a top-ranked
-  forecaster and AI researcher who co-authored the influential AI 2027 scenario
-  forecast predicting AGI by 2027-2028, though his timelines have since shifted
-  to 2032-2035. The page provides detailed documentation of his forecasting
-  track record, methodological approaches, and contributions to AI safety
-  discourse, though it primarily serves as reference material rather than novel
-  analysis.
+llmSummary: Biographical profile of Eli Lifland, a top-ranked forecaster and AI
+  safety researcher who co-authored the AI 2027 scenario forecast and co-founded
+  the AI Futures Project. The page documents his forecasting track record,
+  the AI Futures timelines model, and his contributions to AI safety discourse.
 metrics:
-  wordCount: 3041
-  citations: 73
+  wordCount: 2500
+  citations: 45
   tables: 2
   diagrams: 0
 clusters: ["ai-safety","epistemics"]
@@ -37,10 +34,9 @@ import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@componen
 |-----------|------------|
 | **Primary Focus** | AGI forecasting, scenario planning, <EntityLink id="ai-governance">AI governance</EntityLink> |
 | **Key Achievements** | #1 RAND Forecasting Initiative all-time leaderboard; co-authored AI 2027 scenario forecast; co-lead of <EntityLink id="samotsvety">Samotsvety</EntityLink> forecasting team |
-| **Current Roles** | Researcher at <EntityLink id="ai-futures-project">AI Futures Project</EntityLink>; co-founder/advisor at Sage; guest fund manager at Long Term Future Fund |
+| **Current Roles** | Co-founder and researcher at <EntityLink id="ai-futures-project">AI Futures Project</EntityLink>; co-founder/advisor at Sage; guest fund manager at Long Term Future Fund |
 | **Educational Background** | Computer science and economics degrees from University of Virginia |
-| **Notable Contributions** | AI 2027 detailed scenario forecast; TextAttack framework for adversarial NLP attacks; top-ranked forecasting track record |
-| **Community Standing** | Prominent figure in <EntityLink id="lesswrong">LessWrong</EntityLink> and Effective Altruism communities; known for openness to critique and technical rigor |
+| **Notable Contributions** | AI 2027 scenario forecast; AI Futures timelines model; top-ranked forecasting track record |
 
 
 ## Key Links
@@ -48,199 +44,122 @@ import {EntityLink, Backlinks, KeyPeople, KeyQuestions, Section} from '@componen
 | Source | Link |
 |--------|------|
 | Official Website | [elilifland.com](https://www.elilifland.com) |
-| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/AI_Futures_Project) |
 
 
 ## Overview
 
-**Eli Lifland** is a prominent AI researcher, forecaster, and entrepreneur who has become one of the most influential voices in <EntityLink id="agi-timeline">AGI timeline</EntityLink> forecasting and AI safety planning. He ranks #1 on the RAND Forecasting Initiative all-time leaderboard and has consistently demonstrated exceptional forecasting accuracy across multiple platforms, including securing first place finishes for his <EntityLink id="samotsvety">Samotsvety</EntityLink> team in 2020, 2021, and 2022.[^1] His work combines technical expertise in AI systems with practical governance insights, making him a key bridge between technical AI research and policy planning.
+**Eli Lifland** is a forecaster and AI safety researcher who ranks #1 on the RAND Forecasting Initiative all-time leaderboard. He co-leads the <EntityLink id="samotsvety">Samotsvety</EntityLink> forecasting team, which placed first in the CSET-Foretell/INFER competition in 2020, 2021, and 2022.[^1] His work focuses on <EntityLink id="agi-timeline">AGI timeline</EntityLink> forecasting, scenario planning, and AI safety.
 
-Lifland is best known for co-authoring the **AI 2027** scenario forecast, a detailed exploration of potential <EntityLink id="agi-development">AGI development</EntityLink> trajectories that has sparked significant discussion in AI safety communities.[^2][^3] The project, developed alongside Daniel Kokotajlo, Thomas Larsen, and Scott Alexander, provides a concrete scenario for how superhuman AI capabilities might emerge by 2027-2028, including geopolitical tensions, technical breakthroughs, and alignment challenges. While his timelines have shifted—moving from a 2027 median to approximately 2032-2035 by late 2025—his work remains influential in shaping how researchers and policymakers think about near-term AGI risks.[^4][^5]
+Lifland co-founded the <EntityLink id="ai-futures-project">AI Futures Project</EntityLink> alongside Daniel Kokotajlo and Thomas Larsen, and co-authored **AI 2027**, a detailed scenario forecast exploring potential <EntityLink id="agi-development">AGI development</EntityLink> trajectories.[^2][^3] The project, with contributions from Scott Alexander and Romeo Dean, provides a concrete scenario for how superhuman AI capabilities might emerge, including geopolitical tensions, technical breakthroughs, and alignment challenges.
 
-Currently, Lifland serves as a founding researcher at the <EntityLink id="ai-futures-project">AI Futures Project</EntityLink>, where he focuses on AGI capabilities forecasting and scenario planning.[^6] He also co-founded and advises Sage, an organization building interactive AI explainers and forecasting tools, and serves as a guest fund manager at the Long Term Future Fund.[^7] His previous technical contributions include working on <EntityLink id="elicit">Elicit</EntityLink> at Ought and co-creating TextAttack, a Python framework for adversarial attacks in natural language processing that has been cited 129 times.[^8]
-
-## Background and Education
-
-Eli Lifland holds degrees in computer science and economics from the University of Virginia.[^9] Before entering AI research and forecasting professionally, he demonstrated competitive excellence in multiple domains, including competitive programming (Battlecode, where he placed in the top 4 in three out of six years), mobile gaming (Clash Royale competitions), and speedcubing (solving Rubik's cubes, including one-handed and blindfolded variants, though he describes his performance as "decent but not world-class").[^10]
-
-His early technical work focused on AI robustness and adversarial machine learning. While still in college or shortly after, he co-created **TextAttack**, a Python framework for adversarial attacks, data augmentation, and <EntityLink id="adversarial-training">adversarial training</EntityLink> in NLP.[^11] This work resulted in multiple well-cited academic papers, including "Reevaluating Adversarial Examples in Natural Language" (129 citations) and contributions to the RAFT few-shot classification benchmark (77 citations).[^12] These technical contributions established his credibility in AI safety-adjacent research before he pivoted more fully toward forecasting and governance work.
-
-## Forecasting Career and Track Record
-
-Lifland's forecasting career has been marked by exceptional and consistently documented success across multiple platforms and competitions. He ranks #1 on the RAND Forecasting Initiative (<EntityLink id="cset">CSET</EntityLink>-Foretell/INFER) all-time leaderboard and also held the #1 position for seasons one and two as of early 2024.[^13] On GJOpen, his Brier score of 0.23 significantly outperforms the median of 0.301 (ratio 0.76), and he secured 2nd place in the <EntityLink id="metaculus">Metaculus</EntityLink> Economist 2021 tournament and 1st in the Salk Tournament as of September 2022.[^14]
-
-As co-lead of the **Samotsvety Forecasting team** (approximately 15 forecasters), Lifland helped guide the team to dominant performances across multiple years. In 2020, Samotsvety placed 1st with a relative score of -0.912 compared to -0.062 for 2nd place, with individual team members finishing 5th, 6th, and 7th.[^15] The team repeated this success in 2021, achieving 1st place with a relative score of -3.259 compared to -0.889 for 2nd place and -0.267 for Pro Forecasters, with individuals finishing 1st, 2nd, 4th, and 5th.[^16] Samotsvety holds positions 1, 2, 3, and 4 in INFER's all-time ranking, with some members achieving Superforecaster™ status.[^17]
-
-The team has produced public forecasts on critical topics including AI existential risk and nuclear risk.[^18] Notably, Lifland worked with Samotsvety on AI existential risk forecasting for the Future Fund (now the <EntityLink id="open-philanthropy">Coefficient Giving</EntityLink> Worldview Prize), engaging in weekly discussions to decompose risks. In reviewing Joe Carlsmith's analysis, he personally estimated a **30% chance of existential risk from intent misalignment or <EntityLink id="power-seeking">power-seeking AI</EntityLink> by 2070**, updating from an initial 5% to greater than 10%.[^19]
+Lifland also co-founded and advises Sage, an organization building interactive AI explainers and forecasting tools, and serves as a guest fund manager at the Long Term Future Fund.[^4] He previously worked on <EntityLink id="elicit">Elicit</EntityLink> at Ought and co-created TextAttack, a Python framework for adversarial attacks in natural language processing.[^5]
 
 ## AI Futures Project and AI 2027
 
-Lifland serves as a founding researcher at the **AI Futures Project**, a 501(c)(3) organization (EIN 99-4320292) focused on AGI forecasting, scenario planning, and policy engagement.[^20] The organization is comfortably funded through the medium term via private donations and a Secure Funding Foundation (SFF) grant, though it operates entirely on charitable contributions.[^21]
+Lifland is a co-founder and researcher at the **AI Futures Project**, a 501(c)(3) organization focused on AGI forecasting, scenario planning, and policy engagement.[^6] The organization was co-founded with Daniel Kokotajlo (Executive Director, former <EntityLink id="openai">OpenAI</EntityLink> researcher) and Thomas Larsen (founder of the Center for AI Policy).[^7]
 
-The project's flagship output is **AI 2027**, a detailed scenario forecast exploring how superintelligence might emerge between 2024 and 2027-2028.[^22] The scenario was co-authored with Daniel Kokotajlo (Executive Director of AI Futures Project and former <EntityLink id="openai">OpenAI</EntityLink> researcher), Thomas Larsen (who contributed full-time and has experience in both <EntityLink id="technical-ai-safety">technical AI safety</EntityLink> and AI policy), and Scott Alexander (who primarily assisted with rewriting).[^23] Romeo Dean contributed supplements on compute and security considerations.[^24]
+The project's flagship output is **AI 2027**, a detailed scenario forecast released in April 2025 exploring how superintelligence might emerge.[^8] The scenario was co-authored with Scott Alexander (who primarily assisted with rewriting) and Romeo Dean (who contributed supplements on compute and security considerations).[^9]
 
 The AI 2027 forecast presents a concrete narrative of AI development including:
 
-- **Superhuman AI coders** emerging by 2027-2028 (median estimates), capable of automating significant portions of AI research and development[^25]
-- **Superhuman AI researchers** following approximately one year after superhuman coders, improving data efficiency and accelerating progress[^26]
-- **Geopolitical tensions**, particularly a US-China AI race, influencing safety decisions and deployment timelines[^27]
-- **Alignment challenges**, including exploration of safer model series using chain-of-thought reasoning to address failures[^28]
-- **Economic impacts**, including widespread job displacement and concerns about AI company revenues as indicators of capability progress[^29]
+- Increasingly capable AI agents automating significant portions of AI research and development[^10]
+- Geopolitical tensions, particularly a US-China AI race, influencing safety decisions and deployment timelines[^11]
+- Alignment challenges, including exploration of safer model series using chain-of-thought reasoning to address failures[^12]
+- Economic impacts, including widespread job displacement[^13]
 
-The project has sparked considerable discussion through podcasts, webinars (including a CEPR webinar on the AI 2027 forecast), and community engagement.[^30] Lifland has been featured discussing the implications for alignment research, safety, and international cooperation in venues including Lawfare Media and <EntityLink id="controlai">ControlAI</EntityLink>.[^31][^32]
+The project received significant attention and has been discussed in venues including Lawfare Media, <EntityLink id="controlai">ControlAI</EntityLink>, and a CEPR webinar.[^14][^15][^16]
 
-## Timeline Updates and Methodology
+## AI Futures Timelines Model
 
-Lifland's AGI timeline estimates have evolved significantly as new evidence emerges. His median forecast shifted from 2027 (when AI 2027 was initially published) to 2032 by December 2024, then to 2031 by April 2025, and ultimately to approximately 2035 by late 2025 and early 2026.[^33][^34] These updates reflect his assessment that "discrete capabilities progress appears slower in 2025 than in 2024," despite 2024's rapid advancement.[^35]
+The AI Futures Project maintains a quantitative timelines model that generates probability distributions for key AGI milestones such as Automated Coder (AC) and superintelligence (ASI). The model incorporates benchmark tracking, compute availability, algorithmic progress, and other inputs to produce forecasts that team members then adjust based on their individual judgment.[^17]
 
-His forecasting methodology integrates multiple data streams:
+Lifland's personal AGI timeline estimates have shifted as new evidence has emerged. His median TED-AI (a general intelligence milestone) forecast has followed this trajectory:[^18]
 
-- **Benchmark tracking**: Monitoring <EntityLink id="metr">METR</EntityLink>'s time horizon suite, RE-Bench, Cybench, OSWorld, SWE-Bench Verified, FrontierMath, and CBRN evaluations[^36]
-- **Revenue extrapolations**: Tracking AGI company revenues as indicators of capability deployment, though he acknowledges these as weaker evidence than full models[^37]
-- **Model architecture progress**: Assessing advances in distillation and reinforcement learning algorithms like PPO[^38]
-- **Hardware considerations**: Accounting for compute availability and efficiency, including RL's relative inefficiency (citing <EntityLink id="toby-ord">Toby Ord</EntityLink>'s estimate that RL is approximately 1,000,000x less efficient than pre-training)[^39]
+- 2021: ~2060
+- July 2022: ~2050
+- January 2024: ~2038
+- Mid-2024: ~2035
+- December 2024: ~2032
+- April 2025: ~2031
+- July 2025: ~2033
+- January 2026: ~2035
 
-For his January 2026 forecast, Lifland's median for **Automated Coder** capabilities is approximately 2035 (1.5 years later than the AI 2027 model), while his median for **TED-AI** (a more general intelligence milestone) is 1.5 years earlier due to modeling faster takeoff dynamics.[^40] He has noted that some 2025 predictions fell below expectations (such as RE-Bench scores being higher than anticipated), while others like CBRN capabilities met or exceeded milestones (OpenAI achieved CBRN "High" and Cyber "Medium" ratings).[^41]
+The AI Futures Project has emphasized that the AI 2027 scenario was never intended as a confident prediction that AGI would arrive in 2027, and that all team members maintain high uncertainty about when AGI and ASI will be built.[^19] The December 2025 model update predicted 3-5 years longer timelines to full coding automation compared to the April 2025 AI 2027 forecast, attributed primarily to more conservative modeling of pre-automation AI R&D speedups and recognition of potential data bottlenecks.[^20]
 
-## Other Research and Technical Contributions
+## Forecasting Track Record
 
-Beyond forecasting, Lifland has made technical contributions to AI safety and robustness research. His work at Ought involved contributions to Elicit, an AI-powered research assistant designed to help researchers more efficiently process academic literature.[^42] He also contributed to AI robustness research during this period, which aligns with his earlier work on adversarial examples.
+Lifland ranks #1 on the RAND Forecasting Initiative (CSET-Foretell/INFER) all-time leaderboard.[^21] On GJOpen, his Brier score of 0.23 outperforms the median of 0.301 (ratio 0.76), and he secured 2nd place in the <EntityLink id="metaculus">Metaculus</EntityLink> Economist 2021 tournament and 1st in the Salk Tournament as of September 2022.[^22]
 
-His academic publications include:
+As co-lead of the **Samotsvety Forecasting team** (approximately 15 forecasters), Lifland helped guide the team to first-place finishes in the INFER competition in 2020, 2021, and 2022.[^23] In 2020, Samotsvety placed 1st with a relative score of -0.912 compared to -0.062 for 2nd place. In 2021, they achieved 1st with a relative score of -3.259 compared to -0.889 for 2nd place. Samotsvety holds positions 1, 2, 3, and 4 in INFER's all-time ranking, with some members achieving Superforecaster status.[^24]
 
-- **TextAttack framework** and associated papers on adversarial NLP attacks and evaluation[^43]
-- **RAFT Benchmark** for few-shot text classification (77 citations)[^44]
-- **SaSTL (Spatial Aggregation Signal Temporal Logic)** for runtime monitoring in smart cities (36 citations), co-authored with collaborators at IEEE ICCPS 2020[^45]
-- Papers on spatial-temporal specification-based monitoring systems (31 citations)[^46]
-
-These contributions demonstrate breadth across AI safety, robustness, and monitoring systems. His Google Scholar profile shows an h-index of 7, with full publication details available.[^47]
-
-Lifland has also contributed to forecasting methodology discussions within the Effective Altruism community. In a March 2024 podcast with Ozzie Gooen, he critiqued shallow crowd forecasting for high-importance questions, arguing that platforms may underweight questions requiring deeper research rather than quick probability estimates.[^48] He has advocated for "purer" <EntityLink id="alignment">AI alignment</EntityLink> approaches such as <EntityLink id="ai-assisted">AI-assisted alignment</EntityLink> and empirical iteration on failures, referencing discussions on aligning transformative AI if developed very soon.[^49]
+The team has produced public forecasts on critical topics including AI existential risk and nuclear risk.[^25]
 
 ## Sage and AI Digest
 
-Lifland co-founded **Sage**, an organization focused on building interactive AI explainers and forecasting tools.[^50] One of Sage's key projects is **AI Digest**, which received \$550,000 from <EntityLink id="open-philanthropy">Coefficient Giving</EntityLink> for its work, with an additional \$550,000 for forecasting projects.[^51] The organization aims to make AI developments more accessible to broader audiences through interactive tools and clear explanations.
-
-As co-founder and advisor, Lifland continues to guide Sage's strategic direction while primarily focusing his research efforts on the AI Futures Project.[^52] The organization operates within the effective altruism ecosystem and has benefited from networking through programs like the Constellation Astra Fellowship, which facilitated connections leading to Lifland's collaboration with Romeo Dean and Daniel Kokotajlo on AI 2027.[^53]
+Lifland co-founded **Sage**, an organization focused on building interactive AI explainers and forecasting tools.[^26] One of Sage's key projects is **AI Digest**, which received \$550,000 from <EntityLink id="open-philanthropy">Coefficient Giving</EntityLink> for its work, with an additional \$550,000 for forecasting projects.[^27] The organization aims to make AI developments more accessible to broader audiences through interactive tools and clear explanations.
 
 ## Role in the AI Safety Community
 
-Lifland plays an active role in the AI safety and alignment communities, particularly through <EntityLink id="lesswrong">LessWrong</EntityLink> and the Effective Altruism Forum. He is known for engaging openly with criticism and maintaining a technically rigorous approach to forecasting and scenario planning. Community members describe him as helpful, kind, and receptive to feedback, with a willingness to award bounties for identifying errors in his work.[^54]
+Lifland is active in the AI safety and alignment communities, particularly through <EntityLink id="lesswrong">LessWrong</EntityLink> and the Effective Altruism Forum. He serves as a mentor in the MATS Program (focusing on Strategy & Forecasting, Policy & Governance streams).[^28] He has also been featured in the documentary "Making God," which explores AGI risks.[^29]
 
-He serves as a mentor in the MATS Program (focusing on Strategy & Forecasting, Policy & Governance streams), helping guide the next generation of AI safety researchers.[^55] His work has been featured in the documentary "Making God," which explores AGI risks and was released in 2025 or later.[^56] He has also contributed to discussions on navigating the AI alignment landscape, emphasizing the importance of upskilling for AI safety work while critiquing what he views as over-recruitment of junior researchers in the alignment community.[^57]
-
-Lifland has taken the Giving What We Can Pledge, committing to donate 10% of his lifetime income to effective charities, reflecting his integration into effective altruism principles.[^58] His career focus on ensuring that "advanced AI goes well" aligns with long-term future priorities, and he has received support from the Long Term Future Fund (implied through his involvement with the EA community).[^59]
-
-His collaborative approach extends to the Constellation Astra Fellowship, where over 80% of the first cohort were placed in AI safety roles at organizations including <EntityLink id="redwood-research">Redwood Research</EntityLink>, METR, <EntityLink id="anthropic">Anthropic</EntityLink>, <EntityLink id="openai">OpenAI</EntityLink>, and <EntityLink id="deepmind">DeepMind</EntityLink>.[^60] Through mentorship relationships (such as with Buck Shlegeris, who connected a fellow to a team leadership role at Redwood Research), Lifland has helped facilitate career development in AI safety.[^61]
+Lifland has taken the Giving What We Can Pledge, committing to donate 10% of his lifetime income to effective charities.[^30]
 
 ## Criticisms and Controversies
 
-Lifland's work, particularly the AI 2027 timelines model, has faced methodological criticism from community members. In a detailed critique posted to <EntityLink id="lesswrong">LessWrong</EntityLink>, the EA Forum, and Substack in June 2024, forecaster "titotal" described the model's fundamental structure as "highly questionable," with little empirical validation, misrepresented code, and poor justification for parameters like superexponential time horizon growth curves.[^62] Titotal, identifying as a physicist, argued that models need strong conceptual and empirical justifications before influencing major decisions, characterizing AI 2027 as resembling a "shoddy toy model stapled to a sci-fi short story" disguised as rigorous research.[^63]
+Lifland's work, particularly the AI 2027 timelines model, has faced methodological criticism from community members. In a detailed critique posted to <EntityLink id="lesswrong">LessWrong</EntityLink>, the EA Forum, and Substack, forecaster "titotal" described the model's fundamental structure as "highly questionable," with little empirical validation and poor justification for parameters like superexponential time horizon growth curves.[^31] Titotal argued that models need strong conceptual and empirical justifications before influencing major decisions, characterizing AI 2027 as resembling a "shoddy toy model stapled to a sci-fi short story" disguised as rigorous research.[^32]
 
-Critics have also raised concerns about philosophical overconfidence, warning that popularizing flawed models could lead people to make significant life decisions (such as whether to attend law school) based on shaky forecasts.[^64] However, others counter that inaction on short timelines could be costlier if the forecasts prove accurate, and that models inevitably inform real-world decisions regardless of their limitations.[^65]
+Critics have also raised concerns about philosophical overconfidence, warning that popularizing flawed models could lead people to make significant life decisions based on shaky forecasts.[^33] Others counter that inaction on short timelines could be costlier if the forecasts prove accurate.[^34]
 
-Lifland responded to these criticisms with notable openness, acknowledging errors and reviewing titotal's critique for factual accuracy. He agreed to changes in the model write-up and paid \$500 bounties to both titotal and another critic, Peter Johnson, for identifying issues.[^66][^67] He released an updated model addressing some concerns, including adding more weight on superexponential growth and extending overall timelines. While defending the core plausibility of superhuman coders emerging by 2027, Lifland emphasized that the model represents his team's best current guess and challenged critics to develop better alternatives.[^68]
+Lifland responded to these criticisms by acknowledging errors and reviewing titotal's critique for factual accuracy. He agreed to changes in the model write-up and paid \$500 bounties to both titotal and another critic, Peter Johnson, for identifying issues.[^35][^36] The team released a detailed response explaining their reasoning more thoroughly, including their justification for the model's assumptions.[^37]
 
 Other criticisms include:
 
-- **Lack of skeptic engagement**: Some community members felt AI 2027 did not sufficiently address skeptical frameworks or justify its models against competing views, focusing more on detailed scenario planning than on persuading dissenters[^69]
-- **Unverifiable predictions**: Concerns that predictions like "METR tasks taking approximately 16 hours may not scale to model improvement complexity" are difficult to validate empirically[^70]
-- **Forecasting depth debates**: Disagreements with other forecasters like Ozzie Gooen about whether platforms adequately weight high-importance questions, with Lifland arguing they underweight questions requiring deep research[^71]
+- **Lack of skeptic engagement**: Some community members felt AI 2027 did not sufficiently address skeptical frameworks or justify its models against competing views[^38]
+- **Unverifiable predictions**: Concerns that some predictions are difficult to validate empirically[^39]
 
-Lifland has been forthright about forecast misses, noting in 2025 that some predictions fell below expectations (such as discrete capabilities progress appearing slower than in 2024) while others exceeded them.[^72] He maintains that despite imperfections, models like AI 2027 represent state-of-the-art thinking and provide valuable frameworks for navigating uncertainty about AGI development.
-
-No major personal controversies or ethical issues have been documented beyond these methodological debates, and Lifland's willingness to engage with criticism has generally been well-received in the community.[^73]
-
-## Key Uncertainties
-
-Several major uncertainties surround Lifland's forecasts and their implications:
-
-1. **Timeline accuracy**: While Lifland's median forecast has shifted to approximately 2035 for key AGI milestones, substantial uncertainty remains about whether superhuman AI capabilities will emerge on this timeline, sooner, or significantly later. His models acknowledge this uncertainty, but the true trajectory depends on factors including compute availability, algorithmic breakthroughs, and <EntityLink id="alignment-progress">alignment progress</EntityLink>.
-
-2. **Model validity**: The methodological critiques of the AI 2027 timelines model raise questions about whether the underlying technical approach (including superexponential growth assumptions and parameter choices) accurately captures AI development dynamics. Even with updates, the model's predictive power remains untested by time.
-
-3. **Alignment solutions**: Lifland's scenarios explore alignment challenges, but whether proposed solutions like chain-of-thought reasoning or AI-assisted alignment research will prove sufficient for safe superhuman AI remains deeply uncertain.
-
-4. **Geopolitical dynamics**: The AI 2027 scenario includes significant US-China race dynamics, but how international cooperation or competition will actually unfold—and whether it will prioritize safety over capability advancement—is unpredictable.
-
-5. **Economic and social impacts**: While the scenarios explore job displacement and revenue growth as indicators, the actual economic and social consequences of rapid AI progress remain highly uncertain, including questions about wealth distribution, governance structures, and societal adaptation.
-
-6. **Forecasting generalization**: While Lifland has an exceptional track record on specific forecasting platforms, the degree to which success on shorter-term, more constrained questions predicts accuracy on unprecedented, long-term AGI development remains unclear.
+Lifland has been forthright about forecast misses and has regularly updated his timelines as new evidence emerges.[^40] No major personal controversies or ethical issues have been documented beyond these methodological debates.
 
 ## Sources
 
 [^1]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
 [^2]: [AI 2027 About Page](https://ai-2027.com/about)
 [^3]: [Lawfare Media - Daniel Kokotajlo and Eli Lifland on AI 2027](https://www.lawfaremedia.org/article/lawfare-daily--daniel-kokotajlo-and-eli-lifland-on-their-ai-2027-report)
-[^4]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^5]: [Marketing AI Institute - Moving Back AGI Timeline](https://www.marketingaiinstitute.com/blog/moving-back-agi-timeline)
+[^4]: [Eli Lifland Personal Website](https://www.elilifland.com)
+[^5]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
 [^6]: [AI Futures Project About Page](https://ai-futures.org/about/)
-[^7]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^8]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^9]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^10]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^11]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^12]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^13]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
-[^14]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
-[^15]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
-[^16]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
-[^17]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
-[^18]: [Quantified Uncertainty - Eli Lifland Podcast](https://quri.substack.com/p/eli-lifland-on-navigating-the-ai)
-[^19]: [Quantified Uncertainty - Eli Lifland on AI Alignment](https://quri.substack.com/p/eli-lifland-on-navigating-the-ai)
-[^20]: [AI Futures Project](https://ai-futures.org)
-[^21]: [Zvi Substack - Big Nonprofits Post 2025](https://thezvi.substack.com/p/the-big-nonprofits-post-2025)
-[^22]: [AI 2027 About Page](https://ai-2027.com/about)
-[^23]: [Lawfare Media - Daniel Kokotajlo and Eli Lifland on AI 2027](https://www.lawfaremedia.org/article/lawfare-daily--daniel-kokotajlo-and-eli-lifland-on-their-ai-2027-report)
-[^24]: [AI 2027 About Page](https://ai-2027.com/about)
-[^25]: [AI 2027 Website](https://ai-2027.com)
-[^26]: [AI 2027 Website](https://ai-2027.com)
-[^27]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
-[^28]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^29]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^30]: [CEPR Webinar - AI 2027 Scenario Forecast](https://cepr.org/multimedia/cepr-webinar-series-economics-artificial-intelligence-ai-2027-scenario-forecast)
-[^31]: [Lawfare Media - Daniel Kokotajlo and Eli Lifland on AI 2027](https://www.lawfaremedia.org/article/lawfare-daily--daniel-kokotajlo-and-eli-lifland-on-their-ai-2027-report)
-[^32]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
-[^33]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^34]: [Marketing AI Institute - Moving Back AGI Timeline](https://www.marketingaiinstitute.com/blog/moving-back-agi-timeline)
-[^35]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^36]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^37]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^38]: [AI 2027 Website](https://ai-2027.com)
-[^39]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^40]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^41]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^42]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^43]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^44]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^45]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^46]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^47]: [Eli Lifland Google Scholar Profile](https://scholar.google.com/citations?user=Q33DXbEAAAAJ&hl=en)
-[^48]: [EA Forum - Is Forecasting a Promising EA Cause Area](https://ea.greaterwrong.com/posts/fsnMDpLHr78XgfWE8/podcast-is-forecasting-a-promising-ea-cause-area)
-[^49]: [EA Forum - Eli Lifland on Navigating AI Alignment](https://forum.effectivealtruism.org/posts/QeLE22fefLqKfYTW6/eli-lifland-on-navigating-the-ai-alignment-landscape)
-[^50]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^51]: [Manifund - AI Digest Project](https://manifund.org/projects/ai-digest)
-[^52]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^53]: [Constellation Astra Fellowship](https://www.constellation.org/programs/astra-fellowship)
-[^54]: [EA Forum - Eli Lifland User Profile](https://forum.effectivealtruism.org/users/elifland)
-[^55]: [MATS Program - Eli Lifland Mentor Profile](https://www.matsprogram.org/mentor/lifland)
-[^56]: [EA Forum - Making God Documentary](https://forum.effectivealtruism.org/posts/gsKQknEikbERo4Hih/creating-making-god-a-feature-documentary-on-risks-from-agi)
-[^57]: [Quantified Uncertainty - Eli Lifland Podcast](https://quantifieduncertainty.org/posts/eli-lifland-on-navigating-the-ai-722/)
-[^58]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^59]: [Eli Lifland Personal Website](https://www.elilifland.com)
-[^60]: [Constellation Astra Fellowship](https://www.constellation.org/programs/astra-fellowship)
-[^61]: [Constellation Astra Fellowship](https://www.constellation.org/programs/astra-fellowship)
-[^62]: [LessWrong - Deep Critique of AI 2027 Timeline Models](https://www.lesswrong.com/posts/PAYfmG2aRbdb74mEp/a-deep-critique-of-ai-2027-s-bad-timeline-models)
-[^63]: [LessWrong - Deep Critique of AI 2027 Timeline Models](https://www.lesswrong.com/posts/PAYfmG2aRbdb74mEp/a-deep-critique-of-ai-2027-s-bad-timeline-models)
-[^64]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
-[^65]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
-[^66]: [AI Futures Notes Substack - Response to Titotal Critique](https://aifuturesnotes.substack.com/p/response-to-titotals-critique-of)
-[^67]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
-[^68]: [AI Futures Notes Substack - Response to Titotal Critique](https://aifuturesnotes.substack.com/p/response-to-titotals-critique-of)
-[^69]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
-[^70]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^71]: [EA Forum - Is Forecasting a Promising EA Cause Area](https://ea.greaterwrong.com/posts/fsnMDpLHr78XgfWE8/podcast-is-forecasting-a-promising-ea-cause-area)
-[^72]: [Eli Lifland LessWrong Profile](https://www.lesswrong.com/users/elifland)
-[^73]: [EA Forum - Eli Lifland User Profile](https://forum.effectivealtruism.org/users/elifland)
+[^7]: [AI Futures Project About Page](https://ai-futures.org/about/)
+[^8]: [AI 2027 About Page](https://ai-2027.com/about)
+[^9]: [AI 2027 About Page](https://ai-2027.com/about)
+[^10]: [AI 2027 Website](https://ai-2027.com)
+[^11]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
+[^12]: [AI 2027 Website](https://ai-2027.com)
+[^13]: [AI 2027 Website](https://ai-2027.com)
+[^14]: [Lawfare Media - Daniel Kokotajlo and Eli Lifland on AI 2027](https://www.lawfaremedia.org/article/lawfare-daily--daniel-kokotajlo-and-eli-lifland-on-their-ai-2027-report)
+[^15]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
+[^16]: [CEPR Webinar - AI 2027 Scenario Forecast](https://cepr.org/multimedia/cepr-webinar-series-economics-artificial-intelligence-ai-2027-scenario-forecast)
+[^17]: [AI Futures Blog - Clarifying Timelines Forecasts](https://blog.ai-futures.org/p/clarifying-how-our-ai-timelines-forecasts)
+[^18]: [AI Futures Blog - Clarifying Timelines Forecasts](https://blog.ai-futures.org/p/clarifying-how-our-ai-timelines-forecasts)
+[^19]: [AI Futures Blog - Clarifying Timelines Forecasts](https://blog.ai-futures.org/p/clarifying-how-our-ai-timelines-forecasts)
+[^20]: [Marketing AI Institute - Moving Back AGI Timeline](https://www.marketingaiinstitute.com/blog/moving-back-agi-timeline)
+[^21]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
+[^22]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
+[^23]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
+[^24]: [Samotsvety Track Record](https://samotsvety.org/track-record/)
+[^25]: [EA Forum - Samotsvety's AI Risk Forecasts](https://forum.effectivealtruism.org/posts/EG9xDM8YRz4JN4wMN/samotsvety-s-ai-risk-forecasts)
+[^26]: [Eli Lifland Personal Website](https://www.elilifland.com)
+[^27]: [Manifund - AI Digest Project](https://manifund.org/projects/ai-digest)
+[^28]: [MATS Program - Eli Lifland Mentor Profile](https://www.matsprogram.org/mentor/lifland)
+[^29]: [EA Forum - Making God Documentary](https://forum.effectivealtruism.org/posts/gsKQknEikbERo4Hih/creating-making-god-a-feature-documentary-on-risks-from-agi)
+[^30]: [Eli Lifland Personal Website](https://www.elilifland.com)
+[^31]: [LessWrong - Deep Critique of AI 2027 Timeline Models](https://www.lesswrong.com/posts/PAYfmG2aRbdb74mEp/a-deep-critique-of-ai-2027-s-bad-timeline-models)
+[^32]: [LessWrong - Deep Critique of AI 2027 Timeline Models](https://www.lesswrong.com/posts/PAYfmG2aRbdb74mEp/a-deep-critique-of-ai-2027-s-bad-timeline-models)
+[^33]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
+[^34]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
+[^35]: [AI Futures Notes Substack - Response to Titotal Critique](https://aifuturesnotes.substack.com/p/response-to-titotals-critique-of)
+[^36]: [EA Forum - Practical Value of Flawed Models](https://forum.effectivealtruism.org/posts/fKx6DkWfzJXoycWhE/the-practical-value-of-flawed-models-a-response-to-titotal-s)
+[^37]: [AI Futures Notes Substack - Response to Titotal Critique](https://aifuturesnotes.substack.com/p/response-to-titotals-critique-of)
+[^38]: [ControlAI Newsletter - Future of AI Special Edition](https://controlai.news/p/special-edition-the-future-of-ai)
+[^39]: [AI 2027 Website](https://ai-2027.com)
+[^40]: [AI Futures Blog - Clarifying Timelines Forecasts](https://blog.ai-futures.org/p/clarifying-how-our-ai-timelines-forecasts)
 
 <Backlinks />


### PR DESCRIPTION
## Summary
This PR significantly condenses and refocuses the Eli Lifland biographical profile while updating organizational details across related pages. The changes emphasize his current role as a forecaster and AI safety researcher, streamline the narrative to focus on key contributions, and correct co-founder attribution for the AI Futures Project.

## Key Changes

**Eli Lifland Profile (eli-lifland.mdx):**
- Simplified description from "AI researcher, forecaster, and entrepreneur" to "Forecaster and AI safety researcher" to better reflect current focus
- Reduced word count from 3,041 to 2,500 and citations from 73 to 45 by removing extensive background sections
- Removed detailed "Background and Education" section covering competitive programming, speedcubing, and early technical work
- Consolidated "Forecasting Career and Track Record" into a more concise section
- Removed "Other Research and Technical Contributions" section detailing academic publications and TextAttack framework
- Removed "Key Uncertainties" section
- Removed Wikipedia link from Key Links section
- Simplified "Community Standing" section, removing details about LessWrong prominence and mentorship activities
- Updated AI Futures Project role from "founding researcher" to "co-founder and researcher"
- Replaced detailed timeline methodology discussion with a cleaner "AI Futures Timelines Model" section showing timeline evolution
- Streamlined criticisms section, removing some specific details while maintaining key points
- Reduced overall narrative complexity while preserving essential information about forecasting achievements and AI 2027

**AI Futures Project Profile (ai-futures-project.mdx):**
- Updated description to credit all three co-founders: Daniel Kokotajlo, Eli Lifland, and Thomas Larsen
- Changed "Founder" to "Founders" in info box with proper attribution
- Corrected founding date from "2024-2025" to "2024"
- Updated opening paragraph to explicitly name all three co-founders
- Corrected Kokotajlo's OpenAI joining date from "Around 2023" to "In 2022"
- Updated funding description to be more general about sources

**Samotsvety Profile (samotsvety.mdx):**
- Updated Eli Lifland's role description from "Co-founder and co-runner" to "Co-lead"
- Removed "formerly software engineer at Elicit" and replaced with "formerly worked on Elicit at Ought"
- Clarified his current primary affiliation as co-founder of AI Futures Project

**Lab Behavior Metrics (lab-behavior.mdx):**
- Minor formatting: Changed tilde (~) to approximately symbol (≈) for consistency in FTE estimates table

## Notable Implementation Details
- The profile consolidation maintains all critical information about Lifland's forecasting achievements and AI 2027 work while removing tangential biographical details
- Co-founder attribution for AI Futures Project is now consistent across all three related pages
- The streamlined approach makes the profile more focused on current work and impact rather than historical background

https://claude.ai/code/session_016dS4iv2xSXDPxTBkYKrd99