### PR TITLE
feat: track wiki server unavailability in session logs

### DIFF
--- a/crux/authoring/page-improver/pipeline.ts
+++ b/crux/authoring/page-improver/pipeline.ts
@@ -10,6 +10,7 @@ import { execFileSync } from 'child_process';
 import { appendEditLog, getDefaultRequestedBy } from '../../lib/edit-log.ts';
 import { createSession } from '../../lib/wiki-server/sessions.ts';
 import { saveArtifacts } from '../../lib/wiki-server/artifacts.ts';
+import { isServerAvailable } from '../../lib/wiki-server/client.ts';
 import type {
   PageData, AnalysisResult, ResearchResult, ReviewResult,
   PipelineOptions, PipelineResults, TriageResult, AdversarialLoopResult,
@@ -66,11 +67,19 @@ async function autoLogSession(
   review: ReviewResult | undefined,
   totalDuration: string,
   tierCost: string,
+  serverAvailable: boolean,
 ): Promise<void> {
   try {
     const today = new Date().toISOString().split('T')[0];
     const branch = getCurrentBranch();
-    const summary = buildSessionSummary(page, tier, review, totalDuration);
+    let summary = buildSessionSummary(page, tier, review, totalDuration);
+
+    // Append a constraint note if the wiki server was unreachable during the session.
+    // This surfaces in the page-changes dashboard so reviewers know cross-reference
+    // checks and citation data may have been skipped.
+    if (!serverAvailable) {
+      summary += '\n\nConstraint: wiki server was unreachable. Cross-reference checks, citation verification, and backlink context were unavailable during this session.';
+    }
 
     const entry = {
       date: today,
@@ -82,6 +91,9 @@ async function autoLogSession(
       cost: tierCost,
       prUrl: null,
       pages: [page.id],
+      issuesJson: !serverAvailable
+        ? [{ type: 'server-unavailable', message: 'Wiki server was unreachable during session' }]
+        : null,
     };
 
     const result = await createSession(entry);
@@ -101,6 +113,14 @@ async function autoLogSession(
 /** Main pipeline orchestration. */
 export async function runPipeline(pageId: string, options: PipelineOptions = {}): Promise<PipelineResults> {
   let { tier = 'standard', directions = '', dryRun = false } = options;
+
+  // Check wiki server availability upfront so the session log can record if the
+  // server was unreachable (which means cross-reference checks and citation
+  // verification were silently skipped during this run).
+  const serverAvailable = await isServerAvailable();
+  if (!serverAvailable) {
+    console.warn('  Warning: wiki server unavailable — cross-reference checks and citation data will be skipped.');
+  }
 
   // Find page
   const pages = loadPages();
@@ -391,7 +411,7 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
 
     // Auto-log session to wiki-server DB (default: on; skip with skipSessionLog: true)
     if (!options.skipSessionLog) {
-      await autoLogSession(page, tier, review, totalDuration, tierConfig.cost);
+      await autoLogSession(page, tier, review, totalDuration, tierConfig.cost, serverAvailable);
     }
   }
 

--- a/crux/commands/sessions.ts
+++ b/crux/commands/sessions.ts
@@ -15,6 +15,7 @@ import { createLogger } from '../lib/output.ts';
 import { currentBranch } from '../lib/session-checklist.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { syncSessionFile } from '../wiki-server/sync-session.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import type { CommandResult } from '../lib/cli.ts';
 
 const SESSIONS_DIR = join(PROJECT_ROOT, '.claude/sessions');
@@ -59,6 +60,7 @@ function buildSessionYaml(fields: {
   cost?: string;
   pr?: string;
   pages: string[];
+  serverUnavailable?: boolean;
 }): string {
   const lines: string[] = [
     `date: "${fields.date}"`,
@@ -80,6 +82,16 @@ function buildSessionYaml(fields: {
     for (const p of fields.pages) {
       lines.push(`  - ${p}`);
     }
+  }
+
+  // Record server unavailability as a constraint in the session log.
+  // This surfaces in the page-changes dashboard so reviewers know cross-reference
+  // checks and citation data may have been skipped during this session.
+  if (fields.serverUnavailable) {
+    lines.push(
+      'constraints:',
+      '  - server-unavailable: "Wiki server was unreachable during this session. Cross-reference checks, citation verification, and backlink context were unavailable."',
+    );
   }
 
   lines.push(
@@ -141,6 +153,15 @@ async function write(args: string[], options: Record<string, unknown>): Promise<
   // Parse optional list fields
   const pages = parseList(options.pages);
 
+  // Check wiki server availability so the scaffold can note any constraint.
+  // Fire-and-forget with fallback: if the check fails, assume available.
+  let serverUnavailable = false;
+  try {
+    serverUnavailable = !(await isServerAvailable());
+  } catch {
+    serverUnavailable = false;
+  }
+
   const yamlContent = buildSessionYaml({
     date,
     branch,
@@ -151,6 +172,7 @@ async function write(args: string[], options: Record<string, unknown>): Promise<
     cost: options.cost ? String(options.cost) : undefined,
     pr: options.pr ? String(options.pr) : undefined,
     pages,
+    serverUnavailable,
   });
 
   const alreadyExists = existsSync(outputPath);
@@ -163,6 +185,9 @@ async function write(args: string[], options: Record<string, unknown>): Promise<
   out += `  Branch: ${branch}\n`;
   out += `  Title: ${title}\n`;
   if (pages.length > 0) out += `  Pages: ${pages.join(', ')}\n`;
+  if (serverUnavailable) {
+    out += `  ${c.yellow}⚠ Wiki server unreachable — constraints field added to session log.${c.reset}\n`;
+  }
   out += `\n  Edit the file to add summary, issues, learnings, recommendations and checks, then:\n`;
   out += `  ${c.cyan}pnpm crux wiki-server sync-session ${outputPath}${c.reset}\n`;
 


### PR DESCRIPTION
## Summary

Tracks wiki server unavailability as a session constraint in session logs so reviewers can see when cross-reference checks and citation verification were silently skipped.

### Changes

**`crux/authoring/page-improver/pipeline.ts`**
- Check `isServerAvailable()` at pipeline start
- Pass `serverAvailable` flag down to `autoLogSession()`
- When unavailable: append constraint note to session summary text and add `issues_json` entry with `type: "server-unavailable"`
- Emit a console warning so the user sees the issue in real time

**`crux/commands/sessions.ts`**
- Check server availability in `crux sessions write`
- When unavailable: add `constraints:` YAML block to the scaffolded session file
- Show a yellow warning in the command output

### Why

The improve pipeline already skips server-dependent steps (backlink context, citation verification) when the server is down, but previously logged nothing about this. Reviewers seeing a session log had no way to know those checks were absent. This change surfaces the constraint at both the YAML/DB level and in the user-facing output.

Closes #804
