### PR TITLE
Fix empty Page Changes dashboard

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -14,7 +14,7 @@ import { join, basename, relative } from 'path';
 import { parse } from 'yaml';
 import { extractMetrics, suggestQuality, getQualityDiscrepancy } from '../../../crux/lib/metrics-extractor.ts';
 import { computeRedundancy } from './lib/redundancy.mjs';
-import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, PROJECT_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
+import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, PROJECT_ROOT, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
 import { generateLLMFiles } from './generate-llm-files.mjs';
 import { buildUrlToResourceMap, findUnconvertedLinks, countConvertedLinks } from './lib/unconverted-links.mjs';
 import { generateMdxFromYaml } from './lib/mdx-generator.mjs';
@@ -1469,8 +1469,8 @@ async function main() {
   // Parse .claude/session-log.md and .claude/sessions/*.md, then attach
   // changeHistory to each page.
   // =========================================================================
-  const sessionLogPath = join(PROJECT_ROOT, '..', '.claude', 'session-log.md');
-  const sessionsDir = join(PROJECT_ROOT, '..', '.claude', 'sessions');
+  const sessionLogPath = join(REPO_ROOT, '.claude', 'session-log.md');
+  const sessionsDir = join(REPO_ROOT, '.claude', 'sessions');
   const pageChangeHistory = parseAllSessionLogs(sessionLogPath, sessionsDir);
 
   // Auto-populate PR numbers from GitHub API for entries that don't have them


### PR DESCRIPTION
## Summary
- Fixed the `/internal/page-changes` dashboard showing 0 sessions / 0 page edits
- **Root cause**: `build-data.mjs` used `join(PROJECT_ROOT, \"..\")` to find `.claude/sessions/`, which resolves to `apps/.claude/sessions/` (one level up from `apps/web/`). The correct path is `REPO_ROOT` (two levels up), where `.claude/sessions/` actually lives.
- After fix: 230 pages with session history, 359 total change entries

## Test plan
- [x] Ran `build-data.mjs` from `apps/web/` — confirms `changeHistory: 230 pages have session history` (was 0)
- [x] Verified `database.json` contains 228 pages with 359 changeHistory entries
- [x] All 7 pre-push gate checks pass
- [x] Pre-existing test failure (`session-checklist.test.ts` catalog count) confirmed on main — unrelated

https://claude.ai/code/session_01XEYTeCQhBSRp4t7WetvZFC