### PR TITLE
fix: await async getUpdateSchedule in test

### DIFF
--- a/apps/web/src/data/__tests__/data.test.ts
+++ b/apps/web/src/data/__tests__/data.test.ts
@@ -480,7 +480,8 @@ describe("Data Layer", () => {
   describe("getUpdateSchedule", () => {
     it("includes internal pages in update schedule", async () => {
       const { getUpdateSchedule } = await import("../../data/index");
-      const items = getUpdateSchedule();
+      const result = await getUpdateSchedule();
+      const items = result.data;
       const internalItem = items.find((i: { id: string }) => i.id === "internal-doc");
       expect(internalItem).toBeDefined();
       expect(internalItem!.category).toBe("internal");


### PR DESCRIPTION
## Summary

- Fix `getUpdateSchedule` test that was calling `.find()` on a Promise instead of awaiting it
- `getUpdateSchedule()` returns `Promise<WithSource<UpdateScheduleItem[]>>` after being wrapped with `withApiFallback`, but the test wasn't awaiting the result or accessing `.data`
- This was a pre-existing failure blocking the gate on all branches

## Test plan
- [ ] `pnpm test` — data.test.ts should show 32 passing (was 31 pass + 1 fail)
