### PR TITLE
Add resources auto-sync CI job (#464)

### DIFF
--- a/.github/workflows/sync-resources.yml
+++ b/.github/workflows/sync-resources.yml
@@ -1,0 +1,41 @@
+name: Sync Resources
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/resources/**"
+
+  # Allow manual trigger for full re-sync
+  workflow_dispatch:
+
+# Cancel superseded runs for the same trigger
+concurrency:
+  group: sync-resources-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  sync-resources:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate resource schemas
+        run: pnpm crux validate schema
+
+      - name: Sync resources to wiki-server
+        run: pnpm crux wiki-server sync-resources
+        env:
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}

--- a/crux/commands/wiki-server.ts
+++ b/crux/commands/wiki-server.ts
@@ -12,6 +12,11 @@ const SCRIPTS = {
     description: 'Sync wiki page content and metadata to wiki-server',
     passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size', 'ci'],
   },
+  'sync-resources': {
+    script: 'wiki-server/sync-resources.ts',
+    description: 'Sync data/resources/*.yaml to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
   'sync-session': {
     script: 'wiki-server/sync-session.ts',
     description: 'Sync a single session YAML file to wiki-server',
@@ -35,16 +40,18 @@ ${commandList}
 
 Options:
   --dry-run          Preview what would be synced without making changes
-  --batch-size=N     Number of pages per batch (default: 50)
+  --batch-size=N     Number of items per batch (default: 50 pages, 100 resources)
 
 Environment:
   LONGTERMWIKI_SERVER_URL     Base URL of the wiki server
   LONGTERMWIKI_SERVER_API_KEY Bearer token for authentication
 
 Examples:
-  crux wiki-server sync                  Sync all pages
-  crux wiki-server sync --dry-run        Preview sync
-  crux wiki-server sync --batch-size=25  Use smaller batches
+  crux wiki-server sync                    Sync all pages
+  crux wiki-server sync --dry-run          Preview page sync
+  crux wiki-server sync --batch-size=25    Use smaller batches
+  crux wiki-server sync-resources          Sync all resources
+  crux wiki-server sync-resources --dry-run  Preview resource sync
   crux wiki-server sync-session .claude/sessions/2026-02-21_my-branch.yaml
 `;
 }

--- a/crux/wiki-server/sync-resources.test.ts
+++ b/crux/wiki-server/sync-resources.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { transformResource, syncResources, type SyncResource } from "./sync-resources.ts";
+
+const noSleep = async () => {};
+
+function makeResource(id: string): SyncResource {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: `Resource ${id}`,
+    type: "web",
+    summary: null,
+    review: null,
+    abstract: null,
+    keyPoints: null,
+    publicationId: null,
+    authors: null,
+    publishedDate: null,
+    tags: null,
+    localFilename: null,
+    credibilityOverride: null,
+    fetchedAt: null,
+    contentHash: null,
+    citedBy: null,
+  };
+}
+
+describe("transformResource", () => {
+  it("transforms a minimal YAML resource", () => {
+    const result = transformResource({
+      id: "abc123",
+      url: "https://example.com/paper",
+    });
+
+    expect(result).toEqual({
+      id: "abc123",
+      url: "https://example.com/paper",
+      title: null,
+      type: null,
+      summary: null,
+      review: null,
+      abstract: null,
+      keyPoints: null,
+      publicationId: null,
+      authors: null,
+      publishedDate: null,
+      tags: null,
+      localFilename: null,
+      credibilityOverride: null,
+      fetchedAt: null,
+      contentHash: null,
+      citedBy: null,
+    });
+  });
+
+  it("transforms a fully-populated YAML resource", () => {
+    const result = transformResource({
+      id: "abc123",
+      url: "https://example.com/paper",
+      title: "A Paper",
+      type: "paper",
+      summary: "Summary text",
+      review: "Review text",
+      abstract: "Abstract text",
+      key_points: ["Point 1", "Point 2"],
+      publication_id: "nature",
+      authors: ["Author A", "Author B"],
+      published_date: "2025-01-15",
+      tags: ["ai", "safety"],
+      local_filename: "abc123.txt",
+      credibility_override: 0.9,
+      fetched_at: "2025-12-28 02:55:47",
+      content_hash: "deadbeef",
+      cited_by: ["page-a", "page-b"],
+    });
+
+    expect(result.id).toBe("abc123");
+    expect(result.title).toBe("A Paper");
+    expect(result.type).toBe("paper");
+    expect(result.keyPoints).toEqual(["Point 1", "Point 2"]);
+    expect(result.publicationId).toBe("nature");
+    expect(result.authors).toEqual(["Author A", "Author B"]);
+    expect(result.publishedDate).toBe("2025-01-15");
+    expect(result.tags).toEqual(["ai", "safety"]);
+    expect(result.localFilename).toBe("abc123.txt");
+    expect(result.credibilityOverride).toBe(0.9);
+    expect(result.fetchedAt).toBe("2025-12-28T02:55:47Z");
+    expect(result.contentHash).toBe("deadbeef");
+    expect(result.citedBy).toEqual(["page-a", "page-b"]);
+  });
+
+  it("normalizes Date objects in published_date", () => {
+    const result = transformResource({
+      id: "abc",
+      url: "https://example.com",
+      published_date: new Date("2025-06-15T00:00:00Z"),
+    });
+
+    expect(result.publishedDate).toBe("2025-06-15");
+  });
+
+  it("normalizes Date objects in fetched_at", () => {
+    const result = transformResource({
+      id: "abc",
+      url: "https://example.com",
+      fetched_at: new Date("2025-12-28T02:55:47Z"),
+    });
+
+    expect(result.fetchedAt).toBe("2025-12-28T02:55:47.000Z");
+  });
+
+  it("normalizes date-only fetched_at strings", () => {
+    const result = transformResource({
+      id: "abc",
+      url: "https://example.com",
+      fetched_at: "2025-12-28",
+    });
+
+    expect(result.fetchedAt).toBe("2025-12-28T00:00:00Z");
+  });
+
+  it("returns null for unparseable fetched_at strings", () => {
+    const result = transformResource({
+      id: "abc",
+      url: "https://example.com",
+      fetched_at: "not-a-date",
+    });
+
+    expect(result.fetchedAt).toBeNull();
+  });
+
+  it("returns null for unparseable published_date strings", () => {
+    const result = transformResource({
+      id: "abc",
+      url: "https://example.com",
+      published_date: "bad-date",
+    });
+
+    expect(result.publishedDate).toBeNull();
+  });
+});
+
+describe("syncResources", () => {
+  const origUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.LONGTERMWIKI_SERVER_URL = "http://localhost:3000";
+    process.env.LONGTERMWIKI_SERVER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    if (origUrl !== undefined)
+      process.env.LONGTERMWIKI_SERVER_URL = origUrl;
+    else delete process.env.LONGTERMWIKI_SERVER_URL;
+    if (origKey !== undefined)
+      process.env.LONGTERMWIKI_SERVER_API_KEY = origKey;
+    else delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  it("upserts all resources successfully", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ inserted: 2 }), { status: 200 })
+    );
+
+    const items = [makeResource("a"), makeResource("b"), makeResource("c"), makeResource("d")];
+    const result = await syncResources("http://localhost:3000", items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ upserted: 4, errors: 0 });
+  });
+
+  it("counts errors for failed batches", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ inserted: 2 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response("Bad Request", { status: 400 })
+      );
+
+    const items = [makeResource("a"), makeResource("b"), makeResource("c"), makeResource("d")];
+    const result = await syncResources("http://localhost:3000", items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.upserted).toBe(2);
+    expect(result.errors).toBe(2);
+  });
+
+  it("fast-fails after 3 consecutive batch failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Service Unavailable", { status: 503 })
+    );
+
+    // 10 resources, batch size 2 = 5 batches. Should abort after 3.
+    const items = Array.from({ length: 10 }, (_, i) => makeResource(`r${i}`));
+    const result = await syncResources("http://localhost:3000", items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.upserted).toBe(0);
+    expect(result.errors).toBe(10);
+  });
+
+  it("resets consecutive failure count on success", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // Batch 1: fails (503 -> throw after retries)
+    fetchSpy
+      .mockResolvedValueOnce(new Response("err", { status: 503 }))
+      .mockResolvedValueOnce(new Response("err", { status: 503 }))
+      .mockResolvedValueOnce(new Response("err", { status: 503 }));
+    // Batch 2: succeeds
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 1 }), { status: 200 })
+    );
+    // Batch 3: fails
+    fetchSpy
+      .mockResolvedValueOnce(new Response("err", { status: 503 }))
+      .mockResolvedValueOnce(new Response("err", { status: 503 }))
+      .mockResolvedValueOnce(new Response("err", { status: 503 }));
+    // Batch 4: succeeds
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 1 }), { status: 200 })
+    );
+
+    const items = [makeResource("a"), makeResource("b"), makeResource("c"), makeResource("d")];
+    const result = await syncResources("http://localhost:3000", items, 1, {
+      _sleep: noSleep,
+    });
+
+    expect(result.upserted).toBe(2);
+    expect(result.errors).toBe(2);
+  });
+
+  it("handles empty items array", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await syncResources("http://localhost:3000", [], 100, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ upserted: 0, errors: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles batchSize larger than items array", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 3 }), { status: 200 })
+    );
+
+    const items = [makeResource("a"), makeResource("b"), makeResource("c")];
+    const result = await syncResources("http://localhost:3000", items, 200, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ upserted: 3, errors: 0 });
+  });
+
+  it("sends correct payload to /api/resources/batch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 1 }), { status: 200 })
+    );
+
+    const items = [makeResource("test-id")];
+    await syncResources("http://localhost:3000", items, 100, {
+      _sleep: noSleep,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3000/api/resources/batch",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"test-id"'),
+      })
+    );
+
+    const callBody = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(callBody.items).toHaveLength(1);
+    expect(callBody.items[0].id).toBe("test-id");
+    expect(callBody.items[0].url).toBe("https://example.com/test-id");
+  });
+});

--- a/crux/wiki-server/sync-resources.ts
+++ b/crux/wiki-server/sync-resources.ts
@@ -1,0 +1,326 @@
+/**
+ * Wiki Server Resources Sync
+ *
+ * Reads all data/resources/*.yaml files and bulk-upserts them to the
+ * wiki-server's /api/resources/batch endpoint.
+ *
+ * Reuses the retry + health-check pattern from sync-pages.ts:
+ *   - Pre-sync health check with retries (waits for server to be ready)
+ *   - Per-batch retry with exponential backoff (handles transient 5xx errors)
+ *   - Fast-fail after N consecutive batch failures
+ *
+ * Usage:
+ *   pnpm crux wiki-server sync-resources
+ *   pnpm crux wiki-server sync-resources --dry-run
+ *   pnpm crux wiki-server sync-resources --batch-size=100
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL   - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey, buildHeaders } from "../lib/wiki-server-client.ts";
+import { waitForHealthy, fetchWithRetry } from "./sync-pages.ts";
+
+const PROJECT_ROOT = join(import.meta.dirname!, "../..");
+const RESOURCES_DIR = join(PROJECT_ROOT, "data/resources");
+
+// --- Configuration ---
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+// --- Types ---
+
+interface YamlResource {
+  id: string;
+  url: string;
+  title?: string;
+  type?: string;
+  summary?: string;
+  review?: string;
+  abstract?: string;
+  key_points?: string[];
+  publication_id?: string;
+  authors?: string[];
+  published_date?: string | Date;
+  tags?: string[];
+  local_filename?: string;
+  credibility_override?: number;
+  fetched_at?: string | Date;
+  content_hash?: string;
+  cited_by?: string[];
+}
+
+export interface SyncResource {
+  id: string;
+  url: string;
+  title: string | null;
+  type: string | null;
+  summary: string | null;
+  review: string | null;
+  abstract: string | null;
+  keyPoints: string[] | null;
+  publicationId: string | null;
+  authors: string[] | null;
+  publishedDate: string | null;
+  tags: string[] | null;
+  localFilename: string | null;
+  credibilityOverride: number | null;
+  fetchedAt: string | null;
+  contentHash: string | null;
+  citedBy: string[] | null;
+}
+
+// --- Helpers ---
+
+function normalizeDate(d: string | Date | undefined): string | null {
+  if (!d) return null;
+  if (d instanceof Date) return d.toISOString().split("T")[0];
+  const dateStr = String(d).split(" ")[0];
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+  return null;
+}
+
+function normalizeTimestamp(d: string | Date | undefined): string | null {
+  if (!d) return null;
+  if (d instanceof Date) return d.toISOString();
+  const str = String(d);
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(str)) {
+    return str.replace(" ", "T") + "Z";
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+    return str + "T00:00:00Z";
+  }
+  try {
+    const parsed = new Date(str);
+    if (isNaN(parsed.getTime())) return null;
+    return parsed.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+export function transformResource(r: YamlResource): SyncResource {
+  return {
+    id: r.id,
+    url: r.url,
+    title: r.title ?? null,
+    type: r.type ?? null,
+    summary: r.summary ?? null,
+    review: r.review ?? null,
+    abstract: r.abstract ?? null,
+    keyPoints: r.key_points ?? null,
+    publicationId: r.publication_id ?? null,
+    authors: r.authors ?? null,
+    publishedDate: normalizeDate(r.published_date),
+    tags: r.tags ?? null,
+    localFilename: r.local_filename ?? null,
+    credibilityOverride: r.credibility_override ?? null,
+    fetchedAt: normalizeTimestamp(r.fetched_at),
+    contentHash: r.content_hash ?? null,
+    citedBy: r.cited_by ?? null,
+  };
+}
+
+/**
+ * Read all data/resources/*.yaml files and return parsed resources.
+ * Exported for testing.
+ */
+export function loadResourceYamls(
+  dir: string = RESOURCES_DIR
+): { resources: YamlResource[]; errorFiles: number } {
+  const files = readdirSync(dir).filter((f) => f.endsWith(".yaml"));
+  const resources: YamlResource[] = [];
+  let errorFiles = 0;
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    try {
+      const raw = readFileSync(filePath, "utf-8");
+      const parsed = parseYaml(raw);
+
+      if (!Array.isArray(parsed)) {
+        console.warn(`  WARN: ${file} — not an array, skipping`);
+        errorFiles++;
+        continue;
+      }
+
+      for (const entry of parsed as YamlResource[]) {
+        if (!entry.id || !entry.url) {
+          console.warn(`  WARN: ${file} — entry missing id or url, skipping`);
+          continue;
+        }
+        resources.push(entry);
+      }
+    } catch (err) {
+      console.warn(`  ERROR: ${file} — ${err}`);
+      errorFiles++;
+    }
+  }
+
+  return { resources, errorFiles };
+}
+
+/**
+ * Sync resources to the wiki-server in batches.
+ * Exported for testing.
+ */
+export async function syncResources(
+  serverUrl: string,
+  items: SyncResource[],
+  batchSize: number,
+  options: {
+    _sleep?: (ms: number) => Promise<void>;
+  } = {}
+): Promise<{ upserted: number; errors: number }> {
+  let totalUpserted = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(items.length / batchSize);
+
+    try {
+      const res = await fetchWithRetry(
+        `${serverUrl}/api/resources/batch`,
+        {
+          method: "POST",
+          headers: buildHeaders(),
+          body: JSON.stringify({ items: batch }),
+        },
+        { _sleep: options._sleep }
+      );
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(
+          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${body}`
+        );
+        totalErrors += batch.length;
+        consecutiveFailures++;
+      } else {
+        const result = (await res.json()) as { inserted: number };
+        totalUpserted += result.inserted;
+        consecutiveFailures = 0;
+
+        console.log(
+          `  Batch ${batchNum}/${totalBatches}: ${result.inserted} upserted`
+        );
+      }
+    } catch (err) {
+      console.error(
+        `  Batch ${batchNum}/${totalBatches}: Failed after retries — ${err}`
+      );
+      totalErrors += batch.length;
+      consecutiveFailures++;
+    }
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const remaining = items.length - (i + batchSize);
+      if (remaining > 0) {
+        console.error(
+          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batch failures. ` +
+            `Skipping ${remaining} remaining resources.`
+        );
+        totalErrors += remaining;
+      }
+      break;
+    }
+  }
+
+  return { upserted: totalUpserted, errors: totalErrors };
+}
+
+// --- CLI ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || DEFAULT_BATCH_SIZE;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_URL environment variable is required"
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required"
+    );
+    process.exit(1);
+  }
+
+  // Load resources
+  console.log(`Reading resources from: ${RESOURCES_DIR}`);
+  const { resources: yamlResources, errorFiles } = loadResourceYamls();
+
+  if (errorFiles > 0) {
+    console.warn(`  ${errorFiles} file(s) had errors`);
+  }
+
+  // Transform
+  const syncPayloads = yamlResources.map(transformResource);
+  const withCitations = syncPayloads.filter(
+    (r) => r.citedBy && r.citedBy.length > 0
+  );
+  const totalCitations = syncPayloads.reduce(
+    (sum, r) => sum + (r.citedBy?.length ?? 0),
+    0
+  );
+
+  console.log(
+    `Syncing ${syncPayloads.length} resources to ${serverUrl} (batch size: ${batchSize})`
+  );
+  console.log(
+    `  ${withCitations.length} resources have citations (${totalCitations} total citation links)`
+  );
+
+  if (dryRun) {
+    console.log("\n[dry-run] Would sync these resources:");
+    for (const r of syncPayloads.slice(0, 10)) {
+      console.log(`  ${r.id} — ${r.title ?? r.url}`);
+    }
+    if (syncPayloads.length > 10) {
+      console.log(`  ... and ${syncPayloads.length - 10} more`);
+    }
+    process.exit(0);
+  }
+
+  // Pre-sync health check
+  console.log("\nChecking server health...");
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy after retries. Aborting sync.`
+    );
+    process.exit(1);
+  }
+
+  // Sync
+  const result = await syncResources(serverUrl, syncPayloads, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Upserted: ${result.upserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:  ${result.errors}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("Sync failed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- New `.github/workflows/sync-resources.yml` workflow that syncs `data/resources/*.yaml` to wiki-server on push to main
- New `crux/wiki-server/sync-resources.ts` script reusing the retry + health-check pattern from `sync-pages.ts`
- Registered as `pnpm crux wiki-server sync-resources` CLI command
- 14 unit tests covering transformation, batch sync, error handling, and edge cases

## Details

- Triggers on push to `main` when `data/resources/**` changes, plus manual `workflow_dispatch`
- Pre-sync schema validation gate (`pnpm crux validate schema`)
- Concurrency block to prevent duplicate syncs on rapid pushes
- Reads all `data/resources/*.yaml` files, transforms snake_case YAML fields to camelCase API format, and bulk-upserts via `/api/resources/batch`
- Reuses `waitForHealthy` and `fetchWithRetry` from sync-pages.ts for health checks and exponential backoff retries
- Fast-fails after 3 consecutive batch failures

Closes #464

## Test plan

- [x] 14 unit tests pass (transformResource: 7, syncResources: 7)
- [x] `pnpm crux validate gate` passes (all 8 checks)
- [x] TypeScript type check passes
- [ ] Verify workflow runs on next push to main that changes `data/resources/`

https://claude.ai/code/session_01584895WxkyFjYa1XE1wu28