### PR TITLE
fix: section-writer truncation fallback + quality gate thresholds (#733, #735)

### DIFF
--- a/crux/authoring/orchestrator/quality-gate.test.ts
+++ b/crux/authoring/orchestrator/quality-gate.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for quality-gate.ts
+ *
+ * Covers:
+ *  - Tier threshold calibration (#735)
+ *  - Regression detection (word count, footnotes, tables)
+ *  - Gap summary formatting
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateQualityGate } from './quality-gate.ts';
+import type { OrchestratorContext, BudgetConfig } from './types.ts';
+import { TIER_BUDGETS } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Mock the metrics extractor to return controlled values
+// ---------------------------------------------------------------------------
+
+vi.mock('./tools/index.ts', () => ({
+  extractQualityMetrics: vi.fn(),
+}));
+
+import { extractQualityMetrics } from './tools/index.ts';
+const mockMetrics = vi.mocked(extractQualityMetrics);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(overrides: Partial<OrchestratorContext> = {}): OrchestratorContext {
+  return {
+    page: { id: 'test-page', title: 'Test Page', path: '/test' },
+    filePath: '/tmp/test.mdx',
+    currentContent: '## Test\n\nImproved content.',
+    originalContent: '## Test\n\nOriginal.',
+    sourceCache: [],
+    sections: null,
+    splitPage: null,
+    toolCallCount: 5,
+    researchQueryCount: 2,
+    costEntries: [],
+    totalCost: 3.5,
+    budget: TIER_BUDGETS.standard,
+    directions: '',
+    citationAudit: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Threshold calibration (#735)
+// ---------------------------------------------------------------------------
+
+describe('structuralScore thresholds (#735)', () => {
+  it('standard tier passes with structuralScore=30', () => {
+    const ctx = makeCtx({ budget: TIER_BUDGETS.standard });
+    // Current: meets all thresholds
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 1500,
+      footnoteCount: 12,
+      entityLinkCount: 8,
+      diagramCount: 1,
+      tableCount: 3,
+      sectionCount: 6,
+      structuralScore: 30,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    const structuralGap = result.gaps.find(g => g.includes('Structural score'));
+    expect(structuralGap).toBeUndefined();
+  });
+
+  it('deep tier passes with structuralScore=40', () => {
+    const ctx = makeCtx({ budget: TIER_BUDGETS.deep });
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 2000,
+      footnoteCount: 20,
+      entityLinkCount: 15,
+      diagramCount: 2,
+      tableCount: 5,
+      sectionCount: 8,
+      structuralScore: 40,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    const structuralGap = result.gaps.find(g => g.includes('Structural score'));
+    expect(structuralGap).toBeUndefined();
+  });
+
+  it('deep tier fails with structuralScore=39', () => {
+    const ctx = makeCtx({ budget: TIER_BUDGETS.deep });
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 2000,
+      footnoteCount: 20,
+      entityLinkCount: 15,
+      diagramCount: 2,
+      tableCount: 5,
+      sectionCount: 8,
+      structuralScore: 39,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    const structuralGap = result.gaps.find(g => g.includes('Structural score'));
+    expect(structuralGap).toBeDefined();
+  });
+
+  it('polish tier passes with structuralScore=30', () => {
+    const ctx = makeCtx({ budget: TIER_BUDGETS.polish });
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 800,
+      footnoteCount: 5,
+      entityLinkCount: 4,
+      diagramCount: 0,
+      tableCount: 1,
+      sectionCount: 4,
+      structuralScore: 30,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    const structuralGap = result.gaps.find(g => g.includes('Structural score'));
+    expect(structuralGap).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression detection
+// ---------------------------------------------------------------------------
+
+describe('regression detection', () => {
+  it('detects table count regression', () => {
+    const ctx = makeCtx();
+    // First call = current metrics, second call = original metrics
+    mockMetrics
+      .mockReturnValueOnce({
+        wordCount: 1500, footnoteCount: 10, entityLinkCount: 8,
+        diagramCount: 1, tableCount: 2, sectionCount: 6, structuralScore: 35,
+      })
+      .mockReturnValueOnce({
+        wordCount: 1200, footnoteCount: 8, entityLinkCount: 6,
+        diagramCount: 1, tableCount: 5, sectionCount: 5, structuralScore: 30,
+      });
+
+    const result = evaluateQualityGate(ctx);
+    expect(result.gaps.some(g => g.includes('Table count dropped'))).toBe(true);
+  });
+
+  it('detects significant word count decrease', () => {
+    const ctx = makeCtx();
+    mockMetrics
+      .mockReturnValueOnce({
+        wordCount: 500, footnoteCount: 10, entityLinkCount: 8,
+        diagramCount: 1, tableCount: 3, sectionCount: 6, structuralScore: 35,
+      })
+      .mockReturnValueOnce({
+        wordCount: 1500, footnoteCount: 8, entityLinkCount: 6,
+        diagramCount: 1, tableCount: 3, sectionCount: 5, structuralScore: 30,
+      });
+
+    const result = evaluateQualityGate(ctx);
+    expect(result.gaps.some(g => g.includes('Word count dropped'))).toBe(true);
+  });
+
+  it('detects citation count decrease', () => {
+    const ctx = makeCtx();
+    mockMetrics
+      .mockReturnValueOnce({
+        wordCount: 1500, footnoteCount: 3, entityLinkCount: 8,
+        diagramCount: 1, tableCount: 3, sectionCount: 6, structuralScore: 35,
+      })
+      .mockReturnValueOnce({
+        wordCount: 1200, footnoteCount: 10, entityLinkCount: 6,
+        diagramCount: 1, tableCount: 3, sectionCount: 5, structuralScore: 30,
+      });
+
+    const result = evaluateQualityGate(ctx);
+    expect(result.gaps.some(g => g.includes('Citation count dropped'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gate pass/fail
+// ---------------------------------------------------------------------------
+
+describe('gate pass/fail', () => {
+  it('passes when all metrics meet thresholds and no regressions', () => {
+    const ctx = makeCtx({ budget: TIER_BUDGETS.standard });
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 1500,
+      footnoteCount: 12,
+      entityLinkCount: 8,
+      diagramCount: 1,
+      tableCount: 3,
+      sectionCount: 6,
+      structuralScore: 35,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    expect(result.passed).toBe(true);
+    expect(result.gapSummary).toBe('All quality checks passed.');
+  });
+
+  it('fails when content is unchanged', () => {
+    const content = '## Test\n\nSame content.';
+    const ctx = makeCtx({
+      currentContent: content,
+      originalContent: content,
+      budget: TIER_BUDGETS.standard,
+    });
+    mockMetrics.mockImplementation(() => ({
+      wordCount: 1500,
+      footnoteCount: 12,
+      entityLinkCount: 8,
+      diagramCount: 1,
+      tableCount: 3,
+      sectionCount: 6,
+      structuralScore: 35,
+    }));
+
+    const result = evaluateQualityGate(ctx);
+    expect(result.passed).toBe(false);
+    expect(result.gaps.some(g => g.includes('No changes'))).toBe(true);
+  });
+});

--- a/crux/authoring/orchestrator/quality-gate.ts
+++ b/crux/authoring/orchestrator/quality-gate.ts
@@ -45,13 +45,13 @@ const TIER_THRESHOLDS: Record<OrchestratorTier, QualityThresholds> = {
     minWordCount: 800,
     minFootnotes: 8,
     minEntityLinks: 5,
-    minStructuralScore: 40,
+    minStructuralScore: 30,
   },
   deep: {
     minWordCount: 1200,
     minFootnotes: 15,
     minEntityLinks: 10,
-    minStructuralScore: 55,
+    minStructuralScore: 40,
   },
 };
 

--- a/crux/authoring/orchestrator/types.ts
+++ b/crux/authoring/orchestrator/types.ts
@@ -158,7 +158,7 @@ export interface QualityMetrics {
   diagramCount: number;
   tableCount: number;
   sectionCount: number;
-  /** Structural quality score (0-100). */
+  /** Structural quality score (0-50, normalized from raw 0-15). */
   structuralScore: number;
 }
 

--- a/crux/lib/section-writer.test.ts
+++ b/crux/lib/section-writer.test.ts
@@ -306,11 +306,33 @@ describe('parseGroundedResult', () => {
 
   it('returns a fallback result when JSON is completely unparseable', () => {
     const raw = 'Sorry, I cannot help with that.';
-    const result = parseGroundedResult(raw, makeRequest());
-    // Falls back to raw text as content
-    expect(result.content).toBeTruthy();
+    const request = makeRequest();
+    const result = parseGroundedResult(raw, request);
+    // Falls back to original section content, not the raw LLM output
+    expect(result.content).toBe(request.sectionContent);
     expect(result.claimMap).toHaveLength(0);
     expect(result.unsourceableClaims).toHaveLength(0);
+  });
+
+  it('preserves original section content when JSON is truncated (#733)', () => {
+    // Simulate a truncated LLM response where the JSON is cut off mid-content
+    const raw = '{ "content": "## Background\\n\\nSome new text that got truncat';
+    const request = makeRequest();
+    const result = parseGroundedResult(raw, request);
+    // Must preserve the original section content, not partial JSON fragments
+    expect(result.content).toBe(request.sectionContent);
+    expect(result.claimMap).toHaveLength(0);
+  });
+
+  it('preserves original section content when response contains raw JSON blob (#733)', () => {
+    // Simulate the bug: raw JSON structure written to MDX
+    const raw = '{ "content": "## Background\\nRewritten content", "claimMap": [{ "claim": "truncat';
+    const request = makeRequest();
+    const result = parseGroundedResult(raw, request);
+    // Even if partial extraction pulls a "content" field, Zod validation should
+    // fail and we fall back to the original section content
+    expect(result.content).toBe(request.sectionContent);
+    expect(result.claimMap).toHaveLength(0);
   });
 
   it('handles missing claimMap field gracefully', () => {

--- a/crux/lib/section-writer.ts
+++ b/crux/lib/section-writer.ts
@@ -347,10 +347,13 @@ export function parseGroundedResult(
   );
 
   // Validate against schema — coerce missing arrays to []
+  // When validation fails, always fall back to the original section content.
+  // Don't trust `parsed?.content` from partial JSON extraction — it may be
+  // a truncated fragment that would write garbage to the MDX file (#733).
   const schemaResult = GroundedWriteResponseSchema.safeParse(parsed);
   let response: GroundedWriteResponse = schemaResult.success
     ? schemaResult.data
-    : { content: parsed?.content ?? request.sectionContent, claimMap: [], unsourceableClaims: [] };
+    : { content: request.sectionContent, claimMap: [], unsourceableClaims: [] };
 
   // Guard against garbage output: if the LLM returned refusal text or
   // unparseable content, the fallback sets `content` to the raw response.


### PR DESCRIPTION
## Summary

- **#733 Section-writer truncation**: When Zod validation fails on a partially-extracted LLM response, fall back to original section content instead of trusting partial JSON extraction (which could write garbage JSON blobs to MDX files)
- **#735 Quality gate thresholds**: Lower structuralScore thresholds — standard 40→30, deep 55→40. The deep threshold (55) was impossible to reach since structuralScoreNormalized caps at 50. Standard (40) required near-perfect scoring (12/15 raw)
- Fix QualityMetrics.structuralScore doc comment: 0-50 not 0-100
- Add quality-gate.test.ts with 9 tests covering threshold calibration and regression detection
- Add 2 section-writer truncation tests covering the #733 fallback path

## Test plan

- [x] All 1646 crux tests pass (including 11 new tests)
- [x] All 6 gate checks pass
- [x] Truncation fallback preserves original section content (verified by new tests)
- [x] Deep tier structuralScore threshold is now achievable (40 <= 50 max)

Closes #733
Closes #735