### PR TITLE
feat: add citation accuracy dashboard (#324)

### DIFF
--- a/.claude/sessions/2026-02-19_issue-324-citation-accuracy-dashboard.md
+++ b/.claude/sessions/2026-02-19_issue-324-citation-accuracy-dashboard.md
@@ -1,0 +1,18 @@
+## 2026-02-19 | claude/issue-324-citation-accuracy-dashboard | Build citation accuracy dashboard
+
+**What was done:** Created `/internal/citation-accuracy` dashboard page with summary stats, verdict distribution, per-page accuracy table, flagged citations table, and domain analysis. Data flows from SQLite via a JSON export command (`pnpm crux citations export-dashboard`) that auto-runs after accuracy checks.
+
+**PR:** (auto)
+
+**Model:** opus-4-6
+
+**Duration:** ~45min
+
+**Issues encountered:**
+- Cannot import better-sqlite3 directly in Next.js app (no native dep). Solved with JSON export approach.
+- Paranoid review found domain stats lumping "unsupported" into "inaccurate" — fixed to track separately.
+
+**Learnings/notes:**
+- All existing internal dashboards read YAML/JSON, not SQLite. The JSON export approach is consistent with this pattern.
+- `process.cwd()` in Next.js server components resolves to `apps/web/`, so `../../.cache/` correctly reaches project root.
+- The `fileURLToPath(import.meta.url)` guard is needed on any module with top-level `main()` calls to prevent execution during test imports.

--- a/apps/web/src/app/internal/citation-accuracy/citation-accuracy-dashboard.tsx
+++ b/apps/web/src/app/internal/citation-accuracy/citation-accuracy-dashboard.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { VERDICT_COLORS } from "./verdict-colors";
+import type { PageSummary, FlaggedCitation, DomainSummary } from "./page";
+
+// ---------------------------------------------------------------------------
+// Page Accuracy Table
+// ---------------------------------------------------------------------------
+
+function AccuracyBar({ rate }: { rate: number | null }) {
+  if (rate === null) return <span className="text-muted-foreground">-</span>;
+  const pct = Math.round(rate * 100);
+  const color =
+    pct >= 90
+      ? "bg-emerald-500"
+      : pct >= 75
+        ? "bg-amber-500"
+        : "bg-red-500";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-16 rounded-full bg-muted overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs tabular-nums text-muted-foreground">{pct}%</span>
+    </div>
+  );
+}
+
+function VerdictBadgeSmall({ verdict }: { verdict: string }) {
+  const colorClass = VERDICT_COLORS[verdict] || "bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${colorClass}`}
+    >
+      {verdict.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+const pageColumns: ColumnDef<PageSummary>[] = [
+  {
+    accessorKey: "pageId",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Page</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs font-medium">{row.original.pageId}</span>
+    ),
+  },
+  {
+    accessorKey: "totalCitations",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Citations</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {row.original.totalCitations}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "checked",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Checked</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {row.original.checked}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "accurate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Accurate</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-emerald-600">
+        {row.original.accurate > 0 ? row.original.accurate : ""}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "inaccurate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Issues</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const issues = row.original.inaccurate + row.original.unsupported;
+      if (issues === 0) return null;
+      return (
+        <span className="text-xs tabular-nums text-red-600 font-medium">
+          {issues}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "accuracyRate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Accuracy</SortableHeader>
+    ),
+    cell: ({ row }) => <AccuracyBar rate={row.original.accuracyRate} />,
+    sortingFn: (a, b) => {
+      const aRate = a.original.accuracyRate ?? -1;
+      const bRate = b.original.accuracyRate ?? -1;
+      return aRate - bRate;
+    },
+  },
+  {
+    accessorKey: "avgScore",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Avg Score</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const score = row.original.avgScore;
+      if (score === null || !Number.isFinite(score)) return null;
+      return (
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {score.toFixed(2)}
+        </span>
+      );
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Flagged Citations Table
+// ---------------------------------------------------------------------------
+
+const flaggedColumns: ColumnDef<FlaggedCitation>[] = [
+  {
+    accessorKey: "pageId",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Page</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs font-medium">{row.original.pageId}</span>
+    ),
+  },
+  {
+    accessorKey: "footnote",
+    header: ({ column }) => (
+      <SortableHeader column={column}>#</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        [{row.original.footnote}]
+      </span>
+    ),
+  },
+  {
+    accessorKey: "verdict",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Verdict</SortableHeader>
+    ),
+    cell: ({ row }) => <VerdictBadgeSmall verdict={row.original.verdict} />,
+  },
+  {
+    accessorKey: "score",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Score</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const score = row.original.score;
+      if (score === null || !Number.isFinite(score)) return null;
+      return (
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {score.toFixed(2)}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "claimText",
+    header: "Claim",
+    cell: ({ row }) => (
+      <div className="max-w-md">
+        <p className="text-xs text-foreground line-clamp-2">
+          {row.original.claimText}
+        </p>
+        {row.original.issues && (
+          <p className="text-[11px] text-red-500 mt-0.5 line-clamp-1">
+            {row.original.issues}
+          </p>
+        )}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "difficulty",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Difficulty</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      if (!row.original.difficulty) return null;
+      return (
+        <span className="text-[11px] text-muted-foreground">
+          {row.original.difficulty}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "sourceTitle",
+    header: "Source",
+    cell: ({ row }) => {
+      const { sourceTitle, url } = row.original;
+      if (!sourceTitle && !url) return null;
+      const label = sourceTitle || url || "";
+      const truncated =
+        label.length > 40 ? label.slice(0, 40) + "..." : label;
+      if (url) {
+        return (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-blue-600 hover:underline"
+          >
+            {truncated}
+          </a>
+        );
+      }
+      return (
+        <span className="text-[11px] text-muted-foreground">{truncated}</span>
+      );
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Domain Analysis Table
+// ---------------------------------------------------------------------------
+
+const domainColumns: ColumnDef<DomainSummary>[] = [
+  {
+    accessorKey: "domain",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Domain</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs font-medium">{row.original.domain}</span>
+    ),
+  },
+  {
+    accessorKey: "totalCitations",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Citations</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {row.original.totalCitations}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "checked",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Checked</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {row.original.checked}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "accurate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Accurate</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-emerald-600">
+        {row.original.accurate > 0 ? row.original.accurate : ""}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "inaccurate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Issues</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const issues = row.original.inaccurate + row.original.unsupported;
+      if (issues === 0) return null;
+      return (
+        <span className="text-xs tabular-nums text-red-600 font-medium">
+          {issues}
+        </span>
+      );
+    },
+    sortingFn: (a, b) => {
+      const aIssues = a.original.inaccurate + a.original.unsupported;
+      const bIssues = b.original.inaccurate + b.original.unsupported;
+      return aIssues - bIssues;
+    },
+  },
+  {
+    accessorKey: "inaccuracyRate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Error Rate</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const rate = row.original.inaccuracyRate;
+      if (rate === null) return null;
+      const pct = Math.round(rate * 100);
+      return (
+        <span
+          className={`text-xs tabular-nums font-medium ${pct > 20 ? "text-red-600" : pct > 0 ? "text-amber-600" : "text-muted-foreground"}`}
+        >
+          {pct}%
+        </span>
+      );
+    },
+    sortingFn: (a, b) => {
+      const aRate = a.original.inaccuracyRate ?? -1;
+      const bRate = b.original.inaccuracyRate ?? -1;
+      return aRate - bRate;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tab Switcher
+// ---------------------------------------------------------------------------
+
+type Tab = "pages" | "flagged" | "domains";
+
+export function CitationAccuracyDashboard({
+  pages,
+  flaggedCitations,
+  domainAnalysis,
+}: {
+  pages: PageSummary[];
+  flaggedCitations: FlaggedCitation[];
+  domainAnalysis: DomainSummary[];
+}) {
+  const [activeTab, setActiveTab] = useState<Tab>("pages");
+
+  const tabs: { id: Tab; label: string; count: number }[] = [
+    { id: "pages", label: "Pages", count: pages.length },
+    { id: "flagged", label: "Flagged Citations", count: flaggedCitations.length },
+    { id: "domains", label: "Domains", count: domainAnalysis.length },
+  ];
+
+  return (
+    <div className="not-prose">
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-border mb-4">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab.id
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+            <span className="ml-1.5 text-xs tabular-nums text-muted-foreground">
+              ({tab.count})
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === "pages" && (
+        <DataTable
+          columns={pageColumns}
+          data={pages}
+          searchPlaceholder="Search pages..."
+          defaultSorting={[{ id: "accuracyRate", desc: false }]}
+          getRowClassName={(row) => {
+            const issues =
+              row.original.inaccurate + row.original.unsupported;
+            return issues > 0 ? "bg-red-500/[0.03]" : "";
+          }}
+        />
+      )}
+
+      {activeTab === "flagged" && (
+        <>
+          {flaggedCitations.length === 0 ? (
+            <div className="rounded-lg border border-border/60 p-6 text-center text-muted-foreground">
+              <p className="text-sm">No flagged citations found.</p>
+            </div>
+          ) : (
+            <DataTable
+              columns={flaggedColumns}
+              data={flaggedCitations}
+              searchPlaceholder="Search flagged citations..."
+              defaultSorting={[{ id: "score", desc: false }]}
+              getRowClassName={() => "bg-red-500/[0.02]"}
+            />
+          )}
+        </>
+      )}
+
+      {activeTab === "domains" && (
+        <>
+          {domainAnalysis.length === 0 ? (
+            <div className="rounded-lg border border-border/60 p-6 text-center text-muted-foreground">
+              <p className="text-sm">
+                Not enough data for domain analysis (need 2+ citations per
+                domain).
+              </p>
+            </div>
+          ) : (
+            <DataTable
+              columns={domainColumns}
+              data={domainAnalysis}
+              searchPlaceholder="Search domains..."
+              defaultSorting={[{ id: "inaccuracyRate", desc: true }]}
+              getRowClassName={(row) =>
+                row.original.inaccurate > 0 ? "bg-red-500/[0.03]" : ""
+              }
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/citation-accuracy/page.tsx
+++ b/apps/web/src/app/internal/citation-accuracy/page.tsx
@@ -1,0 +1,276 @@
+import fs from "fs";
+import path from "path";
+import { CitationAccuracyDashboard } from "./citation-accuracy-dashboard";
+import { VERDICT_COLORS } from "./verdict-colors";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Citation Accuracy | Longterm Wiki Internal",
+  description:
+    "Accuracy verification results for wiki citations: verdicts, flagged claims, and domain analysis.",
+};
+
+// Types matching the crux export format
+export interface DashboardData {
+  exportedAt: string;
+  summary: {
+    totalCitations: number;
+    checkedCitations: number;
+    accurateCitations: number;
+    inaccurateCitations: number;
+    unsupportedCitations: number;
+    minorIssueCitations: number;
+    uncheckedCitations: number;
+    averageScore: number | null;
+  };
+  verdictDistribution: Record<string, number>;
+  difficultyDistribution: Record<string, number>;
+  pages: PageSummary[];
+  flaggedCitations: FlaggedCitation[];
+  domainAnalysis: DomainSummary[];
+}
+
+export interface PageSummary {
+  pageId: string;
+  totalCitations: number;
+  checked: number;
+  accurate: number;
+  inaccurate: number;
+  unsupported: number;
+  minorIssues: number;
+  accuracyRate: number | null;
+  avgScore: number | null;
+}
+
+export interface FlaggedCitation {
+  pageId: string;
+  footnote: number;
+  claimText: string;
+  sourceTitle: string | null;
+  url: string | null;
+  verdict: string;
+  score: number | null;
+  issues: string | null;
+  difficulty: string | null;
+  checkedAt: string | null;
+}
+
+export interface DomainSummary {
+  domain: string;
+  totalCitations: number;
+  checked: number;
+  accurate: number;
+  inaccurate: number;
+  unsupported: number;
+  inaccuracyRate: number | null;
+}
+
+function loadDashboardData(): DashboardData | null {
+  const jsonPath = path.resolve(
+    process.cwd(),
+    "../../.cache/citation-accuracy-dashboard.json"
+  );
+  if (!fs.existsSync(jsonPath)) return null;
+
+  try {
+    const raw = fs.readFileSync(jsonPath, "utf-8");
+    return JSON.parse(raw) as DashboardData;
+  } catch {
+    return null;
+  }
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <div className="text-xs text-muted-foreground mb-1">{label}</div>
+      <div className={`text-2xl font-bold tabular-nums ${color || ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default function CitationAccuracyPage() {
+  const data = loadDashboardData();
+
+  if (!data) {
+    return (
+      <article className="prose max-w-none">
+        <h1>Citation Accuracy</h1>
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+          <p className="text-lg font-medium mb-2">No accuracy data available</p>
+          <p className="text-sm">
+            Run the citation accuracy pipeline to generate data:
+          </p>
+          <ol className="text-sm text-left max-w-md mx-auto mt-4 space-y-2">
+            <li>
+              <code className="text-xs">
+                pnpm crux citations extract-quotes --all
+              </code>{" "}
+              &mdash; extract supporting quotes from sources
+            </li>
+            <li>
+              <code className="text-xs">
+                pnpm crux citations check-accuracy --all
+              </code>{" "}
+              &mdash; verify claim accuracy against sources
+            </li>
+            <li>
+              <code className="text-xs">
+                pnpm crux citations export-dashboard
+              </code>{" "}
+              &mdash; export data for this dashboard
+            </li>
+          </ol>
+        </div>
+      </article>
+    );
+  }
+
+  const { summary } = data;
+  const accuracyPct =
+    summary.checkedCitations > 0
+      ? Math.round(
+          ((summary.accurateCitations + summary.minorIssueCitations) /
+            summary.checkedCitations) *
+            100
+        )
+      : null;
+  const problemCount =
+    summary.inaccurateCitations + summary.unsupportedCitations;
+
+  return (
+    <article className="prose max-w-none">
+      <h1>Citation Accuracy</h1>
+      <p className="text-muted-foreground">
+        Accuracy verification results from LLM-powered citation checking.{" "}
+        <span className="font-medium text-foreground">
+          {summary.checkedCitations}
+        </span>{" "}
+        of {summary.totalCitations} citations checked
+        {accuracyPct !== null && (
+          <>
+            ,{" "}
+            <span
+              className={`font-medium ${accuracyPct >= 90 ? "text-emerald-600" : accuracyPct >= 75 ? "text-amber-600" : "text-red-600"}`}
+            >
+              {accuracyPct}% accurate
+            </span>
+          </>
+        )}
+        .
+        {problemCount > 0 && (
+          <span className="text-red-500 font-medium">
+            {" "}
+            {problemCount} citations flagged.
+          </span>
+        )}
+      </p>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 not-prose mb-6">
+        <StatCard label="Total Citations" value={summary.totalCitations} />
+        <StatCard
+          label="Checked"
+          value={summary.checkedCitations}
+          color="text-blue-600"
+        />
+        <StatCard
+          label="Accurate"
+          value={summary.accurateCitations}
+          color="text-emerald-600"
+        />
+        <StatCard
+          label="Flagged"
+          value={problemCount}
+          color={problemCount > 0 ? "text-red-600" : ""}
+        />
+      </div>
+
+      {/* Verdict distribution */}
+      {Object.keys(data.verdictDistribution).length > 0 && (
+        <div className="not-prose mb-6">
+          <h3 className="text-sm font-semibold mb-3">Verdict Distribution</h3>
+          <div className="flex gap-2 flex-wrap">
+            {Object.entries(data.verdictDistribution)
+              .sort(([, a], [, b]) => b - a)
+              .map(([verdict, count]) => (
+                <VerdictBadge
+                  key={verdict}
+                  verdict={verdict}
+                  count={count}
+                />
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Difficulty distribution */}
+      {Object.keys(data.difficultyDistribution).length > 0 && (
+        <div className="not-prose mb-6">
+          <h3 className="text-sm font-semibold mb-3">
+            Verification Difficulty
+          </h3>
+          <div className="flex gap-2 flex-wrap">
+            {Object.entries(data.difficultyDistribution)
+              .sort(([, a], [, b]) => b - a)
+              .map(([difficulty, count]) => (
+                <span
+                  key={difficulty}
+                  className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium bg-muted text-muted-foreground"
+                >
+                  {difficulty}
+                  <span className="tabular-nums font-semibold">{count}</span>
+                </span>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Interactive tables */}
+      <CitationAccuracyDashboard
+        pages={data.pages}
+        flaggedCitations={data.flaggedCitations}
+        domainAnalysis={data.domainAnalysis}
+      />
+
+      <p className="text-xs text-muted-foreground mt-4">
+        Data exported{" "}
+        {new Date(data.exportedAt).toLocaleString("en-US", {
+          dateStyle: "medium",
+          timeStyle: "short",
+        })}
+        . Regenerate with{" "}
+        <code className="text-[11px]">pnpm crux citations export-dashboard</code>
+      </p>
+    </article>
+  );
+}
+
+function VerdictBadge({
+  verdict,
+  count,
+}: {
+  verdict: string;
+  count: number;
+}) {
+  const colorClass = VERDICT_COLORS[verdict] || "bg-muted text-muted-foreground";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${colorClass}`}
+    >
+      {verdict.replace(/_/g, " ")}
+      <span className="tabular-nums font-semibold">{count}</span>
+    </span>
+  );
+}

--- a/apps/web/src/app/internal/citation-accuracy/verdict-colors.ts
+++ b/apps/web/src/app/internal/citation-accuracy/verdict-colors.ts
@@ -1,0 +1,8 @@
+/** Shared verdict color classes for citation accuracy UI */
+export const VERDICT_COLORS: Record<string, string> = {
+  accurate: "bg-emerald-500/15 text-emerald-600",
+  minor_issues: "bg-amber-500/15 text-amber-600",
+  inaccurate: "bg-red-500/15 text-red-600",
+  unsupported: "bg-red-500/10 text-red-500",
+  not_verifiable: "bg-muted text-muted-foreground",
+};

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -336,6 +336,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Auto-Update Runs", href: "/internal/auto-update-runs" },
         { label: "Auto-Update News", href: "/internal/auto-update-news" },
         { label: "GitHub Issues", href: "/internal/github-issues" },
+        { label: "Citation Accuracy", href: "/internal/citation-accuracy" },
       ],
     },
     {

--- a/crux/citations/check-accuracy.ts
+++ b/crux/citations/check-accuracy.ts
@@ -17,6 +17,7 @@ import { parseCliArgs } from '../lib/cli.ts';
 import { citationQuotes, citationContent, getDb } from '../lib/knowledge-db.ts';
 import { checkClaimAccuracy } from '../lib/quote-extractor.ts';
 import type { AccuracyVerdict } from '../lib/quote-extractor.ts';
+import { exportDashboardData } from './export-dashboard.ts';
 
 interface AccuracyResult {
   pageId: string;
@@ -251,6 +252,12 @@ async function main() {
       printSummary(c, totals, allIssues.map((iss) => ({ ...iss, pageId: iss.pageId })));
     }
 
+    // Auto-export dashboard data after accuracy checks
+    const exportPath = exportDashboardData();
+    if (!exportPath && !json && !ci) {
+      console.log(`${c.yellow}Warning: could not export dashboard data${c.reset}`);
+    }
+
     process.exit(totals.inaccurate > 0 ? 1 : 0);
   }
 
@@ -276,6 +283,12 @@ async function main() {
     verbose: true,
     recheck,
   });
+
+  // Auto-export dashboard data after accuracy checks
+  const exportPath = exportDashboardData();
+  if (!exportPath && !json && !ci) {
+    console.log(`${c.yellow}Warning: could not export dashboard data${c.reset}`);
+  }
 
   if (json || ci) {
     console.log(JSON.stringify(result, null, 2));

--- a/crux/citations/export-dashboard.test.ts
+++ b/crux/citations/export-dashboard.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDb } from '../lib/knowledge-db.ts';
+import { buildDashboardExport } from './export-dashboard.ts';
+
+/**
+ * Seed the DB with citation quote rows for testing.
+ * Uses getDb() which creates an in-memory test DB.
+ */
+function seedQuotes(
+  rows: Array<{
+    page_id: string;
+    footnote: number;
+    url?: string;
+    claim_text: string;
+    source_quote?: string;
+    accuracy_verdict?: string;
+    accuracy_score?: number;
+    accuracy_issues?: string;
+    verification_difficulty?: string;
+    source_title?: string;
+  }>,
+) {
+  const db = getDb();
+  const stmt = db.prepare(`
+    INSERT OR REPLACE INTO citation_quotes (
+      page_id, footnote, url, claim_text, source_quote,
+      accuracy_verdict, accuracy_score, accuracy_issues,
+      verification_difficulty, source_title
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const r of rows) {
+    stmt.run(
+      r.page_id,
+      r.footnote,
+      r.url ?? null,
+      r.claim_text,
+      r.source_quote ?? null,
+      r.accuracy_verdict ?? null,
+      r.accuracy_score ?? null,
+      r.accuracy_issues ?? null,
+      r.verification_difficulty ?? null,
+      r.source_title ?? null,
+    );
+  }
+}
+
+function clearQuotes() {
+  getDb().prepare('DELETE FROM citation_quotes').run();
+}
+
+describe('buildDashboardExport', () => {
+  beforeEach(() => {
+    clearQuotes();
+  });
+
+  it('returns null when no quotes exist', () => {
+    const result = buildDashboardExport();
+    expect(result).toBeNull();
+  });
+
+  it('returns correct summary for basic data', () => {
+    seedQuotes([
+      { page_id: 'test-page', footnote: 1, claim_text: 'Claim A', accuracy_verdict: 'accurate', accuracy_score: 0.95 },
+      { page_id: 'test-page', footnote: 2, claim_text: 'Claim B', accuracy_verdict: 'inaccurate', accuracy_score: 0.2 },
+      { page_id: 'test-page', footnote: 3, claim_text: 'Claim C' }, // unchecked
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result).not.toBeNull();
+    expect(result.summary.totalCitations).toBe(3);
+    expect(result.summary.checkedCitations).toBe(2);
+    expect(result.summary.accurateCitations).toBe(1);
+    expect(result.summary.inaccurateCitations).toBe(1);
+    expect(result.summary.uncheckedCitations).toBe(1);
+  });
+
+  it('computes per-page accuracy rate correctly', () => {
+    seedQuotes([
+      { page_id: 'page-a', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'page-a', footnote: 2, claim_text: 'C2', accuracy_verdict: 'accurate', accuracy_score: 0.8 },
+      { page_id: 'page-a', footnote: 3, claim_text: 'C3', accuracy_verdict: 'inaccurate', accuracy_score: 0.3 },
+      { page_id: 'page-b', footnote: 1, claim_text: 'C4', accuracy_verdict: 'accurate', accuracy_score: 1.0 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    const pageA = result.pages.find(p => p.pageId === 'page-a')!;
+    const pageB = result.pages.find(p => p.pageId === 'page-b')!;
+
+    expect(pageA.checked).toBe(3);
+    expect(pageA.accurate).toBe(2);
+    expect(pageA.inaccurate).toBe(1);
+    // accuracy rate = (accurate + minorIssues) / checked = 2/3
+    expect(pageA.accuracyRate).toBeCloseTo(2 / 3);
+
+    expect(pageB.checked).toBe(1);
+    expect(pageB.accuracyRate).toBe(1.0);
+  });
+
+  it('handles minor_issues and unsupported verdicts', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'C1', accuracy_verdict: 'minor_issues', accuracy_score: 0.7 },
+      { page_id: 'p1', footnote: 2, claim_text: 'C2', accuracy_verdict: 'unsupported', accuracy_score: 0.1 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.summary.minorIssueCitations).toBe(1);
+    expect(result.summary.unsupportedCitations).toBe(1);
+
+    const page = result.pages.find(p => p.pageId === 'p1')!;
+    expect(page.minorIssues).toBe(1);
+    expect(page.unsupported).toBe(1);
+    // accuracy rate includes minor_issues as "acceptable"
+    expect(page.accuracyRate).toBe(0.5); // (0 accurate + 1 minor) / 2 checked
+  });
+
+  it('flags inaccurate and unsupported citations', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'Good claim', accuracy_verdict: 'accurate', accuracy_score: 0.95 },
+      { page_id: 'p1', footnote: 2, claim_text: 'Bad claim', accuracy_verdict: 'inaccurate', accuracy_score: 0.2, accuracy_issues: 'Wrong number' },
+      { page_id: 'p1', footnote: 3, claim_text: 'Unsourced claim', accuracy_verdict: 'unsupported', accuracy_score: 0.1 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.flaggedCitations).toHaveLength(2);
+    expect(result.flaggedCitations[0].verdict).toBe('unsupported'); // sorted by score, lowest first
+    expect(result.flaggedCitations[1].verdict).toBe('inaccurate');
+  });
+
+  it('computes verdict distribution', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'p1', footnote: 2, claim_text: 'C2', accuracy_verdict: 'accurate', accuracy_score: 0.8 },
+      { page_id: 'p1', footnote: 3, claim_text: 'C3', accuracy_verdict: 'inaccurate', accuracy_score: 0.3 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.verdictDistribution).toEqual({
+      accurate: 2,
+      inaccurate: 1,
+    });
+  });
+
+  it('computes difficulty distribution', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9, verification_difficulty: 'easy' },
+      { page_id: 'p1', footnote: 2, claim_text: 'C2', accuracy_verdict: 'accurate', accuracy_score: 0.8, verification_difficulty: 'hard' },
+      { page_id: 'p1', footnote: 3, claim_text: 'C3', accuracy_verdict: 'inaccurate', accuracy_score: 0.3, verification_difficulty: 'hard' },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.difficultyDistribution).toEqual({
+      easy: 1,
+      hard: 2,
+    });
+  });
+
+  it('computes domain analysis correctly', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, url: 'https://arxiv.org/abs/1', claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'p1', footnote: 2, url: 'https://arxiv.org/abs/2', claim_text: 'C2', accuracy_verdict: 'inaccurate', accuracy_score: 0.3 },
+      { page_id: 'p2', footnote: 1, url: 'https://arxiv.org/abs/3', claim_text: 'C3', accuracy_verdict: 'unsupported', accuracy_score: 0.1 },
+      { page_id: 'p2', footnote: 2, url: 'https://example.com/1', claim_text: 'C4', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    // example.com only has 1 citation, so it's excluded (MIN_DOMAIN_CITATIONS = 2)
+    expect(result.domainAnalysis).toHaveLength(1);
+
+    const arxiv = result.domainAnalysis[0];
+    expect(arxiv.domain).toBe('arxiv.org');
+    expect(arxiv.totalCitations).toBe(3);
+    expect(arxiv.checked).toBe(3);
+    expect(arxiv.accurate).toBe(1);
+    expect(arxiv.inaccurate).toBe(1);
+    expect(arxiv.unsupported).toBe(1);
+    // inaccuracyRate = (inaccurate + unsupported) / checked = 2/3
+    expect(arxiv.inaccuracyRate).toBeCloseTo(2 / 3);
+  });
+
+  it('strips www. from domains', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, url: 'https://www.example.com/a', claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'p1', footnote: 2, url: 'https://www.example.com/b', claim_text: 'C2', accuracy_verdict: 'accurate', accuracy_score: 0.8 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.domainAnalysis[0].domain).toBe('example.com');
+  });
+
+  it('sorts pages by inaccuracy rate (worst first)', () => {
+    seedQuotes([
+      // page-good: 100% accurate
+      { page_id: 'page-good', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'page-good', footnote: 2, claim_text: 'C2', accuracy_verdict: 'accurate', accuracy_score: 0.8 },
+      // page-bad: 50% inaccurate
+      { page_id: 'page-bad', footnote: 1, claim_text: 'C3', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'page-bad', footnote: 2, claim_text: 'C4', accuracy_verdict: 'inaccurate', accuracy_score: 0.2 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.pages[0].pageId).toBe('page-bad');
+    expect(result.pages[1].pageId).toBe('page-good');
+  });
+
+  it('handles average score with null scores', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+      { page_id: 'p1', footnote: 2, claim_text: 'C2', accuracy_verdict: 'accurate' }, // no score
+    ]);
+
+    const result = buildDashboardExport()!;
+    // Only one score counted
+    expect(result.summary.averageScore).toBe(0.9);
+  });
+
+  it('includes exportedAt timestamp', () => {
+    seedQuotes([
+      { page_id: 'p1', footnote: 1, claim_text: 'C1', accuracy_verdict: 'accurate', accuracy_score: 0.9 },
+    ]);
+
+    const result = buildDashboardExport()!;
+    expect(result.exportedAt).toBeTruthy();
+    // Should be a valid ISO date
+    expect(new Date(result.exportedAt).getTime()).not.toBeNaN();
+  });
+});

--- a/crux/citations/export-dashboard.ts
+++ b/crux/citations/export-dashboard.ts
@@ -1,0 +1,344 @@
+/**
+ * Export Citation Accuracy Dashboard Data
+ *
+ * Reads accuracy data from the SQLite DB and exports a JSON file
+ * that the Next.js internal dashboard can read without needing
+ * a native SQLite dependency.
+ *
+ * Output: .cache/citation-accuracy-dashboard.json
+ *
+ * Usage:
+ *   pnpm crux citations export-dashboard
+ *   pnpm crux citations export-dashboard --json
+ */
+
+import { writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { citationQuotes, getDb, PROJECT_ROOT, CACHE_DIR } from '../lib/knowledge-db.ts';
+import { getColors } from '../lib/output.ts';
+import { parseCliArgs } from '../lib/cli.ts';
+
+// ---------------------------------------------------------------------------
+// Types (shared with the dashboard — keep in sync)
+// ---------------------------------------------------------------------------
+
+export interface DashboardExport {
+  exportedAt: string;
+  summary: {
+    totalCitations: number;
+    checkedCitations: number;
+    accurateCitations: number;
+    inaccurateCitations: number;
+    unsupportedCitations: number;
+    minorIssueCitations: number;
+    uncheckedCitations: number;
+    averageScore: number | null;
+  };
+  verdictDistribution: Record<string, number>;
+  difficultyDistribution: Record<string, number>;
+  pages: PageSummary[];
+  flaggedCitations: FlaggedCitation[];
+  domainAnalysis: DomainSummary[];
+}
+
+export interface PageSummary {
+  pageId: string;
+  totalCitations: number;
+  checked: number;
+  accurate: number;
+  inaccurate: number;
+  unsupported: number;
+  minorIssues: number;
+  accuracyRate: number | null;
+  avgScore: number | null;
+}
+
+export interface FlaggedCitation {
+  pageId: string;
+  footnote: number;
+  claimText: string;
+  sourceTitle: string | null;
+  url: string | null;
+  verdict: string;
+  score: number | null;
+  issues: string | null;
+  difficulty: string | null;
+  checkedAt: string | null;
+}
+
+export interface DomainSummary {
+  domain: string;
+  totalCitations: number;
+  checked: number;
+  accurate: number;
+  inaccurate: number;
+  unsupported: number;
+  inaccuracyRate: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Export logic
+// ---------------------------------------------------------------------------
+
+function extractDomain(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+export function buildDashboardExport(): DashboardExport | null {
+  const dbPath = join(PROJECT_ROOT, '.cache', 'knowledge.db');
+  if (!existsSync(dbPath)) return null;
+
+  // Get all citation quotes
+  const allQuotes = getDb().prepare(
+    'SELECT * FROM citation_quotes ORDER BY page_id, footnote',
+  ).all() as Array<Record<string, unknown>>;
+
+  if (allQuotes.length === 0) return null;
+
+  // Build verdict and difficulty distributions
+  const verdictDist: Record<string, number> = {};
+  const difficultyDist: Record<string, number> = {};
+  let checkedCount = 0;
+  let accurateCount = 0;
+  let inaccurateCount = 0;
+  let unsupportedCount = 0;
+  let minorIssueCount = 0;
+  let scoreSum = 0;
+  let scoreCount = 0;
+
+  // Page-level aggregation
+  const pageMap = new Map<string, {
+    total: number;
+    checked: number;
+    accurate: number;
+    inaccurate: number;
+    unsupported: number;
+    minorIssues: number;
+    scoreSum: number;
+    scoreCount: number;
+  }>();
+
+  // Domain-level aggregation
+  const domainMap = new Map<string, {
+    total: number;
+    checked: number;
+    accurate: number;
+    inaccurate: number;
+    unsupported: number;
+  }>();
+
+  // Flagged citations
+  const flagged: FlaggedCitation[] = [];
+
+  for (const q of allQuotes) {
+    const pageId = q.page_id as string;
+    const verdict = q.accuracy_verdict as string | null;
+    const score = q.accuracy_score as number | null;
+    const difficulty = q.verification_difficulty as string | null;
+    const url = q.url as string | null;
+    const domain = extractDomain(url);
+
+    // Page aggregation
+    if (!pageMap.has(pageId)) {
+      pageMap.set(pageId, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0, minorIssues: 0, scoreSum: 0, scoreCount: 0 });
+    }
+    const page = pageMap.get(pageId)!;
+    page.total++;
+
+    // Domain aggregation
+    if (domain) {
+      if (!domainMap.has(domain)) {
+        domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0 });
+      }
+      const d = domainMap.get(domain)!;
+      d.total++;
+    }
+
+    if (verdict) {
+      checkedCount++;
+      page.checked++;
+      verdictDist[verdict] = (verdictDist[verdict] || 0) + 1;
+
+      if (domain) {
+        domainMap.get(domain)!.checked++;
+      }
+
+      if (score !== null && Number.isFinite(score)) {
+        scoreSum += score;
+        scoreCount++;
+        page.scoreSum += score;
+        page.scoreCount++;
+      }
+
+      if (difficulty) {
+        difficultyDist[difficulty] = (difficultyDist[difficulty] || 0) + 1;
+      }
+
+      if (verdict === 'accurate') {
+        accurateCount++;
+        page.accurate++;
+        if (domain) domainMap.get(domain)!.accurate++;
+      } else if (verdict === 'inaccurate') {
+        inaccurateCount++;
+        page.inaccurate++;
+        if (domain) domainMap.get(domain)!.inaccurate++;
+      } else if (verdict === 'unsupported') {
+        unsupportedCount++;
+        page.unsupported++;
+        if (domain) domainMap.get(domain)!.unsupported++;
+      } else if (verdict === 'minor_issues') {
+        minorIssueCount++;
+        page.minorIssues++;
+        if (domain) domainMap.get(domain)!.accurate++;
+      }
+
+      // Flag problematic citations
+      if (verdict === 'inaccurate' || verdict === 'unsupported') {
+        flagged.push({
+          pageId,
+          footnote: q.footnote as number,
+          claimText: q.claim_text as string,
+          sourceTitle: q.source_title as string | null,
+          url,
+          verdict,
+          score,
+          issues: q.accuracy_issues as string | null,
+          difficulty,
+          checkedAt: q.accuracy_checked_at as string | null,
+        });
+      }
+    }
+  }
+
+  // Build page summaries
+  const pages: PageSummary[] = [];
+  for (const [pageId, p] of pageMap) {
+    pages.push({
+      pageId,
+      totalCitations: p.total,
+      checked: p.checked,
+      accurate: p.accurate,
+      inaccurate: p.inaccurate,
+      unsupported: p.unsupported,
+      minorIssues: p.minorIssues,
+      accuracyRate: p.checked > 0 ? (p.accurate + p.minorIssues) / p.checked : null,
+      avgScore: p.scoreCount > 0 ? Math.round((p.scoreSum / p.scoreCount) * 100) / 100 : null,
+    });
+  }
+  // Sort by inaccuracy rate (worst first), then by total citations
+  pages.sort((a, b) => {
+    const aInacc = a.checked > 0 ? (a.inaccurate + a.unsupported) / a.checked : 0;
+    const bInacc = b.checked > 0 ? (b.inaccurate + b.unsupported) / b.checked : 0;
+    if (bInacc !== aInacc) return bInacc - aInacc;
+    return b.totalCitations - a.totalCitations;
+  });
+
+  // Build domain summaries
+  const MIN_DOMAIN_CITATIONS = 2;
+  const domains: DomainSummary[] = [];
+  for (const [domain, d] of domainMap) {
+    if (d.total < MIN_DOMAIN_CITATIONS) continue;
+    domains.push({
+      domain,
+      totalCitations: d.total,
+      checked: d.checked,
+      accurate: d.accurate,
+      inaccurate: d.inaccurate,
+      unsupported: d.unsupported,
+      inaccuracyRate: d.checked > 0 ? (d.inaccurate + d.unsupported) / d.checked : null,
+    });
+  }
+  domains.sort((a, b) => {
+    const aRate = a.inaccuracyRate ?? 0;
+    const bRate = b.inaccuracyRate ?? 0;
+    if (bRate !== aRate) return bRate - aRate;
+    return b.totalCitations - a.totalCitations;
+  });
+
+  // Sort flagged by score (worst first)
+  flagged.sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
+
+  return {
+    exportedAt: new Date().toISOString(),
+    summary: {
+      totalCitations: allQuotes.length,
+      checkedCitations: checkedCount,
+      accurateCitations: accurateCount,
+      inaccurateCitations: inaccurateCount,
+      unsupportedCitations: unsupportedCount,
+      minorIssueCitations: minorIssueCount,
+      uncheckedCitations: allQuotes.length - checkedCount,
+      averageScore: scoreCount > 0 ? Math.round((scoreSum / scoreCount) * 100) / 100 : null,
+    },
+    verdictDistribution: verdictDist,
+    difficultyDistribution: difficultyDist,
+    pages,
+    flaggedCitations: flagged,
+    domainAnalysis: domains,
+  };
+}
+
+const OUTPUT_PATH = join(CACHE_DIR, 'citation-accuracy-dashboard.json');
+
+export function exportDashboardData(): string | null {
+  const data = buildDashboardExport();
+  if (!data) return null;
+  writeFileSync(OUTPUT_PATH, JSON.stringify(data, null, 2));
+  return OUTPUT_PATH;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const json = args.json === true;
+  const colors = getColors(json);
+
+  const outputPath = exportDashboardData();
+
+  if (!outputPath) {
+    if (json) {
+      console.log(JSON.stringify({ error: 'No citation data available' }));
+    } else {
+      console.log(`${colors.yellow}No citation data available.${colors.reset}`);
+      console.log(`Run ${colors.bold}pnpm crux citations extract-quotes --all${colors.reset} first.`);
+    }
+    process.exit(0);
+  }
+
+  if (json) {
+    const data = buildDashboardExport();
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    const data = buildDashboardExport()!;
+    const c = colors;
+    console.log(`\n${c.bold}${c.blue}Citation Accuracy Dashboard Export${c.reset}\n`);
+    console.log(`  Exported to: ${c.bold}${outputPath}${c.reset}`);
+    console.log(`  Total citations: ${data.summary.totalCitations}`);
+    console.log(`  Checked: ${data.summary.checkedCitations}`);
+    console.log(`  ${c.green}Accurate:${c.reset} ${data.summary.accurateCitations}`);
+    if (data.summary.inaccurateCitations > 0) {
+      console.log(`  ${c.red}Inaccurate:${c.reset} ${data.summary.inaccurateCitations}`);
+    }
+    if (data.summary.unsupportedCitations > 0) {
+      console.log(`  ${c.red}Unsupported:${c.reset} ${data.summary.unsupportedCitations}`);
+    }
+    console.log(`  Pages: ${data.pages.length}`);
+    console.log(`  Flagged: ${data.flaggedCitations.length}`);
+    console.log(`  Domains: ${data.domainAnalysis.length}`);
+    console.log('');
+  }
+}
+
+// Only run when executed directly (not when imported in tests)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/crux/commands/citations.ts
+++ b/crux/commands/citations.ts
@@ -57,6 +57,11 @@ const SCRIPTS = {
     passthrough: ['ci', 'json', 'all', 'limit', 'recheck'],
     positional: true,
   },
+  'export-dashboard': {
+    script: 'citations/export-dashboard.ts',
+    description: 'Export accuracy data as JSON for the internal dashboard',
+    passthrough: ['json'],
+  },
 };
 
 export const commands = buildCommands(SCRIPTS, 'report');
@@ -94,5 +99,6 @@ Examples:
   crux citations verify-quotes existential-risk    Re-verify stored quotes
   crux citations check-accuracy existential-risk   Check claim accuracy vs sources
   crux citations check-accuracy --all              Batch accuracy check
+  crux citations export-dashboard                  Export data for web dashboard
 `;
 }


### PR DESCRIPTION
## Summary

- Created `/internal/citation-accuracy` dashboard page visualizing citation accuracy verification data
- Added `pnpm crux citations export-dashboard` CLI command that exports SQLite data to JSON for the dashboard
- Auto-exports dashboard data after every `check-accuracy` run
- 12 new unit tests for the export logic

## Key Changes

**New files:**
- `crux/citations/export-dashboard.ts` — Reads from `citation_quotes` table, aggregates per-page accuracy, flagged citations, domain analysis, and exports to `.cache/citation-accuracy-dashboard.json`
- `apps/web/src/app/internal/citation-accuracy/page.tsx` — Server component with summary cards, verdict/difficulty distribution badges
- `apps/web/src/app/internal/citation-accuracy/citation-accuracy-dashboard.tsx` — Client component with three DataTable tabs: Pages, Flagged Citations, Domains
- `apps/web/src/app/internal/citation-accuracy/verdict-colors.ts` — Shared verdict color mapping
- `crux/citations/export-dashboard.test.ts` — 12 tests covering aggregation, sorting, edge cases

**Modified files:**
- `crux/citations/check-accuracy.ts` — Auto-exports dashboard data after accuracy checks
- `crux/commands/citations.ts` — Registered `export-dashboard` subcommand
- `apps/web/src/lib/wiki-nav.ts` — Added "Citation Accuracy" nav entry under Dashboards & Tools

## Design Decisions

- **JSON export instead of direct SQLite**: The Next.js app doesn't have `better-sqlite3` as a dependency. Rather than adding a native module, data is exported to JSON — consistent with how all other dashboards read data.
- **Domain analysis tracks unsupported separately**: `inaccuracyRate = (inaccurate + unsupported) / checked` for consistency across all views.

## Test Plan

- [x] Gate passes: 9/9 checks pass (including full Next.js build)
- [x] 28 test files, 684 tests pass (12 new for export logic)
- [x] Dashboard renders in Next.js build (visible in build output as 3.76 kB)
- [x] Paranoid review completed: fixed domain categorization bug, NaN handling, DRY violations
- [x] Empty state handled gracefully when no data exists

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)