### PR TITLE
DRY: Extract shared batchSync<T>() helper from sync scripts

### DIFF
--- a/crux/wiki-server/sync-common.ts
+++ b/crux/wiki-server/sync-common.ts
@@ -1,0 +1,268 @@
+/**
+ * Shared batch sync infrastructure for wiki-server sync scripts.
+ *
+ * Contains:
+ *   - waitForHealthy(): Pre-sync health check with retries
+ *   - fetchWithRetry(): Per-request retry with exponential backoff
+ *   - batchSync<T>(): Generic batch sync loop with consecutive failure detection
+ *
+ * Each sync script defines its own data loading, transformation, and CLI,
+ * then delegates the actual sync loop to batchSync().
+ */
+
+import { buildHeaders } from "../lib/wiki-server-client.ts";
+
+// --- Configuration ---
+const HEALTH_CHECK_RETRIES = 5;
+const HEALTH_CHECK_DELAY_MS = 10_000;
+const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+const BATCH_RETRY_ATTEMPTS = 3;
+const BATCH_RETRY_BASE_DELAY_MS = 2_000;
+const BATCH_TIMEOUT_MS = 30_000;
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+// --- Types ---
+
+export interface BatchSyncOptions<T> {
+  /**
+   * Key to wrap items under in the request body.
+   * E.g., "pages" produces `{ pages: batch }`.
+   * If null, sends `batch[0]` directly (for single-item endpoints).
+   */
+  bodyKey: string | null;
+  /**
+   * Key in the response JSON containing the success count.
+   * If null, counts batch.length on success. Default: "upserted"
+   */
+  responseCountKey?: string | null;
+  /** Label for the items in log/error messages (e.g., "pages", "entities"). Default: "items" */
+  itemLabel?: string;
+  /** Called after a non-ok response for additional error handling (e.g., parsing JSON error messages) */
+  onBatchError?: (body: string) => void;
+  /** Custom success logger. If not provided, default log is used. */
+  onBatchSuccess?: (
+    responseJson: Record<string, unknown>,
+    batch: T[],
+    batchNum: number,
+    totalBatches: number,
+    count: number,
+  ) => void;
+  _sleep?: (ms: number) => Promise<void>;
+}
+
+export interface BatchSyncResult {
+  /** Number of items successfully processed */
+  count: number;
+  /** Number of items that errored */
+  errors: number;
+}
+
+// --- Health check ---
+
+/**
+ * Wait for the server to become healthy before syncing.
+ * Retries up to `maxRetries` times with a fixed delay between attempts.
+ * Exported for testing.
+ */
+export async function waitForHealthy(
+  serverUrl: string,
+  options: {
+    maxRetries?: number;
+    delayMs?: number;
+    timeoutMs?: number;
+    _sleep?: (ms: number) => Promise<void>;
+  } = {}
+): Promise<boolean> {
+  const maxRetries = options.maxRetries ?? HEALTH_CHECK_RETRIES;
+  const delayMs = options.delayMs ?? HEALTH_CHECK_DELAY_MS;
+  const timeoutMs = options.timeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
+  const sleep = options._sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch(`${serverUrl}/health`, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (res.ok) {
+        const body = await res.json();
+        if (body.status === "healthy") {
+          console.log(`  Health check passed (attempt ${attempt}/${maxRetries})`);
+          return true;
+        }
+      }
+      console.warn(
+        `  Health check attempt ${attempt}/${maxRetries}: not healthy (HTTP ${res.status})`
+      );
+    } catch (err) {
+      console.warn(
+        `  Health check attempt ${attempt}/${maxRetries}: ${err instanceof Error ? err.message : err}`
+      );
+    }
+
+    if (attempt < maxRetries) {
+      console.log(`  Retrying in ${delayMs / 1000}s...`);
+      await sleep(delayMs);
+    }
+  }
+
+  return false;
+}
+
+// --- Fetch with retry ---
+
+/**
+ * Fetch with retry and exponential backoff.
+ * Only retries on 5xx status codes or network errors.
+ * Returns the Response on success, or throws on exhausted retries.
+ * Exported for testing.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  options: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    timeoutMs?: number;
+    _sleep?: (ms: number) => Promise<void>;
+  } = {}
+): Promise<Response> {
+  const maxAttempts = options.maxAttempts ?? BATCH_RETRY_ATTEMPTS;
+  const baseDelayMs = options.baseDelayMs ?? BATCH_RETRY_BASE_DELAY_MS;
+  const timeoutMs = options.timeoutMs ?? BATCH_TIMEOUT_MS;
+  const sleep = options._sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      // Strip caller's signal to avoid conflicts with our timeout signal
+      const { signal: _callerSignal, ...initWithoutSignal } = init;
+      const res = await fetch(url, {
+        ...initWithoutSignal,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      // Don't retry client errors (4xx) — they won't resolve on their own
+      if (res.ok || (res.status >= 400 && res.status < 500)) {
+        return res;
+      }
+
+      // 5xx — retry
+      const body = await res.text().catch(() => "");
+      lastError = new Error(`HTTP ${res.status}: ${body.slice(0, 200)}`);
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < maxAttempts) {
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      console.warn(
+        `    Attempt ${attempt + 1}/${maxAttempts}: retrying in ${delay / 1000}s...`
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}
+
+// --- Batch sync ---
+
+/**
+ * Generic batch sync loop that handles batching, retry, consecutive failure
+ * detection, and progress logging.
+ *
+ * Each sync script calls this with its endpoint URL, items, batch size, and
+ * configuration (body key, response key, etc.), then maps the result to its
+ * own return type.
+ */
+export async function batchSync<T>(
+  url: string,
+  items: T[],
+  batchSize: number,
+  options: BatchSyncOptions<T>,
+): Promise<BatchSyncResult> {
+  const {
+    bodyKey,
+    responseCountKey = "upserted",
+    itemLabel = "items",
+    onBatchError,
+    onBatchSuccess,
+    _sleep,
+  } = options;
+
+  let totalCount = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(items.length / batchSize);
+
+    try {
+      const requestBody =
+        bodyKey !== null
+          ? JSON.stringify({ [bodyKey]: batch })
+          : JSON.stringify(batch[0]);
+
+      const res = await fetchWithRetry(
+        url,
+        {
+          method: "POST",
+          headers: buildHeaders(),
+          body: requestBody,
+        },
+        { _sleep },
+      );
+
+      if (!res.ok) {
+        const resBody = await res.text();
+        console.error(
+          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${resBody}`,
+        );
+        onBatchError?.(resBody);
+        totalErrors += batch.length;
+        consecutiveFailures++;
+      } else {
+        const result = (await res.json()) as Record<string, unknown>;
+        const count =
+          responseCountKey !== null
+            ? (result[responseCountKey] as number)
+            : batch.length;
+        totalCount += count;
+        consecutiveFailures = 0;
+
+        if (onBatchSuccess) {
+          onBatchSuccess(result, batch, batchNum, totalBatches, count);
+        } else {
+          const verb = responseCountKey ?? "synced";
+          console.log(
+            `  Batch ${batchNum}/${totalBatches}: ${count} ${verb}`,
+          );
+        }
+      }
+    } catch (err) {
+      console.error(
+        `  Batch ${batchNum}/${totalBatches}: Failed after retries — ${err}`,
+      );
+      totalErrors += batch.length;
+      consecutiveFailures++;
+    }
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const remaining = items.length - (i + batchSize);
+      if (remaining > 0) {
+        console.error(
+          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batch failures. ` +
+            `Skipping ${remaining} remaining ${itemLabel}.`,
+        );
+        totalErrors += remaining;
+      }
+      break;
+    }
+  }
+
+  return { count: totalCount, errors: totalErrors };
+}

--- a/crux/wiki-server/sync-facts.ts
+++ b/crux/wiki-server/sync-facts.ts
@@ -6,7 +6,7 @@
  *
  * YAML stays authoritative — the DB is a read mirror for querying.
  *
- * Reuses the retry + health-check pattern from sync-pages.ts.
+ * Reuses the shared batch sync infrastructure from sync-common.ts.
  *
  * Usage:
  *   pnpm crux wiki-server sync-facts
@@ -23,15 +23,14 @@ import { join } from "path";
 import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
 import { parseCliArgs } from "../lib/cli.ts";
-import { getServerUrl, getApiKey, buildHeaders } from "../lib/wiki-server-client.ts";
-import { waitForHealthy, fetchWithRetry } from "./sync-pages.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server-client.ts";
+import { waitForHealthy, batchSync } from "./sync-common.ts";
 
 const PROJECT_ROOT = join(import.meta.dirname!, "../..");
 const FACTS_DIR = join(PROJECT_ROOT, "data/facts");
 
 // --- Configuration ---
 const DEFAULT_BATCH_SIZE = 200;
-const MAX_CONSECUTIVE_FAILURES = 3;
 
 // --- Types ---
 
@@ -202,64 +201,19 @@ export async function syncFacts(
     _sleep?: (ms: number) => Promise<void>;
   } = {}
 ): Promise<{ upserted: number; errors: number }> {
-  let totalUpserted = 0;
-  let totalErrors = 0;
-  let consecutiveFailures = 0;
+  const result = await batchSync(
+    `${serverUrl}/api/facts/sync`,
+    items,
+    batchSize,
+    {
+      bodyKey: "facts",
+      responseCountKey: "upserted",
+      itemLabel: "facts",
+      _sleep: options._sleep,
+    },
+  );
 
-  for (let i = 0; i < items.length; i += batchSize) {
-    const batch = items.slice(i, i + batchSize);
-    const batchNum = Math.floor(i / batchSize) + 1;
-    const totalBatches = Math.ceil(items.length / batchSize);
-
-    try {
-      const res = await fetchWithRetry(
-        `${serverUrl}/api/facts/sync`,
-        {
-          method: "POST",
-          headers: buildHeaders(),
-          body: JSON.stringify({ facts: batch }),
-        },
-        { _sleep: options._sleep }
-      );
-
-      if (!res.ok) {
-        const body = await res.text();
-        console.error(
-          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${body}`
-        );
-        totalErrors += batch.length;
-        consecutiveFailures++;
-      } else {
-        const result = (await res.json()) as { upserted: number };
-        totalUpserted += result.upserted;
-        consecutiveFailures = 0;
-
-        console.log(
-          `  Batch ${batchNum}/${totalBatches}: ${result.upserted} upserted`
-        );
-      }
-    } catch (err) {
-      console.error(
-        `  Batch ${batchNum}/${totalBatches}: Failed after retries — ${err}`
-      );
-      totalErrors += batch.length;
-      consecutiveFailures++;
-    }
-
-    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-      const remaining = items.length - (i + batchSize);
-      if (remaining > 0) {
-        console.error(
-          `\n  Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batch failures. ` +
-            `Skipping ${remaining} remaining facts.`
-        );
-        totalErrors += remaining;
-      }
-      break;
-    }
-  }
-
-  return { upserted: totalUpserted, errors: totalErrors };
+  return { upserted: result.count, errors: result.errors };
 }
 
 // --- CLI ---


### PR DESCRIPTION
## Summary

- Extracts ~550 lines of duplicated batch sync logic from 7 sync scripts into a generic `batchSync<T>()` function in `crux/wiki-server/sync-common.ts`
- Moves `waitForHealthy()` and `fetchWithRetry()` to `sync-common.ts` (re-exported from `sync-pages.ts` for backward compatibility)
- Each sync script now defines only its data loading/transformation and calls `batchSync()` with endpoint URL, body key, and response count key

The new `batchSync<T>()` helper handles: batching items, POST with retry via `fetchWithRetry`, consecutive failure detection (fast-fail after 3), progress logging, and error counting. It supports both batched endpoints (`bodyKey: "entities"` → `{ entities: batch }`) and single-item endpoints (`bodyKey: null` → sends item directly).

**Net effect:** -556 lines removed, +404 lines added (including the new shared module). Future sync scripts only need ~10 lines of sync code instead of ~100.

## Test plan

- [x] All 98 existing tests across 7 test files pass unchanged
- [x] `pnpm crux validate gate` passes all 8 checks
- [x] TypeScript type check passes

Closes #504

https://claude.ai/code/session_01JRM7z8QCcr7YA74W1aQaq6