### PR TITLE
fix: remove unsourced Constitutional AI adoption claims for OpenAI/DeepMind/Meta

### DIFF
--- a/content/docs/knowledge-base/responses/constitutional-ai.mdx
+++ b/content/docs/knowledge-base/responses/constitutional-ai.mdx
@@ -30,7 +30,7 @@ import {R, EntityLink, Mermaid} from '@components/wiki';
 | **Scalability** | High | RLAIF enables alignment without human feedback bottleneck |
 | **Current Maturity** | High | Production-deployed since 2023; Constitutional Classifiers++ reduce jailbreaks to 0.005/1000 queries |
 | **Time Horizon** | Immediate | Currently operational in all Claude models |
-| **Key Proponents** | <EntityLink id="anthropic">Anthropic</EntityLink> | Extended by <EntityLink id="openai">OpenAI</EntityLink>, <EntityLink id="deepmind">DeepMind</EntityLink>, Meta |
+| **Key Proponents** | <EntityLink id="anthropic">Anthropic</EntityLink> | Broader field influence claimed; competitor adoption unverified |
 
 ## Overview
 
@@ -135,10 +135,7 @@ The CAI process involves:
 
 ### Industry Influence
 
-CAI has influenced safety practices at:
-- **<EntityLink id="openai">OpenAI</EntityLink>**: Incorporating constitutional elements in GPT-4 training
-- **<EntityLink id="deepmind">DeepMind</EntityLink>**: Constitutional principles in Gemini development
-- **Meta**: RLAIF adoption for Llama model alignment
+CAI has influenced the broader AI safety field. Similar self-critique and principle-based training ideas have appeared across the industry, though neither <EntityLink id="openai">OpenAI</EntityLink>, <EntityLink id="deepmind">DeepMind</EntityLink>, nor Meta has publicly described adopting Constitutional AI specifically. Claims that these organizations incorporated CAI into GPT-4, Gemini, or Llama are unverified.
 
 ## Key Advantages & Limitations
 


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
