### PR TITLE
fix: paranoid review of Postgres integration — 7 bugs and issues

### DIFF
--- a/apps/wiki-server/drizzle/0009_add_resource_citations_fk.sql
+++ b/apps/wiki-server/drizzle/0009_add_resource_citations_fk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "resource_citations" ADD CONSTRAINT "resource_citations_resource_id_resources_id_fk" FOREIGN KEY ("resource_id") REFERENCES "public"."resources"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1771700000000,
       "tag": "0008_add_auto_update_results_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1771800000000,
+      "tag": "0009_add_resource_citations_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -703,7 +703,6 @@ citationsRoute.get("/accuracy-dashboard", async (c) => {
         if (domain) domainMap.get(domain)!.unsupported++;
       } else if (verdict === 'minor_issues') {
         minorIssueCount++; page.minorIssues++;
-        if (domain) domainMap.get(domain)!.accurate++;
       }
 
       // Flag problematic citations

--- a/apps/wiki-server/src/routes/ids.ts
+++ b/apps/wiki-server/src/routes/ids.ts
@@ -152,6 +152,16 @@ idsRoute.post("/allocate-batch", async (c) => {
 
       if (inserted.length > 0) {
         results.push(formatIdResponse(inserted[0], true));
+      } else {
+        // Race condition: another request inserted between our SELECT and INSERT.
+        // Re-fetch the existing row.
+        const raced = await tx
+          .select()
+          .from(entityIds)
+          .where(eq(entityIds.slug, item.slug));
+        if (raced.length > 0) {
+          results.push(formatIdResponse(raced[0], false));
+        }
       }
     }
   });

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -123,7 +123,7 @@ async function upsertResource(db: DbClient, d: ResourceInput) {
         credibilityOverride: vals.credibilityOverride,
         fetchedAt: vals.fetchedAt,
         contentHash: vals.contentHash,
-        updatedAt: new Date(),
+        updatedAt: sql`now()`,
       },
     })
     .returning({

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -327,7 +327,9 @@ export const resources = pgTable(
 export const resourceCitations = pgTable(
   "resource_citations",
   {
-    resourceId: text("resource_id").notNull(),
+    resourceId: text("resource_id")
+      .notNull()
+      .references(() => resources.id, { onDelete: "cascade" }),
     pageId: text("page_id").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()


### PR DESCRIPTION
## Summary

Deep review of all recently merged Postgres integration PRs (#427, #428, #432, #434, #436, #438, #440, #441, #442, #444, #445, #446, #447). Found and fixed 3 bugs and 4 code quality issues.

### Bugs Fixed

- **Broken transaction in auto-update-runs POST** — `rawDb.begin()` created a postgres.js transaction, but `getDrizzleDb()` inside the callback returned a Drizzle instance on the *global* connection pool, not the transaction. All inserts ran outside the transaction, making the run + results insert non-atomic. Replaced with `db.transaction()` using `tx` throughout.
- **accuracy-dashboard double-counting minor_issues** — Citations with `minor_issues` verdict were incorrectly counted under `domainMap.accurate++`, inflating domain-level accuracy stats.
- **allocate-batch race condition** — If a concurrent request inserted a slug between the existence check SELECT and the INSERT, `onConflictDoNothing` returned zero rows and the item was silently dropped from the response. Added re-fetch fallback matching the single `/allocate` endpoint behavior.

### Code Quality Fixes

- **edit-logs duplicated helpers** — Route file had its own `parseJsonBody()` and `validationError()` instead of importing from `utils.ts`. Replaced with shared imports.
- **resources updatedAt: new Date()** — Used app-server timestamp instead of `sql\`now()\`` for consistency with all other routes (avoids clock skew).
- **formatRunEntry JSON.parse crash** — `JSON.parse(newPagesCreated)` could throw on malformed data, crashing the response. Wrapped in try-catch.
- **Missing FK on resource_citations** — `resource_id` had no foreign key constraint to `resources.id`. Added FK with CASCADE delete + migration 0009.

### Additional Review Findings (not fixed, noted for future)

- **citation_content PK is URL-only** — The `pageId`/`footnote` columns get overwritten when two pages cite the same URL.
- **Page sync search_vector update runs outside the Drizzle transaction** — Uses raw SQL (no Drizzle tsvector support).
- **`.returning()[0]` without length checks** — ~8 instances. Safe in practice but not defensive.
- **`id-client.mjs` duplicates `wiki-server-client.ts`** — Plain .mjs can't import .ts.

## Test plan

- [x] All 138 wiki-server unit tests pass
- [x] All 8 gate checks pass (data build, tests, validations, typecheck)
- [x] TypeScript compiles cleanly

https://claude.ai/code/session_01B8MQMQmqGeKi1obWCswSci