### PR TITLE
style: re-apply lost References section redesign

### DIFF
--- a/apps/web/src/components/wiki/ReferenceCitationDetails.tsx
+++ b/apps/web/src/components/wiki/ReferenceCitationDetails.tsx
@@ -2,91 +2,118 @@
 
 import { cn } from "@lib/utils";
 import { useCitationQuotes } from "./CitationQuotesContext";
+import { normalizeUrl, VERDICT_STYLES, VERDICT_SEVERITY, MAX_CLAIMS_SHOWN } from "./resource-utils";
+import type { CitationQuote } from "@/lib/citation-data";
+import { renderInlineMarkdown } from "@/lib/inline-markdown";
 import { CheckCircle2, AlertTriangle, XCircle, HelpCircle } from "lucide-react";
 
-const VERDICT_STYLES: Record<string, { icon: typeof CheckCircle2; color: string; label: string }> = {
-  accurate: { icon: CheckCircle2, color: "text-emerald-600", label: "Verified accurate" },
-  minor_issues: { icon: AlertTriangle, color: "text-amber-600", label: "Minor issues" },
-  inaccurate: { icon: XCircle, color: "text-red-600", label: "Inaccurate" },
-  unsupported: { icon: XCircle, color: "text-red-500", label: "Unsupported" },
-  not_verifiable: { icon: HelpCircle, color: "text-muted-foreground", label: "Not verifiable" },
+/** Icon per verdict — only needed in claim rows, not shared */
+const VERDICT_ICONS: Record<string, typeof CheckCircle2> = {
+  accurate: CheckCircle2,
+  minor_issues: AlertTriangle,
+  inaccurate: XCircle,
+  unsupported: XCircle,
+  not_verifiable: HelpCircle,
 };
 
-/** Normalize a URL for fuzzy matching (strip trailing slash, www, protocol) */
-function normalizeUrl(raw: string): string {
-  try {
-    const u = new URL(raw);
-    return (u.host.replace(/^www\./, "") + u.pathname.replace(/\/+$/, "") + u.search).toLowerCase();
-  } catch {
-    return raw.replace(/\/+$/, "").toLowerCase();
-  }
+function ClaimRow({ quote }: { quote: CitationQuote }) {
+  const verdict = quote.accuracyVerdict;
+  const info = verdict ? VERDICT_STYLES[verdict] : null;
+  const Icon = (verdict ? VERDICT_ICONS[verdict] : null) ?? (quote.quoteVerified ? CheckCircle2 : null);
+  const color = info?.color ?? (quote.quoteVerified ? "text-blue-600" : "text-muted-foreground");
+  const bg = info?.bg ?? (quote.quoteVerified ? "bg-blue-500/10" : "");
+  const label = info?.label ?? (quote.quoteVerified ? "Verified" : null);
+  const score = quote.accuracyScore;
+
+  // Use accuracyIssues as the verification description when available
+  const verificationText = quote.accuracyIssues || (
+    verdict === "accurate" ? "Supported by source" :
+    quote.quoteVerified ? "Quote verified" :
+    null
+  );
+
+  return (
+    <div className="flex gap-3 py-1.5 border-b border-border/40 last:border-b-0">
+      {/* Claim from the wiki page */}
+      <div className="flex-1 min-w-0 text-[11px] text-foreground leading-snug">
+        {renderInlineMarkdown(quote.claimText)}
+      </div>
+      {/* Verification result */}
+      <div className="flex-1 min-w-0 text-[11px] leading-snug">
+        {Icon && label && (
+          <span className={cn("inline-flex items-center gap-0.5 px-1 py-px rounded", color, bg)}>
+            <Icon className="w-3 h-3 shrink-0" />
+            {label}
+            {score != null && (
+              <span className="opacity-60 ml-0.5">{Math.round(score * 100)}%</span>
+            )}
+          </span>
+        )}
+        {verificationText && (
+          <p className="text-muted-foreground m-0 mt-0.5">
+            {verificationText}
+          </p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 /**
  * Client component that reads citation quote data from context and renders
  * verification details for a specific resource URL in the expanded reference.
+ *
+ * Two-column layout: claim text (left) | verification verdict + issues (right).
  */
 export function ReferenceCitationDetails({ url }: { url: string }) {
   const quotes = useCitationQuotes();
 
   if (quotes.length === 0) return null;
 
-  // Match quotes by normalized URL
+  // Match all quotes that cite this URL
   const norm = normalizeUrl(url);
   const matching = quotes.filter((q) => q.url && normalizeUrl(q.url) === norm);
   if (matching.length === 0) return null;
 
-  // Pick the most informative quote (prefer one with accuracy verdict and source quote)
-  const best = matching.sort((a, b) => {
-    const scoreA = (a.accuracyVerdict ? 2 : 0) + (a.sourceQuote ? 1 : 0);
-    const scoreB = (b.accuracyVerdict ? 2 : 0) + (b.sourceQuote ? 1 : 0);
-    return scoreB - scoreA;
-  })[0];
+  // Deduplicate by claim text (keep the entry with the best verdict data)
+  const deduped = new Map<string, CitationQuote>();
+  for (const q of matching) {
+    const key = q.claimText.trim().toLowerCase();
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, q);
+    } else {
+      const scoreExisting = (existing.accuracyVerdict ? 2 : 0) + (existing.accuracyIssues ? 1 : 0);
+      const scoreNew = (q.accuracyVerdict ? 2 : 0) + (q.accuracyIssues ? 1 : 0);
+      if (scoreNew > scoreExisting) deduped.set(key, q);
+    }
+  }
+  const unique = [...deduped.values()];
 
-  const verdictInfo = best.accuracyVerdict
-    ? VERDICT_STYLES[best.accuracyVerdict]
-    : best.quoteVerified
-      ? { icon: CheckCircle2, color: "text-blue-500", label: "Source verified" }
-      : null;
+  // Sort: problematic verdicts first, then accurate, then unverified
+  const sorted = unique.sort((a, b) => {
+    const va = a.accuracyVerdict ? (VERDICT_SEVERITY[a.accuracyVerdict] ?? 5) : 6;
+    const vb = b.accuracyVerdict ? (VERDICT_SEVERITY[b.accuracyVerdict] ?? 5) : 6;
+    return va - vb;
+  });
 
-  const hasContent = verdictInfo || best.sourceQuote || best.claimText;
-  if (!hasContent) return null;
-
-  const Icon = verdictInfo?.icon;
+  const shown = sorted.slice(0, MAX_CLAIMS_SHOWN);
+  const remaining = sorted.length - shown.length;
 
   return (
-    <div className="mt-2 pt-2 border-t border-border">
-      {/* Verdict badge */}
-      {verdictInfo && Icon && (
-        <span className={cn("inline-flex items-center gap-1 text-xs mb-1", verdictInfo.color)}>
-          <Icon className="w-3 h-3" />
-          {verdictInfo.label}
-          {best.accuracyScore != null && (
-            <span className="text-muted-foreground ml-0.5">
-              ({Math.round(best.accuracyScore * 100)}%)
-            </span>
-          )}
-        </span>
-      )}
-
-      {/* Source quote — clamped to 2 lines to avoid dominating the section */}
-      {best.sourceQuote && best.sourceQuote.length > 30 && (
-        <blockquote className="text-xs text-muted-foreground border-l-2 border-border pl-2 my-1.5 italic leading-relaxed line-clamp-2">
-          &ldquo;{best.sourceQuote}&rdquo;
-        </blockquote>
-      )}
-
-      {/* Accuracy issues — truncated, subtle styling */}
-      {best.accuracyIssues && (
-        <p className="text-xs text-muted-foreground m-0 mt-1 leading-relaxed line-clamp-3">
-          {best.accuracyIssues}
-        </p>
-      )}
-
-      {/* How many claims cite this source */}
-      {matching.length > 1 && (
-        <span className="text-xs text-muted-foreground opacity-60 mt-1.5 block">
-          {matching.length} claims cite this source
+    <div className="mt-1.5 pt-1.5 border-t border-border pl-2">
+      <div>
+        <div className="flex gap-3 text-[10px] text-muted-foreground/50 uppercase tracking-wide pb-0.5 border-b border-border/40">
+          <div className="flex-1">Claim</div>
+          <div className="flex-1">Verification</div>
+        </div>
+        {shown.map((q, i) => (
+          <ClaimRow key={i} quote={q} />
+        ))}
+      </div>
+      {remaining > 0 && (
+        <span className="text-[11px] text-muted-foreground/60 block mt-0.5">
+          +{remaining} more
         </span>
       )}
     </div>

--- a/apps/web/src/components/wiki/ReferenceCitationDot.tsx
+++ b/apps/web/src/components/wiki/ReferenceCitationDot.tsx
@@ -2,27 +2,7 @@
 
 import { cn } from "@lib/utils";
 import { useCitationQuotes } from "./CitationQuotesContext";
-
-function normalizeUrl(raw: string): string {
-  try {
-    const u = new URL(raw);
-    return (
-      u.host.replace(/^www\./, "") +
-      u.pathname.replace(/\/+$/, "") +
-      u.search
-    ).toLowerCase();
-  } catch {
-    return raw.replace(/\/+$/, "").toLowerCase();
-  }
-}
-
-const VERDICT_COLORS: Record<string, { bg: string; title: string }> = {
-  accurate: { bg: "bg-emerald-500", title: "Verified accurate" },
-  minor_issues: { bg: "bg-amber-500", title: "Minor issues" },
-  inaccurate: { bg: "bg-red-500", title: "Inaccurate" },
-  unsupported: { bg: "bg-red-400", title: "Unsupported" },
-  not_verifiable: { bg: "bg-muted-foreground/40", title: "Not verifiable" },
-};
+import { normalizeUrl, VERDICT_COLORS } from "./resource-utils";
 
 export function ReferenceCitationDot({ url }: { url: string }) {
   const quotes = useCitationQuotes();
@@ -51,7 +31,7 @@ export function ReferenceCitationDot({ url }: { url: string }) {
 
   return (
     <span
-      className={cn("inline-block w-1.5 h-1.5 rounded-full shrink-0", bg)}
+      className={cn("inline-block w-1.5 h-1.5 rounded-full shrink-0 ml-1.5 align-middle", bg)}
       title={title}
     />
   );

--- a/apps/web/src/components/wiki/References.tsx
+++ b/apps/web/src/components/wiki/References.tsx
@@ -8,9 +8,9 @@ import {
 } from "@data";
 import type { Resource } from "@data";
 import { CredibilityBadge } from "./CredibilityBadge";
-import { ResourceTags } from "./ResourceTags";
 import { ReferenceCitationDetails } from "./ReferenceCitationDetails";
 import { ReferenceCitationDot } from "./ReferenceCitationDot";
+import { formatAuthors, getDomain } from "./resource-utils";
 import { cn } from "@lib/utils";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -74,22 +74,6 @@ function resolveRefs(ids: string[]): {
   return { refs, missing };
 }
 
-function formatAuthors(authors: string[]): string {
-  if (authors.length === 0) return "";
-  if (authors.length === 1) return authors[0];
-  if (authors.length === 2) return `${authors[0]} & ${authors[1]}`;
-  if (authors.length <= 4) return authors.slice(0, -1).join(", ") + " & " + authors[authors.length - 1];
-  return `${authors[0]} et al.`;
-}
-
-function getDomain(url: string): string | null {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return null;
-  }
-}
-
 function ReferenceEntry({ entry }: { entry: ResolvedRef }) {
   const { resource, index, credibility, publicationName, peerReviewed } = entry;
   const year = resource.published_date?.slice(0, 4);
@@ -97,14 +81,8 @@ function ReferenceEntry({ entry }: { entry: ResolvedRef }) {
   const typeLabel = TYPE_LABELS[resource.type];
   const domain = resource.url ? getDomain(resource.url) : null;
 
-  // Metadata fragments: author · year · publication · type
+  // Metadata fragments: source · author · year · type (source first, type last)
   const metaParts: React.ReactNode[] = [];
-  if (authorStr) {
-    metaParts.push(<span key="author">{authorStr}</span>);
-  }
-  if (year) {
-    metaParts.push(<span key="year">{year}</span>);
-  }
   if (publicationName) {
     metaParts.push(
       <span key="pub" className="italic">
@@ -112,84 +90,108 @@ function ReferenceEntry({ entry }: { entry: ResolvedRef }) {
         {peerReviewed && " (peer-reviewed)"}
       </span>
     );
+  } else if (domain) {
+    metaParts.push(<span key="domain">{domain}</span>);
+  }
+  if (authorStr) {
+    metaParts.push(<span key="author">{authorStr}</span>);
+  }
+  if (year) {
+    metaParts.push(<span key="year">{year}</span>);
   }
   if (typeLabel) {
     metaParts.push(<span key="type">{typeLabel}</span>);
   }
-  if (!publicationName && domain) {
-    metaParts.push(
-      <span key="domain" className="text-muted-foreground">{domain}</span>
+
+  // Only show expand arrow + details if there's content to expand
+  const hasExpandableContent = !!resource.summary || credibility != null || !!resource.url;
+
+  const titleRow = (
+    <div className="flex items-baseline">
+      {/* Number gutter — lighter than title text */}
+      <span className="shrink-0 w-7 text-xs font-mono text-muted-foreground/60 tabular-nums text-right pr-2">
+        <a
+          href={`#cite-${index}`}
+          className="!no-underline !decoration-0 text-muted-foreground/60 hover:text-foreground"
+          title={`Jump back to citation [${index}] in text`}
+        >
+          {index}
+        </a>
+      </span>
+      {/* Title + verification dot + meta */}
+      <span className="flex-1 min-w-0">
+        <a
+          href={resource.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[13px] text-accent-foreground !no-underline hover:!underline leading-tight"
+        >
+          {resource.title}
+        </a>
+        {resource.url && <ReferenceCitationDot url={resource.url} />}
+        {metaParts.length > 0 && (
+          <span className="text-xs text-muted-foreground ml-1.5">
+            {metaParts.map((part, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <span className="opacity-30 mx-1">{"\u00b7"}</span>}
+                {part}
+              </React.Fragment>
+            ))}
+          </span>
+        )}
+      </span>
+      {hasExpandableContent && (
+        <span className="ref-chevron shrink-0 ml-2 text-muted-foreground/30 text-[10px] transition-transform duration-150 group-hover:text-muted-foreground/60">
+          {"\u25c0"}
+        </span>
+      )}
+    </div>
+  );
+
+  if (!hasExpandableContent) {
+    return (
+      <div
+        id={`ref-${index}`}
+        className="py-1 border-b border-border last:border-b-0"
+      >
+        <span id={`user-content-fn-${index}`} className="scroll-mt-4" />
+        <span id={`fn-${index}`} />
+        <div className="-mx-1.5 px-1.5 py-0.5">
+          {titleRow}
+        </div>
+      </div>
     );
   }
 
-  const metaLine = metaParts.length > 0 ? (
-    <span className="flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground mt-0.5">
-      {metaParts.map((part, i) => (
-        <React.Fragment key={i}>
-          {i > 0 && <span className="opacity-30">{"\u00b7"}</span>}
-          {part}
-        </React.Fragment>
-      ))}
-    </span>
-  ) : null;
-
   return (
-    <li
+    <div
       id={`ref-${index}`}
-      className="py-1.5 border-b border-border last:border-b-0"
+      className="py-1 border-b border-border last:border-b-0"
     >
+      <span id={`user-content-fn-${index}`} className="scroll-mt-4" />
+      <span id={`fn-${index}`} />
       <details className="ref-details group">
-        <summary className="ref-summary cursor-pointer select-none">
-          <div className="flex items-start gap-2">
-            <span className="flex items-center gap-1 shrink-0 mt-[3px]">
-              {resource.url && <ReferenceCitationDot url={resource.url} />}
-              <a
-                href={`#cite-${index}`}
-                className="text-xs font-mono text-muted-foreground no-underline hover:text-foreground tabular-nums"
-                title={`Jump back to citation [${index}] in text`}
-              >
-                {index}
-              </a>
-            </span>
-            <div className="flex-1 min-w-0">
-              <span className="inline">
-                <a
-                  href={resource.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-accent-foreground no-underline hover:underline leading-snug"
-                >
-                  {resource.title}
-                </a>
-                <span className="ref-chevron inline-block ml-1 text-muted-foreground text-xs transition-transform duration-150 align-middle opacity-40 group-hover:opacity-70">
-                  {"\u25b8"}
-                </span>
-              </span>
-              {metaLine}
-            </div>
-          </div>
+        <summary className="ref-summary cursor-pointer select-none hover:bg-muted/50 -mx-1.5 px-1.5 py-0.5 rounded transition-colors">
+          {titleRow}
         </summary>
 
-        <div className="ml-7 mt-2 mb-1 border-l-2 border-border pl-3">
+        <div className="mt-1 mb-0.5 overflow-hidden">
           {resource.summary && (
             <p className="text-xs text-muted-foreground leading-relaxed m-0">
               {resource.summary}
             </p>
           )}
-          <div className="flex flex-wrap items-center gap-1.5 mt-2 empty:hidden">
-            {credibility != null && (
+          {credibility != null && (
+            <div className="mt-1.5">
               <CredibilityBadge level={credibility} size="sm" />
-            )}
-            {resource.tags && resource.tags.length > 0 && (
-              <ResourceTags tags={resource.tags} limit={4} size="sm" />
-            )}
-          </div>
+            </div>
+          )}
           {resource.url && (
             <ReferenceCitationDetails url={resource.url} />
           )}
         </div>
       </details>
-    </li>
+    </div>
   );
 }
 
@@ -213,7 +215,7 @@ function CitationHealthFooter({ pageId }: { pageId: string }) {
   else if (accurate > 0) dotColor = "bg-blue-500";
 
   return (
-    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-4 pt-3 border-t border-border">
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-3 pt-2 border-t border-border">
       <span className={cn("inline-block w-1.5 h-1.5 rounded-full", dotColor)} />
       Citation verification: {parts.join(", ")} of {total} total
     </div>
@@ -249,28 +251,28 @@ export function References({
   return (
     <section
       className={cn(
-        "mt-10 pt-6 border-t border-border",
+        "mt-10 pt-5 border-t border-border",
         className
       )}
       aria-label={title}
     >
       <h2
-        className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3 mt-0 pb-0 border-b-0"
+        className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2 mt-0 pb-0 border-b-0"
         id="references"
       >
         {title}
       </h2>
 
       {refs.length > 0 && (
-        <ol className="list-none pl-0 m-0">
+        <div>
           {refs.map((r) => (
             <ReferenceEntry key={r.resource.id} entry={r} />
           ))}
-        </ol>
+        </div>
       )}
 
       {missing.length > 0 && (
-        <p className="text-xs text-destructive mt-3">
+        <p className="text-xs text-destructive mt-2">
           Missing resources: {missing.join(", ")}
         </p>
       )}

--- a/apps/web/src/components/wiki/resource-utils.ts
+++ b/apps/web/src/components/wiki/resource-utils.ts
@@ -1,4 +1,87 @@
-/** Shared constants for resource rendering components */
+/** Shared constants and helpers for resource rendering components */
+
+/**
+ * Normalize a URL for fuzzy matching between resource URLs and citation URLs.
+ * - Strips protocol and `www.` prefix
+ * - Removes trailing slashes
+ * - Preserves query string, drops hash fragment
+ * - Case-insensitive
+ */
+export function normalizeUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    return (
+      u.host.replace(/^www\./, "") +
+      u.pathname.replace(/\/+$/, "") +
+      u.search
+    ).toLowerCase();
+  } catch {
+    return raw.replace(/\/+$/, "").toLowerCase();
+  }
+}
+
+/** Canonical verdict keys used by the citation verification system */
+export const VERDICT_KEYS = [
+  "accurate",
+  "minor_issues",
+  "inaccurate",
+  "unsupported",
+  "not_verifiable",
+] as const;
+
+export type VerdictKey = (typeof VERDICT_KEYS)[number];
+
+/** Severity ordering for sorting (lower = more severe) */
+export const VERDICT_SEVERITY: Record<string, number> = {
+  inaccurate: 0,
+  unsupported: 1,
+  minor_issues: 2,
+  not_verifiable: 3,
+  accurate: 4,
+};
+
+/** Compact dot colors used by ReferenceCitationDot */
+export const VERDICT_COLORS: Record<string, { bg: string; title: string }> = {
+  accurate: { bg: "bg-emerald-500", title: "Verified accurate" },
+  minor_issues: { bg: "bg-amber-500", title: "Minor issues" },
+  inaccurate: { bg: "bg-red-500", title: "Inaccurate" },
+  unsupported: { bg: "bg-red-400", title: "Unsupported" },
+  not_verifiable: { bg: "bg-muted-foreground/40", title: "Not verifiable" },
+};
+
+/** Rich verdict styles used by ReferenceCitationDetails claim rows */
+export const VERDICT_STYLES: Record<
+  string,
+  { color: string; bg: string; label: string }
+> = {
+  accurate: { color: "text-emerald-700", bg: "bg-emerald-500/10", label: "Accurate" },
+  minor_issues: { color: "text-amber-700", bg: "bg-amber-500/10", label: "Minor issues" },
+  inaccurate: { color: "text-red-700", bg: "bg-red-500/10", label: "Inaccurate" },
+  unsupported: { color: "text-red-600", bg: "bg-red-500/10", label: "Unsupported" },
+  not_verifiable: { color: "text-muted-foreground", bg: "bg-muted", label: "Not verifiable" },
+};
+
+/** Maximum claims to display before showing "+N more" */
+export const MAX_CLAIMS_SHOWN = 8;
+
+/** Format a list of author names for display in reference entries */
+export function formatAuthors(authors: string[]): string {
+  if (authors.length === 0) return "";
+  if (authors.length === 1) return authors[0];
+  if (authors.length === 2) return `${authors[0]} & ${authors[1]}`;
+  if (authors.length <= 4)
+    return authors.slice(0, -1).join(", ") + " & " + authors[authors.length - 1];
+  return `${authors[0]} et al.`;
+}
+
+/** Extract the display domain from a URL (strips www.) */
+export function getDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
 
 export const typeIcons: Record<string, string> = {
   paper: "\ud83d\udcc4",

--- a/apps/web/src/lib/inline-markdown.tsx
+++ b/apps/web/src/lib/inline-markdown.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+/**
+ * Render basic inline markdown: **bold**, *italic*, `code`.
+ *
+ * Useful for displaying short user-facing text that may contain
+ * lightweight formatting without pulling in a full MDX pipeline.
+ */
+export function renderInlineMarkdown(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  const pattern = /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`)/g;
+  let lastIndex = 0;
+  let key = 0;
+  let matched = false;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    matched = true;
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    if (match[2]) {
+      parts.push(<strong key={key++} className="font-semibold">{match[2]}</strong>);
+    } else if (match[3]) {
+      parts.push(<em key={key++}>{match[3]}</em>);
+    } else if (match[4]) {
+      parts.push(
+        <code key={key++} className="text-[0.9em] px-0.5 bg-muted rounded">
+          {match[4]}
+        </code>
+      );
+    }
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!matched) return text;
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
