### PR TITLE
fix: add entityType to remaining pages missing frontmatter declaration

### DIFF
--- a/.claude/sessions/2026-02-19_resolve-issue-254-O2Fdp.md
+++ b/.claude/sessions/2026-02-19_resolve-issue-254-O2Fdp.md
@@ -1,0 +1,17 @@
+## 2026-02-19 | claude/resolve-issue-254-O2Fdp | Migrate existing pages to declare entityType in frontmatter
+
+**What was done:** Added `entityType: approach` to the 2 remaining MDX pages in the `responses` category that were missing it (`recoding-america.mdx` and `state-capacity-ai-governance.mdx`). The migration script (`crux/scripts/migrate-entity-types.mjs`) already existed and was run to apply the changes.
+
+**Pages:** recoding-america, state-capacity-ai-governance
+
+**Model:** sonnet-4
+
+**Duration:** ~15min
+
+**Issues encountered:**
+- The issue description said "~600 existing pages" still needed migration, but nearly all had already been done in prior sessions. Only 2 non-index pages remained.
+- The 7 `index.mdx` files in entity-required categories correctly remain without `entityType` (they're directory listings, not entities).
+
+**Learnings/notes:**
+- The migration script at `crux/scripts/migrate-entity-types.mjs` skips `index.mdx` files, which is correct.
+- YAML entities (`state-capacity-ai-governance` type=concept, `recoding-america` type=resource) take precedence over the frontmatter `entityType: approach` per build-data.mjs logic — the frontmatter addition is safe and additive.

--- a/content/docs/knowledge-base/responses/recoding-america.mdx
+++ b/content/docs/knowledge-base/responses/recoding-america.mdx
@@ -18,6 +18,7 @@ llmSummary: Pahlka's 2023 book argues government digital failures stem from
   'cascade of rigidity' that threatens effective AI governance. While not
   directly about AI safety, it provides important context on state capacity
   limitations that could impede oversight of frontier AI systems.
+entityType: approach
 ---
 import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
 

--- a/content/docs/knowledge-base/responses/state-capacity-ai-governance.mdx
+++ b/content/docs/knowledge-base/responses/state-capacity-ai-governance.mdx
@@ -18,6 +18,7 @@ llmSummary: This article argues that government capacity to implement AI policy
   the civic tech ecosystem's efforts to build this capacity and how recent
   political disruptions (DOGE) have undermined it, while providing concrete
   frameworks for understanding what effective AI governance requires.
+entityType: approach
 ---
 import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
 


### PR DESCRIPTION
## Summary

- Ran `node crux/scripts/migrate-entity-types.mjs` (existing migration script) to add `entityType: approach` to the 2 remaining `responses` pages missing it: `recoding-america` and `state-capacity-ai-governance`
- All other 498 pages in entity-required categories already had `entityType` in frontmatter
- Index pages (directory listings) are correctly skipped by the script
- Changes are purely additive — YAML entity definitions (which take precedence) are untouched

## Test plan

- [x] `node crux/scripts/migrate-entity-types.mjs --dry-run` previewed exactly 2 files
- [x] Migration applied successfully (Migrated: 2, Skipped: 498, Errors: 0)
- [x] All 205 tests pass
- [x] All 7 gate checks pass

Closes #254

https://claude.ai/code/session_01Tt5vxc6skPRRoWxBKC8Nub