### PR TITLE
feat: research agent - multi-source search to SourceCacheEntry[]

### DIFF
--- a/crux/commands/research.ts
+++ b/crux/commands/research.ts
@@ -1,0 +1,166 @@
+/**
+ * Research Command Handlers
+ *
+ * Runs multi-source research for a topic, producing SourceCacheEntry[] for
+ * the section-writer pipeline. Uses Exa, Perplexity/Sonar, and SCRY with
+ * graceful degradation when keys are missing.
+ *
+ * Usage:
+ *   crux research "Anthropic constitutional AI"
+ *   crux research "MIRI funding" --for-page=miri
+ *   crux research "deceptive alignment" --no-exa --no-scry
+ *   crux research "AI safety" --budget=2.00 --json
+ *
+ * See issue #684.
+ */
+
+import { type CommandResult } from '../lib/cli.ts';
+import { createLogger } from '../lib/output.ts';
+import { runResearch } from '../lib/research-agent.ts';
+import type { ResearchRequest } from '../lib/research-agent.ts';
+
+// ---------------------------------------------------------------------------
+// run — default command: research a topic and print structured results
+// ---------------------------------------------------------------------------
+
+export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
+  const log = createLogger(options.ci as boolean);
+  const c = log.colors;
+
+  // Topic is all positional args joined
+  const topic = args.filter(a => !a.startsWith('-')).join(' ').trim();
+  if (!topic) {
+    return {
+      output: `${c.red}Error: topic required.\n\nUsage:\n  crux research "your topic"\n  crux research "topic" --for-page=<page-id>${c.reset}`,
+      exitCode: 1,
+    };
+  }
+
+  // --for-page: optional page ID to focus the query
+  const forPage = options.forPage as string | undefined;
+
+  // --budget: max spend in USD (default 5.00)
+  const budgetCap = options.budget !== undefined ? parseFloat(options.budget as string) : 5.0;
+  if (isNaN(budgetCap) || budgetCap <= 0) {
+    return {
+      output: `${c.red}Error: --budget must be a positive number (e.g. --budget=3.00)${c.reset}`,
+      exitCode: 1,
+    };
+  }
+
+  // Source toggles
+  const useExa = options.noExa ? false : undefined;       // undefined = auto (key present)
+  const usePerplexity = options.noPerplexity ? false : undefined;
+  const useScry = options.noScry ? false : undefined;
+
+  // --max-results: URLs per search source (default 8)
+  const maxResultsPerSource = options.maxResults !== undefined
+    ? parseInt(options.maxResults as string, 10) : undefined;
+
+  // --max-urls: total URLs to fetch (default 20)
+  const maxUrlsToFetch = options.maxUrls !== undefined
+    ? parseInt(options.maxUrls as string, 10) : undefined;
+
+  // --no-facts: skip Haiku fact extraction
+  const extractFacts = options.noFacts ? false : undefined;
+
+  const request: ResearchRequest = {
+    topic,
+    pageContext: forPage ? { title: forPage, type: 'page', entityId: forPage } : undefined,
+    config: {
+      ...(useExa !== undefined && { useExa }),
+      ...(usePerplexity !== undefined && { usePerplexity }),
+      ...(useScry !== undefined && { useScry }),
+      ...(maxResultsPerSource !== undefined && { maxResultsPerSource }),
+      ...(maxUrlsToFetch !== undefined && { maxUrlsToFetch }),
+      ...(extractFacts !== undefined && { extractFacts }),
+    },
+    budgetCap,
+  };
+
+  log.info(`Researching: "${topic}"`);
+  if (forPage) log.info(`  Page context: ${forPage}`);
+
+  let result;
+  try {
+    result = await runResearch(request);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      output: `${c.red}Error running research: ${msg}${c.reset}`,
+      exitCode: 1,
+    };
+  }
+
+  const { sources, metadata } = result;
+
+  if (options.json || options.ci) {
+    return { output: JSON.stringify(result, null, 2), exitCode: 0 };
+  }
+
+  // Human-readable output
+  let output = `\n${c.bold}${c.blue}Research: "${topic}"${c.reset}\n`;
+  output += `${c.dim}Searched: ${metadata.sourcesSearched.join(', ') || 'none'} | `;
+  output += `${metadata.urlsFetched} URL${metadata.urlsFetched !== 1 ? 's' : ''} fetched`;
+  if (metadata.urlsDeduplicated > 0) output += ` (${metadata.urlsDeduplicated} deduplicated)`;
+  output += ` | $${metadata.totalCost.toFixed(4)} | ${Math.round(metadata.durationMs / 1000)}s${c.reset}\n\n`;
+
+  if (sources.length === 0) {
+    output += `${c.yellow}No sources found. Check API keys or try a different topic.${c.reset}\n`;
+    return { output, exitCode: 0 };
+  }
+
+  for (const src of sources) {
+    output += `${c.bold}[${src.id}] ${src.title}${c.reset}\n`;
+    output += `${c.dim}${src.url}${c.reset}\n`;
+    if (src.facts && src.facts.length > 0) {
+      output += `${c.green}Key facts:${c.reset}\n`;
+      for (const fact of src.facts) {
+        output += `  • ${fact}\n`;
+      }
+    } else if (src.content) {
+      const snippet = src.content.slice(0, 200).replace(/\n+/g, ' ');
+      output += `${c.dim}${snippet}${snippet.length < src.content.length ? '…' : ''}${c.reset}\n`;
+    }
+    output += '\n';
+  }
+
+  output += `${c.dim}Cost breakdown: search $${metadata.costBreakdown.searchCost.toFixed(4)}, facts $${metadata.costBreakdown.factExtractionCost.toFixed(4)}${c.reset}\n`;
+
+  return { output, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+export function help(): CommandResult {
+  return {
+    output: `
+Research Command — multi-source search to structured SourceCacheEntry[]
+
+Usage:
+  crux research <topic>                          Research a topic
+  crux research <topic> --for-page=<page-id>     Focus using page context
+  crux research <topic> --json                   Machine-readable JSON output
+
+Options:
+  --for-page=<id>      Page entity ID to focus the research query
+  --budget=<usd>       Max spend in USD (default: 5.00)
+  --max-results=<n>    Max URLs per search provider (default: 8)
+  --max-urls=<n>       Max URLs to fetch in total (default: 20)
+  --no-exa             Skip Exa web search
+  --no-perplexity      Skip Perplexity (OpenRouter)
+  --no-scry            Skip SCRY (EA Forum / LessWrong)
+  --no-facts           Skip Haiku fact extraction
+  --json               JSON output (machine-readable)
+
+Environment:
+  EXA_API_KEY          Exa web search (optional)
+  OPENROUTER_API_KEY   Perplexity via OpenRouter (optional)
+  SCRY_API_KEY         SCRY search (optional; falls back to public key)
+  ANTHROPIC_API_KEY    Required for fact extraction
+`,
+    exitCode: 0,
+  };
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -36,6 +36,7 @@
  *   context     Assemble research bundles for Claude Code sessions (for-page, for-issue, for-entity, for-topic)
  *   enrich      Standalone enrichment tools (entity-links, fact-refs)
  *   sessions    Session log management (write: scaffold a session YAML)
+ *   research    Multi-source research → SourceCacheEntry[] (Exa, Perplexity, SCRY)
  *
  * Global Options:
  *   --ci        JSON output for CI pipelines
@@ -79,6 +80,7 @@ import * as jobsCommands from './commands/jobs.ts';
 import * as contextCommands from './commands/context.ts';
 import * as enrichCommands from './commands/enrich.ts';
 import * as sessionsCommands from './commands/sessions.ts';
+import * as researchCommands from './commands/research.ts';
 
 const domains = {
   validate: validateCommands,
@@ -109,6 +111,7 @@ const domains = {
   context: contextCommands,
   enrich: enrichCommands,
   sessions: sessionsCommands,
+  research: researchCommands,
 };
 
 /**
@@ -185,6 +188,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   context     Assemble research bundles (for-page, for-issue, for-entity, for-topic)
   enrich      Standalone enrichment tools (entity-links, fact-refs)
   sessions    Session log management (write: scaffold a session YAML)
+  research    Multi-source research → SourceCacheEntry[] (Exa, Perplexity, SCRY)
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines

--- a/crux/lib/research-agent.test.ts
+++ b/crux/lib/research-agent.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for research-agent.ts
+ *
+ * Covers:
+ *  - Multi-source search with graceful degradation (missing keys → skip provider)
+ *  - URL deduplication across providers
+ *  - Source fetching via source-fetcher (mocked)
+ *  - Fact extraction via Haiku (mocked)
+ *  - Budget cap enforcement
+ *  - ResearchResult shape and metadata
+ *
+ * All network calls are mocked — tests run fully offline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runResearch } from './research-agent.ts';
+import type { ResearchRequest } from './research-agent.ts';
+
+// ---------------------------------------------------------------------------
+// Mock source-fetcher — avoid real network calls
+// ---------------------------------------------------------------------------
+
+vi.mock('./source-fetcher.ts', () => ({
+  fetchSources: vi.fn(async (requests: Array<{ url: string }>) =>
+    requests.map((req, i) => ({
+      url: req.url,
+      title: `Title for ${req.url}`,
+      fetchedAt: new Date().toISOString(),
+      content: `This is content about AI safety for URL ${i + 1}. It contains facts about organizations and funding.`,
+      relevantExcerpts: [`Relevant excerpt from ${req.url}`],
+      status: 'ok' as const,
+      resource: undefined,
+    }))
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock LLM layer — avoid real API calls
+// ---------------------------------------------------------------------------
+
+vi.mock('./llm.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./llm.ts')>();
+  return {
+    ...actual,
+    createLlmClient: vi.fn(() => ({})),
+    streamingCreate: vi.fn(async () => ({
+      content: [{ type: 'text', text: '["Fact 1 about the topic.", "Fact 2 about funding.", "Fact 3 about research."]' }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    })),
+    extractText: vi.fn((response: { content: Array<{ type: string; text: string }> }) =>
+      response.content
+        .filter((b: { type: string }) => b.type === 'text')
+        .map((b: { type: string; text: string }) => b.text)
+        .join('\n')
+    ),
+    MODELS: { haiku: 'claude-haiku-4-5-20251001', sonnet: 'claude-sonnet-4-6' },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock fetch — control search API responses
+// ---------------------------------------------------------------------------
+
+const mockExaResponse = {
+  results: [
+    { title: 'AI Safety Overview', url: 'https://aisafety.com/overview', text: 'Overview of AI safety.' },
+    { title: 'Alignment Research', url: 'https://alignment.org/research', text: 'Research on alignment.' },
+    { title: 'Shared URL', url: 'https://shared.example.com/page', text: 'Shared across providers.' },
+  ],
+};
+
+const mockPerplexityResponse = {
+  choices: [{
+    message: {
+      content: '[{"url":"https://perplexity.example.com/article","title":"Perplexity Source"},{"url":"https://shared.example.com/page","title":"Shared URL (Perplexity)"}]',
+    },
+  }],
+  citations: ['https://perplexity.example.com/article', 'https://shared.example.com/page'],
+  usage: { cost: 0.0015 },
+};
+
+const mockScryResponse = {
+  rows: [
+    { title: 'EA Forum Post', uri: 'https://forum.effectivealtruism.org/posts/abc', snippet: 'Discussion on AI safety.' },
+    { title: 'LessWrong Post', uri: 'https://lesswrong.com/posts/xyz', snippet: 'Alignment post.' },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFetchMock(scenario: 'all-success' | 'exa-only' | 'no-keys' | 'scry-fails') {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const body = typeof init?.body === 'string' ? init.body : '';
+
+    // Exa search
+    if (url === 'https://api.exa.ai/search') {
+      if (scenario === 'no-keys') throw new Error('Connection refused');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => mockExaResponse,
+        text: async () => JSON.stringify(mockExaResponse),
+      };
+    }
+
+    // Perplexity / OpenRouter
+    if (url === 'https://openrouter.ai/api/v1/chat/completions') {
+      if (scenario === 'exa-only') throw new Error('Connection refused');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => mockPerplexityResponse,
+        text: async () => JSON.stringify(mockPerplexityResponse),
+      };
+    }
+
+    // SCRY search
+    if (url === 'https://api.exopriors.com/v1/scry/query') {
+      if (scenario === 'scry-fails') throw new Error('SCRY unavailable');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => mockScryResponse,
+        text: async () => JSON.stringify(mockScryResponse),
+      };
+    }
+
+    return { ok: false, status: 404, json: async () => ({}), text: async () => '' };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runResearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set a known environment for tests
+    process.env.EXA_API_KEY = 'test-exa-key';
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+    delete process.env.SCRY_API_KEY;
+  });
+
+  it('returns SourceCacheEntry[] with correct shape', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const request: ResearchRequest = {
+      topic: 'AI safety research',
+      config: { useExa: true, usePerplexity: true, useScry: true, maxResultsPerSource: 3 },
+    };
+
+    const result = await runResearch(request);
+
+    expect(result.sources).toBeInstanceOf(Array);
+    expect(result.sources.length).toBeGreaterThan(0);
+
+    // Each source must have required SourceCacheEntry fields
+    for (const src of result.sources) {
+      expect(src).toHaveProperty('id');
+      expect(src).toHaveProperty('url');
+      expect(src).toHaveProperty('title');
+      expect(src).toHaveProperty('content');
+      expect(src.id).toMatch(/^SRC-\d+$/);
+    }
+  });
+
+  it('deduplicates URLs from multiple providers', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: true, maxResultsPerSource: 3 },
+    });
+
+    // 'shared.example.com/page' appears in both Exa and Perplexity
+    const urls = result.sources.map(s => s.url);
+    const sharedCount = urls.filter(u => u.includes('shared.example.com')).length;
+    expect(sharedCount).toBe(1); // deduplicated to 1
+
+    expect(result.metadata.urlsDeduplicated).toBeGreaterThan(0);
+  });
+
+  it('tracks metadata fields correctly', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: true },
+    });
+
+    expect(result.metadata).toHaveProperty('sourcesSearched');
+    expect(result.metadata).toHaveProperty('urlsFound');
+    expect(result.metadata).toHaveProperty('urlsFetched');
+    expect(result.metadata).toHaveProperty('urlsDeduplicated');
+    expect(result.metadata).toHaveProperty('totalCost');
+    expect(result.metadata).toHaveProperty('costBreakdown');
+    expect(result.metadata).toHaveProperty('durationMs');
+    expect(result.metadata.costBreakdown).toHaveProperty('searchCost');
+    expect(result.metadata.costBreakdown).toHaveProperty('factExtractionCost');
+    expect(result.metadata.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('includes Perplexity cost in totalCost', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: false },
+    });
+
+    // Perplexity mock returns cost: 0.0015
+    expect(result.metadata.costBreakdown.searchCost).toBeCloseTo(0.0015, 5);
+  });
+
+  it('degrades gracefully when Perplexity fails (exa-only scenario)', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('exa-only'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: false },
+    });
+
+    // Should still return sources from Exa
+    expect(result.sources.length).toBeGreaterThan(0);
+    // Perplexity failed → not in sourcesSearched
+    expect(result.metadata.sourcesSearched).not.toContain('perplexity');
+    // Exa succeeded → in sourcesSearched
+    expect(result.metadata.sourcesSearched).toContain('exa');
+  });
+
+  it('degrades gracefully when SCRY fails', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('scry-fails'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: false, useScry: true },
+    });
+
+    // Exa sources should still be returned
+    expect(result.sources.length).toBeGreaterThan(0);
+    // SCRY failed → not in sourcesSearched
+    expect(result.metadata.sourcesSearched).not.toContain('scry');
+  });
+
+  it('skips providers when config explicitly disables them', async () => {
+    const fetchMock = makeFetchMock('all-success');
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runResearch({
+      topic: 'AI safety',
+      config: { useExa: false, usePerplexity: false, useScry: true },
+    });
+
+    // Exa and Perplexity should NOT have been called
+    const calledUrls = fetchMock.mock.calls.map((call) => call[0] as string);
+    expect(calledUrls.some(u => u.includes('exa.ai'))).toBe(false);
+    expect(calledUrls.some(u => u.includes('openrouter.ai'))).toBe(false);
+  });
+
+  it('extracts facts when extractFacts is true', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: false, useScry: false, extractFacts: true },
+    });
+
+    // Mock LLM returns 3 facts per source
+    const sourcesWithFacts = result.sources.filter(s => s.facts && s.facts.length > 0);
+    expect(sourcesWithFacts.length).toBeGreaterThan(0);
+    expect(sourcesWithFacts[0].facts).toContain('Fact 1 about the topic.');
+  });
+
+  it('skips fact extraction when extractFacts is false', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: false, useScry: false, extractFacts: false },
+    });
+
+    // No sources should have facts
+    const sourcesWithFacts = result.sources.filter(s => s.facts && s.facts.length > 0);
+    expect(sourcesWithFacts.length).toBe(0);
+    expect(result.metadata.costBreakdown.factExtractionCost).toBe(0);
+  });
+
+  it('uses page context to focus the query', async () => {
+    const fetchMock = makeFetchMock('all-success');
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runResearch({
+      topic: 'funding',
+      pageContext: { title: 'Anthropic', type: 'organization', entityId: 'anthropic' },
+      config: { useExa: true, usePerplexity: false, useScry: false },
+    });
+
+    // Verify that the Exa call was made with a query that includes the page context
+    const exaCall = fetchMock.mock.calls.find(
+      (call) => (call[0] as string) === 'https://api.exa.ai/search'
+    );
+    expect(exaCall).toBeDefined();
+    const body = JSON.parse(exaCall![1]!.body as string);
+    expect(body.query).toContain('Anthropic');
+  });
+
+  it('respects budget cap and stops fact extraction', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: true, extractFacts: true },
+      budgetCap: 0, // Zero budget: no fact extraction should happen
+    });
+
+    // With budgetCap=0, fact extraction should be skipped for all sources
+    // (totalCost starts at searchCost from Perplexity=0.0015 > budgetCap=0)
+    expect(result.metadata.costBreakdown.factExtractionCost).toBe(0);
+  });
+
+  it('returns empty sources when all providers fail', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('Network unreachable'); }));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: true, useScry: true },
+    });
+
+    expect(result.sources).toHaveLength(0);
+    expect(result.metadata.sourcesSearched).toHaveLength(0);
+    expect(result.metadata.urlsFound).toBe(0);
+  });
+
+  it('assigns sequential SRC-N IDs to sources', async () => {
+    vi.stubGlobal('fetch', makeFetchMock('all-success'));
+
+    const result = await runResearch({
+      topic: 'AI safety',
+      config: { useExa: true, usePerplexity: false, useScry: false },
+    });
+
+    for (let i = 0; i < result.sources.length; i++) {
+      expect(result.sources[i].id).toBe(`SRC-${i + 1}`);
+    }
+  });
+});

--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -1,0 +1,608 @@
+/**
+ * Research Agent — Multi-source search to structured SourceCacheEntry[]
+ *
+ * Sits between the source-fetcher (raw URL fetch) and the section-writer /
+ * citation-auditor (which consume SourceCacheEntry[]).
+ *
+ * Pipeline:
+ *   1. Accept a topic / query (+ optional page context)
+ *   2. Run multi-source search: Exa, Perplexity/Sonar, SCRY
+ *      — each source runs only if its API key is present; degrades gracefully
+ *   3. Deduplicate URLs from multiple providers (fetch once, merge metadata)
+ *   4. Fetch each URL via source-fetcher.fetchSource()
+ *   5. Extract 1-sentence structured facts with Haiku (cheap call per source)
+ *   6. Return SourceCacheEntry[] ready for section-writer + research metadata
+ *
+ * Usage:
+ *   import { runResearch } from './research-agent.ts';
+ *
+ *   const result = await runResearch({
+ *     topic: 'Anthropic constitutional AI',
+ *     pageContext: { title: 'Anthropic', type: 'organization', entityId: 'anthropic' },
+ *     budgetCap: 3.00,
+ *   });
+ *   // result.sources — SourceCacheEntry[] for section-writer
+ *   // result.metadata — cost, sources searched, timing
+ *
+ * See issue #684.
+ */
+
+import { getApiKey } from './api-keys.ts';
+import { fetchSources } from './source-fetcher.ts';
+import { createLlmClient, streamingCreate, extractText, MODELS } from './llm.ts';
+import type { SourceCacheEntry } from './section-writer.ts';
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+/** Optional page context to focus research queries. */
+export interface ResearchPageContext {
+  /** Page title, e.g. "Anthropic". */
+  title: string;
+  /** Entity type, e.g. 'organization'. */
+  type: string;
+  /** Optional entity ID from data/entities, e.g. 'anthropic'. */
+  entityId?: string;
+}
+
+/** Which search providers to use and how many results to request. */
+export interface ResearchConfig {
+  /** Use Exa web search (default: true if EXA_API_KEY is set). */
+  useExa?: boolean;
+  /** Use Perplexity via OpenRouter (default: true if OPENROUTER_API_KEY is set). */
+  usePerplexity?: boolean;
+  /** Use SCRY EA Forum / LessWrong search (default: true if SCRY_API_KEY is set, or public key). */
+  useScry?: boolean;
+  /** Max URLs to collect from each search provider (default: 8). */
+  maxResultsPerSource?: number;
+  /** Max URLs to actually fetch (after dedup, default: 20). */
+  maxUrlsToFetch?: number;
+  /** Extract structured facts from each fetched source (default: true). */
+  extractFacts?: boolean;
+  /** Number of facts to extract per source (default: 5). */
+  factsPerSource?: number;
+}
+
+/** Input to the research agent. */
+export interface ResearchRequest {
+  /** Main topic string, e.g. "Anthropic constitutional AI safety". */
+  topic: string;
+  /** Alternative search query if different from topic (e.g. more specific). */
+  query?: string;
+  /** Optional page context to narrow research focus. */
+  pageContext?: ResearchPageContext;
+  /** Search provider configuration. */
+  config?: ResearchConfig;
+  /** Hard budget cap in USD — stops searching/fetching when exceeded (default: 5.00). */
+  budgetCap?: number;
+}
+
+/** Cost breakdown for the research run. */
+export interface ResearchCostBreakdown {
+  /** Cost from Perplexity search queries (USD). */
+  searchCost: number;
+  /** Cost from Haiku fact-extraction calls (USD). */
+  factExtractionCost: number;
+}
+
+/** Result of a research run. */
+export interface ResearchResult {
+  /** Structured sources ready for section-writer. */
+  sources: SourceCacheEntry[];
+  /** Metadata about the research run. */
+  metadata: {
+    /** Which providers were searched (e.g. ['exa', 'perplexity', 'scry']). */
+    sourcesSearched: string[];
+    /** Total unique URLs discovered across all providers. */
+    urlsFound: number;
+    /** URLs actually fetched (may be less than urlsFound due to budget cap). */
+    urlsFetched: number;
+    /** URLs that appeared in multiple providers and were deduplicated. */
+    urlsDeduplicated: number;
+    /** Total USD cost (search + LLM calls). */
+    totalCost: number;
+    costBreakdown: ResearchCostBreakdown;
+    /** Wall-clock duration in milliseconds. */
+    durationMs: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface SearchHit {
+  url: string;
+  title: string;
+  snippet?: string;
+  provider: string;
+}
+
+interface ExaResult {
+  title: string;
+  url: string;
+  publishedDate?: string;
+  text?: string;
+}
+
+interface ExaResponse {
+  results: ExaResult[];
+}
+
+interface ScryRow {
+  title: string;
+  uri: string;
+  snippet?: string;
+}
+
+interface ScryApiResponse {
+  rows?: ScryRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCRY_PUBLIC_KEY = 'exopriors_public_readonly_v1_2025';
+const DEFAULT_BUDGET_CAP = 5.0;
+const DEFAULT_MAX_RESULTS_PER_SOURCE = 8;
+const DEFAULT_MAX_URLS_TO_FETCH = 20;
+const DEFAULT_FACTS_PER_SOURCE = 5;
+
+/** Haiku pricing per million tokens (USD). */
+const HAIKU_INPUT_COST_PER_M = 0.80;
+const HAIKU_OUTPUT_COST_PER_M = 4.00;
+
+// ---------------------------------------------------------------------------
+// Exa search
+// ---------------------------------------------------------------------------
+
+async function searchExa(query: string, maxResults: number): Promise<SearchHit[]> {
+  const apiKey = getApiKey('EXA_API_KEY');
+  if (!apiKey) throw new Error('EXA_API_KEY not set');
+
+  const body = {
+    query,
+    type: 'auto',
+    numResults: maxResults,
+    contents: { text: { maxCharacters: 400 } },
+  };
+
+  const response = await fetch('https://api.exa.ai/search', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Exa API error ${response.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = await response.json() as ExaResponse;
+  return (data.results || [])
+    .filter(r => r.title && r.url)
+    .map(r => ({
+      url: r.url,
+      title: r.title,
+      snippet: r.text?.slice(0, 400),
+      provider: 'exa',
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Perplexity search via OpenRouter
+// ---------------------------------------------------------------------------
+
+interface PerplexityApiResponse {
+  choices?: Array<{ message: { content: string } }>;
+  citations?: string[];
+  usage?: { cost?: number; prompt_tokens?: number; completion_tokens?: number };
+  error?: { message?: string };
+}
+
+async function searchPerplexity(
+  query: string,
+  maxResults: number,
+): Promise<{ hits: SearchHit[]; cost: number }> {
+  const apiKey = getApiKey('OPENROUTER_API_KEY');
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY not set');
+
+  const systemPrompt = `You are a research assistant. Find URLs and titles of ${maxResults} highly relevant sources for the given query. Focus on authoritative, credible sources. Return ONLY a JSON array with objects having "url" and "title" fields — no prose, no markdown.`;
+
+  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://www.longtermwiki.com',
+      'X-Title': 'LongtermWiki Research Agent',
+    },
+    body: JSON.stringify({
+      model: 'perplexity/sonar',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: query },
+      ],
+      max_tokens: 1000,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const data = await response.json() as PerplexityApiResponse;
+
+  if (!response.ok || data.error) {
+    const msg = data.error?.message ?? `HTTP ${response.status}`;
+    throw new Error(`Perplexity/OpenRouter error: ${msg}`);
+  }
+
+  const cost = data.usage?.cost ?? 0;
+
+  // Extract citation URLs from Perplexity response
+  const citations = data.citations ?? [];
+  const content = data.choices?.[0]?.message?.content ?? '';
+
+  // Prefer structured JSON if the model returned it; fall back to citations list
+  let hits: SearchHit[] = [];
+  try {
+    const jsonMatch = content.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]) as Array<{ url?: string; title?: string }>;
+      hits = parsed
+        .filter(item => item.url && item.title)
+        .slice(0, maxResults)
+        .map(item => ({
+          url: item.url!,
+          title: item.title!,
+          snippet: undefined,
+          provider: 'perplexity',
+        }));
+    }
+  } catch {
+    // Fall through to citations
+  }
+
+  // Supplement with raw citation URLs if JSON parse failed or gave few results
+  if (hits.length < maxResults && citations.length > 0) {
+    const existingUrls = new Set(hits.map(h => h.url));
+    for (const url of citations.slice(0, maxResults)) {
+      if (!existingUrls.has(url)) {
+        hits.push({ url, title: url, provider: 'perplexity' });
+        existingUrls.add(url);
+      }
+      if (hits.length >= maxResults) break;
+    }
+  }
+
+  return { hits, cost };
+}
+
+// ---------------------------------------------------------------------------
+// SCRY search (EA Forum + LessWrong)
+// ---------------------------------------------------------------------------
+
+async function searchScry(query: string, maxResults: number): Promise<SearchHit[]> {
+  const apiKey = getApiKey('SCRY_API_KEY') ?? SCRY_PUBLIC_KEY;
+
+  const tables = ['mv_eaforum_posts', 'mv_lesswrong_posts'];
+  const allHits: SearchHit[] = [];
+  const seenUrls = new Set<string>();
+  const perTable = Math.ceil(maxResults / tables.length);
+
+  for (const table of tables) {
+    try {
+      const sql = `SELECT title, uri, snippet FROM scry.search('${query.replace(/'/g, "''")}', '${table}') WHERE title IS NOT NULL AND kind = 'post' LIMIT ${perTable}`;
+
+      const response = await fetch('https://api.exopriors.com/v1/scry/query', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'text/plain',
+        },
+        body: sql,
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const data = await response.json() as ScryApiResponse;
+
+      for (const row of data.rows ?? []) {
+        if (row.title && row.uri && !seenUrls.has(row.uri)) {
+          seenUrls.add(row.uri);
+          allHits.push({
+            url: row.uri,
+            title: row.title,
+            snippet: row.snippet,
+            provider: 'scry',
+          });
+        }
+      }
+    } catch {
+      // One table failing shouldn't abort the other
+    }
+  }
+
+  return allHits.slice(0, maxResults);
+}
+
+// ---------------------------------------------------------------------------
+// Fact extraction via Haiku
+// ---------------------------------------------------------------------------
+
+interface FactExtractionResult {
+  facts: string[];
+  cost: number;
+}
+
+let _llmClient: ReturnType<typeof createLlmClient> | null = null;
+function getLlmClient() {
+  if (!_llmClient) _llmClient = createLlmClient();
+  return _llmClient;
+}
+
+async function extractFacts(
+  content: string,
+  query: string,
+  factsPerSource: number,
+): Promise<FactExtractionResult> {
+  if (!content.trim()) return { facts: [], cost: 0 };
+
+  const excerpt = content.slice(0, 6_000);
+
+  const prompt = `Extract ${factsPerSource} key facts from this source relevant to the query: "${query}".
+
+Source content:
+${excerpt}
+
+Rules:
+- Each fact must be a single clear sentence (≤25 words).
+- Only include facts that are explicitly stated in the source.
+- Prefer concrete, specific facts (numbers, dates, names, claims) over general statements.
+- Return ONLY a JSON array of strings, e.g. ["Fact 1.", "Fact 2."]
+- No preamble, no markdown.`;
+
+  let raw: string;
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  try {
+    const response = await streamingCreate(getLlmClient(), {
+      model: MODELS.haiku,
+      max_tokens: 500,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    raw = extractText(response);
+    inputTokens = response.usage?.input_tokens ?? 0;
+    outputTokens = response.usage?.output_tokens ?? 0;
+  } catch {
+    return { facts: [], cost: 0 };
+  }
+
+  const cost =
+    (inputTokens / 1_000_000) * HAIKU_INPUT_COST_PER_M +
+    (outputTokens / 1_000_000) * HAIKU_OUTPUT_COST_PER_M;
+
+  let facts: string[] = [];
+  try {
+    const jsonMatch = raw.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (Array.isArray(parsed)) {
+        facts = parsed
+          .filter((f): f is string => typeof f === 'string' && f.trim().length > 0)
+          .slice(0, factsPerSource);
+      }
+    }
+  } catch {
+    // If parsing fails, extract lines that look like facts
+    facts = raw
+      .split('\n')
+      .map(l => l.replace(/^[-*•\d.)\s]+/, '').trim())
+      .filter(l => l.length > 10 && l.length < 200)
+      .slice(0, factsPerSource);
+  }
+
+  return { facts, cost };
+}
+
+// ---------------------------------------------------------------------------
+// Main exported function
+// ---------------------------------------------------------------------------
+
+/**
+ * Run multi-source research for a topic, producing SourceCacheEntry[] for
+ * the section-writer pipeline.
+ *
+ * All search providers degrade gracefully: if a key is missing or a provider
+ * times out, the agent continues with whatever data it has.
+ */
+export async function runResearch(request: ResearchRequest): Promise<ResearchResult> {
+  const startMs = Date.now();
+
+  const {
+    topic,
+    query = topic,
+    pageContext,
+    config = {},
+    budgetCap = DEFAULT_BUDGET_CAP,
+  } = request;
+
+  const {
+    useExa = !!getApiKey('EXA_API_KEY'),
+    usePerplexity = !!getApiKey('OPENROUTER_API_KEY'),
+    useScry = true,
+    maxResultsPerSource = DEFAULT_MAX_RESULTS_PER_SOURCE,
+    maxUrlsToFetch = DEFAULT_MAX_URLS_TO_FETCH,
+    extractFacts: shouldExtractFacts = true,
+    factsPerSource = DEFAULT_FACTS_PER_SOURCE,
+  } = config;
+
+  // Focus query with page context if provided
+  const focusedQuery = pageContext
+    ? `${query} ${pageContext.title} ${pageContext.type}`
+    : query;
+
+  let totalCost = 0;
+  let searchCost = 0;
+  let factExtractionCost = 0;
+  const sourcesSearched: string[] = [];
+
+  // -------------------------------------------------------------------------
+  // Phase 1: Multi-source search (run providers in parallel)
+  // -------------------------------------------------------------------------
+
+  const searchPromises: Array<Promise<SearchHit[]>> = [];
+  const providerNames: string[] = [];
+
+  if (useExa) {
+    providerNames.push('exa');
+    searchPromises.push(
+      searchExa(focusedQuery, maxResultsPerSource).catch(err => {
+        console.warn(`[research-agent] Exa search failed: ${err instanceof Error ? err.message : err}`);
+        return [];
+      }),
+    );
+  }
+
+  if (usePerplexity) {
+    providerNames.push('perplexity');
+    searchPromises.push(
+      searchPerplexity(focusedQuery, maxResultsPerSource).then(r => {
+        searchCost += r.cost;
+        totalCost += r.cost;
+        return r.hits;
+      }).catch(err => {
+        console.warn(`[research-agent] Perplexity search failed: ${err instanceof Error ? err.message : err}`);
+        return [];
+      }),
+    );
+  }
+
+  if (useScry) {
+    providerNames.push('scry');
+    searchPromises.push(
+      searchScry(focusedQuery, maxResultsPerSource).catch(err => {
+        console.warn(`[research-agent] SCRY search failed: ${err instanceof Error ? err.message : err}`);
+        return [];
+      }),
+    );
+  }
+
+  const allHitArrays = await Promise.all(searchPromises);
+
+  // Track which providers returned at least one result
+  for (let i = 0; i < providerNames.length; i++) {
+    if (allHitArrays[i].length > 0) {
+      sourcesSearched.push(providerNames[i]);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 2: Deduplicate URLs
+  // -------------------------------------------------------------------------
+
+  const urlToHits = new Map<string, SearchHit[]>();
+
+  for (const hits of allHitArrays) {
+    for (const hit of hits) {
+      // Normalize URL: strip trailing slash
+      const normalized = hit.url.replace(/\/$/, '');
+      const existing = urlToHits.get(normalized) ?? [];
+      existing.push(hit);
+      urlToHits.set(normalized, existing);
+    }
+  }
+
+  const urlsFound = urlToHits.size;
+  const urlsDeduplicated = allHitArrays.reduce((sum, arr) => sum + arr.length, 0) - urlsFound;
+
+  // Build a best-title mapping from all hits for each URL
+  const urlBestTitle = new Map<string, string>();
+  for (const [url, hits] of urlToHits) {
+    // Prefer the hit with a non-URL title
+    const best = hits.find(h => h.title !== h.url) ?? hits[0];
+    urlBestTitle.set(url, best.title);
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 3: Budget-aware URL fetching
+  // -------------------------------------------------------------------------
+
+  const urlsToFetch = [...urlToHits.keys()].slice(0, maxUrlsToFetch);
+  const urlsFetched = urlsToFetch.length;
+
+  const fetchRequests = urlsToFetch.map(url => ({
+    url,
+    extractMode: 'relevant' as const,
+    query: focusedQuery,
+  }));
+
+  const fetchedSources = await fetchSources(fetchRequests, { concurrency: 5, delayMs: 200 });
+
+  // -------------------------------------------------------------------------
+  // Phase 4: Fact extraction (Haiku call per fetched source)
+  // -------------------------------------------------------------------------
+
+  const sources: SourceCacheEntry[] = [];
+
+  for (let i = 0; i < fetchedSources.length; i++) {
+    const fetched = fetchedSources[i];
+    const url = urlsToFetch[i];
+    const title = fetched.title || (urlBestTitle.get(url) ?? url);
+
+    if (totalCost >= budgetCap) {
+      // Budget exhausted — still add the source but skip fact extraction
+      sources.push({
+        id: `SRC-${i + 1}`,
+        url: fetched.url,
+        title,
+        content: fetched.relevantExcerpts.join('\n\n') || fetched.content.slice(0, 3_000),
+        facts: [],
+      });
+      continue;
+    }
+
+    let facts: string[] = [];
+
+    if (shouldExtractFacts && fetched.status === 'ok' && fetched.content) {
+      const extractionResult = await extractFacts(
+        fetched.content,
+        focusedQuery,
+        factsPerSource,
+      );
+      facts = extractionResult.facts;
+      factExtractionCost += extractionResult.cost;
+      totalCost += extractionResult.cost;
+    }
+
+    sources.push({
+      id: `SRC-${i + 1}`,
+      url: fetched.url,
+      title,
+      content: fetched.relevantExcerpts.join('\n\n') || fetched.content.slice(0, 3_000),
+      facts: facts.length > 0 ? facts : undefined,
+    });
+  }
+
+  const durationMs = Date.now() - startMs;
+
+  return {
+    sources,
+    metadata: {
+      sourcesSearched,
+      urlsFound,
+      urlsFetched,
+      urlsDeduplicated,
+      totalCost,
+      costBreakdown: {
+        searchCost,
+        factExtractionCost,
+      },
+      durationMs,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds crux/lib/research-agent.ts - standalone research agent between source-fetcher and section-writer
- Multi-source search: Exa, Perplexity via OpenRouter, SCRY (EA Forum + LessWrong), with graceful degradation
- URL deduplication: same URL from multiple providers is fetched once and merged
- Fact extraction via Haiku: each fetched source gets 1-sentence structured facts extracted
- Budget tracking: reports search cost + fact-extraction cost in result metadata
- Adds crux/commands/research.ts - standalone CLI (crux research <topic>)
- Registers research domain in crux/crux.mjs
- 13 unit tests (fully mocked, offline)

## Test plan
- [x] All 13 research-agent unit tests pass
- [x] Gate passes (all 8 checks green)
- [x] CI green after push

Closes #684