### PR TITLE
fix: remove dead DataExternalLinks invocations from MDX files

### DIFF
--- a/content/docs/ai-transition-model/adaptability.mdx
+++ b/content/docs/ai-transition-model/adaptability.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="adaptability" />
 
 <ATMPage entityId="E307" />

--- a/content/docs/ai-transition-model/adoption.mdx
+++ b/content/docs/ai-transition-model/adoption.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="adoption" />
 
 <ATMPage entityId="E299" />

--- a/content/docs/ai-transition-model/ai-governance.mdx
+++ b/content/docs/ai-transition-model/ai-governance.mdx
@@ -21,8 +21,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-governance" />
 
 <ATMPage entityId="E301" />

--- a/content/docs/ai-transition-model/algorithms.mdx
+++ b/content/docs/ai-transition-model/algorithms.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="algorithms" />
 
 <ATMPage entityId="E302" />

--- a/content/docs/ai-transition-model/biological-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/biological-threat-exposure.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="biological-threat-exposure" />
 
 <ATMPage entityId="E41" />

--- a/content/docs/ai-transition-model/compute.mdx
+++ b/content/docs/ai-transition-model/compute.mdx
@@ -20,8 +20,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="compute" />
 
 <ATMPage entityId="E309" />

--- a/content/docs/ai-transition-model/coordination.mdx
+++ b/content/docs/ai-transition-model/coordination.mdx
@@ -20,8 +20,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="coordination" />
 
 <ATMPage entityId="E311" />

--- a/content/docs/ai-transition-model/cyber-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/cyber-threat-exposure.mdx
@@ -19,8 +19,6 @@ clusters:
   - cyber
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="cyber-threat-exposure" />
 
 <ATMPage entityId="E85" />

--- a/content/docs/ai-transition-model/economic-power.mdx
+++ b/content/docs/ai-transition-model/economic-power.mdx
@@ -20,8 +20,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="economic-power" />
 
 <ATMPage entityId="E315" />

--- a/content/docs/ai-transition-model/economic-stability.mdx
+++ b/content/docs/ai-transition-model/economic-stability.mdx
@@ -19,8 +19,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="economic-stability" />
 
 <ATMPage entityId="E112" />

--- a/content/docs/ai-transition-model/factors-civilizational-competence-epistemics.mdx
+++ b/content/docs/ai-transition-model/factors-civilizational-competence-epistemics.mdx
@@ -19,8 +19,6 @@ clusters:
   - epistemics
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="epistemics" />
 
 <ATMPage entityId="E305" />

--- a/content/docs/ai-transition-model/governance.mdx
+++ b/content/docs/ai-transition-model/governance.mdx
@@ -20,8 +20,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="governance" />
 
 <ATMPage entityId="E306" />

--- a/content/docs/ai-transition-model/lab-safety-practices.mdx
+++ b/content/docs/ai-transition-model/lab-safety-practices.mdx
@@ -20,8 +20,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="lab-safety-practices" />
 
 <ATMPage entityId="E332" />

--- a/content/docs/ai-transition-model/political-power.mdx
+++ b/content/docs/ai-transition-model/political-power.mdx
@@ -20,8 +20,6 @@ clusters:
   - governance
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="political-power" />
 
 <ATMPage entityId="E334" />

--- a/content/docs/ai-transition-model/racing-intensity.mdx
+++ b/content/docs/ai-transition-model/racing-intensity.mdx
@@ -18,8 +18,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="racing-intensity" />
 
 <ATMPage entityId="E242" />

--- a/content/docs/ai-transition-model/recursive-ai-capabilities.mdx
+++ b/content/docs/ai-transition-model/recursive-ai-capabilities.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="recursive-ai-capabilities" />
 
 <ATMPage entityId="E339" />

--- a/content/docs/ai-transition-model/robot-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/robot-threat-exposure.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="robot-threat-exposure" />
 
 <ATMPage entityId="E341" />

--- a/content/docs/ai-transition-model/scenarios-long-term-lockin-epistemics.mdx
+++ b/content/docs/ai-transition-model/scenarios-long-term-lockin-epistemics.mdx
@@ -20,8 +20,6 @@ clusters:
   - epistemics
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="epistemics" />
 
 <ATMPage entityId="E318" />

--- a/content/docs/ai-transition-model/suffering-lock-in.mdx
+++ b/content/docs/ai-transition-model/suffering-lock-in.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="suffering-lock-in" />
 
 <ATMPage entityId="E350" />

--- a/content/docs/ai-transition-model/surprise-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/surprise-threat-exposure.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="surprise-threat-exposure" />
 
 <ATMPage entityId="E351" />

--- a/content/docs/ai-transition-model/technical-ai-safety.mdx
+++ b/content/docs/ai-transition-model/technical-ai-safety.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="technical-ai-safety" />
 
 <ATMPage entityId="E353" />

--- a/content/docs/ai-transition-model/values.mdx
+++ b/content/docs/ai-transition-model/values.mdx
@@ -19,8 +19,6 @@ clusters:
   - ai-safety
 ---
 import {ATMPage} from '@components/wiki/ATMPage';
-import {DataExternalLinks} from '@components/wiki';
 
-<DataExternalLinks pageId="values" />
 
 <ATMPage entityId="E354" />

--- a/content/docs/internal/models.mdx
+++ b/content/docs/internal/models.mdx
@@ -18,9 +18,8 @@ ratings:
   actionability: 3
   completeness: 6
 ---
-import {Mermaid, DataExternalLinks} from '@components/wiki';
+import {Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="models" />
 
 This guide covers **core purpose**, **summary requirements**, **format requirements**, **diagram types**, **methodological principles**, and **rating criteria** for analytical models in this knowledge base.
 

--- a/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
+++ b/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
@@ -110,7 +110,6 @@ Among proper organization pages, section count varies from 8 to 20 H2 sections. 
 
 - 2 of 5 sampled pages lack an "Overview" section, using "Background" instead
 - Risk Assessment tables appear on 3 of 5 (not a template requirement)
-- 21 of ~45 person pages have a manual "Key Links" table, creating redundancy with the `<DataExternalLinks>` component
 - Import sets and component usage vary across every page
 
 ### Model Pages (89 pages)

--- a/content/docs/knowledge-base/capabilities/agentic-ai.mdx
+++ b/content/docs/knowledge-base/capabilities/agentic-ai.mdx
@@ -24,7 +24,7 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Key Links
 
@@ -33,7 +33,6 @@ import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@component
 | Official Website | [edge-ai-vision.com](https://www.edge-ai-vision.com/2025/06/what-is-agentic-ai-a-complete-guide-to-the-future-of-autonomous-intelligence/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/AI_agent) |
 
-<DataExternalLinks pageId="agentic-ai" />
 
 <DataInfoBox entityId="E2" />
 

--- a/content/docs/knowledge-base/capabilities/ai-powered-investigation.mdx
+++ b/content/docs/knowledge-base/capabilities/ai-powered-investigation.mdx
@@ -19,9 +19,8 @@ clusters:
   - governance
   - cyber
 ---
-import {EntityLink, DataExternalLinks} from '@components/wiki';
+import {EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-powered-investigation" />
 
 :::note[Related Pages]
 This page covers AI investigation as a **capability**. For the risk assessment including chilling effects and regulatory gaps, see <EntityLink id="E694" name="ai-investigation-risks">AI-Powered Investigation Risks</EntityLink>. For the specific deanonymization threat, see <EntityLink id="E699" name="deanonymization">AI-Powered Deanonymization</EntityLink>. For the beneficial accountability applications, see <EntityLink id="E700" name="ai-accountability">AI for Accountability and Anti-Corruption</EntityLink>.

--- a/content/docs/knowledge-base/capabilities/coding.mdx
+++ b/content/docs/knowledge-base/capabilities/coding.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "cyber"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="coding" />
 
 <DataInfoBox entityId="E61" />
 

--- a/content/docs/knowledge-base/capabilities/language-models.mdx
+++ b/content/docs/knowledge-base/capabilities/language-models.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters: ["ai-safety", "governance"]
 ---
 
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid, F} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid, F} from '@components/wiki';
 
-<DataExternalLinks pageId="language-models" />
 
 <DataInfoBox entityId="E186" />
 

--- a/content/docs/knowledge-base/capabilities/large-language-models.mdx
+++ b/content/docs/knowledge-base/capabilities/large-language-models.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters: ["ai-safety", "governance"]
 todos: []
 ---
-import {R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="large-language-models" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/capabilities/long-horizon.mdx
+++ b/content/docs/knowledge-base/capabilities/long-horizon.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="long-horizon" />
 
 <DataInfoBox entityId="E192" />
 

--- a/content/docs/knowledge-base/capabilities/persuasion.mdx
+++ b/content/docs/knowledge-base/capabilities/persuasion.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.3
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="persuasion" />
 
 <DataInfoBox entityId="E224" />
 

--- a/content/docs/knowledge-base/capabilities/reasoning.mdx
+++ b/content/docs/knowledge-base/capabilities/reasoning.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="reasoning" />
 
 <DataInfoBox entityId="E246" />
 

--- a/content/docs/knowledge-base/capabilities/scientific-research.mdx
+++ b/content/docs/knowledge-base/capabilities/scientific-research.mdx
@@ -24,7 +24,7 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Key Links
 
@@ -33,7 +33,6 @@ import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@component
 | Official Website | [wikiedu.org](https://wikiedu.org/blog/2018/09/12/wikipedia-an-important-frontier-for-scientific-knowledge/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Research) |
 
-<DataExternalLinks pageId="scientific-research" />
 
 <DataInfoBox entityId="E277" />
 

--- a/content/docs/knowledge-base/capabilities/self-improvement.mdx
+++ b/content/docs/knowledge-base/capabilities/self-improvement.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.8
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="self-improvement" />
 
 <DataInfoBox entityId="E278" />
 

--- a/content/docs/knowledge-base/capabilities/situational-awareness.mdx
+++ b/content/docs/knowledge-base/capabilities/situational-awareness.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7.1
 clusters: ["ai-safety", "governance"]
 ---
-import {DataInfoBox, DataExternalLinks, R, References, Mermaid, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, References, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="situational-awareness" />
 
 <DataInfoBox entityId="E282" />
 

--- a/content/docs/knowledge-base/capabilities/tool-use.mdx
+++ b/content/docs/knowledge-base/capabilities/tool-use.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "cyber"]
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="tool-use" />
 
 <DataInfoBox entityId="E356" />
 

--- a/content/docs/knowledge-base/cruxes/accident-risks.mdx
+++ b/content/docs/knowledge-base/cruxes/accident-risks.mdx
@@ -18,10 +18,9 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "governance"]
 ---
-import {Crux, CruxList, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Crux, CruxList, R, EntityLink} from '@components/wiki';
 import {DataInfoBox, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="accident-risks" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/cruxes/epistemic-risks.mdx
+++ b/content/docs/knowledge-base/cruxes/epistemic-risks.mdx
@@ -18,7 +18,7 @@ ratings:
   completeness: 7
 clusters: ["epistemics", "ai-safety"]
 ---
-import {Crux, CruxList, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {Crux, CruxList, Mermaid, EntityLink} from '@components/wiki';
 
 
 
@@ -31,7 +31,6 @@ import {Crux, CruxList, DataExternalLinks, Mermaid, EntityLink} from '@component
 | <EntityLink id="lesswrong">LessWrong</EntityLink> | [lesswrong.com](https://www.lesswrong.com/posts/WLQspe83ZkiwBc2SR/double-crux) |
 | EA Forum | [forum.effectivealtruism.org](https://forum.effectivealtruism.org/posts/bbtvDJtb6YwwWtJm7/epistemic-status-an-explainer-and-some-thoughts) |
 
-<DataExternalLinks pageId="epistemic-risks" />
 
 ## Risk Assessment
 

--- a/content/docs/knowledge-base/cruxes/misuse-risks.mdx
+++ b/content/docs/knowledge-base/cruxes/misuse-risks.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "biorisks", "cyber", "governance"]
 ---
-import {Crux, CruxList, DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {Crux, CruxList, DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="misuse-risks" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/cruxes/solutions.mdx
+++ b/content/docs/knowledge-base/cruxes/solutions.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "governance"]
 ---
-import {Crux, CruxList, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Crux, CruxList, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="solutions" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/cruxes/structural-risks.mdx
+++ b/content/docs/knowledge-base/cruxes/structural-risks.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.1
 clusters: ["ai-safety", "governance"]
 ---
-import {Crux, CruxList, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Crux, CruxList, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="structural-risks" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/debates/agi-timeline-debate.mdx
+++ b/content/docs/knowledge-base/debates/agi-timeline-debate.mdx
@@ -19,7 +19,7 @@ ratings:
   completeness: 5.5
 clusters: ["ai-safety", "epistemics"]
 ---
-import {DisagreementMap, EntityLink, InfoBox, KeyQuestions, TimelineViz, DataExternalLinks} from '@components/wiki';
+import {DisagreementMap, EntityLink, InfoBox, KeyQuestions, TimelineViz} from '@components/wiki';
 
 
 
@@ -30,7 +30,6 @@ import {DisagreementMap, EntityLink, InfoBox, KeyQuestions, TimelineViz, DataExt
 | Official Website | [firstmovers.ai](https://firstmovers.ai/agi-timeline/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Artificial_general_intelligence) |
 
-<DataExternalLinks pageId="agi-timeline-debate" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/case-against-xrisk.mdx
+++ b/content/docs/knowledge-base/debates/case-against-xrisk.mdx
@@ -21,9 +21,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {InfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="case-against-xrisk" />
 
 <InfoBox
   type="argument"

--- a/content/docs/knowledge-base/debates/case-for-xrisk.mdx
+++ b/content/docs/knowledge-base/debates/case-for-xrisk.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {InfoBox, DisagreementMap, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {InfoBox, DisagreementMap, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="case-for-xrisk" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/debates/interpretability-sufficient.mdx
+++ b/content/docs/knowledge-base/debates/interpretability-sufficient.mdx
@@ -18,7 +18,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
 
 
@@ -28,7 +28,6 @@ import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExte
 |--------|------|
 | Official Website | [ea-crux-project.vercel.app](https://ea-crux-project.vercel.app/knowledge-base/responses/epistemic-tools/) |
 
-<DataExternalLinks pageId="interpretability-sufficient" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/is-ai-xrisk-real.mdx
+++ b/content/docs/knowledge-base/debates/is-ai-xrisk-real.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 1.5
 clusters: ["ai-safety"]
 ---
-import {InfoBox, KeyQuestions, DataExternalLinks} from '@components/wiki';
+import {InfoBox, KeyQuestions} from '@components/wiki';
 
-<DataExternalLinks pageId="is-ai-xrisk-real" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/open-vs-closed.mdx
+++ b/content/docs/knowledge-base/debates/open-vs-closed.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "governance"]
 ---
-import {ComparisonTable, DisagreementMap, InfoBox, KeyQuestions, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {ComparisonTable, DisagreementMap, InfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="open-vs-closed" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/debates/pause-debate.mdx
+++ b/content/docs/knowledge-base/debates/pause-debate.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety", "governance"]
 ---
-import {DisagreementMap, InfoBox, KeyQuestions, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="pause-debate" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/regulation-debate.mdx
+++ b/content/docs/knowledge-base/debates/regulation-debate.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "governance"]
 ---
-import {ComparisonTable, DisagreementMap, InfoBox, KeyQuestions, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {ComparisonTable, DisagreementMap, InfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="regulation-debate" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/scaling-debate.mdx
+++ b/content/docs/knowledge-base/debates/scaling-debate.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 5.5
 clusters: ["ai-safety"]
 ---
-import {DisagreementMap, InfoBox, KeyQuestions, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="scaling-debate" />
 
 <InfoBox
   type="crux"

--- a/content/docs/knowledge-base/debates/why-alignment-easy.mdx
+++ b/content/docs/knowledge-base/debates/why-alignment-easy.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {InfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {InfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="why-alignment-easy" />
 
 <InfoBox
   type="argument"

--- a/content/docs/knowledge-base/debates/why-alignment-hard.mdx
+++ b/content/docs/knowledge-base/debates/why-alignment-hard.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="why-alignment-hard" />
 
 <InfoBox
   type="argument"

--- a/content/docs/knowledge-base/forecasting/agi-development.mdx
+++ b/content/docs/knowledge-base/forecasting/agi-development.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "governance"]
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="agi-development" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/forecasting/agi-timeline.mdx
+++ b/content/docs/knowledge-base/forecasting/agi-timeline.mdx
@@ -17,9 +17,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "epistemics"]
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="agi-timeline" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/future-projections/aligned-agi.mdx
+++ b/content/docs/knowledge-base/future-projections/aligned-agi.mdx
@@ -16,9 +16,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety", "governance"]
 ---
-import {InfoBox, KeyQuestions, DataExternalLinks, Mermaid, DataInfoBox, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="aligned-agi" />
 
 <DataInfoBox entityId="E18" />
 

--- a/content/docs/knowledge-base/future-projections/misaligned-catastrophe.mdx
+++ b/content/docs/knowledge-base/future-projections/misaligned-catastrophe.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 7.1
 clusters: ["ai-safety", "governance"]
 ---
-import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="misaligned-catastrophe" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/future-projections/multipolar-competition.mdx
+++ b/content/docs/knowledge-base/future-projections/multipolar-competition.mdx
@@ -15,7 +15,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "governance"]
 ---
-import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
 
 
@@ -25,7 +25,6 @@ import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '
 |--------|------|
 | Official Website | [ea-crux-project.vercel.app](https://ea-crux-project.vercel.app/knowledge-base/responses/epistemic-tools/) |
 
-<DataExternalLinks pageId="multipolar-competition" />
 
 This scenario explores a future where no single AI system or actor achieves dominance. Instead, multiple competing AI systems empower different actors—nations, corporations, groups—leading to ongoing conflict, instability, and coordination failures. It is neither utopia nor quick catastrophe, but persistent dangerous competition. As the <R id="5f7b130bced9bdd8">World Economic Forum notes</R>, "the world could slide further into fragmentation, with a digital iron curtain separating US-led and China-led tech spheres."
 

--- a/content/docs/knowledge-base/future-projections/pause-and-redirect.mdx
+++ b/content/docs/knowledge-base/future-projections/pause-and-redirect.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "governance"]
 ---
-import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="pause-and-redirect" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/future-projections/slow-takeoff-muddle.mdx
+++ b/content/docs/knowledge-base/future-projections/slow-takeoff-muddle.mdx
@@ -15,7 +15,7 @@ ratings:
   completeness: 7.1
 clusters: ["ai-safety", "governance"]
 ---
-import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
 
 
@@ -27,7 +27,6 @@ import {InfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Wikipedia:Reference_desk/Archives/Science/February_15%E2%80%9321_2006) |
 | GitHub | [github.com](https://github.com/hardykevin/opencourse_coding/blob/master/edx/mit/6.00/ProblemSet3/words.txt) |
 
-<DataExternalLinks pageId="slow-takeoff-muddle" />
 
 This scenario explores what many consider the most likely path: gradual AI development that brings both benefits and harms, with governance struggling to keep pace but never completely failing. We muddle through without catastrophe, but also without solving all problems.
 

--- a/content/docs/knowledge-base/history/deep-learning-era.mdx
+++ b/content/docs/knowledge-base/history/deep-learning-era.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters: ["ai-safety", "community"]
 ---
 
-import {DataInfoBox, DataExternalLinks, Mermaid, EntityLink, F} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink, F} from '@components/wiki';
 
-<DataExternalLinks pageId="deep-learning-era" />
 
 <DataInfoBox entityId="E95" />
 

--- a/content/docs/knowledge-base/history/ea-epistemic-failures-in-the-ftx-era.mdx
+++ b/content/docs/knowledge-base/history/ea-epistemic-failures-in-the-ftx-era.mdx
@@ -34,7 +34,7 @@ balanceFlags:
   - single-source-dominance
   - missing-source-incentives
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/ea-institutions-response-to-the-ftx-collapse.mdx
+++ b/content/docs/knowledge-base/history/ea-institutions-response-to-the-ftx-collapse.mdx
@@ -32,7 +32,7 @@ clusters:
   - community
   - governance
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/early-warnings.mdx
+++ b/content/docs/knowledge-base/history/early-warnings.mdx
@@ -22,9 +22,8 @@ todos:
   - Verify Danny Hillis quote source and add citation when found
   - Expand Soviet cybernetics section with primary sources from Gerovitch (2002) and Glushkov's published works
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="early-warnings" />
 
 <DataInfoBox entityId="E107" />
 

--- a/content/docs/knowledge-base/history/earning-to-give.mdx
+++ b/content/docs/knowledge-base/history/earning-to-give.mdx
@@ -26,7 +26,7 @@ ratings:
 clusters:
   - community
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/ftx-collapse-and-ea-public-credibility.mdx
+++ b/content/docs/knowledge-base/history/ftx-collapse-and-ea-public-credibility.mdx
@@ -32,7 +32,7 @@ balanceFlags:
   - missing-primary-sources
   - unsourced-biographical-details
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/ftx-red-flags-pre-collapse-warning-signs-that-were-overlooked.mdx
+++ b/content/docs/knowledge-base/history/ftx-red-flags-pre-collapse-warning-signs-that-were-overlooked.mdx
@@ -27,7 +27,7 @@ clusters:
   - community
   - epistemics
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/longtermism-credibility-after-ftx.mdx
+++ b/content/docs/knowledge-base/history/longtermism-credibility-after-ftx.mdx
@@ -33,7 +33,7 @@ clusters:
 balanceFlags:
   - missing-primary-sources
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/history/mainstream-era.mdx
+++ b/content/docs/knowledge-base/history/mainstream-era.mdx
@@ -18,7 +18,7 @@ ratings:
   completeness: 6
 clusters: ["ai-safety", "community", "governance"]
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 
 
@@ -29,7 +29,6 @@ import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@component
 | Official Website | [simple.wikipedia.org](https://simple.wikipedia.org/wiki/Timeline_of_the_far_future) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/2020s) |
 
-<DataExternalLinks pageId="mainstream-era" />
 
 <DataInfoBox entityId="E195" />
 

--- a/content/docs/knowledge-base/history/miri-era.mdx
+++ b/content/docs/knowledge-base/history/miri-era.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 6
 clusters: ["community", "ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="miri-era" />
 
 <DataInfoBox entityId="E203" />
 

--- a/content/docs/knowledge-base/intelligence-paradigms/biological-organoid.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/biological-organoid.mdx
@@ -20,9 +20,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "biorisks"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="biological-organoid" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/brain-computer-interfaces.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/brain-computer-interfaces.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="brain-computer-interfaces" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/collective-intelligence.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/collective-intelligence.mdx
@@ -20,7 +20,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
+import {Mermaid, EntityLink, R} from '@components/wiki';
 
 
 
@@ -31,7 +31,6 @@ import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
 | Official Website | [scalehub.com](https://scalehub.com/what-is-collective-intelligence/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Collective_intelligence) |
 
-<DataExternalLinks pageId="collective-intelligence" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/dense-transformers.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/dense-transformers.mdx
@@ -20,9 +20,8 @@ ratings:
   completeness: 7.3
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="dense-transformers" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/intelligence-paradigms/genetic-enhancement.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/genetic-enhancement.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "biorisks"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
+import {Mermaid, EntityLink, R} from '@components/wiki';
 
-<DataExternalLinks pageId="genetic-enhancement" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/heavy-scaffolding.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/heavy-scaffolding.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "governance"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="heavy-scaffolding" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/intelligence-paradigms/light-scaffolding.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/light-scaffolding.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "governance"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="light-scaffolding" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/intelligence-paradigms/minimal-scaffolding.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/minimal-scaffolding.mdx
@@ -20,7 +20,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
 
 
@@ -31,7 +31,6 @@ import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
 | Official Website | [justapedia.org](https://justapedia.org/wiki/Scaffold) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Scaffolding) |
 
-<DataExternalLinks pageId="minimal-scaffolding" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/neuro-symbolic.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/neuro-symbolic.mdx
@@ -19,7 +19,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
 
 
@@ -30,7 +30,6 @@ import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
 | Official Website | [research.ibm.com](https://research.ibm.com/topics/neuro-symbolic-ai) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Neuro-symbolic_AI) |
 
-<DataExternalLinks pageId="neuro-symbolic" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/neuromorphic.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/neuromorphic.mdx
@@ -19,7 +19,7 @@ ratings:
   completeness: 7
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
+import {Mermaid, EntityLink, R} from '@components/wiki';
 
 
 
@@ -30,7 +30,6 @@ import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
 | Official Website | [ibm.com](https://www.ibm.com/think/topics/neuromorphic-computing) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Neuromorphic_computing) |
 
-<DataExternalLinks pageId="neuromorphic" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/provable-safe.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/provable-safe.mdx
@@ -20,9 +20,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety", "governance"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="provable-safe" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/intelligence-paradigms/sparse-moe.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/sparse-moe.mdx
@@ -24,9 +24,8 @@ ratings:
 clusters:
   - "ai-safety"
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sparse-moe" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/ssm-mamba.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/ssm-mamba.mdx
@@ -19,7 +19,7 @@ ratings:
   completeness: 7.1
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
+import {Mermaid, EntityLink, R} from '@components/wiki';
 
 
 
@@ -31,7 +31,6 @@ import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Mamba_(deep_learning_architecture) |
 | arXiv | [arxiv.org](https://arxiv.org/abs/2312.00752) |
 
-<DataExternalLinks pageId="ssm-mamba" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/whole-brain-emulation.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/whole-brain-emulation.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="whole-brain-emulation" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/intelligence-paradigms/world-models.mdx
+++ b/content/docs/knowledge-base/intelligence-paradigms/world-models.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety"]
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="world-models" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/metrics/alignment-progress.mdx
+++ b/content/docs/knowledge-base/metrics/alignment-progress.mdx
@@ -47,9 +47,8 @@ tags:
   - "interpretability"
   - "red-teaming"
 ---
-import {DataInfoBox, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="alignment-progress" />
 
 <DataInfoBox>
 

--- a/content/docs/knowledge-base/metrics/capabilities.mdx
+++ b/content/docs/knowledge-base/metrics/capabilities.mdx
@@ -18,10 +18,9 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety"]
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 import {DataInfoBox} from '@components/wiki';
 
-<DataExternalLinks pageId="capabilities" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/metrics/compute-hardware.mdx
+++ b/content/docs/knowledge-base/metrics/compute-hardware.mdx
@@ -24,9 +24,8 @@ clusters:
   - "governance"
 ---
 
-import {R, Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="compute-hardware" />
 
 ## Executive Summary
 

--- a/content/docs/knowledge-base/metrics/economic-labor.mdx
+++ b/content/docs/knowledge-base/metrics/economic-labor.mdx
@@ -18,7 +18,7 @@ ratings:
 clusters: ["ai-safety", "governance"]
 ---
 
-import {R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, EntityLink} from '@components/wiki';
 
 ## Key Links
 
@@ -27,7 +27,6 @@ import {R, EntityLink, DataExternalLinks} from '@components/wiki';
 | Official Website | [bls.gov](http://www.bls.gov/ect/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Economic_indicator) |
 
-<DataExternalLinks pageId="economic-labor" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/metrics/expert-opinion.mdx
+++ b/content/docs/knowledge-base/metrics/expert-opinion.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "epistemics", "governance"]
 ---
-import {DataInfoBox, DisagreementMap, KeyQuestions, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyQuestions, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="expert-opinion" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/metrics/geopolitics.mdx
+++ b/content/docs/knowledge-base/metrics/geopolitics.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters: ["ai-safety", "governance"]
 ---
 
-import {R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="geopolitics" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/metrics/lab-behavior.mdx
+++ b/content/docs/knowledge-base/metrics/lab-behavior.mdx
@@ -22,9 +22,8 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {R, Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="lab-behavior" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/metrics/public-opinion.mdx
+++ b/content/docs/knowledge-base/metrics/public-opinion.mdx
@@ -18,7 +18,7 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "epistemics"]
 ---
-import {R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, EntityLink} from '@components/wiki';
 
 
 
@@ -29,7 +29,6 @@ import {R, EntityLink, DataExternalLinks} from '@components/wiki';
 | Official Website | [wikiedu.org](https://wikiedu.org/blog/2025/02/06/how-i-learned-to-stop-worrying-and-love-wikipedia/) |
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Public_opinion) |
 
-<DataExternalLinks pageId="public-opinion" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/models/capability-threshold-model.mdx
+++ b/content/docs/knowledge-base/models/capability-threshold-model.mdx
@@ -29,9 +29,8 @@ todos:
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="capability-threshold-model" />
 
 <DataInfoBox entityId="E53" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/carlsmith-six-premises.mdx
+++ b/content/docs/knowledge-base/models/carlsmith-six-premises.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="carlsmith-six-premises" />
 
 <DataInfoBox entityId="E54" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/deceptive-alignment-decomposition.mdx
+++ b/content/docs/knowledge-base/models/deceptive-alignment-decomposition.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'Quantitative Analysis' section (8 placeholders)
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deceptive-alignment-decomposition" />
 
 <DataInfoBox entityId="E94" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/defense-in-depth-model.mdx
+++ b/content/docs/knowledge-base/models/defense-in-depth-model.mdx
@@ -26,9 +26,8 @@ todos:
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="defense-in-depth-model" />
 
 <DataInfoBox entityId="E99" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/instrumental-convergence-framework.mdx
+++ b/content/docs/knowledge-base/models/instrumental-convergence-framework.mdx
@@ -24,9 +24,8 @@ todos:
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="instrumental-convergence-framework" />
 
 <DataInfoBox entityId="E169" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/mesa-optimization-analysis.mdx
+++ b/content/docs/knowledge-base/models/mesa-optimization-analysis.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="mesa-optimization-analysis" />
 
 <DataInfoBox entityId="E198" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/models/projecting-compute-spending.mdx
+++ b/content/docs/knowledge-base/models/projecting-compute-spending.mdx
@@ -24,7 +24,7 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {Mermaid, EntityLink, DataExternalLinks, SquiggleEstimate} from '@components/wiki';
+import {Mermaid, EntityLink, SquiggleEstimate} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/models/proliferation-risk-model.mdx
+++ b/content/docs/knowledge-base/models/proliferation-risk-model.mdx
@@ -27,9 +27,8 @@ todos:
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="proliferation-risk-model" />
 
 <DataInfoBox entityId="E234" ratings={frontmatter.ratings} />
 

--- a/content/docs/knowledge-base/organizations/80000-hours.mdx
+++ b/content/docs/knowledge-base/organizations/80000-hours.mdx
@@ -20,9 +20,8 @@ clusters:
   - community
   - ai-safety
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="80000-hours" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/anthropic.mdx
+++ b/content/docs/knowledge-base/organizations/anthropic.mdx
@@ -26,10 +26,9 @@ clusters:
   - "governance"
 ---
 
-import {DataInfoBox, EntityLink, DataExternalLinks, SquiggleEstimate} from '@components/wiki'
+import {DataInfoBox, EntityLink, SquiggleEstimate} from '@components/wiki'
 import {Calc} from '@components/facts'
 
-<DataExternalLinks pageId="anthropic" />
 
 <DataInfoBox entityId="E22" />
 

--- a/content/docs/knowledge-base/organizations/apollo-research.mdx
+++ b/content/docs/knowledge-base/organizations/apollo-research.mdx
@@ -21,9 +21,8 @@ clusters:
   - community
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="apollo-research" />
 
 <DataInfoBox entityId="E24" />
 

--- a/content/docs/knowledge-base/organizations/arc.mdx
+++ b/content/docs/knowledge-base/organizations/arc.mdx
@@ -21,9 +21,8 @@ clusters:
   - community
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="arc" />
 
 <DataInfoBox entityId="E25" />
 

--- a/content/docs/knowledge-base/organizations/astralis-foundation.mdx
+++ b/content/docs/knowledge-base/organizations/astralis-foundation.mdx
@@ -20,7 +20,7 @@ clusters:
   - ai-safety
   - governance
 ---
-import {EntityLink, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/cais.mdx
+++ b/content/docs/knowledge-base/organizations/cais.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, KeyPeople, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="cais" />
 
 <DataInfoBox entityId="E47" />
 

--- a/content/docs/knowledge-base/organizations/cea.mdx
+++ b/content/docs/knowledge-base/organizations/cea.mdx
@@ -18,7 +18,7 @@ ratings:
 clusters:
   - community
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks, KeyPeople, KeyQuestions, Section} from '@components/wiki';
+import {DataInfoBox, EntityLink, KeyPeople, KeyQuestions, Section} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/chai.mdx
+++ b/content/docs/knowledge-base/organizations/chai.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, KeyPeople, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="chai" />
 
 <DataInfoBox entityId="E57" />
 

--- a/content/docs/knowledge-base/organizations/conjecture.mdx
+++ b/content/docs/knowledge-base/organizations/conjecture.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyPeople, KeyQuestions, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="conjecture" />
 
 <DataInfoBox entityId="E70" />
 

--- a/content/docs/knowledge-base/organizations/cset.mdx
+++ b/content/docs/knowledge-base/organizations/cset.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
   - ai-safety
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="cset" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/deepmind.mdx
+++ b/content/docs/knowledge-base/organizations/deepmind.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deepmind" />
 
 <DataInfoBox entityId="E98" />
 

--- a/content/docs/knowledge-base/organizations/epistemic-orgs-epoch-ai.mdx
+++ b/content/docs/knowledge-base/organizations/epistemic-orgs-epoch-ai.mdx
@@ -22,9 +22,8 @@ clusters:
   - epistemics
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks, KeyQuestions, Section, DisagreementMap} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink, KeyQuestions, Section, DisagreementMap} from '@components/wiki';
 
-<DataExternalLinks pageId="epoch-ai" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/far-ai.mdx
+++ b/content/docs/knowledge-base/organizations/far-ai.mdx
@@ -50,9 +50,8 @@ tags:
   - red-teaming
   - grantmaking
 ---
-import {DataInfoBox, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyPeople, KeyQuestions, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="far-ai" />
 
 <DataInfoBox entityId="E138" />
 

--- a/content/docs/knowledge-base/organizations/fhi.mdx
+++ b/content/docs/knowledge-base/organizations/fhi.mdx
@@ -21,9 +21,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="fhi" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/fri.mdx
+++ b/content/docs/knowledge-base/organizations/fri.mdx
@@ -21,7 +21,7 @@ clusters:
   - community
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/ftx-future-fund.mdx
+++ b/content/docs/knowledge-base/organizations/ftx-future-fund.mdx
@@ -26,7 +26,7 @@ clusters:
   - community
   - ai-safety
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/ftx.mdx
+++ b/content/docs/knowledge-base/organizations/ftx.mdx
@@ -29,7 +29,7 @@ balanceFlags:
   - single-source-dominance
   - missing-primary-sources
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/giving-what-we-can.mdx
+++ b/content/docs/knowledge-base/organizations/giving-what-we-can.mdx
@@ -21,7 +21,7 @@ ratings:
 clusters:
   - community
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 # Giving What We Can
 

--- a/content/docs/knowledge-base/organizations/govai.mdx
+++ b/content/docs/knowledge-base/organizations/govai.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
   - community
 ---
-import {DataInfoBox, KeyPeople, Section, Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="govai" />
 
 <DataInfoBox entityId="E153" />
 

--- a/content/docs/knowledge-base/organizations/lesswrong.mdx
+++ b/content/docs/knowledge-base/organizations/lesswrong.mdx
@@ -20,9 +20,8 @@ clusters:
   - community
   - ai-safety
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="lesswrong" />
 
 {/* Note: LessWrong entity not yet in data layer */}
 

--- a/content/docs/knowledge-base/organizations/manifold.mdx
+++ b/content/docs/knowledge-base/organizations/manifold.mdx
@@ -19,7 +19,7 @@ clusters:
   - epistemics
   - community
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/meta-ai.mdx
+++ b/content/docs/knowledge-base/organizations/meta-ai.mdx
@@ -24,9 +24,8 @@ clusters:
   - "community"
   - "governance"
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="meta-ai" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/metaculus.mdx
+++ b/content/docs/knowledge-base/organizations/metaculus.mdx
@@ -21,7 +21,7 @@ clusters:
   - community
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/metr.mdx
+++ b/content/docs/knowledge-base/organizations/metr.mdx
@@ -22,9 +22,8 @@ clusters:
   - community
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="metr" />
 
 <DataInfoBox entityId="E201" />
 

--- a/content/docs/knowledge-base/organizations/microsoft.mdx
+++ b/content/docs/knowledge-base/organizations/microsoft.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="microsoft" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/miri.mdx
+++ b/content/docs/knowledge-base/organizations/miri.mdx
@@ -20,9 +20,8 @@ clusters:
   - community
   - ai-safety
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="miri" />
 
 <DataInfoBox entityId="E202" />
 

--- a/content/docs/knowledge-base/organizations/openai.mdx
+++ b/content/docs/knowledge-base/organizations/openai.mdx
@@ -25,9 +25,8 @@ clusters:
   - "community"
   - "governance"
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="openai" />
 
 <DataInfoBox entityId="E218" />
 

--- a/content/docs/knowledge-base/organizations/quri.mdx
+++ b/content/docs/knowledge-base/organizations/quri.mdx
@@ -20,7 +20,7 @@ clusters:
   - epistemics
   - community
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/redwood-research.mdx
+++ b/content/docs/knowledge-base/organizations/redwood-research.mdx
@@ -19,7 +19,7 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks, KeyPeople, KeyQuestions, Section} from '@components/wiki';
+import {DataInfoBox, EntityLink, KeyPeople, KeyQuestions, Section} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/organizations/safety-orgs-epoch-ai.mdx
+++ b/content/docs/knowledge-base/organizations/safety-orgs-epoch-ai.mdx
@@ -23,9 +23,8 @@ clusters:
   - epistemics
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="epoch-ai" />
 
 <DataInfoBox entityId="E125" />
 

--- a/content/docs/knowledge-base/organizations/securebio.mdx
+++ b/content/docs/knowledge-base/organizations/securebio.mdx
@@ -21,7 +21,7 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks, KeyPeople, KeyQuestions, Section} from '@components/wiki';
+import {DataInfoBox, EntityLink, KeyPeople, KeyQuestions, Section} from '@components/wiki';
 
 {/* Note: SecureBio entity not yet in data layer */}
 

--- a/content/docs/knowledge-base/organizations/uk-aisi.mdx
+++ b/content/docs/knowledge-base/organizations/uk-aisi.mdx
@@ -21,9 +21,8 @@ clusters:
   - community
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="uk-aisi" />
 
 <DataInfoBox entityId="E364" />
 

--- a/content/docs/knowledge-base/organizations/us-aisi.mdx
+++ b/content/docs/knowledge-base/organizations/us-aisi.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
   - community
 ---
-import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyPeople, KeyQuestions, Section, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="us-aisi" />
 
 <DataInfoBox entityId="E365" />
 

--- a/content/docs/knowledge-base/organizations/xai.mdx
+++ b/content/docs/knowledge-base/organizations/xai.mdx
@@ -24,9 +24,8 @@ clusters:
   - "community"
   - "governance"
 ---
-import {DataInfoBox, Section, DisagreementMap, KeyQuestions, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Section, DisagreementMap, KeyQuestions, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="xai" />
 
 <DataInfoBox entityId="E378" />
 

--- a/content/docs/knowledge-base/people/ajeya-cotra.mdx
+++ b/content/docs/knowledge-base/people/ajeya-cotra.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ajeya-cotra" />
 
 <DataInfoBox entityId="E864" />
 

--- a/content/docs/knowledge-base/people/chris-olah.mdx
+++ b/content/docs/knowledge-base/people/chris-olah.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="chris-olah" />
 
 <DataInfoBox entityId="E59" />
 

--- a/content/docs/knowledge-base/people/connor-leahy.mdx
+++ b/content/docs/knowledge-base/people/connor-leahy.mdx
@@ -17,9 +17,8 @@ ratings:
   completeness: 4
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="connor-leahy" />
 
 <DataInfoBox entityId="E71" />
 

--- a/content/docs/knowledge-base/people/dan-hendrycks.mdx
+++ b/content/docs/knowledge-base/people/dan-hendrycks.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 4
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="dan-hendrycks" />
 
 <DataInfoBox entityId="E89" />
 

--- a/content/docs/knowledge-base/people/daniela-amodei.mdx
+++ b/content/docs/knowledge-base/people/daniela-amodei.mdx
@@ -17,9 +17,8 @@ ratings:
   completeness: 4
 clusters: ["ai-safety","governance"]
 ---
-import {R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="daniela-amodei" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/people/dario-amodei.mdx
+++ b/content/docs/knowledge-base/people/dario-amodei.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="dario-amodei" />
 
 <DataInfoBox entityId="E91" />
 

--- a/content/docs/knowledge-base/people/demis-hassabis.mdx
+++ b/content/docs/knowledge-base/people/demis-hassabis.mdx
@@ -18,7 +18,7 @@ ratings:
   completeness: 7
 clusters: ["ai-safety"]
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
 ## Key Links
 
@@ -26,7 +26,6 @@ import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
 |--------|------|
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Demis_Hassabis) |
 
-<DataExternalLinks pageId="demis-hassabis" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/people/eliezer-yudkowsky.mdx
+++ b/content/docs/knowledge-base/people/eliezer-yudkowsky.mdx
@@ -19,7 +19,7 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, Section, DisagreementMap, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Section, DisagreementMap, EntityLink} from '@components/wiki';
 
 ## Key Links
 
@@ -29,7 +29,6 @@ import {DataInfoBox, Section, DisagreementMap, DataExternalLinks, EntityLink} fr
 | Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Eliezer_Yudkowsky) |
 | Wikidata | [wikidata.org](https://www.wikidata.org/wiki/Q704195) |
 
-<DataExternalLinks pageId="eliezer-yudkowsky" />
 
 <DataInfoBox entityId="E114" />
 

--- a/content/docs/knowledge-base/people/elon-musk.mdx
+++ b/content/docs/knowledge-base/people/elon-musk.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink, Mermaid} from '@components/wiki';
+import {DataInfoBox, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="elon-musk" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/people/evan-hubinger.mdx
+++ b/content/docs/knowledge-base/people/evan-hubinger.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety"]
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="evan-hubinger" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/people/geoffrey-hinton.mdx
+++ b/content/docs/knowledge-base/people/geoffrey-hinton.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="geoffrey-hinton" />
 
 <DataInfoBox entityId="E149" />
 

--- a/content/docs/knowledge-base/people/helen-toner.mdx
+++ b/content/docs/knowledge-base/people/helen-toner.mdx
@@ -17,9 +17,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety","governance"]
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="helen-toner" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/people/holden-karnofsky.mdx
+++ b/content/docs/knowledge-base/people/holden-karnofsky.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["community", "ai-safety", "governance"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="holden-karnofsky" />
 
 <DataInfoBox entityId="E156" />
 

--- a/content/docs/knowledge-base/people/ilya-sutskever.mdx
+++ b/content/docs/knowledge-base/people/ilya-sutskever.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ilya-sutskever" />
 
 <DataInfoBox entityId="E163" />
 

--- a/content/docs/knowledge-base/people/jan-leike.mdx
+++ b/content/docs/knowledge-base/people/jan-leike.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="jan-leike" />
 
 <DataInfoBox entityId="E182" />
 

--- a/content/docs/knowledge-base/people/neel-nanda.mdx
+++ b/content/docs/knowledge-base/people/neel-nanda.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 4.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="neel-nanda" />
 
 <DataInfoBox entityId="E214" />
 

--- a/content/docs/knowledge-base/people/nick-beckstead.mdx
+++ b/content/docs/knowledge-base/people/nick-beckstead.mdx
@@ -29,7 +29,7 @@ balanceFlags:
   - missing-source-incentives
   - unsourced-biographical-details
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/people/nick-bostrom.mdx
+++ b/content/docs/knowledge-base/people/nick-bostrom.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="nick-bostrom" />
 
 <DataInfoBox entityId="E215" />
 

--- a/content/docs/knowledge-base/people/paul-christiano.mdx
+++ b/content/docs/knowledge-base/people/paul-christiano.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, DisagreementMap, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="paul-christiano" />
 
 <DataInfoBox entityId="E220" />
 

--- a/content/docs/knowledge-base/people/sam-altman.mdx
+++ b/content/docs/knowledge-base/people/sam-altman.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety","governance"]
 ---
-import {Mermaid, DataExternalLinks, EntityLink, F} from '@components/wiki';
+import {Mermaid, EntityLink, F} from '@components/wiki';
 
-<DataExternalLinks pageId="sam-altman" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/people/sam-bankman-fried.mdx
+++ b/content/docs/knowledge-base/people/sam-bankman-fried.mdx
@@ -27,7 +27,7 @@ ratings:
 clusters:
   - community
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/people/stuart-russell.mdx
+++ b/content/docs/knowledge-base/people/stuart-russell.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="stuart-russell" />
 
 <DataInfoBox entityId="E290" />
 

--- a/content/docs/knowledge-base/people/toby-ord.mdx
+++ b/content/docs/knowledge-base/people/toby-ord.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6
 clusters: ["community", "ai-safety", "governance"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="toby-ord" />
 
 <DataInfoBox entityId="E355" />
 

--- a/content/docs/knowledge-base/people/will-macaskill.mdx
+++ b/content/docs/knowledge-base/people/will-macaskill.mdx
@@ -22,7 +22,7 @@ clusters:
   - community
   - ai-safety
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, F, Calc, DataInfoBox} from '@components/wiki';
 
 **William MacAskill** (born William David Crouch, 24 March 1987) is a Scottish moral philosopher best known for co-founding the effective altruism (EA) movement and for popularizing the philosophy of longtermism. He has co-founded several influential organizations in the EA ecosystem and has authored widely read books on evidence-based ethics and the long-term future.
 

--- a/content/docs/knowledge-base/people/yann-lecun.mdx
+++ b/content/docs/knowledge-base/people/yann-lecun.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 7.5
 clusters: ["ai-safety"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="yann-lecun" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/people/yoshua-bengio.mdx
+++ b/content/docs/knowledge-base/people/yoshua-bengio.mdx
@@ -18,9 +18,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety","governance"]
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="yoshua-bengio" />
 
 <DataInfoBox entityId="E380" />
 

--- a/content/docs/knowledge-base/responses/adversarial-training.mdx
+++ b/content/docs/knowledge-base/responses/adversarial-training.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="adversarial-training" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/agent-foundations.mdx
+++ b/content/docs/knowledge-base/responses/agent-foundations.mdx
@@ -20,9 +20,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="agent-foundations" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/ai-accountability.mdx
+++ b/content/docs/knowledge-base/responses/ai-accountability.mdx
@@ -18,9 +18,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {EntityLink, DataExternalLinks} from '@components/wiki';
+import {EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-accountability" />
 
 :::note[Related Pages]
 This page covers the **beneficial accountability applications** of AI investigation. For the underlying capability assessment, see <EntityLink id="ai-powered-investigation">AI-Powered Investigation</EntityLink>. For the risk side including privacy erosion and chilling effects, see <EntityLink id="ai-investigation-risks">AI-Powered Investigation Risks</EntityLink>. For the specific deanonymization threat, see <EntityLink id="deanonymization">AI-Powered Deanonymization</EntityLink>.

--- a/content/docs/knowledge-base/responses/ai-assisted.mdx
+++ b/content/docs/knowledge-base/responses/ai-assisted.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-assisted" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/ai-control.mdx
+++ b/content/docs/knowledge-base/responses/ai-control.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-control" />
 
 <DataInfoBox entityId="E6" />
 

--- a/content/docs/knowledge-base/responses/ai-forecasting-benchmark.mdx
+++ b/content/docs/knowledge-base/responses/ai-forecasting-benchmark.mdx
@@ -20,7 +20,7 @@ clusters:
   - epistemics
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/ai-forecasting.mdx
+++ b/content/docs/knowledge-base/responses/ai-forecasting.mdx
@@ -24,9 +24,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-forecasting" />
 
 <DataInfoBox entityId="E9" />
 

--- a/content/docs/knowledge-base/responses/ai-safety-institutes.mdx
+++ b/content/docs/knowledge-base/responses/ai-safety-institutes.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'Limitations' section (6 placeholders)
 styleGuideVersion: kb-2.0
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-safety-institutes" />
 
 <DataInfoBox entityId="E13" />
 

--- a/content/docs/knowledge-base/responses/alignment-evals.mdx
+++ b/content/docs/knowledge-base/responses/alignment-evals.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, R, EntityLink} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="alignment-evals" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/alignment.mdx
+++ b/content/docs/knowledge-base/responses/alignment.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="alignment" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/california-sb1047.mdx
+++ b/content/docs/knowledge-base/responses/california-sb1047.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="california-sb1047" />
 
 <DataInfoBox entityId="E48" />
 

--- a/content/docs/knowledge-base/responses/capability-elicitation.mdx
+++ b/content/docs/knowledge-base/responses/capability-elicitation.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="capability-elicitation" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/capability-unlearning.mdx
+++ b/content/docs/knowledge-base/responses/capability-unlearning.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="capability-unlearning" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/circuit-breakers.mdx
+++ b/content/docs/knowledge-base/responses/circuit-breakers.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="circuit-breakers" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/cirl.mdx
+++ b/content/docs/knowledge-base/responses/cirl.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="cirl" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/constitutional-ai.mdx
+++ b/content/docs/knowledge-base/responses/constitutional-ai.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="constitutional-ai" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/content-authentication.mdx
+++ b/content/docs/knowledge-base/responses/content-authentication.mdx
@@ -22,9 +22,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, KeyQuestions, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="content-authentication" />
 
 <DataInfoBox entityId="E74" />
 

--- a/content/docs/knowledge-base/responses/cooperative-ai.mdx
+++ b/content/docs/knowledge-base/responses/cooperative-ai.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="cooperative-ai" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/coordination-mechanisms.mdx
+++ b/content/docs/knowledge-base/responses/coordination-mechanisms.mdx
@@ -18,9 +18,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="coordination-mechanisms" />
 
 International coordination represents one of the most challenging yet potentially crucial approaches to AI safety, involving the development of global cooperation mechanisms to ensure advanced AI systems are developed and deployed safely across all major AI powers. As AI capabilities advance rapidly across multiple nations—particularly the United States, China, and the United Kingdom—the absence of coordinated safety measures could lead to dangerous race dynamics where competitive pressures override safety considerations.
 

--- a/content/docs/knowledge-base/responses/coordination-tech.mdx
+++ b/content/docs/knowledge-base/responses/coordination-tech.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
   - epistemics
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="coordination-tech" />
 
 <DataInfoBox entityId="E77" />
 

--- a/content/docs/knowledge-base/responses/corporate-influence.mdx
+++ b/content/docs/knowledge-base/responses/corporate-influence.mdx
@@ -24,9 +24,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="corporate-influence" />
 
 <DataInfoBox entityId="E78" />
 

--- a/content/docs/knowledge-base/responses/corporate.mdx
+++ b/content/docs/knowledge-base/responses/corporate.mdx
@@ -21,9 +21,8 @@ todos:
   - Complete 'How It Works' section
   - Add Mermaid diagram showing corporate safety governance structure
 ---
-import {R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="corporate" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/corrigibility.mdx
+++ b/content/docs/knowledge-base/responses/corrigibility.mdx
@@ -17,9 +17,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="corrigibility" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/dangerous-cap-evals.mdx
+++ b/content/docs/knowledge-base/responses/dangerous-cap-evals.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="dangerous-cap-evals" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/debate.mdx
+++ b/content/docs/knowledge-base/responses/debate.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="debate" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/deepfake-detection.mdx
+++ b/content/docs/knowledge-base/responses/deepfake-detection.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - epistemics
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deepfake-detection" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/deliberation.mdx
+++ b/content/docs/knowledge-base/responses/deliberation.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deliberation" />
 
 <DataInfoBox entityId="E100" />
 

--- a/content/docs/knowledge-base/responses/effectiveness-assessment.mdx
+++ b/content/docs/knowledge-base/responses/effectiveness-assessment.mdx
@@ -23,9 +23,8 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="effectiveness-assessment" />
 
 <DataInfoBox entityId="E113" />
 

--- a/content/docs/knowledge-base/responses/eliciting-latent-knowledge.mdx
+++ b/content/docs/knowledge-base/responses/eliciting-latent-knowledge.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks, DataInfoBox} from '@components/wiki';
+import {Mermaid, R, EntityLink, DataInfoBox} from '@components/wiki';
 
-<DataExternalLinks pageId="eliciting-latent-knowledge" />
 
 
 ## Quick Assessment

--- a/content/docs/knowledge-base/responses/epistemic-infrastructure.mdx
+++ b/content/docs/knowledge-base/responses/epistemic-infrastructure.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="epistemic-infrastructure" />
 
 <DataInfoBox entityId="E122" />
 

--- a/content/docs/knowledge-base/responses/eval-saturation.mdx
+++ b/content/docs/knowledge-base/responses/eval-saturation.mdx
@@ -25,9 +25,8 @@ todos:
   - Add cause-effect diagram showing how eval saturation affects RSP governance
 contentType: analysis
 ---
-import {EntityLink, R, Mermaid, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="eval-saturation" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/evals-governance.mdx
+++ b/content/docs/knowledge-base/responses/evals-governance.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks, DataInfoBox} from '@components/wiki';
+import {Mermaid, R, EntityLink, DataInfoBox} from '@components/wiki';
 
-<DataExternalLinks pageId="evals-governance" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/evals.mdx
+++ b/content/docs/knowledge-base/responses/evals.mdx
@@ -18,9 +18,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="evals" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/evaluation-awareness.mdx
+++ b/content/docs/knowledge-base/responses/evaluation-awareness.mdx
@@ -26,9 +26,8 @@ todos:
   - Add cause-effect diagram showing how eval awareness cascades to governance failures
 contentType: analysis
 ---
-import {EntityLink, R, Mermaid, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="evaluation-awareness" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/evaluation.mdx
+++ b/content/docs/knowledge-base/responses/evaluation.mdx
@@ -19,9 +19,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "governance"]
 ---
-import {R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="evaluation" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/export-controls.mdx
+++ b/content/docs/knowledge-base/responses/export-controls.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'Limitations' section (6 placeholders)
 styleGuideVersion: kb-2.0
 ---
-import {DataInfoBox, KeyQuestions, DisagreementMap, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, DisagreementMap, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="export-controls" />
 
 <DataInfoBox entityId="E136" />
 

--- a/content/docs/knowledge-base/responses/field-building-analysis.mdx
+++ b/content/docs/knowledge-base/responses/field-building-analysis.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="field-building-analysis" />
 
 <DataInfoBox entityId="E141" />
 

--- a/content/docs/knowledge-base/responses/forecastbench.mdx
+++ b/content/docs/knowledge-base/responses/forecastbench.mdx
@@ -20,7 +20,7 @@ clusters:
   - epistemics
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/formal-verification.mdx
+++ b/content/docs/knowledge-base/responses/formal-verification.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="formal-verification" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/goal-misgeneralization-research.mdx
+++ b/content/docs/knowledge-base/responses/goal-misgeneralization-research.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="goal-misgeneralization" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/governance-policy.mdx
+++ b/content/docs/knowledge-base/responses/governance-policy.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, DisagreementMap, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="governance-policy" />
 
 <DataInfoBox entityId="E154" />
 

--- a/content/docs/knowledge-base/responses/government-authority-commercial-ai-infrastructure.mdx
+++ b/content/docs/knowledge-base/responses/government-authority-commercial-ai-infrastructure.mdx
@@ -23,9 +23,8 @@ clusters:
   - "governance"
   - "ai-safety"
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="government-authority-commercial-ai-infrastructure" />
 
 <DataInfoBox entityId="government-authority-commercial-ai-infrastructure" />
 

--- a/content/docs/knowledge-base/responses/hardware-enabled-governance.mdx
+++ b/content/docs/knowledge-base/responses/hardware-enabled-governance.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="hardware-enabled-governance" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/hybrid-systems.mdx
+++ b/content/docs/knowledge-base/responses/hybrid-systems.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - epistemics
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="hybrid-systems" />
 
 <DataInfoBox entityId="E161" />
 

--- a/content/docs/knowledge-base/responses/international-regimes.mdx
+++ b/content/docs/knowledge-base/responses/international-regimes.mdx
@@ -24,7 +24,7 @@ todos:
   - Complete 'Limitations' section (6 placeholders)
 styleGuideVersion: kb-2.0
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
 <DataInfoBox entityId="E170" />
 
@@ -84,7 +84,6 @@ The evolving international AI governance landscape involves multiple overlapping
 
 import {Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="international-regimes" />
 
 <Mermaid chart={`
 flowchart TD

--- a/content/docs/knowledge-base/responses/international-summits.mdx
+++ b/content/docs/knowledge-base/responses/international-summits.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="international-summits" />
 
 <DataInfoBox entityId="E173" />
 

--- a/content/docs/knowledge-base/responses/interpretability.mdx
+++ b/content/docs/knowledge-base/responses/interpretability.mdx
@@ -28,9 +28,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks, KeyTakeaways} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, KeyTakeaways} from '@components/wiki';
 
-<DataExternalLinks pageId="interpretability" />
 
 <DataInfoBox entityId="E174" />
 

--- a/content/docs/knowledge-base/responses/lab-culture.mdx
+++ b/content/docs/knowledge-base/responses/lab-culture.mdx
@@ -18,9 +18,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="lab-culture" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/labor-transition.mdx
+++ b/content/docs/knowledge-base/responses/labor-transition.mdx
@@ -24,9 +24,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="labor-transition" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/longterm-wiki.mdx
+++ b/content/docs/knowledge-base/responses/longterm-wiki.mdx
@@ -22,7 +22,7 @@ clusters:
   - epistemics
   - community
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/maim.mdx
+++ b/content/docs/knowledge-base/responses/maim.mdx
@@ -22,9 +22,8 @@ clusters:
   - governance
   - geopolitics
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="maim" />
 
 <DataInfoBox entityId="E685" />
 

--- a/content/docs/knowledge-base/responses/mech-interp.mdx
+++ b/content/docs/knowledge-base/responses/mech-interp.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="mech-interp" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/metaforecast.mdx
+++ b/content/docs/knowledge-base/responses/metaforecast.mdx
@@ -19,7 +19,7 @@ clusters:
   - epistemics
   - community
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/model-auditing.mdx
+++ b/content/docs/knowledge-base/responses/model-auditing.mdx
@@ -21,9 +21,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, R, EntityLink} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="model-auditing" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/model-registries.mdx
+++ b/content/docs/knowledge-base/responses/model-registries.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="model-registries" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/model-spec.mdx
+++ b/content/docs/knowledge-base/responses/model-spec.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="model-spec" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/monitoring.mdx
+++ b/content/docs/knowledge-base/responses/monitoring.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'Limitations' section (6 placeholders)
 styleGuideVersion: kb-2.0
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="monitoring" />
 
 <DataInfoBox entityId="E66" />
 

--- a/content/docs/knowledge-base/responses/multi-agent.mdx
+++ b/content/docs/knowledge-base/responses/multi-agent.mdx
@@ -17,9 +17,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="multi-agent" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/nist-ai-rmf.mdx
+++ b/content/docs/knowledge-base/responses/nist-ai-rmf.mdx
@@ -24,7 +24,7 @@ clusters:
   - "governance"
 todos: []
 ---
-import {DataInfoBox, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
 <DataInfoBox entityId="E216" />
 
@@ -503,7 +503,6 @@ The absence of standardized effectiveness metrics creates challenges for evidenc
 
 import {ArticleSources} from '@components/wiki';
 
-<DataExternalLinks pageId="nist-ai-rmf" />
 
 <ArticleSources entityId="E216" />
 

--- a/content/docs/knowledge-base/responses/open-source.mdx
+++ b/content/docs/knowledge-base/responses/open-source.mdx
@@ -20,9 +20,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {Mermaid, ModelsList, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, ModelsList, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="open-source" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/pause-moratorium.mdx
+++ b/content/docs/knowledge-base/responses/pause-moratorium.mdx
@@ -21,9 +21,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="pause-moratorium" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/pause.mdx
+++ b/content/docs/knowledge-base/responses/pause.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, KeyQuestions, DisagreementMap, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, DisagreementMap, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="pause" />
 
 <DataInfoBox entityId="E221" />
 

--- a/content/docs/knowledge-base/responses/prediction-markets.mdx
+++ b/content/docs/knowledge-base/responses/prediction-markets.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - epistemics
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="prediction-markets" />
 
 <DataInfoBox entityId="E228" />
 

--- a/content/docs/knowledge-base/responses/preference-optimization.mdx
+++ b/content/docs/knowledge-base/responses/preference-optimization.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, EntityLink, DataExternalLinks, R} from '@components/wiki';
+import {Mermaid, EntityLink, R} from '@components/wiki';
 
-<DataExternalLinks pageId="preference-optimization" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/probing.mdx
+++ b/content/docs/knowledge-base/responses/probing.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, DataExternalLinks} from '@components/wiki';
+import {Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="probing" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/process-supervision.mdx
+++ b/content/docs/knowledge-base/responses/process-supervision.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="process-supervision" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/provably-safe.mdx
+++ b/content/docs/knowledge-base/responses/provably-safe.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="provably-safe" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/public-education.mdx
+++ b/content/docs/knowledge-base/responses/public-education.mdx
@@ -22,9 +22,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="public-education" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/recoding-america.mdx
+++ b/content/docs/knowledge-base/responses/recoding-america.mdx
@@ -24,7 +24,7 @@ ratings:
 clusters:
   - governance
 ---
-import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, DataInfoBox} from '@components/wiki';
 
 <DataInfoBox>
 | Field | Value |
@@ -37,7 +37,6 @@ import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
 | **Primary Thesis** | Government technology failures stem from institutional culture that separates policy from implementation |
 </DataInfoBox>
 
-<DataExternalLinks
   officialSite="https://www.recodingamerica.us/"
 />
 

--- a/content/docs/knowledge-base/responses/red-teaming.mdx
+++ b/content/docs/knowledge-base/responses/red-teaming.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - cyber
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="red-teaming" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/refusal-training.mdx
+++ b/content/docs/knowledge-base/responses/refusal-training.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="refusal-training" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/representation-engineering.mdx
+++ b/content/docs/knowledge-base/responses/representation-engineering.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="representation-engineering" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/research-agendas.mdx
+++ b/content/docs/knowledge-base/responses/research-agendas.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {ComparisonTable, DataInfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {ComparisonTable, DataInfoBox, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="research-agendas" />
 
 <DataInfoBox entityId="E251" />
 

--- a/content/docs/knowledge-base/responses/responsible-scaling-policies.mdx
+++ b/content/docs/knowledge-base/responses/responsible-scaling-policies.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="responsible-scaling-policies" />
 
 <DataInfoBox entityId="E252" />
 

--- a/content/docs/knowledge-base/responses/reward-modeling.mdx
+++ b/content/docs/knowledge-base/responses/reward-modeling.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="reward-modeling" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/rlhf.mdx
+++ b/content/docs/knowledge-base/responses/rlhf.mdx
@@ -17,9 +17,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="rlhf" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/rsp.mdx
+++ b/content/docs/knowledge-base/responses/rsp.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="rsp" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/safety-cases.mdx
+++ b/content/docs/knowledge-base/responses/safety-cases.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="safety-cases" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/sandboxing.mdx
+++ b/content/docs/knowledge-base/responses/sandboxing.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - cyber
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sandboxing" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/scalable-eval-approaches.mdx
+++ b/content/docs/knowledge-base/responses/scalable-eval-approaches.mdx
@@ -26,9 +26,8 @@ todos:
   - Add cost comparison matrix once additional lab cost disclosures are available
 contentType: analysis
 ---
-import {EntityLink, R, Mermaid, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="scalable-eval-approaches" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/scalable-oversight.mdx
+++ b/content/docs/knowledge-base/responses/scalable-oversight.mdx
@@ -22,9 +22,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyPeople, Section, DisagreementMap, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="scalable-oversight" />
 
 <DataInfoBox entityId="E271" />
 

--- a/content/docs/knowledge-base/responses/scheming-detection.mdx
+++ b/content/docs/knowledge-base/responses/scheming-detection.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
 todos: []
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="scheming-detection" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/seoul-declaration.mdx
+++ b/content/docs/knowledge-base/responses/seoul-declaration.mdx
@@ -23,9 +23,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Limitations' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="seoul-declaration" />
 
 <DataInfoBox entityId="E279" />
 

--- a/content/docs/knowledge-base/responses/singapore-consensus.mdx
+++ b/content/docs/knowledge-base/responses/singapore-consensus.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="singapore-consensus" />
 
 <DataInfoBox entityId="E701" />
 

--- a/content/docs/knowledge-base/responses/sleeper-agent-detection.mdx
+++ b/content/docs/knowledge-base/responses/sleeper-agent-detection.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sleeper-agent-detection" />
 
 ## Research Investment & Detection Landscape
 

--- a/content/docs/knowledge-base/responses/sparse-autoencoders.mdx
+++ b/content/docs/knowledge-base/responses/sparse-autoencoders.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {Mermaid, DataExternalLinks, DataInfoBox, R, EntityLink} from '@components/wiki';
+import {Mermaid, DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sparse-autoencoders" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/squiggle.mdx
+++ b/content/docs/knowledge-base/responses/squiggle.mdx
@@ -20,7 +20,7 @@ clusters:
   - epistemics
   - community
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/squiggleai.mdx
+++ b/content/docs/knowledge-base/responses/squiggleai.mdx
@@ -21,7 +21,7 @@ clusters:
   - community
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/standards-bodies.mdx
+++ b/content/docs/knowledge-base/responses/standards-bodies.mdx
@@ -24,9 +24,8 @@ todos:
   - Complete 'Quick Assessment' section (4 placeholders)
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="standards-bodies" />
 
 <DataInfoBox entityId="E288" />
 

--- a/content/docs/knowledge-base/responses/state-capacity-ai-governance.mdx
+++ b/content/docs/knowledge-base/responses/state-capacity-ai-governance.mdx
@@ -25,7 +25,7 @@ clusters:
   - ai-safety
   - governance
 ---
-import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, DataInfoBox} from '@components/wiki';
 
 <DataInfoBox>
 | Dimension | Assessment |
@@ -39,7 +39,6 @@ import {EntityLink, R, DataInfoBox, DataExternalLinks} from '@components/wiki';
 | **Political Dimension** | Tension between state capacity libertarianism and laissez-faire approaches |
 </DataInfoBox>
 
-<DataExternalLinks
   wikipedia="https://en.wikipedia.org/wiki/State_capacity"
   officialSites={[
     {name: "Code for America", url: "https://www.codeforamerica.org/"},

--- a/content/docs/knowledge-base/responses/structured-access.mdx
+++ b/content/docs/knowledge-base/responses/structured-access.mdx
@@ -21,9 +21,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks, DataInfoBox} from '@components/wiki';
+import {Mermaid, R, EntityLink, DataInfoBox} from '@components/wiki';
 
-<DataExternalLinks pageId="structured-access" />
 
 
 ## Quick Assessment

--- a/content/docs/knowledge-base/responses/thresholds.mdx
+++ b/content/docs/knowledge-base/responses/thresholds.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
 styleGuideVersion: kb-2.0
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="thresholds" />
 
 <DataInfoBox entityId="E67" />
 

--- a/content/docs/knowledge-base/responses/tool-restrictions.mdx
+++ b/content/docs/knowledge-base/responses/tool-restrictions.mdx
@@ -21,9 +21,8 @@ clusters:
   - governance
   - cyber
 ---
-import {Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="tool-restrictions" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/training-programs.mdx
+++ b/content/docs/knowledge-base/responses/training-programs.mdx
@@ -20,9 +20,8 @@ clusters:
   - community
   - ai-safety
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="training-programs" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/us-executive-order.mdx
+++ b/content/docs/knowledge-base/responses/us-executive-order.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="us-executive-order" />
 
 <DataInfoBox entityId="E366" />
 

--- a/content/docs/knowledge-base/responses/voluntary-commitments.mdx
+++ b/content/docs/knowledge-base/responses/voluntary-commitments.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="voluntary-commitments" />
 
 <DataInfoBox entityId="E369" />
 

--- a/content/docs/knowledge-base/responses/weak-to-strong.mdx
+++ b/content/docs/knowledge-base/responses/weak-to-strong.mdx
@@ -19,9 +19,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="weak-to-strong" />
 
 ## Overview
 

--- a/content/docs/knowledge-base/responses/whistleblower-protections.mdx
+++ b/content/docs/knowledge-base/responses/whistleblower-protections.mdx
@@ -20,9 +20,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="whistleblower-protections" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/responses/xpt.mdx
+++ b/content/docs/knowledge-base/responses/xpt.mdx
@@ -21,7 +21,7 @@ clusters:
   - ai-safety
   - community
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/risks/ai-enabled-untraceable-misuse.mdx
+++ b/content/docs/knowledge-base/risks/ai-enabled-untraceable-misuse.mdx
@@ -23,7 +23,7 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
 ## Overview
 

--- a/content/docs/knowledge-base/risks/ai-investigation-risks.mdx
+++ b/content/docs/knowledge-base/risks/ai-investigation-risks.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
   - cyber
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="ai-investigation-risks" />
 
 <DataInfoBox entityId="E694" />
 

--- a/content/docs/knowledge-base/risks/authentication-collapse.mdx
+++ b/content/docs/knowledge-base/risks/authentication-collapse.mdx
@@ -22,9 +22,8 @@ clusters:
   - epistemics
   - ai-safety
 ---
-import {DataInfoBox, KeyQuestions, R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="authentication-collapse" />
 
 <DataInfoBox entityId="E27" />
 

--- a/content/docs/knowledge-base/risks/authoritarian-takeover.mdx
+++ b/content/docs/knowledge-base/risks/authoritarian-takeover.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="authoritarian-takeover" />
 
 <DataInfoBox entityId="E29" />
 

--- a/content/docs/knowledge-base/risks/authoritarian-tools.mdx
+++ b/content/docs/knowledge-base/risks/authoritarian-tools.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="authoritarian-tools" />
 
 <DataInfoBox entityId="E30" />
 

--- a/content/docs/knowledge-base/risks/automation-bias.mdx
+++ b/content/docs/knowledge-base/risks/automation-bias.mdx
@@ -21,9 +21,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="automation-bias" />
 
 <DataInfoBox entityId="E32" />
 

--- a/content/docs/knowledge-base/risks/autonomous-weapons.mdx
+++ b/content/docs/knowledge-base/risks/autonomous-weapons.mdx
@@ -26,9 +26,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="autonomous-weapons" />
 
 <DataInfoBox entityId="E35" />
 

--- a/content/docs/knowledge-base/risks/bioweapons.mdx
+++ b/content/docs/knowledge-base/risks/bioweapons.mdx
@@ -25,9 +25,8 @@ clusters:
 styleGuideVersion: kb-2.0
 ---
 
-import {DataInfoBox, ModelsList, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, ModelsList, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="bioweapons" />
 
 <DataInfoBox entityId="E42" />
 

--- a/content/docs/knowledge-base/risks/compute-concentration.mdx
+++ b/content/docs/knowledge-base/risks/compute-concentration.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
 seeAlso: concentration-of-power
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="compute-concentration" />
 
 <DataInfoBox entityId="E684" />
 

--- a/content/docs/knowledge-base/risks/concentrated-compute-cybersecurity-risk.mdx
+++ b/content/docs/knowledge-base/risks/concentrated-compute-cybersecurity-risk.mdx
@@ -23,9 +23,8 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="concentrated-compute-cybersecurity-risk" />
 
 <DataInfoBox entityId="concentrated-compute-cybersecurity-risk" />
 

--- a/content/docs/knowledge-base/risks/concentration-of-power.mdx
+++ b/content/docs/knowledge-base/risks/concentration-of-power.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
 seeAlso: ai-control-concentration
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="concentration-of-power" />
 
 <DataInfoBox entityId="E68" />
 

--- a/content/docs/knowledge-base/risks/consensus-manufacturing.mdx
+++ b/content/docs/knowledge-base/risks/consensus-manufacturing.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, ModelsList, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, ModelsList, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="consensus-manufacturing" />
 
 <DataInfoBox entityId="E72" />
 

--- a/content/docs/knowledge-base/risks/corrigibility-failure.mdx
+++ b/content/docs/knowledge-base/risks/corrigibility-failure.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'Risk Assessment' section (4 placeholders)
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="corrigibility-failure" />
 
 <DataInfoBox entityId="E80" />
 

--- a/content/docs/knowledge-base/risks/cyber-psychosis.mdx
+++ b/content/docs/knowledge-base/risks/cyber-psychosis.mdx
@@ -26,9 +26,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="cyber-psychosis" />
 
 <DataInfoBox entityId="E83" />
 

--- a/content/docs/knowledge-base/risks/cyberweapons.mdx
+++ b/content/docs/knowledge-base/risks/cyberweapons.mdx
@@ -23,9 +23,8 @@ clusters:
   - cyber
   - ai-safety
 ---
-import {DataInfoBox, ModelsList, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, ModelsList, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="cyberweapons" />
 
 <DataInfoBox entityId="E86" />
 

--- a/content/docs/knowledge-base/risks/deanonymization.mdx
+++ b/content/docs/knowledge-base/risks/deanonymization.mdx
@@ -19,9 +19,8 @@ clusters:
   - governance
   - cyber
 ---
-import {EntityLink, DataExternalLinks} from '@components/wiki';
+import {EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deanonymization" />
 
 :::note[Related Pages]
 This page covers **deanonymization** as a specific AI risk. For the broader AI investigation capability, see <EntityLink id="ai-powered-investigation">AI-Powered Investigation</EntityLink>. For the broader risk assessment including chilling effects, see <EntityLink id="ai-investigation-risks">AI-Powered Investigation Risks</EntityLink>. For the beneficial counterpart, see <EntityLink id="ai-accountability">AI for Accountability and Anti-Corruption</EntityLink>.

--- a/content/docs/knowledge-base/risks/deceptive-alignment.mdx
+++ b/content/docs/knowledge-base/risks/deceptive-alignment.mdx
@@ -23,9 +23,8 @@ clusters:
 todos:
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, DisagreementMap, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, DisagreementMap, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="deceptive-alignment" />
 
 <DataInfoBox entityId="E93" />
 

--- a/content/docs/knowledge-base/risks/deepfakes.mdx
+++ b/content/docs/knowledge-base/risks/deepfakes.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="deepfakes" />
 
 <DataInfoBox entityId="E96" />
 

--- a/content/docs/knowledge-base/risks/disinformation.mdx
+++ b/content/docs/knowledge-base/risks/disinformation.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="disinformation" />
 
 <DataInfoBox entityId="E102" />
 

--- a/content/docs/knowledge-base/risks/distributional-shift.mdx
+++ b/content/docs/knowledge-base/risks/distributional-shift.mdx
@@ -21,7 +21,7 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, R, Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
 <DataInfoBox entityId="E105" />
 
@@ -249,4 +249,3 @@ The relationship between distributional shift and AI alignment in advanced syste
 
 Finally, there's significant uncertainty about the ultimate solvability of the distributional shift problem. Some researchers argue that perfect robustness is impossible given the infinite variety of possible deployment contexts, while others believe that sufficiently sophisticated AI systems will naturally develop robust generalization capabilities. The resolution of this debate has profound implications for the long-term safety and reliability of AI systems.
 
-<DataExternalLinks pageId="distributional-shift" />

--- a/content/docs/knowledge-base/risks/economic-disruption.mdx
+++ b/content/docs/knowledge-base/risks/economic-disruption.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
 seeAlso: economic-stability
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="economic-disruption" />
 
 <DataInfoBox entityId="E108" />
 

--- a/content/docs/knowledge-base/risks/emergent-capabilities.mdx
+++ b/content/docs/knowledge-base/risks/emergent-capabilities.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="emergent-capabilities" />
 
 <DataInfoBox entityId="E117" />
 

--- a/content/docs/knowledge-base/risks/enfeeblement.mdx
+++ b/content/docs/knowledge-base/risks/enfeeblement.mdx
@@ -22,9 +22,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="enfeeblement" />
 
 <DataInfoBox entityId="E118" />
 

--- a/content/docs/knowledge-base/risks/epistemic-collapse.mdx
+++ b/content/docs/knowledge-base/risks/epistemic-collapse.mdx
@@ -25,9 +25,8 @@ clusters:
   - ai-safety
 seeAlso: epistemic-health
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="epistemic-collapse" />
 
 <DataInfoBox entityId="E119" />
 

--- a/content/docs/knowledge-base/risks/epistemic-sycophancy.mdx
+++ b/content/docs/knowledge-base/risks/epistemic-sycophancy.mdx
@@ -25,9 +25,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="epistemic-sycophancy" />
 
 <DataInfoBox entityId="E124" />
 

--- a/content/docs/knowledge-base/risks/erosion-of-agency.mdx
+++ b/content/docs/knowledge-base/risks/erosion-of-agency.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
 seeAlso: human-agency
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="erosion-of-agency" />
 
 <DataInfoBox entityId="E126" />
 

--- a/content/docs/knowledge-base/risks/expertise-atrophy.mdx
+++ b/content/docs/knowledge-base/risks/expertise-atrophy.mdx
@@ -24,9 +24,8 @@ clusters:
   - epistemics
 seeAlso: human-expertise
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="expertise-atrophy" />
 
 <DataInfoBox entityId="E133" />
 

--- a/content/docs/knowledge-base/risks/financial-stability-risks-ai-capex.mdx
+++ b/content/docs/knowledge-base/risks/financial-stability-risks-ai-capex.mdx
@@ -23,9 +23,8 @@ clusters:
   - "ai-safety"
   - "governance"
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="financial-stability-risks-ai-capex" />
 
 <DataInfoBox entityId="financial-stability-risks-ai-capex" />
 

--- a/content/docs/knowledge-base/risks/flash-dynamics.mdx
+++ b/content/docs/knowledge-base/risks/flash-dynamics.mdx
@@ -25,9 +25,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R} from '@components/wiki';
 
-<DataExternalLinks pageId="flash-dynamics" />
 
 <DataInfoBox entityId="E142" />
 

--- a/content/docs/knowledge-base/risks/fraud.mdx
+++ b/content/docs/knowledge-base/risks/fraud.mdx
@@ -25,9 +25,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="fraud" />
 
 <DataInfoBox entityId="E145" />
 

--- a/content/docs/knowledge-base/risks/goal-misgeneralization.mdx
+++ b/content/docs/knowledge-base/risks/goal-misgeneralization.mdx
@@ -22,9 +22,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="goal-misgeneralization" />
 
 <DataInfoBox entityId="E151" />
 

--- a/content/docs/knowledge-base/risks/historical-revisionism.mdx
+++ b/content/docs/knowledge-base/risks/historical-revisionism.mdx
@@ -26,9 +26,8 @@ todos:
   - Complete 'How It Works' section
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="historical-revisionism" />
 
 <DataInfoBox entityId="E155" />
 

--- a/content/docs/knowledge-base/risks/institutional-capture.mdx
+++ b/content/docs/knowledge-base/risks/institutional-capture.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, KeyQuestions, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="institutional-capture" />
 
 <DataInfoBox entityId="E166" />
 

--- a/content/docs/knowledge-base/risks/instrumental-convergence.mdx
+++ b/content/docs/knowledge-base/risks/instrumental-convergence.mdx
@@ -21,9 +21,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="instrumental-convergence" />
 
 <DataInfoBox entityId="E168" />
 

--- a/content/docs/knowledge-base/risks/irreversibility.mdx
+++ b/content/docs/knowledge-base/risks/irreversibility.mdx
@@ -25,9 +25,8 @@ clusters:
 todos:
   - Complete 'Risk Assessment' section (4 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="irreversibility" />
 
 <DataInfoBox entityId="E179" />
 

--- a/content/docs/knowledge-base/risks/knowledge-monopoly.mdx
+++ b/content/docs/knowledge-base/risks/knowledge-monopoly.mdx
@@ -25,9 +25,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="knowledge-monopoly" />
 
 <DataInfoBox entityId="E183" />
 

--- a/content/docs/knowledge-base/risks/learned-helplessness.mdx
+++ b/content/docs/knowledge-base/risks/learned-helplessness.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="learned-helplessness" />
 
 <DataInfoBox entityId="E187" />
 

--- a/content/docs/knowledge-base/risks/legal-evidence-crisis.mdx
+++ b/content/docs/knowledge-base/risks/legal-evidence-crisis.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Complete 'Risk Assessment' section (4 placeholders)
 ---
-import {DataInfoBox, KeyQuestions, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="legal-evidence-crisis" />
 
 <DataInfoBox entityId="E188" />
 

--- a/content/docs/knowledge-base/risks/lock-in.mdx
+++ b/content/docs/knowledge-base/risks/lock-in.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Complete 'Risk Assessment' section (4 placeholders)
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="lock-in" />
 
 <DataInfoBox entityId="E189" />
 

--- a/content/docs/knowledge-base/risks/mesa-optimization.mdx
+++ b/content/docs/knowledge-base/risks/mesa-optimization.mdx
@@ -21,9 +21,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="mesa-optimization" />
 
 <DataInfoBox entityId="E197" />
 

--- a/content/docs/knowledge-base/risks/multipolar-trap.mdx
+++ b/content/docs/knowledge-base/risks/multipolar-trap.mdx
@@ -23,9 +23,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, Mermaid, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="multipolar-trap" />
 
 <DataInfoBox entityId="E209" />
 

--- a/content/docs/knowledge-base/risks/power-seeking.mdx
+++ b/content/docs/knowledge-base/risks/power-seeking.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="power-seeking" />
 
 <DataInfoBox entityId="E226" />
 

--- a/content/docs/knowledge-base/risks/preference-manipulation.mdx
+++ b/content/docs/knowledge-base/risks/preference-manipulation.mdx
@@ -24,9 +24,8 @@ clusters:
   - epistemics
 seeAlso: preference-authenticity
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="preference-manipulation" />
 
 <DataInfoBox entityId="E230" />
 

--- a/content/docs/knowledge-base/risks/proliferation.mdx
+++ b/content/docs/knowledge-base/risks/proliferation.mdx
@@ -24,9 +24,8 @@ clusters:
 todos:
   - Monitor emerging international coordination efforts; track effectiveness of compute governance measures; analyze impact of new open-source models on proliferation dynamics
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="proliferation" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/risks/racing-dynamics.mdx
+++ b/content/docs/knowledge-base/risks/racing-dynamics.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="racing-dynamics" />
 
 <DataInfoBox entityId="E239" />
 

--- a/content/docs/knowledge-base/risks/reality-fragmentation.mdx
+++ b/content/docs/knowledge-base/risks/reality-fragmentation.mdx
@@ -28,9 +28,8 @@ todos:
   - Include more intervention research
 seeAlso: reality-coherence
 ---
-import {DataInfoBox, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="reality-fragmentation" />
 
 <DataInfoBox entityId="E244" />
 

--- a/content/docs/knowledge-base/risks/reward-hacking.mdx
+++ b/content/docs/knowledge-base/risks/reward-hacking.mdx
@@ -21,9 +21,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="reward-hacking" />
 
 <DataInfoBox entityId="E253" />
 

--- a/content/docs/knowledge-base/risks/rogue-ai-scenarios.mdx
+++ b/content/docs/knowledge-base/risks/rogue-ai-scenarios.mdx
@@ -25,9 +25,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="rogue-ai-scenarios" />
 
 <DataInfoBox entityId="E490" />
 

--- a/content/docs/knowledge-base/risks/sandbagging.mdx
+++ b/content/docs/knowledge-base/risks/sandbagging.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {DataInfoBox, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sandbagging" />
 
 <DataInfoBox entityId="E270" />
 

--- a/content/docs/knowledge-base/risks/scheming.mdx
+++ b/content/docs/knowledge-base/risks/scheming.mdx
@@ -30,9 +30,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks, KeyTakeaways} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink, KeyTakeaways} from '@components/wiki';
 
-<DataExternalLinks pageId="scheming" />
 
 <DataInfoBox entityId="E274" />
 

--- a/content/docs/knowledge-base/risks/scientific-corruption.mdx
+++ b/content/docs/knowledge-base/risks/scientific-corruption.mdx
@@ -22,9 +22,8 @@ clusters:
   - epistemics
   - ai-safety
 ---
-import {DataInfoBox, KeyQuestions, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="scientific-corruption" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/risks/sharp-left-turn.mdx
+++ b/content/docs/knowledge-base/risks/sharp-left-turn.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
   - governance
 ---
-import {DataInfoBox, Mermaid, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="sharp-left-turn" />
 
 <DataInfoBox entityId="E281" />
 

--- a/content/docs/knowledge-base/risks/steganography.mdx
+++ b/content/docs/knowledge-base/risks/steganography.mdx
@@ -20,9 +20,8 @@ ratings:
 clusters:
   - ai-safety
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="steganography" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/risks/surveillance.mdx
+++ b/content/docs/knowledge-base/risks/surveillance.mdx
@@ -23,9 +23,8 @@ clusters:
   - governance
   - cyber
 ---
-import {DataInfoBox, Mermaid, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="surveillance" />
 
 <DataInfoBox entityId="E292" />
 

--- a/content/docs/knowledge-base/risks/sycophancy.mdx
+++ b/content/docs/knowledge-base/risks/sycophancy.mdx
@@ -23,9 +23,8 @@ clusters:
 todos:
   - Complete 'Key Uncertainties' section (6 placeholders)
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="sycophancy" />
 
 <DataInfoBox entityId="E295" />
 

--- a/content/docs/knowledge-base/risks/treacherous-turn.mdx
+++ b/content/docs/knowledge-base/risks/treacherous-turn.mdx
@@ -22,9 +22,8 @@ clusters:
   - ai-safety
 todos: []
 ---
-import {DataInfoBox, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="treacherous-turn" />
 
 <DataInfoBox entityId="E359" />
 

--- a/content/docs/knowledge-base/risks/trust-cascade.mdx
+++ b/content/docs/knowledge-base/risks/trust-cascade.mdx
@@ -52,9 +52,8 @@ tags:
   - deepfakes
   - cascade-failure
 ---
-import {DataInfoBox, KeyQuestions, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {DataInfoBox, KeyQuestions, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="trust-cascade" />
 
 <DataInfoBox entityId="E360" />
 

--- a/content/docs/knowledge-base/risks/trust-decline.mdx
+++ b/content/docs/knowledge-base/risks/trust-decline.mdx
@@ -24,9 +24,8 @@ clusters:
   - governance
 seeAlso: societal-trust
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks, Mermaid} from '@components/wiki';
+import {DataInfoBox, R, EntityLink, Mermaid} from '@components/wiki';
 
-<DataExternalLinks pageId="trust-decline" />
 
 <DataInfoBox entityId="E362" />
 

--- a/content/docs/knowledge-base/risks/winner-take-all.mdx
+++ b/content/docs/knowledge-base/risks/winner-take-all.mdx
@@ -25,9 +25,8 @@ clusters:
 todos:
   - Complete 'How It Works' section
 ---
-import {DataInfoBox, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="winner-take-all" />
 
 <DataInfoBox entityId="E374" />
 

--- a/content/docs/knowledge-base/worldviews/doomer.mdx
+++ b/content/docs/knowledge-base/worldviews/doomer.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 6
 clusters: ["ai-safety", "epistemics"]
 ---
-import {Tags, R, EntityLink, DataExternalLinks} from '@components/wiki';
+import {Tags, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="doomer" />
 
 **Core belief**: Advanced AI will be developed soon, alignment is fundamentally hard, and catastrophe is likely unless drastic action is taken.
 

--- a/content/docs/knowledge-base/worldviews/governance-focused.mdx
+++ b/content/docs/knowledge-base/worldviews/governance-focused.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 7.5
 clusters: ["epistemics", "governance", "ai-safety"]
 ---
-import {Tags, Mermaid, R, DataExternalLinks, EntityLink} from '@components/wiki';
+import {Tags, Mermaid, R, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="governance-focused" />
 
 ## Quick Assessment
 

--- a/content/docs/knowledge-base/worldviews/long-timelines.mdx
+++ b/content/docs/knowledge-base/worldviews/long-timelines.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 6.5
 clusters: ["ai-safety", "epistemics"]
 ---
-import {Tags, R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {Tags, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="long-timelines" />
 
 ### Quick Assessment
 

--- a/content/docs/knowledge-base/worldviews/optimistic.mdx
+++ b/content/docs/knowledge-base/worldviews/optimistic.mdx
@@ -15,9 +15,8 @@ ratings:
   completeness: 7
 clusters: ["ai-safety", "epistemics"]
 ---
-import {Tags, R, DataExternalLinks, Mermaid, EntityLink} from '@components/wiki';
+import {Tags, R, Mermaid, EntityLink} from '@components/wiki';
 
-<DataExternalLinks pageId="optimistic" />
 
 ## Quick Assessment
 

--- a/content/docs/tools/resources.mdx
+++ b/content/docs/tools/resources.mdx
@@ -17,9 +17,8 @@ ratings:
 clusters: []
 tableOfContents: false
 ---
-import {ResourcesIndex, DataExternalLinks} from '@components/wiki';
+import {ResourcesIndex} from '@components/wiki';
 
-<DataExternalLinks pageId="resources" />
 
 Browse all external resources (papers, books, blog posts, reports, etc.) referenced throughout the knowledge base. Use the filters to find resources by type or search by title/author.
 


### PR DESCRIPTION
## Summary

- Removed all `<DataExternalLinks pageId="..." />` component invocations from 323 MDX files
- Also removed associated import statements (both standalone `import {DataExternalLinks}` lines and mixed imports where it was combined with other components)
- External links are auto-injected via the DataInfoBox sidebar component, so these invocations were dead code

## Changes

- 323 MDX content files: removed `<DataExternalLinks>` usage lines and cleaned up imports
- No functional changes — external links still render correctly via DataInfoBox
- The component file itself (`DataExternalLinks.tsx`) and its registration in `mdx-components.tsx` are preserved for backward compatibility

## Notes

- The issue mentions 617 files; the current repo has 323 files with this component after recent merges to main reduced the count
- One prose mention of `DataExternalLinks` remains in `content/docs/internal/reports/website-consistency-audit-2026-02.mdx` — this is documentation text in backticks describing old page structure, not an actual component invocation

Closes #855
