### PR TITLE
fix: batch inserts, shared dashboard utility, data source indicators

### DIFF
--- a/apps/web/src/app/internal/auto-update-runs/page.tsx
+++ b/apps/web/src/app/internal/auto-update-runs/page.tsx
@@ -1,6 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { loadYaml } from "@lib/yaml";
+import {
+  fetchFromWikiServer,
+  withApiFallback,
+  dataSourceLabel,
+} from "@lib/wiki-server";
 import { RunsTable } from "./runs-table";
 import type { Metadata } from "next";
 
@@ -87,56 +92,40 @@ interface ApiRunEntry {
 }
 
 async function loadRunsFromApi(): Promise<RunRow[] | null> {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
-  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
-  if (!serverUrl) return null;
+  const data = await fetchFromWikiServer<{ entries: ApiRunEntry[] }>(
+    "/api/auto-update-runs/all?limit=200",
+    { revalidate: 60 }
+  );
+  if (!data) return null;
 
-  try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
+  return data.entries.map((r) => {
+    const startMs = new Date(r.startedAt).getTime();
+    const endMs = r.completedAt ? new Date(r.completedAt).getTime() : startMs;
+
+    return {
+      date: r.date,
+      startedAt: r.startedAt,
+      trigger: r.trigger || "manual",
+      sourcesChecked: r.sourcesChecked ?? 0,
+      sourcesFailed: r.sourcesFailed ?? 0,
+      itemsFetched: r.itemsFetched ?? 0,
+      itemsRelevant: r.itemsRelevant ?? 0,
+      pagesPlanned: r.pagesPlanned ?? 0,
+      pagesUpdated: r.pagesUpdated ?? 0,
+      pagesFailed: r.pagesFailed ?? 0,
+      pagesSkipped: r.pagesSkipped ?? 0,
+      budgetLimit: r.budgetLimit ?? 0,
+      budgetSpent: r.budgetSpent ?? 0,
+      durationMinutes: Math.round((endMs - startMs) / 60000),
+      results: r.results.map((res) => ({
+        pageId: res.pageId,
+        status: res.status as "success" | "failed" | "skipped",
+        tier: res.tier || "",
+        error: res.errorMessage ?? undefined,
+        durationMs: res.durationMs ?? undefined,
+      })),
     };
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
-    }
-
-    const res = await fetch(`${serverUrl}/api/auto-update-runs/all?limit=200`, {
-      headers,
-      next: { revalidate: 60 },
-    });
-    if (!res.ok) return null;
-
-    const data = (await res.json()) as { entries: ApiRunEntry[] };
-    return data.entries.map((r) => {
-      const startMs = new Date(r.startedAt).getTime();
-      const endMs = r.completedAt ? new Date(r.completedAt).getTime() : startMs;
-
-      return {
-        date: r.date,
-        startedAt: r.startedAt,
-        trigger: r.trigger || "manual",
-        sourcesChecked: r.sourcesChecked ?? 0,
-        sourcesFailed: r.sourcesFailed ?? 0,
-        itemsFetched: r.itemsFetched ?? 0,
-        itemsRelevant: r.itemsRelevant ?? 0,
-        pagesPlanned: r.pagesPlanned ?? 0,
-        pagesUpdated: r.pagesUpdated ?? 0,
-        pagesFailed: r.pagesFailed ?? 0,
-        pagesSkipped: r.pagesSkipped ?? 0,
-        budgetLimit: r.budgetLimit ?? 0,
-        budgetSpent: r.budgetSpent ?? 0,
-        durationMinutes: Math.round((endMs - startMs) / 60000),
-        results: r.results.map((res) => ({
-          pageId: res.pageId,
-          status: res.status as "success" | "failed" | "skipped",
-          tier: res.tier || "",
-          error: res.errorMessage ?? undefined,
-          durationMs: res.durationMs ?? undefined,
-        })),
-      };
-    });
-  } catch {
-    return null;
-  }
+  });
 }
 
 // ── YAML Fallback ─────────────────────────────────────────────────────────
@@ -187,8 +176,10 @@ function loadRunReportsFromYaml(): RunRow[] {
 // ── Page Component ────────────────────────────────────────────────────────
 
 export default async function AutoUpdateRunsPage() {
-  // Try API first, fall back to YAML
-  const runs = (await loadRunsFromApi()) ?? loadRunReportsFromYaml();
+  const { data: runs, source } = await withApiFallback(
+    loadRunsFromApi,
+    loadRunReportsFromYaml
+  );
 
   const totalSpent = runs.reduce((sum, r) => sum + r.budgetSpent, 0);
   const totalUpdated = runs.reduce((sum, r) => sum + r.pagesUpdated, 0);
@@ -237,6 +228,10 @@ export default async function AutoUpdateRunsPage() {
       ) : (
         <RunsTable data={runs} />
       )}
+
+      <p className="text-xs text-muted-foreground mt-4">
+        Data source: {dataSourceLabel(source)}
+      </p>
     </article>
   );
 }

--- a/apps/web/src/app/internal/hallucination-risk/page.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/page.tsx
@@ -1,4 +1,9 @@
 import { getAllPages } from "@/data";
+import {
+  getWikiServerConfig,
+  withApiFallback,
+  dataSourceLabel,
+} from "@lib/wiki-server";
 import { HallucinationRiskDashboard } from "./hallucination-risk-dashboard";
 import type { Metadata } from "next";
 
@@ -38,16 +43,10 @@ interface ApiRiskPage {
  * Returns null if the server is unavailable.
  */
 async function loadRiskDataFromApi(): Promise<RiskPageData[] | null> {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
-  if (!serverUrl) return null;
+  const config = getWikiServerConfig();
+  if (!config) return null;
 
   try {
-    const headers: Record<string, string> = {};
-    const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
-    }
-
     // Paginate to fetch all risk scores (guard against infinite loop)
     const allApiPages: ApiRiskPage[] = [];
     let offset = 0;
@@ -56,8 +55,8 @@ async function loadRiskDataFromApi(): Promise<RiskPageData[] | null> {
 
     for (let page = 0; page < maxPages; page++) {
       const res = await fetch(
-        `${serverUrl}/api/hallucination-risk/latest?limit=${pageSize}&offset=${offset}`,
-        { headers, next: { revalidate: 300 } }
+        `${config.serverUrl}/api/hallucination-risk/latest?limit=${pageSize}&offset=${offset}`,
+        { headers: config.headers, next: { revalidate: 300 } }
       );
       if (!res.ok) return null;
 
@@ -142,8 +141,10 @@ function StatCard({
 
 export default async function HallucinationRiskPage() {
   // Try wiki-server API first, fall back to database.json
-  const riskPages =
-    (await loadRiskDataFromApi()) ?? loadRiskDataFromDatabase();
+  const { data: riskPages, source } = await withApiFallback(
+    loadRiskDataFromApi,
+    loadRiskDataFromDatabase
+  );
 
   const highCount = riskPages.filter((p) => p.level === "high").length;
   const mediumCount = riskPages.filter((p) => p.level === "medium").length;
@@ -274,7 +275,7 @@ export default async function HallucinationRiskPage() {
       <p className="text-xs text-muted-foreground mt-4">
         Scores computed at build time by the canonical scorer (
         <code className="text-[11px]">crux/lib/hallucination-risk.ts</code>).
-        Historical trends stored in PostgreSQL when wiki server is configured.
+        Data source: {dataSourceLabel(source)}.
         Run{" "}
         <code className="text-[11px]">
           pnpm crux validate hallucination-risk

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared utilities for fetching data from the wiki-server API
+ * with automatic fallback to local data sources (YAML, database.json).
+ *
+ * Used by internal dashboard pages that display data from either
+ * the wiki-server PostgreSQL database or local files.
+ */
+
+export type DataSource = "api" | "local";
+
+export interface WithSource<T> {
+  data: T;
+  source: DataSource;
+}
+
+/**
+ * Fetch JSON from the wiki-server API.
+ * Returns null if the server URL is not configured or the request fails.
+ */
+export async function fetchFromWikiServer<T>(
+  path: string,
+  options?: { revalidate?: number }
+): Promise<T | null> {
+  const config = getWikiServerConfig();
+  if (!config) return null;
+
+  try {
+    const res = await fetch(`${config.serverUrl}${path}`, {
+      headers: config.headers,
+      next: { revalidate: options?.revalidate ?? 300 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the wiki-server URL and auth headers.
+ * Useful for dashboards that need custom fetch logic (e.g. pagination).
+ * Returns null if the server URL is not configured.
+ */
+export function getWikiServerConfig(): {
+  serverUrl: string;
+  headers: Record<string, string>;
+} | null {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl) return null;
+
+  const headers: Record<string, string> = {};
+  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  return { serverUrl, headers };
+}
+
+/**
+ * Try loading data from the wiki-server API, falling back to a local loader.
+ * Returns the data along with its source ("api" or "local").
+ */
+export async function withApiFallback<T>(
+  apiLoader: () => Promise<T | null>,
+  localLoader: () => T
+): Promise<WithSource<T>>;
+export async function withApiFallback<T>(
+  apiLoader: () => Promise<T | null>,
+  localLoader: () => T | null
+): Promise<WithSource<T | null>>;
+export async function withApiFallback<T>(
+  apiLoader: () => Promise<T | null>,
+  localLoader: () => T | null
+): Promise<WithSource<T | null>> {
+  const apiData = await apiLoader();
+  if (apiData !== null) {
+    return { data: apiData, source: "api" };
+  }
+  return { data: localLoader(), source: "local" };
+}
+
+/** Human-readable label for the data source, for dashboard footers. */
+export function dataSourceLabel(source: DataSource): string {
+  return source === "api" ? "wiki-server API" : "local files";
+}

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -26,22 +26,30 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   // ---- INSERT INTO claims ----
   if (q.includes("insert into") && q.includes('"claims"')) {
     const now = new Date();
-    const id = nextId++;
-    const row: Record<string, unknown> = {
-      id,
-      entity_id: params[0],
-      entity_type: params[1],
-      claim_type: params[2],
-      claim_text: params[3],
-      value: params[4],
-      unit: params[5],
-      confidence: params[6],
-      source_quote: params[7],
-      created_at: now,
-      updated_at: now,
-    };
-    claimStore.set(id, row);
-    return [row];
+    const PARAMS_PER_ROW = 8;
+    const rowCount = Math.max(1, Math.floor(params.length / PARAMS_PER_ROW));
+    const results: Record<string, unknown>[] = [];
+
+    for (let i = 0; i < rowCount; i++) {
+      const off = i * PARAMS_PER_ROW;
+      const id = nextId++;
+      const row: Record<string, unknown> = {
+        id,
+        entity_id: params[off],
+        entity_type: params[off + 1],
+        claim_type: params[off + 2],
+        claim_text: params[off + 3],
+        value: params[off + 4],
+        unit: params[off + 5],
+        confidence: params[off + 6],
+        source_quote: params[off + 7],
+        created_at: now,
+        updated_at: now,
+      };
+      claimStore.set(id, row);
+      results.push(row);
+    }
+    return results;
   }
 
   // ---- DELETE FROM claims WHERE entity_id = $1 ----

--- a/apps/wiki-server/src/__tests__/integration.test.ts
+++ b/apps/wiki-server/src/__tests__/integration.test.ts
@@ -27,7 +27,7 @@ const __dirname = path.dirname(__filename);
 const migrationsFolder = path.resolve(__dirname, "../../drizzle");
 
 /**
- * Drop ALL tables created by migrations 0000-0011, in reverse dependency order.
+ * Drop ALL tables created by migrations 0000-0013, in reverse dependency order.
  * Uses CASCADE so FK ordering is handled automatically, but we list children
  * first for clarity.
  */
@@ -36,6 +36,7 @@ async function dropAllTables(conn: ReturnType<typeof postgres>) {
   await conn`DROP TABLE IF EXISTS resource_citations CASCADE`;
   await conn`DROP TABLE IF EXISTS auto_update_results CASCADE`;
   await conn`DROP TABLE IF EXISTS session_pages CASCADE`;
+  await conn`DROP TABLE IF EXISTS page_links CASCADE`;
   await conn`DROP TABLE IF EXISTS claims CASCADE`;
   // Parent tables
   await conn`DROP TABLE IF EXISTS summaries CASCADE`;
@@ -72,6 +73,7 @@ const ALL_EXPECTED_TABLES = [
   "resource_citations",
   "summaries",
   "claims",
+  "page_links",
 ];
 
 describeWithDb("Integration: Drizzle migrations", () => {
@@ -92,7 +94,7 @@ describeWithDb("Integration: Drizzle migrations", () => {
   it("applies migration on a fresh database", async () => {
     await migrate(db, { migrationsFolder });
 
-    // Verify ALL tables from migrations 0000-0009 exist
+    // Verify ALL tables from migrations 0000-0013 exist
     const tables = await sqlConn`
       SELECT table_name FROM information_schema.tables
       WHERE table_schema = 'public'

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -314,11 +314,18 @@ export const summaries = pgTable(
   ]
 );
 
+/**
+ * Claims extracted from wiki pages.
+ *
+ * `entityId` is a logical reference to a wiki entity (page or data entity)
+ * but is NOT enforced via FK — claims may reference entities from multiple
+ * source tables (wikiPages, summaries, etc.) or entities not yet synced.
+ */
 export const claims = pgTable(
   "claims",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    entityId: text("entity_id").notNull(),
+    entityId: text("entity_id").notNull(), // logical FK — see table comment above
     entityType: text("entity_type").notNull(),
     claimType: text("claim_type").notNull(),
     claimText: text("claim_text").notNull(),


### PR DESCRIPTION
## Summary

- **Batch insert fix (#481):** Replace per-row INSERT loops with multi-row `.values()` in summaries and claims batch routes, reducing round-trips from N to 1 per batch request
- **Shared dashboard utility (#483):** Extract repeated \"try wiki-server API, fallback to local files\" pattern from 4 dashboard pages into `apps/web/src/lib/wiki-server.ts`
- **Data source indicator (#481):** Each dashboard footer now shows whether data came from \"wiki-server API\" or \"local files\"
- **Post-merge cleanup (#481):** Add documenting comment on `claims.entityId` (logical FK), fix integration test migration comments (0000-0013), add missing `page_links` table to test fixtures

## Key Changes

| File | Change |
|------|--------|
| `apps/wiki-server/src/routes/summaries.ts` | Batch route: single multi-row INSERT with `excluded` refs instead of per-row loop |
| `apps/wiki-server/src/routes/claims.ts` | Batch route: single multi-row INSERT instead of per-row loop |
| `apps/wiki-server/src/schema.ts` | Documenting comment on `claims.entityId` (no FK, logical reference) |
| `apps/wiki-server/src/__tests__/integration.test.ts` | Fix migration comments 0000-0013, add `page_links` to drop/expected |
| `apps/wiki-server/src/__tests__/summaries.test.ts` | Mock handles multi-row INSERT params |
| `apps/wiki-server/src/__tests__/claims.test.ts` | Mock handles multi-row INSERT params |
| `apps/web/src/lib/wiki-server.ts` | **New** — `fetchFromWikiServer`, `getWikiServerConfig`, `withApiFallback`, `dataSourceLabel` |
| 4 dashboard `page.tsx` files | Refactored to use shared utility + data source indicator |

## Test Plan

- [x] `pnpm crux validate gate --fix` — all 10 checks pass, 218 tests pass
- [x] `npx vitest run` in wiki-server — 182 tests pass (21 integration skipped)
- [x] `npx tsc --noEmit` — clean in both apps/web and apps/wiki-server
- [x] Full Next.js production build passes (auto-escalated by pre-push hook)
- [x] Paranoid review via fresh subagent — no bugs found

Closes #481, closes #483

https://claude.ai/code/session_0192R6ssdHmMFjxfgPuRbPcy