### PR TITLE
fix: lint --json, edit-log robustness, auto-fix Closes syntax (#624, #526, #632)

### DIFF
--- a/crux/commands/edit-log.ts
+++ b/crux/commands/edit-log.ts
@@ -90,8 +90,8 @@ export async function list(args: string[], options: Record<string, unknown>): Pr
   }
 
   try {
-    // Fetch enough entries to build a per-page summary
-    const params = new URLSearchParams({ limit: '5000', offset: '0' });
+    // Fetch entries for per-page summary (capped to avoid excessive bandwidth)
+    const params = new URLSearchParams({ limit: '500', offset: '0' });
     if (filterTool) params.set('tool', filterTool);
     if (filterAgency) params.set('agency', filterAgency);
 
@@ -201,7 +201,7 @@ export async function stats(_args: string[], options: Record<string, unknown>): 
   }
 
   output += `\n${c.bold}By Agency:${c.reset}\n`;
-  for (const [agency, cnt] of Object.entries(serverStats.byAgency).sort((a, b) => b[1] - a[1])) {
+  for (const [agency, cnt] of Object.entries(serverStats.byAgency ?? {}).sort((a, b) => b[1] - a[1])) {
     output += `  ${agency.padEnd(18)} ${String(cnt).padStart(5)}\n`;
   }
 

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeClosesSyntax } from './pr.ts';
+
+describe('normalizeClosesSyntax', () => {
+  it('rewrites comma-separated Closes to one-per-line', () => {
+    const { result, fixed } = normalizeClosesSyntax('Closes #1, #2, #3');
+    expect(result).toBe('Closes #1\nCloses #2\nCloses #3');
+    expect(fixed).toBe(1);
+  });
+
+  it('handles Fixes keyword', () => {
+    const { result } = normalizeClosesSyntax('Fixes #10, #20');
+    expect(result).toBe('Fixes #10\nFixes #20');
+  });
+
+  it('handles Resolves keyword', () => {
+    const { result } = normalizeClosesSyntax('Resolves #5, #6, #7');
+    expect(result).toBe('Resolves #5\nResolves #6\nResolves #7');
+  });
+
+  it('handles "and" separator', () => {
+    const { result } = normalizeClosesSyntax('Closes #1 and #2');
+    expect(result).toBe('Closes #1\nCloses #2');
+  });
+
+  it('leaves already-correct one-per-line format unchanged', () => {
+    const input = 'Closes #1\nCloses #2\nCloses #3';
+    const { result, fixed } = normalizeClosesSyntax(input);
+    expect(result).toBe(input);
+    expect(fixed).toBe(0);
+  });
+
+  it('leaves single Closes unchanged', () => {
+    const input = 'Closes #42';
+    const { result, fixed } = normalizeClosesSyntax(input);
+    expect(result).toBe(input);
+    expect(fixed).toBe(0);
+  });
+
+  it('handles mixed content around Closes lines', () => {
+    const input = '## Summary\nSome text\n\nCloses #1, #2\n\nMore text';
+    const { result } = normalizeClosesSyntax(input);
+    expect(result).toBe('## Summary\nSome text\n\nCloses #1\nCloses #2\n\nMore text');
+  });
+
+  it('handles numbers without # prefix', () => {
+    const { result } = normalizeClosesSyntax('Closes #1, 2, 3');
+    expect(result).toBe('Closes #1\nCloses #2\nCloses #3');
+  });
+});


### PR DESCRIPTION
## Summary

- **#624**: `crux issues lint --json` now outputs structured `{pass, fail, issues}` JSON. Formatting warnings are shown by default in `crux issues list` (previously hidden behind `--scores`)
- **#526**: `edit-log stats` guards `byAgency` against undefined (prevents runtime crash). `edit-log list` fetch limit reduced from 5000 to 500 (stats only needs aggregates)
- **#632**: `crux pr fix-body` now auto-normalizes comma-separated `Closes #1, #2, #3` to one-per-line format. Includes 8 unit tests for the rewriting logic

Closes #624
Closes #526
Closes #632

## Test plan

- [x] All 1309 tests pass (1301 existing + 8 new)
- [x] Gate check passes
- [ ] Manual: `crux issues lint --json` returns structured output
- [ ] Manual: `crux issues list` shows formatting warnings without `--scores`

🤖 Generated with [Claude Code](https://claude.com/claude-code)