### PR TITLE
Add Internal filter to Field row on /wiki page

### DIFF
--- a/.claude/sessions/2026-02-17_add-internal-links-filter-QDfFJ.md
+++ b/.claude/sessions/2026-02-17_add-internal-links-filter-QDfFJ.md
@@ -1,0 +1,12 @@
+## 2026-02-17 | claude/add-internal-links-filter-QDfFJ | Add Internal filter to Field row on /wiki
+
+**What was done:** Added "Internal" as a filter option in the Field filter row on the /wiki explore page, allowing users to quickly filter for internal pages without scrolling through the Entity type filter.
+
+**Pages:** (no page content changes — UI filter only)
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- FIELD_GROUPS now supports an optional `entityType` property for type-based filtering alongside cluster-based filtering
+- The same pattern can be reused to add other type-based entries to the Field row in the future

--- a/app/src/components/explore/ExploreGrid.tsx
+++ b/app/src/components/explore/ExploreGrid.tsx
@@ -10,8 +10,8 @@ import { ExploreTable } from "./ExploreTable";
 
 type ViewMode = "cards" | "table";
 
-// FIELD filter — based on page clusters
-const FIELD_GROUPS: { label: string; cluster: string | null }[] = [
+// FIELD filter — based on page clusters (or entity type for special entries)
+const FIELD_GROUPS: { label: string; cluster: string | null; entityType?: string }[] = [
   { label: "All", cluster: null },
   { label: "AI Safety", cluster: "ai-safety" },
   { label: "Governance", cluster: "governance" },
@@ -19,6 +19,7 @@ const FIELD_GROUPS: { label: string; cluster: string | null }[] = [
   { label: "Community", cluster: "community" },
   { label: "Cyber", cluster: "cyber" },
   { label: "Biorisks", cluster: "biorisks" },
+  { label: "Internal", cluster: null, entityType: "internal" },
 ];
 
 // RISK CATEGORY filter
@@ -270,6 +271,7 @@ export function ExploreGrid({ items }: { items: ExploreItem[] }) {
   // Compute field filter counts (against search-filtered items)
   const fieldCounts = useMemo(() => {
     return FIELD_GROUPS.map((group) => {
+      if (group.entityType) return searchFiltered.filter((item) => item.type === group.entityType).length;
       if (!group.cluster) return searchFiltered.length;
       return searchFiltered.filter((item) => item.clusters.includes(group.cluster!)).length;
     });
@@ -278,6 +280,7 @@ export function ExploreGrid({ items }: { items: ExploreItem[] }) {
   // Items after search + field filter
   const fieldFiltered = useMemo(() => {
     const group = FIELD_GROUPS[activeField];
+    if (group.entityType) return searchFiltered.filter((item) => item.type === group.entityType);
     if (!group.cluster) return searchFiltered;
     return searchFiltered.filter((item) => item.clusters.includes(group.cluster!));
   }, [searchFiltered, activeField]);


### PR DESCRIPTION
## Summary
- Adds "Internal" as a filter option in the Field filter row on the /wiki explore page
- Users can now quickly filter for internal pages from the top-level Field filter instead of scrolling through the Entity type row
- Extended FIELD_GROUPS to support optional `entityType`-based filtering alongside cluster-based filtering

## Test plan
- [ ] Visit /wiki and verify the "Internal" button appears in the Field filter row
- [ ] Click "Internal" and verify only internal pages are shown
- [ ] Verify count badge shows correct number of internal pages
- [ ] Verify clicking "All" resets to showing all pages
- [ ] Verify other Field filters (AI Safety, Governance, etc.) still work correctly

https://claude.ai/code/session_01PLJ16ffr64Z7pWAhe2EMXW