### PR TITLE
Add stale claude-working label cleanup to scheduled maintenance

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -87,6 +87,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cleanup stale claude-working labels
+        run: pnpm crux issues cleanup --fix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run maintenance
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

- Adds a `pnpm crux issues cleanup --fix` step to the scheduled maintenance workflow
- Runs before the main Claude maintenance sweep, on all cadences (daily/weekly/monthly)
- Automatically removes stale `claude-working` labels when associated branches no longer exist on remote

## Context

The `claude-working` label on GitHub issues becomes stale when Claude sessions fail, timeout, or finish without calling `crux issues done`. Previously this required manual cleanup. This change automates it as part of the existing scheduled maintenance workflow.

The cleanup step is deterministic (no AI judgment needed) — it checks if the branch referenced in issue comments still exists, and removes the label + posts a comment if not. The command always returns exit code 0 so it will not fail the workflow.

Closes #402

## Test plan

- [x] Verified `crux issues cleanup --fix` command logic is already tested in `crux/commands/issues.test.ts`
- [x] Verified the workflow has required `issues: write` permission
- [x] Verified `GITHUB_TOKEN` is properly passed via `env:` block
- [x] Confirmed gate failure (`mdx.test.ts` / missing `rehype-slug`) is pre-existing on main

https://claude.ai/code/session_015MkmWibeNmiaEwdmGoyHz4