### PR TITLE
feat: add operational workflows (backup, restore, deploy verification, security scan)

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -36,6 +36,11 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL secret is not set"
+            exit 1
+          fi
+
           # Parse DATABASE_URL
           PROTO="$(echo "$DATABASE_URL" | grep :// | sed -e 's,^\(.*://\).*,\1,g')"
           URL="${DATABASE_URL/$PROTO/}"
@@ -60,8 +65,11 @@ jobs:
             -d "${DB_NAME}" \
             --no-owner \
             --no-privileges \
-            --verbose \
-            2>&1 | gzip > "${FILENAME}"
+            --verbose 2>/tmp/pg_dump.log \
+            | gzip > "${FILENAME}"
+
+          echo "pg_dump output:"
+          cat /tmp/pg_dump.log
 
           FILE_SIZE=$(du -h "${FILENAME}" | cut -f1)
           echo "Backup completed: ${FILENAME} (${FILE_SIZE})"

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -23,12 +23,6 @@ jobs:
     if: github.event.inputs.confirm == 'RESTORE'
 
     steps:
-      - name: Validate confirmation
-        if: github.event.inputs.confirm != 'RESTORE'
-        run: |
-          echo "::error::You must type RESTORE to confirm the restore operation."
-          exit 1
-
       - uses: actions/checkout@v4
 
       - name: Install PostgreSQL client
@@ -45,7 +39,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter wiki-server
 
       - name: Download backup artifact
         uses: actions/download-artifact@v4
@@ -59,6 +53,11 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL secret is not set"
+            exit 1
+          fi
+
           # Parse DATABASE_URL
           PROTO="$(echo "$DATABASE_URL" | grep :// | sed -e 's,^\(.*://\).*,\1,g')"
           URL="${DATABASE_URL/$PROTO/}"
@@ -82,7 +81,7 @@ jobs:
             -d "${DB_NAME}" \
             --no-owner \
             --no-privileges \
-            2>&1 | gzip > "${SAFETY_FILENAME}"
+            | gzip > "${SAFETY_FILENAME}"
 
           FILE_SIZE=$(du -h "${SAFETY_FILENAME}" | cut -f1)
           echo "Safety backup completed: ${SAFETY_FILENAME} (${FILE_SIZE})"

--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -7,6 +7,7 @@ on:
       - "apps/wiki-server/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/wiki-server-docker.yml"
+      - ".github/workflows/database-backup.yml"
   workflow_dispatch:
 
 concurrency:
@@ -72,7 +73,7 @@ jobs:
     steps:
       - name: Update ArgoCD image tag
         env:
-          ARGOCD_SERVER: argo.k8s.quantifieduncertainty.org
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
         run: |
           IMAGE_TAG="sha-${{ github.sha }}"
@@ -98,7 +99,7 @@ jobs:
 
       - name: Verify deployed SHA
         env:
-          ARGOCD_SERVER: argo.k8s.quantifieduncertainty.org
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
         run: |
           EXPECTED_TAG="sha-${{ github.sha }}"
@@ -194,7 +195,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ghcr.io/quantified-uncertainty/longterm-wiki-server:sha-${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Summary

- **Database backup workflow** (`database-backup.yml`): Reusable + daily scheduled (2 AM UTC) + manual trigger. Backs up PostgreSQL via `pg_dump | gzip`, uploads to GitHub artifacts (30-day retention), optional S3 upload.
- **Database restore workflow** (`database-restore.yml`): Manual trigger with "RESTORE" confirmation. Downloads backup artifact, creates pre-restore safety backup (7-day retention), restores via `gunzip | psql`, runs Drizzle migrations.
- **Restructured deploy pipeline** (`wiki-server-docker.yml`): Split into 4 jobs — build → pre-deploy backup → deploy (with SHA verification) → security scan (parallel). SHA verification confirms the correct image is running after ArgoCD deploy.
- **Security scanning**: Trivy vulnerability scanner (pinned v0.30.0) with SARIF output uploaded to GitHub Security tab.

## Pipeline flow
```
build-and-push  →  pre-deploy-backup  →  deploy (ArgoCD + SHA verify + smoke test)
                →  security-scan      (parallel with backup+deploy)
```

## Deployment blocker

⚠️ **Requires DATABASE_URL secret** — see #572. Without it, pre-deploy backup will fail and block all deployments. Must be configured before merging.

## Review fixes (second commit)

- Fixed pg_dump corruption: verbose stderr was being piped into the SQL dump via 2>&1
- Added DATABASE_URL empty guard with clear error message
- Removed unreachable dead code in restore validation step
- Changed hardcoded ArgoCD server to use ARGOCD_SERVER secret (consistent with discord-bot)
- Pinned trivy-action to v0.30.0 instead of @master
- Added database-backup.yml to trigger paths
- Used --filter wiki-server for restore dependency install

## Test plan
- [x] Validate YAML syntax locally (all 3 files pass)
- [x] All 8 pre-push gate checks pass
- [ ] Configure DATABASE_URL secret (#572)
- [ ] Trigger manual backup: gh workflow run database-backup.yml
- [ ] Merge to main → verify full build → backup → deploy → scan pipeline
- [ ] Verify backup artifact appears in GitHub Actions
- [ ] Verify Trivy results appear in GitHub Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)