### PR TITLE
Improve GitHub integration: crux pr commands, MCP config, remove curl footguns

### DIFF
--- a/.claude/commands/agent-session-ready-PR.md
+++ b/.claude/commands/agent-session-ready-PR.md
@@ -25,7 +25,7 @@ Pay special attention to:
 
 ## Step 3: Write / update PR description
 
-Check if a PR exists and update it with: summary, key changes, test plan, issue references.
+Check if a PR exists using `pnpm crux pr detect` and update it with: summary, key changes, test plan, issue references. If no PR exists yet, `/push-and-ensure-green` will create one using `crux pr create`.
 
 ## Step 4: Update GitHub issue
 

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -40,8 +40,21 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies and build data
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+          node apps/web/scripts/build-data.mjs
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/github-mcp-server"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ pnpm crux issues cleanup --fix   # Auto-remove stale labels
 pnpm crux issues close <N> --duplicate=M  # Close issue as duplicate of another
 pnpm crux issues close <N> --reason="..."  # Close with comment
 
+# GitHub PR management (corruption-safe — always use instead of raw curl)
+pnpm crux pr create --title="..." --body="..."  # Create PR for current branch
+pnpm crux pr detect              # Check if PR exists for current branch
+pnpm crux pr detect --ci         # JSON output for scripts
+pnpm crux pr fix-body            # Auto-fix literal \n in PR body
+
 # Issue formatting standard (enforced by crux issues lint)
 # Well-formatted issues require:
 #   1. ## Problem section (or long freeform body)
@@ -281,6 +287,16 @@ When a session works on a GitHub issue, signal activity on that issue. See `.cla
 1. **At session start**: `pnpm crux issues start <N>` — posts a comment + adds `claude-working` label
 2. **At session end**: `pnpm crux issues done <N> --pr=<URL>` — posts completion comment + removes label
 3. **To pick the next issue**: `/next-issue` — fetches and ranks open issues, starts work on the top one
+
+## GitHub MCP Server
+
+A GitHub MCP server is configured at project level (`.mcp.json`). This gives Claude Code direct access to GitHub APIs via MCP tools.
+
+**When to use which:**
+- **`crux issues/pr/ci` commands**: For all workflow operations (issue tracking, PR creation, CI monitoring). These route through `githubApi()` which validates for shell-expansion corruption. Always prefer crux for writes.
+- **MCP GitHub tools**: For ad-hoc reads — checking a PR diff, reading a file from another branch, looking up a user, browsing repo contents. MCP tools bypass bash entirely, so shell-expansion corruption doesn't apply.
+
+**Do NOT** use raw `curl` commands for GitHub API calls. Use either crux commands (for workflow operations) or MCP tools (for ad-hoc reads).
 
 ## PR Review & Ship Workflow — MANDATORY
 

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -4,8 +4,10 @@
  * Utilities for managing GitHub Pull Requests associated with the current branch.
  *
  * Usage:
- *   crux pr fix-body          Detect and repair literal \n in the current branch's PR body
- *   crux pr fix-body --pr=N   Target a specific PR number instead of auto-detecting
+ *   crux pr create             Create a PR for the current branch (corruption-safe)
+ *   crux pr detect             Detect open PR for current branch (returns PR URL + number)
+ *   crux pr fix-body           Detect and repair literal \n in the current branch's PR body
+ *   crux pr fix-body --pr=N    Target a specific PR number instead of auto-detecting
  */
 
 import { createLogger } from '../lib/output.ts';
@@ -13,10 +15,118 @@ import { githubApi, REPO } from '../lib/github.ts';
 import { currentBranch } from '../lib/session-checklist.ts';
 import type { CommandResult } from '../lib/cli.ts';
 
+type CommandOptions = Record<string, unknown>;
+
 interface GitHubPR {
   number: number;
   html_url: string;
   body: string | null;
+  head: { ref: string };
+  base: { ref: string };
+}
+
+/**
+ * Detect the open PR for the current branch.
+ *
+ * Returns the PR number and URL if found, or a clear message if not.
+ * Useful for scripts and skill files that need to know if a PR exists.
+ */
+async function detect(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+
+  const branch = currentBranch();
+  const prs = await githubApi<GitHubPR[]>(
+    `/repos/${REPO}/pulls?head=quantified-uncertainty:${branch}&state=open`
+  );
+
+  if (!prs.length) {
+    if (options.ci) {
+      return { output: JSON.stringify({ found: false, branch }) + '\n', exitCode: 1 };
+    }
+    return {
+      output: `${c.yellow}No open PR found for branch ${branch}.${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const pr = prs[0];
+  if (options.ci) {
+    return {
+      output: JSON.stringify({ found: true, number: pr.number, url: pr.html_url, branch }) + '\n',
+      exitCode: 0,
+    };
+  }
+
+  return {
+    output: `${c.green}✓${c.reset} PR #${pr.number}: ${pr.html_url}\n`,
+    exitCode: 0,
+  };
+}
+
+/**
+ * Create a PR for the current branch (corruption-safe).
+ *
+ * All string fields are passed through githubApi() which validates for
+ * shell-expansion corruption before sending. This is the safe alternative
+ * to constructing curl commands with jq in bash.
+ *
+ * Options:
+ *   --title="PR title"      Required. Title for the PR.
+ *   --body="PR body"        Required. Markdown body for the PR.
+ *   --base=main             Base branch (default: main).
+ *   --draft                 Create as draft PR.
+ *
+ * If a PR already exists for this branch, reports it instead of creating a duplicate.
+ */
+async function create(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+
+  const branch = currentBranch();
+  const title = options.title as string | undefined;
+  const body = options.body as string | undefined;
+  const base = (options.base as string) || 'main';
+  const draft = Boolean(options.draft);
+
+  if (!title) {
+    return {
+      output: `${c.red}Usage: crux pr create --title="PR title" --body="PR body" [--base=main] [--draft]${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  // Check for existing PR first
+  const existing = await githubApi<GitHubPR[]>(
+    `/repos/${REPO}/pulls?head=quantified-uncertainty:${branch}&state=open`
+  );
+
+  if (existing.length > 0) {
+    const pr = existing[0];
+    return {
+      output:
+        `${c.yellow}PR already exists for branch ${branch}:${c.reset}\n` +
+        `  PR #${pr.number}: ${pr.html_url}\n` +
+        `  ${c.dim}Use \`crux pr fix-body\` to update the body if needed.${c.reset}\n`,
+      exitCode: 0,
+    };
+  }
+
+  const pr = await githubApi<GitHubPR>(`/repos/${REPO}/pulls`, {
+    method: 'POST',
+    body: {
+      title,
+      body: body || '',
+      head: branch,
+      base,
+      draft,
+    },
+  });
+
+  let output = `${c.green}✓${c.reset} Created PR #${pr.number}: ${pr.html_url}\n`;
+  if (draft) output += `  ${c.dim}(draft)${c.reset}\n`;
+
+  return { output, exitCode: 0 };
 }
 
 /**
@@ -32,8 +142,8 @@ interface GitHubPR {
  *
  * Exit codes: 0 = clean or fixed, 1 = error (API failure, no token, no PR)
  */
-async function fixBody(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
-  const log = createLogger(options.ci);
+async function fixBody(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
   const c = log.colors;
 
   // Determine PR number
@@ -91,6 +201,8 @@ async function fixBody(args: string[], options: Record<string, unknown>): Promis
 // ---------------------------------------------------------------------------
 
 export const commands = {
+  create,
+  detect,
   'fix-body': fixBody,
 };
 
@@ -99,12 +211,27 @@ export function getHelp(): string {
 PR Domain — GitHub Pull Request utilities
 
 Commands:
+  create              Create a PR for the current branch (corruption-safe).
+  detect              Detect open PR for current branch (returns URL + number).
   fix-body [--pr=N]   Detect and repair literal \\n in the current branch's PR body.
-                      Auto-detects the open PR for the current branch unless --pr=N given.
-                      Exits 0 whether clean or fixed (safe to use as a verifyCommand).
+
+Options (create):
+  --title="..."       Required. PR title.
+  --body="..."        Required. PR body (markdown).
+  --base=main         Base branch (default: main).
+  --draft             Create as draft PR.
+
+Options (detect):
+  --ci                JSON output.
+
+Options (fix-body):
+  --pr=N              Target a specific PR number instead of auto-detecting.
 
 Examples:
-  pnpm crux pr fix-body          # Fix PR for current branch
-  pnpm crux pr fix-body --pr=42  # Fix a specific PR
+  pnpm crux pr create --title="Add feature X" --body="## Summary\\n- Added X"
+  pnpm crux pr detect                    # Check if PR exists for this branch
+  pnpm crux pr detect --ci               # JSON output for scripts
+  pnpm crux pr fix-body                  # Fix PR for current branch
+  pnpm crux pr fix-body --pr=42          # Fix a specific PR
 `.trim();
 }

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -2,6 +2,17 @@
  * Shared GitHub API utilities.
  *
  * Used by crux maintain, crux ci, and other domains that call the GitHub API.
+ *
+ * Corruption detection: All writes through `githubApi()` are validated for
+ * shell-expansion corruption (ANSI codes, dotenv output, etc.) before sending.
+ * This catches a class of bugs where bash variable expansion or command
+ * substitution injects terminal garbage into GitHub API payloads.
+ *
+ * MCP exemption: The GitHub MCP server (configured in `.mcp.json`) bypasses
+ * this validation because MCP tools don't go through bash — they communicate
+ * via JSON-RPC, so shell-expansion corruption cannot occur. MCP is safe for
+ * ad-hoc reads; prefer `githubApi()` (via crux commands) for workflow writes
+ * where corruption detection adds an important safety layer.
  */
 
 export const REPO = 'quantified-uncertainty/longterm-wiki';


### PR DESCRIPTION
## Summary

- Add crux pr create and crux pr detect commands for corruption-safe PR management
- Rewrite push-and-ensure-green.md to use crux commands instead of curl
- Remove all curl examples from github-issue-tracking.md (crux-only now)
- Add project-level .mcp.json with GitHub MCP server config
- Add MCP vs crux guidance to CLAUDE.md
- Enrich claude-assistant.yml with Node.js setup, pnpm install, data build, and env vars
- Document corruption detection exemption for MCP in github.ts

## Test plan
- Gate passes (236 tests, all validations)
- crux pr detect and crux pr --help work correctly
- TypeScript type check clean