### PR TITLE
fix: auto-quote frontmatter values with YAML-breaking characters

### DIFF
--- a/crux/authoring/page-improver/utils.test.ts
+++ b/crux/authoring/page-improver/utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { repairFrontmatter } from './utils.js';
+
+describe('repairFrontmatter', () => {
+  describe('Fix 4: YAML-safe quoting', () => {
+    it('quotes llmSummary containing colon-space', () => {
+      const input = [
+        '---',
+        "llmSummary: Stuart Russell co-authored 'Artificial Intelligence: A Modern Approach'",
+        '---',
+        'Body text',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain(
+        'llmSummary: "Stuart Russell co-authored \'Artificial Intelligence: A Modern Approach\'"'
+      );
+    });
+
+    it('quotes description containing colon-space', () => {
+      const input = [
+        '---',
+        "description: Author of 'Human Compatible: Machines and Human Values'",
+        '---',
+        'Body',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain(
+        'description: "Author of \'Human Compatible: Machines and Human Values\'"'
+      );
+    });
+
+    it('does not double-quote already-quoted values', () => {
+      const input = [
+        '---',
+        'llmSummary: "Already quoted: with colons"',
+        '---',
+        'Body',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain('llmSummary: "Already quoted: with colons"');
+      // Should not have escaped inner quotes or double-wrapped
+      expect(result).not.toContain('\\"');
+    });
+
+    it('does not quote values without colon-space', () => {
+      const input = [
+        '---',
+        'llmSummary: A simple summary without problematic characters',
+        '---',
+        'Body',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain(
+        'llmSummary: A simple summary without problematic characters'
+      );
+      // Should remain unquoted
+      expect(result).not.toContain('"A simple');
+    });
+
+    it('escapes internal double quotes when wrapping', () => {
+      const input = [
+        '---',
+        'description: He said "hello: world" to everyone',
+        '---',
+        'Body',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain(
+        'description: "He said \\"hello: world\\" to everyone"'
+      );
+    });
+
+    it('does not touch non-string fields', () => {
+      const input = [
+        '---',
+        'quality: 30',
+        'sidebar:',
+        '  order: 5',
+        '---',
+        'Body',
+      ].join('\n');
+
+      const result = repairFrontmatter(input);
+      expect(result).toContain('quality: 30');
+      expect(result).toContain('sidebar:');
+    });
+  });
+});

--- a/crux/authoring/page-improver/utils.ts
+++ b/crux/authoring/page-improver/utils.ts
@@ -201,6 +201,31 @@ export function repairFrontmatter(content: string): string {
   }
   fm = repaired.join('\n');
 
+  // Fix 4: Quote string values that contain YAML-breaking characters.
+  // LLMs often produce unquoted values like:
+  //   llmSummary: Text with 'Title: Subtitle' here
+  // The colon-space inside single quotes breaks YAML parsers.
+  // We wrap such values in double quotes to make them safe.
+  const STRING_FIELDS = new Set([
+    'llmSummary', 'description', 'title',
+  ]);
+  const fmLines = fm.split('\n');
+  for (let i = 0; i < fmLines.length; i++) {
+    const keyMatch = fmLines[i].match(/^(\w+):\s+(.*)/);
+    if (!keyMatch) continue;
+    const [, key, value] = keyMatch;
+    if (!STRING_FIELDS.has(key)) continue;
+    // Skip if already quoted
+    if (/^["']/.test(value)) continue;
+    // Check for YAML-breaking patterns: colon-space in the value
+    if (/:\s/.test(value)) {
+      // Escape any internal double quotes, then wrap
+      const escaped = value.replace(/"/g, '\\"');
+      fmLines[i] = `${key}: "${escaped}"`;
+    }
+  }
+  fm = fmLines.join('\n');
+
   return '---\n' + fm + '\n---' + rest;
 }
 


### PR DESCRIPTION
## Summary
- Adds Fix 4 to `repairFrontmatter()` in the improve pipeline that detects unquoted frontmatter string values containing colon-space (`: `) patterns and wraps them in double quotes
- Prevents YAML parse errors like the one that broke CI on PR #858, where `llmSummary` contained `'Artificial Intelligence: A Modern Approach'` (colon inside single quotes in an unquoted YAML value)
- Applies to `llmSummary`, `description`, and `title` fields — the long-text fields most prone to this issue
- Includes tests covering quoting, skip-if-already-quoted, skip-if-no-colons, and double-quote escaping

## Test plan
- [x] 6 unit tests pass (`pnpm test -- crux/authoring/page-improver/utils.test.ts`)
- [x] Gate check passes locally
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)
