### PR TITLE
feat(crux): enforce --model and --criteria at issue creation time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ pnpm crux issues next            # Show next highest-priority issue to work on
 pnpm crux issues lint            # Check all issues for formatting problems
 pnpm crux issues lint <N>        # Lint a single issue
 pnpm crux issues create "title" --label=tooling \
-  --problem="..." --model=sonnet \
-  --criteria="item1|item2" --cost="~$2-4"  # File a structured issue
+  --problem="..." --model=sonnet \          # --model is REQUIRED
+  --criteria="item1|item2" --cost="~$2-4"  # --criteria is REQUIRED
 pnpm crux issues update-body <N> --model=sonnet --problem="..." --criteria="a|b"
 pnpm crux issues start <N>       # Signal start: comment + add claude-working label
 pnpm crux issues done <N>        # Signal completion: comment + remove label

--- a/crux/lib/session-checklist.ts
+++ b/crux/lib/session-checklist.ts
@@ -416,7 +416,7 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     label: 'Tooling gaps actioned',
     description:
       'Review the gaps listed under `tooling-gaps-found` in Key Decisions. For each: implement now if easy (<1hr). ' +
-      'For harder ones: `pnpm crux issues create "Add validation: <desc>" --label=tooling` — then paste the URL in Key Decisions.',
+      'For harder ones: `pnpm crux issues create "Add validation: <desc>" --label=tooling --model=haiku --criteria="..."` — then paste the URL in Key Decisions.',
     phase: 'ship',
     applicableTypes: 'all',
   },


### PR DESCRIPTION
## Summary

- crux issues create now fails with exit 1 if --model or --criteria flags are missing, preventing issues from being created without proper formatting
- New --draft flag allows bypassing validation for WIP issues
- Raw --body flag also bypasses the validation as an escape hatch for freeform issues
- Updated tooling-gaps-actioned checklist item to include --model and --criteria in the create example
- CLAUDE.md examples now explicitly mark --model and --criteria as required

## Key Changes

- crux/commands/issues.ts: Add required-flag validation block; add draft?: boolean to CommandOptions; update help text to reflect required flags; split create/update-body options in help
- crux/lib/session-checklist.ts: Update tooling-gaps-actioned description example
- CLAUDE.md: Add comments to create example marking required flags
- crux/commands/issues.test.ts: Add 6 new tests (missing --model, missing --criteria, both missing, --draft bypass, --body bypass, warning in draft mode)

## Test Plan

- [x] crux issues create fails with exit 1 when --model or --criteria missing
- [x] --draft flag bypasses validation
- [x] --body flag bypasses validation (freeform escape hatch)
- [x] All 109 issues.test.ts tests pass
- [x] Gate check passes (5/5)

Closes #654

https://claude.ai/code/session_01Th4wsp7HwoBG7EoQcw4Nnm