### PR TITLE
fix: preserve entity context in knowledge-base category redirects

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -73,8 +73,10 @@ export function middleware(request: NextRequest) {
     }
     const slug = segments[segments.length - 1];
     if (segments.length === 2 && KB_CATEGORIES.has(slug)) {
-      // Category index: /knowledge-base/risks
+      // Category index: /knowledge-base/risks → /wiki?entity=risks
+      // Preserve category context so the explore grid can pre-filter by type.
       url.pathname = "/wiki";
+      url.searchParams.set("entity", slug);
       return NextResponse.redirect(url, 308);
     }
     url.pathname = `/wiki/${slug}`;


### PR DESCRIPTION
## Summary

- Knowledge-base category index URLs (e.g. `/knowledge-base/people/`, `/knowledge-base/organizations/`) previously redirected to plain `/wiki`, losing all category context
- Now redirects go to `/wiki?entity=<category>` (e.g. `/wiki?entity=people`), so the ExploreGrid entity filter is pre-applied
- The `resolveEntityGroupIndex` function in `ExploreGrid.tsx` already handles these plural category names via label matching and singularization, so no frontend changes were needed

## What changed

Single change in `apps/web/src/middleware.ts`: the KB category index redirect sets `url.searchParams.set("entity", slug)` before redirecting to `/wiki`.

**Affected categories:** capabilities, cruxes, debates, forecasting, future-projections, history, incidents, intelligence-paradigms, metrics, models, organizations, people, reports, responses, risks, worldviews.

## Test plan

- [ ] Visit `/knowledge-base/people/` — should redirect to `/wiki?entity=people` and show People-type entities
- [ ] Visit `/knowledge-base/organizations/` — should redirect to `/wiki?entity=organizations` with Organizations filter active
- [ ] Visit `/knowledge-base/risks/` — should redirect to `/wiki?entity=risks` with Risks filter active
- [ ] Visit `/knowledge-base/anthropic` (individual page) — should still redirect to `/wiki/anthropic` (unaffected)
- [ ] Visit `/knowledge-base` (root) — should still redirect to `/wiki` (unaffected)

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)
