### PR TITLE
Follow-up fixes for frontmatter field ordering (PR #407)

### DIFF
--- a/crux/authoring/creator/grading.ts
+++ b/crux/authoring/creator/grading.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { createClient, MODELS, parseJsonResponse } from '../../lib/anthropic.ts';
 import { appendEditLog } from '../../lib/edit-log.ts';
+import { reorderFrontmatterObject } from '../../lib/frontmatter-order.ts';
 import { extractText } from '../../lib/llm.ts';
 import { READER_IMPORTANCE_GUIDELINES, TACTICAL_VALUE_GUIDELINES } from '../../lib/grading-shared.ts';
 import type { TopicPhaseContext } from './types.ts';
@@ -197,9 +198,10 @@ Respond with JSON:
     // by crux/lib/metrics-extractor.ts — not stored in frontmatter.
     delete frontmatter.metrics;
 
-    // Write updated file
+    // Write updated file — reorder keys to canonical order before serialization
+    const orderedFrontmatter = reorderFrontmatterObject(frontmatter);
     const { stringify: stringifyYaml } = await import('yaml');
-    let yamlStr = stringifyYaml(frontmatter);
+    let yamlStr = stringifyYaml(orderedFrontmatter);
     yamlStr = yamlStr.replace(/^(lastEdited:\s*)(\d{4}-\d{2}-\d{2})$/m, '$1"$2"');
     const newContent = `---\n${yamlStr}---\n${body}`;
     fs.writeFileSync(finalPath, newContent);

--- a/crux/authoring/grading/apply.ts
+++ b/crux/authoring/grading/apply.ts
@@ -7,6 +7,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { FRONTMATTER_RE } from '../../lib/patterns.ts';
+import { reorderFrontmatterObject } from '../../lib/frontmatter-order.ts';
 import type { PageInfo, GradeResult, Metrics } from './types.ts';
 
 /** Apply grades to frontmatter YAML in the source file. */
@@ -44,7 +45,11 @@ export function applyGradesToFile(
     fm.lastEdited = fm.lastEdited.toISOString().split('T')[0];
   }
 
-  let newFm: string = stringifyYaml(fm, {
+  // Reorder keys to canonical order before serialization so newly-added
+  // fields (e.g. tacticalValue) land in the correct position.
+  const orderedFm = reorderFrontmatterObject(fm);
+
+  let newFm: string = stringifyYaml(orderedFm, {
     defaultStringType: 'QUOTE_DOUBLE',
     defaultKeyType: 'PLAIN',
     lineWidth: 0,

--- a/crux/auto-fix.ts
+++ b/crux/auto-fix.ts
@@ -55,6 +55,11 @@ const fixers: Fixer[] = [
     description: 'Fix markdown lists and bold labels',
     command: 'node --import tsx/esm crux/validate/validate-unified.ts --rules=markdown-lists,consecutive-bold-labels --fix',
   },
+  {
+    name: 'Frontmatter Field Order',
+    description: 'Reorder frontmatter fields to canonical order (identity first, volatile last)',
+    command: 'node --import tsx/esm crux/fix/fix-frontmatter-order.ts --apply',
+  },
 ];
 
 function runFixer(fixer: Fixer): FixerResult {

--- a/crux/fix/fix-frontmatter-order.ts
+++ b/crux/fix/fix-frontmatter-order.ts
@@ -84,7 +84,9 @@ interface FrontmatterBlock {
  * column 0, word characters, followed by colon).
  */
 function parseFrontmatterBlocks(content: string): FrontmatterBlock | null {
-  const lines = content.split('\n');
+  // Strip BOM and normalize CRLF to LF so delimiter checks work on all platforms
+  const normalized = content.replace(/^\ufeff/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const lines = normalized.split('\n');
 
   // Find opening ---
   if (lines[0] !== '---') return null;

--- a/crux/lib/frontmatter-order.ts
+++ b/crux/lib/frontmatter-order.ts
@@ -125,3 +125,22 @@ export function sortFields(fields: string[]): string[] {
     return a.localeCompare(b);
   });
 }
+
+/**
+ * Reorder a frontmatter object's keys to canonical order.
+ *
+ * Use this when a code path modifies a parsed frontmatter object and then
+ * re-serializes it with yaml.stringify(). JS object property order follows
+ * insertion order, so newly added fields (e.g. tacticalValue from grading)
+ * would otherwise end up at the bottom instead of their canonical position.
+ *
+ * Returns a new object with keys in canonical order.
+ */
+export function reorderFrontmatterObject<T extends Record<string, unknown>>(obj: T): T {
+  const sorted = sortFields(Object.keys(obj));
+  const result = {} as Record<string, unknown>;
+  for (const key of sorted) {
+    result[key] = obj[key];
+  }
+  return result as T;
+}

--- a/crux/lib/rules/frontmatter-order.ts
+++ b/crux/lib/rules/frontmatter-order.ts
@@ -17,7 +17,9 @@ import { getFieldSortIndex } from '../frontmatter-order.ts';
  * preserving their source order.
  */
 function extractFieldOrder(raw: string): string[] {
-  const lines = raw.split('\n');
+  // Strip BOM and normalize CRLF so delimiter checks work on all platforms
+  const normalized = raw.replace(/^\ufeff/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const lines = normalized.split('\n');
   if (lines[0] !== '---') return [];
 
   const fields: string[] = [];


### PR DESCRIPTION
## Summary

Intense review of PR #407 (frontmatter field ordering convention, fixer, and linter) found several integration gaps where the canonical ordering would drift over time. This PR fixes them.

### Fixes

- **Parser hardening**: Strip BOM markers and normalize CRLF line endings in both the fixer and validation rule, so files from Windows editors aren't silently skipped
- **Auto-fix pipeline**: Add frontmatter-order to `crux fix all` so it runs alongside escaping and markdown fixes
- **Merge conflict resolver**: Sort merged frontmatter fields by canonical order instead of using HEAD's arbitrary insertion order
- **Grading pipeline order drift** (most significant): Added `reorderFrontmatterObject()` utility and integrated into both `grading/apply.ts` and `creator/grading.ts` — previously, when grading added a new field like `tacticalValue`, it would land at the bottom of frontmatter (after `clusters`) instead of its canonical position
- **Tests**: 6 new tests for `reorderFrontmatterObject`, CRLF handling, and BOM handling (27 total, all pass)

### Remaining advisory items (not in this PR)

- Duplicated canonical order list in merge resolver `.mjs` (can't import TS) — sync risk
- `importance/sync.ts` uses regex insertion with its own ordering logic
- `clusters` field used in 639 files but not in Zod schema (works via `.passthrough()`)
- WARNING severity means drift can accumulate between manual fix runs

## Test plan

- [x] All 27 frontmatter-order tests pass (6 new)
- [x] Gate check passes (pre-existing mdx.test.ts failure from missing rehype-slug is unrelated)
- [x] `pnpm crux fix frontmatter-order` dry-run confirms all 704 files still in canonical order
- [x] Verified grading order-drift bug with manual test: new fields now land in correct position

https://claude.ai/code/session_01B6HWu6Min2zkXo6n3uXZm5