### PR TITLE
fix: resolve conflicting trial date in openai-foundation.mdx

### DIFF
--- a/content/docs/knowledge-base/organizations/openai-foundation.mdx
+++ b/content/docs/knowledge-base/organizations/openai-foundation.mdx
@@ -432,7 +432,7 @@ These concerns gained public attention following incidents such as a teenager's 
 
 ### Legal Challenges
 
-The restructuring faces ongoing legal challenges, most notably from Elon Musk, who filed a lawsuit arguing that his \$44 million investment was contingent on OpenAI remaining a nonprofit organization in perpetuity. Musk's lawsuit alleges that the restructuring violates founding agreements and represents a breach of the terms under which he and others provided initial funding.[^46] A trial is scheduled for fall 2025.
+The restructuring faces ongoing legal challenges, most notably from Elon Musk, who filed a lawsuit arguing that his \$44 million investment was contingent on OpenAI remaining a nonprofit organization in perpetuity. Musk's lawsuit alleges that the restructuring violates founding agreements and represents a breach of the terms under which he and others provided initial funding.[^46] Trial is scheduled for March 2026.
 
 The EyesOnOpenAI coalition, led by the San Francisco Foundation, has continued to raise concerns about asset valuation and independence even after the California and Delaware Attorneys General approved the restructuring with conditions. In January 2025, the coalition sent an open letter to California AG Rob Bonta calling for action to protect OpenAI's charitable assets and ensure proper safeguards.[^47]
 


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
