### PR TITLE
fix: post-merge hook path + stale docs + issue cleanup

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -7,7 +7,7 @@ Recurring problems encountered across Claude Code sessions. When you hit a known
 ## Build & CI
 
 ### Data layer must be built before tests or app build
-`node apps/web/scripts/build-data.mjs` must run before `pnpm test` or `pnpm build`. If tests fail with missing data errors, this is likely why.
+The data layer must be built before `pnpm test` or `pnpm build`. If tests fail with missing data errors, run `pnpm run --filter longterm-next sync:data`. Note: `build-data.mjs` uses `process.cwd()` for path resolution and must be run from `apps/web/` (the pnpm filter handles this).
 
 ### API keys are in environment, not .env files
 Check `env | grep -i API` — keys are set as environment variables, not in `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`.

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -11,7 +11,7 @@ CHANGED_FILES=$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD 2>/de
 
 NEEDS_REBUILD=false
 
-if echo "$CHANGED_FILES" | grep -qE '^(data/|content/docs/|app/scripts/build-data)'; then
+if echo "$CHANGED_FILES" | grep -qE '^(data/|content/docs/|apps/web/scripts/build-data)'; then
   NEEDS_REBUILD=true
 fi
 
@@ -19,9 +19,9 @@ if [ "$NEEDS_REBUILD" = true ]; then
   echo ""
   echo "Data files changed — rebuilding data layer..."
   echo ""
-  if (cd "$(git rev-parse --show-toplevel)/app" && node --import tsx/esm scripts/build-data.mjs 2>/dev/null); then
+  if (cd "$(git rev-parse --show-toplevel)/apps/web" && node --import tsx/esm scripts/build-data.mjs 2>/dev/null); then
     echo "Data layer rebuilt successfully."
   else
-    echo "WARNING: Data layer rebuild failed. Run manually: pnpm run --filter longterm-next sync:data"
+    echo "WARNING: Data layer rebuild failed. Run manually: node apps/web/scripts/build-data.mjs"
   fi
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ pnpm setup:check                 # Check environment without changing anything
 pnpm dev                         # Start dev server on port 3001
 pnpm build                      # Production build (runs assign-ids + build-data automatically)
 
-# Numeric ID assignment (requires wiki server)
-node apps/web/scripts/assign-ids.mjs              # Assign numericIds to new entities/pages
-node apps/web/scripts/assign-ids.mjs --dry-run    # Preview assignments without writing files
+# Numeric ID assignment (requires wiki server — run from apps/web/)
+(cd apps/web && node scripts/assign-ids.mjs)              # Assign numericIds to new entities/pages
+(cd apps/web && node scripts/assign-ids.mjs --dry-run)    # Preview assignments without writing files
 
 # Testing
 pnpm test                        # Run vitest tests
@@ -206,7 +206,7 @@ When creating or editing wiki pages, **always use the Crux content pipeline**. D
 
 If `apps/web/src/data/pages.json` doesn't exist, generate it first:
 ```bash
-node apps/web/scripts/build-data.mjs
+pnpm run --filter longterm-next sync:data
 ```
 
 ### Creating a new page


### PR DESCRIPTION
## Summary
- Fix post-merge hook: referenced stale `/app` path instead of `/apps/web`, causing silent rebuild failures on every `git pull`
- Fix CLAUDE.md and common-issues.md: `build-data.mjs` and `assign-ids.mjs` commands now correctly handle cwd requirements
- Clean up 3 stale `claude-working` labels (#694, #695, #696) — branches no longer exist
- Close 4 superseded issues (#210, #211, #219, #437) — covered by content quality pipeline #589-#592

## Test plan
- [x] Gate check passes (all 6 checks)
- [x] post-merge hook path verified correct
- [x] `pnpm run --filter longterm-next sync:data` works from repo root

https://claude.ai/code/session_01CLcHgDj3gNv5LncAaYNtE6