### PR TITLE
fix: crux issues robustness (#622, #625, #628, #629, #630)

### DIFF
--- a/crux/lib/cli.ts
+++ b/crux/lib/cli.ts
@@ -122,6 +122,16 @@ export function parseIntOpt(val: unknown, fallback: number): number {
 }
 
 /**
+ * Parse a required positive-integer positional arg (e.g. an issue number).
+ * Returns the parsed number, or null if the arg is missing, non-numeric, or <= 0.
+ */
+export function parseRequiredInt(val: string | undefined): number | null {
+  if (!val) return null;
+  const n = parseInt(val, 10);
+  return Number.isNaN(n) || n <= 0 ? null : n;
+}
+
+/**
  * Format duration in human-readable form
  */
 export function formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary

- **#629**: `close --duplicate=foo` now returns a clear error instead of producing `#NaN` in output
- **#630**: `cleanup` fetches comments with `direction=asc` and `per_page=100` so old start-comments aren't missed on busy issues
- **#622**: `update-body` replaces existing sections in-place via `mergeSections()` instead of blindly prepending (no more duplicate `## Problem` / `## Recommended Model` headers)
- **#625**: Extracts `parseRequiredInt()` helper to `cli.ts`, replacing 6 instances of repeated `parseInt` + `isNaN` validation boilerplate
- **#628**: Strips `{/* CROSS-PAGE CHECK */}` comments before applying MDX files to disk, preserving them in temp files for review

Closes #629
Closes #630
Closes #622
Closes #625
Closes #628

## Test plan

- [x] All 1301 tests pass
- [x] Gate check passes (build-data, tests, unified rules, schema, TypeScript)
- [ ] Manual: `crux issues close 999 --duplicate=abc` should return error (not `#NaN`)
- [ ] Manual: `crux issues update-body <N> --model=sonnet` on an issue that already has `## Recommended Model` should replace, not duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)