### PR TITLE
feat: wire writing modules into improve pipeline (#668, #669)

### DIFF
--- a/crux/authoring/page-improver/index.ts
+++ b/crux/authoring/page-improver/index.ts
@@ -107,6 +107,7 @@ Options:
   --apply                         Apply changes directly (don't just preview)
   --no-grade                      Skip auto-grading after apply (grading runs by default)
   --skip-session-log              Skip auto-posting session log to wiki-server after apply
+  --skip-enrich                   Skip post-improve enrichment (entity-links, fact-refs)
   --triage                        Run news-check triage only (no improvement)
   --list                          List pages needing improvement
   --limit N                       Limit list results (default: 20)
@@ -171,6 +172,7 @@ Examples:
       ? parseInt(opts['max-adversarial-iterations'] as string, 10)
       : undefined,
     skipSessionLog: opts['skip-session-log'] === true ? true : undefined,
+    skipEnrich: opts['skip-enrich'] === true ? true : undefined,
   });
 }
 

--- a/crux/authoring/page-improver/phases.ts
+++ b/crux/authoring/page-improver/phases.ts
@@ -12,6 +12,7 @@
  *   phases/validate.ts             — In-process validation + auto-fixes
  *   phases/gap-fill.ts             — Fix remaining issues from review
  *   phases/triage.ts               — News-based tier auto-selection
+ *   phases/enrich.ts               — Post-improve enrichment (entity-links, fact-refs)
  *   phases/adversarial-review.ts   — Adversarial reviewer (fact density, speculation, gaps)
  *   phases/adversarial-loop.ts     — Re-research feedback loop driven by adversarial review
  */
@@ -20,6 +21,7 @@ export {
   analyzePhase,
   researchPhase,
   improvePhase,
+  enrichPhase,
   reviewPhase,
   validatePhase,
   gapFillPhase,

--- a/crux/authoring/page-improver/phases/enrich.ts
+++ b/crux/authoring/page-improver/phases/enrich.ts
@@ -1,0 +1,57 @@
+/**
+ * Enrich Phase
+ *
+ * Runs standalone enrichment tools (entity-links, fact-refs) as post-processing
+ * after the improve phase. These are cheap (Haiku), idempotent operations that
+ * normalize EntityLink and fact-ref coverage across all pipeline runs.
+ *
+ * See issue #669.
+ */
+
+import { enrichEntityLinks } from '../../../enrich/enrich-entity-links.ts';
+import { enrichFactRefs } from '../../../enrich/enrich-fact-refs.ts';
+import type { PageData, EnrichResult, PipelineOptions } from '../types.ts';
+import { ROOT, log, writeTemp } from '../utils.ts';
+
+export async function enrichPhase(
+  page: PageData,
+  content: string,
+  _options: PipelineOptions,
+): Promise<{ content: string; result: EnrichResult }> {
+  log('enrich', 'Starting post-improve enrichment');
+
+  let enrichedContent = content;
+
+  // Step 1: Entity-link enrichment
+  log('enrich', 'Running entity-link enrichment...');
+  const entityLinkResult = await enrichEntityLinks(enrichedContent, { root: ROOT });
+  enrichedContent = entityLinkResult.content;
+  if (entityLinkResult.insertedCount > 0) {
+    log('enrich', `  Added ${entityLinkResult.insertedCount} EntityLink(s)`);
+  } else {
+    log('enrich', '  No new EntityLinks needed');
+  }
+
+  // Step 2: Fact-ref enrichment
+  log('enrich', 'Running fact-ref enrichment...');
+  const factRefResult = await enrichFactRefs(enrichedContent, { pageId: page.id, root: ROOT });
+  enrichedContent = factRefResult.content;
+  if (factRefResult.insertedCount > 0) {
+    log('enrich', `  Added ${factRefResult.insertedCount} fact-ref(s)`);
+  } else {
+    log('enrich', '  No new fact-refs needed');
+  }
+
+  writeTemp(page.id, 'enriched.mdx', enrichedContent);
+
+  const result: EnrichResult = {
+    entityLinks: { insertedCount: entityLinkResult.insertedCount },
+    factRefs: { insertedCount: factRefResult.insertedCount },
+  };
+  writeTemp(page.id, 'enrich-result.json', result);
+
+  const totalAdded = entityLinkResult.insertedCount + factRefResult.insertedCount;
+  log('enrich', `Complete (${totalAdded} total enrichments added)`);
+
+  return { content: enrichedContent, result };
+}

--- a/crux/authoring/page-improver/phases/index.ts
+++ b/crux/authoring/page-improver/phases/index.ts
@@ -8,6 +8,7 @@
 export { analyzePhase } from './analyze.ts';
 export { researchPhase } from './research.ts';
 export { improvePhase } from './improve.ts';
+export { enrichPhase } from './enrich.ts';
 export { reviewPhase } from './review.ts';
 export { validatePhase } from './validate.ts';
 export { gapFillPhase } from './gap-fill.ts';

--- a/crux/authoring/page-improver/phases/research.test.ts
+++ b/crux/authoring/page-improver/phases/research.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the source cache adapter (buildSourceCache).
+ *
+ * Tests the conversion from research sources + fetched content → SourceCacheEntry[].
+ * All tests are offline — no network calls.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSourceCache } from './research.ts';
+import type { FetchedSource } from '../../../lib/source-fetcher.ts';
+
+function makeFetchedSource(overrides: Partial<FetchedSource> = {}): FetchedSource {
+  return {
+    url: 'https://example.com/article',
+    title: 'Example Article',
+    fetchedAt: '2026-02-22T12:00:00Z',
+    content: 'This is the full content of the article. It has enough characters to pass the threshold easily.',
+    relevantExcerpts: [],
+    status: 'ok',
+    ...overrides,
+  };
+}
+
+describe('buildSourceCache', () => {
+  it('converts research sources with fetched content into SourceCacheEntry[]', () => {
+    const researchSources = [
+      { topic: 'funding', title: 'Funding Article', url: 'https://example.com/a', author: 'Alice', date: '2025-01-15', facts: ['Raised $100M'], relevance: 'high' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/a', title: 'Funding Article (fetched)', content: 'Full article about raising $100M in Series B funding.' }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache).toHaveLength(1);
+    expect(cache[0].id).toBe('SRC-1');
+    expect(cache[0].url).toBe('https://example.com/a');
+    expect(cache[0].title).toBe('Funding Article (fetched)'); // prefers fetched title
+    expect(cache[0].author).toBe('Alice');
+    expect(cache[0].date).toBe('2025-01-15');
+    expect(cache[0].content).toContain('$100M');
+    expect(cache[0].facts).toEqual(['Raised $100M']);
+  });
+
+  it('uses relevant excerpts when available instead of raw content', () => {
+    const researchSources = [
+      { topic: 'safety', title: 'Safety Report', url: 'https://example.com/b', facts: [], relevance: 'high' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({
+        url: 'https://example.com/b',
+        content: 'Very long article content that is definitely long enough to pass the threshold check for minimum content length.',
+        relevantExcerpts: ['Key safety finding: RSPs are effective', 'Second excerpt about evals'],
+      }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache[0].content).toContain('Key safety finding');
+    expect(cache[0].content).toContain('Second excerpt about evals');
+    expect(cache[0].content).toContain('---'); // separator between excerpts
+  });
+
+  it('falls back to LLM-extracted facts when source is dead', () => {
+    const researchSources = [
+      { topic: 'history', title: 'Dead Link', url: 'https://example.com/dead', facts: ['Founded in 2020', 'Grew to 500 employees'], relevance: 'medium' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/dead', content: '', status: 'dead' }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache[0].content).toBe('Founded in 2020\nGrew to 500 employees');
+    expect(cache[0].facts).toEqual(['Founded in 2020', 'Grew to 500 employees']);
+  });
+
+  it('falls back to facts when source is paywalled', () => {
+    const researchSources = [
+      { topic: 'revenue', title: 'Paywalled', url: 'https://example.com/paywall', facts: ['Revenue of $2B'], relevance: 'high' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/paywall', content: 'Subscribe to read more', status: 'paywall' }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache[0].content).toBe('Revenue of $2B');
+  });
+
+  it('falls back to facts when fetched content is too short', () => {
+    const researchSources = [
+      { topic: 'test', title: 'Short Page', url: 'https://example.com/short', facts: ['Key fact'], relevance: 'low' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/short', content: 'Too short', status: 'ok' }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache[0].content).toBe('Key fact');
+  });
+
+  it('skips sources without URLs', () => {
+    const researchSources = [
+      { topic: 'general', title: 'No URL', url: '', facts: ['Some fact'], relevance: 'low' },
+    ];
+
+    const cache = buildSourceCache(researchSources, []);
+    expect(cache).toHaveLength(0);
+  });
+
+  it('handles multiple sources with sequential IDs', () => {
+    const researchSources = [
+      { topic: 'a', title: 'First', url: 'https://example.com/1', facts: ['Fact 1'], relevance: 'high' },
+      { topic: 'b', title: 'Second', url: 'https://example.com/2', facts: ['Fact 2'], relevance: 'high' },
+      { topic: 'c', title: 'Third', url: 'https://example.com/3', facts: ['Fact 3'], relevance: 'medium' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/1' }),
+      makeFetchedSource({ url: 'https://example.com/2' }),
+      makeFetchedSource({ url: 'https://example.com/3' }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache).toHaveLength(3);
+    expect(cache[0].id).toBe('SRC-1');
+    expect(cache[1].id).toBe('SRC-2');
+    expect(cache[2].id).toBe('SRC-3');
+  });
+
+  it('handles sources with no fetched match (URL not found)', () => {
+    const researchSources = [
+      { topic: 'test', title: 'Unfetched', url: 'https://example.com/unfetched', facts: ['Fallback fact'], relevance: 'high' },
+    ];
+
+    const cache = buildSourceCache(researchSources, []);
+    expect(cache).toHaveLength(1);
+    expect(cache[0].content).toBe('Fallback fact');
+    expect(cache[0].title).toBe('Unfetched'); // falls back to research title
+  });
+
+  it('truncates long content to 5000 chars', () => {
+    const longContent = 'A'.repeat(10_000);
+    const researchSources = [
+      { topic: 'test', title: 'Long', url: 'https://example.com/long', facts: [], relevance: 'high' },
+    ];
+    const fetched: FetchedSource[] = [
+      makeFetchedSource({ url: 'https://example.com/long', content: longContent }),
+    ];
+
+    const cache = buildSourceCache(researchSources, fetched);
+    expect(cache[0].content.length).toBe(5000);
+  });
+});

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -2,6 +2,8 @@
  * Types for the page-improver pipeline.
  */
 
+import type { SourceCacheEntry } from '../../lib/section-writer.ts';
+
 export interface TierConfig {
   name: string;
   cost: string;
@@ -52,6 +54,8 @@ export interface ResearchResult {
   summary?: string;
   raw?: string;
   error?: string;
+  /** Grounded source cache built by fetching URLs via source-fetcher (#668). */
+  sourceCache?: SourceCacheEntry[];
 }
 
 export interface ReviewResult {
@@ -108,6 +112,13 @@ export interface PipelineOptions {
    * Use this when the caller (e.g. auto-update batch) wants to write its own aggregate log.
    */
   skipSessionLog?: boolean;
+  /** When true, skip post-improve enrichment (entity-links + fact-refs). */
+  skipEnrich?: boolean;
+}
+
+export interface EnrichResult {
+  entityLinks: { insertedCount: number };
+  factRefs: { insertedCount: number };
 }
 
 export interface PipelineResults {
@@ -120,6 +131,8 @@ export interface PipelineResults {
   review: ReviewResult | undefined;
   /** Set when the deep tier's adversarial-loop phase ran. */
   adversarialLoopResult?: AdversarialLoopResult;
+  /** Set when the enrich phase ran. */
+  enrichResult?: EnrichResult;
   outputPath: string;
 }
 

--- a/crux/authoring/page-improver/utils.ts
+++ b/crux/authoring/page-improver/utils.ts
@@ -57,19 +57,19 @@ export const TIERS: Record<string, TierConfig> = {
   polish: {
     name: 'Polish',
     cost: '$2-3',
-    phases: ['analyze', 'improve', 'validate'],
+    phases: ['analyze', 'improve', 'enrich', 'validate'],
     description: 'Quick single-pass improvement without research'
   },
   standard: {
     name: 'Standard',
     cost: '$5-8',
-    phases: ['analyze', 'research', 'improve', 'validate', 'review'],
+    phases: ['analyze', 'research', 'improve', 'enrich', 'validate', 'review'],
     description: 'Light research + improvement + validation + review'
   },
   deep: {
     name: 'Deep Research',
     cost: '$15-25',
-    phases: ['analyze', 'research-deep', 'improve', 'validate', 'adversarial-loop', 'review', 'gap-fill'],
+    phases: ['analyze', 'research-deep', 'improve', 'enrich', 'validate', 'adversarial-loop', 'review', 'gap-fill'],
     description: 'Full SCRY + web research, adversarial review + re-research loop, multi-phase improvement'
   }
 };

--- a/crux/commands/content.ts
+++ b/crux/commands/content.ts
@@ -14,7 +14,7 @@ const SCRIPTS: Record<string, ScriptConfig> = {
   improve: {
     script: 'authoring/page-improver/index.ts',
     description: 'Improve an existing page with AI assistance',
-    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log'],
+    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log', 'skip-enrich'],
     positional: true,
   },
   create: {


### PR DESCRIPTION
## Summary

- **Post-improve enrichment phase (#669)**: Runs enrichEntityLinks() + enrichFactRefs() as idempotent post-processing after the improve phase, before validation. Added to all tiers (polish, standard, deep). Skippable via --skip-enrich. These are cheap Haiku calls that normalize EntityLink and fact-ref coverage across all pipeline runs.

- **Source-fetcher in research phase (#668)**: After the LLM discovers source URLs via web/SCRY search, pipes them through fetchSources() to build a grounded SourceCacheEntry[]. Includes buildSourceCache() adapter with 9 tests covering conversion, dead/paywall fallbacks, and content truncation. The source cache is stored on ResearchResult.sourceCache for downstream modules (section-writer, citation-auditor).

- **Created 4 tracking issues** for the full writing architecture integration roadmap:
  - #668 Wire source-fetcher into research phase (implemented here)
  - #669 Post-improve enrichment (implemented here)
  - #670 Post-improve citation audit (advisory) -- future
  - #671 Section splitter + per-section rewriting -- future

## Pipeline flow change

Before: analyze -> research -> improve -> validate -> review

After: analyze -> research -> [fetch sources] -> improve -> enrich -> validate -> review

## Test plan

- [x] 9 unit tests for buildSourceCache() adapter (all passing)
- [x] All 6 gate checks pass (236 app tests, schema, MDX, frontmatter, TypeScript, returning guard)
- [ ] Run improve pipeline on a test page to verify enrichment phase works end-to-end

Closes #669
Closes #668

https://claude.ai/code/session_01A6DrkKZ2v3ENaPfMe2nMUj