### PR TITLE
Use batch allocation in assign-ids.mjs

### DIFF
--- a/apps/web/scripts/lib/__tests__/id-client.test.mjs
+++ b/apps/web/scripts/lib/__tests__/id-client.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isServerAvailable, allocateId, allocateBatch } from "../id-client.mjs";
+import { isServerAvailable, allocateId, allocateBatch, allocateIds } from "../id-client.mjs";
 
 let originalFetch;
 let savedEnv;
@@ -161,6 +161,115 @@ describe("id-client", () => {
       process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
       global.fetch = vi.fn().mockRejectedValue(new Error("network error"));
       expect(await allocateBatch([{ slug: "a" }])).toBeNull();
+    });
+  });
+
+  describe("allocateIds", () => {
+    it("returns a Map of slug → numericId", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              { numericId: "E100", slug: "alpha", created: true },
+              { numericId: "E101", slug: "beta", created: true },
+            ],
+          }),
+      });
+      const result = await allocateIds(["alpha", "beta"]);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get("alpha")).toBe("E100");
+      expect(result.get("beta")).toBe("E101");
+    });
+
+    it("returns empty Map for empty input", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      const result = await allocateIds([]);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it("chunks large batches into groups of 50", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      // Create 75 slugs — should result in 2 fetch calls (50 + 25)
+      const slugs = Array.from({ length: 75 }, (_, i) => `slug-${i}`);
+      let callCount = 0;
+      global.fetch = vi.fn().mockImplementation(async (_url, opts) => {
+        callCount++;
+        const body = JSON.parse(opts.body);
+        const results = body.items.map((item, idx) => ({
+          numericId: `E${callCount * 100 + idx}`,
+          slug: item.slug,
+          created: true,
+        }));
+        return { ok: true, json: () => Promise.resolve({ results }) };
+      });
+
+      const result = await allocateIds(slugs);
+      expect(result.size).toBe(75);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // First batch: 50 items, second batch: 25 items
+      const firstCall = JSON.parse(global.fetch.mock.calls[0][1].body);
+      const secondCall = JSON.parse(global.fetch.mock.calls[1][1].body);
+      expect(firstCall.items).toHaveLength(50);
+      expect(secondCall.items).toHaveLength(25);
+    });
+
+    it("throws when a batch request fails", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+      await expect(allocateIds(["fail-slug"])).rejects.toThrow(
+        "Batch allocation failed"
+      );
+    });
+
+    it("throws when a batch request returns null (network error)", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      global.fetch = vi.fn().mockRejectedValue(new Error("timeout"));
+      await expect(allocateIds(["fail-slug"])).rejects.toThrow(
+        "Batch allocation failed"
+      );
+    });
+
+    it("throws when second chunk fails (partial batch failure)", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      // 60 slugs → chunk 1 (50) succeeds, chunk 2 (10) fails
+      const slugs = Array.from({ length: 60 }, (_, i) => `slug-${i}`);
+      let callCount = 0;
+      global.fetch = vi.fn().mockImplementation(async (_url, opts) => {
+        callCount++;
+        if (callCount === 2) {
+          return { ok: false, status: 500 };
+        }
+        const body = JSON.parse(opts.body);
+        const results = body.items.map((item, idx) => ({
+          numericId: `E${idx}`,
+          slug: item.slug,
+          created: true,
+        }));
+        return { ok: true, json: () => Promise.resolve({ results }) };
+      });
+
+      await expect(allocateIds(slugs)).rejects.toThrow("Batch allocation failed");
+    });
+
+    it("throws when server omits a slug from the response", async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3100";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            // Only returns result for "alpha", omits "beta"
+            results: [{ numericId: "E100", slug: "alpha", created: true }],
+          }),
+      });
+      await expect(allocateIds(["alpha", "beta"])).rejects.toThrow(
+        "Batch allocation missing results for slugs: beta"
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Batch ID allocation**: `assign-ids.mjs` now collects all entities/pages needing IDs upfront and allocates them via `allocateBatch()` in chunks of 50, instead of calling `allocateId()` one-at-a-time in a loop
- **New `allocateIds()` function** in `id-client.mjs`: takes `string[]` of slugs, auto-chunks to respect server limits, returns `Map<slug, numericId>`, with post-condition validation
- **Increased batch timeout** to 30s (vs 5s for single requests) to handle larger transactions
- **Fixed dry-run summary messages** that incorrectly said "assigned" when no assignment occurred

## Test plan

- [x] All 21 id-client tests pass (7 new: happy path, empty input, chunking at 50, server failure, network error, partial batch failure, missing slug detection)
- [x] Full gate check passes (218 tests, all validations)
- [x] Backward compatible: `allocateId()` and `allocateBatch()` remain exported for other callers

Closes #421

https://claude.ai/code/session_01GAPcsbiEb9oChBubzpZUX2