### PR TITLE
feat(citations): backfill citation_content full text to PostgreSQL

### DIFF
--- a/crux/citations/backfill-citation-content.ts
+++ b/crux/citations/backfill-citation-content.ts
@@ -1,0 +1,154 @@
+/**
+ * Backfill Citation Content to PostgreSQL
+ *
+ * Reads all citation_content rows from the local SQLite knowledge.db and
+ * upserts them into the wiki-server PostgreSQL database via the API.
+ *
+ * Usage:
+ *   pnpm crux citations backfill-content           # Run backfill
+ *   pnpm crux citations backfill-content --dry-run # Preview without writing
+ *
+ * Prerequisites:
+ *   - LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY must be set
+ *   - SQLite knowledge.db must exist with citation_content rows
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { citationContent, PROJECT_ROOT } from '../lib/knowledge-db.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import {
+  upsertCitationContent,
+  getCitationContentStats,
+  type UpsertCitationContentInput,
+} from '../lib/wiki-server/citations.ts';
+import { getColors } from '../lib/output.ts';
+import { parseCliArgs } from '../lib/cli.ts';
+
+const BATCH_SIZE = 20;
+const FULL_TEXT_MAX = 5 * 1024 * 1024;  // 5 MB
+const PREVIEW_MAX = 50 * 1024;           // 50 KB
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const colors = getColors(false);
+  const c = colors;
+
+  console.log(`\n${c.bold}${c.blue}Backfill Citation Content → PostgreSQL${c.reset}\n`);
+
+  if (dryRun) {
+    console.log(`  ${c.yellow}DRY RUN — no data will be written${c.reset}\n`);
+  }
+
+  // Check SQLite DB exists
+  const dbPath = join(PROJECT_ROOT, '.cache', 'knowledge.db');
+  if (!existsSync(dbPath)) {
+    console.log(`${c.red}No SQLite knowledge.db found at ${dbPath}${c.reset}`);
+    console.log('Run citation verification first to populate the local DB.');
+    process.exit(1);
+  }
+
+  // Check server availability
+  const serverAvailable = await isServerAvailable();
+  if (!serverAvailable) {
+    console.log(`${c.red}Wiki server not available.${c.reset}`);
+    console.log('Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.');
+    process.exit(1);
+  }
+
+  // Read all citation content from SQLite
+  const allRows = citationContent.getAll();
+  const withFullText = allRows.filter(r => r.full_text && r.full_text.length > 0);
+  const withoutFullText = allRows.filter(r => !r.full_text || r.full_text.length === 0);
+
+  console.log(`  SQLite total rows:      ${allRows.length}`);
+  console.log(`  With full text:         ${c.green}${withFullText.length}${c.reset}`);
+  console.log(`  Without full text:      ${c.yellow}${withoutFullText.length}${c.reset} (metadata only, will skip)`);
+
+  if (withFullText.length === 0) {
+    console.log(`\n${c.yellow}No full-text content to backfill.${c.reset}`);
+    process.exit(0);
+  }
+
+  // Show PG stats before
+  const statsBefore = await getCitationContentStats();
+  if (statsBefore.ok) {
+    console.log(`\n  PG before: ${statsBefore.data.total} total, ${statsBefore.data.withFullText} with full text`);
+  }
+
+  if (dryRun) {
+    const totalBytes = withFullText.reduce((sum, r) => sum + (r.content_length ?? 0), 0);
+    console.log(`\n  Would backfill: ${withFullText.length} rows (~${(totalBytes / 1024 / 1024).toFixed(1)} MB)`);
+    console.log(`\n${c.green}Dry run complete. Use without --dry-run to backfill.${c.reset}\n`);
+    return;
+  }
+
+  // Upsert in batches
+  let succeeded = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < withFullText.length; i += BATCH_SIZE) {
+    const batch = withFullText.slice(i, i + BATCH_SIZE);
+
+    for (const row of batch) {
+      if (!row.full_text) { skipped++; continue; }
+
+      const fullText = row.full_text.length > FULL_TEXT_MAX
+        ? row.full_text.slice(0, FULL_TEXT_MAX)
+        : row.full_text;
+      const fullTextPreview = fullText.slice(0, PREVIEW_MAX);
+
+      const item: UpsertCitationContentInput = {
+        url: row.url,
+        fetchedAt: row.fetched_at ?? new Date().toISOString(),
+        httpStatus: row.http_status ?? null,
+        contentType: row.content_type ?? null,
+        pageTitle: row.page_title ?? null,
+        fullText,
+        fullTextPreview,
+        contentLength: row.content_length ?? null,
+        contentHash: row.content_hash ?? null,
+      };
+
+      const result = await upsertCitationContent(item);
+      if (result.ok) {
+        succeeded++;
+      } else {
+        failed++;
+      }
+    }
+
+    // Progress
+    const processed = Math.min(i + BATCH_SIZE, withFullText.length);
+    const pct = Math.round((processed / withFullText.length) * 100);
+    process.stdout.write(`\r  Progress: ${pct}% (${succeeded} ok, ${failed} failed, ${skipped} skipped)`);
+  }
+  console.log('');
+
+  // Show PG stats after
+  const statsAfter = await getCitationContentStats();
+  if (statsAfter.ok) {
+    console.log(`\n  PG after:  ${statsAfter.data.total} total, ${statsAfter.data.withFullText} with full text`);
+  }
+
+  console.log(`\n${c.bold}Backfill complete:${c.reset}`);
+  console.log(`  Succeeded: ${c.green}${succeeded}${c.reset}`);
+  if (failed > 0) {
+    console.log(`  Failed:    ${c.red}${failed}${c.reset}`);
+  }
+  if (skipped > 0) {
+    console.log(`  Skipped:   ${c.yellow}${skipped}${c.reset} (no full text)`);
+  }
+  console.log('');
+}
+
+// Only run when executed directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Backfill failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/citations/citation-content-coverage.ts
+++ b/crux/citations/citation-content-coverage.ts
@@ -1,0 +1,139 @@
+/**
+ * Citation Content Coverage Stats
+ *
+ * Shows how many citation URLs have full text cached in SQLite and PostgreSQL.
+ * Useful for understanding backfill coverage before running verification.
+ *
+ * Usage:
+ *   pnpm crux citations content-coverage        # Show coverage stats
+ *   pnpm crux citations content-coverage --json # JSON output
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { citationContent, PROJECT_ROOT } from '../lib/knowledge-db.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import { getCitationContentStats } from '../lib/wiki-server/citations.ts';
+import { getColors } from '../lib/output.ts';
+import { parseCliArgs } from '../lib/cli.ts';
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const json = args.json === true;
+  const c = getColors(json);
+
+  // SQLite stats
+  const dbPath = join(PROJECT_ROOT, '.cache', 'knowledge.db');
+  const dbExists = existsSync(dbPath);
+
+  let sqliteStats: { totalUrls: number; totalPages: number; totalBytes: number } | null = null;
+  let sqliteWithFullText = 0;
+
+  if (dbExists) {
+    try {
+      sqliteStats = citationContent.stats();
+      const allRows = citationContent.getAll();
+      sqliteWithFullText = allRows.filter(r => r.full_text && r.full_text.length > 0).length;
+    } catch {
+      // DB may be locked or unavailable
+    }
+  }
+
+  // PostgreSQL stats
+  const serverAvailable = await isServerAvailable();
+  let pgStats: {
+    total: number;
+    withFullText: number;
+    withPreview: number;
+    coverage: number;
+    okCount: number;
+    deadCount: number;
+    avgContentLength: number | null;
+  } | null = null;
+
+  if (serverAvailable) {
+    const result = await getCitationContentStats();
+    if (result.ok) {
+      pgStats = result.data;
+    }
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      sqlite: sqliteStats ? {
+        totalUrls: sqliteStats.totalUrls,
+        totalPages: sqliteStats.totalPages,
+        totalBytes: sqliteStats.totalBytes,
+        withFullText: sqliteWithFullText,
+        coveragePct: sqliteStats.totalUrls > 0
+          ? Math.round((sqliteWithFullText / sqliteStats.totalUrls) * 100)
+          : 0,
+      } : null,
+      postgres: pgStats ? {
+        total: pgStats.total,
+        withFullText: pgStats.withFullText,
+        withPreview: pgStats.withPreview,
+        coverage: pgStats.coverage,
+        okCount: pgStats.okCount,
+        deadCount: pgStats.deadCount,
+        avgContentLength: pgStats.avgContentLength,
+      } : null,
+    }, null, 2));
+    return;
+  }
+
+  console.log(`\n${c.bold}${c.blue}Citation Content Coverage${c.reset}\n`);
+
+  // SQLite section
+  console.log(`${c.bold}SQLite (local cache):${c.reset}`);
+  if (!dbExists) {
+    console.log(`  ${c.yellow}No knowledge.db found at ${dbPath}${c.reset}`);
+    console.log(`  Run 'pnpm crux citations verify' to populate the local cache.`);
+  } else if (!sqliteStats) {
+    console.log(`  ${c.red}Could not read SQLite stats (DB locked?)${c.reset}`);
+  } else {
+    const pct = sqliteStats.totalUrls > 0
+      ? Math.round((sqliteWithFullText / sqliteStats.totalUrls) * 100)
+      : 0;
+    console.log(`  Total URLs:    ${sqliteStats.totalUrls}`);
+    console.log(`  Total pages:   ${sqliteStats.totalPages}`);
+    console.log(`  With full text: ${c.green}${sqliteWithFullText}${c.reset} / ${sqliteStats.totalUrls} (${pct}%)`);
+    console.log(`  Total size:    ${(sqliteStats.totalBytes / 1024 / 1024).toFixed(1)} MB`);
+  }
+
+  // PostgreSQL section
+  console.log(`\n${c.bold}PostgreSQL (server cache):${c.reset}`);
+  if (!serverAvailable) {
+    console.log(`  ${c.yellow}Server not available — set LONGTERMWIKI_SERVER_URL${c.reset}`);
+  } else if (!pgStats) {
+    console.log(`  ${c.red}Could not fetch PG stats${c.reset}`);
+  } else {
+    const pct = Math.round(pgStats.coverage * 100);
+    console.log(`  Total URLs:    ${pgStats.total}`);
+    console.log(`  With full text: ${c.green}${pgStats.withFullText}${c.reset} / ${pgStats.total} (${pct}%)`);
+    console.log(`  With preview:  ${pgStats.withPreview}`);
+    console.log(`  HTTP 200 ok:   ${pgStats.okCount}`);
+    console.log(`  HTTP 4xx dead: ${pgStats.deadCount}`);
+    if (pgStats.avgContentLength) {
+      console.log(`  Avg length:    ${(pgStats.avgContentLength / 1024).toFixed(0)} KB`);
+    }
+  }
+
+  // Backfill hint
+  if (sqliteWithFullText > 0 && pgStats && pgStats.withFullText < sqliteWithFullText) {
+    const gap = sqliteWithFullText - pgStats.withFullText;
+    console.log(`\n${c.yellow}Hint: ${gap} rows in SQLite not yet in PG.${c.reset}`);
+    console.log(`  Run: pnpm crux citations backfill-content`);
+  }
+
+  console.log('');
+}
+
+// Only run when executed directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Coverage check failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/commands/citations.ts
+++ b/crux/commands/citations.ts
@@ -96,6 +96,16 @@ const SCRIPTS = {
     passthrough: ['json', 'no-fetch', 'threshold', 'model', 'delay'],
     positional: true,
   },
+  'backfill-content': {
+    script: 'citations/backfill-citation-content.ts',
+    description: 'Backfill citation_content full text from SQLite to PostgreSQL',
+    passthrough: ['dry-run'],
+  },
+  'content-coverage': {
+    script: 'citations/citation-content-coverage.ts',
+    description: 'Show citation content coverage stats (SQLite vs PostgreSQL)',
+    passthrough: ['json'],
+  },
 };
 
 export const commands = buildCommands(SCRIPTS, 'report');

--- a/crux/lib/knowledge-db.ts
+++ b/crux/lib/knowledge-db.ts
@@ -882,6 +882,13 @@ export const citationContent = {
   },
 
   /**
+   * Get all stored citation content rows (for backfill/export)
+   */
+  getAll(): CitationContentRow[] {
+    return getDb().prepare('SELECT * FROM citation_content ORDER BY created_at').all() as CitationContentRow[];
+  },
+
+  /**
    * Get storage stats
    */
   stats(): { totalUrls: number; totalPages: number; totalBytes: number } {


### PR DESCRIPTION
## Summary

- Adds `citationContent.getAll()` to `knowledge-db.ts` to retrieve all SQLite citation_content rows
- New `pnpm crux citations backfill-content` script: reads full text from local SQLite `.cache/knowledge.db` and upserts to PostgreSQL in batches, with `--dry-run` support
- New `pnpm crux citations content-coverage` command: shows side-by-side SQLite vs PG coverage stats and hints when PG lags behind SQLite
- Register both commands in `crux/commands/citations.ts`

## Background

The SQLite citation_content cache has full source text for many URLs locally (e.g., ~34/37 Kalshi URLs), but PostgreSQL had 0 entries because `LONGTERMWIKI_SERVER_URL` isn't always set during fetches. The verification rate doubles (15% → 34%) when full text is available. Backfilling PG makes this available cross-machine.

## Usage

```bash
pnpm crux citations content-coverage            # Check current coverage
pnpm crux citations backfill-content --dry-run  # Preview without writing
pnpm crux citations backfill-content            # Run backfill
```

Note: The SQLite DB lives in `.cache/knowledge.db` in the main repo. Run from there or symlink `.cache` if working in a worktree.

## Test plan
- [x] Gate checks pass (`pnpm crux validate gate`)
- [x] TypeScript type check passes for both app and crux
- [x] `backfill-content` exits cleanly when SQLite DB not found
- [x] `content-coverage` shows helpful stats with/without server

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
