### PR TITLE
Fix diverged-branch handling in push-and-ensure-green

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -46,6 +46,13 @@ Use `\<` not `<` in prose (outside of JSX tags). The unified validator catches t
 ### Branch naming for Claude Code web sessions
 Branches must start with `claude/` and end with the session ID, otherwise push fails with 403.
 
+### "ahead N, behind M" diverged branch state
+When `git status -b --short` shows `[ahead 3, behind 23]`, it means the auto-rebase GitHub Actions workflow already rebased the remote branch onto main (force-pushing to origin), but the local session still has the old (pre-rebase) commits.
+
+**Fix:** Run `git pull --rebase` to rebase local commits onto the updated remote. Then push with `git push --force-with-lease -u origin HEAD` (force-with-lease is required because the rebase rewrote history).
+
+This is handled automatically by the `/push-and-ensure-green` Step 0 workflow. If `git pull --rebase` succeeds cleanly (no conflicts), no manual conflict resolution is needed — the auto-rebase workflow already incorporated your commits on top of main on the remote side.
+
 ---
 
 ## Dependencies

--- a/.claude/sessions/2026-02-18_debug-code-app-issues-PGmhR.md
+++ b/.claude/sessions/2026-02-18_debug-code-app-issues-PGmhR.md
@@ -1,0 +1,17 @@
+## 2026-02-18 | claude/debug-code-app-issues-PGmhR | Fix diverged-branch handling in push-and-ensure-green
+
+**What was done:** Diagnosed the recurring "[ahead N, behind M]" branch state in Claude Code App sessions. Root cause: the auto-rebase GitHub Actions workflow rebases feature branches on the remote after each main merge (force-push to origin), but local sessions don't pull those changes. The old push-and-ensure-green Step 0 just warned about being behind without fixing it. Updated Step 0 to auto-rebase (`git pull --rebase`) when the branch is diverged or behind, and updated Step 2 to use `--force-with-lease` after a rebase. Added the pattern to common-issues.md.
+
+**Pages:** (none — workflow documentation only)
+
+**Model:** sonnet-4
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- None — changes are to workflow instruction files only (no code changes).
+
+**Learnings/notes:**
+- "[ahead 3, behind 23]" means the auto-rebase workflow ran on origin and force-pushed a rebased version, but the local session is stale. `git pull --rebase` resolves this cleanly.
+- After `git pull --rebase`, a `--force-with-lease` push is required (history was rewritten).
+- The root cause of branches being far behind was a now-fixed bug in auto-rebase.yml (commit 2bdf334): `git push origin -- "$branch" --force-with-lease` was treating `--force-with-lease` as a refspec due to the `--` separator.


### PR DESCRIPTION
## Summary

- Updates push-and-ensure-green Step 0 to auto-rebase when the branch shows `[ahead N, behind M]` (the diverged state caused by the auto-rebase workflow updating the remote)
- Adds `--force-with-lease` push in Step 2 after a rebase
- Documents the pattern in common-issues.md

## Root Cause

When the auto-rebase workflow successfully rebases a branch on the remote (force-pushing to origin), local sessions see `[ahead 3, behind 23]`. The old Step 0 just warned the user. Now Step 0 detects each case and runs `git pull --rebase` to fix the diverged state before pushing.
