### PR TITLE
Add stamp-based caching to validate gate to skip re-runs

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -114,7 +114,7 @@ const SCRIPTS = {
   gate: {
     script: 'validate/validate-gate.ts',
     description: 'CI-blocking checks (pre-push gate)',
-    passthrough: ['ci', 'full', 'fix', 'fullGate', 'noTriage'],
+    passthrough: ['ci', 'full', 'fix', 'fullGate', 'noTriage', 'noCache'],
   },
   'hallucination-risk': {
     script: 'validate/validate-hallucination-risk.ts',
@@ -153,7 +153,8 @@ Examples:
   crux validate gate                      Run CI-blocking checks (with triage)
   crux validate gate --full               Include full Next.js build
   crux validate gate --no-triage          Skip LLM triage, run all checks
-  crux validate gate --full-gate          Force all checks (implies --no-triage)
+  crux validate gate --no-cache           Force re-run even if stamp matches HEAD
+  crux validate gate --full-gate          Force all checks (implies --no-triage, --no-cache)
   crux validate compile --quick           Quick compile check
   crux validate unified --rules=dollar-signs,markdown-lists
   crux validate unified --fix             Auto-fix unified rule issues

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -20,11 +20,12 @@
  *   4. Full Next.js production build
  *
  * Flags:
- *   --full-gate    Force all checks, no triage (implies --no-triage)
+ *   --full-gate    Force all checks, no triage (implies --no-triage, --no-cache)
  *   --no-triage    Skip LLM triage call, run all checks
+ *   --no-cache     Ignore stamp cache, force full re-run
  *   --fix          Auto-fix escaping + markdown before validation
  *   --full         Include full Next.js production build
- *   --ci           JSON output for CI pipelines
+ *   --ci           JSON output for CI pipelines (implies --no-cache)
  *
  * Exit codes:
  *   0 = All checks passed
@@ -32,6 +33,8 @@
  */
 
 import { execSync, spawn, type ChildProcess } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
 import { categorizeFiles, canSkipBuildData, triageGateChecks, type TriageResult } from './gate-triage.ts';
@@ -41,6 +44,42 @@ const FIX_MODE: boolean = args.includes('--fix');
 const CI_MODE: boolean = args.includes('--ci') || process.env.CI === 'true';
 const FULL_GATE: boolean = args.includes('--full-gate');
 const NO_TRIAGE: boolean = args.includes('--no-triage') || FULL_GATE || CI_MODE;
+const NO_CACHE: boolean = args.includes('--no-cache') || FULL_GATE || CI_MODE;
+
+// ── Stamp-based caching ──────────────────────────────────────────────────────
+// After a successful gate run, we write the HEAD commit hash + mode to a stamp
+// file inside .git/. On subsequent runs, if HEAD hasn't changed and the mode
+// is compatible, we skip the entire gate. This prevents re-running a ~5min
+// check suite on repeated push attempts for the same commit.
+
+const STAMP_FILE = join(PROJECT_ROOT, '.git', 'gate-stamp');
+
+function getHeadHash(): string {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: PROJECT_ROOT, encoding: 'utf-8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function readStamp(): { hash: string; mode: string } | null {
+  try {
+    const content = readFileSync(STAMP_FILE, 'utf-8').trim();
+    const [hash, mode] = content.split(' ');
+    if (hash && mode) return { hash, mode };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStamp(hash: string, mode: string): void {
+  try {
+    writeFileSync(STAMP_FILE, `${hash} ${mode}\n`);
+  } catch {
+    // Non-fatal: stamp write failure just means next push will re-run the gate
+  }
+}
 
 /**
  * Get the list of files changed on this branch vs main.
@@ -355,6 +394,24 @@ async function main(): Promise<void> {
   let triageResult: TriageResult | null = null;
   let skippedBuildData = false;
 
+  // ── Stamp cache check — skip gate if HEAD unchanged since last pass ────────
+  if (!NO_CACHE) {
+    const headHash = getHeadHash();
+    const stamp = readStamp();
+    if (headHash && stamp && stamp.hash === headHash) {
+      // A "full" stamp satisfies both full and fast requests.
+      // A "fast" stamp only satisfies fast requests.
+      const modeOk = stamp.mode === 'full' || !FULL_MODE;
+      if (modeOk) {
+        if (!CI_MODE) {
+          console.log(`\n${c.green}${c.bold}  ✅ Gate already passed for this commit${c.reset} ${c.dim}(${headHash.slice(0, 8)}, ${stamp.mode} mode)${c.reset}`);
+          console.log(`${c.dim}  Skipping re-run. Use --no-cache to force.${c.reset}\n`);
+        }
+        process.exit(0);
+      }
+    }
+  }
+
   // ── Phase 0: Triage — decide which checks to skip ─────────────────────────
   if (!NO_TRIAGE && changedFiles.length > 0) {
     const categories = categorizeFiles(changedFiles);
@@ -446,6 +503,13 @@ async function main(): Promise<void> {
   }
 
   printSummary(allResults, totalStart, skippedCount);
+
+  // Write stamp so subsequent pushes of the same commit skip the gate
+  const headHash = getHeadHash();
+  if (headHash) {
+    writeStamp(headHash, FULL_MODE ? 'full' : 'fast');
+  }
+
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
Implements a stamp-based caching mechanism for the validate gate to avoid re-running the ~5 minute check suite when the same commit is pushed multiple times. The gate now writes a stamp file containing the HEAD commit hash and execution mode after a successful run, and skips execution on subsequent runs if the commit hasn't changed.

## Key Changes
- **Stamp caching system**: Added `readStamp()`, `writeStamp()`, and `getHeadHash()` functions to manage a `.git/gate-stamp` file that tracks the last successful gate run
- **New `--no-cache` flag**: Allows users to force a full re-run even if the stamp matches the current HEAD commit
- **Mode-aware caching**: Distinguishes between "full" and "fast" mode stamps—a "full" stamp satisfies both full and fast requests, but a "fast" stamp only satisfies fast requests
- **Automatic cache invalidation**: The `--full-gate` and `--ci` flags now imply `--no-cache` to ensure these critical paths always run fresh
- **User feedback**: When a gate is skipped due to cache hit, displays the commit hash and mode (only in non-CI mode)
- **Updated CLI documentation**: Added `--no-cache` to the passthrough arguments and updated help text to reflect the new flag and its implications

## Implementation Details
- The stamp file is stored in `.git/gate-stamp` (git-ignored, non-critical)
- Stamp format is simple: `<commit-hash> <mode>` (e.g., `abc1234def5678 full`)
- Cache checks happen early in the main flow, before any triage or validation work
- Stamp write failures are non-fatal and logged silently to prevent gate failures
- The cache respects the execution mode: full builds require a "full" stamp, while fast runs accept either mode

https://claude.ai/code/session_011YLUUT5Zic33NJq7CuPuff