### PR TITLE
feat: add job queue handlers, worker runner, and batch commit system (#555)

### DIFF
--- a/.github/workflows/job-worker.yml
+++ b/.github/workflows/job-worker.yml
@@ -1,13 +1,21 @@
 name: Job Worker
 
-# Processes background jobs from the job queue.
+# Processes background jobs from the job queue using the Node.js worker runner.
 #
 # Two triggers:
 # 1. workflow_dispatch — called by the server when a new job is created
 # 2. schedule — polls every 5 minutes for unclaimed jobs
 #
 # The worker claims a job atomically via the /api/jobs/claim endpoint,
-# executes it, and reports results back via /complete or /fail.
+# executes the registered handler, and reports results back via /complete or /fail.
+#
+# Supported job types:
+#   - ping: smoke test
+#   - citation-verify: verify citations on a wiki page
+#   - page-improve: run content improvement pipeline
+#   - page-create: run content creation pipeline
+#   - batch-commit: collect completed job results and create a PR
+#   - auto-update-digest: fetch news digest and create page-improve jobs
 
 on:
   schedule:
@@ -19,6 +27,11 @@ on:
         required: false
         default: ''
         type: string
+      max_jobs:
+        description: 'Max jobs to process per worker (default: 1)'
+        required: false
+        default: '1'
+        type: string
 
 # Limit concurrent workers
 concurrency:
@@ -26,7 +39,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 env:
   LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
@@ -35,7 +49,7 @@ env:
 jobs:
   process-jobs:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         worker: [1, 2, 3]
@@ -43,6 +57,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -57,127 +74,48 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Claim and process job
-        id: worker
-        run: |
-          set -euo pipefail
+      - name: Build data layer
+        run: cd apps/web && node --import tsx/esm scripts/build-data.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          WORKER_ID="gha-${GITHUB_RUN_ID}-worker-${{ matrix.worker }}"
-          JOB_TYPE="${{ inputs.job_type || '' }}"
+      - name: Configure git
+        run: |
+          git config user.name "longterm-wiki-bot"
+          git config user.email "bot@longterm.wiki"
+
+      - name: Run worker
+        id: worker
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SCRY_API_KEY: ${{ secrets.SCRY_API_KEY }}
+          FIRECRAWL_KEY: ${{ secrets.FIRECRAWL_KEY }}
+          EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass inputs via env vars to avoid shell injection from workflow_dispatch
+          INPUT_JOB_TYPE: ${{ inputs.job_type }}
+          INPUT_MAX_JOBS: ${{ inputs.max_jobs }}
+          WORKER_NUM: ${{ matrix.worker }}
+        run: |
+          WORKER_ID="gha-${GITHUB_RUN_ID}-worker-${WORKER_NUM}"
+          JOB_TYPE="${INPUT_JOB_TYPE:-}"
+          MAX_JOBS="${INPUT_MAX_JOBS:-1}"
+
+          ARGS="--worker-id=$WORKER_ID --max-jobs=$MAX_JOBS --verbose"
+          if [ -n "$JOB_TYPE" ]; then
+            ARGS="$ARGS --type=$JOB_TYPE"
+          fi
 
           echo "Worker: $WORKER_ID"
           echo "Job type filter: ${JOB_TYPE:-any}"
+          echo "Max jobs: $MAX_JOBS"
 
-          # Build the claim payload
-          if [ -n "$JOB_TYPE" ]; then
-            CLAIM_BODY=$(jq -n --arg wid "$WORKER_ID" --arg type "$JOB_TYPE" '{workerId: $wid, type: $type}')
-          else
-            CLAIM_BODY=$(jq -n --arg wid "$WORKER_ID" '{workerId: $wid}')
-          fi
-
-          # Claim a job (log errors instead of silently falling back)
-          HTTP_CODE=$(curl -s -o /tmp/claim_response.json -w "%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$CLAIM_BODY" \
-            "${LONGTERMWIKI_SERVER_URL}/api/jobs/claim" || echo "000")
-
-          if [ "$HTTP_CODE" = "000" ]; then
-            echo "::error::Failed to connect to wiki server at ${LONGTERMWIKI_SERVER_URL}"
-            exit 1
-          elif [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Claim request failed with HTTP $HTTP_CODE"
-            cat /tmp/claim_response.json 2>/dev/null || true
-            exit 1
-          fi
-
-          CLAIM_RESPONSE=$(cat /tmp/claim_response.json)
-
-          JOB_ID=$(echo "$CLAIM_RESPONSE" | jq -r '.job.id // empty')
-
-          if [ -z "$JOB_ID" ]; then
-            echo "No pending jobs available"
-            echo "claimed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          JOB_TYPE_ACTUAL=$(echo "$CLAIM_RESPONSE" | jq -r '.job.type')
-          JOB_PARAMS=$(echo "$CLAIM_RESPONSE" | jq -c '.job.params // {}')
-
-          echo "Claimed job #$JOB_ID (type: $JOB_TYPE_ACTUAL)"
-          echo "Job params: $JOB_PARAMS"
-
-          # Validate job type against allowlist to prevent execution of unexpected types
-          ALLOWED_TYPES="ping citation-verify"
-          if ! echo "$ALLOWED_TYPES" | grep -qw "$JOB_TYPE_ACTUAL"; then
-            echo "::warning::Unknown job type '$JOB_TYPE_ACTUAL' — will report as failed"
-          fi
-          echo "claimed=true" >> "$GITHUB_OUTPUT"
-          echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
-          echo "job_type=$JOB_TYPE_ACTUAL" >> "$GITHUB_OUTPUT"
-
-          # Mark as running
-          curl -sf \
-            -X POST \
-            -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" \
-            -H "Content-Type: application/json" \
-            "${LONGTERMWIKI_SERVER_URL}/api/jobs/${JOB_ID}/start" > /dev/null
-
-          echo "Job #$JOB_ID marked as running"
-
-          # Execute job based on type
-          set +e
-          case "$JOB_TYPE_ACTUAL" in
-            ping)
-              echo "Executing ping job..."
-              RESULT='{"ok":true,"worker":"'"$WORKER_ID"'"}'
-              EXIT_CODE=0
-              ;;
-            citation-verify)
-              PAGE_ID=$(echo "$JOB_PARAMS" | jq -r '.pageId // empty')
-              if [ -z "$PAGE_ID" ]; then
-                RESULT='{"error":"missing pageId param"}'
-                EXIT_CODE=1
-              else
-                echo "Verifying citations for page: $PAGE_ID"
-                OUTPUT=$(pnpm crux citations verify "$PAGE_ID" --json 2>&1) || true
-                EXIT_CODE=$?
-                RESULT=$(echo "$OUTPUT" | jq -c '.' 2>/dev/null || jq -n --arg out "$OUTPUT" '{output: $out}')
-              fi
-              ;;
-            *)
-              echo "Unknown job type: $JOB_TYPE_ACTUAL"
-              RESULT='{"error":"unknown job type"}'
-              EXIT_CODE=1
-              ;;
-          esac
-          set -e
-
-          # Report result
-          if [ $EXIT_CODE -eq 0 ]; then
-            echo "Job #$JOB_ID completed successfully"
-            curl -sf \
-              -X POST \
-              -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --argjson result "$RESULT" '{result: $result}')" \
-              "${LONGTERMWIKI_SERVER_URL}/api/jobs/${JOB_ID}/complete" > /dev/null
-          else
-            echo "Job #$JOB_ID failed"
-            ERROR_MSG=$(echo "$RESULT" | jq -r '.error // "Job execution failed with exit code '"$EXIT_CODE"'"' 2>/dev/null || echo "Job execution failed")
-            curl -sf \
-              -X POST \
-              -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --arg error "$ERROR_MSG" '{error: $error}')" \
-              "${LONGTERMWIKI_SERVER_URL}/api/jobs/${JOB_ID}/fail" > /dev/null
-          fi
+          node --import tsx/esm crux/worker/run.ts $ARGS
 
       - name: Summary
-        if: steps.worker.outputs.claimed == 'true'
+        if: always()
         run: |
           echo "### Job Worker Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- Job ID: #${{ steps.worker.outputs.job_id }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Type: ${{ steps.worker.outputs.job_type }}" >> $GITHUB_STEP_SUMMARY
           echo "- Worker: ${{ matrix.worker }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Run: ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY

--- a/crux/lib/job-handlers/auto-update-digest.ts
+++ b/crux/lib/job-handlers/auto-update-digest.ts
@@ -1,0 +1,287 @@
+/**
+ * Auto-Update Digest Job Handler
+ *
+ * Runs the first three stages of the auto-update pipeline (fetch → digest → route)
+ * and creates individual page-improve jobs for each planned update, followed by
+ * a batch-commit job that will collect all results into a single PR.
+ *
+ * This replaces the monolithic auto-update orchestrator's execution stage with
+ * a parallelizable job-based approach:
+ *
+ *   1. This job: fetch news → build digest → route to pages → create child jobs
+ *   2. N page-improve workers run in parallel
+ *   3. 1 batch-commit worker collects results → creates PR
+ *
+ * Params:
+ *   - budget: number (optional, default: 50) — max dollars for page improvements
+ *   - maxPages: number (optional, default: 10) — max pages to update
+ *   - sources: string (optional) — comma-separated source IDs
+ *   - dryRun: boolean (optional) — if true, plans but doesn't create child jobs
+ */
+
+import type { JobHandlerContext, JobHandlerResult, AutoUpdateDigestParams } from './types.ts';
+import { createJob, createJobBatch } from '../wiki-server/jobs.ts';
+
+export async function handleAutoUpdateDigest(
+  params: Record<string, unknown>,
+  ctx: JobHandlerContext,
+): Promise<JobHandlerResult> {
+  const {
+    budget = 50,
+    maxPages = 10,
+    sources,
+    dryRun = false,
+  } = params as unknown as AutoUpdateDigestParams;
+
+  if (ctx.verbose) {
+    console.log(`[auto-update-digest] Starting (budget: $${budget}, maxPages: ${maxPages}, dryRun: ${dryRun})`);
+  }
+
+  const startTime = Date.now();
+  const date = new Date().toISOString().slice(0, 10);
+  const batchId = `auto-update-${date}-${Date.now()}`;
+
+  try {
+    // ── Stage 1: Fetch news sources ────────────────────────────────────
+
+    // Dynamic import to avoid loading heavy modules unless needed
+    const { fetchAllSources, loadSeenItems, saveSeenItems } = await import('../../auto-update/feed-fetcher.ts');
+    const { buildDigest, normalizeTitle } = await import('../../auto-update/digest.ts');
+    const { routeDigest } = await import('../../auto-update/page-router.ts');
+    const { getDueWatchlistUpdates } = await import('../../auto-update/watchlist.ts');
+    const { loadPages } = await import('../content-types.ts');
+
+    if (ctx.verbose) console.log('[auto-update-digest] Stage 1: Fetching news sources...');
+
+    const sourceIds = sources ? sources.split(',').map(s => s.trim()) : undefined;
+    const fetchResult = await fetchAllSources(sourceIds, ctx.verbose);
+
+    if (ctx.verbose) {
+      console.log(`  Fetched: ${fetchResult.fetchedSources.length} sources, ${fetchResult.items.length} items`);
+    }
+
+    // ── Stage 2: Build digest ──────────────────────────────────────────
+
+    if (ctx.verbose) console.log('[auto-update-digest] Stage 2: Building news digest...');
+
+    const pages = loadPages();
+    const entityIds = pages.map(p => p.id).filter((id): id is string => Boolean(id));
+    const previouslySeen = loadSeenItems();
+
+    const digest = await buildDigest(
+      fetchResult.items,
+      fetchResult.fetchedSources,
+      fetchResult.failedSources.map(f => f.id),
+      { entityIds, previouslySeen, verbose: ctx.verbose },
+    );
+
+    // Save seen items for future runs
+    if (digest.items.length > 0) {
+      const now = new Date().toISOString().slice(0, 10);
+      const newHashes: Record<string, string> = {};
+      for (const item of digest.items) {
+        const hash = normalizeTitle(item.title);
+        if (hash.length >= 5) newHashes[hash] = now;
+      }
+      saveSeenItems(newHashes);
+    }
+
+    if (digest.itemCount === 0) {
+      return {
+        success: true,
+        data: {
+          batchId,
+          date,
+          phase: 'digest',
+          sourcesChecked: fetchResult.fetchedSources.length,
+          sourcesFailed: fetchResult.failedSources.length,
+          itemsFetched: fetchResult.items.length,
+          itemsRelevant: 0,
+          message: 'No relevant news found. No child jobs created.',
+        },
+      };
+    }
+
+    // ── Stage 3: Route to pages ────────────────────────────────────────
+
+    if (ctx.verbose) console.log('[auto-update-digest] Stage 3: Routing to wiki pages...');
+
+    const plan = await routeDigest(digest, {
+      maxPages,
+      maxBudget: budget,
+      verbose: ctx.verbose,
+    });
+
+    // Inject watchlist-scheduled updates
+    const watchlistUpdates = getDueWatchlistUpdates(date, ctx.verbose);
+    if (watchlistUpdates.length > 0) {
+      const existingIds = new Set(plan.pageUpdates.map(u => u.pageId));
+      for (const wu of watchlistUpdates) {
+        if (!existingIds.has(wu.pageId)) {
+          plan.pageUpdates.unshift(wu);
+        }
+      }
+    }
+
+    if (ctx.verbose) {
+      console.log(`  Plan: ${plan.pageUpdates.length} page updates`);
+    }
+
+    if (plan.pageUpdates.length === 0) {
+      return {
+        success: true,
+        data: {
+          batchId,
+          date,
+          phase: 'routing',
+          sourcesChecked: fetchResult.fetchedSources.length,
+          itemsRelevant: digest.itemCount,
+          pagesPlanned: 0,
+          message: 'No pages matched for updates.',
+        },
+      };
+    }
+
+    if (dryRun) {
+      return {
+        success: true,
+        data: {
+          batchId,
+          date,
+          phase: 'dry-run',
+          sourcesChecked: fetchResult.fetchedSources.length,
+          itemsFetched: fetchResult.items.length,
+          itemsRelevant: digest.itemCount,
+          pagesPlanned: plan.pageUpdates.length,
+          plannedUpdates: plan.pageUpdates.map(u => ({
+            pageId: u.pageId,
+            pageTitle: u.pageTitle,
+            tier: u.suggestedTier,
+            reason: u.reason.slice(0, 200),
+          })),
+          newPageSuggestions: plan.newPageSuggestions.map(s => ({
+            title: s.suggestedTitle,
+            id: s.suggestedId,
+          })),
+          message: 'Dry run — no child jobs created.',
+        },
+      };
+    }
+
+    // ── Stage 4: Create child jobs ─────────────────────────────────────
+
+    if (ctx.verbose) console.log('[auto-update-digest] Stage 4: Creating child jobs...');
+
+    const costMap: Record<string, number> = { polish: 2.5, standard: 6.5, deep: 12.5 };
+    let budgetUsed = 0;
+    const jobInputs: Array<{
+      type: string;
+      params: Record<string, unknown>;
+      priority: number;
+      maxRetries: number;
+    }> = [];
+
+    for (const update of plan.pageUpdates) {
+      const cost = costMap[update.suggestedTier] || 6.5;
+      if (budgetUsed + cost > budget) {
+        if (ctx.verbose) {
+          console.log(`  Skipping ${update.pageId} (budget exceeded: $${budgetUsed}/$${budget})`);
+        }
+        continue;
+      }
+
+      jobInputs.push({
+        type: 'page-improve',
+        params: {
+          pageId: update.pageId,
+          tier: update.suggestedTier,
+          directions: update.directions,
+          batchId,
+        },
+        priority: 5, // Medium-high priority for auto-update jobs
+        maxRetries: 2,
+      });
+
+      budgetUsed += cost;
+    }
+
+    // Create all page-improve jobs
+    const childJobIds: number[] = [];
+    const createResult = await createJobBatch(jobInputs);
+
+    if (!createResult.ok) {
+      // Fall back to individual creation
+      if (ctx.verbose) {
+        console.log('  Batch creation failed, falling back to individual...');
+      }
+      for (const input of jobInputs) {
+        const singleResult = await createJob(input);
+        if (singleResult.ok) {
+          childJobIds.push(singleResult.data.id);
+        }
+      }
+    } else {
+      for (const job of createResult.data) {
+        childJobIds.push(job.id);
+      }
+    }
+
+    if (ctx.verbose) {
+      console.log(`  Created ${childJobIds.length} page-improve jobs`);
+    }
+
+    // Create the batch-commit job
+    let batchCommitJobId: number | null = null;
+    const commitResult = await createJob({
+      type: 'batch-commit',
+      params: {
+        batchId,
+        childJobIds,
+        prTitle: `Auto-update: ${date} daily wiki refresh`,
+        prBody: `Automated news-driven wiki update via job queue.\n\n- **Sources checked**: ${fetchResult.fetchedSources.length}\n- **Relevant items**: ${digest.itemCount}\n- **Pages updated**: ${childJobIds.length}`,
+        prLabels: ['auto-update'],
+      },
+      priority: 1, // Lower priority — should run after all page-improve jobs
+      maxRetries: 5, // More retries since it depends on children
+    });
+
+    if (commitResult.ok) {
+      batchCommitJobId = commitResult.data.id;
+      if (ctx.verbose) {
+        console.log(`  Created batch-commit job #${batchCommitJobId}`);
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        batchId,
+        date,
+        phase: 'jobs-created',
+        sourcesChecked: fetchResult.fetchedSources.length,
+        sourcesFailed: fetchResult.failedSources.length,
+        itemsFetched: fetchResult.items.length,
+        itemsRelevant: digest.itemCount,
+        pagesPlanned: plan.pageUpdates.length,
+        childJobIds,
+        batchCommitJobId,
+        estimatedBudget: budgetUsed,
+        durationMs,
+        plannedUpdates: plan.pageUpdates.slice(0, jobInputs.length).map(u => ({
+          pageId: u.pageId,
+          pageTitle: u.pageTitle,
+          tier: u.suggestedTier,
+        })),
+      },
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      data: { batchId, date, durationMs: Date.now() - startTime },
+      error: error.slice(0, 500),
+    };
+  }
+}

--- a/crux/lib/job-handlers/batch-commit.ts
+++ b/crux/lib/job-handlers/batch-commit.ts
@@ -1,0 +1,411 @@
+/**
+ * Batch Commit Job Handler
+ *
+ * Collects results from completed content jobs (page-improve, page-create),
+ * applies their file changes to a fresh branch, runs validation, and creates
+ * a GitHub PR.
+ *
+ * This enables the "50 parallel workers → 1 PR" workflow: many page-improve
+ * jobs run in parallel, each storing their file changes in the job result.
+ * This handler then combines all changes into a single commit.
+ *
+ * Params:
+ *   - batchId: string (required) — identifies the batch
+ *   - childJobIds: number[] (required) — job IDs to collect results from
+ *   - branchName: string (optional) — branch name (default: auto-generated)
+ *   - prTitle: string (required) — PR title
+ *   - prBody: string (optional) — PR body markdown
+ *   - prLabels: string[] (optional) — labels to add to the PR
+ */
+
+import { execFileSync } from 'child_process';
+import type { JobHandlerContext, JobHandlerResult, BatchCommitParams, FileChange } from './types.ts';
+import { getJob } from '../wiki-server/jobs.ts';
+import { applyFileChanges } from './utils.ts';
+
+/** Maximum number of incomplete child jobs before we give up waiting */
+const MAX_INCOMPLETE_TOLERANCE = 0;
+
+/**
+ * Sanitize a string for use as a git branch name.
+ * Removes characters that are invalid in git refs.
+ */
+function sanitizeBranchName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9\-_/]/g, '-')  // Replace invalid chars with hyphens
+    .replace(/\.{2,}/g, '-')              // No consecutive dots
+    .replace(/\/\//g, '/')                // No double slashes
+    .replace(/^[.\-/]+/, '')              // No leading dots, hyphens, slashes
+    .replace(/[.\-/]+$/, '')              // No trailing dots, hyphens, slashes
+    .slice(0, 100);                        // Reasonable length limit
+}
+
+export async function handleBatchCommit(
+  params: Record<string, unknown>,
+  ctx: JobHandlerContext,
+): Promise<JobHandlerResult> {
+  const {
+    batchId,
+    childJobIds,
+    branchName,
+    prTitle,
+    prBody,
+    prLabels = [],
+  } = params as unknown as BatchCommitParams;
+
+  if (!batchId) {
+    return { success: false, data: {}, error: 'Missing required param: batchId' };
+  }
+  if (!childJobIds || childJobIds.length === 0) {
+    return { success: false, data: {}, error: 'Missing required param: childJobIds (must be non-empty array)' };
+  }
+  if (!prTitle) {
+    return { success: false, data: {}, error: 'Missing required param: prTitle' };
+  }
+
+  if (ctx.verbose) {
+    console.log(`[batch-commit] Starting batch "${batchId}" with ${childJobIds.length} child jobs`);
+  }
+
+  const startTime = Date.now();
+
+  try {
+    // ── Step 1: Collect results from child jobs ─────────────────────────
+
+    const allFileChanges: FileChange[] = [];
+    const jobSummaries: Array<{
+      id: number;
+      type: string;
+      status: string;
+      pageId?: string;
+    }> = [];
+    const errors: string[] = [];
+    let incompleteCount = 0;
+
+    for (const jobId of childJobIds) {
+      const result = await getJob(jobId);
+
+      if (!result.ok) {
+        errors.push(`Failed to fetch job #${jobId}: ${result.message}`);
+        continue;
+      }
+
+      const job = result.data;
+      jobSummaries.push({
+        id: job.id,
+        type: job.type,
+        status: job.status,
+        pageId: (job.result as Record<string, unknown>)?.pageId as string | undefined,
+      });
+
+      if (job.status !== 'completed') {
+        incompleteCount++;
+        if (job.status === 'failed') {
+          errors.push(`Job #${jobId} (${job.type}) failed: ${job.error ?? 'unknown error'}`);
+        } else {
+          errors.push(`Job #${jobId} (${job.type}) not yet completed (status: ${job.status})`);
+        }
+        continue;
+      }
+
+      // Extract file changes from the job result
+      const jobResult = job.result as Record<string, unknown> | null;
+      const fileChanges = (jobResult?.fileChanges ?? []) as FileChange[];
+
+      for (const change of fileChanges) {
+        // Deduplicate: later jobs win for the same file path
+        const existingIdx = allFileChanges.findIndex(c => c.path === change.path);
+        if (existingIdx >= 0) {
+          allFileChanges[existingIdx] = change;
+        } else {
+          allFileChanges.push(change);
+        }
+      }
+    }
+
+    // Check if too many children are incomplete
+    if (incompleteCount > MAX_INCOMPLETE_TOLERANCE) {
+      return {
+        success: false,
+        data: {
+          batchId,
+          childJobIds,
+          incompleteCount,
+          jobSummaries,
+          errors,
+        },
+        error: `${incompleteCount} child job(s) not yet completed. Retry after all children finish.`,
+      };
+    }
+
+    if (allFileChanges.length === 0) {
+      return {
+        success: true,
+        data: {
+          batchId,
+          childJobIds,
+          filesApplied: 0,
+          jobSummaries,
+          message: 'No file changes to commit (all jobs may have produced no changes)',
+        },
+      };
+    }
+
+    if (ctx.verbose) {
+      console.log(`[batch-commit] Collected ${allFileChanges.length} file changes from ${jobSummaries.length} jobs`);
+    }
+
+    // ── Step 2: Create branch and apply changes ─────────────────────────
+
+    const branch = sanitizeBranchName(branchName ?? `batch/${batchId}`);
+
+    // Ensure we're on a clean main/HEAD first
+    try {
+      execFileSync('git', ['checkout', 'main'], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+      execFileSync('git', ['pull', '--ff-only', 'origin', 'main'], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+    } catch {
+      // May fail if no remote or not on main — try origin/main
+      try {
+        execFileSync('git', ['fetch', 'origin', 'main'], {
+          cwd: ctx.projectRoot,
+          stdio: 'pipe',
+        });
+      } catch {
+        // Continue anyway
+      }
+    }
+
+    // Create the branch
+    try {
+      execFileSync('git', ['checkout', '-b', branch], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+    } catch {
+      // Branch may already exist — reset it
+      execFileSync('git', ['checkout', branch], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+      execFileSync('git', ['reset', '--hard', 'main'], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+    }
+
+    // Apply all file changes (with path traversal protection)
+    const { applied, errors: applyErrors, appliedPaths } = applyFileChanges(ctx.projectRoot, allFileChanges);
+
+    if (applyErrors.length > 0) {
+      errors.push(...applyErrors.map(e => `Apply error: ${e}`));
+    }
+
+    if (ctx.verbose) {
+      console.log(`[batch-commit] Applied ${applied} file changes`);
+    }
+
+    // ── Step 3: Run validation ──────────────────────────────────────────
+
+    let validationPassed = false;
+    try {
+      execFileSync('node', [
+        '--import', 'tsx/esm', '--no-warnings',
+        'crux/crux.mjs', 'validate', 'gate', '--fix',
+      ], {
+        cwd: ctx.projectRoot,
+        timeout: 10 * 60 * 1000,
+        stdio: ctx.verbose ? 'inherit' : 'pipe',
+      });
+      validationPassed = true;
+    } catch {
+      if (ctx.verbose) {
+        console.log('[batch-commit] Validation had issues (continuing with commit)');
+      }
+    }
+
+    // ── Step 4: Commit (stage only specific files, not -A) ──────────────
+
+    // Stage only the files that were actually applied
+    if (appliedPaths.length > 0) {
+      execFileSync('git', ['add', ...appliedPaths], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+    }
+
+    // Check if there are staged changes
+    try {
+      execFileSync('git', ['diff', '--staged', '--quiet'], {
+        cwd: ctx.projectRoot,
+        stdio: 'pipe',
+      });
+      // No changes to commit
+      return {
+        success: true,
+        data: {
+          batchId,
+          childJobIds,
+          filesApplied: applied,
+          jobSummaries,
+          message: 'No changes after applying (files may be identical to main)',
+        },
+      };
+    } catch {
+      // There are staged changes — proceed with commit
+    }
+
+    const successCount = jobSummaries.filter(j => j.status === 'completed').length;
+    const failedCount = jobSummaries.filter(j => j.status === 'failed').length;
+
+    const commitMsg = [
+      prTitle,
+      '',
+      `Batch: ${batchId}`,
+      `Jobs: ${successCount} completed, ${failedCount} failed`,
+      `Files: ${applied} changed`,
+      validationPassed ? 'Validation: passed' : 'Validation: issues detected',
+    ].join('\n');
+
+    execFileSync('git', ['commit', '-m', commitMsg], {
+      cwd: ctx.projectRoot,
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'longterm-wiki-bot',
+        GIT_AUTHOR_EMAIL: 'bot@longterm.wiki',
+        GIT_COMMITTER_NAME: 'longterm-wiki-bot',
+        GIT_COMMITTER_EMAIL: 'bot@longterm.wiki',
+      },
+    });
+
+    // ── Step 5: Push and create PR ──────────────────────────────────────
+
+    execFileSync('git', ['push', '-u', 'origin', branch], {
+      cwd: ctx.projectRoot,
+      timeout: 60_000,
+      stdio: 'pipe',
+    });
+
+    // Build PR body
+    const body = buildPrBody({
+      batchId,
+      prBody,
+      jobSummaries,
+      applied,
+      validationPassed,
+      errors,
+    });
+
+    // Create PR via gh CLI
+    const prArgs = [
+      'pr', 'create',
+      '--title', prTitle,
+      '--body', body,
+      '--base', 'main',
+      '--head', branch,
+    ];
+
+    for (const label of prLabels) {
+      prArgs.push('--label', label);
+    }
+
+    let prUrl = '';
+    try {
+      prUrl = execFileSync('gh', prArgs, {
+        cwd: ctx.projectRoot,
+        encoding: 'utf-8',
+        timeout: 30_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+    } catch (err) {
+      if (ctx.verbose) {
+        console.log(`[batch-commit] gh pr create failed, PR must be created manually: ${err}`);
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        batchId,
+        childJobIds,
+        branch,
+        prUrl,
+        filesApplied: applied,
+        validationPassed,
+        jobSummaries,
+        durationMs,
+        errors: errors.length > 0 ? errors : undefined,
+      },
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      data: { batchId, childJobIds, durationMs: Date.now() - startTime },
+      error: error.slice(0, 500),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PR Body Builder
+// ---------------------------------------------------------------------------
+
+function buildPrBody(opts: {
+  batchId: string;
+  prBody?: string;
+  jobSummaries: Array<{ id: number; type: string; status: string; pageId?: string }>;
+  applied: number;
+  validationPassed: boolean;
+  errors: string[];
+}): string {
+  const lines: string[] = [];
+
+  lines.push('## Summary');
+  lines.push('');
+  if (opts.prBody) {
+    lines.push(opts.prBody);
+    lines.push('');
+  }
+  lines.push(`- **Batch**: \`${opts.batchId}\``);
+  lines.push(`- **Files changed**: ${opts.applied}`);
+  lines.push(`- **Validation**: ${opts.validationPassed ? 'Passed' : 'Issues detected'}`);
+  lines.push('');
+
+  // Job results table
+  lines.push('## Job Results');
+  lines.push('');
+  lines.push('| Job | Type | Status | Page |');
+  lines.push('|-----|------|--------|------|');
+  for (const job of opts.jobSummaries) {
+    const statusIcon = job.status === 'completed' ? '✅' : job.status === 'failed' ? '❌' : '⏳';
+    lines.push(`| #${job.id} | ${job.type} | ${statusIcon} ${job.status} | ${job.pageId ?? '—'} |`);
+  }
+  lines.push('');
+
+  const completed = opts.jobSummaries.filter(j => j.status === 'completed').length;
+  const total = opts.jobSummaries.length;
+  lines.push(`**${completed}/${total}** jobs completed successfully.`);
+
+  if (opts.errors.length > 0) {
+    lines.push('');
+    lines.push('## Errors');
+    lines.push('');
+    for (const error of opts.errors.slice(0, 10)) {
+      lines.push(`- ${error}`);
+    }
+    if (opts.errors.length > 10) {
+      lines.push(`- ...and ${opts.errors.length - 10} more`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Job Handler Registry
+ *
+ * Maps job type strings to handler functions. The worker runner uses this
+ * to dispatch claimed jobs to the correct handler.
+ *
+ * Each handler receives job params and a context object, and returns a
+ * JobHandlerResult with success/failure status and result data.
+ */
+
+import { execFileSync } from 'child_process';
+import type { JobHandler } from './types.ts';
+import { handlePageImprove } from './page-improve.ts';
+import { handlePageCreate } from './page-create.ts';
+import { handleBatchCommit } from './batch-commit.ts';
+import { handleAutoUpdateDigest } from './auto-update-digest.ts';
+
+// ---------------------------------------------------------------------------
+// Handler Registry
+// ---------------------------------------------------------------------------
+
+const handlers: Record<string, JobHandler> = {
+  // Simple handlers
+  ping: async (_params, ctx) => {
+    return {
+      success: true,
+      data: { ok: true, worker: ctx.workerId, timestamp: new Date().toISOString() },
+    };
+  },
+
+  'citation-verify': async (params, ctx) => {
+    const pageId = params.pageId as string | undefined;
+    if (!pageId) {
+      return { success: false, data: {}, error: 'Missing required param: pageId' };
+    }
+
+    try {
+      const output = execFileSync('node', [
+        '--import', 'tsx/esm', '--no-warnings',
+        'crux/crux.mjs', 'citations', 'verify', pageId, '--json',
+      ], {
+        cwd: ctx.projectRoot,
+        encoding: 'utf-8',
+        timeout: 5 * 60 * 1000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      try {
+        const result = JSON.parse(output);
+        return { success: true, data: result };
+      } catch {
+        return { success: true, data: { output } };
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err.message : String(err);
+      return { success: false, data: { pageId }, error: error.slice(0, 500) };
+    }
+  },
+
+  // Content-modifying handlers
+  'page-improve': handlePageImprove,
+  'page-create': handlePageCreate,
+
+  // Batch orchestration
+  'batch-commit': handleBatchCommit,
+
+  // Auto-update pipeline
+  'auto-update-digest': handleAutoUpdateDigest,
+};
+
+/**
+ * Get the handler for a job type.
+ * Returns undefined if no handler is registered for the type.
+ */
+export function getHandler(type: string): JobHandler | undefined {
+  return handlers[type];
+}
+
+/**
+ * Get all registered job type names.
+ */
+export function getRegisteredTypes(): string[] {
+  return Object.keys(handlers);
+}
+
+/**
+ * Check if a job type has a registered handler.
+ */
+export function isKnownType(type: string): boolean {
+  return type in handlers;
+}
+
+export type { JobHandler, JobHandlerResult, JobHandlerContext } from './types.ts';

--- a/crux/lib/job-handlers/job-handlers.test.ts
+++ b/crux/lib/job-handlers/job-handlers.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { JobHandlerContext } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Test context helper
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<JobHandlerContext> = {}): JobHandlerContext {
+  return {
+    workerId: 'test-worker-1',
+    projectRoot: '/tmp/test-project',
+    verbose: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler Registry Tests
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/index', () => {
+  it('exports getHandler, isKnownType, getRegisteredTypes', async () => {
+    const mod = await import('./index.ts');
+    expect(typeof mod.getHandler).toBe('function');
+    expect(typeof mod.isKnownType).toBe('function');
+    expect(typeof mod.getRegisteredTypes).toBe('function');
+  });
+
+  it('registers all expected job types', async () => {
+    const { getRegisteredTypes } = await import('./index.ts');
+    const types = getRegisteredTypes();
+
+    expect(types).toContain('ping');
+    expect(types).toContain('citation-verify');
+    expect(types).toContain('page-improve');
+    expect(types).toContain('page-create');
+    expect(types).toContain('batch-commit');
+    expect(types).toContain('auto-update-digest');
+  });
+
+  it('isKnownType returns true for registered types', async () => {
+    const { isKnownType } = await import('./index.ts');
+    expect(isKnownType('ping')).toBe(true);
+    expect(isKnownType('page-improve')).toBe(true);
+    expect(isKnownType('nonexistent')).toBe(false);
+  });
+
+  it('getHandler returns a function for registered types', async () => {
+    const { getHandler } = await import('./index.ts');
+    const handler = getHandler('ping');
+    expect(typeof handler).toBe('function');
+  });
+
+  it('getHandler returns undefined for unknown types', async () => {
+    const { getHandler } = await import('./index.ts');
+    expect(getHandler('nonexistent')).toBeUndefined();
+  });
+
+  it('ping handler returns success', async () => {
+    const { getHandler } = await import('./index.ts');
+    const handler = getHandler('ping')!;
+    const result = await handler({}, makeContext());
+
+    expect(result.success).toBe(true);
+    expect(result.data.ok).toBe(true);
+    expect(result.data.worker).toBe('test-worker-1');
+    expect(result.data.timestamp).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page Improve Handler Tests (validation only — no actual execution)
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/page-improve', () => {
+  it('rejects missing pageId', async () => {
+    const { handlePageImprove } = await import('./page-improve.ts');
+    const result = await handlePageImprove({}, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('pageId');
+  });
+
+  it('rejects invalid tier', async () => {
+    const { handlePageImprove } = await import('./page-improve.ts');
+    const result = await handlePageImprove(
+      { pageId: 'test', tier: 'invalid' },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid tier');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page Create Handler Tests (validation only)
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/page-create', () => {
+  it('rejects missing title', async () => {
+    const { handlePageCreate } = await import('./page-create.ts');
+    const result = await handlePageCreate({}, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('title');
+  });
+
+  it('rejects invalid tier', async () => {
+    const { handlePageCreate } = await import('./page-create.ts');
+    const result = await handlePageCreate(
+      { title: 'Test Page', tier: 'invalid' },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid tier');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batch Commit Handler Tests (validation only)
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/batch-commit', () => {
+  it('rejects missing batchId', async () => {
+    const { handleBatchCommit } = await import('./batch-commit.ts');
+    const result = await handleBatchCommit({}, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('batchId');
+  });
+
+  it('rejects missing childJobIds', async () => {
+    const { handleBatchCommit } = await import('./batch-commit.ts');
+    const result = await handleBatchCommit(
+      { batchId: 'test', prTitle: 'Test PR' },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('childJobIds');
+  });
+
+  it('rejects empty childJobIds', async () => {
+    const { handleBatchCommit } = await import('./batch-commit.ts');
+    const result = await handleBatchCommit(
+      { batchId: 'test', childJobIds: [], prTitle: 'Test PR' },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('childJobIds');
+  });
+
+  it('rejects missing prTitle', async () => {
+    const { handleBatchCommit } = await import('./batch-commit.ts');
+    const result = await handleBatchCommit(
+      { batchId: 'test', childJobIds: [1, 2] },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('prTitle');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-Update Digest Handler Tests (validation only)
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/auto-update-digest', () => {
+  // This handler requires external services, so we only test that the
+  // module loads and exports correctly.
+  it('exports handleAutoUpdateDigest', async () => {
+    const { handleAutoUpdateDigest } = await import('./auto-update-digest.ts');
+    expect(typeof handleAutoUpdateDigest).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utils Tests
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/utils', () => {
+  it('isContentFile identifies MDX files', async () => {
+    const { isContentFile } = await import('./utils.ts');
+    expect(isContentFile('content/docs/concepts/ai-safety.mdx')).toBe(true);
+    expect(isContentFile('data/entities/concepts.yaml')).toBe(true);
+    expect(isContentFile('node_modules/foo.js')).toBe(false);
+    expect(isContentFile('apps/web/src/app.tsx')).toBe(false);
+    expect(isContentFile('random.yaml')).toBe(true);
+    expect(isContentFile('random.mdx')).toBe(true);
+  });
+
+  it('applyFileChanges blocks path traversal', async () => {
+    const { applyFileChanges } = await import('./utils.ts');
+    const result = applyFileChanges('/tmp/fake-root', [
+      { path: '../../../etc/passwd', content: 'malicious' },
+      { path: 'content/docs/legit.mdx', content: 'ok' },
+    ]);
+
+    // The traversal attempt should be rejected
+    expect(result.errors.some(e => e.includes('path traversal'))).toBe(true);
+    // The legit file should fail because /tmp/fake-root doesn't exist,
+    // but it shouldn't be blocked by path traversal
+    expect(result.errors.filter(e => e.includes('path traversal')).length).toBe(1);
+  });
+
+  it('applyFileChanges blocks non-content files', async () => {
+    const { applyFileChanges } = await import('./utils.ts');
+    const result = applyFileChanges('/tmp/fake-root', [
+      { path: 'package.json', content: '{}' },
+      { path: '.env', content: 'SECRET=x' },
+    ]);
+
+    // Both should be rejected as non-content files
+    expect(result.errors.filter(e => e.includes('not a content file')).length).toBe(2);
+    expect(result.applied).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Types Tests (compile-time)
+// ---------------------------------------------------------------------------
+
+describe('job-handlers/types', () => {
+  it('exports expected types', async () => {
+    // This just verifies the module loads without errors
+    const types = await import('./types.ts');
+    expect(types).toBeDefined();
+  });
+});

--- a/crux/lib/job-handlers/page-create.ts
+++ b/crux/lib/job-handlers/page-create.ts
@@ -1,0 +1,119 @@
+/**
+ * Page Create Job Handler
+ *
+ * Runs `pnpm crux content create` for a new page and captures the
+ * file changes produced. Changes are stored in the job result so that
+ * a batch-commit job can later apply them to a branch and create a PR.
+ *
+ * Params:
+ *   - title: string (required) — the page title
+ *   - tier: 'budget' | 'standard' | 'premium' (default: 'standard')
+ *   - batchId: string (optional) — links this job to a batch-commit group
+ */
+
+import { execFileSync } from 'child_process';
+import type { JobHandlerContext, JobHandlerResult, PageCreateParams } from './types.ts';
+import { collectChangedFiles, restoreGitState, isContentFile } from './utils.ts';
+
+export async function handlePageCreate(
+  params: Record<string, unknown>,
+  ctx: JobHandlerContext,
+): Promise<JobHandlerResult> {
+  const { title, tier = 'standard', batchId } = params as unknown as PageCreateParams;
+
+  if (!title) {
+    return { success: false, data: {}, error: 'Missing required param: title' };
+  }
+
+  const validTiers = ['budget', 'standard', 'premium'];
+  if (!validTiers.includes(tier)) {
+    return { success: false, data: {}, error: `Invalid tier: ${tier}. Must be one of: ${validTiers.join(', ')}` };
+  }
+
+  if (ctx.verbose) {
+    console.log(`[page-create] Starting: "${title}" (tier: ${tier})`);
+  }
+
+  const startTime = Date.now();
+
+  try {
+    // Ensure clean starting state
+    restoreGitState(ctx.projectRoot);
+
+    // Run the content create pipeline
+    const args = [
+      '--import', 'tsx/esm', '--no-warnings',
+      'crux/authoring/page-creator/index.ts',
+      '--', title,
+      '--tier', tier,
+    ];
+
+    const output = execFileSync('node', args, {
+      cwd: ctx.projectRoot,
+      timeout: 30 * 60 * 1000,
+      stdio: ctx.verbose ? 'inherit' : 'pipe',
+      encoding: 'utf-8',
+      env: { ...process.env },
+    });
+
+    // Try to extract the created page ID from output
+    let pageId: string | null = null;
+    if (typeof output === 'string') {
+      const match = output.match(/Page created:\s+(\S+)/i) || output.match(/id:\s*["']?(\S+?)["']?\s/);
+      if (match) pageId = match[1];
+    }
+
+    // Run escaping fix
+    try {
+      execFileSync('node', [
+        '--import', 'tsx/esm', '--no-warnings',
+        'crux/crux.mjs', 'fix', 'escaping',
+      ], {
+        cwd: ctx.projectRoot,
+        timeout: 60_000,
+        stdio: 'pipe',
+      });
+    } catch {
+      // Best-effort
+    }
+
+    // Capture file changes
+    const fileChanges = collectChangedFiles(ctx.projectRoot, isContentFile);
+    const durationMs = Date.now() - startTime;
+
+    if (ctx.verbose) {
+      console.log(`[page-create] Completed: "${title}" → ${pageId ?? 'unknown'} (${fileChanges.length} files, ${durationMs}ms)`);
+    }
+
+    // Restore git state
+    restoreGitState(ctx.projectRoot);
+
+    return {
+      success: true,
+      data: {
+        title,
+        pageId,
+        tier,
+        batchId: batchId ?? null,
+        fileChanges,
+        durationMs,
+        filesChanged: fileChanges.length,
+      },
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    const durationMs = Date.now() - startTime;
+
+    try {
+      restoreGitState(ctx.projectRoot);
+    } catch {
+      // Best effort
+    }
+
+    return {
+      success: false,
+      data: { title, tier, batchId: batchId ?? null, durationMs },
+      error: error.slice(0, 500),
+    };
+  }
+}

--- a/crux/lib/job-handlers/page-improve.ts
+++ b/crux/lib/job-handlers/page-improve.ts
@@ -1,0 +1,118 @@
+/**
+ * Page Improve Job Handler
+ *
+ * Runs `pnpm crux content improve` for a given page and captures the
+ * file changes produced. Changes are stored in the job result so that
+ * a batch-commit job can later apply them to a branch and create a PR.
+ *
+ * Params:
+ *   - pageId: string (required) — the wiki page to improve
+ *   - tier: 'polish' | 'standard' | 'deep' (default: 'standard')
+ *   - directions: string (optional) — specific improvement instructions
+ *   - batchId: string (optional) — links this job to a batch-commit group
+ */
+
+import { execFileSync } from 'child_process';
+import type { JobHandlerContext, JobHandlerResult, PageImproveParams } from './types.ts';
+import { collectChangedFiles, restoreGitState, isContentFile } from './utils.ts';
+
+export async function handlePageImprove(
+  params: Record<string, unknown>,
+  ctx: JobHandlerContext,
+): Promise<JobHandlerResult> {
+  const { pageId, tier = 'standard', directions, batchId } = params as unknown as PageImproveParams;
+
+  if (!pageId) {
+    return { success: false, data: {}, error: 'Missing required param: pageId' };
+  }
+
+  const validTiers = ['polish', 'standard', 'deep'];
+  if (!validTiers.includes(tier)) {
+    return { success: false, data: {}, error: `Invalid tier: ${tier}. Must be one of: ${validTiers.join(', ')}` };
+  }
+
+  if (ctx.verbose) {
+    console.log(`[page-improve] Starting: ${pageId} (tier: ${tier})`);
+    if (directions) console.log(`[page-improve] Directions: ${directions.slice(0, 100)}...`);
+  }
+
+  const startTime = Date.now();
+
+  try {
+    // Ensure clean starting state
+    restoreGitState(ctx.projectRoot);
+
+    // Run the content improve pipeline
+    const args = [
+      '--import', 'tsx/esm', '--no-warnings',
+      'crux/authoring/page-improver/index.ts',
+      '--', pageId,
+      '--tier', tier,
+      '--apply',
+    ];
+
+    if (directions) {
+      args.push('--directions', directions);
+    }
+
+    execFileSync('node', args, {
+      cwd: ctx.projectRoot,
+      timeout: 30 * 60 * 1000, // 30 min per page
+      stdio: ctx.verbose ? 'inherit' : 'pipe',
+      env: { ...process.env },
+    });
+
+    // Run escaping fix on the changed files
+    try {
+      execFileSync('node', [
+        '--import', 'tsx/esm', '--no-warnings',
+        'crux/crux.mjs', 'fix', 'escaping',
+      ], {
+        cwd: ctx.projectRoot,
+        timeout: 60_000,
+        stdio: 'pipe',
+      });
+    } catch {
+      // Fix escaping is best-effort
+    }
+
+    // Capture file changes produced by the improvement
+    const fileChanges = collectChangedFiles(ctx.projectRoot, isContentFile);
+    const durationMs = Date.now() - startTime;
+
+    if (ctx.verbose) {
+      console.log(`[page-improve] Completed: ${pageId} (${fileChanges.length} files changed, ${durationMs}ms)`);
+    }
+
+    // Restore git state so the worker's checkout stays clean for the next job
+    restoreGitState(ctx.projectRoot);
+
+    return {
+      success: true,
+      data: {
+        pageId,
+        tier,
+        batchId: batchId ?? null,
+        fileChanges,
+        durationMs,
+        filesChanged: fileChanges.length,
+      },
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    const durationMs = Date.now() - startTime;
+
+    // Clean up any partial changes
+    try {
+      restoreGitState(ctx.projectRoot);
+    } catch {
+      // Best effort cleanup
+    }
+
+    return {
+      success: false,
+      data: { pageId, tier, batchId: batchId ?? null, durationMs },
+      error: error.slice(0, 500),
+    };
+  }
+}

--- a/crux/lib/job-handlers/types.ts
+++ b/crux/lib/job-handlers/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Job Handler Types
+ *
+ * Shared types for the job processing system.
+ */
+
+// ---------------------------------------------------------------------------
+// File Change — the unit of work output from content-modifying jobs
+// ---------------------------------------------------------------------------
+
+export interface FileChange {
+  /** Relative path from project root (e.g., "content/docs/concepts/ai-safety.mdx") */
+  path: string;
+  /** Full file content after modification. null means file was deleted. */
+  content: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Job Handler interface
+// ---------------------------------------------------------------------------
+
+export interface JobHandlerContext {
+  /** Unique worker identifier (e.g., "gha-12345-worker-1") */
+  workerId: string;
+  /** Project root directory */
+  projectRoot: string;
+  /** Whether to print verbose output */
+  verbose: boolean;
+}
+
+export interface JobHandlerResult {
+  /** Whether the job succeeded */
+  success: boolean;
+  /** Structured result data (stored in job.result) */
+  data: Record<string, unknown>;
+  /** Error message if failed */
+  error?: string;
+}
+
+export type JobHandler = (
+  params: Record<string, unknown>,
+  context: JobHandlerContext,
+) => Promise<JobHandlerResult>;
+
+// ---------------------------------------------------------------------------
+// Batch-related types
+// ---------------------------------------------------------------------------
+
+export interface BatchInfo {
+  /** Unique batch identifier (e.g., "auto-update-2026-02-22") */
+  batchId: string;
+  /** Job IDs belonging to this batch */
+  childJobIds: number[];
+  /** Type of batch (determines commit behavior) */
+  batchType: 'auto-update' | 'bulk-create' | 'bulk-improve';
+  /** Human-readable description for PR title */
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Content job params
+// ---------------------------------------------------------------------------
+
+export interface PageImproveParams {
+  pageId: string;
+  tier: 'polish' | 'standard' | 'deep';
+  directions?: string;
+  batchId?: string;
+  /** Whether to apply changes directly (default: true) */
+  apply?: boolean;
+}
+
+export interface PageCreateParams {
+  title: string;
+  tier: 'budget' | 'standard' | 'premium';
+  batchId?: string;
+}
+
+export interface BatchCommitParams {
+  batchId: string;
+  /** Job IDs to collect results from */
+  childJobIds: number[];
+  /** Branch name to create (default: auto-generated) */
+  branchName?: string;
+  /** PR title */
+  prTitle: string;
+  /** PR body description */
+  prBody?: string;
+  /** Labels to add to the PR */
+  prLabels?: string[];
+}
+
+export interface AutoUpdateDigestParams {
+  /** Max budget in dollars */
+  budget?: number;
+  /** Max pages to update */
+  maxPages?: number;
+  /** Comma-separated source IDs (empty = all) */
+  sources?: string;
+  /** Whether this is a dry run (no child jobs created) */
+  dryRun?: boolean;
+}

--- a/crux/lib/job-handlers/utils.ts
+++ b/crux/lib/job-handlers/utils.ts
@@ -1,0 +1,208 @@
+/**
+ * Job Handler Utilities
+ *
+ * Shared helpers for git state management, file change tracking,
+ * and other common operations used by job handlers.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import type { FileChange } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Git State Management
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the current git state (list of file hashes) for later comparison.
+ * Returns a Map of relative path → short hash for tracked files.
+ */
+export function captureGitChanges(projectRoot: string): Map<string, string> {
+  const hashes = new Map<string, string>();
+
+  try {
+    const output = execFileSync(
+      'git', ['ls-files', '-s'],
+      { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+
+    for (const line of output.split('\n')) {
+      if (!line) continue;
+      // Format: mode hash stage\tpath
+      const parts = line.split('\t');
+      if (parts.length >= 2) {
+        const hash = parts[0].split(' ')[1];
+        const path = parts[1];
+        hashes.set(path, hash);
+      }
+    }
+  } catch {
+    // Ignore git errors
+  }
+
+  return hashes;
+}
+
+/**
+ * Restore git working tree to HEAD state.
+ * Removes untracked files in content/data directories and resets modifications.
+ */
+export function restoreGitState(projectRoot: string): void {
+  try {
+    // Reset tracked file modifications
+    execFileSync('git', ['checkout', '--', '.'], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+    });
+
+    // Remove untracked files in content/data directories only
+    execFileSync('git', ['clean', '-fd', 'content/', 'data/'], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+    });
+  } catch {
+    // Best effort
+  }
+}
+
+/**
+ * Collect all changed files (modified, added, deleted) relative to HEAD.
+ * Returns FileChange entries with the current content of each file.
+ */
+export function collectChangedFiles(
+  projectRoot: string,
+  filter?: (path: string) => boolean,
+): FileChange[] {
+  const changes: FileChange[] = [];
+  const changedFiles = new Set<string>();
+
+  try {
+    // Get modified/deleted files relative to HEAD
+    const diffOutput = execFileSync(
+      'git', ['diff', '--name-only', 'HEAD'],
+      { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+
+    if (diffOutput) {
+      for (const line of diffOutput.split('\n')) {
+        if (line.trim()) changedFiles.add(line.trim());
+      }
+    }
+
+    // Get untracked files
+    const untrackedOutput = execFileSync(
+      'git', ['ls-files', '--others', '--exclude-standard'],
+      { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+
+    if (untrackedOutput) {
+      for (const line of untrackedOutput.split('\n')) {
+        if (line.trim()) changedFiles.add(line.trim());
+      }
+    }
+  } catch {
+    return changes;
+  }
+
+  for (const relativePath of changedFiles) {
+    if (filter && !filter(relativePath)) continue;
+
+    try {
+      const fullPath = `${projectRoot}/${relativePath}`;
+      const content = readFileSync(fullPath, 'utf-8');
+      changes.push({ path: relativePath, content });
+    } catch {
+      changes.push({ path: relativePath, content: null });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Check if a file path is wiki content (MDX pages, YAML data, etc.).
+ */
+export function isContentFile(path: string): boolean {
+  if (path.startsWith('content/docs/')) return true;
+  if (path.startsWith('data/')) return true;
+  if (path.endsWith('.mdx') || path.endsWith('.yaml') || path.endsWith('.yml')) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Branch & PR Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new git branch from the current HEAD.
+ * Returns true if the branch was created (or already exists).
+ */
+export function createBranch(projectRoot: string, branchName: string): boolean {
+  try {
+    execFileSync('git', ['checkout', '-b', branchName], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    // Branch may already exist
+    try {
+      execFileSync('git', ['checkout', branchName], {
+        cwd: projectRoot,
+        stdio: 'pipe',
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Apply file changes to the working tree.
+ * Writes each file's content (or deletes if content is null).
+ * Validates that all paths resolve within the project root (prevents path traversal).
+ */
+export function applyFileChanges(
+  projectRoot: string,
+  changes: FileChange[],
+): { applied: number; errors: string[]; appliedPaths: string[] } {
+  const resolvedRoot = resolve(projectRoot);
+  let applied = 0;
+  const errors: string[] = [];
+  const appliedPaths: string[] = [];
+
+  for (const change of changes) {
+    const fullPath = resolve(join(projectRoot, change.path));
+
+    // Path traversal check: resolved path must start with the project root
+    if (!fullPath.startsWith(resolvedRoot + '/') && fullPath !== resolvedRoot) {
+      errors.push(`${change.path}: path traversal detected (resolves outside project root)`);
+      continue;
+    }
+
+    // Only allow content-related paths
+    if (!isContentFile(change.path)) {
+      errors.push(`${change.path}: not a content file (skipped for safety)`);
+      continue;
+    }
+
+    try {
+      if (change.content === null) {
+        // Delete
+        unlinkSync(fullPath);
+      } else {
+        // Write (create directories if needed)
+        mkdirSync(dirname(fullPath), { recursive: true });
+        writeFileSync(fullPath, change.content, 'utf-8');
+      }
+      applied++;
+      appliedPaths.push(change.path);
+    } catch (err) {
+      errors.push(`${change.path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { applied, errors, appliedPaths };
+}

--- a/crux/worker/run.ts
+++ b/crux/worker/run.ts
@@ -1,0 +1,194 @@
+/**
+ * Job Worker Runner
+ *
+ * Standalone worker process that claims and executes jobs from the queue.
+ * Designed to run both locally (CLI) and in GitHub Actions.
+ *
+ * Usage:
+ *   node --import tsx/esm crux/worker/run.ts [options]
+ *
+ * Options:
+ *   --type=<type>     Only claim jobs of this type
+ *   --max-jobs=<n>    Max jobs to process before exiting (default: 1)
+ *   --poll            Keep polling for jobs (instead of exit after max-jobs)
+ *   --poll-interval=<ms>  Polling interval in ms (default: 30000)
+ *   --verbose         Verbose output
+ *   --worker-id=<id>  Custom worker ID (default: auto-generated)
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL     — Wiki server URL (required)
+ *   LONGTERMWIKI_SERVER_API_KEY — API key for authentication
+ */
+
+import { join } from 'path';
+import { getHandler, isKnownType, getRegisteredTypes } from '../lib/job-handlers/index.ts';
+import { claimJob, startJob, completeJob, failJob } from '../lib/wiki-server/jobs.ts';
+import type { JobHandlerContext } from '../lib/job-handlers/types.ts';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+interface WorkerConfig {
+  workerId: string;
+  type?: string;
+  maxJobs: number;
+  poll: boolean;
+  pollIntervalMs: number;
+  verbose: boolean;
+  projectRoot: string;
+}
+
+function parseConfig(): WorkerConfig {
+  const args = process.argv.slice(2);
+  const opts: Record<string, string | boolean> = {};
+
+  for (const arg of args) {
+    if (arg.startsWith('--')) {
+      const [key, ...valueParts] = arg.slice(2).split('=');
+      const value = valueParts.join('=');
+      opts[key] = value || true;
+    }
+  }
+
+  const workerId = (opts['worker-id'] as string) ??
+    `worker-${process.pid}-${Date.now().toString(36)}`;
+
+  return {
+    workerId,
+    type: opts['type'] as string | undefined,
+    maxJobs: parseInt(opts['max-jobs'] as string || '1', 10),
+    poll: opts['poll'] === true,
+    pollIntervalMs: parseInt(opts['poll-interval'] as string || '30000', 10),
+    verbose: opts['verbose'] === true,
+    projectRoot: join(import.meta.dirname ?? process.cwd(), '..'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Worker Loop
+// ---------------------------------------------------------------------------
+
+async function processOneJob(config: WorkerConfig): Promise<boolean> {
+  const { workerId, type, verbose, projectRoot } = config;
+
+  // Claim a job
+  if (verbose) {
+    console.log(`[worker] Claiming job (type: ${type ?? 'any'})...`);
+  }
+
+  const claimResult = await claimJob(workerId, type);
+
+  if (!claimResult.ok) {
+    console.error(`[worker] Failed to claim job: ${claimResult.message}`);
+    return false;
+  }
+
+  const claimed = claimResult.data.job;
+  if (!claimed) {
+    if (verbose) {
+      console.log('[worker] No pending jobs available');
+    }
+    return false;
+  }
+
+  const jobId = claimed.id;
+  const jobType = claimed.type;
+  const jobParams = (claimed.params ?? {}) as Record<string, unknown>;
+
+  console.log(`[worker] Claimed job #${jobId} (type: ${jobType})`);
+
+  // Mark as running — if this fails (e.g. job was cancelled), skip execution
+  const startResult = await startJob(jobId);
+  if (!startResult.ok) {
+    console.error(`[worker] Failed to start job #${jobId}: ${startResult.message}`);
+    return true; // Job was claimed but couldn't start — continue to next
+  }
+
+  // Look up the handler
+  const handler = getHandler(jobType);
+
+  if (!handler) {
+    const msg = `Unknown job type: ${jobType}. Known types: ${getRegisteredTypes().join(', ')}`;
+    console.error(`[worker] ${msg}`);
+    await failJob(jobId, msg);
+    return true; // Job was processed (failed), continue to next
+  }
+
+  // Execute the handler
+  const context: JobHandlerContext = {
+    workerId,
+    projectRoot,
+    verbose,
+  };
+
+  try {
+    const result = await handler(jobParams, context);
+
+    if (result.success) {
+      console.log(`[worker] Job #${jobId} completed successfully`);
+      await completeJob(jobId, result.data);
+    } else {
+      console.error(`[worker] Job #${jobId} failed: ${result.error}`);
+      await failJob(jobId, result.error ?? 'Handler returned success: false');
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.error(`[worker] Job #${jobId} threw exception: ${error}`);
+    await failJob(jobId, error.slice(0, 500));
+  }
+
+  return true;
+}
+
+async function runWorker(config: WorkerConfig): Promise<void> {
+  console.log(`[worker] Starting (id: ${config.workerId})`);
+  console.log(`[worker] Type filter: ${config.type ?? 'any'}`);
+  console.log(`[worker] Max jobs: ${config.maxJobs}`);
+  console.log(`[worker] Poll mode: ${config.poll}`);
+  console.log(`[worker] Known types: ${getRegisteredTypes().join(', ')}`);
+
+  let processed = 0;
+
+  while (processed < config.maxJobs || config.poll) {
+    const didProcess = await processOneJob(config);
+
+    if (didProcess) {
+      processed++;
+      console.log(`[worker] Processed ${processed}/${config.maxJobs} jobs`);
+
+      if (!config.poll && processed >= config.maxJobs) {
+        break;
+      }
+    }
+
+    if (!didProcess && config.poll) {
+      if (config.verbose) {
+        console.log(`[worker] No jobs available, waiting ${config.pollIntervalMs}ms...`);
+      }
+      await new Promise(resolve => setTimeout(resolve, config.pollIntervalMs));
+    } else if (!didProcess) {
+      // No job available and not polling — exit
+      break;
+    }
+  }
+
+  console.log(`[worker] Finished (processed ${processed} jobs)`);
+}
+
+// ---------------------------------------------------------------------------
+// Entry Point
+// ---------------------------------------------------------------------------
+
+const config = parseConfig();
+
+// Validate configuration
+if (config.type && !isKnownType(config.type)) {
+  console.warn(`[worker] Warning: type "${config.type}" has no registered handler`);
+  console.warn(`[worker] Known types: ${getRegisteredTypes().join(', ')}`);
+}
+
+runWorker(config).catch(err => {
+  console.error(`[worker] Fatal error: ${err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add the job handler framework and worker runner that powers the job queue system for server-orchestrated, GitHub Actions-executed work.

- **Job handler registry** with typed handlers for: `ping`, `citation-verify`, `page-improve`, `page-create`, `batch-commit`, `auto-update-digest`
- **Node.js worker runner** (`crux/worker/run.ts`) replacing inline bash in GHA workflow — claims jobs, dispatches to handlers, reports results
- **Batch commit handler** that collects file changes from parallel worker jobs and creates a single PR with all changes
- **Auto-update digest handler** that decomposes the auto-update pipeline into parallel page-improve jobs + a batch-commit job
- **CLI commands**: `pnpm crux jobs batch`, `pnpm crux jobs worker`, `pnpm crux jobs types`, `pnpm crux auto-update submit`
- **Security hardening**: path traversal protection, shell injection prevention via env vars, content-file-only filtering, branch name sanitization, selective git staging

## Key changes

| File | Description |
|------|-------------|
| `crux/lib/job-handlers/types.ts` | Core type definitions |
| `crux/lib/job-handlers/index.ts` | Handler registry (6 job types) |
| `crux/lib/job-handlers/page-improve.ts` | Runs content improve pipeline, captures file changes |
| `crux/lib/job-handlers/page-create.ts` | Runs content create pipeline |
| `crux/lib/job-handlers/batch-commit.ts` | Collects results from N workers → 1 PR |
| `crux/lib/job-handlers/auto-update-digest.ts` | Orchestrates auto-update via job queue |
| `crux/lib/job-handlers/utils.ts` | Git state management, path traversal protection |
| `crux/worker/run.ts` | Node.js worker process |
| `crux/commands/jobs.ts` | Added batch, worker, types subcommands |
| `crux/commands/auto-update.ts` | Added submit subcommand |
| `.github/workflows/job-worker.yml` | Updated to use Node.js worker |
| `crux/lib/job-handlers/job-handlers.test.ts` | 19 tests |

## Architecture

```
Server creates jobs → GHA workflow triggers → Node.js worker claims jobs
  → Handler registry dispatches → Results stored in job.result
  → batch-commit collects all results → Creates PR
```

File changes are stored in `job.result` JSONB field (since #554 DB content tables aren't ready yet). The batch-commit handler reads completed child jobs, deduplicates file changes, applies them to a branch, and creates a PR.

## Test plan

- [x] 19 unit tests pass (handler registry, validation, utils, security)
- [x] All 8 gate checks pass (build-data, tests, MDX syntax, YAML schema, frontmatter, numeric IDs, EntityLink, TypeScript)
- [x] Paranoid review completed — found and fixed: command injection, path traversal, unrestricted git add, DRY violations
- [x] Rebased on latest main with no conflicts
- [x] Compatible with recently merged #574 (jobs API refactor)

Closes #555

https://claude.ai/code/session_01NGLjBywq8EYMk9jUG5T851