### PR TITLE
Add session logging and common-issues tracking for Claude Code sessions

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -1,0 +1,51 @@
+# Common Issues & Solutions
+
+Recurring problems encountered across Claude Code sessions. When you hit a known issue, check here first. When you discover a new recurring issue, add it here.
+
+---
+
+## Build & CI
+
+### Data layer must be built before tests or app build
+`node app/scripts/build-data.mjs` must run before `pnpm test` or `pnpm build`. If tests fail with missing data errors, this is likely why.
+
+### API keys are in environment, not .env files
+Check `env | grep -i API` — keys are set as environment variables, not in `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`.
+
+### CI verification requires curl, not gh
+`gh` CLI is not installed. Use `curl` with `$GITHUB_TOKEN` to check CI status (see CLAUDE.md for the exact command).
+
+---
+
+## Page Authoring
+
+### Always use the Crux pipeline, never write pages manually
+If `pnpm crux content create` or `pnpm crux content improve` fails, fix the pipeline — don't bypass it. See CLAUDE.md for details.
+
+### Run escaping fixes after any page edit
+```bash
+pnpm crux fix escaping
+pnpm crux fix markdown
+pnpm crux validate unified --rules=comparison-operators,dollar-signs --errors-only
+```
+
+---
+
+## MDX & Rendering
+
+### Dollar signs must be escaped
+Use `\$100` not `$100` in MDX files. The unified validator catches this.
+
+### Comparison operators must be escaped
+Use `\<` not `<` in prose (outside of JSX tags). The unified validator catches this.
+
+---
+
+## Git & Branches
+
+### Branch naming for Claude Code web sessions
+Branches must start with `claude/` and end with the session ID, otherwise push fails with 403.
+
+---
+
+_Add new issues below as they're discovered. Group by category._

--- a/.claude/rules/session-logging.md
+++ b/.claude/rules/session-logging.md
@@ -1,0 +1,29 @@
+# Session Logging
+
+Before your final commit in any session, append a brief session summary entry to `.claude/session-log.md`.
+
+## Format
+
+Add an entry at the **top** of the log (below the header), using this format:
+
+```
+## YYYY-MM-DD | branch-name | short-title
+
+**What was done:** 1-2 sentence summary of the changes made.
+
+**Issues encountered:**
+- List any problems, errors, or unexpected behavior (or "None")
+
+**Learnings/notes:**
+- Anything a future session should know (or "None")
+
+---
+```
+
+## Rules
+
+- Keep entries concise (5-10 lines max)
+- Always include the branch name so entries can be correlated with PRs
+- If you encountered an issue that seems likely to recur, also add it to `.claude/common-issues.md`
+- Do NOT skip logging just because the session was small — even one-line fixes are worth tracking
+- The session log entry should be part of the same commit as your other changes (not a separate commit)

--- a/.claude/session-log.md
+++ b/.claude/session-log.md
@@ -1,0 +1,16 @@
+# Session Log
+
+Reverse-chronological log of Claude Code sessions on this repo. Each session appends a summary before its final commit. See `.claude/rules/session-logging.md` for the format.
+
+## 2026-02-13 | claude/session-logging-tracking-d4d6K | Add session logging system
+
+**What was done:** Created a session logging and common-issues tracking system. Added `.claude/rules/session-logging.md` (instructs each session to log a summary), `.claude/session-log.md` (the log itself), and `.claude/common-issues.md` (recurring issues and solutions seeded from CLAUDE.md knowledge).
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- Hook-based logging (SessionStart/SessionEnd) captures metadata but not what actually happened. Rule-based self-logging is more useful for understanding session outcomes.
+- The `.claude/rules/` directory is read automatically by Claude Code — no settings.json needed for rules.
+
+---


### PR DESCRIPTION
Introduces a lightweight system so each Claude Code session logs what it
did and what issues it hit, enabling cross-session learning:

- .claude/rules/session-logging.md: rule instructing sessions to self-log
- .claude/session-log.md: reverse-chronological session summaries
- .claude/common-issues.md: recurring problems and solutions

https://claude.ai/code/session_01Sb6JVPG3k7eedbQyZfA7oV