### PR TITLE
feat: add visible error indicators to API-backed internal dashboards

### DIFF
--- a/apps/web/src/app/internal/page-changes/page.tsx
+++ b/apps/web/src/app/internal/page-changes/page.tsx
@@ -5,10 +5,10 @@ import {
   type PageChangesSession,
 } from "@/data";
 import {
-  fetchFromWikiServer,
+  fetchDetailed,
   withApiFallback,
-  dataSourceLabel,
 } from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { PageChangesSessions } from "./page-changes-sessions";
 import type { Metadata } from "next";
 
@@ -46,12 +46,12 @@ function extractPrNumber(prUrl: string | null): number | undefined {
  * Load page-changes data from the wiki-server API.
  * Returns null if the server is unavailable.
  */
-async function loadSessionsFromApi(): Promise<PageChangesSession[] | null> {
-  const data = await fetchFromWikiServer<{ sessions: ApiSession[] }>(
+async function loadSessionsFromApi() {
+  const result = await fetchDetailed<{ sessions: ApiSession[] }>(
     "/api/sessions/page-changes",
     { revalidate: 300 }
   );
-  if (!data) return null;
+  if (!result.ok) return result;
 
   // Build a page metadata lookup from local database.json
   const pages = getAllPages();
@@ -68,7 +68,10 @@ async function loadSessionsFromApi(): Promise<PageChangesSession[] | null> {
     ])
   );
 
-  return data.sessions
+  const data = result.data;
+  return {
+    ok: true as const,
+    data: data.sessions
     .filter((s) => s.pages.length > 0)
     .map((s) => {
       const pr = extractPrNumber(s.prUrl);
@@ -93,12 +96,13 @@ async function loadSessionsFromApi(): Promise<PageChangesSession[] | null> {
           };
         }),
       };
-    });
+    }),
+  };
 }
 
 export default async function PageChangesPage() {
   // Try wiki-server API first, fall back to database.json
-  const { data: sessions, source } = await withApiFallback(
+  const { data: sessions, source, apiError } = await withApiFallback(
     loadSessionsFromApi,
     getPageChangeSessions
   );
@@ -129,9 +133,7 @@ export default async function PageChangesPage() {
         <PageChangesSessions sessions={sessions} />
       )}
 
-      <p className="text-xs text-muted-foreground mt-4">
-        Data source: {dataSourceLabel(source)}
-      </p>
+      <DataSourceBanner source={source} apiError={apiError} />
     </article>
   );
 }

--- a/apps/web/src/components/internal/DataSourceBanner.tsx
+++ b/apps/web/src/components/internal/DataSourceBanner.tsx
@@ -1,0 +1,53 @@
+import type { DataSource, ApiErrorReason } from "@lib/wiki-server";
+
+interface DataSourceBannerProps {
+  source: DataSource;
+  apiError?: ApiErrorReason;
+}
+
+export function DataSourceBanner({ source, apiError }: DataSourceBannerProps) {
+  if (source === "api") {
+    return (
+      <p className="text-xs text-emerald-600 dark:text-emerald-400 mb-4">
+        Live data from wiki-server
+      </p>
+    );
+  }
+
+  if (!apiError || apiError.type === "not-configured") {
+    return (
+      <div className="border-l-4 border-blue-400 bg-blue-50 dark:bg-blue-950/30 px-4 py-3 mb-4 not-prose">
+        <p className="text-sm text-blue-800 dark:text-blue-200">
+          Using local data. Set{" "}
+          <code className="text-xs bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 rounded">
+            LONGTERMWIKI_SERVER_URL
+          </code>{" "}
+          to enable live data from wiki-server.
+        </p>
+      </div>
+    );
+  }
+
+  if (apiError.type === "connection-error") {
+    return (
+      <div className="border-l-4 border-amber-400 bg-amber-50 dark:bg-amber-950/30 px-4 py-3 mb-4 not-prose">
+        <p className="text-sm text-amber-800 dark:text-amber-200">
+          Could not reach wiki-server &mdash; showing local data.
+        </p>
+        <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+          Error: {apiError.message}
+        </p>
+      </div>
+    );
+  }
+
+  // server-error
+  return (
+    <div className="border-l-4 border-red-400 bg-red-50 dark:bg-red-950/30 px-4 py-3 mb-4 not-prose">
+      <p className="text-sm text-red-800 dark:text-red-200">
+        Wiki-server returned HTTP {apiError.status} ({apiError.statusText})
+        &mdash; showing local data.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- When wiki-server is unreachable, internal dashboards now show color-coded banners instead of a tiny "Data source: local files" footer
- Adds `fetchDetailed()` to `wiki-server.ts` that returns structured error info (`not-configured`, `connection-error`, `server-error`) instead of just `null`
- New shared `DataSourceBanner` component used by all 5 API-backed dashboards: page-changes, auto-update-runs, auto-update-news, citation-accuracy, hallucination-risk

## Test plan

- [ ] Start dev server with correct `.env` — dashboards show green "Live data from wiki-server"
- [ ] Unset `LONGTERMWIKI_SERVER_URL`, restart — dashboards show blue "not configured" info box
- [ ] Set URL to a bad host, restart — dashboards show amber "connection error" warning
- [ ] `pnpm crux validate gate` passes (verified locally, all 9 checks including full Next.js build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)