### PR TITLE
Add canonical facts usage guide and showDate prop to F component

### DIFF
--- a/.claude/sessions/2026-02-17_clarify-calc-usage-SMCaw.md
+++ b/.claude/sessions/2026-02-17_clarify-calc-usage-SMCaw.md
@@ -1,0 +1,12 @@
+## 2026-02-17 | claude/clarify-calc-usage-SMCaw | Canonical facts & Calc usage guide
+
+**What was done:** Created an internal style guide page documenting the strategy for using `<F>` and `<Calc>` components — when numbers should be facts (3-tier decision framework), `<F>` vs `<Calc>` roles, YAML structure, and scaling plan. Added `showDate` prop to the `<F>` component for rendering temporal claims inline (e.g., "300,000+ (as of 2025)"). Added nav entry and CLAUDE.md reference.
+
+**Pages:** canonical-facts
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- `<F>` and `<Calc>` currently used on only ~5 pages (all Anthropic-related). Main expansion opportunities are other organizations with volatile financials and cross-referenced field-level metrics.
+- The `@components/facts` import path used by anthropic-valuation.mdx is an alias that resolves through the MDX components map in `mdx-components.tsx`, not a separate barrel file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ GitHub Actions workflow (`.github/workflows/auto-update.yml`) runs daily at 06:0
 - **Tailwind CSS v4** with shadcn/ui components
 - **Squiggle models**: See `app/CLAUDE.md` for SquiggleEstimate style guide
 - **Internal sidebar** (`app/src/lib/internal-nav.ts`): When adding internal pages, place them in the correct section. "Research" is for research reports/proposals only. Schema/architecture/technical docs go in "Architecture & Schema". Check existing section semantics before adding.
+- **Canonical facts & Calc**: Follow `content/docs/internal/canonical-facts.mdx` style guide — use `<F>` for volatile numbers, `<Calc>` for derived computations, `showDate` for temporal claims. Facts YAML in `data/facts/`.
 - **Mermaid diagrams**: Follow `content/docs/internal/mermaid-diagrams.mdx` style guide — prefer `flowchart TD`, max 3-4 parallel nodes, use tables for taxonomies, max 15-20 nodes per diagram.
 - **Page templates**: Defined in `crux/lib/page-templates.ts`, style guides in `content/docs/internal/`
 - **Edit logs**: Per-page edit history in `data/edit-logs/<page-id>.yaml`, auto-maintained by Crux pipelines. Use `pnpm crux edit-log view <page-id>` to inspect. See `crux/lib/edit-log.ts` for the API.

--- a/app/src/components/wiki/F.tsx
+++ b/app/src/components/wiki/F.tsx
@@ -6,6 +6,8 @@ interface FProps {
   e: string;
   /** Fact ID within the entity (e.g., "valuation-2024") */
   f: string;
+  /** Show the asOf date inline after the value, e.g. "300,000+ (as of 2025)" */
+  showDate?: boolean;
   /** Optional display override */
   children?: React.ReactNode;
   className?: string;
@@ -17,7 +19,7 @@ interface FProps {
  * Renders a fact value from the canonical facts store with a hover tooltip
  * showing metadata (asOf, source, note, computed status).
  */
-export function F({ e, f, children, className }: FProps) {
+export function F({ e, f, showDate, children, className }: FProps) {
   const fact = getFact(e, f);
 
   if (!fact) {
@@ -34,7 +36,11 @@ export function F({ e, f, children, className }: FProps) {
     );
   }
 
-  const displayValue = children || fact.value || `[no value: ${e}.${f}]`;
+  const baseValue = children || fact.value || `[no value: ${e}.${f}]`;
+  const showDateInline = showDate && fact.asOf && !children;
+  const displayValue = showDateInline ? (
+    <>{baseValue} <span className="text-muted-foreground font-normal">(as of {fact.asOf})</span></>
+  ) : baseValue;
   const isComputed = Boolean(fact.computed);
   const hasMetadata = fact.asOf || fact.source || fact.note || isComputed;
 
@@ -66,7 +72,7 @@ export function F({ e, f, children, className }: FProps) {
         role="tooltip"
       >
         <span className="block font-semibold text-foreground mb-1">
-          {fact.value || displayValue}
+          {fact.value || baseValue}
         </span>
         {isComputed && (
           <span className="block text-blue-500 text-[10px] font-medium mb-0.5">

--- a/app/src/lib/wiki-nav.ts
+++ b/app/src/lib/wiki-nav.ts
@@ -315,6 +315,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Stub Pages", href: href("stub-style-guide") },
         { label: "Rating System", href: href("rating-system") },
         { label: "Mermaid Diagrams", href: href("mermaid-diagrams") },
+        { label: "Canonical Facts & Calc", href: href("canonical-facts") },
         { label: "Cause-Effect Diagrams", href: href("cause-effect-diagrams") },
         { label: "Research Reports", href: href("research-reports") },
         { label: "AI Transition Model", href: href("ai-transition-model-style-guide") },

--- a/content/docs/internal/canonical-facts.mdx
+++ b/content/docs/internal/canonical-facts.mdx
@@ -1,0 +1,248 @@
+---
+numericId: E827
+title: "Canonical Facts & Calc Usage Guide"
+entityType: internal
+description: "Strategy and conventions for using the F (fact) and Calc (computed value) components across wiki pages — when to make a number a fact, how to use showDate for temporal claims, and scaling guidelines."
+sidebar:
+  order: 10
+readerImportance: 12
+researchImportance: 15
+quality: 50
+ratings:
+  novelty: 3
+  rigor: 6
+  actionability: 8
+  completeness: 7
+lastEdited: "2026-02-17"
+evergreen: true
+update_frequency: 90
+---
+
+## Purpose
+
+The canonical facts system lets us store key numbers (valuations, revenue, headcounts) in YAML and reference them across wiki pages. When a number changes, we update one YAML file and every page that references it stays correct.
+
+Two MDX components power this:
+- **`<F>`** — display a single fact inline (with hover tooltip showing metadata)
+- **`<Calc>`** — compute a derived value from 2+ facts (e.g. revenue multiples, growth rates)
+
+## Quick Reference
+
+```jsx
+{/* Simple fact display */}
+<F e="anthropic" f="valuation">$380B</F>
+
+{/* Fact with auto-rendered value (no children needed) */}
+<F e="anthropic" f="valuation" />
+
+{/* Fact with inline date — renders "300,000+ (as of 2025)" */}
+<F e="anthropic" f="business-customers" showDate />
+
+{/* Computed value from two facts */}
+<Calc expr="{anthropic.valuation} / {anthropic.revenue-run-rate}" precision={0} suffix="x" />
+
+{/* Growth percentage */}
+<Calc expr="({anthropic.revenue-mid-2025} / {anthropic.revenue-early-2025} - 1) * 100" precision={0} suffix="%" />
+```
+
+## Which Numbers Should Be Facts?
+
+Not every number in the wiki should be a fact. The key question is: **will this number change when new data arrives?**
+
+### Must be facts (Tier 1)
+
+Numbers that **change over time** AND **appear on 2+ pages**.
+
+| Example | Why |
+|---------|-----|
+| Anthropic's valuation | Updated every funding round, referenced on IPO, valuation, and company pages |
+| OpenAI's revenue | Changes quarterly, appears on multiple comparison pages |
+| Total AI safety funding | Updated annually, appears on funding and field overview pages |
+
+These are the highest-ROI facts. Updating one YAML entry keeps N pages correct.
+
+### Should be facts (Tier 2)
+
+Numbers that **change over time** but currently appear on only 1 page.
+
+| Example | Why |
+|---------|-----|
+| "300,000+ business customers" | Will be 400,000+ within months |
+| Prediction market probabilities | Change daily |
+| Net cash burn rates | Updated quarterly |
+
+Even on one page, wrapping these in `<F>` means the update workflow is "edit YAML" not "search through prose."
+
+### Should NOT be facts (Tier 3)
+
+**Fixed historical numbers** that will never change.
+
+| Example | Why |
+|---------|-----|
+| "Founded in 2021" | Historical fact, won't update |
+| "Series A raised \$124M in May 2021" | Fixed in time |
+| "Hired Wilson Sonsini in December 2025" | One-time event |
+
+Making these into facts adds overhead with no benefit.
+
+### Decision flowchart
+
+1. Will this number change when new data comes in? **No** → plain text
+2. Does it appear on 2+ pages? **Yes** → must be a fact (Tier 1)
+3. Appears on 1 page but will change? **Yes** → should be a fact (Tier 2)
+
+## When to Use `<F>` vs `<Calc>`
+
+### Use `<F>` for single fact display
+
+Any time you're showing a stored number — a valuation, revenue figure, headcount, date — use `<F>`.
+
+```jsx
+{/* With explicit display text */}
+<F e="anthropic" f="valuation">\$380 billion</F>
+
+{/* Auto-display from the fact's value field */}
+<F e="anthropic" f="valuation" />
+
+{/* With inline date for temporal claims */}
+Over <F e="anthropic" f="business-customers" showDate /> business customers
+{/* Renders: "Over 300,000+ (as of 2025) business customers" */}
+```
+
+**`showDate`** is important for sentences where the recency of a number is part of the claim. When the fact gets updated (e.g. to 400,000+ / 2026-06), the prose automatically reads the new number and date without anyone needing to edit the surrounding text.
+
+### Use `<Calc>` for derived computations
+
+When you need a value that's **computed from 2+ facts** — ratios, multiples, growth percentages — use `<Calc>`.
+
+```jsx
+{/* Revenue multiple */}
+<Calc expr="{anthropic.valuation} / {anthropic.revenue-run-rate}" precision={0} suffix="x" />
+
+{/* Growth rate */}
+<Calc expr="({anthropic.revenue-mid-2025} / {anthropic.revenue-early-2025} - 1) * 100" precision={0} suffix="%" />
+
+{/* Comparison */}
+<Calc expr="{openai.valuation-2025} / {anthropic.valuation}" precision={1} suffix="x" />
+```
+
+The power: when **either** input fact updates, the derived number auto-updates too. A revenue multiple stays correct whether the valuation or revenue changes.
+
+### Do NOT use `<Calc>` for single values
+
+If you're just displaying one fact with no computation, use `<F>`, not `<Calc>`. `<Calc>` is for math, `<F>` is for display.
+
+```jsx
+{/* Wrong — no computation happening */}
+<Calc expr="{anthropic.valuation}" format="currency" />
+
+{/* Right — just display the fact */}
+<F e="anthropic" f="valuation" />
+```
+
+### Use plain text for everything else
+
+Historical numbers, qualitative descriptions, and one-off figures that won't change don't need either component.
+
+## YAML Fact Structure
+
+Facts live in `data/facts/<entity>.yaml`:
+
+```yaml
+entity: anthropic
+facts:
+  valuation:
+    value: "$380 billion"        # Human-readable display string
+    numeric: 380000000000        # Raw number (required for Calc)
+    asOf: "2026-02"              # When this was current
+    note: "Series G post-money"  # Context shown in tooltip
+    source: "https://..."        # Attribution URL
+```
+
+**Required fields:**
+- `value` — display string (used by `<F>` when no children are provided)
+- `numeric` — raw number (required if used in any `<Calc>` expression)
+- `asOf` — temporal anchor (strongly recommended for any changing number)
+
+**Optional fields:**
+- `note` — shown in tooltip
+- `source` — attribution link
+- `noCompute: true` — skip build-time computation (for non-numeric values like "2028")
+- `compute` — formula for build-time derived facts
+- `format` / `formatDivisor` — display formatting hints
+
+## Updating Facts
+
+When new data arrives:
+
+1. Edit the YAML file in `data/facts/<entity>.yaml`
+2. Update `value`, `numeric`, and `asOf`
+3. Run `node app/scripts/build-data.mjs` to rebuild
+4. Every `<F>` and `<Calc>` referencing that fact auto-updates
+
+**Keep old point-in-time facts as separate entries** when pages reference them explicitly:
+
+```yaml
+# Current valuation (gets updated)
+valuation:
+  value: "$380 billion"
+  numeric: 380000000000
+  asOf: "2026-02"
+
+# Historical snapshot (stays fixed, referenced by comparison sections)
+valuation-nov-2025:
+  value: "$350 billion"
+  numeric: 350000000000
+  asOf: "2025-11"
+```
+
+## Scaling Strategy
+
+Current state: 4 entity YAML files, ~5 pages using facts. Priority order for expansion:
+
+**Phase 1 — Organizations with fast-changing financials**
+Anthropic, OpenAI, xAI, Google DeepMind, Meta AI. These have valuations, revenue, headcounts that change quarterly. Highest density of volatile numbers.
+
+**Phase 2 — Field-level metrics**
+Compute benchmarks, total AI safety funding, researcher headcounts. Numbers that get updated with each new report and appear across multiple pages.
+
+**Phase 3 — Cross-referenced numbers**
+Any figure appearing on 3+ pages. Find these via grep and migrate to facts for consistency.
+
+Don't try to fact-ify everything at once. Expand entity-by-entity as pages get created or updated.
+
+## Common Patterns
+
+### Valuation with context
+
+```jsx
+valued at <F e="anthropic" f="valuation" /> in its latest funding round
+```
+
+### Temporal metric in prose
+
+```jsx
+Over <F e="anthropic" f="business-customers" showDate /> business customers
+{/* → "Over 300,000+ (as of 2025) business customers" */}
+```
+
+### Revenue multiple in a table
+
+```jsx
+| Metric | Value |
+|--------|-------|
+| **Revenue Multiple** | <Calc expr="{anthropic.valuation} / {anthropic.revenue-run-rate}" precision={0} suffix="x" /> |
+```
+
+### Growth rate comparison
+
+```jsx
+revenue grew <Calc expr="({anthropic.revenue-mid-2025} / {anthropic.revenue-early-2025} - 1) * 100" precision={0} suffix="%" /> in seven months
+```
+
+### Side-by-side company comparison
+
+```jsx
+Anthropic trades at ≈<Calc expr="{anthropic.valuation} / {anthropic.revenue-run-rate}" precision={0} suffix="x" /> revenue
+vs OpenAI's ≈<Calc expr="{openai.valuation-2025} / {openai.revenue-arr-2025}" precision={0} suffix="x" />
+```


### PR DESCRIPTION
## Summary
Created a comprehensive internal style guide for the canonical facts system (`<F>` and `<Calc>` components) and enhanced the `<F>` component with a `showDate` prop for rendering temporal metadata inline.

## Changes

- **New guide page** (`content/docs/internal/canonical-facts.mdx`): Documents strategy for using `<F>` and `<Calc>` components, including:
  - 3-tier decision framework for which numbers should be facts (Tier 1: multi-page changing numbers, Tier 2: single-page changing numbers, Tier 3: fixed historical numbers)
  - Clear guidance on `<F>` vs `<Calc>` usage patterns
  - YAML fact structure and required/optional fields
  - Workflow for updating facts
  - Scaling strategy for expanding the facts system across entities
  - Common usage patterns with code examples

- **Enhanced `<F>` component** (`app/src/components/wiki/F.tsx`):
  - Added `showDate?: boolean` prop to render the `asOf` date inline after the value
  - When `showDate` is true and no children override is provided, displays as: `"300,000+ (as of 2025)"`
  - Date is styled with muted foreground color and normal font weight to de-emphasize it
  - Only renders when `asOf` exists and no custom children are provided

- **Navigation update** (`app/src/lib/wiki-nav.ts`): Added "Canonical Facts & Calc Usage Guide" to internal sidebar navigation

- **Documentation** (`.claude/sessions/` and `CLAUDE.md`): Added session notes and reference to the new guide

## Implementation Details

The `showDate` prop enables temporal claims to stay current automatically. When a fact's `asOf` date updates in YAML, any page using `<F showDate />` will display the new date without requiring prose edits. This is particularly useful for metrics like customer counts or funding figures where recency is part of the claim's validity.

The date rendering only applies when using the auto-display mode (no children); explicit display text overrides take precedence.

https://claude.ai/code/session_0145YhzPnCiuzxzR4FPRymAB