### PR TITLE
Update Sonnet model to claude-sonnet-4-6

### DIFF
--- a/.claude/sessions/2026-02-17_sonnet-4.6-update-f176B.md
+++ b/.claude/sessions/2026-02-17_sonnet-4.6-update-f176B.md
@@ -1,0 +1,10 @@
+## 2026-02-17 | claude/sonnet-4.6-update-f176B | Update codebase for Sonnet 4.6 launch
+
+**What was done:** Updated model configuration, aliases, and hardcoded references from Claude Sonnet 4.5 (`claude-sonnet-4-5-20250929`) to Sonnet 4.6 (`claude-sonnet-4-6`) across infrastructure code, GitHub workflow scripts, and internal documentation. Wiki content pages referencing Sonnet 4.5 were reviewed and confirmed to be historical (benchmark results, system card citations) — no content changes needed.
+
+**Issues encountered:**
+- Build data script (`build-data.mjs`) fails due to path resolution issue (pre-existing, unrelated to this change)
+
+**Learnings/notes:**
+- SquiggleAI pages (squiggleai.mdx, quri.mdx) reference Sonnet 4.5 as their primary model — these describe that tool's actual implementation and should only be updated when QURI confirms they've switched to Sonnet 4.6
+- Sonnet 4.6 uses a date-less model ID format (`claude-sonnet-4-6`) matching Opus 4.6's convention

--- a/.github/scripts/resolve-conflicts.mjs
+++ b/.github/scripts/resolve-conflicts.mjs
@@ -297,7 +297,7 @@ async function resolveLargeFile(filePath, content) {
     );
 
     const result = await callAPIWithRetry({
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-4-6",
       max_tokens: 16_000,
       system: HUNK_SYSTEM_PROMPT,
       messages: [
@@ -398,7 +398,7 @@ async function resolveFile(filePath) {
   } else {
     // Small file — send the whole thing
     const result = await callAPIWithRetry({
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-4-6",
       max_tokens: 64_000,
       system: SYSTEM_PROMPT,
       messages: [

--- a/content/docs/internal/content-database.mdx
+++ b/content/docs/internal/content-database.mdx
@@ -209,7 +209,7 @@ npm run crux -- generate summaries --dry-run
 | Model | ID | Cost (per 1M input tokens) | Use case |
 |-------|----|-----------------------------|----------|
 | haiku | claude-haiku-4-5-20251001 | ≈\$0.25 | Bulk summarization |
-| sonnet | claude-sonnet-4-5-20250929 | ≈\$3.00 | Higher quality |
+| sonnet | claude-sonnet-4-6 | ≈\$3.00 | Higher quality |
 | opus | claude-opus-4-6 | ≈\$5.00 | Best quality |
 
 **Cost estimates:**

--- a/crux/lib/anthropic.test.ts
+++ b/crux/lib/anthropic.test.ts
@@ -24,6 +24,7 @@ describe('resolveModel', () => {
 
   it('resolves alternate model IDs', () => {
     expect(resolveModel('claude-sonnet-4-5-20250929')).toBe(MODELS.sonnet);
+    expect(resolveModel('claude-sonnet-4-6')).toBe(MODELS.sonnet);
     expect(resolveModel('claude-opus-4-6')).toBe(MODELS.opus);
   });
 

--- a/crux/lib/anthropic.ts
+++ b/crux/lib/anthropic.ts
@@ -28,7 +28,7 @@ config({ path: '.env.local' });
  * validate-models.ts warns if this is more than 60 days old.
  * Update this date after confirming models are still the latest versions.
  */
-export const MODELS_LAST_VERIFIED = '2026-02-12';
+export const MODELS_LAST_VERIFIED = '2026-02-17';
 
 /**
  * Available Claude models with standardized names
@@ -37,7 +37,7 @@ export const MODELS: Record<string, string> = {
   // Fast and cheap - good for high-volume tasks
   haiku: 'claude-haiku-4-5-20251001',
   // Balanced - good for most tasks
-  sonnet: 'claude-sonnet-4-5-20250929',
+  sonnet: 'claude-sonnet-4-6',
   // Most capable - for complex tasks
   opus: 'claude-opus-4-6',
 };
@@ -54,6 +54,7 @@ const MODEL_ALIASES: Record<string, string> = {
   'claude-3-5-haiku-20241022': MODELS.haiku,
   'claude-sonnet-4-20250514': MODELS.sonnet,
   'claude-sonnet-4-5-20250929': MODELS.sonnet,
+  'claude-sonnet-4-6': MODELS.sonnet,
   'claude-opus-4-20250514': MODELS.opus,
   'claude-opus-4-5-20251101': MODELS.opus,
   'claude-opus-4-6': MODELS.opus,


### PR DESCRIPTION
## Summary
- Update default Sonnet model from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` (launched 2026-02-17)
- Add backward compatibility alias for old Sonnet 4.5 model ID
- Update hardcoded model references in conflict resolution workflow
- Update internal docs model table
- Bump `MODELS_LAST_VERIFIED` to today

Pricing unchanged ($3/$15 per MTok). Wiki content pages referencing Sonnet 4.5 are historical (benchmark results, system card citations) and left as-is.

## Test plan
- [x] All 290 crux tests pass (including model resolution tests)
- [x] All 96 app tests pass
- [x] `pnpm crux validate gate --fix` passes all 8 checks
- [x] Backward compatibility: old `claude-sonnet-4-5-20250929` alias still resolves correctly

https://claude.ai/code/session_012WiGeyiC9P7cBJ2nPUkYUw