### PR TITLE
feat(claims): support <R> resource citations in extraction and verification

### DIFF
--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -44,6 +44,8 @@ function cleanMdxForExtraction(body: string): string {
   return body
     // Remove import/export statements
     .replace(/^(import|export)\s+.*$/gm, '')
+    // Convert <R id="HASH">Text</R> to [^R:HASH] citation markers before stripping JSX
+    .replace(/<R\s+id="([^"]+)">[^<]*<\/R>/g, '[^R:$1]')
     // Remove JSX self-closing tags: <EntityLink id="..." />, <F id="..." />, etc.
     .replace(/<\w[\w.]*[^>]*\/>/g, ' ')
     // Remove JSX block components: <InfoBox>...</InfoBox>, <Callout>...</Callout>
@@ -117,7 +119,7 @@ const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a sect
 For each claim:
 - "claimText": a single atomic, self-contained statement (not a question or heading)
 - "claimType": one of "factual" (specific facts, numbers, dates), "evaluative" (assessments or judgments), "causal" (cause-effect statements), or "historical" (historical events or trends)
-- "footnoteRefs": array of footnote numbers (as strings) that cite this claim — look for [^N] patterns near the claim
+- "footnoteRefs": array of citation references (as strings) that cite this claim — look for [^N] footnote patterns (e.g. [^1], [^3]) and [^R:HASH] resource references (e.g. [^R:abc123]) near the claim. Include both types.
 
 Rules:
 - Each claim must be atomic (one assertion per claim)
@@ -128,7 +130,7 @@ Rules:
 - Return only claims that appear in the given text
 
 Respond ONLY with JSON:
-{"claims": [{"claimText": "...", "claimType": "factual", "footnoteRefs": ["1", "3"]}]}`;
+{"claims": [{"claimText": "...", "claimType": "factual", "footnoteRefs": ["1", "R:abc123"]}]}`;
 
 async function extractClaimsFromSection(
   section: Section,

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -31,6 +31,7 @@ import {
 import { extractCitationsFromContent } from '../lib/citation-archive.ts';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
+import { getResourceById } from '../lib/resource-lookup.ts';
 import { readFileSync } from 'fs';
 
 const MIN_SOURCE_LENGTH = 100;
@@ -68,8 +69,11 @@ async function getSourceText(url: string): Promise<string | null> {
 // URL lookup from citation archive for a page
 // ---------------------------------------------------------------------------
 
-/** Build a map of footnote ref → URL from the page MDX. */
-function buildFootnoteUrlMap(pageId: string): Map<string, string> {
+/**
+ * Build a map of citation ref → URL from the page MDX.
+ * Handles both [^N] footnote references and <R id="HASH"> resource references.
+ */
+function buildCitationUrlMap(pageId: string): Map<string, string> {
   const map = new Map<string, string>();
   const filePath = findPageFile(pageId);
   if (!filePath) return map;
@@ -77,9 +81,23 @@ function buildFootnoteUrlMap(pageId: string): Map<string, string> {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const body = stripFrontmatter(raw);
+
+    // Standard [^N] footnotes
     const citations = extractCitationsFromContent(body);
     for (const cit of citations) {
       map.set(String(cit.footnote), cit.url);
+    }
+
+    // <R id="HASH"> resource references → mapped as "R:HASH"
+    const rPattern = /<R\s+id="([^"]+)">/g;
+    let match;
+    while ((match = rPattern.exec(raw)) !== null) {
+      const resourceId = match[1];
+      if (map.has(`R:${resourceId}`)) continue;
+      const resource = getResourceById(resourceId);
+      if (resource?.url) {
+        map.set(`R:${resourceId}`, resource.url);
+      }
     }
   } catch {
     // Page not found or parse error — return empty map
@@ -184,7 +202,7 @@ async function main() {
   console.log('');
 
   // Build footnote → URL map from the page
-  const footnoteUrlMap = buildFootnoteUrlMap(pageId);
+  const footnoteUrlMap = buildCitationUrlMap(pageId);
   console.log(`  Citation URLs mapped: ${footnoteUrlMap.size}`);
 
   // Verify each claim


### PR DESCRIPTION
## Summary

Pages using `<R id="HASH">Title</R>` resource citations (195 pages) were completely invisible to the claims extraction pipeline — all claims showed as "unsourced" because the extractor only recognized `[^N]` markdown footnotes. This fixes the gap.

### Changes

- **Extract**: Convert `<R id="HASH">Text</R>` to `[^R:HASH]` markers in `cleanMdxForExtraction()` before stripping JSX, preserving citation information for the LLM
- **Extract prompt**: Updated to recognize both `[^N]` footnote patterns and `[^R:HASH]` resource reference patterns
- **Verify**: Renamed `buildFootnoteUrlMap()` to `buildCitationUrlMap()` and added resource ID → URL resolution via `getResourceById()` from `resource-lookup.ts`

### Impact

- Yoshua Bengio page: was 0/101 sourced claims, now has sourced claims with `[^R:...]` references
- Affects ~195 pages that use `<R>` components for citations
- Pages using `[^N]` footnotes (174 pages) are unaffected

## Test plan

- [x] `crux claims extract yoshua-bengio --dry-run` shows sourced claims with R: refs
- [x] All 1842 tests pass
- [x] Gate check passes (TS type check clean)
