### PR TITLE
fix(citations): wire PostgreSQL writes into verify, extract-quotes, verify-quotes

### DIFF
--- a/crux/lib/citation-archive.test.ts
+++ b/crux/lib/citation-archive.test.ts
@@ -1,5 +1,43 @@
-import { describe, it, expect } from 'vitest';
-import { extractClaimSentence, extractCitationsFromContent } from './citation-archive.ts';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { extractClaimSentence, extractCitationsFromContent, verifyCitationsForPage } from './citation-archive.ts';
+
+// ---------------------------------------------------------------------------
+// Mocks for verifyCitationsForPage tests
+// ---------------------------------------------------------------------------
+
+// Mock knowledge-db (SQLite) — best-effort local store
+vi.mock('./knowledge-db.ts', () => ({
+  citationContent: {
+    getByUrl: vi.fn(() => null),
+    upsert: vi.fn(),
+  },
+}));
+
+// Mock wiki-server citations client (PostgreSQL)
+const mockUpsertCitationContent = vi.fn().mockResolvedValue({ ok: true, data: { url: 'mock' } });
+vi.mock('./wiki-server/citations.ts', () => ({
+  upsertCitationContent: (...args: unknown[]) => mockUpsertCitationContent(...args),
+}));
+
+// Mock fs to prevent YAML archive writes during tests
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn((p: string) => {
+        // Allow real existsSync for non-archive paths
+        if (typeof p === 'string' && p.includes('citation-archive')) return true;
+        return actual.existsSync(p);
+      }),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      readFileSync: actual.readFileSync,
+      readdirSync: actual.readdirSync,
+    },
+  };
+});
 
 describe('extractClaimSentence', () => {
   const sampleBody = `
@@ -204,5 +242,207 @@ Claim A.[^1] Claim B.[^2] Claim C.[^3] Claim D.[^4]
     expect(citations[1].url).toBe('https://example.com/embedded');
     expect(citations[2].url).toBe('https://example.com/text-url');
     expect(citations[3].url).toBe('https://example.com/bare');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyCitationsForPage — PostgreSQL integration tests
+// ---------------------------------------------------------------------------
+
+const SAMPLE_HTML = `<html><head><title>Test Page</title></head><body><p>Hello world content for testing</p></body></html>`;
+
+describe('verifyCitationsForPage — PostgreSQL writes', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    mockUpsertCitationContent.mockClear();
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('calls upsertCitationContent for verified URLs with content', async () => {
+    fetchSpy.mockResolvedValue(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Test Source](https://example.com/test-page)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).toHaveBeenCalledTimes(1);
+    const call = mockUpsertCitationContent.mock.calls[0][0];
+    expect(call.url).toBe('https://example.com/test-page');
+    expect(call.httpStatus).toBe(200);
+    expect(call.fullText).toContain('Hello world content');
+    expect(call.pageTitle).toBe('Test Page');
+    expect(call.contentLength).toBeGreaterThan(0);
+    expect(call.fetchedAt).toBeTruthy();
+  });
+
+  it('does NOT call upsertCitationContent for broken URLs (4xx)', async () => {
+    fetchSpy.mockResolvedValue(new Response('Not Found', {
+      status: 404,
+      headers: { 'content-type': 'text/html' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Dead Link](https://example.com/missing)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call upsertCitationContent for unverifiable domains', async () => {
+    const body = `Some claim.[^1]\n\n[^1]: [Tweet](https://twitter.com/user/status/123)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+    // fetch should not even be called for unverifiable domains
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls upsertCitationContent for each URL when page has multiple citations', async () => {
+    // Must return a fresh Response each call (body can only be consumed once)
+    fetchSpy.mockImplementation(() => Promise.resolve(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })));
+
+    const body = `Claim A.[^1] Claim B.[^2]\n\n[^1]: [Source A](https://example.com/a)\n[^2]: [Source B](https://example.com/b)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).toHaveBeenCalledTimes(2);
+    const urls = mockUpsertCitationContent.mock.calls.map((c: unknown[]) => (c[0] as { url: string }).url);
+    expect(urls).toContain('https://example.com/a');
+    expect(urls).toContain('https://example.com/b');
+  });
+
+  it('gracefully handles wiki-server failure (does not throw)', async () => {
+    mockUpsertCitationContent.mockRejectedValue(new Error('Connection refused'));
+
+    fetchSpy.mockResolvedValue(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Source](https://example.com/server-down)`;
+    // Should not throw even though PG write fails
+    const archive = await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(archive.verified).toBe(1);
+    expect(archive.citations[0].status).toBe('verified');
+  });
+
+  it('does NOT call upsertCitationContent for PDFs (no text content)', async () => {
+    fetchSpy.mockResolvedValue(new Response(null, {
+      status: 200,
+      headers: { 'content-type': 'application/pdf', 'content-length': '12345' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Paper](https://example.com/paper.pdf)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call upsertCitationContent for non-HTML content types', async () => {
+    fetchSpy.mockResolvedValue(new Response('plain text data', {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Data File](https://example.com/data.txt)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    // Non-HTML responses don't have fullHtml/fullText extracted
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+  });
+
+  it('passes correct field types to upsertCitationContent', async () => {
+    fetchSpy.mockResolvedValue(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Source](https://example.com/types-check)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    const call = mockUpsertCitationContent.mock.calls[0][0];
+    // Verify field types match UpsertCitationContentSchema expectations
+    expect(typeof call.url).toBe('string');
+    expect(typeof call.fetchedAt).toBe('string');
+    expect(typeof call.httpStatus).toBe('number');
+    expect(typeof call.fullText).toBe('string');
+    expect(typeof call.contentLength).toBe('number');
+    // contentType and pageTitle can be string or null
+    expect(call.contentType === null || typeof call.contentType === 'string').toBe(true);
+    expect(call.pageTitle === null || typeof call.pageTitle === 'string').toBe(true);
+  });
+
+  it('fetchedAt is a valid ISO 8601 datetime (matches Zod .datetime())', async () => {
+    fetchSpy.mockResolvedValue(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }));
+
+    const body = `Some claim.[^1]\n\n[^1]: [Source](https://example.com/datetime-test)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    const call = mockUpsertCitationContent.mock.calls[0][0];
+    // Zod .datetime() expects ISO 8601: 2026-02-22T09:16:34.123Z
+    expect(call.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+  });
+
+  it('does NOT call upsertCitationContent on fetch timeout', async () => {
+    // Use fake timers so retry delays resolve instantly
+    vi.useFakeTimers();
+
+    fetchSpy.mockImplementation(() => {
+      throw new Error('The operation was aborted due to timeout');
+    });
+
+    const body = `Some claim.[^1]\n\n[^1]: [Source](https://example.com/slow-site)`;
+    const promise = verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    // Advance past all retry delays (2s + 4s)
+    await vi.advanceTimersByTimeAsync(10_000);
+    const archive = await promise;
+
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+    // Timeout should mark as unverifiable, not broken
+    expect(archive.citations[0].status).toBe('unverifiable');
+
+    vi.useRealTimers();
+  });
+
+  it('does NOT call upsertCitationContent on network error', async () => {
+    fetchSpy.mockImplementation(() => {
+      throw new Error('ECONNREFUSED');
+    });
+
+    const body = `Some claim.[^1]\n\n[^1]: [Source](https://example.com/down-host)`;
+    const archive = await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    expect(mockUpsertCitationContent).not.toHaveBeenCalled();
+    expect(archive.citations[0].status).toBe('broken');
+  });
+
+  it('handles page with mix of verifiable and unverifiable citations', async () => {
+    fetchSpy.mockImplementation(() => Promise.resolve(new Response(SAMPLE_HTML, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })));
+
+    const body = `Claim A.[^1] Claim B.[^2] Claim C.[^3]\n\n[^1]: [Source](https://example.com/good)\n[^2]: [Tweet](https://twitter.com/user/123)\n[^3]: [Source](https://example.com/also-good)`;
+    await verifyCitationsForPage('test-page', body, { delayMs: 0 });
+
+    // Only 2 PG writes: example.com/good and example.com/also-good (not twitter)
+    expect(mockUpsertCitationContent).toHaveBeenCalledTimes(2);
+    const urls = mockUpsertCitationContent.mock.calls.map((c: unknown[]) => (c[0] as { url: string }).url);
+    expect(urls).toContain('https://example.com/good');
+    expect(urls).toContain('https://example.com/also-good');
+    expect(urls).not.toContain('https://twitter.com/user/123');
   });
 });


### PR DESCRIPTION
## Summary

- `pnpm crux citations verify` stored fetched content in SQLite only, never pushing full_text to PostgreSQL — the PR #685 test plan item would fail
- `extract-quotes` and `verify-quotes` had the same gap: fetch content but only cache locally
- All three commands now write to PostgreSQL via `saveFetchResultToPostgres()`
- `extract-quotes` and `verify-quotes` now also **read** from PostgreSQL as a cache tier (SQLite -> PG -> network), with SQLite backfill on PG hits
- 12 new tests covering: verified URLs, broken URLs, timeouts, unverifiable domains, PDFs, non-HTML, network errors, graceful degradation, ISO datetime format, mixed citation types

## Test plan

- [x] All 1455 crux tests pass (27 in citation-archive.test.ts)
- [x] All 6 gate checks pass
- [x] TypeScript compiles cleanly
- [x] Pre-existing wiki-server test failures confirmed unrelated (fail on main too)
- [ ] Verify pnpm crux citations verify populates full_text in wiki-server DB (requires running wiki-server)
- [ ] Verify /internal/citation-content dashboard shows entries after verify run

Closes the unchecked test plan items from #685.

Generated with [Claude Code](https://claude.com/claude-code)
