### PR TITLE
fix: consolidate wiki-server DB layer

### DIFF
--- a/apps/web/scripts/lib/risk-client.mjs
+++ b/apps/web/scripts/lib/risk-client.mjs
@@ -1,78 +1,8 @@
 /**
- * risk-client.mjs — HTTP client for the wiki server (hallucination risk snapshots)
+ * risk-client.mjs — Thin wrapper re-exporting from the shared wiki-server client.
  *
  * Used by build-data.mjs to record risk score snapshots after computing
  * hallucination risk. Gracefully skips if server is unavailable.
- *
- * Configuration via environment variables:
- *   LONGTERMWIKI_SERVER_URL     — Base URL (e.g. "https://wiki-server.k8s.quantifieduncertainty.org")
- *   LONGTERMWIKI_SERVER_API_KEY — Bearer token for authentication
  */
 
-const TIMEOUT_MS = 30_000; // larger timeout for batch inserts
-const BATCH_SIZE = 100; // split large batches to avoid overwhelming the server
-
-function getServerUrl() {
-  return process.env.LONGTERMWIKI_SERVER_URL || "";
-}
-
-function getApiKey() {
-  return process.env.LONGTERMWIKI_SERVER_API_KEY || "";
-}
-
-function getHeaders() {
-  const headers = { "Content-Type": "application/json" };
-  const apiKey = getApiKey();
-  if (apiKey) {
-    headers["Authorization"] = `Bearer ${apiKey}`;
-  }
-  return headers;
-}
-
-/**
- * Record hallucination risk snapshots for multiple pages.
- *
- * @param {Array<{ pageId: string, score: number, level: string, factors: string[], integrityIssues?: string[] }>} snapshots
- * @returns {Promise<{ inserted: number } | null>} — null on failure
- */
-export async function recordRiskSnapshots(snapshots) {
-  const serverUrl = getServerUrl();
-  if (!serverUrl) return null;
-
-  let totalInserted = 0;
-
-  // Split into batches
-  for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
-    const batch = snapshots.slice(i, i + BATCH_SIZE);
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-      const res = await fetch(`${serverUrl}/api/hallucination-risk/batch`, {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify({ snapshots: batch }),
-        signal: controller.signal,
-      });
-      clearTimeout(timer);
-
-      if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        console.warn(
-          `  WARNING: Risk snapshot batch failed (${res.status}): ${text.slice(0, 200)}`
-        );
-        return null;
-      }
-
-      const data = await res.json();
-      totalInserted += data.inserted;
-    } catch (err) {
-      console.warn(
-        `  WARNING: Risk snapshot batch failed: ${err.message || err}`
-      );
-      return null;
-    }
-  }
-
-  return { inserted: totalInserted };
-}
+export { recordRiskSnapshots } from '../../../../crux/lib/wiki-server-client.ts';

--- a/apps/web/src/app/internal/hallucination-risk/hallucination-risk-dashboard.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/hallucination-risk-dashboard.tsx
@@ -144,7 +144,7 @@ export function HallucinationRiskDashboard({
         })}
       </div>
 
-      <DataTable columns={columns} data={sorted} />
+      <DataTable columns={columns} data={sorted} searchPlaceholder="Search pages..." />
     </div>
   );
 }

--- a/apps/wiki-server/drizzle/0008_add_auto_update_results_fk.sql
+++ b/apps/wiki-server/drizzle/0008_add_auto_update_results_fk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "auto_update_results" ADD CONSTRAINT "auto_update_results_run_id_auto_update_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."auto_update_runs"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1771648111614,
       "tag": "0007_good_marvex",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1771700000000,
+      "tag": "0008_add_auto_update_results_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -275,7 +275,9 @@ export const autoUpdateResults = pgTable(
   "auto_update_results",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    runId: bigint("run_id", { mode: "number" }).notNull(),
+    runId: bigint("run_id", { mode: "number" })
+      .notNull()
+      .references(() => autoUpdateRuns.id, { onDelete: "cascade" }),
     pageId: text("page_id").notNull(),
     status: text("status").notNull(),
     tier: text("tier"),


### PR DESCRIPTION
## Summary

Multiple PRs added wiki-server features in parallel (sessions, auto-update-runs, hallucination-risk APIs). The parallel work introduced a broken build, data corruption risks, DRY violations, and inconsistent patterns. This PR consolidates and fixes all of them.

### Changes (by priority)

- **P1: Fix broken build** — `hallucination-risk-dashboard.tsx` used non-existent `searchColumn` prop on `DataTable`; replaced with `searchPlaceholder`
- **P2: Fix data corruption risk** — `newPagesCreated` was stored via comma-join/split, which silently corrupts page IDs containing commas; switched to `JSON.stringify`/`JSON.parse`
- **P3: Add missing FK constraint** — `autoUpdateResults.runId` now references `autoUpdateRuns.id` with `ON DELETE CASCADE` (new migration `0007`)
- **P4: Add fetch timeout** — `sync-pages.ts` fetch calls now have `AbortSignal.timeout(30_000)` to prevent infinite hangs
- **P5: Consolidate wiki-server clients** — Exported shared helpers (`getServerUrl`, `getApiKey`, `buildHeaders`, `isServerAvailable`) from `crux/lib/wiki-server-client.ts`; added `recordRiskSnapshots()`. `risk-client.mjs` is now a thin re-export wrapper. `id-client.mjs` mirrors the helpers inline (runs under plain `node` without tsx). `sync-pages.ts` uses shared `buildHeaders()`.
- **P6: Consistent error handling** — `sessions.ts` and `auto-update-runs.ts` now import `parseJsonBody`, `validationError`, `invalidJsonError`, `notFoundError` from shared `utils.ts` instead of defining them locally

Net: -43 lines, 4 fewer duplicate implementations of `getServerUrl`/`getApiKey`/`buildHeaders`.

## Test plan

- [x] `pnpm crux validate gate --full` — all 9 checks pass (211 tests, full Next.js build)
- [x] `cd apps/wiki-server && pnpm test` — 118 tests pass (7 files)
- [x] TypeScript checks pass (`apps/web`, `apps/wiki-server`)
- [x] Import resolution verified for refactored `risk-client.mjs` and `id-client.mjs`
- [x] `build-data.mjs` runs successfully with refactored risk-client
- [x] `assign-ids.mjs` runs successfully (plain node, no tsx) with self-contained id-client

🤖 Generated with [Claude Code](https://claude.com/claude-code)