### PR TITLE
fix: post-merge review — help text, ToC perf, job error messages

### DIFF
--- a/apps/web/src/components/wiki/TableOfContents.tsx
+++ b/apps/web/src/components/wiki/TableOfContents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { ChevronDown, ChevronUp, List } from "lucide-react";
 import type { TocHeading } from "@/lib/mdx";
 
@@ -22,9 +22,10 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
 
   // Only show h3s when the total heading count is manageable
   const h2Only = headings.length > 14;
-  const visibleHeadings = h2Only
-    ? headings.filter((h) => h.depth === 2)
-    : headings;
+  const visibleHeadings = useMemo(
+    () => (h2Only ? headings.filter((h) => h.depth === 2) : headings),
+    [headings, h2Only]
+  );
 
   useEffect(() => {
     // Clean up any previous observer

--- a/apps/wiki-server/src/routes/jobs.ts
+++ b/apps/wiki-server/src/routes/jobs.ts
@@ -302,7 +302,7 @@ jobsRoute.post("/:id/fail", async (c) => {
     // Distinguish "not found" from "wrong status" for accurate error messages.
     const db = getDrizzleDb();
     const exists = await db
-      .select({ id: jobs.id })
+      .select({ id: jobs.id, status: jobs.status })
       .from(jobs)
       .where(eq(jobs.id, id));
     if (exists.length === 0) {
@@ -310,7 +310,7 @@ jobsRoute.post("/:id/fail", async (c) => {
     }
     return validationError(
       c,
-      "Job is not in 'running' or 'claimed' status"
+      `Job is in '${exists[0].status}' status, expected 'running' or 'claimed'`
     );
   }
 

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -32,6 +32,7 @@
  *   facts       Propose new canonical facts from wiki page content
  *   entity      Entity ID management (rename with safe word-boundary matching)
  *   query       Query wiki-server DB (search, entity, facts, related, risk, stats…)
+ *   jobs        Job queue management (list, stats, create, claim, sweep)
  *
  * Global Options:
  *   --ci        JSON output for CI pipelines


### PR DESCRIPTION
## Summary

Three direct fixes from a paranoid review of recently merged PRs (#557–#576):

- **crux.mjs**: Restore `jobs` domain in CLI help text (removed in PR #575)
- **TableOfContents.tsx**: Memoize `visibleHeadings` with `useMemo` to prevent the IntersectionObserver from being torn down and recreated on every render
- **jobs.ts /fail**: Include actual job status in error message (e.g., `"Job is in 'completed' status, expected 'running' or 'claimed'"`) instead of generic message

## Related issues filed

Seven issues filed for larger-scope items found during the review:

- #593: Health monitor retry + debounce
- #594: Session log durability (DB-only storage)
- #595: API type duplication across 3 codebases
- #596: Job worker concurrency model
- #597: formatRawJobRow weak typing
- #598: recentEdits client-side date filtering
- #599: Discord bot rate limiting

## Test plan

- [x] `pnpm crux validate gate` passes (236 tests, all 8 checks)
- [x] Dev server renders pages correctly
- [x] Prod wiki-server health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)