### PR TITLE
fix(auto-update): guard paranoid review against jq parse errors from pnpm preamble

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -185,14 +185,18 @@ jobs:
             PAGE_ID=$(basename "$FILE" .mdx)
             echo "Reviewing: $PAGE_ID ($FILE)"
 
-            RESULT=$(pnpm crux content review "$PAGE_ID" \
+            RESULT_RAW=$(pnpm --silent crux content review "$PAGE_ID" \
               --model=claude-haiku-4-5-20251001 --json 2>/dev/null \
-              || echo '{"error":"review failed","gapCount":0,"needsReResearch":false}')
+              || true)
 
-            NEEDS_RESEARCH=$(echo "$RESULT" | jq -r '.needsReResearch // false')
-            GAP_COUNT=$(echo "$RESULT" | jq -r '.gapCount // 0')
-            ASSESSMENT=$(echo "$RESULT" | jq -r '.overallAssessment // "No assessment"')
-            ERROR=$(echo "$RESULT" | jq -r '.error // ""')
+            # Extract just the JSON object line (guards against any pnpm/dotenv preamble)
+            JSON_LINE=$(echo "$RESULT_RAW" | grep -E '^\{' | tail -1)
+            RESULT="${JSON_LINE:-{\"error\":\"review failed\",\"gapCount\":0,\"needsReResearch\":false}}"
+
+            NEEDS_RESEARCH=$(echo "$RESULT" | jq -r '.needsReResearch // false' 2>/dev/null || echo "false")
+            GAP_COUNT=$(echo "$RESULT" | jq -r '.gapCount // 0' 2>/dev/null || echo "0")
+            ASSESSMENT=$(echo "$RESULT" | jq -r '.overallAssessment // "No assessment"' 2>/dev/null || echo "No assessment")
+            ERROR=$(echo "$RESULT" | jq -r '.error // ""' 2>/dev/null || echo "parse-error")
 
             if [ -n "$ERROR" ] && [ "$ERROR" != "null" ]; then
               echo "::warning::$PAGE_ID — review failed: $ERROR"


### PR DESCRIPTION
## Summary

The "Paranoid review" step in `auto-update.yml` was failing with `jq: parse error: Invalid numeric literal` because `pnpm` and/or `dotenv` can output preamble text to stdout before the JSON from `crux content review --json`, polluting the `RESULT` variable.

**Root cause:** `pnpm crux content review language-models --json` returned output like:
```
[pnpm/dotenv preamble line]
{"pageId":"language-models",...}
```
When `jq` tried to parse this, it failed on the preamble line.

**Fix:**
- Use `pnpm --silent` to suppress pnpm's own output lines  
- Extract only the JSON line from the output using `grep -E '^\{'`
- Add `2>/dev/null || echo fallback` to each `jq` call to survive any remaining parse failures gracefully (warn and continue rather than failing CI)

## Test plan
- [ ] Auto-update workflow no longer fails on paranoid review jq parse errors
- [ ] Pages that genuinely fail review are still blocked (real JSON output still parsed correctly)
- [ ] Pages where review errors occur emit `::warning::` annotations instead of breaking CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
