### PR TITLE
Set weekly update frequency for LongtermWiki page and faster meta-page rules

### DIFF
--- a/content/docs/knowledge-base/models/longtermwiki-impact.mdx
+++ b/content/docs/knowledge-base/models/longtermwiki-impact.mdx
@@ -13,7 +13,7 @@ ratings:
   actionability: 6
 lastEdited: "2026-02-04"
 importance: 50
-update_frequency: 90
+update_frequency: 21
 llmSummary: "Fermi estimation of LongtermWiki value grounded in base rates. GiveWell shows 3% of donors choose based on effectiveness research; 80k Hours achieves ~107 significant plan changes/year; think tanks rarely demonstrate causal policy impact. Conservative central estimate: $100-500K/yr in effective value through researcher onboarding (primary), funder information improvement (secondary), with high-variance 'inspiration' pathway that's hard to quantify. Much lower than naive estimates due to: limited counterfactual impact of information on decisions, small target audience, and low probability of behavioral change."
 metrics:
   wordCount: 3200

--- a/content/docs/knowledge-base/responses/longterm-wiki.mdx
+++ b/content/docs/knowledge-base/responses/longterm-wiki.mdx
@@ -4,6 +4,8 @@ description: A strategic intelligence platform for AI safety prioritization that
 sidebar:
   order: 3
 importance: 12
+lastEdited: "2026-02-13"
+update_frequency: 7
 clusters:
   - epistemics
   - community

--- a/crux/authoring/reassign-update-frequency.ts
+++ b/crux/authoring/reassign-update-frequency.ts
@@ -157,6 +157,7 @@ function getPathDefault(pagePath: string): number | null {
   if (pagePath.includes('cruxes/')) return 45;
   if (pagePath.includes('scenarios/')) return 45;
   if (pagePath.includes('worldviews/')) return 45;
+  if (pagePath.includes('project/')) return 21;   // meta pages about this wiki
   // organizations/ without a subcategory match → let Haiku decide
   return null; // ambiguous
 }
@@ -188,6 +189,13 @@ const TITLE_EXACT_OVERRIDES: Record<string, number> = {
   'Sam Altman': 7,
   'Dario Amodei': 7,
   'Elon Musk': 7,
+
+  // Meta / self-referential pages (about this wiki) → 7d
+  // The wiki itself changes constantly, so pages describing it need weekly updates
+  'Longterm Wiki': 7,
+
+  // Wiki impact model → 21d (inputs change as the wiki grows)
+  'LongtermWiki Impact Model': 21,
 
   // Analytical pages about labs → use subcategory/path instead (no override)
 };


### PR DESCRIPTION
The LongtermWiki page describes this wiki, which changes constantly, so it
needs a weekly update frequency (7d). Also reduced the LongtermWiki Impact
Model from 90d to 21d since its inputs change as the wiki grows. Added
title overrides and a path rule for project/ pages in the reassign script
to prevent these from being reset to slower frequencies.

https://claude.ai/code/session_017FTfCqkR1MwRxdNG8j1mof