### PR TITLE
fix: CitationOverlay cleanup, URL validation, badge colors

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -441,17 +441,15 @@
   cursor: default;
 }
 
-/* Badge in the footnote section at the bottom */
+/* Badge in the footnote section at the bottom — colors set via Tailwind on each instance */
 .citation-fn-badge {
   display: inline-flex;
   align-items: center;
   margin-left: 0.5rem;
   padding: 0.1rem 0.4rem;
   border-radius: 9999px;
-  background: var(--color-muted);
   font-size: 10px;
   line-height: 1.4;
-  color: var(--color-muted-foreground);
   vertical-align: middle;
 }
 

--- a/apps/web/src/components/wiki/CitationOverlay.tsx
+++ b/apps/web/src/components/wiki/CitationOverlay.tsx
@@ -19,6 +19,7 @@ interface VerdictConfig {
   color: string;
   iconColor: string;
   dotColor: string;
+  badgeBg: string;
 }
 
 const VERDICT_CONFIG: Record<string, VerdictConfig> = {
@@ -28,6 +29,7 @@ const VERDICT_CONFIG: Record<string, VerdictConfig> = {
     color: "text-emerald-700 dark:text-emerald-400",
     iconColor: "text-emerald-500",
     dotColor: "bg-emerald-500",
+    badgeBg: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
   },
   minor_issues: {
     icon: AlertTriangle,
@@ -35,6 +37,7 @@ const VERDICT_CONFIG: Record<string, VerdictConfig> = {
     color: "text-amber-700 dark:text-amber-400",
     iconColor: "text-amber-500",
     dotColor: "bg-amber-500",
+    badgeBg: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
   },
   inaccurate: {
     icon: XCircle,
@@ -42,6 +45,7 @@ const VERDICT_CONFIG: Record<string, VerdictConfig> = {
     color: "text-red-700 dark:text-red-400",
     iconColor: "text-red-500",
     dotColor: "bg-red-500",
+    badgeBg: "bg-red-500/10 text-red-700 dark:text-red-400",
   },
   unsupported: {
     icon: XCircle,
@@ -49,6 +53,7 @@ const VERDICT_CONFIG: Record<string, VerdictConfig> = {
     color: "text-red-600 dark:text-red-400",
     iconColor: "text-red-400",
     dotColor: "bg-red-400",
+    badgeBg: "bg-red-500/10 text-red-700 dark:text-red-400",
   },
   not_verifiable: {
     icon: HelpCircle,
@@ -56,6 +61,7 @@ const VERDICT_CONFIG: Record<string, VerdictConfig> = {
     color: "text-muted-foreground",
     iconColor: "text-muted-foreground",
     dotColor: "bg-muted-foreground",
+    badgeBg: "bg-muted/50 text-muted-foreground",
   },
 };
 
@@ -66,6 +72,7 @@ const VERIFIED_ONLY_CONFIG: VerdictConfig = {
   color: "text-blue-700 dark:text-blue-400",
   iconColor: "text-blue-500",
   dotColor: "bg-blue-500",
+  badgeBg: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
 };
 
 function getVerdictConfig(quote: CitationQuote): VerdictConfig | null {
@@ -76,6 +83,16 @@ function getVerdictConfig(quote: CitationQuote): VerdictConfig | null {
     return VERIFIED_ONLY_CONFIG;
   }
   return null;
+}
+
+/** Only allow safe URL schemes in citation links */
+export function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function formatDate(iso: string): string {
@@ -158,7 +175,7 @@ function FootnoteIndicator({ quote, anchor }: { quote: CitationQuote; anchor: HT
                 Checked {formatDate(checkedAt)}
               </span>
             )}
-            {quote.url && (
+            {quote.url && isSafeUrl(quote.url) && (
               <a
                 href={quote.url}
                 target="_blank"
@@ -221,7 +238,7 @@ function FootnoteSectionEnricher({
         if (!config) return null;
         return createPortal(
           <span
-            className={`citation-fn-badge ${config.dotColor.replace("bg-", "badge-")}`}
+            className={`citation-fn-badge ${config.badgeBg}`}
             title={config.label}
           >
             <span className={`inline-block w-1.5 h-1.5 rounded-full ${config.dotColor} mr-1`} />
@@ -258,6 +275,7 @@ export function CitationOverlay({ quotes }: { quotes: CitationQuote[] }) {
 
     const quoteMap = new Map(quotes.map((q) => [q.footnote, q]));
     const anchors: Array<{ wrapper: HTMLElement; quote: CitationQuote }> = [];
+    const createdElements: HTMLElement[] = [];
 
     // Find all inline footnote refs: <a data-footnote-ref href="#user-content-fn-N">
     const refs = article.querySelectorAll<HTMLAnchorElement>(
@@ -281,12 +299,21 @@ export function CitationOverlay({ quotes }: { quotes: CitationQuote[] }) {
         wrapper.style.position = "relative";
         wrapper.style.display = "inline";
         ref.parentNode?.insertBefore(wrapper, ref.nextSibling);
+        createdElements.push(wrapper);
       }
 
       anchors.push({ wrapper, quote });
     }
 
     setRefAnchors(anchors);
+
+    // Cleanup: remove created DOM elements on unmount or re-render
+    return () => {
+      for (const el of createdElements) {
+        el.remove();
+      }
+      setRefAnchors([]);
+    };
   }, [quotes]);
 
   if (quotes.length === 0) return null;

--- a/apps/web/src/lib/__tests__/citation-data.test.ts
+++ b/apps/web/src/lib/__tests__/citation-data.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   computeCitationHealth,
   type CitationQuote,
 } from "../citation-data";
+import { isSafeUrl } from "../../components/wiki/CitationOverlay";
 
 function makeQuote(overrides: Partial<CitationQuote> = {}): CitationQuote {
   return {
@@ -118,5 +119,72 @@ describe("computeCitationHealth", () => {
     const health = computeCitationHealth(quotes);
     expect(health.accurate).toBe(1);
     expect(health.verified).toBe(0); // not double-counted
+  });
+});
+
+describe("getCitationQuotes", () => {
+  it("returns empty array when server returns null", async () => {
+    vi.resetModules();
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: vi.fn().mockResolvedValue(null),
+    }));
+    const mod = await import("../citation-data");
+    const result = await mod.getCitationQuotes("test-page");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when quotes field is missing", async () => {
+    vi.resetModules();
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: vi.fn().mockResolvedValue({}),
+    }));
+    const mod = await import("../citation-data");
+    const result = await mod.getCitationQuotes("test-page");
+    expect(result).toEqual([]);
+  });
+
+  it("filters out quotes without verification data", async () => {
+    vi.resetModules();
+    const mockQuotes = [
+      makeQuote({ footnote: 1, quoteVerified: true }), // has verification
+      makeQuote({ footnote: 2 }), // no verification data — should be filtered
+      makeQuote({ footnote: 3, accuracyVerdict: "accurate" }), // has accuracy
+    ];
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: vi.fn().mockResolvedValue({ quotes: mockQuotes }),
+    }));
+    const mod = await import("../citation-data");
+    const result = await mod.getCitationQuotes("test-page");
+    expect(result).toHaveLength(2);
+    expect(result[0].footnote).toBe(1);
+    expect(result[1].footnote).toBe(3);
+  });
+});
+
+describe("isSafeUrl", () => {
+  it("allows https URLs", () => {
+    expect(isSafeUrl("https://example.com")).toBe(true);
+    expect(isSafeUrl("https://arxiv.org/abs/2301.00001")).toBe(true);
+  });
+
+  it("allows http URLs", () => {
+    expect(isSafeUrl("http://example.com")).toBe(true);
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(isSafeUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(isSafeUrl("data:text/html,<h1>hi</h1>")).toBe(false);
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(isSafeUrl("not a url")).toBe(false);
+    expect(isSafeUrl("")).toBe(false);
+  });
+
+  it("rejects ftp: URLs", () => {
+    expect(isSafeUrl("ftp://example.com/file")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Three fixes for the citation verification UI (PR #710):

1. **useEffect cleanup**: The effect that creates wrapper `<span>` elements for portal targets now returns a cleanup function that removes them on unmount/re-render, preventing DOM element accumulation
2. **URL scheme validation**: Added `isSafeUrl()` helper that validates URLs against `http:`/`https:` before rendering in `<a href>`, preventing potential XSS via `javascript:` URLs in citation data
3. **Badge colors**: Replaced broken `badge-*` CSS class substitution (`dotColor.replace("bg-", "badge-")` created nonexistent classes like `badge-emerald-500`) with per-verdict `badgeBg` field using Tailwind `bg-color/10` + `text-color` classes for proper color-differentiated footnote badges

Also adds 9 new tests:
- 3 for `getCitationQuotes()` with mocked `fetchFromWikiServer` (null response, missing quotes field, filtering logic)
- 6 for `isSafeUrl()` covering https, http, javascript:, data:, ftp:, and invalid URLs

## Test plan

- [x] All 253 web tests pass (17 in citation-data.test.ts, up from 8)
- [x] All 7 gate checks pass (including full Next.js build — 1679 static pages)
- [x] TypeScript compiles cleanly

Closes #714
Closes #717

Generated with [Claude Code](https://claude.com/claude-code)