### PR TITLE
fix: make hallucination-risk page dynamic to avoid build timeout

### DIFF
--- a/apps/web/src/app/internal/hallucination-risk/page.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/page.tsx
@@ -9,6 +9,9 @@ import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { HallucinationRiskDashboard } from "./hallucination-risk-dashboard";
 import type { Metadata } from "next";
 
+// Render on-demand — avoid build-time timeout when wiki-server is unreachable
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Hallucination Risk | Longterm Wiki Internal",
   description:


### PR DESCRIPTION
## Summary
- Add `export const dynamic = "force-dynamic"` to `/internal/hallucination-risk` page
- This page makes paginated API calls to the wiki-server during rendering; when the server is slow or unreachable from Vercel's build environment, the fetch hangs until the 60-second static generation timeout, failing after 3 retries
- Since it's an internal dashboard with no SEO benefit and frequently changing data, on-demand rendering is the right approach

## Context
The `build-and-test` CI job was failing on main due to this page timing out during `next build` static generation. The page paginates through up to 4000 risk scores from the wiki-server API — if the server is unreachable, each attempt hangs for the full timeout duration.

## Test plan
- [ ] CI `build-and-test` passes (this was the failing job)
- [ ] `/internal/hallucination-risk` renders correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
