### PR TITLE
fix: citation-audit ordering comment + citationAuditPhase unit tests (#705, #706)

### DIFF
--- a/crux/authoring/page-improver/phases/citation-audit.test.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.test.ts
@@ -3,14 +3,43 @@
  *
  * Tests cover:
  *   - buildAuditorSourceCache(): converting SourceCacheEntry[] → Map<string, FetchedSource>
+ *   - citationAuditPhase(): advisory/gate logging, empty-citation handling, source cache
+ *     passthrough, undefined-cache behaviour, and option forwarding.
  *
  * All tests are offline — no network calls, no LLM calls.
  */
 
-import { describe, it, expect } from 'vitest';
-import { buildAuditorSourceCache } from './citation-audit.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildAuditorSourceCache, citationAuditPhase } from './citation-audit.ts';
 import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation-auditor.ts';
+import type { AuditResult } from '../../../lib/citation-auditor.ts';
 import type { SourceCacheEntry } from '../../../lib/section-writer.ts';
+import type { ResearchResult, PipelineOptions, PageData } from '../types.ts';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Mock auditCitations to avoid LLM/network calls; preserve MIN_SOURCE_CONTENT_LENGTH
+// and other non-function exports so buildAuditorSourceCache tests continue to work.
+vi.mock('../../../lib/citation-auditor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/citation-auditor.ts')>();
+  return { ...actual, auditCitations: vi.fn() };
+});
+
+// Mock log and writeTemp to avoid console output and file-system access in tests.
+vi.mock('../utils.ts', () => ({
+  log: vi.fn(),
+  writeTemp: vi.fn(),
+}));
+
+// Pull the mocked references after vi.mock declarations so vitest hoisting works.
+import { auditCitations } from '../../../lib/citation-auditor.ts';
+import { log, writeTemp } from '../utils.ts';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
 function makeEntry(overrides: Partial<SourceCacheEntry> = {}): SourceCacheEntry {
   return {
@@ -21,6 +50,31 @@ function makeEntry(overrides: Partial<SourceCacheEntry> = {}): SourceCacheEntry 
     ...overrides,
   };
 }
+
+const mockPage: PageData = {
+  id: 'test-page',
+  title: 'Test Page',
+  path: '/test-page',
+};
+
+function makeAuditResult(overrides: Partial<AuditResult> = {}): AuditResult {
+  return {
+    citations: [],
+    summary: { total: 0, verified: 0, failed: 0, misattributed: 0, unchecked: 0 },
+    newUngroundedClaims: [],
+    pass: true,
+    ...overrides,
+  };
+}
+
+/** Extract message arguments from all `log` calls (log is called as log(phase, message)). */
+function getLogMessages(): string[] {
+  return vi.mocked(log).mock.calls.map(c => c[1] as string);
+}
+
+// ---------------------------------------------------------------------------
+// buildAuditorSourceCache tests
+// ---------------------------------------------------------------------------
 
 describe('buildAuditorSourceCache', () => {
   it('converts SourceCacheEntry[] into a Map keyed by URL', () => {
@@ -102,5 +156,144 @@ describe('buildAuditorSourceCache', () => {
     const aboveBoundaryEntry = makeEntry({ url: 'https://example.com/above', content: 'A'.repeat(MIN_SOURCE_CONTENT_LENGTH + 1) });
     const cacheAbove = buildAuditorSourceCache([aboveBoundaryEntry]);
     expect(cacheAbove.get(aboveBoundaryEntry.url)?.status).toBe('ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// citationAuditPhase tests
+// ---------------------------------------------------------------------------
+
+describe('citationAuditPhase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the AuditResult from auditCitations', async () => {
+    const expected = makeAuditResult({
+      summary: { total: 1, verified: 1, failed: 0, misattributed: 0, unchecked: 0 },
+      pass: true,
+    });
+    vi.mocked(auditCitations).mockResolvedValueOnce(expected);
+
+    const result = await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    expect(result).toBe(expected);
+  });
+
+  it('logs "No citations found" when total is 0', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());  // total: 0 by default
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    expect(getLogMessages()).toContain('No citations found — skipping verification');
+  });
+
+  it('logs "Citation audit passed" when audit passes with citations', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
+      summary: { total: 2, verified: 2, failed: 0, misattributed: 0, unchecked: 0 },
+      pass: true,
+    }));
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    expect(getLogMessages().some(msg => msg.includes('Citation audit passed'))).toBe(true);
+  });
+
+  it('logs [WARNING] in advisory mode when audit fails', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
+      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0 },
+      pass: false,
+    }));
+
+    const options: PipelineOptions = {};  // no citationGate → advisory mode
+    await citationAuditPhase(mockPage, 'content', undefined, options);
+
+    const messages = getLogMessages();
+    expect(messages.some(msg => msg.includes('[WARNING]'))).toBe(true);
+    expect(messages.some(msg => msg.includes('[GATE]'))).toBe(false);
+  });
+
+  it('logs [GATE] in gate mode when audit fails', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
+      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0 },
+      pass: false,
+    }));
+
+    const options: PipelineOptions = { citationGate: true };
+    await citationAuditPhase(mockPage, 'content', undefined, options);
+
+    const messages = getLogMessages();
+    expect(messages.some(msg => msg.includes('[GATE]'))).toBe(true);
+    expect(messages.some(msg => msg.includes('[WARNING]'))).toBe(false);
+  });
+
+  it('passes source cache to auditCitations when research includes sourceCache', async () => {
+    const sourceCacheEntries: SourceCacheEntry[] = [
+      { id: 'SRC-1', url: 'https://example.com/article', title: 'Article', content: 'A'.repeat(MIN_SOURCE_CONTENT_LENGTH + 1) },
+    ];
+    const research: ResearchResult = { sources: [], sourceCache: sourceCacheEntries };
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', research, {});
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect(auditCall.sourceCache).toBeDefined();
+    expect(auditCall.sourceCache!.has('https://example.com/article')).toBe(true);
+  });
+
+  it('passes undefined sourceCache to auditCitations when research is absent', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect(auditCall.sourceCache).toBeUndefined();
+  });
+
+  it('passes undefined sourceCache when research exists but has no sourceCache', async () => {
+    const research: ResearchResult = { sources: [] };  // no sourceCache field
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', research, {});
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect(auditCall.sourceCache).toBeUndefined();
+  });
+
+  it('forwards citationAuditModel option to auditCitations as model', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', undefined, { citationAuditModel: 'my-model' });
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect(auditCall.model).toBe('my-model');
+  });
+
+  it('omits model key when citationAuditModel is not set', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect('model' in auditCall).toBe(false);
+  });
+
+  it('always passes fetchMissing: true and passThreshold: 0.8 to auditCitations', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult());
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    const auditCall = vi.mocked(auditCitations).mock.calls[0][0];
+    expect(auditCall.fetchMissing).toBe(true);
+    expect(auditCall.passThreshold).toBe(0.8);
+  });
+
+  it('writes the audit result to a temp file via writeTemp', async () => {
+    const auditResult = makeAuditResult();
+    vi.mocked(auditCitations).mockResolvedValueOnce(auditResult);
+
+    await citationAuditPhase(mockPage, 'content', undefined, {});
+
+    expect(vi.mocked(writeTemp)).toHaveBeenCalledWith(mockPage.id, 'citation-audit.json', auditResult);
   });
 });

--- a/crux/authoring/page-improver/utils.ts
+++ b/crux/authoring/page-improver/utils.ts
@@ -69,8 +69,12 @@ export const TIERS: Record<string, TierConfig> = {
   deep: {
     name: 'Deep Research',
     cost: '$15-25',
+    // citation-audit is intentionally last: it must run after adversarial-loop and gap-fill
+    // so that any citations added by those phases are also verified.  Running it earlier
+    // (e.g., before adversarial-loop) would leave newly-added citations unaudited.
+    // Cost impact: ~$0.01-0.03 extra per citation for the additional verification pass.
     phases: ['analyze', 'research-deep', 'improve', 'enrich', 'validate', 'adversarial-loop', 'review', 'gap-fill', 'citation-audit'],
-    description: 'Full SCRY + web research, adversarial review + re-research loop, multi-phase improvement'
+    description: 'Full SCRY + web research, adversarial review + re-research loop, multi-phase improvement + citation audit'
   }
 };
 


### PR DESCRIPTION
## Summary

- **#706**: Documents the intentional placement of citation-audit last in the deep tier phase sequence (after adversarial-loop and gap-fill), with a rationale comment and cost impact note (~sh.01-0.03 per citation). Updates the deep tier description to mention citation audit.
- **#705**: Adds 12 new offline unit tests for citationAuditPhase(), covering every execution path called out in the issue acceptance criteria plus option-forwarding edge cases found during review.

## Key changes

crux/authoring/page-improver/utils.ts
- Add 3-line comment explaining why citation-audit is last in deep tier
- Update deep tier description to include citation audit

crux/authoring/page-improver/phases/citation-audit.test.ts
- Add citationAuditPhase describe block with 12 new tests (all offline via vi.mock)
- Covers: return value passthrough, no-citations log, pass log, advisory [WARNING], gate [GATE], source cache passthrough, undefined cache when research absent, undefined cache when research has no sourceCache, citationAuditModel forwarding, model key absent when unset, fetchMissing/passThreshold forwarding, writeTemp call verification
- Extracts getLogMessages() helper to reduce duplication
- Uses MIN_SOURCE_CONTENT_LENGTH + 1 instead of magic number 100 in source cache test

## Test plan

- All 22 tests pass (10 original + 12 new)
- Gate validation: all 6 checks pass

Closes #705
Closes #706