### PR TITLE
Fix numericId conflict: astralis-foundation E698 -> E702

### DIFF
--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -2099,7 +2099,7 @@
     - community
   lastUpdated: 2026-02
 - id: astralis-foundation
-  numericId: E698
+  numericId: E702
   type: organization
   title: Astralis Foundation
   website: https://astralisfoundation.org


### PR DESCRIPTION
E698 was claimed by both `ai-powered-investigation` and `astralis-foundation` (from separate PRs merged into main). Reassigns astralis-foundation to E702.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>