### PR TITLE
maintain: propagate session learnings + clean stale labels

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -12,6 +12,9 @@ The data layer must be built before `pnpm test` or `pnpm build`. If tests fail w
 ### API keys are in environment, not .env files
 Check `env | grep -i API` — keys are set as environment variables, not in `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`.
 
+### OpenRouter model IDs can be deprecated without warning
+Model IDs like `google/gemini-flash-1.5` get removed from OpenRouter. When a pipeline call returns a model-not-found error, check the [OpenRouter models page](https://openrouter.ai/models) for the current ID. As of Feb 2026, Gemini Flash is `google/gemini-2.0-flash-001`.
+
 ### CI verification requires curl, not gh
 `gh` CLI is not installed. Use `curl` with `$GITHUB_TOKEN` to check CI status (see CLAUDE.md for the exact command).
 
@@ -69,6 +72,9 @@ If you get errors about `better-sqlite3` native bindings, run:
 ```bash
 npx node-gyp rebuild
 ```
+
+### better-sqlite3 cannot be imported in Next.js app code
+Next.js apps cannot import native Node modules like `better-sqlite3` directly — they're not available at build/runtime in the Next.js environment. Use a JSON export approach instead: have a crux script write data to a `.json` or `.cache/` file, then read that from the Next.js server component via `fs`.
 
 ---
 


### PR DESCRIPTION
## Summary

- `pnpm crux citations verify` stored fetched content in SQLite only, never pushing full_text to PostgreSQL — the PR #685 test plan item would fail
- `extract-quotes` and `verify-quotes` had the same gap: fetch content but only cache locally
- All three commands now write to PostgreSQL via `saveFetchResultToPostgres()`
- `extract-quotes` and `verify-quotes` now also **read** from PostgreSQL as a cache tier (SQLite -> PG -> network), with SQLite backfill on PG hits
- 12 new tests covering: verified URLs, broken URLs, timeouts, unverifiable domains, PDFs, non-HTML, network errors, graceful degradation, ISO datetime format, mixed citation types

## Test plan

- [x] All 1455 crux tests pass (27 in citation-archive.test.ts)
- [x] All 6 gate checks pass
- [x] TypeScript compiles cleanly
- [x] Pre-existing wiki-server test failures confirmed unrelated (fail on main too)
- [ ] Verify pnpm crux citations verify populates full_text in wiki-server DB (requires running wiki-server)
- [ ] Verify /internal/citation-content dashboard shows entries after verify run

Closes the unchecked test plan items from #685.

Generated with [Claude Code](https://claude.com/claude-code)
