### PR TITLE
refactor: extract shared claim-extraction patterns into crux/lib/claim-patterns.ts

### DIFF
--- a/crux/authoring/orchestrator/tools/adversarial-review.ts
+++ b/crux/authoring/orchestrator/tools/adversarial-review.ts
@@ -8,6 +8,11 @@
  */
 
 import { stripFrontmatter } from '../../../lib/patterns.ts';
+import {
+  SPECULATION_PATTERNS,
+  WEASEL_PATTERNS,
+  FACTUAL_CLAIM_PATTERNS,
+} from '../../../lib/claim-patterns.ts';
 import type { ToolRegistration } from './types.ts';
 
 // ---------------------------------------------------------------------------
@@ -20,28 +25,6 @@ interface ExtractedIssue {
   section?: string;
   severity: 'critical' | 'warning' | 'info';
 }
-
-/** Words/phrases that indicate speculative or hedging language. */
-const SPECULATION_PATTERNS = [
-  /\b(?:might|may|could|possibly|perhaps|likely|probably|presumably|arguably)\b/i,
-  /\b(?:it is believed|some believe|many think|it is thought|widely considered)\b/i,
-  /\b(?:appears to|seems to|tends to)\b/i,
-];
-
-/** Weasel words that weaken claims without attribution. */
-const WEASEL_PATTERNS = [
-  /\b(?:some experts|many researchers|critics argue|supporters claim|some say)\b/i,
-  /\b(?:it has been suggested|it is often said|it is sometimes argued)\b/i,
-];
-
-/** Patterns that indicate factual claims (dates, numbers, dollar amounts). */
-const FACTUAL_CLAIM_PATTERNS = [
-  /\$[\d,.]+\s*(?:billion|million|trillion|B|M|K|T)/i,
-  /\b(?:founded|established|created|launched)\s+in\s+\d{4}/i,
-  /\b\d[\d,]*\s+(?:employees?|staff|researchers?|members?|people)\b/i,
-  /\b(?:raised|received|secured|invested)\s+\$[\d,.]+/i,
-  /\bin\s+\d{4},/i, // "In 2023," temporal claims
-];
 
 function analyzeContent(content: string): ExtractedIssue[] {
   const body = stripFrontmatter(content);

--- a/crux/evals/agents/cross-reference-checker.ts
+++ b/crux/evals/agents/cross-reference-checker.ts
@@ -15,6 +15,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import type { AdversarialFinding } from '../types.ts';
 import { stripFrontmatter } from '../../lib/patterns.ts';
+import { ENTITY_FACT_PATTERNS, type FactType } from '../../lib/claim-patterns.ts';
 
 // ---------------------------------------------------------------------------
 // Fact extraction (regex-based, no LLM)
@@ -23,41 +24,11 @@ import { stripFrontmatter } from '../../lib/patterns.ts';
 interface ExtractedFact {
   pageId: string;
   entityMention: string; // The entity name mentioned
-  factType: 'founding-year' | 'funding' | 'employee-count' | 'role' | 'date';
+  factType: FactType;
   value: string;
   context: string; // Surrounding sentence
   paragraphIndex: number;
 }
-
-/** Patterns to extract structured facts. */
-const FACT_PATTERNS: Array<{
-  regex: RegExp;
-  factType: ExtractedFact['factType'];
-  entityGroup: number;
-  valueGroup: number;
-}> = [
-  // "X was founded in YYYY"
-  {
-    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:was )?(?:founded|established|created|launched|incorporated) (?:in )?((?:19|20)\d{2})/g,
-    factType: 'founding-year',
-    entityGroup: 1,
-    valueGroup: 2,
-  },
-  // "X raised $N million/billion" (handles escaped \$ in MDX)
-  {
-    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:has )?(?:raised|received|secured) \\?\$([\d,.]+)\s*(million|billion)/gi,
-    factType: 'funding',
-    entityGroup: 1,
-    valueGroup: 2,
-  },
-  // "X has/had/grown to N employees/staff/researchers"
-  {
-    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:has|had|employs|employed)(?: grown to)? (?:approximately |about |around |~)?([\d,]+) (?:employees|staff|researchers|people|members)/gi,
-    factType: 'employee-count',
-    entityGroup: 1,
-    valueGroup: 2,
-  },
-];
 
 /**
  * Extract structured facts from a page.
@@ -70,7 +41,7 @@ export function extractFacts(pageId: string, content: string): ExtractedFact[] {
   for (let pi = 0; pi < paragraphs.length; pi++) {
     const para = paragraphs[pi];
 
-    for (const pattern of FACT_PATTERNS) {
+    for (const pattern of ENTITY_FACT_PATTERNS) {
       const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
       let match: RegExpExecArray | null;
 

--- a/crux/evals/injectors/wrong-numbers.ts
+++ b/crux/evals/injectors/wrong-numbers.ts
@@ -9,22 +9,7 @@
 
 import type { InjectedError } from '../types.ts';
 import { stripFrontmatter } from '../../lib/patterns.ts';
-
-/** Patterns that match numeric claims in wiki prose. */
-const NUMBER_PATTERNS: { regex: RegExp; label: string }[] = [
-  // Years: "founded in 2015", "established 2019", "since 2020"
-  { regex: /\b((?:founded|established|created|launched|started|formed|incorporated)\s+(?:in\s+)?)((?:19|20)\d{2})\b/gi, label: 'founding-year' },
-  // Dollar amounts: "$100 million", "$2.5 billion", "$500,000"
-  { regex: /(\$)([\d,.]+)\s*(million|billion|thousand|[MBK])\b/gi, label: 'dollar-amount' },
-  // Plain dollar amounts: "$100", "$2,500"
-  { regex: /(\$)([\d,]+)(?!\s*(?:million|billion|thousand|[MBK]))/gi, label: 'dollar-plain' },
-  // Employee/staff counts: "50 employees", "200 researchers", "~150 staff"
-  { regex: /(~?\s*)([\d,]+)\s*(employees?|researchers?|staff|people|members?|engineers?|scientists?)\b/gi, label: 'headcount' },
-  // Percentages: "25%", "increased by 50%"
-  { regex: /([\d.]+)(%)/g, label: 'percentage' },
-  // Year references: "in 2023", "by 2025", "since 2019"
-  { regex: /\b(in|by|since|from|during|around)\s+((?:19|20)\d{2})\b/gi, label: 'year-reference' },
-];
+import { NUMBER_EXTRACTION_PATTERNS } from '../../lib/claim-patterns.ts';
 
 /** Corrupt a number by a plausible amount. */
 function corruptNumber(value: string, label: string): string {
@@ -101,7 +86,7 @@ function findNumericFacts(content: string): Array<{
     // Find where this paragraph actually starts in the body
     const paraStart = body.indexOf(para, charOffset);
 
-    for (const { regex, label } of NUMBER_PATTERNS) {
+    for (const { regex, label } of NUMBER_EXTRACTION_PATTERNS) {
       regex.lastIndex = 0;
       let match: RegExpExecArray | null;
       while ((match = regex.exec(para)) !== null) {

--- a/crux/lib/claim-patterns.ts
+++ b/crux/lib/claim-patterns.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared claim-extraction regex patterns.
+ *
+ * Centralises patterns used by three consumers to ensure consistency:
+ *   - adversarial-review.ts   (FACTUAL_CLAIM_PATTERNS, SPECULATION_PATTERNS, WEASEL_PATTERNS)
+ *   - wrong-numbers.ts        (NUMBER_EXTRACTION_PATTERNS)
+ *   - cross-reference-checker.ts (ENTITY_FACT_PATTERNS, FactType)
+ *
+ * When adding a new pattern here it is automatically picked up by all three.
+ */
+
+// ---------------------------------------------------------------------------
+// Claim quality assessment patterns (adversarial-review)
+// ---------------------------------------------------------------------------
+
+/** Words/phrases that indicate speculative or hedging language. */
+export const SPECULATION_PATTERNS: RegExp[] = [
+  /\b(?:might|may|could|possibly|perhaps|likely|probably|presumably|arguably)\b/i,
+  /\b(?:it is believed|some believe|many think|it is thought|widely considered)\b/i,
+  /\b(?:appears to|seems to|tends to)\b/i,
+];
+
+/** Weasel words that weaken claims without attribution. */
+export const WEASEL_PATTERNS: RegExp[] = [
+  /\b(?:some experts|many researchers|critics argue|supporters claim|some say)\b/i,
+  /\b(?:it has been suggested|it is often said|it is sometimes argued)\b/i,
+];
+
+/** Patterns that indicate factual claims (dates, numbers, dollar amounts). */
+export const FACTUAL_CLAIM_PATTERNS: RegExp[] = [
+  /\$[\d,.]+\s*(?:billion|million|trillion|B|M|K|T)/i,
+  /\b(?:founded|established|created|launched)\s+in\s+\d{4}/i,
+  /\b\d[\d,]*\s+(?:employees?|staff|researchers?|members?|people)\b/i,
+  /\b(?:raised|received|secured|invested)\s+\$[\d,.]+/i,
+  /\bin\s+\d{4},/i, // "In 2023," temporal claims
+];
+
+// ---------------------------------------------------------------------------
+// Number extraction patterns (wrong-numbers injector)
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns with capture groups for extracting and mutating specific numbers.
+ *
+ * Capture structure: [prefix (group 1), number (group 2), suffix (group 3)].
+ * Exception: the 'percentage' label has [number (group 1), suffix (group 2)] — no prefix group.
+ */
+export const NUMBER_EXTRACTION_PATTERNS: { regex: RegExp; label: string }[] = [
+  // Years: "founded in 2015", "established 2019", "since 2020"
+  {
+    regex: /\b((?:founded|established|created|launched|started|formed|incorporated)\s+(?:in\s+)?)((?:19|20)\d{2})\b/gi,
+    label: 'founding-year',
+  },
+  // Dollar amounts with scale: "$100 million", "$2.5 billion"
+  {
+    regex: /(\$)([\d,.]+)\s*(million|billion|thousand|[MBK])\b/gi,
+    label: 'dollar-amount',
+  },
+  // Plain dollar amounts: "$100", "$2,500"
+  {
+    regex: /(\$)([\d,]+)(?!\s*(?:million|billion|thousand|[MBK]))/gi,
+    label: 'dollar-plain',
+  },
+  // Employee/staff counts: "50 employees", "200 researchers", "~150 staff"
+  {
+    regex: /(~?\s*)([\d,]+)\s*(employees?|researchers?|staff|people|members?|engineers?|scientists?)\b/gi,
+    label: 'headcount',
+  },
+  // Percentages: "25%", "increased by 50%"
+  {
+    regex: /([\d.]+)(%)/g,
+    label: 'percentage',
+  },
+  // Year references: "in 2023", "by 2025", "since 2019"
+  {
+    regex: /\b(in|by|since|from|during|around)\s+((?:19|20)\d{2})\b/gi,
+    label: 'year-reference',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Entity-aware fact extraction patterns (cross-reference-checker)
+// ---------------------------------------------------------------------------
+
+/** Fact types extracted by entity-aware patterns. */
+export type FactType = 'founding-year' | 'funding' | 'employee-count' | 'role' | 'date';
+
+/**
+ * Patterns for extracting structured facts with entity name capture groups.
+ * Used for cross-page contradiction detection.
+ *
+ * Each entry captures: [entity name (group entityGroup), value (group valueGroup)].
+ */
+export const ENTITY_FACT_PATTERNS: Array<{
+  regex: RegExp;
+  factType: FactType;
+  entityGroup: number;
+  valueGroup: number;
+}> = [
+  // "X was founded in YYYY"
+  {
+    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:was )?(?:founded|established|created|launched|incorporated) (?:in )?((?:19|20)\d{2})/g,
+    factType: 'founding-year',
+    entityGroup: 1,
+    valueGroup: 2,
+  },
+  // "X raised $N million/billion" (handles escaped \$ in MDX)
+  {
+    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:has )?(?:raised|received|secured) \\?\$([\d,.]+)\s*(million|billion)/gi,
+    factType: 'funding',
+    entityGroup: 1,
+    valueGroup: 2,
+  },
+  // "X has/had/grown to N employees/staff/researchers"
+  {
+    regex: /(\b[A-Z][a-zA-Z\s&.-]+?) (?:has|had|employs|employed)(?: grown to)? (?:approximately |about |around |~)?([\d,]+) (?:employees|staff|researchers|people|members)/gi,
+    factType: 'employee-count',
+    entityGroup: 1,
+    valueGroup: 2,
+  },
+];


### PR DESCRIPTION
## Summary

- Created `crux/lib/claim-patterns.ts` exporting shared pattern sets used across three files
- Removed ~71 lines of duplicated regex definitions from the three consumer files
- All three files now import from the shared module and can layer context-specific logic on top

## Problem

Three files independently maintained similar regex patterns for extracting factual claims:
- `adversarial-review.ts`: `FACTUAL_CLAIM_PATTERNS`, `SPECULATION_PATTERNS`, `WEASEL_PATTERNS`
- `wrong-numbers.ts`: `NUMBER_PATTERNS` (dates, dollar amounts, percentages, action verbs)
- `cross-reference-checker.ts`: `FACT_PATTERNS` (founding years, funding amounts, employee counts with entity capture groups)

When a new pattern was added to one file, the others did not get it.

## Key Changes

- `crux/lib/claim-patterns.ts` exports:
  - `SPECULATION_PATTERNS` / `WEASEL_PATTERNS` / `FACTUAL_CLAIM_PATTERNS` (claim quality assessment)
  - `NUMBER_EXTRACTION_PATTERNS` (numeric extraction with capture groups, for wrong-numbers injector)
  - `ENTITY_FACT_PATTERNS` / `FactType` (entity-aware fact extraction, for cross-reference-checker)
- `adversarial-review.ts`: imports the three pattern sets instead of defining them locally
- `wrong-numbers.ts`: imports `NUMBER_EXTRACTION_PATTERNS` (was `NUMBER_PATTERNS`) from shared module
- `cross-reference-checker.ts`: imports `ENTITY_FACT_PATTERNS` and `FactType` from shared module

## Test Plan

- [x] All 1635 tests pass unchanged (`pnpm test`)
- [x] All 6 gate checks pass (`pnpm crux validate gate`)
- [x] No errors in the modified/new TypeScript files

Closes #763
