### PR TITLE
refactor(discord-bot): extract pricing logic to pricing.ts

### DIFF
--- a/.claude/sessions/2026-02-19_issue-293-Sc3fS.md
+++ b/.claude/sessions/2026-02-19_issue-293-Sc3fS.md
@@ -1,0 +1,16 @@
+## 2026-02-19 | claude/issue-293-Sc3fS | Discord bot: refactor cost tracking into pricing.ts
+
+**What was done:** Extracted the `PRICING` table from `logger.ts` into a new `pricing.ts` module. Fixed the stale `claude-sonnet-4-20250514` model ID to `claude-sonnet-4-6`, added cache-read token pricing (~10% of input), added a `console.warn` for unknown models, and updated `calculateCost` to accept an optional `cacheReadTokens` parameter. Updated `index.ts` to pass `cacheReadTokens` to `calculateCost`. Extended tests to cover cache-read pricing and the unknown-model warning.
+
+**Pages:** (none — infrastructure-only)
+
+**Model:** sonnet-4
+
+**Duration:** ~20min
+
+**Issues encountered:**
+- None
+
+**Learnings/notes:**
+- The existing test for "unknown model" was silent about warnings; now it explicitly asserts the `console.warn` call.
+- `claude-sonnet-4-6` is the correct model ID for Sonnet 4 per the system prompt.

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -99,7 +99,8 @@ client.on(Events.MessageCreate, async (message) => {
     const estimatedCostUsd = calculateCost(
       queryResult.inputTokens,
       queryResult.outputTokens,
-      queryResult.model
+      queryResult.model,
+      queryResult.cacheReadTokens
     );
 
     const queryLog: QueryLog = {

--- a/apps/discord-bot/src/pricing.ts
+++ b/apps/discord-bot/src/pricing.ts
@@ -1,0 +1,23 @@
+// Claude pricing per 1M tokens
+export interface ModelPricing {
+  input: number;
+  output: number;
+  cacheRead: number; // ~10% of input price
+}
+
+export const PRICING: Record<string, ModelPricing> = {
+  "claude-opus-4-6": { input: 5.0, output: 25.0, cacheRead: 0.5 },
+  "claude-sonnet-4-6": { input: 3.0, output: 15.0, cacheRead: 0.3 },
+  "claude-3-5-sonnet-20241022": { input: 3.0, output: 15.0, cacheRead: 0.3 },
+  "claude-3-5-haiku-20241022": { input: 0.8, output: 4.0, cacheRead: 0.08 },
+  default: { input: 3.0, output: 15.0, cacheRead: 0.3 },
+};
+
+export function getPricing(model?: string): ModelPricing {
+  if (model && !PRICING[model]) {
+    console.warn(
+      `[pricing] Unknown model "${model}" — using default pricing. Update pricing.ts if this model is new.`
+    );
+  }
+  return (model && PRICING[model]) || PRICING["default"]!;
+}


### PR DESCRIPTION
## Summary

- Moved `PRICING` table from `logger.ts` into a new `pricing.ts` module
- Fixed stale model ID: `claude-sonnet-4-20250514` → `claude-sonnet-4-6`
- Added cache-read token pricing (~10% of input price per model)
- Added `console.warn` when an unknown model ID is encountered (makes stale pricing visible)
- Updated `calculateCost()` to accept optional `cacheReadTokens` parameter
- Updated `index.ts` to pass `cacheReadTokens` through to `calculateCost`

## Test plan

- [x] All existing tests pass (28 in discord-bot, 462 in crux, 205 in app)
- [x] New tests cover cache-read pricing for each model tier
- [x] New test verifies `console.warn` fires for unknown model IDs
- [x] Gate check passes (9/9 blocking checks green)

Closes #293

https://claude.ai/code/session_015Zj5RVBpk4YSHKjP2zyGDN