### PR TITLE
fix: enricher skip ranges, PG cache TTL, section-writer guard, URL normalization

### DIFF
--- a/apps/wiki-server/src/routes/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/agent-sessions.ts
@@ -27,8 +27,9 @@ agentSessionsRoute.post("/", async (c) => {
   const d = parsed.data;
   const db = getDrizzleDb();
 
-  // Atomic upsert: wrap select+insert/update in a serializable transaction
-  // to prevent concurrent requests from creating duplicate sessions (#567).
+  // Atomic upsert: wrap select+insert/update in a transaction.
+  // Note: this uses READ COMMITTED (Drizzle default), not serializable.
+  // Concurrent requests are unlikely in practice (one agent per branch).
   const { row, isUpdate } = await db.transaction(async (tx) => {
     const existing = await tx
       .select()

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -166,12 +166,16 @@ citationsRoute.get("/quotes", async (c) => {
   const pageId = c.req.query("page_id");
   if (!pageId) return validationError(c, "page_id query parameter is required");
 
+  const limitParam = c.req.query("limit");
+  const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500) : 100;
+
   const db = getDrizzleDb();
   const rows = await db
     .select()
     .from(citationQuotes)
     .where(eq(citationQuotes.pageId, pageId))
-    .orderBy(asc(citationQuotes.footnote));
+    .orderBy(asc(citationQuotes.footnote))
+    .limit(limit);
 
   return c.json({ quotes: rows });
 });

--- a/crux/enrich/enrich-entity-links.test.ts
+++ b/crux/enrich/enrich-entity-links.test.ts
@@ -358,4 +358,36 @@ Anthropic is a company.`;
     expect(result).toContain('<EntityLink id="E51">Phil</EntityLink> also');
     expect(result).not.toMatch(/<EntityLink id="E50">Open<EntityLink/);
   });
+
+  it('skips entity name inside <R> resource reference tags', () => {
+    const content = 'See <R id="abc123">AI Impacts survey</R> for details. AI Impacts is important.';
+    const replacements = [{ entityId: 'E60', searchText: 'AI Impacts', displayName: 'AI Impacts' }];
+    const { content: result, applied } = applyEntityLinkReplacements(content, replacements);
+
+    expect(applied).toBe(1);
+    // Should NOT link inside <R> tag, but SHOULD link the second occurrence
+    expect(result).toContain('<R id="abc123">AI Impacts survey</R>');
+    expect(result).toContain('<EntityLink id="E60">AI Impacts</EntityLink> is important');
+  });
+
+  it('skips entity name inside footnote definitions', () => {
+    const content = 'MIRI researches AI safety.\n\n[^1]: MIRI History (https://miri.org)';
+    const replacements = [{ entityId: 'E70', searchText: 'MIRI', displayName: 'MIRI' }];
+    const { content: result, applied } = applyEntityLinkReplacements(content, replacements);
+
+    expect(applied).toBe(1);
+    expect(result).toContain('<EntityLink id="E70">MIRI</EntityLink> researches');
+    // Footnote definition should be untouched
+    expect(result).toContain('[^1]: MIRI History');
+    expect(result).not.toMatch(/\[\^1\]:.*<EntityLink/);
+  });
+
+  it('handles inline code between code fences without false skip range', () => {
+    const content = '```python\nx = 1\n```\n\nOpenAI provides an API.\n\n```js\ny = 2\n```';
+    const replacements = [{ entityId: 'E80', searchText: 'OpenAI', displayName: 'OpenAI' }];
+    const { content: result, applied } = applyEntityLinkReplacements(content, replacements);
+
+    expect(applied).toBe(1);
+    expect(result).toContain('<EntityLink id="E80">OpenAI</EntityLink>');
+  });
 });

--- a/crux/enrich/enrich-entity-links.ts
+++ b/crux/enrich/enrich-entity-links.ts
@@ -103,14 +103,17 @@ function buildSkipRanges(content: string): Array<[number, number]> {
     }
   }
 
-  // Skip code blocks (```...``` and inline `...`)
+  // Skip code blocks (```...```) — must come before inline code
   const codeBlock = /```[\s\S]*?```/g;
   for (const match of content.matchAll(codeBlock)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
     }
   }
-  const inlineCode = /`[^`]+`/g;
+  // Skip inline code (`...`) — exclude newlines to avoid false matches
+  // between code fences (backticks at fence boundaries would create a
+  // giant false skip range covering prose between fences).
+  const inlineCode = /`[^`\n]+`/g;
   for (const match of content.matchAll(inlineCode)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
@@ -167,6 +170,23 @@ function buildSkipRanges(content: string): Array<[number, number]> {
   // Skip MDX/JSX comments {/* ... */} (#681)
   const mdxComment = /\{\/\*[\s\S]*?\*\/\}/g;
   for (const match of content.matchAll(mdxComment)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip <R>...</R> resource reference tags — display text could contain entity names
+  const rTag = /<R\s[^>]*>[\s\S]*?<\/R>/g;
+  for (const match of content.matchAll(rTag)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip footnote definition lines [^N]: ... — entity names in definitions
+  // should not be linked as they'd corrupt footnote syntax.
+  const footnoteDef = /^\[\^[^\]]+\]:\s.+$/gm;
+  for (const match of content.matchAll(footnoteDef)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
     }

--- a/crux/enrich/enrich-fact-refs.test.ts
+++ b/crux/enrich/enrich-fact-refs.test.ts
@@ -329,6 +329,64 @@ Anthropic raised \\$30 billion.`;
     // $1B and $30B wrapped, $380B already wrapped = 2 new
     expect(applied).toBe(2);
   });
+
+  it('skips numbers inside JSX open tag attributes', () => {
+    const content = '<DataInfoBox items={500} /> Their budget is $500M.';
+    const replacements: FactRefReplacement[] = [{
+      entityId: 'test',
+      factId: 'abc12300',
+      searchText: '$500M',
+      displayText: '\\$500M',
+    }];
+    const { content: result, applied } = applyFactRefReplacements(content, replacements);
+    expect(applied).toBe(1);
+    expect(result).toContain('<F e="test" f="abc12300">\\$500M</F>');
+    // The 500 inside the JSX tag should be untouched
+    expect(result).toContain('items={500}');
+  });
+
+  it('skips numbers inside MDX comments', () => {
+    const content = '{/* TODO: 500 employees */}\nThey have 500 employees.';
+    const replacements: FactRefReplacement[] = [{
+      entityId: 'test',
+      factId: 'def45600',
+      searchText: '500 employees',
+      displayText: '500 employees',
+    }];
+    const { content: result, applied } = applyFactRefReplacements(content, replacements);
+    expect(applied).toBe(1);
+    expect(result).toContain('{/* TODO: 500 employees */}');
+    expect(result).toContain('<F e="test" f="def45600">500 employees</F>');
+  });
+
+  it('skips numbers inside <R> resource tags', () => {
+    const content = '<R id="abc">2023 Survey</R> published in 2023.';
+    const replacements: FactRefReplacement[] = [{
+      entityId: 'test',
+      factId: 'a0b78900',
+      searchText: '2023',
+      displayText: '2023',
+    }];
+    const { content: result, applied } = applyFactRefReplacements(content, replacements);
+    expect(applied).toBe(1);
+    expect(result).toContain('<R id="abc">2023 Survey</R>');
+    expect(result).toContain('<F e="test" f="a0b78900">2023</F>');
+  });
+
+  it('skips numbers inside footnote definitions', () => {
+    const content = 'Revenue was $100M.\n\n[^1]: Report shows $100M in 2023.';
+    const replacements: FactRefReplacement[] = [{
+      entityId: 'test',
+      factId: 'c0d01200',
+      searchText: '$100M',
+      displayText: '\\$100M',
+    }];
+    const { content: result, applied } = applyFactRefReplacements(content, replacements);
+    expect(applied).toBe(1);
+    // Should link in body, not in footnote
+    expect(result).toMatch(/<F e="test" f="c0d01200">\\\$100M<\/F>\./);
+    expect(result).toContain('[^1]: Report shows $100M');
+  });
 });
 
 describe('fixDoubleNestedFTags', () => {

--- a/crux/enrich/enrich-fact-refs.ts
+++ b/crux/enrich/enrich-fact-refs.ts
@@ -103,14 +103,15 @@ function buildSkipRanges(content: string): Array<[number, number]> {
     }
   }
 
-  // Skip code blocks
+  // Skip code blocks — must come before inline code
   const codeBlock = /```[\s\S]*?```/g;
   for (const match of content.matchAll(codeBlock)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
     }
   }
-  const inlineCode = /`[^`]+`/g;
+  // Skip inline code — exclude newlines to avoid false matches between fences
+  const inlineCode = /`[^`\n]+`/g;
   for (const match of content.matchAll(inlineCode)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
@@ -159,6 +160,38 @@ function buildSkipRanges(content: string): Array<[number, number]> {
   // Skip reference-style link definitions [ref]: url (#687)
   const refDef = /^\[[^\]]+\]:\s+\S+.*$/gm;
   for (const match of content.matchAll(refDef)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip HTML/JSX open tags with attributes (matches entity-link enricher)
+  const jsxOpenTag = /<[A-Z][a-zA-Z0-9]*\s[^>]*>/g;
+  for (const match of content.matchAll(jsxOpenTag)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip MDX/JSX comments {/* ... */}
+  const mdxComment = /\{\/\*[\s\S]*?\*\/\}/g;
+  for (const match of content.matchAll(mdxComment)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip <R>...</R> resource reference tags
+  const rTag = /<R\s[^>]*>[\s\S]*?<\/R>/g;
+  for (const match of content.matchAll(rTag)) {
+    if (match.index !== undefined) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+
+  // Skip footnote definition lines [^N]: ...
+  const footnoteDef = /^\[\^[^\]]+\]:\s.+$/gm;
+  for (const match of content.matchAll(footnoteDef)) {
     if (match.index !== undefined) {
       ranges.push([match.index, match.index + match[0].length]);
     }

--- a/crux/lib/research-agent.test.ts
+++ b/crux/lib/research-agent.test.ts
@@ -370,7 +370,7 @@ describe('runResearch', () => {
     expect(result.metadata.sourcesSearched).toContain('exa');
   });
 
-  it('uses undefined (not empty array) for facts when budget exhausted', async () => {
+  it('uses empty array for facts when budget exhausted (avoids downstream TypeError)', async () => {
     vi.stubGlobal('fetch', makeFetchMock('all-success'));
 
     const result = await runResearch({
@@ -379,13 +379,10 @@ describe('runResearch', () => {
       budgetCap: 0, // Force budget-cap path immediately
     });
 
-    // Budget-exhausted sources should have facts: undefined, not facts: []
+    // Budget-exhausted sources get facts: [] (safe default) so downstream code
+    // can always call .length, .map, etc. without null-checks.
     for (const src of result.sources) {
-      expect(src.facts).not.toEqual([]);
-      // facts should be either undefined or a non-empty array
-      if (src.facts !== undefined) {
-        expect(src.facts.length).toBeGreaterThan(0);
-      }
+      expect(Array.isArray(src.facts)).toBe(true);
     }
   });
 });

--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -518,8 +518,11 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
 
   for (const hits of allHitArrays) {
     for (const hit of hits) {
-      // Normalize URL: strip trailing slash
-      const normalized = hit.url.replace(/\/$/, '');
+      // Normalize URL: strip trailing slash, www prefix, force https
+      const normalized = hit.url
+        .replace(/^http:\/\//, 'https://')
+        .replace(/^(https:\/\/)www\./, '$1')
+        .replace(/\/$/, '');
       const existing = urlToHits.get(normalized) ?? [];
       existing.push(hit);
       urlToHits.set(normalized, existing);
@@ -570,7 +573,7 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
         url: fetched.url,
         title,
         content: fetched.relevantExcerpts.join('\n\n') || fetched.content.slice(0, 3_000),
-        facts: undefined,
+        facts: [],
       });
       continue;
     }

--- a/crux/lib/section-writer.ts
+++ b/crux/lib/section-writer.ts
@@ -345,9 +345,29 @@ export function parseGroundedResult(
 
   // Validate against schema — coerce missing arrays to []
   const schemaResult = GroundedWriteResponseSchema.safeParse(parsed);
-  const response: GroundedWriteResponse = schemaResult.success
+  let response: GroundedWriteResponse = schemaResult.success
     ? schemaResult.data
     : { content: parsed?.content ?? raw, claimMap: [], unsourceableClaims: [] };
+
+  // Guard against garbage output: if the LLM returned refusal text or
+  // unparseable content, the fallback sets `content` to the raw response.
+  // Detect this by checking if the content starts with a heading (##) or
+  // frontmatter (---). If it doesn't look like section content, fall back
+  // to the original section content from the request.
+  const contentTrimmed = response.content.trim();
+  if (
+    !contentTrimmed.startsWith('##') &&
+    !contentTrimmed.startsWith('---') &&
+    !contentTrimmed.startsWith('#') &&
+    request.sectionContent.trim().length > 0
+  ) {
+    // Check if the "content" is mostly prose (LLM preamble/refusal)
+    // vs actual markdown by looking for the section heading
+    const headingLine = request.sectionContent.split('\n')[0];
+    if (!contentTrimmed.includes(headingLine)) {
+      response = { content: request.sectionContent, claimMap: [], unsourceableClaims: [] };
+    }
+  }
 
   // Validate factIds against the source cache.
   //

--- a/crux/lib/source-fetcher.test.ts
+++ b/crux/lib/source-fetcher.test.ts
@@ -875,20 +875,21 @@ describe('PostgreSQL write path', () => {
   it('serves from PostgreSQL cache when session cache is empty', async () => {
     const { getCitationContentByUrl } = await import('./wiki-server/citations.ts');
     const getMock = getCitationContentByUrl as ReturnType<typeof vi.fn>;
+    const recentDate = new Date(Date.now() - 3600_000).toISOString(); // 1 hour ago (within TTL)
     getMock.mockResolvedValueOnce({
       ok: true,
       data: {
         url: 'https://example.com/pg-cached',
         pageTitle: 'PG Cached Page',
         fullText: 'Content stored in PostgreSQL about AI safety.',
-        fetchedAt: '2025-01-01T00:00:00.000Z',
+        fetchedAt: recentDate,
         httpStatus: 200,
         contentType: 'text/html',
         fullTextPreview: null,
         contentLength: 44,
         contentHash: null,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
+        createdAt: recentDate,
+        updatedAt: recentDate,
       },
     });
 
@@ -906,20 +907,21 @@ describe('PostgreSQL write path', () => {
   it('extracts relevant excerpts from PostgreSQL-cached content', async () => {
     const { getCitationContentByUrl } = await import('./wiki-server/citations.ts');
     const getMock = getCitationContentByUrl as ReturnType<typeof vi.fn>;
+    const recentDate = new Date(Date.now() - 3600_000).toISOString(); // 1 hour ago (within TTL)
     getMock.mockResolvedValueOnce({
       ok: true,
       data: {
         url: 'https://example.com/pg-relevant',
         pageTitle: 'AI Safety Report',
         fullText: 'Global spending on AI safety research reached $100 million.\n\nResearchers worldwide have increased commitments to AI alignment.\n\nUnrelated paragraph about climate science.',
-        fetchedAt: '2025-01-01T00:00:00.000Z',
+        fetchedAt: recentDate,
         httpStatus: 200,
         contentType: 'text/html',
         fullTextPreview: null,
         contentLength: 100,
         contentHash: null,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
+        createdAt: recentDate,
+        updatedAt: recentDate,
       },
     });
 
@@ -963,20 +965,21 @@ describe('PostgreSQL write path', () => {
   it('backfills SQLite when served from PostgreSQL cache', async () => {
     const { getCitationContentByUrl } = await import('./wiki-server/citations.ts');
     const getMock = getCitationContentByUrl as ReturnType<typeof vi.fn>;
+    const recentDate = new Date(Date.now() - 3600_000).toISOString(); // 1 hour ago (within TTL)
     getMock.mockResolvedValueOnce({
       ok: true,
       data: {
         url: 'https://example.com/backfill-test',
         pageTitle: 'Backfill Test',
         fullText: 'PostgreSQL content for backfill test.',
-        fetchedAt: '2025-01-01T00:00:00.000Z',
+        fetchedAt: recentDate,
         httpStatus: 200,
         contentType: 'text/html',
         fullTextPreview: null,
         contentLength: 37,
         contentHash: null,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
+        createdAt: recentDate,
+        updatedAt: recentDate,
       },
     });
 
@@ -994,5 +997,46 @@ describe('PostgreSQL write path', () => {
       url: 'https://example.com/backfill-test',
       fullText: 'PostgreSQL content for backfill test.',
     }));
+  });
+
+  it('rejects stale PostgreSQL cache entries beyond TTL', async () => {
+    const { getCitationContentByUrl } = await import('./wiki-server/citations.ts');
+    const getMock = getCitationContentByUrl as ReturnType<typeof vi.fn>;
+    // 8 days ago — beyond the 7-day TTL
+    const staleDate = new Date(Date.now() - 8 * 24 * 3600_000).toISOString();
+    getMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        url: 'https://example.com/stale-pg',
+        pageTitle: 'Stale PG Page',
+        fullText: 'This content is stale.',
+        fetchedAt: staleDate,
+        httpStatus: 200,
+        contentType: 'text/html',
+        fullTextPreview: null,
+        contentLength: 22,
+        contentHash: null,
+        createdAt: staleDate,
+        updatedAt: staleDate,
+      },
+    });
+
+    // SQLite also stale
+    const { citationContent } = await import('./knowledge-db.ts');
+    const getByUrlMock = citationContent.getByUrl as ReturnType<typeof vi.fn>;
+    getByUrlMock.mockReturnValueOnce(null);
+
+    // Network fetch returns fresh content
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(
+      '<html><head><title>Fresh Page</title></head><body>Fresh content.</body></html>',
+      { status: 200, headers: { 'content-type': 'text/html' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchSource({ url: 'https://example.com/stale-pg', extractMode: 'full' });
+
+    // Should have made a network call since both caches were stale/empty
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result.status).toBe('ok');
   });
 });

--- a/crux/lib/source-fetcher.ts
+++ b/crux/lib/source-fetcher.ts
@@ -448,9 +448,16 @@ function saveToDb(url: string, title: string, content: string, httpStatus: numbe
  */
 async function loadFromPostgres(
   url: string,
+  maxAgeMs: number = DB_CACHE_TTL_MS,
 ): Promise<(Pick<FetchedSource, 'title' | 'content' | 'fetchedAt'> & { httpStatus: number | null }) | null> {
   const result = await getCitationContentByUrl(url);
   if (result.ok && result.data.fullText && result.data.fullText.length > 0) {
+    // Check TTL — match the SQLite cache's 7-day expiry to avoid serving
+    // stale content that could give false positives in citation audits.
+    if (result.data.fetchedAt) {
+      const age = Date.now() - new Date(result.data.fetchedAt).getTime();
+      if (age > maxAgeMs) return null;
+    }
     return {
       title: result.data.pageTitle ?? '',
       content: result.data.fullText,


### PR DESCRIPTION
## Summary

Round 3 of paranoid review fixes across enrichers, caching, and LLM output handling:

- **Enricher skip ranges** (entity-links + fact-refs): Add skip ranges for R tags, footnote definitions, JSX open tags with attributes, and MDX comments. Fix inline code regex to exclude newlines (prevents false giant skip ranges between code fences).
- **PG cache TTL**: PostgreSQL source cache now enforces 7-day TTL matching SQLite, preventing stale content from being served indefinitely.
- **Section-writer garbage detection**: Detect LLM refusal/garbage output and fall back to original section content.
- **Research-agent URL normalization**: Normalize search result URLs (force https, strip www, trailing slash) to improve deduplication.
- **Research-agent facts consistency**: Use facts:[] instead of undefined for budget-exhausted sources.
- **Wiki-server citations**: Fix GET /quotes to respect limit parameter.
- **Wiki-server agent-sessions**: Fix misleading serializable comment.

## Test plan

- [x] 7 new enricher tests (R tags, footnote defs, JSX attrs, MDX comments, inline code between fences)
- [x] 1 new PG cache TTL rejection test
- [x] Updated PG cache test mocks to use recent dates (within TTL)
- [x] Updated research-agent test for facts:[] behavior
- [x] All 1569 crux tests pass
- [x] All 253 web tests pass
- [x] Full gate check passes

Closes #622
Closes #625
Closes #629
Closes #630

Generated with [Claude Code](https://claude.com/claude-code)