### PR TITLE
Add content integrity signals to hallucination risk score

### DIFF
--- a/crux/lib/content-integrity.test.ts
+++ b/crux/lib/content-integrity.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findFootnoteRefs,
+  findFootnoteDefs,
+  detectOrphanedFootnotes,
+  detectDuplicateFootnoteDefs,
+  detectSequentialArxivIds,
+  detectUnsourcedFootnotes,
+  computeIntegrityRisk,
+  assessContentIntegrity,
+} from './content-integrity.ts';
+
+// ---------------------------------------------------------------------------
+// findFootnoteRefs
+// ---------------------------------------------------------------------------
+
+describe('findFootnoteRefs', () => {
+  it('finds inline footnote references', () => {
+    const body = 'Some claim[^1] and another[^2] and repeated[^1].';
+    expect(findFootnoteRefs(body)).toEqual(new Set([1, 2]));
+  });
+
+  it('excludes definition lines', () => {
+    const body = `Some claim[^1] here.
+
+[^1]: This is the definition with [^2] inside it.`;
+    // Only [^1] from the body, not [^2] from the definition line
+    expect(findFootnoteRefs(body)).toEqual(new Set([1]));
+  });
+
+  it('returns empty set when no refs', () => {
+    expect(findFootnoteRefs('No footnotes here.')).toEqual(new Set());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findFootnoteDefs
+// ---------------------------------------------------------------------------
+
+describe('findFootnoteDefs', () => {
+  it('finds footnote definitions', () => {
+    const body = `Some text.
+
+[^1]: First source https://example.com
+[^2]: Second source`;
+    expect(findFootnoteDefs(body)).toEqual(new Set([1, 2]));
+  });
+
+  it('returns empty set when no definitions', () => {
+    expect(findFootnoteDefs('No definitions.')).toEqual(new Set());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectOrphanedFootnotes
+// ---------------------------------------------------------------------------
+
+describe('detectOrphanedFootnotes', () => {
+  it('detects no orphans when all refs have definitions', () => {
+    const body = `Claim[^1] and another[^2].
+
+[^1]: Source one https://example.com
+[^2]: Source two https://example.com`;
+    const result = detectOrphanedFootnotes(body);
+    expect(result.orphanedRefs).toEqual([]);
+    expect(result.orphanedRatio).toBe(0);
+  });
+
+  it('detects orphaned refs (truncated page)', () => {
+    const body = `Claim[^1] and another[^2] and more[^3].
+
+[^1]: Source one https://example.com`;
+    // [^2] and [^3] have no definitions
+    const result = detectOrphanedFootnotes(body);
+    expect(result.orphanedRefs).toEqual([2, 3]);
+    expect(result.totalRefs).toBe(3);
+    expect(result.totalDefs).toBe(1);
+    expect(result.orphanedRatio).toBeCloseTo(2 / 3);
+  });
+
+  it('detects all orphaned (fully truncated)', () => {
+    const body = 'Claim[^1] and another[^2] and more[^3].';
+    const result = detectOrphanedFootnotes(body);
+    expect(result.orphanedRefs).toEqual([1, 2, 3]);
+    expect(result.orphanedRatio).toBe(1);
+  });
+
+  it('handles page with no footnotes at all', () => {
+    const result = detectOrphanedFootnotes('Just plain text.');
+    expect(result.orphanedRefs).toEqual([]);
+    expect(result.orphanedRatio).toBe(0);
+    expect(result.totalRefs).toBe(0);
+    expect(result.totalDefs).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectDuplicateFootnoteDefs
+// ---------------------------------------------------------------------------
+
+describe('detectDuplicateFootnoteDefs', () => {
+  it('detects no duplicates when all unique', () => {
+    const body = `[^1]: Source one
+[^2]: Source two`;
+    expect(detectDuplicateFootnoteDefs(body)).toEqual([]);
+  });
+
+  it('detects duplicate definitions', () => {
+    const body = `[^1]: Source one
+[^2]: Source two
+[^1]: Duplicate of source one`;
+    expect(detectDuplicateFootnoteDefs(body)).toEqual([1]);
+  });
+
+  it('handles no definitions', () => {
+    expect(detectDuplicateFootnoteDefs('No defs.')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectSequentialArxivIds
+// ---------------------------------------------------------------------------
+
+describe('detectSequentialArxivIds', () => {
+  it('detects sequential arxiv IDs', () => {
+    const body = `
+Some paper (2506.00001) and next (2506.00002) and third (2506.00003).
+`;
+    const result = detectSequentialArxivIds(body);
+    expect(result.suspicious).toBe(true);
+    expect(result.longestRun).toBe(3);
+    expect(result.sequentialIds).toEqual(['2506.00001', '2506.00002', '2506.00003']);
+  });
+
+  it('detects long runs of fabricated IDs', () => {
+    const ids = Array.from({ length: 10 }, (_, i) =>
+      `2506.${String(i).padStart(5, '0')}`
+    ).join(', ');
+    const body = `References: ${ids}`;
+    const result = detectSequentialArxivIds(body);
+    expect(result.suspicious).toBe(true);
+    expect(result.longestRun).toBe(10);
+  });
+
+  it('does not flag non-sequential IDs', () => {
+    const body = `
+Real papers: 2301.07041, 2305.14314, 2310.01234.
+`;
+    const result = detectSequentialArxivIds(body);
+    expect(result.suspicious).toBe(false);
+    expect(result.longestRun).toBeLessThan(3);
+  });
+
+  it('does not flag fewer than minRunLength sequential IDs', () => {
+    const body = 'Papers: 2506.00001, 2506.00002';
+    const result = detectSequentialArxivIds(body, 3);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('handles no arxiv-like IDs', () => {
+    const result = detectSequentialArxivIds('No arxiv references here.');
+    expect(result.suspicious).toBe(false);
+    expect(result.longestRun).toBe(0);
+  });
+
+  it('respects custom minRunLength', () => {
+    const body = 'Papers: 2506.00001, 2506.00002';
+    expect(detectSequentialArxivIds(body, 2).suspicious).toBe(true);
+    expect(detectSequentialArxivIds(body, 3).suspicious).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectUnsourcedFootnotes
+// ---------------------------------------------------------------------------
+
+describe('detectUnsourcedFootnotes', () => {
+  it('detects footnotes with URLs as sourced', () => {
+    const body = `[^1]: Source https://example.com/paper
+[^2]: Another https://arxiv.org/abs/2301.12345`;
+    const result = detectUnsourcedFootnotes(body);
+    expect(result.unsourced).toBe(0);
+    expect(result.totalDefs).toBe(2);
+    expect(result.unsourcedRatio).toBe(0);
+  });
+
+  it('detects unsourced footnotes (no URL)', () => {
+    const body = `[^1]: Just some text without a link.
+[^2]: Source https://example.com`;
+    const result = detectUnsourcedFootnotes(body);
+    expect(result.unsourced).toBe(1);
+    expect(result.totalDefs).toBe(2);
+    expect(result.unsourcedRatio).toBe(0.5);
+  });
+
+  it('handles multi-line footnote definitions', () => {
+    const body = `[^1]: This is a long footnote that continues
+    on the next line with a URL https://example.com
+[^2]: This has no URL
+    even on continuation lines.`;
+    const result = detectUnsourcedFootnotes(body);
+    expect(result.unsourced).toBe(1); // [^2] has no URL
+    expect(result.totalDefs).toBe(2);
+  });
+
+  it('handles empty body', () => {
+    const result = detectUnsourcedFootnotes('');
+    expect(result.unsourced).toBe(0);
+    expect(result.totalDefs).toBe(0);
+    expect(result.unsourcedRatio).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeIntegrityRisk
+// ---------------------------------------------------------------------------
+
+describe('computeIntegrityRisk', () => {
+  it('returns 0 for clean page', () => {
+    const integrity = assessContentIntegrity(`Claim[^1] here.
+
+[^1]: Source https://example.com`);
+    const { score, factors } = computeIntegrityRisk(integrity);
+    expect(score).toBe(0);
+    expect(factors).toEqual([]);
+  });
+
+  it('returns high score for severely truncated page', () => {
+    // 3 refs, 0 defs = 100% orphaned
+    const integrity = assessContentIntegrity(
+      'Claim[^1] and[^2] and[^3].'
+    );
+    const { score, factors } = computeIntegrityRisk(integrity);
+    expect(score).toBe(30);
+    expect(factors).toContain('severe-truncation');
+  });
+
+  it('returns moderate score for partial orphaning', () => {
+    const integrity = assessContentIntegrity(`Claim[^1] and[^2] and[^3].
+
+[^1]: Source https://example.com
+[^2]: Source https://example.com`);
+    // 1 out of 3 refs orphaned = 33% (not >50%, so orphaned-footnotes not severe-truncation)
+    const { score, factors } = computeIntegrityRisk(integrity);
+    expect(score).toBe(15);
+    expect(factors).toContain('orphaned-footnotes');
+  });
+
+  it('returns high score for fabricated arxiv IDs', () => {
+    const integrity = assessContentIntegrity(
+      'Papers: 2506.00001, 2506.00002, 2506.00003'
+    );
+    const { score, factors } = computeIntegrityRisk(integrity);
+    expect(score).toBe(25);
+    expect(factors).toContain('suspicious-sequential-ids');
+  });
+
+  it('accumulates multiple risk factors', () => {
+    // Orphaned footnotes + sequential arxiv IDs + no URLs
+    const integrity = assessContentIntegrity(
+      `Claim[^1] from 2506.00001, 2506.00002, 2506.00003.
+
+[^1]: No URL here just text.`
+    );
+    const { score, factors } = computeIntegrityRisk(integrity);
+    // orphaned: [^1] has def so no orphans; sequential IDs: +25; unsourced: 1/1 = 100% → +10
+    expect(factors).toContain('suspicious-sequential-ids');
+    expect(factors).toContain('mostly-unsourced-footnotes');
+    expect(score).toBe(35); // 25 + 10
+  });
+});

--- a/crux/lib/content-integrity.ts
+++ b/crux/lib/content-integrity.ts
@@ -1,0 +1,310 @@
+/**
+ * Content Integrity Checks
+ *
+ * Pure functions that detect structural corruption, fabrication signals,
+ * and content integrity issues in MDX pages. These feed into the
+ * hallucination risk score as additional risk factors.
+ *
+ * Designed to catch issues like:
+ *   - Page truncation (orphaned footnote references without definitions)
+ *   - Fabricated citations (sequential arxiv IDs)
+ *   - Duplicate footnote definitions
+ *   - Unsourced footnotes (definitions with no URL)
+ */
+
+// ---------------------------------------------------------------------------
+// Orphaned footnotes (truncation detection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find footnote reference numbers [^N] used inline in the body.
+ * Excludes definition lines (lines starting with [^N]:).
+ */
+export function findFootnoteRefs(body: string): Set<number> {
+  const refs = new Set<number>();
+  const pattern = /\[\^(\d+)\]/g;
+  for (const line of body.split('\n')) {
+    if (/^\[\^\d+\]:/.test(line.trim())) continue; // skip definitions
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(line)) !== null) {
+      refs.add(parseInt(match[1], 10));
+    }
+  }
+  return refs;
+}
+
+/**
+ * Find footnote definition numbers [^N]: at the start of lines.
+ */
+export function findFootnoteDefs(body: string): Set<number> {
+  const defs = new Set<number>();
+  const pattern = /^\[\^(\d+)\]:/m;
+  for (const line of body.split('\n')) {
+    const match = pattern.exec(line.trim());
+    if (match) {
+      defs.add(parseInt(match[1], 10));
+    }
+  }
+  return defs;
+}
+
+/**
+ * Detect orphaned footnote references — inline [^N] with no matching [^N]: definition.
+ * Strong signal of page truncation (the definitions section was cut off).
+ */
+export function detectOrphanedFootnotes(body: string): {
+  orphanedRefs: number[];
+  totalRefs: number;
+  totalDefs: number;
+  orphanedRatio: number;
+} {
+  const refs = findFootnoteRefs(body);
+  const defs = findFootnoteDefs(body);
+
+  const orphaned: number[] = [];
+  for (const ref of refs) {
+    if (!defs.has(ref)) orphaned.push(ref);
+  }
+  orphaned.sort((a, b) => a - b);
+
+  return {
+    orphanedRefs: orphaned,
+    totalRefs: refs.size,
+    totalDefs: defs.size,
+    orphanedRatio: refs.size > 0 ? orphaned.length / refs.size : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate footnote definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect duplicate footnote definitions — same [^N]: appearing more than once.
+ * Indicates copy-paste or merge errors.
+ */
+export function detectDuplicateFootnoteDefs(body: string): number[] {
+  const seen = new Map<number, number>(); // footnote num → count
+  const pattern = /^\[\^(\d+)\]:/m;
+  for (const line of body.split('\n')) {
+    const match = pattern.exec(line.trim());
+    if (match) {
+      const num = parseInt(match[1], 10);
+      seen.set(num, (seen.get(num) ?? 0) + 1);
+    }
+  }
+  const duplicates: number[] = [];
+  for (const [num, count] of seen) {
+    if (count > 1) duplicates.push(num);
+  }
+  return duplicates.sort((a, b) => a - b);
+}
+
+// ---------------------------------------------------------------------------
+// Suspicious sequential IDs (fabrication detection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect suspicious sequential arxiv IDs that suggest LLM fabrication.
+ * Real arxiv IDs are sparse (e.g., 2301.07041, 2305.14314); fabricated ones
+ * are often sequential (2506.00001, 2506.00002, ...).
+ *
+ * Returns the longest run of sequential IDs found, if >= minRunLength.
+ */
+export function detectSequentialArxivIds(
+  body: string,
+  minRunLength: number = 3,
+): {
+  suspicious: boolean;
+  longestRun: number;
+  sequentialIds: string[];
+} {
+  // Extract all arxiv-like IDs: YYMM.NNNNN or YYMM.NNNN
+  const arxivPattern = /\b(\d{4}\.\d{4,5})\b/g;
+  const ids: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = arxivPattern.exec(body)) !== null) {
+    ids.push(match[1]);
+  }
+
+  if (ids.length < minRunLength) {
+    return { suspicious: false, longestRun: 0, sequentialIds: [] };
+  }
+
+  // Deduplicate and sort numerically
+  const unique = [...new Set(ids)].sort();
+
+  // Find longest run of sequential IDs (same prefix, consecutive numbers)
+  let longestRun = 1;
+  let currentRun = 1;
+  let longestRunStart = 0;
+  let currentRunStart = 0;
+
+  for (let i = 1; i < unique.length; i++) {
+    const prev = unique[i - 1];
+    const curr = unique[i];
+
+    // Check if same YYMM prefix and consecutive serial numbers
+    const prevParts = prev.split('.');
+    const currParts = curr.split('.');
+
+    if (
+      prevParts[0] === currParts[0] &&
+      parseInt(currParts[1], 10) === parseInt(prevParts[1], 10) + 1
+    ) {
+      currentRun++;
+      if (currentRun > longestRun) {
+        longestRun = currentRun;
+        longestRunStart = currentRunStart;
+      }
+    } else {
+      currentRun = 1;
+      currentRunStart = i;
+    }
+  }
+
+  const suspicious = longestRun >= minRunLength;
+  const sequentialIds = suspicious
+    ? unique.slice(longestRunStart, longestRunStart + longestRun)
+    : [];
+
+  return { suspicious, longestRun, sequentialIds };
+}
+
+// ---------------------------------------------------------------------------
+// Unsourced footnotes (no URL in definition)
+// ---------------------------------------------------------------------------
+
+/**
+ * Count footnote definitions that contain no URL.
+ * A footnote definition without a URL is likely fabricated or at minimum
+ * unverifiable. Real citations should link to a source.
+ */
+export function detectUnsourcedFootnotes(body: string): {
+  unsourced: number;
+  totalDefs: number;
+  unsourcedRatio: number;
+} {
+  const urlPattern = /https?:\/\/\S+/;
+  let totalDefs = 0;
+  let unsourced = 0;
+
+  // Footnote definitions can span multiple lines (continuation lines are indented)
+  const lines = body.split('\n');
+  let currentDefContent = '';
+  let inDef = false;
+
+  for (const line of lines) {
+    const defMatch = /^\[\^\d+\]:/.test(line.trim());
+
+    if (defMatch) {
+      // Flush previous definition
+      if (inDef) {
+        totalDefs++;
+        if (!urlPattern.test(currentDefContent)) unsourced++;
+      }
+      currentDefContent = line;
+      inDef = true;
+    } else if (inDef && /^\s+\S/.test(line)) {
+      // Continuation line (indented)
+      currentDefContent += ' ' + line;
+    } else {
+      // End of footnote block
+      if (inDef) {
+        totalDefs++;
+        if (!urlPattern.test(currentDefContent)) unsourced++;
+      }
+      inDef = false;
+      currentDefContent = '';
+    }
+  }
+
+  // Flush final definition
+  if (inDef) {
+    totalDefs++;
+    if (!urlPattern.test(currentDefContent)) unsourced++;
+  }
+
+  return {
+    unsourced,
+    totalDefs,
+    unsourcedRatio: totalDefs > 0 ? unsourced / totalDefs : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Composite integrity assessment
+// ---------------------------------------------------------------------------
+
+export interface IntegrityResult {
+  orphanedFootnotes: ReturnType<typeof detectOrphanedFootnotes>;
+  duplicateFootnoteDefs: number[];
+  sequentialArxivIds: ReturnType<typeof detectSequentialArxivIds>;
+  unsourcedFootnotes: ReturnType<typeof detectUnsourcedFootnotes>;
+}
+
+/**
+ * Run all content integrity checks on a page body.
+ * Returns a structured result suitable for feeding into risk scoring.
+ */
+export function assessContentIntegrity(body: string): IntegrityResult {
+  return {
+    orphanedFootnotes: detectOrphanedFootnotes(body),
+    duplicateFootnoteDefs: detectDuplicateFootnoteDefs(body),
+    sequentialArxivIds: detectSequentialArxivIds(body),
+    unsourcedFootnotes: detectUnsourcedFootnotes(body),
+  };
+}
+
+/**
+ * Compute risk score contribution from content integrity signals.
+ * Returns individual factor contributions for transparency in the risk report.
+ */
+export function computeIntegrityRisk(integrity: IntegrityResult): {
+  score: number;
+  factors: string[];
+} {
+  let score = 0;
+  const factors: string[] = [];
+
+  // Orphaned footnotes — strong truncation signal
+  const { orphanedRatio, orphanedRefs } = integrity.orphanedFootnotes;
+  if (orphanedRefs.length > 0) {
+    if (orphanedRatio > 0.5) {
+      // Majority of footnotes are orphaned — page is severely truncated
+      score += 30;
+      factors.push('severe-truncation');
+    } else {
+      // Some orphaned footnotes — partial truncation or editing issues
+      score += 15;
+      factors.push('orphaned-footnotes');
+    }
+  }
+
+  // Sequential arxiv IDs — fabrication signal
+  if (integrity.sequentialArxivIds.suspicious) {
+    score += 25;
+    factors.push('suspicious-sequential-ids');
+  }
+
+  // Duplicate footnote definitions — editing/merge error
+  if (integrity.duplicateFootnoteDefs.length > 0) {
+    score += 10;
+    factors.push('duplicate-footnote-defs');
+  }
+
+  // Unsourced footnotes — unverifiable claims
+  const { unsourcedRatio, unsourced } = integrity.unsourcedFootnotes;
+  if (unsourced > 0) {
+    if (unsourcedRatio > 0.5) {
+      score += 10;
+      factors.push('mostly-unsourced-footnotes');
+    } else {
+      score += 5;
+      factors.push('some-unsourced-footnotes');
+    }
+  }
+
+  return { score, factors };
+}


### PR DESCRIPTION
## Summary

Enriches the hallucination risk scoring system with four content integrity checks that detect structural corruption, truncation, and fabrication signals in wiki pages. These feed into both the build-time scorer (frontend confidence banners) and the validation-time scorer (CLI `pnpm crux validate hallucination-risk`).

**Motivation:** Issue #404 revealed that the auto-update pipeline can produce fabricated citations (35 sequential fake arxiv IDs) and truncated pages (62 orphaned footnote references). These signals are now automatically detected and reflected in the risk score.

### New risk factors

| Factor | Points | Trigger |
|---|---|---|
| `severe-truncation` | +30 | >50% of footnote refs have no matching definition |
| `orphaned-footnotes` | +15 | Any footnote refs without definitions |
| `suspicious-sequential-ids` | +25 | 3+ sequential arxiv-like IDs (fabrication signal) |
| `duplicate-footnote-defs` | +10 | Same `[^N]:` defined multiple times |
| `mostly-unsourced-footnotes` | +10 | >50% of footnote defs contain no URL |
| `some-unsourced-footnotes` | +5 | Any footnote defs without URLs |

### Impact on current pages

- 104 high-risk pages (was 99 before integrity signals)
- 2 pages flagged with `orphaned-footnotes` (agentic-ai, why-alignment-hard)
- 17 pages flagged with unsourced footnotes
- 0 pages with sequential IDs or duplicates (fabricated content was already fixed)

### Files changed

- **New:** `crux/lib/content-integrity.ts` — Pure detection functions + composite scoring
- **New:** `crux/lib/content-integrity.test.ts` — 27 tests
- **Modified:** `crux/validate/validate-hallucination-risk.ts` — Added Factor 8 (integrity signals)
- **Modified:** `apps/web/scripts/build-data.mjs` — Added integrity signals to build-time scorer, reordered blocks so rawContent is available

## Test plan

- [x] 27 new unit tests pass (content integrity detection + scoring)
- [x] All 908 crux tests pass
- [x] All 229 app tests pass
- [x] `pnpm crux validate gate` passes (all 8 checks)
- [x] Build-data produces correct risk counts (104 high, 494 medium, 114 low)
- [x] Live data test: confirmed integrity factors appear in risk report

🤖 Generated with [Claude Code](https://claude.com/claude-code)