### PR TITLE
fix: raise resource authors array limit from 1000 to 5000

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -301,7 +301,7 @@ export const UpsertResourceSchema = z.object({
   abstract: z.string().max(50000).nullable().optional(),
   keyPoints: z.array(z.string().max(2000)).max(50).nullable().optional(),
   publicationId: z.string().max(200).nullable().optional(),
-  authors: z.array(z.string().max(500)).max(1000).nullable().optional(),
+  authors: z.array(z.string().max(500)).max(5000).nullable().optional(),
   publishedDate: DateStringSchema.nullable().optional(),
   tags: z.array(z.string().max(200)).max(50).nullable().optional(),
   localFilename: z.string().max(500).nullable().optional(),

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -38,7 +38,7 @@ const UpsertResourceSchema = z.object({
   abstract: z.string().max(50000).nullable().optional(),
   keyPoints: z.array(z.string().max(2000)).max(50).nullable().optional(),
   publicationId: z.string().max(200).nullable().optional(),
-  authors: z.array(z.string().max(500)).max(1000).nullable().optional(),
+  authors: z.array(z.string().max(500)).max(5000).nullable().optional(),
   publishedDate: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)


### PR DESCRIPTION
## Summary
- The Gemini Report paper (arxiv 2312.11805) has 1,351 authors, exceeding the Zod validation limit of 1,000
- This caused batch 9 of resource sync to fail, dropping 100 resources per sync
- Raised the limit from 1,000 to 5,000 in both `api-types.ts` and `routes/resources.ts`

## Test plan
- [x] All 233 wiki-server tests pass
- [x] All 236 app tests pass
- [x] All 8 gate checks pass
- [x] Resource sync now succeeds for all 3,160 resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)