### PR TITLE
feat(auto-update): replace LLM web search with Exa API for news sources

### DIFF
--- a/.claude/sessions/2026-02-18_resolve-issue-268-s2ybS.md
+++ b/.claude/sessions/2026-02-18_resolve-issue-268-s2ybS.md
@@ -1,0 +1,17 @@
+## 2026-02-18 | claude/resolve-issue-268-s2ybS | Replace LLM web search with Exa API for auto-update sources
+
+**What was done:** Replaced the `executeWebSearch` (Anthropic Sonnet + web_search_20250305 tool) call in the auto-update feed fetcher with the Exa API as the primary search method. Added graceful fallback to the LLM-based search when `EXA_API_KEY` is unset or Exa errors. Also replaced the `arxiv-ai-safety` web-search source in `sources.yaml` with two reliable RSS feeds (`arxiv.org/rss/cs.AI` and `arxiv.org/rss/cs.CL`).
+
+**Pages:** (none — infrastructure-only change)
+
+**Model:** sonnet-4
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- Exa API endpoint: `https://api.exa.ai/search` (POST). Key fields: `type: "auto"`, `numResults`, `startPublishedDate`, `contents.text.maxCharacters`.
+- Exa returns `publishedDate` as an ISO string; the LLM fallback assigns today's date.
+- arxiv RSS feeds are more reliable and cheaper than web-searching for arxiv papers.

--- a/data/auto-update/sources.yaml
+++ b/data/auto-update/sources.yaml
@@ -9,7 +9,8 @@
 #   name:        Human-readable name
 #   type:        rss | atom | web-search
 #   url:         Feed URL (for rss/atom types)
-#   query:       Search query (for web-search types)
+#   query:       Search query (for web-search types; uses Exa API if EXA_API_KEY
+#                is set, otherwise falls back to Anthropic web_search tool)
 #   frequency:   How often to check: daily | twice-daily | weekly
 #   categories:  Topic categories this source covers (used for routing)
 #   reliability: high | medium | low (affects how aggressively we trust items)
@@ -170,13 +171,22 @@ sources:
 
   # ── Arxiv ─────────────────────────────────────────────────────────────────
 
-  - id: arxiv-ai-safety
-    name: arXiv AI Safety Papers
-    type: web-search
-    query: "arxiv AI safety alignment interpretability new paper 2026"
+  - id: arxiv-cs-ai
+    name: arXiv cs.AI (Artificial Intelligence)
+    type: rss
+    url: https://arxiv.org/rss/cs.AI
     frequency: daily
     categories: [research, safety, alignment, interpretability]
-    reliability: medium
+    reliability: high
+    enabled: true
+
+  - id: arxiv-cs-cl
+    name: arXiv cs.CL (Computation and Language)
+    type: rss
+    url: https://arxiv.org/rss/cs.CL
+    frequency: daily
+    categories: [research, models, capabilities]
+    reliability: high
     enabled: true
 
   # ── Compute & Industry ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces the expensive/fragile  (Claude Sonnet +  tool) with the **Exa API** () as the primary backend for  type sources in the auto-update pipeline
- Exa returns structured JSON (, , , ) — no regex parsing of LLM output needed
- Native  param on Exa handles date filtering cleanly and cheaply
- Keeps the Anthropic  tool as a fallback when  is unset or an Exa call fails (graceful degradation via )
- Replaces the  web-search source with two reliable RSS feeds:  and  (more reliable, no API cost)

## Test plan

- [x] All local gate checks pass (9/9)
- [x] TypeScript compiles cleanly — no new type errors
- [x]  is read from environment; missing key triggers fallback path, not a crash
- [ ] Verify Exa search returns results on next auto-update run

Closes #268

https://claude.ai/code/session_01F1C3XL3S45Z8q2CFWzoqs8