### PR TITLE
fix: make prepare script tolerant of missing git in Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "setup": "bash scripts/setup.sh",
     "setup:quick": "bash scripts/setup.sh --quick",
     "setup:check": "bash scripts/setup.sh --check",
-    "prepare": "git config core.hooksPath .githooks"
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",


### PR DESCRIPTION
## Summary

- The `prepare` lifecycle script in `package.json` runs `git config core.hooksPath .githooks` on every `pnpm install`
- In the Discord bot Dockerfile (`node:22-alpine`), `git` is not installed, causing the install step to fail with `sh: git: not found`
- Fix: append `|| true` so the script silently no-ops when git is unavailable, while still configuring git hooks in normal developer environments

## Test plan
- [ ] Docker build for discord-bot should now succeed (no `sh: git: not found` error)
- [ ] Local `pnpm install` still sets up `.githooks` correctly when git is present

https://claude.ai/code/session_019e8FwRtmSEkPFfqZGuVEKi