### PR TITLE
fix: guard .returning()[0] accesses with firstOrThrow + CI validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
       - name: TypeScript type check — wiki-server (blocking)
         run: cd apps/wiki-server && npx tsc --noEmit
 
+      - name: .returning() guard check (blocking)
+        run: npx tsx crux/validate/validate-returning-guard.ts
+
       - name: Run validation suite (advisory)
         if: "!cancelled()"
         continue-on-error: true

--- a/apps/wiki-server/src/routes/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/agent-sessions.ts
@@ -6,6 +6,7 @@ import {
   parseJsonBody,
   validationError,
   invalidJsonError,
+  firstOrThrow,
 } from "./utils.js";
 import {
   CreateAgentSessionSchema,
@@ -48,7 +49,7 @@ agentSessionsRoute.post("/", async (c) => {
         })
         .where(eq(agentSessions.id, existing[0].id))
         .returning();
-      return { row: updated[0], isUpdate: true };
+      return { row: firstOrThrow(updated, "agent session update"), isUpdate: true };
     }
 
     const inserted = await tx
@@ -61,7 +62,7 @@ agentSessionsRoute.post("/", async (c) => {
         checklistMd: d.checklistMd,
       })
       .returning();
-    return { row: inserted[0], isUpdate: false };
+    return { row: firstOrThrow(inserted, "agent session insert"), isUpdate: false };
   });
 
   return c.json(row, isUpdate ? 200 : 201);

--- a/apps/wiki-server/src/routes/jobs.ts
+++ b/apps/wiki-server/src/routes/jobs.ts
@@ -7,6 +7,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  firstOrThrow,
 } from "./utils.js";
 import {
   CreateJobSchema,
@@ -104,7 +105,7 @@ jobsRoute.post("/", async (c) => {
     })
     .returning();
 
-  return c.json(formatJob(rows[0]), 201);
+  return c.json(formatJob(firstOrThrow(rows, "job insert")), 201);
 });
 
 // ---- GET / (list jobs with filters) ----

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -156,6 +156,13 @@ const PARALLEL_STEPS: Step[] = [
     args: ['tsc', '--noEmit'],
     cwd: APP_DIR,
   },
+  {
+    id: 'returning-guard',
+    name: '.returning() guard check',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-returning-guard.ts'],
+    cwd: PROJECT_ROOT,
+  },
 ];
 
 // Phase 4 (--full only): Runs after all validations pass

--- a/crux/validate/validate-returning-guard.ts
+++ b/crux/validate/validate-returning-guard.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that `.returning()` results are accessed safely.
+ *
+ * Scans wiki-server route files for patterns where a `.returning()` result
+ * is accessed via `[0]` without either:
+ *   - Being wrapped in `firstOrThrow()`
+ *   - Having a prior `.length` check
+ *
+ * This prevents silent crashes when INSERT/UPDATE returns zero rows
+ * (race conditions, constraint violations, etc.).
+ *
+ * Usage: npx tsx crux/validate/validate-returning-guard.ts
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { getColors } from '../lib/output.ts';
+
+const ROUTES_DIR = 'apps/wiki-server/src/routes';
+
+interface Violation {
+  file: string;
+  line: number;
+  variable: string;
+  text: string;
+}
+
+/**
+ * Find all `.returning()` assignments and check if `[0]` accesses are guarded.
+ */
+function checkFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+
+  // Track variables assigned from .returning()
+  // Pattern: `const <name> = await <expr>.returning();` or similar
+  const returningAssignments: Array<{ varName: string; line: number }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Match variable assignments that precede a .returning() chain
+    // e.g., `const rows = await db.insert(...).values(...).returning();`
+    // The variable name is often on a line like `const rows = await db` or `const rows = await tx`
+    // and `.returning()` is several lines later.
+    //
+    // Strategy: find `.returning()` lines and look backwards for the variable name.
+    if (line.includes('.returning(')) {
+      // Look backwards to find the assignment
+      for (let j = i; j >= Math.max(0, i - 15); j--) {
+        const assignMatch = lines[j].match(/\b(?:const|let)\s+(\w+)\s*=\s*(?:await\s+)?/);
+        if (assignMatch) {
+          returningAssignments.push({ varName: assignMatch[1], line: i + 1 });
+          break;
+        }
+      }
+    }
+  }
+
+  // Deduplicate: if multiple .returning() assignments use the same variable name,
+  // only check the window from each assignment to the next one.
+  const seen = new Set<number>();
+
+  for (let idx = 0; idx < returningAssignments.length; idx++) {
+    const { varName, line: returningLine } = returningAssignments[idx];
+
+    // Determine scan window: from this .returning() to the next .returning() or +20 lines
+    const nextReturningLine = idx + 1 < returningAssignments.length
+      ? returningAssignments[idx + 1].line
+      : returningLine + 20;
+    const scanEnd = Math.min(lines.length, nextReturningLine);
+
+    for (let i = returningLine; i < scanEnd; i++) {
+      const line = lines[i];
+
+      // Check for [0] access on this variable
+      if (!line.includes(`${varName}[0]`)) continue;
+
+      // Deduplicate by line number
+      if (seen.has(i + 1)) continue;
+
+      // Check if wrapped in firstOrThrow()
+      if (line.includes('firstOrThrow(')) continue;
+
+      // Check if there's a .length check between .returning() and this line
+      let hasLengthCheck = false;
+      for (let j = returningLine; j < i; j++) {
+        if (lines[j].includes(`${varName}.length`)) {
+          hasLengthCheck = true;
+          break;
+        }
+      }
+      if (hasLengthCheck) continue;
+
+      seen.add(i + 1);
+      violations.push({
+        file: filePath,
+        line: i + 1,
+        variable: varName,
+        text: line.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: Violation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking .returning() guard patterns in wiki-server routes...${c.reset}\n`);
+
+  let files: string[];
+  try {
+    files = readdirSync(ROUTES_DIR)
+      .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+      .map((f) => join(ROUTES_DIR, f));
+  } catch {
+    console.log(`${c.dim}Skipping: ${ROUTES_DIR} not found${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: Violation[] = [];
+
+  for (const file of files) {
+    const violations = checkFile(file);
+    allViolations.push(...violations);
+  }
+
+  if (allViolations.length === 0) {
+    console.log(`${c.green}All .returning() results are safely guarded (${files.length} files checked)${c.reset}`);
+  } else {
+    console.log(`${c.red}Found ${allViolations.length} unguarded .returning()[0] access(es):${c.reset}\n`);
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}`);
+      console.log(`    Variable: ${v.variable}`);
+      console.log(`    ${c.dim}${v.text}${c.reset}`);
+      console.log(`    ${c.dim}Fix: use firstOrThrow(${v.variable}, "context") or add a .length check${c.reset}\n`);
+    }
+  }
+
+  return { passed: allViolations.length === 0, errors: allViolations.length, violations: allViolations };
+}
+
+if (process.argv[1]?.includes('validate-returning-guard')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}


### PR DESCRIPTION
## Summary
- Fix 3 unguarded `rows[0]` accesses after `.returning()` in `jobs.ts` and `agent-sessions.ts` by using the existing `firstOrThrow()` helper
- Add `crux/validate/validate-returning-guard.ts` — a validator that scans wiki-server route files for unguarded `[0]` accesses after `.returning()` calls
- Wire the validator into:
  - Gate check (parallel step alongside tests, unified rules, YAML schema, typecheck)
  - CI workflow (blocking step in the `validate` job)

Closes #522

## Test plan
- [ ] Validator detects violations (manually tested by reverting a fix)
- [ ] Validator passes clean after fixes (18 route files checked)
- [ ] Gate check passes with new parallel step (6 checks)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)