### PR TITLE
Add mobile sidebar with slide-out overlay

### DIFF
--- a/.claude/sessions/2026-02-18_mobile-sidebar-collapse-aM9Hd.md
+++ b/.claude/sessions/2026-02-18_mobile-sidebar-collapse-aM9Hd.md
@@ -1,0 +1,14 @@
+## 2026-02-18 | claude/mobile-sidebar-collapse-aM9Hd | Mobile sidebar collapse
+
+**What was done:** Added mobile sidebar support — on screens below 768px, the static sidebar is hidden and replaced with a hamburger trigger button that opens a slide-out overlay panel with smooth transitions. Auto-closes on route navigation, Escape key, and backdrop click.
+
+**Model:** opus-4-6
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- `SidebarTrigger` component existed but was never used — created separate `MobileSidebar` and `MobileSidebarTrigger` components with dedicated mobile context to avoid coupling desktop and mobile state
+- No Sheet/Dialog radix primitive was installed, so built the overlay with plain CSS transitions (opacity + transform) to avoid adding dependencies

--- a/app/src/app/internal/layout.tsx
+++ b/app/src/app/internal/layout.tsx
@@ -1,4 +1,4 @@
-import { WikiSidebar } from "@/components/wiki/WikiSidebar";
+import { WikiSidebar, MobileSidebarTrigger } from "@/components/wiki/WikiSidebar";
 import { getInternalNav } from "@/lib/wiki-nav";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import type { Metadata } from "next";
@@ -16,7 +16,12 @@ export default function InternalLayout({
   return (
     <SidebarProvider>
       <WikiSidebar sections={sections} />
-      <div className="flex-1 min-w-0 px-8 py-4">{children}</div>
+      <div className="flex-1 min-w-0">
+        <div className="md:hidden px-4 pt-3">
+          <MobileSidebarTrigger />
+        </div>
+        <div className="px-8 py-4">{children}</div>
+      </div>
     </SidebarProvider>
   );
 }

--- a/app/src/app/wiki/[id]/page.tsx
+++ b/app/src/app/wiki/[id]/page.tsx
@@ -13,7 +13,7 @@ import { CONTENT_FORMAT_INFO, isFullWidth } from "@/lib/page-types";
 import { PageStatus } from "@/components/PageStatus";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { RelatedPages } from "@/components/RelatedPages";
-import { WikiSidebar } from "@/components/wiki/WikiSidebar";
+import { WikiSidebar, MobileSidebarTrigger } from "@/components/wiki/WikiSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { detectSidebarType, getWikiNav, isAboutPage } from "@/lib/wiki-nav";
 import { AlertTriangle, Database, Github } from "lucide-react";
@@ -310,6 +310,9 @@ function WithSidebar({
     <SidebarProvider>
       <WikiSidebar sections={sections} />
       <div className="flex-1 min-w-0">
+        <div className="md:hidden px-4 pt-3">
+          <MobileSidebarTrigger />
+        </div>
         <div className={contentClass}>{children}</div>
       </div>
     </SidebarProvider>

--- a/app/src/components/wiki/WikiSidebar.tsx
+++ b/app/src/components/wiki/WikiSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useEffect } from "react";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 import {
@@ -17,6 +18,9 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
+  MobileSidebar,
+  MobileSidebarTrigger,
+  useMobileSidebar,
 } from "@/components/ui/sidebar";
 import type { NavSection } from "@/lib/internal-nav";
 
@@ -58,14 +62,45 @@ function SidebarNavSection({ section }: { section: NavSection }) {
   );
 }
 
-export function WikiSidebar({ sections }: { sections: NavSection[] }) {
+function SidebarNav({ sections }: { sections: NavSection[] }) {
   return (
-    <Sidebar className="sticky top-14 h-[calc(100vh-3.5rem)] border-r-0">
-      <SidebarContent className="pt-2">
-        {sections.map((section) => (
-          <SidebarNavSection key={section.title} section={section} />
-        ))}
-      </SidebarContent>
-    </Sidebar>
+    <SidebarContent className="pt-2">
+      {sections.map((section) => (
+        <SidebarNavSection key={section.title} section={section} />
+      ))}
+    </SidebarContent>
   );
 }
+
+/** Auto-close mobile sidebar on route change */
+function MobileSidebarAutoClose() {
+  const pathname = usePathname();
+  const { setMobileOpen } = useMobileSidebar();
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname, setMobileOpen]);
+
+  return null;
+}
+
+export function WikiSidebar({ sections }: { sections: NavSection[] }) {
+  return (
+    <>
+      {/* Desktop: static sidebar */}
+      <Sidebar className="sticky top-14 h-[calc(100vh-3.5rem)] border-r-0">
+        <SidebarNav sections={sections} />
+      </Sidebar>
+
+      {/* Mobile: slide-out overlay */}
+      <MobileSidebar>
+        <SidebarNav sections={sections} />
+      </MobileSidebar>
+
+      <MobileSidebarAutoClose />
+    </>
+  );
+}
+
+/** Trigger button for mobile sidebar — place in content area */
+export { MobileSidebarTrigger };


### PR DESCRIPTION
## Summary
- On mobile (< 768px), the static sidebar is replaced with a hamburger trigger button
- Tapping the trigger opens a slide-out navigation panel with backdrop overlay
- Smooth CSS transitions for panel slide-in and backdrop fade
- Auto-closes on route change, Escape key, or backdrop click
- Separate MobileSidebarContext with memoized value to avoid unnecessary re-renders

## Test plan
- [ ] Verify sidebar is hidden on mobile viewports
- [ ] Verify hamburger trigger appears on mobile for wiki pages with sidebars
- [ ] Verify slide-out panel opens/closes correctly
- [ ] Verify auto-close on navigation
- [ ] Verify desktop sidebar is unchanged

https://claude.ai/code/session_01Ta6ZHkg7qijQHuVkPTBEri