### PR TITLE
Add Internal filter to Explore page and search index

### DIFF
--- a/.claude/sessions/2026-02-17_add-internal-search-filter-NXkxf.md
+++ b/.claude/sessions/2026-02-17_add-internal-search-filter-NXkxf.md
@@ -1,0 +1,11 @@
+## 2026-02-17 | claude/add-internal-search-filter-NXkxf | Add Internal filter to Explore page
+
+**What was done:** Added an "Internal" entity filter to the Explore page so internal pages (style guides, architecture docs, reports, etc.) are discoverable via search and filtering. Previously internal pages were completely excluded from the Explore grid and search index.
+
+**Pages:** (no page content changes — infrastructure only)
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- Internal pages were excluded in three places: `getExploreItems()` in `data/index.ts`, the search index builder in `search.mjs`, and validated by a test in `data.test.ts`. All three needed updating.

--- a/app/scripts/lib/search.mjs
+++ b/app/scripts/lib/search.mjs
@@ -33,7 +33,6 @@ export function buildSearchIndex(typedEntities, pages, idRegistry) {
 
   // 1. Entities with pages — primary search targets
   for (const entity of typedEntities) {
-    if (entity.entityType === 'internal') continue; // skip internal pages
     const page = pageMap.get(entity.id);
     if (!page) continue; // skip entities without content pages
 

--- a/app/src/data/__tests__/data.test.ts
+++ b/app/src/data/__tests__/data.test.ts
@@ -437,15 +437,13 @@ describe("Data Layer", () => {
       expect(tableItems).toHaveLength(2);
     });
 
-    it("excludes internal pages from explore items", async () => {
+    it("includes internal pages in explore items", async () => {
       const { getExploreItems } = await import("../../data/index");
       const items = getExploreItems();
-      // internal-doc has entityType "internal" — must NOT appear in explore
+      // internal-doc has entityType "internal" — should appear in explore
       const internalItem = items.find((i) => i.id === "internal-doc");
-      expect(internalItem).toBeUndefined();
-      // No items should have type "internal"
-      const internalItems = items.filter((i) => i.type === "internal");
-      expect(internalItems).toHaveLength(0);
+      expect(internalItem).toBeDefined();
+      expect(internalItem!.type).toBe("internal");
     });
   });
 

--- a/app/src/data/entity-ontology.ts
+++ b/app/src/data/entity-ontology.ts
@@ -309,6 +309,7 @@ export const ENTITY_GROUPS: { label: string; types: string[] }[] = [
   { label: "Concepts", types: ["concept", "crux", "argument", "analysis", "historical"] },
   { label: "Tables", types: ["table"] },
   { label: "Diagrams", types: ["diagram"] },
+  { label: "Internal", types: ["internal"] },
 ];
 
 // ---------------------------------------------------------------------------

--- a/app/src/data/index.ts
+++ b/app/src/data/index.ts
@@ -1049,8 +1049,7 @@ export function getExploreItems(): ExploreItem[] {
   const entityIds = new Set(typedEntities.map((e) => e.id));
 
   // Items from typed entities (only those with actual content pages)
-  // Exclude internal pages — they participate in entity/backlink infrastructure but are not public content
-  const entityItems: ExploreItem[] = typedEntities.filter((entity) => pageMap.has(entity.id) && entity.entityType !== "internal").map((entity) => {
+  const entityItems: ExploreItem[] = typedEntities.filter((entity) => pageMap.has(entity.id)).map((entity) => {
     const page = pageMap.get(entity.id)!;
     return {
       id: entity.id,


### PR DESCRIPTION
## Summary
This PR makes internal pages (style guides, architecture docs, reports, etc.) discoverable through the Explore page and search functionality by adding them as a filterable entity type, rather than completely excluding them from the system.

## Key Changes
- **Entity Ontology**: Added "Internal" as a new entity group in `ENTITY_GROUPS`, making it available as a filter option alongside Concepts, Tables, and Diagrams
- **Explore Items**: Removed the `entity.entityType !== "internal"` filter from `getExploreItems()` in `data/index.ts` so internal pages are now included in the Explore grid
- **Search Index**: Removed the skip condition for internal entities in `search.mjs`, allowing internal pages to be indexed and searchable
- **Tests**: Updated the test in `data.test.ts` to verify that internal pages are now included in explore items rather than excluded

## Implementation Details
Previously, internal pages were filtered out in three separate locations (explore items, search index, and tests), creating a complete barrier to discovery. This change treats internal pages as a legitimate content type with its own filter category, allowing users to optionally view them while keeping them separate from public-facing content by default.

https://claude.ai/code/session_017V7Pikr7dNqj4CC8wHv7in