### PR TITLE
Fix max_tokens exceeding Sonnet 4.5 limit

### DIFF
--- a/.claude/sessions/2026-02-13_automate-conflict-resolution-U6ars.md
+++ b/.claude/sessions/2026-02-13_automate-conflict-resolution-U6ars.md
@@ -14,3 +14,4 @@
 - The two workflows complement each other: auto-rebase handles ~90% of cases, conflict resolver handles the rest
 - Per-session files completely eliminate the #1 merge conflict source (every session prepending to the same file)
 - Must delete the old `.claude/session-log.md` file when migrating — leaving it behind causes the very conflicts the migration was designed to prevent
+- `claude-sonnet-4-5-20250929` has a max output token limit of 64000, not 65536 — using 65536 causes a 400 error

--- a/.github/scripts/resolve-conflicts.mjs
+++ b/.github/scripts/resolve-conflicts.mjs
@@ -163,7 +163,7 @@ async function resolveFile(filePath) {
 
   const result = await callAPIWithRetry({
     model: "claude-sonnet-4-5-20250929",
-    max_tokens: 65536,
+    max_tokens: 64000,
     system: SYSTEM_PROMPT,
     messages: [
       {


### PR DESCRIPTION
## Summary
- The conflict resolver script (`resolve-conflicts.mjs`) was setting `max_tokens: 65536`, but `claude-sonnet-4-5-20250929` only allows a maximum of 64000 output tokens
- This caused all conflict resolution attempts to fail with a 400 error, as seen in [this CI run](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/22001533049/job/63575148270)
- Fixed by changing `max_tokens` from 65536 to 64000

## Test plan
- [ ] Verify the resolve-conflicts workflow succeeds on the next PR with merge conflicts

https://claude.ai/code/session_014fT4BkYvavZXCv4GLhdGuB