### PR TITLE
Improve merge conflict resolver: fix PR #374 and #377 failure modes

### DIFF
--- a/.github/scripts/resolve-conflicts.mjs
+++ b/.github/scripts/resolve-conflicts.mjs
@@ -44,7 +44,7 @@ if (!/^[a-zA-Z0-9._\/-]+$/.test(PR_BRANCH)) {
   process.exit(1);
 }
 
-const MAX_CONFLICTED_FILES = 20;
+const MAX_CONFLICTED_FILES = 50;
 const LARGE_FILE_THRESHOLD = 32_000; // chars — files above this use hunk-by-hunk resolution
 const CONTEXT_LINES = 20; // lines of context around each conflict hunk
 
@@ -341,6 +341,152 @@ async function resolveLargeFile(filePath, content) {
   return lines.join("\n");
 }
 
+// ── Frontmatter-only conflict resolution (no API call) ─────────────────
+
+/**
+ * Detect if all conflicts in a file are within the YAML frontmatter block
+ * (between the opening and closing `---` delimiters). If so, resolve them
+ * deterministically without an API call by merging fields from both sides.
+ *
+ * Strategy: for each conflict hunk within frontmatter, parse key-value lines
+ * from both sides. Take all keys from both sides; for duplicate top-level
+ * keys, prefer HEAD (the PR branch) since the PR's changes are intentional.
+ *
+ * Returns the resolved file content, or null if the conflict isn't
+ * purely in frontmatter or can't be resolved deterministically.
+ */
+function tryResolveFrontmatterOnly(filePath, content) {
+  // Only applies to MDX and YAML files with frontmatter
+  if (!filePath.endsWith(".mdx") && !filePath.endsWith(".yaml") && !filePath.endsWith(".yml")) {
+    return null;
+  }
+
+  const lines = content.split("\n");
+
+  // For MDX: find the frontmatter region (between first and second `---`)
+  // For YAML: the entire file is "frontmatter"
+  const isYaml = filePath.endsWith(".yaml") || filePath.endsWith(".yml");
+  let fmStart = 0;
+  let fmEnd = lines.length - 1;
+
+  if (!isYaml) {
+    // MDX: must start with `---`
+    if (lines[0].trim() !== "---") return null;
+    fmStart = 0;
+
+    // Find closing `---`
+    let closingIdx = -1;
+    for (let i = 1; i < lines.length; i++) {
+      // The closing `---` could be after a conflict block, so look for `---`
+      // that isn't inside a conflict marker
+      if (lines[i].trim() === "---" && !lines[i].startsWith("<<<<<<<") && !lines[i].startsWith(">>>>>>>") && !lines[i].startsWith("=======")) {
+        closingIdx = i;
+        break;
+      }
+    }
+    if (closingIdx === -1) return null;
+    fmEnd = closingIdx;
+  }
+
+  // Check that ALL conflict markers are within the frontmatter region
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("<<<<<<<") || lines[i].startsWith(">>>>>>>") || lines[i].startsWith("=======")) {
+      if (i < fmStart || i > fmEnd) {
+        return null; // Conflict outside frontmatter — can't use deterministic resolution
+      }
+    }
+  }
+
+  // Find all conflict blocks within the frontmatter
+  const blocks = findConflictBlocks(lines);
+  if (blocks.length === 0) return null;
+
+  // Resolve each conflict block by merging YAML fields deterministically
+  // Work backwards to preserve line indices
+  for (let b = blocks.length - 1; b >= 0; b--) {
+    const block = blocks[b];
+
+    // Extract HEAD and MAIN sides
+    const headLines = [];
+    const mainLines = [];
+    let inHead = false;
+    let inMain = false;
+
+    for (let i = block.start; i <= block.end; i++) {
+      if (lines[i].startsWith("<<<<<<<")) { inHead = true; continue; }
+      if (lines[i].startsWith("=======")) { inHead = false; inMain = true; continue; }
+      if (lines[i].startsWith(">>>>>>>")) { inMain = false; continue; }
+      if (inHead) headLines.push(lines[i]);
+      if (inMain) mainLines.push(lines[i]);
+    }
+
+    // Parse top-level YAML keys from each side
+    // We track full "blocks" per top-level key to handle multi-line values
+    // (like arrays under `clusters:` or `ratings:`)
+    const parseYamlBlocks = (yamlLines) => {
+      const blocks = new Map(); // key → array of lines (including the key line and nested lines)
+      const order = [];
+      let currentKey = null;
+
+      for (const line of yamlLines) {
+        // A top-level key starts at column 0, is not a comment, and contains ':'
+        const topLevelMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*)\s*:/);
+        if (topLevelMatch) {
+          currentKey = topLevelMatch[1];
+          if (!blocks.has(currentKey)) {
+            order.push(currentKey);
+          }
+          blocks.set(currentKey, [line]);
+        } else if (currentKey && (line.startsWith("  ") || line.startsWith("\t") || line.trim() === "")) {
+          // Continuation of current key (nested value or blank line within block)
+          const existing = blocks.get(currentKey) || [];
+          existing.push(line);
+          blocks.set(currentKey, existing);
+        } else if (line.startsWith("- ") && currentKey) {
+          // YAML list continuation at top level (for edit-log entries)
+          const existing = blocks.get(currentKey) || [];
+          existing.push(line);
+          blocks.set(currentKey, existing);
+        }
+      }
+
+      return { blocks, order };
+    };
+
+    const head = parseYamlBlocks(headLines);
+    const main = parseYamlBlocks(mainLines);
+
+    // Merge: take HEAD's order as base, then append any keys only in MAIN
+    const mergedLines = [];
+    const seen = new Set();
+
+    for (const key of head.order) {
+      seen.add(key);
+      // Prefer HEAD's value for this key
+      mergedLines.push(...(head.blocks.get(key) || []));
+    }
+
+    for (const key of main.order) {
+      if (!seen.has(key)) {
+        // New key from main — add it
+        mergedLines.push(...(main.blocks.get(key) || []));
+      }
+    }
+
+    // Replace the conflict block with merged lines
+    lines.splice(block.start, block.end - block.start + 1, ...mergedLines);
+  }
+
+  const resolved = lines.join("\n");
+
+  // Safety check
+  if (resolved.includes("<<<<<<<") || resolved.includes(">>>>>>>")) {
+    return null;
+  }
+
+  return resolved;
+}
+
 // ── File resolution ────────────────────────────────────────────────────
 
 async function resolveFile(filePath) {
@@ -389,6 +535,16 @@ async function resolveFile(filePath) {
   }
 
   console.log(`  Resolving: ${filePath} (${content.length} chars)`);
+
+  // Try deterministic frontmatter resolution first (no API call needed)
+  const frontmatterResolved = tryResolveFrontmatterOnly(filePath, content);
+  if (frontmatterResolved !== null) {
+    writeFileSync(filePath, frontmatterResolved);
+    git("add", "--", filePath);
+    console.log(`  Resolved: ${filePath} (deterministic frontmatter merge — no API call)`);
+    addDiagnostic(filePath, "resolved", "deterministic frontmatter merge");
+    return true;
+  }
 
   let resolvedContent;
 

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -155,6 +155,13 @@ jobs:
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.resolve.outcome == 'success'
         run: pnpm install --frozen-lockfile
 
+      - name: "Tier 1: Auto-fix escaping and markdown after merge"
+        if: always() && steps.fingerprint.outputs.skip != 'true' && steps.resolve.outcome == 'success'
+        run: |
+          echo "Running auto-fix for MDX escaping and markdown formatting..."
+          pnpm crux fix escaping || true
+          pnpm crux fix markdown || true
+
       - name: "Tier 1: Validate resolved code"
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.resolve.outcome == 'success'
         id: validate
@@ -217,9 +224,18 @@ jobs:
              - TypeScript/JS files with type errors from combining incompatible changes
              - Build-data failures from mismatched entity/fact references between files
              - MDX files with broken EntityLink references
-          3. After fixing, verify by running: pnpm crux validate gate --fix
-          4. Only fix what's needed to pass validation — do not make unrelated changes
-          5. Stage your changes with git add but do NOT commit or push
+             - Numeric ID reassignment errors (e.g. "Numeric ID reassignment detected"):
+               These happen when a numericId (like E696) was removed from a source YAML/MDX
+               file during the merge and build-data would assign a different one. Fix by
+               restoring the original numericId value in the source file. Check both
+               data/entities/*.yaml and content/docs/**/*.mdx frontmatter for numericId fields.
+               Do NOT use --allow-id-reassignment.
+             - Unescaped dollar signs in MDX files (e.g. "$100" should be "\\$100")
+             - Deprecated frontmatter fields (e.g. "importance" should be "readerImportance")
+          3. Run auto-fixers first: pnpm crux fix escaping && pnpm crux fix markdown
+          4. After fixing, verify by running: pnpm crux validate gate --fix
+          5. Only fix what's needed to pass validation — do not make unrelated changes
+          6. Stage your changes with git add but do NOT commit or push
           PROMPT_EOF
           )"
 


### PR DESCRIPTION
## Summary

- **Raise `MAX_CONFLICTED_FILES` from 20 to 50** — PR #374 had 29 trivial frontmatter-only conflicts but was blocked by the old limit. At ~$0.01-0.05/file, even 50 files costs under $2.50.
- **Add `crux fix escaping/markdown` step** between Tier 1 conflict resolution and validation — auto-fixes unescaped dollar signs and markdown formatting before the validation gate runs, preventing the dollar-sign failures seen on PR #377.
- **Enhance Tier 2 (Claude Code) prompt** with specific guidance for numericId reassignment errors, unescaped dollar signs, and deprecated frontmatter fields — the key failure modes that Tier 2 couldn't resolve on PR #377.
- **Add deterministic frontmatter-only conflict resolution** — when all conflicts in a file are within YAML frontmatter (the most common case in this wiki), merge fields from both sides without an API call. Keeps HEAD values for duplicate keys, adds new keys from main. This is free, instant, and handles the exact pattern that caused 25/29 conflicts in PR #374.

## Test plan
- [x] All 8 gate checks pass (`pnpm crux validate gate`)
- [x] 229 tests pass
- [ ] Verify on next conflicting PR that deterministic frontmatter merge works
- [ ] Verify Tier 1 auto-fix step catches dollar sign escaping issues

https://claude.ai/code/session_01GrbhuELwGWixpgFVrvFpvN