### PR TITLE
fix(test): update getUpdateSchedule test for async WithSource return type

### DIFF
--- a/apps/web/src/data/__tests__/data.test.ts
+++ b/apps/web/src/data/__tests__/data.test.ts
@@ -480,7 +480,8 @@ describe("Data Layer", () => {
   describe("getUpdateSchedule", () => {
     it("includes internal pages in update schedule", async () => {
       const { getUpdateSchedule } = await import("../../data/index");
-      const items = getUpdateSchedule();
+      const result = await getUpdateSchedule();
+      const items = result.data;
       const internalItem = items.find((i: { id: string }) => i.id === "internal-doc");
       expect(internalItem).toBeDefined();
       expect(internalItem!.category).toBe("internal");


### PR DESCRIPTION
## Summary

PR #954 changed `getUpdateSchedule()` from a synchronous function returning `UpdateScheduleItem[]` to an async function returning `Promise<WithSource<UpdateScheduleItem[]>>`. The test was not updated to match, causing:

- Test failure: `TypeError: items.find is not a function` (calling `.find` on a Promise)
- TypeScript error: `Property 'find' does not exist on type 'Promise<WithSource<UpdateScheduleItem[]>>'`

**Fix:** `await getUpdateSchedule()` and extract `.data` before calling `.find()`.

## Test plan
- [ ] `pnpm test` passes (all 32 tests in data.test.ts green)
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
