### PR TITLE
refactor: clean up block-IR from PR #841

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,10 @@ pnpm crux query citations --broken       # Wiki-wide broken citations
 pnpm crux query risk <page-id>           # Hallucination risk score
 pnpm crux query risk --level=high        # All high-risk pages
 pnpm crux query stats                    # Wiki-wide statistics
+pnpm crux query blocks <page-id>         # Section structure from block-level IR
+pnpm crux query blocks --entity=<id>     # Sections referencing a given entity
+pnpm crux query blocks --component=squiggle  # Pages using a component type
+pnpm crux query blocks --uncited         # Sections with no citations (>50 words)
 # All commands support --json for machine-readable output
 # Requires LONGTERMWIKI_SERVER_URL (set in environment)
 
@@ -227,9 +231,13 @@ pnpm crux query recent-changes --days=7  # What changed this week?
 pnpm crux query citations <page-id>      # Citation health for a page
 pnpm crux query risk <page-id>           # Hallucination risk score
 pnpm crux query stats                    # Wiki-wide statistics
+pnpm crux query blocks <page-id>         # Section structure (local block-index.json)
+pnpm crux query blocks --entity=<id>     # Sections referencing entity
+pnpm crux query blocks --component=squiggle  # Pages using component type
+pnpm crux query blocks --uncited         # Uncited sections (>50 words)
 ```
 
-All commands support `--json` for machine-readable output. Requires `LONGTERMWIKI_SERVER_URL` (set in environment).
+All commands support `--json` for machine-readable output. Server commands require `LONGTERMWIKI_SERVER_URL`. The `blocks` command reads from local `block-index.json` (built by `build-data.mjs`).
 
 ## Page Authoring Workflow
 

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -1396,12 +1396,12 @@ async function main() {
   // =========================================================================
   // BLOCK-LEVEL IR — extract per-section metadata (entity links, facts,
   // citations, components, word counts) via remark AST parsing.
-  // Must run BEFORE rawContent is deleted.
+  // IMPORTANT: Must run BEFORE rawContent is deleted (below).
   // =========================================================================
   console.log('  Extracting block-level IR...');
   let blockIRExtracted = 0;
   let blockIRSections = 0;
-  let blockIRErrors = 0;
+  const blockIRErrorPages = [];
   const blockIndex = {};
   try {
     const { extractBlockIR } = await import('../../../crux/lib/block-ir.ts');
@@ -1413,13 +1413,16 @@ async function main() {
         blockIRExtracted++;
         blockIRSections += ir.sections.length;
       } catch (err) {
-        blockIRErrors++;
-        if (blockIRErrors <= 3) {
-          console.warn(`    ⚠ block-ir error on ${page.id}: ${err.message}`);
+        blockIRErrorPages.push(page.id);
+        if (blockIRErrorPages.length <= 5) {
+          console.warn(`    ⚠ block-ir parse error on ${page.id}: ${err.message}`);
         }
       }
     }
-    console.log(`  blockIR: ${blockIRSections} sections across ${blockIRExtracted} pages${blockIRErrors > 0 ? ` (${blockIRErrors} errors)` : ''}`);
+    if (blockIRErrorPages.length > 5) {
+      console.warn(`    ⚠ ...and ${blockIRErrorPages.length - 5} more parse errors`);
+    }
+    console.log(`  blockIR: ${blockIRSections} sections across ${blockIRExtracted} pages${blockIRErrorPages.length > 0 ? ` (${blockIRErrorPages.length} parse errors — typically complex JSX expressions)` : ''}`);
   } catch (err) {
     console.warn(`  ⚠ block-ir extraction skipped: ${err.message}`);
   }

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -748,7 +748,7 @@ export async function stats(_args: string[], options: Record<string, unknown>): 
 // ---------------------------------------------------------------------------
 
 import { loadBlockIndex } from '../lib/content-types.ts';
-import type { SectionBlock } from '../lib/block-ir.ts';
+import type { SectionIR } from '../lib/block-ir.ts';
 
 export async function blocks(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const log = createLogger(options.ci as boolean);
@@ -758,6 +758,21 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
   const componentFilter = options.component as string | undefined;
   const uncited = options.uncited as boolean;
   const pageId = args.find((a) => !a.startsWith('-'));
+
+  // Validate: at most one filter mode
+  const filterCount = [!!entityFilter, !!componentFilter, uncited].filter(Boolean).length;
+  if (pageId && filterCount > 0) {
+    return {
+      output: `${c.red}Error: <page-id> and --entity/--component/--uncited are mutually exclusive.${c.reset}`,
+      exitCode: 1,
+    };
+  }
+  if (filterCount > 1) {
+    return {
+      output: `${c.red}Error: use only one of --entity, --component, or --uncited at a time.${c.reset}`,
+      exitCode: 1,
+    };
+  }
 
   const index = loadBlockIndex();
   const pageCount = Object.keys(index).length;
@@ -770,7 +785,7 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
   }
 
   // --- Per-page view: crux query blocks <page-id> ---
-  if (pageId && !entityFilter && !componentFilter && !uncited) {
+  if (pageId) {
     const ir = index[pageId];
     if (!ir) {
       return { output: `${c.yellow}Page not found in block index: ${pageId}${c.reset}`, exitCode: 1 };
@@ -786,9 +801,10 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
     for (const s of ir.sections) {
       const label = s.level === 0 ? `${c.dim}(preamble)${c.reset}` : `${'#'.repeat(s.level)} ${s.heading}`;
       const flags: string[] = [];
-      if (s.hasSquiggle) flags.push('squiggle');
-      if (s.hasMermaid) flags.push('mermaid');
-      if (s.hasCalc) flags.push('calc');
+      // Section-level component names
+      if (s.componentNames?.length > 0) {
+        flags.push(...s.componentNames);
+      }
       if (s.tables.length > 0) flags.push(`${s.tables.length} table${s.tables.length > 1 ? 's' : ''}`);
       const flagStr = flags.length > 0 ? ` ${c.dim}[${flags.join(', ')}]${c.reset}` : '';
 
@@ -810,15 +826,12 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
       output += '\n';
     }
 
-    // Component summary
+    // Component summary from Record<string, number>
     const comp = ir.components;
     const parts: string[] = [];
-    if (comp.squiggleCount > 0) parts.push(`${comp.squiggleCount} squiggle`);
-    if (comp.mermaidCount > 0) parts.push(`${comp.mermaidCount} mermaid`);
-    if (comp.calcCount > 0) parts.push(`${comp.calcCount} calc`);
-    if (comp.calloutCount > 0) parts.push(`${comp.calloutCount} callout`);
-    if (comp.dataInfoBoxCount > 0) parts.push(`${comp.dataInfoBoxCount} DataInfoBox`);
-    if (comp.totalTables > 0) parts.push(`${comp.totalTables} table`);
+    for (const [name, count] of Object.entries(comp)) {
+      if (count > 0) parts.push(`${count} ${name}`);
+    }
     if (parts.length > 0) {
       output += `${c.dim}Components: ${parts.join(', ')}${c.reset}\n`;
     }
@@ -831,7 +844,7 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
   // crux query blocks --entity=<id>
   if (entityFilter) {
     const limit = parseIntOpt(options.limit, 20);
-    const results: Array<{ pageId: string; section: SectionBlock }> = [];
+    const results: Array<{ pageId: string; section: SectionIR }> = [];
 
     for (const ir of Object.values(index)) {
       for (const s of ir.sections) {
@@ -866,37 +879,32 @@ export async function blocks(args: string[], options: Record<string, unknown>): 
   // crux query blocks --component=<type>
   if (componentFilter) {
     const limit = parseIntOpt(options.limit, 20);
-    const validComponents = ['squiggle', 'mermaid', 'calc', 'callout', 'datainfobox', 'table'];
     const normalised = componentFilter.toLowerCase();
-    if (!validComponents.includes(normalised)) {
-      return {
-        output: `${c.red}Unknown component: ${componentFilter}. Valid: ${validComponents.join(', ')}${c.reset}`,
-        exitCode: 1,
-      };
-    }
 
     const results: Array<{ pageId: string; count: number }> = [];
     for (const ir of Object.values(index)) {
-      let count = 0;
-      switch (normalised) {
-        case 'squiggle': count = ir.components.squiggleCount; break;
-        case 'mermaid': count = ir.components.mermaidCount; break;
-        case 'calc': count = ir.components.calcCount; break;
-        case 'callout': count = ir.components.calloutCount; break;
-        case 'datainfobox': count = ir.components.dataInfoBoxCount; break;
-        case 'table': count = ir.components.totalTables; break;
-      }
+      const count = ir.components[normalised] || 0;
       if (count > 0) results.push({ pageId: ir.pageId, count });
+    }
+
+    if (results.length === 0) {
+      // Collect all known component names across the index for a helpful error
+      const knownNames = new Set<string>();
+      for (const ir of Object.values(index)) {
+        for (const name of Object.keys(ir.components)) {
+          knownNames.add(name);
+        }
+      }
+      return {
+        output: `${c.dim}No pages use component: ${componentFilter}. Known: ${[...knownNames].sort().join(', ') || 'none'}${c.reset}`,
+        exitCode: 0,
+      };
     }
 
     results.sort((a, b) => b.count - a.count);
 
     if (options.json || options.ci) {
       return { output: JSON.stringify(results.slice(0, limit), null, 2), exitCode: 0 };
-    }
-
-    if (results.length === 0) {
-      return { output: `${c.dim}No pages use component: ${componentFilter}${c.reset}`, exitCode: 0 };
     }
 
     let output = `${c.bold}${c.blue}Pages with ${componentFilter}${c.reset}\n`;

--- a/crux/lib/block-ir.test.ts
+++ b/crux/lib/block-ir.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { extractBlockIR } from './block-ir.ts';
-import type { PageBlockIR, SectionBlock } from './block-ir.ts';
+import type { PageBlockIR, SectionIR } from './block-ir.ts';
 
 // ---------------------------------------------------------------------------
 // Fixture: a realistic MDX page with multiple features
@@ -152,30 +152,31 @@ describe('extractBlockIR', () => {
     );
   });
 
-  it('detects component flags per section', () => {
+  it('detects component names per section', () => {
     const ir = extractBlockIR('test-org', FIXTURE_MDX);
 
     // Key Research has SquiggleEstimate
-    expect(ir.sections[2].hasSquiggle).toBe(true);
-    expect(ir.sections[2].hasMermaid).toBe(false);
+    expect(ir.sections[2].componentNames).toContain('squiggle');
+    expect(ir.sections[2].componentNames).not.toContain('mermaid');
 
     // Governance has MermaidDiagram
-    expect(ir.sections[3].hasMermaid).toBe(true);
-    expect(ir.sections[3].hasSquiggle).toBe(false);
+    expect(ir.sections[3].componentNames).toContain('mermaid');
+    expect(ir.sections[3].componentNames).not.toContain('squiggle');
 
-    // Quantitative Analysis has Calc
-    expect(ir.sections[4].hasCalc).toBe(true);
+    // Quantitative Analysis has Calc and Callout
+    expect(ir.sections[4].componentNames).toContain('calc');
+    expect(ir.sections[4].componentNames).toContain('callout');
   });
 
   it('aggregates page-level component counts', () => {
     const ir = extractBlockIR('test-org', FIXTURE_MDX);
 
-    expect(ir.components.squiggleCount).toBe(1);
-    expect(ir.components.mermaidCount).toBe(1);
-    expect(ir.components.calcCount).toBe(1);
-    expect(ir.components.calloutCount).toBe(1);
-    expect(ir.components.dataInfoBoxCount).toBe(1);
-    expect(ir.components.totalTables).toBe(1);
+    expect(ir.components.squiggle).toBe(1);
+    expect(ir.components.mermaid).toBe(1);
+    expect(ir.components.calc).toBe(1);
+    expect(ir.components.callout).toBe(1);
+    expect(ir.components.datainfobox).toBe(1);
+    expect(ir.components.table).toBe(1);
   });
 
   it('counts words per section (non-zero for content sections)', () => {
@@ -353,5 +354,24 @@ See [compute page](/ai-transition-model/compute/) and [overview](/knowledge-base
 <EntityLink id="test"
 `;
     expect(() => extractBlockIR('parse-error', mdx)).toThrow();
+  });
+
+  it('does not include untracked components in componentNames', () => {
+    const mdx = `## Section
+
+<SomeCustomComponent foo="bar">content</SomeCustomComponent>
+
+<SquiggleEstimate title="Test" code={\`x = 1\`} />
+`;
+    const ir = extractBlockIR('custom-comp', mdx);
+
+    const section = ir.sections.find(s => s.heading === 'Section')!;
+    // Only tracked components should appear
+    expect(section.componentNames).toContain('squiggle');
+    expect(section.componentNames).toHaveLength(1);
+
+    // Page-level should also only track known components
+    expect(ir.components.squiggle).toBe(1);
+    expect(Object.keys(ir.components)).toHaveLength(1);
   });
 });

--- a/crux/lib/block-ir.ts
+++ b/crux/lib/block-ir.ts
@@ -14,17 +14,20 @@
  * See issue #829.
  */
 
-import { createRequire } from 'module';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
+import remarkGfm from 'remark-gfm';
 import { headingToId } from './section-splitter.ts';
-
-const __filename_ir = fileURLToPath(import.meta.url);
-const __dirname_ir = dirname(__filename_ir);
+import {
+  nodeLine,
+  nodeEndLine,
+  extractText,
+  countWords,
+  getJsxAttr,
+  isJsxElement,
+} from './mdx-ast-helpers.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,7 +47,7 @@ export interface TableBlock {
   startLine: number;
 }
 
-export interface SectionBlock {
+export interface SectionIR {
   heading: string;
   headingId: string;
   level: number; // 0=preamble, 2-6=heading depth
@@ -57,51 +60,50 @@ export interface SectionBlock {
   externalLinks: string[];
   tables: TableBlock[];
   wordCount: number;
-  hasSquiggle: boolean;
-  hasMermaid: boolean;
-  hasCalc: boolean;
+  /** Component names present in this section (e.g. ['squiggle', 'mermaid']) */
+  componentNames: string[];
 }
+
+/** @deprecated Use SectionIR instead */
+export type SectionBlock = SectionIR;
+
+/**
+ * Known component names tracked by the block IR extractor.
+ * New components can be added here — the rest of the code is data-driven.
+ */
+const TRACKED_COMPONENTS: Record<string, string> = {
+  SquiggleEstimate: 'squiggle',
+  MermaidDiagram: 'mermaid',
+  Calc: 'calc',
+  Callout: 'callout',
+  DataInfoBox: 'datainfobox',
+};
 
 export interface PageBlockIR {
   pageId: string;
-  sections: SectionBlock[];
-  components: {
-    squiggleCount: number;
-    mermaidCount: number;
-    calcCount: number;
-    calloutCount: number;
-    dataInfoBoxCount: number;
-    totalTables: number;
-  };
+  sections: SectionIR[];
+  /** Component counts keyed by normalized name (e.g. { squiggle: 1, mermaid: 2 }) */
+  components: Record<string, number>;
 }
 
 export type BlockIndex = Record<string, PageBlockIR>;
 
 // ---------------------------------------------------------------------------
-// Remark plugin resolution
-// remark-gfm lives in apps/web/node_modules (not the root).
-// All other plugins are available via direct ESM imports above.
+// Remark pipeline (cached singleton)
 // ---------------------------------------------------------------------------
 
-// Resolve from this file's location (crux/lib/) so it works regardless of cwd
-const appRequire = createRequire(join(__dirname_ir, '../../apps/web/package.json'));
-let remarkGfm: any;
-try {
-  remarkGfm = appRequire('remark-gfm').default ?? appRequire('remark-gfm');
-} catch {
-  // Graceful fallback — tables appear as text instead of structured nodes
-}
-
+// Pipeline is cached globally. Safe because build-data.mjs processes pages
+// sequentially. If parallelized in future, use a factory instead.
 let _pipeline: any = null;
 
 function getParser(): any {
   if (_pipeline) return _pipeline;
-
-  let pipeline = unified().use(remarkParse).use(remarkFrontmatter).use(remarkMdx);
-  if (remarkGfm) pipeline = pipeline.use(remarkGfm);
-
-  _pipeline = pipeline;
-  return pipeline;
+  _pipeline = unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter)
+    .use(remarkMdx)
+    .use(remarkGfm);
+  return _pipeline;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,9 +124,7 @@ interface SectionAccumulator {
   externalLinks: Set<string>;
   tables: TableBlock[];
   wordCount: number;
-  hasSquiggle: boolean;
-  hasMermaid: boolean;
-  hasCalc: boolean;
+  componentNames: Set<string>;
 }
 
 function createAccumulator(heading: string, level: number, startLine: number): SectionAccumulator {
@@ -142,13 +142,11 @@ function createAccumulator(heading: string, level: number, startLine: number): S
     externalLinks: new Set(),
     tables: [],
     wordCount: 0,
-    hasSquiggle: false,
-    hasMermaid: false,
-    hasCalc: false,
+    componentNames: new Set(),
   };
 }
 
-function accToSection(acc: SectionAccumulator): SectionBlock {
+function accToSection(acc: SectionAccumulator): SectionIR {
   return {
     heading: acc.heading,
     headingId: acc.headingId,
@@ -162,65 +160,8 @@ function accToSection(acc: SectionAccumulator): SectionBlock {
     externalLinks: [...acc.externalLinks],
     tables: acc.tables,
     wordCount: acc.wordCount,
-    hasSquiggle: acc.hasSquiggle,
-    hasMermaid: acc.hasMermaid,
-    hasCalc: acc.hasCalc,
+    componentNames: [...acc.componentNames],
   };
-}
-
-// ---------------------------------------------------------------------------
-// Node inspection helpers
-// ---------------------------------------------------------------------------
-
-/** Get the start line of a node (1-indexed from remark) */
-function nodeLine(node: any): number {
-  return node?.position?.start?.line ?? 0;
-}
-
-/** Get the end line of a node */
-function nodeEndLine(node: any): number {
-  return node?.position?.end?.line ?? nodeLine(node);
-}
-
-/** Extract plain text from any MDAST node tree */
-function extractText(node: any): string {
-  if (!node) return '';
-  if (node.type === 'text' || node.type === 'inlineCode') return node.value || '';
-  if (Array.isArray(node.children)) {
-    return node.children.map(extractText).join('');
-  }
-  return '';
-}
-
-/** Count words in a string */
-function countWords(text: string): number {
-  const trimmed = text.trim();
-  if (!trimmed) return 0;
-  return trimmed.split(/\s+/).length;
-}
-
-/**
- * Get the value of a JSX attribute by name.
- * Handles both simple string attributes and expression attributes.
- */
-function getJsxAttr(node: any, name: string): string | undefined {
-  if (!node.attributes) return undefined;
-  for (const attr of node.attributes) {
-    if (attr.type === 'mdxJsxAttribute' && attr.name === name) {
-      if (typeof attr.value === 'string') return attr.value;
-      // Expression attribute: {value} — extract if simple literal
-      if (attr.value?.type === 'mdxJsxAttributeValueExpression') {
-        return attr.value.value;
-      }
-      return undefined;
-    }
-  }
-  return undefined;
-}
-
-/** Check if a node is a JSX element (flow or text) */
-function isJsxElement(node: any): boolean {
-  return node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement';
 }
 
 // ---------------------------------------------------------------------------
@@ -320,14 +261,7 @@ export function extractBlockIR(pageId: string, mdxContent: string): PageBlockIR 
   }
 
   // 3. Walk the tree and dispatch nodes to sections
-  const componentCounts = {
-    squiggleCount: 0,
-    mermaidCount: 0,
-    calcCount: 0,
-    calloutCount: 0,
-    dataInfoBoxCount: 0,
-    totalTables: 0,
-  };
+  const componentCounts: Record<string, number> = {};
 
   walkTree(tree, accumulators, componentCounts);
 
@@ -341,8 +275,8 @@ export function extractBlockIR(pageId: string, mdxContent: string): PageBlockIR 
     }
   }
 
-  // 5. Convert accumulators to sections, filtering empty preamble
-  const sections: SectionBlock[] = [];
+  // 5. Convert accumulators to sections
+  const sections: SectionIR[] = [];
   for (const acc of accumulators) {
     // Keep preamble even if empty — it conveys structural info
     sections.push(accToSection(acc));
@@ -371,9 +305,12 @@ function collectHeadings(node: any, result: Array<{ text: string; level: number;
   }
 }
 
-/** Find which section a node belongs to (by its start line) */
+/**
+ * Find which section a node belongs to by its start line.
+ * Walks backwards through accumulators — the last one with startLine <= line
+ * is the enclosing section (sections are ordered by startLine).
+ */
 function findSection(accumulators: SectionAccumulator[], line: number): SectionAccumulator {
-  // Walk backwards — the last accumulator with startLine <= line is the match
   for (let i = accumulators.length - 1; i >= 0; i--) {
     if (accumulators[i].startLine <= line) {
       return accumulators[i];
@@ -382,11 +319,15 @@ function findSection(accumulators: SectionAccumulator[], line: number): SectionA
   return accumulators[0]; // fallback to preamble
 }
 
-/** Walk the entire MDAST and dispatch each node to its section */
+/**
+ * Walk the entire MDAST and dispatch each top-level node to its section.
+ * Only recurses into the root's children — each top-level node is then
+ * processed by processNode which handles deeper recursion.
+ */
 function walkTree(
   node: any,
   accumulators: SectionAccumulator[],
-  componentCounts: PageBlockIR['components'],
+  componentCounts: Record<string, number>,
 ): void {
   if (!node) return;
 
@@ -416,7 +357,7 @@ function walkTree(
 function processNode(
   node: any,
   section: SectionAccumulator,
-  componentCounts: PageBlockIR['components'],
+  componentCounts: Record<string, number>,
 ): void {
   switch (node.type) {
     case 'text':
@@ -451,7 +392,7 @@ function processNode(
     case 'table': {
       const table = extractTable(node);
       section.tables.push(table);
-      componentCounts.totalTables++;
+      componentCounts.table = (componentCounts.table || 0) + 1;
       // Entity links and facts from table cells are added to the section
       for (const id of table.entityLinksInCells) {
         section.entityLinks.add(id);
@@ -510,15 +451,16 @@ function handleJsxComponent(
   name: string | null | undefined,
   node: any,
   section: SectionAccumulator,
-  componentCounts: PageBlockIR['components'],
+  componentCounts: Record<string, number>,
 ): void {
   if (!name) return;
 
+  // EntityLink and F are data-bearing components, not tracked as "components"
   switch (name) {
     case 'EntityLink': {
       const id = getJsxAttr(node, 'id');
       if (id) section.entityLinks.add(id);
-      break;
+      return;
     }
 
     case 'F': {
@@ -532,30 +474,14 @@ function handleJsxComponent(
           section.facts.push({ entityId: e, factId: f, ...(display && { display }) });
         }
       }
-      break;
+      return;
     }
+  }
 
-    case 'SquiggleEstimate':
-      section.hasSquiggle = true;
-      componentCounts.squiggleCount++;
-      break;
-
-    case 'MermaidDiagram':
-      section.hasMermaid = true;
-      componentCounts.mermaidCount++;
-      break;
-
-    case 'Calc':
-      section.hasCalc = true;
-      componentCounts.calcCount++;
-      break;
-
-    case 'Callout':
-      componentCounts.calloutCount++;
-      break;
-
-    case 'DataInfoBox':
-      componentCounts.dataInfoBoxCount++;
-      break;
+  // Check if it's a tracked component
+  const normalized = TRACKED_COMPONENTS[name];
+  if (normalized) {
+    section.componentNames.add(normalized);
+    componentCounts[normalized] = (componentCounts[normalized] || 0) + 1;
   }
 }

--- a/crux/lib/content-types.ts
+++ b/crux/lib/content-types.ts
@@ -378,7 +378,7 @@ export function loadExperts(): ExpertEntry[] {
   return loadGeneratedJson<ExpertEntry[]>('experts.json', []);
 }
 
-export type { BlockIndex } from './block-ir.ts';
+export type { BlockIndex, SectionIR, SectionBlock } from './block-ir.ts';
 
 export function loadBlockIndex(): import('./block-ir.ts').BlockIndex {
   return loadGeneratedJson<import('./block-ir.ts').BlockIndex>('block-index.json', {});

--- a/crux/lib/mdx-ast-helpers.ts
+++ b/crux/lib/mdx-ast-helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared MDAST (Markdown AST) Helpers
+ *
+ * Generic utilities for inspecting remark/unified AST nodes.
+ * Used by block-ir.ts and potentially other AST-based analysis modules.
+ */
+
+/** Get the start line of a node (1-indexed from remark) */
+export function nodeLine(node: any): number {
+  return node?.position?.start?.line ?? 0;
+}
+
+/** Get the end line of a node */
+export function nodeEndLine(node: any): number {
+  return node?.position?.end?.line ?? nodeLine(node);
+}
+
+/** Extract plain text from any MDAST node tree */
+export function extractText(node: any): string {
+  if (!node) return '';
+  if (node.type === 'text' || node.type === 'inlineCode') return node.value || '';
+  if (Array.isArray(node.children)) {
+    return node.children.map(extractText).join('');
+  }
+  return '';
+}
+
+/** Count words in a string */
+export function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Get the value of a JSX attribute by name from a remark-mdx AST node.
+ * Handles both simple string attributes and expression attributes.
+ */
+export function getJsxAttr(node: any, name: string): string | undefined {
+  if (!node.attributes) return undefined;
+  for (const attr of node.attributes) {
+    if (attr.type === 'mdxJsxAttribute' && attr.name === name) {
+      if (typeof attr.value === 'string') return attr.value;
+      // Expression attribute: {value} — extract if simple literal
+      if (attr.value?.type === 'mdxJsxAttributeValueExpression') {
+        return attr.value.value;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Check if a node is a JSX element (flow or text) */
+export function isJsxElement(node: any): boolean {
+  return node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement';
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^22.0.0",
     "@types/pdf-parse": "^1.1.5",
     "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "remark-mdx": "^3.1.0",
     "remark-mdx-frontmatter": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       remark-frontmatter:
         specifier: ^5.0.0
         version: 5.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
