### PR TITLE
fix: prevent improve pipeline from writing JSON blobs to MDX files

### DIFF
--- a/crux/authoring/page-improver/phases/improve.ts
+++ b/crux/authoring/page-improver/phases/improve.ts
@@ -52,6 +52,11 @@ export async function improvePhase(page: PageData, analysis: AnalysisResult, res
   });
 
   let improvedContent: string = result;
+
+  // Strategy 1: If the response starts with frontmatter, use it directly.
+  // Strategy 2: Extract content from markdown code fences (```mdx, ```markdown, ```json, or bare ```)
+  // Strategy 3: Detect JSON-wrapped responses with "content" field and extract the markdown.
+  // Strategy 4: Fall back to original content if nothing looks like valid MDX.
   if (!improvedContent.startsWith('---')) {
     // Scan all code blocks and prefer the one whose content is valid MDX (starts with ---).
     // The non-greedy single-match regex previously picked the *first* code block, which
@@ -66,6 +71,53 @@ export async function improvePhase(page: PageData, analysis: AnalysisResult, res
       const largest = codeBlocks.reduce((a, b) => a[1].length >= b[1].length ? a : b);
       improvedContent = largest[1];
     }
+
+    // Detect JSON-wrapped responses: {"content": "...", "claimMap": [...]}
+    // The LLM sometimes returns structured JSON instead of raw MDX.
+    const contentFieldMatch = improvedContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/s);
+    if (contentFieldMatch) {
+      log('improve', '⚠ Detected JSON-wrapped response — extracting "content" field');
+      try {
+        // Unescape JSON string: \n → newline, \" → ", \\ → \, \t → tab
+        const extracted = JSON.parse(`"${contentFieldMatch[1]}"`);
+        if (typeof extracted === 'string' && extracted.length > 100) {
+          improvedContent = extracted;
+        }
+      } catch {
+        // JSON.parse may fail on truncated strings — try manual unescaping
+        let raw = contentFieldMatch[1];
+        let manual = '';
+        for (let i = 0; i < raw.length; i++) {
+          if (raw[i] === '\\' && i + 1 < raw.length) {
+            const next = raw[i + 1];
+            if (next === 'n') { manual += '\n'; i++; }
+            else if (next === '"') { manual += '"'; i++; }
+            else if (next === '\\') { manual += '\\'; i++; }
+            else if (next === 't') { manual += '\t'; i++; }
+            else { manual += raw[i]; }
+          } else {
+            manual += raw[i];
+          }
+        }
+        if (manual.length > 100) {
+          log('improve', '  Used manual unescaping for truncated JSON content string');
+          improvedContent = manual;
+        }
+      }
+    }
+  }
+
+  // Validate: improved content should look like MDX (start with frontmatter or heading).
+  // If it looks like raw JSON or garbage, fall back to original content.
+  const trimmed = improvedContent.trim();
+  if (
+    !trimmed.startsWith('---') &&
+    !trimmed.startsWith('#') &&
+    !trimmed.startsWith('import ') &&
+    !trimmed.startsWith('<')
+  ) {
+    log('improve', `⚠ Response does not look like MDX (starts with "${trimmed.substring(0, 40)}...") — keeping original`);
+    return currentContent;
   }
 
   // Guard against LLM truncation: if output is significantly shorter than input,

--- a/crux/lib/rules/pipeline-artifacts.ts
+++ b/crux/lib/rules/pipeline-artifacts.ts
@@ -47,13 +47,37 @@ export const pipelineArtifactsRule = {
 
     const lines = body.split('\n');
     let inCodeBlock = false;
+    let codeBlockStart = -1;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      // Track fenced code blocks — don't flag JSON inside legitimate ``` blocks
+      // Track fenced code blocks
       if (line.trim().startsWith('```')) {
-        inCodeBlock = !inCodeBlock;
+        if (!inCodeBlock) {
+          inCodeBlock = true;
+          codeBlockStart = i;
+        } else {
+          // Closing a code block — check if this code block IS a JSON blob artifact.
+          // Pipeline artifacts often appear as ```json code fences containing
+          // {"content": "...", "claimMap": [...]} structures.
+          const blockContent = lines.slice(codeBlockStart + 1, i).join('\n');
+          const matchCount = JSON_FIELD_PATTERNS.filter(p => p.test(blockContent)).length;
+          if (matchCount >= 2) {
+            issues.push(new Issue({
+              rule: 'pipeline-artifacts',
+              file: contentFile.path,
+              line: codeBlockStart + 1,
+              message:
+                `Pipeline artifact: code fence contains JSON fields ("content", "claimMap", etc.) ` +
+                `that look like a leaked improve-pipeline response. ` +
+                `The content should be extracted from the JSON and rendered as MDX.`,
+              severity: Severity.ERROR,
+            }));
+          }
+          inCodeBlock = false;
+          codeBlockStart = -1;
+        }
         continue;
       }
       if (inCodeBlock) continue;
@@ -75,6 +99,23 @@ export const pipelineArtifactsRule = {
             `Pipeline artifact: standalone \`{\` with JSON fields ("content", "claimMap", etc.) ` +
             `detected in MDX body. This is a leaked improve-pipeline JSON response — ` +
             `the page will render as raw JSON. Remove the blob and restore the MDX content.`,
+          severity: Severity.ERROR,
+        }));
+      }
+    }
+
+    // Handle unclosed code blocks containing JSON artifacts (truncated pipeline output)
+    if (inCodeBlock && codeBlockStart >= 0) {
+      const blockContent = lines.slice(codeBlockStart + 1).join('\n');
+      const matchCount = JSON_FIELD_PATTERNS.filter(p => p.test(blockContent)).length;
+      if (matchCount >= 2) {
+        issues.push(new Issue({
+          rule: 'pipeline-artifacts',
+          file: contentFile.path,
+          line: codeBlockStart + 1,
+          message:
+            `Pipeline artifact: unclosed code fence contains JSON fields ("content", "claimMap", etc.) ` +
+            `from a truncated improve-pipeline response.`,
           severity: Severity.ERROR,
         }));
       }


### PR DESCRIPTION
## Summary

Root cause fix for the JSON blob pipeline artifacts that corrupted 6+ wiki pages (fixed in PRs #795 and #807). Two changes:

### 1. `improve.ts` — Prevent JSON blobs from being written

When the LLM returns `{"content": "...", "claimMap": [...]}` instead of raw MDX, the pipeline now:
- Detects the JSON `"content"` field and extracts the markdown from it
- Unescapes JSON strings (`\n` → newline, `\"` → `"`, etc.)
- Falls back to manual unescaping when `JSON.parse` fails on truncated strings
- Validates that extracted content looks like MDX (starts with `---`, `#`, `import`, or `<`) before accepting it
- Falls back to original page content if validation fails

This works alongside the upstream code fence scanning improvements.

### 2. `pipeline-artifacts.ts` — Detect JSON blobs inside code fences

The existing validation rule only caught JSON blobs outside code fences (standalone `{` lines). All 6 corrupted files had their JSON blobs INSIDE ` ```json` code fences. Now also detects:
- JSON blobs inside closed code fences (` ```json ... ``` `)
- JSON blobs in unclosed code fences (truncated pipeline output)

## Test plan
- [x] All 251 tests pass
- [x] TypeScript compiles cleanly
- [x] Manual review of the 6 previously corrupted files confirms the detection regex would have caught them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
