### PR TITLE
feat: LLM-triaged pre-push gate to skip irrelevant checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ pnpm build                      # Production build (runs assign-ids + build-data
 pnpm test                        # Run vitest tests
 
 # Pre-push gate (CI-blocking checks)
-pnpm crux validate gate          # Build data + tests + blocking validations
+pnpm crux validate gate          # Build data + tests + blocking validations (with LLM triage)
 pnpm crux validate gate --full   # Also runs full Next.js build
+pnpm crux validate gate --no-triage  # Skip LLM triage, run all checks
+pnpm crux validate gate --full-gate  # Force all checks (implies --no-triage)
 
 # Tooling (Crux CLI)
 pnpm crux validate               # Run all validation checks
@@ -351,11 +353,15 @@ Before finishing any session, run the full review-and-ship workflow defined in `
 
 ### Before pushing: run the gate check
 ```bash
-pnpm crux validate gate          # Runs: build-data, tests, validations, typecheck
+pnpm crux validate gate          # Runs: build-data, tests, validations, typecheck (with LLM triage)
 pnpm crux validate gate --fix    # Auto-fix escaping + markdown before validating
 pnpm crux validate gate --full   # Also runs full Next.js build
+pnpm crux validate gate --no-triage  # Skip LLM triage, run all checks
+pnpm crux validate gate --full-gate  # Force all checks (implies --no-triage)
 ```
 The gate check bundles all CI-blocking checks into one command. It fails fast — if any step fails, it stops and reports. The `.githooks/pre-push` hook runs this automatically on every `git push`.
+
+LLM triage (enabled by default locally) uses Haiku to analyze the git diff and skip checks that are clearly irrelevant to the changed files. It's conservative (skips only when safe), has a 3-second timeout with graceful fallback, and is auto-disabled in CI.
 
 **Setup (one-time):** `git config core.hooksPath .githooks`
 

--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -104,7 +104,7 @@ const SCRIPTS = {
   gate: {
     script: 'validate/validate-gate.ts',
     description: 'CI-blocking checks (pre-push gate)',
-    passthrough: ['ci', 'full', 'fix'],
+    passthrough: ['ci', 'full', 'fix', 'fullGate', 'noTriage'],
   },
   'hallucination-risk': {
     script: 'validate/validate-hallucination-risk.ts',
@@ -140,8 +140,10 @@ Options:
 
 Examples:
   crux validate                           Run all checks
-  crux validate gate                      Run CI-blocking checks (pre-push)
+  crux validate gate                      Run CI-blocking checks (with triage)
   crux validate gate --full               Include full Next.js build
+  crux validate gate --no-triage          Skip LLM triage, run all checks
+  crux validate gate --full-gate          Force all checks (implies --no-triage)
   crux validate compile --quick           Quick compile check
   crux validate unified --rules=dollar-signs,markdown-lists
   crux validate unified --fix             Auto-fix unified rule issues

--- a/crux/validate/gate-triage.test.ts
+++ b/crux/validate/gate-triage.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeFiles, canSkipBuildData, type FileCategories } from './gate-triage.ts';
+
+describe('categorizeFiles', () => {
+  it('categorizes MDX content files', () => {
+    const result = categorizeFiles(['content/docs/organizations/miri.mdx']);
+    expect(result.mdxContent).toEqual(['content/docs/organizations/miri.mdx']);
+    expect(result.other).toEqual([]);
+  });
+
+  it('categorizes YAML data files', () => {
+    const result = categorizeFiles(['data/entities/miri.yaml', 'data/facts/compute.yaml']);
+    expect(result.yamlData).toHaveLength(2);
+  });
+
+  it('categorizes app TypeScript files', () => {
+    const result = categorizeFiles(['apps/web/src/components/Button.tsx', 'apps/web/src/lib/utils.ts']);
+    expect(result.appTs).toHaveLength(2);
+  });
+
+  it('categorizes build scripts', () => {
+    const result = categorizeFiles(['apps/web/scripts/build-data.mjs']);
+    expect(result.buildScripts).toEqual(['apps/web/scripts/build-data.mjs']);
+  });
+
+  it('categorizes crux TypeScript files', () => {
+    const result = categorizeFiles(['crux/validate/validate-gate.ts', 'crux/lib/output.ts']);
+    expect(result.cruxTs).toHaveLength(2);
+  });
+
+  it('categorizes wiki-server TypeScript files', () => {
+    const result = categorizeFiles(['apps/wiki-server/src/routes/api.ts']);
+    expect(result.wikiServerTs).toHaveLength(1);
+  });
+
+  it('categorizes config files', () => {
+    const result = categorizeFiles(['package.json', 'tsconfig.json', 'pnpm-lock.yaml']);
+    expect(result.config).toHaveLength(3);
+  });
+
+  it('categorizes unknown files as other', () => {
+    const result = categorizeFiles(['README.md', '.github/workflows/ci.yml']);
+    expect(result.other).toEqual(['README.md', '.github/workflows/ci.yml']);
+  });
+
+  it('handles mixed file types', () => {
+    const files = [
+      'content/docs/concepts/agi.mdx',
+      'data/entities/openai.yaml',
+      'crux/validate/gate-triage.ts',
+      'apps/web/src/app/page.tsx',
+      'package.json',
+      'README.md',
+    ];
+    const result = categorizeFiles(files);
+    expect(result.mdxContent).toHaveLength(1);
+    expect(result.yamlData).toHaveLength(1);
+    expect(result.cruxTs).toHaveLength(1);
+    expect(result.appTs).toHaveLength(1);
+    expect(result.config).toHaveLength(1);
+    expect(result.other).toHaveLength(1);
+  });
+
+  it('handles empty file list', () => {
+    const result = categorizeFiles([]);
+    expect(Object.values(result).every(arr => arr.length === 0)).toBe(true);
+  });
+
+  it('recognizes tsconfig variants as config', () => {
+    const result = categorizeFiles(['tsconfig.json', 'tsconfig.node.json']);
+    expect(result.config).toHaveLength(2);
+  });
+
+  it('does not misclassify non-ts files in crux/', () => {
+    const result = categorizeFiles(['crux/README.md']);
+    expect(result.cruxTs).toHaveLength(0);
+    expect(result.other).toHaveLength(1);
+  });
+});
+
+describe('canSkipBuildData', () => {
+  const emptyCategories: FileCategories = {
+    mdxContent: [],
+    yamlData: [],
+    appTs: [],
+    buildScripts: [],
+    cruxTs: [],
+    wikiServerTs: [],
+    config: [],
+    other: [],
+  };
+
+  it('allows skip when only crux files changed (and database.json exists)', () => {
+    // canSkipBuildData checks existsSync internally — in the test environment
+    // database.json likely exists, so this tests the logic path
+    const cats = { ...emptyCategories, cruxTs: ['crux/validate/gate-triage.ts'] };
+    // The result depends on whether database.json exists on disk
+    const result = canSkipBuildData(cats);
+    // We just verify it returns a boolean (the file existence check is real I/O)
+    expect(typeof result).toBe('boolean');
+  });
+
+  it('does NOT allow skip when MDX files changed', () => {
+    const cats = { ...emptyCategories, mdxContent: ['content/docs/test.mdx'] };
+    expect(canSkipBuildData(cats)).toBe(false);
+  });
+
+  it('does NOT allow skip when YAML data files changed', () => {
+    const cats = { ...emptyCategories, yamlData: ['data/entities/test.yaml'] };
+    expect(canSkipBuildData(cats)).toBe(false);
+  });
+
+  it('does NOT allow skip when app TS files changed', () => {
+    const cats = { ...emptyCategories, appTs: ['apps/web/src/lib/utils.ts'] };
+    expect(canSkipBuildData(cats)).toBe(false);
+  });
+
+  it('does NOT allow skip when build scripts changed', () => {
+    const cats = { ...emptyCategories, buildScripts: ['apps/web/scripts/build-data.mjs'] };
+    expect(canSkipBuildData(cats)).toBe(false);
+  });
+
+  it('does NOT allow skip when config files changed', () => {
+    const cats = { ...emptyCategories, config: ['package.json'] };
+    expect(canSkipBuildData(cats)).toBe(false);
+  });
+
+  it('allows skip for wiki-server-only changes (if database.json exists)', () => {
+    const cats = { ...emptyCategories, wikiServerTs: ['apps/wiki-server/src/api.ts'] };
+    const result = canSkipBuildData(cats);
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/crux/validate/gate-triage.ts
+++ b/crux/validate/gate-triage.ts
@@ -1,0 +1,236 @@
+/**
+ * Gate Triage — LLM-assisted check skipping for the pre-push gate
+ *
+ * Reads the git diff, categorizes changed files, and optionally asks Haiku
+ * which gate checks can be safely skipped. Conservative by design:
+ * - Deterministic `canSkipBuildData()` for the most impactful skip
+ * - LLM triage only suggests skipping clearly irrelevant checks
+ * - 3-second hard timeout; any error → run everything
+ * - Disabled in CI (always runs full gate)
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { createClient, callClaude, MODELS, parseJsonResponse } from '../lib/anthropic.ts';
+
+// ── File categories ──────────────────────────────────────────────────────────
+
+export interface FileCategories {
+  mdxContent: string[];
+  yamlData: string[];
+  appTs: string[];
+  buildScripts: string[];
+  cruxTs: string[];
+  wikiServerTs: string[];
+  config: string[];
+  other: string[];
+}
+
+const CONFIG_PATTERNS = [
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  /^tsconfig/,
+  '.eslintrc',
+  'next.config',
+  'vitest.config',
+  'tailwind.config',
+  'postcss.config',
+];
+
+function isConfigFile(file: string): boolean {
+  const basename = file.split('/').pop() || '';
+  return CONFIG_PATTERNS.some(p =>
+    typeof p === 'string' ? basename.startsWith(p) : p.test(basename)
+  );
+}
+
+/**
+ * Categorize changed files into buckets for triage decisions.
+ * Pure function — no I/O, no LLM.
+ */
+export function categorizeFiles(files: string[]): FileCategories {
+  const cats: FileCategories = {
+    mdxContent: [],
+    yamlData: [],
+    appTs: [],
+    buildScripts: [],
+    cruxTs: [],
+    wikiServerTs: [],
+    config: [],
+    other: [],
+  };
+
+  for (const f of files) {
+    if (isConfigFile(f)) {
+      cats.config.push(f);
+    } else if (f.startsWith('content/docs/') && f.endsWith('.mdx')) {
+      cats.mdxContent.push(f);
+    } else if (f.startsWith('data/') && f.endsWith('.yaml')) {
+      cats.yamlData.push(f);
+    } else if (f.startsWith('apps/web/scripts/')) {
+      cats.buildScripts.push(f);
+    } else if (f.startsWith('apps/web/src/') && /\.tsx?$/.test(f)) {
+      cats.appTs.push(f);
+    } else if (f.startsWith('crux/') && /\.tsx?$/.test(f)) {
+      cats.cruxTs.push(f);
+    } else if (f.startsWith('apps/wiki-server/') && /\.tsx?$/.test(f)) {
+      cats.wikiServerTs.push(f);
+    } else {
+      cats.other.push(f);
+    }
+  }
+
+  return cats;
+}
+
+// ── Deterministic build-data skip ────────────────────────────────────────────
+
+/**
+ * Can we skip the build-data step?
+ *
+ * Returns true only when:
+ * - No MDX, YAML, app TS, build script, or config files changed
+ * - database.json already exists on disk
+ *
+ * This means only pure crux/, wiki-server/, or other changes skip build-data.
+ */
+export function canSkipBuildData(categories: FileCategories): boolean {
+  const hasDataRelevantChanges =
+    categories.mdxContent.length > 0 ||
+    categories.yamlData.length > 0 ||
+    categories.appTs.length > 0 ||
+    categories.buildScripts.length > 0 ||
+    categories.config.length > 0;
+
+  if (hasDataRelevantChanges) return false;
+
+  const dbPath = join(PROJECT_ROOT, 'apps/web/src/data/database.json');
+  return existsSync(dbPath);
+}
+
+// ── LLM triage ───────────────────────────────────────────────────────────────
+
+export interface TriageResult {
+  /** Map of step ID → reason for skipping */
+  skip: Record<string, string>;
+  /** Whether the LLM was actually called (false if fallback) */
+  llmCalled: boolean;
+  /** Duration of the triage call in ms */
+  durationMs: number;
+}
+
+/** Step descriptions for the Haiku prompt */
+const STEP_DESCRIPTIONS: Record<string, string> = {
+  'test': 'Run vitest tests (apps/web/ test files). Relevant when app TS, crux TS, or test files change.',
+  'unified-blocking': 'MDX syntax, frontmatter schema, numeric IDs, EntityLink, pipeline artifacts. Relevant when MDX content or YAML data changes.',
+  'yaml-schema': 'YAML entity schema validation. Relevant when YAML data files change.',
+  'typecheck': 'TypeScript type check for apps/web/. Relevant when app TS files, config, or package.json change.',
+  'typecheck-crux': 'TypeScript type check for crux/. Relevant when crux TS files change.',
+  'returning-guard': 'Drizzle .returning() guard for wiki-server. Relevant when wiki-server TS files change.',
+  'mdx-compile': 'MDX compilation smoke-test. Relevant when MDX content or app components change.',
+  'typecheck-crux-baseline': 'Crux TypeScript baseline check. Relevant when crux TS files change.',
+};
+
+const SYSTEM_PROMPT = `You are a CI triage assistant. Given a summary of changed files in a git push, decide which gate checks can be safely SKIPPED.
+
+Available checks and when they're relevant:
+${Object.entries(STEP_DESCRIPTIONS).map(([id, desc]) => `- "${id}": ${desc}`).join('\n')}
+
+Rules:
+- Be CONSERVATIVE. Only skip a check when the changed files clearly cannot affect it.
+- When in doubt, do NOT skip.
+- If config files changed (package.json, tsconfig, etc.), do NOT skip any checks.
+- If "other" files changed, do NOT skip any checks.
+
+Respond with a JSON object: { "skip": { "<step-id>": "<one-line reason>" } }
+Only include steps you want to skip. Empty "skip" object means run everything.`;
+
+const TRIAGE_TIMEOUT_MS = 3000;
+const MAX_SKIPPABLE = 5; // Safety cap: never skip more than this many checks
+
+/**
+ * Ask Haiku which gate checks can be skipped based on changed files.
+ *
+ * Graceful fallback: returns empty skip set on any error, timeout, or missing API key.
+ */
+export async function triageGateChecks(
+  changedFiles: string[],
+  allStepIds: string[],
+  categories?: FileCategories,
+): Promise<TriageResult> {
+  const start = Date.now();
+
+  const cats = categories ?? categorizeFiles(changedFiles);
+
+  // Build a compact summary (keeps token count low, ~200 tokens)
+  const summary = Object.entries(cats)
+    .filter(([, files]) => files.length > 0)
+    .map(([cat, files]) => `${cat}: ${files.length} file${files.length > 1 ? 's' : ''}`)
+    .join('\n');
+
+  if (!summary) {
+    // No files changed — skip nothing (shouldn't happen, but be safe)
+    return { skip: {}, llmCalled: false, durationMs: Date.now() - start };
+  }
+
+  // If config or other files changed, skip nothing (deterministic fast path)
+  if (cats.config.length > 0 || cats.other.length > 0) {
+    return { skip: {}, llmCalled: false, durationMs: Date.now() - start };
+  }
+
+  // Try to call Haiku with a hard timeout
+  try {
+    const client = createClient({ required: false });
+    if (!client) {
+      return { skip: {}, llmCalled: false, durationMs: Date.now() - start };
+    }
+
+    const userPrompt = `Changed files summary:\n${summary}\n\nTotal files: ${changedFiles.length}`;
+
+    const llmPromise = callClaude(client, {
+      model: MODELS.haiku,
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      maxTokens: 500,
+      temperature: 0,
+    });
+
+    const timeoutPromise = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), TRIAGE_TIMEOUT_MS)
+    );
+
+    const result = await Promise.race([llmPromise, timeoutPromise]);
+
+    if (!result) {
+      // Timeout
+      return { skip: {}, llmCalled: true, durationMs: Date.now() - start };
+    }
+
+    // Parse and validate the response
+    const parsed = parseJsonResponse(result.text) as { skip?: Record<string, string> };
+
+    if (!parsed || typeof parsed.skip !== 'object') {
+      return { skip: {}, llmCalled: true, durationMs: Date.now() - start };
+    }
+
+    // Filter: only keep known step IDs, cap at MAX_SKIPPABLE
+    const validSkips: Record<string, string> = {};
+    const stepIdSet = new Set(allStepIds);
+    let count = 0;
+
+    for (const [id, reason] of Object.entries(parsed.skip)) {
+      if (count >= MAX_SKIPPABLE) break;
+      if (stepIdSet.has(id) && typeof reason === 'string') {
+        validSkips[id] = reason;
+        count++;
+      }
+    }
+
+    return { skip: validSkips, llmCalled: true, durationMs: Date.now() - start };
+  } catch {
+    // Any error → fallback to running everything
+    return { skip: {}, llmCalled: false, durationMs: Date.now() - start };
+  }
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -7,7 +7,8 @@
  * Used by .githooks/pre-push to mechanically block bad pushes.
  *
  * Steps (fast mode, default):
- *   1. Build data layer (required for validation + tests)
+ *   0. Triage — categorize diff, optionally ask Haiku which checks to skip
+ *   1. Build data layer (required for validation + tests) — skippable if only crux/ changed
  *   2. Auto-fix escaping + markdown (with --fix)
  *   3. [Parallel] Run vitest tests
  *      [Parallel] Unified blocking rules (MDX syntax, frontmatter, numeric IDs, EntityLink)
@@ -18,6 +19,13 @@
  * With --full:
  *   4. Full Next.js production build
  *
+ * Flags:
+ *   --full-gate    Force all checks, no triage (implies --no-triage)
+ *   --no-triage    Skip LLM triage call, run all checks
+ *   --fix          Auto-fix escaping + markdown before validation
+ *   --full         Include full Next.js production build
+ *   --ci           JSON output for CI pipelines
+ *
  * Exit codes:
  *   0 = All checks passed
  *   1 = One or more checks failed
@@ -26,20 +34,20 @@
 import { execSync, spawn, type ChildProcess } from 'child_process';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
+import { categorizeFiles, canSkipBuildData, triageGateChecks, type TriageResult } from './gate-triage.ts';
 
 const args: string[] = process.argv.slice(2);
 const FIX_MODE: boolean = args.includes('--fix');
 const CI_MODE: boolean = args.includes('--ci') || process.env.CI === 'true';
+const FULL_GATE: boolean = args.includes('--full-gate');
+const NO_TRIAGE: boolean = args.includes('--no-triage') || FULL_GATE || CI_MODE;
 
 /**
- * Auto-detect whether --full (Next.js build) is needed based on changed files.
- * Triggers when the diff includes app page components or data files that are
- * prerendered at build time (e.g. auto-update YAML that dashboards read).
+ * Get the list of files changed on this branch vs main.
+ * Reused by shouldAutoEscalateToFull() and the triage phase.
  */
-function shouldAutoEscalateToFull(): boolean {
+function getChangedFiles(): string[] {
   try {
-    // Check all files changed on the branch vs main (covers all commits being pushed).
-    // Falls back to HEAD~1 if merge-base fails (e.g. shallow clone).
     let diffOutput = '';
     try {
       const base = execSync('git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null',
@@ -52,24 +60,32 @@ function shouldAutoEscalateToFull(): boolean {
       diffOutput = execSync('git diff --name-only HEAD~1 HEAD 2>/dev/null || echo ""',
         { cwd: PROJECT_ROOT, encoding: 'utf-8' }).trim();
     }
-    if (!diffOutput) return false;
-
-    const files = diffOutput.split('\n');
-    return files.some(f =>
-      // App page components (prerendered by Next.js)
-      f.startsWith('apps/web/src/app/') ||
-      // Auto-update run data (read by dashboard pages at build time)
-      f.startsWith('data/auto-update/runs/') ||
-      // Auto-update state/sources (read by dashboard pages at build time)
-      (f.startsWith('data/auto-update/') && f.endsWith('.yaml'))
-    );
+    if (!diffOutput) return [];
+    return diffOutput.split('\n').filter(Boolean);
   } catch {
-    return false;
+    return [];
   }
 }
 
+/**
+ * Auto-detect whether --full (Next.js build) is needed based on changed files.
+ * Triggers when the diff includes app page components or data files that are
+ * prerendered at build time (e.g. auto-update YAML that dashboards read).
+ */
+function shouldAutoEscalateToFull(files: string[]): boolean {
+  return files.some(f =>
+    // App page components (prerendered by Next.js)
+    f.startsWith('apps/web/src/app/') ||
+    // Auto-update run data (read by dashboard pages at build time)
+    f.startsWith('data/auto-update/runs/') ||
+    // Auto-update state/sources (read by dashboard pages at build time)
+    (f.startsWith('data/auto-update/') && f.endsWith('.yaml'))
+  );
+}
+
+const changedFiles = getChangedFiles();
 const EXPLICIT_FULL: boolean = args.includes('--full');
-const AUTO_FULL: boolean = !EXPLICIT_FULL && shouldAutoEscalateToFull();
+const AUTO_FULL: boolean = !EXPLICIT_FULL && shouldAutoEscalateToFull(changedFiles);
 const FULL_MODE: boolean = EXPLICIT_FULL || AUTO_FULL;
 
 const c = getColors(CI_MODE);
@@ -336,8 +352,29 @@ function formatMs(ms: number): string {
 async function main(): Promise<void> {
   const totalStart = Date.now();
   const allResults: StepResult[] = [];
+  let triageResult: TriageResult | null = null;
+  let skippedBuildData = false;
 
-  const totalSteps = 1 + (FIX_MODE ? FIX_STEPS.length : 0) + PARALLEL_STEPS.length + (FULL_MODE ? 1 : 0);
+  // ── Phase 0: Triage — decide which checks to skip ─────────────────────────
+  if (!NO_TRIAGE && changedFiles.length > 0) {
+    const categories = categorizeFiles(changedFiles);
+
+    // Deterministic: skip build-data if only crux/wiki-server changes
+    if (canSkipBuildData(categories)) {
+      skippedBuildData = true;
+    }
+
+    // LLM triage: ask Haiku which parallel checks to skip
+    const allStepIds = PARALLEL_STEPS.map(s => s.id);
+    triageResult = await triageGateChecks(changedFiles, allStepIds, categories);
+  }
+
+  // Filter parallel steps based on triage
+  const skippedStepIds = new Set(triageResult ? Object.keys(triageResult.skip) : []);
+  const activeParallelSteps = PARALLEL_STEPS.filter(s => !skippedStepIds.has(s.id));
+  const skippedCount = PARALLEL_STEPS.length - activeParallelSteps.length + (skippedBuildData ? 1 : 0);
+
+  const totalSteps = (skippedBuildData ? 0 : 1) + (FIX_MODE ? FIX_STEPS.length : 0) + activeParallelSteps.length + (FULL_MODE ? 1 : 0);
 
   if (!CI_MODE) {
     const mode = FULL_MODE ? 'full' : 'fast';
@@ -347,15 +384,35 @@ async function main(): Promise<void> {
     if (AUTO_FULL) {
       console.log(`${c.dim}  Auto-escalated to full build (app pages or data files changed)${c.reset}`);
     }
-    console.log(`${c.dim}  Running ${totalSteps} CI-blocking checks (${PARALLEL_STEPS.length} in parallel)...${c.reset}\n`);
+    if (skippedCount > 0) {
+      console.log(`${c.dim}  Triage: ${skippedCount} check${skippedCount > 1 ? 's' : ''} skipped based on diff analysis${c.reset}`);
+      if (skippedBuildData) {
+        console.log(`${c.dim}    - build-data: no MDX/YAML/app changes, database.json exists${c.reset}`);
+      }
+      if (triageResult) {
+        for (const [id, reason] of Object.entries(triageResult.skip)) {
+          console.log(`${c.dim}    - ${id}: ${reason}${c.reset}`);
+        }
+        if (triageResult.llmCalled) {
+          console.log(`${c.dim}    (Haiku triage in ${triageResult.durationMs}ms)${c.reset}`);
+        }
+      }
+    }
+    console.log(`${c.dim}  Running ${totalSteps} CI-blocking checks (${activeParallelSteps.length} in parallel)...${c.reset}\n`);
   }
 
   // ── Phase 1: Build data (prerequisite for everything) ──────────────────────
-  const buildDataResult = await runSequential(BUILD_DATA_STEP);
-  allResults.push(buildDataResult);
-  if (!buildDataResult.passed) {
-    printSummary(allResults, totalStart);
-    process.exit(1);
+  if (skippedBuildData) {
+    if (!CI_MODE) {
+      console.log(`${c.dim}⊘ Build data layer (skipped — no data changes)${c.reset}\n`);
+    }
+  } else {
+    const buildDataResult = await runSequential(BUILD_DATA_STEP);
+    allResults.push(buildDataResult);
+    if (!buildDataResult.passed) {
+      printSummary(allResults, totalStart, skippedCount);
+      process.exit(1);
+    }
   }
 
   // ── Phase 2: Auto-fix (sequential, must run before validation) ─────────────
@@ -364,17 +421,17 @@ async function main(): Promise<void> {
       const result = await runSequential(step);
       allResults.push(result);
       if (!result.passed) {
-        printSummary(allResults, totalStart);
+        printSummary(allResults, totalStart, skippedCount);
         process.exit(1);
       }
     }
   }
 
   // ── Phase 3: Independent checks in parallel ────────────────────────────────
-  const parallelResults = await runParallel(PARALLEL_STEPS);
+  const parallelResults = await runParallel(activeParallelSteps);
   allResults.push(...parallelResults);
   if (parallelResults.some(r => !r.passed && !r.advisory)) {
-    printSummary(allResults, totalStart);
+    printSummary(allResults, totalStart, skippedCount);
     process.exit(1);
   }
 
@@ -383,16 +440,16 @@ async function main(): Promise<void> {
     const buildResult = await runSequential(BUILD_STEP);
     allResults.push(buildResult);
     if (!buildResult.passed) {
-      printSummary(allResults, totalStart);
+      printSummary(allResults, totalStart, skippedCount);
       process.exit(1);
     }
   }
 
-  printSummary(allResults, totalStart);
+  printSummary(allResults, totalStart, skippedCount);
   process.exit(0);
 }
 
-function printSummary(results: StepResult[], totalStart: number): void {
+function printSummary(results: StepResult[], totalStart: number, skippedCount: number = 0): void {
   const totalDuration = Date.now() - totalStart;
   const blockingFailed = results.filter((r) => !r.passed && !r.advisory);
   const advisoryFailed = results.filter((r) => !r.passed && r.advisory);
@@ -400,13 +457,14 @@ function printSummary(results: StepResult[], totalStart: number): void {
   const failed = blockingFailed;
 
   if (CI_MODE) {
-    console.log(JSON.stringify({ passed, results: results.map(r => ({ id: r.id, name: r.name, passed: r.passed, duration: r.duration, exitCode: r.exitCode })), duration: formatMs(totalDuration) }));
+    console.log(JSON.stringify({ passed, skippedCount, results: results.map(r => ({ id: r.id, name: r.name, passed: r.passed, duration: r.duration, exitCode: r.exitCode })), duration: formatMs(totalDuration) }));
   } else {
     console.log(`${c.bold}${c.blue}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${c.reset}`);
     if (passed) {
+      const skippedNote = skippedCount > 0 ? `, ${skippedCount} skipped by triage` : '';
       const advisoryNote = advisoryFailed.length > 0
-        ? ` ${c.dim}(${advisoryFailed.length} advisory warning${advisoryFailed.length > 1 ? 's' : ''})${c.reset}`
-        : '';
+        ? ` ${c.dim}(${advisoryFailed.length} advisory warning${advisoryFailed.length > 1 ? 's' : ''}${skippedNote})${c.reset}`
+        : (skippedNote ? ` ${c.dim}(${skippedNote.slice(2)})${c.reset}` : '');
       console.log(`${c.green}${c.bold}  ✅ All ${results.length} gate checks passed${c.reset} ${c.dim}(${formatMs(totalDuration)})${c.reset}${advisoryNote}`);
       for (const f of advisoryFailed) {
         console.log(`${c.yellow}  ⚠ ${f.name}${c.reset}`);


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
