### PR TITLE
Fix two CI workflow bugs: auto-rebase push args + resolve-conflicts shell injection

### DIFF
--- a/.claude/sessions/2026-02-18_review-recent-prs-Q89Nt.md
+++ b/.claude/sessions/2026-02-18_review-recent-prs-Q89Nt.md
@@ -1,0 +1,19 @@
+## 2026-02-18 | claude/review-recent-prs-Q89Nt | Fix CI workflow bugs found in PR review
+
+**What was done:** Reviewed last 20 PRs and their GitHub Actions CI logs. Found and fixed two workflow bugs: (1) `auto-rebase.yml` used `git push origin -- "$branch" --force-with-lease` where `--` causes `--force-with-lease` to be treated as a refspec instead of a flag, breaking every rebase push; (2) `resolve-conflicts.yml` "Post failure comment" step used `DIAG="${{ steps.resolve.outputs.diagnostic_summary }}"` inline, causing bash to interpret markdown backticks in the diagnostic summary as command substitution (e.g. trying to exec `app/scripts/build-data.mjs`).
+
+**Pages:** (none — infrastructure only)
+
+**Model:** sonnet-4
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- PR #160 (Postgres server) is a long-lived open branch that keeps conflicting with `app/scripts/build-data.mjs` and `package.json`. The auto-resolver resolves conflicts via Claude API successfully, but the merged `build-data.mjs` fails validation in 34ms (immediate failure — likely AI-introduced syntax error). This will recur every 2 hours indefinitely. Manual intervention required.
+- PR #228 (fact-wrap CLI) was closed without merging — auto-rebase tried to push after rebasing it and hit the `--force-with-lease` refspec bug.
+
+**Learnings/notes:**
+- In bash, `git push origin -- "$branch" --force-with-lease` passes `--force-with-lease` as a refspec (after `--`), not a flag. Fix: `git push --force-with-lease origin "$branch"`.
+- GitHub Actions inline expression `${{ steps.X.outputs.Y }}` expands before shell runs, so any backticks in the value cause unintended command substitution. Fix: pass via `env:` block so the value arrives as a proper env var.
+- All 20 PRs had green `build-and-test` and `validate` CI — the only failures were the `resolve-conflicts` and `auto-rebase` workflow jobs.
+- PR #160 needs to either be closed or have its `build-data.mjs` conflict manually resolved before the auto-resolver can make progress on it.

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -57,7 +57,7 @@ jobs:
               continue
             fi
 
-            if ! git fetch origin -- "$branch" 2>/dev/null; then
+            if ! git fetch origin "$branch" 2>/dev/null; then
               echo "::warning::PR #${pr_number} — could not fetch branch ${branch} (may be from a fork)."
               echo "::endgroup::"
               continue
@@ -70,7 +70,7 @@ jobs:
               # Check if rebase actually changed anything
               if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$branch")" ]; then
                 push_output=""
-                if push_output=$(git push origin -- "$branch" --force-with-lease 2>&1); then
+                if push_output=$(git push --force-with-lease origin "$branch" 2>&1); then
                   echo "Rebased and pushed successfully."
                 else
                   echo "::error::PR #${pr_number} — push failed: ${push_output}"

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -172,19 +172,15 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass through env var (not inline expression) to avoid bash treating
+          # markdown backticks in the diagnostic summary as command substitution.
+          DIAG: ${{ steps.resolve.outputs.diagnostic_summary }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ matrix.number }}
         run: |
-          DIAG="${{ steps.resolve.outputs.diagnostic_summary }}"
           if [ -n "$DIAG" ]; then
-            BODY="$(cat <<EOFBODY
-          Automatic conflict resolution failed for this PR. Manual resolution is needed.
-
-          **Diagnostics:**
-          $DIAG
-
-          [View workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          EOFBODY
-          )"
+            BODY="$(printf 'Automatic conflict resolution failed for this PR. Manual resolution is needed.\n\n**Diagnostics:**\n%s\n\n[View workflow logs](%s)' "$DIAG" "$RUN_URL")"
           else
-            BODY="Automatic conflict resolution failed for this PR. Manual resolution is needed. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            BODY="Automatic conflict resolution failed for this PR. Manual resolution is needed. [View logs]($RUN_URL)"
           fi
-          gh pr comment "${{ matrix.number }}" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY"


### PR DESCRIPTION
## Summary

- **Bug 1 (auto-rebase.yml):** `git push origin -- "$branch" --force-with-lease` was broken — the `--` separator causes `--force-with-lease` to be treated as a refspec (not a flag), giving "src refspec --force-with-lease does not match any". Fixed: `git push --force-with-lease origin "$branch"`. This was causing all rebase pushes to fail with exit code 1 on every merge to main.

- **Bug 2 (resolve-conflicts.yml):** The "Post failure comment" step used `DIAG="${{ steps.resolve.outputs.diagnostic_summary }}"` inline in bash. The diagnostic summary contains markdown backticks around filenames, which bash interpreted as command substitution (trying to exec `app/scripts/build-data.mjs` etc.). Fixed: pass via `env:` block and use `printf` instead of heredoc.

## Test plan
- [ ] Verify auto-rebase workflow succeeds on next push to main
- [ ] Verify resolve-conflicts "Post failure comment" step no longer exits 127

https://claude.ai/code/session_0185ocxsp4UVQo3mrcQSGNyP