### PR TITLE
fix: 8 bugs from V2 editor review (gate IDs, cost tracking, batch hardening)

### DIFF
--- a/crux/authoring/batch-runner.ts
+++ b/crux/authoring/batch-runner.ts
@@ -108,7 +108,20 @@ function loadState(): BatchState | null {
 function saveState(state: BatchState): void {
   const dir = path.dirname(STATE_FILE);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  // Atomic write: write to temp file then rename to avoid corruption on crash
+  const tmpFile = STATE_FILE + '.tmp';
+  fs.writeFileSync(tmpFile, JSON.stringify(state, null, 2));
+  try {
+    fs.renameSync(tmpFile, STATE_FILE);
+  } catch (err: unknown) {
+    // EXDEV: cross-device link — fall back to copy + unlink
+    if ((err as NodeJS.ErrnoException)?.code === 'EXDEV') {
+      fs.copyFileSync(tmpFile, STATE_FILE);
+      fs.unlinkSync(tmpFile);
+    } else {
+      throw err;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +287,20 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
     };
   }
 
+  // ── Validate page IDs ───────────────────────────────────────────────────
+
+  if (total === 0) {
+    log('batch', '⚠ No page IDs provided — nothing to do. Check --batch or --batch-file args.');
+    return [];
+  }
+
+  const pages = getCachedPages();
+  const knownIds = new Set(pages.map((p: { id: string }) => p.id));
+  const unknownIds = pageIds.filter(id => !knownIds.has(id));
+  if (unknownIds.length > 0) {
+    log('batch', `⚠ ${unknownIds.length} unknown page ID(s) will be skipped: ${unknownIds.join(', ')}`);
+  }
+
   // ── Header ──────────────────────────────────────────────────────────────
 
   console.log('\n' + '═'.repeat(70));
@@ -295,6 +322,13 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
       continue;
     }
 
+    // Skip unknown pages early (validated above)
+    if (!knownIds.has(pageId)) {
+      log('batch', `[${pageNum}/${total}] ${pageId}... skipped (unknown page ID)`);
+      results.push({ pageId, status: 'skipped', error: 'Unknown page ID' });
+      continue;
+    }
+
     // Check budget before starting
     if (budgetLimit && cumulativeCost >= budgetLimit) {
       log('batch', `[${pageNum}/${total}] ${pageId}... skipped (budget exhausted: ${formatCost(cumulativeCost)}/${formatCost(budgetLimit)})`);
@@ -306,6 +340,11 @@ export async function runBatch(options: BatchOptions): Promise<PageResult[]> {
       state.completedPages[pageId] = budgetResult;
       saveState(state);
       continue;
+    }
+
+    // Warn when approaching budget limit (within 90%)
+    if (budgetLimit && cumulativeCost >= budgetLimit * 0.9) {
+      log('batch', `⚠ Budget ${Math.round((cumulativeCost / budgetLimit) * 100)}% used (${formatCost(cumulativeCost)}/${formatCost(budgetLimit)}) — next page may cause overage`);
     }
 
     // Large pages get a shorter timeout since they're more likely to stall

--- a/crux/authoring/orchestrator/orchestrator.test.ts
+++ b/crux/authoring/orchestrator/orchestrator.test.ts
@@ -16,8 +16,9 @@ import { TIER_BUDGETS, type OrchestratorContext, type BudgetConfig } from './typ
 import { buildToolDefinitions, extractQualityMetrics, wrapWithTracking, type ToolHandler } from './tools/index.ts';
 import { evaluateQualityGate } from './quality-gate.ts';
 import { buildImproveSystemPrompt, buildRefinementPrompt } from './prompts.ts';
-import { deduplicateFootnotes } from './orchestrator.ts';
+import { deduplicateFootnotes, normalizeDollarEscaping } from './orchestrator.ts';
 import { CostTracker } from '../../lib/cost-tracker.ts';
+import { getModelPricing, calculateCost } from '../../lib/pricing.ts';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -414,5 +415,85 @@ Text[^1] and[^2].
   it('handles content with no footnotes', () => {
     const input = 'Just plain text without footnotes.';
     expect(deduplicateFootnotes(input)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeDollarEscaping
+// ---------------------------------------------------------------------------
+
+describe('normalizeDollarEscaping', () => {
+  it('collapses triple+ backslashes before $ to single backslash', () => {
+    expect(normalizeDollarEscaping('costs \\\\\\$100')).toBe('costs \\$100');
+    expect(normalizeDollarEscaping('\\\\\\\\$500')).toBe('\\$500');
+  });
+
+  it('leaves single escaped dollars untouched', () => {
+    expect(normalizeDollarEscaping('costs \\$100')).toBe('costs \\$100');
+  });
+
+  it('leaves double backslash + dollar untouched (literal backslash)', () => {
+    // \\$ means "literal backslash followed by dollar" — should NOT be collapsed
+    expect(normalizeDollarEscaping('path\\\\$HOME')).toBe('path\\\\$HOME');
+  });
+
+  it('leaves bare dollars untouched', () => {
+    expect(normalizeDollarEscaping('costs $100')).toBe('costs $100');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CostTracker.recordExternalCost
+// ---------------------------------------------------------------------------
+
+describe('CostTracker.recordExternalCost', () => {
+  it('records external costs and includes them in totalCost', () => {
+    const tracker = new CostTracker();
+    tracker.recordExternalCost('perplexity/sonar', 0.05, 'research_search');
+    expect(tracker.totalCost).toBeCloseTo(0.05);
+    expect(tracker.entries).toHaveLength(1);
+    expect(tracker.entries[0].model).toBe('perplexity/sonar');
+    expect(tracker.entries[0].label).toBe('research_search');
+    expect(tracker.entries[0].inputTokens).toBe(0);
+    expect(tracker.entries[0].outputTokens).toBe(0);
+  });
+
+  it('includes external costs in breakdown', () => {
+    const tracker = new CostTracker();
+    tracker.recordExternalCost('perplexity/sonar', 0.05, 'research_search');
+    tracker.record('claude-haiku-4-5-20251001', { input_tokens: 1000, output_tokens: 100 }, 'research_facts');
+    const breakdown = tracker.breakdown();
+    expect(breakdown['research_search']).toBeCloseTo(0.05);
+    expect(breakdown['research_facts']).toBeGreaterThan(0);
+    expect(tracker.totalCost).toBeGreaterThan(0.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pricing: OpenRouter models recognized
+// ---------------------------------------------------------------------------
+
+describe('getModelPricing', () => {
+  it('recognizes Anthropic models', () => {
+    expect(getModelPricing('claude-sonnet-4-6')).toBeDefined();
+    expect(getModelPricing('claude-opus-4-6')).toBeDefined();
+    expect(getModelPricing('claude-haiku-4-5-20251001')).toBeDefined();
+  });
+
+  it('recognizes OpenRouter models', () => {
+    expect(getModelPricing('perplexity/sonar')).toBeDefined();
+    expect(getModelPricing('perplexity/sonar-pro')).toBeDefined();
+    expect(getModelPricing('google/gemini-2.0-flash-001')).toBeDefined();
+    expect(getModelPricing('deepseek/deepseek-chat')).toBeDefined();
+  });
+
+  it('returns undefined for unknown models', () => {
+    expect(getModelPricing('unknown/model')).toBeUndefined();
+  });
+
+  it('calculates cost correctly for OpenRouter models', () => {
+    // perplexity/sonar: $1/M input, $1/M output
+    const cost = calculateCost('perplexity/sonar', { inputTokens: 1_000_000, outputTokens: 500_000 });
+    expect(cost).toBeCloseTo(1.50); // 1.00 + 0.50
   });
 });

--- a/crux/authoring/orchestrator/orchestrator.ts
+++ b/crux/authoring/orchestrator/orchestrator.ts
@@ -45,12 +45,16 @@ const log = createPhaseLogger();
 // ---------------------------------------------------------------------------
 
 /**
- * Collapse any sequence of 2+ backslashes before $ down to a single \$.
+ * Collapse corrupted multi-backslash sequences before $ down to a single \$.
  * This is a safety net that catches corruption from the auto-fixer or LLM
  * (e.g. \\\\\$ → \$). Runs once at finalization and after each section rewrite.
+ *
+ * Only collapses 3+ backslashes (which are always corruption). Two backslashes
+ * (\\$) could legitimately mean "literal backslash followed by dollar" and are
+ * left untouched.
  */
 export function normalizeDollarEscaping(content: string): string {
-  return content.replace(/\\{2,}\$/g, '\\$');
+  return content.replace(/\\{3,}\$/g, '\\$');
 }
 
 /** Error message patterns that indicate a transient/retryable failure. */

--- a/crux/lib/cost-tracker.ts
+++ b/crux/lib/cost-tracker.ts
@@ -65,6 +65,25 @@ export class CostTracker {
     });
   }
 
+  /**
+   * Record a cost from an external API that reports cost directly (not via tokens).
+   * Used for OpenRouter/Perplexity calls that bypass the Anthropic SDK.
+   *
+   * @param model - Model identifier (e.g. "perplexity/sonar")
+   * @param cost - Cost in USD as reported by the API
+   * @param label - Grouping label
+   */
+  recordExternalCost(model: string, cost: number, label: string): void {
+    this.entries.push({
+      model,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost,
+      label,
+      timestamp: Date.now(),
+    });
+  }
+
   /** Total actual cost across all recorded calls. */
   get totalCost(): number {
     return this.entries.reduce((sum, e) => sum + e.cost, 0);

--- a/crux/lib/pricing.ts
+++ b/crux/lib/pricing.ts
@@ -17,11 +17,21 @@ export interface ModelPricing {
 
 /**
  * Per-model pricing table. Keyed by exact model ID.
+ * Includes Anthropic models (via SDK) and OpenRouter models (via raw fetch).
  */
 export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic models (used via streamingCreate / Anthropic SDK)
   'claude-haiku-4-5-20251001': { inputPerM: 0.80, outputPerM: 4.00 },
   'claude-sonnet-4-6': { inputPerM: 3.00, outputPerM: 15.00 },
   'claude-opus-4-6': { inputPerM: 15.00, outputPerM: 75.00 },
+
+  // OpenRouter models (used via raw fetch in research-agent / openrouter.ts)
+  'perplexity/sonar': { inputPerM: 1.00, outputPerM: 1.00 },
+  'perplexity/sonar-pro': { inputPerM: 3.00, outputPerM: 15.00 },
+  'google/gemini-2.0-flash-001': { inputPerM: 0.075, outputPerM: 0.30 },
+  'deepseek/deepseek-chat': { inputPerM: 0.14, outputPerM: 0.28 },
+  'google/gemini-pro-1.5': { inputPerM: 1.25, outputPerM: 5.00 },
+  'openai/gpt-4o-mini': { inputPerM: 0.15, outputPerM: 0.60 },
 };
 
 /** Date these prices were last verified. */

--- a/crux/lib/research-agent.ts
+++ b/crux/lib/research-agent.ts
@@ -495,6 +495,11 @@ export async function runResearch(request: ResearchRequest): Promise<ResearchRes
       searchPerplexity(focusedQuery, maxResultsPerSource).then(r => {
         searchCost += r.cost;
         totalCost += r.cost;
+        // Record Perplexity/OpenRouter cost in the tracker so batch reports
+        // include it (this call bypasses streamingCreate, so needs manual recording).
+        if (tracker && r.cost > 0) {
+          tracker.recordExternalCost('perplexity/sonar', r.cost, 'research_search');
+        }
         return r.hits;
       }).catch(err => {
         console.warn(`[research-agent] Perplexity search failed: ${err instanceof Error ? err.message : err}`);

--- a/crux/lib/rules/footnote-integrity.test.ts
+++ b/crux/lib/rules/footnote-integrity.test.ts
@@ -130,4 +130,16 @@ Claim A.[^1] Claim B.[^3] Claim C.[^5]
     expect(orphanedRefs).toHaveLength(2);
     expect(orphanedDefs).toHaveLength(2);
   });
+
+  it('recognizes footnote definitions without space after colon', () => {
+    const body = `## Section
+
+Claim here.[^1]
+
+[^1]:Source without space (https://example.com)
+`;
+    const issues = footnoteIntegrityRule.check(makeContentFile(body), engine);
+    // Should NOT report orphaned ref or def — the definition is valid
+    expect(issues).toHaveLength(0);
+  });
 });

--- a/crux/lib/rules/footnote-integrity.ts
+++ b/crux/lib/rules/footnote-integrity.ts
@@ -17,8 +17,8 @@ import type { ContentFile, ValidationEngine } from '../validation-engine.ts';
 /** Matches inline footnote refs [^MARKER] (not inside definition lines). */
 const INLINE_REF_RE = /\[\^([^\]]+)\](?!:)/g;
 
-/** Matches footnote definition lines [^MARKER]: text */
-const DEF_RE = /^\[\^([^\]]+)\]:\s/gm;
+/** Matches footnote definition lines [^MARKER]: text (space after colon is optional per markdown spec). */
+const DEF_RE = /^\[\^([^\]]+)\]:\s?/gm;
 
 /** Matches SRC-style markers that should have been renumbered. */
 const SRC_MARKER_RE = /\[\^(SRC-\d+|S\d+-SRC-\d+)\]/g;
@@ -70,8 +70,8 @@ export const footnoteIntegrityRule = {
         definedMarkers.add(defMatch[1]);
       }
 
-      // Collect inline ref markers (exclude definition lines)
-      if (!/^\[\^[^\]]+\]:\s/.test(line)) {
+      // Collect inline ref markers (exclude definition lines — space after colon is optional)
+      if (!/^\[\^[^\]]+\]:\s?/.test(line)) {
         INLINE_REF_RE.lastIndex = 0;
         let refMatch: RegExpExecArray | null;
         while ((refMatch = INLINE_REF_RE.exec(line)) !== null) {

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -185,7 +185,7 @@ const PARALLEL_STEPS: Step[] = [
     advisory: true,
   },
   {
-    id: 'typecheck-crux',
+    id: 'typecheck-crux-baseline',
     name: 'Crux TypeScript check',
     command: 'npx',
     args: ['tsx', 'crux/validate/validate-crux-tsc.ts'],


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
