### PR TITLE
Add YAML parse error handling in build-data.mjs

### DIFF
--- a/.claude/sessions/2026-02-18_resolve-issue-246-BYl9h.md
+++ b/.claude/sessions/2026-02-18_resolve-issue-246-BYl9h.md
@@ -1,0 +1,13 @@
+## 2026-02-18 | claude/resolve-issue-246-BYl9h | Add YAML parse error handling in build-data.mjs
+
+**What was done:** Added try-catch error handling around three unprotected `parse()` calls in `app/scripts/build-data.mjs` — in the path registry entity loader, facts loader, and fact-measures loader. The existing `loadYaml()` and `loadYamlDir()` functions already had error handling; this closes the remaining gaps. Fixes #246.
+
+**Model:** opus-4-6
+
+**Duration:** ~10min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The `loadYaml()` and `loadYamlDir()` functions already had try-catch handling when the issue was filed, but three other `parse()` call sites in the same file did not.

--- a/app/scripts/build-data.mjs
+++ b/app/scripts/build-data.mjs
@@ -735,7 +735,14 @@ function buildPathRegistry() {
     for (const file of readdirSync(entityDir)) {
       if (!file.endsWith('.yaml')) continue;
       const content = readFileSync(join(entityDir, file), 'utf-8');
-      const entities = parse(content);
+      let entities;
+      try {
+        entities = parse(content);
+      } catch (e) {
+        console.error(`Failed to parse YAML ${join(entityDir, file)}: ${e.message}`);
+        process.exitCode = 1;
+        continue;
+      }
       if (!Array.isArray(entities)) continue;
       for (const entity of entities) {
         if (!entity.id || registry[entity.id]) continue;
@@ -1088,7 +1095,14 @@ async function main() {
     for (const file of factFiles) {
       const filepath = join(factsDir, file);
       const content = readFileSync(filepath, 'utf-8');
-      const parsed = parse(content);
+      let parsed;
+      try {
+        parsed = parse(content);
+      } catch (e) {
+        console.error(`Failed to parse YAML ${filepath}: ${e.message}`);
+        process.exitCode = 1;
+        continue;
+      }
       if (parsed && parsed.entity && parsed.facts) {
         for (const [factId, factData] of Object.entries(parsed.facts)) {
           const key = `${parsed.entity}.${factId}`;
@@ -1106,7 +1120,13 @@ async function main() {
   const factMeasures = {};
   if (existsSync(factMeasuresPath)) {
     const measuresContent = readFileSync(factMeasuresPath, 'utf-8');
-    const measuresParsed = parse(measuresContent);
+    let measuresParsed;
+    try {
+      measuresParsed = parse(measuresContent);
+    } catch (e) {
+      console.error(`Failed to parse YAML ${factMeasuresPath}: ${e.message}`);
+      process.exitCode = 1;
+    }
     if (measuresParsed && measuresParsed.measures) {
       for (const [measureId, measureDef] of Object.entries(measuresParsed.measures)) {
         factMeasures[measureId] = { id: measureId, ...measureDef };


### PR DESCRIPTION
## Summary
- Adds try-catch error handling around 3 unprotected `parse()` calls in `app/scripts/build-data.mjs` (entity path registry, facts loader, fact-measures loader)
- On YAML parse failure, logs the filepath and error message, sets `process.exitCode = 1`, and continues with empty/skipped data
- Consistent with existing error handling pattern in `loadYaml()` and `loadYamlDir()`

Fixes #246

## Test plan
- [x] `pnpm crux validate gate --fix` passes (all 9 checks)
- [x] Build completes successfully with no YAML errors
- [x] All 121 app tests + 294 crux tests pass

https://claude.ai/code/session_01NHuwJtxYYTTFGRW78mGXX3