### PR TITLE
fix: batch inserts and N+1 query in wiki-server

### DIFF
--- a/apps/wiki-server/src/__tests__/edit-logs.test.ts
+++ b/apps/wiki-server/src/__tests__/edit-logs.test.ts
@@ -100,21 +100,28 @@ function createMockSql() {
       return [];
     }
 
-    // ---- INSERT INTO edit_logs ----
+    // ---- INSERT INTO edit_logs (supports multi-row) ----
     if (q.includes("insert into") && q.includes("edit_logs")) {
-      // Drizzle sends positional params: page_id, date, tool, agency, requested_by, note
-      const row = {
-        id: nextId++,
-        page_id: params[0] as string,
-        date: String(params[1]),
-        tool: params[2] as string,
-        agency: params[3] as string,
-        requested_by: (params[4] as string) ?? null,
-        note: (params[5] as string) ?? null,
-        created_at: new Date(),
-      };
-      editStore.push(row);
-      return [row];
+      // Drizzle sends positional params: page_id, date, tool, agency, requested_by, note per row
+      const COLS = 6;
+      const numRows = params.length / COLS;
+      const rows = [];
+      for (let i = 0; i < numRows; i++) {
+        const o = i * COLS;
+        const row = {
+          id: nextId++,
+          page_id: params[o] as string,
+          date: String(params[o + 1]),
+          tool: params[o + 2] as string,
+          agency: params[o + 3] as string,
+          requested_by: (params[o + 4] as string) ?? null,
+          note: (params[o + 5] as string) ?? null,
+          created_at: new Date(),
+        };
+        editStore.push(row);
+        rows.push(row);
+      }
+      return rows;
     }
 
     // ---- SELECT count(distinct page_id) FROM edit_logs ----

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -70,19 +70,24 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // ---- INSERT INTO resource_citations ----
+  // ---- INSERT INTO resource_citations (supports multi-row) ----
   if (q.includes("insert into") && q.includes("resource_citations")) {
-    const resourceId = params[0] as string;
-    const pageId = params[1] as string;
-    const exists = citationStore.some(
-      (c) => c.resource_id === resourceId && c.page_id === pageId
-    );
-    if (!exists) {
-      citationStore.push({
-        resource_id: resourceId,
-        page_id: pageId,
-        created_at: new Date(),
-      });
+    const COLS = 2; // resource_id, page_id
+    const numRows = params.length / COLS;
+    for (let i = 0; i < numRows; i++) {
+      const o = i * COLS;
+      const resourceId = params[o] as string;
+      const pageId = params[o + 1] as string;
+      const exists = citationStore.some(
+        (c) => c.resource_id === resourceId && c.page_id === pageId
+      );
+      if (!exists) {
+        citationStore.push({
+          resource_id: resourceId,
+          page_id: pageId,
+          created_at: new Date(),
+        });
+      }
     }
     return [];
   }

--- a/apps/wiki-server/src/__tests__/sessions.test.ts
+++ b/apps/wiki-server/src/__tests__/sessions.test.ts
@@ -145,14 +145,21 @@ vi.mock("../db.js", async () => {
       return [row];
     }
 
-    // ---- INSERT INTO session_pages ----
+    // ---- INSERT INTO session_pages (supports multi-row) ----
     if (q.includes("insert into") && q.includes("session_pages")) {
-      const row = {
-        session_id: params[0] as number,
-        page_id: params[1] as string,
-      };
-      sessionPageStore.push(row);
-      return [row];
+      const COLS = 2;
+      const numRows = params.length / COLS;
+      const rows = [];
+      for (let i = 0; i < numRows; i++) {
+        const o = i * COLS;
+        const row = {
+          session_id: params[o] as number,
+          page_id: params[o + 1] as string,
+        };
+        sessionPageStore.push(row);
+        rows.push(row);
+      }
+      return rows;
     }
 
     // ---- SELECT count(*) FROM sessions (no group by) ----

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -162,13 +162,34 @@ citationsRoute.post("/quotes/upsert-batch", async (c) => {
 
   const { items } = parsed.data;
   const db = getDrizzleDb();
-  const results: Array<{ id: number; pageId: string; footnote: number }> = [];
 
-  await db.transaction(async (tx) => {
-    for (const d of items) {
-      const rows = await upsertQuote(tx, d);
-      results.push({ id: rows[0].id, pageId: rows[0].pageId, footnote: rows[0].footnote });
-    }
+  const results = await db.transaction(async (tx) => {
+    return await tx
+      .insert(citationQuotes)
+      .values(items.map((d) => quoteValues(d)))
+      .onConflictDoUpdate({
+        target: [citationQuotes.pageId, citationQuotes.footnote],
+        set: {
+          url: sql`excluded.url`,
+          resourceId: sql`excluded.resource_id`,
+          claimText: sql`excluded.claim_text`,
+          claimContext: sql`excluded.claim_context`,
+          sourceQuote: sql`excluded.source_quote`,
+          sourceLocation: sql`excluded.source_location`,
+          quoteVerified: sql`excluded.quote_verified`,
+          verificationMethod: sql`excluded.verification_method`,
+          verificationScore: sql`excluded.verification_score`,
+          sourceTitle: sql`excluded.source_title`,
+          sourceType: sql`excluded.source_type`,
+          extractionModel: sql`excluded.extraction_model`,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({
+        id: citationQuotes.id,
+        pageId: citationQuotes.pageId,
+        footnote: citationQuotes.footnote,
+      });
   });
 
   return c.json({ results });
@@ -514,12 +535,12 @@ citationsRoute.post("/accuracy-snapshot", async (c) => {
     .having(sql`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end) > 0`);
 
   // Insert snapshots for all pages with accuracy data
-  const inserted: Array<{ id: number; pageId: string }> = [];
-  await db.transaction(async (tx) => {
-    for (const ps of pageStats) {
-      const rows = await tx
-        .insert(citationAccuracySnapshots)
-        .values({
+  let inserted: Array<{ id: number; pageId: string }> = [];
+  if (pageStats.length > 0) {
+    inserted = await db
+      .insert(citationAccuracySnapshots)
+      .values(
+        pageStats.map((ps) => ({
           pageId: ps.pageId,
           totalCitations: ps.totalCitations,
           checkedCitations: Number(ps.checkedCitations),
@@ -529,14 +550,13 @@ citationsRoute.post("/accuracy-snapshot", async (c) => {
           unsupportedCount: Number(ps.unsupportedCount),
           notVerifiableCount: Number(ps.notVerifiableCount),
           averageScore: ps.averageScore != null ? Number(ps.averageScore) : null,
-        })
-        .returning({
-          id: citationAccuracySnapshots.id,
-          pageId: citationAccuracySnapshots.pageId,
-        });
-      inserted.push(rows[0]);
-    }
-  });
+        }))
+      )
+      .returning({
+        id: citationAccuracySnapshots.id,
+        pageId: citationAccuracySnapshots.pageId,
+      });
+  }
 
   return c.json({
     snapshotCount: inserted.length,

--- a/apps/wiki-server/src/routes/edit-logs.ts
+++ b/apps/wiki-server/src/routes/edit-logs.ts
@@ -93,22 +93,19 @@ editLogsRoute.post("/batch", async (c) => {
   const db = getDrizzleDb();
 
   const results = await db.transaction(async (tx) => {
-    const rows: Array<{ id: number; pageId: string }> = [];
-    for (const d of items) {
-      const inserted = await tx
-        .insert(editLogs)
-        .values({
+    return await tx
+      .insert(editLogs)
+      .values(
+        items.map((d) => ({
           pageId: d.pageId,
           date: d.date,
           tool: d.tool,
           agency: d.agency,
           requestedBy: d.requestedBy ?? null,
           note: d.note ?? null,
-        })
-        .returning({ id: editLogs.id, pageId: editLogs.pageId });
-      rows.push(inserted[0]);
-    }
-    return rows;
+        }))
+      )
+      .returning({ id: editLogs.id, pageId: editLogs.pageId });
   });
 
   return c.json({ inserted: results.length, results }, 201);

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -138,12 +138,10 @@ async function upsertResource(db: DbClient, d: ResourceInput) {
     await db
       .delete(resourceCitations)
       .where(eq(resourceCitations.resourceId, d.id));
-    for (const pageId of d.citedBy) {
-      await db
-        .insert(resourceCitations)
-        .values({ resourceId: d.id, pageId })
-        .onConflictDoNothing();
-    }
+    await db
+      .insert(resourceCitations)
+      .values(d.citedBy.map((pageId) => ({ resourceId: d.id, pageId })))
+      .onConflictDoNothing();
   }
 
   return rows[0];

--- a/apps/wiki-server/src/routes/sessions.ts
+++ b/apps/wiki-server/src/routes/sessions.ts
@@ -108,11 +108,9 @@ sessionsRoute.post("/", async (c) => {
 
     // Insert page associations
     if (d.pages.length > 0) {
-      for (const pageId of d.pages) {
-        await tx
-          .insert(sessionPages)
-          .values({ sessionId: session.id, pageId });
-      }
+      await tx
+        .insert(sessionPages)
+        .values(d.pages.map((pageId) => ({ sessionId: session.id, pageId })));
     }
 
     return { ...session, pages: d.pages };
@@ -158,11 +156,9 @@ sessionsRoute.post("/batch", async (c) => {
       const session = rows[0];
 
       if (d.pages.length > 0) {
-        for (const pageId of d.pages) {
-          await tx
-            .insert(sessionPages)
-            .values({ sessionId: session.id, pageId });
-        }
+        await tx
+          .insert(sessionPages)
+          .values(d.pages.map((pageId) => ({ sessionId: session.id, pageId })));
       }
 
       created.push({


### PR DESCRIPTION
## Summary
- **Fix N+1 query** in `auto-update-runs` GET `/all` endpoint: replace per-run result fetches with a single `inArray()` query + JS grouping (#457)
- **Batch inserts** across all route handlers: replace loop-based `insert().values({...})` with multi-row `insert().values([...])` in edit-logs, sessions, resources, citations, pages, and auto-update-runs (#458)
- **Convert seed scripts** from raw postgres.js to Drizzle ORM with 500-item chunking (seed-edit-logs, seed-sessions, seed-auto-update-runs, seed-resources)
- **Update test mocks** to handle multi-row INSERT params (all 6 test files)

Closes #457, closes #458

## Changed files (16)
**Route handlers** (6): auto-update-runs.ts, citations.ts, edit-logs.ts, pages.ts, resources.ts, sessions.ts
**Seed scripts** (4): seed-edit-logs.ts, seed-sessions.ts, seed-auto-update-runs.ts, seed-resources.ts
**Test mocks** (6): auto-update-runs.test.ts, citations.test.ts, edit-logs.test.ts, pages.test.ts, resources.test.ts, sessions.test.ts

## Test plan
- [x] All 138 wiki-server tests pass
- [x] All 8 gate checks pass (build-data, tests, MDX syntax, YAML schema, frontmatter, numeric IDs, EntityLink, TypeScript)

https://claude.ai/code/session_01QB9E2W1BtuYggeCjkcBRJY