### PR TITLE
Remove legacy pageTemplate frontmatter from 15 MDX files

### DIFF
--- a/.claude/sessions/2026-02-18_resolve-issue-251-XhJkg.md
+++ b/.claude/sessions/2026-02-18_resolve-issue-251-XhJkg.md
@@ -1,0 +1,15 @@
+## 2026-02-18 | claude/resolve-issue-251-XhJkg | Remove legacy pageTemplate frontmatter
+
+**What was done:** Removed the legacy `pageTemplate` frontmatter field from 15 MDX files. This field was carried over from the Astro/Starlight era and is not used by the Next.js application.
+
+**Pages:** table, cause-effect-demo, deployment-architectures-table, architecture-scenarios-table, reducing-hallucinations, safety-generalizability-table, accident-risks-table, safety-approaches-table, pre-tai-capital-deployment, ai-talent-market-dynamics, ai-megaproject-infrastructure, safety-spending-at-scale, eval-types-table, frontier-lab-cost-structure, planning-for-frontier-lab-scaling
+
+**Model:** opus-4-6
+
+**Duration:** ~10min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The `pageTemplate` field is still referenced in crux grading code (`page-templates.ts`, `grade-by-template.ts`) but those paths handle missing values gracefully via null checks, so removal from MDX is safe without code changes.

--- a/content/docs/ai-transition-model/table.mdx
+++ b/content/docs/ai-transition-model/table.mdx
@@ -3,7 +3,6 @@ numericId: E675
 title: "Parameter Table"
 description: "Sortable tables showing all parameters in the AI Transition Model with ratings for changeability, uncertainty, and impact."
 contentFormat: table
-pageTemplate: data-table
 sidebar:
   order: 5
 readerImportance: 69

--- a/content/docs/guides/cause-effect-demo.mdx
+++ b/content/docs/guides/cause-effect-demo.mdx
@@ -2,7 +2,6 @@
 title: "Cause-Effect Graph Demo"
 description: "Interactive visualization of cause and effect relationships"
 contentFormat: diagram
-pageTemplate: visualization
 tableOfContents: false
 readerImportance: 73.5
 researchImportance: 73.5

--- a/content/docs/knowledge-base/architecture-scenarios-table.mdx
+++ b/content/docs/knowledge-base/architecture-scenarios-table.mdx
@@ -3,7 +3,6 @@ numericId: E634
 title: "Architecture Scenarios Table"
 description: "Interactive comparison table of scalable intelligence paradigms and deployment patterns."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 43
 researchImportance: 68
 update_frequency: 30

--- a/content/docs/knowledge-base/deployment-architectures-table.mdx
+++ b/content/docs/knowledge-base/deployment-architectures-table.mdx
@@ -3,7 +3,6 @@ numericId: E635
 title: "Deployment Architectures Table"
 description: "Interactive comparison table of AI deployment and safety architectures."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 34.5
 researchImportance: 63
 update_frequency: 30

--- a/content/docs/knowledge-base/models/ai-megaproject-infrastructure.mdx
+++ b/content/docs/knowledge-base/models/ai-megaproject-infrastructure.mdx
@@ -13,7 +13,6 @@ readerImportance: 6.5
 researchImportance: 6.5
 lastEdited: "2026-02-15"
 llmSummary: "Analysis of AI infrastructure buildout economics. Individual frontier data center campuses cost $10-50B and require 100MW-1GW+ power each. Stargate commits $500B over 4+ years. 2025 big tech AI capex exceeds $320B. Key constraints: TSMC advanced packaging (CoWoS), power grid connections (2-5 year lead times), and cooling at density. The infrastructure race creates geographic and economic lock-in, with implications for safety governance and concentration of power."
-pageTemplate: knowledge-base-model
 clusters:
   - governance
   - ai-safety

--- a/content/docs/knowledge-base/models/ai-talent-market-dynamics.mdx
+++ b/content/docs/knowledge-base/models/ai-talent-market-dynamics.mdx
@@ -13,7 +13,6 @@ readerImportance: 6
 researchImportance: 6
 lastEdited: "2026-02-15"
 llmSummary: "The AI talent market constrains scaling in both capabilities and safety research. An estimated 5,000-10,000 researchers globally can contribute to frontier AI, with 500-1,000 at the highest level. Senior researcher compensation ranges from $500K to $3M+, creating a 3-8x differential versus academic and safety research positions. The top 3 labs employ 40-50% of the top 100 researchers. The safety research workforce (~2,000-3,500 dedicated) is approximately an order of magnitude smaller than capabilities. The pipeline produces ~200-350 new safety researchers per year. Geographic concentration (35% Bay Area) and organizational concentration create structural dependencies."
-pageTemplate: knowledge-base-model
 clusters:
   - ai-safety
   - community

--- a/content/docs/knowledge-base/models/eval-types-table.mdx
+++ b/content/docs/knowledge-base/models/eval-types-table.mdx
@@ -3,7 +3,6 @@ numericId: E637
 title: "Evaluation Types Table"
 description: "Interactive comparison table of AI evaluation methodologies and their strategic value."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 35
 researchImportance: 59
 update_frequency: 30

--- a/content/docs/knowledge-base/models/frontier-lab-cost-structure.mdx
+++ b/content/docs/knowledge-base/models/frontier-lab-cost-structure.mdx
@@ -13,7 +13,6 @@ readerImportance: 5.5
 researchImportance: 6
 lastEdited: "2026-02-15"
 llmSummary: "Analysis of capital allocation at frontier AI labs. OpenAI operates on approximately $20B ARR with $14B+ annual costs; Anthropic on approximately $9B ARR with $7-10B costs; Google DeepMind within Alphabet's $75B capex budget. Compute infrastructure represents 50-65% of costs, while safety receives 1-8% depending on the lab. Financial structure creates incentives affecting safety spending: investor return expectations, competitive dynamics, and revenue-dependent compute access influence resource allocation. The path-to-profitability timeline (estimated 2028-2032 for independent labs) represents a period where financial pressure and safety spending allocation decisions are particularly consequential."
-pageTemplate: knowledge-base-model
 clusters:
   - ai-safety
   - governance

--- a/content/docs/knowledge-base/models/planning-for-frontier-lab-scaling.mdx
+++ b/content/docs/knowledge-base/models/planning-for-frontier-lab-scaling.mdx
@@ -13,7 +13,6 @@ readerImportance: 5.5
 researchImportance: 5.5
 lastEdited: "2026-02-15"
 llmSummary: "Strategic framework analyzing how non-lab actors could respond to frontier AI labs deploying $100-300B+ pre-TAI. For philanthropies: analysis of potential shifts from matching spend to maximizing leverage; focus on pipeline, governance advocacy, and strategic timing. For governments: options for adaptive regulation, mandatory safety spending, public compute infrastructure. For academia: analysis of industry partnerships, safety curricula, talent retention via joint appointments. For startups: potential safety-as-service, evaluation infrastructure, niche specialization opportunities. For civil society: frameworks for accountability infrastructure, coalition building, public education. Key theme: the 2025-2028 window may be particularly important because lab spending patterns are being established, IPOs create new accountability mechanisms, and the pre-TAI period may be the last window for meaningful external influence."
-pageTemplate: knowledge-base-model
 clusters:
   - ai-safety
   - governance

--- a/content/docs/knowledge-base/models/pre-tai-capital-deployment.mdx
+++ b/content/docs/knowledge-base/models/pre-tai-capital-deployment.mdx
@@ -13,7 +13,6 @@ readerImportance: 5.5
 researchImportance: 5.5
 lastEdited: "2026-02-15"
 llmSummary: "Analysis of how frontier AI labs (Anthropic, OpenAI, Google DeepMind) could deploy $100-300B+ before TAI. Compute infrastructure absorbs 50-65% of spending ($200-400B+ across the industry), with Stargate alone at $500B committed. Safety spending remains at 1-5% ($1-15B) representing different allocation choices across labs. Historical analogies (Manhattan Project $30B, Apollo $200B) provide context for current AI investment levels. Key finding: the spending pattern—and especially the safety allocation—is a variable that other organizations, governments, and funders are actively planning around."
-pageTemplate: knowledge-base-model
 clusters:
   - ai-safety
   - governance

--- a/content/docs/knowledge-base/models/safety-spending-at-scale.mdx
+++ b/content/docs/knowledge-base/models/safety-spending-at-scale.mdx
@@ -13,7 +13,6 @@ readerImportance: 5.5
 researchImportance: 5.5
 lastEdited: "2026-02-15"
 llmSummary: "Models what AI safety spending could accomplish at different budget levels from $1B to $50B+/year. Current global safety spending (~$500M-1B/year) is 100-600x below capabilities investment. At $5B/year, could fund 5,000+ dedicated safety researchers, comprehensive interpretability programs, and independent evaluation infrastructure. Key finding: absorptive capacity is the binding constraint below $10B/year—the field cannot productively absorb unlimited funding without growing the researcher pipeline (current ~1,000 qualified safety researchers globally). Above $10B/year, institutional capacity and research direction clarity become primary constraints. Provides concrete portfolio recommendations at each funding level."
-pageTemplate: knowledge-base-model
 clusters:
   - ai-safety
   - community

--- a/content/docs/knowledge-base/responses/reducing-hallucinations.mdx
+++ b/content/docs/knowledge-base/responses/reducing-hallucinations.mdx
@@ -3,7 +3,6 @@ numericId: E814
 title: "Reducing Hallucinations in AI-Generated Wiki Content"
 description: "Technical and procedural strategies to ground AI-generated content in verified information and reduce factual errors in wiki articles"
 entityType: approach
-pageTemplate: knowledge-base-response
 lastEdited: "2026-02-17"
 createdAt: 2026-02-17
 sidebar:

--- a/content/docs/knowledge-base/responses/safety-approaches-table.mdx
+++ b/content/docs/knowledge-base/responses/safety-approaches-table.mdx
@@ -3,7 +3,6 @@ numericId: E657
 title: "Safety Approaches Table"
 description: "Interactive comparison table of AI safety approaches, evaluating safety uplift vs capability uplift tradeoffs."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 19
 researchImportance: 27.5
 update_frequency: 30

--- a/content/docs/knowledge-base/responses/safety-generalizability-table.mdx
+++ b/content/docs/knowledge-base/responses/safety-generalizability-table.mdx
@@ -3,7 +3,6 @@ numericId: E658
 title: "Safety Generalizability Table"
 description: "Interactive table showing which AI safety research approaches generalize across architectures."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 19
 researchImportance: 18
 update_frequency: 30

--- a/content/docs/knowledge-base/risks/accident-risks-table.mdx
+++ b/content/docs/knowledge-base/risks/accident-risks-table.mdx
@@ -3,7 +3,6 @@ numericId: E659
 title: "Accident Risks Table"
 description: "Interactive comparison table of AI accident and misalignment risks with overlap analysis."
 contentFormat: table
-pageTemplate: data-table
 readerImportance: 18
 researchImportance: 23
 update_frequency: 30


### PR DESCRIPTION
## Summary

- Removes the legacy `pageTemplate` frontmatter field from all 15 remaining MDX files that had it
- This field was carried over from the Astro/Starlight era and is ignored by the current Next.js application
- Values removed: `data-table` (8 files), `knowledge-base-model` (6 files), `visualization` (1 file)

Closes #251

## Test plan

- [x] `grep -r "^pageTemplate:" content/` returns zero matches
- [x] `pnpm crux validate gate --fix` passes all 9 checks
- [x] Frontmatter schema validation passes (field is optional in Zod schema)
- [x] No runtime code in `app/` references `pageTemplate`
- [x] Crux grading code handles missing `pageTemplate` gracefully via null guards