### PR TITLE
feat: track actual API costs in V2 orchestrator

### DIFF
--- a/crux/authoring/batch-runner.ts
+++ b/crux/authoring/batch-runner.ts
@@ -76,6 +76,8 @@ export interface PageResult {
   status: 'completed' | 'failed' | 'skipped' | 'budget-exceeded' | 'timeout';
   duration?: string;
   cost?: number;
+  /** Actual cost from API usage data (when available). */
+  actualCost?: number;
   qualityGatePassed?: boolean;
   error?: string;
   toolCallCount?: number;
@@ -343,7 +345,9 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
       );
 
       const pageDuration = Date.now() - pageStart;
-      cumulativeCost += orchResult.totalCost;
+      // Prefer actual cost for budget tracking when available
+      const effectiveCost = orchResult.actualTotalCost ?? orchResult.totalCost;
+      cumulativeCost += effectiveCost;
 
       // Snapshot post-improvement metrics (re-read file after apply)
       if (pageFile && apply) {
@@ -356,6 +360,7 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
         status: 'completed',
         duration: formatDuration(pageDuration),
         cost: orchResult.totalCost,
+        actualCost: orchResult.actualTotalCost ?? undefined,
         qualityGatePassed: orchResult.qualityGatePassed,
         toolCallCount: orchResult.toolCallCount,
       };
@@ -484,6 +489,36 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
     }
   }
 
+  // Write cost-analysis.json with per-page breakdowns
+  const costAnalysisPath = path.join(ROOT, '.claude/temp/cost-analysis.json');
+  const costAnalysis = {
+    generatedAt: new Date().toISOString(),
+    tier,
+    budgetLimit: budgetLimit ?? null,
+    totals: {
+      estimatedCost: results.reduce((sum, r) => sum + (r.cost ?? 0), 0),
+      actualCost: results.reduce((sum, r) => sum + (r.actualCost ?? 0), 0),
+      pages: results.length,
+      completed: completed.length,
+    },
+    pages: results.map(r => ({
+      pageId: r.pageId,
+      status: r.status,
+      estimatedCost: r.cost ?? null,
+      actualCost: r.actualCost ?? null,
+      duration: r.duration ?? null,
+      toolCallCount: r.toolCallCount ?? null,
+    })),
+  };
+  try {
+    const costDir = path.dirname(costAnalysisPath);
+    if (!fs.existsSync(costDir)) fs.mkdirSync(costDir, { recursive: true });
+    fs.writeFileSync(costAnalysisPath, JSON.stringify(costAnalysis, null, 2));
+    log('batch', `Cost analysis written to ${costAnalysisPath}`);
+  } catch {
+    // Non-critical — don't fail the batch
+  }
+
   // Clean up state file on successful full completion (no failures)
   if (failed.length === 0 && timedOut.length === 0 && skipped.filter(r => r.status === 'budget-exceeded').length === 0) {
     try { fs.unlinkSync(STATE_FILE); } catch { /* ok */ }
@@ -527,9 +562,17 @@ function generateReport(data: ReportData): string {
   lines.push(`  Quality gate: ${gatesPassed.length}/${completed.length} passed`);
   lines.push('');
 
+  // Check if any results have actual costs
+  const hasActualCosts = results.some(r => r.actualCost != null);
+
   // Results table
-  lines.push('| # | Page | Status | Cost | Duration | Gate | Tool Calls |');
-  lines.push('|---|------|--------|------|----------|------|------------|');
+  if (hasActualCosts) {
+    lines.push('| # | Page | Status | Est. | Actual | Duration | Gate | Tool Calls |');
+    lines.push('|---|------|--------|------|--------|----------|------|------------|');
+  } else {
+    lines.push('| # | Page | Status | Cost | Duration | Gate | Tool Calls |');
+    lines.push('|---|------|--------|------|----------|------|------------|');
+  }
 
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
@@ -538,11 +581,16 @@ function generateReport(data: ReportData): string {
                    r.status === 'timeout' ? 'TIMEOUT' :
                    r.status === 'budget-exceeded' ? 'BUDGET' : 'SKIP';
     const cost = r.cost ? formatCost(r.cost) : '-';
+    const actualCost = r.actualCost != null ? formatCost(r.actualCost) : '-';
     const dur = r.duration || '-';
     const gate = r.qualityGatePassed === undefined ? '-' :
                  r.qualityGatePassed ? 'PASS' : 'FAIL';
     const tools = r.toolCallCount ?? '-';
-    lines.push(`| ${i + 1} | ${r.pageId} | ${status} | ${cost} | ${dur} | ${gate} | ${tools} |`);
+    if (hasActualCosts) {
+      lines.push(`| ${i + 1} | ${r.pageId} | ${status} | ${cost} | ${actualCost} | ${dur} | ${gate} | ${tools} |`);
+    } else {
+      lines.push(`| ${i + 1} | ${r.pageId} | ${status} | ${cost} | ${dur} | ${gate} | ${tools} |`);
+    }
   }
 
   // Failures detail

--- a/crux/authoring/orchestrator/index.ts
+++ b/crux/authoring/orchestrator/index.ts
@@ -105,7 +105,10 @@ async function autoLogSession(
   try {
     const today = new Date().toISOString().split('T')[0];
     const branch = getCurrentBranch();
-    const summary = `Improved "${page.title}" via orchestrator v2 (${tier}, ${result.toolCallCount} tool calls, ${result.refinementCycles} refinement cycles). Quality gate: ${result.qualityGatePassed ? 'passed' : 'failed'}. Cost: ~$${result.totalCost.toFixed(2)}.`;
+    const displayCost = result.actualTotalCost != null
+      ? `$${result.actualTotalCost.toFixed(2)} actual`
+      : `~$${result.totalCost.toFixed(2)} estimated`;
+    const summary = `Improved "${page.title}" via orchestrator v2 (${tier}, ${result.toolCallCount} tool calls, ${result.refinementCycles} refinement cycles). Quality gate: ${result.qualityGatePassed ? 'passed' : 'failed'}. Cost: ${displayCost}.`;
 
     const entry = {
       date: today,
@@ -114,7 +117,9 @@ async function autoLogSession(
       summary,
       model: null,
       duration: `${result.duration}s`,
-      cost: `~$${result.totalCost.toFixed(2)}`,
+      cost: result.actualTotalCost != null
+        ? `$${result.actualTotalCost.toFixed(2)}`
+        : `~$${result.totalCost.toFixed(2)}`,
       prUrl: null,
       pages: [page.id],
     };
@@ -208,18 +213,29 @@ export async function runOrchestratorPipeline(
 
   // ── Report ─────────────────────────────────────────────────────────────
 
+  const costStr = result.actualTotalCost != null
+    ? `~$${result.totalCost.toFixed(2)} estimated / $${result.actualTotalCost.toFixed(2)} actual`
+    : `~$${result.totalCost.toFixed(2)}`;
+
   console.log('\n' + '='.repeat(60));
   console.log('Orchestrator Complete');
   console.log('='.repeat(60));
   console.log(`Duration: ${result.duration}s`);
   console.log(`Tool calls: ${result.toolCallCount}`);
   console.log(`Refinement cycles: ${result.refinementCycles}`);
-  console.log(`Cost: ~$${result.totalCost.toFixed(2)}`);
+  console.log(`Cost: ${costStr}`);
   console.log(`Quality gate: ${result.qualityGatePassed ? 'PASSED' : 'FAILED'}`);
   console.log(`Output: ${tempPath}`);
 
+  if (result.actualCostBreakdown && Object.keys(result.actualCostBreakdown).length > 0) {
+    console.log('\nActual cost breakdown (from API usage):');
+    for (const [label, cost] of Object.entries(result.actualCostBreakdown).sort((a, b) => b[1] - a[1])) {
+      if (cost > 0) console.log(`  ${label}: $${cost.toFixed(4)}`);
+    }
+  }
+
   if (result.costBreakdown) {
-    console.log('\nCost breakdown:');
+    console.log('\nEstimated cost breakdown:');
     for (const [tool, cost] of Object.entries(result.costBreakdown).sort((a, b) => b[1] - a[1])) {
       if (cost > 0) console.log(`  ${tool}: $${cost.toFixed(2)}`);
     }

--- a/crux/authoring/orchestrator/orchestrator.test.ts
+++ b/crux/authoring/orchestrator/orchestrator.test.ts
@@ -17,6 +17,7 @@ import { buildToolDefinitions, extractQualityMetrics, wrapWithTracking, type Too
 import { evaluateQualityGate } from './quality-gate.ts';
 import { buildImproveSystemPrompt, buildRefinementPrompt } from './prompts.ts';
 import { deduplicateFootnotes } from './orchestrator.ts';
+import { CostTracker } from '../../lib/cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -71,6 +72,7 @@ function makeContext(overrides: Partial<OrchestratorContext> = {}): Orchestrator
     budget: TIER_BUDGETS.standard,
     directions: '',
     citationAudit: null,
+    tracker: new CostTracker(),
     ...overrides,
   };
 }

--- a/crux/authoring/orchestrator/orchestrator.ts
+++ b/crux/authoring/orchestrator/orchestrator.ts
@@ -18,10 +18,11 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam, ToolUseBlock, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages';
 
-import { createLlmClient, streamingCreate } from '../../lib/llm.ts';
+import { createLlmClient, streamingCreate, type StreamingCreateOptions } from '../../lib/llm.ts';
 import { MODELS } from '../../lib/anthropic.ts';
 import { withRetry, startHeartbeat } from '../../lib/resilience.ts';
 import { createPhaseLogger } from '../../lib/output.ts';
+import { CostTracker } from '../../lib/cost-tracker.ts';
 
 import {
   type OrchestratorContext,
@@ -149,6 +150,11 @@ async function runAgentLoop(
     { role: 'user', content: userMessage },
   ];
 
+  const trackingOptions: StreamingCreateOptions = {
+    tracker: ctx.tracker,
+    label: 'orchestrator',
+  };
+
   const makeRequest = (msgs: MessageParam[]) =>
     withRetry(
       () => streamingCreate(client, {
@@ -157,7 +163,7 @@ async function runAgentLoop(
         system: systemPrompt,
         tools: tools as Anthropic.Messages.Tool[],
         messages: msgs,
-      }),
+      }, trackingOptions),
       { label: `orchestrator(${orchestratorModel})` },
     );
 
@@ -315,6 +321,8 @@ export async function runOrchestrator(
 
   // ── Build context ─────────────────────────────────────────────────────────
 
+  const tracker = new CostTracker();
+
   const ctx: OrchestratorContext = {
     page,
     filePath,
@@ -330,6 +338,7 @@ export async function runOrchestrator(
     budget,
     directions,
     citationAudit: null,
+    tracker,
   };
 
   // ── Build tools ───────────────────────────────────────────────────────────
@@ -408,7 +417,7 @@ export async function runOrchestrator(
   const finalGate = evaluateQualityGate(ctx);
   const duration = ((Date.now() - startTime) / 1000).toFixed(1);
 
-  // Cost breakdown by tool
+  // Cost breakdown by tool (estimated)
   const costBreakdown: Record<string, number> = {};
   for (const entry of ctx.costEntries) {
     costBreakdown[entry.toolName] = (costBreakdown[entry.toolName] || 0) + entry.estimatedCost;
@@ -419,12 +428,25 @@ export async function runOrchestrator(
   costBreakdown['orchestrator_llm'] = orchestratorLlmCost;
   ctx.totalCost += orchestratorLlmCost;
 
+  // Actual costs from CostTracker (null if no API calls were tracked)
+  const actualTotalCost = tracker.entries.length > 0 ? tracker.totalCost : null;
+  const actualCostBreakdown = tracker.entries.length > 0 ? tracker.breakdown() : null;
+
   log('orchestrator', '═'.repeat(50));
   log('orchestrator', 'Orchestrator Complete');
   log('orchestrator', `Duration: ${duration}s`);
   log('orchestrator', `Tool calls: ${ctx.toolCallCount}`);
   log('orchestrator', `Refinement cycles: ${refinementCycles}`);
-  log('orchestrator', `Total cost: ~$${ctx.totalCost.toFixed(2)}`);
+  if (actualTotalCost != null) {
+    log('orchestrator', `Cost: ~$${ctx.totalCost.toFixed(2)} estimated / $${actualTotalCost.toFixed(2)} actual`);
+  } else {
+    log('orchestrator', `Cost: ~$${ctx.totalCost.toFixed(2)} estimated`);
+  }
+  if (actualCostBreakdown && Object.keys(actualCostBreakdown).length > 0) {
+    for (const [label, cost] of Object.entries(actualCostBreakdown).sort((a, b) => b[1] - a[1])) {
+      log('orchestrator', `  ${label}: $${cost.toFixed(4)}`);
+    }
+  }
   log('orchestrator', `Quality gate: ${finalGate.passed ? 'PASSED' : 'FAILED'}`);
   log('orchestrator', `Final metrics: ${JSON.stringify(finalMetrics)}`);
   log('orchestrator', '═'.repeat(50));
@@ -439,6 +461,8 @@ export async function runOrchestrator(
     refinementCycles,
     totalCost: ctx.totalCost,
     costBreakdown,
+    actualTotalCost,
+    actualCostBreakdown,
     qualityMetrics: finalMetrics,
     qualityGatePassed: finalGate.passed,
     outputPath: '', // Set by caller

--- a/crux/authoring/orchestrator/quality-gate.test.ts
+++ b/crux/authoring/orchestrator/quality-gate.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { evaluateQualityGate } from './quality-gate.ts';
 import type { OrchestratorContext, BudgetConfig } from './types.ts';
 import { TIER_BUDGETS } from './types.ts';
+import { CostTracker } from '../../lib/cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Mock the metrics extractor to return controlled values
@@ -43,6 +44,7 @@ function makeCtx(overrides: Partial<OrchestratorContext> = {}): OrchestratorCont
     budget: TIER_BUDGETS.standard,
     directions: '',
     citationAudit: null,
+    tracker: new CostTracker(),
     ...overrides,
   };
 }

--- a/crux/authoring/orchestrator/tools/rewrite-section.ts
+++ b/crux/authoring/orchestrator/tools/rewrite-section.ts
@@ -88,7 +88,7 @@ export const tool: ToolRegistration = {
             requireClaimMap: sectionSources.length > 0,
           },
         },
-        { model: options.writerModel },
+        { model: options.writerModel, tracker: ctx.tracker },
       );
 
       // Normalize dollar-sign escaping before checking tables or storing

--- a/crux/authoring/orchestrator/tools/run-research.ts
+++ b/crux/authoring/orchestrator/tools/run-research.ts
@@ -52,6 +52,7 @@ export const tool: ToolRegistration = {
           entityId: ctx.page.id,
         },
         budgetCap: 3.00,
+        tracker: ctx.tracker,
       };
 
       const result = await runResearch(request);

--- a/crux/authoring/orchestrator/types.ts
+++ b/crux/authoring/orchestrator/types.ts
@@ -9,6 +9,7 @@
 import type { SourceCacheEntry } from '../../lib/section-writer.ts';
 import type { ParsedSection, SplitPage } from '../../lib/section-splitter.ts';
 import type { CitationAudit } from '../../lib/citation-auditor.ts';
+import type { CostTracker } from '../../lib/cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Budget & tier configuration
@@ -146,6 +147,8 @@ export interface OrchestratorContext {
   directions: string;
   /** Citation audit results (if audit has been run). */
   citationAudit: CitationAudit[] | null;
+  /** Actual cost tracker for LLM API calls. */
+  tracker: CostTracker;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,8 +232,12 @@ export interface OrchestratorResult {
   refinementCycles: number;
   /** Total estimated cost. */
   totalCost: number;
-  /** Per-tool cost breakdown. */
+  /** Per-tool cost breakdown (estimated). */
   costBreakdown: Record<string, number>;
+  /** Actual total cost from API usage data (null if tracker unavailable). */
+  actualTotalCost: number | null;
+  /** Actual cost breakdown by label (null if tracker unavailable). */
+  actualCostBreakdown: Record<string, number> | null;
   /** Final quality metrics. */
   qualityMetrics: QualityMetrics;
   /** Whether the quality gate passed. */

--- a/crux/lib/cost-tracker.ts
+++ b/crux/lib/cost-tracker.ts
@@ -1,0 +1,107 @@
+/**
+ * CostTracker — Session-level actual cost collector.
+ *
+ * Hooks into streamingCreate() via an optional parameter. Every LLM API call
+ * that passes a tracker automatically gets recorded with model, tokens, cost,
+ * and a human-readable label.
+ *
+ * Usage:
+ *   const tracker = new CostTracker();
+ *   await streamingCreate(client, params, { tracker, label: 'orchestrator' });
+ *   console.log(tracker.totalCost);        // $2.34
+ *   console.log(tracker.breakdown());       // { orchestrator: 2.34 }
+ */
+
+import { calculateCost } from './pricing.ts';
+
+/** A single recorded LLM API call. */
+export interface CostEntry {
+  /** Model ID used for the call. */
+  model: string;
+  /** Input tokens from response.usage. */
+  inputTokens: number;
+  /** Output tokens from response.usage. */
+  outputTokens: number;
+  /** Calculated cost in USD. */
+  cost: number;
+  /** Human-readable label for grouping (e.g. "orchestrator", "rewrite_section"). */
+  label: string;
+  /** Unix timestamp (ms) when the call completed. */
+  timestamp: number;
+}
+
+/**
+ * Collects actual API costs across an orchestrator run.
+ *
+ * Thread-safe for sequential use (one call at a time, which is how
+ * the orchestrator works). Not designed for concurrent recording.
+ */
+export class CostTracker {
+  readonly entries: CostEntry[] = [];
+
+  /**
+   * Record a completed API call.
+   *
+   * @param model - Model ID from the request params
+   * @param usage - Usage object from the Anthropic response (input_tokens, output_tokens)
+   * @param label - Grouping label (default: "unknown")
+   */
+  record(
+    model: string,
+    usage: { input_tokens: number; output_tokens: number },
+    label?: string,
+  ): void {
+    const inputTokens = usage.input_tokens;
+    const outputTokens = usage.output_tokens;
+    const cost = calculateCost(model, { inputTokens, outputTokens });
+
+    this.entries.push({
+      model,
+      inputTokens,
+      outputTokens,
+      cost,
+      label: label ?? 'unknown',
+      timestamp: Date.now(),
+    });
+  }
+
+  /** Total actual cost across all recorded calls. */
+  get totalCost(): number {
+    return this.entries.reduce((sum, e) => sum + e.cost, 0);
+  }
+
+  /** Total tokens across all recorded calls. */
+  get totalTokens(): { input: number; output: number } {
+    return this.entries.reduce(
+      (acc, e) => ({
+        input: acc.input + e.inputTokens,
+        output: acc.output + e.outputTokens,
+      }),
+      { input: 0, output: 0 },
+    );
+  }
+
+  /** Cost summed by label. */
+  breakdown(): Record<string, number> {
+    const result: Record<string, number> = {};
+    for (const entry of this.entries) {
+      result[entry.label] = (result[entry.label] || 0) + entry.cost;
+    }
+    return result;
+  }
+
+  /** Serializable summary for JSON output / logging. */
+  toJSON(): {
+    entries: CostEntry[];
+    totalCost: number;
+    totalTokens: { input: number; output: number };
+    breakdown: Record<string, number>;
+  } {
+    return {
+      entries: this.entries,
+      totalCost: this.totalCost,
+      totalTokens: this.totalTokens,
+      breakdown: this.breakdown(),
+    };
+  }
+}

--- a/crux/lib/llm.ts
+++ b/crux/lib/llm.ts
@@ -19,6 +19,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam, ToolUseBlock, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages';
 import { createClient, MODELS } from './anthropic.ts';
 import { withRetry, startHeartbeat } from './resilience.ts';
+import type { CostTracker } from './cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Client creation
@@ -45,17 +46,40 @@ export function createLlmClient(options?: LlmClientOptions): Anthropic {
 // Low-level streaming call
 // ---------------------------------------------------------------------------
 
+/** Options for streamingCreate (tracker integration). */
+export interface StreamingCreateOptions {
+  /** If provided, the call's usage is automatically recorded. */
+  tracker?: CostTracker;
+  /** Label for the cost entry (e.g. "orchestrator", "rewrite_section"). */
+  label?: string;
+}
+
 /**
  * Execute a streaming Claude API call and return the final message.
  * Handles SSE streaming through proxies.
+ *
+ * When a CostTracker is provided via options, the call's token usage is
+ * automatically recorded — no caller-side bookkeeping needed.
  */
 export async function streamingCreate(
   client: Anthropic,
-  params: Parameters<typeof client.messages.create>[0]
+  params: Parameters<typeof client.messages.create>[0],
+  options?: StreamingCreateOptions,
 ): Promise<Anthropic.Messages.Message> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stream = client.messages.stream(params as any);
-  return await stream.finalMessage();
+  const message = await stream.finalMessage();
+
+  // Auto-record if tracker provided
+  if (options?.tracker && message.usage) {
+    options.tracker.record(
+      params.model,
+      message.usage,
+      options.label,
+    );
+  }
+
+  return message;
 }
 
 /**
@@ -104,6 +128,10 @@ export interface StreamCallOptions {
   temperature?: number;
   retryLabel?: string;
   heartbeatPhase?: string;
+  /** If provided, the call's usage is automatically recorded. */
+  tracker?: CostTracker;
+  /** Label for the cost entry (e.g. "rewrite_section"). */
+  label?: string;
 }
 
 /**
@@ -122,7 +150,12 @@ export async function streamLlmCall(
     temperature,
     retryLabel = 'llm-call',
     heartbeatPhase = 'api',
+    tracker,
+    label,
   } = options;
+
+  const trackingOptions: StreamingCreateOptions | undefined =
+    tracker ? { tracker, label } : undefined;
 
   const stopHeartbeat = startHeartbeat(heartbeatPhase, 30);
   try {
@@ -133,7 +166,7 @@ export async function streamLlmCall(
         ...(systemPrompt && { system: systemPrompt }),
         ...(temperature !== undefined && { temperature }),
         messages: [{ role: 'user', content: prompt }],
-      }),
+      }, trackingOptions),
       { label: retryLabel }
     );
 

--- a/crux/lib/pricing.ts
+++ b/crux/lib/pricing.ts
@@ -1,0 +1,81 @@
+/**
+ * Model Pricing — Single source of truth for per-token pricing.
+ *
+ * Used by CostTracker to calculate actual costs from API usage data,
+ * and by research-agent.ts for fact-extraction cost estimates.
+ *
+ * Prices are in USD per million tokens.
+ * Last verified against https://docs.anthropic.com/en/docs/about-claude/pricing
+ */
+
+export interface ModelPricing {
+  /** USD per million input tokens. */
+  inputPerM: number;
+  /** USD per million output tokens. */
+  outputPerM: number;
+}
+
+/**
+ * Per-model pricing table. Keyed by exact model ID.
+ */
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  'claude-haiku-4-5-20251001': { inputPerM: 0.80, outputPerM: 4.00 },
+  'claude-sonnet-4-6': { inputPerM: 3.00, outputPerM: 15.00 },
+  'claude-opus-4-6': { inputPerM: 15.00, outputPerM: 75.00 },
+};
+
+/** Date these prices were last verified. */
+export const PRICING_LAST_VERIFIED = '2026-02-23';
+
+/**
+ * Alias map: short names → exact model IDs.
+ * Allows callers to pass "haiku", "sonnet", or "opus" and get the right pricing.
+ */
+const MODEL_ALIASES: Record<string, string> = {
+  haiku: 'claude-haiku-4-5-20251001',
+  sonnet: 'claude-sonnet-4-6',
+  opus: 'claude-opus-4-6',
+};
+
+/**
+ * Resolve a model string (exact ID or alias) to its pricing entry.
+ * Returns undefined if the model is not recognized.
+ */
+export function getModelPricing(model: string): ModelPricing | undefined {
+  // Direct match
+  if (MODEL_PRICING[model]) return MODEL_PRICING[model];
+
+  // Alias match
+  const aliasId = MODEL_ALIASES[model.toLowerCase()];
+  if (aliasId && MODEL_PRICING[aliasId]) return MODEL_PRICING[aliasId];
+
+  // Partial match: model ID with date suffix (e.g. "claude-sonnet-4-6-20260101" matches "claude-sonnet-4-6")
+  for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
+    if (model.startsWith(key)) return pricing;
+  }
+
+  return undefined;
+}
+
+/**
+ * Calculate the cost of an API call given the model and token usage.
+ *
+ * @param model - Model ID or alias (e.g. "claude-sonnet-4-6" or "sonnet")
+ * @param usage - Token counts from the API response
+ * @returns Cost in USD, or 0 if model pricing is unknown
+ */
+export function calculateCost(
+  model: string,
+  usage: { inputTokens: number; outputTokens: number },
+): number {
+  const pricing = getModelPricing(model);
+  if (!pricing) {
+    console.warn(`[pricing] Unknown model "${model}" — cost will be reported as $0.00`);
+    return 0;
+  }
+
+  return (
+    (usage.inputTokens / 1_000_000) * pricing.inputPerM +
+    (usage.outputTokens / 1_000_000) * pricing.outputPerM
+  );
+}

--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -31,6 +31,8 @@ import { getApiKey } from './api-keys.ts';
 import { fetchSources } from './source-fetcher.ts';
 import { createLlmClient, streamingCreate, extractText, MODELS } from './llm.ts';
 import type { SourceCacheEntry } from './section-writer.ts';
+import type { CostTracker } from './cost-tracker.ts';
+import { MODEL_PRICING } from './pricing.ts';
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -76,6 +78,8 @@ export interface ResearchRequest {
   config?: ResearchConfig;
   /** Hard budget cap in USD — stops searching/fetching when exceeded (default: 5.00). */
   budgetCap?: number;
+  /** If provided, records actual API costs for fact-extraction calls. */
+  tracker?: CostTracker;
 }
 
 /** Cost breakdown for the research run. */
@@ -150,9 +154,10 @@ const DEFAULT_MAX_RESULTS_PER_SOURCE = 8;
 const DEFAULT_MAX_URLS_TO_FETCH = 20;
 const DEFAULT_FACTS_PER_SOURCE = 5;
 
-/** Haiku pricing per million tokens (USD). */
-const HAIKU_INPUT_COST_PER_M = 0.80;
-const HAIKU_OUTPUT_COST_PER_M = 4.00;
+/** Haiku pricing per million tokens (USD) — sourced from shared pricing table. */
+const HAIKU_PRICING = MODEL_PRICING['claude-haiku-4-5-20251001'];
+const HAIKU_INPUT_COST_PER_M = HAIKU_PRICING.inputPerM;
+const HAIKU_OUTPUT_COST_PER_M = HAIKU_PRICING.outputPerM;
 
 // ---------------------------------------------------------------------------
 // Exa search
@@ -356,6 +361,7 @@ async function extractFacts(
   content: string,
   query: string,
   factsPerSource: number,
+  tracker?: CostTracker,
 ): Promise<FactExtractionResult> {
   if (!content.trim()) return { facts: [], cost: 0 };
 
@@ -382,7 +388,7 @@ Rules:
       model: MODELS.haiku,
       max_tokens: 500,
       messages: [{ role: 'user', content: prompt }],
-    });
+    }, tracker ? { tracker, label: 'research_facts' } : undefined);
     raw = extractText(response);
     inputTokens = response.usage?.input_tokens ?? 0;
     outputTokens = response.usage?.output_tokens ?? 0;
@@ -438,6 +444,7 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
     pageContext,
     config = {},
     budgetCap = DEFAULT_BUDGET_CAP,
+    tracker,
   } = request;
 
   const {
@@ -590,6 +597,7 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
         fetched.content,
         focusedQuery,
         factsPerSource,
+        tracker,
       );
       facts = extractionResult.facts;
       factExtractionCost += extractionResult.cost;

--- a/crux/lib/section-writer.ts
+++ b/crux/lib/section-writer.ts
@@ -40,6 +40,7 @@
 import { z } from 'zod';
 import { createLlmClient, streamLlmCall, MODELS } from './llm.ts';
 import { parseJsonFromLlm } from './json-parsing.ts';
+import type { CostTracker } from './cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -154,6 +155,8 @@ export interface SectionWriterOptions {
   model?: string;
   /** Max output tokens.  Defaults to 4000. */
   maxTokens?: number;
+  /** If provided, records actual API cost for this call. */
+  tracker?: CostTracker;
 }
 
 // ---------------------------------------------------------------------------
@@ -499,6 +502,7 @@ export async function rewriteSection(
   const {
     model = MODELS.sonnet,
     maxTokens = 4_000,
+    tracker,
   } = options;
 
   const prompt = buildSectionWriterPrompt(request);
@@ -507,6 +511,8 @@ export async function rewriteSection(
     maxTokens,
     retryLabel: 'section-writer',
     heartbeatPhase: 'section-writer',
+    tracker,
+    label: 'rewrite_section',
   });
 
   return parseGroundedResult(raw, request);


### PR DESCRIPTION
## Summary

Adds actual API cost tracking to the V2 orchestrator, replacing the current fixed per-tool cost estimates with real token usage data from the Anthropic API.

- **New `CostTracker` class** (`crux/lib/cost-tracker.ts`) — session-level collector that hooks into `streamingCreate()`, the single chokepoint for all Anthropic API calls
- **New `pricing.ts`** (`crux/lib/pricing.ts`) — single source of truth for per-token model pricing, replacing hardcoded constants in `research-agent.ts`
- **Backward-compatible `tracker` option** added to `streamingCreate()` and `streamLlmCall()` — existing callers unaffected
- **Wired through full pipeline**: orchestrator agent loop, section-writer, research-agent fact extraction
- **Dual reporting**: both estimated and actual costs shown in orchestrator output, session logs, and batch summaries
- **Batch runner**: prefers actual cost for budget enforcement; writes `cost-analysis.json` with per-page breakdowns

Closes #822

## Key changes

| File | Change |
|------|--------|
| `crux/lib/pricing.ts` | New — model pricing constants + `calculateCost()` |
| `crux/lib/cost-tracker.ts` | New — `CostTracker` class with `record()`, `totalCost`, `breakdown()` |
| `crux/lib/llm.ts` | Added optional `tracker`/`label` to `streamingCreate()` and `streamLlmCall()` |
| `crux/authoring/orchestrator/types.ts` | Added `tracker` to context, `actualTotalCost`/`actualCostBreakdown` to result |
| `crux/authoring/orchestrator/orchestrator.ts` | Creates tracker, wires through agent loop, reports actual vs estimated |
| `crux/lib/section-writer.ts` | Accepts and passes tracker to `streamLlmCall()` |
| `crux/lib/research-agent.ts` | Uses shared pricing, accepts tracker for fact extraction |
| `crux/authoring/orchestrator/tools/*.ts` | Pass `ctx.tracker` to section-writer and research-agent |
| `crux/authoring/orchestrator/index.ts` | Shows actual costs in report, prefers actual in session logs |
| `crux/authoring/batch-runner.ts` | Actual cost column in summary, `cost-analysis.json` output |

## Test plan

- [x] `pnpm crux validate gate` passes (all 251 tests, all blocking validations)
- [x] TypeScript compiles cleanly for all modified files
- [x] Existing orchestrator and quality-gate tests updated with `tracker` field
- [x] Paranoid code review completed — fixed ambiguous prefix match in pricing, added unknown-model warning, made `actualTotalCost` genuinely nullable
- [ ] Run `pnpm crux content improve <page> --engine=v2 --tier=polish` to verify actual costs appear alongside estimates (requires live API call)

---

Generated with [Claude Code](https://claude.com/claude-code)
