### PR TITLE
maintain: ATM homepage section, session learnings, gate pass (#358)

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -88,4 +88,30 @@ When running inside Claude Code SDK (web sessions), the `CLAUDECODE` env var is 
 
 ---
 
+## Crux / CLI Modules
+
+### Add `process.argv[1]` guard to any module with a top-level `main()` call
+If a crux/validate script calls `main()` at module level (not inside a `__main__`-equivalent guard), it will execute during test imports and cause `process.exit()` side-effects or timing errors. Fix:
+```ts
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}
+```
+Required on any script where `main()` was previously called at the bottom of the file unconditionally.
+
+### SQLite `SUM()` returns null on empty tables
+Use `COALESCE(SUM(col), 0)` for display-facing queries. `SUM()` over zero rows returns SQL `NULL`, not `0`.
+
+---
+
+## Content / Citations
+
+### Pages with footnote definitions but no inline refs produce no quote results
+Some pages list sources as `[^N]: [Title](URL)` at the bottom but never reference `[^N]` inline in the prose. The citation pipeline extracts no quotes from these pages because there's no claim context. Flag these pages for inline-citation cleanup — the sources are there, they just need to be referenced.
+
+### Sandbox blocks most external URL fetches
+Inside Claude Code sandboxed environments, outbound HTTP fetches fail. For citation pipeline runs (`crux citations verify`, `crux citations extract-quotes`), you may need `dangerouslyDisableSandbox: true` when using the Bash tool. This is expected — the sandbox prevents web access by default.
+
+---
+
 _Add new issues below as they're discovered. Group by category._

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,9 +2,18 @@ import Link from "next/link";
 import { getExploreItems, getAllPages } from "@/data";
 import { ContentCard } from "@/components/explore/ContentCard";
 import { getTypeLabel, getTypeColor } from "@/components/explore/explore-utils";
-import { Shield, Bug, Scale, Brain, BookOpen, Building2 } from "lucide-react";
+import { Shield, Bug, Scale, Brain, BookOpen, Building2, Network } from "lucide-react";
 import type { ExploreItem } from "@/data";
 import type { LucideIcon } from "lucide-react";
+
+// AI Transition Model direct links
+const ATM_LINKS = [
+  { label: "Model Overview", href: "/wiki/ai-transition-model" },
+  { label: "Root Factors", href: "/wiki/E667" },
+  { label: "Scenarios", href: "/wiki/E674" },
+  { label: "Outcomes", href: "/wiki/E669" },
+  { label: "Interactive Graph", href: "/ai-transition-model/graph" },
+];
 
 // Field clusters with descriptions for the topic sections
 const TOPIC_SECTIONS: {
@@ -198,6 +207,29 @@ export default function Home() {
                 </div>
               );
             })}
+          </div>
+        </section>
+
+        {/* AI Transition Model */}
+        <section className="py-8 border-t border-border">
+          <div className="flex items-center gap-2 mb-2">
+            <Network className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+            <h2 className="text-xl font-semibold">AI Transition Model</h2>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4 max-w-2xl">
+            A causal model of how root factors — alignment, capabilities, governance — shape AI
+            transition scenarios and ultimate outcomes. 68 interconnected pages.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {ATM_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center px-4 py-1.5 border border-border rounded-full text-sm text-foreground no-underline hover:bg-muted transition-colors"
+              >
+                {link.label}
+              </Link>
+            ))}
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

- Add AI Transition Model section to homepage with links to Overview, Root Factors, Scenarios, Outcomes, and Interactive Graph (#358)
- Propagate 4 session log learnings to :  guard for main() modules, SQLite COALESCE for SUM(), footnotes-without-inline-refs pattern, sandbox URL fetch restriction

## Changes

- : New ATM spotlight section (pill-link row) between topic clusters and recently-updated
- : Added Crux/CLI and Content/Citations sections with four recurring patterns

## Test plan
- [x] Gate check passes (all 6 checks including full Next.js build)
- [x] ATM links resolve: /wiki/ai-transition-model, /wiki/E667, /wiki/E674, /wiki/E669, /ai-transition-model/graph

Closes #358