### PR TITLE
feat: consolidate citation accuracy into PostgreSQL

### DIFF
--- a/apps/wiki-server/drizzle/0003_wild_cardiac.sql
+++ b/apps/wiki-server/drizzle/0003_wild_cardiac.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "citation_accuracy_snapshots" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"page_id" text NOT NULL,
+	"total_citations" integer NOT NULL,
+	"checked_citations" integer NOT NULL,
+	"accurate_count" integer DEFAULT 0 NOT NULL,
+	"minor_issues_count" integer DEFAULT 0 NOT NULL,
+	"inaccurate_count" integer DEFAULT 0 NOT NULL,
+	"unsupported_count" integer DEFAULT 0 NOT NULL,
+	"not_verifiable_count" integer DEFAULT 0 NOT NULL,
+	"average_score" real,
+	"snapshot_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_cas_page_id" ON "citation_accuracy_snapshots" USING btree ("page_id");--> statement-breakpoint
+CREATE INDEX "idx_cas_snapshot_at" ON "citation_accuracy_snapshots" USING btree ("snapshot_at");

--- a/apps/wiki-server/drizzle/meta/0003_snapshot.json
+++ b/apps/wiki-server/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,842 @@
+{
+  "id": "e3d6b7dd-4c54-4baf-8252-eaee69bb7d50",
+  "prevId": "b01faf88-7b2b-45f5-8f46-e7d548cc171b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.citation_accuracy_snapshots": {
+      "name": "citation_accuracy_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_citations": {
+          "name": "total_citations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_citations": {
+          "name": "checked_citations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accurate_count": {
+          "name": "accurate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "minor_issues_count": {
+          "name": "minor_issues_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inaccurate_count": {
+          "name": "inaccurate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsupported_count": {
+          "name": "unsupported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "not_verifiable_count": {
+          "name": "not_verifiable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cas_page_id": {
+          "name": "idx_cas_page_id",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cas_snapshot_at": {
+          "name": "idx_cas_snapshot_at",
+          "columns": [
+            {
+              "expression": "snapshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.citation_content": {
+      "name": "citation_content",
+      "schema": "",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footnote": {
+          "name": "footnote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text_preview": {
+          "name": "full_text_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cc_page_id": {
+          "name": "idx_cc_page_id",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.citation_quotes": {
+      "name": "citation_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footnote": {
+          "name": "footnote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_context": {
+          "name": "claim_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_quote": {
+          "name": "source_quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_verified": {
+          "name": "quote_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_method": {
+          "name": "verification_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_score": {
+          "name": "verification_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_title": {
+          "name": "source_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_verdict": {
+          "name": "accuracy_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_issues": {
+          "name": "accuracy_issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_score": {
+          "name": "accuracy_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_checked_at": {
+          "name": "accuracy_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy_supporting_quotes": {
+          "name": "accuracy_supporting_quotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_difficulty": {
+          "name": "verification_difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "citation_quotes_page_id_footnote_unique": {
+          "name": "citation_quotes_page_id_footnote_unique",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "footnote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cq_page_id": {
+          "name": "idx_cq_page_id",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cq_url": {
+          "name": "idx_cq_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cq_verified": {
+          "name": "idx_cq_verified",
+          "columns": [
+            {
+              "expression": "quote_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cq_accuracy": {
+          "name": "idx_cq_accuracy",
+          "columns": [
+            {
+              "expression": "accuracy_verdict",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_logs": {
+      "name": "edit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_el_page_id": {
+          "name": "idx_el_page_id",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_el_date": {
+          "name": "idx_el_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_el_tool": {
+          "name": "idx_el_tool",
+          "columns": [
+            {
+              "expression": "tool",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_ids": {
+      "name": "entity_ids",
+      "schema": "",
+      "columns": {
+        "numeric_id": {
+          "name": "numeric_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_ids_slug_unique": {
+          "name": "entity_ids_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_pages": {
+      "name": "wiki_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "numeric_id": {
+          "name": "numeric_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_summary": {
+          "name": "llm_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_importance": {
+          "name": "reader_importance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallucination_risk_level": {
+          "name": "hallucination_risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hallucination_risk_score": {
+          "name": "hallucination_risk_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_plaintext": {
+          "name": "content_plaintext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wp_numeric_id": {
+          "name": "idx_wp_numeric_id",
+          "columns": [
+            {
+              "expression": "numeric_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wp_category": {
+          "name": "idx_wp_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wp_entity_type": {
+          "name": "idx_wp_entity_type",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wp_reader_importance": {
+          "name": "idx_wp_reader_importance",
+          "columns": [
+            {
+              "expression": "reader_importance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.entity_id_seq": {
+      "name": "entity_id_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771643173953,
       "tag": "0002_yellow_sinister_six",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1771647151474,
+      "tag": "0003_wild_cardiac",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -133,6 +133,29 @@ export const citationContent = pgTable(
   (table) => [index("idx_cc_page_id").on(table.pageId)]
 );
 
+export const citationAccuracySnapshots = pgTable(
+  "citation_accuracy_snapshots",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    pageId: text("page_id").notNull(),
+    totalCitations: integer("total_citations").notNull(),
+    checkedCitations: integer("checked_citations").notNull(),
+    accurateCount: integer("accurate_count").notNull().default(0),
+    minorIssuesCount: integer("minor_issues_count").notNull().default(0),
+    inaccurateCount: integer("inaccurate_count").notNull().default(0),
+    unsupportedCount: integer("unsupported_count").notNull().default(0),
+    notVerifiableCount: integer("not_verifiable_count").notNull().default(0),
+    averageScore: real("average_score"),
+    snapshotAt: timestamp("snapshot_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cas_page_id").on(table.pageId),
+    index("idx_cas_snapshot_at").on(table.snapshotAt),
+  ]
+);
+
 export const editLogs = pgTable(
   "edit_logs",
   {

--- a/crux/citations/migrate-accuracy-to-db.ts
+++ b/crux/citations/migrate-accuracy-to-db.ts
@@ -1,0 +1,165 @@
+/**
+ * Migrate Citation Accuracy Data to PostgreSQL
+ *
+ * Reads accuracy data from the local SQLite knowledge.db and pushes it
+ * to the wiki-server PostgreSQL database via the API.
+ *
+ * Usage:
+ *   pnpm crux citations migrate-accuracy       # Run migration
+ *   pnpm crux citations migrate-accuracy --dry-run  # Preview without writing
+ *
+ * Prerequisites:
+ *   - LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY must be set
+ *   - SQLite knowledge.db must exist with accuracy data
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { citationQuotes, PROJECT_ROOT } from '../lib/knowledge-db.ts';
+import {
+  isServerAvailable,
+  markCitationAccuracyBatch,
+  createAccuracySnapshot,
+  type MarkAccuracyItem,
+} from '../lib/wiki-server-client.ts';
+import { getColors } from '../lib/output.ts';
+import { parseCliArgs } from '../lib/cli.ts';
+
+const BATCH_SIZE = 50;
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const colors = getColors(false);
+
+  console.log(`\n${colors.bold}${colors.blue}Migrate Citation Accuracy → PostgreSQL${colors.reset}\n`);
+
+  if (dryRun) {
+    console.log(`  ${colors.yellow}DRY RUN — no data will be written${colors.reset}\n`);
+  }
+
+  // Check SQLite DB exists
+  const dbPath = join(PROJECT_ROOT, '.cache', 'knowledge.db');
+  if (!existsSync(dbPath)) {
+    console.log(`${colors.red}No SQLite knowledge.db found at ${dbPath}${colors.reset}`);
+    console.log('Run citation accuracy checks first to populate the local DB.');
+    process.exit(1);
+  }
+
+  // Check server availability
+  const serverAvailable = await isServerAvailable();
+  if (!serverAvailable) {
+    console.log(`${colors.red}Wiki server not available.${colors.reset}`);
+    console.log('Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.');
+    process.exit(1);
+  }
+
+  // Read all accuracy data from SQLite
+  const allQuotes = citationQuotes.getAll();
+  const withAccuracy = allQuotes.filter(q => q.accuracy_verdict !== null);
+
+  console.log(`  SQLite quotes: ${allQuotes.length}`);
+  console.log(`  With accuracy data: ${withAccuracy.length}`);
+
+  if (withAccuracy.length === 0) {
+    console.log(`\n${colors.yellow}No accuracy data to migrate.${colors.reset}`);
+    process.exit(0);
+  }
+
+  // Map verdicts to valid API values
+  const validVerdicts = new Set(['accurate', 'inaccurate', 'unsupported', 'minor_issues', 'not_verifiable']);
+
+  // Build batch items
+  const items: MarkAccuracyItem[] = [];
+  let skipped = 0;
+
+  for (const q of withAccuracy) {
+    const verdict = q.accuracy_verdict;
+    if (!verdict || !validVerdicts.has(verdict)) {
+      skipped++;
+      continue;
+    }
+
+    items.push({
+      pageId: q.page_id,
+      footnote: q.footnote,
+      verdict: verdict as MarkAccuracyItem['verdict'],
+      score: q.accuracy_score ?? 0,
+      issues: q.accuracy_issues || null,
+      supportingQuotes: q.accuracy_supporting_quotes || null,
+      verificationDifficulty: (['easy', 'moderate', 'hard'].includes(q.verification_difficulty || '')
+        ? q.verification_difficulty as 'easy' | 'moderate' | 'hard'
+        : null),
+    });
+  }
+
+  if (skipped > 0) {
+    console.log(`  Skipped (invalid verdict): ${skipped}`);
+  }
+
+  console.log(`  Items to migrate: ${items.length}`);
+
+  if (dryRun) {
+    // Show breakdown by verdict
+    const byVerdict: Record<string, number> = {};
+    for (const item of items) {
+      byVerdict[item.verdict] = (byVerdict[item.verdict] || 0) + 1;
+    }
+    console.log('\n  Verdict breakdown:');
+    for (const [verdict, count] of Object.entries(byVerdict).sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${verdict}: ${count}`);
+    }
+
+    // Show page count
+    const pages = new Set(items.map(i => i.pageId));
+    console.log(`\n  Pages: ${pages.size}`);
+    console.log(`\n${colors.green}Dry run complete. Use without --dry-run to migrate.${colors.reset}\n`);
+    return;
+  }
+
+  // Send in batches
+  let migrated = 0;
+  let failed = 0;
+
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const batch = items.slice(i, i + BATCH_SIZE);
+    const result = await markCitationAccuracyBatch(batch);
+
+    if (result) {
+      migrated += result.updated;
+    } else {
+      failed += batch.length;
+      console.log(`  ${colors.red}Batch ${Math.floor(i / BATCH_SIZE) + 1} failed${colors.reset}`);
+    }
+
+    // Progress indicator
+    const pct = Math.round(((i + batch.length) / items.length) * 100);
+    process.stdout.write(`\r  Progress: ${pct}% (${migrated} migrated, ${failed} failed)`);
+  }
+  console.log('');
+
+  // Create an accuracy snapshot
+  console.log(`\n  Creating accuracy snapshot...`);
+  const snapshot = await createAccuracySnapshot();
+  if (snapshot) {
+    console.log(`  ${colors.green}Snapshot created for ${snapshot.snapshotCount} pages${colors.reset}`);
+  } else {
+    console.log(`  ${colors.yellow}Snapshot creation failed${colors.reset}`);
+  }
+
+  console.log(`\n${colors.bold}Migration complete:${colors.reset}`);
+  console.log(`  Migrated: ${colors.green}${migrated}${colors.reset}`);
+  if (failed > 0) {
+    console.log(`  Failed: ${colors.red}${failed}${colors.reset}`);
+  }
+  console.log('');
+}
+
+// Only run when executed directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Migration failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/commands/citations.ts
+++ b/crux/commands/citations.ts
@@ -66,7 +66,12 @@ const SCRIPTS = {
   'export-dashboard': {
     script: 'citations/export-dashboard.ts',
     description: 'Export accuracy data as YAML for the internal dashboard',
-    passthrough: ['json'],
+    passthrough: ['json', 'from-db'],
+  },
+  'migrate-accuracy': {
+    script: 'citations/migrate-accuracy-to-db.ts',
+    description: 'Migrate citation accuracy data from SQLite to PostgreSQL',
+    passthrough: ['dry-run'],
   },
   'fix-inaccuracies': {
     script: 'citations/fix-inaccuracies.ts',
@@ -123,6 +128,9 @@ Examples:
   crux citations normalize-footnotes --fix          Auto-fix to [Title](URL) format
   crux citations normalize-footnotes --fix <id>     Fix one page
   crux citations export-dashboard                  Export data for web dashboard
+  crux citations export-dashboard --from-db        Export from PostgreSQL instead of SQLite
+  crux citations migrate-accuracy                   Migrate accuracy data to PostgreSQL
+  crux citations migrate-accuracy --dry-run         Preview migration
   crux citations fix-inaccuracies                   Dry-run fix proposals for all flagged
   crux citations fix-inaccuracies --apply           Apply fixes to pages
   crux citations fix-inaccuracies <id>              Fix one page

--- a/crux/lib/wiki-server-client.ts
+++ b/crux/lib/wiki-server-client.ts
@@ -171,3 +171,120 @@ export async function getEditLogsForPage(
 export async function getEditLogStats(): Promise<StatsResult | null> {
   return apiRequest<StatsResult>('GET', '/api/edit-logs/stats');
 }
+
+// ---------------------------------------------------------------------------
+// Citation Accuracy API
+// ---------------------------------------------------------------------------
+
+export type AccuracyVerdict = 'accurate' | 'inaccurate' | 'unsupported' | 'minor_issues' | 'not_verifiable';
+
+export interface MarkAccuracyItem {
+  pageId: string;
+  footnote: number;
+  verdict: AccuracyVerdict;
+  score: number;
+  issues?: string | null;
+  supportingQuotes?: string | null;
+  verificationDifficulty?: 'easy' | 'moderate' | 'hard' | null;
+}
+
+interface MarkAccuracyResult {
+  updated: true;
+  pageId: string;
+  footnote: number;
+  verdict: string;
+}
+
+interface MarkAccuracyBatchResult {
+  updated: number;
+  results: Array<{ pageId: string; footnote: number; verdict: string }>;
+}
+
+interface SnapshotResult {
+  snapshotCount: number;
+  pages: string[];
+}
+
+export interface AccuracyDashboardData {
+  exportedAt: string;
+  summary: {
+    totalCitations: number;
+    checkedCitations: number;
+    accurateCitations: number;
+    inaccurateCitations: number;
+    unsupportedCitations: number;
+    minorIssueCitations: number;
+    uncheckedCitations: number;
+    averageScore: number | null;
+  };
+  verdictDistribution: Record<string, number>;
+  difficultyDistribution: Record<string, number>;
+  pages: Array<{
+    pageId: string;
+    totalCitations: number;
+    checked: number;
+    accurate: number;
+    inaccurate: number;
+    unsupported: number;
+    minorIssues: number;
+    accuracyRate: number | null;
+    avgScore: number | null;
+  }>;
+  flaggedCitations: Array<{
+    pageId: string;
+    footnote: number;
+    claimText: string;
+    sourceTitle: string | null;
+    url: string | null;
+    verdict: string;
+    score: number | null;
+    issues: string | null;
+    difficulty: string | null;
+    checkedAt: string | null;
+  }>;
+  domainAnalysis: Array<{
+    domain: string;
+    totalCitations: number;
+    checked: number;
+    accurate: number;
+    inaccurate: number;
+    unsupported: number;
+    inaccuracyRate: number | null;
+  }>;
+}
+
+/**
+ * Mark accuracy verdict for a single citation.
+ */
+export async function markCitationAccuracy(
+  item: MarkAccuracyItem,
+): Promise<MarkAccuracyResult | null> {
+  return apiRequest<MarkAccuracyResult>('POST', '/api/citations/quotes/mark-accuracy', item);
+}
+
+/**
+ * Mark accuracy verdicts for multiple citations in a single batch.
+ */
+export async function markCitationAccuracyBatch(
+  items: MarkAccuracyItem[],
+): Promise<MarkAccuracyBatchResult | null> {
+  return apiRequest<MarkAccuracyBatchResult>(
+    'POST',
+    '/api/citations/quotes/mark-accuracy-batch',
+    { items },
+  );
+}
+
+/**
+ * Create accuracy snapshots for all pages with accuracy data.
+ */
+export async function createAccuracySnapshot(): Promise<SnapshotResult | null> {
+  return apiRequest<SnapshotResult>('POST', '/api/citations/accuracy-snapshot', {});
+}
+
+/**
+ * Get accuracy dashboard data (replaces YAML export).
+ */
+export async function getAccuracyDashboard(): Promise<AccuracyDashboardData | null> {
+  return apiRequest<AccuracyDashboardData>('GET', '/api/citations/accuracy-dashboard');
+}


### PR DESCRIPTION
## Summary

Resolves #432 — makes the PostgreSQL `citation_quotes` accuracy fields the single source of truth and adds infrastructure for accuracy trend tracking.

### Changes

- **New `citation_accuracy_snapshots` table** + Drizzle migration (0003): stores point-in-time per-page accuracy summaries for trend analysis
- **New API endpoints**:
  - `POST /quotes/mark-accuracy-batch` — batch update accuracy verdicts (up to 100 at a time)
  - `POST /accuracy-snapshot` — create snapshots for all pages with accuracy data
  - `GET /accuracy-trends?page_id=X` — per-page or global accuracy trend queries from snapshots
  - `GET /accuracy-dashboard` — full dashboard data computed live from PostgreSQL (replaces YAML export as data source)
- **Extended verdict types**: `MarkAccuracySchema` now supports `minor_issues` and `not_verifiable` in addition to `accurate`/`inaccurate`/`unsupported`
- **Dual-write in `check-accuracy.ts`**: accuracy results now written to both SQLite (for local pipeline) and wiki-server PostgreSQL
- **`export-dashboard --from-db`**: new flag to export YAML dashboard data from PostgreSQL instead of SQLite
- **Dashboard page**: tries wiki-server API first (real-time data), falls back to YAML files on disk
- **Migration script** (`crux citations migrate-accuracy`): imports existing SQLite accuracy data into PostgreSQL, with `--dry-run` support
- **Wiki-server-client**: new methods for `markCitationAccuracy`, `markCitationAccuracyBatch`, `createAccuracySnapshot`, `getAccuracyDashboard`
- **Comprehensive tests**: 12 new test cases covering batch accuracy, snapshots, trends, and dashboard endpoints

### Migration path

1. Deploy the wiki-server with the new migration (0003)
2. Run `pnpm crux citations migrate-accuracy` to import existing SQLite data
3. Future `check-accuracy` runs will dual-write to both stores
4. YAML files remain as production fallback until the dashboard is fully API-driven

## Test plan

- [x] All 8 gate checks pass (build-data, tests, validations, typecheck)
- [x] All 77 wiki-server tests pass (33 citation tests including 12 new ones)
- [x] Drizzle migration generates correct SQL
- [ ] Verify CI passes after push
- [ ] After deployment, run `migrate-accuracy --dry-run` to validate data mapping

https://claude.ai/code/session_01LBjKLSrtHQEe2CpMRpZeG9