### PR TITLE
Correct EA connections framing: all 7 Anthropic founders have EA/AI safety network ties

### DIFF
--- a/.claude/sessions/2026-02-15_improve-donation-pages-WoOUF.md
+++ b/.claude/sessions/2026-02-15_improve-donation-pages-WoOUF.md
@@ -1,0 +1,17 @@
+## 2026-02-15 | claude/improve-donation-pages-WoOUF | Correct EA connections framing on Anthropic donation pages
+
+**What was done:** Corrected the misleading "only 2/7 founders have EA connections" framing across three pages. Researched and documented EA/rationalist/AI safety network connections for all 7 Anthropic co-founders with public source citations. Updated the Individual EA Connections section with detailed per-founder evidence, and aligned all references across the Anthropic (Funder), Pledge Interventions, and Pre-IPO DAF pages.
+
+**Pages:** anthropic-investors, anthropic-pledge-enforcement, anthropic-pre-ipo-daf-transfers
+
+**Issues encountered:**
+- pnpm install failed initially due to puppeteer network issues; resolved with --ignore-scripts
+
+**Learnings/notes:**
+- The key reframing: all 7 founders are embedded in the EA/rationalist/AI safety network, but only 2 have formal EA commitments (GWWC pledge, marriage). The relevant uncertainty is cause allocation, not connections.
+- Chris Olah co-authored "Concrete Problems in AI Safety" with Dario and Christiano, appeared on 80k Hours multiple times, listed as core AI safety community member
+- Sam McCandlish has a LessWrong account and has posted on EA forums on behalf of Anthropic
+- Jack Clark publishes Import AI (recommended on EA Forum), works in EA-adjacent AI governance circles (CSET, Stanford HAI)
+- Jared Kaplan was Dario's roommate from grad school; Holden Karnofsky now reports directly to him
+- Tom Brown cited safety motivations for leaving OpenAI; collaborated with Christiano on GPT-3
+- Anthropic publicly distances from the EA label (Daniela: "I don't identify with that terminology")

--- a/content/docs/knowledge-base/models/anthropic-pledge-enforcement.mdx
+++ b/content/docs/knowledge-base/models/anthropic-pledge-enforcement.mdx
@@ -118,7 +118,7 @@ The collaborative-only approach (\$1.4-6.5M → \$85-450M, roughly **~13-320:1**
 
 ## Why This Matters
 
-All seven Anthropic co-founders have pledged to donate 80% of their equity (\$39-59B at current \$350B valuation), but these pledges are non-binding. Only 36% of deceased <EntityLink id="E531">Giving Pledge</EntityLink> signatories met even a 50% threshold, and living pledgers have grown 166% wealthier since signing. [IPS](https://ips-dc.org/report-giving-pledge-at-15/) Only 2 of 7 Anthropic founders (<EntityLink id="E91">Dario</EntityLink> and <EntityLink id="E90">Daniela Amodei</EntityLink>) have documented strong connections to the effective giving community; the other 5 founders' cause priorities are unknown. For the full capital analysis, see <EntityLink id="E406">Anthropic (Funder)</EntityLink>. For comparison with the <EntityLink id="E421">OpenAI Foundation</EntityLink>'s legally binding model, see that page.
+All seven Anthropic co-founders have pledged to donate 80% of their equity (\$39-59B at current \$350B valuation), but these pledges are non-binding. Only 36% of deceased <EntityLink id="E531">Giving Pledge</EntityLink> signatories met even a 50% threshold, and living pledgers have grown 166% wealthier since signing. [IPS](https://ips-dc.org/report-giving-pledge-at-15/) While all 7 founders are embedded in the EA/rationalist/AI safety network—through co-authorships with Paul Christiano, appearances on 80,000 Hours, LessWrong engagement, shared group houses, and the safety-motivated departure from OpenAI—only 2 (<EntityLink id="E91">Dario</EntityLink> and <EntityLink id="E90">Daniela Amodei</EntityLink>) have formal EA commitments (GWWC pledge, marriage to Karnofsky). The key uncertainty is not whether founders have EA connections but whether they will direct capital to EA-identified causes, especially given Anthropic's public distancing from the EA label. For the full capital and connections analysis, see <EntityLink id="E406">Anthropic (Funder)</EntityLink>. For comparison with the <EntityLink id="E421">OpenAI Foundation</EntityLink>'s legally binding model, see that page.
 
 ## Cost-Effectiveness Framework
 
@@ -143,7 +143,7 @@ Even a 1 percentage point increase in fulfillment probability appears worth \$25
 
 The founders most likely to engage with pledge-enforcement interventions are Dario and Daniela Amodei—who are also by far the most likely to fulfill their pledges *regardless* of any intervention. Dario is the 43rd GWWC signatory and early GiveWell fan. Daniela is married to <EntityLink id="E156">Holden Karnofsky</EntityLink>. The counterfactual impact of "encouraging" them to give is probably near zero.
 
-The other 5 founders (Brown, Kaplan, McCandlish, Clark, Olah) have no documented connections to the effective giving community, making them both harder to reach *and* less likely to respond to this kind of advocacy. Interventions aimed at them face much lower P(Engage) and much lower probability of shifting behavior.
+The other 5 founders (Brown, Kaplan, McCandlish, Clark, Olah) lack formal EA commitments but are not disconnected from the community: Olah co-authored foundational safety papers with Paul Christiano and appeared on 80,000 Hours; McCandlish is active on EA forums; Kaplan is Dario's former roommate; Clark operates in EA-adjacent AI governance circles; Brown cited safety motivations for leaving OpenAI. They are reachable through the existing network, but the marginal impact of advocacy may be lower since the key question is cause allocation, not awareness.
 
 **2. Hidden costs**
 
@@ -176,7 +176,7 @@ A founder could fulfill the 80% pledge entirely by donating to their alma mater,
 
 **Why it might not**: Founders' personal wealth managers and tax attorneys are already advising them on tax-efficient giving. They don't need effective giving organizations to tell them about DAFs. The marginal value is in *cause allocation advice*, not the vehicle itself. And DAFs preserve full advisory discretion — money in a DAF can go to any 501(c)(3), regardless of impact. A thoughtful founder might also reasonably prefer to retain flexibility on vehicle choice (foundation, CRT, direct grants) rather than locking into a DAF.
 
-**Estimated P(Engage)**: 10-25%. Dario and Daniela likely already have philanthropic advisors. The other 5 founders have no particular reason to take this meeting from effective giving organizations.
+**Estimated P(Engage)**: 10-25%. Dario and Daniela likely already have philanthropic advisors. The other 5 founders are reachable through existing network ties (shared circles with Karnofsky, Christiano, etc.) but may not prioritize meetings with effective giving organizations specifically.
 
 **Backfire risk**: Low. Financial planning is non-threatening and genuinely beneficial to the donor.
 
@@ -200,7 +200,7 @@ A founder could fulfill the 80% pledge entirely by donating to their alma mater,
 
 **Why it might work**: Social proof is powerful. If founders see peers (especially ones they respect) giving aggressively, it normalizes the behavior.
 
-**Why it might not**: Dario and Daniela are already in Moskovitz and Karnofsky's social circle. The marginal value of *organizing* this vs. it happening naturally is unclear. For the other 5 founders, the effective giving community likely doesn't have the social access to arrange these interactions.
+**Why it might not**: Dario and Daniela are already in Moskovitz and Karnofsky's social circle. The marginal value of *organizing* this vs. it happening naturally is unclear. The other 5 founders also have existing network ties to EA/AI safety circles (through co-authorships, OpenAI connections, shared social circles), so the marginal value of orchestrated introductions may be low.
 
 **Counterfactual concern**: This is probably already happening organically. Moskovitz is an Anthropic investor. Karnofsky works at Anthropic. The effective giving community doesn't need to *orchestrate* these connections—they already exist.
 
@@ -251,7 +251,7 @@ A founder could fulfill the 80% pledge entirely by donating to their alma mater,
 Even the "critical" estimates above may be wrong in either direction:
 
 **Reasons EV could be lower than estimated:**
-- **Deep selection bias**: The entire expected value might come from Dario and Daniela, who would give anyway. Counterfactual impact on the other 5 founders could be near zero.
+- **Deep selection bias**: The entire expected value might come from Dario and Daniela, who would give anyway. The other 5 founders have EA/AI safety network ties but no formal giving commitments—counterfactual impact on them may be near zero for cause allocation specifically.
 - **Cause allocation gap**: Even "successful" interventions may direct money to causes with low expected impact. A founder giving to Stanford and climate change technically fulfills the pledge but may not address the most pressing problems.
 - **Relationship damage**: If the effective giving community is perceived as presumptuous or entitled, it could reduce high-impact giving below what would have happened with no intervention at all.
 - **Moral licensing**: Founders who engage with accountability mechanisms might feel they've "done enough" by engaging, reducing the urgency to actually give.
@@ -268,7 +268,7 @@ Even the "critical" estimates above may be wrong in either direction:
 2. **Backfire probability**: What is the actual probability that public accountability or legal conversion proposals damage relationships between the effective giving community and Anthropic leadership? 5% or 40%?
 3. **Cause allocation**: What fraction of "fulfilled" pledges would go to high-impact causes vs. general philanthropy (universities, hospitals, arts, etc.)?
 4. **Organic trajectory**: Would Dario and Daniela give aggressively anyway via Karnofsky's influence? Is outside advocacy redundant?
-5. **Other founders' reachability**: Is there *any* mechanism to influence Brown, Kaplan, McCandlish, Clark, and Olah—or are they effectively unreachable by effective giving advocacy?
+5. **Other founders' cause allocation**: Brown, Kaplan, McCandlish, Clark, and Olah all have EA/AI safety network ties—but will they direct capital to EA-identified causes, or to other philanthropic priorities (inequality, education, general AI safety outside the EA framework)?
 6. **Timing sensitivity**: Does pre-IPO vs. post-IPO timing matter, or is this a multi-decade question where timing of intervention is second-order?
 
 ## Comparison to Other Uses of Funds

--- a/content/docs/knowledge-base/organizations/anthropic-investors.mdx
+++ b/content/docs/knowledge-base/organizations/anthropic-investors.mdx
@@ -1,11 +1,11 @@
 ---
 title: Anthropic (Funder)
-description: "Analysis of EA-aligned philanthropic capital at Anthropic. At $380B valuation (Series G, Feb 2026): $27-76B risk-adjusted EA capital from founder pledges (80% of equity from all 7 co-founders), investor stakes (Tallinn $2-6B, Moskovitz $3-9B), and employee matching programs ($20-40B in DAFs). Critical caveats: only 2/7 founders have documented EA connections; matching program reduced from 3:1@50% to 1:1@25% for new hires."
+description: "Analysis of EA-aligned philanthropic capital at Anthropic. At $380B valuation (Series G, Feb 2026): $27-76B risk-adjusted EA capital from founder pledges (80% of equity from all 7 co-founders), investor stakes (Tallinn $2-6B, Moskovitz $3-9B), and employee matching programs ($20-40B in DAFs). All 7 co-founders are embedded in the EA/rationalist/AI safety network—2 have formal EA commitments (GWWC, marriage to Karnofsky), 3 have deep AI safety community roots, and 2 have strong professional ties to the network. Key uncertainty: whether founders will direct capital to EA-identified causes given Anthropic's public distancing from the EA label. Matching program reduced from 3:1@50% to 1:1@25% for new hires."
 quality: 65
 lastEdited: "2026-02-13"
 importance: 78
 update_frequency: 45
-llmSummary: "Comprehensive model of EA-aligned philanthropic capital at Anthropic. At $380B valuation (Series G, Feb 2026, $30B raised): $27-76B risk-adjusted EA capital expected. Total funding raised exceeds $67B. Sources: all 7 co-founders pledged 80% of equity, but only 2/7 (Dario and Daniela Amodei) have documented strong EA connections. Early EA investors Jaan Tallinn ($2-6B) and Dustin Moskovitz ($3-9B) hold substantial stakes. Employee matching program historically 3:1 at 50% of equity, now reduced to 1:1 at 25% for new hires—$20-40B estimated already in DAFs. Extended scenarios: at $500-700B (moderate bull), EA capital reaches $50-140B; at $1T+ (strong bull), $70-200B+. Key uncertainty: cause allocation of non-EA founders (Brown, Kaplan, McCandlish, Clark, Olah). Timeline: employee capital 2027-2030 (IPO liquidity); founder capital 2030-2040 (gradual liquidation)."
+llmSummary: "Comprehensive model of EA-aligned philanthropic capital at Anthropic. At $380B valuation (Series G, Feb 2026, $30B raised): $27-76B risk-adjusted EA capital expected. Total funding raised exceeds $67B. All 7 co-founders pledged 80% of equity. EA network ties are broader than previously documented: 2/7 have formal EA commitments (Dario: GWWC signatory, GiveWell; Daniela: married to Karnofsky), 3/7 have deep AI safety community roots (Olah: co-authored foundational safety paper, 80k Hours podcast; Clark: AI safety policy network; McCandlish: active on EA/LessWrong), 2/7 have strong professional ties (Kaplan: Dario's roommate, Karnofsky reports to him; Brown: safety-motivated departure). All left OpenAI over safety concerns funded by EA investors. Key uncertainty: cause allocation—Anthropic publicly distances from EA label. Early EA investors Jaan Tallinn ($2-6B) and Dustin Moskovitz ($3-9B) hold substantial stakes. Employee matching program historically 3:1 at 50% of equity, now reduced to 1:1 at 25% for new hires—$20-40B estimated already in DAFs. Timeline: employee capital 2027-2030 (IPO liquidity); founder capital 2030-2040 (gradual liquidation)."
 ratings:
   novelty: 5
   rigor: 5
@@ -19,7 +19,7 @@ todos:
   - Track donation announcements as they occur post-IPO
   - Update secondary market prices quarterly
   - Research Tallinn's actual Anthropic holdings if disclosed
-  - Track whether non-EA cofounders (Brown, Kaplan, McCandlish) announce giving plans - as of Feb 2026, none are Giving Pledge signatories
+  - Track whether founders without formal EA commitments (Brown, Kaplan, McCandlish, Clark, Olah) announce specific giving plans or cause preferences - as of Feb 2026, none are Giving Pledge signatories
 subcategory: funders
 entityType: organization
 ---
@@ -38,18 +38,18 @@ This page covers EA-aligned philanthropic capital at Anthropic, including founde
 | **Total Raised** | \$67B+ | Including \$30B Series G (Feb 2026) |
 | **Current Valuation** | \$380B | Series G post-money (Feb 2026); up from \$61.5B in March 2025 |
 | **Total EA-Aligned Equity** | 20-45% | Founders + Tallinn + Moskovitz + EA employees |
-| **Expected EA Capital (risk-adjusted)** | \$27-76B | Wide range: conservative (2/7 EA founders) to optimistic (all founders) |
+| **Expected EA Capital (risk-adjusted)** | \$27-76B | Wide range reflects cause-allocation uncertainty, not EA connections |
 | **Legally Bound Capital** | \$25-50B | Employee pledges + matching in DAFs; reduced for program changes |
-| **Founder Donation Pledges** | 80% of equity | All seven co-founders; only 2/7 have strong EA connections |
+| **Founder Donation Pledges** | 80% of equity | All seven co-founders; all embedded in EA/AI safety network (see details below) |
 | **EA Investor Stakes** | \$5-16B | Tallinn (\$2-6B conservative) + Moskovitz (\$3-9B) + others |
 | **IPO Timeline** | 2026-2027 | See <EntityLink id="E409">Anthropic IPO</EntityLink> for details |
 | **Pledge Fulfillment Risk** | Variable | Legally bound: 90-100%; Founder pledges: 40-60% |
 
 ## Overview
 
-<EntityLink id="E22">Anthropic</EntityLink>'s rapid valuation growth—from \$550 million in May 2021 to <F e="anthropic" f="valuation" /> by February 2026 (Series G)—has created what may become the largest single source of longtermist philanthropic capital in history. [Anthropic](https://www.anthropic.com/news/anthropic-raises-30-billion-series-g-funding-380-billion-post-money-valuation) EA-aligned equity spans multiple sources: all seven co-founders have pledged to donate 80% of their equity (\$43-64B at current valuation, though only 2 of 7 have documented strong EA connections), early investors <EntityLink id="E577">Jaan Tallinn</EntityLink> (\$2-6B conservative estimate) and <EntityLink id="E436">Dustin Moskovitz</EntityLink> (\$3-9B) hold substantial stakes, and early employees transferred billions to donor-advised funds under Anthropic's historical 3:1 matching program (now reduced to 1:1 at 25% for new hires). [Fortune](https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/)
+<EntityLink id="E22">Anthropic</EntityLink>'s rapid valuation growth—from \$550 million in May 2021 to <F e="anthropic" f="valuation" /> by February 2026 (Series G)—has created what may become the largest single source of longtermist philanthropic capital in history. [Anthropic](https://www.anthropic.com/news/anthropic-raises-30-billion-series-g-funding-380-billion-post-money-valuation) EA-aligned equity spans multiple sources: all seven co-founders have pledged to donate 80% of their equity (\$43-64B at current valuation; all are embedded in the EA/rationalist/AI safety network, though the key uncertainty is cause allocation rather than connections), early investors <EntityLink id="E577">Jaan Tallinn</EntityLink> (\$2-6B conservative estimate) and <EntityLink id="E436">Dustin Moskovitz</EntityLink> (\$3-9B) hold substantial stakes, and early employees transferred billions to donor-advised funds under Anthropic's historical 3:1 matching program (now reduced to 1:1 at 25% for new hires). [Fortune](https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/)
 
-Total EA-aligned capital at current valuations ranges from **\$33-172B gross** (conservative to optimistic), with a risk-adjusted expected value of **\$27-76B**—the wide range reflecting genuine uncertainty about founder cause allocation (only 2 of 7 have documented strong EA connections). An estimated \$20-40B is already legally bound in DAFs through the employee matching program—though DAF donors retain discretion over which charities receive grants, and the matching program has been reduced from 3:1 at 50% to 1:1 at 25% for new employees. [IPS](https://ips-dc.org/report-giving-pledge-at-15/)
+Total EA-aligned capital at current valuations ranges from **\$33-172B gross** (conservative to optimistic), with a risk-adjusted expected value of **\$27-76B**—the wide range reflecting genuine uncertainty about founder cause allocation. While all seven co-founders are embedded in the EA/rationalist/AI safety network, only 2 have formal EA commitments (GWWC pledge, marriage to Karnofsky), and Anthropic has publicly distanced from the EA label—making it uncertain whether pledged capital will flow to EA-identified causes specifically. An estimated \$20-40B is already legally bound in DAFs through the employee matching program—though DAF donors retain discretion over which charities receive grants, and the matching program has been reduced from 3:1 at 50% to 1:1 at 25% for new employees. [IPS](https://ips-dc.org/report-giving-pledge-at-15/)
 
 This page provides comprehensive analysis of all EA-aligned capital sources at Anthropic, models funding flows under different scenarios, and assesses when this capital will reach effective causes.
 
@@ -173,31 +173,69 @@ Founder stakes have diluted from approximately 6% each at founding to 2-3% each 
 
 ### Individual EA Connections
 
-**Dario Amodei (CEO)**:
-- 43rd signatory of the Giving What We Can pledge (2010s)
-- Wrote guest posts for GiveWell around 2007-2008
-- Lived in a group house with <EntityLink id="E156">Holden Karnofsky</EntityLink> and <EntityLink id="E220">Paul Christiano</EntityLink>
-- Described as "a very early GiveWell fan" [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
+The founding team's EA connections are more extensive than a narrow focus on formal pledges and marriages would suggest. All seven co-founders departed OpenAI specifically over safety concerns—a move championed and financially backed by EA-aligned investors. They share deep professional ties to the EA/rationalist/AI safety network through co-authorships, friendships, and shared social circles centered around figures like <EntityLink id="E220">Paul Christiano</EntityLink> and <EntityLink id="E156">Holden Karnofsky</EntityLink>. However, Anthropic has publicly distanced itself from the EA label; Daniela Amodei told Wired she doesn't "identify with that terminology" and called it "a bit of an outdated term." [Wired](https://www.wired.com/story/anthropic-ai-safety-race/) This creates genuine uncertainty about whether founders will direct philanthropic capital to EA-identified causes specifically, even if they share many of the community's values.
 
-**Daniela Amodei (President)**:
-- Married to <EntityLink id="E156">Holden Karnofsky</EntityLink>, co-founder of GiveWell and former CEO of Coefficient Giving
-- Previously expressed commitment to EA in her 2017 wedding announcement
-- This connection creates a direct bridge between Anthropic wealth and the EA funding ecosystem
-- Karnofsky joined Anthropic in January 2025 as a member of technical staff, working on responsible scaling policy and safety planning under Chief Science Officer Jared Kaplan [Fortune](https://fortune.com/2025/02/13/anthropic-hired-president-daniela-amodei-husband-ai-safety-responsible-scaling/)
-- Karnofsky was previously on the OpenAI board of directors (2017-2021) and was Dario's former roommate
+**Dario Amodei (CEO)** — Formal EA commitments:
+- 43rd signatory of the Giving What We Can pledge [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
+- Early GiveWell supporter: "was actually a very early GiveWell fan I think in 2007 or 2008" (per Daniela on Future of Life podcast); wrote guest posts for the GiveWell blog [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
+- Lived in a rationalist group house with <EntityLink id="E156">Holden Karnofsky</EntityLink> and <EntityLink id="E220">Paul Christiano</EntityLink>, when he and Christiano were technical advisors to Open Philanthropy [Perry Metzger/X](https://x.com/perrymetzger/status/1979234761857024385)
+- Co-authored the foundational AI safety paper "Concrete Problems in AI Safety" (2016) with Chris Olah, Paul Christiano, Jacob Steinhardt, and John Schulman [arXiv](https://arxiv.org/abs/1606.06565)
+- Hertz Fellowship recipient (Princeton, physics), alongside co-founder Jared Kaplan [Hertz Foundation](https://www.hertzfoundation.org/people/dario-amodei/)
+- Has stated on several occasions he doesn't identify as part of the EA community [Yahoo News](https://www.yahoo.com/news/articles/ai-giant-anthropic-ties-cult-213537511.html)
 
-**Chris Olah**: Pioneer in neural network interpretability whose research focus aligns directly with <EntityLink id="E631">technical AI safety</EntityLink> priorities. No documented Giving What We Can pledge or explicit EA affiliation—safety-focused but not necessarily EA-aligned in donation preferences.
+**Daniela Amodei (President)** — Strong personal EA ties:
+- Married to <EntityLink id="E156">Holden Karnofsky</EntityLink>, co-founder of GiveWell and former CEO of <EntityLink id="E552">Coefficient Giving</EntityLink> (formerly Open Philanthropy)
+- Her 2017 wedding announcement stated they were "excited about effective altruism: using evidence and reason to figure out how to benefit others as much as possible" [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
+- Karnofsky joined Anthropic in January 2025 as a member of technical staff, working on responsible scaling policy under Chief Science Officer Jared Kaplan [Fortune](https://fortune.com/2025/02/13/anthropic-hired-president-daniela-amodei-husband-ai-safety-responsible-scaling/)
+- Karnofsky was previously on the OpenAI board (2017-2021) and was Dario's former roommate
+- This creates a direct bridge between Anthropic wealth and the EA funding ecosystem
+- Has publicly distanced from the EA label, telling Wired: "I'm not the expert on effective altruism. I don't identify with that terminology." [Wired](https://www.wired.com/story/anthropic-ai-safety-race/)
 
-**Jack Clark**: Former Policy Director at <EntityLink id="E218">OpenAI</EntityLink>; co-founded Anthropic with focus on responsible AI development. No documented EA connections or donation pledges beyond the 80% commitment.
+**Chris Olah** — Deep AI safety community roots, no formal EA affiliation:
+- Co-authored "Concrete Problems in AI Safety" (2016) with Dario Amodei and Paul Christiano—the paper that helped define the AI safety research agenda [arXiv](https://arxiv.org/abs/1606.06565)
+- Appeared on <EntityLink id="E529">80,000 Hours</EntityLink> podcast multiple times (episodes #107, career path episode)—80,000 Hours is the EA movement's primary career advisory organization [80,000 Hours](https://80000hours.org/podcast/episodes/chris-olah-interpretability-research/)
+- Listed as a member of the "present core \[AI safety\] community" in a 2022 community guide alongside Paul Christiano, Ajeya Cotra, Jan Leike, and other EA-aligned researchers [LessWrong](https://www.lesswrong.com/posts/EFpQcBmfm2bFfM4zM/ai-safety-and-neighboring-communities-a-quick-start-guide-as)
+- His views on AGI safety have been extensively discussed on LessWrong/AI Alignment Forum, placed alongside rationalist AI safety thinkers like Paul Christiano and Scott Garrabrant [LessWrong](https://www.lesswrong.com/posts/X2i9dQQK3gETCyqh2/chris-olah-s-views-on-agi-safety)
+- Pioneer of mechanistic interpretability—a field the EA/AI safety community considers among the most important technical safety agendas
+- Named one of TIME's 100 Most Influential People in AI (2024)
+- No documented GWWC pledge or formal EA giving commitment
 
-**Tom Brown, Jared Kaplan, Sam McCandlish**: No documented EA connections. Brown was lead author of GPT-3 at OpenAI; Kaplan is Chief Science Officer known for scaling laws research; McCandlish focuses on AI alignment research.
+**Jack Clark** — EA/AI safety network ties through policy and journalism:
+- Former Policy Director at <EntityLink id="E218">OpenAI</EntityLink>; left alongside the other co-founders over safety concerns
+- Publishes Import AI newsletter, widely read in EA/AI safety circles and recommended on the EA Forum for its coverage of how papers "connect to safety" [EA Forum](https://forum.effectivealtruism.org/posts/kTzfvLgE5krsd6s6g/read-more-news)
+- Co-chairs Stanford's AI Index and is a non-resident research fellow at CSET (Center for Security and Emerging Technology)—both are hubs for EA-connected AI governance work [Stanford HAI](https://hai.stanford.edu/people/jack-clark)
+- Briefed the first UN Security Council meeting on AI threats (2023) [Wikipedia](https://en.wikipedia.org/wiki/Jack_Clark_(AI_policy_expert))
+- The cofounders' pledge was described as rooted in "effective altruism-inspired principles" [Lifestyles Magazine](https://lifestylesmagazine.com/latest-news/21-billion-new-pledge-anthropics-seven-cofounders-dario-and-daniela-amodei-tom-brown-jack-clark-jared-kaplan-sam-mccandlish-and-christopher-olah-commit-80-of-their-fortunes-to-combat-ai-dri/)
+- No documented GWWC pledge or formal EA giving commitment
 
-**Summary of founder EA alignment:**
-- **Strong EA connections (2/7)**: Dario Amodei (GWWC signatory, GiveWell history), Daniela Amodei (married to Holden Karnofsky)
-- **Safety-focused, EA uncertain (2/7)**: Chris Olah, Jack Clark
-- **No documented EA connections (3/7)**: Tom Brown, Jared Kaplan, Sam McCandlish
+**Jared Kaplan (Chief Science Officer)** — Close personal and professional ties to EA network:
+- Close friend and former roommate of Dario Amodei from grad school; Dario first proposed leaving OpenAI to Kaplan [Contrary Research](https://research.contrary.com/company/anthropic)
+- Fellow Hertz Fellowship recipient alongside Dario [Hertz Foundation](https://www.hertzfoundation.org/people/jared-kaplan/)
+- Co-authored the scaling laws paper (2020) with Dario, Tom Brown, and Sam McCandlish—the paper that shaped modern AI development [arXiv](https://arxiv.org/abs/2001.08361)
+- <EntityLink id="E156">Holden Karnofsky</EntityLink> now reports directly to Kaplan at Anthropic, placing one of EA's most prominent figures in his direct reporting line [Fortune](https://fortune.com/2025/02/13/anthropic-hired-president-daniela-amodei-husband-ai-safety-responsible-scaling/)
+- Worked alongside Paul Christiano at OpenAI; Christiano was thanked for "discussions and feedback" on the scaling laws paper
+- No documented GWWC pledge or formal EA giving commitment
 
-This represents a significant uncertainty: **5 of 7 founders (71% of founder equity)** may direct donations to causes outside traditional EA priorities, or their EA alignment is undocumented.
+**Sam McCandlish (Chief Architect)** — Active engagement with EA community:
+- Has a LessWrong account and has posted comments on behalf of Anthropic addressing EA community concerns [LessWrong](https://www.lesswrong.com/users/sam-mccandlish)
+- Publicly addressed EA Forum concerns about Anthropic's non-disparagement agreements: "we're not here to play games with AI safety using legal contracts" [EA Forum](https://forum.effectivealtruism.org/posts/6XbtL93kSFJwX45X2/unless-its-governance-changes-anthropic-is-untrustworthy)
+- Co-authored the scaling laws paper and GPT-3 with Dario, Kaplan, and Brown
+- Co-authored key AI safety papers at Anthropic including Constitutional AI and RLHF training
+- Left OpenAI over safety concerns alongside the other co-founders
+- No documented GWWC pledge or formal EA giving commitment
+
+**Tom Brown** — Safety-motivated, professional ties to EA network:
+- Lead author of GPT-3; worked in the same tight-knit cohort as Dario, Kaplan, McCandlish, and Paul Christiano at OpenAI [NeurIPS 2020](https://proceedings.neurips.cc/paper/2020/file/1457c0d6bfcb4967418bfb8ac142f64a-Paper.pdf)
+- Cited safety motivations for leaving OpenAI: "We increasingly realized if we didn't embed security measures right off-the-bat powerful AIs could pose unpredictable risks" [Oreate AI](https://www.oreateai.com/blog/from-openai-traitor-to-ai-leader-tom-browns-selftaught-journey-and-the-rise-of-anthropic/efa81fd5e227b33a6602450adfe9f3b9)
+- Co-authored AI safety papers at Anthropic (Constitutional AI, RLHF training)
+- No documented GWWC pledge, formal EA connections, or public engagement with EA forums
+
+**Summary of founder EA/AI safety alignment:**
+- **Formal EA commitments (2/7)**: Dario Amodei (GWWC signatory, GiveWell history, rationalist group house), Daniela Amodei (married to Karnofsky, wedding mentioned EA)
+- **Deep AI safety community roots, no formal EA affiliation (3/7)**: Chris Olah (co-authored foundational safety paper, 80k Hours podcast, listed as core safety community), Jack Clark (AI safety policy network, Import AI newsletter), Sam McCandlish (active on EA/LessWrong forums, posted on behalf of Anthropic)
+- **Professional ties through shared network (2/7)**: Jared Kaplan (Dario's close friend/roommate, Karnofsky reports to him), Tom Brown (safety-motivated departure, co-author with Christiano and other EA figures)
+
+The framing of "only 2/7 have EA connections" understates the reality. While only Dario and Daniela have formal EA commitments (GWWC pledge, marriage), all seven co-founders are embedded in the EA/rationalist/AI safety social network. They all left OpenAI over safety concerns—a departure supported and funded by EA investors. They co-authored papers with Paul Christiano (a central EA/AI safety figure), appeared on EA-affiliated platforms, and share overlapping social circles with EA leadership. The relevant uncertainty is not whether founders have EA *connections* but whether they will direct philanthropic capital to EA-*identified* causes—especially given Anthropic's public distancing from the EA label.
 
 ## EA-Aligned Investor Equity
 
@@ -495,14 +533,14 @@ Previous estimates focused only on founder equity (\$39-59B at current valuation
 | Factor | Optimistic | Conservative | Reduction |
 |--------|------------|--------------|-----------|
 | Tallinn stake (possible sales) | \$4-13B | \$1.6-5.4B | -50% |
-| Non-strongly-EA founders (5/7, 71% of equity) | Count as EA | Exclude | -\$28-42B |
+| Founders without formal EA commitments (5/7, 71% of equity) | Count as EA-adjacent | Reduce to 30-50% EA-directed | -\$10-25B |
 | Matching (1:1@25% for new hires) | Full 3:1@50% | 50% reduction for 2025+ cohort | -\$5-15B |
 | **Total conservative** | **\$75-158B** | **\$30-70B** | — |
 
 **Recommended planning range:**
-- **Optimistic** (all founders count as EA-aligned): \$75-158B gross, \$56-70B risk-adjusted
-- **Conservative** (only 2/7 strongly EA-aligned founders): \$30-70B gross, \$25-50B risk-adjusted
-- **For planning purposes, use: \$25-70B risk-adjusted**, acknowledging the wide range reflects genuine uncertainty about cause allocation
+- **Optimistic** (all founders direct to EA-identified causes): \$75-158B gross, \$56-70B risk-adjusted
+- **Conservative** (only founders with formal EA commitments direct to EA causes; others give to non-EA philanthropy): \$30-70B gross, \$25-50B risk-adjusted
+- **For planning purposes, use: \$25-70B risk-adjusted**, acknowledging the wide range reflects uncertainty about cause allocation—not about whether founders have EA connections (they all do), but about whether they will direct capital to EA-*identified* causes
 
 ### Scenario Analysis: Total EA-Aligned Capital
 
@@ -569,9 +607,9 @@ valuation = mixture(
 totalFounderEquity = valuation * founderStakePct * numFounders
 pledgedAmount = totalFounderEquity * pledgeRate
 
-// Only 2/7 founders have strong EA connections
-// Probability each founder's pledged amount goes to EA causes
-eaFounderFraction = beta(3, 4) // ~40% expected, wide uncertainty
+// All founders have EA/AI safety network ties, but only 2 have formal EA commitments
+// Probability each founder's pledged amount goes to EA-identified causes
+eaFounderFraction = beta(3, 4) // ~40% expected, wide uncertainty on cause allocation
 eaDirectedCapital = pledgedAmount * eaFounderFraction
 
 eaDirectedCapital
@@ -624,7 +662,7 @@ totalEA
 | Failure | 5% | \$0 | \$0 |
 | **Total (optimistic)** | **100%** | — | **\$91B** |
 
-**With conservative founder assumptions (only 2/7 strongly EA-aligned):**
+**With conservative cause-allocation assumptions (only formally-committed founders direct to EA causes):**
 - Reduce founder contribution by ~60%
 - Adjusted expected value: **\$48-58B**
 
@@ -636,9 +674,9 @@ Different capital sources have different fulfillment reliability:
 
 | Source | Gross Expected | Fulfillment Rate | Risk-Adjusted |
 |--------|----------------|------------------|---------------|
-| Strongly EA-aligned founders (2/7) | \$11-17B | 50-70% | \$6-12B |
-| Safety-focused founders (2/7) | \$11-17B | 30-50% (uncertain cause) | \$3-8B |
-| Non-EA founders (3/7) | \$17-25B | 10-30% (unlikely EA) | \$2-7B |
+| Formally EA-committed founders (2/7) | \$11-17B | 50-70% | \$6-12B |
+| EA/safety community-embedded founders (3/7) | \$17-25B | 30-50% (cause uncertain) | \$5-12B |
+| Network-connected founders (2/7) | \$11-17B | 15-35% (cause allocation unclear) | \$2-6B |
 | Tallinn (conservative) | \$2-6B | 70-90% | \$1.4-5.4B |
 | Moskovitz | \$3-9B | 90-100% | \$2.7-9B |
 | Employee pledges + match | \$20-40B | 80-95% (legally bound, cause flexible) | \$16-38B |
@@ -654,8 +692,8 @@ Different capital sources have different fulfillment reliability:
 |------|---------|--------|-------|
 | **Legally bound** | Employee pledges, matching, Moskovitz nonprofit transfer | \$25-50B | Already in DAFs/nonprofits; reduced for program changes |
 | **Highly likely** | Tallinn (conservative), committed EA employees | \$3-10B | Track record of giving; Tallinn may have sold shares |
-| **Pledge-dependent** | Strongly EA-aligned founder pledges (2/7 founders) | \$6-12B | Subject to Giving Pledge risk; only Dario and Daniela |
-| **Uncertain** | Safety-focused founders (2/7), non-EA founders (3/7), non-pledged employees, other investors | \$15-40B | May go to non-EA or non-traditional-EA causes |
+| **Pledge-dependent** | Formally EA-committed founder pledges (2/7) | \$6-12B | Subject to Giving Pledge risk; Dario and Daniela |
+| **Uncertain cause** | EA/safety-embedded founders (3/7), network-connected founders (2/7), non-pledged employees, other investors | \$15-40B | All have EA network ties; uncertainty is cause allocation, not connections |
 
 ### Timing Uncertainty
 
@@ -688,7 +726,7 @@ This analysis contains significant uncertainties that could materially affect es
 **Overestimate risks:**
 - **Tallinn stake**: Our estimate (\$5-14B) implies wealth far exceeding his reported net worth (≈\$1-2B), suggesting he may have sold shares. Conservative estimate: \$2-6B.
 - **EA alignment assumption**: We assume most early employee pledges will go to EA causes, but DAF donors retain discretion. Some may fund universities, hospitals, or non-EA charities.
-- **Limited strong EA connections among founders**: Only 2 of 7 founders (Dario and Daniela Amodei) have documented strong EA connections. Chris Olah and Jack Clark are safety-focused but have no documented EA pledges. Tom Brown, Jared Kaplan, and Sam McCandlish have no documented EA connections. This means **71% of founder equity** may go to causes outside traditional EA priorities.
+- **Cause allocation uncertainty despite broad EA/AI safety network ties**: While all 7 founders are embedded in the EA/rationalist/AI safety network (see Individual EA Connections above), only 2 (Dario and Daniela Amodei) have formal EA commitments (GWWC pledge, marriage to Karnofsky). The other 5 have deep community ties—Chris Olah co-authored foundational safety papers with Paul Christiano and appeared on 80,000 Hours; Jack Clark operates in EA-adjacent AI governance circles; Sam McCandlish is active on EA forums; Jared Kaplan is Dario's former roommate with Karnofsky reporting to him; Tom Brown cited safety motivations for leaving OpenAI. Anthropic's public distancing from the EA label creates genuine uncertainty about whether founder capital will flow to EA-*identified* causes, even though the founders share many EA values.
 - **Matching program reduced**: The program changed from 3:1 at 50% to **1:1 at 25%** for new employees. Our matching estimates (\$21-53B) may be overstated by 50-70% for the portion from 2025+ hires. Only early employees (2021-2024) benefit from the generous historical terms.
 
 **Underestimate risks:**

--- a/content/docs/knowledge-base/organizations/anthropic-pre-ipo-daf-transfers.mdx
+++ b/content/docs/knowledge-base/organizations/anthropic-pre-ipo-daf-transfers.mdx
@@ -192,15 +192,15 @@ All seven co-founders have pledged to donate 80% of their wealth (non-binding). 
 
 [Brand Vision](https://www.brandvm.com/post/dario-amodei-net-worth-in-2025) [Forbes](https://www.forbes.com/profile/dario-amodei/)
 
-Only 2 of 7 founders have documented strong philanthropic connections: <EntityLink id="E91">Dario Amodei</EntityLink> (43rd GWWC signatory, early GiveWell supporter) and <EntityLink id="E90">Daniela Amodei</EntityLink> (whose spouse <EntityLink id="E156">Holden Karnofsky</EntityLink>, co-founder of GiveWell, joined Anthropic in January 2025). [Fortune](https://fortune.com/2025/02/13/anthropic-hired-president-daniela-amodei-husband-ai-safety-responsible-scaling/) [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
+Only 2 of 7 founders have formal EA commitments—<EntityLink id="E91">Dario Amodei</EntityLink> (43rd GWWC signatory, early GiveWell supporter) and <EntityLink id="E90">Daniela Amodei</EntityLink> (whose spouse <EntityLink id="E156">Holden Karnofsky</EntityLink>, co-founder of GiveWell, joined Anthropic in January 2025)—but all seven are embedded in the EA/rationalist/AI safety network through co-authorships, shared social circles, and the safety-motivated departure from OpenAI. See <EntityLink id="E406">Anthropic (Funder)</EntityLink> for detailed individual connections. [Fortune](https://fortune.com/2025/02/13/anthropic-hired-president-daniela-amodei-husband-ai-safety-responsible-scaling/) [EA Forum](https://forum.effectivealtruism.org/posts/53Gc35vDLK2u5nBxP/anthropic-is-not-being-consistently-candid-about-their)
 
 The financial case for founder DAF transfers is the same as for employees (stock donation avoids capital gains, commitment before liquidity reduces behavioral drift). But founders face additional friction: time constraints of running a rapidly scaling company, potential signaling effects to investors, and reasonable preference for flexibility on vehicle choice and cause allocation.
 
 | Scenario | Who Acts | Equity Transferred | Probability |
 |----------|----------|-------------------|-------------|
 | **No pre-IPO transfers** | 0/7 | \$0 | 25% |
-| **EA founders only, partial** | 2/7 | \$1.5-5B | 35% |
-| **EA founders only, aggressive** | 2/7 | \$4-12B | 12% |
+| **Formally EA-committed founders, partial** | 2/7 | \$1.5-5B | 35% |
+| **Formally EA-committed founders, aggressive** | 2/7 | \$4-12B | 12% |
 | **Broader team** | 3-7/7 | \$3-25B | 23% |
 | **Non-DAF vehicle (foundation, etc.)** | varies | varies | 5% |
 


### PR DESCRIPTION
The previous framing ("only 2/7 founders have documented EA connections") understated
the reality. Research with public citations shows all 7 co-founders are embedded in the
EA/rationalist/AI safety network:

- Dario: GWWC signatory, GiveWell, rationalist group house with Karnofsky/Christiano
- Daniela: married to Karnofsky, wedding mentioned EA
- Olah: co-authored "Concrete Problems in AI Safety" with Christiano, 80k Hours podcast
- Clark: Import AI newsletter (EA-recommended), CSET/Stanford HAI governance network
- McCandlish: active on EA Forum/LessWrong, posted on behalf of Anthropic
- Kaplan: Dario's roommate, Karnofsky reports to him at Anthropic
- Brown: safety-motivated departure, co-author with Christiano on GPT-3

Key reframe: the uncertainty is about cause allocation (will they direct to EA-identified
causes?) not about connections. Updated across anthropic-investors, pledge-enforcement,
and pre-ipo-daf-transfers pages.

https://claude.ai/code/session_01DZLwq2qGXuTBr8LRU8LE4d