### PR TITLE
fix(claims): fix coverage %, distinct unsupported confidence, source hint

### DIFF
--- a/crux/citations/citation-content-coverage.ts
+++ b/crux/citations/citation-content-coverage.ts
@@ -109,7 +109,7 @@ async function main() {
   } else if (!pgStats) {
     console.log(`  ${c.red}Could not fetch PG stats${c.reset}`);
   } else {
-    const pct = Math.round(pgStats.coverage * 100);
+    const pct = pgStats.coverage > 1 ? Math.round(pgStats.coverage) : Math.round(pgStats.coverage * 100);
     console.log(`  Total URLs:    ${pgStats.total}`);
     console.log(`  With full text: ${c.green}${pgStats.withFullText}${c.reset} / ${pgStats.total} (${pct}%)`);
     console.log(`  With preview:  ${pgStats.withPreview}`);

--- a/crux/claims/status.ts
+++ b/crux/claims/status.ts
@@ -90,11 +90,12 @@ async function main() {
   console.log(`  Unsourced:      ${claims.length - sourced}`);
 
   console.log(`\n${c.bold}By Confidence:${c.reset}`);
-  const confOrder = ['verified', 'unverified', 'unsourced'];
+  const confOrder = ['verified', 'unsupported', 'unverified', 'unsourced'];
   const confColors: Record<string, string> = {
     verified: c.green,
+    unsupported: c.red,
     unverified: c.yellow,
-    unsourced: c.red,
+    unsourced: c.dim,
   };
   for (const conf of [...confOrder, ...Object.keys(byConfidence).filter(k => !confOrder.includes(k))]) {
     if (byConfidence[conf] !== undefined) {

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -233,7 +233,7 @@ async function main() {
       process.stdout.write(`  ${c.green}✓${c.reset} [verified] ${claim.claimText.slice(0, 60)}...\n`);
     } else {
       unsupported++;
-      updatedClaims.push({ ...claim, newConfidence: 'unverified', newSourceQuote: '' });
+      updatedClaims.push({ ...claim, newConfidence: 'unsupported', newSourceQuote: '' });
       process.stdout.write(`  ${c.red}✗${c.reset} [unsupported] ${claim.claimText.slice(0, 60)}...\n`);
     }
   }
@@ -243,6 +243,15 @@ async function main() {
   console.log(`  ${c.red}Unsupported:${c.reset} ${unsupported}`);
   console.log(`  ${c.yellow}Unsourced:${c.reset}   ${unsourced}`);
   console.log(`  ${c.dim}No source:${c.reset}   ${noSource}`);
+
+  // Hint when most sourced claims have no cached source text
+  const sourcedTotal = claims.length - unsourced;
+  if (noSource > 0 && sourcedTotal > 0 && noSource / sourcedTotal > 0.5) {
+    console.log(`\n  ${c.yellow}Most sourced claims lack cached source text.${c.reset}`);
+    console.log(`  Run this first to fetch and cache citation full text:`);
+    console.log(`    pnpm crux citations verify ${pageId}`);
+    console.log(`  Then re-run: pnpm crux claims verify ${pageId}`);
+  }
 
   if (dryRun) {
     console.log(`\n${c.green}Dry run complete. Remove --dry-run to store results.${c.reset}\n`);


### PR DESCRIPTION
## Summary

Fixes three bugs discovered while testing merged PRs #933-#937:

1. **Citation content-coverage shows 10000% instead of 100%** — The server returns `coverage` as a percentage (e.g. 100), but the display code multiplied by 100 again. Added guard for values > 1.

2. **Claims verify stores "unsupported" as "unverified"** — Claims actively contradicted by sources were being stored with the same confidence as claims that simply haven't been checked yet. Now stores "unsupported" as a distinct confidence level so users can distinguish between "needs checking" and "source contradicts this."

3. **Claims verify gives no guidance when sources are uncached** — When >50% of sourced claims can't find cached source text, now prints a hint directing users to run `citations verify <page>` first.

Also updates `claims status` display to show `unsupported` in red and `unsourced` in dim, with correct ordering.

## Test plan

- [x] `pnpm crux citations content-coverage` shows 100% not 10000%
- [x] `pnpm crux claims status kalshi` shows unsupported as distinct category
- [x] All 1842 tests pass
- [x] Gate check passes
