### PR TITLE
fix: harden backup and health monitor workflows

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -6,6 +6,9 @@ name: Database Backup
 # This provides a safety net for the PostgreSQL data that was previously
 # committed as YAML files in git. If the database is lost, these JSON
 # snapshots can be used to restore session history and edit logs.
+#
+# Note: Each endpoint is fetched once with its MAX_PAGE_SIZE limit.
+# If data grows beyond a single page, this workflow will need pagination.
 
 on:
   schedule:
@@ -40,41 +43,43 @@ jobs:
 
           DATE=$(date -u '+%Y-%m-%d')
           echo "Backing up wiki-server data for $DATE"
+          FAILURES=0
 
-          # Export sessions (paginated, up to 10000)
-          echo "Exporting sessions..."
-          curl -sf --max-time 30 \
-            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-            "${LONGTERMWIKI_SERVER_URL}/api/sessions?limit=1000&offset=0" \
-            -o /tmp/backup/sessions.json || echo '{"error":"fetch failed"}' > /tmp/backup/sessions.json
+          fetch_endpoint() {
+            local label="$1" url="$2" output="$3"
+            echo "Exporting ${label}..."
+            if curl -sf --max-time 60 \
+              ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+              "${url}" \
+              -o "${output}"; then
+              echo "  ✓ ${label} OK"
+            else
+              echo "::error::Failed to export ${label} from ${url}"
+              FAILURES=$((FAILURES + 1))
+            fi
+          }
 
-          # Export edit logs (paginated, up to 10000)
-          echo "Exporting edit logs..."
-          curl -sf --max-time 30 \
-            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+          # Sessions: server MAX_PAGE_SIZE is 500
+          fetch_endpoint "sessions" \
+            "${LONGTERMWIKI_SERVER_URL}/api/sessions?limit=500&offset=0" \
+            /tmp/backup/sessions.json
+
+          # Edit logs: server MAX_PAGE_SIZE is 1000
+          fetch_endpoint "edit logs" \
             "${LONGTERMWIKI_SERVER_URL}/api/edit-logs/all?limit=1000&offset=0" \
-            -o /tmp/backup/edit-logs.json || echo '{"error":"fetch failed"}' > /tmp/backup/edit-logs.json
+            /tmp/backup/edit-logs.json
 
-          # Export edit log stats
-          echo "Exporting edit log stats..."
-          curl -sf --max-time 30 \
-            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+          fetch_endpoint "edit log stats" \
             "${LONGTERMWIKI_SERVER_URL}/api/edit-logs/stats" \
-            -o /tmp/backup/edit-log-stats.json || echo '{"error":"fetch failed"}' > /tmp/backup/edit-log-stats.json
+            /tmp/backup/edit-log-stats.json
 
-          # Export job stats
-          echo "Exporting job stats..."
-          curl -sf --max-time 30 \
-            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+          fetch_endpoint "job stats" \
             "${LONGTERMWIKI_SERVER_URL}/api/jobs/stats" \
-            -o /tmp/backup/job-stats.json || echo '{"error":"fetch failed"}' > /tmp/backup/job-stats.json
+            /tmp/backup/job-stats.json
 
-          # Export latest edit dates (used by build-data)
-          echo "Exporting latest dates..."
-          curl -sf --max-time 30 \
-            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+          fetch_endpoint "latest dates" \
             "${LONGTERMWIKI_SERVER_URL}/api/edit-logs/latest-dates" \
-            -o /tmp/backup/latest-dates.json || echo '{"error":"fetch failed"}' > /tmp/backup/latest-dates.json
+            /tmp/backup/latest-dates.json
 
           # Summary
           echo ""
@@ -83,6 +88,11 @@ jobs:
             SIZE=$(wc -c < "$f" | tr -d ' ')
             echo "  $(basename "$f"): ${SIZE} bytes"
           done
+
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "::error::${FAILURES} endpoint(s) failed to export"
+            exit 1
+          fi
 
       - name: Upload backup artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/server-health-monitor.yml
+++ b/.github/workflows/server-health-monitor.yml
@@ -107,33 +107,34 @@ jobs:
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-          # Build the issue body directly with a heredoc (no fragile sed replacements)
-          cat > /tmp/issue_body.md <<ISSUE_BODY
+          # Build the issue body with a quoted heredoc to prevent shell injection
+          # from untrusted HEALTH_RESPONSE content. Variables are inserted via sed.
+          cat > /tmp/issue_body.md <<'ISSUE_BODY'
           ## Wiki server health check failed
 
           | Field | Value |
           |-------|-------|
           | **Status** | :red_circle: Unhealthy |
-          | **Detected at** | ${TIMESTAMP} |
-          | **Error** | ${HEALTH_ERROR} |
-          | **HTTP status** | ${HEALTH_HTTP_CODE} |
+          | **Detected at** | __TIMESTAMP__ |
+          | **Error** | __HEALTH_ERROR__ |
+          | **HTTP status** | __HEALTH_HTTP_CODE__ |
 
           ### Health endpoint response
 
-          \`\`\`json
-          ${HEALTH_RESPONSE}
-          \`\`\`
+          ```json
+          __HEALTH_RESPONSE__
+          ```
 
           ### Possible causes
 
           - **HTTP 503 / connection refused** — Pod is crashing or not running
-          - **\`database: "error"\`** — Database connection or query failure (bad migration, permissions, DB down)
-          - **\`status: "degraded"\`** — Server is running but some queries are failing
+          - **`database: "error"`** — Database connection or query failure (bad migration, permissions, DB down)
+          - **`status: "degraded"`** — Server is running but some queries are failing
           - **Connection timeout** — DNS, ingress, or networking issue
 
           ### Useful commands
 
-          \`\`\`bash
+          ```bash
           # Pod status
           kubectl get pods -n longtermwiki
 
@@ -145,7 +146,7 @@ jobs:
 
           # Restart the deployment
           kubectl rollout restart deployment -n longtermwiki longterm-wiki-server-wiki-server
-          \`\`\`
+          ```
 
           ---
           *Created automatically by the [health monitor workflow](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/server-health-monitor.yml). Will be closed automatically when the server recovers.*
@@ -153,6 +154,13 @@ jobs:
 
           # Strip leading whitespace from heredoc (YAML indentation)
           sed -i 's/^          //' /tmp/issue_body.md
+
+          # Safely substitute values (escape sed special chars in values first)
+          escape_sed() { printf '%s\n' "$1" | sed 's/[&/\]/\\&/g'; }
+          sed -i "s|__TIMESTAMP__|$(escape_sed "$TIMESTAMP")|g" /tmp/issue_body.md
+          sed -i "s|__HEALTH_ERROR__|$(escape_sed "$HEALTH_ERROR")|g" /tmp/issue_body.md
+          sed -i "s|__HEALTH_HTTP_CODE__|$(escape_sed "$HEALTH_HTTP_CODE")|g" /tmp/issue_body.md
+          sed -i "s|__HEALTH_RESPONSE__|$(escape_sed "$HEALTH_RESPONSE")|g" /tmp/issue_body.md
 
           if [ -n "$EXISTING_ISSUE" ]; then
             # Reopen and comment on existing issue instead of creating a new one


### PR DESCRIPTION
## Summary

- **Backup workflow**: Fix sessions `limit=1000` → `500` (server's `MAX_PAGE_SIZE` is 500, Zod would reject/clamp the request). Replace silent `{"error":"fetch failed"}` fallback with proper error handling — workflow now fails with `::error::` annotations when endpoints can't be reached. DRY `fetch_endpoint` helper reduces duplication.
- **Health monitor**: Use quoted heredoc (`<<'ISSUE_BODY'`) to prevent shell injection from untrusted health endpoint response content. Variables are now substituted safely via `sed` with proper escaping of special characters.

Both issues found by paranoid review of recent PRs #609 and #613.

## Test plan
- [ ] Backup: trigger manually via workflow_dispatch, verify it completes (or fails cleanly if server is unreachable)
- [ ] Health monitor: verify issue creation still works by temporarily breaking the URL or waiting for a natural check

🤖 Generated with [Claude Code](https://claude.com/claude-code)