### PR TITLE
Fetch update schedule from wiki-server with local fallback

### DIFF
--- a/apps/web/src/app/internal/updates/page.tsx
+++ b/apps/web/src/app/internal/updates/page.tsx
@@ -7,8 +7,8 @@ export const metadata: Metadata = {
   description: "Pages ranked by update priority based on staleness and importance.",
 };
 
-export default function UpdatesPage() {
-  const items = getUpdateSchedule();
+export default async function UpdatesPage() {
+  const { data: items } = await getUpdateSchedule();
 
   return (
     <article className="prose max-w-none">

--- a/apps/web/src/data/__tests__/data.test.ts
+++ b/apps/web/src/data/__tests__/data.test.ts
@@ -480,7 +480,7 @@ describe("Data Layer", () => {
   describe("getUpdateSchedule", () => {
     it("includes internal pages in update schedule", async () => {
       const { getUpdateSchedule } = await import("../../data/index");
-      const items = getUpdateSchedule();
+      const { data: items } = await getUpdateSchedule();
       const internalItem = items.find((i) => i.id === "internal-doc");
       expect(internalItem).toBeDefined();
       expect(internalItem!.category).toBe("internal");

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -660,9 +660,17 @@ export interface UpdateScheduleItem {
   category: string;
 }
 
-export function getUpdateSchedule(): UpdateScheduleItem[] {
-  // Pre-computed at build time in build-data.mjs (staleness, priority, daysSince, daysUntil)
-  return getDatabase().updateSchedule || [];
+export async function getUpdateSchedule(): Promise<WithSource<UpdateScheduleItem[]>> {
+  return withApiFallback(
+    async () => {
+      const data = await fetchFromWikiServer<UpdateScheduleItem[]>(
+        `/api/pages/update-schedule`
+      );
+      return data;
+    },
+    // Local fallback: pre-computed at build time in build-data.mjs
+    () => getDatabase().updateSchedule || []
+  );
 }
 
 export interface PageRankingItem {


### PR DESCRIPTION
## Summary

- Makes `getUpdateSchedule()` async, fetching live staleness data from `/api/pages/update-schedule` on the wiki-server
- Falls back to pre-computed build-time data in `database.json` when the server is unavailable (using the existing `withApiFallback` pattern)
- Updates `UpdatesPage` to be async and await the new function
- Updates the test to use `await` and destructure `{ data: items }`

This follows the same pattern as `getRelatedGraphWithFallback()` and `getBacklinksWithFallback()` added in #947.

## Why

`daysSinceUpdate` is frozen at build time and becomes increasingly stale. The wiki-server's `wiki_pages` table has live `last_updated` timestamps that can compute accurate staleness on every request.

## Test plan
- [x] All 1842 tests pass
- [x] TypeScript app check passes (`tsc --noEmit`)
- [x] Follows same `withApiFallback` pattern as related/backlinks endpoints
- [x] Local fallback still works when server is unavailable

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
