### PR TITLE
fix: sectional chunking for enrichment tools (fix 6000-char truncation)

### DIFF
--- a/crux/enrich/enrich-entity-links.test.ts
+++ b/crux/enrich/enrich-entity-links.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { applyEntityLinkReplacements, splitContentForEnrichment, type EntityLinkReplacement } from './enrich-entity-links.ts';
+import { applyEntityLinkReplacements, type EntityLinkReplacement } from './enrich-entity-links.ts';
+import { splitContentForEnrichment } from '../lib/content-chunker.ts';
 
 describe('applyEntityLinkReplacements', () => {
   it('inserts EntityLink for a simple mention', () => {
@@ -384,21 +385,22 @@ describe('splitContentForEnrichment', () => {
   });
 
   it('entity mention at position >6000 chars is included in a chunk (#673)', () => {
-    // Create content where "Anthropic" first appears well past position 6000.
+    // Create content where standalone "Anthropic" first appears well past position 6000.
     // section1 is intentionally large to push section2's content past the 6000-char boundary.
     const preamble = 'Introduction.\n\n';
     const section1 = '## First Section\n' + 'x'.repeat(4000) + '\n\n';
-    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nAnthropicFoundation.\n';
+    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nMentions Anthropic here.\n';
     const content = preamble + section1 + section2;
 
-    // Verify "Anthropic" is beyond position 6000 in the original content
+    // Verify standalone "Anthropic" is beyond position 6000 in the original content
     expect(content.indexOf('Anthropic')).toBeGreaterThan(6000);
 
     const chunks = splitContentForEnrichment(content);
 
-    // At least one chunk must contain "Anthropic" so the LLM can find it
-    const chunkWithMention = chunks.some(c => c.includes('Anthropic'));
-    expect(chunkWithMention).toBe(true);
+    // "## Second Section" chunk must contain the standalone entity mention
+    const chunkWithMention = chunks.find(c => c.includes('## Second Section'));
+    expect(chunkWithMention).toBeDefined();
+    expect(chunkWithMention).toContain('Mentions Anthropic here.');
   });
 
   it('no content is lost when splitting', () => {

--- a/crux/enrich/enrich-entity-links.ts
+++ b/crux/enrich/enrich-entity-links.ts
@@ -28,14 +28,7 @@ import { createClient, MODELS, callClaude, parseJsonResponse } from '../lib/anth
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { NUMERIC_ID_RE } from '../lib/patterns.ts';
-import { splitIntoSections } from '../lib/section-splitter.ts';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Maximum content size (chars) sent to the LLM per call. Larger content is chunked. */
-const MAX_CHUNK_SIZE = 5000;
+import { splitContentForEnrichment } from '../lib/content-chunker.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,44 +58,6 @@ interface LlmEntityLinkResponse {
     entityId?: string;
     displayName?: string;
   }>;
-}
-
-// ---------------------------------------------------------------------------
-// Chunking helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Split MDX content into chunks for LLM processing.
- *
- * Splits at H2 section boundaries so each LLM call sees a complete, coherent
- * section rather than an arbitrary 6000-char window. Falls back to
- * hard-splitting at MAX_CHUNK_SIZE for unusually large sections.
- *
- * Exported for testing.
- */
-export function splitContentForEnrichment(content: string): string[] {
-  if (content.length <= MAX_CHUNK_SIZE) return [content];
-
-  const { frontmatter, preamble, sections } = splitIntoSections(content);
-  const chunks: string[] = [];
-
-  // First chunk: frontmatter + preamble (intro paragraph before first H2)
-  const intro = [frontmatter, preamble].filter(s => s.trim()).join('\n');
-  if (intro.trim()) chunks.push(intro);
-
-  // Each H2 section becomes its own chunk
-  for (const section of sections) {
-    if (section.content.length <= MAX_CHUNK_SIZE) {
-      chunks.push(section.content);
-    } else {
-      // Very large section: hard-split at MAX_CHUNK_SIZE
-      for (let i = 0; i < section.content.length; i += MAX_CHUNK_SIZE) {
-        chunks.push(section.content.slice(i, i + MAX_CHUNK_SIZE));
-      }
-    }
-  }
-
-  return chunks.filter(c => c.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/enrich/enrich-fact-refs.test.ts
+++ b/crux/enrich/enrich-fact-refs.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { applyFactRefReplacements, fixDoubleNestedFTags, fixStrayBackslashBeforeFTag, splitContentForEnrichment, type FactRefReplacement } from './enrich-fact-refs.ts';
+import { applyFactRefReplacements, fixDoubleNestedFTags, fixStrayBackslashBeforeFTag, type FactRefReplacement } from './enrich-fact-refs.ts';
+import { splitContentForEnrichment } from '../lib/content-chunker.ts';
 
 describe('applyFactRefReplacements', () => {
   it('wraps a matching number with <F> tags', () => {
@@ -386,7 +387,7 @@ describe('splitContentForEnrichment', () => {
     // section1 is intentionally large to push section2's content past the 6000-char boundary.
     const preamble = 'Introduction.\n\n';
     const section1 = '## First Section\n' + 'x'.repeat(4000) + '\n\n';
-    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nAnthropicRaised \\$30 billion.\n';
+    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nRaised \\$30 billion in 2024.\n';
     const content = preamble + section1 + section2;
 
     // Verify "\\$30 billion" is beyond position 6000 in the original content
@@ -394,9 +395,10 @@ describe('splitContentForEnrichment', () => {
 
     const chunks = splitContentForEnrichment(content);
 
-    // At least one chunk must contain "\\$30 billion" so the LLM can find it
-    const chunkWithFact = chunks.some(c => c.includes('\\$30 billion'));
-    expect(chunkWithFact).toBe(true);
+    // "## Second Section" chunk must contain the fact reference
+    const chunkWithFact = chunks.find(c => c.includes('## Second Section'));
+    expect(chunkWithFact).toBeDefined();
+    expect(chunkWithFact).toContain('\\$30 billion');
   });
 
   it('no content is lost when splitting', () => {

--- a/crux/enrich/enrich-fact-refs.ts
+++ b/crux/enrich/enrich-fact-refs.ts
@@ -27,14 +27,7 @@ import { buildFactLookupForContent } from '../lib/fact-lookup.ts';
 import { createClient, MODELS, callClaude, parseJsonResponse } from '../lib/anthropic.ts';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
-import { splitIntoSections } from '../lib/section-splitter.ts';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Maximum content size (chars) sent to the LLM per call. Larger content is chunked. */
-const MAX_CHUNK_SIZE = 5000;
+import { splitContentForEnrichment } from '../lib/content-chunker.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,44 +60,6 @@ interface LlmFactRefResponse {
     factId?: string;
     displayText?: string;
   }>;
-}
-
-// ---------------------------------------------------------------------------
-// Chunking helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Split MDX content into chunks for LLM processing.
- *
- * Splits at H2 section boundaries so each LLM call sees a complete, coherent
- * section rather than an arbitrary 6000-char window. Falls back to
- * hard-splitting at MAX_CHUNK_SIZE for unusually large sections.
- *
- * Exported for testing.
- */
-export function splitContentForEnrichment(content: string): string[] {
-  if (content.length <= MAX_CHUNK_SIZE) return [content];
-
-  const { frontmatter, preamble, sections } = splitIntoSections(content);
-  const chunks: string[] = [];
-
-  // First chunk: frontmatter + preamble (intro paragraph before first H2)
-  const intro = [frontmatter, preamble].filter(s => s.trim()).join('\n');
-  if (intro.trim()) chunks.push(intro);
-
-  // Each H2 section becomes its own chunk
-  for (const section of sections) {
-    if (section.content.length <= MAX_CHUNK_SIZE) {
-      chunks.push(section.content);
-    } else {
-      // Very large section: hard-split at MAX_CHUNK_SIZE
-      for (let i = 0; i < section.content.length; i += MAX_CHUNK_SIZE) {
-        chunks.push(section.content.slice(i, i + MAX_CHUNK_SIZE));
-      }
-    }
-  }
-
-  return chunks.filter(c => c.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/content-chunker.test.ts
+++ b/crux/lib/content-chunker.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for content-chunker.ts (splitContentForEnrichment).
+ *
+ * Covers:
+ * - Short content: single chunk returned unchanged
+ * - H2-boundary splitting for content > MAX_CHUNK_SIZE
+ * - Frontmatter exclusion (LLM should not see YAML metadata)
+ * - Line-boundary fallback for sections > MAX_CHUNK_SIZE
+ * - No content loss: all section text present across chunks
+ */
+
+import { describe, it, expect } from 'vitest';
+import { splitContentForEnrichment, MAX_CHUNK_SIZE } from './content-chunker.ts';
+
+describe('splitContentForEnrichment', () => {
+  it('returns single chunk for short content', () => {
+    const content = 'Short content that fits in one chunk.';
+    const chunks = splitContentForEnrichment(content);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(content);
+  });
+
+  it('splits long content at H2 section boundaries', () => {
+    const section1 = '## Section One\n' + 'A'.repeat(3000);
+    const section2 = '## Section Two\n' + 'B'.repeat(3000);
+    const content = `---\ntitle: Test\n---\n\nPreamble text.\n\n${section1}\n\n${section2}`;
+
+    const chunks = splitContentForEnrichment(content);
+
+    // Should produce at least 3 chunks: preamble, section1, section2
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    expect(chunks.some(c => c.includes('Preamble text'))).toBe(true);
+    expect(chunks.some(c => c.includes('## Section One'))).toBe(true);
+    expect(chunks.some(c => c.includes('## Section Two'))).toBe(true);
+  });
+
+  it('excludes frontmatter from all chunks (YAML metadata should not reach LLM)', () => {
+    // Content must be > MAX_CHUNK_SIZE to trigger chunking (otherwise the fast path
+    // returns it unchanged — frontmatter exclusion only applies when chunking is needed).
+    const section = '## Section\n' + 'x'.repeat(3000) + '\nContent.';
+    const section2 = '## Section Two\n' + 'y'.repeat(3000) + '\nMore.';
+    const content = `---\ntitle: "Test Page"\nentityId: anthropic\n---\n\nPreamble.\n\n${section}\n\n${section2}`;
+
+    // Confirm content is long enough to trigger chunking
+    expect(content.length).toBeGreaterThan(MAX_CHUNK_SIZE);
+
+    const chunks = splitContentForEnrichment(content);
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // None of the chunks should contain the raw frontmatter YAML
+    for (const chunk of chunks) {
+      expect(chunk).not.toContain('entityId: anthropic');
+      expect(chunk).not.toContain('title: "Test Page"');
+    }
+    // But preamble and section text should still be present
+    const combined = chunks.join('\n');
+    expect(combined).toContain('Preamble.');
+    expect(combined).toContain('## Section');
+  });
+
+  it('entity mention at position >6000 chars is in a chunk (#673)', () => {
+    // "Anthropic" (standalone) is placed past the 6000-char boundary.
+    // section1 is intentionally padded to push section2 past position 6000.
+    const preamble = 'Introduction.\n\n';
+    const section1 = '## First Section\n' + 'x'.repeat(4000) + '\n\n';
+    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nMentions Anthropic here.\n';
+    const content = preamble + section1 + section2;
+
+    // Confirm "Anthropic" is past 6000 chars in the source
+    expect(content.indexOf('Anthropic')).toBeGreaterThan(6000);
+
+    const chunks = splitContentForEnrichment(content);
+
+    // The second section chunk must contain the exact entity mention
+    const chunkWithMention = chunks.find(c => c.includes('## Second Section'));
+    expect(chunkWithMention).toBeDefined();
+    expect(chunkWithMention).toContain('Mentions Anthropic here.');
+  });
+
+  it('fact reference at position >6000 chars is in a chunk (#673)', () => {
+    const preamble = 'Introduction.\n\n';
+    const section1 = '## First Section\n' + 'x'.repeat(4000) + '\n\n';
+    const section2 = '## Second Section\n' + 'y'.repeat(2000) + '\n\nRaised \\$30 billion in 2024.\n';
+    const content = preamble + section1 + section2;
+
+    expect(content.indexOf('\\$30 billion')).toBeGreaterThan(6000);
+
+    const chunks = splitContentForEnrichment(content);
+
+    const chunkWithFact = chunks.find(c => c.includes('## Second Section'));
+    expect(chunkWithFact).toBeDefined();
+    expect(chunkWithFact).toContain('\\$30 billion');
+  });
+
+  it('no content is lost: all section headings and preamble present across chunks', () => {
+    const section1 = '## Alpha\n' + 'a'.repeat(2000);
+    const section2 = '## Beta\n' + 'b'.repeat(2000);
+    const section3 = '## Gamma\n' + 'c'.repeat(2000);
+    const content = `Intro text.\n\n${section1}\n\n${section2}\n\n${section3}`;
+
+    const chunks = splitContentForEnrichment(content);
+    const combined = chunks.join('\n');
+
+    expect(combined).toContain('Intro text.');
+    expect(combined).toContain('## Alpha');
+    expect(combined).toContain('## Beta');
+    expect(combined).toContain('## Gamma');
+  });
+
+  it('splits large sections at line boundaries, not arbitrary char positions', () => {
+    // Create a section with lines of known length so we can verify split is at line end
+    const lineLength = 100;
+    const numLines = Math.ceil((MAX_CHUNK_SIZE * 1.5) / lineLength) + 1;
+    const lines = Array.from({ length: numLines }, (_, i) => `Line ${i}: ${'x'.repeat(lineLength - 8)}`);
+    const sectionContent = '## Big Section\n' + lines.join('\n');
+    const content = `---\ntitle: Test\n---\n\nPreamble.\n\n${sectionContent}`;
+
+    const chunks = splitContentForEnrichment(content);
+
+    // Every chunk should start at a line boundary (no mid-line starts)
+    for (const chunk of chunks) {
+      if (chunk.startsWith('Line ')) {
+        // Hard-split chunks should start with a full line, not a partial one
+        expect(chunk).toMatch(/^Line \d+:/);
+      }
+    }
+    // All lines should appear exactly once across all chunks
+    const combined = chunks.join('\n');
+    for (let i = 0; i < numLines; i++) {
+      expect(combined).toContain(`Line ${i}:`);
+    }
+  });
+
+  it('returns no empty chunks', () => {
+    const content = `---\ntitle: Sparse\n---\n\n\n## Section\nContent.`;
+    const chunks = splitContentForEnrichment(content);
+    for (const chunk of chunks) {
+      expect(chunk.trim()).not.toBe('');
+    }
+  });
+});

--- a/crux/lib/content-chunker.ts
+++ b/crux/lib/content-chunker.ts
@@ -1,0 +1,66 @@
+/**
+ * Content chunking for enrichment LLM calls.
+ *
+ * Splits MDX content into sections small enough to fit in a single LLM call,
+ * without the 6000-char truncation that silently drops mentions in long pages.
+ *
+ * Design choices:
+ *  - Splits at H2 boundaries (via section-splitter) so each chunk is a
+ *    coherent section, not an arbitrary window.
+ *  - Excludes frontmatter from LLM chunks: it contains only YAML metadata
+ *    and the LLM system prompt already says to skip it.
+ *  - Falls back to line-boundary splitting for sections > MAX_CHUNK_SIZE,
+ *    avoiding mid-entity-name or mid-tag cuts.
+ *
+ * See issue #673.
+ */
+
+import { splitIntoSections } from './section-splitter.ts';
+
+/** Maximum content size (chars) sent to the LLM per call. Larger content is split. */
+export const MAX_CHUNK_SIZE = 5000;
+
+/**
+ * Split MDX content into chunks for LLM processing.
+ *
+ * Returns one chunk per H2 section (plus an intro chunk for preamble text).
+ * Frontmatter is excluded — it is YAML metadata that the LLM prompt already
+ * instructs the model to skip, so sending it wastes tokens.
+ * Falls back to line-boundary splitting at MAX_CHUNK_SIZE for large sections.
+ *
+ * Exported for testing.
+ */
+export function splitContentForEnrichment(content: string): string[] {
+  if (content.length <= MAX_CHUNK_SIZE) return [content];
+
+  const { preamble, sections } = splitIntoSections(content);
+  const chunks: string[] = [];
+
+  // Intro chunk: preamble only (text before first H2).
+  // Frontmatter is intentionally excluded — see module docstring.
+  if (preamble.trim()) chunks.push(preamble);
+
+  // Each H2 section becomes its own chunk.
+  for (const section of sections) {
+    if (section.content.length <= MAX_CHUNK_SIZE) {
+      chunks.push(section.content);
+    } else {
+      // Very large section: split at line boundaries near MAX_CHUNK_SIZE.
+      // Splitting at arbitrary byte positions can bisect entity names, JSX tags,
+      // or backtick-delimited spans, causing the LLM to miss or corrupt them.
+      let i = 0;
+      while (i < section.content.length) {
+        let end = i + MAX_CHUNK_SIZE;
+        if (end < section.content.length) {
+          // Walk back to the last newline to avoid mid-line cuts.
+          const lastNewline = section.content.lastIndexOf('\n', end);
+          if (lastNewline > i) end = lastNewline + 1; // include the newline
+        }
+        chunks.push(section.content.slice(i, end));
+        i = end;
+      }
+    }
+  }
+
+  return chunks.filter(c => c.trim());
+}


### PR DESCRIPTION
## Summary

Both enrich-entity-links.ts and enrich-fact-refs.ts silently truncated content to 6000 chars before sending to the LLM, causing entity mentions and fact references in the second half of long pages to be completely missed.

Fix: split content at H2 section boundaries and call the LLM once per section, merging results before applying to the full content.

## Key Changes

- New shared module crux/lib/content-chunker.ts with splitContentForEnrichment(): splits MDX at H2 boundaries, excludes frontmatter from LLM chunks, line-boundary fallback for sections over 5000 chars
- enrichEntityLinks(): iterates chunks with accumulated alreadyLinked sets across sections (first-mention-only per entity enforced page-wide)
- enrichFactRefs(): iterates chunks and merges all proposals (applyFactRefReplacements deduplicates by searchText)
- Removed content.slice(0, 6000) truncation from both LLM call functions

## Test Plan

- crux/lib/content-chunker.test.ts: 8 new tests covering short-content fast path, H2 splitting, frontmatter exclusion, entity/fact at >6000 chars, line-boundary fallback, no empty chunks
- All enrich tests updated to import from shared module; entity/fact mention at >6000 chars verified in correct chunk
- pnpm crux validate gate --fix passes all 8 checks (67 tests)
- Paranoid review findings fixed: DRY (shared module), test substring match (standalone word), arbitrary hard-split (line-boundary split), frontmatter in LLM chunks (excluded)

Closes #673

https://claude.ai/code/session_01EMnZurWUVBF9fLBWFiDLEY