### PR TITLE
Add prediction market section to Anthropic (Funder) page

### DIFF
--- a/.claude/sessions/2026-02-13_update-anthropic-funder-page-I6TbZ.md
+++ b/.claude/sessions/2026-02-13_update-anthropic-funder-page-I6TbZ.md
@@ -1,0 +1,9 @@
+## 2026-02-13 | claude/update-anthropic-funder-page-I6TbZ | Add prediction market to Anthropic funder page
+
+**What was done:** Added a "Prediction Markets" section to the Anthropic (Funder) page referencing a Manifold Markets prediction market on total Anthropic charitable donations by end of 2030. Includes outcome bracket table with contextual notes tying each bracket to the page's existing estimates.
+
+**Issues encountered:**
+- Dependencies not installed; needed `pnpm install --ignore-scripts` (puppeteer postinstall failed due to network)
+
+**Learnings/notes:**
+- None

--- a/content/docs/knowledge-base/organizations/anthropic-investors.mdx
+++ b/content/docs/knowledge-base/organizations/anthropic-investors.mdx
@@ -812,6 +812,22 @@ Unlike the OpenAI Foundation's legal control over board appointments, Anthropic 
 
 For analysis of interventions that could increase pledge fulfillment probability—including legal pledge conversion, DAF pre-commitment campaigns, and public accountability tracking—see <EntityLink id="E411">Anthropic Founder Pledge Interventions</EntityLink>.
 
+## Prediction Markets
+
+A [Manifold Markets prediction market](https://manifold.markets/MichaelDickens/by-the-end-of-2030-how-much-anthrop) asks: "By the end of 2030, how much Anthropic money will have been donated to charity?" The market covers donations from all Anthropic-derived wealth, including individual donations from founders and employees who gained wealth through equity, as well as company matching contributions.
+
+| Outcome Bracket | Notes |
+|-----------------|-------|
+| \$0 | No significant donations before 2030 |
+| \<\$100M | Token giving only |
+| \$100M–\$1B | Modest fulfillment; comparable to early employee buyback-era giving |
+| \$1B–\$3B | Partial pledge fulfillment; likely employee DAF distributions |
+| \$3B–\$10B | Substantial giving; consistent with legally bound employee capital arriving post-IPO |
+| \$10B–\$30B | Near full deployment of legally bound capital plus some founder giving |
+| \>\$30B | Exceeds most conservative risk-adjusted estimates for this timeline |
+
+This market provides a useful external reference point for the estimates on this page. The risk-adjusted range of \$27-76B estimated above covers total eventual EA-aligned capital, but much of that is expected to deploy over 2027-2035. By end of 2030, actual donations may be substantially lower than the total eventual figure, depending on IPO timing, lock-up periods, and founder decision timelines.
+
 ## Key Uncertainties Summary
 
 | Uncertainty | Range | Key Drivers |


### PR DESCRIPTION
Reference Manifold Markets prediction market on total Anthropic charitable
donations by end of 2030. Includes outcome bracket table with contextual
notes linking each bracket to the page's existing capital estimates.

https://claude.ai/code/session_01X6hsUd3ppWfYLHWh2YXFmu