### PR TITLE
fix: correct 404 link in about.mdx and wrong DataInfoBox entityId

### DIFF
--- a/content/docs/about.mdx
+++ b/content/docs/about.mdx
@@ -94,7 +94,7 @@ This wiki is an experimental project exploring how to structure and communicate 
 | Adequate (3) — Meets basic standards | {wikiStats.qualitySummary.adequate} |
 | High (4-5) — Well-developed | {wikiStats.qualitySummary.high} |
 
-For detailed quality metrics and entity gap analysis, see the [Dashboard](/dashboard/).
+For detailed quality metrics and entity gap analysis, see the [Entities Dashboard](/internal/entities).
 
 ---
 

--- a/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
+++ b/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
@@ -24,7 +24,7 @@ clusters:
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, EntityLink, SquiggleEstimate} from '@components/wiki';
 
-<DataInfoBox entityId="E886" ratings={frontmatter.ratings} />
+<DataInfoBox entityId="E887" ratings={frontmatter.ratings} />
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
