### PR TITLE
fix: citation dashboard pagination, auto-update section-level flag

### DIFF
--- a/apps/web/src/app/internal/citation-content/page.tsx
+++ b/apps/web/src/app/internal/citation-content/page.tsx
@@ -39,7 +39,7 @@ interface ApiStatsResult {
 
 async function loadContentFromApi(): Promise<FetchResult<{ entries: ContentEntry[]; stats: ApiStatsResult }>> {
   const [listResult, statsResult] = await Promise.all([
-    fetchDetailed<ApiListResult>("/api/citations/content/list?limit=500", {
+    fetchDetailed<ApiListResult>("/api/citations/content/list?limit=5000", {
       revalidate: 120,
     }),
     fetchDetailed<ApiStatsResult>("/api/citations/content/stats", {
@@ -144,6 +144,12 @@ export default async function CitationContentPage() {
             }
           />
         </div>
+      )}
+
+      {entries.length > 0 && stats.total > entries.length && (
+        <p className="text-sm text-muted-foreground mb-4">
+          Showing {entries.length.toLocaleString()} of {stats.total.toLocaleString()} entries.
+        </p>
       )}
 
       {entries.length === 0 ? (

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -24,7 +24,7 @@ export const citationsRoute = new Hono();
 // ---- Constants ----
 
 const BROKEN_SCORE_THRESHOLD = 0.5;
-const MAX_PAGE_SIZE = 1000;
+const MAX_PAGE_SIZE = 5000;
 
 // ---- Schemas (from shared api-types) ----
 

--- a/crux/auto-update/orchestrator.ts
+++ b/crux/auto-update/orchestrator.ts
@@ -142,6 +142,7 @@ function executePageImprove(
   tier: string,
   directions: string,
   verbose = false,
+  sectionLevel = false,
 ): RunResult {
   const start = Date.now();
 
@@ -156,6 +157,10 @@ function executePageImprove(
 
     if (directions) {
       args.push('--directions', directions);
+    }
+
+    if (sectionLevel) {
+      args.push('--section-level');
     }
 
     if (verbose) {
@@ -403,6 +408,7 @@ export async function runPipeline(options: AutoUpdateOptions = {}): Promise<Pipe
       update.suggestedTier,
       update.directions,
       verbose,
+      update.sectionLevel ?? false,
     );
     results.push(result);
 

--- a/crux/auto-update/types.ts
+++ b/crux/auto-update/types.ts
@@ -67,6 +67,7 @@ export interface PageUpdate {
     summary: string;
   }>;
   directions: string;        // Specific update instructions for the improver
+  sectionLevel?: boolean;    // When true, use per-## section rewriting (--section-level)
 }
 
 export interface NewPageSuggestion {


### PR DESCRIPTION
## Summary

Two quick fixes from the issue backlog:

- **Citation-content dashboard** (#697): Raise fetch limit from 500 to 5000 entries, raise server MAX_PAGE_SIZE from 1000 to 5000 (all internal endpoints), add truncation notice when total entries exceed the fetched count.
- **Auto-update section-level flag** (#701): Wire `--section-level` flag through `executePageImprove()` to the page-improver CLI. Add `sectionLevel` field to `PageUpdate` interface so the page router can enable per-section rewriting for specific pages.

Also closed as already-fixed:
- #693 (PG cache TTL) — fixed in PR #724
- #706 (citation-audit after adversarial-loop) — deep tier already has citation-audit last

## Test plan

- [x] Gate check passes (all 7 checks)
- [x] TypeScript compiles cleanly
- [x] All tests pass

Closes #697
Closes #701

Generated with [Claude Code](https://claude.com/claude-code)