### PR TITLE
perf: wiki-server query optimization + snapshot retention

### DIFF
--- a/apps/wiki-server/drizzle/0014_query_performance.sql
+++ b/apps/wiki-server/drizzle/0014_query_performance.sql
@@ -1,0 +1,20 @@
+-- 1. Compound index on hallucination_risk_snapshots for "latest per page" queries
+CREATE INDEX IF NOT EXISTS "idx_hrs_page_computed" ON "hallucination_risk_snapshots" USING btree ("page_id", "computed_at" DESC);
+
+-- 2. Add search_vector tsvector column to resources (same pattern as wiki_pages)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'resources' AND column_name = 'search_vector') THEN
+    ALTER TABLE "resources" ADD COLUMN "search_vector" tsvector;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_res_search_vector" ON "resources" USING gin ("search_vector");
+--> statement-breakpoint
+
+-- 3. Backfill search_vector for existing resources
+UPDATE resources SET search_vector =
+  setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+  setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+  setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
+  setweight(to_tsvector('english', coalesce(review, '')), 'D')
+WHERE search_vector IS NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1771900300000,
       "tag": "0013_add_page_links",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1771900400000,
+      "tag": "0014_query_performance",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
+++ b/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
 
 // ---- In-memory store simulating the hallucination_risk_snapshots table ----
 
@@ -19,181 +20,198 @@ function resetStore() {
   nextId = 1;
 }
 
-function createMockSql() {
-  function dispatch(query: string, params: unknown[]): unknown[] {
-    const q = query.toLowerCase();
-
-    // ---- entity_ids (for health check) ----
-    if (q.includes("count(*)") && q.includes("entity_ids")) {
-      return [{ count: 0 }];
+/** Get latest snapshot per page (shared logic for stats/latest mock queries). */
+function getLatestByPage() {
+  const latestByPage = new Map<string, (typeof riskStore)[0]>();
+  for (const r of riskStore) {
+    const existing = latestByPage.get(r.page_id);
+    if (!existing || r.computed_at > existing.computed_at) {
+      latestByPage.set(r.page_id, r);
     }
-    if (q.includes("last_value")) {
-      return [{ last_value: 0, is_called: false }];
-    }
+  }
+  return latestByPage;
+}
 
-    // ---- INSERT INTO hallucination_risk_snapshots ----
-    if (q.includes("insert into") && q.includes("hallucination_risk_snapshots")) {
-      const row = {
-        id: nextId++,
-        page_id: params[0] as string,
-        score: params[1] as number,
-        level: params[2] as string,
-        factors: params[3] as string[] | null,
-        integrity_issues: params[4] as string[] | null,
-        computed_at: new Date(),
-      };
-      riskStore.push(row);
-      return [row];
-    }
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
 
-    // ---- SELECT count(distinct page_id) FROM hallucination_risk_snapshots ----
-    if (q.includes("count(distinct") && q.includes("page_id") && q.includes("hallucination_risk_snapshots")) {
-      const uniquePages = new Set(riskStore.map((e) => e.page_id));
-      return [{ page_id: uniquePages.size }];
-    }
-
-    // ---- SELECT count(*) FROM hallucination_risk_snapshots (not GROUP BY) ----
-    if (q.includes("count(*)") && q.includes("hallucination_risk_snapshots") && !q.includes("group by")) {
-      return [{ count: riskStore.length }];
-    }
-
-    // ---- SELECT level, count FROM hallucination_risk_snapshots GROUP BY level ----
-    if (q.includes("hallucination_risk_snapshots") && q.includes("group by") && q.includes('"level"')) {
-      // This is for stats — latest snapshot per page
-      // Simplified: just group all entries by level
-      const latestByPage = new Map<string, typeof riskStore[0]>();
-      for (const r of riskStore) {
-        const existing = latestByPage.get(r.page_id);
-        if (!existing || r.computed_at > existing.computed_at) {
-          latestByPage.set(r.page_id, r);
-        }
-      }
-      const counts: Record<string, number> = {};
-      for (const r of latestByPage.values()) {
-        counts[r.level] = (counts[r.level] || 0) + 1;
-      }
-      return Object.entries(counts)
-        .map(([level, count]) => ({ level, count }))
-        .sort((a, b) => b.count - a.count);
-    }
-
-    // ---- SELECT ... WHERE page_id = $1 ORDER BY computed_at DESC LIMIT ----
-    if (q.includes("hallucination_risk_snapshots") && q.includes("where") && q.includes("page_id") && !q.includes("in (")) {
-      const pageId = params[0] as string;
-      const limit = params[1] as number || 50;
-      return riskStore
-        .filter((e) => e.page_id === pageId)
-        .sort((a, b) => b.computed_at.getTime() - a.computed_at.getTime())
-        .slice(0, limit);
-    }
-
-    // ---- SELECT ... (latest per page, for /latest endpoint) ORDER BY score DESC ----
-    if (q.includes("hallucination_risk_snapshots") && q.includes("in (") && q.includes("order by")) {
-      const latestByPage = new Map<string, typeof riskStore[0]>();
-      for (const r of riskStore) {
-        const existing = latestByPage.get(r.page_id);
-        if (!existing || r.computed_at > existing.computed_at) {
-          latestByPage.set(r.page_id, r);
-        }
-      }
-      let results = [...latestByPage.values()];
-
-      // Check for level filter
-      const levelParamIndex = params.findIndex(
-        (p) => p === "high" || p === "medium" || p === "low"
-      );
-      if (levelParamIndex >= 0) {
-        const level = params[levelParamIndex] as string;
-        results = results.filter((r) => r.level === level);
-      }
-
-      results.sort((a, b) => b.score - a.score);
-      const limit = (params.find((p) => typeof p === "number" && p <= 200) as number) || 50;
-      const offset = (params.find((p, i) => typeof p === "number" && i > 0 && p !== limit) as number) || 0;
-      return results.slice(offset, offset + limit);
-    }
-
-    return [];
+  // ---- entity_ids (for health check) ----
+  if (q.includes("count(*)") && q.includes("entity_ids")) {
+    return [{ count: 0 }];
+  }
+  if (q.includes("last_value")) {
+    return [{ last_value: 0, is_called: false }];
   }
 
-  const mockSql: any = (strings: TemplateStringsArray, ...values: unknown[]) => {
-    const query = strings.join("$").trim();
-    return dispatch(query, values);
-  };
-
-  // ---- Shared helpers ----
-
-  function extractColumns(query: string): (string | null)[] {
-    const q = query.trim();
-    let clauseMatch = q.match(/returning\s+(.+?)$/is);
-    if (!clauseMatch) clauseMatch = q.match(/^select\s+(.+?)\s+from\s/is);
-    if (!clauseMatch) return [];
-    const clause = clauseMatch[1];
-    const parts: string[] = [];
-    let depth = 0;
-    let current = "";
-    for (const ch of clause) {
-      if (ch === "(") depth++;
-      else if (ch === ")") depth--;
-      else if (ch === "," && depth === 0) { parts.push(current.trim()); current = ""; continue; }
-      current += ch;
-    }
-    if (current.trim()) parts.push(current.trim());
-    return parts.map((part) => {
-      const matches = [...part.matchAll(/"([^"]+)"/g)];
-      return matches.length > 0 ? matches[matches.length - 1][1] : null;
-    });
-  }
-
-  function createQueryResult(rows: unknown[], query: string): any {
-    const promise = Promise.resolve(rows);
-    return {
-      then: promise.then.bind(promise),
-      catch: promise.catch.bind(promise),
-      finally: promise.finally.bind(promise),
-      [Symbol.toStringTag]: "Promise",
-      count: rows.length,
-      values: () => {
-        const cols = extractColumns(query);
-        const arrayRows = rows.map((row: any) => {
-          if (cols.length > 0 && cols.some((c) => c !== null)) {
-            return cols.map((col, i) => col !== null ? row[col] : Object.values(row)[i]);
-          }
-          return Object.values(row);
-        });
-        return createQueryResult(arrayRows, query);
-      },
+  // ---- INSERT INTO hallucination_risk_snapshots ----
+  if (
+    q.includes("insert into") &&
+    q.includes("hallucination_risk_snapshots")
+  ) {
+    const row = {
+      id: nextId++,
+      page_id: params[0] as string,
+      score: params[1] as number,
+      level: params[2] as string,
+      factors: params[3] as string[] | null,
+      integrity_issues: params[4] as string[] | null,
+      computed_at: new Date(),
     };
+    riskStore.push(row);
+    return [row];
   }
 
-  mockSql.unsafe = (query: string, params: unknown[] = []) => {
-    return createQueryResult(dispatch(query, params), query);
-  };
+  // ---- SELECT count(distinct page_id) FROM hallucination_risk_snapshots ----
+  if (
+    q.includes("count(distinct") &&
+    q.includes("page_id") &&
+    q.includes("hallucination_risk_snapshots")
+  ) {
+    const uniquePages = new Set(riskStore.map((e) => e.page_id));
+    return [{ page_id: uniquePages.size }];
+  }
 
-  mockSql.begin = async (fn: (tx: typeof mockSql) => Promise<any>) => {
-    return await fn(mockSql);
-  };
+  // ---- Cleanup dry-run: total count (SELECT count(*)::int AS total) ----
+  if (
+    q.includes("count(*)") &&
+    q.includes("as total") &&
+    q.includes("hallucination_risk_snapshots")
+  ) {
+    return [{ total: riskStore.length }];
+  }
 
-  mockSql.reserve = () => Promise.resolve(mockSql);
-  mockSql.release = () => {};
-  mockSql.options = { parsers: {}, serializers: {} };
+  // ---- SELECT count(*) FROM hallucination_risk_snapshots (not GROUP BY) ----
+  if (
+    q.includes("count(*)") &&
+    q.includes("hallucination_risk_snapshots") &&
+    !q.includes("group by") &&
+    !q.includes("not in")
+  ) {
+    return [{ count: riskStore.length }];
+  }
 
-  return mockSql;
+  // ---- Stats: DISTINCT ON level distribution (raw SQL tagged template) ----
+  // Matches: SELECT level, count(*)::int AS count FROM (SELECT DISTINCT ON ...
+  if (
+    q.includes("distinct on") &&
+    q.includes("group by") &&
+    q.includes("level")
+  ) {
+    const latestByPage = getLatestByPage();
+    const counts: Record<string, number> = {};
+    for (const r of latestByPage.values()) {
+      counts[r.level] = (counts[r.level] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([level, count]) => ({ level, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // ---- Latest: DISTINCT ON per page (raw SQL tagged template) ----
+  // Matches: SELECT page_id, score, level, ... FROM (SELECT DISTINCT ON (page_id) ...
+  if (
+    q.includes("distinct on") &&
+    q.includes("order by") &&
+    q.includes("score") &&
+    !q.includes("group by")
+  ) {
+    const latestByPage = getLatestByPage();
+    let results = [...latestByPage.values()];
+
+    // Check for level filter
+    const levelParam = params.find(
+      (p) => p === "high" || p === "medium" || p === "low"
+    );
+    if (levelParam) {
+      results = results.filter((r) => r.level === levelParam);
+    }
+
+    results.sort((a, b) => b.score - a.score);
+
+    // Extract limit/offset from params (numbers)
+    const numParams = params.filter((p) => typeof p === "number") as number[];
+    const limit = numParams[0] || 50;
+    const offset = numParams[1] || 0;
+    return results.slice(offset, offset + limit);
+  }
+
+  // ---- SELECT ... WHERE page_id = $1 ORDER BY computed_at DESC LIMIT ----
+  if (
+    q.includes("hallucination_risk_snapshots") &&
+    q.includes("where") &&
+    q.includes("page_id") &&
+    !q.includes("distinct on") &&
+    !q.includes("not in")
+  ) {
+    const pageId = params[0] as string;
+    const limit = (params[1] as number) || 50;
+    return riskStore
+      .filter((e) => e.page_id === pageId)
+      .sort((a, b) => b.computed_at.getTime() - a.computed_at.getTime())
+      .slice(0, limit);
+  }
+
+  // ---- Cleanup dry-run: count rows that would be deleted ----
+  if (
+    q.includes("count(*)") &&
+    q.includes("not in") &&
+    q.includes("row_number")
+  ) {
+    const keep = params[0] as number;
+    // Group by page_id, count rows beyond the keep threshold
+    const byPage = new Map<string, typeof riskStore>();
+    for (const r of riskStore) {
+      const arr = byPage.get(r.page_id) || [];
+      arr.push(r);
+      byPage.set(r.page_id, arr);
+    }
+    let wouldDelete = 0;
+    for (const rows of byPage.values()) {
+      rows.sort(
+        (a, b) => b.computed_at.getTime() - a.computed_at.getTime()
+      );
+      if (rows.length > keep) {
+        wouldDelete += rows.length - keep;
+      }
+    }
+    return [{ count: wouldDelete }];
+  }
+
+  // ---- Cleanup actual delete ----
+  if (
+    q.includes("delete") &&
+    q.includes("hallucination_risk_snapshots") &&
+    q.includes("not in") &&
+    q.includes("row_number")
+  ) {
+    const keep = params[0] as number;
+    const byPage = new Map<string, typeof riskStore>();
+    for (const r of riskStore) {
+      const arr = byPage.get(r.page_id) || [];
+      arr.push(r);
+      byPage.set(r.page_id, arr);
+    }
+    const toDelete = new Set<number>();
+    for (const rows of byPage.values()) {
+      rows.sort(
+        (a, b) => b.computed_at.getTime() - a.computed_at.getTime()
+      );
+      for (let i = keep; i < rows.length; i++) {
+        toDelete.add(rows[i].id);
+      }
+    }
+    const deletedCount = toDelete.size;
+    riskStore = riskStore.filter((r) => !toDelete.has(r.id));
+    // Tagged template handler sets result.count = rows.length,
+    // so return an array with length equal to deleted count
+    return new Array(deletedCount).fill({});
+  }
+
+  return [];
 }
 
 // Mock the db module before importing routes
-vi.mock("../db.js", async () => {
-  const { drizzle } = await import("drizzle-orm/postgres-js");
-  const schema = await import("../schema.js");
-  const mockSql = createMockSql();
-  const mockDrizzle = drizzle(mockSql, { schema });
-  return {
-    getDb: () => mockSql,
-    getDrizzleDb: () => mockDrizzle,
-    initDb: vi.fn(),
-    closeDb: vi.fn(),
-  };
-});
+vi.mock("../db.js", () => mockDbModule(dispatch));
 
 const { createApp } = await import("../app.js");
 
@@ -210,15 +228,11 @@ describe("Hallucination Risk API", () => {
 
   describe("POST /api/hallucination-risk", () => {
     it("records a single snapshot and returns 201", async () => {
-      const res = await app.request("/api/hallucination-risk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          pageId: "open-philanthropy",
-          score: 55,
-          level: "medium",
-          factors: ["biographical-claims", "low-citation-density"],
-        }),
+      const res = await postJson(app, "/api/hallucination-risk", {
+        pageId: "open-philanthropy",
+        score: 55,
+        level: "medium",
+        factors: ["biographical-claims", "low-citation-density"],
       });
       expect(res.status).toBe(201);
       const body = await res.json();
@@ -229,41 +243,29 @@ describe("Hallucination Risk API", () => {
     });
 
     it("rejects invalid level", async () => {
-      const res = await app.request("/api/hallucination-risk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          pageId: "test",
-          score: 50,
-          level: "critical",
-          factors: [],
-        }),
+      const res = await postJson(app, "/api/hallucination-risk", {
+        pageId: "test",
+        score: 50,
+        level: "critical",
+        factors: [],
       });
       expect(res.status).toBe(400);
     });
 
     it("rejects score out of range", async () => {
-      const res = await app.request("/api/hallucination-risk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          pageId: "test",
-          score: 150,
-          level: "high",
-        }),
+      const res = await postJson(app, "/api/hallucination-risk", {
+        pageId: "test",
+        score: 150,
+        level: "high",
       });
       expect(res.status).toBe(400);
     });
 
     it("accepts entries without optional fields", async () => {
-      const res = await app.request("/api/hallucination-risk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          pageId: "test-page",
-          score: 30,
-          level: "low",
-        }),
+      const res = await postJson(app, "/api/hallucination-risk", {
+        pageId: "test-page",
+        score: 30,
+        level: "low",
       });
       expect(res.status).toBe(201);
     });
@@ -271,15 +273,21 @@ describe("Hallucination Risk API", () => {
 
   describe("POST /api/hallucination-risk/batch", () => {
     it("inserts multiple snapshots", async () => {
-      const res = await app.request("/api/hallucination-risk/batch", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          snapshots: [
-            { pageId: "page-a", score: 70, level: "high", factors: ["no-citations"] },
-            { pageId: "page-b", score: 25, level: "low", factors: ["well-cited"] },
-          ],
-        }),
+      const res = await postJson(app, "/api/hallucination-risk/batch", {
+        snapshots: [
+          {
+            pageId: "page-a",
+            score: 70,
+            level: "high",
+            factors: ["no-citations"],
+          },
+          {
+            pageId: "page-b",
+            score: 25,
+            level: "low",
+            factors: ["well-cited"],
+          },
+        ],
       });
       expect(res.status).toBe(201);
       const body = await res.json();
@@ -287,10 +295,8 @@ describe("Hallucination Risk API", () => {
     });
 
     it("rejects empty batch", async () => {
-      const res = await app.request("/api/hallucination-risk/batch", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ snapshots: [] }),
+      const res = await postJson(app, "/api/hallucination-risk/batch", {
+        snapshots: [],
       });
       expect(res.status).toBe(400);
     });
@@ -298,20 +304,27 @@ describe("Hallucination Risk API", () => {
 
   describe("GET /api/hallucination-risk/history?page_id=X", () => {
     it("returns history for a page", async () => {
-      // Insert some snapshots
       for (const entry of [
-        { pageId: "my-page", score: 60, level: "medium", factors: ["no-citations"] },
-        { pageId: "my-page", score: 45, level: "medium", factors: ["low-citation-density"] },
+        {
+          pageId: "my-page",
+          score: 60,
+          level: "medium",
+          factors: ["no-citations"],
+        },
+        {
+          pageId: "my-page",
+          score: 45,
+          level: "medium",
+          factors: ["low-citation-density"],
+        },
         { pageId: "other-page", score: 20, level: "low" },
       ]) {
-        await app.request("/api/hallucination-risk", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(entry),
-        });
+        await postJson(app, "/api/hallucination-risk", entry);
       }
 
-      const res = await app.request("/api/hallucination-risk/history?page_id=my-page");
+      const res = await app.request(
+        "/api/hallucination-risk/history?page_id=my-page"
+      );
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.pageId).toBe("my-page");
@@ -319,7 +332,9 @@ describe("Hallucination Risk API", () => {
     });
 
     it("returns empty for unknown page", async () => {
-      const res = await app.request("/api/hallucination-risk/history?page_id=nonexistent");
+      const res = await app.request(
+        "/api/hallucination-risk/history?page_id=nonexistent"
+      );
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.snapshots).toHaveLength(0);
@@ -338,11 +353,7 @@ describe("Hallucination Risk API", () => {
         { pageId: "page-b", score: 25, level: "low" },
         { pageId: "page-c", score: 45, level: "medium" },
       ]) {
-        await app.request("/api/hallucination-risk", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(entry),
-        });
+        await postJson(app, "/api/hallucination-risk", entry);
       }
 
       const res = await app.request("/api/hallucination-risk/stats");
@@ -364,14 +375,20 @@ describe("Hallucination Risk API", () => {
   describe("GET /api/hallucination-risk/latest", () => {
     it("returns 200 with pages array", async () => {
       for (const entry of [
-        { pageId: "page-a", score: 70, level: "high", factors: ["no-citations"] },
-        { pageId: "page-b", score: 25, level: "low", factors: ["well-cited"] },
+        {
+          pageId: "page-a",
+          score: 70,
+          level: "high",
+          factors: ["no-citations"],
+        },
+        {
+          pageId: "page-b",
+          score: 25,
+          level: "low",
+          factors: ["well-cited"],
+        },
       ]) {
-        await app.request("/api/hallucination-risk", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(entry),
-        });
+        await postJson(app, "/api/hallucination-risk", entry);
       }
 
       const res = await app.request("/api/hallucination-risk/latest");
@@ -379,6 +396,72 @@ describe("Hallucination Risk API", () => {
       const body = await res.json();
       expect(body.pages).toBeDefined();
       expect(Array.isArray(body.pages)).toBe(true);
+    });
+  });
+
+  describe("DELETE /api/hallucination-risk/cleanup", () => {
+    it("dry run reports what would be deleted", async () => {
+      // Insert 5 snapshots for page-a (should keep latest 2)
+      for (let i = 0; i < 5; i++) {
+        await postJson(app, "/api/hallucination-risk", {
+          pageId: "page-a",
+          score: 50 + i,
+          level: "medium",
+        });
+      }
+
+      const res = await app.request(
+        "/api/hallucination-risk/cleanup?keep=2&dry_run=true",
+        { method: "DELETE" }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.dryRun).toBe(true);
+      expect(body.keep).toBe(2);
+      expect(body.totalSnapshots).toBe(5);
+      expect(body.wouldDelete).toBe(3);
+      expect(body.wouldRetain).toBe(2);
+    });
+
+    it("actually deletes old snapshots", async () => {
+      // Insert 4 snapshots for page-a
+      for (let i = 0; i < 4; i++) {
+        await postJson(app, "/api/hallucination-risk", {
+          pageId: "page-a",
+          score: 50 + i,
+          level: "medium",
+        });
+      }
+      // Insert 2 for page-b
+      for (let i = 0; i < 2; i++) {
+        await postJson(app, "/api/hallucination-risk", {
+          pageId: "page-b",
+          score: 30 + i,
+          level: "low",
+        });
+      }
+
+      const res = await app.request(
+        "/api/hallucination-risk/cleanup?keep=2",
+        { method: "DELETE" }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // page-a: 4 snapshots, keep 2 → delete 2
+      // page-b: 2 snapshots, keep 2 → delete 0
+      expect(body.deleted).toBe(2);
+      expect(body.keep).toBe(2);
+      expect(riskStore).toHaveLength(4); // 2 + 2 remaining
+    });
+
+    it("defaults to keeping 30 snapshots per page", async () => {
+      const res = await app.request(
+        "/api/hallucination-risk/cleanup?dry_run=true",
+        { method: "DELETE" }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.keep).toBe(30);
     });
   });
 });

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, desc, sql, and } from "drizzle-orm";
-import { getDrizzleDb } from "../db.js";
+import { eq, count, desc, sql } from "drizzle-orm";
+import { getDrizzleDb, getDb } from "../db.js";
 import { hallucinationRiskSnapshots } from "../schema.js";
 import {
   parseJsonBody,
@@ -149,6 +149,7 @@ hallucinationRiskRoute.get("/stats", async (c) => {
   if (!parsed.success) return validationError(c, parsed.error.message);
 
   const db = getDrizzleDb();
+  const rawDb = getDb();
 
   // Total snapshots
   const totalResult = await db
@@ -164,25 +165,22 @@ hallucinationRiskRoute.get("/stats", async (c) => {
     .from(hallucinationRiskSnapshots);
   const uniquePages = Number(pagesResult[0].count);
 
-  // Level distribution (from latest snapshot per page)
-  const levelDist = await db
-    .select({
-      level: hallucinationRiskSnapshots.level,
-      count: count(),
-    })
-    .from(hallucinationRiskSnapshots)
-    .where(
-      sql`(${hallucinationRiskSnapshots.pageId}, ${hallucinationRiskSnapshots.computedAt}) IN (
-        SELECT page_id, MAX(computed_at) FROM hallucination_risk_snapshots GROUP BY page_id
-      )`
-    )
-    .groupBy(hallucinationRiskSnapshots.level);
+  // Level distribution (from latest snapshot per page) using DISTINCT ON
+  const levelDist = await rawDb`
+    SELECT level, count(*)::int AS count
+    FROM (
+      SELECT DISTINCT ON (page_id) level
+      FROM hallucination_risk_snapshots
+      ORDER BY page_id, computed_at DESC
+    ) latest
+    GROUP BY level
+  `;
 
   return c.json({
     totalSnapshots,
     uniquePages,
     levelDistribution: Object.fromEntries(
-      levelDist.map((r) => [r.level, r.count])
+      levelDist.map((r: any) => [r.level, r.count])
     ),
   });
 });
@@ -194,35 +192,108 @@ hallucinationRiskRoute.get("/latest", async (c) => {
   if (!parsed.success) return validationError(c, parsed.error.message);
 
   const { limit, offset, level } = parsed.data;
-  const db = getDrizzleDb();
+  const rawDb = getDb();
 
-  // Use a subquery to get the most recent snapshot per page
-  const conditions = [
-    sql`(${hallucinationRiskSnapshots.pageId}, ${hallucinationRiskSnapshots.computedAt}) IN (
-      SELECT page_id, MAX(computed_at) FROM hallucination_risk_snapshots GROUP BY page_id
-    )`,
-  ];
-
-  if (level) {
-    conditions.push(eq(hallucinationRiskSnapshots.level, level));
-  }
-
-  const rows = await db
-    .select()
-    .from(hallucinationRiskSnapshots)
-    .where(and(...conditions))
-    .orderBy(desc(hallucinationRiskSnapshots.score))
-    .limit(limit)
-    .offset(offset);
+  // Use DISTINCT ON for efficient "latest per page" query
+  const rows = level
+    ? await rawDb`
+        SELECT page_id, score, level, factors, integrity_issues, computed_at
+        FROM (
+          SELECT DISTINCT ON (page_id) *
+          FROM hallucination_risk_snapshots
+          ORDER BY page_id, computed_at DESC
+        ) latest
+        WHERE level = ${level}
+        ORDER BY score DESC
+        LIMIT ${limit} OFFSET ${offset}
+      `
+    : await rawDb`
+        SELECT page_id, score, level, factors, integrity_issues, computed_at
+        FROM (
+          SELECT DISTINCT ON (page_id) *
+          FROM hallucination_risk_snapshots
+          ORDER BY page_id, computed_at DESC
+        ) latest
+        ORDER BY score DESC
+        LIMIT ${limit} OFFSET ${offset}
+      `;
 
   return c.json({
-    pages: rows.map((r) => ({
-      pageId: r.pageId,
+    pages: rows.map((r: any) => ({
+      pageId: r.page_id,
       score: r.score,
       level: r.level,
       factors: r.factors,
-      integrityIssues: r.integrityIssues,
-      computedAt: r.computedAt,
+      integrityIssues: r.integrity_issues,
+      computedAt: r.computed_at,
     })),
   });
+});
+
+// ---- DELETE /cleanup (retention: keep latest N snapshots per page) ----
+
+const CleanupQuery = z.object({
+  keep: z.coerce.number().int().min(1).max(1000).default(30),
+  dry_run: z
+    .enum(["true", "false", "1", "0"])
+    .transform((v) => v === "true" || v === "1")
+    .default("false"),
+});
+
+hallucinationRiskRoute.delete("/cleanup", async (c) => {
+  const parsed = CleanupQuery.safeParse(c.req.query());
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { keep, dry_run } = parsed.data;
+  const rawDb = getDb();
+
+  if (dry_run) {
+    // Count how many rows would be deleted
+    const result = await rawDb`
+      SELECT count(*)::int AS count
+      FROM hallucination_risk_snapshots hrs
+      WHERE id NOT IN (
+        SELECT id FROM (
+          SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY page_id ORDER BY computed_at DESC
+          ) AS rn
+          FROM hallucination_risk_snapshots
+        ) ranked
+        WHERE rn <= ${keep}
+      )
+    `;
+    const wouldDelete = result[0]?.count ?? 0;
+
+    // Total count
+    const totalResult = await rawDb`
+      SELECT count(*)::int AS total FROM hallucination_risk_snapshots
+    `;
+    const total = totalResult[0]?.total ?? 0;
+
+    return c.json({
+      dryRun: true,
+      keep,
+      totalSnapshots: total,
+      wouldDelete,
+      wouldRetain: total - wouldDelete,
+    });
+  }
+
+  // Actually delete old snapshots, keeping latest `keep` per page
+  const result = await rawDb`
+    DELETE FROM hallucination_risk_snapshots
+    WHERE id NOT IN (
+      SELECT id FROM (
+        SELECT id, ROW_NUMBER() OVER (
+          PARTITION BY page_id ORDER BY computed_at DESC
+        ) AS rn
+        FROM hallucination_risk_snapshots
+      ) ranked
+      WHERE rn <= ${keep}
+    )
+  `;
+
+  const deleted = result.count;
+
+  return c.json({ deleted, keep });
 });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -359,6 +359,8 @@ export const resources = pgTable(
     credibilityOverride: real("credibility_override"),
     fetchedAt: timestamp("fetched_at", { withTimezone: true }),
     contentHash: text("content_hash"),
+    // search_vector tsvector column is managed via raw SQL migration
+    // (Drizzle doesn't have native tsvector support)
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -370,6 +372,7 @@ export const resources = pgTable(
     uniqueIndex("idx_res_url").on(table.url),
     index("idx_res_type").on(table.type),
     index("idx_res_publication_id").on(table.publicationId),
+    // GIN index on search_vector is created in migration SQL
   ]
 );
 


### PR DESCRIPTION
## Summary

- **Hallucination risk queries**: Replace slow correlated subqueries (`WHERE (page_id, computed_at) IN (SELECT ... MAX ... GROUP BY)`) with PostgreSQL `DISTINCT ON` for the `/latest` and `/stats` endpoints — significantly faster on 133K+ row table
- **Compound index**: Add `(page_id, computed_at DESC)` index to efficiently support the "latest per page" query pattern
- **Full-text search for resources**: Replace `ILIKE '%query%'` on title/summary with proper `tsvector` + GIN index + `plainto_tsquery` with `ts_rank_cd` ranking — supports stemming, ranking, and scales to 3000+ resources
- **Snapshot retention**: Add `DELETE /cleanup` endpoint that keeps the latest N snapshots per page (default: 30), with dry-run support for previewing what would be deleted

Closes #493

## Changes

### Migration (`0014_query_performance.sql`)
- Compound index on `hallucination_risk_snapshots(page_id, computed_at DESC)`
- `search_vector` tsvector column on `resources` table with GIN index
- Backfill existing resources' search vectors

### Hallucination Risk (`hallucination-risk.ts`)
- `/stats` level distribution now uses `DISTINCT ON` via raw SQL
- `/latest` now uses `DISTINCT ON` via raw SQL (with optional level filter)
- New `DELETE /cleanup?keep=N&dry_run=true|false` endpoint for retention

### Resources (`resources.ts`)
- Search endpoint switched from `ILIKE` to full-text search with `plainto_tsquery`
- `upsertResource` now updates `search_vector` on every insert/update
- Search results include relevance ranking

### Schema
- Added comments documenting tsvector columns (same pattern as wiki_pages)

## Test plan

- [x] All hallucination-risk tests pass (15 tests including 3 new cleanup tests)
- [x] All resources tests pass (20 tests including updated search test)
- [x] Full test suite: 1483 tests pass across all workspaces
- [x] Gate check: all 10 checks pass (including TypeScript type check)
- [x] New cleanup endpoint tested: dry-run reporting, actual deletion, default keep=30

https://claude.ai/code/session_01TDPCHSpF8eUw9ggn5ruawn