### PR TITLE
feat: add bulk sync commands for edit-logs, sessions, and auto-update runs

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -1,0 +1,52 @@
+name: Sync Data to Wiki Server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/edit-logs/**"
+      - ".claude/sessions/**"
+      - "data/auto-update/runs/**"
+
+  # Allow manual trigger for full re-sync
+  workflow_dispatch:
+
+# Cancel superseded runs for the same trigger
+concurrency:
+  group: sync-data-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  sync-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync edit logs to wiki-server
+        run: pnpm crux wiki-server sync-edit-logs
+        env:
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+
+      - name: Sync sessions to wiki-server
+        run: pnpm crux wiki-server sync-sessions
+        env:
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+
+      - name: Sync auto-update runs to wiki-server
+        run: pnpm crux wiki-server sync-auto-update-runs
+        env:
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}

--- a/crux/commands/wiki-server.ts
+++ b/crux/commands/wiki-server.ts
@@ -23,13 +23,30 @@ const SCRIPTS = {
     passthrough: [],
     positional: true,
   },
+  'sync-edit-logs': {
+    script: 'wiki-server/sync-edit-logs.ts',
+    description: 'Sync data/edit-logs/*.yaml to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
+  'sync-sessions': {
+    script: 'wiki-server/sync-sessions.ts',
+    description: 'Sync all .claude/sessions/*.yaml to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
+  'sync-auto-update-runs': {
+    script: 'wiki-server/sync-auto-update-runs.ts',
+    description: 'Sync data/auto-update/runs/*.yaml to wiki-server',
+    passthrough: ['dryRun', 'dry-run'],
+  },
 };
 
 export const commands = buildCommands(SCRIPTS, 'sync');
 
 export function getHelp() {
+  const maxLen = Math.max(...Object.keys(SCRIPTS).map((n) => n.length));
+  const pad = maxLen + 2;
   const commandList = Object.entries(SCRIPTS)
-    .map(([name, config]) => `  ${name.padEnd(14)} ${config.description}`)
+    .map(([name, config]) => `  ${name.padEnd(pad)} ${config.description}`)
     .join('\n');
 
   return `
@@ -53,5 +70,8 @@ Examples:
   crux wiki-server sync-resources          Sync all resources
   crux wiki-server sync-resources --dry-run  Preview resource sync
   crux wiki-server sync-session .claude/sessions/2026-02-21_my-branch.yaml
+  crux wiki-server sync-edit-logs          Sync all edit logs
+  crux wiki-server sync-sessions           Sync all session logs
+  crux wiki-server sync-auto-update-runs   Sync all auto-update runs
 `;
 }

--- a/crux/lib/wiki-server-client.ts
+++ b/crux/lib/wiki-server-client.ts
@@ -814,3 +814,41 @@ export async function syncPageLinks(
 
   return { upserted: totalUpserted };
 }
+
+// ---------------------------------------------------------------------------
+// Resources API (single upsert for fire-and-forget dual-write)
+// ---------------------------------------------------------------------------
+
+export interface UpsertResourceItem {
+  id: string;
+  url: string;
+  title?: string | null;
+  type?: string | null;
+  summary?: string | null;
+  review?: string | null;
+  abstract?: string | null;
+  keyPoints?: string[] | null;
+  publicationId?: string | null;
+  authors?: string[] | null;
+  publishedDate?: string | null;
+  tags?: string[] | null;
+  localFilename?: string | null;
+  credibilityOverride?: number | null;
+  fetchedAt?: string | null;
+  contentHash?: string | null;
+  citedBy?: string[] | null;
+}
+
+interface UpsertResourceResult {
+  id: string;
+  url: string;
+}
+
+/**
+ * Upsert a single resource to the wiki-server database.
+ */
+export async function upsertResource(
+  item: UpsertResourceItem,
+): Promise<UpsertResourceResult | null> {
+  return apiRequest<UpsertResourceResult>('POST', '/api/resources', item);
+}

--- a/crux/resource-io.ts
+++ b/crux/resource-io.ts
@@ -2,6 +2,13 @@
  * Resource Manager — YAML I/O
  *
  * Reading and writing resource YAML files, publication loading.
+ *
+ * Note: Resources are NOT dual-written to the wiki-server here because the
+ * server's upsert endpoint does a full column replacement. The in-memory
+ * Resource type lacks fields like review, keyPoints, localFilename, etc.
+ * that exist in the YAML files, so a fire-and-forget upsert from here would
+ * overwrite valid data with nulls. Instead, `crux wiki-server sync-resources`
+ * (which reads the full YAML) handles syncing to Postgres.
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';

--- a/crux/wiki-server/sync-auto-update-runs.test.ts
+++ b/crux/wiki-server/sync-auto-update-runs.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseRunYaml, loadRunYamls, syncAutoUpdateRuns } from './sync-auto-update-runs.ts';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { RecordAutoUpdateRunInput } from '../lib/wiki-server-client.ts';
+
+const noSleep = async () => {};
+
+function makeRun(date: string = '2026-01-15'): RecordAutoUpdateRunInput {
+  return {
+    date,
+    startedAt: `${date}T06:00:00.000Z`,
+    completedAt: `${date}T07:00:00.000Z`,
+    trigger: 'scheduled',
+    budgetLimit: 30,
+    budgetSpent: 25,
+    sourcesChecked: 10,
+    sourcesFailed: 1,
+    itemsFetched: 100,
+    itemsRelevant: 50,
+    pagesPlanned: 5,
+    pagesUpdated: 4,
+    pagesFailed: 0,
+    pagesSkipped: 1,
+    newPagesCreated: [],
+    results: [
+      { pageId: 'test-page', status: 'success', tier: 'standard', durationMs: 5000, errorMessage: null },
+    ],
+  };
+}
+
+describe('parseRunYaml', () => {
+  it('parses a complete run YAML file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    const filePath = join(dir, '2026-01-15T06-00-00.yaml');
+    writeFileSync(
+      filePath,
+      `date: 2026-01-15
+startedAt: 2026-01-15T06:00:00.000Z
+completedAt: 2026-01-15T07:00:00.000Z
+trigger: scheduled
+budget:
+  limit: 30
+  spent: 25
+digest:
+  sourcesChecked: 10
+  sourcesFailed: 1
+  itemsFetched: 100
+  itemsRelevant: 50
+plan:
+  pagesPlanned: 5
+execution:
+  pagesUpdated: 4
+  pagesFailed: 0
+  pagesSkipped: 1
+  results:
+    - pageId: test-page
+      status: success
+      tier: standard
+      durationMs: 5000
+newPagesCreated: []
+`,
+    );
+
+    const result = parseRunYaml(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe('2026-01-15');
+    expect(result!.trigger).toBe('scheduled');
+    expect(result!.budgetLimit).toBe(30);
+    expect(result!.budgetSpent).toBe(25);
+    expect(result!.pagesUpdated).toBe(4);
+    expect(result!.results).toHaveLength(1);
+    expect(result!.results![0].pageId).toBe('test-page');
+    expect(result!.results![0].status).toBe('success');
+  });
+
+  it('parses a minimal run YAML file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    const filePath = join(dir, '2026-01-15.yaml');
+    writeFileSync(
+      filePath,
+      `date: 2026-01-15
+startedAt: 2026-01-15T06:00:00.000Z
+trigger: manual
+budget:
+  limit: 50
+  spent: 0
+digest:
+  sourcesChecked: 15
+execution:
+  pagesUpdated: 0
+  results: []
+newPagesCreated: []
+`,
+    );
+
+    const result = parseRunYaml(filePath);
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger).toBe('manual');
+    expect(result!.completedAt).toBeNull();
+    expect(result!.results).toEqual([]);
+  });
+
+  it('falls back to startedAt when date is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    const filePath = join(dir, 'no-date.yaml');
+    writeFileSync(
+      filePath,
+      `startedAt: 2026-02-10T14:30:00.000Z\ntrigger: manual\nexecution:\n  results: []\nnewPagesCreated: []\n`,
+    );
+
+    const result = parseRunYaml(filePath);
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe('2026-02-10');
+  });
+
+  it('returns null for files without startedAt', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    const filePath = join(dir, 'bad.yaml');
+    writeFileSync(filePath, `date: 2026-01-15\ntrigger: manual\n`);
+
+    const result = parseRunYaml(filePath);
+    expect(result).toBeNull();
+  });
+});
+
+describe('loadRunYamls', () => {
+  it('loads runs from YAML files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    writeFileSync(
+      join(dir, '2026-01-15T06-00-00.yaml'),
+      `date: 2026-01-15\nstartedAt: 2026-01-15T06:00:00.000Z\ntrigger: scheduled\nexecution:\n  results: []\nnewPagesCreated: []\n`,
+    );
+
+    const { runs, fileCount, errorFiles } = loadRunYamls(dir);
+
+    expect(fileCount).toBe(1);
+    expect(errorFiles).toBe(0);
+    expect(runs).toHaveLength(1);
+  });
+
+  it('skips detail files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    writeFileSync(
+      join(dir, '2026-01-15T06-00-00.yaml'),
+      `date: 2026-01-15\nstartedAt: 2026-01-15T06:00:00.000Z\ntrigger: scheduled\nexecution:\n  results: []\nnewPagesCreated: []\n`,
+    );
+    writeFileSync(
+      join(dir, '2026-01-15T06-00-00-details.yaml'),
+      `someDetail: data\n`,
+    );
+
+    const { runs, fileCount } = loadRunYamls(dir);
+
+    expect(fileCount).toBe(1); // detail file excluded
+    expect(runs).toHaveLength(1);
+  });
+
+  it('handles empty directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'runs-'));
+    const { runs, fileCount } = loadRunYamls(dir);
+    expect(runs).toHaveLength(0);
+    expect(fileCount).toBe(0);
+  });
+});
+
+describe('syncAutoUpdateRuns', () => {
+  const origUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3000';
+    process.env.LONGTERMWIKI_SERVER_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    if (origUrl !== undefined) process.env.LONGTERMWIKI_SERVER_URL = origUrl;
+    else delete process.env.LONGTERMWIKI_SERVER_URL;
+    if (origKey !== undefined) process.env.LONGTERMWIKI_SERVER_API_KEY = origKey;
+    else delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  it('inserts all runs successfully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ id: 1, resultsInserted: 1 }), { status: 200 }),
+    );
+
+    const runs = [makeRun('2026-01-15'), makeRun('2026-01-16')];
+    const result = await syncAutoUpdateRuns('http://localhost:3000', runs, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 2, errors: 0 });
+  });
+
+  it('counts errors for failed runs', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 1, resultsInserted: 1 }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
+
+    const runs = [makeRun('2026-01-15'), makeRun('2026-01-16')];
+    const result = await syncAutoUpdateRuns('http://localhost:3000', runs, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(result.errors).toBe(1);
+  });
+
+  it('fast-fails after 3 consecutive failures', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Service Unavailable', { status: 503 }),
+    );
+
+    const runs = Array.from({ length: 6 }, (_, i) => makeRun(`2026-01-${15 + i}`));
+    const result = await syncAutoUpdateRuns('http://localhost:3000', runs, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.errors).toBe(6);
+  });
+
+  it('handles empty runs array', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = await syncAutoUpdateRuns('http://localhost:3000', [], {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 0, errors: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends correct payload to /api/auto-update-runs', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 1, resultsInserted: 1 }), { status: 200 }),
+    );
+
+    const runs = [makeRun('2026-01-15')];
+    await syncAutoUpdateRuns('http://localhost:3000', runs, {
+      _sleep: noSleep,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:3000/api/auto-update-runs',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"2026-01-15"'),
+      }),
+    );
+  });
+});

--- a/crux/wiki-server/sync-auto-update-runs.ts
+++ b/crux/wiki-server/sync-auto-update-runs.ts
@@ -1,0 +1,311 @@
+/**
+ * Wiki Server Auto-Update Runs Sync
+ *
+ * Reads all data/auto-update/runs/*.yaml files and POSTs each one to the
+ * wiki-server's /api/auto-update-runs endpoint.
+ *
+ * Unlike edit-logs and sessions which have batch endpoints, auto-update runs
+ * are POSTed individually (each run is a complex object with nested results).
+ *
+ * Reuses the retry + health-check pattern from sync-pages.ts.
+ *
+ * Usage:
+ *   pnpm crux wiki-server sync-auto-update-runs
+ *   pnpm crux wiki-server sync-auto-update-runs --dry-run
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL   - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+import { parseCliArgs } from '../lib/cli.ts';
+import {
+  getServerUrl,
+  getApiKey,
+  buildHeaders,
+  type RecordAutoUpdateRunInput,
+  type AutoUpdateRunResultEntry,
+} from '../lib/wiki-server-client.ts';
+import { waitForHealthy, fetchWithRetry } from './sync-pages.ts';
+
+const PROJECT_ROOT = join(import.meta.dirname!, '../..');
+const RUNS_DIR = join(PROJECT_ROOT, 'data/auto-update/runs');
+
+// --- Configuration ---
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+// --- Types ---
+
+interface YamlAutoUpdateRun {
+  date: string | Date;
+  startedAt: string | Date;
+  completedAt?: string | Date;
+  trigger: string;
+  budget?: {
+    limit?: number;
+    spent?: number;
+  };
+  digest?: {
+    sourcesChecked?: number;
+    sourcesFailed?: number;
+    itemsFetched?: number;
+    itemsRelevant?: number;
+  };
+  plan?: {
+    pagesPlanned?: number;
+    newPagesSuggested?: number;
+  };
+  execution?: {
+    pagesUpdated?: number;
+    pagesFailed?: number;
+    pagesSkipped?: number;
+    results?: Array<{
+      pageId: string;
+      status: string;
+      tier?: string;
+      durationMs?: number;
+      errorMessage?: string;
+    }>;
+  };
+  newPagesCreated?: string[];
+}
+
+// --- Helpers ---
+
+function normalizeTimestamp(d: string | Date): string {
+  if (d instanceof Date) return d.toISOString();
+  const str = String(d);
+  // Already an ISO string
+  if (str.includes('T')) return str;
+  // Just a date — add midnight
+  return str + 'T00:00:00Z';
+}
+
+function toTrigger(raw: string): 'scheduled' | 'manual' {
+  return raw === 'scheduled' ? 'scheduled' : 'manual';
+}
+
+/**
+ * Parse a single auto-update run YAML file into the API input format.
+ * Returns null for detail files (e.g., *-details.yaml).
+ */
+export function parseRunYaml(filePath: string): RecordAutoUpdateRunInput | null {
+  const raw = readFileSync(filePath, 'utf-8');
+  const parsed = parseYaml(raw) as YamlAutoUpdateRun;
+
+  if (!parsed || typeof parsed !== 'object' || !parsed.startedAt) {
+    return null;
+  }
+
+  const results: AutoUpdateRunResultEntry[] = [];
+  if (parsed.execution?.results && Array.isArray(parsed.execution.results)) {
+    for (const r of parsed.execution.results) {
+      if (!r.pageId || !r.status) continue;
+      results.push({
+        pageId: r.pageId,
+        status: r.status as 'success' | 'failed' | 'skipped',
+        tier: r.tier ?? null,
+        durationMs: r.durationMs ?? null,
+        errorMessage: r.errorMessage ?? null,
+      });
+    }
+  }
+
+  return {
+    date: parsed.date
+      ? (parsed.date instanceof Date ? parsed.date.toISOString().split('T')[0] : String(parsed.date))
+      : normalizeTimestamp(parsed.startedAt).split('T')[0],
+    startedAt: normalizeTimestamp(parsed.startedAt),
+    completedAt: parsed.completedAt ? normalizeTimestamp(parsed.completedAt) : null,
+    trigger: toTrigger(String(parsed.trigger || 'manual')),
+    budgetLimit: parsed.budget?.limit ?? null,
+    budgetSpent: parsed.budget?.spent ?? null,
+    sourcesChecked: parsed.digest?.sourcesChecked ?? null,
+    sourcesFailed: parsed.digest?.sourcesFailed ?? null,
+    itemsFetched: parsed.digest?.itemsFetched ?? null,
+    itemsRelevant: parsed.digest?.itemsRelevant ?? null,
+    pagesPlanned: parsed.plan?.pagesPlanned ?? null,
+    pagesUpdated: parsed.execution?.pagesUpdated ?? null,
+    pagesFailed: parsed.execution?.pagesFailed ?? null,
+    pagesSkipped: parsed.execution?.pagesSkipped ?? null,
+    newPagesCreated: parsed.newPagesCreated ?? [],
+    results,
+  };
+}
+
+/**
+ * Read all data/auto-update/runs/*.yaml files and return parsed run entries.
+ * Skips detail files (*-details.yaml) which contain supplementary data.
+ * Exported for testing.
+ */
+export function loadRunYamls(
+  dir: string = RUNS_DIR,
+): { runs: RecordAutoUpdateRunInput[]; fileCount: number; errorFiles: number } {
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.yaml') && !f.includes('-details'));
+  const runs: RecordAutoUpdateRunInput[] = [];
+  let errorFiles = 0;
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    try {
+      const run = parseRunYaml(filePath);
+      if (run) {
+        runs.push(run);
+      } else {
+        console.warn(`  WARN: ${file} — could not parse, skipping`);
+        errorFiles++;
+      }
+    } catch (err) {
+      console.warn(`  ERROR: ${file} — ${err}`);
+      errorFiles++;
+    }
+  }
+
+  return { runs, fileCount: files.length, errorFiles };
+}
+
+/**
+ * Sync auto-update runs to the wiki-server one at a time.
+ * Exported for testing.
+ */
+export async function syncAutoUpdateRuns(
+  serverUrl: string,
+  runs: RecordAutoUpdateRunInput[],
+  options: {
+    _sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<{ inserted: number; errors: number }> {
+  let totalInserted = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+
+  for (let i = 0; i < runs.length; i++) {
+    const run = runs[i];
+
+    try {
+      const res = await fetchWithRetry(
+        `${serverUrl}/api/auto-update-runs`,
+        {
+          method: 'POST',
+          headers: buildHeaders(),
+          body: JSON.stringify(run),
+        },
+        { _sleep: options._sleep },
+      );
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(
+          `  Run ${i + 1}/${runs.length} (${run.date}): HTTP ${res.status} — ${body}`,
+        );
+        totalErrors++;
+        consecutiveFailures++;
+      } else {
+        const result = (await res.json()) as { id: number; resultsInserted: number };
+        totalInserted++;
+        consecutiveFailures = 0;
+
+        console.log(
+          `  Run ${i + 1}/${runs.length} (${run.date}): inserted (id: ${result.id}, ${result.resultsInserted} results)`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `  Run ${i + 1}/${runs.length} (${run.date}): Failed after retries — ${err}`,
+      );
+      totalErrors++;
+      consecutiveFailures++;
+    }
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const remaining = runs.length - (i + 1);
+      if (remaining > 0) {
+        console.error(
+          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive failures. ` +
+            `Skipping ${remaining} remaining runs.`,
+        );
+        totalErrors += remaining;
+      }
+      break;
+    }
+  }
+
+  return { inserted: totalInserted, errors: totalErrors };
+}
+
+// --- CLI ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error('Error: LONGTERMWIKI_SERVER_URL environment variable is required');
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error('Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  // Load runs
+  console.log(`Reading auto-update runs from: ${RUNS_DIR}`);
+  const { runs, fileCount, errorFiles } = loadRunYamls();
+
+  console.log(`  Found ${runs.length} runs across ${fileCount} files`);
+  if (errorFiles > 0) {
+    console.warn(`  ${errorFiles} file(s) had errors`);
+  }
+
+  const totalResults = runs.reduce((sum, r) => sum + (r.results?.length ?? 0), 0);
+  console.log(
+    `Syncing ${runs.length} auto-update runs to ${serverUrl}`,
+  );
+  console.log(`  ${totalResults} total per-page results`);
+
+  if (dryRun) {
+    console.log('\n[dry-run] Would sync these auto-update runs:');
+    for (const run of runs) {
+      console.log(
+        `  ${run.date} — ${run.trigger} — ` +
+          `${run.pagesUpdated ?? 0} updated, ${run.pagesFailed ?? 0} failed`,
+      );
+    }
+    process.exit(0);
+  }
+
+  // Pre-sync health check
+  console.log('\nChecking server health...');
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy after retries. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  // Sync
+  const result = await syncAutoUpdateRuns(serverUrl, runs);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Inserted: ${result.inserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:  ${result.errors}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Sync failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/wiki-server/sync-edit-logs.test.ts
+++ b/crux/wiki-server/sync-edit-logs.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadEditLogYamls, syncEditLogs } from './sync-edit-logs.ts';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { EditLogApiEntry } from '../lib/wiki-server-client.ts';
+
+const noSleep = async () => {};
+
+function makeEntry(pageId: string, date: string = '2026-01-15'): EditLogApiEntry {
+  return {
+    pageId,
+    date,
+    tool: 'crux-improve',
+    agency: 'ai-directed',
+    requestedBy: 'system',
+    note: `Updated ${pageId}`,
+  };
+}
+
+describe('loadEditLogYamls', () => {
+  it('loads entries from YAML files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-logs-'));
+    writeFileSync(
+      join(dir, 'anthropic.yaml'),
+      `- date: 2026-01-15\n  tool: crux-improve\n  agency: ai-directed\n  note: Updated page\n`,
+    );
+    writeFileSync(
+      join(dir, 'miri.yaml'),
+      `- date: 2026-01-16\n  tool: crux-fix\n  agency: automated\n`,
+    );
+
+    const { entries, fileCount, errorFiles } = loadEditLogYamls(dir);
+
+    expect(fileCount).toBe(2);
+    expect(errorFiles).toBe(0);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].pageId).toBe('anthropic');
+    expect(entries[0].date).toBe('2026-01-15');
+    expect(entries[0].tool).toBe('crux-improve');
+    expect(entries[1].pageId).toBe('miri');
+    expect(entries[1].tool).toBe('crux-fix');
+  });
+
+  it('handles Date objects in YAML', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-logs-'));
+    // YAML parser converts bare dates to Date objects
+    writeFileSync(
+      join(dir, 'test-page.yaml'),
+      `- date: 2026-01-15\n  tool: crux-fix\n  agency: automated\n`,
+    );
+
+    const { entries } = loadEditLogYamls(dir);
+    expect(entries).toHaveLength(1);
+    // normalizeDate should handle Date objects from YAML parser
+    expect(entries[0].date).toBe('2026-01-15');
+  });
+
+  it('skips files that are not arrays', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-logs-'));
+    writeFileSync(join(dir, 'bad.yaml'), 'key: value\n');
+
+    const { entries, errorFiles } = loadEditLogYamls(dir);
+    expect(entries).toHaveLength(0);
+    expect(errorFiles).toBe(1);
+  });
+
+  it('skips entries missing required fields', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-logs-'));
+    writeFileSync(
+      join(dir, 'page.yaml'),
+      `- date: 2026-01-15\n  tool: crux-fix\n  agency: automated\n- date: 2026-01-16\n  note: missing tool and agency\n`,
+    );
+
+    const { entries } = loadEditLogYamls(dir);
+    expect(entries).toHaveLength(1);
+  });
+
+  it('handles empty directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-logs-'));
+    const { entries, fileCount } = loadEditLogYamls(dir);
+    expect(entries).toHaveLength(0);
+    expect(fileCount).toBe(0);
+  });
+});
+
+describe('syncEditLogs', () => {
+  const origUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3000';
+    process.env.LONGTERMWIKI_SERVER_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    if (origUrl !== undefined) process.env.LONGTERMWIKI_SERVER_URL = origUrl;
+    else delete process.env.LONGTERMWIKI_SERVER_URL;
+    if (origKey !== undefined) process.env.LONGTERMWIKI_SERVER_API_KEY = origKey;
+    else delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  it('inserts all entries successfully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ inserted: 2 }), { status: 200 }),
+    );
+
+    const items = [makeEntry('a'), makeEntry('b'), makeEntry('c'), makeEntry('d')];
+    const result = await syncEditLogs('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 4, errors: 0 });
+  });
+
+  it('counts errors for failed batches', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ inserted: 2 }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
+
+    const items = [makeEntry('a'), makeEntry('b'), makeEntry('c'), makeEntry('d')];
+    const result = await syncEditLogs('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(2);
+    expect(result.errors).toBe(2);
+  });
+
+  it('fast-fails after 3 consecutive failures', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Service Unavailable', { status: 503 }),
+    );
+
+    const items = Array.from({ length: 10 }, (_, i) => makeEntry(`p${i}`));
+    const result = await syncEditLogs('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.errors).toBe(10);
+  });
+
+  it('handles empty items array', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = await syncEditLogs('http://localhost:3000', [], 100, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 0, errors: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends correct payload to /api/edit-logs/batch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 1 }), { status: 200 }),
+    );
+
+    const items = [makeEntry('test-page')];
+    await syncEditLogs('http://localhost:3000', items, 100, {
+      _sleep: noSleep,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:3000/api/edit-logs/batch',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"test-page"'),
+      }),
+    );
+
+    const callBody = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(callBody.items).toHaveLength(1);
+    expect(callBody.items[0].pageId).toBe('test-page');
+  });
+});

--- a/crux/wiki-server/sync-edit-logs.ts
+++ b/crux/wiki-server/sync-edit-logs.ts
@@ -1,0 +1,242 @@
+/**
+ * Wiki Server Edit Logs Sync
+ *
+ * Reads all data/edit-logs/*.yaml files and bulk-upserts them to the
+ * wiki-server's /api/edit-logs/batch endpoint.
+ *
+ * Reuses the retry + health-check pattern from sync-pages.ts.
+ *
+ * Usage:
+ *   pnpm crux wiki-server sync-edit-logs
+ *   pnpm crux wiki-server sync-edit-logs --dry-run
+ *   pnpm crux wiki-server sync-edit-logs --batch-size=200
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL   - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+import { parseCliArgs } from '../lib/cli.ts';
+import { getServerUrl, getApiKey, buildHeaders, type EditLogApiEntry } from '../lib/wiki-server-client.ts';
+import { waitForHealthy, fetchWithRetry } from './sync-pages.ts';
+
+const PROJECT_ROOT = join(import.meta.dirname!, '../..');
+const EDIT_LOGS_DIR = join(PROJECT_ROOT, 'data/edit-logs');
+
+// --- Configuration ---
+const DEFAULT_BATCH_SIZE = 200;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+// --- Types ---
+
+interface YamlEditLogEntry {
+  date: string | Date;
+  tool: string;
+  agency: string;
+  requestedBy?: string;
+  note?: string;
+}
+
+// --- Helpers ---
+
+function normalizeDate(d: string | Date): string {
+  if (d instanceof Date) return d.toISOString().split('T')[0];
+  return String(d);
+}
+
+/**
+ * Read all data/edit-logs/*.yaml files and return flattened entries.
+ * Each YAML file is an array of entries for the page whose ID matches the filename.
+ * Exported for testing.
+ */
+export function loadEditLogYamls(
+  dir: string = EDIT_LOGS_DIR,
+): { entries: EditLogApiEntry[]; fileCount: number; errorFiles: number } {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.yaml'));
+  const entries: EditLogApiEntry[] = [];
+  let errorFiles = 0;
+
+  for (const file of files) {
+    const pageId = file.replace('.yaml', '');
+    const filePath = join(dir, file);
+    try {
+      const raw = readFileSync(filePath, 'utf-8');
+      const parsed = parseYaml(raw);
+
+      if (!Array.isArray(parsed)) {
+        console.warn(`  WARN: ${file} — not an array, skipping`);
+        errorFiles++;
+        continue;
+      }
+
+      for (const entry of parsed as YamlEditLogEntry[]) {
+        if (!entry.date || !entry.tool || !entry.agency) {
+          console.warn(`  WARN: ${file} — entry missing required fields, skipping`);
+          continue;
+        }
+        entries.push({
+          pageId,
+          date: normalizeDate(entry.date),
+          tool: String(entry.tool),
+          agency: String(entry.agency),
+          requestedBy: entry.requestedBy ? String(entry.requestedBy) : null,
+          note: entry.note ? String(entry.note) : null,
+        });
+      }
+    } catch (err) {
+      console.warn(`  ERROR: ${file} — ${err}`);
+      errorFiles++;
+    }
+  }
+
+  return { entries, fileCount: files.length, errorFiles };
+}
+
+/**
+ * Sync edit log entries to the wiki-server in batches.
+ * Exported for testing.
+ */
+export async function syncEditLogs(
+  serverUrl: string,
+  items: EditLogApiEntry[],
+  batchSize: number,
+  options: {
+    _sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<{ inserted: number; errors: number }> {
+  let totalInserted = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(items.length / batchSize);
+
+    try {
+      const res = await fetchWithRetry(
+        `${serverUrl}/api/edit-logs/batch`,
+        {
+          method: 'POST',
+          headers: buildHeaders(),
+          body: JSON.stringify({ items: batch }),
+        },
+        { _sleep: options._sleep },
+      );
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(
+          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${body}`,
+        );
+        totalErrors += batch.length;
+        consecutiveFailures++;
+      } else {
+        const result = (await res.json()) as { inserted: number };
+        totalInserted += result.inserted;
+        consecutiveFailures = 0;
+
+        console.log(
+          `  Batch ${batchNum}/${totalBatches}: ${result.inserted} inserted`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `  Batch ${batchNum}/${totalBatches}: Failed after retries — ${err}`,
+      );
+      totalErrors += batch.length;
+      consecutiveFailures++;
+    }
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const remaining = items.length - (i + batchSize);
+      if (remaining > 0) {
+        console.error(
+          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batch failures. ` +
+            `Skipping ${remaining} remaining entries.`,
+        );
+        totalErrors += remaining;
+      }
+      break;
+    }
+  }
+
+  return { inserted: totalInserted, errors: totalErrors };
+}
+
+// --- CLI ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const batchSize = Number(args['batch-size']) || DEFAULT_BATCH_SIZE;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error('Error: LONGTERMWIKI_SERVER_URL environment variable is required');
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error('Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  // Load edit logs
+  console.log(`Reading edit logs from: ${EDIT_LOGS_DIR}`);
+  const { entries, fileCount, errorFiles } = loadEditLogYamls();
+
+  console.log(`  Found ${entries.length} entries across ${fileCount} files`);
+  if (errorFiles > 0) {
+    console.warn(`  ${errorFiles} file(s) had errors`);
+  }
+
+  console.log(
+    `Syncing ${entries.length} edit log entries to ${serverUrl} (batch size: ${batchSize})`,
+  );
+
+  if (dryRun) {
+    console.log('\n[dry-run] Would sync these edit log entries:');
+    const uniquePages = new Set(entries.map((e) => e.pageId));
+    console.log(`  ${entries.length} entries across ${uniquePages.size} pages`);
+    for (const entry of entries.slice(0, 10)) {
+      console.log(`  ${entry.pageId} — ${entry.date} — ${entry.tool} (${entry.agency})`);
+    }
+    if (entries.length > 10) {
+      console.log(`  ... and ${entries.length - 10} more`);
+    }
+    process.exit(0);
+  }
+
+  // Pre-sync health check
+  console.log('\nChecking server health...');
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy after retries. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  // Sync
+  const result = await syncEditLogs(serverUrl, entries, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Inserted: ${result.inserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:  ${result.errors}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Sync failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/wiki-server/sync-sessions.test.ts
+++ b/crux/wiki-server/sync-sessions.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadSessionYamls, syncSessions } from './sync-sessions.ts';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { SessionApiEntry } from '../lib/wiki-server-client.ts';
+
+const noSleep = async () => {};
+
+function makeSession(title: string, date: string = '2026-01-15'): SessionApiEntry {
+  return {
+    date,
+    branch: 'claude/test',
+    title,
+    summary: null,
+    model: 'claude-opus-4-6',
+    duration: '~30min',
+    cost: '~$5',
+    prUrl: null,
+    checksYaml: null,
+    pages: ['page-a', 'page-b'],
+  };
+}
+
+describe('loadSessionYamls', () => {
+  it('loads sessions from YAML files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sessions-'));
+    writeFileSync(
+      join(dir, '2026-01-15_test-branch.yaml'),
+      `date: "2026-01-15"\nbranch: claude/test\ntitle: Test session\npages:\n  - page-a\n  - page-b\n`,
+    );
+    writeFileSync(
+      join(dir, '2026-01-16_other-branch.yaml'),
+      `date: "2026-01-16"\nbranch: claude/other\ntitle: Other session\npages: []\n`,
+    );
+
+    const { sessions, fileCount, errorFiles } = loadSessionYamls(dir);
+
+    expect(fileCount).toBe(2);
+    expect(errorFiles).toBe(0);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].title).toBe('Test session');
+    expect(sessions[0].pages).toEqual(['page-a', 'page-b']);
+    expect(sessions[1].title).toBe('Other session');
+  });
+
+  it('handles bare YAML dates (parsed as Date objects)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sessions-'));
+    // Bare date (no quotes) — YAML parser converts to Date object
+    writeFileSync(
+      join(dir, '2026-01-15_bare-date.yaml'),
+      `date: 2026-01-15\ntitle: Bare date session\npages: []\n`,
+    );
+
+    const { sessions, errorFiles } = loadSessionYamls(dir);
+
+    expect(errorFiles).toBe(0);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].date).toBe('2026-01-15');
+  });
+
+  it('skips files that cannot be parsed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sessions-'));
+    writeFileSync(join(dir, 'bad.yaml'), 'not: valid: session\n');
+
+    const { sessions, errorFiles } = loadSessionYamls(dir);
+    expect(sessions).toHaveLength(0);
+    expect(errorFiles).toBe(1);
+  });
+
+  it('handles empty directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sessions-'));
+    const { sessions, fileCount } = loadSessionYamls(dir);
+    expect(sessions).toHaveLength(0);
+    expect(fileCount).toBe(0);
+  });
+});
+
+describe('syncSessions', () => {
+  const origUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3000';
+    process.env.LONGTERMWIKI_SERVER_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    if (origUrl !== undefined) process.env.LONGTERMWIKI_SERVER_URL = origUrl;
+    else delete process.env.LONGTERMWIKI_SERVER_URL;
+    if (origKey !== undefined) process.env.LONGTERMWIKI_SERVER_API_KEY = origKey;
+    else delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  it('inserts all sessions successfully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ inserted: 2 }), { status: 200 }),
+    );
+
+    const items = [
+      makeSession('Session A'),
+      makeSession('Session B'),
+      makeSession('Session C'),
+      makeSession('Session D'),
+    ];
+    const result = await syncSessions('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 4, errors: 0 });
+  });
+
+  it('counts errors for failed batches', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ inserted: 2 }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
+
+    const items = [
+      makeSession('A'),
+      makeSession('B'),
+      makeSession('C'),
+      makeSession('D'),
+    ];
+    const result = await syncSessions('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(2);
+    expect(result.errors).toBe(2);
+  });
+
+  it('fast-fails after 3 consecutive failures', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Service Unavailable', { status: 503 }),
+    );
+
+    const items = Array.from({ length: 10 }, (_, i) => makeSession(`S${i}`));
+    const result = await syncSessions('http://localhost:3000', items, 2, {
+      _sleep: noSleep,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.errors).toBe(10);
+  });
+
+  it('handles empty items array', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = await syncSessions('http://localhost:3000', [], 100, {
+      _sleep: noSleep,
+    });
+
+    expect(result).toEqual({ inserted: 0, errors: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends correct payload to /api/sessions/batch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ inserted: 1 }), { status: 200 }),
+    );
+
+    const items = [makeSession('Test Session')];
+    await syncSessions('http://localhost:3000', items, 100, {
+      _sleep: noSleep,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:3000/api/sessions/batch',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"Test Session"'),
+      }),
+    );
+
+    const callBody = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(callBody.items).toHaveLength(1);
+    expect(callBody.items[0].title).toBe('Test Session');
+  });
+});

--- a/crux/wiki-server/sync-sessions.ts
+++ b/crux/wiki-server/sync-sessions.ts
@@ -1,0 +1,207 @@
+/**
+ * Wiki Server Sessions Sync (bulk)
+ *
+ * Reads all .claude/sessions/*.yaml files and bulk-upserts them to the
+ * wiki-server's /api/sessions/batch endpoint.
+ *
+ * Reuses the retry + health-check pattern from sync-pages.ts.
+ *
+ * Usage:
+ *   pnpm crux wiki-server sync-sessions
+ *   pnpm crux wiki-server sync-sessions --dry-run
+ *   pnpm crux wiki-server sync-sessions --batch-size=50
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL   - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { parseCliArgs } from '../lib/cli.ts';
+import { getServerUrl, getApiKey, buildHeaders, type SessionApiEntry } from '../lib/wiki-server-client.ts';
+import { waitForHealthy, fetchWithRetry } from './sync-pages.ts';
+import { parseSessionYaml } from './sync-session.ts';
+
+const PROJECT_ROOT = join(import.meta.dirname!, '../..');
+const SESSIONS_DIR = join(PROJECT_ROOT, '.claude/sessions');
+
+// --- Configuration ---
+const DEFAULT_BATCH_SIZE = 50;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+/**
+ * Read all .claude/sessions/*.yaml files and return parsed session entries.
+ * Exported for testing.
+ */
+export function loadSessionYamls(
+  dir: string = SESSIONS_DIR,
+): { sessions: SessionApiEntry[]; fileCount: number; errorFiles: number } {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.yaml'));
+  const sessions: SessionApiEntry[] = [];
+  let errorFiles = 0;
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    try {
+      const entry = parseSessionYaml(filePath);
+      if (entry) {
+        sessions.push(entry);
+      } else {
+        console.warn(`  WARN: ${file} — could not parse, skipping`);
+        errorFiles++;
+      }
+    } catch (err) {
+      console.warn(`  ERROR: ${file} — ${err}`);
+      errorFiles++;
+    }
+  }
+
+  return { sessions, fileCount: files.length, errorFiles };
+}
+
+/**
+ * Sync session entries to the wiki-server in batches.
+ * Exported for testing.
+ */
+export async function syncSessions(
+  serverUrl: string,
+  items: SessionApiEntry[],
+  batchSize: number,
+  options: {
+    _sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<{ inserted: number; errors: number }> {
+  let totalInserted = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(items.length / batchSize);
+
+    try {
+      const res = await fetchWithRetry(
+        `${serverUrl}/api/sessions/batch`,
+        {
+          method: 'POST',
+          headers: buildHeaders(),
+          body: JSON.stringify({ items: batch }),
+        },
+        { _sleep: options._sleep },
+      );
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(
+          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${body}`,
+        );
+        totalErrors += batch.length;
+        consecutiveFailures++;
+      } else {
+        const result = (await res.json()) as { inserted: number };
+        totalInserted += result.inserted;
+        consecutiveFailures = 0;
+
+        console.log(
+          `  Batch ${batchNum}/${totalBatches}: ${result.inserted} inserted`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `  Batch ${batchNum}/${totalBatches}: Failed after retries — ${err}`,
+      );
+      totalErrors += batch.length;
+      consecutiveFailures++;
+    }
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const remaining = items.length - (i + batchSize);
+      if (remaining > 0) {
+        console.error(
+          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batch failures. ` +
+            `Skipping ${remaining} remaining sessions.`,
+        );
+        totalErrors += remaining;
+      }
+      break;
+    }
+  }
+
+  return { inserted: totalInserted, errors: totalErrors };
+}
+
+// --- CLI ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const batchSize = Number(args['batch-size']) || DEFAULT_BATCH_SIZE;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error('Error: LONGTERMWIKI_SERVER_URL environment variable is required');
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error('Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  // Load sessions
+  console.log(`Reading sessions from: ${SESSIONS_DIR}`);
+  const { sessions, fileCount, errorFiles } = loadSessionYamls();
+
+  console.log(`  Found ${sessions.length} sessions across ${fileCount} files`);
+  if (errorFiles > 0) {
+    console.warn(`  ${errorFiles} file(s) had errors`);
+  }
+
+  const totalPages = sessions.reduce((sum, s) => sum + (s.pages?.length ?? 0), 0);
+  console.log(
+    `Syncing ${sessions.length} sessions to ${serverUrl} (batch size: ${batchSize})`,
+  );
+  console.log(`  ${totalPages} total page associations`);
+
+  if (dryRun) {
+    console.log('\n[dry-run] Would sync these sessions:');
+    for (const session of sessions.slice(0, 10)) {
+      console.log(`  ${session.date} — ${session.title} (${session.pages?.length ?? 0} pages)`);
+    }
+    if (sessions.length > 10) {
+      console.log(`  ... and ${sessions.length - 10} more`);
+    }
+    process.exit(0);
+  }
+
+  // Pre-sync health check
+  console.log('\nChecking server health...');
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy after retries. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  // Sync
+  const result = await syncSessions(serverUrl, sessions, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Inserted: ${result.inserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:  ${result.errors}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Sync failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Add three new `crux wiki-server sync-*` commands to populate empty wiki-server tables from local YAML data
- Add CI workflow to auto-sync edit-logs, sessions, and auto-update runs on push to main
- Add `upsertResource()\ method to wiki-server client for single-resource operations

## Key Changes

### New sync commands
- **`sync-edit-logs`** — reads `data/edit-logs/*.yaml`, POSTs to `/api/edit-logs/batch` in configurable batches
- **`sync-sessions`** — reads `.claude/sessions/*.yaml`, POSTs to `/api/sessions/batch` in configurable batches
- **`sync-auto-update-runs`** — reads `data/auto-update/runs/*.yaml`, POSTs individually to `/api/auto-update-runs`

Each follows the existing sync-pages/sync-resources pattern: health checks, batch retry with exponential backoff, consecutive failure abort, and `--dry-run` support.

### CI workflow
- `.github/workflows/sync-data.yml` triggers on push to main when relevant data paths change
- Runs all three sync commands sequentially

### Design decision: no resource dual-write
The issue proposed adding fire-and-forget dual-writes to `resource-io.ts`. After investigation, this was found to be **unsafe**: the server's resource UPSERT does full column replacement, and the in-memory `Resource` type lacks fields like `review`, `keyPoints`, `localFilename` that exist in the YAML. A fire-and-forget upsert would overwrite valid data with nulls. The existing `sync-resources` CI workflow (which reads the full YAML) is the correct path.

## Test Plan

- [x] 31 unit tests covering YAML loading, batch sync, error handling, and edge cases
- [x] Gate passes (8/8 checks including TypeScript, schema, MDX validation)
- [x] Verified against real YAML data in the repository
- [x] All commands support `--dry-run` for safe previewing

Closes #494

https://claude.ai/code/session_017MEy1CRfrya3pjZ6csc11X