### PR TITLE
Add Model, Duration, Cost metadata to session logs

### DIFF
--- a/.claude/rules/session-logging.md
+++ b/.claude/rules/session-logging.md
@@ -21,6 +21,12 @@ Where `<branch-suffix>` is the branch name without the `claude/` prefix (e.g., f
 
 **PR:** #123
 
+**Model:** opus-4-6
+
+**Duration:** ~45min
+
+**Cost:** ~$5
+
 **Issues encountered:**
 - List any problems, errors, or unexpected behavior (or "None")
 
@@ -34,8 +40,11 @@ Where `<branch-suffix>` is the branch name without the `claude/` prefix (e.g., f
 - Always include the branch name so entries can be correlated with PRs
 - **Always include the `Pages:` field** listing the page IDs (filenames without `.mdx`) of any wiki pages created or edited in the session. Use the page slug (e.g., `ai-risks`, `compute-governance`), not the full path. Omit the field only if the session made no page content changes (infrastructure-only work).
 - **The `PR:` field is optional** — PR numbers are auto-populated at build time by looking up branches via the GitHub API (`app/scripts/lib/github-pr-lookup.mjs`). You can include `**PR:** #123` manually as an override, but it's not required.
+- **Always include the `Model:` field** with the short model name (e.g., `opus-4-6`, `sonnet-4`, `sonnet-4-5`). This is the LLM model powering the session. Check the system prompt for "You are powered by the model named..." to find the current model ID.
+- **Always include the `Duration:` field** with an approximate session duration (e.g., `~15min`, `~45min`, `~2h`). Estimate based on how much work was done — a single small fix is ~10-15min, a multi-file feature is ~30-60min, a large refactor or page creation session is ~1-2h+.
+- **The `Cost:` field is optional** — include it when the session used the content pipeline (`crux content create/improve`) since tiers map to approximate costs (budget ~\$2-3, standard ~\$5-8, premium ~\$10-15). For infrastructure-only sessions, omit this field.
 - If you encountered an issue that seems likely to recur, also add it to `.claude/common-issues.md`
 - Do NOT skip logging just because the session was small — even one-line fixes are worth tracking
 - The session log file should be part of the same commit as your other changes (not a separate commit)
 - Each session gets its own file — this avoids merge conflicts between parallel sessions
-- **Format is machine-parsed**: The `## date | branch | title` heading, `**Pages:**` field, and `**PR:**` field are parsed by `app/scripts/lib/session-log-parser.mjs` to build the `/internal/page-changes` dashboard. If you change the format here, update the parser and its tests too.
+- **Format is machine-parsed**: The `## date | branch | title` heading, `**Pages:**`, `**PR:**`, `**Model:**`, `**Duration:**`, and `**Cost:**` fields are parsed by `app/scripts/lib/session-log-parser.mjs` to build the `/internal/page-changes` dashboard. If you change the format here, update the parser and its tests too.

--- a/.claude/sessions/2026-02-18_enhance-pr-logs-vRyPk.md
+++ b/.claude/sessions/2026-02-18_enhance-pr-logs-vRyPk.md
@@ -1,0 +1,14 @@
+## 2026-02-18 | claude/enhance-pr-logs-vRyPk | Add LLM metadata to session/PR logs
+
+**What was done:** Added three new optional fields to session logs — Model, Duration, and Cost — so the page-changes dashboard and per-page change history show which LLM did the work, how long it took, and approximate cost. Updated parser, types, tests, dashboard table (new Model column), and PageStatus sidebar.
+
+**Model:** opus-4-6
+
+**Duration:** ~30min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The session log parser uses a simple regex pattern `**Field:**\s*(.+?)(?:\n\n|\n\*\*|\n---)` for each field, so new fields are trivial to add as long as they follow the same bold-label format
+- Existing ~70 session files gracefully degrade — new fields are undefined for old sessions, shown as "—" in the dashboard

--- a/app/scripts/lib/__tests__/session-log-parser.test.mjs
+++ b/app/scripts/lib/__tests__/session-log-parser.test.mjs
@@ -164,6 +164,97 @@ describe('parseSessionLogContent', () => {
     expect(result['page-one'][0].pr).toBeUndefined();
   });
 
+  it('parses Model field', () => {
+    const content = `## 2026-02-15 | claude/my-branch | Fix some bug
+
+**What was done:** Fixed the thing.
+
+**Pages:** page-one
+
+**Model:** opus-4-6
+
+**Issues encountered:**
+- None
+`;
+    const result = parseSessionLogContent(content);
+    expect(result['page-one'][0].model).toBe('opus-4-6');
+  });
+
+  it('parses Duration field', () => {
+    const content = `## 2026-02-15 | claude/my-branch | Fix some bug
+
+**What was done:** Fixed the thing.
+
+**Pages:** page-one
+
+**Duration:** ~45min
+
+**Issues encountered:**
+- None
+`;
+    const result = parseSessionLogContent(content);
+    expect(result['page-one'][0].duration).toBe('~45min');
+  });
+
+  it('parses Cost field', () => {
+    const content = `## 2026-02-15 | claude/my-branch | Fix some bug
+
+**What was done:** Fixed the thing.
+
+**Pages:** page-one
+
+**Cost:** ~$5
+
+**Issues encountered:**
+- None
+`;
+    const result = parseSessionLogContent(content);
+    expect(result['page-one'][0].cost).toBe('~$5');
+  });
+
+  it('parses all metadata fields together', () => {
+    const content = `## 2026-02-15 | claude/my-branch | Full metadata session
+
+**What was done:** Did everything.
+
+**Pages:** page-one
+
+**PR:** #42
+
+**Model:** sonnet-4
+
+**Duration:** ~2h
+
+**Cost:** ~$12 (premium tier)
+
+**Issues encountered:**
+- None
+`;
+    const result = parseSessionLogContent(content);
+    const entry = result['page-one'][0];
+    expect(entry.pr).toBe(42);
+    expect(entry.model).toBe('sonnet-4');
+    expect(entry.duration).toBe('~2h');
+    expect(entry.cost).toBe('~$12 (premium tier)');
+  });
+
+  it('omits metadata fields when not specified', () => {
+    const content = `## 2026-02-15 | claude/my-branch | No metadata
+
+**What was done:** Minimal entry.
+
+**Pages:** page-one
+
+**Issues encountered:**
+- None
+`;
+    const result = parseSessionLogContent(content);
+    const entry = result['page-one'][0];
+    expect(entry.model).toBeUndefined();
+    expect(entry.duration).toBeUndefined();
+    expect(entry.cost).toBeUndefined();
+  });
+
   it('accumulates multiple entries for the same page', () => {
     const content = `## 2026-02-14 | claude/a | First edit
 

--- a/app/scripts/lib/session-log-parser.mjs
+++ b/app/scripts/lib/session-log-parser.mjs
@@ -72,12 +72,27 @@ export function parseSessionLogContent(content) {
       }
     }
 
+    // Extract optional "Model" field (e.g., "opus-4-6", "sonnet-4")
+    const modelMatch = body.match(/\*\*Model:\*\*\s*(.+?)(?:\n\n|\n\*\*|\n---)/s);
+    const model = modelMatch ? modelMatch[1].trim() : undefined;
+
+    // Extract optional "Duration" field (e.g., "~45min", "~2h")
+    const durationMatch = body.match(/\*\*Duration:\*\*\s*(.+?)(?:\n\n|\n\*\*|\n---)/s);
+    const duration = durationMatch ? durationMatch[1].trim() : undefined;
+
+    // Extract optional "Cost" field (e.g., "~$5", "~$12 (premium tier)")
+    const costMatch = body.match(/\*\*Cost:\*\*\s*(.+?)(?:\n\n|\n\*\*|\n---)/s);
+    const cost = costMatch ? costMatch[1].trim() : undefined;
+
     const changeEntry = {
       date: entry.date,
       branch: entry.branch,
       title: entry.title,
       summary,
       ...(pr !== undefined && { pr }),
+      ...(model !== undefined && { model }),
+      ...(duration !== undefined && { duration }),
+      ...(cost !== undefined && { cost }),
     };
 
     for (const pageId of pageIds) {

--- a/app/src/app/internal/page-changes/page-changes-table.tsx
+++ b/app/src/app/internal/page-changes/page-changes-table.tsx
@@ -52,8 +52,29 @@ const columns: ColumnDef<PageChangeItem>[] = [
             {row.original.summary}
           </p>
         )}
+        {(row.original.duration || row.original.cost) && (
+          <p className="mt-0.5 text-[11px] text-muted-foreground/60">
+            {[row.original.duration, row.original.cost]
+              .filter(Boolean)
+              .join(" · ")}
+          </p>
+        )}
       </div>
     ),
+  },
+  {
+    accessorKey: "model",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Model</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.model ? (
+        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 whitespace-nowrap">
+          {row.original.model}
+        </span>
+      ) : (
+        <span className="text-[11px] text-muted-foreground/40">—</span>
+      ),
   },
   {
     accessorKey: "category",

--- a/app/src/components/PageStatus.tsx
+++ b/app/src/components/PageStatus.tsx
@@ -795,6 +795,13 @@ function ChangeHistorySection({
                 {entry.summary}
               </p>
             )}
+            {(entry.model || entry.duration || entry.cost) && (
+              <p className="mt-0.5 ml-[18px] text-muted-foreground/60 text-[11px]">
+                {[entry.model, entry.duration, entry.cost]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/app/src/data/index.ts
+++ b/app/src/data/index.ts
@@ -291,6 +291,9 @@ export interface ChangeEntry {
   title: string;
   summary: string;
   pr?: number;
+  model?: string;
+  duration?: string;
+  cost?: string;
 }
 
 export interface Page {
@@ -593,6 +596,9 @@ export interface PageChangeItem {
   summary: string;
   category: string;
   pr?: number;
+  model?: string;
+  duration?: string;
+  cost?: string;
 }
 
 export function getPageChanges(): PageChangeItem[] {
@@ -615,6 +621,9 @@ export function getPageChanges(): PageChangeItem[] {
         summary: entry.summary,
         category: page.category,
         ...(entry.pr !== undefined && { pr: entry.pr }),
+        ...(entry.model !== undefined && { model: entry.model }),
+        ...(entry.duration !== undefined && { duration: entry.duration }),
+        ...(entry.cost !== undefined && { cost: entry.cost }),
       });
     }
   }


### PR DESCRIPTION
## Summary
- Adds three new optional fields to session logs: **Model** (which LLM), **Duration** (approx time), **Cost** (approx spend)
- Parser extracts them using the same regex pattern as existing fields
- Dashboard gets a new sortable **Model** column with violet badge; duration/cost shown as secondary text under session title
- PageStatus sidebar shows model/duration/cost in change history entries
- All backward-compatible — old session files without these fields display "—" gracefully

## Test plan
- [x] All 20 parser tests pass (15 existing + 5 new covering individual fields, all-together, and omission)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify dashboard renders new Model column correctly
- [ ] Verify PageStatus sidebar shows metadata line for entries that have it

https://claude.ai/code/session_015b5g45xbiqwQYv6EXgtjTU