### PR TITLE
Remove dead Experiments sidebar links from internal nav

### DIFF
--- a/.claude/sessions/2026-02-15_check-considerations-index-tBtzY.md
+++ b/.claude/sessions/2026-02-15_check-considerations-index-tBtzY.md
@@ -1,0 +1,12 @@
+## 2026-02-15 | claude/check-considerations-index-tBtzY | Remove dead Experiments sidebar links
+
+**What was done:** Removed the "Experiments" section from the internal sidebar nav, which contained two dead links (insight-grid-experiments and risk-trajectory-experiments) whose MDX pages had been previously deleted.
+
+**Pages:** (no page content changes — infrastructure-only fix)
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The wiki uses "Cruxes" (not "Crucial Considerations") as the canonical entity type for key uncertainties. There is no dedicated Crucial Considerations index page.
+- Both experiment pages were identified as "walls of gray boxes" in the STUB_AUDIT plan and recommended for deletion; the pages were removed but the nav entries were not cleaned up.

--- a/app/src/lib/internal-nav.ts
+++ b/app/src/lib/internal-nav.ts
@@ -16,7 +16,6 @@ export interface NavSection {
  *  - Dashboards & Tools: interactive tools and dashboards
  *  - Architecture & Schema: technical docs (data schema, architecture, data flow)
  *  - Style Guides: writing and content style guides
- *  - Experiments: experimental features and prototypes
  *  - Research: research reports and proposals (theoretical, not technical docs)
  */
 export const INTERNAL_NAV: NavSection[] = [
@@ -60,13 +59,6 @@ export const INTERNAL_NAV: NavSection[] = [
       { label: "Cause-Effect Diagrams", href: "/internal/cause-effect-diagrams" },
       { label: "Research Reports", href: "/internal/research-reports" },
       { label: "AI Transition Model", href: "/internal/ai-transition-model-style-guide" },
-    ],
-  },
-  {
-    title: "Experiments",
-    items: [
-      { label: "Insight Grid", href: "/internal/insight-grid-experiments" },
-      { label: "Risk Trajectory", href: "/internal/risk-trajectory-experiments" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
Removed the "Experiments" section from the internal sidebar navigation, which contained two dead links to pages that were previously deleted.

## Changes
- Removed the "Experiments" nav section from `INTERNAL_NAV` configuration
- Deleted entries for "Insight Grid" and "Risk Trajectory" experiment pages
- Updated the nav section documentation comment to remove reference to the Experiments category

## Details
Both experiment pages (`insight-grid-experiments` and `risk-trajectory-experiments`) had been identified for deletion in the STUB_AUDIT plan but their navigation entries were not cleaned up. This change completes that cleanup by removing the orphaned sidebar links.

https://claude.ai/code/session_01VC3CbAogQiMkBQTkwSM2gJ