### PR TITLE
fix: improve ToC layout and sidebar styling

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -44,11 +44,11 @@ export default function RootLayout({
       <body className="min-h-screen bg-background text-foreground">
         {/* Top nav bar */}
         <header className="sticky top-0 z-40 border-b border-border bg-card">
-          <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
-            <Link href="/" className="text-lg font-bold no-underline text-foreground">
+          <div className="flex items-center">
+            <Link href="/" className="w-64 shrink-0 px-4 py-3 text-lg font-bold no-underline text-foreground max-md:w-auto">
               Longterm Wiki
             </Link>
-            <nav className="flex items-center gap-4">
+            <nav className="flex-1 flex items-center justify-end gap-4 px-6 py-3">
               <Link
                 href="/wiki"
                 className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -261,7 +261,7 @@ export function SidebarContent({
     <div
       data-slot="sidebar-content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto [scrollbar-gutter:stable]",
         className
       )}
       {...props}
@@ -276,7 +276,7 @@ export function SidebarGroup({
   return (
     <div
       data-slot="sidebar-group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col px-2 py-0.5", className)}
       {...props}
     />
   );
@@ -293,7 +293,7 @@ export function SidebarGroupLabel({
     <Comp
       data-slot="sidebar-group-label"
       className={cn(
-        "text-muted-foreground flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-semibold uppercase tracking-wide",
+        "text-foreground/70 flex h-7 shrink-0 items-center rounded-md px-2 text-sm font-semibold",
         className
       )}
       {...props}
@@ -341,13 +341,13 @@ export function SidebarMenuItem({
 }
 
 const sidebarMenuButtonVariants = cva(
-  "flex w-full items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-left text-sm outline-none transition-colors text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[active=true]:bg-accent data-[active=true]:font-medium data-[active=true]:text-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "flex w-full items-center gap-2 overflow-hidden rounded-md px-3 py-1 text-left text-sm outline-none transition-colors text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[active=true]:bg-blue-50 data-[active=true]:text-blue-700 data-[active=true]:font-medium dark:data-[active=true]:bg-blue-950/40 dark:data-[active=true]:text-blue-300 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm",
+        default: "min-h-8 text-sm",
+        sm: "min-h-7 text-xs",
+        lg: "min-h-12 text-sm",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/wiki/TableOfContents.tsx
+++ b/apps/web/src/components/wiki/TableOfContents.tsx
@@ -11,14 +11,20 @@ interface TableOfContentsProps {
 /**
  * TableOfContents — auto-generated TOC for long articles (wordCount > 1500).
  *
- * On desktop: floats right of the prose content (Wikipedia-style).
- * On mobile: renders inline with a collapsible toggle.
- * Highlights the active heading as the user scrolls.
+ * Full-width inline block with 2-column layout on desktop.
+ * Collapsible toggle. Highlights the active heading as the user scrolls.
+ * Drops h3s when total heading count exceeds 14 to keep it compact.
  */
 export function TableOfContents({ headings }: TableOfContentsProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [activeSlug, setActiveSlug] = useState<string>("");
   const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Only show h3s when the total heading count is manageable
+  const h2Only = headings.length > 14;
+  const visibleHeadings = h2Only
+    ? headings.filter((h) => h.depth === 2)
+    : headings;
 
   useEffect(() => {
     // Clean up any previous observer
@@ -28,7 +34,6 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
 
     const observer = new IntersectionObserver(
       (entries) => {
-        // Find the first heading that is intersecting (top-most visible)
         const intersecting = entries
           .filter((e) => e.isIntersecting)
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
@@ -36,28 +41,27 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
           setActiveSlug(intersecting[0].target.id);
         }
       },
-      // Trigger when heading enters top 20% of viewport
       { rootMargin: "0px 0px -75% 0px", threshold: 0 }
     );
 
     observerRef.current = observer;
 
-    headings.forEach(({ slug }) => {
+    visibleHeadings.forEach(({ slug }) => {
       const el = document.getElementById(slug);
       if (el) observer.observe(el);
     });
 
     return () => observer.disconnect();
-  }, [headings]);
+  }, [visibleHeadings]);
 
-  if (headings.length === 0) return null;
+  if (visibleHeadings.length === 0) return null;
 
   return (
-    <div className="not-prose md:float-right md:clear-right md:ml-6 md:mb-4 md:w-52 w-full mb-6 border border-border rounded-lg bg-muted/40 text-sm shrink-0">
+    <div className="not-prose w-full mb-6 border border-border rounded-lg bg-muted/40 text-sm">
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full px-3 py-2 font-medium text-sm text-foreground/80 hover:text-foreground transition-colors"
+        className="flex items-center justify-between w-full px-5 py-2.5 font-medium text-sm text-foreground/80 hover:text-foreground transition-colors"
         aria-expanded={isOpen}
         aria-controls="toc-content"
       >
@@ -73,25 +77,38 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
       </button>
       {isOpen && (
         <nav id="toc-content" aria-label="Table of contents">
-          <ol className="px-3 pb-3 space-y-0.5 list-none m-0">
-            {headings.map((heading, i) => (
-              <li
-                key={`${heading.slug}-${i}`}
-                className={`m-0 ${heading.depth === 3 ? "pl-3" : ""}`}
-              >
-                <a
-                  href={`#${heading.slug}`}
-                  className={`block py-0.5 text-xs leading-snug no-underline transition-colors ${
-                    activeSlug === heading.slug
-                      ? "text-foreground font-medium"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
+          <div className="px-5 pb-4 columns-1 md:columns-2 gap-x-8">
+            {visibleHeadings.map((heading, i) => {
+              const isH2 = heading.depth === 2;
+              const prevDepth = i > 0 ? visibleHeadings[i - 1].depth : 2;
+              const needsGap = isH2 && i > 0 && prevDepth === 3;
+              return (
+                <div
+                  key={`${heading.slug}-${i}`}
+                  className={`break-inside-avoid ${needsGap ? "mt-1.5" : ""}`}
                 >
-                  {heading.text}
-                </a>
-              </li>
-            ))}
-          </ol>
+                  <a
+                    href={`#${heading.slug}`}
+                    className={`block no-underline transition-colors ${
+                      isH2
+                        ? `py-[3px] text-[13px] leading-snug font-medium ${
+                            activeSlug === heading.slug
+                              ? "text-foreground"
+                              : "text-foreground/80 hover:text-foreground"
+                          }`
+                        : `py-[2px] pl-4 text-xs leading-snug border-l border-border/60 ${
+                            activeSlug === heading.slug
+                              ? "text-foreground border-foreground/40"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`
+                    }`}
+                  >
+                    {heading.text}
+                  </a>
+                </div>
+              );
+            })}
+          </div>
         </nav>
       )}
     </div>

--- a/apps/web/src/components/wiki/WikiSidebar.tsx
+++ b/apps/web/src/components/wiki/WikiSidebar.tsx
@@ -35,7 +35,7 @@ function SidebarNavSection({ section }: { section: NavSection }) {
     >
       <SidebarGroup>
         <SidebarGroupLabel asChild>
-          <CollapsibleTrigger className="flex w-full items-center justify-between">
+          <CollapsibleTrigger className="flex w-full items-center justify-between hover:bg-accent hover:text-accent-foreground rounded-md transition-colors">
             <span>{section.title}</span>
             <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]/collapsible:rotate-90" />
           </CollapsibleTrigger>
@@ -64,7 +64,7 @@ function SidebarNavSection({ section }: { section: NavSection }) {
 
 function SidebarNav({ sections }: { sections: NavSection[] }) {
   return (
-    <SidebarContent className="pt-2">
+    <SidebarContent className="pt-4">
       {sections.map((section) => (
         <SidebarNavSection key={section.title} section={section} />
       ))}
@@ -88,7 +88,7 @@ export function WikiSidebar({ sections }: { sections: NavSection[] }) {
   return (
     <>
       {/* Desktop: static sidebar */}
-      <Sidebar className="sticky top-14 h-[calc(100vh-3.5rem)] border-r-0">
+      <Sidebar className="sticky top-14 h-[calc(100vh-3.5rem)] border-r border-border/50 bg-muted/30">
         <SidebarNav sections={sections} />
       </Sidebar>
 


### PR DESCRIPTION
- ToC: full-width 2-column layout instead of narrow float-right
- ToC: drop h3s when >14 headings for compact display
- ToC: no bullets, proper h2/h3 visual hierarchy with indentation
- Sidebar: tighter spacing (reduced group/button padding)
- Sidebar: title case headers instead of ALL CAPS
- Sidebar: blue active state distinguishable from hover
- Sidebar: hover effect on section headers
- Sidebar: subtle background + right border for visual separation
- Sidebar: scrollbar-gutter:stable to prevent layout shift
- Sidebar: min-h instead of fixed h to prevent text overlap
- Header: logo width matches sidebar for alignment