### PR TITLE
feat: citation data tables and REST API for wiki-server

### DIFF
--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -1,0 +1,650 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+// ---- In-memory stores simulating Postgres tables ----
+
+let nextQuoteId = 1;
+let quotesStore: Map<
+  string, // key: `${page_id}:${footnote}`
+  Record<string, unknown>
+>;
+let contentStore: Map<string, Record<string, unknown>>; // key: url
+
+function resetStores() {
+  nextQuoteId = 1;
+  quotesStore = new Map();
+  contentStore = new Map();
+}
+
+function quoteKey(pageId: string, footnote: number) {
+  return `${pageId}:${footnote}`;
+}
+
+/**
+ * Mock tagged-template SQL that dispatches based on query text.
+ * Handles citation_quotes, citation_content, and entity_ids tables.
+ */
+function createMockSql() {
+  const mockSql = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.join("?").trim();
+
+    // --- Schema creation (initDb) ---
+    if (
+      query.includes("CREATE TABLE") ||
+      query.includes("CREATE INDEX") ||
+      query.includes("CREATE SEQUENCE") ||
+      query.includes("DO $$")
+    ) {
+      return [];
+    }
+
+    // --- citation_quotes: INSERT ... ON CONFLICT ---
+    if (query.includes("INSERT INTO citation_quotes")) {
+      const [pageId, footnote, url, resourceId, claimText, claimContext,
+        sourceQuote, sourceLocation, quoteVerified, verificationMethod,
+        verificationScore, sourceTitle, sourceType, extractionModel] = values;
+
+      const key = quoteKey(pageId as string, footnote as number);
+      const now = new Date().toISOString();
+      const existing = quotesStore.get(key);
+
+      if (existing) {
+        // ON CONFLICT DO UPDATE
+        const updated = {
+          ...existing,
+          url, resource_id: resourceId, claim_text: claimText,
+          claim_context: claimContext, source_quote: sourceQuote,
+          source_location: sourceLocation, quote_verified: quoteVerified ?? false,
+          verification_method: verificationMethod, verification_score: verificationScore,
+          source_title: sourceTitle, source_type: sourceType,
+          extraction_model: extractionModel, updated_at: now,
+        };
+        quotesStore.set(key, updated);
+        return [updated];
+      }
+
+      const row: Record<string, unknown> = {
+        id: nextQuoteId++,
+        page_id: pageId, footnote, url, resource_id: resourceId,
+        claim_text: claimText, claim_context: claimContext,
+        source_quote: sourceQuote, source_location: sourceLocation,
+        quote_verified: quoteVerified ?? false,
+        verification_method: verificationMethod, verification_score: verificationScore,
+        verified_at: null, source_title: sourceTitle, source_type: sourceType,
+        extraction_model: extractionModel,
+        accuracy_verdict: null, accuracy_issues: null, accuracy_score: null,
+        accuracy_checked_at: null, accuracy_supporting_quotes: null,
+        verification_difficulty: null,
+        created_at: now, updated_at: now,
+      };
+      quotesStore.set(key, row);
+      return [row];
+    }
+
+    // --- citation_quotes: UPDATE ... mark-accuracy ---
+    if (query.includes("UPDATE citation_quotes") && query.includes("accuracy_verdict")) {
+      const [verdict, score, issues, supportingQuotes, difficulty, pageId, footnote] = values;
+      const key = quoteKey(pageId as string, footnote as number);
+      const existing = quotesStore.get(key);
+      if (!existing) return [];
+      existing.accuracy_verdict = verdict;
+      existing.accuracy_score = score;
+      existing.accuracy_issues = issues;
+      existing.accuracy_supporting_quotes = supportingQuotes;
+      existing.verification_difficulty = difficulty;
+      existing.accuracy_checked_at = new Date().toISOString();
+      existing.updated_at = new Date().toISOString();
+      return [existing];
+    }
+
+    // --- citation_quotes: UPDATE ... mark-verified ---
+    if (query.includes("UPDATE citation_quotes") && query.includes("quote_verified")) {
+      const [method, score, pageId, footnote] = values;
+      const key = quoteKey(pageId as string, footnote as number);
+      const existing = quotesStore.get(key);
+      if (!existing) return [];
+      existing.quote_verified = true;
+      existing.verification_method = method;
+      existing.verification_score = score;
+      existing.verified_at = new Date().toISOString();
+      existing.updated_at = new Date().toISOString();
+      return [existing];
+    }
+
+    // --- citation_quotes: SELECT * WHERE page_id ---
+    if (query.includes("FROM citation_quotes") && query.includes("WHERE page_id")) {
+      const pageId = values[0] as string;
+      return Array.from(quotesStore.values())
+        .filter((r) => r.page_id === pageId)
+        .sort((a, b) => (a.footnote as number) - (b.footnote as number));
+    }
+
+    // --- citation_quotes: SELECT * ORDER BY (all, paginated — has LIMIT) ---
+    if (query.includes("FROM citation_quotes") && query.includes("ORDER BY page_id") && query.includes("LIMIT")) {
+      const limit = values[0] as number;
+      const offset = values[1] as number;
+      const all = Array.from(quotesStore.values()).sort((a, b) => {
+        const pc = (a.page_id as string).localeCompare(b.page_id as string);
+        return pc !== 0 ? pc : (a.footnote as number) - (b.footnote as number);
+      });
+      return all.slice(offset, offset + limit);
+    }
+
+    // --- citation_quotes: SELECT COUNT(*) ---
+    if (query.includes("SELECT COUNT(*)") && query.includes("citation_quotes")) {
+      return [{ count: quotesStore.size }];
+    }
+
+    // --- citation_quotes: Stats aggregation ---
+    if (query.includes("FROM citation_quotes") && query.includes("total_quotes")) {
+      const all = Array.from(quotesStore.values());
+      const withQuotes = all.filter((r) => r.source_quote != null).length;
+      const verified = all.filter((r) => r.quote_verified === true).length;
+      const scores = all.filter((r) => r.verification_score != null).map((r) => r.verification_score as number);
+      const avgScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+      const pages = new Set(all.map((r) => r.page_id));
+      return [{
+        total_quotes: all.length,
+        with_quotes: withQuotes,
+        verified,
+        unverified: all.length - verified,
+        total_pages: pages.size,
+        average_score: avgScore,
+      }];
+    }
+
+    // --- citation_quotes: Accuracy summary (check before page-stats since both have GROUP BY) ---
+    if (query.includes("GROUP BY page_id") && query.includes("HAVING")) {
+      const byPage = new Map<string, Record<string, unknown>[]>();
+      for (const r of quotesStore.values()) {
+        if (r.accuracy_verdict != null) {
+          const arr = byPage.get(r.page_id as string) || [];
+          arr.push(r);
+          byPage.set(r.page_id as string, arr);
+        }
+      }
+      return Array.from(byPage.entries())
+        .map(([pageId, rows]) => ({
+          page_id: pageId,
+          checked: rows.length,
+          accurate: rows.filter((r) => r.accuracy_verdict === "accurate").length,
+          inaccurate: rows.filter((r) => r.accuracy_verdict === "inaccurate").length,
+          unsupported: rows.filter((r) => r.accuracy_verdict === "unsupported").length,
+        }))
+        .sort((a, b) => a.page_id.localeCompare(b.page_id));
+    }
+
+    // --- citation_quotes: Page stats aggregation ---
+    if (query.includes("GROUP BY page_id") && query.includes("with_quotes")) {
+      const byPage = new Map<string, Record<string, unknown>[]>();
+      for (const r of quotesStore.values()) {
+        const arr = byPage.get(r.page_id as string) || [];
+        arr.push(r);
+        byPage.set(r.page_id as string, arr);
+      }
+      return Array.from(byPage.entries())
+        .map(([pageId, rows]) => ({
+          page_id: pageId,
+          total: rows.length,
+          with_quotes: rows.filter((r) => r.source_quote != null).length,
+          verified: rows.filter((r) => r.quote_verified === true).length,
+          avg_score: null,
+          accuracy_checked: rows.filter((r) => r.accuracy_verdict != null).length,
+          accurate: rows.filter((r) => r.accuracy_verdict === "accurate").length,
+          inaccurate: rows.filter((r) => r.accuracy_verdict === "inaccurate").length,
+        }))
+        .sort((a, b) => a.page_id.localeCompare(b.page_id));
+    }
+
+    // --- citation_quotes: Broken quotes (verification_score < threshold) ---
+    if (query.includes("verification_score <") && !query.includes("LIMIT")) {
+      const threshold = (values[0] as number) ?? 0.5;
+      return Array.from(quotesStore.values())
+        .filter((r) => r.quote_verified === true && r.verification_score != null && (r.verification_score as number) < threshold)
+        .sort((a, b) => (a.verification_score as number) - (b.verification_score as number))
+        .map((r) => ({
+          page_id: r.page_id, footnote: r.footnote, url: r.url,
+          claim_text: r.claim_text, verification_score: r.verification_score,
+        }));
+    }
+
+    // --- citation_content: INSERT ... ON CONFLICT ---
+    if (query.includes("INSERT INTO citation_content")) {
+      const [url, pageId, footnote, fetchedAt, httpStatus, contentType,
+        pageTitle, fullTextPreview, contentLength, contentHash] = values;
+      const now = new Date().toISOString();
+      const existing = contentStore.get(url as string);
+      const row: Record<string, unknown> = {
+        url, page_id: pageId, footnote, fetched_at: fetchedAt,
+        http_status: httpStatus, content_type: contentType,
+        page_title: pageTitle, full_text_preview: fullTextPreview,
+        content_length: contentLength, content_hash: contentHash,
+        created_at: existing?.created_at ?? now,
+        updated_at: now,
+      };
+      contentStore.set(url as string, row);
+      return [row];
+    }
+
+    // --- citation_content: SELECT * WHERE url ---
+    if (query.includes("FROM citation_content") && query.includes("WHERE url")) {
+      const url = values[0] as string;
+      const row = contentStore.get(url);
+      return row ? [row] : [];
+    }
+
+    // --- entity_ids fallbacks (from ids.test patterns) ---
+    if (query.includes("SELECT COUNT(*)")) {
+      return [{ count: 0 }];
+    }
+
+    return [];
+  };
+
+  mockSql.begin = async (fn: (tx: typeof mockSql) => Promise<void>) => {
+    await fn(mockSql);
+  };
+
+  return mockSql;
+}
+
+// Mock the db module
+vi.mock("../db.js", () => {
+  const mockSql = createMockSql();
+  return {
+    getDb: () => mockSql,
+    initDb: vi.fn(),
+    closeDb: vi.fn(),
+  };
+});
+
+const { createApp } = await import("../app.js");
+
+// ---- Helpers ----
+
+function postJson(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function upsertQuote(app: Hono, pageId: string, footnote: number, claimText = "Test claim") {
+  return postJson(app, "/api/citations/quotes/upsert", {
+    pageId,
+    footnote,
+    claimText,
+    url: `https://example.com/${pageId}/${footnote}`,
+  });
+}
+
+// ---- Tests ----
+
+describe("Citation Server API", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  // ---- Quote Upsert ----
+
+  describe("POST /api/citations/quotes/upsert", () => {
+    it("creates a new quote and returns 200", async () => {
+      const res = await upsertQuote(app, "test-page", 1);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pageId).toBe("test-page");
+      expect(body.footnote).toBe(1);
+      expect(body.id).toBe(1);
+    });
+
+    it("updates existing quote on conflict", async () => {
+      await upsertQuote(app, "test-page", 1, "Original claim");
+      const res = await postJson(app, "/api/citations/quotes/upsert", {
+        pageId: "test-page",
+        footnote: 1,
+        claimText: "Updated claim",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pageId).toBe("test-page");
+    });
+
+    it("rejects missing claimText", async () => {
+      const res = await postJson(app, "/api/citations/quotes/upsert", {
+        pageId: "test-page",
+        footnote: 1,
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("validation_error");
+    });
+
+    it("rejects invalid JSON", async () => {
+      const res = await app.request("/api/citations/quotes/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_json");
+    });
+  });
+
+  // ---- Batch Upsert ----
+
+  describe("POST /api/citations/quotes/upsert-batch", () => {
+    it("creates multiple quotes in a batch", async () => {
+      const res = await postJson(app, "/api/citations/quotes/upsert-batch", {
+        items: [
+          { pageId: "page-a", footnote: 1, claimText: "Claim 1" },
+          { pageId: "page-a", footnote: 2, claimText: "Claim 2" },
+          { pageId: "page-b", footnote: 1, claimText: "Claim 3" },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toHaveLength(3);
+      expect(body.results[0].pageId).toBe("page-a");
+      expect(body.results[2].pageId).toBe("page-b");
+    });
+
+    it("rejects empty batch", async () => {
+      const res = await postJson(app, "/api/citations/quotes/upsert-batch", {
+        items: [],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Get Quotes ----
+
+  describe("GET /api/citations/quotes", () => {
+    it("returns quotes for a page", async () => {
+      await upsertQuote(app, "my-page", 1, "Claim one");
+      await upsertQuote(app, "my-page", 2, "Claim two");
+      await upsertQuote(app, "other-page", 1, "Other claim");
+
+      const res = await app.request("/api/citations/quotes?page_id=my-page");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.quotes).toHaveLength(2);
+      expect(body.quotes[0].footnote).toBe(1);
+      expect(body.quotes[1].footnote).toBe(2);
+    });
+
+    it("returns empty array for unknown page", async () => {
+      const res = await app.request("/api/citations/quotes?page_id=nonexistent");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.quotes).toHaveLength(0);
+    });
+
+    it("requires page_id parameter", async () => {
+      const res = await app.request("/api/citations/quotes");
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Get All Quotes (paginated) ----
+
+  describe("GET /api/citations/quotes/all", () => {
+    it("returns paginated quotes", async () => {
+      for (let i = 1; i <= 5; i++) {
+        await upsertQuote(app, "page-x", i);
+      }
+
+      const res = await app.request("/api/citations/quotes/all?limit=3&offset=0");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.quotes).toHaveLength(3);
+      expect(body.total).toBe(5);
+      expect(body.limit).toBe(3);
+      expect(body.offset).toBe(0);
+    });
+  });
+
+  // ---- Mark Verified ----
+
+  describe("POST /api/citations/quotes/mark-verified", () => {
+    it("marks a quote as verified", async () => {
+      await upsertQuote(app, "verify-page", 1);
+
+      const res = await postJson(app, "/api/citations/quotes/mark-verified", {
+        pageId: "verify-page",
+        footnote: 1,
+        method: "text-match",
+        score: 0.95,
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updated).toBe(true);
+    });
+
+    it("returns 404 for nonexistent quote", async () => {
+      const res = await postJson(app, "/api/citations/quotes/mark-verified", {
+        pageId: "nonexistent",
+        footnote: 99,
+        method: "text-match",
+        score: 0.5,
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ---- Mark Accuracy ----
+
+  describe("POST /api/citations/quotes/mark-accuracy", () => {
+    it("marks accuracy verdict", async () => {
+      await upsertQuote(app, "acc-page", 1);
+
+      const res = await postJson(app, "/api/citations/quotes/mark-accuracy", {
+        pageId: "acc-page",
+        footnote: 1,
+        verdict: "accurate",
+        score: 0.9,
+        issues: null,
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updated).toBe(true);
+      expect(body.verdict).toBe("accurate");
+    });
+
+    it("rejects invalid verdict", async () => {
+      const res = await postJson(app, "/api/citations/quotes/mark-accuracy", {
+        pageId: "acc-page",
+        footnote: 1,
+        verdict: "maybe",
+        score: 0.5,
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Stats ----
+
+  describe("GET /api/citations/stats", () => {
+    it("returns aggregate statistics", async () => {
+      await upsertQuote(app, "stats-page", 1);
+      await upsertQuote(app, "stats-page", 2);
+
+      const res = await app.request("/api/citations/stats");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.totalQuotes).toBe(2);
+      expect(body.totalPages).toBe(1);
+      expect(body.verified).toBe(0);
+      expect(body.unverified).toBe(2);
+    });
+  });
+
+  // ---- Page Stats ----
+
+  describe("GET /api/citations/page-stats", () => {
+    it("returns per-page statistics", async () => {
+      await upsertQuote(app, "page-a", 1);
+      await upsertQuote(app, "page-a", 2);
+      await upsertQuote(app, "page-b", 1);
+
+      const res = await app.request("/api/citations/page-stats");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pages).toHaveLength(2);
+      expect(body.pages[0].pageId).toBe("page-a");
+      expect(body.pages[0].total).toBe(2);
+      expect(body.pages[1].pageId).toBe("page-b");
+      expect(body.pages[1].total).toBe(1);
+    });
+  });
+
+  // ---- Accuracy Summary ----
+
+  describe("GET /api/citations/accuracy-summary", () => {
+    it("returns pages with accuracy data", async () => {
+      await upsertQuote(app, "acc-page", 1);
+      await upsertQuote(app, "acc-page", 2);
+      await upsertQuote(app, "no-acc-page", 1);
+
+      // Mark accuracy on one page
+      await postJson(app, "/api/citations/quotes/mark-accuracy", {
+        pageId: "acc-page", footnote: 1, verdict: "accurate", score: 0.9,
+      });
+      await postJson(app, "/api/citations/quotes/mark-accuracy", {
+        pageId: "acc-page", footnote: 2, verdict: "inaccurate", score: 0.3,
+      });
+
+      const res = await app.request("/api/citations/accuracy-summary");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pages).toHaveLength(1);
+      expect(body.pages[0].pageId).toBe("acc-page");
+      expect(body.pages[0].accurate).toBe(1);
+      expect(body.pages[0].inaccurate).toBe(1);
+    });
+  });
+
+  // ---- Broken Quotes ----
+
+  describe("GET /api/citations/broken", () => {
+    it("returns verified quotes with low scores", async () => {
+      await upsertQuote(app, "broken-page", 1);
+      await upsertQuote(app, "broken-page", 2);
+
+      // Mark one as verified with low score
+      await postJson(app, "/api/citations/quotes/mark-verified", {
+        pageId: "broken-page", footnote: 1, method: "text-match", score: 0.2,
+      });
+      // Mark one as verified with high score
+      await postJson(app, "/api/citations/quotes/mark-verified", {
+        pageId: "broken-page", footnote: 2, method: "text-match", score: 0.9,
+      });
+
+      const res = await app.request("/api/citations/broken");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.broken).toHaveLength(1);
+      expect(body.broken[0].footnote).toBe(1);
+      expect(body.broken[0].verificationScore).toBe(0.2);
+    });
+  });
+
+  // ---- Content Upsert ----
+
+  describe("POST /api/citations/content/upsert", () => {
+    it("creates content entry", async () => {
+      const res = await postJson(app, "/api/citations/content/upsert", {
+        url: "https://example.com/article",
+        pageId: "test-page",
+        footnote: 1,
+        fetchedAt: "2025-01-01T00:00:00Z",
+        httpStatus: 200,
+        contentType: "text/html",
+        pageTitle: "Test Article",
+        fullTextPreview: "Some content...",
+        contentLength: 1234,
+        contentHash: "abc123",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.url).toBe("https://example.com/article");
+      expect(body.pageId).toBe("test-page");
+    });
+
+    it("rejects missing url", async () => {
+      const res = await postJson(app, "/api/citations/content/upsert", {
+        pageId: "test-page",
+        footnote: 1,
+        fetchedAt: "2025-01-01T00:00:00Z",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Content Get ----
+
+  describe("GET /api/citations/content", () => {
+    it("returns content for a URL", async () => {
+      await postJson(app, "/api/citations/content/upsert", {
+        url: "https://example.com/article",
+        pageId: "test-page",
+        footnote: 1,
+        fetchedAt: "2025-01-01T00:00:00Z",
+        httpStatus: 200,
+        pageTitle: "Test Article",
+      });
+
+      const res = await app.request(
+        "/api/citations/content?url=https://example.com/article"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.url).toBe("https://example.com/article");
+      expect(body.pageTitle).toBe("Test Article");
+      expect(body.httpStatus).toBe(200);
+    });
+
+    it("returns 404 for unknown URL", async () => {
+      const res = await app.request(
+        "/api/citations/content?url=https://example.com/unknown"
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("requires url parameter", async () => {
+      const res = await app.request("/api/citations/content");
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Bearer auth ----
+
+  describe("Bearer auth for citation routes", () => {
+    it("rejects unauthenticated requests when API key is set", async () => {
+      process.env.LONGTERMWIKI_SERVER_API_KEY = "test-key";
+      const authedApp = createApp();
+
+      const res = await authedApp.request("/api/citations/stats");
+      expect(res.status).toBe(401);
+
+      delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    });
+
+    it("accepts requests with correct token", async () => {
+      process.env.LONGTERMWIKI_SERVER_API_KEY = "test-key";
+      const authedApp = createApp();
+
+      const res = await authedApp.request("/api/citations/stats", {
+        headers: { Authorization: "Bearer test-key" },
+      });
+      expect(res.status).toBe(200);
+
+      delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    });
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { bearerAuth } from "hono/bearer-auth";
 import { healthRoute } from "./routes/health.js";
 import { idsRoute } from "./routes/ids.js";
+import { citationsRoute } from "./routes/citations.js";
 
 export function createApp() {
   const app = new Hono();
@@ -34,6 +35,7 @@ export function createApp() {
   }
 
   app.route("/api/ids", idsRoute);
+  app.route("/api/citations", citationsRoute);
 
   return app;
 }

--- a/apps/wiki-server/src/db.ts
+++ b/apps/wiki-server/src/db.ts
@@ -55,6 +55,62 @@ export async function initDb() {
     END
     $$
   `;
+
+  // Citation quotes — one record per (page_id, footnote)
+  await db`
+    CREATE TABLE IF NOT EXISTS citation_quotes (
+      id              BIGSERIAL PRIMARY KEY,
+      page_id         TEXT NOT NULL,
+      footnote        INTEGER NOT NULL,
+      url             TEXT,
+      resource_id     TEXT,
+      claim_text      TEXT NOT NULL,
+      claim_context   TEXT,
+      source_quote    TEXT,
+      source_location TEXT,
+      quote_verified  BOOLEAN NOT NULL DEFAULT false,
+      verification_method TEXT,
+      verification_score  REAL,
+      verified_at     TIMESTAMPTZ,
+      source_title    TEXT,
+      source_type     TEXT,
+      extraction_model TEXT,
+      accuracy_verdict TEXT,
+      accuracy_issues  TEXT,
+      accuracy_score   REAL,
+      accuracy_checked_at TIMESTAMPTZ,
+      accuracy_supporting_quotes TEXT,
+      verification_difficulty TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE(page_id, footnote)
+    )
+  `;
+
+  await db`CREATE INDEX IF NOT EXISTS idx_cq_page_id ON citation_quotes(page_id)`;
+  await db`CREATE INDEX IF NOT EXISTS idx_cq_url ON citation_quotes(url)`;
+  await db`CREATE INDEX IF NOT EXISTS idx_cq_verified ON citation_quotes(quote_verified)`;
+  await db`CREATE INDEX IF NOT EXISTS idx_cq_accuracy ON citation_quotes(accuracy_verdict)`;
+
+  // Citation content — cached source text, keyed by URL
+  await db`
+    CREATE TABLE IF NOT EXISTS citation_content (
+      url              TEXT PRIMARY KEY,
+      page_id          TEXT NOT NULL,
+      footnote         INTEGER NOT NULL,
+      fetched_at       TIMESTAMPTZ NOT NULL,
+      http_status      INTEGER,
+      content_type     TEXT,
+      page_title       TEXT,
+      full_text_preview TEXT,
+      content_length   INTEGER,
+      content_hash     TEXT,
+      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await db`CREATE INDEX IF NOT EXISTS idx_cc_page_id ON citation_content(page_id)`;
 }
 
 export async function closeDb() {

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -1,0 +1,478 @@
+import { Hono, type Context } from "hono";
+import { z } from "zod";
+import { getDb, type SqlQuery } from "../db.js";
+
+export const citationsRoute = new Hono();
+
+// ---- Constants ----
+
+const BROKEN_SCORE_THRESHOLD = 0.5;
+const MAX_BATCH_SIZE = 100;
+const MAX_PAGE_SIZE = 1000;
+const MAX_PREVIEW_LENGTH = 50 * 1024; // 50KB
+
+// ---- Schemas ----
+
+const UpsertQuoteSchema = z.object({
+  pageId: z.string().min(1).max(200),
+  footnote: z.number().int().min(0),
+  url: z.string().max(2000).nullable().optional(),
+  resourceId: z.string().max(200).nullable().optional(),
+  claimText: z.string().min(1).max(10000),
+  claimContext: z.string().max(10000).nullable().optional(),
+  sourceQuote: z.string().max(10000).nullable().optional(),
+  sourceLocation: z.string().max(1000).nullable().optional(),
+  quoteVerified: z.boolean().optional(),
+  verificationMethod: z.string().max(200).nullable().optional(),
+  verificationScore: z.number().min(0).max(1).nullable().optional(),
+  sourceTitle: z.string().max(1000).nullable().optional(),
+  sourceType: z.string().max(100).nullable().optional(),
+  extractionModel: z.string().max(200).nullable().optional(),
+});
+
+type UpsertQuoteData = z.infer<typeof UpsertQuoteSchema>;
+
+const UpsertBatchSchema = z.object({
+  items: z.array(UpsertQuoteSchema).min(1).max(MAX_BATCH_SIZE),
+});
+
+const MarkVerifiedSchema = z.object({
+  pageId: z.string().min(1).max(200),
+  footnote: z.number().int().min(0),
+  method: z.string().min(1).max(200),
+  score: z.number().min(0).max(1),
+});
+
+const MarkAccuracySchema = z.object({
+  pageId: z.string().min(1).max(200),
+  footnote: z.number().int().min(0),
+  verdict: z.enum(["accurate", "inaccurate", "unsupported"]),
+  score: z.number().min(0).max(1),
+  issues: z.string().max(10000).nullable().optional(),
+  supportingQuotes: z.string().max(10000).nullable().optional(),
+  verificationDifficulty: z.enum(["easy", "moderate", "hard"]).nullable().optional(),
+});
+
+const UpsertContentSchema = z.object({
+  url: z.string().min(1).max(2000),
+  pageId: z.string().min(1).max(200),
+  footnote: z.number().int().min(0),
+  fetchedAt: z.string().datetime(),
+  httpStatus: z.number().int().nullable().optional(),
+  contentType: z.string().max(200).nullable().optional(),
+  pageTitle: z.string().max(1000).nullable().optional(),
+  fullTextPreview: z.string().max(MAX_PREVIEW_LENGTH).nullable().optional(),
+  contentLength: z.number().int().nullable().optional(),
+  contentHash: z.string().max(64).nullable().optional(),
+});
+
+const PaginationQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ---- Helpers ----
+
+function parseJsonBody(c: Context) {
+  return c.req.json().catch(() => null);
+}
+
+function validationError(c: Context, message: string) {
+  return c.json({ error: "validation_error", message }, 400);
+}
+
+/** Shared upsert SQL for single and batch quote operations. */
+function upsertQuoteSql(db: { (s: TemplateStringsArray, ...v: unknown[]): unknown }, d: UpsertQuoteData) {
+  return db`
+    INSERT INTO citation_quotes (
+      page_id, footnote, url, resource_id, claim_text, claim_context,
+      source_quote, source_location, quote_verified, verification_method,
+      verification_score, source_title, source_type, extraction_model
+    ) VALUES (
+      ${d.pageId}, ${d.footnote}, ${d.url ?? null}, ${d.resourceId ?? null},
+      ${d.claimText}, ${d.claimContext ?? null}, ${d.sourceQuote ?? null},
+      ${d.sourceLocation ?? null}, ${d.quoteVerified ?? false},
+      ${d.verificationMethod ?? null}, ${d.verificationScore ?? null},
+      ${d.sourceTitle ?? null}, ${d.sourceType ?? null}, ${d.extractionModel ?? null}
+    )
+    ON CONFLICT (page_id, footnote) DO UPDATE SET
+      url = EXCLUDED.url,
+      resource_id = EXCLUDED.resource_id,
+      claim_text = EXCLUDED.claim_text,
+      claim_context = EXCLUDED.claim_context,
+      source_quote = EXCLUDED.source_quote,
+      source_location = EXCLUDED.source_location,
+      quote_verified = EXCLUDED.quote_verified,
+      verification_method = EXCLUDED.verification_method,
+      verification_score = EXCLUDED.verification_score,
+      source_title = EXCLUDED.source_title,
+      source_type = EXCLUDED.source_type,
+      extraction_model = EXCLUDED.extraction_model,
+      updated_at = NOW()
+    RETURNING id, page_id, footnote, created_at, updated_at
+  `;
+}
+
+// ---- POST /quotes/upsert ----
+
+citationsRoute.post("/quotes/upsert", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return c.json({ error: "invalid_json", message: "Request body must be valid JSON" }, 400);
+
+  const parsed = UpsertQuoteSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const db = getDb();
+  const rows = await upsertQuoteSql(db, parsed.data) as any[];
+
+  const row = rows[0];
+  return c.json({
+    id: row.id,
+    pageId: row.page_id,
+    footnote: row.footnote,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }, 200);
+});
+
+// ---- POST /quotes/upsert-batch ----
+
+citationsRoute.post("/quotes/upsert-batch", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return c.json({ error: "invalid_json", message: "Request body must be valid JSON" }, 400);
+
+  const parsed = UpsertBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDb();
+  const results: Array<{ id: number; pageId: string; footnote: number }> = [];
+
+  await db.begin(async (tx) => {
+    const q = tx as unknown as SqlQuery;
+    for (const d of items) {
+      const rows = await upsertQuoteSql(q as any, d) as any[];
+      results.push({ id: rows[0].id, pageId: rows[0].page_id, footnote: rows[0].footnote });
+    }
+  });
+
+  return c.json({ results });
+});
+
+// ---- GET /quotes?page_id=X ----
+
+citationsRoute.get("/quotes", async (c) => {
+  const pageId = c.req.query("page_id");
+  if (!pageId) return validationError(c, "page_id query parameter is required");
+
+  const db = getDb();
+  const rows = await db`
+    SELECT * FROM citation_quotes
+    WHERE page_id = ${pageId}
+    ORDER BY footnote
+  `;
+
+  return c.json({ quotes: rows.map(formatQuoteRow) });
+});
+
+// ---- GET /quotes/all (paginated) ----
+
+citationsRoute.get("/quotes/all", async (c) => {
+  const parsed = PaginationQuery.safeParse(c.req.query());
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { limit, offset } = parsed.data;
+  const db = getDb();
+
+  const rows = await db`
+    SELECT * FROM citation_quotes
+    ORDER BY page_id, footnote
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+
+  const countResult = await db`SELECT COUNT(*) AS count FROM citation_quotes`;
+  const total = Number(countResult[0].count);
+
+  return c.json({
+    quotes: rows.map(formatQuoteRow),
+    total,
+    limit,
+    offset,
+  });
+});
+
+// ---- POST /quotes/mark-verified ----
+
+citationsRoute.post("/quotes/mark-verified", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return c.json({ error: "invalid_json", message: "Request body must be valid JSON" }, 400);
+
+  const parsed = MarkVerifiedSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { pageId, footnote, method, score } = parsed.data;
+  const db = getDb();
+
+  const rows = await db`
+    UPDATE citation_quotes
+    SET quote_verified = true,
+        verification_method = ${method},
+        verification_score = ${score},
+        verified_at = NOW(),
+        updated_at = NOW()
+    WHERE page_id = ${pageId} AND footnote = ${footnote}
+    RETURNING id, page_id, footnote
+  `;
+
+  if (rows.length === 0) {
+    return c.json({ error: "not_found", message: `No quote for page=${pageId} footnote=${footnote}` }, 404);
+  }
+
+  return c.json({ updated: true, pageId, footnote });
+});
+
+// ---- POST /quotes/mark-accuracy ----
+
+citationsRoute.post("/quotes/mark-accuracy", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return c.json({ error: "invalid_json", message: "Request body must be valid JSON" }, 400);
+
+  const parsed = MarkAccuracySchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { pageId, footnote, verdict, score, issues, supportingQuotes, verificationDifficulty } = parsed.data;
+  const db = getDb();
+
+  const rows = await db`
+    UPDATE citation_quotes
+    SET accuracy_verdict = ${verdict},
+        accuracy_score = ${score},
+        accuracy_issues = ${issues ?? null},
+        accuracy_supporting_quotes = ${supportingQuotes ?? null},
+        verification_difficulty = ${verificationDifficulty ?? null},
+        accuracy_checked_at = NOW(),
+        updated_at = NOW()
+    WHERE page_id = ${pageId} AND footnote = ${footnote}
+    RETURNING id, page_id, footnote
+  `;
+
+  if (rows.length === 0) {
+    return c.json({ error: "not_found", message: `No quote for page=${pageId} footnote=${footnote}` }, 404);
+  }
+
+  return c.json({ updated: true, pageId, footnote, verdict });
+});
+
+// ---- GET /stats ----
+
+citationsRoute.get("/stats", async (c) => {
+  const db = getDb();
+
+  const rows = await db`
+    SELECT
+      COUNT(*) AS total_quotes,
+      COUNT(CASE WHEN source_quote IS NOT NULL THEN 1 END) AS with_quotes,
+      COUNT(CASE WHEN quote_verified = true THEN 1 END) AS verified,
+      COUNT(CASE WHEN quote_verified = false OR quote_verified IS NULL THEN 1 END) AS unverified,
+      COUNT(DISTINCT page_id) AS total_pages,
+      AVG(CASE WHEN verification_score IS NOT NULL THEN verification_score END) AS average_score
+    FROM citation_quotes
+  `;
+
+  const r = rows[0];
+  return c.json({
+    totalQuotes: Number(r.total_quotes),
+    withQuotes: Number(r.with_quotes),
+    verified: Number(r.verified),
+    unverified: Number(r.unverified),
+    totalPages: Number(r.total_pages),
+    averageScore: r.average_score != null ? Number(r.average_score) : null,
+  });
+});
+
+// ---- GET /page-stats ----
+
+citationsRoute.get("/page-stats", async (c) => {
+  const db = getDb();
+
+  const rows = await db`
+    SELECT
+      page_id,
+      COUNT(*) AS total,
+      COUNT(CASE WHEN source_quote IS NOT NULL THEN 1 END) AS with_quotes,
+      COUNT(CASE WHEN quote_verified = true THEN 1 END) AS verified,
+      AVG(CASE WHEN verification_score IS NOT NULL THEN verification_score END) AS avg_score,
+      COUNT(CASE WHEN accuracy_verdict IS NOT NULL THEN 1 END) AS accuracy_checked,
+      COUNT(CASE WHEN accuracy_verdict = 'accurate' THEN 1 END) AS accurate,
+      COUNT(CASE WHEN accuracy_verdict = 'inaccurate' THEN 1 END) AS inaccurate
+    FROM citation_quotes
+    GROUP BY page_id
+    ORDER BY page_id
+  `;
+
+  return c.json({
+    pages: rows.map((r) => ({
+      pageId: r.page_id,
+      total: Number(r.total),
+      withQuotes: Number(r.with_quotes),
+      verified: Number(r.verified),
+      avgScore: r.avg_score != null ? Number(r.avg_score) : null,
+      accuracyChecked: Number(r.accuracy_checked),
+      accurate: Number(r.accurate),
+      inaccurate: Number(r.inaccurate),
+    })),
+  });
+});
+
+// ---- GET /accuracy-summary ----
+
+citationsRoute.get("/accuracy-summary", async (c) => {
+  const db = getDb();
+
+  const rows = await db`
+    SELECT
+      page_id,
+      COUNT(CASE WHEN accuracy_verdict IS NOT NULL THEN 1 END) AS checked,
+      COUNT(CASE WHEN accuracy_verdict = 'accurate' THEN 1 END) AS accurate,
+      COUNT(CASE WHEN accuracy_verdict = 'inaccurate' THEN 1 END) AS inaccurate,
+      COUNT(CASE WHEN accuracy_verdict = 'unsupported' THEN 1 END) AS unsupported
+    FROM citation_quotes
+    GROUP BY page_id
+    HAVING COUNT(CASE WHEN accuracy_verdict IS NOT NULL THEN 1 END) > 0
+    ORDER BY page_id
+  `;
+
+  return c.json({
+    pages: rows.map((r) => ({
+      pageId: r.page_id,
+      checked: Number(r.checked),
+      accurate: Number(r.accurate),
+      inaccurate: Number(r.inaccurate),
+      unsupported: Number(r.unsupported),
+    })),
+  });
+});
+
+// ---- GET /broken ----
+
+citationsRoute.get("/broken", async (c) => {
+  const db = getDb();
+
+  const rows = await db`
+    SELECT page_id, footnote, url, claim_text, verification_score
+    FROM citation_quotes
+    WHERE quote_verified = true AND verification_score IS NOT NULL AND verification_score < ${BROKEN_SCORE_THRESHOLD}
+    ORDER BY verification_score ASC, page_id, footnote
+  `;
+
+  return c.json({
+    broken: rows.map((r) => ({
+      pageId: r.page_id,
+      footnote: r.footnote,
+      url: r.url,
+      claimText: r.claim_text,
+      verificationScore: r.verification_score,
+    })),
+  });
+});
+
+// ---- POST /content/upsert ----
+
+citationsRoute.post("/content/upsert", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return c.json({ error: "invalid_json", message: "Request body must be valid JSON" }, 400);
+
+  const parsed = UpsertContentSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const d = parsed.data;
+  const db = getDb();
+
+  await db`
+    INSERT INTO citation_content (
+      url, page_id, footnote, fetched_at, http_status, content_type,
+      page_title, full_text_preview, content_length, content_hash
+    ) VALUES (
+      ${d.url}, ${d.pageId}, ${d.footnote}, ${d.fetchedAt},
+      ${d.httpStatus ?? null}, ${d.contentType ?? null}, ${d.pageTitle ?? null},
+      ${d.fullTextPreview ?? null}, ${d.contentLength ?? null}, ${d.contentHash ?? null}
+    )
+    ON CONFLICT (url) DO UPDATE SET
+      page_id = EXCLUDED.page_id,
+      footnote = EXCLUDED.footnote,
+      fetched_at = EXCLUDED.fetched_at,
+      http_status = EXCLUDED.http_status,
+      content_type = EXCLUDED.content_type,
+      page_title = EXCLUDED.page_title,
+      full_text_preview = EXCLUDED.full_text_preview,
+      content_length = EXCLUDED.content_length,
+      content_hash = EXCLUDED.content_hash,
+      updated_at = NOW()
+    RETURNING url, page_id, footnote
+  `;
+
+  return c.json({ url: d.url, pageId: d.pageId, footnote: d.footnote });
+});
+
+// ---- GET /content?url=X ----
+
+citationsRoute.get("/content", async (c) => {
+  const url = c.req.query("url");
+  if (!url) return validationError(c, "url query parameter is required");
+
+  const db = getDb();
+  const rows = await db`
+    SELECT * FROM citation_content WHERE url = ${url}
+  `;
+
+  if (rows.length === 0) {
+    return c.json({ error: "not_found", message: `No content for url: ${url}` }, 404);
+  }
+
+  const r = rows[0];
+  return c.json({
+    url: r.url,
+    pageId: r.page_id,
+    footnote: r.footnote,
+    fetchedAt: r.fetched_at,
+    httpStatus: r.http_status,
+    contentType: r.content_type,
+    pageTitle: r.page_title,
+    fullTextPreview: r.full_text_preview,
+    contentLength: r.content_length,
+    contentHash: r.content_hash,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  });
+});
+
+// ---- Row formatter ----
+
+function formatQuoteRow(r: Record<string, unknown>) {
+  return {
+    id: r.id,
+    pageId: r.page_id,
+    footnote: r.footnote,
+    url: r.url,
+    resourceId: r.resource_id,
+    claimText: r.claim_text,
+    claimContext: r.claim_context,
+    sourceQuote: r.source_quote,
+    sourceLocation: r.source_location,
+    quoteVerified: r.quote_verified,
+    verificationMethod: r.verification_method,
+    verificationScore: r.verification_score,
+    verifiedAt: r.verified_at,
+    sourceTitle: r.source_title,
+    sourceType: r.source_type,
+    extractionModel: r.extraction_model,
+    accuracyVerdict: r.accuracy_verdict,
+    accuracyIssues: r.accuracy_issues,
+    accuracyScore: r.accuracy_score,
+    accuracyCheckedAt: r.accuracy_checked_at,
+    accuracySupportingQuotes: r.accuracy_supporting_quotes,
+    verificationDifficulty: r.verification_difficulty,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}


### PR DESCRIPTION
## Summary

Extends the wiki-server (from #415) with Postgres-backed citation storage. This is Phase 1 of the [citation data migration plan](/.claude/plans/drifting-floating-spindle.md) — server-side tables and endpoints only, no client changes yet.

- **2 new Postgres tables**: `citation_quotes` (one record per page_id+footnote) and `citation_content` (URL-keyed content cache with 50KB text preview)
- **12 REST endpoints** under `/api/citations/` for CRUD, verification, accuracy marking, and analytics
- **25 integration tests** following the existing mock SQL pattern from `ids.test.ts`

### Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | /quotes/upsert | Create/update a quote |
| POST | /quotes/upsert-batch | Batch upsert (up to 100) |
| GET | /quotes?page_id=X | Get quotes for a page |
| GET | /quotes/all | Paginated list of all quotes |
| POST | /quotes/mark-verified | Mark quote as verified |
| POST | /quotes/mark-accuracy | Set accuracy verdict |
| GET | /stats | Aggregate statistics |
| GET | /page-stats | Per-page statistics |
| GET | /accuracy-summary | Pages with accuracy data |
| GET | /broken | Verified quotes with low scores |
| POST | /content/upsert | Cache source content |
| GET | /content?url=X | Get cached content |

### Review findings addressed
- Extracted `upsertQuoteSql` helper to eliminate SQL duplication between single/batch upsert
- Added `z.string().datetime()` validation on `fetchedAt` to prevent Postgres 500s
- Added `updated_at` column to `citation_content` table
- Extracted named constants for thresholds (`BROKEN_SCORE_THRESHOLD`, `MAX_BATCH_SIZE`, etc.)
- Fixed `validationError` helper typing (proper Hono `Context` type)

### Next phases (not in this PR)
- **Phase 2**: Citation client + DAO wrapper (server-first, SQLite fallback)
- **Phase 3**: Migrate 7 consumer files to use new DAO
- **Phase 4**: Seed script + CI integration

## Test plan
- [x] 25 new citation endpoint tests pass
- [x] 16 existing ID endpoint tests still pass (41 total)
- [x] Full repo test suite passes (960 tests)
- [x] All 8 gate checks pass
- [x] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)