### PR TITLE
fix: research-agent facts consistency ([] → undefined)

### DIFF
--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -564,7 +564,7 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
         url: fetched.url,
         title,
         content: fetched.relevantExcerpts.join('\n\n') || fetched.content.slice(0, 3_000),
-        facts: [],
+        facts: undefined,
       });
       continue;
     }


### PR DESCRIPTION
## Summary

- Budget-exhausted code path in `research-agent.ts:567` was setting `facts: []` while the normal path at line 590 converts empty arrays to `undefined`
- This one-line fix aligns the budget-exhausted path with the normal path, fixing the test "uses undefined (not empty array) for facts when budget exhausted"

## Test plan

- [x] All 15 research-agent tests pass (including the previously failing one)
- [x] All 6 gate checks pass
- [x] TypeScript compiles cleanly

Generated with [Claude Code](https://claude.com/claude-code)