### PR TITLE
feat: add desktop sidebar hide/show toggle

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -22,6 +22,8 @@ export function useSidebar() {
   return context;
 }
 
+const SIDEBAR_STORAGE_KEY = "wiki-sidebar-open";
+
 export function SidebarProvider({
   defaultOpen = true,
   className,
@@ -34,8 +36,18 @@ export function SidebarProvider({
   // Mobile sidebar is closed by default
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
+  // Sync initial state from localStorage on mount
+  React.useEffect(() => {
+    const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    if (stored !== null) setOpen(stored === "true");
+  }, []);
+
   const toggleSidebar = React.useCallback(() => {
-    setOpen((prev) => !prev);
+    setOpen((prev) => {
+      const next = !prev;
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next));
+      return next;
+    });
   }, []);
 
   const contextValue = React.useMemo<SidebarContextProps>(
@@ -186,12 +198,15 @@ export function Sidebar({
 }: React.ComponentProps<"div"> & {
   side?: "left" | "right";
 }) {
+  const { open } = useSidebar();
+
   return (
     <div
       data-slot="sidebar"
       data-side={side}
       className={cn(
         "flex flex-col w-64 flex-shrink-0 border-r border-border bg-background text-foreground max-md:hidden",
+        !open && "hidden",
         className
       )}
       {...props}

--- a/apps/web/src/components/wiki/WikiSidebar.tsx
+++ b/apps/web/src/components/wiki/WikiSidebar.tsx
@@ -18,9 +18,11 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
+  SidebarTrigger,
   MobileSidebar,
   MobileSidebarTrigger,
   useMobileSidebar,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import type { NavSection } from "@/lib/internal-nav";
 
@@ -84,13 +86,36 @@ function MobileSidebarAutoClose() {
   return null;
 }
 
+/** Floating expand button shown on desktop when sidebar is collapsed */
+function DesktopExpandTrigger() {
+  const { open } = useSidebar();
+  if (open) return null;
+  return (
+    <div className="hidden md:block sticky top-16 z-20 self-start">
+      <SidebarTrigger
+        aria-label="Show sidebar"
+        className="m-1 bg-background border border-border/60 shadow-sm rounded-md"
+      />
+    </div>
+  );
+}
+
 export function WikiSidebar({ sections }: { sections: NavSection[] }) {
   return (
     <>
-      {/* Desktop: static sidebar */}
+      {/* Desktop: static sidebar with collapse button */}
       <Sidebar className="sticky top-14 h-[calc(100vh-3.5rem)] border-r border-border/50 bg-muted/30">
+        <div className="flex items-center justify-end px-2 py-1 border-b border-border/30">
+          <SidebarTrigger
+            aria-label="Hide sidebar"
+            className="text-muted-foreground"
+          />
+        </div>
         <SidebarNav sections={sections} />
       </Sidebar>
+
+      {/* Floating expand button — visible on desktop when sidebar is hidden */}
+      <DesktopExpandTrigger />
 
       {/* Mobile: slide-out overlay */}
       <MobileSidebar>


### PR DESCRIPTION
## Summary

- Add a collapse/expand button at the top of the left sidebar on wiki pages
- Sidebar open/closed preference is persisted to `localStorage` so it survives navigation
- When collapsed, a sticky expand button appears at the left edge so users can always reopen it
- Mobile sidebar behavior is completely unchanged (uses its own overlay mechanism)

## How it works

1. `SidebarProvider` reads/writes `wiki-sidebar-open` from localStorage on toggle
2. `Sidebar` component now uses `useSidebar()` context — adds `hidden` class when collapsed on desktop
3. `WikiSidebar` gets a collapse button (PanelLeft icon) at the top of the sidebar header
4. `DesktopExpandTrigger` renders a small sticky button when sidebar is hidden

## Test plan

- [x] 264 tests pass
- [x] TypeScript clean
- [x] All 9 gate checks pass
- [ ] Manual: sidebar collapses/expands on click
- [ ] Manual: preference persists across page navigation
- [ ] Manual: mobile sidebar still works (separate mechanism)

Closes #927
