### PR TITLE
Add page: Relative Longtermist Value Comparisons (E886)

### DIFF
--- a/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
+++ b/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
@@ -85,7 +85,7 @@ Where:
 - **P(AI x-risk)**: probability that AI causes existential catastrophe (Carlsmith: \>10%; superforecasters: ≈0.4%; Toby Ord: 10%; AI experts median: ≈5%)
 - **N_future**: expected number of future people if catastrophe is avoided (~10²² to 10²⁸, depending on space settlement and timescales)
 - **w_future**: moral weight of future generations relative to present (0 under pure time discount, 1 under person-affecting views that extend far forward)
-- **V_person in GEUs**: GEU value of one statistical life (\≈\$4,000–10,000 / person, so 0.5–3 GEUs per person using GiveWell's \≈\$3,000–8,000/life)
+- **V_person in GEUs**: GEU value of one statistical life (≈\$4,000–10,000 / person, so 0.5–3 GEUs per person using GiveWell's ≈\$3,000–8,000/life)
 
 **Working estimate**: Under moderate longtermist assumptions (P(x-risk) = 15%, N_future = 10²³, w_future = 0.5, V_person = 1 GEU), the value of 1% x-risk reduction is approximately **10²² GEUs** — a number so large it only becomes actionable through tractability: how much does \$1 actually move x-risk?
 


### PR DESCRIPTION
## Summary

- New model page `longtermist-value-comparisons` (entity E886) providing a quantitative framework for comparing longtermist allocations on a GiveWell-Equivalent Unit (GEU) scale
- ~2/3 of the page covers specific variable analysis: value of 1% x-risk reduction, 1 year before TAI, $1 to Coefficient TAI Fund, $1 to LTFF, $1 in Anthropic secondary equity, and Coefficient Giving's 13 cause clusters
- Ends with two embedded Squiggle components: a rendered probability model and an interactive calculator (`showEditor={true}`) where readers can adjust P(x-risk), moral weight, and tractability to see their personal conclusions

## Key content

- **GiveWell-Equivalent Units**: defines the reference anchor ($1 to GiveWell = 1 GEU), calibrated at 0.02–0.05 DALYs/dollar
- **X-risk reduction value**: formula + Mermaid value-chain diagram; dominated by moral weight of future generations and P(x-risk)
- **1 year before TAI**: cross-referenced to AI Acceleration Tradeoff Model; equivalent to ~$1B–$100T in direct safety research
- **Coefficient TAI Fund**: full counterfactual chain table, 68% evaluation-heavy allocation noted; estimate 50–500,000 GEUs/$
- **LTFF**: comparison table vs Coefficient, guidance on when to prefer each; bimodal efficiency distribution
- **Anthropic secondary equity**: sign-uncertain analysis (distribution spans negative); contrasted with primary-round investing
- **13 cause clusters**: table comparing all Coefficient funds under longtermist vs neartermist priors
- **Cross-comparison matrix**: all pairwise ratios

## Validation

- All 6 CI-blocking checks passed (pre-push gate): MDX syntax, dollar-sign escaping, frontmatter schema, no-quoted-subcategory, numeric-id-integrity, prefer-entitylink
- YAML schema: 3928 items pass
- TypeScript: clean
- Tests: 253/253 passed
