### PR TITLE
Add Astralis Foundation organization wiki page

### DIFF
--- a/.claude/sessions/2026-02-16_astralis-foundation-wiki-oPDAc.md
+++ b/.claude/sessions/2026-02-16_astralis-foundation-wiki-oPDAc.md
@@ -1,0 +1,15 @@
+## 2026-02-16 | claude/astralis-foundation-wiki-oPDAc | Add Astralis Foundation wiki page
+
+**What was done:** Created a new wiki page for the Astralis Foundation, a Swedish AI safety and governance philanthropy. Added the organization entity to YAML with connections to Longview Philanthropy, Rethink Priorities, Beth Barnes, and METR.
+
+**Pages:** astralis-foundation
+
+**Issues encountered:**
+- Crux content create pipeline failed: Perplexity research phase returned "fetch failed" (likely network restrictions in sandbox)
+- Tried `--source-file` workaround which loaded research successfully, but synthesis phase failed because it spawns a nested `claude` subprocess which is blocked inside an existing Claude Code session
+- Wrote page manually using research gathered via WebFetch from astralisfoundation.org, then ran fix/validation pipeline
+
+**Learnings/notes:**
+- The crux content create pipeline cannot work inside a Claude Code web session because the synthesis phase spawns a nested `claude` CLI process, which is explicitly blocked
+- The `--source-file` flag successfully skips all network research phases, but the synthesis subprocess remains a blocker
+- Workaround: write page manually following organization page template structure, then run `crux fix escaping`, `crux fix markdown`, and all three blocking validators

--- a/content/docs/knowledge-base/organizations/astralis-foundation.mdx
+++ b/content/docs/knowledge-base/organizations/astralis-foundation.mdx
@@ -1,0 +1,120 @@
+---
+title: Astralis Foundation
+description: "Astralis Foundation is a Swedish philanthropic organization focused on AI safety and governance, operating the Shared Horizons Fund and supporting initiatives like the International Dialogues on AI Safety (IDAIS) and the Nordics AI Safety Summit. Led by CEO Jona Glade and President Vilhelm Skoglund, it maintains offices in Stockholm, London, New York, and Vienna."
+sidebar:
+  order: 50
+quality: 30
+lastEdited: "2026-02-16"
+importance: 30
+update_frequency: 90
+ratings:
+  novelty: 3
+  rigor: 3
+  actionability: 3
+  completeness: 4
+clusters:
+  - community
+  - ai-safety
+  - governance
+subcategory: funders
+entityType: organization
+---
+import {EntityLink, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Quick Assessment
+
+| Dimension | Assessment | Evidence |
+|-----------|------------|----------|
+| **Scale** | Emerging | Operates the Shared Horizons Fund; total grantmaking volume not publicly disclosed |
+| **Role** | Funder + Convener | Funds AI safety initiatives, convenes multi-stakeholder dialogues |
+| **Focus** | AI safety and governance | West-Asia AI governance bridges, European AI safety leadership, risk communication |
+| **Team** | ≈6 core staff + advisors | Stockholm HQ; offices in London, New York, Vienna |
+| **Key People** | Jona Glade (CEO), Vilhelm Skoglund (President) | Board connections to <EntityLink id="E542">Longview Philanthropy</EntityLink> and <EntityLink id="E558">Rethink Priorities</EntityLink> |
+
+## Organization Details
+
+| Attribute | Details |
+|-----------|---------|
+| **Full Name** | Astralis Foundation |
+| **Type** | Philanthropic foundation |
+| **Leadership** | Jona Glade (CEO), Vilhelm Skoglund (President) |
+| **Headquarters** | Stockholm, Sweden |
+| **Other Offices** | London, New York, Vienna |
+| **Key Programs** | Shared Horizons Fund, support for IDAIS, Nordics AI Safety Summit |
+| **Funding Policy** | Does not accept unsolicited funding requests |
+| **Website** | [astralisfoundation.org](https://astralisfoundation.org) |
+
+## Overview
+
+[Astralis Foundation](https://astralisfoundation.org) is a philanthropic organization with the stated vision of "a flourishing world with secure and beneficial AI for all."[^1] The foundation unites funders, experts, and entrepreneurs to develop and expand interventions in AI safety and governance, providing funding, strategic guidance, and network access to steer AI development toward beneficial outcomes.
+
+The foundation's operational approach emphasizes venture-style high-risk/high-reward philanthropic bets, multi-funder collaboration, evidence-based decision-making, and expert-driven strategy.[^1] Astralis operates from four offices across Stockholm, London, New York, and Vienna, reflecting its global orientation.
+
+Astralis has notable connections to the broader effective altruism and AI safety ecosystem. CEO Jona Glade serves on the board of <EntityLink id="E542">Longview Philanthropy</EntityLink>, and Senior Advisor Tim Shavers sits on the board of <EntityLink id="E558">Rethink Priorities</EntityLink>. Board member <EntityLink id="E39">Beth Barnes</EntityLink> founded <EntityLink id="E201">METR</EntityLink> (formerly ARC Evals), one of the leading AI model evaluation organizations.
+
+## Focus Areas
+
+Astralis organizes its work around three primary focus areas:[^1]
+
+### Building West-Asia Bridges
+
+The foundation supports efforts to establish global governance structures for trustworthy AI innovation. Its flagship initiative in this area is support for the International Dialogues on AI Safety (IDAIS), which brings together AI scientists and policymakers from Western nations and China to discuss safety standards and cooperation. According to the foundation, IDAIS is now in its fourth session.[^1]
+
+### European AI Safety Leadership
+
+Astralis works to strengthen Europe's capacity for safe AI development while preventing catastrophic risks. In this area, the foundation supported the Langsikt Centre in producing policy recommendations for Norwegian decision-makers on AI safety and governance.[^1]
+
+### AI Risk and Opportunity Communication
+
+The foundation aims to inform stakeholders and decision-makers about AI progress and associated dangers. Astralis co-hosted the 2024 Nordics AI Safety Summit and the 2025 Nordic AI Retreat in Stockholm.[^1][^2]
+
+## Shared Horizons Fund
+
+Astralis operates the Shared Horizons Fund, a multi-funder vehicle for AI safety grantmaking. The fund is led by Senior Advisor Tim Shavers.[^3] Specific details about the fund's size, grantees, and disbursement strategy have not been publicly disclosed.
+
+## Leadership and Team
+
+### Jona Glade (CEO)
+
+Glade provides strategic counsel on AI safety to decision-makers and leads both Astralis and cFactual, an organization focused on high-impact philanthropy. According to the foundation, Glade has led over 20 strategic initiatives focused on AI safety and high-impact philanthropy. He serves on the board of <EntityLink id="E542">Longview Philanthropy</EntityLink> and previously consulted at BCG and founded Consultants for Impact. He studied organizational psychology at the University of Vienna.[^3]
+
+### Vilhelm Skoglund (President)
+
+Skoglund leads funder relationships for the foundation. He co-founded Impact Academy, which prepares talent to address catastrophic risks, and serves as a board member of the FROS Foundation. He also runs a Swedish family office. His background includes law, developmental economics, and sustainability studies at Uppsala University and Cornell University.[^3]
+
+### Senior Advisors
+
+| Name | Role | Background |
+|------|------|------------|
+| **Abraham Rowe** | Senior Advisor | Former COO at <EntityLink id="E558">Rethink Priorities</EntityLink> (scaled from 10 to 100+ staff); founded Good Structures (operations consultancy); co-founded Wild Animal Initiative |
+| **Tim Shavers** | Senior Advisor | Leads grantmaking and Shared Horizons Fund; nearly 20 years at McKinsey; 10+ years in venture capital; board member of <EntityLink id="E558">Rethink Priorities</EntityLink> |
+
+### Core Staff
+
+| Name | Role | Background |
+|------|------|------------|
+| **Henri Thunberg** | Chief of Staff | Former Development Officer at <EntityLink id="E558">Rethink Priorities</EntityLink>; founded Bigheart and Ge Effektivt |
+| **Nathaniel Andreae** | Executive Assistant & Operations | Research and writing experience at The Cricketer and The Times |
+
+### Board Members and Advisors
+
+The foundation's board and advisory circle includes Simran Dhaliwal, Samuel Hargestam, Oliver Edholm, <EntityLink id="E39">Beth Barnes</EntityLink> (founder of <EntityLink id="E201">METR</EntityLink>), and Andreas Ehn (first CTO of Spotify).[^3]
+
+## Ecosystem Connections
+
+Astralis occupies a distinctive niche in the AI safety funding ecosystem, bridging Scandinavian philanthropic networks with the global AI safety community. Several team members have prior experience at <EntityLink id="E558">Rethink Priorities</EntityLink> (Abraham Rowe as COO, Tim Shavers as board member, Henri Thunberg as Development Officer), and CEO Jona Glade's board seat at <EntityLink id="E542">Longview Philanthropy</EntityLink> positions the foundation near major longtermist funding flows.
+
+The foundation's focus on European and West-Asia governance bridges distinguishes it from US-centric AI safety funders. Its support for IDAIS and the Nordics AI Safety Summit suggests a strategy centered on international cooperation and policy influence rather than direct technical research funding.
+
+## Key Uncertainties
+
+- **Grantmaking scale**: Astralis has not publicly disclosed its total funding deployed or annual budget, making it difficult to assess its philanthropic weight relative to other AI safety funders.
+- **Track record**: As a relatively newer entrant in the AI safety funding space, there is limited public information about the outcomes and impact of its grants.
+- **Shared Horizons Fund specifics**: The fund's size, grantee portfolio, and decision-making process are not publicly documented.
+- **Relationship to cFactual**: CEO Jona Glade leads both Astralis and cFactual, but the operational relationship between the two organizations is unclear.
+
+## Sources and Further Reading
+
+[^1]: [Astralis Foundation website](https://astralisfoundation.org) - organizational overview and focus areas.
+[^2]: Longview Philanthropy wiki page - reference to Astralis Foundation as co-host of Nordic AI Retreat in Stockholm 2025.
+[^3]: [Astralis Foundation - Our People](https://astralisfoundation.org/our-people) - leadership and team information.

--- a/data/edit-logs/astralis-foundation.yaml
+++ b/data/edit-logs/astralis-foundation.yaml
@@ -1,0 +1,4 @@
+- date: 2026-02-16
+  tool: crux-fix
+  agency: automated
+  note: Auto-fixed validation issues (escaping, markdown, etc.)

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -2075,6 +2075,46 @@
     - ai-safety
     - community
   lastUpdated: 2026-02
+- id: astralis-foundation
+  numericId: E698
+  type: organization
+  title: Astralis Foundation
+  website: https://astralisfoundation.org
+  relatedEntries:
+    - id: longview-philanthropy
+      type: organization
+      relationship: leads-to
+    - id: rethink-priorities
+      type: organization
+      relationship: leads-to
+    - id: beth-barnes
+      type: researcher
+      relationship: leads-to
+    - id: metr
+      type: organization
+      relationship: leads-to
+  sources:
+    - title: Astralis Foundation Website
+      url: https://astralisfoundation.org
+    - title: Astralis Foundation - Our People
+      url: https://astralisfoundation.org/our-people
+  description: >-
+    Astralis Foundation is a Swedish philanthropic organization focused on AI
+    safety and governance. It operates the Shared Horizons Fund and supports
+    initiatives such as the International Dialogues on AI Safety (IDAIS) and the
+    Nordics AI Safety Summit. Led by CEO Jona Glade and President Vilhelm
+    Skoglund, with offices in Stockholm, London, New York, and Vienna.
+  tags:
+    - ai-safety
+    - ai-governance
+    - philanthropy
+    - international-cooperation
+    - european-ai-policy
+  clusters:
+    - ai-safety
+    - governance
+    - community
+  lastUpdated: 2026-02
 - id: nvidia
   numericId: E693
   type: organization


### PR DESCRIPTION
## Summary
Added comprehensive documentation for Astralis Foundation, a Swedish philanthropic organization focused on AI safety and governance, to the knowledge base.

## Changes Made

- **New wiki page** (`content/docs/knowledge-base/organizations/astralis-foundation.mdx`): Complete organization profile including:
  - Quick assessment table covering scale, role, focus, team size, and key personnel
  - Detailed organization information (leadership, offices, programs, funding policy)
  - Overview of the foundation's mission and operational approach
  - Three primary focus areas: West-Asia bridges, European AI safety leadership, and AI risk communication
  - Information on the Shared Horizons Fund
  - Detailed leadership profiles (CEO Jona Glade, President Vilhelm Skoglund, senior advisors, core staff, and board members)
  - Ecosystem connections highlighting relationships with Longview Philanthropy, Rethink Priorities, and METR
  - Key uncertainties and gaps in public information

- **Updated entity registry** (`data/entities/organizations.yaml`): Added Astralis Foundation entity (E698) with:
  - Metadata and website reference
  - Relationship links to Longview Philanthropy, Rethink Priorities, Beth Barnes, and METR
  - Descriptive summary and relevant tags (ai-safety, ai-governance, philanthropy, etc.)
  - Cluster categorization (ai-safety, governance, community)

- **Edit log** (`data/edit-logs/astralis-foundation.yaml`): Recorded automated validation fixes applied to the new content

## Notable Details

- The wiki page includes structured tables for quick reference and detailed narrative sections
- Establishes cross-references to related organizations and individuals in the knowledge base via EntityLink components
- Documents the foundation's distinctive position bridging Scandinavian philanthropy with global AI safety networks
- Identifies key uncertainties around grantmaking scale and track record due to limited public disclosure

https://claude.ai/code/session_01UAWZikhZJ5qQ2BoMpHqkS5