### PR TITLE
fix: load .env credentials reliably in assign-ids and verify manual numericIds

### DIFF
--- a/apps/web/scripts/assign-ids.mjs
+++ b/apps/web/scripts/assign-ids.mjs
@@ -21,10 +21,24 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, basename } from 'path';
 import { parse } from 'yaml';
-import { CONTENT_DIR, DATA_DIR, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
+import { CONTENT_DIR, DATA_DIR, TOP_LEVEL_CONTENT_DIRS, REPO_ROOT } from './lib/content-types.mjs';
 import { scanFrontmatterEntities } from './lib/frontmatter-scanner.mjs';
 import { buildIdMaps, filterEligiblePages } from './lib/id-assignment.mjs';
-import { isServerAvailable, allocateIds } from './lib/id-client.mjs';
+import { isServerAvailable, allocateIds, fetchServerEntityIdMap } from './lib/id-client.mjs';
+
+// ---------------------------------------------------------------------------
+// .env loading — must run before any process.env access
+// ---------------------------------------------------------------------------
+// Load .env from repo root so `node scripts/assign-ids.mjs` works without
+// pre-setting LONGTERMWIKI_SERVER_URL / LONGTERMWIKI_SERVER_API_KEY in the
+// shell.  dotenv.config() is a no-op when the file is absent or vars are
+// already set, so this is safe to call unconditionally.
+try {
+  const { config } = await import('dotenv');
+  config({ path: join(REPO_ROOT, '.env') });
+} catch {
+  // dotenv not available or .env missing — rely on shell environment
+}
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -158,6 +172,68 @@ async function main() {
     console.error('\n  ERROR: numericId conflicts detected:');
     for (const c of conflicts) console.error(`    ${c}`);
     process.exit(1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Verify manually-set numericIds for YAML entities against the server.
+  //
+  // YAML entity numericIds cannot be written back by assign-ids (we have no
+  // safe way to round-trip YAML), so they must be added manually.  When
+  // someone manually writes a numericId in a YAML file there is a risk of
+  // bypassing the server-based ID allocation — e.g. writing a numericId
+  // that the server has already allocated to a different slug.
+  //
+  // This step verifies every manually-set YAML entity numericId by asking the
+  // server what ID it allocated for that slug.  The allocate endpoint is
+  // idempotent: if the server has already registered the slug (e.g. from a
+  // previous run), it returns the same ID with created=false; if not, it
+  // creates a new one.  If the server-allocated ID differs from the local
+  // manual value, we report a clear error.
+  //
+  // When the server is unavailable we skip verification and warn — this keeps
+  // the offline/CI-without-server workflow working.
+  // -------------------------------------------------------------------------
+  const yamlEntitiesWithManualIds = yamlEntityItems.filter(e => e.numericId);
+
+  if (yamlEntitiesWithManualIds.length > 0 && serverAvailable && !DRY_RUN) {
+    // Verify manually-set numericIds against the server using a bulk read-only
+    // lookup (no side effects — uses GET /api/entities, not the allocate endpoint).
+    // We fetch all server-registered entities once and compare in-memory.
+    console.log(`  Verifying ${yamlEntitiesWithManualIds.length} manually-set YAML entity numericIds against server...`);
+    const serverIdMap = await fetchServerEntityIdMap();
+
+    if (serverIdMap.size === 0) {
+      console.warn(`  WARNING: Could not fetch entity registry from server — skipping numericId verification.`);
+    } else {
+      let conflictFound = false;
+      let verified = 0;
+      let notInServer = 0;
+      for (const entity of yamlEntitiesWithManualIds) {
+        const serverNumericId = serverIdMap.get(entity.id);
+        if (!serverNumericId) {
+          // Server has no record for this slug — new entity, skip
+          notInServer++;
+          continue;
+        }
+        verified++;
+        if (serverNumericId !== entity.numericId) {
+          console.error(`    ERROR: numericId conflict for YAML entity "${entity.id}":`);
+          console.error(`      Locally set:       ${entity.numericId}`);
+          console.error(`      Server registered: ${serverNumericId}`);
+          console.error(`      Fix: update numericId in data/entities/ to "${serverNumericId}",`);
+          console.error(`           or ask an admin to register "${entity.numericId}" for "${entity.id}" on the server.`);
+          conflictFound = true;
+        }
+      }
+      if (conflictFound) {
+        console.error('\n  Manual numericId bypass detected. Aborting to prevent ID registry corruption.');
+        process.exit(1);
+      }
+      const notInServerNote = notInServer > 0 ? ` (${notInServer} not yet in server — OK for new entities)` : '';
+      console.log(`  Verification complete: ${verified} numericIds verified OK${notInServerNote}.`);
+    }
+  } else if (yamlEntitiesWithManualIds.length > 0 && !serverAvailable && !DRY_RUN) {
+    console.warn(`  WARNING: Server unavailable — skipping verification of ${yamlEntitiesWithManualIds.length} manually-set YAML entity numericIds.`);
   }
 
   // -------------------------------------------------------------------------

--- a/apps/web/scripts/lib/id-client.mjs
+++ b/apps/web/scripts/lib/id-client.mjs
@@ -149,3 +149,50 @@ export async function allocateIds(slugs) {
 
   return resultMap;
 }
+
+/**
+ * Fetch all entity ID registrations from the server as a slug→numericId map.
+ *
+ * Paginates through GET /api/entities with the given page size until all
+ * entities have been fetched.  Returns an empty Map on any failure — the
+ * caller should treat an empty result as "server unavailable" and skip
+ * verification rather than failing the build.
+ *
+ * @param {number} [pageSize=200]
+ * @returns {Promise<Map<string, string>>}  Map of slug → numericId
+ */
+export async function fetchServerEntityIdMap(pageSize = 200) {
+  const serverUrl = getServerUrl();
+  if (!serverUrl) return new Map();
+
+  const resultMap = new Map();
+  let offset = 0;
+
+  try {
+    while (true) {
+      const res = await fetch(
+        `${serverUrl}/api/entities?limit=${pageSize}&offset=${offset}`,
+        {
+          headers: buildHeaders(),
+          signal: AbortSignal.timeout(BATCH_TIMEOUT_MS),
+        },
+      );
+      if (!res.ok) break;
+
+      const data = await res.json();
+      const entities = data.entities || [];
+      for (const entity of entities) {
+        if (entity.id && entity.numericId) {
+          resultMap.set(entity.id, entity.numericId);
+        }
+      }
+
+      if (entities.length < pageSize) break; // last page
+      offset += pageSize;
+    }
+  } catch {
+    // Network error or timeout — return whatever we have (possibly empty)
+  }
+
+  return resultMap;
+}

--- a/content/docs/internal/coverage-guide.mdx
+++ b/content/docs/internal/coverage-guide.mdx
@@ -1,4 +1,5 @@
 ---
+numericId: E888
 title: "Page Coverage Guide"
 description: "What each content layer means, why it matters, and how to add it to a wiki page."
 sidebar:


### PR DESCRIPTION
## Summary

Prevents manual `numericId` bypass of the server-based ID allocation system in two ways:

### 1. Reliable `.env` credential loading

`assign-ids.mjs` now loads the repo-root `.env` file at startup via `dotenv.config()`. Previously, running `node scripts/assign-ids.mjs` directly (outside of pnpm) would silently skip credential loading, causing the server connection to fail and leaving new pages/entities without IDs.

### 2. Server-side verification of manually-set YAML entity numericIds

YAML entity numericIds (in `data/entities/*.yaml`) must be set manually since the script cannot write back to YAML files. This created a bypass risk: someone could write any numericId without server validation.

Now, when the server is available, `assign-ids.mjs` fetches the server's complete entity registry and verifies all manually-set numericIds against it. If any numericId mismatches the server's canonical allocation:

```
ERROR: numericId conflict for YAML entity "example-entity":
  Locally set:       E100
  Server registered: E200
  Fix: update numericId in data/entities/ to "E200"
```

**Graceful fallback**: if the server is unavailable, verification is skipped with a clear warning rather than failing the build.

### New function in `id-client.mjs`

`fetchServerEntityIdMap()` — bulk read-only lookup (GET /api/entities) with no allocation side effects. Paginates until all server entities are fetched.

## Acceptance Criteria

- [x] `assign-ids.mjs` loads `.env` credentials reliably
- [x] CI validates numericIds against server registry (via assign-ids prebuild step)
- [x] Clear error on manual ID conflict
- [x] Graceful fallback when server unavailable

Closes #865
