### PR TITLE
fix: correct Cotra affiliation and remove duplicate Simon quote in agi-timeline-debate.mdx

### DIFF
--- a/content/docs/knowledge-base/debates/agi-timeline-debate.mdx
+++ b/content/docs/knowledge-base/debates/agi-timeline-debate.mdx
@@ -166,7 +166,7 @@ The answer determines how much time we have to solve alignment, whether to prior
       quote: "Median 2035, but 25th-75th percentile spans 2027-2050"
     },
     {
-      name: "Ajeya Cotra (Coefficient Giving)",
+      name: "Ajeya Cotra (METR)",
       stance: "medium-timelines",
       confidence: "low",
       reasoning: "Bio-anchors framework suggests median 2040-2050, but shifted shorter recently.",
@@ -270,8 +270,7 @@ The answer determines how much time we have to solve alignment, whether to prior
 ## Historical Track Record
 
 **Past AGI predictions:**
-- 1958: "Machines will be capable, within twenty years, of doing any work that a man can do" - Herbert Simon
-- 1965: "Machines will be capable, within twenty years, of doing any work that a man can do" - Herbert Simon (updated)
+- 1965: "Machines will be capable, within twenty years, of doing any work that a man can do" - Herbert Simon
 - 1970: "In from three to eight years we will have a machine with the general intelligence of an average human being" - Marvin Minsky
 - 1980s: Expert systems will lead to AGI by 2000
 - 2000s: AGI by 2020


### PR DESCRIPTION
## Summary
- Update Ajeya Cotra's affiliation from 'Coefficient Giving' to 'METR' (she moved there in 2025) (issue #884)
- Remove duplicate Herbert Simon 'within twenty years' quote from 1958 entry (the 1965 entry is the correct one; the 1958 Simon/Newell prediction was about chess, not general intelligence) (issue #885)

Closes #884
Closes #885
