### PR TITLE
Clean up GitHub issues: close duplicates, add tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ pnpm crux issues next            # Show next highest-priority issue to work on
 pnpm crux issues create "title" --label=tooling  # File a new issue (use during tooling-gaps-actioned)
 pnpm crux issues start <N>       # Signal start: comment + add claude-working label
 pnpm crux issues done <N>        # Signal completion: comment + remove label
+pnpm crux issues cleanup         # Detect stale claude-working labels + potential duplicates
+pnpm crux issues cleanup --fix   # Auto-remove stale labels
+pnpm crux issues close <N> --duplicate=M  # Close issue as duplicate of another
+pnpm crux issues close <N> --reason="..."  # Close with comment
 
 # Hallucination risk & review tracking
 pnpm crux validate hallucination-risk         # Risk assessment report


### PR DESCRIPTION
## Summary

- **Closed 4 duplicate issues** with explanatory comments and cross-references:
  - #383 (duplicate of completed #361: legacy frontmatter cleanup)
  - #384 (duplicate of #362: quality scores — PR #374 in progress)
  - #381 (duplicate of #360: R citation standardization)
  - #379 (duplicate of #357: table/section standardization)
- **Removed stale `claude-working` labels** from #387 and #389 (sessions abandoned, branches never pushed)
- **Added cross-reference comments** on #252, #357, #360, #220, #221 linking related issues and noting dependencies
- **Added missing labels** to 6 unlabeled issues (#1, #100, #107, #237, #238, #288)
- **New CLI commands:**
  - `crux issues cleanup` — detects stale `claude-working` labels (verifies branch existence on remote) and potential duplicate issues (Jaccard title similarity). Supports `--fix` to auto-remove stale labels.
  - `crux issues close <N>` — close an issue with optional `--reason` and `--duplicate=N` flags
- **13 new test cases** covering `findPotentialDuplicates`, `cleanup`, and `close` commands

## Issue count: 39 → 35 open

## Test plan

- [x] All existing tests pass (229 app + 28 discord-bot + 51 crux)
- [x] All 8 gate checks pass
- [x] New `findPotentialDuplicates` tests verify similarity detection
- [x] New `cleanup` test verifies stale label detection flow
- [x] New `close` tests verify input validation

https://claude.ai/code/session_011sk6KTHetaUXf1yya34Pxt