### PR TITLE
feat(claims): add crux claims extract/verify/status commands

### DIFF
--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -1,0 +1,298 @@
+/**
+ * Claims Extract — extract atomic claims from a wiki page
+ *
+ * Uses LLM to extract factual claims from each section of a wiki page,
+ * then stores them in PostgreSQL for verification and display.
+ *
+ * Claims are stored in the `claims` table with:
+ *   entityId    = page slug (e.g., "kalshi")
+ *   entityType  = "wiki-page"
+ *   claimType   = "factual" | "evaluative" | "causal" | "historical"
+ *   claimText   = the atomic claim
+ *   value       = section name where claim appears
+ *   unit        = footnote refs as comma-separated string (e.g. "1,3,7")
+ *   confidence  = "unverified" (initial) | "verified" | "unsourced"
+ *
+ * Usage:
+ *   pnpm crux claims extract <page-id>
+ *   pnpm crux claims extract <page-id> --model=google/gemini-2.0-flash-001
+ *   pnpm crux claims extract <page-id> --dry-run
+ *
+ * Requires: OPENROUTER_API_KEY or ANTHROPIC_API_KEY
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { parseCliArgs } from '../lib/cli.ts';
+import { getColors } from '../lib/output.ts';
+import { findPageFile } from '../lib/file-utils.ts';
+import { stripFrontmatter } from '../lib/patterns.ts';
+import { callOpenRouter, stripCodeFences, DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import {
+  insertClaimBatch,
+  clearClaimsForEntity,
+  type InsertClaimItem,
+} from '../lib/wiki-server/claims.ts';
+
+// ---------------------------------------------------------------------------
+// MDX preprocessing — strip JSX components and get clean text
+// ---------------------------------------------------------------------------
+
+/** Strip MDX/JSX components and return plain text suitable for LLM analysis. */
+function cleanMdxForExtraction(body: string): string {
+  return body
+    // Remove import/export statements
+    .replace(/^(import|export)\s+.*$/gm, '')
+    // Remove JSX self-closing tags: <EntityLink id="..." />, <F id="..." />, etc.
+    .replace(/<\w[\w.]*[^>]*\/>/g, ' ')
+    // Remove JSX block components: <InfoBox>...</InfoBox>, <Callout>...</Callout>
+    .replace(/<(\w[\w.]*)[^>]*>[\s\S]*?<\/\1>/g, ' ')
+    // Remove remaining JSX open/close tags
+    .replace(/<[/]?\w[\w.]*[^>]*>/g, ' ')
+    // Remove MDX-style curly expressions: {/* ... */}, {someVar}
+    .replace(/\{[^}]*\}/g, ' ')
+    // Collapse multiple blank lines
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Section splitting
+// ---------------------------------------------------------------------------
+
+interface Section {
+  heading: string;
+  content: string;
+  level: number;
+}
+
+/** Split MDX body into sections by H2/H3 headings. */
+function splitIntoSections(body: string): Section[] {
+  const lines = body.split('\n');
+  const sections: Section[] = [];
+  let currentHeading = 'Introduction';
+  let currentLevel = 1;
+  let currentLines: string[] = [];
+
+  for (const line of lines) {
+    const h2 = line.match(/^##\s+(.+)/);
+    const h3 = line.match(/^###\s+(.+)/);
+
+    if (h2 || h3) {
+      // Save previous section if it has content
+      const content = currentLines.join('\n').trim();
+      if (content.length > 50) {
+        sections.push({ heading: currentHeading, content, level: currentLevel });
+      }
+      currentHeading = (h2 || h3)![1].trim();
+      currentLevel = h2 ? 2 : 3;
+      currentLines = [];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  // Last section
+  const content = currentLines.join('\n').trim();
+  if (content.length > 50) {
+    sections.push({ heading: currentHeading, content, level: currentLevel });
+  }
+
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// LLM claim extraction
+// ---------------------------------------------------------------------------
+
+interface ExtractedClaim {
+  claimText: string;
+  claimType: 'factual' | 'evaluative' | 'causal' | 'historical';
+  footnoteRefs: string[];  // e.g. ["1", "3", "7"]
+}
+
+const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a section of a wiki article about AI safety, extract the specific, verifiable factual claims.
+
+For each claim:
+- "claimText": a single atomic, self-contained statement (not a question or heading)
+- "claimType": one of "factual" (specific facts, numbers, dates), "evaluative" (assessments or judgments), "causal" (cause-effect statements), or "historical" (historical events or trends)
+- "footnoteRefs": array of footnote numbers (as strings) that cite this claim — look for [^N] patterns near the claim
+
+Rules:
+- Each claim must be atomic (one assertion per claim)
+- Include specific numbers, names, dates when present
+- Skip headings, navigation text, and pure descriptions
+- Skip claims that are just definitions or explanations without verifiable content
+- Extract 3-8 claims per section (skip trivial or duplicate content)
+- Return only claims that appear in the given text
+
+Respond ONLY with JSON:
+{"claims": [{"claimText": "...", "claimType": "factual", "footnoteRefs": ["1", "3"]}]}`;
+
+async function extractClaimsFromSection(
+  section: Section,
+  opts: { model?: string } = {},
+): Promise<ExtractedClaim[]> {
+  const userPrompt = `SECTION: ${section.heading}
+
+${section.content}
+
+Extract atomic claims from this section. Return JSON only.`;
+
+  try {
+    const raw = await callOpenRouter(EXTRACT_SYSTEM_PROMPT, userPrompt, {
+      model: opts.model ?? DEFAULT_CITATION_MODEL,
+      maxTokens: 2000,
+      title: 'LongtermWiki Claims Extraction',
+    });
+
+    const json = stripCodeFences(raw);
+    const parsed = JSON.parse(json) as { claims?: unknown[] };
+
+    if (!Array.isArray(parsed.claims)) return [];
+
+    return parsed.claims
+      .filter((c): c is ExtractedClaim =>
+        typeof c === 'object' && c !== null &&
+        typeof (c as ExtractedClaim).claimText === 'string' &&
+        (c as ExtractedClaim).claimText.length > 10
+      )
+      .map(c => ({
+        claimText: (c as ExtractedClaim).claimText,
+        claimType: (['factual', 'evaluative', 'causal', 'historical'].includes((c as ExtractedClaim).claimType)
+          ? (c as ExtractedClaim).claimType
+          : 'factual') as ExtractedClaim['claimType'],
+        footnoteRefs: Array.isArray((c as ExtractedClaim).footnoteRefs)
+          ? (c as ExtractedClaim).footnoteRefs.map(String)
+          : [],
+      }));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const model = typeof args.model === 'string' ? args.model : undefined;
+  const c = getColors(false);
+  const positional = (args._positional as string[]) || [];
+  const pageId = positional[0];
+
+  if (!pageId) {
+    console.error(`${c.red}Error: provide a page ID${c.reset}`);
+    console.error(`  Usage: pnpm crux claims extract <page-id>`);
+    process.exit(1);
+  }
+
+  // Check server availability (unless dry-run)
+  if (!dryRun) {
+    const serverAvailable = await isServerAvailable();
+    if (!serverAvailable) {
+      console.error(`${c.red}Wiki server not available. Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.${c.reset}`);
+      console.error(`  Use --dry-run to extract without storing.`);
+      process.exit(1);
+    }
+  }
+
+  // Find and read page
+  const filePath = findPageFile(pageId);
+  if (!filePath) {
+    console.error(`${c.red}Error: page "${pageId}" not found${c.reset}`);
+    process.exit(1);
+  }
+
+  const raw = readFileSync(filePath, 'utf-8');
+  const body = stripFrontmatter(raw);
+  const cleanBody = cleanMdxForExtraction(body);
+  const sections = splitIntoSections(cleanBody);
+
+  console.log(`\n${c.bold}${c.blue}Claims Extract: ${pageId}${c.reset}\n`);
+  console.log(`  Sections found: ${sections.length}`);
+  if (dryRun) {
+    console.log(`  ${c.yellow}DRY RUN — claims will not be stored${c.reset}`);
+  }
+  console.log('');
+
+  // Extract claims from each section
+  const allClaims: Array<ExtractedClaim & { section: string }> = [];
+
+  for (const section of sections) {
+    process.stdout.write(`  ${c.dim}Extracting: ${section.heading.slice(0, 50)}...${c.reset}`);
+    const claims = await extractClaimsFromSection(section, { model });
+    allClaims.push(...claims.map(c => ({ ...c, section: section.heading })));
+    console.log(` ${c.green}${claims.length} claims${c.reset}`);
+  }
+
+  console.log(`\n  Total extracted: ${c.bold}${allClaims.length}${c.reset} claims`);
+
+  if (dryRun) {
+    console.log(`\n${c.bold}Sample claims:${c.reset}`);
+    for (const claim of allClaims.slice(0, 10)) {
+      const refs = claim.footnoteRefs.length > 0 ? ` [^${claim.footnoteRefs.join(', ^')}]` : ' (unsourced)';
+      console.log(`  [${claim.claimType}] ${claim.claimText.slice(0, 100)}${refs}`);
+    }
+    if (allClaims.length > 10) {
+      console.log(`  ... and ${allClaims.length - 10} more`);
+    }
+    console.log(`\n${c.green}Dry run complete. Remove --dry-run to store.${c.reset}\n`);
+    return;
+  }
+
+  // Store in PostgreSQL
+  console.log(`\n  Storing in PostgreSQL...`);
+
+  // Clear existing claims for this page
+  const cleared = await clearClaimsForEntity(pageId);
+  if (cleared.ok) {
+    console.log(`  ${c.dim}Cleared ${cleared.data.deleted} existing claims${c.reset}`);
+  }
+
+  // Batch insert
+  const BATCH_SIZE = 50;
+  let inserted = 0;
+  let failed = 0;
+
+  for (let i = 0; i < allClaims.length; i += BATCH_SIZE) {
+    const batch = allClaims.slice(i, i + BATCH_SIZE);
+    const items: InsertClaimItem[] = batch.map(claim => ({
+      entityId: pageId,
+      entityType: 'wiki-page',
+      claimType: claim.claimType,
+      claimText: claim.claimText,
+      value: claim.section,
+      unit: claim.footnoteRefs.length > 0 ? claim.footnoteRefs.join(',') : null,
+      confidence: 'unverified',
+      sourceQuote: null,
+    }));
+
+    const result = await insertClaimBatch(items);
+    if (result.ok) {
+      inserted += result.data.inserted;
+    } else {
+      failed += batch.length;
+    }
+  }
+
+  console.log(`\n${c.bold}Done:${c.reset}`);
+  console.log(`  Inserted: ${c.green}${inserted}${c.reset} claims`);
+  if (failed > 0) {
+    console.log(`  Failed:   ${c.red}${failed}${c.reset}`);
+  }
+  console.log(`\n  Next steps:`);
+  console.log(`    pnpm crux claims verify ${pageId}    # Verify claims against source text`);
+  console.log(`    pnpm crux claims status ${pageId}    # Show claim breakdown`);
+  console.log('');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Claims extract failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/claims/status.ts
+++ b/crux/claims/status.ts
@@ -1,0 +1,134 @@
+/**
+ * Claims Status — show claim count and verification breakdown for a page
+ *
+ * Usage:
+ *   pnpm crux claims status <page-id>
+ *   pnpm crux claims status <page-id> --json
+ */
+
+import { fileURLToPath } from 'url';
+import { parseCliArgs } from '../lib/cli.ts';
+import { getColors } from '../lib/output.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import { getClaimsByEntity } from '../lib/wiki-server/claims.ts';
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const json = args.json === true;
+  const c = getColors(json);
+  const positional = (args._positional as string[]) || [];
+  const pageId = positional[0];
+
+  if (!pageId) {
+    console.error(`${c.red}Error: provide a page ID${c.reset}`);
+    console.error(`  Usage: pnpm crux claims status <page-id>`);
+    process.exit(1);
+  }
+
+  const serverAvailable = await isServerAvailable();
+  if (!serverAvailable) {
+    console.error(`${c.red}Wiki server not available. Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.${c.reset}`);
+    process.exit(1);
+  }
+
+  const result = await getClaimsByEntity(pageId);
+  if (!result.ok) {
+    console.error(`${c.red}Could not fetch claims for ${pageId}${c.reset}`);
+    process.exit(1);
+  }
+
+  const claims = result.data.claims;
+
+  if (claims.length === 0) {
+    if (json) {
+      console.log(JSON.stringify({ pageId, total: 0, message: 'No claims found. Run: pnpm crux claims extract ' + pageId }));
+    } else {
+      console.log(`${c.yellow}No claims found for ${pageId}${c.reset}`);
+      console.log(`  Run: pnpm crux claims extract ${pageId}`);
+    }
+    process.exit(0);
+  }
+
+  // Count by type and confidence
+  const byType: Record<string, number> = {};
+  const byConfidence: Record<string, number> = {};
+  const bySection: Record<string, number> = {};
+  const sourced = claims.filter(c => c.unit && c.unit.length > 0).length;
+
+  for (const claim of claims) {
+    byType[claim.claimType] = (byType[claim.claimType] ?? 0) + 1;
+    const conf = claim.confidence ?? 'unverified';
+    byConfidence[conf] = (byConfidence[conf] ?? 0) + 1;
+    const section = claim.value ?? 'Unknown';
+    bySection[section] = (bySection[section] ?? 0) + 1;
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      pageId,
+      total: claims.length,
+      sourced,
+      unsourced: claims.length - sourced,
+      byType,
+      byConfidence,
+      bySection,
+      claims: claims.map(cl => ({
+        id: cl.id,
+        claimText: cl.claimText,
+        claimType: cl.claimType,
+        section: cl.value,
+        footnoteRefs: cl.unit ? cl.unit.split(',') : [],
+        confidence: cl.confidence,
+      })),
+    }, null, 2));
+    return;
+  }
+
+  console.log(`\n${c.bold}${c.blue}Claims Status: ${pageId}${c.reset}\n`);
+  console.log(`  Total claims:   ${c.bold}${claims.length}${c.reset}`);
+  console.log(`  Sourced:        ${sourced} (have footnote refs)`);
+  console.log(`  Unsourced:      ${claims.length - sourced}`);
+
+  console.log(`\n${c.bold}By Confidence:${c.reset}`);
+  const confOrder = ['verified', 'unverified', 'unsourced'];
+  const confColors: Record<string, string> = {
+    verified: c.green,
+    unverified: c.yellow,
+    unsourced: c.red,
+  };
+  for (const conf of [...confOrder, ...Object.keys(byConfidence).filter(k => !confOrder.includes(k))]) {
+    if (byConfidence[conf] !== undefined) {
+      const col = confColors[conf] ?? c.dim;
+      console.log(`  ${col}${conf.padEnd(12)}${c.reset}  ${byConfidence[conf]}`);
+    }
+  }
+
+  console.log(`\n${c.bold}By Claim Type:${c.reset}`);
+  for (const [type, count] of Object.entries(byType).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${type.padEnd(14)}  ${count}`);
+  }
+
+  console.log(`\n${c.bold}By Section:${c.reset}`);
+  for (const [section, count] of Object.entries(bySection).sort((a, b) => b[1] - a[1]).slice(0, 10)) {
+    console.log(`  ${section.slice(0, 40).padEnd(40)}  ${count}`);
+  }
+
+  // Show a sample of unverified claims
+  const unverified = claims.filter(cl => cl.confidence === 'unverified');
+  if (unverified.length > 0 && byConfidence['verified'] === undefined) {
+    console.log(`\n${c.yellow}No claims verified yet. Run:${c.reset}`);
+    console.log(`  pnpm crux claims verify ${pageId}`);
+  } else if (unverified.length > 0) {
+    console.log(`\n${c.yellow}${unverified.length} unverified claim(s). Run:${c.reset}`);
+    console.log(`  pnpm crux claims verify ${pageId}`);
+  }
+
+  console.log('');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Claims status failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -1,0 +1,290 @@
+/**
+ * Claims Verify — verify extracted claims against citation_content full text
+ *
+ * Reads claims stored in PG for a page, looks up source text from SQLite
+ * (local, fast) then PG (cross-machine), and verifies each claim using an LLM.
+ * Updates the stored claims with verification results (confidence field).
+ *
+ * Usage:
+ *   pnpm crux claims verify <page-id>
+ *   pnpm crux claims verify <page-id> --model=google/gemini-2.0-flash-001
+ *   pnpm crux claims verify <page-id> --dry-run   # report only, no DB writes
+ *
+ * Requires: OPENROUTER_API_KEY or ANTHROPIC_API_KEY
+ * Optional: LONGTERMWIKI_SERVER_URL (for PG fallback when SQLite is empty)
+ */
+
+import { fileURLToPath } from 'url';
+import { parseCliArgs } from '../lib/cli.ts';
+import { getColors } from '../lib/output.ts';
+import { callOpenRouter, stripCodeFences, DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
+import { citationContent } from '../lib/knowledge-db.ts';
+import { getCitationContentByUrl } from '../lib/wiki-server/citations.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import {
+  getClaimsByEntity,
+  clearClaimsForEntity,
+  insertClaimBatch,
+  type ClaimRow,
+  type InsertClaimItem,
+} from '../lib/wiki-server/claims.ts';
+import { extractCitationsFromContent } from '../lib/citation-archive.ts';
+import { findPageFile } from '../lib/file-utils.ts';
+import { stripFrontmatter } from '../lib/patterns.ts';
+import { readFileSync } from 'fs';
+
+const MIN_SOURCE_LENGTH = 100;
+const MAX_SOURCE_CHARS = 80_000;
+
+// ---------------------------------------------------------------------------
+// Source resolution — SQLite first, then PG (no network calls)
+// ---------------------------------------------------------------------------
+
+async function getSourceText(url: string): Promise<string | null> {
+  // Tier 1: SQLite local cache (fast, no network)
+  try {
+    const row = citationContent.getByUrl(url);
+    if (row?.full_text && row.full_text.length > MIN_SOURCE_LENGTH) {
+      return row.full_text.slice(0, MAX_SOURCE_CHARS);
+    }
+  } catch {
+    // SQLite unavailable
+  }
+
+  // Tier 2: PostgreSQL cache (cross-machine)
+  try {
+    const result = await getCitationContentByUrl(url);
+    if (result.ok && result.data.fullText && result.data.fullText.length > MIN_SOURCE_LENGTH) {
+      return result.data.fullText.slice(0, MAX_SOURCE_CHARS);
+    }
+  } catch {
+    // PG unavailable
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// URL lookup from citation archive for a page
+// ---------------------------------------------------------------------------
+
+/** Build a map of footnote ref → URL from the page MDX. */
+function buildFootnoteUrlMap(pageId: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const filePath = findPageFile(pageId);
+  if (!filePath) return map;
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const body = stripFrontmatter(raw);
+    const citations = extractCitationsFromContent(body);
+    for (const cit of citations) {
+      map.set(String(cit.footnote), cit.url);
+    }
+  } catch {
+    // Page not found or parse error — return empty map
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// LLM claim verification
+// ---------------------------------------------------------------------------
+
+type VerificationResult = 'verified' | 'unsupported' | 'unsourced';
+
+const VERIFY_SYSTEM_PROMPT = `You are a fact-checking assistant. Given a claim from a wiki article and the full text of its cited source, determine whether the source supports the claim.
+
+Verdicts:
+- "verified": the source clearly and directly supports the claim
+- "unsupported": the source does not contain relevant information to support this claim
+
+Rules:
+- Be strict: specific numbers, dates, and names must match exactly
+- Return "unsupported" only if you've checked the full source
+- Keep the explanation concise (1-2 sentences)
+
+Respond ONLY with JSON:
+{"verdict": "verified", "relevantQuote": "exact text from source", "explanation": "reason"}`;
+
+async function verifyClaim(
+  claimText: string,
+  sourceText: string,
+  opts: { model?: string } = {},
+): Promise<{ verdict: VerificationResult; quote: string; explanation: string }> {
+  const truncated = sourceText.slice(0, MAX_SOURCE_CHARS);
+  const userPrompt = `CLAIM: ${claimText}\n\nSOURCE TEXT:\n${truncated}\n\nReturn JSON only.`;
+
+  try {
+    const raw = await callOpenRouter(VERIFY_SYSTEM_PROMPT, userPrompt, {
+      model: opts.model ?? DEFAULT_CITATION_MODEL,
+      maxTokens: 400,
+      title: 'LongtermWiki Claim Verification',
+    });
+
+    const json = stripCodeFences(raw);
+    const parsed = JSON.parse(json) as { verdict?: string; relevantQuote?: string; explanation?: string };
+    const verdict = parsed.verdict === 'verified' ? 'verified' : 'unsupported';
+
+    return {
+      verdict,
+      quote: typeof parsed.relevantQuote === 'string' ? parsed.relevantQuote : '',
+      explanation: typeof parsed.explanation === 'string' ? parsed.explanation : '',
+    };
+  } catch {
+    return { verdict: 'unsupported', quote: '', explanation: 'Failed to parse verification response.' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args['dry-run'] === true;
+  const model = typeof args.model === 'string' ? args.model : undefined;
+  const c = getColors(false);
+  const positional = (args._positional as string[]) || [];
+  const pageId = positional[0];
+
+  if (!pageId) {
+    console.error(`${c.red}Error: provide a page ID${c.reset}`);
+    console.error(`  Usage: pnpm crux claims verify <page-id>`);
+    process.exit(1);
+  }
+
+  const serverAvailable = await isServerAvailable();
+  if (!serverAvailable) {
+    console.error(`${c.red}Wiki server not available. Set LONGTERMWIKI_SERVER_URL and LONGTERMWIKI_SERVER_API_KEY.${c.reset}`);
+    process.exit(1);
+  }
+
+  // Fetch stored claims
+  const claimsResult = await getClaimsByEntity(pageId);
+  if (!claimsResult.ok) {
+    console.error(`${c.red}Could not fetch claims for ${pageId}. Run extract first.${c.reset}`);
+    console.error(`  pnpm crux claims extract ${pageId}`);
+    process.exit(1);
+  }
+
+  const claims = claimsResult.data.claims;
+  if (claims.length === 0) {
+    console.log(`${c.yellow}No claims found for ${pageId}. Run extract first.${c.reset}`);
+    console.log(`  pnpm crux claims extract ${pageId}`);
+    process.exit(0);
+  }
+
+  console.log(`\n${c.bold}${c.blue}Claims Verify: ${pageId}${c.reset}\n`);
+  console.log(`  Claims to verify: ${claims.length}`);
+  if (dryRun) {
+    console.log(`  ${c.yellow}DRY RUN — results not stored${c.reset}`);
+  }
+  console.log('');
+
+  // Build footnote → URL map from the page
+  const footnoteUrlMap = buildFootnoteUrlMap(pageId);
+  console.log(`  Citation URLs mapped: ${footnoteUrlMap.size}`);
+
+  // Verify each claim
+  const updatedClaims: Array<ClaimRow & { newConfidence: string; newSourceQuote: string }> = [];
+
+  let verified = 0;
+  let unsupported = 0;
+  let unsourced = 0;
+  let noSource = 0;
+
+  for (const claim of claims) {
+    const footnoteRefs = claim.unit ? claim.unit.split(',').map(s => s.trim()) : [];
+
+    // If no footnote refs, mark as unsourced
+    if (footnoteRefs.length === 0) {
+      unsourced++;
+      updatedClaims.push({ ...claim, newConfidence: 'unsourced', newSourceQuote: '' });
+      process.stdout.write(`  ${c.yellow}○${c.reset} [unsourced] ${claim.claimText.slice(0, 60)}...\n`);
+      continue;
+    }
+
+    // Find source text for the first available footnote ref
+    let sourceText: string | null = null;
+    let sourceUrl = '';
+    for (const ref of footnoteRefs) {
+      const url = footnoteUrlMap.get(ref);
+      if (url) {
+        sourceText = await getSourceText(url);
+        if (sourceText) { sourceUrl = url; break; }
+      }
+    }
+
+    if (!sourceText) {
+      noSource++;
+      updatedClaims.push({ ...claim, newConfidence: 'unverified', newSourceQuote: '' });
+      process.stdout.write(`  ${c.dim}? [no-source] ${claim.claimText.slice(0, 60)}...\n`);
+      continue;
+    }
+
+    // Verify with LLM
+    const result = await verifyClaim(claim.claimText, sourceText, { model });
+
+    if (result.verdict === 'verified') {
+      verified++;
+      updatedClaims.push({ ...claim, newConfidence: 'verified', newSourceQuote: result.quote });
+      process.stdout.write(`  ${c.green}✓${c.reset} [verified] ${claim.claimText.slice(0, 60)}...\n`);
+    } else {
+      unsupported++;
+      updatedClaims.push({ ...claim, newConfidence: 'unverified', newSourceQuote: '' });
+      process.stdout.write(`  ${c.red}✗${c.reset} [unsupported] ${claim.claimText.slice(0, 60)}...\n`);
+    }
+  }
+
+  console.log(`\n${c.bold}Verification Summary:${c.reset}`);
+  console.log(`  ${c.green}Verified:${c.reset}    ${verified}`);
+  console.log(`  ${c.red}Unsupported:${c.reset} ${unsupported}`);
+  console.log(`  ${c.yellow}Unsourced:${c.reset}   ${unsourced}`);
+  console.log(`  ${c.dim}No source:${c.reset}   ${noSource}`);
+
+  if (dryRun) {
+    console.log(`\n${c.green}Dry run complete. Remove --dry-run to store results.${c.reset}\n`);
+    return;
+  }
+
+  // Store updated claims: clear + re-insert with updated confidence
+  console.log(`\n  Storing updated claims...`);
+
+  const cleared = await clearClaimsForEntity(pageId);
+  if (!cleared.ok) {
+    console.error(`${c.red}Failed to clear existing claims${c.reset}`);
+    process.exit(1);
+  }
+
+  const BATCH_SIZE = 50;
+  let inserted = 0;
+
+  for (let i = 0; i < updatedClaims.length; i += BATCH_SIZE) {
+    const batch = updatedClaims.slice(i, i + BATCH_SIZE);
+    const items: InsertClaimItem[] = batch.map(claim => ({
+      entityId: claim.entityId,
+      entityType: claim.entityType,
+      claimType: claim.claimType,
+      claimText: claim.claimText,
+      value: claim.value,
+      unit: claim.unit,
+      confidence: claim.newConfidence,
+      sourceQuote: claim.newSourceQuote || null,
+    }));
+
+    const result = await insertClaimBatch(items);
+    if (result.ok) inserted += result.data.inserted;
+  }
+
+  console.log(`  ${c.green}Updated ${inserted} claims${c.reset}`);
+  console.log(`\n  Run 'pnpm crux claims status ${pageId}' to see the full breakdown.\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Claims verify failed:', err);
+    process.exit(1);
+  });
+}

--- a/crux/commands/claims.ts
+++ b/crux/commands/claims.ts
@@ -1,0 +1,71 @@
+/**
+ * Claims Command Handlers
+ *
+ * Extract, verify, and report on atomic factual claims from wiki pages.
+ * Claims are stored in PostgreSQL for transparency display on wiki page Data tabs.
+ *
+ * Usage:
+ *   crux claims extract <page-id>    Extract atomic claims from a page (LLM)
+ *   crux claims verify <page-id>     Verify claims against citation_content full text
+ *   crux claims status <page-id>     Show claim count and verification breakdown
+ */
+
+import { buildCommands } from '../lib/cli.ts';
+
+const SCRIPTS = {
+  extract: {
+    script: 'claims/extract.ts',
+    description: 'Extract atomic claims from a wiki page using LLM',
+    passthrough: ['dry-run', 'model'],
+    positional: true,
+  },
+  verify: {
+    script: 'claims/verify.ts',
+    description: 'Verify extracted claims against citation_content full text',
+    passthrough: ['dry-run', 'model'],
+    positional: true,
+  },
+  status: {
+    script: 'claims/status.ts',
+    description: 'Show claim count and verification breakdown for a page',
+    passthrough: ['json'],
+    positional: true,
+  },
+};
+
+export const commands = buildCommands(SCRIPTS, 'status');
+
+export function getHelp(): string {
+  const commandList = Object.entries(SCRIPTS)
+    .map(([name, config]) => `  ${name.padEnd(12)} ${config.description}`)
+    .join('\n');
+
+  return `
+Claims Domain - Extract and verify atomic factual claims from wiki pages
+
+Commands:
+${commandList}
+
+Options:
+  --dry-run     Preview without storing to database
+  --model=M     LLM model override (default: google/gemini-2.0-flash-001)
+  --json        JSON output (status only)
+
+Examples:
+  crux claims extract kalshi                   Extract claims from the Kalshi page
+  crux claims extract kalshi --dry-run         Preview without storing
+  crux claims verify kalshi                    Verify claims against citation sources
+  crux claims status kalshi                    Show verification breakdown
+  crux claims status kalshi --json             JSON output
+
+Workflow:
+  1. crux claims extract <page-id>             Extract and store claims in PG
+  2. crux claims verify <page-id>              Verify against citation_content (SQLite/PG)
+  3. crux claims status <page-id>              Check coverage
+
+Notes:
+  - Extraction requires OPENROUTER_API_KEY
+  - Verification reads from local SQLite (.cache/knowledge.db) first, then PG
+  - Claims are stored with entityType="wiki-page" in the claims table
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -84,6 +84,7 @@ import * as sessionsCommands from './commands/sessions.ts';
 import * as researchCommands from './commands/research.ts';
 import * as evalsCommands from './commands/evals.ts';
 import * as healthCommands from './commands/health.ts';
+import * as claimsCommands from './commands/claims.ts';
 
 const domains = {
   validate: validateCommands,
@@ -117,6 +118,7 @@ const domains = {
   research: researchCommands,
   evals: evalsCommands,
   health: healthCommands,
+  claims: claimsCommands,
 };
 
 /**
@@ -195,6 +197,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   sessions    Session log management (write: scaffold a session YAML)
   research    Multi-source research → SourceCacheEntry[] (Exa, Perplexity, SCRY)
   evals       Hallucination detection evals & adversarial agents
+  claims      Extract and verify atomic factual claims from wiki pages
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -28,9 +28,36 @@ export interface ClearClaimsResult {
   deleted: number;
 }
 
+export interface ClaimRow {
+  id: number;
+  entityId: string;
+  entityType: string;
+  claimType: string;
+  claimText: string;
+  value: string | null;
+  unit: string | null;
+  confidence: string | null;
+  sourceQuote: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetClaimsResult {
+  claims: ClaimRow[];
+}
+
 // ---------------------------------------------------------------------------
 // API functions
 // ---------------------------------------------------------------------------
+
+export async function getClaimsByEntity(
+  entityId: string,
+): Promise<ApiResult<GetClaimsResult>> {
+  return apiRequest<GetClaimsResult>(
+    'GET',
+    `/api/claims/by-entity/${encodeURIComponent(entityId)}`,
+  );
+}
 
 export async function insertClaim(
   item: InsertClaimItem,


### PR DESCRIPTION
## Summary

New `claims` domain in crux CLI for extracting and verifying atomic factual claims from wiki pages:

- `pnpm crux claims extract <page-id>` — strips MDX, splits by section, uses LLM to extract atomic claims, stores in PG claims table
- `pnpm crux claims verify <page-id>` — reads stored claims, finds source text from SQLite (fast) then PG, verifies each claim, updates confidence
- `pnpm crux claims status <page-id>` — shows count, by-confidence/type/section breakdown with `--json` support
- `ClaimRow` type and `getClaimsByEntity()` added to `crux/lib/wiki-server/claims.ts`

## How it works

Claims are stored in the existing `claims` table with these field mappings:
- `entityId` = page slug (e.g. `kalshi`)
- `entityType` = `"wiki-page"`
- `claimType` = `"factual"` | `"evaluative"` | `"causal"` | `"historical"`
- `value` = section heading name
- `unit` = comma-separated footnote refs (e.g. `"1,3,7"`)
- `confidence` = `"unverified"` → `"verified"` | `"unsourced"` after verification

## Workflow

```bash
pnpm crux claims extract kalshi            # Extract claims (LLM, ~$0.02/page)
pnpm crux claims verify kalshi             # Verify against cached full text
pnpm crux claims status kalshi             # Show breakdown
```

Note: verification reads from local SQLite `.cache/knowledge.db` first (no network needed), then PG as fallback.

## Test plan
- [x] Gate checks pass (`pnpm crux validate gate`)
- [x] TypeScript type check passes for both app and crux
- [x] `extract --dry-run` shows claims without storing
- [x] `verify --dry-run` shows verification results without storing
- [x] `status` exits cleanly when no claims exist

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)
