### PR TITLE
Fix 502 errors on large files with hunk-by-hunk conflict resolution

### DIFF
--- a/.claude/sessions/2026-02-13_automate-conflict-resolution-U6ars.md
+++ b/.claude/sessions/2026-02-13_automate-conflict-resolution-U6ars.md
@@ -15,3 +15,6 @@
 - Per-session files completely eliminate the #1 merge conflict source (every session prepending to the same file)
 - Must delete the old `.claude/session-log.md` file when migrating — leaving it behind causes the very conflicts the migration was designed to prevent
 - `claude-sonnet-4-5-20250929` has a max output token limit of 64000, not 65536 — using 65536 causes a 400 error
+- Large YAML data files (69K-119K chars) cause 502 API gateway timeouts when sent whole — resolved by adding hunk-by-hunk conflict resolution that extracts individual conflict blocks with surrounding context
+- Network-level errors ("fetch failed") need explicit try/catch in the retry loop — they bypass the HTTP status code handling
+- Retry backoff of 2s/4s/8s is too aggressive for large API requests — increased to 4s/8s/16s/32s/60s with 5 attempts

--- a/.github/scripts/resolve-conflicts.mjs
+++ b/.github/scripts/resolve-conflicts.mjs
@@ -7,6 +7,11 @@
  * Attempts `git merge main`, reads conflict markers, sends each file to Claude
  * for resolution, then commits and pushes the result.
  *
+ * For small files (<32K chars): sends the entire file to Claude.
+ * For large files (>=32K chars): extracts individual conflict hunks with
+ * surrounding context and resolves each one separately. This avoids API
+ * timeouts (502 errors) on large YAML data files.
+ *
  * Environment variables:
  *   ANTHROPIC_API_KEY — required
  *   PR_BRANCH        — the branch to resolve conflicts on
@@ -39,6 +44,8 @@ if (!/^[a-zA-Z0-9._\/-]+$/.test(PR_BRANCH)) {
 }
 
 const MAX_CONFLICTED_FILES = 20;
+const LARGE_FILE_THRESHOLD = 32_000; // chars — files above this use hunk-by-hunk resolution
+const CONTEXT_LINES = 20; // lines of context around each conflict hunk
 
 // ── Shell-free git helpers ─────────────────────────────────────────────
 
@@ -112,36 +119,188 @@ Rules:
 
 Think carefully about the semantic intent of both sides before resolving.`;
 
-async function callAPIWithRetry(body, retries = 3) {
+const HUNK_SYSTEM_PROMPT = `You are a merge conflict resolver for a wiki repository.
+
+You will receive a SECTION of a larger file. The section contains a Git merge conflict (<<<<<<< HEAD, =======, >>>>>>> origin/main) surrounded by context lines for reference.
+
+Rules:
+1. KEEP BOTH SIDES' changes whenever possible.
+2. For YAML data: merge entries from both sides. If the same key was modified differently, prefer HEAD's version but include any new entries from the other side.
+3. For MDX content: preserve all content from both sides.
+4. NEVER leave conflict markers (<<<<<<, =======, >>>>>>>) in the output.
+5. Output the ENTIRE section (including the unchanged context lines before and after) with the conflict resolved.
+6. Do NOT add any explanations, commentary, or markdown code fences.
+7. Preserve indentation and formatting exactly.
+
+Output the complete resolved section — context lines unchanged, conflict region merged.`;
+
+// ── API call with robust retry ─────────────────────────────────────────
+
+async function callAPIWithRetry(body, retries = 5) {
   for (let attempt = 1; attempt <= retries; attempt++) {
-    const response = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify(body),
-    });
+    try {
+      const response = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": ANTHROPIC_API_KEY,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(300_000), // 5 minute timeout per request
+      });
 
-    if (response.ok) {
-      return { ok: true, data: await response.json() };
+      if (response.ok) {
+        return { ok: true, data: await response.json() };
+      }
+
+      const status = response.status;
+      const errText = await response.text();
+
+      // Retry on transient errors (429 rate limit, 5xx server errors)
+      if ((status === 429 || status >= 500) && attempt < retries) {
+        const delay = Math.min(Math.pow(2, attempt + 1) * 1000, 60_000); // 4s, 8s, 16s, 32s, 60s
+        console.error(`  API ${status} (attempt ${attempt}/${retries}) — retrying in ${delay / 1000}s...`);
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+
+      return { ok: false, status, error: errText };
+    } catch (fetchErr) {
+      // Handle network errors (DNS failures, connection resets, timeouts, "fetch failed")
+      if (attempt < retries) {
+        const delay = Math.min(Math.pow(2, attempt + 1) * 1000, 60_000);
+        console.error(
+          `  Network error (attempt ${attempt}/${retries}): ${fetchErr.message} — retrying in ${delay / 1000}s...`
+        );
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      return { ok: false, status: 0, error: `Network error: ${fetchErr.message}` };
     }
-
-    const status = response.status;
-    const errText = await response.text();
-
-    // Retry on transient errors (429 rate limit, 5xx server errors)
-    if ((status === 429 || status >= 500) && attempt < retries) {
-      const delay = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
-      console.error(`  API ${status} (attempt ${attempt}/${retries}) — retrying in ${delay / 1000}s...`);
-      await new Promise((r) => setTimeout(r, delay));
-      continue;
-    }
-
-    return { ok: false, status, error: errText };
   }
 }
+
+// ── Hunk-based resolution for large files ──────────────────────────────
+
+/**
+ * Find all conflict blocks (<<<<<<< to >>>>>>>) in the file.
+ * Returns array of { start, end } line indices (inclusive).
+ */
+function findConflictBlocks(lines) {
+  const blocks = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    if (lines[i].startsWith("<<<<<<<")) {
+      const startLine = i;
+      let endLine = i + 1;
+      while (endLine < lines.length && !lines[endLine].startsWith(">>>>>>>")) {
+        endLine++;
+      }
+      if (endLine < lines.length) {
+        blocks.push({ start: startLine, end: endLine });
+      }
+      i = endLine + 1;
+    } else {
+      i++;
+    }
+  }
+
+  return blocks;
+}
+
+/**
+ * Merge nearby conflict blocks so their context windows don't overlap.
+ * If two blocks are within 2*CONTEXT_LINES of each other, treat them
+ * as a single hunk to avoid sending partial/overlapping context.
+ */
+function mergeNearbyBlocks(blocks) {
+  if (blocks.length <= 1) return blocks;
+
+  const merged = [{ ...blocks[0] }];
+  for (let i = 1; i < blocks.length; i++) {
+    const prev = merged[merged.length - 1];
+    if (blocks[i].start - prev.end <= CONTEXT_LINES * 2) {
+      // Merge into previous block
+      prev.end = blocks[i].end;
+    } else {
+      merged.push({ ...blocks[i] });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Resolve a large file by extracting individual conflict hunks,
+ * resolving each one separately via Claude, and reassembling.
+ */
+async function resolveLargeFile(filePath, content) {
+  const lines = content.split("\n");
+  let blocks = findConflictBlocks(lines);
+
+  if (blocks.length === 0) return content;
+
+  blocks = mergeNearbyBlocks(blocks);
+  console.log(`  Large file mode: ${blocks.length} conflict hunk(s), resolving individually`);
+
+  // Work backwards so line indices stay valid after each replacement
+  for (let b = blocks.length - 1; b >= 0; b--) {
+    const block = blocks[b];
+    const ctxStart = Math.max(0, block.start - CONTEXT_LINES);
+    const ctxEnd = Math.min(lines.length - 1, block.end + CONTEXT_LINES);
+
+    const hunkLines = lines.slice(ctxStart, ctxEnd + 1);
+    const hunkContent = hunkLines.join("\n");
+
+    console.log(
+      `  Hunk ${blocks.length - b}/${blocks.length}: lines ${block.start + 1}-${block.end + 1} (${hunkContent.length} chars with context)`
+    );
+
+    const result = await callAPIWithRetry({
+      model: "claude-sonnet-4-5-20250929",
+      max_tokens: 16_000,
+      system: HUNK_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Resolve the merge conflict in this section of ${filePath} (lines ${ctxStart + 1}-${ctxEnd + 1}):\n\n${hunkContent}`,
+        },
+      ],
+    });
+
+    if (!result.ok) {
+      console.error(`  API error for hunk in ${filePath}: ${result.status} ${result.error}`);
+      return null;
+    }
+
+    const data = result.data;
+    const resolvedHunk = data.content?.[0]?.text;
+
+    if (!resolvedHunk) {
+      console.error(`  Empty response for hunk in ${filePath}`);
+      return null;
+    }
+
+    if (data.stop_reason === "max_tokens") {
+      console.error(`  Hunk resolution truncated for ${filePath} — skipping file.`);
+      return null;
+    }
+
+    if (resolvedHunk.includes("<<<<<<<") || resolvedHunk.includes(">>>>>>>")) {
+      console.error(`  Conflict markers remain in resolved hunk for ${filePath}`);
+      return null;
+    }
+
+    // Replace the hunk section (context + conflict) with resolved content
+    const resolvedHunkLines = resolvedHunk.split("\n");
+    lines.splice(ctxStart, ctxEnd - ctxStart + 1, ...resolvedHunkLines);
+  }
+
+  return lines.join("\n");
+}
+
+// ── File resolution ────────────────────────────────────────────────────
 
 async function resolveFile(filePath) {
   const content = readFileSync(filePath, "utf-8");
@@ -161,34 +320,46 @@ async function resolveFile(filePath) {
 
   console.log(`  Resolving: ${filePath} (${content.length} chars)`);
 
-  const result = await callAPIWithRetry({
-    model: "claude-sonnet-4-5-20250929",
-    max_tokens: 64000,
-    system: SYSTEM_PROMPT,
-    messages: [
-      {
-        role: "user",
-        content: `Resolve the merge conflicts in this file (${filePath}):\n\n${content}`,
-      },
-    ],
-  });
+  let resolvedContent;
 
-  if (!result.ok) {
-    console.error(`  API error for ${filePath}: ${result.status} ${result.error}`);
-    return false;
+  if (content.length > LARGE_FILE_THRESHOLD) {
+    // Large file — resolve conflict hunks individually to avoid API timeouts
+    resolvedContent = await resolveLargeFile(filePath, content);
+  } else {
+    // Small file — send the whole thing
+    const result = await callAPIWithRetry({
+      model: "claude-sonnet-4-5-20250929",
+      max_tokens: 64_000,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Resolve the merge conflicts in this file (${filePath}):\n\n${content}`,
+        },
+      ],
+    });
+
+    if (!result.ok) {
+      console.error(`  API error for ${filePath}: ${result.status} ${result.error}`);
+      return false;
+    }
+
+    const data = result.data;
+    resolvedContent = data.content?.[0]?.text;
+
+    if (!resolvedContent) {
+      console.error(`  Empty response for ${filePath}`);
+      return false;
+    }
+
+    // Check for truncation — if the model hit the token limit, the file is incomplete
+    if (data.stop_reason === "max_tokens") {
+      console.error(`  Response was truncated for ${filePath} (hit max_tokens) — skipping.`);
+      return false;
+    }
   }
 
-  const data = result.data;
-  const resolvedContent = data.content?.[0]?.text;
-
-  if (!resolvedContent) {
-    console.error(`  Empty response for ${filePath}`);
-    return false;
-  }
-
-  // Check for truncation — if the model hit the token limit, the file is incomplete
-  if (data.stop_reason === "max_tokens") {
-    console.error(`  Response was truncated for ${filePath} (hit max_tokens) — skipping.`);
+  if (resolvedContent === null) {
     return false;
   }
 


### PR DESCRIPTION
Large YAML data files (69K-119K chars like organizations.yaml, responses.yaml, risks.yaml) were causing API 502 gateway timeouts when sent as a whole to Claude.

Changes:
- Add hunk-by-hunk resolution for files >32K chars: extracts individual conflict blocks with 20 lines of context, resolves each separately, then reassembles the file
- Merge nearby conflict blocks to avoid overlapping context windows
- Increase retry attempts from 3 to 5 with longer backoff (4s-60s)
- Add 5-minute fetch timeout via AbortSignal.timeout()
- Add try/catch for network errors ("fetch failed", DNS failures, connection resets) which were bypassing the HTTP retry logic
- Add dedicated HUNK_SYSTEM_PROMPT optimized for section-level resolution

https://claude.ai/code/session_014fT4BkYvavZXCv4GLhdGuB