### PR TITLE
fix: swap Vercel ignoreCommand exit codes so production gets built

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,5 @@
   "framework": "nextjs",
   "installCommand": "cd .. && npx pnpm@9 install",
   "buildCommand": "node scripts/build-data.mjs && next build",
-  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == claude/* ]]; then echo \"Skipping build: claude/* branch (automated PR)\"; exit 1; fi; exit 0"
+  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == claude/* ]]; then echo \"Skipping build: claude/* branch (automated PR)\"; exit 0; fi; exit 1"
 }


### PR DESCRIPTION
## Problem

Production deployments on Vercel stopped happening. The Vercel dashboard showed many preview builds for `claude/*` branches but zero production deployments.

## Root Cause

`apps/web/vercel.json` had the `ignoreCommand` exit codes backwards.

Vercel's `ignoreCommand` semantics:
- `exit 0` = skip the build
- `exit 1` = proceed with the build

The previous code had them inverted:
```bash
# BEFORE (broken):
if [[ "$VERCEL_GIT_COMMIT_REF" == claude/* ]]; then
  exit 1   # ← "proceed" — builds all claude/* branches (preview spam)
fi
exit 0     # ← "skip" — skips main and every other branch (no prod deploys!)
```

This caused Vercel's Git integration to build all automated `claude/*` PR branches (producing the many preview deployments visible in the dashboard) while skipping `main` entirely.

## Fix

Swap the exit codes so the intent matches the behavior:
```bash
# AFTER (fixed):
if [[ "$VERCEL_GIT_COMMIT_REF" == claude/* ]]; then
  exit 0   # ← "skip" — automated PR branches not built by Vercel Git integration
fi
exit 1     # ← "proceed" — main and other branches are built normally
```

## Notes

- The GitHub Actions `deploy` job (which uses `VERCEL_DEPLOY_HOOK_URL` to trigger prod deploys post-CI) will continue to work as before — deploy hooks bypass `ignoreCommand` entirely
- With this fix, Vercel's own Git integration will also build `main` on push, providing a double safety net

https://claude.ai/code/session_01JVDh4zAabj6CefjWDeK5dQ
