### PR TITLE
Fix CauseEffectGraph silent layout failure (#247)

### DIFF
--- a/.claude/sessions/2026-02-18_resolve-issue-247-U1zzq.md
+++ b/.claude/sessions/2026-02-18_resolve-issue-247-U1zzq.md
@@ -1,0 +1,13 @@
+## 2026-02-18 | claude/resolve-issue-247-U1zzq | Fix CauseEffectGraph silent layout failure
+
+**What was done:** Fixed CauseEffectGraph layout failure handling so the UI no longer gets stuck on "Computing layout..." indefinitely. Added a 10-second timeout, improved error banner styling with proper CSS, and added a retry button.
+
+**Model:** opus-4-6
+
+**Duration:** ~15min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The component already had basic error handling (catch block, layoutError state), but lacked a timeout for hung computations and had poor error UX (inline styles, no retry option).

--- a/app/src/components/wiki/CauseEffectGraph/CauseEffectGraph.css
+++ b/app/src/components/wiki/CauseEffectGraph/CauseEffectGraph.css
@@ -105,6 +105,60 @@
   z-index: 10;
 }
 
+/* Layout error banner */
+.cause-effect-graph__error {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background-color: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fbbf24;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  white-space: nowrap;
+}
+
+.cause-effect-graph__error-retry {
+  all: unset;
+  box-sizing: border-box;
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #92400e;
+  background-color: rgba(146, 64, 14, 0.1);
+  border: 1px solid #d97706;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.cause-effect-graph__error-retry:hover {
+  background-color: rgba(146, 64, 14, 0.2);
+}
+
+.dark .cause-effect-graph__error {
+  background-color: #422006;
+  color: #fbbf24;
+  border-color: #92400e;
+}
+
+.dark .cause-effect-graph__error-retry {
+  color: #fbbf24;
+  background-color: rgba(251, 191, 36, 0.1);
+  border-color: #b45309;
+}
+
+.dark .cause-effect-graph__error-retry:hover {
+  background-color: rgba(251, 191, 36, 0.2);
+}
+
 /* Details panel - positioned on the left to avoid overlapping "On this page" nav */
 .cause-effect-graph__panel {
   position: absolute;


### PR DESCRIPTION
## Summary
- Add 10-second timeout to prevent UI stuck on "Computing layout..." indefinitely
- Improve error banner styling with proper CSS class (amber warning with border, dark mode support)
- Add retry button so users can re-attempt layout without refreshing
- Fall back to unpositioned nodes on both timeout and error

Closes #247

## Test plan
- [ ] Verify normal graph layout still works (no regression)
- [ ] Verify error banner appears with retry button when layout fails
- [ ] Verify dark mode error banner styling
- [ ] Verify retry button triggers new layout attempt

https://claude.ai/code/session_01Tdkwoh3kib2Tt7zHCCQpi1