### PR TITLE
fix: load workspace-root .env in Next.js for wiki-server API access

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,9 @@
 import type { NextConfig } from "next";
+import { config as loadEnv } from "dotenv";
+import { resolve } from "path";
+
+// Load workspace-root .env so wiki-server vars are available to Next.js
+loadEnv({ path: resolve(import.meta.dirname, "../../.env") });
 
 const nextConfig: NextConfig = {
   transpilePackages: [


### PR DESCRIPTION
## Summary
- Next.js loads `.env` from its CWD (`apps/web/`), but the wiki-server env vars (`LONGTERMWIKI_SERVER_URL`, `LONGTERMWIKI_SERVER_API_KEY`) live in the workspace root `.env`
- Added `dotenv` loading of `../../.env` in `next.config.ts`
- Without this, all 5 API-backed internal dashboards fell back to "local files" in dev

## Before/After
| Dashboard | Before | After |
|-----------|--------|-------|
| page-changes | local files | wiki-server API |
| auto-update-runs | local files | wiki-server API |
| auto-update-news | local files | wiki-server API |
| citation-accuracy | local files | wiki-server API |
| hallucination-risk | local files | wiki-server API |

## Test plan
- [x] Started dev server, verified all 5 API-backed dashboards show "wiki-server API"
- [x] Verified all build-time dashboards still render (entities, facts, importance-rankings, updates, similarity)
- [x] All 8 gate checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)