### PR TITLE
Add camelCase flag support and update-title command

### DIFF
--- a/content/docs/internal/citation-architecture.mdx
+++ b/content/docs/internal/citation-architecture.mdx
@@ -98,7 +98,7 @@ The Kalshi page is a good exemplar because it exercises the full system:
 | Metric | Value |
 |--------|-------|
 | Total footnotes | 87 |
-| Unique source URLs | \≈35 |
+| Unique source URLs | ≈35 |
 | Resource YAML entries | 31 |
 | Citation quotes (Postgres) | 87 |
 | Verified accurate | 84 (96.6%) |

--- a/crux/commands/issues.test.ts
+++ b/crux/commands/issues.test.ts
@@ -1357,3 +1357,45 @@ describe('issues update-body — camelCase flag keys (#981)', () => {
     unlinkSync(tmpPath);
   });
 });
+
+// ---------------------------------------------------------------------------
+// update-title command
+// ---------------------------------------------------------------------------
+
+describe('issues update-title', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates issue title', async () => {
+    mockGithubApi.mockResolvedValueOnce({
+      number: 500,
+      html_url: 'https://github.com/test/issues/500',
+      title: 'Old Title',
+      body: '## Problem\n\nSome problem.',
+      labels: [],
+    });
+    mockGithubApi.mockResolvedValueOnce({}); // PATCH
+
+    const result = await commands['update-title'](['500'], { title: 'New Title' });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Updated title');
+    expect(result.output).toContain('Old Title');
+    expect(result.output).toContain('New Title');
+
+    const patchCall = mockGithubApi.mock.calls[1];
+    expect((patchCall[1] as { body: { title: string } }).body.title).toBe('New Title');
+  });
+
+  it('returns error when no issue number provided', async () => {
+    const result = await commands['update-title']([], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Usage');
+  });
+
+  it('returns error when --title flag is missing', async () => {
+    const result = await commands['update-title'](['500'], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Missing --title');
+  });
+});

--- a/crux/commands/issues.ts
+++ b/crux/commands/issues.ts
@@ -1348,6 +1348,48 @@ async function lint(args: string[], options: CommandOptions): Promise<CommandRes
 }
 
 // ---------------------------------------------------------------------------
+// update-title
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the title of an existing issue.
+ */
+async function updateTitle(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const issueNum = parseRequiredInt(args[0]);
+  if (!issueNum) {
+    return {
+      output: `${c.red}Usage: crux issues update-title <issue-number> --title="New title"${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const newTitle = options.title as string | undefined;
+  if (!newTitle) {
+    return {
+      output: `${c.red}Missing --title flag. Usage: crux issues update-title <N> --title="New title"${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const issue = await githubApi<GitHubIssueResponse>(`/repos/${REPO}/issues/${issueNum}`);
+
+  await githubApi(`/repos/${REPO}/issues/${issueNum}`, {
+    method: 'PATCH',
+    body: { title: newTitle },
+  });
+
+  let output = `${c.green}✓${c.reset} Updated title for issue #${issueNum}\n`;
+  output += `  ${c.dim}Old:${c.reset} ${issue.title}\n`;
+  output += `  ${c.green}New:${c.reset} ${newTitle}\n`;
+  output += `  ${c.cyan}${issue.html_url}${c.reset}\n`;
+
+  return { output, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
 // Command registry
 // ---------------------------------------------------------------------------
 
@@ -1357,6 +1399,7 @@ export const commands = {
   next,
   create,
   'update-body': updateBody,
+  'update-title': updateTitle,
   lint,
   start,
   done,
@@ -1373,6 +1416,7 @@ Commands:
   next                Show the single next issue to pick up
   create <title>      Create a new GitHub issue (supports structured template)
   update-body <N>     Update an issue body using structured template args
+  update-title <N>    Update an issue title
   lint [N]            Check issue formatting (all issues, or single by number)
   start <N>           Signal start: post comment + add \`claude-working\` label
   done <N>            Signal completion: post comment + remove label
@@ -1396,6 +1440,9 @@ Options (create):
   --model=haiku|sonnet|opus  Recommended model for this issue (REQUIRED)
   --cost="~$2-4"      Estimated AI cost
   --draft             Skip --model/--criteria validation (for WIP issues)
+
+Options (update-title):
+  --title="..."       New title for the issue (REQUIRED)
 
 Options (update-body):
   --body-file=<path>  Set raw body directly (no merge — use for rich multi-section bodies)


### PR DESCRIPTION
## Summary
This PR adds support for camelCase flag keys in the issues commands and introduces a new `update-title` command for updating issue titles.

## Key Changes

- **camelCase flag support (#981)**: Updated `create` and `update-body` commands to accept both camelCase (`bodyFile`, `problemFile`) and kebab-case (`body-file`, `problem-file`) flag formats. The implementation checks for camelCase first, falling back to kebab-case for backward compatibility.

- **New `update-title` command**: Added a new command to update issue titles with the following features:
  - Requires issue number as argument
  - Requires `--title` flag with new title text
  - Displays old and new titles in output
  - Includes proper error handling for missing arguments/flags

- **Documentation updates**: Updated help text to include the new `update-title` command and its options

- **Test coverage**: Added comprehensive test suites for:
  - camelCase `bodyFile` and `problemFile` in `create` command
  - camelCase `bodyFile` and `problemFile` in `update-body` command
  - `update-title` command functionality and error cases

- **Minor fix**: Corrected escaped character in citation-architecture documentation (changed `\≈` to `≈`)

## Implementation Details

The camelCase support is implemented by checking the camelCase version first before falling back to the kebab-case version:
```typescript
bodyFromFile = readFileFlag((options.bodyFile ?? options['body-file']) as string | undefined) ?? undefined;
```

This approach maintains backward compatibility while supporting the CLI's automatic kebab-to-camel conversion.

https://claude.ai/code/session_017QjtT1cmy133ZwVPHaqV6M