### PR TITLE
fix: correct factual errors in bioweapons.mdx

### DIFF
--- a/content/docs/knowledge-base/risks/bioweapons.mdx
+++ b/content/docs/knowledge-base/risks/bioweapons.mdx
@@ -38,7 +38,7 @@ import {DataInfoBox, ModelsList, Mermaid, R, EntityLink} from '@components/wiki'
 | **Expert Risk Estimate** | 0.3% → 1.5% annual with AI capabilities | [FRI survey](https://forecastingresearch.org/ai-enabled-biorisk): 5x increase if AI matches expert virologists |
 | **Frontier Model Status** | Expert-level knowledge achieved | <EntityLink id="openai">OpenAI</EntityLink>'s o3: 94th percentile on VCT; Claude Opus 4 triggered ASL-3 |
 | **Screening Evasion** | 75%+ pre-patch; 97% post-patch | Microsoft 2024; patch deployed globally Oct 2025 |
-| **Open-Source Risk** | High concern | <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink> "worst tested" for biosafety (Amodei 2025) |
+| **Open-Source Risk** | High concern | DeepSeek "worst tested" for biosafety (Amodei 2025) |
 | **Wet Lab Bottleneck** | Remains primary barrier | Soviet Biopreparat: 30,000+ staff over decades; Aum Shinrikyo failed |
 | **Defense Trajectory** | Favored long-term | mRNA platforms, metagenomic surveillance, far-UVC maturing |
 | **Policy Readiness** | Inadequate | [CSIS 2025](https://www.csis.org/analysis/opportunities-strengthen-us-biosecurity-ai-enabled-bioterrorism-what-policymakers-should): measures "ill-equipped" for AI threats |
@@ -51,7 +51,7 @@ This is considered one of the most severe near-term AI risks because biological 
 
 The key debate centers on whether AI provides meaningful "uplift"—whether it genuinely helps beyond what's already accessible through scientific literature and internet searches, or whether wet-lab skills remain the true bottleneck. Current evidence is reportedly mixed: a 2024 RAND Corporation study found no statistically significant AI uplift for bioweapon attack planning,[^1] while separate Microsoft research indicated that AI-designed toxins evaded more than 75% of <EntityLink id="E564" name="securedna">SecureDNA</EntityLink> tools.[^2]
 
-However, 2025 has marked a significant shift in official assessments. OpenAI has stated it expects its next-generation models to reach "high-risk classification" for biological capabilities—meaning they could provide "meaningful counterfactual assistance to novice actors."[^3] Anthropic reportedly activated ASL-3 (AI Safety Level 3) protections for Claude Opus 4 specifically due to biological and chemical weapon concerns.[^4] The <EntityLink id="E140" name="fhi">Future of Humanity Institute</EntityLink>' March 2025 report *The Age of AI in the Life Sciences* found that while current biological design tools cannot yet design self-replicating pathogens, monitoring and mitigation are urgently needed.[^5] OpenAI's o3 model has also scored at the 94th percentile on the Virology Capabilities Test (VCT), a benchmark designed to measure dangerous biological knowledge.[^6]
+However, 2025 has marked a significant shift in official assessments. OpenAI has stated it expects its next-generation models to reach "high-risk classification" for biological capabilities—meaning they could provide "meaningful counterfactual assistance to novice actors."[^3] Anthropic reportedly activated ASL-3 (AI Safety Level 3) protections for Claude Opus 4 specifically due to biological and chemical weapon concerns.[^4] The National Academies of Sciences, Engineering, and Medicine's March 2025 report *The Age of AI in the Life Sciences* found that while current biological design tools cannot yet design self-replicating pathogens, monitoring and mitigation are urgently needed.[^5] OpenAI's o3 model has also scored at the 94th percentile on the Virology Capabilities Test (VCT), a benchmark designed to measure dangerous biological knowledge.[^6]
 
 ### Risk Assessment
 
@@ -611,7 +611,7 @@ Biological threats exist on a spectrum. State programs have historically been th
 
 #### State Bioweapons Programs
 
-Multiple nations have maintained offensive biological weapons programs despite the Bioweapons Risk (BWC):[^39]
+Multiple nations have maintained offensive biological weapons programs despite the Biological Weapons Convention (BWC):[^39]
 
 | Program | Era | Scale | Outcome |
 |---------|-----|-------|-------|


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
