### PR TITLE
fix: correct Brand Clarity causality in coefficient-giving and remove broken llmSummary from ATM pages

### DIFF
--- a/content/docs/ai-transition-model/adaptability.mdx
+++ b/content/docs/ai-transition-model/adaptability.mdx
@@ -9,7 +9,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 8
 researchImportance: 45.5
-llmSummary: This page contains only React component imports with no actual content about adaptability as a civilizational competence factor. The page is a complete stub that provides no information, analysis, or actionable guidance.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/adoption.mdx
+++ b/content/docs/ai-transition-model/adoption.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-capabilities
 quality: 0
 readerImportance: 33.5
 researchImportance: 65.5
-llmSummary: This page contains only React component imports with no actual content about AI adoption capabilities. It is a placeholder or stub that provides no information for evaluation.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/ai-control-concentration.mdx
+++ b/content/docs/ai-transition-model/ai-control-concentration.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 68
 researchImportance: 81.5
-llmSummary: This page contains only a React component placeholder with no actual content loaded. Cannot evaluate substance, methodology, or conclusions.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/ai-governance.mdx
+++ b/content/docs/ai-transition-model/ai-governance.mdx
@@ -10,7 +10,6 @@ quality: 0
 readerImportance: 89
 researchImportance: 87
 tacticalValue: 84
-llmSummary: This page contains only component imports with no actual content - it displays dynamically loaded data from an external source that cannot be evaluated.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/algorithms.mdx
+++ b/content/docs/ai-transition-model/algorithms.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-capabilities
 quality: 0
 readerImportance: 60
 researchImportance: 54.5
-llmSummary: This page contains only React component imports with no actual content about AI algorithms, their capabilities, or their implications for AI risk. The page is effectively a placeholder or stub.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/alignment-robustness.mdx
+++ b/content/docs/ai-transition-model/alignment-robustness.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 89
 researchImportance: 89.5
-llmSummary: This page contains only a React component import with no actual content rendered in the provided text. Cannot assess importance or quality without the actual substantive content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/biological-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/biological-threat-exposure.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misuse-potential
 quality: 0
 readerImportance: 68
 researchImportance: 90.5
-llmSummary: This page contains only placeholder component imports with no actual content about biological threat exposure from AI systems. Cannot assess methodology or conclusions as no substantive information is provided.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/companies.mdx
+++ b/content/docs/ai-transition-model/companies.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-ownership
 quality: 0
 readerImportance: 7.5
 researchImportance: 13.5
-llmSummary: This page contains only a React component import with no actual content displayed. Cannot assess as there is no substantive text, analysis, or information present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/compute-forecast-sketch.mdx
+++ b/content/docs/ai-transition-model/compute-forecast-sketch.mdx
@@ -9,7 +9,6 @@ subcategory: models
 quality: 0
 readerImportance: 60
 researchImportance: 54.5
-llmSummary: This page contains only a React component import with no accessible content. Cannot evaluate substance, methodology, or conclusions.
 ratings:
   focus: 0
   novelty: 0

--- a/content/docs/ai-transition-model/compute.mdx
+++ b/content/docs/ai-transition-model/compute.mdx
@@ -10,7 +10,6 @@ quality: 0
 readerImportance: 90
 researchImportance: 53
 tacticalValue: 82
-llmSummary: This page contains only React component imports with no actual content about compute capabilities or their role in AI risk. It is a technical stub awaiting data population.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/coordination-capacity.mdx
+++ b/content/docs/ai-transition-model/coordination-capacity.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 60.5
 researchImportance: 78.5
-llmSummary: This page contains only a React component reference with no actual content rendered in the provided text. Unable to evaluate coordination capacity analysis without the component's output.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/coordination.mdx
+++ b/content/docs/ai-transition-model/coordination.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-uses
 quality: 0
 readerImportance: 60
 researchImportance: 72
-llmSummary: Empty placeholder page containing only component imports with no actual content about AI coordination uses, methodology, or analysis.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/countries.mdx
+++ b/content/docs/ai-transition-model/countries.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-ownership
 quality: 0
 readerImportance: 7
 researchImportance: 13
-llmSummary: This page contains only a React component call with no actual content visible for evaluation. Cannot assess methodology or conclusions without rendered content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/cyber-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/cyber-threat-exposure.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misuse-potential
 quality: 0
 readerImportance: 68
 researchImportance: 90
-llmSummary: This page contains only component imports with no actual content. It appears to be a placeholder or template for content about cyber threat exposure in the AI transition model framework.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/economic-power.mdx
+++ b/content/docs/ai-transition-model/economic-power.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-long-term-lockin
 quality: 0
 readerImportance: 55.5
 researchImportance: 76
-llmSummary: This page contains only component imports with no actual content about economic power lock-in scenarios or their implications for AI transition models.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/economic-stability.mdx
+++ b/content/docs/ai-transition-model/economic-stability.mdx
@@ -8,7 +8,6 @@ subcategory: factors-transition-turbulence
 quality: 0
 readerImportance: 13
 researchImportance: 45.5
-llmSummary: This page contains only React component imports with no actual content about economic stability during AI transitions. Cannot assess topic relevance without content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/epistemic-health.mdx
+++ b/content/docs/ai-transition-model/epistemic-health.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 59.5
 researchImportance: 16
-llmSummary: This page contains only a component placeholder with no actual content. Cannot be evaluated for AI prioritization relevance.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/epistemics.mdx
+++ b/content/docs/ai-transition-model/epistemics.mdx
@@ -7,7 +7,6 @@ sidebar:
 quality: 3
 readerImportance: 18.5
 tacticalValue: 12
-llmSummary: "This page is essentially a stub that loads content dynamically via a React component, providing no evaluable text content beyond a brief description of 'Epistemic Foundation' as a measure of collective human thinking capacity."
 ratings:
   focus: 1
   novelty: 1

--- a/content/docs/ai-transition-model/existential-catastrophe.mdx
+++ b/content/docs/ai-transition-model/existential-catastrophe.mdx
@@ -8,7 +8,6 @@ subcategory: outcomes
 quality: 0
 readerImportance: 92
 researchImportance: 46.5
-llmSummary: This page contains only a React component placeholder with no actual content visible for evaluation. The component would need to render content dynamically for assessment.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/factors-ai-capabilities-overview.mdx
+++ b/content/docs/ai-transition-model/factors-ai-capabilities-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 52.3
 researchImportance: 54.5
 tacticalValue: 72
 lastEdited: "2026-01-03"
-llmSummary: "This is a high-level index/overview page for AI capabilities as a root factor in an AI Transition Model, cataloging dimensions like reasoning, coding, and agentic AI with brief status labels and linking to scenario types (takeover, misuse). It provides no original analysis, quantification, or actionable guidance—functioning primarily as a navigation hub with thin descriptive content."
 ratings:
   focus: 6.5
   novelty: 2

--- a/content/docs/ai-transition-model/factors-ai-ownership-overview.mdx
+++ b/content/docs/ai-transition-model/factors-ai-ownership-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 42
 researchImportance: 53
 tacticalValue: 62
 lastEdited: "2026-01-05"
-llmSummary: "This is a stub overview page for an 'AI Ownership' factor in a transition model, defining the concept and listing four high-level debates (concentration, profit vs. safety, open source, US-China) without substantive analysis or evidence. It functions as a navigation/index page rather than a content page, with nearly all substance deferred to linked sub-items and external components."
 ratings:
   focus: 6.5
   novelty: 1.5

--- a/content/docs/ai-transition-model/factors-civilizational-competence-epistemics.mdx
+++ b/content/docs/ai-transition-model/factors-civilizational-competence-epistemics.mdx
@@ -9,7 +9,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 13.5
 researchImportance: 16
-llmSummary: This page contains only component placeholders with no actual content about epistemics or civilizational competence. No information is provided to evaluate or act upon.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/factors-civilizational-competence-overview.mdx
+++ b/content/docs/ai-transition-model/factors-civilizational-competence-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 42
 researchImportance: 54.5
 tacticalValue: 35
 lastEdited: "2026-01-06"
-llmSummary: "This is a stub overview page defining 'Civilizational Competence' as a protective factor across AI risk scenarios, with almost no substantive content beyond a brief definition and three bullet points. It appears to be a navigation/index page that defers to sub-components and embedded components for actual content."
 ratings:
   focus: 5.5
   novelty: 1.5

--- a/content/docs/ai-transition-model/factors-misalignment-potential-overview.mdx
+++ b/content/docs/ai-transition-model/factors-misalignment-potential-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 52.3
 researchImportance: 56
 tacticalValue: 42
 lastEdited: "2026-01-03"
-llmSummary: "This is a stub/index page for a 'Misalignment Potential' factor in an AI transition model, defining it as the likelihood AI pursues unintended goals and listing it as the primary driver of AI Takeover scenarios; actual content is almost entirely delegated to dynamic components (FactorSubItemsList, ImpactList, etc.) that are not rendered here."
 ratings:
   focus: 6.5
   novelty: 1.5

--- a/content/docs/ai-transition-model/factors-overview.mdx
+++ b/content/docs/ai-transition-model/factors-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 38.5
 researchImportance: 52
 tacticalValue: 30
 lastEdited: "2026-01-05"
-llmSummary: "This is a navigation/index page for a proprietary 'AI transition model' that names seven root factors (Misalignment Potential, AI Capabilities, AI Uses, AI Ownership, Civilizational Competence, Transition Turbulence, Misuse Potential) but contains almost no substantive content—the actual content is deferred to interactive components and linked sub-pages."
 ratings:
   focus: 6
   novelty: 3.5

--- a/content/docs/ai-transition-model/governance.mdx
+++ b/content/docs/ai-transition-model/governance.mdx
@@ -9,7 +9,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 55.5
 researchImportance: 45.5
-llmSummary: This is a placeholder page with no actual content - only component imports that would render data from elsewhere in the system. Cannot assess importance or quality without the underlying content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/governments.mdx
+++ b/content/docs/ai-transition-model/governments.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-uses
 quality: 0
 readerImportance: 7.5
 researchImportance: 13.5
-llmSummary: This page contains only a dynamic component reference with no actual content rendered in the provided text. Cannot assess importance or quality without the underlying content that would be loaded by the ATMPage component.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/gradual.mdx
+++ b/content/docs/ai-transition-model/gradual.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-ai-takeover
 quality: 0
 readerImportance: 54
 researchImportance: 46
-llmSummary: This page contains only a React component import with no actual content rendered in the provided text. Cannot assess importance or quality without the content that would be dynamically loaded by the TransitionModelContent component.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/human-agency.mdx
+++ b/content/docs/ai-transition-model/human-agency.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 53
 researchImportance: 46
-llmSummary: This page contains only a React component reference with no actual content displayed. Cannot evaluate substance as no text, analysis, or information is present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/human-expertise.mdx
+++ b/content/docs/ai-transition-model/human-expertise.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 7.5
 researchImportance: 7.5
-llmSummary: This page contains only a React component placeholder with no actual content, making it impossible to evaluate for expertise on human capabilities during AI transition.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/human-oversight-quality.mdx
+++ b/content/docs/ai-transition-model/human-oversight-quality.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 62.5
 researchImportance: 90
-llmSummary: This page contains only a React component placeholder with no actual content rendered. Cannot assess substance, methodology, or conclusions.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/industries.mdx
+++ b/content/docs/ai-transition-model/industries.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-uses
 quality: 0
 readerImportance: 7.5
 researchImportance: 45.5
-llmSummary: This page contains only a React component reference with no visible content to evaluate. Without access to the actual content rendered by the ATMPage component, no assessment of the page's substance is possible.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/information-authenticity.mdx
+++ b/content/docs/ai-transition-model/information-authenticity.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 44.5
 researchImportance: 53.5
-llmSummary: This page contains only a component import statement with no actual content displayed. Cannot be evaluated for information authenticity discussion or any substantive analysis.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/institutional-quality.mdx
+++ b/content/docs/ai-transition-model/institutional-quality.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 60
 researchImportance: 88.5
-llmSummary: This page contains only a React component import with no actual content rendered. It cannot be evaluated for substance, methodology, or conclusions.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/international-coordination.mdx
+++ b/content/docs/ai-transition-model/international-coordination.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 60.5
 researchImportance: 81.5
-llmSummary: This page contains only a React component placeholder with no actual content rendered. Cannot assess importance or quality without substantive text.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/interpretability-coverage.mdx
+++ b/content/docs/ai-transition-model/interpretability-coverage.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 68.5
 researchImportance: 89
-llmSummary: This page contains only a React component import with no actual content displayed. Cannot assess interpretability coverage methodology or findings without rendered content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/lab-safety-practices.mdx
+++ b/content/docs/ai-transition-model/lab-safety-practices.mdx
@@ -9,7 +9,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 62.5
 researchImportance: 90
-llmSummary: This page contains no actual content - only template code for dynamically loading data. Cannot assess substance, methodology, or conclusions as none are present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/long-term-trajectory.mdx
+++ b/content/docs/ai-transition-model/long-term-trajectory.mdx
@@ -8,7 +8,6 @@ subcategory: outcomes
 quality: 0
 readerImportance: 53
 researchImportance: 46
-llmSummary: This page contains only a React component reference with no actual content loaded. Cannot assess substance as no text, analysis, or information is present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/outcomes-overview.mdx
+++ b/content/docs/ai-transition-model/outcomes-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 38.5
 researchImportance: 46
 tacticalValue: 20
 lastEdited: "2026-01-03"
-llmSummary: "This overview page defines two ultimate outcomes for AI transition analysis—existential catastrophe and long-term trajectory—and explains why they are treated as partially independent dimensions rather than a single metric. It is a structural/navigational page within a larger model framework, offering no original empirical content or quantified estimates."
 ratings:
   focus: 7.5
   novelty: 2.5

--- a/content/docs/ai-transition-model/political-power.mdx
+++ b/content/docs/ai-transition-model/political-power.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-long-term-lockin
 quality: 0
 readerImportance: 54.5
 researchImportance: 76
-llmSummary: This page contains only component imports with no actual content - it appears to be a placeholder that dynamically loads content from an external source identified as 'tmc-political-power'.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/preference-authenticity.mdx
+++ b/content/docs/ai-transition-model/preference-authenticity.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 45
 researchImportance: 88.5
-llmSummary: This page contains only a React component reference with no actual content displayed. Cannot assess the substantive topic of preference authenticity in AI transitions without the rendered content.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/racing-intensity.mdx
+++ b/content/docs/ai-transition-model/racing-intensity.mdx
@@ -8,7 +8,6 @@ subcategory: factors-transition-turbulence
 quality: 0
 readerImportance: 58.5
 researchImportance: 90
-llmSummary: This page contains only React component imports with no actual content about racing intensity or transition turbulence factors. It appears to be a placeholder or template awaiting content population.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/rapid.mdx
+++ b/content/docs/ai-transition-model/rapid.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-ai-takeover
 quality: 0
 readerImportance: 58.5
 researchImportance: 72.5
-llmSummary: This page contains only a React component import with no actual content visible for evaluation. The component dynamically loads content with entity ID 'tmc-rapid' but provides no substantive information in the source.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/reality-coherence.mdx
+++ b/content/docs/ai-transition-model/reality-coherence.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 44.5
 researchImportance: 88.5
-llmSummary: This page contains only a React component call with no actual content visible for evaluation. Unable to assess any substantive material about reality coherence or its role in AI transition models.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/recursive-ai-capabilities.mdx
+++ b/content/docs/ai-transition-model/recursive-ai-capabilities.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-uses
 quality: 0
 readerImportance: 68.5
 researchImportance: 90.5
-llmSummary: This page contains only component placeholders with no actual content about recursive AI capabilities - where AI systems improve their own capabilities or develop more advanced AI systems. Cannot be evaluated as it provides no information.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/regulatory-capacity.mdx
+++ b/content/docs/ai-transition-model/regulatory-capacity.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 60.5
 researchImportance: 81.5
-llmSummary: Empty page with only a component reference - no actual content to evaluate.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/robot-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/robot-threat-exposure.mdx
@@ -9,7 +9,6 @@ subcategory: factors-misuse-potential
 quality: 0
 readerImportance: 18.5
 researchImportance: 72.5
-llmSummary: This page contains only React component imports with no actual content about robot threat exposure or its implications for AI risk. The page is a placeholder without text, analysis, or substantive information.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/rogue-actor.mdx
+++ b/content/docs/ai-transition-model/rogue-actor.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-human-catastrophe
 quality: 0
 readerImportance: 51.5
 researchImportance: 82
-llmSummary: This page contains only a React component reference with no actual content visible for evaluation. Unable to assess any substantive material about rogue actor catastrophe scenarios.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/safety-capability-gap.mdx
+++ b/content/docs/ai-transition-model/safety-capability-gap.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 59
 researchImportance: 83
-llmSummary: This page contains no actual content - only a React component reference that dynamically loads content from elsewhere in the system. Cannot evaluate substance, methodology, or conclusions without the actual content being rendered.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/safety-culture-strength.mdx
+++ b/content/docs/ai-transition-model/safety-culture-strength.mdx
@@ -8,7 +8,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 8
 researchImportance: 16
-llmSummary: This page contains only a React component import with no actual content displayed. Cannot assess the substantive content about safety culture strength in AI development.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/scenarios-ai-takeover-overview.mdx
+++ b/content/docs/ai-transition-model/scenarios-ai-takeover-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 52.3
 researchImportance: 50
 tacticalValue: 48
 lastEdited: "2026-01-03"
-llmSummary: "This is a stub overview page for AI takeover scenarios that defines the concept and links to sub-items and relationship diagrams, but contains almost no substantive content itself. The actual analysis is deferred entirely to dynamic components (FactorSubItemsList, ImpactList, etc.) whose rendered content is not visible here."
 ratings:
   focus: 6
   novelty: 1.5

--- a/content/docs/ai-transition-model/scenarios-human-catastrophe-overview.mdx
+++ b/content/docs/ai-transition-model/scenarios-human-catastrophe-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 52.3
 researchImportance: 52.5
 tacticalValue: 55
 lastEdited: "2026-01-03"
-llmSummary: "This is a stub overview page for human-caused AI catastrophe scenarios, distinguishing deliberate misuse from AI takeover, but containing almost no substantive content beyond component references and two outcome bullets."
 ratings:
   focus: 6
   novelty: 1.5

--- a/content/docs/ai-transition-model/scenarios-long-term-lockin-epistemics.mdx
+++ b/content/docs/ai-transition-model/scenarios-long-term-lockin-epistemics.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-long-term-lockin
 quality: 0
 readerImportance: 13.5
 researchImportance: 15.5
-llmSummary: This page contains only UI component imports with no actual content about epistemic lock-in. It is a technical placeholder that loads external data but provides no information to evaluate.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/scenarios-long-term-lockin-overview.mdx
+++ b/content/docs/ai-transition-model/scenarios-long-term-lockin-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 52.3
 researchImportance: 52.5
 tacticalValue: 35
 lastEdited: "2026-01-03"
-llmSummary: "This is a skeletal overview page for the 'long-term lock-in' risk category, noting it can be positive or negative and primarily affects long-term trajectory; it contains almost no substantive analysis, relying entirely on dynamic components to populate content."
 ratings:
   focus: 6.5
   novelty: 2

--- a/content/docs/ai-transition-model/scenarios-overview.mdx
+++ b/content/docs/ai-transition-model/scenarios-overview.mdx
@@ -12,7 +12,6 @@ readerImportance: 38.5
 researchImportance: 52
 tacticalValue: 25
 lastEdited: "2026-01-04"
-llmSummary: "This is a structural overview page for an 'AI Transition Model' framework, defining three ultimate scenarios (AI Takeover, Human-Caused Catastrophe, Long-term Lock-in) as intermediate pathways between root factors and outcomes, with no quantitative content or original analysis."
 ratings:
   focus: 7.5
   novelty: 2.5

--- a/content/docs/ai-transition-model/shareholders.mdx
+++ b/content/docs/ai-transition-model/shareholders.mdx
@@ -9,7 +9,6 @@ subcategory: factors-ai-ownership
 quality: 0
 readerImportance: 7
 researchImportance: 13
-llmSummary: This page contains only a dynamic component placeholder with no actual content to evaluate. It appears to be a technical stub that loads content client-side from an entity ID.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/societal-resilience.mdx
+++ b/content/docs/ai-transition-model/societal-resilience.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 13
 researchImportance: 16
-llmSummary: This page contains only a component reference with no visible content. Unable to assess any substantive material about societal resilience or its role in AI transitions.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/societal-trust.mdx
+++ b/content/docs/ai-transition-model/societal-trust.mdx
@@ -8,7 +8,6 @@ subcategory: factors-civilizational-competence
 quality: 0
 readerImportance: 8
 researchImportance: 13.5
-llmSummary: This page contains only a React component placeholder with no actual content rendered. No information about societal trust as a factor in AI transition is present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/state-actor.mdx
+++ b/content/docs/ai-transition-model/state-actor.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-human-catastrophe
 quality: 0
 readerImportance: 54.5
 researchImportance: 82
-llmSummary: This page contains only a React component reference with no actual content visible. Cannot assess methodology or conclusions as no substantive information is present.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/suffering-lock-in.mdx
+++ b/content/docs/ai-transition-model/suffering-lock-in.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-long-term-lockin
 quality: 0
 readerImportance: 54.5
 researchImportance: 72.5
-llmSummary: This page contains no substantive content - only component placeholders that would load external data. Without the actual content displayed, there is no methodology or analysis to evaluate.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/surprise-threat-exposure.mdx
+++ b/content/docs/ai-transition-model/surprise-threat-exposure.mdx
@@ -9,7 +9,6 @@ subcategory: factors-misuse-potential
 quality: 0
 readerImportance: 18.5
 researchImportance: 72
-llmSummary: This page contains only component imports with no substantive content - it appears to be a technical stub that dynamically loads content from an external data source.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/technical-ai-safety.mdx
+++ b/content/docs/ai-transition-model/technical-ai-safety.mdx
@@ -9,7 +9,6 @@ subcategory: factors-misalignment-potential
 quality: 0
 readerImportance: 89.5
 researchImportance: 88.5
-llmSummary: This page contains only code/component references with no actual content about technical AI safety. The page is a stub that imports React components but provides no information, analysis, or substance.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/ai-transition-model/values.mdx
+++ b/content/docs/ai-transition-model/values.mdx
@@ -9,7 +9,6 @@ subcategory: scenarios-long-term-lockin
 quality: 0
 readerImportance: 54.5
 researchImportance: 76
-llmSummary: This page contains only placeholder React components with no actual content about value lock-in scenarios or their implications for AI risk prioritization.
 ratings:
   novelty: 0
   rigor: 0

--- a/content/docs/knowledge-base/organizations/coefficient-giving.mdx
+++ b/content/docs/knowledge-base/organizations/coefficient-giving.mdx
@@ -86,7 +86,7 @@ On November 18, 2025, Open Philanthropy [announced its rebranding to Coefficient
 
 **Multi-Donor Expansion**: The organization moved from primarily serving Good Ventures to operating pooled funds open to any philanthropist. In 2024, Coefficient directed over \$100 million from donors besides Good Ventures; by 2025, non-Good Ventures funding had more than doubled.
 
-**Brand Clarity**: The "Coefficient Giving" name created confusion—journalists mistook them for <EntityLink id="openai">OpenAI</EntityLink>, potential grantees confused them with Open Society Foundations. "Coefficient" provided a distinctive identity.
+**Brand Clarity**: The old "Open Philanthropy" name created confusion—journalists mistook it for <EntityLink id="openai">OpenAI</EntityLink>, and potential grantees confused it with Open Society Foundations. "Coefficient Giving" was chosen to provide a distinctive identity and resolve that confusion.
 
 **Structural Reorganization**: The organization restructured from program areas to 13 distinct funds, each with dedicated leadership and transparent goals, allowing donors to support specific causes at scale.
 


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
