### PR TITLE
fix: add per-query tool call limit to Discord bot

### DIFF
--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -9,3 +9,6 @@ export const WIKI_BASE_URL =
   );
 
 export const TIMEOUT_MS = 90_000;
+
+/** Max tool calls per query to prevent runaway API usage. */
+export const MAX_TOOL_CALLS = 10;

--- a/apps/discord-bot/src/query.ts
+++ b/apps/discord-bot/src/query.ts
@@ -1,5 +1,5 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { WIKI_BASE_URL, TIMEOUT_MS } from "./config.js";
+import { WIKI_BASE_URL, TIMEOUT_MS, MAX_TOOL_CALLS } from "./config.js";
 import { wikiMcpServer } from "./wiki-tools.js";
 
 export interface QueryResult {
@@ -117,6 +117,15 @@ export async function runQuery(question: string): Promise<QueryResult> {
                 `${elapsed()} 💬 Text: ${block.text.slice(0, 100)}...`
               );
             }
+          }
+          if (toolCalls.length >= MAX_TOOL_CALLS) {
+            console.log(
+              `${elapsed()} ⚠️ Tool call limit reached (${MAX_TOOL_CALLS}), stopping query`
+            );
+            result =
+              (lastResult || result) +
+              `\n\n*(Stopped after ${MAX_TOOL_CALLS} tool calls to limit API usage)*`;
+            break;
           }
         }
       } else if (msgType === "result") {


### PR DESCRIPTION
## Summary

- Add `MAX_TOOL_CALLS=10` constant in config to cap tool calls per query
- Enforce limit in the Agent SDK streaming loop — when reached, stop the query and return partial result with a truncation note
- Prevents adversarial interactions from generating unlimited sequential API calls against the wiki-server

The bot already has per-user rate limiting (30s cooldown) and global concurrency cap (3 simultaneous), but had no limit on how many tool calls a single query could make.

## Test plan
- [x] All 128 Discord bot tests pass
- [x] Full gate check passes

Closes #599