### PR TITLE
Add creation date tracking and sorting to explore interface

### DIFF
--- a/apps/web/src/components/explore/ExploreTable.tsx
+++ b/apps/web/src/components/explore/ExploreTable.tsx
@@ -144,6 +144,17 @@ function buildColumns(onSearchChange: (value: string) => void): ColumnDef<Explor
       sortUndefined: "last",
     },
     {
+      accessorKey: "dateCreated",
+      header: ({ column }) => <SortableHeader column={column}>Created</SortableHeader>,
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs whitespace-nowrap">
+          {formatDate(row.original.dateCreated ?? null)}
+        </span>
+      ),
+      size: 110,
+      sortUndefined: "last",
+    },
+    {
       accessorKey: "category",
       header: ({ column }) => <SortableHeader column={column}>Category</SortableHeader>,
       cell: ({ row }) => {

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -363,6 +363,7 @@ export interface Page {
   uncertainty: number | null;
   causalLevel: string | null;
   lastUpdated: string | null;
+  dateCreated?: string | null;
   llmSummary: string | null;
   structuredSummary: StructuredSummary | null;
   description: string | null;
@@ -1298,6 +1299,7 @@ export interface ExploreItem {
   category: string | null;
   riskCategory: string | null;
   lastUpdated: string | null;
+  dateCreated?: string | null;
   contentFormat?: ContentFormat;
   href?: string;
   meta?: string;
@@ -1353,6 +1355,7 @@ export function getExploreItems(): ExploreItem[] {
       category: page?.category ?? null,
       riskCategory: isRisk(entity) ? (entity.riskCategory || null) : null,
       lastUpdated: page?.lastUpdated ?? null,
+      dateCreated: page?.dateCreated ?? null,
       contentFormat: page?.contentFormat,
     };
   });
@@ -1378,6 +1381,7 @@ export function getExploreItems(): ExploreItem[] {
       category: page.category ?? null,
       riskCategory: null,
       lastUpdated: page.lastUpdated ?? null,
+      dateCreated: page.dateCreated ?? null,
       contentFormat: page.contentFormat,
     }));
 
@@ -1435,6 +1439,7 @@ export function getExploreItems(): ExploreItem[] {
         category: null,
         riskCategory: null,
         lastUpdated: e.lastUpdated || null,
+        dateCreated: null,
         contentFormat: "diagram" as ContentFormat,
         href: resolveDiagramHref(e)!,
         meta: `${nodeCount} nodes`,


### PR DESCRIPTION
## Summary
This PR adds support for tracking and displaying content creation dates throughout the explore interface, complementing the existing last-updated tracking. It includes reading creation dates from frontmatter, extracting them from edit logs, and exposing them as a new sort option.

## Key Changes

- **Build script enhancements** (`build-data.mjs`):
  - Added `toDateString()` utility to normalize date values (strings or Date objects) to YYYY-MM-DD format
  - Added `maxDate()` utility for null-safe date comparison
  - Added `buildEditLogDateMap()` to pre-read all edit logs and extract the latest edit date per page
  - Enhanced `buildPagesRegistry()` to populate `dateCreated` from frontmatter (`createdAt` or `dateCreated` fields)
  - Updated `lastUpdated` logic to use the maximum of frontmatter values and actual edit log history

- **Data types** (`src/data/index.ts`):
  - Added optional `dateCreated` field to `Page` interface
  - Added optional `dateCreated` field to `ExploreItem` interface
  - Updated `getExploreItems()` to populate `dateCreated` for all item types

- **Explore UI** (`src/components/explore/ExploreGrid.tsx`):
  - Added "recentlyCreated" as a new sort key option
  - Implemented URL parameter persistence for sort selection (defaults to "recommended")
  - Added `handleSortChange()` to manage sort changes with URL updates
  - Added sorting logic for the "recentlyCreated" option using `dateCreated` field

- **Explore table** (`src/components/explore/ExploreTable.tsx`):
  - Added "Created" column to the table view with sortable header and formatted date display

## Implementation Details

- Edit log dates are read once during build and cached in a Map for efficient lookup
- The `lastUpdated` field now represents the maximum of: frontmatter `lastUpdated`, frontmatter `lastEdited`, and actual edit log history
- Sort state is persisted in URL parameters, allowing users to share filtered/sorted views
- The "recentlyCreated" sort option uses string comparison on YYYY-MM-DD formatted dates for consistency

https://claude.ai/code/session_01WjxFqibv6gRwHdABAmuorC