### PR TITLE
Extract DRY helpers (isFullWidth, isIndexFile) and add .md support

### DIFF
--- a/.claude/sessions/2026-02-17_fix-internal-wiki-pages-hPJcM.md
+++ b/.claude/sessions/2026-02-17_fix-internal-wiki-pages-hPJcM.md
@@ -1,0 +1,14 @@
+## 2026-02-17 | claude/fix-internal-wiki-pages-hPJcM | DRY helpers and .md support for wiki infrastructure
+
+**What was done:** Added `isFullWidth()` helper (eliminates 2x duplication in wiki route), `isIndexFile()` helper (eliminates 3x duplication in wiki-nav), and `.md` file support in research report generator. Rebased after parallel work on main superseded the original internal-page routing changes.
+
+**Pages:** (no page content changes — infrastructure only)
+
+**Issues encountered:**
+- Major rebase conflict: main merged opposite architectural approach (internal pages route through `/wiki/E<id>` instead of `/internal/*`), superseding ~80% of original PR changes
+- Had to reset to main and apply only the still-additive DRY/defensive changes
+
+**Learnings/notes:**
+- Main now routes internal pages through `/wiki/E<id>` with `isInternal` checks to hide wiki-only UI — our original `/internal/*` rendering approach was superseded
+- `findMdxFiles()` in `crux/lib/file-utils.ts` already supports `.md`, so validate-mdx-compile.ts didn't need changes
+- When parallel PRs diverge architecturally, better to reset to main and cherry-pick additive changes than attempt a complex rebase

--- a/app/src/app/wiki/[id]/page.tsx
+++ b/app/src/app/wiki/[id]/page.tsx
@@ -9,7 +9,7 @@ import {
 import type { MdxPage, MdxError } from "@/lib/mdx";
 import { getEntityById, getPageById, getEntityPath } from "@/data";
 import type { Page, ContentFormat } from "@/data";
-import { CONTENT_FORMAT_INFO } from "@/lib/page-types";
+import { CONTENT_FORMAT_INFO, isFullWidth } from "@/lib/page-types";
 import { PageStatus } from "@/components/PageStatus";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { RelatedPages } from "@/components/RelatedPages";
@@ -321,8 +321,8 @@ export default async function WikiPage({ params }: PageProps) {
 
     const entityPath = getEntityPath(slug) || "";
     const pageData = getPageById(slug);
-    const formatInfo = CONTENT_FORMAT_INFO[(pageData?.contentFormat || "article") as ContentFormat];
-    const fullWidth = result.frontmatter.fullWidth === true || formatInfo?.fullWidth === true;
+    const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;
+    const fullWidth = isFullWidth(contentFormat, result.frontmatter);
     return (
       <WithSidebar entityPath={entityPath} fullWidth={fullWidth}>
         <ContentView
@@ -349,8 +349,8 @@ export default async function WikiPage({ params }: PageProps) {
 
     const entityPath = getEntityPath(id) || "";
     const pageData = getPageById(id);
-    const formatInfo = CONTENT_FORMAT_INFO[(pageData?.contentFormat || "article") as ContentFormat];
-    const fullWidth = result.frontmatter.fullWidth === true || formatInfo?.fullWidth === true;
+    const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;
+    const fullWidth = isFullWidth(contentFormat, result.frontmatter);
     return (
       <WithSidebar entityPath={entityPath} fullWidth={fullWidth}>
         <ContentView

--- a/app/src/lib/page-types.ts
+++ b/app/src/lib/page-types.ts
@@ -114,6 +114,14 @@ export const PAGE_TYPE_INFO: Record<PageType, PageTypeInfo> = {
   },
 };
 
+/** Determine if a page should use full-width layout based on format and frontmatter. */
+export function isFullWidth(
+  contentFormat: ContentFormat,
+  frontmatter: Record<string, unknown>
+): boolean {
+  return frontmatter.fullWidth === true || CONTENT_FORMAT_INFO[contentFormat].fullWidth;
+}
+
 export function detectPageType(
   pathname: string,
   frontmatterType?: string

--- a/app/src/lib/wiki-nav.ts
+++ b/app/src/lib/wiki-nav.ts
@@ -14,6 +14,11 @@ import type { NavSection } from "./internal-nav";
 // Re-export NavSection so consumers can import from one place
 export type { NavSection } from "./internal-nav";
 
+/** Check if a filePath is an index file (should be excluded from sidebar nav). */
+function isIndexFile(filePath: string): boolean {
+  return filePath.endsWith("index.mdx") || filePath.endsWith("index.md");
+}
+
 // ============================================================================
 // MODEL CATEGORY LABELS
 // ============================================================================
@@ -61,7 +66,7 @@ export function getModelsNav(): NavSection[] {
     (p) =>
       p.filePath &&
       p.filePath.startsWith("knowledge-base/models/") &&
-      !p.filePath.endsWith("index.mdx")
+      !isIndexFile(p.filePath)
   );
 
   // Group by subcategory (set during content flattening)
@@ -104,7 +109,7 @@ export function getMetricsNav(): NavSection[] {
     (p) =>
       p.filePath &&
       p.filePath.startsWith("knowledge-base/metrics/") &&
-      !p.filePath.endsWith("index.mdx")
+      !isIndexFile(p.filePath)
   );
 
   const items = pages
@@ -168,7 +173,7 @@ export function getAtmNav(): NavSection[] {
     (p) =>
       p.filePath &&
       p.filePath.startsWith("ai-transition-model/") &&
-      !p.filePath.endsWith("index.mdx")
+      !isIndexFile(p.filePath)
   );
 
   // Top-level items (overview, parameter table)

--- a/crux/generate/generate-research-reports.ts
+++ b/crux/generate/generate-research-reports.ts
@@ -77,7 +77,7 @@ function getEntitiesWithReports(): Set<string> {
 
   if (!fs.existsSync(reportsDir)) return entityIds;
 
-  const files = fs.readdirSync(reportsDir).filter(f => f.endsWith('.mdx') && f !== 'index.mdx');
+  const files = fs.readdirSync(reportsDir).filter(f => (f.endsWith('.mdx') || f.endsWith('.md')) && f !== 'index.mdx' && f !== 'index.md');
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(reportsDir, file), 'utf-8');


### PR DESCRIPTION
## Summary
DRY cleanup and defensive improvements after the internal pages infrastructure work.

- **`isFullWidth()` helper** in `page-types.ts` — replaces duplicated `frontmatter.fullWidth || formatInfo.fullWidth` pattern (was 2x in wiki route)
- **`isIndexFile()` helper** in `wiki-nav.ts` — replaces duplicated `endsWith("index.mdx")` checks (was 3x), also handles `.md` extension defensively
- **`.md` file support** in `generate-research-reports.ts` — was only scanning `.mdx` files

Note: The original scope (internal page rendering, routing, breadcrumbs) was superseded by parallel work merged into main. This PR was rebased and reduced to only the remaining additive changes.

## Test plan
- [ ] Verify wiki pages render correctly (isFullWidth helper produces same behavior)
- [ ] Verify sidebar navigation still excludes index pages (isIndexFile helper)
- [ ] Build passes cleanly

https://claude.ai/code/session_01QT2yjJHLGVDPn4oD9TanTv