### PR TITLE
Add live-data-test checklist item to agent-checklist

### DIFF
--- a/.claude/sessions/2026-02-19_add-testing-checklist-item-ZfUJl.yaml
+++ b/.claude/sessions/2026-02-19_add-testing-checklist-item-ZfUJl.yaml
@@ -1,0 +1,16 @@
+date: 2026-02-19
+branch: claude/add-testing-checklist-item-ZfUJl
+title: Add live-data-test item to agent-checklist
+model: sonnet-4
+duration: ~15min
+pages: []
+summary: >
+  Added a new "Tested on live data" checklist item (id: live-data-test) to the
+  agent-checklist review phase, applicable to infrastructure, commands, bugfix,
+  and refactor session types. Also updated the test suite accordingly.
+issues:
+  - The existing "content type has more items than infrastructure" test had to be
+    relaxed to >=, since the new non-content item made the counts equal.
+learnings:
+  - The count-based item test in session-checklist.test.ts is brittle to new
+    items being added; ID-specific tests are more durable.

--- a/crux/lib/session-checklist.test.ts
+++ b/crux/lib/session-checklist.test.ts
@@ -105,10 +105,24 @@ describe('getItemsForType', () => {
     expect(bugfixItems.some(i => i.id === 'behavior-unchanged')).toBe(false);
   });
 
-  it('content type has more items than infrastructure', () => {
+  it('includes live-data-test for non-content types only', () => {
+    const infraItems = getItemsForType('infrastructure');
+    const cmdItems = getItemsForType('commands');
+    const bugfixItems = getItemsForType('bugfix');
+    const refactorItems = getItemsForType('refactor');
+    const contentItems = getItemsForType('content');
+
+    expect(infraItems.some(i => i.id === 'live-data-test')).toBe(true);
+    expect(cmdItems.some(i => i.id === 'live-data-test')).toBe(true);
+    expect(bugfixItems.some(i => i.id === 'live-data-test')).toBe(true);
+    expect(refactorItems.some(i => i.id === 'live-data-test')).toBe(true);
+    expect(contentItems.some(i => i.id === 'live-data-test')).toBe(false);
+  });
+
+  it('content type has at least as many items as infrastructure', () => {
     const contentItems = getItemsForType('content');
     const infraItems = getItemsForType('infrastructure');
-    expect(contentItems.length).toBeGreaterThan(infraItems.length);
+    expect(contentItems.length).toBeGreaterThanOrEqual(infraItems.length);
   });
 });
 

--- a/crux/lib/session-checklist.ts
+++ b/crux/lib/session-checklist.ts
@@ -240,6 +240,14 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     applicableTypes: 'all',
   },
   {
+    id: 'live-data-test',
+    label: 'Tested on live data',
+    description:
+      'If possible, run the code against real data, review the output, and adjust. Repeat the loop until results look correct. Do not ship untested scripts.',
+    phase: 'review',
+    applicableTypes: ['infrastructure', 'commands', 'bugfix', 'refactor'],
+  },
+  {
     id: 'entitylinks-resolve',
     label: 'EntityLinks resolve',
     description: 'Every `<EntityLink id="X">` has a matching entity in `data/entities/*.yaml`.',


### PR DESCRIPTION
## Summary

- Adds a new `live-data-test` checklist item to the **review phase** of the agent-checklist tool
- Applies to `infrastructure`, `commands`, `bugfix`, and `refactor` session types (not `content`, which already has pipeline-based testing)
- Item text: *"If possible, run the code against real data, review the output, and adjust. Repeat the loop until results look correct. Do not ship untested scripts."*

**Motivation:** Addresses cases where agents write scripts or commands that process data (e.g., doc-processing scripts) but never actually run them against real content before shipping.

## Test plan

- [x] Added a new test in `session-checklist.test.ts` asserting the item appears for all four applicable types and is absent for `content`
- [x] Updated a brittle item-count assertion (`toBeGreaterThan` → `toBeGreaterThanOrEqual`) that broke when infrastructure gained the new item
- [x] `pnpm test` — 521 tests pass
- [x] `pnpm crux validate gate` — all 7 gate checks pass

https://claude.ai/code/session_01WZQnkabh6TyfKJnrgrQ8rP