### PR TITLE
fix: fail CI loudly when VERCEL_DEPLOY_HOOK_URL is not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,15 @@ jobs:
       - name: Trigger Vercel production deploy
         run: |
           if [ -z "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}" ]; then
-            echo "::warning::VERCEL_DEPLOY_HOOK_URL not set — skipping deploy trigger (see scheduled-deploy.yml for setup instructions)"
-            exit 0
+            echo "::error::VERCEL_DEPLOY_HOOK_URL secret is not set — production will NOT be deployed."
+            echo ""
+            echo "Setup (one-time):"
+            echo "  1. Vercel Dashboard → Project → Settings → Git → Deploy Hooks"
+            echo "  2. Create a hook: Name 'GitHub CI Deploy', Branch 'main'"
+            echo "  3. Copy the URL"
+            echo "  4. GitHub repo → Settings → Secrets → Actions → New secret"
+            echo "     Name: VERCEL_DEPLOY_HOOK_URL  Value: <paste URL>"
+            exit 1
           fi
           RESPONSE=$(curl -s -o /tmp/vercel_response.json -w "%{http_code}" \
             -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}")


### PR DESCRIPTION
## Summary

- **Root cause of missing prod deploys**: `VERCEL_DEPLOY_HOOK_URL` GitHub Actions secret was never configured. The CI `deploy` job ran on every main push but silently exited 0 with only a `::warning::` annotation — CI showed green while no production deployment was ever triggered.
- **Evidence**: CI logs for run #22264222537 show the script evaluating `if [ -z "" ]` (empty string), hitting the skip path, and exiting 0.
- **Preview deployments still worked** because those are created by Vercel's native GitHub App integration (no secret needed). Production deploys depended entirely on the hook URL.

## Change

`.github/workflows/ci.yml` — `deploy` job:
- `::warning::` → `::error::` (now visible as a CI failure annotation)
- `exit 0` → `exit 1` (now fails the job so the problem is impossible to miss)
- Added inline setup instructions so the next person knows exactly what to do

## What you still need to do (one-time setup)

1. **Vercel Dashboard** → Project → Settings → Git → **Deploy Hooks**
2. Create hook: Name `GitHub CI Deploy`, Branch `main`
3. Copy the generated URL
4. **GitHub repo** → Settings → Secrets and variables → Actions → New repository secret
   - Name: `VERCEL_DEPLOY_HOOK_URL`
   - Value: `<paste URL>`

Once the secret is set, the `deploy` job will trigger a Vercel production build after every successful CI run on main.

## Test plan

- [x] Gate check passes locally (all 8 checks green, 236 tests pass)
- [ ] After merging: CI `deploy` job should fail with `::error::` annotation until the secret is configured
- [ ] After secret is added: CI `deploy` job should trigger a Vercel production deployment and return HTTP 200

https://claude.ai/code/session_01HN4L95KtdSZXnv537mra3t