### PR TITLE
refactor: DB schema tuneup — dead code removal & integration fixes

### DIFF
--- a/crux/citations/export-dashboard.ts
+++ b/crux/citations/export-dashboard.ts
@@ -1,16 +1,17 @@
 /**
  * Export Citation Accuracy Dashboard Data
  *
- * Reads accuracy data from the SQLite DB and exports YAML files
- * to data/citation-accuracy/ so they're available in production
- * (SQLite is not available on Vercel).
+ * Prefers PG (wiki-server) data when available, falls back to local SQLite.
+ * Exports YAML files to data/citation-accuracy/ so they're available in
+ * production (neither SQLite nor PG is available on Vercel).
  *
  * Output:
  *   data/citation-accuracy/summary.yaml          — global stats, page summaries, domain analysis
  *   data/citation-accuracy/pages/<pageId>.yaml    — per-page flagged citations
  *
  * Usage:
- *   pnpm crux citations export-dashboard
+ *   pnpm crux citations export-dashboard              # Auto-uses PG if available
+ *   pnpm crux citations export-dashboard --local-only  # Force local SQLite only
  *   pnpm crux citations export-dashboard --json
  */
 
@@ -364,24 +365,26 @@ export function exportDashboardData(fromDbData?: DashboardExport | null): { path
 async function main() {
   const args = parseCliArgs(process.argv.slice(2));
   const json = args.json === true;
-  const fromDb = args['from-db'] === true;
+  const localOnly = args['local-only'] === true;
   const colors = getColors(json);
 
+  // Prefer PG data (4,881+ records) over SQLite (local cache, often sparse).
+  // Use --local-only to force SQLite-only mode.
   let dbData: DashboardExport | null = null;
-  if (fromDb) {
+  if (!localOnly) {
     const serverUp = await isServerAvailable();
-    if (!serverUp) {
-      console.log(`${colors.red}Wiki server not available. Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.${colors.reset}`);
-      process.exit(1);
-    }
-    const dashboardResult = await getAccuracyDashboard();
-    if (!dashboardResult.ok) {
-      console.log(`${colors.yellow}No accuracy data returned from wiki server (${dashboardResult.error}).${colors.reset}`);
-      process.exit(0);
-    }
-    dbData = dashboardResult.data;
-    if (!json) {
-      console.log(`${colors.dim}Using data from wiki-server DB${colors.reset}`);
+    if (serverUp) {
+      const dashboardResult = await getAccuracyDashboard();
+      if (dashboardResult.ok) {
+        dbData = dashboardResult.data;
+        if (!json) {
+          console.log(`${colors.dim}Using data from wiki-server DB${colors.reset}`);
+        }
+      } else if (!json) {
+        console.log(`${colors.dim}Wiki server returned no data (${dashboardResult.error}), falling back to local SQLite${colors.reset}`);
+      }
+    } else if (!json) {
+      console.log(`${colors.dim}Wiki server not available, falling back to local SQLite${colors.reset}`);
     }
   }
 

--- a/crux/commands/citations.ts
+++ b/crux/commands/citations.ts
@@ -66,7 +66,7 @@ const SCRIPTS = {
   'export-dashboard': {
     script: 'citations/export-dashboard.ts',
     description: 'Export accuracy data as YAML for the internal dashboard',
-    passthrough: ['json', 'from-db'],
+    passthrough: ['json', 'local-only'],
   },
   'migrate-accuracy': {
     script: 'citations/migrate-accuracy-to-db.ts',
@@ -140,8 +140,8 @@ Examples:
   crux citations normalize-footnotes                Report footnote format issues
   crux citations normalize-footnotes --fix          Auto-fix to [Title](URL) format
   crux citations normalize-footnotes --fix <id>     Fix one page
-  crux citations export-dashboard                  Export data for web dashboard
-  crux citations export-dashboard --from-db        Export from PostgreSQL instead of SQLite
+  crux citations export-dashboard                  Export data for web dashboard (prefers PG)
+  crux citations export-dashboard --local-only     Force local SQLite only
   crux citations migrate-accuracy                   Migrate accuracy data to PostgreSQL
   crux citations migrate-accuracy --dry-run         Preview migration
   crux citations backfill-resource-ids               Backfill resource_id for existing quotes

--- a/crux/lib/knowledge-db.test.ts
+++ b/crux/lib/knowledge-db.test.ts
@@ -20,7 +20,6 @@ describe('getDb', () => {
     expect(tableNames).toContain('articles');
     expect(tableNames).toContain('sources');
     expect(tableNames).toContain('article_sources');
-    expect(tableNames).toContain('entity_relations');
     expect(tableNames).toContain('summaries');
     expect(tableNames).toContain('claims');
     expect(tableNames).toContain('citation_content');

--- a/crux/lib/knowledge-db.ts
+++ b/crux/lib/knowledge-db.ts
@@ -1,8 +1,11 @@
 /**
  * Knowledge Database Module
  *
- * SQLite-based storage for articles, sources, summaries, and claims.
- * Designed for scale: 1000+ articles, 10,000+ sources.
+ * Local SQLite cache for articles, sources, summaries, claims, and citation quotes.
+ * PostgreSQL (wiki-server) is the authoritative store for citations, claims, and
+ * summaries. Write operations dual-write to both SQLite and PG; read operations
+ * use SQLite for local/offline access but PG should be preferred when available
+ * (especially for citation data where PG has ~5K records vs sparse SQLite).
  *
  * The database is lazy-initialized on first access via getDb(). Importing
  * this module loads better-sqlite3 bindings but does NOT create the SQLite
@@ -93,15 +96,9 @@ function initSchema(db: InstanceType<typeof Database>) {
       PRIMARY KEY (article_id, source_id)
     );
 
-    -- Entity relationships (from entities.yaml)
-    CREATE TABLE IF NOT EXISTS entity_relations (
-      from_id TEXT,
-      to_id TEXT,
-      relationship TEXT,
-      PRIMARY KEY (from_id, to_id)
-    );
-
     -- AI-generated summaries
+    -- TODO: Summaries pipeline not wired up yet — 0 records in both SQLite and PG.
+    -- Table is kept for the planned summarization feature.
     CREATE TABLE IF NOT EXISTS summaries (
       entity_id TEXT PRIMARY KEY,
       entity_type TEXT NOT NULL,
@@ -136,8 +133,6 @@ function initSchema(db: InstanceType<typeof Database>) {
     CREATE INDEX IF NOT EXISTS idx_summaries_type ON summaries(entity_type);
     CREATE INDEX IF NOT EXISTS idx_claims_entity ON claims(entity_id);
     CREATE INDEX IF NOT EXISTS idx_claims_type ON claims(claim_type);
-    CREATE INDEX IF NOT EXISTS idx_entity_relations_from ON entity_relations(from_id);
-    CREATE INDEX IF NOT EXISTS idx_entity_relations_to ON entity_relations(to_id);
   `);
 
   // Migrations
@@ -349,17 +344,6 @@ export interface ClaimInsertData {
   sourceQuote?: string | null;
 }
 
-export interface RelationRow {
-  id: string;
-  relationship: string;
-}
-
-export interface RelationInsertData {
-  fromId: string;
-  toId: string;
-  relationship?: string;
-}
-
 export interface SourceStats {
   total: number;
   pending: number;
@@ -487,17 +471,6 @@ export const articles = {
     return (getDb().prepare('SELECT COUNT(*) as count FROM articles').get() as { count: number }).count;
   },
 
-  /**
-   * Search articles by content
-   */
-  search(query: string): ArticleRow[] {
-    return getDb().prepare(`
-      SELECT * FROM articles
-      WHERE content LIKE '%' || ? || '%' OR title LIKE '%' || ? || '%'
-      ORDER BY quality DESC
-      LIMIT 50
-    `).all(query, query) as ArticleRow[];
-  }
 };
 
 // =============================================================================
@@ -625,19 +598,6 @@ export const sources = {
   },
 
   /**
-   * Get sources for an article
-   */
-  getForArticle(articleId: string): SourceRow[] {
-    return getDb().prepare(`
-      SELECT s.*, sm.summary as source_summary, ars.citation_context
-      FROM sources s
-      JOIN article_sources ars ON s.id = ars.source_id
-      LEFT JOIN summaries sm ON s.id = sm.entity_id AND sm.entity_type = 'source'
-      WHERE ars.article_id = ?
-    `).all(articleId) as SourceRow[];
-  },
-
-  /**
    * Link a source to an article
    */
   linkToArticle(articleId: string, sourceId: string, citationContext: string | null = null) {
@@ -692,59 +652,6 @@ export const sources = {
 };
 
 // =============================================================================
-// ENTITY RELATIONS
-// =============================================================================
-
-export const relations = {
-  /**
-   * Set a relationship between entities
-   */
-  set(fromId: string, toId: string, relationship: string = 'related') {
-    const stmt = getDb().prepare(`
-      INSERT INTO entity_relations (from_id, to_id, relationship)
-      VALUES (?, ?, ?)
-      ON CONFLICT DO UPDATE SET relationship = ?
-    `);
-    return stmt.run(fromId, toId, relationship, relationship);
-  },
-
-  /**
-   * Get related entities
-   */
-  getRelated(entityId: string): RelationRow[] {
-    return getDb().prepare(`
-      SELECT to_id as id, relationship FROM entity_relations WHERE from_id = ?
-      UNION
-      SELECT from_id as id, relationship FROM entity_relations WHERE to_id = ?
-    `).all(entityId, entityId) as RelationRow[];
-  },
-
-  /**
-   * Clear all relations (for rebuild)
-   */
-  clear() {
-    return getDb().prepare('DELETE FROM entity_relations').run();
-  },
-
-  /**
-   * Bulk insert relations
-   */
-  bulkInsert(relationsData: RelationInsertData[]) {
-    const db = getDb();
-    const stmt = db.prepare(`
-      INSERT OR REPLACE INTO entity_relations (from_id, to_id, relationship)
-      VALUES (?, ?, ?)
-    `);
-    const insertMany = db.transaction((rels: RelationInsertData[]) => {
-      for (const rel of rels) {
-        stmt.run(rel.fromId, rel.toId, rel.relationship || 'related');
-      }
-    });
-    insertMany(relationsData);
-  }
-};
-
-// =============================================================================
 // SUMMARIES
 // =============================================================================
 
@@ -790,7 +697,7 @@ export const summaries = {
       model: data.model,
       tokensUsed: data.tokensUsed,
     }).catch(() => {
-      // Silently ignore — SQLite is authoritative during migration period
+      // Silently ignore — PG is authoritative; SQLite is a local cache
     });
 
     return result;
@@ -874,35 +781,10 @@ export const claims = {
       confidence: claim.confidence ?? null,
       sourceQuote: claim.sourceQuote ?? null,
     }).catch(() => {
-      // Silently ignore — SQLite is authoritative during migration period
+      // Silently ignore — PG is authoritative; SQLite is a local cache
     });
 
     return result;
-  },
-
-  /**
-   * Get claims for an entity
-   */
-  getForEntity(entityId: string): ClaimRow[] {
-    return getDb().prepare('SELECT * FROM claims WHERE entity_id = ?').all(entityId) as ClaimRow[];
-  },
-
-  /**
-   * Get claims by type
-   */
-  getByType(claimType: string): ClaimRow[] {
-    return getDb().prepare('SELECT * FROM claims WHERE claim_type = ?').all(claimType) as ClaimRow[];
-  },
-
-  /**
-   * Find similar claims (for consistency checking)
-   */
-  findSimilar(claimText: string): ClaimRow[] {
-    return getDb().prepare(`
-      SELECT * FROM claims
-      WHERE claim_text LIKE '%' || ? || '%'
-      ORDER BY entity_id
-    `).all(claimText) as ClaimRow[];
   },
 
   /**
@@ -913,7 +795,7 @@ export const claims = {
 
     // Fire-and-forget write to wiki-server DB
     clearClaimsOnServer(entityId).catch(() => {
-      // Silently ignore — SQLite is authoritative during migration period
+      // Silently ignore — PG is authoritative; SQLite is a local cache
     });
 
     return result;
@@ -1140,7 +1022,7 @@ export const citationQuotes = {
       extractionModel: data.extractionModel ?? null,
     };
     upsertCitationQuoteOnServer(serverItem).catch(() => {
-      // Silently ignore — SQLite is authoritative during migration period
+      // Silently ignore — PG is authoritative; SQLite is a local cache
     });
 
     return result;
@@ -1376,7 +1258,7 @@ export const citationQuotes = {
           ? verificationDifficulty as 'easy' | 'moderate' | 'hard'
           : null,
       }).catch(() => {
-        // Silently ignore — SQLite is authoritative during migration period
+        // Silently ignore — PG is authoritative; SQLite is a local cache
       });
     } else {
       // Verdict not in recognized set — skip server write but warn

--- a/crux/scan-content.ts
+++ b/crux/scan-content.ts
@@ -6,7 +6,6 @@
  * Scans all MDX files and populates the knowledge database with:
  * - Article content and metadata
  * - Source references (URLs, DOIs)
- * - Entity relationships (from entities.yaml)
  *
  * Usage:
  *   node crux/scan-content.ts [options]
@@ -17,14 +16,12 @@
  *   --verbose     Show detailed progress
  */
 
-import { readFileSync, existsSync, readdirSync } from 'fs';
-import { join, basename, relative } from 'path';
+import { readFileSync } from 'fs';
+import { basename, relative } from 'path';
 import { fileURLToPath } from 'url';
-import { parse as parseYaml } from 'yaml';
 import {
   articles,
   sources,
-  relations,
   contentHash,
   hashId,
   getStats,
@@ -33,8 +30,6 @@ import { findMdxFiles } from './lib/file-utils.ts';
 import { parseFrontmatter, getContentBody } from './lib/mdx-utils.ts';
 import { getColors } from './lib/output.ts';
 import { PROJECT_ROOT, CONTENT_DIR_ABS as CONTENT_DIR, DATA_DIR_ABS as DATA_DIR } from './lib/content-types.ts';
-
-const ENTITIES_DIR = join(DATA_DIR, 'entities');
 
 const args = process.argv.slice(2);
 const FORCE = args.includes('--force');
@@ -71,14 +66,6 @@ interface ProcessFileResult {
   wordCount?: number;
   sourcesFound?: number;
   skipped: boolean;
-}
-
-interface YamlEntity {
-  id: string;
-  relatedEntries?: Array<{
-    id: string;
-    relationship?: string;
-  }>;
 }
 
 // =============================================================================
@@ -261,50 +248,6 @@ function processFile(filePath: string): ProcessFileResult {
 }
 
 // =============================================================================
-// ENTITY RELATIONS
-// =============================================================================
-
-/**
- * Load and process entity relationships from entities.yaml
- */
-function processEntityRelations(): number {
-  if (!existsSync(ENTITIES_DIR)) {
-    console.log(`${colors.yellow}⚠️  entities directory not found${colors.reset}`);
-    return 0;
-  }
-
-  // Load all entity YAML files from the entities directory
-  let entities: YamlEntity[] = [];
-  for (const file of readdirSync(ENTITIES_DIR).filter(f => f.endsWith('.yaml'))) {
-    const content = readFileSync(join(ENTITIES_DIR, file), 'utf-8');
-    const parsed = parseYaml(content);
-    if (Array.isArray(parsed)) entities.push(...parsed);
-  }
-
-  // Clear existing relations
-  relations.clear();
-
-  // Build relations array
-  const allRelations: Array<{ fromId: string; toId: string; relationship: string }> = [];
-  for (const entity of entities) {
-    if (entity.relatedEntries && Array.isArray(entity.relatedEntries)) {
-      for (const related of entity.relatedEntries) {
-        allRelations.push({
-          fromId: entity.id,
-          toId: related.id,
-          relationship: related.relationship || 'related'
-        });
-      }
-    }
-  }
-
-  // Bulk insert
-  relations.bulkInsert(allRelations);
-
-  return allRelations.length;
-}
-
-// =============================================================================
 // MAIN
 // =============================================================================
 
@@ -354,10 +297,6 @@ function main(): void {
     }
   }
 
-  // Process entity relations
-  console.log(`\n${colors.blue}Processing entity relations...${colors.reset}`);
-  const relationsCount = processEntityRelations();
-
   // Summary
   console.log(`\n${'─'.repeat(50)}`);
   console.log(`${colors.green}✅ Scan complete${colors.reset}\n`);
@@ -365,7 +304,6 @@ function main(): void {
   console.log(`  Files skipped (unchanged): ${skipped}`);
   console.log(`  Total words: ${totalWords.toLocaleString()}`);
   console.log(`  Source references found: ${totalSources}`);
-  console.log(`  Entity relations loaded: ${relationsCount}`);
 
   // Show current stats
   const stats = getStats();


### PR DESCRIPTION
## Summary

- Remove 5 dead SQLite DAO methods that had no callers (`claims.getForEntity`, `claims.getByType`, `claims.findSimilar`, `sources.getForArticle`, `articles.search`)
- Remove `entity_relations` SQLite table and `relations` namespace (superseded by PG `page_links`)
- Remove `processEntityRelations()` from scan-content.ts and clean up unused imports
- Update "migration period" comments to reflect PG as the authoritative store (SQLite is local cache)
- Fix `export-dashboard` to prefer PG data when wiki-server is available (PG has ~5K records vs ~4 in SQLite), replacing `--from-db` flag with `--local-only`
- Add TODO comment on summaries table (pipeline not wired up yet)
- Update module docstring to document dual-DB architecture

Net: -178 lines removed across 5 files.

## Test plan
- [x] `pnpm crux validate gate --fix` — all blocking checks pass (251 tests)
- [x] `pnpm vitest run crux/lib/knowledge-db.test.ts` — all 12 tests pass (updated to remove `entity_relations` table check)
- [x] `grep -r "entity_relations\|entityRelations" crux/` — no remaining references
- [x] `grep -r "getForEntity\|getByType\|findSimilar\|getForArticle\|articles\.search" crux/` — no remaining references to dead methods
- [x] Paranoid review by fresh subagent — found and fixed stale JSDoc in scan-content.ts and stale `--from-db` flag in citations command router
