### PR TITLE
feat: add /internal/reviews dashboard for human review tracking

### DIFF
--- a/apps/web/src/app/internal/reviews/page.tsx
+++ b/apps/web/src/app/internal/reviews/page.tsx
@@ -1,0 +1,241 @@
+import fs from "fs";
+import path from "path";
+import { parse as parseYaml } from "yaml";
+import { getAllPages } from "@/data";
+import { ReviewsDashboard } from "./reviews-dashboard";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Human Reviews | Longterm Wiki Internal",
+  description:
+    "Human review tracking — coverage, staleness alerts, and unreviewed high-risk pages.",
+};
+
+// ---------------------------------------------------------------------------
+// Data types (mirroring crux/lib/review-tracking.ts)
+// ---------------------------------------------------------------------------
+
+interface ReviewEntry {
+  date: string;
+  reviewer: string;
+  scope?: string;
+  note?: string;
+}
+
+export interface ReviewedPageRow {
+  pageId: string;
+  title: string;
+  entityType: string | undefined;
+  reviewer: string;
+  date: string;
+  scope: string | undefined;
+  note: string | undefined;
+  reviewCount: number;
+  daysSinceReview: number;
+  stale: boolean;
+}
+
+export interface UnreviewedHighRiskRow {
+  pageId: string;
+  title: string;
+  entityType: string | undefined;
+  riskLevel: "low" | "medium" | "high";
+  riskScore: number;
+}
+
+export interface ReviewerStat {
+  reviewer: string;
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Data loading
+// ---------------------------------------------------------------------------
+
+const REVIEWS_DIR = path.resolve(process.cwd(), "../../data/reviews");
+
+function loadReviewFiles(): Map<string, ReviewEntry[]> {
+  const map = new Map<string, ReviewEntry[]>();
+  if (!fs.existsSync(REVIEWS_DIR)) return map;
+
+  try {
+    const files = fs.readdirSync(REVIEWS_DIR).filter((f) => f.endsWith(".yaml"));
+    for (const file of files) {
+      const pageId = file.replace(/\.yaml$/, "");
+      try {
+        const raw = fs.readFileSync(path.join(REVIEWS_DIR, file), "utf-8");
+        const parsed = parseYaml(raw);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          map.set(pageId, parsed as ReviewEntry[]);
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+  } catch {
+    // Reviews dir not readable
+  }
+
+  return map;
+}
+
+function daysSince(dateStr: string): number {
+  const today = new Date();
+  const reviewed = new Date(dateStr);
+  return Math.floor((today.getTime() - reviewed.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+// ---------------------------------------------------------------------------
+// Stat card component (server-rendered)
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <div className="text-xs text-muted-foreground mb-1">{label}</div>
+      <div className={`text-2xl font-bold tabular-nums ${color || ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export default function ReviewsPage() {
+  const allPages = getAllPages();
+  const reviewFiles = loadReviewFiles();
+
+  // Build reviewed pages table
+  const reviewedRows: ReviewedPageRow[] = [];
+  for (const [pageId, entries] of reviewFiles) {
+    const page = allPages.find((p) => p.id === pageId);
+    const last = entries[entries.length - 1];
+    const days = daysSince(last.date);
+    reviewedRows.push({
+      pageId,
+      title: page?.title || pageId,
+      entityType: page?.entityType,
+      reviewer: last.reviewer,
+      date: last.date,
+      scope: last.scope,
+      note: last.note,
+      reviewCount: entries.length,
+      daysSinceReview: days,
+      stale: days > 90,
+    });
+  }
+
+  // Sort by most recent first
+  reviewedRows.sort((a, b) => b.date.localeCompare(a.date));
+
+  // Unreviewed high-risk pages
+  const reviewedIds = new Set(reviewFiles.keys());
+  const unreviewedHighRisk: UnreviewedHighRiskRow[] = allPages
+    .filter(
+      (p) =>
+        !reviewedIds.has(p.id) &&
+        p.hallucinationRisk &&
+        (p.hallucinationRisk.level === "high" || p.hallucinationRisk.level === "medium")
+    )
+    .map((p) => ({
+      pageId: p.id,
+      title: p.title,
+      entityType: p.entityType,
+      riskLevel: p.hallucinationRisk!.level,
+      riskScore: p.hallucinationRisk!.score,
+    }))
+    .sort((a, b) => b.riskScore - a.riskScore)
+    .slice(0, 50); // Show top 50 unreviewed high-risk pages
+
+  // By-reviewer breakdown
+  const reviewerMap = new Map<string, number>();
+  for (const [, entries] of reviewFiles) {
+    for (const e of entries) {
+      reviewerMap.set(e.reviewer, (reviewerMap.get(e.reviewer) || 0) + 1);
+    }
+  }
+  const reviewerStats: ReviewerStat[] = [...reviewerMap.entries()]
+    .map(([reviewer, count]) => ({ reviewer, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Summary stats
+  const totalPages = allPages.length;
+  const reviewedCount = reviewedRows.length;
+  const staleCount = reviewedRows.filter((r) => r.stale).length;
+  const coveragePct =
+    totalPages > 0 ? Math.round((reviewedCount / totalPages) * 100) : 0;
+
+  return (
+    <article className="prose max-w-none">
+      <h1>Human Review Tracking</h1>
+      <p className="text-muted-foreground">
+        Pages manually reviewed by humans to verify accuracy. Use{" "}
+        <code className="text-[11px]">pnpm crux review mark &lt;page-id&gt; --reviewer=&quot;name&quot;</code>{" "}
+        to mark a page as reviewed.
+      </p>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 not-prose mb-6">
+        <StatCard label="Total Pages" value={totalPages} />
+        <StatCard
+          label="Reviewed"
+          value={`${reviewedCount} (${coveragePct}%)`}
+          color="text-emerald-600"
+        />
+        <StatCard
+          label="Unreviewed"
+          value={totalPages - reviewedCount}
+          color={totalPages - reviewedCount > 0 ? "text-amber-600" : ""}
+        />
+        <StatCard
+          label="Stale (>90 days)"
+          value={staleCount}
+          color={staleCount > 0 ? "text-red-600" : ""}
+        />
+      </div>
+
+      {/* By-reviewer breakdown */}
+      {reviewerStats.length > 0 && (
+        <div className="not-prose mb-6">
+          <h3 className="text-sm font-semibold mb-3">Reviews by Reviewer</h3>
+          <div className="flex gap-2 flex-wrap">
+            {reviewerStats.map(({ reviewer, count }) => (
+              <span
+                key={reviewer}
+                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium bg-muted text-muted-foreground"
+              >
+                {reviewer}
+                <span className="tabular-nums font-semibold">{count}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Interactive tables */}
+      <ReviewsDashboard
+        reviewedRows={reviewedRows}
+        unreviewedHighRisk={unreviewedHighRisk}
+      />
+
+      <p className="text-xs text-muted-foreground mt-4">
+        Review records stored in{" "}
+        <code className="text-[11px]">data/reviews/&lt;page-id&gt;.yaml</code>.
+        Staleness threshold: 90 days. Run{" "}
+        <code className="text-[11px]">pnpm crux review list</code> for a CLI
+        report.
+      </p>
+    </article>
+  );
+}

--- a/apps/web/src/app/internal/reviews/reviews-dashboard.tsx
+++ b/apps/web/src/app/internal/reviews/reviews-dashboard.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import type { ReviewedPageRow, UnreviewedHighRiskRow } from "./page";
+
+// ---------------------------------------------------------------------------
+// Reviewed pages table
+// ---------------------------------------------------------------------------
+
+function StaleBadge({ stale }: { stale: boolean }) {
+  if (!stale) return null;
+  return (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-red-500/15 text-red-500">
+      stale
+    </span>
+  );
+}
+
+function ScopeBadge({ scope }: { scope: string | undefined }) {
+  if (!scope) return <span className="text-xs text-muted-foreground">-</span>;
+  return (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+      {scope}
+    </span>
+  );
+}
+
+const reviewedColumns: ColumnDef<ReviewedPageRow>[] = [
+  {
+    accessorKey: "title",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Page</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={`/wiki/${row.original.pageId}`}
+        className="text-sm font-medium text-accent-foreground hover:underline no-underline"
+      >
+        {row.original.title}
+      </Link>
+    ),
+    filterFn: "includesString",
+  },
+  {
+    accessorKey: "reviewer",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Reviewer</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm">{row.original.reviewer}</span>
+    ),
+  },
+  {
+    accessorKey: "date",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Date</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm tabular-nums text-muted-foreground">
+        {row.original.date}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "daysSinceReview",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Days Ago</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <div className="flex items-center gap-2">
+        <span className="text-sm tabular-nums text-muted-foreground">
+          {row.original.daysSinceReview}d
+        </span>
+        <StaleBadge stale={row.original.stale} />
+      </div>
+    ),
+  },
+  {
+    accessorKey: "scope",
+    header: "Scope",
+    cell: ({ row }) => <ScopeBadge scope={row.original.scope} />,
+    enableSorting: false,
+  },
+  {
+    accessorKey: "reviewCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Reviews</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {row.original.reviewCount}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "entityType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.entityType || "-"}
+      </span>
+    ),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Unreviewed high-risk pages table
+// ---------------------------------------------------------------------------
+
+function RiskLevelBadge({ level }: { level: "low" | "medium" | "high" }) {
+  const config = {
+    high: "bg-red-500/15 text-red-500",
+    medium: "bg-amber-500/15 text-amber-500",
+    low: "bg-emerald-500/15 text-emerald-500",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${config[level]}`}
+    >
+      {level}
+    </span>
+  );
+}
+
+const unreviewedColumns: ColumnDef<UnreviewedHighRiskRow>[] = [
+  {
+    accessorKey: "title",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Page</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={`/wiki/${row.original.pageId}`}
+        className="text-sm font-medium text-accent-foreground hover:underline no-underline"
+      >
+        {row.original.title}
+      </Link>
+    ),
+    filterFn: "includesString",
+  },
+  {
+    accessorKey: "riskScore",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Risk Score</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm tabular-nums font-medium">
+        {row.original.riskScore}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "riskLevel",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Risk Level</SortableHeader>
+    ),
+    cell: ({ row }) => <RiskLevelBadge level={row.original.riskLevel} />,
+  },
+  {
+    accessorKey: "entityType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.entityType || "-"}
+      </span>
+    ),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Main dashboard component
+// ---------------------------------------------------------------------------
+
+type ActiveTab = "reviewed" | "unreviewed";
+
+export function ReviewsDashboard({
+  reviewedRows,
+  unreviewedHighRisk,
+}: {
+  reviewedRows: ReviewedPageRow[];
+  unreviewedHighRisk: UnreviewedHighRiskRow[];
+}) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("reviewed");
+  const [showStaleOnly, setShowStaleOnly] = useState(false);
+
+  const filteredReviewed = showStaleOnly
+    ? reviewedRows.filter((r) => r.stale)
+    : reviewedRows;
+
+  const staleCount = reviewedRows.filter((r) => r.stale).length;
+
+  return (
+    <div className="not-prose space-y-4">
+      {/* Tab switcher */}
+      <div className="flex gap-2 flex-wrap items-center">
+        <button
+          onClick={() => setActiveTab("reviewed")}
+          className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+            activeTab === "reviewed"
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+        >
+          Reviewed{" "}
+          <span className="tabular-nums">({reviewedRows.length})</span>
+        </button>
+        <button
+          onClick={() => setActiveTab("unreviewed")}
+          className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+            activeTab === "unreviewed"
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+        >
+          Unreviewed High-Risk{" "}
+          <span className="tabular-nums">({unreviewedHighRisk.length})</span>
+        </button>
+      </div>
+
+      {/* Reviewed pages panel */}
+      {activeTab === "reviewed" && (
+        <div className="space-y-3">
+          {staleCount > 0 && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowStaleOnly(!showStaleOnly)}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  showStaleOnly
+                    ? "bg-red-500/15 text-red-600"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+                }`}
+              >
+                Stale only{" "}
+                <span className="tabular-nums">({staleCount})</span>
+              </button>
+              {showStaleOnly && (
+                <button
+                  onClick={() => setShowStaleOnly(false)}
+                  className="px-3 py-1.5 rounded-md text-xs font-medium bg-muted text-muted-foreground hover:bg-muted/80 transition-colors"
+                >
+                  Show all
+                </button>
+              )}
+            </div>
+          )}
+          {filteredReviewed.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-8 text-center">
+              No reviewed pages yet. Run{" "}
+              <code className="text-[11px]">
+                pnpm crux review mark &lt;page-id&gt; --reviewer=&quot;name&quot;
+              </code>{" "}
+              to mark a page as reviewed.
+            </p>
+          ) : (
+            <DataTable
+              columns={reviewedColumns}
+              data={filteredReviewed}
+              searchPlaceholder="Search reviewed pages..."
+            />
+          )}
+        </div>
+      )}
+
+      {/* Unreviewed high-risk panel */}
+      {activeTab === "unreviewed" && (
+        <div className="space-y-3">
+          {unreviewedHighRisk.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-8 text-center">
+              No unreviewed high-risk or medium-risk pages found.
+            </p>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground">
+                Unreviewed pages with medium or high hallucination risk — sorted
+                by risk score descending. These are the highest-priority
+                candidates for human review.
+              </p>
+              <DataTable
+                columns={unreviewedColumns}
+                data={unreviewedHighRisk}
+                searchPlaceholder="Search high-risk pages..."
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -348,6 +348,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Citation Content", href: "/internal/citation-content" },
         { label: "Hallucination Risk", href: "/internal/hallucination-risk" },
         { label: "Hallucination Evals", href: "/internal/hallucination-evals" },
+        { label: "Human Reviews", href: "/internal/reviews" },
         { label: "Improve Runs", href: "/internal/improve-runs" },
         { label: "Job Queue", href: "/internal/jobs" },
       ],


### PR DESCRIPTION
## Summary

Builds the `/internal/reviews` dashboard for human review tracking (issue #213).

- **Server component** (`page.tsx`) reads `data/reviews/*.yaml` via `fs` + `yaml`, cross-references `getAllPages()` for page metadata and hallucination risk scores, computes summary stats
- **Client component** (`reviews-dashboard.tsx`) renders two interactive `DataTable` views: reviewed pages and unreviewed high-risk pages
- **Navigation entry** added to the "Dashboards & Tools" section in `wiki-nav.ts`

## Acceptance Criteria

- [x] Dashboard at `/internal/reviews` shows review coverage
- [x] Reviewed pages table with reviewer, date, staleness (>90 days = stale)
- [x] Unreviewed high-risk pages highlighted (cross-referenced with hallucination risk scores, top 50 by score)
- [x] Navigation entry added to `wiki-nav.ts` under "Dashboards & Tools"
- [x] By-reviewer breakdown (pill badges showing each reviewer's total count)
- [x] Staleness alerts (stale badge on rows, filterable "stale only" toggle)

## Features implemented

1. **Review coverage summary**: 4-card stat grid — Total Pages, Reviewed (with %), Unreviewed, Stale (>90 days)
2. **Reviewed pages table**: Page title (linked), reviewer, date, days-ago, stale badge, scope badge, review count, entity type — sortable + searchable
3. **Unreviewed high-risk pages**: Cross-referenced with `hallucinationRisk` from `database.json`, shows medium+high risk pages sorted by score descending
4. **By-reviewer breakdown**: Pill badges showing per-reviewer totals
5. **Staleness alerts**: Red "stale" badge on rows >90 days old; "stale only" filter button
6. **Empty state**: Graceful message when no reviews exist yet

## Technical notes

- Reads `data/reviews/*.yaml` directly via `fs` (same directory used by `crux/lib/review-tracking.ts`)
- No API dependency — works without wiki-server
- TypeScript clean in `apps/web` (`tsc --noEmit` passes with no errors)
- Pre-existing crux TS errors unchanged (baseline 28)

Closes #213
