### PR TITLE
test: add query blocks tests, block-section-quality validation rule

### DIFF
--- a/crux/commands/query-blocks.test.ts
+++ b/crux/commands/query-blocks.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for `crux query blocks` command
+ *
+ * Tests option validation, per-page view, cross-page filters,
+ * and default summary output.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockIndex, PageBlockIR, SectionIR } from '../lib/block-ir.ts';
+
+// ---------------------------------------------------------------------------
+// Mock loadBlockIndex before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockIndex: BlockIndex = {};
+
+vi.mock('../lib/content-types.ts', () => ({
+  loadBlockIndex: () => mockIndex,
+}));
+
+// Import after mocking
+const { blocks } = await import('./query.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSection(overrides: Partial<SectionIR> = {}): SectionIR {
+  return {
+    heading: 'Test Section',
+    headingId: 'test-section',
+    level: 2,
+    startLine: 10,
+    endLine: 30,
+    entityLinks: [],
+    facts: [],
+    footnoteRefs: [],
+    internalLinks: [],
+    externalLinks: [],
+    tables: [],
+    wordCount: 100,
+    componentNames: [],
+    ...overrides,
+  };
+}
+
+function makePage(pageId: string, sections: SectionIR[], components: Record<string, number> = {}): PageBlockIR {
+  return { pageId, sections, components };
+}
+
+function seedIndex(pages: PageBlockIR[]): void {
+  // Clear existing
+  for (const key of Object.keys(mockIndex)) {
+    delete mockIndex[key];
+  }
+  for (const p of pages) {
+    mockIndex[p.pageId] = p;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('crux query blocks', () => {
+  beforeEach(() => {
+    seedIndex([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Option validation
+  // -----------------------------------------------------------------------
+
+  describe('option validation', () => {
+    it('rejects page-id combined with --entity', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks(['test'], { entity: 'anthropic' });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('mutually exclusive');
+    });
+
+    it('rejects page-id combined with --component', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks(['test'], { component: 'squiggle' });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('mutually exclusive');
+    });
+
+    it('rejects page-id combined with --uncited', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks(['test'], { uncited: true });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('mutually exclusive');
+    });
+
+    it('rejects --entity combined with --component', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks([], { entity: 'anthropic', component: 'squiggle' });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('only one of');
+    });
+
+    it('rejects --entity combined with --uncited', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks([], { entity: 'anthropic', uncited: true });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('only one of');
+    });
+
+    it('rejects --component combined with --uncited', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks([], { component: 'squiggle', uncited: true });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('only one of');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty index
+  // -----------------------------------------------------------------------
+
+  describe('empty index', () => {
+    it('returns error when block index is empty', async () => {
+      const result = await blocks([], {});
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('No block-index.json');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-page view
+  // -----------------------------------------------------------------------
+
+  describe('per-page view', () => {
+    it('returns page not found for missing page', async () => {
+      seedIndex([makePage('anthropic', [makeSection()])]);
+      const result = await blocks(['nonexistent'], {});
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Page not found');
+    });
+
+    it('renders section structure for a page', async () => {
+      seedIndex([makePage('anthropic', [
+        makeSection({ heading: '__preamble__', level: 0, wordCount: 50 }),
+        makeSection({ heading: 'Overview', wordCount: 200, entityLinks: ['dario-amodei'] }),
+        makeSection({ heading: 'History', wordCount: 300, footnoteRefs: ['1', '2'] }),
+      ])]);
+
+      const result = await blocks(['anthropic'], {});
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('anthropic');
+      expect(result.output).toContain('Overview');
+      expect(result.output).toContain('History');
+      expect(result.output).toContain('dario-amodei');
+    });
+
+    it('returns JSON for --json flag', async () => {
+      seedIndex([makePage('test-page', [makeSection()], { squiggle: 2 })]);
+      const result = await blocks(['test-page'], { json: true });
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.output);
+      expect(parsed.pageId).toBe('test-page');
+      expect(parsed.components.squiggle).toBe(2);
+    });
+
+    it('displays component summary', async () => {
+      seedIndex([makePage('test-page', [
+        makeSection({ componentNames: ['squiggle'] }),
+      ], { squiggle: 1, mermaid: 2 })]);
+
+      const result = await blocks(['test-page'], {});
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('squiggle');
+      expect(result.output).toContain('mermaid');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Entity filter
+  // -----------------------------------------------------------------------
+
+  describe('--entity filter', () => {
+    it('finds sections referencing an entity', async () => {
+      seedIndex([
+        makePage('page-a', [
+          makeSection({ heading: 'Overview', entityLinks: ['anthropic', 'openai'] }),
+          makeSection({ heading: 'History', entityLinks: ['openai'] }),
+        ]),
+        makePage('page-b', [
+          makeSection({ heading: 'Analysis', entityLinks: ['anthropic'] }),
+        ]),
+      ]);
+
+      const result = await blocks([], { entity: 'anthropic' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('2 section');
+      expect(result.output).toContain('page-a');
+      expect(result.output).toContain('page-b');
+    });
+
+    it('returns empty result for unknown entity', async () => {
+      seedIndex([makePage('test', [makeSection({ entityLinks: ['openai'] })])]);
+      const result = await blocks([], { entity: 'nonexistent' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('No sections reference');
+    });
+
+    it('returns JSON for --json flag', async () => {
+      seedIndex([makePage('page-a', [
+        makeSection({ heading: 'Overview', entityLinks: ['anthropic'] }),
+      ])]);
+      const result = await blocks([], { entity: 'anthropic', json: true });
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.output);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].pageId).toBe('page-a');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Component filter
+  // -----------------------------------------------------------------------
+
+  describe('--component filter', () => {
+    it('finds pages using a component', async () => {
+      seedIndex([
+        makePage('page-a', [makeSection()], { squiggle: 3 }),
+        makePage('page-b', [makeSection()], { squiggle: 1 }),
+        makePage('page-c', [makeSection()], { mermaid: 2 }),
+      ]);
+
+      const result = await blocks([], { component: 'squiggle' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('2 page');
+      expect(result.output).toContain('page-a');
+      expect(result.output).toContain('page-b');
+    });
+
+    it('is case-insensitive', async () => {
+      seedIndex([makePage('test', [makeSection()], { squiggle: 1 })]);
+      const result = await blocks([], { component: 'Squiggle' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('1 page');
+    });
+
+    it('suggests known components for unknown type', async () => {
+      seedIndex([makePage('test', [makeSection()], { squiggle: 1, mermaid: 2 })]);
+      const result = await blocks([], { component: 'nonexistent' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('Known:');
+      expect(result.output).toContain('squiggle');
+    });
+
+    it('sorts by count descending', async () => {
+      seedIndex([
+        makePage('page-a', [makeSection()], { squiggle: 1 }),
+        makePage('page-b', [makeSection()], { squiggle: 5 }),
+      ]);
+      const result = await blocks([], { component: 'squiggle', json: true });
+      const parsed = JSON.parse(result.output);
+      expect(parsed[0].pageId).toBe('page-b');
+      expect(parsed[0].count).toBe(5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Uncited filter
+  // -----------------------------------------------------------------------
+
+  describe('--uncited filter', () => {
+    it('finds sections with enough words but no citations', async () => {
+      seedIndex([makePage('page-a', [
+        makeSection({ heading: '__preamble__', level: 0, wordCount: 200, footnoteRefs: [] }),
+        makeSection({ heading: 'Cited', wordCount: 200, footnoteRefs: ['1'] }),
+        makeSection({ heading: 'Uncited', wordCount: 150, footnoteRefs: [] }),
+        makeSection({ heading: 'Short', wordCount: 20, footnoteRefs: [] }),
+      ])]);
+
+      const result = await blocks([], { uncited: true });
+      expect(result.exitCode).toBe(0);
+      // Only "Uncited" should appear (preamble excluded by level>0, Cited has refs, Short is too short)
+      expect(result.output).toContain('Uncited');
+      expect(result.output).not.toContain('Cited');
+      expect(result.output).not.toContain('Short');
+      expect(result.output).not.toContain('preamble');
+    });
+
+    it('respects --min-words option', async () => {
+      seedIndex([makePage('test', [
+        makeSection({ heading: 'Medium', wordCount: 80, footnoteRefs: [] }),
+        makeSection({ heading: 'Long', wordCount: 200, footnoteRefs: [] }),
+      ])]);
+
+      const result = await blocks([], { uncited: true, 'min-words': '100' });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('Long');
+      expect(result.output).not.toContain('Medium');
+    });
+
+    it('reports no issues when all sections are cited', async () => {
+      seedIndex([makePage('test', [
+        makeSection({ heading: 'Section', wordCount: 200, footnoteRefs: ['1'] }),
+      ])]);
+
+      const result = await blocks([], { uncited: true });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('No uncited sections');
+    });
+
+    it('sorts by word count descending', async () => {
+      seedIndex([makePage('test', [
+        makeSection({ heading: 'Small', wordCount: 60, footnoteRefs: [] }),
+        makeSection({ heading: 'Big', wordCount: 500, footnoteRefs: [] }),
+      ])]);
+
+      const result = await blocks([], { uncited: true, json: true });
+      const parsed = JSON.parse(result.output);
+      expect(parsed[0].section).toBe('Big');
+      expect(parsed[0].wordCount).toBe(500);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Default summary
+  // -----------------------------------------------------------------------
+
+  describe('default summary', () => {
+    it('shows page and section counts', async () => {
+      seedIndex([
+        makePage('page-a', [makeSection(), makeSection()]),
+        makePage('page-b', [makeSection()]),
+      ]);
+
+      const result = await blocks([], {});
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('2');  // 2 pages
+      expect(result.output).toContain('3');  // 3 sections
+    });
+
+    it('returns JSON for --json flag', async () => {
+      seedIndex([makePage('test', [makeSection()])]);
+      const result = await blocks([], { json: true });
+      const parsed = JSON.parse(result.output);
+      expect(parsed.pages).toBe(1);
+      expect(parsed.sections).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Limit option
+  // -----------------------------------------------------------------------
+
+  describe('--limit option', () => {
+    it('limits entity filter results', async () => {
+      const sections = Array.from({ length: 30 }, (_, i) =>
+        makeSection({ heading: `Section ${i}`, entityLinks: ['anthropic'] }),
+      );
+      seedIndex([makePage('big-page', sections)]);
+
+      const result = await blocks([], { entity: 'anthropic', limit: '5', json: true });
+      const parsed = JSON.parse(result.output);
+      expect(parsed).toHaveLength(5);
+    });
+  });
+});

--- a/crux/lib/rules/block-section-quality.test.ts
+++ b/crux/lib/rules/block-section-quality.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for block-section-quality validation rule
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockIndex, PageBlockIR, SectionIR } from '../block-ir.ts';
+import { ValidationEngine, Severity } from '../validation-engine.ts';
+
+// ---------------------------------------------------------------------------
+// Mock loadBlockIndex
+// ---------------------------------------------------------------------------
+
+const mockIndex: BlockIndex = {};
+
+vi.mock('../content-types.ts', () => ({
+  loadBlockIndex: () => mockIndex,
+}));
+
+// Import after mocking
+const { blockSectionQualityRule, _resetCache } = await import('./block-section-quality.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSection(overrides: Partial<SectionIR> = {}): SectionIR {
+  return {
+    heading: 'Test Section',
+    headingId: 'test-section',
+    level: 2,
+    startLine: 10,
+    endLine: 30,
+    entityLinks: [],
+    facts: [],
+    footnoteRefs: [],
+    internalLinks: [],
+    externalLinks: [],
+    tables: [],
+    wordCount: 100,
+    componentNames: [],
+    ...overrides,
+  };
+}
+
+function seedIndex(pages: PageBlockIR[]): void {
+  for (const key of Object.keys(mockIndex)) {
+    delete mockIndex[key];
+  }
+  for (const p of pages) {
+    mockIndex[p.pageId] = p;
+  }
+}
+
+function makeContentFile(
+  slug: string,
+  opts: { pageType?: string; isIndex?: boolean } = {},
+) {
+  return {
+    path: `/content/docs/knowledge-base/${slug}.mdx`,
+    relativePath: `knowledge-base/${slug}.mdx`,
+    slug: `knowledge-base/${slug}`,
+    frontmatter: { pageType: opts.pageType } as any,
+    body: '',
+    isIndex: opts.isIndex ?? false,
+  } as any;
+}
+
+const engine = {} as ValidationEngine;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('blockSectionQualityRule', () => {
+  beforeEach(() => {
+    _resetCache();
+    seedIndex([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Uncited long sections
+  // -----------------------------------------------------------------------
+
+  describe('uncited long sections', () => {
+    it('flags sections with ≥200 words and no citations', () => {
+      seedIndex([{
+        pageId: 'anthropic',
+        sections: [
+          makeSection({ heading: '__preamble__', level: 0, wordCount: 50 }),
+          makeSection({ heading: 'Overview', wordCount: 250, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('anthropic')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain('Overview');
+      expect(issues[0].message).toContain('250 words');
+      expect(issues[0].message).toContain('no footnote citations');
+      expect(issues[0].severity).toBe(Severity.WARNING);
+    });
+
+    it('does not flag sections with citations', () => {
+      seedIndex([{
+        pageId: 'anthropic',
+        sections: [
+          makeSection({ heading: 'History', wordCount: 300, footnoteRefs: ['1', '2'] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('anthropic')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it('does not flag sections below the word threshold', () => {
+      seedIndex([{
+        pageId: 'anthropic',
+        sections: [
+          makeSection({ heading: 'Brief', wordCount: 150, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('anthropic')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it('skips preamble sections', () => {
+      seedIndex([{
+        pageId: 'anthropic',
+        sections: [
+          makeSection({ heading: '__preamble__', level: 0, wordCount: 500, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('anthropic')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty sections
+  // -----------------------------------------------------------------------
+
+  describe('empty sections', () => {
+    it('flags sections with ≤10 words', () => {
+      seedIndex([{
+        pageId: 'test-page',
+        sections: [
+          makeSection({ heading: 'Empty Heading', wordCount: 5, startLine: 20 }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('test-page')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain('Empty Heading');
+      expect(issues[0].message).toContain('5 words');
+      expect(issues[0].line).toBe(20);
+    });
+
+    it('does not flag sections with enough content', () => {
+      seedIndex([{
+        pageId: 'test-page',
+        sections: [
+          makeSection({ heading: 'Good Section', wordCount: 50 }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('test-page')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it('flags 0-word sections', () => {
+      seedIndex([{
+        pageId: 'test-page',
+        sections: [
+          makeSection({ heading: 'Placeholder', wordCount: 0 }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('test-page')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain('0 words');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering
+  // -----------------------------------------------------------------------
+
+  describe('page filtering', () => {
+    it('skips non-knowledge-base pages', () => {
+      seedIndex([{
+        pageId: 'internal-page',
+        sections: [
+          makeSection({ heading: 'Uncited', wordCount: 500, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const cf = {
+        path: '/content/docs/internal/page.mdx',
+        relativePath: 'internal/page.mdx',
+        slug: 'internal/page',
+        frontmatter: {} as any,
+        body: '',
+        isIndex: false,
+      } as any;
+
+      const issues = blockSectionQualityRule.check([cf], engine);
+      expect(issues).toHaveLength(0);
+    });
+
+    it('skips index pages', () => {
+      seedIndex([{
+        pageId: 'organizations',
+        sections: [
+          makeSection({ heading: 'All Orgs', wordCount: 500, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('organizations', { isIndex: true })],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it('skips stub pages', () => {
+      seedIndex([{
+        pageId: 'stub-page',
+        sections: [
+          makeSection({ heading: 'Placeholder', wordCount: 500, footnoteRefs: [] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('stub-page', { pageType: 'stub' })],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it('handles pages not in block index gracefully', () => {
+      seedIndex([]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('missing-page')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Combined checks
+  // -----------------------------------------------------------------------
+
+  describe('combined checks', () => {
+    it('can flag both uncited and empty on the same page', () => {
+      seedIndex([{
+        pageId: 'messy-page',
+        sections: [
+          makeSection({ heading: '__preamble__', level: 0, wordCount: 30 }),
+          makeSection({ heading: 'Big Uncited', wordCount: 300, footnoteRefs: [] }),
+          makeSection({ heading: 'Empty', wordCount: 3 }),
+          makeSection({ heading: 'Good', wordCount: 100, footnoteRefs: ['1'] }),
+        ],
+        components: {},
+      }]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('messy-page')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(2);
+      const messages = issues.map(i => i.message);
+      expect(messages.some(m => m.includes('Big Uncited'))).toBe(true);
+      expect(messages.some(m => m.includes('Empty'))).toBe(true);
+    });
+
+    it('handles multiple pages', () => {
+      seedIndex([
+        {
+          pageId: 'page-a',
+          sections: [makeSection({ heading: 'Long', wordCount: 400, footnoteRefs: [] })],
+          components: {},
+        },
+        {
+          pageId: 'page-b',
+          sections: [makeSection({ heading: 'Short', wordCount: 2 })],
+          components: {},
+        },
+      ]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('page-a'), makeContentFile('page-b')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty block index
+  // -----------------------------------------------------------------------
+
+  describe('empty block index', () => {
+    it('returns no issues when block index is empty', () => {
+      seedIndex([]);
+
+      const issues = blockSectionQualityRule.check(
+        [makeContentFile('anthropic')],
+        engine,
+      );
+
+      expect(issues).toHaveLength(0);
+    });
+  });
+});

--- a/crux/lib/rules/block-section-quality.ts
+++ b/crux/lib/rules/block-section-quality.ts
@@ -1,0 +1,101 @@
+/**
+ * Block Section Quality Validation Rule (global scope)
+ *
+ * Uses the block-level IR (block-index.json) to detect structural issues
+ * that are invisible to line-level text rules:
+ *
+ * 1. Uncited long sections: Sections with ≥200 words of prose and zero
+ *    footnote citations. These are the highest-risk content for hallucination.
+ *
+ * 2. Empty sections: H2 sections with fewer than 10 words — likely leftover
+ *    headings from templates or incomplete drafts.
+ *
+ * Only applies to knowledge-base pages. Skips preamble sections (level 0),
+ * pages that failed block-IR parsing, and non-KB pages.
+ */
+
+import { Severity, Issue, type ContentFile, type ValidationEngine } from '../validation-engine.ts';
+import { loadBlockIndex } from '../content-types.ts';
+import type { BlockIndex } from '../block-ir.ts';
+
+/** Minimum word count to flag an uncited section */
+const UNCITED_MIN_WORDS = 200;
+
+/** Sections below this word count are flagged as empty */
+const EMPTY_SECTION_MAX_WORDS = 10;
+
+/** Cache the block index across invocations within a single validation run */
+let cachedIndex: BlockIndex | null = null;
+
+function getBlockIndex(): BlockIndex {
+  if (!cachedIndex) {
+    cachedIndex = loadBlockIndex();
+  }
+  return cachedIndex;
+}
+
+/** Reset the cached index (used by tests) */
+export function _resetCache(): void {
+  cachedIndex = null;
+}
+
+export const blockSectionQualityRule = {
+  id: 'block-section-quality',
+  name: 'Block Section Quality',
+  description: 'Detect uncited long sections and empty sections using block-level IR',
+  scope: 'global' as const,
+
+  check(files: ContentFile | ContentFile[], _engine: ValidationEngine): Issue[] {
+    const contentFiles = Array.isArray(files) ? files : [files];
+    const issues: Issue[] = [];
+
+    const index = getBlockIndex();
+    if (Object.keys(index).length === 0) return issues;
+
+    for (const cf of contentFiles) {
+      // Only apply to knowledge-base pages
+      if (!cf.relativePath.startsWith('knowledge-base/')) continue;
+
+      // Skip index pages and stubs
+      if (cf.isIndex) continue;
+      if (cf.frontmatter.pageType === 'stub') continue;
+
+      // Resolve page ID from the content file's slug
+      const pageId = cf.slug.replace(/^knowledge-base\//, '');
+      const ir = index[pageId];
+      if (!ir) continue;
+
+      for (const section of ir.sections) {
+        // Skip preamble
+        if (section.level === 0) continue;
+
+        // Check 1: Uncited long sections
+        if (
+          section.wordCount >= UNCITED_MIN_WORDS &&
+          section.footnoteRefs.length === 0
+        ) {
+          issues.push(new Issue({
+            rule: 'block-section-quality',
+            file: cf.path,
+            line: section.startLine,
+            message: `Section "${section.heading}" has ${section.wordCount} words but no footnote citations — consider adding sources`,
+            severity: Severity.WARNING,
+          }));
+        }
+
+        // Check 2: Empty sections
+        if (section.wordCount <= EMPTY_SECTION_MAX_WORDS) {
+          issues.push(new Issue({
+            rule: 'block-section-quality',
+            file: cf.path,
+            line: section.startLine,
+            message: `Section "${section.heading}" has only ${section.wordCount} word${section.wordCount !== 1 ? 's' : ''} — remove or populate this section`,
+            severity: Severity.WARNING,
+          }));
+        }
+      }
+    }
+
+    return issues;
+  },
+};

--- a/crux/lib/rules/index.ts
+++ b/crux/lib/rules/index.ts
@@ -101,6 +101,9 @@ import { pipelineArtifactsRule } from './pipeline-artifacts.ts';
 // Footnote integrity (orphans, leaked SRC markers)
 import { footnoteIntegrityRule } from './footnote-integrity.ts';
 
+// Block-level structural quality (uses block-index.json IR)
+import { blockSectionQualityRule } from './block-section-quality.ts';
+
 // Re-export all rules individually
 export {
   entityLinkIdsRule,
@@ -154,6 +157,7 @@ export {
   resourceRefIntegrityRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,
+  blockSectionQualityRule,
 };
 
 export const allRules: Rule[] = [
@@ -208,6 +212,7 @@ export const allRules: Rule[] = [
   resourceRefIntegrityRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,
+  blockSectionQualityRule,
 ];
 
 export default allRules;


### PR DESCRIPTION
Item 8: 25 tests for `crux query blocks` covering option validation, per-page view, entity/component/uncited filters, JSON output, limits.

Item 9: New `block-section-quality` global validation rule that uses block-index.json to detect uncited long sections (≥200 words, 0 citations) and empty sections (≤10 words). 14 tests. Registered in rules index.