### PR TITLE
feat(issues): weighted scoring, blocked detection, claude-ready boost, score breakdown

### DIFF
--- a/.claude/sessions/2026-02-18_investigate-issue-273-aNlY2.md
+++ b/.claude/sessions/2026-02-18_investigate-issue-273-aNlY2.md
@@ -1,0 +1,17 @@
+## 2026-02-18 | claude/investigate-issue-273-aNlY2 | Improve crux issues next: weighted scoring + blocked detection
+
+**What was done:** Implemented all four proposals from issue #273 — weighted scoring function (A), blocked issue detection (B), claude-ready label boost (C), and score breakdown display (D) — in `crux/commands/issues.ts`. Added 42 tests covering new and existing behavior.
+
+**Pages:** (none — infrastructure only)
+
+**Model:** sonnet-4
+
+**Duration:** ~30min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- `on-hold` was already in SKIP_LABELS (silently filtered), so removed it from BLOCKED_LABELS to avoid confusion — on-hold issues remain hidden rather than shown as blocked
+- Score total = priority + bugBonus + claudeReadyBonus + effortAdjustment + recencyBonus + ageBonus; claude-ready applies a 50% uplift on the base subtotal
+- New `--scores` flag on both `list` and `next` shows inline breakdown for transparency


### PR DESCRIPTION
Implements all four proposals from #273:

**A. Weighted scoring** — replaces priority+age sort with a `scoreIssue()` function combining priority (P0=1000, P1=500, P2=200, P3=100, unlabeled=50), bug bonus (+50), effort adjustment (±20), recency bonus (+15 if updated within 7 days), and age bonus (+1/month, capped at +10).

**B. Blocked detection** — issues with `blocked`/`waiting`/`needs-info`/`stalled` labels, or body text matching "blocked by", "waiting for", "depends on #N" patterns, are shown in a separate Blocked section and excluded from the queue.

**C. Claude-ready label** — a `claude-ready` label applies a 1.5× multiplier to the issue score, surfacing well-scoped issues for AI assistance.

**D. Score breakdown** — new `--scores` flag on both `list` and `next` commands shows inline breakdown, e.g. `[score:570 = priority:500 bug:+50 age:+10]`.

Also adds 42 tests covering the new `scoreIssue()` and `isBlocked()` helpers, plus integration tests for all new behaviors in `list`/`next` commands.

Closes #273