### PR TITLE
Skip automation workflows for draft pull requests

### DIFF
--- a/.github/workflows/auto-update-review-gate.yml
+++ b/.github/workflows/auto-update-review-gate.yml
@@ -17,8 +17,8 @@ permissions:
 
 jobs:
   audit-gate:
-    # Only run on auto-update PRs
-    if: contains(github.event.pull_request.labels.*.name, 'auto-update')
+    # Only run on non-draft auto-update PRs
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-update')
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -45,6 +45,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check if PR is a draft
+        id: check-draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IS_DRAFT=$(gh pr list \
+            --head "${{ github.event.workflow_run.head_branch }}" \
+            --json isDraft \
+            --jq '.[0].isDraft // false')
+          echo "is_draft=$IS_DRAFT" >> "$GITHUB_OUTPUT"
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "PR is a draft — skipping autofix to avoid wasted spend."
+          fi
+
       - name: Check for prior autofix attempts
         id: check-attempts
         env:
@@ -63,7 +77,7 @@ jobs:
           fi
 
       - name: Auto-fix CI failure
-        if: steps.check-attempts.outputs.should_fix == 'true'
+        if: steps.check-draft.outputs.is_draft != 'true' && steps.check-attempts.outputs.should_fix == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -57,9 +57,9 @@ jobs:
           # short delay so we don't miss freshly-conflicted PRs.
           for attempt in 1 2 3; do
             all_prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open \
-              --json number,headRefName,mergeable)
+              --json number,headRefName,mergeable,isDraft)
 
-            unknown_count=$(echo "$all_prs" | jq '[.[] | select(.mergeable == "UNKNOWN")] | length')
+            unknown_count=$(echo "$all_prs" | jq '[.[] | select(.isDraft == false) | select(.mergeable == "UNKNOWN")] | length')
 
             if [ "$unknown_count" -eq 0 ] || [ "$attempt" -eq 3 ]; then
               break
@@ -69,7 +69,7 @@ jobs:
             sleep 10
           done
 
-          prs=$(echo "$all_prs" | jq -c '[.[] | select(.mergeable == "CONFLICTING") | {number: .number, branch: .headRefName}]')
+          prs=$(echo "$all_prs" | jq -c '[.[] | select(.isDraft == false) | select(.mergeable == "CONFLICTING") | {number: .number, branch: .headRefName}]')
 
           echo "Conflicted PRs: $prs"
 


### PR DESCRIPTION
## Summary
This change prevents automated workflows from running on draft pull requests to avoid unnecessary resource consumption and API costs.

## Key Changes
- **ci-autofix.yml**: Added a check to detect draft PRs and skip the Claude Code Action autofix step if the PR is in draft status
- **resolve-conflicts.yml**: Updated conflict resolution logic to exclude draft PRs from processing, filtering out drafts when checking for conflicting and unknown-status PRs
- **auto-update-review-gate.yml**: Added a condition to only run the audit gate workflow on non-draft auto-update PRs

## Implementation Details
- Draft PR detection uses the GitHub CLI `gh pr list` command with the `isDraft` JSON field
- The checks are applied at the workflow step level (ci-autofix) and within jq filters (resolve-conflicts) to prevent unnecessary processing
- All three workflows now respect draft status before executing their respective automation tasks, reducing wasted spend on draft PRs that are still being developed

https://claude.ai/code/session_014cKD2ZcayPKnixto7WJx4K