### PR TITLE
feat: add page_links table and API for server-side backlinks/related pages

### DIFF
--- a/apps/web/scripts/lib/links-client.mjs
+++ b/apps/web/scripts/lib/links-client.mjs
@@ -1,0 +1,8 @@
+/**
+ * links-client.mjs — Thin wrapper re-exporting from the shared wiki-server client.
+ *
+ * Used by build-data.mjs to sync page links (backlinks, related-page signals)
+ * to the wiki-server. Gracefully skips if server is unavailable.
+ */
+
+export { syncPageLinks } from '../../../../crux/lib/wiki-server-client.ts';

--- a/apps/wiki-server/drizzle/0013_add_page_links.sql
+++ b/apps/wiki-server/drizzle/0013_add_page_links.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "page_links" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"source_id" text NOT NULL,
+	"target_id" text NOT NULL,
+	"link_type" text NOT NULL,
+	"relationship" text,
+	"weight" real DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_pl_source_target_type" ON "page_links" USING btree ("source_id","target_id","link_type");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pl_source_id" ON "page_links" USING btree ("source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pl_target_id" ON "page_links" USING btree ("target_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pl_link_type" ON "page_links" USING btree ("link_type");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1771900200000,
       "tag": "0012_add_claims",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1771900300000,
+      "tag": "0013_add_page_links",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/links.test.ts
+++ b/apps/wiki-server/src/__tests__/links.test.ts
@@ -1,0 +1,625 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- In-memory stores ----
+
+interface LinkRow {
+  id: number;
+  source_id: string;
+  target_id: string;
+  link_type: string;
+  relationship: string | null;
+  weight: number;
+  created_at: Date;
+}
+
+interface PageRow {
+  id: string;
+  title: string;
+  entity_type: string | null;
+  quality: number | null;
+  reader_importance: number | null;
+  [key: string]: unknown;
+}
+
+let linksStore: Map<string, LinkRow>;
+let pagesStore: Map<string, PageRow>;
+let nextId: number;
+
+function resetStores() {
+  linksStore = new Map();
+  pagesStore = new Map();
+  nextId = 1;
+}
+
+function linkKey(sourceId: string, targetId: string, linkType: string) {
+  return `${sourceId}|${targetId}|${linkType}`;
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- page_links: DELETE all ---
+  if (q.includes("delete from") && q.includes("page_links")) {
+    linksStore.clear();
+    return [];
+  }
+
+  // --- page_links: INSERT ... ON CONFLICT DO UPDATE (multi-row) ---
+  if (q.includes("insert into") && q.includes("page_links")) {
+    const COLS = 5;
+    const numRows = params.length / COLS;
+    const rows: LinkRow[] = [];
+    const now = new Date();
+    for (let i = 0; i < numRows; i++) {
+      const o = i * COLS;
+      const row: LinkRow = {
+        id: nextId++,
+        source_id: params[o] as string,
+        target_id: params[o + 1] as string,
+        link_type: params[o + 2] as string,
+        relationship: (params[o + 3] as string) || null,
+        weight: params[o + 4] as number,
+        created_at: now,
+      };
+      const key = linkKey(row.source_id, row.target_id, row.link_type);
+      const existing = linksStore.get(key);
+      if (existing) {
+        // Update on conflict
+        existing.weight = row.weight;
+        existing.relationship = row.relationship;
+        rows.push(existing);
+      } else {
+        linksStore.set(key, row);
+        rows.push(row);
+      }
+    }
+    return rows;
+  }
+
+  // --- page_links: DISTINCT ON backlinks query ---
+  if (
+    q.includes("page_links") &&
+    q.includes("distinct on") &&
+    q.includes("target_id")
+  ) {
+    const targetId = params[0] as string;
+    const limit = (params[1] as number) || 50;
+    const results: Record<string, unknown>[] = [];
+    const seen = new Set<string>();
+
+    for (const row of linksStore.values()) {
+      if (row.target_id === targetId && !seen.has(row.source_id)) {
+        seen.add(row.source_id);
+        const page = pagesStore.get(row.source_id);
+        results.push({
+          source_id: row.source_id,
+          link_type: row.link_type,
+          relationship: row.relationship,
+          weight: row.weight,
+          source_title: page?.title || null,
+          source_type: page?.entity_type || null,
+        });
+      }
+    }
+    return results.slice(0, limit);
+  }
+
+  // --- page_links: bidirectional links CTE (related endpoint) ---
+  if (q.includes("bidirectional_links") || q.includes("aggregated")) {
+    const entityId = params[0] as string;
+    const minScore = params[2] as number;
+    const limit = (params[3] as number) || 75;
+
+    // Gather bidirectional links
+    const neighborScores = new Map<string, number>();
+    const neighborRelationship = new Map<string, string | null>();
+
+    for (const row of linksStore.values()) {
+      let neighborId: string | null = null;
+      if (row.source_id === entityId) neighborId = row.target_id;
+      else if (row.target_id === entityId) neighborId = row.source_id;
+      if (!neighborId || neighborId === entityId) continue;
+
+      neighborScores.set(
+        neighborId,
+        (neighborScores.get(neighborId) || 0) + row.weight
+      );
+      if (
+        row.link_type === "yaml_related" &&
+        row.relationship &&
+        !neighborRelationship.has(neighborId)
+      ) {
+        neighborRelationship.set(neighborId, row.relationship);
+      }
+    }
+
+    // Apply quality boost and filter
+    const results: Record<string, unknown>[] = [];
+    for (const [neighborId, rawScore] of neighborScores) {
+      const page = pagesStore.get(neighborId);
+      const q2 = page?.quality ?? 5;
+      const imp = page?.reader_importance ?? 50;
+      const score = rawScore * (1.0 + q2 / 40.0 + imp / 400.0);
+      if (score < minScore) continue;
+
+      results.push({
+        id: neighborId,
+        raw_score: rawScore,
+        relationship: neighborRelationship.get(neighborId) || null,
+        title: page?.title || null,
+        entity_type: page?.entity_type || null,
+        quality: page?.quality ?? null,
+        reader_importance: page?.reader_importance ?? null,
+        score,
+      });
+    }
+
+    results.sort(
+      (a, b) => (b.score as number) - (a.score as number)
+    );
+    return results.slice(0, limit);
+  }
+
+  // --- page_links: graph query ---
+  if (
+    q.includes("page_links") &&
+    (q.includes("source_title") || q.includes("target_title")) &&
+    !q.includes("distinct on") &&
+    !q.includes("bidirectional")
+  ) {
+    const entityId = params[0] as string;
+    const results: Record<string, unknown>[] = [];
+
+    for (const row of linksStore.values()) {
+      if (row.source_id === entityId || row.target_id === entityId) {
+        const sourcePage = pagesStore.get(row.source_id);
+        const targetPage = pagesStore.get(row.target_id);
+        results.push({
+          source_id: row.source_id,
+          target_id: row.target_id,
+          link_type: row.link_type,
+          relationship: row.relationship,
+          weight: row.weight,
+          source_title: sourcePage?.title || null,
+          source_type: sourcePage?.entity_type || null,
+          target_title: targetPage?.title || null,
+          target_type: targetPage?.entity_type || null,
+        });
+      }
+    }
+
+    results.sort(
+      (a, b) => (b.weight as number) - (a.weight as number)
+    );
+    return results;
+  }
+
+  // --- page_links: stats (count by type) ---
+  if (q.includes("link_type") && q.includes("group by") && q.includes("avg")) {
+    const byType = new Map<string, { count: number; totalWeight: number }>();
+    for (const row of linksStore.values()) {
+      const entry = byType.get(row.link_type) || {
+        count: 0,
+        totalWeight: 0,
+      };
+      entry.count++;
+      entry.totalWeight += row.weight;
+      byType.set(row.link_type, entry);
+    }
+    return Array.from(byType).map(([type, { count, totalWeight }]) => ({
+      link_type: type,
+      count,
+      avg_weight: (totalWeight / count).toFixed(2),
+    }));
+  }
+
+  // --- page_links: total count ---
+  if (
+    q.includes("count(*)") &&
+    q.includes("page_links") &&
+    !q.includes("distinct")
+  ) {
+    return [{ total: linksStore.size }];
+  }
+
+  // --- page_links: unique sources/targets ---
+  if (q.includes("distinct source_id") && q.includes("distinct target_id")) {
+    const sources = new Set<string>();
+    const targets = new Set<string>();
+    for (const row of linksStore.values()) {
+      sources.add(row.source_id);
+      targets.add(row.target_id);
+    }
+    return [{ sources: sources.size, targets: targets.size }];
+  }
+
+  // --- wiki_pages: INSERT (for seeding) ---
+  if (q.includes("insert into") && q.includes("wiki_pages")) {
+    const COLS = 17;
+    const numRows = params.length / COLS;
+    const rows: PageRow[] = [];
+    for (let i = 0; i < numRows; i++) {
+      const o = i * COLS;
+      const row: PageRow = {
+        id: params[o] as string,
+        title: params[o + 2] as string,
+        entity_type: (params[o + 7] as string) || null,
+        quality: (params[o + 9] as number) || null,
+        reader_importance: (params[o + 10] as number) || null,
+      };
+      pagesStore.set(row.id, row);
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  // --- wiki_pages: search vector update ---
+  if (q.includes("update wiki_pages") && q.includes("search_vector")) {
+    return [];
+  }
+
+  // --- health check fallbacks ---
+  if (q.includes("count(*)")) {
+    return [{ count: 0 }];
+  }
+  if (q.includes("last_value")) {
+    return [{ last_value: 0, is_called: true }];
+  }
+
+  return [];
+}
+
+// Mock the db module
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Helpers ----
+
+function seedPage(
+  app: Hono,
+  id: string,
+  title: string,
+  opts: Record<string, unknown> = {}
+) {
+  return postJson(app, "/api/pages/sync", {
+    pages: [
+      {
+        id,
+        title,
+        numericId: opts.numericId ?? `E${Math.floor(Math.random() * 1000)}`,
+        description: opts.description ?? `Description of ${title}`,
+        category: opts.category ?? "concept",
+        entityType: opts.entityType ?? "concept",
+        readerImportance: opts.readerImportance ?? 50,
+        quality: opts.quality ?? 60,
+        ...opts,
+      },
+    ],
+  });
+}
+
+function syncLinks(app: Hono, links: unknown[], replace = false) {
+  return postJson(app, "/api/links/sync", { links, replace });
+}
+
+// ---- Tests ----
+
+describe("Links API", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  // ---- Sync ----
+
+  describe("POST /api/links/sync", () => {
+    it("creates new links", async () => {
+      const res = await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          relationship: "supports",
+          weight: 10,
+        },
+        {
+          sourceId: "openai",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          relationship: "contributes-to",
+          weight: 10,
+        },
+      ]);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(2);
+    });
+
+    it("upserts on conflict", async () => {
+      await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          weight: 5,
+        },
+      ]);
+
+      const res = await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          weight: 10,
+        },
+      ]);
+
+      expect(res.status).toBe(200);
+      // Weight should be updated
+    });
+
+    it("replaces all links when replace=true", async () => {
+      await syncLinks(app, [
+        {
+          sourceId: "old-source",
+          targetId: "old-target",
+          linkType: "entity_link",
+          weight: 5,
+        },
+      ]);
+
+      const res = await syncLinks(
+        app,
+        [
+          {
+            sourceId: "new-source",
+            targetId: "new-target",
+            linkType: "entity_link",
+            weight: 5,
+          },
+        ],
+        true
+      );
+
+      expect(res.status).toBe(200);
+      // Old links should be deleted
+      expect(linksStore.size).toBe(1);
+      expect(linksStore.has("new-source|new-target|entity_link")).toBe(true);
+    });
+
+    it("rejects empty batch", async () => {
+      const res = await syncLinks(app, []);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid link type", async () => {
+      const res = await syncLinks(app, [
+        {
+          sourceId: "a",
+          targetId: "b",
+          linkType: "invalid_type",
+          weight: 1,
+        },
+      ]);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ---- Backlinks ----
+
+  describe("GET /api/links/backlinks/:id", () => {
+    it("returns backlinks for a target entity", async () => {
+      await seedPage(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+      });
+      await seedPage(app, "openai", "OpenAI", { entityType: "organization" });
+      await seedPage(app, "ai-safety", "AI Safety", { entityType: "concept" });
+
+      await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          relationship: "supports",
+          weight: 10,
+        },
+        {
+          sourceId: "openai",
+          targetId: "ai-safety",
+          linkType: "entity_link",
+          weight: 5,
+        },
+      ]);
+
+      const res = await app.request("/api/links/backlinks/ai-safety");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.targetId).toBe("ai-safety");
+      expect(body.backlinks).toHaveLength(2);
+      expect(body.backlinks.map((b: any) => b.id).sort()).toEqual([
+        "anthropic",
+        "openai",
+      ]);
+    });
+
+    it("returns empty array for entity with no backlinks", async () => {
+      const res = await app.request("/api/links/backlinks/nonexistent");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.backlinks).toHaveLength(0);
+    });
+
+    it("includes relationship labels", async () => {
+      await syncLinks(app, [
+        {
+          sourceId: "misalignment",
+          targetId: "existential-risk",
+          linkType: "yaml_related",
+          relationship: "causes",
+          weight: 10,
+        },
+      ]);
+
+      const res = await app.request("/api/links/backlinks/existential-risk");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.backlinks[0].relationship).toBe("causes");
+    });
+  });
+
+  // ---- Related ----
+
+  describe("GET /api/links/related/:id", () => {
+    it("returns related pages with scores", async () => {
+      await seedPage(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+        quality: 80,
+        readerImportance: 90,
+      });
+      await seedPage(app, "openai", "OpenAI", {
+        entityType: "organization",
+        quality: 70,
+        readerImportance: 85,
+      });
+      await seedPage(app, "ai-safety", "AI Safety", {
+        entityType: "concept",
+        quality: 60,
+        readerImportance: 70,
+      });
+
+      await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          weight: 10,
+        },
+        {
+          sourceId: "anthropic",
+          targetId: "openai",
+          linkType: "entity_link",
+          weight: 5,
+        },
+      ]);
+
+      const res = await app.request("/api/links/related/anthropic");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.entityId).toBe("anthropic");
+      expect(body.related.length).toBeGreaterThan(0);
+      // Each entry should have id, type, title, score
+      for (const item of body.related) {
+        expect(item.id).toBeDefined();
+        expect(item.type).toBeDefined();
+        expect(item.score).toBeGreaterThanOrEqual(MIN_SCORE);
+      }
+    });
+
+    it("returns empty for entity with no links", async () => {
+      const res = await app.request("/api/links/related/nonexistent");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.related).toHaveLength(0);
+    });
+
+    it("computes bidirectional scores", async () => {
+      await seedPage(app, "a", "Entity A", { quality: 50, readerImportance: 50 });
+      await seedPage(app, "b", "Entity B", { quality: 50, readerImportance: 50 });
+
+      // Link from A → B
+      await syncLinks(app, [
+        {
+          sourceId: "a",
+          targetId: "b",
+          linkType: "yaml_related",
+          weight: 10,
+        },
+      ]);
+
+      // Both A and B should see each other as related
+      const resA = await app.request("/api/links/related/a");
+      const bodyA = await resA.json();
+      expect(bodyA.related.some((r: any) => r.id === "b")).toBe(true);
+
+      const resB = await app.request("/api/links/related/b");
+      const bodyB = await resB.json();
+      expect(bodyB.related.some((r: any) => r.id === "a")).toBe(true);
+    });
+  });
+
+  // ---- Graph ----
+
+  describe("GET /api/links/graph/:id", () => {
+    it("returns graph data with nodes and edges", async () => {
+      await seedPage(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+      });
+      await seedPage(app, "ai-safety", "AI Safety", {
+        entityType: "concept",
+      });
+
+      await syncLinks(app, [
+        {
+          sourceId: "anthropic",
+          targetId: "ai-safety",
+          linkType: "yaml_related",
+          relationship: "supports",
+          weight: 10,
+        },
+      ]);
+
+      const res = await app.request("/api/links/graph/anthropic");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.entityId).toBe("anthropic");
+      expect(body.nodes).toHaveLength(2);
+      expect(body.edges).toHaveLength(1);
+      expect(body.edges[0].source).toBe("anthropic");
+      expect(body.edges[0].target).toBe("ai-safety");
+      expect(body.edges[0].relationship).toBe("supports");
+    });
+  });
+
+  // ---- Stats ----
+
+  describe("GET /api/links/stats", () => {
+    it("returns link statistics", async () => {
+      await syncLinks(app, [
+        {
+          sourceId: "a",
+          targetId: "b",
+          linkType: "yaml_related",
+          weight: 10,
+        },
+        {
+          sourceId: "c",
+          targetId: "d",
+          linkType: "entity_link",
+          weight: 5,
+        },
+        {
+          sourceId: "a",
+          targetId: "d",
+          linkType: "entity_link",
+          weight: 5,
+        },
+      ]);
+
+      const res = await app.request("/api/links/stats");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(3);
+      expect(body.byType).toHaveLength(2);
+    });
+  });
+});
+
+// Reference constant from the route
+const MIN_SCORE = 1.0;

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -12,6 +12,7 @@ import { sessionsRoute } from "./routes/sessions.js";
 import { resourcesRoute } from "./routes/resources.js";
 import { summariesRoute } from "./routes/summaries.js";
 import { claimsRoute } from "./routes/claims.js";
+import { linksRoute } from "./routes/links.js";
 
 export function createApp() {
   const app = new Hono();
@@ -52,6 +53,7 @@ export function createApp() {
   app.route("/api/resources", resourcesRoute);
   app.route("/api/summaries", summariesRoute);
   app.route("/api/claims", claimsRoute);
+  app.route("/api/links", linksRoute);
 
   return app;
 }

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -1,0 +1,440 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { getDrizzleDb, getDb } from "../db.js";
+import { pageLinks } from "../schema.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+} from "./utils.js";
+
+export const linksRoute = new Hono();
+
+// ---- Constants ----
+
+const MAX_BATCH_SIZE = 5000; // Links are small rows; builds produce many
+const MAX_RELATED = 25;
+const MIN_SCORE = 1.0;
+const MIN_PER_TYPE = 2;
+
+/**
+ * Inverse relationship labels — given a forward label, returns the reverse.
+ * e.g. "causes" → "caused by"
+ */
+const INVERSE_LABEL: Record<string, string> = {
+  causes: "caused by",
+  cause: "caused by",
+  mitigates: "mitigated by",
+  "mitigated-by": "mitigates",
+  mitigation: "mitigated by",
+  requires: "required by",
+  enables: "enabled by",
+  blocks: "blocked by",
+  supersedes: "superseded by",
+  increases: "increased by",
+  decreases: "decreased by",
+  supports: "supported by",
+  measures: "measured by",
+  "measured-by": "measures",
+  "analyzed-by": "analyzes",
+  analyzes: "analyzed by",
+  "child-of": "parent of",
+  "composed-of": "component of",
+  component: "composed of",
+  addresses: "addressed by",
+  affects: "affected by",
+  amplifies: "amplified by",
+  "contributes-to": "receives contribution from",
+  "driven-by": "drives",
+  driver: "driven by",
+  drives: "driven by",
+  "leads-to": "leads",
+  "shaped-by": "shapes",
+  prerequisite: "depends on",
+  research: "researched by",
+  models: "modeled by",
+};
+
+// ---- Schemas ----
+
+const LinkSchema = z.object({
+  sourceId: z.string().min(1).max(300),
+  targetId: z.string().min(1).max(300),
+  linkType: z.enum([
+    "yaml_related",
+    "entity_link",
+    "name_prefix",
+    "similarity",
+    "shared_tag",
+  ]),
+  relationship: z.string().max(100).nullable().optional(),
+  weight: z.number().min(0).max(100).default(1.0),
+});
+
+const SyncBatchSchema = z.object({
+  links: z.array(LinkSchema).min(1).max(MAX_BATCH_SIZE),
+  /** If true, delete all existing links before inserting (full replace). */
+  replace: z.boolean().optional().default(false),
+});
+
+const BacklinksQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+const RelatedQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(MAX_RELATED),
+});
+
+// ---- POST /sync ----
+
+linksRoute.post("/sync", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { links, replace } = parsed.data;
+  const db = getDrizzleDb();
+
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    if (replace) {
+      await tx.delete(pageLinks);
+    }
+
+    // Batch upsert — on conflict (source, target, type) update weight + relationship
+    for (let i = 0; i < links.length; i += 500) {
+      const batch = links.slice(i, i + 500);
+      const vals = batch.map((link) => ({
+        sourceId: link.sourceId,
+        targetId: link.targetId,
+        linkType: link.linkType,
+        relationship: link.relationship ?? null,
+        weight: link.weight,
+      }));
+
+      await tx
+        .insert(pageLinks)
+        .values(vals)
+        .onConflictDoUpdate({
+          target: [pageLinks.sourceId, pageLinks.targetId, pageLinks.linkType],
+          set: {
+            weight: sql`excluded.weight`,
+            relationship: sql`excluded.relationship`,
+          },
+        });
+
+      upserted += vals.length;
+    }
+  });
+
+  return c.json({ upserted });
+});
+
+// ---- GET /backlinks/:id ----
+
+linksRoute.get("/backlinks/:id", async (c) => {
+  const targetId = c.req.param("id");
+  if (!targetId) return validationError(c, "Entity ID is required");
+
+  const parsed = BacklinksQuery.safeParse(c.req.query());
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { limit } = parsed.data;
+  const rawDb = getDb();
+
+  // Find all pages/entities that link TO this target.
+  // Join with wiki_pages to get title and entity_type for the source.
+  // Deduplicate by source_id (a source may link via multiple link_types),
+  // then order by weight descending (most relevant first).
+  const results = await rawDb`
+    SELECT * FROM (
+      SELECT DISTINCT ON (pl.source_id)
+        pl.source_id,
+        pl.link_type,
+        pl.relationship,
+        pl.weight,
+        wp.title AS source_title,
+        wp.entity_type AS source_type
+      FROM page_links pl
+      LEFT JOIN wiki_pages wp ON wp.id = pl.source_id
+      WHERE pl.target_id = ${targetId}
+      ORDER BY pl.source_id, pl.weight DESC
+    ) sub
+    ORDER BY sub.weight DESC
+    LIMIT ${limit}
+  `;
+
+  const backlinks = results.map((r: any) => ({
+    id: r.source_id,
+    type: r.source_type || "concept",
+    title: r.source_title || r.source_id,
+    relationship: r.relationship || undefined,
+    linkType: r.link_type,
+    weight: r.weight,
+  }));
+
+  return c.json({
+    targetId,
+    backlinks,
+    total: backlinks.length,
+  });
+});
+
+// ---- GET /related/:id ----
+
+linksRoute.get("/related/:id", async (c) => {
+  const entityId = c.req.param("id");
+  if (!entityId) return validationError(c, "Entity ID is required");
+
+  const parsed = RelatedQuery.safeParse(c.req.query());
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { limit } = parsed.data;
+  const rawDb = getDb();
+
+  // Compute related pages by aggregating all link signals bidirectionally.
+  // For each neighbor, sum the weights of all link types connecting them.
+  // Apply quality boost: 1 + quality/40 + reader_importance/400 (max ~1.45x).
+  // Relationship labels come from yaml_related links.
+  const results = await rawDb`
+    WITH bidirectional_links AS (
+      -- Forward links: entityId is source (is_reverse = false)
+      SELECT target_id AS neighbor_id, link_type, relationship, weight, false AS is_reverse
+      FROM page_links
+      WHERE source_id = ${entityId}
+      UNION ALL
+      -- Reverse links: entityId is target (is_reverse = true)
+      SELECT source_id AS neighbor_id, link_type, relationship, weight, true AS is_reverse
+      FROM page_links
+      WHERE target_id = ${entityId}
+    ),
+    aggregated AS (
+      SELECT
+        bl.neighbor_id,
+        SUM(bl.weight) AS raw_score,
+        -- Pick the first non-null relationship label (from yaml_related)
+        (SELECT bl2.relationship
+         FROM bidirectional_links bl2
+         WHERE bl2.neighbor_id = bl.neighbor_id
+           AND bl2.relationship IS NOT NULL
+           AND bl2.link_type = 'yaml_related'
+         LIMIT 1
+        ) AS relationship,
+        -- Track direction of the yaml_related link for label inversion
+        (SELECT bl2.is_reverse
+         FROM bidirectional_links bl2
+         WHERE bl2.neighbor_id = bl.neighbor_id
+           AND bl2.relationship IS NOT NULL
+           AND bl2.link_type = 'yaml_related'
+         LIMIT 1
+        ) AS relationship_is_reverse
+      FROM bidirectional_links bl
+      WHERE bl.neighbor_id != ${entityId}
+      GROUP BY bl.neighbor_id
+    )
+    SELECT
+      a.neighbor_id AS id,
+      a.raw_score,
+      a.relationship,
+      a.relationship_is_reverse,
+      wp.title,
+      wp.entity_type,
+      wp.quality,
+      wp.reader_importance,
+      -- Apply quality boost: unrated pages get defaults (q=5, imp=50)
+      a.raw_score * (1.0 + COALESCE(wp.quality, 5)::real / 40.0
+                         + COALESCE(wp.reader_importance, 50)::real / 400.0) AS score
+    FROM aggregated a
+    LEFT JOIN wiki_pages wp ON wp.id = a.neighbor_id
+    WHERE a.raw_score * (1.0 + COALESCE(wp.quality, 5)::real / 40.0
+                             + COALESCE(wp.reader_importance, 50)::real / 400.0) >= ${MIN_SCORE}
+    ORDER BY score DESC
+    LIMIT ${limit * 3}
+  `;
+
+  // Type-diverse selection: guarantee MIN_PER_TYPE from each entity type,
+  // then fill remaining slots with highest-scoring entries.
+  const scored = results.map((r: any) => ({
+    id: r.id as string,
+    type: (r.entity_type as string) || "concept",
+    title: (r.title as string) || r.id,
+    score: Math.round(parseFloat(r.score) * 100) / 100,
+    label: formatRelationshipLabel(r.relationship, !!r.relationship_is_reverse) || undefined,
+  }));
+
+  const selected = typeDiverseSelect(scored, limit);
+
+  return c.json({
+    entityId,
+    related: selected,
+    total: selected.length,
+  });
+});
+
+// ---- GET /graph/:id ----
+
+linksRoute.get("/graph/:id", async (c) => {
+  const entityId = c.req.param("id");
+  if (!entityId) return validationError(c, "Entity ID is required");
+
+  const rawDb = getDb();
+  const MAX_GRAPH_EDGES = 500;
+
+  // Get all direct links (both directions) for the entity.
+  // This provides the raw graph data for visualization.
+  const results = await rawDb`
+    SELECT
+      pl.source_id,
+      pl.target_id,
+      pl.link_type,
+      pl.relationship,
+      pl.weight,
+      ws.title AS source_title,
+      ws.entity_type AS source_type,
+      wt.title AS target_title,
+      wt.entity_type AS target_type
+    FROM page_links pl
+    LEFT JOIN wiki_pages ws ON ws.id = pl.source_id
+    LEFT JOIN wiki_pages wt ON wt.id = pl.target_id
+    WHERE pl.source_id = ${entityId} OR pl.target_id = ${entityId}
+    ORDER BY pl.weight DESC
+    LIMIT ${MAX_GRAPH_EDGES}
+  `;
+
+  // Build node and edge sets
+  const nodeMap = new Map<string, { id: string; type: string; title: string }>();
+  const edges: Array<{
+    source: string;
+    target: string;
+    linkType: string;
+    relationship?: string;
+    weight: number;
+  }> = [];
+
+  for (const r of results as any[]) {
+    if (!nodeMap.has(r.source_id)) {
+      nodeMap.set(r.source_id, {
+        id: r.source_id,
+        type: r.source_type || "concept",
+        title: r.source_title || r.source_id,
+      });
+    }
+    if (!nodeMap.has(r.target_id)) {
+      nodeMap.set(r.target_id, {
+        id: r.target_id,
+        type: r.target_type || "concept",
+        title: r.target_title || r.target_id,
+      });
+    }
+    edges.push({
+      source: r.source_id,
+      target: r.target_id,
+      linkType: r.link_type,
+      relationship: r.relationship || undefined,
+      weight: r.weight,
+    });
+  }
+
+  return c.json({
+    entityId,
+    nodes: Array.from(nodeMap.values()),
+    edges,
+  });
+});
+
+// ---- GET /stats ----
+
+linksRoute.get("/stats", async (c) => {
+  const rawDb = getDb();
+
+  const stats = await rawDb`
+    SELECT
+      link_type,
+      COUNT(*)::int AS count,
+      ROUND(AVG(weight)::numeric, 2) AS avg_weight
+    FROM page_links
+    GROUP BY link_type
+    ORDER BY count DESC
+  `;
+
+  const totalResult = await rawDb`
+    SELECT COUNT(*)::int AS total FROM page_links
+  `;
+
+  const uniquePagesResult = await rawDb`
+    SELECT COUNT(DISTINCT source_id)::int AS sources,
+           COUNT(DISTINCT target_id)::int AS targets
+    FROM page_links
+  `;
+
+  return c.json({
+    total: (totalResult[0] as any)?.total || 0,
+    uniqueSources: (uniquePagesResult[0] as any)?.sources || 0,
+    uniqueTargets: (uniquePagesResult[0] as any)?.targets || 0,
+    byType: stats.map((s: any) => ({
+      linkType: s.link_type,
+      count: s.count,
+      avgWeight: parseFloat(s.avg_weight),
+    })),
+  });
+});
+
+// ---- Helpers ----
+
+/**
+ * Format a relationship label, applying inverse if needed.
+ *
+ * In the related query, the relationship label comes from the source→target
+ * direction of the yaml_related link. If the current entity is the target
+ * (i.e., the link points TO us), we need the inverse label.
+ *
+ * @param relationship - Raw relationship string from DB
+ * @param isReverse - Whether the link was found in the reverse direction
+ */
+function formatRelationshipLabel(
+  relationship: string | null,
+  isReverse: boolean
+): string | null {
+  if (!relationship || relationship === "related") return null;
+  const label = isReverse
+    ? INVERSE_LABEL[relationship] || relationship
+    : relationship;
+  return label.replace(/-/g, " ");
+}
+
+/**
+ * Type-diverse selection: guarantees MIN_PER_TYPE entries from each entity type,
+ * then fills remaining slots by score.
+ */
+function typeDiverseSelect(
+  scored: Array<{ id: string; type: string; title: string; score: number; label?: string }>,
+  maxItems: number
+): typeof scored {
+  const selected = new Set<string>();
+  const byType = new Map<string, typeof scored>();
+
+  for (const entry of scored) {
+    if (!byType.has(entry.type)) byType.set(entry.type, []);
+    byType.get(entry.type)!.push(entry);
+  }
+
+  // Phase 1: take top MIN_PER_TYPE from each type
+  for (const [, entries] of byType) {
+    for (const entry of entries.slice(0, MIN_PER_TYPE)) {
+      selected.add(entry.id);
+    }
+  }
+
+  // Phase 2: fill remaining slots by score
+  for (const entry of scored) {
+    if (selected.size >= maxItems) break;
+    selected.add(entry.id);
+  }
+
+  // Build final list in score order
+  return scored.filter((e) => selected.has(e.id)).slice(0, maxItems);
+}


### PR DESCRIPTION
## Summary

Moves backlink and related-page graph computation to the wiki-server (PostgreSQL), resolving #469.

- **New `page_links` table**: Stores directional links between entities from 5 signal types (`yaml_related`, `entity_link`, `name_prefix`, `similarity`, `shared_tag`) with weights and optional relationship labels
- **New API endpoints**: `POST /sync`, `GET /backlinks/:id`, `GET /related/:id`, `GET /graph/:id`, `GET /stats` — all under `/api/links`
- **Build-data integration**: `collectLinkSignals()` extracts all link signals during build and syncs them to the wiki-server via the new client function `syncPageLinks()`
- **Server-side computation**: Backlinks computed via SQL reverse lookup with deduplication; related pages use bidirectional aggregation with quality boost and type-diverse selection; inverse relationship labels properly applied
- **13 unit tests** covering sync, backlinks, related pages, graph, and stats endpoints

## Test plan

- [x] All 13 new link tests pass
- [x] All 182 existing wiki-server tests pass (no regressions)
- [x] All 218 web app tests pass
- [x] Gate check passes (all 8 CI-blocking checks)
- [x] TypeScript compiles cleanly in both wiki-server and web app

https://claude.ai/code/session_01DvsSHwQmdZMSqS3WmB4m1f