### PR TITLE
feat: paranoid review as pre-commit gate in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -163,6 +163,57 @@ jobs:
           fi
           echo "All NEEDS CITATION markers resolved."
 
+      - name: Paranoid review of changed pages
+        if: success()
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          # Find MDX files modified by the auto-update pipeline (not yet committed)
+          CHANGED_MDX=$(git diff --name-only HEAD -- content/docs/ | grep '\.mdx$' || true)
+
+          if [ -z "$CHANGED_MDX" ]; then
+            echo "No MDX files changed — skipping paranoid review"
+            exit 0
+          fi
+
+          COUNT=$(echo "$CHANGED_MDX" | wc -l | tr -d ' ')
+          echo "Running paranoid review on $COUNT changed page(s)..."
+
+          BLOCKED=""
+          for FILE in $CHANGED_MDX; do
+            PAGE_ID=$(basename "$FILE" .mdx)
+            echo "Reviewing: $PAGE_ID ($FILE)"
+
+            RESULT=$(pnpm crux content review "$PAGE_ID" \
+              --model=claude-haiku-4-5-20251001 --json 2>/dev/null \
+              || echo '{"error":"review failed","gapCount":0,"needsReResearch":false}')
+
+            NEEDS_RESEARCH=$(echo "$RESULT" | jq -r '.needsReResearch // false')
+            GAP_COUNT=$(echo "$RESULT" | jq -r '.gapCount // 0')
+            ASSESSMENT=$(echo "$RESULT" | jq -r '.overallAssessment // "No assessment"')
+            ERROR=$(echo "$RESULT" | jq -r '.error // ""')
+
+            if [ -n "$ERROR" ] && [ "$ERROR" != "null" ]; then
+              echo "::warning::$PAGE_ID — review failed: $ERROR"
+            elif [ "$NEEDS_RESEARCH" = "true" ]; then
+              echo "::error::$PAGE_ID — needs re-research ($GAP_COUNT gap(s)): $ASSESSMENT"
+              BLOCKED="$BLOCKED $PAGE_ID"
+            elif [ "$GAP_COUNT" -gt 0 ]; then
+              echo "::warning::$PAGE_ID — $GAP_COUNT gap(s) (editorial): $ASSESSMENT"
+            else
+              echo "  $PAGE_ID: clean"
+            fi
+          done
+
+          if [ -n "$BLOCKED" ]; then
+            echo "::error::Paranoid review blocked commit for:$BLOCKED"
+            echo "Re-run the improve pipeline on these pages or fix the issues manually."
+            exit 1
+          fi
+
+          echo "All changed pages passed paranoid review"
+
       - name: Find run report
         id: report
         if: always()

--- a/crux/authoring/page-review.ts
+++ b/crux/authoring/page-review.ts
@@ -9,6 +9,8 @@
  *   pnpm crux content review <page-id>
  *   pnpm crux content review <page-id> --model=claude-sonnet-4-20250514
  *   pnpm crux content review --batch --limit=10
+ *   pnpm crux content review <page-id> --json            # Machine-readable output
+ *   pnpm crux content review <page-id> --json --exit-code # Exit 1 if re-research needed
  */
 
 import fs from 'fs';
@@ -93,6 +95,9 @@ async function main(): Promise<void> {
   const batch = args.batch === true;
   const limit = typeof args.limit === 'string' ? parseInt(args.limit, 10) : 10;
   const model = typeof args.model === 'string' ? args.model : undefined;
+  const jsonMode = args.json === true;
+  // --exit-code: exit 1 if the page needs re-research (useful for CI gating)
+  const exitCode = args['exit-code'] === true;
 
   if (args.help === true) {
     console.log(`
@@ -104,6 +109,8 @@ Options:
   --model=<m>    LLM model for review (default: sonnet)
   --batch        Review multiple pages (lowest quality first)
   --limit=<n>    Number of pages in batch mode (default: 10)
+  --json         Output machine-readable JSON (single page only)
+  --exit-code    Exit 1 if review finds re-research-needed gaps (for CI gating)
   --help         Show this help
 `);
     process.exit(0);
@@ -160,7 +167,25 @@ Options:
 
     const content = fs.readFileSync(filePath, 'utf-8');
     const review = await adversarialReviewPhase(page, content, options);
-    printReview(page, review);
+
+    if (jsonMode) {
+      // Machine-readable output for CI integration
+      console.log(JSON.stringify({
+        pageId: page.id,
+        title: page.title,
+        gapCount: review.gaps.length,
+        needsReResearch: review.needsReResearch,
+        gaps: review.gaps,
+        reResearchQueries: review.reResearchQueries,
+        overallAssessment: review.overallAssessment ?? null,
+      }));
+    } else {
+      printReview(page, review);
+    }
+
+    if (exitCode && review.needsReResearch) {
+      process.exit(1);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Adds paranoid review as a blocking pre-commit gate for the auto-update orchestrator, preventing the "improve → fix bugs → fix more bugs" commit noise pattern.

### New `--json` and `--exit-code` flags for `crux content review`

`pnpm crux content review <page-id> --json` now outputs machine-readable JSON:
```json
{
  "pageId": "string",
  "title": "string",
  "gapCount": number,
  "needsReResearch": boolean,
  "gaps": [...],
  "reResearchQueries": ["..."],
  "overallAssessment": "..."
}
```

`--exit-code` exits with code 1 when `needsReResearch` is true, enabling shell-script gating.

### New workflow step: "Paranoid review of changed pages"

Inserted between "Review AI-generated content" and "Find run report" in `.github/workflows/auto-update.yml`. The step:

1. Finds all MDX files modified by the auto-update pipeline (before commit)
2. Runs adversarial review on each using Haiku (cheap, ~$0.10/page)
3. **Blocks the commit** if any page has gaps requiring re-research (factual claims without sources)
4. Emits warnings (non-blocking) for editorial gaps only (redundancy, fact density)
5. Skips gracefully if the review fails (LLM error, page not found)

## Acceptance Criteria

- [x] Orchestrator runs paranoid-review before committing
- [x] Paranoid-review failures block the commit rather than creating follow-up fix commits
- [x] Single review-then-commit cycle per page batch

Closes #802
