### PR TITLE
Add comprehensive Claude Code workshop guide

### DIFF
--- a/.claude/sessions/2026-02-15_update-workshop-links-8QX5Z.md
+++ b/.claude/sessions/2026-02-15_update-workshop-links-8QX5Z.md
@@ -1,0 +1,13 @@
+## 2026-02-15 | claude/update-workshop-links-8QX5Z | Update workshop page instructions
+
+**What was done:** Researched the workshop page at cairn-meta.vercel.app/workshop/ (source in quantified-uncertainty/cairn repo at apps/meta/src/content/docs/workshop.mdx) and produced detailed edit instructions for updating it. Changes include: fixing deprecated ea-crux-project.vercel.app URLs to longtermwiki.com, adding links to relevant wiki pages (E681, E384, E238), adding an Obsidian/Notion/NotebookLM non-code alternatives section, updating Claude Code description to include claude.ai/code web interface and app Code feature, updating page counts from ~500 to ~640, and reframing past events.
+
+**Pages:** (no longterm-wiki pages edited — changes target cairn repo workshop.mdx)
+
+**Issues encountered:**
+- The workshop.mdx file lives in the cairn repo (quantified-uncertainty/cairn), not the longterm-wiki repo. The git proxy only allows access to longterm-wiki, so direct edits to the cairn repo weren't possible.
+- The updated workshop.mdx was saved as workshop-updated.mdx in the longterm-wiki repo root as a reference artifact, with detailed instructions provided for applying changes.
+
+**Learnings/notes:**
+- ea-crux-project.vercel.app redirects to a deprecated version of the wiki. Current URL is www.longtermwiki.com (~640 pages).
+- The cairn repo is the original monorepo; longterm-wiki was split out in Feb 2025.

--- a/workshop-updated.mdx
+++ b/workshop-updated.mdx
@@ -1,0 +1,792 @@
+---
+title: "Workshop: Building Research Websites with Claude Code"
+description: A hands-on workshop on using Claude Code to build research mini-textbooks, wikis, and structured knowledge bases
+---
+
+import { Aside, Steps, Tabs, TabItem, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Claude Code can automate substantial portions of research documentation — generating mini-textbooks, interactive wikis, and structured knowledge bases from your research questions. This workshop teaches you how.
+
+<Aside type="note" title="Collaborative Doc">
+**[Open the shared workshop document](https://docs.google.com/document/d/1nwqUdjeqkcI8SaDaLK9k6bivMvh9qKFpz7tJHNMy3_c/edit?usp=sharing)** — for questions, sharing your site, getting help, and coordinating during the event.
+</Aside>
+
+<Aside type="caution" title="Before the Workshop — Do This Now">
+Install these **before** arriving so we can dive straight into building:
+1. **Node.js 18+** — [nodejs.org](https://nodejs.org/) (LTS version)
+2. **Claude Code** — `npm install -g @anthropic-ai/claude-code`, then run `claude` once to authenticate ([cost info below](#installing-claude-code))
+3. **A terminal** you're comfortable with (iTerm2, VS Code, Windows Terminal, etc.)
+
+Basic familiarity with Claude Code and the command line will be very useful.
+</Aside>
+
+---
+
+## About This Workshop
+
+**Organized by** the [Quantified Uncertainty Research Institute (QURI)](https://quantifieduncertainty.org/).
+
+**Format:**
+1. **Opening presentation** — How Claude Code builds research websites, key techniques, and what makes topics well-suited for this approach
+2. **Hands-on session** — Begin your own research mini-website with guidance
+3. **Closing presentation** — Share progress, discuss challenges, next steps
+
+**Slides:** [Google Slides](https://docs.google.com/presentation/d/1Q2oisP95LRLs0mGwWIStrhhPDRMpxxrNPpvbzE59yBQ/edit?usp=sharing)
+
+<details>
+<summary>**Past events**</summary>
+
+- **January 2026** — MOXSF (full workshop, 1.5 hours)
+- **February 2026** — EAG SF (shorter version)
+
+This page serves as a standalone guide — you can follow it on your own anytime.
+
+</details>
+
+---
+
+## What We're Building
+
+You'll start building a **research mini-website** — a structured knowledge base, mini-textbook, or wiki on a topic in prioritization research, EA cause areas, or related domains. Building a finished website would take longer, but this should be enough for a decent start.
+
+The workflow:
+
+1. **You** decide the research topic, structure, and editorial direction
+2. **Claude Code** does the heavy lifting — scaffolding, writing drafts, creating pages, fixing build errors
+3. **You** review, edit, and iterate
+
+### What is Claude Code?
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is an agentic coding tool from Anthropic that lets you use Claude AI directly on your codebase. It can read, write, and edit files in your project, run commands, and search the web — all through a conversational interface. You type instructions, Claude executes them.
+
+Claude Code is available in several forms:
+- **Terminal CLI** — `claude` in your terminal (what this workshop focuses on). Install via npm or Homebrew.
+- **Web interface** — [claude.ai/code](https://claude.ai/code) lets you use Claude Code directly in the browser with no local setup. Great for trying it out or working from any device.
+- **Claude desktop/mobile app** — The Claude app now includes a built-in Code feature for working with projects.
+- **IDE extensions** — Available for VS Code and JetBrains IDEs.
+
+Think of it as pair programming with an AI that can actually touch your files.
+
+### Demo Projects
+
+These were all built primarily with Claude Code:
+
+| Project | Description | Scale |
+|---------|-------------|-------|
+| [Longterm Wiki](https://www.longtermwiki.com/) | Comprehensive AI safety knowledge base — risks, interventions, organizations, key uncertainties, expert disagreement tracking | ~640 pages, YAML data layer, custom components |
+| [Delegation Risk](https://delegation-risk-framework.vercel.app/) | Structured mini-textbook with theory, case studies, and interactive tools | ~100 pages |
+
+The Longterm Wiki source is at [github.com/quantified-uncertainty/longterm-wiki](https://github.com/quantified-uncertainty/longterm-wiki). The original monorepo (including Delegation Risk) is at [github.com/quantified-uncertainty/cairn](https://github.com/quantified-uncertainty/cairn). The Longterm Wiki took months of iterative work, but the basic structure was scaffolded in a single session.
+
+<Aside type="tip" title="Relevant Longterm Wiki pages">
+The Longterm Wiki itself has pages relevant to this workshop's topic:
+- **[AI-Assisted Knowledge Management](https://www.longtermwiki.com/wiki/E681)** — Comprehensive overview of tools and platforms for AI-assisted knowledge creation, including cost comparisons and hallucination risks
+- **[Longterm Wiki](https://www.longtermwiki.com/wiki/E384)** — How this wiki was built with Claude Code, including its architecture and content pipeline
+- **[QURI](https://www.longtermwiki.com/wiki/E238)** — The organization behind this workshop and the Longterm Wiki
+</Aside>
+
+### Rough Time Budget (Hands-on Session)
+
+| Phase | Time | What You're Doing |
+|-------|------|-------------------|
+| Setup & scaffold | ~10 min | Create project, start dev server, open Claude Code |
+| Initial structure | ~10 min | Create page structure with one big prompt |
+| Content creation | ~35 min | Expand pages, iterate on content, add detail |
+| Polish & extras | ~10 min | Cross-references, fix issues, customize appearance |
+| Wrap-up | ~5 min | Git commit, discuss deployment options |
+
+---
+
+## Installing Claude Code
+
+<Tabs>
+  <TabItem label="npm (recommended)">
+    ```bash
+    npm install -g @anthropic-ai/claude-code
+    ```
+  </TabItem>
+  <TabItem label="Homebrew (macOS)">
+    ```bash
+    brew install claude-code
+    ```
+  </TabItem>
+</Tabs>
+
+After installing, run `claude` in your terminal to start. You'll be prompted to authenticate with your Anthropic account.
+
+<Aside type="caution" title="Cost — Read Before the Workshop">
+**Recommended: Use a Claude subscription.** Claude **Pro** (\$20/mo) or **Max** (\$100/mo or \$200/mo) subscriptions include Claude Code usage — no surprise bills. This is the easiest option for the workshop.
+
+**If using the API instead:** You can sign up for an Anthropic API account at [console.anthropic.com](https://console.anthropic.com/). Before the workshop, **set a spending limit** — go to Settings → Limits and set a hard limit (e.g., \$20). A typical 90-minute workshop session involves 15-30 substantial Claude interactions and costs roughly **\$5-15 on the API**. Pro subscription users should be fine but may hit rate limits if making very rapid requests.
+</Aside>
+
+### Key Resources
+
+- **Claude Code on the web**: [claude.ai/code](https://claude.ai/code) — use Claude Code in the browser with no local install
+- **Official docs**: [docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- **GitHub repo**: [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code)
+- **VS Code extension**: Search "Claude Code" in the VS Code marketplace
+- **JetBrains plugin**: Available in the JetBrains Marketplace
+- **Best practices**: [docs.anthropic.com/en/docs/claude-code/best-practices](https://docs.anthropic.com/en/docs/claude-code/best-practices)
+
+---
+
+## Terminal Setup: The Multi-Window Workflow
+
+The most important workflow pattern: run **multiple terminal windows simultaneously**.
+
+### The Three-Window Setup
+
+| Window | Purpose | What's Running |
+|--------|---------|----------------|
+| **Window 1** (large) | Claude Code | `claude` — your main LLM interaction |
+| **Window 2** | Dev server | `npm run dev` — live preview of your site |
+| **Window 3** | General terminal | Git commands, file browsing, manual edits |
+
+Plus keep your **browser open** to `http://localhost:4321` — it auto-refreshes as Claude makes changes.
+
+### Setting Up Split Panes
+
+<Tabs>
+  <TabItem label="iTerm2 (macOS)">
+    - **Cmd+D** — Split pane vertically
+    - **Cmd+Shift+D** — Split pane horizontally
+    - **Cmd+\[** / **Cmd+\]** — Switch between panes
+
+    Recommended: Claude Code in a tall left pane, dev server top-right, general terminal bottom-right.
+  </TabItem>
+  <TabItem label="VS Code">
+    Use the built-in terminal with split (**Cmd+\\** in terminal panel). Or use the Claude Code VS Code extension — Claude in the sidebar, terminals below.
+  </TabItem>
+  <TabItem label="Windows Terminal">
+    - **Alt+Shift+D** — Duplicate pane
+    - **Alt+Shift+Plus** — Split vertically
+    - **Alt+Shift+Minus** — Split horizontally
+    - **Alt+Arrow** — Switch panes
+  </TabItem>
+</Tabs>
+
+### Why This Matters
+
+- **Watch your site rebuild in real-time** as Claude makes changes
+- **Alt-tab to the browser** to see what Claude built, then go back to give feedback
+- **Run git commits** without interrupting Claude's flow
+
+---
+
+## Choosing a Framework
+
+### Comparison
+
+| Framework | Best For | Scaffold Command |
+|-----------|----------|-----------------|
+| **[Astro + Starlight](https://starlight.astro.build/)** | Wikis, research docs (our pick) | `npm create astro@latest -- --template starlight` |
+| **[Docusaurus](https://docusaurus.io/)** | Docs, blogs (Meta) | `npx create-docusaurus@latest my-wiki classic` |
+| **[VitePress](https://vitepress.dev/)** | Vue-based docs | `npx vitepress init` |
+| **[MkDocs Material](https://squidfunk.github.io/mkdocs-material/)** | Python-based docs | `pip install mkdocs-material && mkdocs new .` |
+
+### Why We Use Astro + Starlight
+
+- **Markdown/MDX native** — Write in Markdown, add React components when needed
+- **Great defaults** — Search, sidebar, dark mode, mobile-responsive out of the box
+- **Fast** — Static output, minimal client-side JS
+- **LLM-friendly** — MDX is the format Claude works best with
+- **Auto-sidebar** — Can auto-generate sidebar from folder structure (less config to manage)
+
+This workshop assumes Starlight, but the Claude Code workflow is the same for any framework.
+
+### Non-Code Alternatives
+
+Not everyone wants to build a website from scratch. If you prefer a tool with a visual editor, these options support AI-assisted knowledge management without touching code:
+
+| Tool | Strengths | Limitations | AI Features |
+|------|-----------|-------------|-------------|
+| **[Obsidian](https://obsidian.md/)** | Local-first, Markdown, graph view, huge plugin ecosystem | No built-in web publishing (use [Quartz](https://quartz.jzhao.xyz/) or [Obsidian Publish](https://obsidian.md/publish)) | Community AI plugins (Smart Connections, Copilot) for semantic search and chat over notes |
+| **[Notion](https://www.notion.so/)** | Polished UI, real-time collaboration, databases | Proprietary format, limited export | [Notion AI](https://www.notion.so/product/ai) built-in for writing, summarizing, and Q&A over your workspace |
+| **[Google NotebookLM](https://notebooklm.google.com/)** | Source-grounded answers, audio overviews | Not a wiki (analysis tool), limited export, no custom structure | Core product is AI — generates summaries, answers questions grounded in your uploaded sources |
+
+**When to use these instead of a code-based wiki:**
+- You want something fast and don't care about custom components or deployment
+- You're working collaboratively with non-technical people
+- Your goal is personal knowledge organization rather than a public research resource
+
+**When to use Starlight / code approach:**
+- You want full control over structure, styling, and components
+- You're building a public resource with dozens to hundreds of pages
+- You want version control (git), automated validation, or a data layer
+- You plan to use Claude Code extensively for content generation
+
+For more on this landscape, see the Longterm Wiki's page on [AI-Assisted Knowledge Management](https://www.longtermwiki.com/wiki/E681), which covers these tools and others in detail.
+
+---
+
+## Workshop Walkthrough
+
+<Steps>
+
+1. **Pick your research topic**
+
+   Choose a topic in **prioritization research, EA cause areas, or related domains** that you know something about. For the hands-on session, aim for **3-5 sections with 2-4 pages each** (10-20 pages total).
+
+   Good scope examples:
+   - "Key uncertainties in AI governance" (Policy Approaches, Technical Standards, International Coordination, Key Debates)
+   - "Guide to biosecurity funding landscape" (Major Funders, Funding Gaps, Grant Mechanisms, Emerging Priorities)
+   - "S-risk research overview" (Definitions & Scope, Key Scenarios, Interventions, Open Questions)
+   - "Forecasting methods for cause prioritization" (Base Rates, Expert Elicitation, Prediction Markets, Model Comparison)
+   - "Animal welfare intervention cost-effectiveness" (Factory Farming, Wild Animal Welfare, Measurement Challenges, Key Organizations)
+
+   **Too broad**: "Everything about existential risk"
+   **Too narrow**: "One specific Metaculus question" (one page, not a wiki)
+
+   <Aside type="tip" title="What makes a topic well-suited?">
+   The best topics for this format share a few traits:
+
+   - **Natural decomposition** — The topic breaks cleanly into sections and sub-pages. If you can sketch 3-5 groups of 2-4 related subtopics, you have a good fit.
+   - **Existing literature to synthesize** — Claude draws on published material. Topics with substantial writing (blog posts, papers, reports) produce much better output than cutting-edge unpublished research.
+   - **Value from organization, not original analysis** — This format excels at structuring and connecting existing knowledge. If the value comes from novel calculations or original arguments, Claude will be unreliable.
+   - **You can verify the output** — Pick a topic you know well enough to catch errors. Claude will hallucinate facts, invent citations, and present contested claims as consensus. Your domain knowledge is the quality filter.
+
+   **Topics to avoid:** Anything requiring precise quantitative calculations (use a spreadsheet), topics where most sources are behind paywalls (Claude can't access them), and topics where you'd be generating novel research claims rather than synthesizing existing ones.
+   </Aside>
+
+2. **Scaffold the project**
+
+   Pick either option — both work fine for the workshop.
+
+   <Tabs>
+     <TabItem label="Vanilla Starlight">
+       A plain Starlight project. Simple and clean:
+
+       ```bash
+       npm create astro@latest -- --template starlight my-wiki
+       ```
+
+       The wizard will ask a few questions — pick:
+       - **Install dependencies?** → Yes
+       - **Initialize a new git repository?** → Yes
+       - **TypeScript?** → Strictest
+
+       Then: `cd my-wiki`
+     </TabItem>
+     <TabItem label="QURI Starter">
+       Our pre-configured starter includes Mermaid diagrams, math rendering (KaTeX), React components, Tailwind CSS, and a CLAUDE.md. Useful if you know you'll want these features:
+
+       ```bash
+       npx degit quantified-uncertainty/cairn/starters/research-wiki my-wiki
+       cd my-wiki
+       npm install
+       ```
+
+       This also includes example pages showing each feature in action — you'll delete these when you create your own content.
+     </TabItem>
+   </Tabs>
+
+   **Checkpoint:** You should have a `my-wiki/` folder with `src/content/docs/`, `astro.config.mjs`, and `package.json`.
+
+3. **Start the dev server** (in Window 2)
+
+   ```bash
+   npm run dev
+   ```
+   Open `http://localhost:4321` in your browser. If you used our starter, you should see "My Research Wiki" with a splash page. If you used vanilla Starlight, you should see "Welcome to Starlight."
+
+   **Checkpoint:** Browser shows a working docs site.
+
+4. **Start Claude Code** (in Window 1)
+
+   ```bash
+   claude
+   ```
+
+   <Aside type="tip" title="Handling Permissions">
+   Claude Code asks permission before editing files, reading directories, and running commands. You have options:
+
+   - **Approve individually** — Click "Allow" each time (safest, but slow)
+   - **Allow for the session** — Choose "Allow always" when prompted for common operations like file edits
+   - **Skip all permissions** — Start with `claude --dangerously-skip-permissions` to auto-approve everything. Only use this for throwaway workshop projects — it allows Claude to run arbitrary shell commands.
+
+   For the workshop, we recommend "Allow always" for file edits, or `--dangerously-skip-permissions` if you want maximum speed.
+   </Aside>
+
+5. **Create your entire page structure in one prompt**
+
+   This is the magic moment. Give Claude a detailed prompt and watch it create your whole wiki skeleton. Use **Shift+Enter** for multi-line input, then **Enter** to submit.
+
+   Here's a **fully worked-out example** you can adapt — this is what a real prompt looks like:
+
+   <Tabs>
+     <TabItem label="Full Example (AI Governance)">
+       ```
+       I'm building a research wiki about key uncertainties in
+       AI governance. Create the following structure:
+
+       Sections:
+       1. Policy Approaches — pages: compute-governance,
+          licensing-regimes, liability-frameworks,
+          international-treaties
+       2. Technical Standards — pages: model-evaluations,
+          safety-benchmarks, deployment-standards,
+          red-teaming-requirements
+       3. International Coordination — pages:
+          us-china-dynamics, eu-ai-act, global-governance-gaps,
+          multilateral-proposals
+       4. Key Debates — pages: open-vs-closed-source,
+          pace-of-regulation, voluntary-vs-mandatory,
+          frontier-vs-broad-regulation
+
+       For each page:
+       - Create an MDX file in src/content/docs/ with
+         appropriate subdirectories
+       - Include frontmatter with title and description
+       - Write a 2-3 paragraph introduction covering the
+         current state of debate
+       - Add 3-4 section headers outlining what the page
+         will cover (e.g., Background, Key Arguments,
+         Open Questions, Further Reading)
+       - Include at least one Markdown table where relevant
+         (e.g., comparing policy proposals, listing key
+         actors, summarizing positions)
+
+       Also:
+       - Remove the default/example pages that came with
+         the template (e.g., the example/ directory)
+       - Update astro.config.mjs to use autogenerate for
+         each section directory, like:
+         { label: 'Policy Approaches',
+           autogenerate: { directory: 'policy-approaches' } }
+       - Update the site title to
+         "AI Governance: Key Uncertainties"
+       - Use .mdx extension for all files.
+       ```
+     </TabItem>
+     <TabItem label="Template: Research Wiki">
+       ```
+       I'm building a research wiki about [TOPIC]. Create
+       the following structure:
+
+       Sections:
+       1. [Section 1] — pages: [page-a], [page-b], [page-c]
+       2. [Section 2] — pages: [page-d], [page-e]
+       3. [Section 3] — pages: [page-f], [page-g], [page-h]
+       4. [Section 4] — pages: [page-i], [page-j]
+
+       For each page:
+       - Create an MDX file in src/content/docs/ with
+         appropriate subdirectories
+       - Include frontmatter with title and description
+       - Write a 2-3 paragraph introduction
+       - Add section headers for what the page will cover
+       - Include at least one Markdown table where relevant
+
+       Also:
+       - Remove the default/example pages that came with
+         the template
+       - Update astro.config.mjs to use autogenerate for
+         each section directory
+       - Update the site title to "[YOUR WIKI NAME]"
+       - Use .mdx extension for all files.
+       ```
+     </TabItem>
+     <TabItem label="Template: Mini-Textbook">
+       ```
+       I'm building a mini-textbook about [TOPIC]. Create
+       the following chapter structure:
+
+       Chapters:
+       1. [Chapter 1 Title] — 3 pages covering [subtopics]
+       2. [Chapter 2 Title] — 3 pages covering [subtopics]
+       3. [Chapter 3 Title] — 2 pages covering [subtopics]
+       4. [Chapter 4 Title] — 2 pages covering [subtopics]
+
+       Each chapter should have an index.mdx overview page
+       plus individual topic pages. Write in a clear,
+       analytical tone aimed at researchers and policy
+       professionals.
+
+       For each page, include:
+       - A clear introduction explaining why this matters
+       - Key concepts with explanations and evidence
+       - At least one concrete example or case study
+       - A "Key Takeaways" section at the end
+       - An "Open Questions" section where relevant
+
+       Also:
+       - Remove the default/example pages that came with
+         the template
+       - Update astro.config.mjs to use autogenerate for
+         each chapter directory
+       - Update the site title to "[YOUR TEXTBOOK NAME]"
+       - Use .mdx extension for all files.
+       ```
+     </TabItem>
+   </Tabs>
+
+   **Checkpoint:** After Claude finishes (~2-5 minutes), your browser should show your wiki with all sections in the sidebar and stub pages with introductions.
+
+6. **Check the browser and start expanding**
+
+   Look at your site. Pick a page that interests you and start filling it in:
+
+   ```
+   Expand the page at src/content/docs/policy-approaches/compute-governance.mdx
+   with detailed content. Include the key proposals (chip export controls, compute
+   thresholds, KYC for cloud), a table comparing approaches by feasibility and
+   effectiveness, and a section on open questions.
+   ```
+
+   Or improve based on what you see:
+
+   ```
+   The intro on the licensing-regimes page is too vague. Add specific examples
+   of existing licensing proposals (EU AI Act tiers, proposed US frameworks),
+   a comparison table, and the key arguments for and against.
+   ```
+
+   <Aside type="tip" title="Claude can search the web">
+   Claude Code can search the web for current information. This is especially valuable for research content:
+
+   - "Research the latest developments in [policy area] and update this page with current information"
+   - "Search for recent papers on [topic] and add a literature summary to this page"
+   - "Find the latest funding figures for [organization/cause area] and include them"
+   </Aside>
+
+   **Iterate in layers — this is where quality comes from.** Your first prompt produces a scaffold; the next 2-3 prompts are what make it actually good. Here's what a real iteration sequence looks like on a single page:
+
+   | Turn | You say | What improves |
+   |------|---------|---------------|
+   | 1 | "Create a page about compute governance" | You get a generic overview with placeholder-ish content |
+   | 2 | "Too surface-level. Add the specific proposals: chip export controls (Oct 2022 BIS rules), compute thresholds (10^25 FLOP), KYC for cloud. Include a table comparing them by feasibility and effectiveness." | Real substance — specific proposals, structured comparison |
+   | 3 | "The Open Questions section is weak. Add: (1) Does compute governance become less relevant as algorithmic efficiency improves? (2) How do you enforce thresholds when distillation makes smaller models more capable?" | Analytical depth — the kind of questions researchers actually care about |
+   | 4 | "Add cross-references to the licensing-regimes and international-coordination pages." | Connected knowledge base, not isolated pages |
+
+   Each turn takes 1-2 minutes. Four turns gets you from generic to genuinely useful. **The most common workshop mistake is creating 15 shallow pages instead of making 5 pages good.**
+
+7. **If you're stuck: try these prompts**
+
+   During the content phase, if you're not sure what to do next:
+
+   | What You Want | Prompt |
+   |---------------|--------|
+   | Deepen a page | "Expand [page] with specific evidence, key arguments from the literature, and quantitative estimates where available" |
+   | Add structure | "Add a comparison table to [page] covering the major positions/proposals/interventions" |
+   | Connect pages | "Add cross-references between related pages — link from each page to relevant others" |
+   | Sharpen analysis | "Rewrite the intro of [page] to be more analytically precise. State the key cruxes upfront." |
+   | Add a diagram | "Add a Mermaid diagram to [page] showing the causal chain from [intervention] to [outcome]" |
+   | Create a new page | "Create a new page at src/content/docs/[section]/[name].mdx about [topic]" |
+   | Fix something broken | "The dev server is showing an error. Read the terminal output and fix whatever is wrong." |
+   | Research and write | "Search the web for [topic], then update [page] with current information and citations" |
+   | Add a literature review | "Add a 'Key Papers' section to [page] summarizing the 3-5 most important papers on this topic" |
+   | Create an overview | "Create an index page at src/content/docs/index.mdx that summarizes the research area and links to all sections" |
+
+8. **Customize the appearance** (~2 minutes, very satisfying)
+
+   Ask Claude:
+   ```
+   Customize this site: change the title to "[Your Research Topic]",
+   add a tagline "[your tagline]", and change the accent color
+   to [blue/green/purple/orange]. Also update the hero section
+   on the landing page.
+   ```
+
+   Starlight supports [theme customization](https://starlight.astro.build/guides/css-and-tailwind/) including colors, fonts, and custom CSS.
+
+9. **Save your progress** (in Window 3)
+
+   ```bash
+   git add -A && git commit -m "workshop: initial research wiki"
+   ```
+
+   **Checkpoint:** You should have a multi-section research site with fleshed-out pages, cross-references, and your own branding.
+
+</Steps>
+
+---
+
+## Claude Code Tips
+
+### Essential Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `claude` | Start Claude Code in current directory |
+| `claude "prompt here"` | Start with an initial prompt |
+| `claude --continue` | Resume your last conversation (if terminal crashed or you closed it) |
+| **Shift+Enter** | New line (for multi-line prompts) |
+| **Enter** | Submit your prompt |
+| `/clear` | Clear conversation context (start fresh) |
+| `/compact` | Compress conversation to save context window |
+| `/init` | Auto-generate a CLAUDE.md for your project |
+| `Ctrl+C` | Cancel current Claude operation |
+| `Ctrl+D` | Exit Claude Code |
+
+**When to use `/clear` vs `/compact`:**
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Claude is confused or producing bad output | `/clear` | Nuclear reset — throws away all context and starts fresh |
+| You get a "context too long" warning or Claude forgets earlier instructions | `/compact` | Compresses the conversation into a summary, freeing space while keeping context |
+| Switching to a completely different task | Start a new `claude` session | Clean slate with fresh permissions |
+
+### Working Effectively
+
+**Give feedback, not just instructions.** After Claude makes changes, look at the result in your browser and tell it what to fix:
+> "The analysis is too surface-level. Add specific numbers, cite key papers, and state the key uncertainties."
+
+**Reference specific files** when you want changes:
+> "Read src/content/docs/key-debates/open-vs-closed.mdx and improve it — the arguments section needs steel-manned versions of both sides."
+
+**When Claude gets confused**, use `/clear` to reset context, or `/compact` to free up space. For a long session you may hit context limits — `/compact` is your friend.
+
+**When Claude asks about something you don't care about**, just say "your call" or "whatever you think is best" to keep things moving.
+
+**Check what changed** after Claude does a big edit:
+> In Window 3, run `git diff` to see exactly what changed, or just check the browser.
+
+---
+
+## CLAUDE.md: Teaching Claude About Your Project
+
+The `CLAUDE.md` file in your project root is read by Claude Code automatically at the start of every session. It's like a briefing document that gives Claude persistent context about your project's structure, commands, and conventions.
+
+### Quick Setup
+
+If you used the QURI starter, a `CLAUDE.md` is already included — you're set.
+
+Otherwise, the fastest way — ask Claude to create one:
+
+```
+/init
+```
+
+This auto-generates a `CLAUDE.md` based on your project's files. Or ask Claude directly:
+
+```
+Create a CLAUDE.md for this project. Include the dev command,
+build command, project structure, content conventions, and the
+sidebar autogenerate pattern we're using.
+```
+
+### Starter Template (Manual)
+
+```markdown
+# My Research Wiki
+
+## Commands
+- `npm run dev` — Start dev server at localhost:4321
+- `npm run build` — Build for production
+
+## Structure
+- `src/content/docs/` — All wiki pages (MDX format)
+- `astro.config.mjs` — Site config and sidebar
+- `public/` — Static assets (images, etc.)
+
+## Conventions
+- Use .mdx extension for all pages
+- Use Markdown tables for comparisons
+- Keep pages focused on one topic each
+- Escape $ signs in MDX: \$100
+- Use autogenerate for sidebar sections in astro.config.mjs
+- Put images in public/images/ and reference as /images/name.png
+
+## Content Style
+- Analytical and evidence-based tone
+- Cite sources where possible
+- Include "Open Questions" sections
+- Use tables for comparing positions/proposals
+```
+
+### Why It Matters
+
+Without `CLAUDE.md`, Claude starts fresh every conversation — it has to re-discover your project structure each time. With one, it immediately knows your commands, conventions, and patterns. This becomes critical once you're past the workshop and working across multiple sessions.
+
+---
+
+## Effective Prompting for Research Content
+
+### What Works Well
+
+**Be specific about structure:**
+> "Create a page about X with: a background section, a 'Key Arguments' section with the major positions, a comparison table, an 'Open Questions' section, and a 'Further Reading' section."
+
+**Reference existing pages as templates:**
+> "Look at src/content/docs/section-1/page-a.mdx and create a similar-style page for [new topic]."
+
+**Use web search for current data:**
+> "Research the latest developments in [topic] and write a page with current figures, recent papers, and links to sources."
+
+**Iterate in layers** — first get structure right, then fill in detail:
+> "The section on X is too vague. Add specific estimates, cite Ord/Cotra/Davidson/etc., and state the key cruxes."
+
+### What to Watch Out For
+
+- **LLMs hallucinate facts and citations** — Review factual claims carefully, especially numbers, dates, quotes, and paper citations. When accuracy matters, ask Claude to search the web first.
+- **MDX has quirks** — Characters like `<`, `{`, and `$` need escaping. If the build breaks, just paste the error to Claude and it'll fix it.
+- **Quality over quantity** — 10 well-researched pages beats 30 shallow ones. Spend time iterating on content, not just creating more pages.
+- **"Key Arguments" sections may be strawmen** — Claude tends to present steelmanned versions of mainstream views and weak versions of minority positions. Check that opposing arguments are represented as their proponents would state them.
+- **Quantitative claims need verification** — Claude confidently produces numbers that are plausible but wrong. Any specific dollar amount, percentage, or date should be checked.
+
+### Reviewing Content Effectively
+
+The best workshop strategy: **scaffold broadly, then review narrowly.** Generate your full page structure in the first 20 minutes, then spend the remaining time deeply improving 3-5 pages rather than trying to make all 15 good.
+
+For pages you want to actually trust, use this review approach:
+
+1. **Spot-check citations** — If Claude names a specific paper, organization, or statistic, verify it exists. Ask: "Search the web to verify whether [specific claim] is accurate."
+2. **Ask Claude to self-audit** — "Read this page and list any claims you're less than 80% confident are factually correct." Claude is surprisingly good at flagging its own uncertainty when asked directly.
+3. **Check for missing perspectives** — "What important perspectives or counterarguments are missing from this page?" This often surfaces viewpoints Claude omitted to present a cleaner narrative.
+4. **Look for false precision** — Vague claims dressed up as specific ones (exact percentages, confident timelines, precise cost figures) are a hallmark of LLM content. Soften or verify these.
+
+---
+
+## Useful Patterns
+
+### Auto-Generated Sidebar
+
+Instead of manually listing every page in `astro.config.mjs`, use directory-based auto-generation (this is what our starter prompts use):
+
+```js
+sidebar: [
+  { label: 'Policy Approaches', autogenerate: { directory: 'policy-approaches' } },
+  { label: 'Key Debates', autogenerate: { directory: 'key-debates' } },
+  { label: 'Open Questions', autogenerate: { directory: 'open-questions' } },
+]
+```
+
+Pages are ordered alphabetically by filename. Prefix with numbers for custom order: `01-intro.mdx`, `02-background.mdx`. Or use frontmatter `sidebar: { order: 1 }` to control ordering.
+
+### Adding Images
+
+Put images in the `public/` directory and reference them in MDX:
+
+```markdown
+![Description of the image](/images/my-diagram.png)
+```
+
+### Tables Over Paragraphs
+
+For comparisons, positions, or structured data, tables are almost always better than prose:
+
+```markdown
+| Approach | Feasibility | Effectiveness | Key Proponents |
+|----------|-------------|---------------|----------------|
+| Compute governance | High | Medium | Brundage, Heim |
+| Licensing regimes | Medium | Medium-High | EU, NIST |
+| Voluntary commitments | High | Low | Industry |
+```
+
+### Cross-References
+
+Link pages together — this is what makes a wiki a wiki, not just a collection of essays:
+
+```mdx
+See [the compute governance page](/policy-approaches/compute-governance/) for details.
+```
+
+---
+
+## Deployment (After the Workshop)
+
+When you're ready to put your site online:
+
+<Tabs>
+  <TabItem label="Netlify (easiest)">
+    1. Push your repo to GitHub
+    2. Go to [netlify.com](https://www.netlify.com/), sign in with GitHub
+    3. "Add new site" → "Import an existing project" → Select your repo
+    4. Build command: `npm run build`, Publish directory: `dist/`
+    5. Click Deploy — you'll get a URL like `your-site.netlify.app`
+  </TabItem>
+  <TabItem label="Vercel">
+    1. Push to GitHub
+    2. Go to [vercel.com](https://vercel.com/), import your repo
+    3. It auto-detects Astro — just click Deploy
+  </TabItem>
+  <TabItem label="GitHub Pages (free)">
+    Push to GitHub, then ask Claude:
+    > "Create a GitHub Actions workflow that builds my Astro site and deploys to GitHub Pages."
+  </TabItem>
+  <TabItem label="Cloudflare Pages (free)">
+    1. Push to GitHub
+    2. Go to [pages.cloudflare.com](https://pages.cloudflare.com/)
+    3. Connect repo, set build command `npm run build`, output `dist/`
+  </TabItem>
+</Tabs>
+
+---
+
+## After the Workshop
+
+Your research site is just getting started. Here's how to keep building:
+
+- **Deploy it** — Having a live URL motivates you to keep improving. Takes 5 minutes with Netlify or Vercel.
+- **Run `/init`** to create a `CLAUDE.md` if you haven't — makes every future session more productive
+- **Add 3-5 pages per session** — Even 30 minutes a week with Claude Code adds up fast
+- **Focus on depth over breadth** — Improve existing pages before adding more
+- **Learn Starlight** — [The docs](https://starlight.astro.build/) cover theming, custom components, i18n, and more
+- **Ask Claude to create custom components** — If you repeat a pattern (info boxes, comparison cards, cost-effectiveness tables), ask Claude to make it a reusable MDX component
+
+### What Scaled Projects Look Like
+
+For the [Longterm Wiki](https://www.longtermwiki.com/) (~640 pages), we eventually added:
+- A CLI with 15+ validators (link checking, quality scoring, schema validation, etc.)
+- YAML-driven data layer with cross-references between 100+ entities
+- Custom React components for interactive content (causal diagrams, Squiggle models)
+- Automated content improvement pipelines using Claude
+- Expert disagreement tracking and crux mapping
+
+You don't need any of this to start — but it shows where the approach can go. The source is open at [github.com/quantified-uncertainty/longterm-wiki](https://github.com/quantified-uncertainty/longterm-wiki).
+
+---
+
+## Quick Reference Links
+
+| Resource | URL |
+|----------|-----|
+| **Workshop slides** | [Google Slides](https://docs.google.com/presentation/d/1Q2oisP95LRLs0mGwWIStrhhPDRMpxxrNPpvbzE59yBQ/edit?usp=sharing) |
+| **QURI** | [quantifieduncertainty.org](https://quantifieduncertainty.org/) |
+| **Claude Code (web)** | [claude.ai/code](https://claude.ai/code) |
+| **Claude Code docs** | [docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview) |
+| **Claude Code GitHub** | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) |
+| **Claude Code best practices** | [docs.anthropic.com/en/docs/claude-code/best-practices](https://docs.anthropic.com/en/docs/claude-code/best-practices) |
+| **Starlight docs** | [starlight.astro.build](https://starlight.astro.build/) |
+| **Starlight frontmatter ref** | [starlight.astro.build/reference/frontmatter](https://starlight.astro.build/reference/frontmatter/) |
+| **Starlight theming** | [starlight.astro.build/guides/css-and-tailwind](https://starlight.astro.build/guides/css-and-tailwind/) |
+| **Docusaurus docs** | [docusaurus.io](https://docusaurus.io/) |
+| **VitePress docs** | [vitepress.dev](https://vitepress.dev/) |
+| **Astro docs** | [docs.astro.build](https://docs.astro.build/) |
+| **MDX docs** | [mdxjs.com](https://mdxjs.com/) |
+| **QURI Starter template** | `npx degit quantified-uncertainty/cairn/starters/research-wiki my-wiki` |
+| **Longterm Wiki** | [longtermwiki.com](https://www.longtermwiki.com/) |
+| **Longterm Wiki source** | [github.com/quantified-uncertainty/longterm-wiki](https://github.com/quantified-uncertainty/longterm-wiki) |
+| **CAIRN monorepo** | [github.com/quantified-uncertainty/cairn](https://github.com/quantified-uncertainty/cairn) |
+| **AI-Assisted Knowledge Management** | [longtermwiki.com/wiki/E681](https://www.longtermwiki.com/wiki/E681) |
+
+---
+
+## Troubleshooting
+
+**Build errors after creating pages**
+- Usually invalid MDX frontmatter (bad YAML) or unescaped special characters (`$`, `<`, `{`)
+- Just paste the error to Claude: "The build failed with this error: [paste]. Fix it."
+
+**Sidebar doesn't show new pages**
+- If using `autogenerate`, make sure the directory name in `astro.config.mjs` matches the actual folder name in `src/content/docs/`
+- If a section is totally missing from the sidebar, Claude probably forgot to add it to the config — ask it to check
+
+**Claude seems confused or repetitive**
+- `/clear` — Reset context entirely (start a fresh conversation)
+- `/compact` — Compress conversation (keeps context summary, frees space)
+- Make sure you're running `claude` from the project root directory, not a subdirectory
+
+**Claude keeps making the same mistake**
+- Add the correction to `CLAUDE.md` — Claude reads this at the start of every session
+- e.g., "IMPORTANT: Always escape \$ signs in MDX files"
+
+**Dev server crashed**
+- Just restart it: `npm run dev` in Window 2
+- Common cause: a syntax error in an MDX file that Claude can fix
+
+**Pages show up but look wrong**
+- Starlight handles most styling automatically — custom CSS rarely needed
+- If content looks garbled, it's usually an MDX syntax issue (unescaped characters, unclosed tags)
+- Ask Claude: "The page at [path] looks broken in the browser. Read it and fix the MDX syntax."


### PR DESCRIPTION
## Summary
Add a complete hands-on workshop guide for building research websites using Claude Code. This document provides step-by-step instructions, best practices, and reference materials for participants.

## Key Changes
- **New workshop guide** (`workshop-updated.mdx`): Comprehensive 792-line guide covering:
  - Pre-workshop setup instructions (Node.js, Claude Code installation, cost information)
  - Framework comparison (Astro + Starlight, Docusaurus, VitePress, MkDocs)
  - Detailed walkthrough with 9 steps from topic selection through deployment
  - Terminal workflow setup (multi-window patterns for iTerm2, VS Code, Windows Terminal)
  - Claude Code tips and essential commands
  - Effective prompting patterns for research content
  - Deployment options (Netlify, Vercel, GitHub Pages, Cloudflare Pages)
  - Troubleshooting guide and quick reference links

- **Session notes** (`.claude/sessions/2026-02-15_update-workshop-links-8QX5Z.md`): Documents research and edit instructions for updating existing workshop page with current links and information

## Notable Details
- Includes worked examples of real prompts for scaffolding wikis and mini-textbooks
- Covers non-code alternatives (Obsidian, Notion, Google NotebookLM) for users who prefer visual editors
- Provides time budgets and scope guidance for choosing research topics
- References demo projects (Longterm Wiki ~640 pages, Delegation Risk framework)
- Includes CLAUDE.md best practices for persistent project context
- Emphasizes iterative content improvement over breadth-first page creation

https://claude.ai/code/session_01HUwpZYQKj9qEwuV1rjAXjq