### PR TITLE
fix: use firstOrThrow() instead of rows[0] after .returning() in summaries and claims POST endpoints

### DIFF
--- a/.claude/sessions/2026-02-21_fix-summaries-null-guard-UzsIf.yaml
+++ b/.claude/sessions/2026-02-21_fix-summaries-null-guard-UzsIf.yaml
@@ -1,0 +1,62 @@
+date: "2026-02-21"
+branch: claude/fix-summaries-null-guard-UzsIf
+title: "Fix: use firstOrThrow() instead of rows[0] after .returning() in summaries and claims POST endpoints"
+issue: 516
+pr: ""
+model: claude-sonnet-4-6
+duration: ~10m
+cost: ~$0.10
+pages: []
+
+summary: |
+  Fixed a null-guard bug in the summaries POST endpoint where rows[0] was accessed after
+  .returning() without checking if the insert returned any rows. If the DB insert failed
+  silently, rows[0] would be undefined, causing the endpoint to return undefined as JSON.
+  Replaced with firstOrThrow(rows, "summary upsert") — consistent with how all other
+  wiki-server routes handle this pattern (edit-logs, sessions, resources, hallucination-risk,
+  citations). Also fixed the identical bug in claims.ts POST /.
+
+key_decisions:
+  - "Used existing firstOrThrow helper from utils.ts — already exported and used by 5+ other route files"
+  - "Fixed claims.ts too: same rows[0] after .returning() pattern at claims.ts:92"
+  - "No new tests: pure null-guard fix using already-tested helper; existing integration tests cover the endpoints"
+  - "Tooling gap filed as #522: add ESLint rule to flag rows[0] after .returning() without firstOrThrow guard"
+
+files_changed:
+  - apps/wiki-server/src/routes/summaries.ts
+  - apps/wiki-server/src/routes/claims.ts
+
+checks:
+  initialized: true
+  type: infrastructure
+  initiated_at: "2026-02-21T19:31:40.890Z"
+  total: 32
+  completed: 25
+  na: 4
+  skipped: 3
+  items:
+    - read-issue
+    - explore-code
+    - plan-approach
+    - no-hardcoded
+    - typescript-used
+    - correctness
+    - shell-injection
+    - security
+    - no-dead-code
+    - no-dry-violations
+    - full-integration
+    - no-regressions
+    - live-data-test
+    - backward-compatible
+    - multi-environment
+    - ci-coverage
+    - tooling-gaps-found
+    - self-audit-commands
+    - self-audit-files
+    - self-audit-no-fabrication
+    - gate-passes
+    - pr-description
+    - session-log
+    - check-recent-merges
+    - tooling-gaps-actioned

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  firstOrThrow,
 } from "./utils.js";
 import {
   InsertClaimSchema as SharedInsertClaimSchema,
@@ -89,7 +90,7 @@ claimsRoute.post("/", async (c) => {
       claimType: claims.claimType,
     });
 
-  return c.json(rows[0], 201);
+  return c.json(firstOrThrow(rows, "claim insert"), 201);
 });
 
 // ---- POST /batch (insert multiple claims) ----

--- a/apps/wiki-server/src/routes/summaries.ts
+++ b/apps/wiki-server/src/routes/summaries.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  firstOrThrow,
 } from "./utils.js";
 
 export const summariesRoute = new Hono();
@@ -111,7 +112,7 @@ summariesRoute.post("/", async (c) => {
       entityType: summaries.entityType,
     });
 
-  return c.json(rows[0], 201);
+  return c.json(firstOrThrow(rows, "summary upsert"), 201);
 });
 
 // ---- POST /batch (upsert multiple summaries) ----


### PR DESCRIPTION
## Summary

- Replace `rows[0]` with `firstOrThrow(rows, context)` in `summaries.ts` POST / — if the DB insert returned an empty `.returning()` result, `rows[0]` would be `undefined`, serialized as JSON and returned with 201
- Same fix applied to `claims.ts` POST /, which had the identical pattern
- Both now use the existing `firstOrThrow()` helper already exported from `utils.ts` and used by 5+ other route files (edit-logs, sessions, resources, hallucination-risk, citations)

Fixes #516.

## Test plan
- [x] Gate check passes: `pnpm crux validate gate` — 236 tests pass, all 8 blocking checks green
- [x] TypeScript type check passes (apps/web)
- [x] No regressions: grep for rows[0] after .returning() in other routes — all others already use firstOrThrow or have explicit length checks

## Tooling gap
Filed #522 to track adding an ESLint rule that automatically flags `rows[0]` after `.returning()` without a `firstOrThrow` guard.

https://claude.ai/code/session_019e8FwRtmSEkPFfqZGuVEKi