### PR TITLE
feat: add responsive hamburger menu for mobile navigation

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { DevModeToggle } from "@/components/DevModeToggle";
 import { SearchButton, SearchDialog } from "@/components/SearchDialog";
+import { MobileNav } from "@/components/MobileNav";
 import { SITE_URL } from "@/lib/site-config";
 import "./globals.css";
 import "katex/dist/katex.min.css";
@@ -52,24 +53,25 @@ export default function RootLayout({
             <nav className="flex-1 flex items-center justify-end gap-4 px-6 py-3">
               <Link
                 href="/wiki"
-                className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+                className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >
                 Explore
               </Link>
               <Link
                 href="/wiki/E755"
-                className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+                className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >
                 About
               </Link>
               <Link
                 href="/wiki/E779"
-                className="text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+                className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >
                 Internal
               </Link>
               <SearchButton />
               <DevModeToggle />
+              <MobileNav />
             </nav>
           </div>
         </header>

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_LINKS = [
+  { href: "/wiki", label: "Explore" },
+  { href: "/wiki/E755", label: "About" },
+  { href: "/wiki/E779", label: "Internal" },
+];
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  // Close menu on route change
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Close menu on Escape
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  return (
+    <div ref={menuRef} className="md:hidden relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+        className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {open ? (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        ) : (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <nav
+          className="absolute right-0 top-full mt-1 w-48 bg-card border border-border rounded-lg shadow-lg py-1 z-50"
+          aria-label="Mobile navigation"
+        >
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="block px-4 py-2.5 text-sm text-foreground no-underline hover:bg-muted transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a responsive hamburger menu for mobile navigation. On screens below the `md` breakpoint (768px), the three nav links (Explore, About, Internal) collapse into a dropdown menu triggered by a hamburger icon. Search and DevMode toggle remain always visible in the header.

- New `MobileNav` client component with hamburger toggle, dropdown menu, and proper ARIA attributes
- Desktop nav links hidden on mobile via `hidden md:inline`
- Menu auto-closes on route change, Escape key, and outside clicks

Closes #786

## Test plan

- [x] Gate validation passes (all 7 checks including full Next.js build)
- [ ] Visual check at 320px, 375px, 768px widths
- [ ] Keyboard navigation: Tab to hamburger, Enter to open, Escape to close
