### PR TITLE
Wire RelatedPages and Backlinks to wiki-server API with local fallback

### DIFF
--- a/apps/web/src/components/RelatedPages.tsx
+++ b/apps/web/src/components/RelatedPages.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getRelatedGraphFor, getPageById, getEntityById } from "@/data";
+import { getRelatedGraphWithFallback, getPageById, getEntityById } from "@/data";
 import { ENTITY_TYPES } from "@/data/entity-ontology";
 import { getEntityTypeIcon } from "./wiki/EntityTypeIcon";
 import { getTypeLabel, getTypeColor } from "./explore/explore-utils";
@@ -179,14 +179,15 @@ function GroupSection({ group }: { group: TypeGroup }) {
   );
 }
 
-export function RelatedPages({
+export async function RelatedPages({
   entityId,
   entity,
 }: {
   entityId: string;
   entity?: { type?: string } | null;
 }) {
-  const allItems: RelatedPageItem[] = getRelatedGraphFor(entityId)
+  const { data: relatedEntries } = await getRelatedGraphWithFallback(entityId);
+  const allItems: RelatedPageItem[] = relatedEntries
     .filter((entry) => !entry.id.startsWith("__index__"))
     .map((entry) => {
       const page = getPageById(entry.id);

--- a/apps/web/src/components/wiki/Backlinks.tsx
+++ b/apps/web/src/components/wiki/Backlinks.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Link from "next/link";
-import { getBacklinksFor } from "@data";
+import { getBacklinksWithFallback } from "@data";
 import { Link2, ArrowLeft } from "lucide-react";
 
-export function Backlinks({
+export async function Backlinks({
   entityId,
   title = "What links here",
   showEmpty = false,
@@ -16,7 +16,7 @@ export function Backlinks({
   maxItems?: number;
   compact?: boolean;
 }) {
-  const links = getBacklinksFor(entityId);
+  const { data: links } = await getBacklinksWithFallback(entityId);
 
   if (links.length === 0 && !showEmpty) return null;
 

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -11,6 +11,7 @@
 import fs from "fs";
 import path from "path";
 import { loadYaml } from "@lib/yaml";
+import { fetchFromWikiServer, withApiFallback, type WithSource } from "@lib/wiki-server";
 import {
   TypedEntitySchema,
   type TypedEntity,
@@ -1076,6 +1077,44 @@ export function getBacklinksFor(
   }));
 }
 
+/** Server response shape for backlinks endpoint */
+interface ServerBacklink {
+  id: string;
+  type: string;
+  title: string;
+  relationship?: string;
+}
+
+/**
+ * Fetch backlinks from wiki-server with fallback to local database.json.
+ * Adds `href` to each entry (server doesn't include path information).
+ */
+export async function getBacklinksWithFallback(
+  entityId: string
+): Promise<WithSource<Array<{
+  id: string;
+  type: string;
+  title: string;
+  href: string;
+  relationship?: string;
+}>>> {
+  const slug = resolveId(entityId);
+
+  return withApiFallback(
+    async () => {
+      const data = await fetchFromWikiServer<{ backlinks: ServerBacklink[] }>(
+        `/api/links/backlinks/${encodeURIComponent(slug)}`
+      );
+      if (!data) return null;
+      return data.backlinks.map((link) => ({
+        ...link,
+        href: getEntityHref(link.id, link.type),
+      }));
+    },
+    () => getBacklinksFor(entityId)
+  );
+}
+
 // ============================================================================
 // RELATED GRAPH (bidirectional, multi-signal)
 // ============================================================================
@@ -1096,6 +1135,44 @@ export function getRelatedGraphFor(
     ...entry,
     href: getEntityHref(entry.id, entry.type),
   }));
+}
+
+/** Server response shape for related endpoint */
+interface ServerRelatedEntry {
+  id: string;
+  type: string;
+  title: string;
+  score: number;
+  label?: string;
+}
+
+/**
+ * Fetch related pages from wiki-server with fallback to local database.json.
+ * Adds `href` to each entry (server doesn't include path information).
+ */
+export async function getRelatedGraphWithFallback(
+  entityId: string
+): Promise<WithSource<Array<{
+  id: string;
+  type: string;
+  title: string;
+  href: string;
+  score: number;
+  label?: string;
+}>>> {
+  return withApiFallback(
+    async () => {
+      const data = await fetchFromWikiServer<{ related: ServerRelatedEntry[] }>(
+        `/api/links/related/${encodeURIComponent(entityId)}`
+      );
+      if (!data) return null;
+      return data.related.map((entry) => ({
+        ...entry,
+        href: getEntityHref(entry.id, entry.type),
+      }));
+    },
+    () => getRelatedGraphFor(entityId)
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Populates the `resource_id` column in `citation_quotes` by looking up resources during quote extraction. This enables answering "which wiki claims cite this resource?" and enriching citation data with resource metadata.

- Improved URL normalization (`http`->`https`, fragment/UTM removal, query param sorting) for higher match rates between citations and resources
- Added resource lookup in the `extract-quotes.ts` pipeline before each upsert
- Created `backfill-resource-ids` command to populate existing records (`pnpm crux citations backfill-resource-ids --dry-run`)
- Added `getByResourceId()` DAO method and SQLite/PostgreSQL indexes on `resource_id`

Closes #834

## Test plan

- [x] `pnpm crux validate gate` passes (251 tests, all blocking validations green)
- [x] `pnpm crux citations backfill-resource-ids --dry-run` runs without errors
- [x] TypeScript type check passes (app)
- [ ] After deploying PG migration: `pnpm crux citations backfill-resource-ids` populates resource_ids
- [ ] `pnpm crux citations extract-quotes <page-id> --recheck` shows resource_id in output
