### PR TITLE
Add About navigation section for user-facing pages

### DIFF
--- a/.claude/sessions/2026-02-18_add-about-navigation-mvtfb.md
+++ b/.claude/sessions/2026-02-18_add-about-navigation-mvtfb.md
@@ -1,0 +1,14 @@
+## 2026-02-18 | claude/add-about-navigation-mvtfb | Add About navigation section
+
+**What was done:** Added an "About" section to the header navigation and sidebar, separating user-facing pages (About This Wiki, Vision, Strategy, Roadmap, Value Proposition) from the developer-focused Internal section. About pages get their own sidebar, breadcrumbs, and are no longer marked as noindex for search engines.
+
+**Model:** opus-4-6
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- About pages still physically live under `content/docs/internal/` but are detected via `isAboutPage()` slug matching in `wiki-nav.ts`. Future work could move them to a dedicated `content/docs/about/` directory.
+- The `ABOUT_PAGE_SLUGS` set in `wiki-nav.ts` must be updated when adding new about pages.

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -56,6 +56,12 @@ export default function RootLayout({
                 Explore
               </Link>
               <Link
+                href="/wiki/E755"
+                className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+              >
+                About
+              </Link>
+              <Link
                 href="/wiki/E779"
                 className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >

--- a/app/src/app/wiki/[id]/page.tsx
+++ b/app/src/app/wiki/[id]/page.tsx
@@ -15,7 +15,7 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { RelatedPages } from "@/components/RelatedPages";
 import { WikiSidebar } from "@/components/wiki/WikiSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { detectSidebarType, getWikiNav } from "@/lib/wiki-nav";
+import { detectSidebarType, getWikiNav, isAboutPage } from "@/lib/wiki-nav";
 import { AlertTriangle, Database, Github } from "lucide-react";
 import { PageFeedback } from "@/components/wiki/PageFeedback";
 import type { Metadata } from "next";
@@ -59,6 +59,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageData = getPageById(slug);
   const entityPath = getEntityPath(slug);
   const isInternal = entityPath?.startsWith("/internal");
+  const isAbout = entityPath ? isAboutPage(entityPath) : false;
   const title = entity?.title || pageData?.title || slug;
   const description = entity?.description || pageData?.description || undefined;
   const format = (pageData?.contentFormat || "article") as ContentFormat;
@@ -66,8 +67,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
-    // Internal pages should not be indexed by search engines
-    ...(isInternal && { robots: { index: false, follow: false } }),
+    // Internal pages (but not About pages) should not be indexed by search engines
+    ...(isInternal && !isAbout && { robots: { index: false, follow: false } }),
     openGraph: {
       title,
       description,
@@ -130,12 +131,14 @@ function ContentMeta({
   slug,
   contentFormat,
   isInternal,
+  isAbout,
 }: {
   page: MdxPage;
   pageData: Page | undefined;
   slug: string;
   contentFormat: ContentFormat;
   isInternal?: boolean;
+  isAbout?: boolean;
 }) {
   const lastUpdated = pageData?.lastUpdated;
   const githubUrl = pageData?.filePath
@@ -151,6 +154,7 @@ function ContentMeta({
         category={pageData?.category}
         title={page.frontmatter.title || entity?.title}
         isInternal={isInternal}
+        isAbout={isAbout}
       />
       <div className="page-meta">
         {lastUpdated && (
@@ -222,6 +226,7 @@ function ContentView({
   const formatInfo = CONTENT_FORMAT_INFO[contentFormat];
   const isArticle = contentFormat === "article";
   const isInternal = entityPath.startsWith("/internal");
+  const isAbout = isAboutPage(entityPath);
 
   return (
     <InfoBoxVisibilityProvider>
@@ -232,6 +237,7 @@ function ContentView({
         slug={slug}
         contentFormat={contentFormat}
         isInternal={isInternal}
+        isAbout={isAbout}
       />
       {!isInternal && (
         <ContentConfidenceBanner

--- a/app/src/components/Breadcrumbs.tsx
+++ b/app/src/components/Breadcrumbs.tsx
@@ -17,14 +17,18 @@ export function Breadcrumbs({
   category,
   title,
   isInternal,
+  isAbout,
 }: {
   category?: string | null;
   title?: string;
   isInternal?: boolean;
+  isAbout?: boolean;
 }) {
-  const items: BreadcrumbItem[] = isInternal
-    ? [{ label: "Internal", href: "/wiki/E779" }]
-    : [{ label: "Wiki", href: "/wiki" }];
+  const items: BreadcrumbItem[] = isAbout
+    ? [{ label: "About", href: "/wiki/E755" }]
+    : isInternal
+      ? [{ label: "Internal", href: "/wiki/E779" }]
+      : [{ label: "Wiki", href: "/wiki" }];
 
   if (category && !isInternal) {
     items.push({

--- a/app/src/lib/wiki-nav.ts
+++ b/app/src/lib/wiki-nav.ts
@@ -253,6 +253,53 @@ export function getAtmNav(): NavSection[] {
 }
 
 // ============================================================================
+// ABOUT NAV (user-facing pages)
+// ============================================================================
+
+/** Slugs that belong to the "About" section rather than "Internal". */
+const ABOUT_PAGE_SLUGS = new Set([
+  "about-this-wiki",
+  "longterm-vision",
+  "longterm-strategy",
+  "project-roadmap",
+  "longtermwiki-value-proposition",
+]);
+
+/** Check whether an entity path belongs to the About section. */
+export function isAboutPage(entityPath: string): boolean {
+  if (!entityPath.startsWith("/internal/")) return false;
+  const slug = entityPath.replace(/^\/internal\//, "").replace(/\/$/, "");
+  return ABOUT_PAGE_SLUGS.has(slug);
+}
+
+/** Resolve a slug to its /wiki/E<id> URL, falling back to /internal/ path */
+function internalHref(slug: string, fallback?: string): string {
+  const resolved = getEntityHref(slug);
+  if (resolved.startsWith("/wiki/E")) return resolved;
+  return fallback || resolved;
+}
+
+/**
+ * Build "About" sidebar navigation for user-facing pages
+ * (About, Vision, Strategy, Roadmap, Value Proposition).
+ */
+export function getAboutNav(): NavSection[] {
+  return [
+    {
+      title: "About",
+      defaultOpen: true,
+      items: [
+        { label: "About This Wiki", href: internalHref("about-this-wiki") },
+        { label: "Vision", href: internalHref("longterm-vision") },
+        { label: "Strategy", href: internalHref("longterm-strategy") },
+        { label: "Roadmap", href: internalHref("project-roadmap") },
+        { label: "Value Proposition", href: internalHref("longtermwiki-value-proposition") },
+      ],
+    },
+  ];
+}
+
+// ============================================================================
 // INTERNAL NAV
 // ============================================================================
 
@@ -262,40 +309,26 @@ export function getAtmNav(): NavSection[] {
  * For React dashboard pages (no entity), keeps /internal/ URLs.
  */
 export function getInternalNav(): NavSection[] {
-  /** Resolve a slug to its /wiki/E<id> URL, falling back to /internal/ path */
-  function href(slug: string, internalPath?: string): string {
-    const resolved = getEntityHref(slug);
-    // getEntityHref always returns /wiki/...; if the slug had a numericId it will be /wiki/E<id>
-    // If slug is not found in registry, it returns /wiki/<slug> which won't resolve — use fallback
-    if (resolved.startsWith("/wiki/E")) return resolved;
-    return internalPath || resolved;
-  }
-
   return [
     {
       title: "Overview",
       defaultOpen: true,
       items: [
-        { label: "Internal Home", href: href("__index__/internal", "/wiki/E779") },
-        { label: "About This Wiki", href: href("about-this-wiki") },
-        { label: "Vision", href: href("longterm-vision") },
-        { label: "Strategy", href: href("longterm-strategy") },
-        { label: "Roadmap", href: href("project-roadmap") },
-        { label: "Value Proposition", href: href("longtermwiki-value-proposition") },
+        { label: "Internal Home", href: internalHref("__index__/internal", "/wiki/E779") },
       ],
     },
     {
       title: "Dashboards & Tools",
       defaultOpen: true,
       items: [
-        { label: "Enhancement Queue", href: href("enhancement-queue") },
+        { label: "Enhancement Queue", href: internalHref("enhancement-queue") },
         { label: "Suggested Pages", href: "/internal/suggested-pages" },
         { label: "Update Schedule", href: "/internal/updates" },
         { label: "Page Changes", href: "/internal/page-changes" },
         { label: "PR Descriptions", href: "/internal/pr-descriptions" },
         { label: "Fact Dashboard", href: "/internal/facts" },
-        { label: "Automation Tools", href: href("automation-tools") },
-        { label: "Content Database", href: href("content-database") },
+        { label: "Automation Tools", href: internalHref("automation-tools") },
+        { label: "Content Database", href: internalHref("content-database") },
         { label: "Importance Rankings", href: "/internal/importance-rankings" },
         { label: "Page Similarity", href: "/internal/similarity" },
         { label: "Interventions", href: "/internal/interventions" },
@@ -307,42 +340,42 @@ export function getInternalNav(): NavSection[] {
     {
       title: "Style Guides",
       items: [
-        { label: "Common Writing Principles", href: href("common-writing-principles") },
-        { label: "Page Types", href: href("page-types") },
-        { label: "Knowledge Base", href: href("knowledge-base") },
-        { label: "Risk Pages", href: href("risk-style-guide") },
-        { label: "Response Pages", href: href("response-style-guide") },
-        { label: "Models", href: href("models-style-guide") },
-        { label: "Stub Pages", href: href("stub-style-guide") },
-        { label: "Rating System", href: href("rating-system") },
-        { label: "Mermaid Diagrams", href: href("mermaid-diagrams") },
-        { label: "Canonical Facts & Calc", href: href("canonical-facts") },
-        { label: "Cause-Effect Diagrams", href: href("cause-effect-diagrams") },
-        { label: "Research Reports", href: href("research-reports") },
-        { label: "AI Transition Model", href: href("ai-transition-model-style-guide") },
+        { label: "Common Writing Principles", href: internalHref("common-writing-principles") },
+        { label: "Page Types", href: internalHref("page-types") },
+        { label: "Knowledge Base", href: internalHref("knowledge-base") },
+        { label: "Risk Pages", href: internalHref("risk-style-guide") },
+        { label: "Response Pages", href: internalHref("response-style-guide") },
+        { label: "Models", href: internalHref("models-style-guide") },
+        { label: "Stub Pages", href: internalHref("stub-style-guide") },
+        { label: "Rating System", href: internalHref("rating-system") },
+        { label: "Mermaid Diagrams", href: internalHref("mermaid-diagrams") },
+        { label: "Canonical Facts & Calc", href: internalHref("canonical-facts") },
+        { label: "Cause-Effect Diagrams", href: internalHref("cause-effect-diagrams") },
+        { label: "Research Reports", href: internalHref("research-reports") },
+        { label: "AI Transition Model", href: internalHref("ai-transition-model-style-guide") },
       ],
     },
     {
       title: "Research",
       items: [
-        { label: "Reports Index", href: href("__index__/internal/reports", "/wiki/E780") },
-        { label: "AI Research Workflows", href: href("ai-research-workflows") },
-        { label: "Causal Diagram Visualization", href: href("causal-diagram-visualization") },
-        { label: "Controlled Vocabulary", href: href("controlled-vocabulary") },
-        { label: "Cross-Link Automation", href: href("cross-link-automation-proposal") },
-        { label: "Diagram Naming", href: href("diagram-naming-research") },
-        { label: "Page Creator Pipeline", href: href("page-creator-pipeline") },
-        { label: "Gap Analysis (Feb 2026)", href: href("gap-analysis-2026-02") },
+        { label: "Reports Index", href: internalHref("__index__/internal/reports", "/wiki/E780") },
+        { label: "AI Research Workflows", href: internalHref("ai-research-workflows") },
+        { label: "Causal Diagram Visualization", href: internalHref("causal-diagram-visualization") },
+        { label: "Controlled Vocabulary", href: internalHref("controlled-vocabulary") },
+        { label: "Cross-Link Automation", href: internalHref("cross-link-automation-proposal") },
+        { label: "Diagram Naming", href: internalHref("diagram-naming-research") },
+        { label: "Page Creator Pipeline", href: internalHref("page-creator-pipeline") },
+        { label: "Gap Analysis (Feb 2026)", href: internalHref("gap-analysis-2026-02") },
       ],
     },
     {
       title: "Architecture & Schema",
       items: [
-        { label: "Architecture", href: href("architecture") },
-        { label: "Wiki Generation Architecture", href: href("wiki-generation-architecture") },
-        { label: "Schema Overview", href: href("__index__/internal/schema", "/wiki/E781") },
-        { label: "Entity Reference", href: href("entities") },
-        { label: "Schema Diagrams", href: href("diagrams") },
+        { label: "Architecture", href: internalHref("architecture") },
+        { label: "Wiki Generation Architecture", href: internalHref("wiki-generation-architecture") },
+        { label: "Schema Overview", href: internalHref("__index__/internal/schema", "/wiki/E781") },
+        { label: "Entity Reference", href: internalHref("entities") },
+        { label: "Schema Diagrams", href: internalHref("diagrams") },
       ],
     },
   ];
@@ -352,7 +385,7 @@ export function getInternalNav(): NavSection[] {
 // DETECT WHICH SIDEBAR TO SHOW
 // ============================================================================
 
-export type WikiSidebarType = "models" | "atm" | "internal" | "kb" | null;
+export type WikiSidebarType = "models" | "atm" | "internal" | "about" | "kb" | null;
 
 /**
  * Determine which sidebar to show based on the entity path.
@@ -373,6 +406,12 @@ export function detectSidebarType(entityPath: string): WikiSidebarType {
 
   if (entityPath.startsWith("/ai-transition-model/")) {
     return "atm";
+  }
+
+  // About pages live under /internal/ but get their own sidebar.
+  // Must check before the generic /internal/ pattern below.
+  if (isAboutPage(entityPath)) {
+    return "about";
   }
 
   if (entityPath.startsWith("/internal/") || entityPath === "/internal") {
@@ -417,6 +456,8 @@ export function getWikiNav(
       ];
     case "atm":
       return getAtmNav();
+    case "about":
+      return getAboutNav();
     case "internal":
       return getInternalNav();
     case "kb": {


### PR DESCRIPTION
## Summary

- Adds an "About" link in the header navigation pointing to the About This Wiki page
- Creates a dedicated About sidebar with user-facing pages: About This Wiki, Vision, Strategy, Roadmap, Value Proposition
- Removes those pages from the Internal section (which now focuses on dev-team content: dashboards, style guides, research, architecture)
- About pages get "About" breadcrumbs and are now indexable by search engines

## Test plan

- [ ] Click "About" in header — should navigate to About This Wiki page with About sidebar
- [ ] Navigate between About pages — sidebar should persist and highlight active page
- [ ] Click "Internal" in header — should show Internal section without About pages
- [ ] Verify breadcrumbs show "About" (not "Internal") on About pages
- [ ] Run `pnpm crux validate gate` — all checks pass

https://claude.ai/code/session_01VKgmihkKmzx1xCTN1n6Pz8