### PR TITLE
fix: SCRY table validation, enrich error handling, research schema validation

### DIFF
--- a/crux/authoring/page-improver/api.test.ts
+++ b/crux/authoring/page-improver/api.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for api.ts — SCRY search table validation (#694)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { executeScrySearch } from './api.ts';
+
+// Mock the LLM layer and utils so the module loads without side effects
+vi.mock('../../lib/llm.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/llm.ts')>();
+  return {
+    ...actual,
+    createLlmClient: vi.fn(() => ({})),
+    streamingCreate: vi.fn(async () => ({ content: [{ type: 'text', text: '' }] })),
+    extractText: vi.fn(() => ''),
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+});
+
+describe('executeScrySearch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects invalid table names', async () => {
+    const result = await executeScrySearch('test query', 'DROP TABLE users; --');
+    expect(result).toContain('invalid table');
+    expect(result).toContain('mv_eaforum_posts');
+  });
+
+  it('accepts valid table mv_eaforum_posts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      text: async () => JSON.stringify({ rows: [] }),
+    }));
+
+    const result = await executeScrySearch('test query', 'mv_eaforum_posts');
+    expect(result).not.toContain('invalid table');
+  });
+
+  it('accepts valid table mv_lesswrong_posts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      text: async () => JSON.stringify({ rows: [] }),
+    }));
+
+    const result = await executeScrySearch('test query', 'mv_lesswrong_posts');
+    expect(result).not.toContain('invalid table');
+  });
+});

--- a/crux/authoring/page-improver/api.ts
+++ b/crux/authoring/page-improver/api.ts
@@ -51,7 +51,12 @@ export async function executeWebSearch(query: string): Promise<string> {
   return extractText(response);
 }
 
+const VALID_SCRY_TABLES = new Set(['mv_eaforum_posts', 'mv_lesswrong_posts']);
+
 export async function executeScrySearch(query: string, table: string = 'mv_eaforum_posts'): Promise<string> {
+  if (!VALID_SCRY_TABLES.has(table)) {
+    return `SCRY search error: invalid table "${table}" — must be one of: ${[...VALID_SCRY_TABLES].join(', ')}`;
+  }
   const sql = `SELECT title, uri, snippet, original_author, original_timestamp::date as date
     FROM scry.search('${query.replace(/'/g, "''")}', '${table}')
     WHERE title IS NOT NULL AND kind = 'post'

--- a/crux/authoring/page-improver/phases/enrich.test.ts
+++ b/crux/authoring/page-improver/phases/enrich.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for enrich.ts — error handling (#695)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enrichPhase } from './enrich.ts';
+import type { PageData, PipelineOptions } from '../types.ts';
+
+// Mock enrichment modules
+vi.mock('../../../enrich/enrich-entity-links.ts', () => ({
+  enrichEntityLinks: vi.fn(async (content: string) => ({
+    content,
+    insertedCount: 0,
+  })),
+}));
+
+vi.mock('../../../enrich/enrich-fact-refs.ts', () => ({
+  enrichFactRefs: vi.fn(async (content: string) => ({
+    content,
+    insertedCount: 0,
+  })),
+}));
+
+// Mock utils to suppress logging
+vi.mock('../utils.ts', () => ({
+  ROOT: '/tmp/test',
+  log: vi.fn(),
+  writeTemp: vi.fn(),
+}));
+
+const makePage = (): PageData => ({
+  id: 'test-page',
+  title: 'Test Page',
+  path: 'test-page.mdx',
+  content: '## Test\n\nSome content.',
+  frontmatter: {},
+});
+
+const makeOptions = (): PipelineOptions => ({
+  tier: 'standard',
+  deep: false,
+});
+
+describe('enrichPhase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns enriched content on success', async () => {
+    const { enrichEntityLinks } = await import('../../../enrich/enrich-entity-links.ts');
+    (enrichEntityLinks as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: '## Test\n\n<EntityLink id="miri">MIRI</EntityLink> content.',
+      insertedCount: 1,
+    });
+
+    const { content, result } = await enrichPhase(makePage(), '## Test\n\nMIRI content.', makeOptions());
+    expect(content).toContain('EntityLink');
+    expect(result.entityLinks.insertedCount).toBe(1);
+  });
+
+  it('continues with original content when entity-link enrichment throws (#695)', async () => {
+    const { enrichEntityLinks } = await import('../../../enrich/enrich-entity-links.ts');
+    (enrichEntityLinks as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('LLM timeout'));
+
+    const input = '## Test\n\nOriginal content.';
+    const { content, result } = await enrichPhase(makePage(), input, makeOptions());
+
+    // Should return the original content, not throw
+    expect(content).toBe(input);
+    expect(result.entityLinks.insertedCount).toBe(0);
+  });
+
+  it('continues with current content when fact-ref enrichment throws (#695)', async () => {
+    const { enrichFactRefs } = await import('../../../enrich/enrich-fact-refs.ts');
+    (enrichFactRefs as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Schema error'));
+
+    const input = '## Test\n\nContent with facts.';
+    const { content, result } = await enrichPhase(makePage(), input, makeOptions());
+
+    expect(content).toBe(input);
+    expect(result.factRefs.insertedCount).toBe(0);
+  });
+
+  it('entity-link failure does not prevent fact-ref enrichment', async () => {
+    const { enrichEntityLinks } = await import('../../../enrich/enrich-entity-links.ts');
+    const { enrichFactRefs } = await import('../../../enrich/enrich-fact-refs.ts');
+    (enrichEntityLinks as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('LLM timeout'));
+    (enrichFactRefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: '## Test\n\nContent with <F entity="x" fact="y" />.',
+      insertedCount: 1,
+    });
+
+    const { content, result } = await enrichPhase(makePage(), '## Test\n\nContent.', makeOptions());
+
+    // Fact-ref should still have run successfully
+    expect(content).toContain('<F entity=');
+    expect(result.entityLinks.insertedCount).toBe(0); // failed
+    expect(result.factRefs.insertedCount).toBe(1); // succeeded
+  });
+});

--- a/crux/authoring/page-improver/phases/research.ts
+++ b/crux/authoring/page-improver/phases/research.ts
@@ -12,7 +12,7 @@ import type { SourceCacheEntry } from '../../../lib/section-writer.ts';
 import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '../types.ts';
 import { log, writeTemp } from '../utils.ts';
 import { runAgent } from '../api.ts';
-import { parseJsonFromLlm } from './json-parsing.ts';
+import { parseAndValidate, ResearchResultSchema } from './json-parsing.ts';
 
 /**
  * Convert research sources + fetched content into SourceCacheEntry[] for
@@ -145,7 +145,7 @@ Output ONLY valid JSON at the end.`;
     tools
   });
 
-  const research = parseJsonFromLlm<ResearchResult>(result, 'research', (raw, error) => ({
+  const research = parseAndValidate<ResearchResult>(result, ResearchResultSchema, 'research', (raw, error) => ({
     sources: [],
     raw,
     error,

--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -286,10 +286,12 @@ async function searchPerplexity(
 // SCRY search (EA Forum + LessWrong)
 // ---------------------------------------------------------------------------
 
+const VALID_SCRY_TABLES = ['mv_eaforum_posts', 'mv_lesswrong_posts'] as const;
+
 async function searchScry(query: string, maxResults: number): Promise<SearchHit[]> {
   const apiKey = getApiKey('SCRY_API_KEY') ?? SCRY_PUBLIC_KEY;
 
-  const tables = ['mv_eaforum_posts', 'mv_lesswrong_posts'];
+  const tables = VALID_SCRY_TABLES;
   const allHits: SearchHit[] = [];
   const seenUrls = new Set<string>();
   const perTable = Math.ceil(maxResults / tables.length);


### PR DESCRIPTION
## Summary

- **SCRY table allowlist** (#694): Validate the `table` parameter in `executeScrySearch()` against a `Set` of valid SCRY tables before interpolating into SQL. Returns a clear error message for invalid tables. Also extracted `VALID_SCRY_TABLES` constant in `research-agent.ts` for consistency.
- **Enrich error handling** (#695): Wrapped each enrichment step (entity-links, fact-refs) in try/catch so a failure in one doesn't crash the pipeline or block the other. On failure, logs a warning and continues with the content so far.
- **Research Zod validation** (#696): Switched `researchPhase` from `parseJsonFromLlm` (no schema) to `parseAndValidate` with `ResearchResultSchema`, matching the pattern used in other phases.

## Test plan

- [x] Added 3 tests for SCRY table validation (rejects invalid, accepts both valid tables)
- [x] Added 4 tests for enrich error handling (success, entity-link failure, fact-ref failure, entity-link failure doesn't block fact-ref)
- [x] All 1450 tests pass (64 test files)
- [x] Gate check passes

Closes #694
Closes #695
Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)