### PR TITLE
fix: unify formatRawJobRow, add server-side date filtering

### DIFF
--- a/apps/wiki-server/src/routes/jobs.ts
+++ b/apps/wiki-server/src/routes/jobs.ts
@@ -187,21 +187,7 @@ jobsRoute.post("/claim", async (c) => {
     return c.json({ job: null }, 200);
   }
 
-  const row = result[0] as Record<string, unknown>;
-  return c.json({
-    job: {
-      id: row.id,
-      type: row.type,
-      status: row.status,
-      params: row.params,
-      priority: row.priority,
-      retries: row.retries,
-      maxRetries: row.max_retries,
-      createdAt: row.created_at,
-      claimedAt: row.claimed_at,
-      workerId: row.worker_id,
-    },
-  });
+  return c.json({ job: formatRawJobRow(result[0] as Record<string, unknown>) });
 });
 
 // ---- POST /:id/start (mark as running) ----

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -529,22 +529,19 @@ export async function recentEdits(_args: string[], options: Record<string, unkno
   const c = log.colors;
 
   const days = parseIntOpt(options.days, 7);
-  // Cap at 200 to stay well within server's MAX_PAGE_SIZE=1000 even after client-side date filtering
   const limit = Math.min(parseIntOpt(options.limit, 30), 200);
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - days);
   const cutoff = cutoffDate.toISOString().slice(0, 10);
 
-  // Fetch extra rows to account for date filtering; cap at server's max
-  const fetchLimit = Math.min(limit * 5, 1000);
   const result = await apiRequest<EditLogAllResult>(
     'GET',
-    `/api/edit-logs/all?limit=${fetchLimit}&offset=0`,
+    `/api/edit-logs/all?limit=${limit}&offset=0&since=${cutoff}`,
   );
 
   if (!result.ok) return serverUnavailableError(log, result);
 
-  const entries = result.data.entries.filter((e) => e.date >= cutoff).slice(0, limit);
+  const entries = result.data.entries;
 
   if (options.json || options.ci) {
     return { output: JSON.stringify({ entries, total: result.data.total }, null, 2), exitCode: 0 };


### PR DESCRIPTION
## Summary

- Replace inline snake_case→camelCase property mapping in `/api/jobs/claim` with `formatRawJobRow` to eliminate code duplication (#597)
- Add `since` query parameter to `GET /api/edit-logs/all` for server-side date filtering, replacing fragile client-side filtering in `recentEdits` that could miss entries (#598)
- Parallelize main query + count query in `/all` endpoint
- Add test for `since` parameter

## Test plan
- [x] All 1136 tests pass (including new `since` filter test)
- [x] Full gate check passes

Closes #597
Closes #598