### PR TITLE
fix: broken dashboard link in about.mdx and wrong DataInfoBox entityId

### DIFF
--- a/content/docs/about.mdx
+++ b/content/docs/about.mdx
@@ -94,7 +94,7 @@ This wiki is an experimental project exploring how to structure and communicate 
 | Adequate (3) — Meets basic standards | {wikiStats.qualitySummary.adequate} |
 | High (4-5) — Well-developed | {wikiStats.qualitySummary.high} |
 
-For detailed quality metrics and entity gap analysis, see the [Dashboard](/dashboard/).
+For detailed quality metrics and entity gap analysis, see the [Importance Rankings](/internal/importance-rankings) and [Entities](/internal/entities) dashboards.
 
 ---
 

--- a/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
+++ b/content/docs/knowledge-base/models/longtermist-value-comparisons.mdx
@@ -24,7 +24,7 @@ clusters:
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, EntityLink, SquiggleEstimate} from '@components/wiki';
 
-<DataInfoBox entityId="E886" ratings={frontmatter.ratings} />
+<DataInfoBox entityId="E887" ratings={frontmatter.ratings} />
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Two simple content/data bug fixes:

### #879 — about.mdx links to /dashboard/ which returns 404

Replaced the dead `/dashboard/` link with two working links to the internal dashboards that cover quality metrics and entity gap analysis:
- [Importance Rankings](/internal/importance-rankings) — quality/importance scores for all pages
- [Entities](/internal/entities) — entity coverage and gap analysis

### #880 — longtermist-value-comparisons DataInfoBox uses wrong entityId (E886 instead of E887)

The page's own frontmatter declares `numericId: E887`, but the `<DataInfoBox>` was using `entityId="E886"` (a different entity). Fixed to `entityId="E887"` so the DataInfoBox loads the correct entity data.

Closes #879
Closes #880
