### PR TITLE
Add wiki page: Reducing Hallucinations in AI-Generated Wiki Content

### DIFF
--- a/.claude/sessions/2026-02-17_reduce-hallucinations-2XdJp.md
+++ b/.claude/sessions/2026-02-17_reduce-hallucinations-2XdJp.md
@@ -1,0 +1,16 @@
+## 2026-02-17 | claude/reduce-hallucinations-2XdJp | Add hallucination reduction research page
+
+**What was done:** Created a new wiki page on reducing hallucinations in AI-generated wiki content using the Crux content pipeline. The page covers RAG, WikiChat, prompt engineering, verification techniques, fine-tuning, human-in-the-loop systems, and their limitations, with 71 citations from Perplexity research.
+
+**Pages:** reducing-hallucinations
+
+**Issues encountered:**
+- Crux synthesis phase timed out at 300s when using Claude CLI subprocess; succeeded with `--api-direct` flag using the Anthropic API directly
+- Firecrawl package not installed (`@mendable/firecrawl-js`), so source fetching was skipped; synthesis relied on Perplexity summaries only
+- SCRY searches timed out for EA Forum and LessWrong
+- Entity type `response` is not in the schema; used `approach` instead
+
+**Learnings/notes:**
+- When synthesis times out, `--api-direct` mode bypasses the Claude CLI subprocess and uses the Anthropic API directly, which is more reliable
+- The `--phase` flag allows resuming individual pipeline phases without re-running the full pipeline
+- Entity types for responses should be `approach` or `policy`, not `response` (which isn't in the Zod schema)

--- a/content/docs/knowledge-base/responses/reducing-hallucinations.mdx
+++ b/content/docs/knowledge-base/responses/reducing-hallucinations.mdx
@@ -1,0 +1,475 @@
+---
+numericId: E814
+title: "Reducing Hallucinations in AI-Generated Wiki Content"
+description: "Technical and procedural strategies to ground AI-generated content in verified information and reduce factual errors in wiki articles"
+entityType: approach
+pageTemplate: knowledge-base-response
+lastEdited: "2026-02-17"
+createdAt: 2026-02-17
+sidebar:
+  order: 50
+ratings:
+  novelty: 4
+  rigor: 7
+  actionability: 8
+  completeness: 8
+readerImportance: 55
+quality: 68
+evergreen: false
+llmSummary: "This comprehensive technical guide documents methods to reduce AI hallucinations in wiki content from 3-27% to 0-6% through RAG, verification techniques, and human oversight, though notes complete elimination remains impossible. The article provides extensive quantified evidence (40+ citations) showing that while techniques like RAG with quality sources can dramatically reduce errors, fundamental architectural limitations mean hallucinations persist even in advanced systems."
+---
+
+import {EntityLink} from '@components/wiki';
+
+## Quick Assessment
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Primary Challenge** | AI models generate plausible but factually incorrect content based on statistical patterns rather than truth verification |
+| **Most Effective Technique** | Retrieval-Augmented Generation (RAG) combined with human review |
+| **Typical Hallucination Rate** | 3-27% for document summarization; can be reduced to 0-6% with proper techniques |
+| **Complete Elimination** | Not currently possible; remains a fundamental challenge for all LLMs |
+| **Key Applications** | Wiki content generation, medical information, legal research, technical documentation |
+| **Main Trade-off** | Accuracy improvements vs. reduced creative flexibility and increased implementation complexity |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Official Website | [Stanford HAI WikiChat Research](https://hai.stanford.edu/research/wikichat-stopping-the-hallucination-of-large-language-model-chatbots-by-few-shot-grounding-on-wikipedia) |
+| Wikipedia | [Hallucination (artificial intelligence)](https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence)) |
+| Technical Survey | [arXiv:2401.01313](https://arxiv.org/abs/2401.01313) |
+
+## Overview
+
+**Reducing hallucinations in AI-generated wiki content** refers to techniques and systems designed to prevent large language models from generating plausible but factually incorrect information when creating or editing encyclopedia-style articles. AI hallucinations occur because LLMs predict outputs based on statistical likelihood rather than truthfulness—they generate text word-by-word based on probability patterns learned from training data, without internal fact-checking mechanisms.[^1] This becomes particularly problematic for wiki applications where accuracy and verifiability are foundational requirements.
+
+For context, GPT-4 shows a hallucination rate of approximately 3% according to recent benchmarks,[^2] while general chatbots exhibit rates between 3-27% when summarizing documents.[^3] However, these rates can be significantly reduced through strategic interventions. Research demonstrates that RAG-based systems with reliable information sources achieve hallucination rates of 2-18% compared to 39% for conventional models without retrieval grounding.[^4] In medical applications specifically, one study found that incorporating reliable cancer information through RAG reduced hallucinations to 0% (GPT-4) or 6% (GPT-3.5) compared to 19-40% for conventional approaches.[^5]
+
+The fundamental challenge stems from how LLMs work: they generate content by predicting the next word based on patterns in their training data, not by verifying facts against a knowledge base. When asked to generate wiki content about obscure topics, recent events, or specialized subjects, models may "fill gaps" with statistically plausible but invented information—creating fake citations, incorrect dates, or fabricated biographical details that superficially resemble legitimate encyclopedia entries.
+
+## Definition and Mechanisms
+
+AI hallucinations in wiki content manifest as confident-sounding but factually incorrect outputs such as nonexistent facts, fabricated citations, or inaccurate descriptions that mimic reliable Wikipedia-style articles.[^6] The term reflects outputs where models generate information that appears plausible based on linguistic patterns but lacks grounding in reality.
+
+### How Hallucinations Occur
+
+Several mechanisms contribute to hallucinations in AI-generated content:
+
+**Pre-training limitations**: Models learn next-word prediction on vast unverified text corpora, memorizing patterns without distinguishing true from false statements.[^7] During training, LLMs absorb both accurate and inaccurate information, biases, and contradictory claims without developing inherent truth-verification capabilities.
+
+**Missing or ambiguous data**: When query information is absent or unclear in the training data, models "fill gaps" with guesses amplified by design pressure to provide complete responses.[^8] For wiki articles on obscure topics or recent events post-dating the training data, models may confabulate details to maintain conversational flow.
+
+**Cascade effects**: Errors compound as models build on their own prior (potentially wrong) outputs in long-form content like wiki articles.[^9] An initial incorrect claim may influence subsequent paragraphs, creating internally consistent but externally false narratives.
+
+**Statistical generation without verification**: LLMs predict subsequent words based on probability distributions, not fact-checking processes.[^10] This fundamental architecture means that even highly probable sequences may be factually incorrect—the model cannot distinguish between "sounds right" and "is right."
+
+### Examples in Wiki Contexts
+
+Common hallucination patterns for wiki content include:
+
+- **Fabricated references**: Citing nonexistent papers or books with plausible-sounding titles and authors
+- **Incorrect biographical details**: Inventing dates, educational credentials, or career milestones for real people
+- **False historical claims**: Creating events that never occurred or misattributing actions and statements
+- **Nonexistent entities**: Generating articles about fictional organizations, products, or concepts presented as real
+
+The Galactica AI model famously demonstrated this problem by generating citations to fictitious papers attributed to real researchers,[^11] illustrating how hallucinations can blend real and invented information in ways that appear credible at first glance.
+
+## Primary Mitigation Techniques
+
+### Retrieval-Augmented Generation (RAG)
+
+RAG represents the most effective and widely recommended technical approach for reducing hallucinations in wiki applications.[^12] This technique fundamentally changes how AI generates content by integrating external knowledge sources directly into the generation process.
+
+Rather than relying solely on an LLM's parametric memory (information encoded in model weights during training), RAG systems first query verified databases before generating responses. The process works as follows:
+
+1. **Query conversion**: User prompts are converted to vector embeddings using models like BERT
+2. **Knowledge retrieval**: The system searches domain-specific vector databases or knowledge bases for relevant factual information
+3. **Context integration**: Retrieved documents are provided as context to the LLM
+4. **Grounded generation**: The model generates content based on both the prompt and the verified information
+
+For wiki content, RAG can query existing verified articles, academic databases like PubMed, or curated reference materials to ensure generated content aligns with established facts.[^13] This approach has demonstrated substantial improvements: one NIH study showed RAG-based medical chatbots achieved 0% (GPT-4) to 6% (GPT-3.5) hallucination rates when using reliable cancer information sources, compared to 19-35% when using Google searches and 40% for conventional chatbots without retrieval.[^14] The odds ratio for hallucinations was 16.1 times lower with quality RAG sources compared to conventional approaches (95% CI 3.7-50.0, P\<.001).
+
+A 2024 Stanford study combining RAG with other techniques reported achieving up to 96% reduction in hallucinations,[^15] though this figure represents an upper bound under optimal conditions rather than typical performance.
+
+#### RAG Implementation Challenges
+
+Despite its effectiveness, RAG introduces complexity:
+
+- **Source quality dependence**: RAG is only as good as its knowledge base—using low-quality or biased sources can perpetuate misinformation[^16]
+- **Retrieval accuracy**: Systems must retrieve relevant documents; irrelevant context can confuse models
+- **Computational overhead**: Real-time database queries add latency and infrastructure requirements
+- **Context window limits**: Retrieved documents must fit within model context windows, requiring careful chunk selection
+
+### Stanford WikiChat System
+
+WikiChat represents a specialized application of RAG techniques specifically designed for wiki-style content generation. Developed by Stanford's Human-Centered AI Institute and published in 2023, WikiChat achieves 97.9% factual accuracy in human conversations by implementing a multi-stage verification process:[^17]
+
+1. **Response generation**: The system generates initial responses using few-shot prompting grounded in Wikipedia articles
+2. **Fact extraction**: It extracts individual factual claims from the generated text
+3. **Additional retrieval**: For each claim, the system retrieves relevant Wikipedia content
+4. **Ungrounded filtering**: Claims that cannot be verified against retrieved sources are removed, replaced with "Sorry, I'm not sure" responses
+
+This approach outperformed GPT-4 by 55% on recent topics and exceeded baseline approaches by 3.9-51% across different knowledge types.[^18] The system includes model distillation to reduce latency while maintaining accuracy, making it more practical for production deployment.
+
+### Prompt Engineering Techniques
+
+Advanced prompting strategies provide substantial reductions in hallucinations without requiring infrastructure changes. Research shows these techniques can reduce hallucination rates from 53% to 23% (a 30-percentage-point improvement) for models like GPT-4o.[^19]
+
+**Chain-of-thought prompting** instructs models to break down complex topics into intermediate reasoning steps, improving accuracy for nuanced wiki entries.[^20] Rather than directly generating article content, the model first outlines its reasoning process, which surfaces potential errors and inconsistencies before final generation.
+
+**Structured prompting** organizes instructions into clear blocks:[^21]
+
+- **Role definition**: "You are a fact-checking wiki editor"
+- **Objective guidelines**: "Generate content only when you can cite specific sources"
+- **Output format**: "Structure articles with clear sections and inline citations"
+- **Accuracy emphasis**: "No answer is better than an incorrect answer; admit uncertainty"
+
+**Few-shot prompting** provides example answers that guide models toward correct responses.[^22] For wiki applications, this might include examples of well-sourced biographical entries or properly structured historical articles.
+
+**Explicit source requirements** instruct models to cite sources for each claim and admit when information is uncertain.[^23] This shifts models from pure content generation toward synthesis of verified information.
+
+### Fine-Tuning and Reinforcement Learning
+
+**Domain-specific fine-tuning** trains models on curated, accurate datasets to teach correct information and behaviors.[^24] For wiki applications, this means training on high-quality, fact-checked encyclopedia content rather than general web text. Fine-tuning requires significant computational resources and domain expertise but can substantially reduce hallucinations in specialized areas.
+
+**Reinforcement Learning from Human Feedback (RLHF)** trains models to prefer outputs that human reviewers label as correct.[^25] Research shows RLHF can reduce factual errors by 40% (GPT-4) and harmful hallucinations by 85% according to reports from <EntityLink id="anthropic">Anthropic</EntityLink>.[^26] The 2025 AI Index Report highlights progress via RLHF, RLAIF (Reinforcement Learning from AI Feedback), and DPO (Direct Preference Optimization), though notes that hallucination benchmarks continue to present challenges.[^27]
+
+The trade-off is implementation complexity: fine-tuning demands high-quality labeled data and computational resources, while RLHF requires extensive human feedback collection and training iterations.
+
+### Verification and Post-Processing
+
+Multiple verification techniques identify and correct hallucinations after initial generation:[^28]
+
+**Self-consistency** generates multiple responses to the same query and uses quality checks to identify the most consistent (and likely correct) answer. For wiki content, this might involve generating three versions of a biographical section and selecting claims that appear in all versions.
+
+**Chain of Verification (CoVe)** prompts the LLM to verify each generated statement and correct inconsistencies.[^29] The system asks the model follow-up questions about its own claims: "What evidence supports this date?" or "Which source confirms this affiliation?"
+
+**RealTime Verification and Rectification (EVER)** applies verification during the generation process itself,[^30] checking low-confidence statements against external sources like web search APIs and using hierarchical relevance rankings to assess retrieved information quality.
+
+Research indicates verification techniques can provide an additional 20% reduction in hallucinations when combined with RAG.[^31]
+
+### Human-in-the-Loop Systems
+
+Human oversight remains essential for high-stakes wiki content. Agentic AI workflows implement custom hallucination detection with predefined confidence thresholds, routing flagged content to human reviewers when confidence falls below acceptable levels.[^32]
+
+Amazon Bedrock Agents demonstrates this approach using RAGAS evaluation metrics (including faithfulness, answer relevance, and context alignment scores) to detect potential hallucinations.[^33] When detection thresholds are exceeded, the system sends notifications to human reviewers via SNS queues for fact-checking and correction before publication.
+
+This hybrid approach acknowledges that automated systems cannot catch all errors while making human review more efficient by pre-filtering likely accurate content.
+
+## Supporting Strategies
+
+### Model Parameter Optimization
+
+Adjusting generation parameters affects hallucination rates:[^34]
+
+- **Temperature reduction**: Lower temperature settings (e.g., 0.3 vs. 0.7) make outputs more deterministic and less creative, reducing random fabrications
+- **Top-k sampling**: Limiting the model to selecting from the top k most likely next tokens (e.g., k=20) prevents improbable word choices that might lead to hallucinations
+- **Top-p (nucleus) sampling**: Similar to top-k but uses cumulative probability thresholds
+
+Research on production query bots found k=20 chunks optimal for balancing retrieval quality and hallucination reduction after iterative testing.[^35]
+
+### Temporal Knowledge Graphs
+
+Knowledge graphs store conversation context and relationships between entities in structured formats, improving consistency and reducing contradictory or invented information.[^36] For wiki content, knowledge graphs can represent relationships between people, events, and concepts, helping models maintain factual consistency across article sections.
+
+### Transparency Mechanisms
+
+Rather than attempting to eliminate all hallucinations, transparency approaches help users assess reliability:[^37]
+
+- **Confidence indicators**: Displaying model uncertainty scores for generated claims
+- **Uncertainty language**: Training models to use hedging language ("According to some sources..." rather than definitive claims) for low-confidence information
+- **Source links**: Providing inline citations and links to source materials for verification
+- **Annotation systems**: Marking AI-generated vs. human-verified content
+
+### Guardrails and Contextual Grounding
+
+Modern guardrail systems verify that LLM responses remain factually grounded in source materials, flagging any information not supported by cited sources.[^38] These systems implement rule-based checks for contextual alignment, cross-referencing outputs with trusted databases to ensure claims match verified information.
+
+Context alignment scores in RAG pipelines measure how well generated content adheres to retrieved documents, with lower scores triggering additional verification or human review.[^39]
+
+## Applications and Use Cases
+
+| Application Area | Primary Techniques | Specific Considerations |
+|-----------------|-------------------|------------------------|
+| **Biographical entries** | RAG + fact-checking + human review | Verify dates, achievements, affiliations; high risk of fabricated credentials |
+| **Historical articles** | Chain-of-thought + verification + RAG | Break down complex narratives; cross-reference with academic sources; date accuracy critical |
+| **Technical documentation** | RAG + fine-tuning | Ground in official documentation; fine-tune on domain-specific materials; terminology consistency |
+| **Current events** | Human-in-the-loop + real-time verification | Flag rapidly changing information for human review before publication |
+| **Stub generation** | Prompt engineering + guardrails | Use explicit instructions to generate minimal content only when confident; admit knowledge gaps |
+| **Content expansion** | RAG + CoVe | Retrieve source material; verify each claim before adding to existing articles; maintain consistency |
+| **Medical/health information** | RAG with curated databases + mandatory review | Legal and ethical stakes; require human expert verification; cite peer-reviewed sources |
+
+## Research Evidence and Quantified Results
+
+### Medical Domain Studies
+
+A peer-reviewed study published in JMIR Cancer (PubMed ID: 40934488) demonstrated significant hallucination reduction through RAG in cancer information chatbots:[^40]
+
+- **Conventional chatbots**: ~40% hallucination rate
+- **Google-augmented RAG**: 19% (GPT-4) and 35% (GPT-3.5) hallucination rates
+- **CIS (Cancer Information Service)-augmented RAG**: 0% (GPT-4) and 6% (GPT-3.5) hallucination rates
+- **Statistical significance**: Odds ratio 9.4 (95% CI 1.2-17.5, P\<.01) for more hallucinations with Google vs. CIS sources; OR 16.1 (95% CI 3.7-50.0, P\<.001) comparing CIS-RAG to conventional approaches
+
+This study highlights that RAG effectiveness depends critically on source quality—curated medical databases outperformed general web search by substantial margins.
+
+### Foundation Model Performance
+
+A study published on MedRxiv examining foundation models in clinical contexts found that chain-of-thought prompting and search augmentation reduced medical hallucination rates, though non-trivial levels persisted.[^41] The research used physician-annotated LLM responses to real clinical cases, finding that even advanced mitigation techniques leave residual hallucination risks in medical applications.
+
+Separately, Medicomp Systems reported that AI-captured information from complex clinical encounters showed 8-10% flagging rates by their hallucination detection tool,[^42] indicating that even specialized medical AI systems produce concerning levels of unverified content.
+
+### Legal Domain Results
+
+Research from Stanford HAI examining legal AI models found hallucination rates of 58-82% on legal queries for general chatbots.[^43] Even RAG-based legal tools designed specifically for legal research continued to hallucinate, contradicting claims that they are "hallucination-free."
+
+### Comprehensive Survey Findings
+
+A comprehensive January 2024 survey published on arXiv (arXiv:2401.01313) cataloged over 32 distinct hallucination mitigation techniques, categorizing them by dataset utilization, task types, feedback mechanisms, and retriever types.[^44] The survey identified several foundational methods:
+
+- **RAG** (Lewis et al., 2021): Retrieval-augmented generation
+- **Knowledge Retrieval** (Varshney et al., 2023): Enhanced knowledge integration
+- **CoNLI** (Lei et al., 2023): Contrastive natural language inference
+- **CoVe** (Dhuliawala et al., 2023): Chain of verification
+
+The survey concluded that hallucinations can be reduced substantially but not eliminated, and that performance varies significantly across domains and tasks.
+
+### Model Evolution
+
+According to OpenAI's research published in August 2025, GPT-5 shows "significant advances" in reducing hallucinations compared to prior models, especially in reasoning tasks.[^45] However, the research acknowledges hallucinations remain a "fundamental challenge" for all LLMs.
+
+Interestingly, the same research found that newer reasoning models like o4-mini sometimes show higher error rates despite better accuracy in certain metrics, due to strategic guessing behavior—models answer questions they should decline, prioritizing perceived helpfulness over accuracy.[^46]
+
+## Limitations and Persistent Challenges
+
+### Structural Inevitability
+
+Hallucinations cannot be completely eliminated with current LLM architectures.[^47] The fundamental mechanism of next-token prediction based on statistical patterns means models will occasionally generate plausible but false information, regardless of mitigation techniques. Even advanced models like GPT-5 continue to hallucinate, though at reduced rates.
+
+### Implementation Complexity
+
+Effective hallucination reduction requires substantial infrastructure:[^48]
+
+- **RAG systems**: Demand vector databases, embedding models, retrieval pipelines, and ongoing maintenance
+- **Custom thresholds**: Require extensive testing to balance false positives (over-filtering) and false negatives (missed hallucinations)
+- **Human review workflows**: Need trained fact-checkers, notification systems, and quality assurance processes
+- **Computational overhead**: Real-time verification and multiple generation passes increase latency and cost
+
+### Performance Trade-offs
+
+Reducing hallucinations often conflicts with other desirable properties:[^49]
+
+- **Creativity reduction**: Strict factual grounding limits models' ability to generate novel insights or creative interpretations
+- **Completeness vs. accuracy**: Models forced to admit uncertainty produce less comprehensive content
+- **Speed vs. verification**: Multiple verification passes and retrieval steps increase response time
+- **Cost increases**: Additional API calls, human review, and computational requirements raise operational costs
+
+### Domain Dependency
+
+Mitigation effectiveness varies significantly by domain:[^50]
+
+- **Well-documented fields**: RAG works well for topics with extensive reliable sources (e.g., established medical knowledge)
+- **Emerging topics**: Recent events or cutting-edge research lack comprehensive source databases
+- **Specialized knowledge**: Niche subjects may have limited high-quality training data or retrieval sources
+- **Subjective areas**: Topics involving interpretation or opinion are harder to fact-check objectively
+
+### Source Quality Challenges
+
+RAG systems inherit the limitations of their knowledge bases:[^51]
+
+- **Wikipedia limitations**: While generally reliable, Wikipedia contains errors, biases, and gaps, particularly for non-English topics or recent events
+- **Database currency**: Static knowledge bases become outdated without continuous updating
+- **Contradictory sources**: Different reliable sources may disagree, forcing models to choose or reconcile conflicting information
+- **Bias propagation**: Training or retrieval from biased sources perpetuates those biases in generated content
+
+### Evaluation Difficulties
+
+Measuring hallucination rates presents challenges:[^52]
+
+- **Manual annotation**: Human fact-checking is time-consuming and costly, limiting evaluation scale
+- **Subtle errors**: Some hallucinations are difficult to detect without deep expertise
+- **Context dependency**: Whether content qualifies as a hallucination can depend on interpretation
+- **Benchmark limitations**: Test sets may not represent real-world complexity or edge cases
+
+The 2025 AI Index Report noted that hallucination benchmarks continue to struggle with reliable measurement despite progress in mitigation techniques.[^53]
+
+## Recent Developments (2024-2026)
+
+### Multimodal RAG Systems
+
+Enterprise-grade RAG implementations have evolved to support multimodal inputs and provide enhanced transparency. Morphik introduced open-source multimodal RAG kits for finance, healthcare, and legal applications in 2024-2025, featuring:[^54]
+
+- Full-page context processing (not just extracted text)
+- Traceable citations linking generated claims to source documents
+- Faithfulness@5 metrics for evaluating grounding quality
+- GPU acceleration for production deployment
+
+### Agentic Workflow Advances
+
+Amazon Bedrock Agents (launched post-2023) demonstrates scalable custom hallucination detection using RAGAS metrics with predefined thresholds.[^55] The system routes detected hallucinations to human reviewers via SNS notifications without requiring workflow restructuring, enabling dynamic intervention across various generation tasks.
+
+### Prompt Engineering Refinements
+
+Research published in npj Digital Medicine in 2025 showed that prompt engineering techniques reduced GPT-4o hallucinations from 53% to 23%—a 30-percentage-point improvement—without model fine-tuning or RAG infrastructure.[^56] This demonstrates that even relatively simple interventions can yield substantial benefits.
+
+### Medical AI Applications
+
+A collaboration between the American Cancer Society and Layer Health announced in early 2026 focuses on LLM platforms for Cancer Prevention Study-3 data abstraction (involving 300,000 participants), prioritizing transparency mechanisms to eliminate hallucinations in medical record processing.[^57] This reflects growing emphasis on domain-specific applications with enhanced verification.
+
+### Tool Integration
+
+Production query bots deployed in 2024-2025 demonstrate iteratively optimized approaches, with companies like Tredence reporting that top-k=20 chunk sampling provides optimal balance after extensive testing.[^58] These real-world deployments provide practical validation for academic research findings.
+
+## Criticisms and Controversies
+
+### Overstatement of Solutions
+
+Critics argue that claims of "hallucination-free" AI tools are misleading, particularly in legal and medical domains where RAG-based systems continue to produce significant error rates.[^59] Stanford research showing 58-82% hallucination rates even in specialized legal tools contradicts vendor marketing claims, raising concerns about premature deployment.
+
+### Strategic Guessing Problem
+
+OpenAI's research revealed that binary evaluation systems (correct vs. incorrect) create perverse incentives for models to guess rather than admit uncertainty.[^60] Newer models sometimes show higher error rates despite better accuracy on some metrics because they attempt answers they should decline—a systemic issue stemming from training and evaluation practices.
+
+### Persistent Inequality Across Domains
+
+Hallucination reduction techniques show "artificial jagged intelligence"—uneven performance across different knowledge areas.[^61] Models achieve higher reliability in expert-consensus domains but remain risky for sensitive applications like medical records, legal analysis, and financial advice where errors have serious consequences.
+
+### Privacy and Opacity Limitations
+
+The probabilistic nature of LLMs and corporate opacity around training data limit external verification of hallucination mitigation claims.[^62] Users cannot independently assess whether deployed systems implement claimed safeguards or maintain advertised accuracy levels, creating accountability gaps.
+
+### Wikipedia Ecosystem Concerns
+
+The broader impact of AI-generated content on Wikipedia itself presents concerns. Research from King's College London found that while "fears of Wikipedia's end" from AI are "overblown," challenges remain in detecting and managing AI-generated articles.[^63] Some fully hallucinated articles generated by AI have been flagged for deletion under Wikipedia's PROD (proposed deletion) process, though some were subsequently restored after editor review, highlighting community disagreement about handling AI content.[^64]
+
+### Training Data Contamination
+
+As AI-generated content proliferates online, future LLMs trained on web data risk ingesting AI hallucinations as training material, potentially creating feedback loops that amplify rather than reduce misinformation.[^65] This presents a long-term challenge for maintaining content quality across the internet ecosystem.
+
+## Key Uncertainties
+
+Several fundamental questions remain unresolved:
+
+**Can hallucinations ever be fully eliminated?** Current evidence suggests no—the statistical nature of LLM generation appears to make some baseline hallucination rate inevitable. Research consistently shows reductions but not elimination, even with sophisticated techniques. However, it remains uncertain whether fundamentally different architectures might solve this problem.
+
+**What are acceptable hallucination rates for wiki content?** No consensus exists on target error rates for different use cases. Medical information clearly demands near-zero hallucination rates, but standards for historical articles, biographical stubs, or general knowledge content remain undefined. Trade-offs between completeness and accuracy lack principled resolution.
+
+**How should we measure hallucination severity?** Current metrics treat all hallucinations equally, but fabricated dates may be more harmful than minor omissions, and medical misinformation more serious than entertainment facts. Weighted severity metrics and context-dependent evaluation frameworks remain underdeveloped.
+
+**What long-term effects will AI content have on knowledge ecosystems?** The downstream impact of AI-generated wiki content on research, education, and public understanding is largely unknown. If AI systems train on AI-generated content, feedback effects could either amplify or reduce hallucination rates over time.
+
+**Will improved models reduce hallucinations automatically?** Evidence is mixed—while GPT-5 shows fewer hallucinations than GPT-4 in some contexts, newer reasoning models sometimes exhibit higher error rates despite better accuracy on other metrics. Whether continued scaling leads to lower hallucination rates remains uncertain.
+
+**How effective are different mitigation combinations?** While individual techniques show promise, optimal combinations of RAG, prompting, fine-tuning, and verification remain under-explored. The 96% reduction claimed by the Stanford study represents an upper bound under ideal conditions, but typical achievable reductions in production systems across diverse topics are less well characterized.
+
+## Counterarguments and Alternative Perspectives
+
+### Creativity Trade-off Argument
+
+Some researchers argue that aggressive hallucination reduction stifles AI's creative and innovative potential, which relies on hallucination-like processes for generating novel ideas beyond rote factual recall.[^66] From this perspective, complete elimination is neither feasible nor desirable, as it would limit AI's value in creative applications while still requiring human oversight.
+
+According to this view, AI must "hallucinate" to create new content rather than merely regurgitating existing data, akin to human dreaming or imagination.[^67] Suppressing this capability could hinder novel outputs valuable for wiki expansions on speculative or underexplored topics.
+
+### Application-Specific Flexibility
+
+Rather than seeking universal hallucination reduction, some argue for application-specific calibration—loose constraints for brainstorming wiki drafts, tight constraints for final verification—allowing "both ways" without blanket reduction.[^68] This pragmatic approach acknowledges different use cases require different accuracy-creativity balances.
+
+### Source Quality Concerns
+
+Critics note that RAG systems rely on external sources like Wikipedia, which may themselves contain inaccuracies or biases, potentially propagating errors under the guise of factuality.[^69] From this perspective, RAG doesn't eliminate hallucinations so much as substitute the LLM's hallucinations for the errors and biases present in retrieval databases.
+
+### Terminology and Framing Issues
+
+Some researchers object to the term "hallucination" itself, arguing it carries negative psychiatric connotations that unfairly pathologize useful generative behaviors.[^70] Reframing might reduce pressure for aggressive suppression and enable more nuanced discussions of when creative generation is valuable versus when strict factuality is required.
+
+### Empirical Performance Questions
+
+The claimed 96% hallucination reduction from combined techniques[^71] represents performance under optimal research conditions with carefully curated knowledge bases and extensive human oversight. Real-world deployment conditions—with imperfect source data, resource constraints, and diverse query types—likely achieve substantially lower reductions, making the headline figure potentially misleading for typical applications.
+
+## Implications for Wiki Content Generation
+
+For <EntityLink id="E384">LongtermWiki</EntityLink> and similar AI safety knowledge bases, reducing hallucinations presents both technical challenges and strategic opportunities:
+
+**Quality-quantity trade-offs**: Aggressive hallucination reduction through human review may limit the volume of content that can be generated, requiring prioritization of high-value articles over comprehensive coverage. RAG-based generation may excel at expanding well-documented topics while struggling with emerging research or niche subjects.
+
+**Source dependency**: Wiki projects must carefully curate retrieval databases, balancing Wikipedia's broad coverage against specialized sources for AI safety, effective altruism, and related technical topics. Poor source selection could propagate biases or outdated information even with technically sound RAG implementation.
+
+**Human oversight requirements**: Even with advanced mitigation techniques, human fact-checking remains essential for wiki content. Organizations must allocate resources for expert review rather than treating AI generation as fully automated.
+
+**Transparency standards**: Wiki projects should clearly mark AI-generated vs. human-verified content, provide confidence indicators, and link to sources for verification. Users deserve transparency about content provenance and reliability limitations.
+
+**Continuous improvement**: As models and mitigation techniques evolve, wiki projects should regularly evaluate and update their approaches, monitoring hallucination rates and adjusting thresholds based on empirical performance rather than vendor claims.
+
+## Sources
+
+[^1]: [Nielsen Norman Group: AI Hallucinations](https://www.nngroup.com/articles/ai-hallucinations/)
+[^2]: [Knostic: AI Hallucinations Guide](https://www.knostic.ai/blog/ai-hallucinations)
+[^3]: [Grammarly: What Are AI Hallucinations?](https://www.grammarly.com/blog/ai/what-are-ai-hallucinations/)
+[^4]: [NIH PMC: RAG for Cancer Information](https://pmc.ncbi.nlm.nih.gov/articles/PMC12425422/)
+[^5]: [PubMed: Reducing Hallucinations with RAG](https://pubmed.ncbi.nlm.nih.gov/40934488/)
+[^6]: [GPTZero: AI Hallucinations Definition](https://gptzero.me/news/ai-hallucinations-definition-examples/)
+[^7]: [Wikipedia: Hallucination (artificial intelligence)](https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence))
+[^8]: [GPTZero: AI Hallucinations Definition](https://gptzero.me/news/ai-hallucinations-definition-examples/)
+[^9]: [Wikipedia: Hallucination (artificial intelligence)](https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence))
+[^10]: [Grammarly: What Are AI Hallucinations?](https://www.grammarly.com/blog/ai/what-are-ai-hallucinations/)
+[^11]: [Evidently AI: AI Hallucinations Examples](https://www.evidentlyai.com/blog/ai-hallucinations-examples)
+[^12]: [Conductor Academy: AI Hallucinations](https://www.conductor.com/academy/ai-hallucinations/)
+[^13]: [Getzep: Reducing LLM Hallucinations](https://www.getzep.com/ai-agents/reducing-llm-hallucinations/)
+[^14]: [NIH PMC: RAG for Cancer Information](https://pmc.ncbi.nlm.nih.gov/articles/PMC12425422/)
+[^15]: [Voiceflow: Prevent LLM Hallucinations](https://www.voiceflow.com/blog/prevent-llm-hallucinations)
+[^16]: [Red Hat: When LLMs Daydream](https://www.redhat.com/en/blog/when-llms-day-dream-hallucinations-how-prevent-them)
+[^17]: [Stanford HAI: WikiChat Research](https://hai.stanford.edu/research/wikichat-stopping-the-hallucination-of-large-language-model-chatbots-by-few-shot-grounding-on-wikipedia)
+[^18]: [ACL Anthology: WikiChat Paper](https://aclanthology.org/2023.findings-emnlp.157.pdf)
+[^19]: [Lakera: Guide to Hallucinations in LLMs](https://www.lakera.ai/blog/guide-to-hallucinations-in-large-language-models)
+[^20]: [Red Hat: When LLMs Daydream](https://www.redhat.com/en/blog/when-llms-day-dream-hallucinations-how-prevent-them)
+[^21]: [Data.world: AI Hallucination Blog](https://data.world/blog/ai-hallucination/)
+[^22]: [The Learning Agency: Hallucination Techniques](https://the-learning-agency.com/the-cutting-ed/article/hallucination-techniques/)
+[^23]: [Salesforce: Generative AI Hallucinations](https://www.salesforce.com/blog/generative-ai-hallucinations/)
+[^24]: [Getzep: Reducing LLM Hallucinations](https://www.getzep.com/ai-agents/reducing-llm-hallucinations/)
+[^25]: [Voiceflow: Prevent LLM Hallucinations](https://www.voiceflow.com/blog/prevent-llm-hallucinations)
+[^26]: [Voiceflow: Prevent LLM Hallucinations](https://www.voiceflow.com/blog/prevent-llm-hallucinations)
+[^27]: [OpenAI: Why Language Models Hallucinate PDF](https://cdn.openai.com/pdf/d04913be-3f6f-4d2b-b283-ff432ef4aaa5/why-language-models-hallucinate.pdf)
+[^28]: [The Learning Agency: Hallucination Techniques](https://the-learning-agency.com/the-cutting-ed/article/hallucination-techniques/)
+[^29]: [The Learning Agency: Hallucination Techniques](https://the-learning-agency.com/the-cutting-ed/article/hallucination-techniques/)
+[^30]: [The Learning Agency: Hallucination Techniques](https://the-learning-agency.com/the-cutting-ed/article/hallucination-techniques/)
+[^31]: [Knostic: AI Hallucinations Guide](https://www.knostic.ai/blog/ai-hallucinations)
+[^32]: [AWS: Reducing Hallucinations with Bedrock Agents](https://aws.amazon.com/blogs/machine-learning/reducing-hallucinations-in-large-language-models-with-custom-intervention-using-amazon-bedrock-agents/)
+[^33]: [AWS: Reducing Hallucinations with Bedrock Agents](https://aws.amazon.com/blogs/machine-learning/reducing-hallucinations-in-large-language-models-with-custom-intervention-using-amazon-bedrock-agents/)
+[^34]: [Red Hat: When LLMs Daydream](https://www.redhat.com/en/blog/when-llms-day-dream-hallucinations-how-prevent-them)
+[^35]: [Tredence: Mitigating Hallucination in LLMs](https://www.tredence.com/blog/mitigating-hallucination-in-large-language-models)
+[^36]: [Getzep: Reducing LLM Hallucinations](https://www.getzep.com/ai-agents/reducing-llm-hallucinations/)
+[^37]: [Nielsen Norman Group: AI Hallucinations](https://www.nngroup.com/articles/ai-hallucinations/)
+[^38]: [Red Hat: When LLMs Daydream](https://www.redhat.com/en/blog/when-llms-day-dream-hallucinations-how-prevent-them)
+[^39]: [Knostic: AI Hallucinations Guide](https://www.knostic.ai/blog/ai-hallucinations)
+[^40]: [PubMed: Reducing Hallucinations with RAG](https://pubmed.ncbi.nlm.nih.gov/40934488/)
+[^41]: [MobiHealthNews: Study on AI Hallucinations](https://www.mobihealthnews.com/news/study-ai-hallucinations-limit-reliability-foundation-models)
+[^42]: [MobiHealthNews: Study on AI Hallucinations](https://www.mobihealthnews.com/news/study-ai-hallucinations-limit-reliability-foundation-models)
+[^43]: [Stanford HAI: AI on Trial](https://hai.stanford.edu/news/ai-trial-legal-models-hallucinate-1-out-6-or-more-benchmarking-queries)
+[^44]: [arXiv: Survey of Hallucination Mitigation](https://arxiv.org/abs/2401.01313)
+[^45]: [OpenAI: Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)
+[^46]: [OpenAI: Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)
+[^47]: [Red Hat: When LLMs Daydream](https://www.redhat.com/en/blog/when-llms-day-dream-hallucinations-how-prevent-them)
+[^48]: [AWS: Reducing Hallucinations with Bedrock Agents](https://aws.amazon.com/blogs/machine-learning/reducing-hallucinations-in-large-language-models-with-custom-intervention-using-amazon-bedrock-agents/)
+[^49]: [OpenAI: Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)
+[^50]: [arXiv: Survey of Hallucination Mitigation](https://arxiv.org/abs/2401.01313)
+[^51]: [Free Think: AI Hallucinations](https://www.freethink.com/robots-ai/ai-hallucinations)
+[^52]: [arXiv: Survey of Hallucination Mitigation](https://arxiv.org/abs/2401.01313)
+[^53]: [OpenAI: Why Language Models Hallucinate PDF](https://cdn.openai.com/pdf/d04913be-3f6f-4d2b-b283-ff432ef4aaa5/why-language-models-hallucinate.pdf)
+[^54]: [Morphik: Eliminate Hallucinations Guide](https://www.morphik.ai/blog/eliminate-hallucinations-guide)
+[^55]: [AWS: Reducing Hallucinations with Bedrock Agents](https://aws.amazon.com/blogs/machine-learning/reducing-hallucinations-in-large-language-models-with-custom-intervention-using-amazon-bedrock-agents/)
+[^56]: [Lakera: Guide to Hallucinations in LLMs](https://www.lakera.ai/blog/guide-to-hallucinations-in-large-language-models)
+[^57]: [MobiHealthNews: Study on AI Hallucinations](https://www.mobihealthnews.com/news/study-ai-hallucinations-limit-reliability-foundation-models)
+[^58]: [Tredence: Mitigating Hallucination in LLMs](https://www.tredence.com/blog/mitigating-hallucination-in-large-language-models)
+[^59]: [Stanford HAI: AI on Trial](https://hai.stanford.edu/news/ai-trial-legal-models-hallucinate-1-out-6-or-more-benchmarking-queries)
+[^60]: [OpenAI: Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)
+[^61]: [Harvard Misinforeview: New Sources of Inaccuracy](https://misinforeview.hks.harvard.edu/article/new-sources-of-inaccuracy-a-conceptual-framework-for-studying-ai-hallucinations/)
+[^62]: [Harvard Misinforeview: New Sources of Inaccuracy](https://misinforeview.hks.harvard.edu/article/new-sources-of-inaccuracy-a-conceptual-framework-for-studying-ai-hallucinations/)
+[^63]: [King's College London: Fears of Wikipedia's End](https://www.kcl.ac.uk/news/fears-of-wikipedias-end-overblown-but-challenges-remain-warn-researchers)
+[^64]: [Wiki Education: GenAI and Wikipedia Editing](https://wikiedu.org/blog/2026/01/29/generative-ai-and-wikipedia-editing-what-we-learned-in-2025/)
+[^65]: [GPTZero: AI Hallucinations Definition](https://gptzero.me/news/ai-hallucinations-definition-examples/)
+[^66]: [Free Think: AI Hallucinations](https://www.freethink.com/robots-ai/ai-hallucinations)
+[^67]: [Free Think: AI Hallucinations](https://www.freethink.com/robots-ai/ai-hallucinations)
+[^68]: [Free Think: AI Hallucinations](https://www.freethink.com/robots-ai/ai-hallucinations)
+[^69]: [Free Think: AI Hallucinations](https://www.freethink.com/robots-ai/ai-hallucinations)
+[^70]: [NIH PMC: Hallucination Terminology](https://pmc.ncbi.nlm.nih.gov/articles/PMC10483440/)
+[^71]: [Voiceflow: Prevent LLM Hallucinations](https://www.voiceflow.com/blog/prevent-llm-hallucinations)

--- a/data/edit-logs/reducing-hallucinations.yaml
+++ b/data/edit-logs/reducing-hallucinations.yaml
@@ -1,0 +1,4 @@
+- date: 2026-02-17
+  tool: crux-grade
+  agency: automated
+  note: "Initial creation grading: quality=68, readerImportance=55"

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -3687,3 +3687,11 @@
     A 2023 book by Jennifer Pahlka arguing that government digital failures stem from institutional culture that separates
     policy from implementation, creating a "cascade of rigidity" with implications for AI governance and state capacity.
   lastUpdated: 2026-02
+- id: reducing-hallucinations
+  numericId: E814
+  type: approach
+  title: Reducing Hallucinations in AI-Generated Wiki Content
+  description: >-
+    Technical and procedural strategies to ground AI-generated content in verified information and reduce factual
+    errors in wiki articles, covering RAG, verification techniques, prompt engineering, and human oversight.
+  lastUpdated: 2026-02


### PR DESCRIPTION
## Summary
- New wiki page covering techniques for reducing hallucinations in AI-generated wiki content
- Created via Crux content pipeline (standard tier, API-direct mode) with Perplexity research
- 71 citations covering RAG, WikiChat, prompt engineering, verification, fine-tuning, human-in-the-loop
- Entity registered as E814 (type: approach) in responses.yaml

## Test plan
- [x] All 8 gate checks pass (build-data, tests, MDX syntax, YAML schema, frontmatter schema, TypeScript, escaping, markdown)
- [x] Paranoid PR review completed
- [ ] CI green on GitHub

https://claude.ai/code/session_011McyXKohP6QzxefgbQfTUu