### PR TITLE
Make section sidebar detection fully generic

### DIFF
--- a/apps/web/src/app/wiki/[id]/page.tsx
+++ b/apps/web/src/app/wiki/[id]/page.tsx
@@ -307,6 +307,8 @@ function WithSidebar({
   children: React.ReactNode;
 }) {
   const sidebarType = detectSidebarType(entityPath);
+  const sections = sidebarType && !hideSidebar ? getWikiNav(sidebarType, entityPath) : [];
+  const hasSidebar = sections.length > 0;
 
   // Compute content container class:
   // - hideSidebar + fullWidth: wide centered layout, no sidebar
@@ -317,15 +319,14 @@ function WithSidebar({
     ? "max-w-[90rem] mx-auto px-8 py-6"
     : fullWidth
       ? "w-full px-3 py-4"
-      : sidebarType
+      : hasSidebar
         ? "max-w-[65rem] mx-auto px-8 py-4"
         : "max-w-7xl mx-auto px-6 py-8";
 
-  if (!sidebarType || hideSidebar) {
+  if (!sections.length) {
     return <div className={contentClass}>{children}</div>;
   }
 
-  const sections = getWikiNav(sidebarType, entityPath);
   return (
     <SidebarProvider>
       <WikiSidebar sections={sections} />

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -435,13 +435,10 @@ export function detectSidebarType(entityPath: string): WikiSidebarType {
     }
   }
 
-  // Top-level sections with their own sidebar nav
-  if (
-    entityPath.startsWith("/browse/") || entityPath === "/browse" ||
-    entityPath.startsWith("/guides/") || entityPath === "/guides" ||
-    entityPath.startsWith("/project/") || entityPath === "/project" ||
-    entityPath.startsWith("/insight-hunting/") || entityPath === "/insight-hunting"
-  ) {
+  // Any other top-level path with child pages gets a generic section sidebar.
+  // No hardcoded list — buildSectionNav discovers pages from the data layer.
+  const firstSegment = entityPath.split("/").filter(Boolean)[0];
+  if (firstSegment) {
     return "section";
   }
 
@@ -468,8 +465,9 @@ function extractSection(entityPath: string): string | null {
 }
 
 /**
- * Build sidebar navigation for a top-level section (browse, guides, project, insight-hunting).
+ * Build sidebar navigation for any top-level section.
  * Uses the generic buildSectionNav which reads page data and groups by subcategory.
+ * Returns empty array if the section has no pages (no sidebar will render).
  */
 function getSectionNav(sectionKey: string): NavSection[] {
   return buildSectionNav(sectionKey, sectionKey);


### PR DESCRIPTION
## Summary

Follow-up to #403 — removes the hardcoded list of section paths (`browse`, `guides`, `project`, `insight-hunting`) from `detectSidebarType` and replaces it with a fully generic fallback.

## Changes

- **`wiki-nav.ts`**: `detectSidebarType` now returns `"section"` for any top-level path not already handled by a specific type (models, atm, internal, about, kb). `buildSectionNav` discovers pages from the data layer — no code changes needed when new sections are added.
- **`page.tsx`**: `WithSidebar` now bases layout width and sidebar rendering on actual section content (`sections.length > 0`) rather than sidebar type detection. Prevents empty sidebar containers for sections with no pages.

## Test plan

- [x] `pnpm crux validate gate` passes (all 9 checks including full Next.js build, 229 tests)
- [x] Verified existing sections (browse, guides, project, insight-hunting) still get correct sidebars
- [x] Verified sections with no pages (e.g., paths without matching content) get no sidebar
- [x] Layout width correctly uses wider max when sidebar is empty

https://claude.ai/code/session_01UdWgib2aeBiMefY6u4veZc