### PR TITLE
Update numeric IDs for Epstein and EA Anthropic entities

### DIFF
--- a/content/docs/knowledge-base/history/epstein-ai-connections.mdx
+++ b/content/docs/knowledge-base/history/epstein-ai-connections.mdx
@@ -1,5 +1,5 @@
 ---
-numericId: E851
+numericId: E854
 title: Jeffrey Epstein's Connections to AI Researchers
 description: An overview of Jeffrey Epstein's financial and professional
   relationships with AI researchers and organizations, including funding for

--- a/data/entities/concepts.yaml
+++ b/data/entities/concepts.yaml
@@ -2,7 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: ea-shareholder-diversification-anthropic
-  numericId: E858
+  numericId: E851
   type: concept
   title: EA Shareholder Diversification from Anthropic
   description: >-


### PR DESCRIPTION
## Summary
Updated numeric identifiers for two related entities in the knowledge base to maintain consistency and correct ID assignments.

## Key Changes
- Updated `epstein-ai-connections.mdx`: Changed numericId from E851 to E854
- Updated `concepts.yaml`: Changed numericId for "EA Shareholder Diversification from Anthropic" from E858 to E851

## Details
These changes appear to be ID reassignments, likely to resolve conflicts or correct previous numbering. The E851 ID was reassigned from the Epstein AI connections document to the EA Anthropic concept, while the Epstein document received the E854 ID.

https://claude.ai/code/session_01U1J17YxSho1rKiEijsHo7R