### PR TITLE
feat(citations): store full_text in PostgreSQL, add citation-content dashboard

### DIFF
--- a/apps/web/src/app/internal/citation-content/citation-content-table.tsx
+++ b/apps/web/src/app/internal/citation-content/citation-content-table.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import type { ContentEntry } from "./page";
+
+function StatusBadge({ httpStatus }: { httpStatus: number | null }) {
+  if (httpStatus === null) {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+        unknown
+      </span>
+    );
+  }
+  if (httpStatus >= 200 && httpStatus < 300) {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-emerald-500/15 text-emerald-600">
+        {httpStatus}
+      </span>
+    );
+  }
+  if (httpStatus >= 400) {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-red-500/15 text-red-500">
+        {httpStatus}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-yellow-500/15 text-yellow-600">
+      {httpStatus}
+    </span>
+  );
+}
+
+function CoverageBadge({ has }: { has: boolean }) {
+  return has ? (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-emerald-500/15 text-emerald-600">
+      yes
+    </span>
+  ) : (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+      no
+    </span>
+  );
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "—";
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+const columns: ColumnDef<ContentEntry>[] = [
+  {
+    accessorKey: "url",
+    header: ({ column }) => <SortableHeader column={column}>URL</SortableHeader>,
+    cell: ({ row }) => {
+      const url = row.original.url;
+      const domain = getDomain(url);
+      const title = row.original.pageTitle;
+      return (
+        <div className="max-w-xs">
+          {title && (
+            <p className="text-xs font-medium text-foreground truncate">
+              {title}
+            </p>
+          )}
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-muted-foreground hover:text-foreground truncate block"
+            title={url}
+          >
+            {domain}
+          </a>
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "fetchedAt",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Fetched</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap">
+        {new Date(row.original.fetchedAt).toLocaleDateString()}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "httpStatus",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Status</SortableHeader>
+    ),
+    cell: ({ row }) => <StatusBadge httpStatus={row.original.httpStatus} />,
+  },
+  {
+    accessorKey: "contentLength",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Size</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {formatBytes(row.original.contentLength)}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "hasFullText",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Full Text</SortableHeader>
+    ),
+    cell: ({ row }) => <CoverageBadge has={row.original.hasFullText} />,
+  },
+  {
+    accessorKey: "hasPreview",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Preview</SortableHeader>
+    ),
+    cell: ({ row }) => <CoverageBadge has={row.original.hasPreview} />,
+  },
+];
+
+export function CitationContentTable({ data }: { data: ContentEntry[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      searchPlaceholder="Search URLs or titles..."
+      defaultSorting={[{ id: "fetchedAt", desc: true }]}
+      getRowClassName={(row) =>
+        row.original.httpStatus !== null && row.original.httpStatus >= 400
+          ? "bg-red-500/[0.03]"
+          : ""
+      }
+    />
+  );
+}

--- a/apps/web/src/app/internal/citation-content/page.tsx
+++ b/apps/web/src/app/internal/citation-content/page.tsx
@@ -1,0 +1,181 @@
+import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { CitationContentTable } from "./citation-content-table";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Citation Content | Longterm Wiki Internal",
+  description:
+    "Fetched citation content stored in PostgreSQL — coverage stats and URL inventory.",
+};
+
+export interface ContentEntry {
+  url: string;
+  fetchedAt: string;
+  httpStatus: number | null;
+  pageTitle: string | null;
+  contentLength: number | null;
+  hasFullText: boolean;
+  hasPreview: boolean;
+  updatedAt: string;
+}
+
+interface ApiListResult {
+  entries: ContentEntry[];
+  total: number;
+  withFullText: number;
+  withPreview: number;
+}
+
+interface ApiStatsResult {
+  total: number;
+  withFullText: number;
+  withPreview: number;
+  coverage: number;
+  okCount: number;
+  deadCount: number;
+  avgContentLength: number | null;
+}
+
+async function loadContentFromApi(): Promise<FetchResult<{ entries: ContentEntry[]; stats: ApiStatsResult }>> {
+  const [listResult, statsResult] = await Promise.all([
+    fetchDetailed<ApiListResult>("/api/citations/content/list?limit=500", {
+      revalidate: 120,
+    }),
+    fetchDetailed<ApiStatsResult>("/api/citations/content/stats", {
+      revalidate: 120,
+    }),
+  ]);
+
+  if (!listResult.ok) return { ok: false, error: listResult.error };
+
+  const stats: ApiStatsResult = statsResult.ok
+    ? statsResult.data
+    : {
+        total: listResult.data.total,
+        withFullText: listResult.data.withFullText,
+        withPreview: listResult.data.withPreview,
+        coverage:
+          listResult.data.total > 0
+            ? Math.round(
+                (listResult.data.withFullText / listResult.data.total) * 100
+              )
+            : 0,
+        okCount: 0,
+        deadCount: 0,
+        avgContentLength: null,
+      };
+
+  return {
+    ok: true,
+    data: {
+      entries: listResult.data.entries,
+      stats,
+    },
+  };
+}
+
+function emptyData() {
+  return {
+    entries: [] as ContentEntry[],
+    stats: {
+      total: 0,
+      withFullText: 0,
+      withPreview: 0,
+      coverage: 0,
+      okCount: 0,
+      deadCount: 0,
+      avgContentLength: null,
+    } as ApiStatsResult,
+  };
+}
+
+export default async function CitationContentPage() {
+  const { data, source, apiError } = await withApiFallback(
+    loadContentFromApi,
+    emptyData
+  );
+
+  const { entries, stats } = data ?? emptyData();
+
+  return (
+    <article className="prose max-w-none">
+      <h1>Citation Content</h1>
+      <p className="text-muted-foreground">
+        Full-text content fetched from citation URLs, stored durably in
+        PostgreSQL.{" "}
+        {stats.total > 0 ? (
+          <>
+            <span className="font-medium text-foreground">{stats.total}</span>{" "}
+            URLs stored,{" "}
+            <span className="font-medium text-foreground">
+              {stats.withFullText}
+            </span>{" "}
+            with full text ({stats.coverage}% coverage).
+            {stats.deadCount > 0 && (
+              <span className="text-red-500 font-medium ml-1">
+                {stats.deadCount} dead links.
+              </span>
+            )}
+          </>
+        ) : (
+          <>
+            No content stored yet. Run{" "}
+            <code className="text-xs">pnpm crux citations verify --all</code>{" "}
+            to populate.
+          </>
+        )}
+      </p>
+
+      {stats.total > 0 && (
+        <div className="not-prose grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+          <StatCard label="Total URLs" value={stats.total} />
+          <StatCard
+            label="Full Text"
+            value={`${stats.withFullText} (${stats.coverage}%)`}
+          />
+          <StatCard label="Live (2xx)" value={stats.okCount} />
+          <StatCard
+            label="Avg Size"
+            value={
+              stats.avgContentLength
+                ? `${Math.round(stats.avgContentLength / 1000)}KB`
+                : "—"
+            }
+          />
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+          <p className="text-lg font-medium mb-2">No citation content stored</p>
+          <p className="text-sm">
+            Citation content is stored automatically when citations are verified.
+            Run{" "}
+            <code className="text-xs">pnpm crux citations verify --all</code>{" "}
+            to populate.
+          </p>
+        </div>
+      ) : (
+        <CitationContentTable data={entries} />
+      )}
+
+      <DataSourceBanner source={source} apiError={apiError} />
+    </article>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-3">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-lg font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -345,6 +345,7 @@ export function getInternalNav(): NavSection[] {
         { label: "GitHub Issues", href: "/internal/github-issues" },
         { label: "Agent Sessions", href: "/internal/agent-sessions" },
         { label: "Citation Accuracy", href: "/internal/citation-accuracy" },
+        { label: "Citation Content", href: "/internal/citation-content" },
         { label: "Hallucination Risk", href: "/internal/hallucination-risk" },
         { label: "Job Queue", href: "/internal/jobs" },
       ],

--- a/apps/wiki-server/drizzle/0021_add_citation_content_full_text.sql
+++ b/apps/wiki-server/drizzle/0021_add_citation_content_full_text.sql
@@ -1,0 +1,9 @@
+-- Add full_text column to citation_content table.
+-- fullTextPreview (50KB) remains for fast access; full_text stores the complete fetched content
+-- for durable cross-environment reuse. source-fetcher.ts writes full_text after successful fetches
+-- and checks PostgreSQL before SQLite for cross-machine cache hits.
+
+ALTER TABLE "citation_content" ADD COLUMN "full_text" text;
+
+CREATE INDEX IF NOT EXISTS "idx_cc_fetched_at" ON "citation_content" ("fetched_at");
+CREATE INDEX IF NOT EXISTS "idx_cc_http_status" ON "citation_content" ("http_status");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1771901000000,
       "tag": "0020_add_agent_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1771901100000,
+      "tag": "0021_add_citation_content_full_text",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -123,6 +123,26 @@ export const MarkAccuracyBatchSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Citation Content
+// ---------------------------------------------------------------------------
+
+/** Maximum size for the full-text preview field (50 KB). */
+export const CITATION_CONTENT_PREVIEW_MAX = 50 * 1024;
+
+export const UpsertCitationContentSchema = z.object({
+  url: z.string().min(1).max(2000),
+  fetchedAt: z.string().datetime(),
+  httpStatus: z.number().int().nullable().optional(),
+  contentType: z.string().max(200).nullable().optional(),
+  pageTitle: z.string().max(1000).nullable().optional(),
+  fullTextPreview: z.string().max(CITATION_CONTENT_PREVIEW_MAX).nullable().optional(),
+  fullText: z.string().nullable().optional(),
+  contentLength: z.number().int().nullable().optional(),
+  contentHash: z.string().max(64).nullable().optional(),
+});
+export type UpsertCitationContent = z.infer<typeof UpsertCitationContentSchema>;
+
+// ---------------------------------------------------------------------------
 // Sessions
 // ---------------------------------------------------------------------------
 

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -15,6 +15,8 @@ import {
   UpsertCitationQuoteBatchSchema,
   MarkAccuracySchema as SharedMarkAccuracySchema,
   MarkAccuracyBatchSchema as SharedMarkAccuracyBatchSchema,
+  UpsertCitationContentSchema,
+  CITATION_CONTENT_PREVIEW_MAX,
 } from "../api-types.js";
 
 export const citationsRoute = new Hono();
@@ -23,7 +25,6 @@ export const citationsRoute = new Hono();
 
 const BROKEN_SCORE_THRESHOLD = 0.5;
 const MAX_PAGE_SIZE = 1000;
-const MAX_PREVIEW_LENGTH = 50 * 1024; // 50KB
 
 // ---- Schemas (from shared api-types) ----
 
@@ -42,16 +43,7 @@ const MarkVerifiedSchema = z.object({
 const MarkAccuracySchema = SharedMarkAccuracySchema;
 const MarkAccuracyBatchSchema = SharedMarkAccuracyBatchSchema;
 
-const UpsertContentSchema = z.object({
-  url: z.string().min(1).max(2000),
-  fetchedAt: z.string().datetime(),
-  httpStatus: z.number().int().nullable().optional(),
-  contentType: z.string().max(200).nullable().optional(),
-  pageTitle: z.string().max(1000).nullable().optional(),
-  fullTextPreview: z.string().max(MAX_PREVIEW_LENGTH).nullable().optional(),
-  contentLength: z.number().int().nullable().optional(),
-  contentHash: z.string().max(64).nullable().optional(),
-});
+const UpsertContentSchema = UpsertCitationContentSchema;
 
 const PaginationQuery = z.object({
   limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
@@ -425,7 +417,8 @@ citationsRoute.post("/content/upsert", async (c) => {
     httpStatus: d.httpStatus ?? null,
     contentType: d.contentType ?? null,
     pageTitle: d.pageTitle ?? null,
-    fullTextPreview: d.fullTextPreview ?? null,
+    fullTextPreview: d.fullTextPreview ?? (d.fullText ? d.fullText.slice(0, CITATION_CONTENT_PREVIEW_MAX) : null),
+    fullText: d.fullText ?? null,
     contentLength: d.contentLength ?? null,
     contentHash: d.contentHash ?? null,
   };
@@ -793,4 +786,78 @@ citationsRoute.get("/content", async (c) => {
   }
 
   return c.json(rows[0]);
+});
+
+// ---- GET /content/list (paginated, metadata only — no full_text) ----
+
+citationsRoute.get("/content/list", async (c) => {
+  const parsed = PaginationQuery.safeParse(c.req.query());
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { limit, offset } = parsed.data;
+  const db = getDrizzleDb();
+
+  const rows = await db
+    .select({
+      url: citationContent.url,
+      fetchedAt: citationContent.fetchedAt,
+      httpStatus: citationContent.httpStatus,
+      contentType: citationContent.contentType,
+      pageTitle: citationContent.pageTitle,
+      contentLength: citationContent.contentLength,
+      contentHash: citationContent.contentHash,
+      hasFullText: sql<boolean>`(${citationContent.fullText} IS NOT NULL)`,
+      hasPreview: sql<boolean>`(${citationContent.fullTextPreview} IS NOT NULL)`,
+      createdAt: citationContent.createdAt,
+      updatedAt: citationContent.updatedAt,
+    })
+    .from(citationContent)
+    .orderBy(desc(citationContent.fetchedAt))
+    .limit(limit)
+    .offset(offset);
+
+  const countResult = await db.select({ total: count() }).from(citationContent);
+  const withFullTextResult = await db
+    .select({ withFullText: count() })
+    .from(citationContent)
+    .where(isNotNull(citationContent.fullText));
+  const withPreviewResult = await db
+    .select({ withPreview: count() })
+    .from(citationContent)
+    .where(isNotNull(citationContent.fullTextPreview));
+
+  return c.json({
+    entries: rows,
+    total: countResult[0].total,
+    withFullText: withFullTextResult[0].withFullText,
+    withPreview: withPreviewResult[0].withPreview,
+    limit,
+    offset,
+  });
+});
+
+// ---- GET /content/stats ----
+
+citationsRoute.get("/content/stats", async (c) => {
+  const db = getDrizzleDb();
+
+  const rows = await db.select({
+    total: count(),
+    withFullText: sql<number>`count(case when ${citationContent.fullText} is not null then 1 end)`,
+    withPreview: sql<number>`count(case when ${citationContent.fullTextPreview} is not null then 1 end)`,
+    okCount: sql<number>`count(case when ${citationContent.httpStatus} = 200 then 1 end)`,
+    deadCount: sql<number>`count(case when ${citationContent.httpStatus} >= 400 then 1 end)`,
+    avgContentLength: avg(citationContent.contentLength),
+  }).from(citationContent);
+
+  const r = rows[0];
+  return c.json({
+    total: r.total,
+    withFullText: Number(r.withFullText),
+    withPreview: Number(r.withPreview),
+    coverage: r.total > 0 ? Math.round((Number(r.withFullText) / r.total) * 100) : 0,
+    okCount: Number(r.okCount),
+    deadCount: Number(r.deadCount),
+    avgContentLength: r.avgContentLength != null ? Math.round(Number(r.avgContentLength)) : null,
+  });
 });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -113,22 +113,30 @@ export const wikiPages = pgTable(
   ]
 );
 
-export const citationContent = pgTable("citation_content", {
-  url: text("url").primaryKey(),
-  fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),
-  httpStatus: integer("http_status"),
-  contentType: text("content_type"),
-  pageTitle: text("page_title"),
-  fullTextPreview: text("full_text_preview"),
-  contentLength: integer("content_length"),
-  contentHash: text("content_hash"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-});
+export const citationContent = pgTable(
+  "citation_content",
+  {
+    url: text("url").primaryKey(),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),
+    httpStatus: integer("http_status"),
+    contentType: text("content_type"),
+    pageTitle: text("page_title"),
+    fullTextPreview: text("full_text_preview"),
+    fullText: text("full_text"),
+    contentLength: integer("content_length"),
+    contentHash: text("content_hash"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cc_fetched_at").on(table.fetchedAt),
+    index("idx_cc_http_status").on(table.httpStatus),
+  ]
+);
 
 export const citationAccuracySnapshots = pgTable(
   "citation_accuracy_snapshots",

--- a/crux/lib/source-fetcher.ts
+++ b/crux/lib/source-fetcher.ts
@@ -11,7 +11,8 @@
  *
  * Caching strategy:
  *   - In-memory Map for session-level deduplication (cleared on process exit)
- *   - SQLite citation_content table for cross-session persistence
+ *   - PostgreSQL (wiki-server) citation_content.full_text — durable cross-machine cache
+ *   - SQLite citation_content table — fast local fallback
  *
  * Usage:
  *   import { fetchSource, fetchSources, extractRelevantExcerpts } from './source-fetcher.ts';
@@ -27,6 +28,10 @@
 
 import { getApiKey } from './api-keys.ts';
 import { citationContent } from './knowledge-db.ts';
+import {
+  upsertCitationContent,
+  getCitationContentByUrl,
+} from './wiki-server/citations.ts';
 import {
   getResourceById,
   getResourceByUrl,
@@ -422,6 +427,49 @@ function saveToDb(url: string, title: string, content: string, httpStatus: numbe
 }
 
 // ---------------------------------------------------------------------------
+// PostgreSQL cross-machine cache helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to load a previously fetched result from PostgreSQL (wiki-server).
+ * Returns null if the server is unavailable or the URL has not been cached.
+ */
+async function loadFromPostgres(url: string): Promise<Pick<FetchedSource, 'title' | 'content' | 'fetchedAt'> | null> {
+  try {
+    const result = await getCitationContentByUrl(url);
+    if (result.ok && result.data.fullText && result.data.fullText.length > 0) {
+      return {
+        title: result.data.pageTitle ?? '',
+        content: result.data.fullText,
+        fetchedAt: result.data.fetchedAt ?? new Date().toISOString(),
+      };
+    }
+  } catch {
+    // Server unavailable — fall through
+  }
+  return null;
+}
+
+/**
+ * Fire-and-forget write of fetched content to PostgreSQL.
+ * Errors are silently ignored — PostgreSQL is a durable secondary store,
+ * not a hard dependency.
+ */
+function saveToPostgres(url: string, title: string, content: string, httpStatus: number): void {
+  upsertCitationContent({
+    url,
+    fetchedAt: new Date().toISOString(),
+    httpStatus,
+    contentType: 'text/html',
+    pageTitle: title || null,
+    fullText: content,
+    contentLength: content.length,
+  }).catch(() => {
+    // Best-effort — don't fail if server unavailable
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Resource resolution
 // ---------------------------------------------------------------------------
 
@@ -494,7 +542,29 @@ async function _fetchSourceCore(
     return result;
   }
 
-  // ---- 2. SQLite cross-session cache ----
+  // ---- 2. PostgreSQL cross-machine cache (async, durable source of truth) ----
+  const pgRow = await loadFromPostgres(url);
+  if (pgRow) {
+    const excerpts = extractMode === 'relevant' && query
+      ? extractRelevantExcerpts(pgRow.content, query)
+      : [];
+    const paywall = detectPaywall(pgRow.content);
+    const result: FetchedSource = {
+      url,
+      title: pgRow.title || resource?.title || '',
+      fetchedAt: pgRow.fetchedAt,
+      content: pgRow.content,
+      relevantExcerpts: excerpts,
+      status: paywall ? 'paywall' : 'ok',
+      resource: resourceMeta,
+    };
+    // Backfill SQLite so subsequent calls are served from the fast local cache
+    saveToDb(url, pgRow.title, pgRow.content, 200);
+    sessionCacheSet(url, result);
+    return result;
+  }
+
+  // ---- 3. SQLite local cache (fast fallback when PostgreSQL is unavailable) ----
   const dbRow = loadFromDb(url);
   if (dbRow) {
     const excerpts = extractMode === 'relevant' && query
@@ -514,7 +584,7 @@ async function _fetchSourceCore(
     return result;
   }
 
-  // ---- 3. Network fetch (Firecrawl → built-in fallback) ----
+  // ---- 4. Network fetch (Firecrawl → built-in fallback) ----
   let title = '';
   let content = '';
   let httpStatus = 0;
@@ -549,9 +619,10 @@ async function _fetchSourceCore(
     status = 'ok'; // PDF or non-HTML with 200 status
   }
 
-  // ---- 5. Persist to SQLite ----
+  // ---- 5. Persist to SQLite (fast local cache) and PostgreSQL (durable source of truth) ----
   if (content.length > 0) {
     saveToDb(url, title, content, httpStatus);
+    saveToPostgres(url, title, content, httpStatus);
   }
 
   // ---- 6. Extract excerpts ----
@@ -571,6 +642,7 @@ async function _fetchSourceCore(
   sessionCacheSet(url, result);
 
   // ---- 9. Reflect status back to resource YAML (if requested) ----
+
   if (request.updateResourceStatus && resource) {
     try {
       updateResourceFetchStatus(resource.id, {
@@ -592,8 +664,12 @@ async function _fetchSourceCore(
  * Caching layers:
  *   1. In-memory session cache (fastest, LRU-evicted at 500 entries)
  *   2. In-flight dedup (concurrent requests for same URL share one fetch)
- *   3. SQLite cross-session cache
- *   4. Network fetch (Firecrawl preferred, built-in fallback)
+ *   3. PostgreSQL (wiki-server) — durable cross-machine source of truth
+ *   4. SQLite — fast local fallback (used when PostgreSQL is unavailable)
+ *   5. Network fetch (Firecrawl preferred, built-in fallback)
+ *
+ * Writes: successful network fetches are stored in both SQLite (fast local cache)
+ * and PostgreSQL (durable, fire-and-forget).
  */
 export async function fetchSource(request: FetchRequest): Promise<FetchedSource> {
   const { extractMode, query } = request;

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -9,6 +9,7 @@ import type {
   UpsertCitationQuote,
   AccuracyVerdict as AccuracyVerdictType,
   MarkAccuracy,
+  UpsertCitationContent,
 } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -148,5 +149,87 @@ export async function createAccuracySnapshot(): Promise<ApiResult<SnapshotResult
 
 export async function getAccuracyDashboard(): Promise<ApiResult<AccuracyDashboardData>> {
   return apiRequest<AccuracyDashboardData>('GET', '/api/citations/accuracy-dashboard');
+}
+
+// ---------------------------------------------------------------------------
+// Citation Content API functions
+// ---------------------------------------------------------------------------
+
+export type UpsertCitationContentInput = UpsertCitationContent;
+
+export interface CitationContentRow {
+  url: string;
+  fetchedAt: string;
+  httpStatus: number | null;
+  contentType: string | null;
+  pageTitle: string | null;
+  fullTextPreview: string | null;
+  fullText: string | null;
+  contentLength: number | null;
+  contentHash: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CitationContentListEntry {
+  url: string;
+  fetchedAt: string;
+  httpStatus: number | null;
+  contentType: string | null;
+  pageTitle: string | null;
+  contentLength: number | null;
+  contentHash: string | null;
+  hasFullText: boolean;
+  hasPreview: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CitationContentListResult {
+  entries: CitationContentListEntry[];
+  total: number;
+  withFullText: number;
+  withPreview: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CitationContentStatsResult {
+  total: number;
+  withFullText: number;
+  withPreview: number;
+  coverage: number;
+  okCount: number;
+  deadCount: number;
+  avgContentLength: number | null;
+}
+
+export async function upsertCitationContent(
+  item: UpsertCitationContentInput,
+): Promise<ApiResult<{ url: string }>> {
+  return apiRequest<{ url: string }>('POST', '/api/citations/content/upsert', item);
+}
+
+export async function getCitationContentByUrl(
+  url: string,
+): Promise<ApiResult<CitationContentRow>> {
+  return apiRequest<CitationContentRow>(
+    'GET',
+    `/api/citations/content?url=${encodeURIComponent(url)}`,
+  );
+}
+
+export async function listCitationContent(
+  limit = 100,
+  offset = 0,
+): Promise<ApiResult<CitationContentListResult>> {
+  return apiRequest<CitationContentListResult>(
+    'GET',
+    `/api/citations/content/list?limit=${limit}&offset=${offset}`,
+  );
+}
+
+export async function getCitationContentStats(): Promise<ApiResult<CitationContentStatsResult>> {
+  return apiRequest<CitationContentStatsResult>('GET', '/api/citations/content/stats');
 }
 


### PR DESCRIPTION
## Summary

- PostgreSQL migration (0021_add_citation_content_full_text.sql): adds full_text column to citation_content table plus indexes on fetched_at and http_status
- source-fetcher cache hierarchy: PostgreSQL is now checked before SQLite (durable cross-machine source of truth); SQLite is fast local fallback; successful network fetches write to both stores (fire-and-forget)
- wiki-server: UpsertCitationContentSchema promoted to shared api-types.ts; POST /content/upsert accepts full_text; new GET /content/list and GET /content/stats endpoints added
- crux client: new upsertCitationContent, getCitationContentByUrl, listCitationContent, getCitationContentStats functions
- dashboard (/internal/citation-content): shows URL inventory, fetch status badges, full-text coverage stats, content sizes; added to internal sidebar nav
- 6 new tests: PG write path, PG cache hits, SQLite fallback when PG unavailable, SQLite backfill from PG, excerpt extraction from PG-cached content, no write on dead links

Cache hierarchy: session cache -> PostgreSQL -> SQLite -> network fetch

## Test plan

- [x] vitest run crux/lib/source-fetcher.test.ts -- 53 tests pass
- [x] pnpm crux validate gate --full -- all 6 gate checks pass including full Next.js build
- [ ] Verify /internal/citation-content renders correctly once deployed
- [ ] Confirm pnpm crux citations verify populates full_text in wiki-server DB

Closes #647

https://claude.ai/code/session_01Du4QyT9mVW2N2nPe2VFBRs