### PR TITLE
feat: discord bot — replace file-based search with wiki-server API

### DIFF
--- a/.github/workflows/discord-bot-docker.yml
+++ b/.github/workflows/discord-bot-docker.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "apps/discord-bot/**"
-      - "content/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/discord-bot-docker.yml"
   workflow_dispatch:

--- a/apps/discord-bot/.env.example
+++ b/apps/discord-bot/.env.example
@@ -4,10 +4,9 @@ DISCORD_TOKEN=your-discord-bot-token
 # Anthropic API key from https://console.anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
-# Absolute path to the longterm-wiki repo root (where content/docs/ lives)
-# Optional: auto-detected as three levels up from apps/discord-bot/src/ (repo root).
-# Only set this if running the bot from outside the repo.
-# WIKI_ROOT=/path/to/longterm-wiki
+# Wiki server API (required — bot fetches wiki content from this server)
+LONGTERMWIKI_SERVER_URL=https://wiki-server.k8s.quantifieduncertainty.org
+LONGTERMWIKI_SERVER_API_KEY=your-api-key
 
 # Public base URL for wiki pages (no trailing slash)
 WIKI_BASE_URL=https://www.longtermwiki.com

--- a/apps/discord-bot/Dockerfile
+++ b/apps/discord-bot/Dockerfile
@@ -12,12 +12,9 @@ COPY apps/discord-bot/package.json ./apps/discord-bot/
 # Install only discord-bot dependencies
 RUN pnpm install --frozen-lockfile --filter discord-bot
 
-# Copy bot source and wiki content (bot reads content/docs/ at runtime)
+# Copy bot source (bot reads wiki content from wiki-server API, not local files)
 COPY apps/discord-bot/ ./apps/discord-bot/
-COPY content/ ./content/
 
-# WIKI_ROOT defaults to three levels up from apps/discord-bot/src/ = /repo
-# Override via env var if needed
 ENV NODE_ENV=production
 
 WORKDIR /repo/apps/discord-bot

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
     "discord.js": "^14.16.3",
-    "dotenv": "^16.4.7"
+    "dotenv": "^16.4.7",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -1,13 +1,6 @@
-import { resolve } from "path";
-import { fileURLToPath } from "url";
+export const WIKI_SERVER_URL = process.env.LONGTERMWIKI_SERVER_URL ?? "";
 
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
-
-// Default WIKI_ROOT to the repo root (three levels up from apps/discord-bot/src/)
-export const WIKI_ROOT =
-  process.env.WIKI_ROOT ?? resolve(__dirname, "../../..");
-
-export const WIKI_CONTENT_PATH = `${WIKI_ROOT}/content/docs`;
+export const WIKI_SERVER_API_KEY = process.env.LONGTERMWIKI_SERVER_API_KEY ?? "";
 
 export const WIKI_BASE_URL =
   (process.env.WIKI_BASE_URL ?? "https://www.longtermwiki.com").replace(

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -19,6 +19,16 @@ if (!process.env.ANTHROPIC_API_KEY) {
   process.exit(1);
 }
 
+if (!process.env.LONGTERMWIKI_SERVER_URL) {
+  console.error("Missing LONGTERMWIKI_SERVER_URL in environment");
+  process.exit(1);
+}
+
+if (!process.env.LONGTERMWIKI_SERVER_API_KEY) {
+  console.error("Missing LONGTERMWIKI_SERVER_API_KEY in environment");
+  process.exit(1);
+}
+
 const RATE_LIMIT_MS = 30_000; // 30 second per-user cooldown
 const MAX_CONCURRENT_REQUESTS = 3; // global concurrency cap
 

--- a/apps/discord-bot/src/query.test.ts
+++ b/apps/discord-bot/src/query.test.ts
@@ -12,20 +12,14 @@ describe("buildPrompt", () => {
     expect(prompt).toContain('"What is AI safety?"');
   });
 
-  it("references the wiki content path", () => {
+  it("instructs to use search_wiki tool", () => {
     const prompt = buildPrompt("test question");
-    expect(prompt).toContain("/content/docs");
+    expect(prompt).toContain("search_wiki");
   });
 
-  it("instructs to use Grep to search .mdx files", () => {
-    const prompt = buildPrompt("test");
-    expect(prompt).toContain("Grep");
-    expect(prompt).toContain(".mdx");
-  });
-
-  it("instructs to use Read for relevant files", () => {
-    const prompt = buildPrompt("test");
-    expect(prompt).toContain("Read");
+  it("instructs to use get_page tool", () => {
+    const prompt = buildPrompt("test question");
+    expect(prompt).toContain("get_page");
   });
 
   it("includes the wiki base URL for link formatting", () => {
@@ -41,6 +35,20 @@ describe("buildPrompt", () => {
   it("includes fallback instruction for missing information", () => {
     const prompt = buildPrompt("test");
     expect(prompt).toContain("couldn't find information");
+  });
+
+  it("does not reference local file paths or .mdx files", () => {
+    const prompt = buildPrompt("test");
+    expect(prompt).not.toContain("/content/docs");
+    expect(prompt).not.toContain(".mdx");
+    expect(prompt).not.toContain("Grep");
+    expect(prompt).not.toContain("Read");
+  });
+
+  it("uses /wiki/ URL format (not /knowledge-base/)", () => {
+    const prompt = buildPrompt("test");
+    expect(prompt).toContain("/wiki/");
+    expect(prompt).not.toMatch(/knowledge-base\/\{id\}/);
   });
 
   it("produces consistent output for the same input", () => {

--- a/apps/discord-bot/src/test-suite.ts
+++ b/apps/discord-bot/src/test-suite.ts
@@ -2,6 +2,8 @@ import "dotenv/config";
 import { runQuery } from "./query.js";
 import { WIKI_BASE_URL } from "./config.js";
 
+// Requires LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY env vars to be set
+
 interface TestCase {
   name: string;
   question: string;

--- a/apps/discord-bot/src/wiki-api.test.ts
+++ b/apps/discord-bot/src/wiki-api.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock config before importing wiki-api
+vi.mock("./config.js", () => ({
+  WIKI_SERVER_URL: "https://wiki-server.test.example",
+  WIKI_SERVER_API_KEY: "test-api-key-123",
+}));
+
+const { searchWiki, getPage } = await import("./wiki-api.js");
+
+describe("searchWiki", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs correct URL with query and limit", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [], query: "test", total: 0 }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await searchWiki("scheming", 5);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/pages/search");
+    expect(url).toContain("q=scheming");
+    expect(url).toContain("limit=5");
+    expect(options.headers["Authorization"]).toBe("Bearer test-api-key-123");
+  });
+
+  it("returns results on success", async () => {
+    const mockResults = [
+      { id: "scheming", title: "Scheming", score: 1.5 },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: mockResults, query: "scheming", total: 1 }),
+      })
+    );
+
+    const results = await searchWiki("scheming");
+    expect(results).toEqual(mockResults);
+  });
+
+  it("returns empty array on HTTP error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      })
+    );
+
+    const results = await searchWiki("test");
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty array on network error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error"))
+    );
+
+    const results = await searchWiki("test");
+    expect(results).toEqual([]);
+  });
+});
+
+describe("getPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs correct URL with page ID", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "scheming", title: "Scheming" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getPage("scheming");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/pages/scheming");
+    expect(options.headers["Authorization"]).toBe("Bearer test-api-key-123");
+  });
+
+  it("encodes special characters in page ID", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "test page", title: "Test" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getPage("test page");
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/pages/test%20page");
+  });
+
+  it("returns page data on success", async () => {
+    const mockPage = {
+      id: "scheming",
+      title: "Scheming",
+      contentPlaintext: "Content here",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockPage,
+      })
+    );
+
+    const page = await getPage("scheming");
+    expect(page).toEqual(mockPage);
+  });
+
+  it("returns null on 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      })
+    );
+
+    const page = await getPage("nonexistent");
+    expect(page).toBeNull();
+  });
+
+  it("returns null on HTTP error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      })
+    );
+
+    const page = await getPage("test");
+    expect(page).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error"))
+    );
+
+    const page = await getPage("test");
+    expect(page).toBeNull();
+  });
+});

--- a/apps/discord-bot/src/wiki-api.ts
+++ b/apps/discord-bot/src/wiki-api.ts
@@ -1,0 +1,85 @@
+import { WIKI_SERVER_URL, WIKI_SERVER_API_KEY } from "./config.js";
+
+export interface SearchResult {
+  id: string;
+  numericId: string | null;
+  title: string;
+  description: string | null;
+  entityType: string | null;
+  category: string | null;
+  readerImportance: number | null;
+  quality: number | null;
+  score: number;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  query: string;
+  total: number;
+}
+
+export interface PageDetail {
+  id: string;
+  numericId: string | null;
+  title: string;
+  description: string | null;
+  llmSummary: string | null;
+  category: string | null;
+  subcategory: string | null;
+  entityType: string | null;
+  tags: string | null;
+  quality: number | null;
+  readerImportance: number | null;
+  contentPlaintext: string | null;
+  wordCount: number | null;
+  lastUpdated: string | null;
+}
+
+function headers(): Record<string, string> {
+  const h: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (WIKI_SERVER_API_KEY) {
+    h["Authorization"] = `Bearer ${WIKI_SERVER_API_KEY}`;
+  }
+  return h;
+}
+
+export async function searchWiki(
+  query: string,
+  limit = 10
+): Promise<SearchResult[]> {
+  const url = new URL("/api/pages/search", WIKI_SERVER_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("limit", String(limit));
+
+  try {
+    const res = await fetch(url.toString(), { headers: headers() });
+    if (!res.ok) {
+      console.error(`Wiki search failed: ${res.status} ${res.statusText}`);
+      return [];
+    }
+    const data = (await res.json()) as SearchResponse;
+    return data.results;
+  } catch (error) {
+    console.error("Wiki search error:", error);
+    return [];
+  }
+}
+
+export async function getPage(id: string): Promise<PageDetail | null> {
+  const url = new URL(`/api/pages/${encodeURIComponent(id)}`, WIKI_SERVER_URL);
+
+  try {
+    const res = await fetch(url.toString(), { headers: headers() });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      console.error(`Wiki getPage failed: ${res.status} ${res.statusText}`);
+      return null;
+    }
+    return (await res.json()) as PageDetail;
+  } catch (error) {
+    console.error("Wiki getPage error:", error);
+    return null;
+  }
+}

--- a/apps/discord-bot/src/wiki-tools.test.ts
+++ b/apps/discord-bot/src/wiki-tools.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the wiki-api module
+vi.mock("./wiki-api.js", () => ({
+  searchWiki: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+// Mock the SDK to avoid loading the real MCP server infrastructure
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  tool: (
+    name: string,
+    description: string,
+    schema: unknown,
+    handler: (args: any) => Promise<any>
+  ) => ({ name, description, schema, handler }),
+  createSdkMcpServer: (options: any) => ({
+    name: options.name,
+    tools: options.tools,
+  }),
+}));
+
+const { searchWiki, getPage } = await import("./wiki-api.js");
+const wikiToolsModule = await import("./wiki-tools.js");
+// Our mock returns { name, tools } but the real SDK type is McpSdkServerConfigWithInstance
+const wikiMcpServer = wikiToolsModule.wikiMcpServer as any;
+
+describe("wiki MCP tools", () => {
+  beforeEach(() => {
+    vi.mocked(searchWiki).mockReset();
+    vi.mocked(getPage).mockReset();
+  });
+
+  it("exports an MCP server with two tools", () => {
+    expect(wikiMcpServer.name).toBe("wiki-server");
+    expect(wikiMcpServer.tools).toHaveLength(2);
+    expect(wikiMcpServer.tools[0].name).toBe("search_wiki");
+    expect(wikiMcpServer.tools[1].name).toBe("get_page");
+  });
+
+  describe("search_wiki tool", () => {
+    const searchHandler = () => (wikiMcpServer.tools[0] as any).handler;
+
+    it("calls searchWiki and returns JSON results", async () => {
+      const mockResults = [
+        { id: "scheming", title: "Scheming", score: 1.5 },
+      ];
+      vi.mocked(searchWiki).mockResolvedValue(mockResults as any);
+
+      const result = await searchHandler()({ query: "scheming" });
+
+      expect(searchWiki).toHaveBeenCalledWith("scheming", undefined);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe("text");
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResults);
+    });
+
+    it("passes limit parameter", async () => {
+      vi.mocked(searchWiki).mockResolvedValue([]);
+
+      await searchHandler()({ query: "test", limit: 5 });
+
+      expect(searchWiki).toHaveBeenCalledWith("test", 5);
+    });
+
+    it("returns empty array JSON when no results", async () => {
+      vi.mocked(searchWiki).mockResolvedValue([]);
+
+      const result = await searchHandler()({ query: "nonexistent" });
+
+      expect(JSON.parse(result.content[0].text)).toEqual([]);
+    });
+  });
+
+  describe("get_page tool", () => {
+    const getPageHandler = () => (wikiMcpServer.tools[1] as any).handler;
+
+    it("returns formatted page content", async () => {
+      vi.mocked(getPage).mockResolvedValue({
+        id: "scheming",
+        title: "Scheming",
+        description: "AI deception risk",
+        contentPlaintext: "Full page content here.",
+      } as any);
+
+      const result = await getPageHandler()({ id: "scheming" });
+
+      expect(getPage).toHaveBeenCalledWith("scheming");
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toContain("# Scheming");
+      expect(result.content[0].text).toContain("AI deception risk");
+      expect(result.content[0].text).toContain("Full page content here.");
+    });
+
+    it("returns 'Page not found' for missing pages", async () => {
+      vi.mocked(getPage).mockResolvedValue(null);
+
+      const result = await getPageHandler()({ id: "nonexistent" });
+
+      expect(result.content[0].text).toBe("Page not found");
+    });
+
+    it("handles null description and content gracefully", async () => {
+      vi.mocked(getPage).mockResolvedValue({
+        id: "stub",
+        title: "Stub Page",
+        description: null,
+        contentPlaintext: null,
+      } as any);
+
+      const result = await getPageHandler()({ id: "stub" });
+
+      expect(result.content[0].text).toContain("# Stub Page");
+      expect(result.content[0].text).toContain("(no content)");
+      // Should not contain "null" as literal text
+      expect(result.content[0].text).not.toContain("null");
+    });
+  });
+});

--- a/apps/discord-bot/src/wiki-tools.ts
+++ b/apps/discord-bot/src/wiki-tools.ts
@@ -1,0 +1,42 @@
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { searchWiki, getPage } from "./wiki-api.js";
+
+const searchTool = tool(
+  "search_wiki",
+  "Search the AI safety wiki for pages matching a query. Returns ranked results with titles, descriptions, and relevance scores.",
+  {
+    query: z.string().describe("Search query"),
+    limit: z
+      .number()
+      .optional()
+      .describe("Max results to return (default 10)"),
+  },
+  async (args) => {
+    const results = await searchWiki(args.query, args.limit);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(results, null, 2) }],
+    };
+  }
+);
+
+const getPageTool = tool(
+  "get_page",
+  "Get the full content of a wiki page by its slug ID (e.g. 'scheming') or numeric ID (e.g. 'E42'). Returns the page title, description, and full plaintext content.",
+  {
+    id: z.string().describe("Page slug (e.g. 'scheming') or numeric ID (e.g. 'E42')"),
+  },
+  async (args) => {
+    const page = await getPage(args.id);
+    if (!page) {
+      return { content: [{ type: "text" as const, text: "Page not found" }] };
+    }
+    const text = `# ${page.title}\n\n${page.description ?? ""}\n\n${page.contentPlaintext ?? "(no content)"}`;
+    return { content: [{ type: "text" as const, text }] };
+  }
+);
+
+export const wikiMcpServer = createSdkMcpServer({
+  name: "wiki-server",
+  tools: [searchTool, getPageTool],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.10.0


### PR DESCRIPTION
## Summary

- Replaces the discord bot's file-based wiki search (Grep/Read/Glob on 625+ baked-in MDX files) with two custom MCP tools (`search_wiki`, `get_page`) that call the wiki-server pages API
- Docker image no longer needs `content/` directory — wiki content updates no longer trigger rebuilds
- CI workflow no longer triggers on `content/**` path changes

## Changes

**New files:**
- `wiki-api.ts` — fetch wrapper for `/api/pages/search` and `/api/pages/:id` with Bearer auth
- `wiki-tools.ts` — MCP tool definitions using Agent SDK `tool()` + `createSdkMcpServer()`
- `wiki-api.test.ts` — 10 unit tests (URL construction, auth headers, error handling)
- `wiki-tools.test.ts` — 7 unit tests (tool formatting, null handling, MCP server structure)

**Modified files:**
- `config.ts` — replaced `WIKI_ROOT`/`WIKI_CONTENT_PATH` with `LONGTERMWIKI_SERVER_URL`/`LONGTERMWIKI_SERVER_API_KEY`
- `query.ts` — switched from file tools to MCP tools, updated prompt to use `search_wiki`/`get_page` and `/wiki/{id}` URL format
- `index.ts` — added env validation for server URL/key
- `query.test.ts` — 11 tests covering new prompt format
- `Dockerfile` — removed `COPY content/`
- `.github/workflows/discord-bot-docker.yml` — removed `content/**` trigger
- `.env.example` — updated with new env vars
- `deploy/README.md` — rewritten for API-based architecture

## Deployment prerequisites

**Before merging**, the K8s secret `longterm-wiki-discord-bot-secrets` needs two new entries:
- `LONGTERMWIKI_SERVER_URL` — wiki-server API URL
- `LONGTERMWIKI_SERVER_API_KEY` — Bearer token for auth

These use the same env var names as the rest of the codebase (crux sync, CI workflows, etc.).

## Test plan

- [x] `tsc --noEmit` — no type errors
- [x] `vitest run` — 46 tests pass across 4 files
- [x] `pnpm crux validate gate` — all 8 gate checks pass
- [ ] Manual: set `LONGTERMWIKI_SERVER_URL` + key, run `pnpm test:query "What is scheming?"` — verify API-based results
- [ ] Docker build succeeds without `content/` directory
- [ ] Deploy with new K8s secrets, verify bot responds in Discord