### PR TITLE
Sort 'Recently Created' by EID instead of date_created

### DIFF
--- a/apps/web/src/components/explore/ExploreGrid.tsx
+++ b/apps/web/src/components/explore/ExploreGrid.tsx
@@ -608,8 +608,11 @@ export function ExploreGrid({ initialItems, initialTotal, initialFacets, allItem
             return (b.wordCount || 0) - (a.wordCount || 0);
           case "recentlyEdited":
             return (b.lastUpdated || "").localeCompare(a.lastUpdated || "");
-          case "recentlyCreated":
-            return (b.dateCreated || "").localeCompare(a.dateCreated || "");
+          case "recentlyCreated": {
+            const aNum = parseInt(a.numericId?.replace(/^E/, "") || "0", 10);
+            const bNum = parseInt(b.numericId?.replace(/^E/, "") || "0", 10);
+            return bNum - aNum;
+          }
           case "relevance": {
             const scoreA = (a.readerImportance || 0) * 2 + (a.quality || 0);
             const scoreB = (b.readerImportance || 0) * 2 + (b.quality || 0);

--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -176,7 +176,7 @@ const SORT_COLUMNS: Record<string, string> = {
   researchImportance: "wp.research_importance",
   tacticalValue: "wp.tactical_value",
   recentlyEdited: "wp.last_updated",
-  recentlyCreated: "wp.date_created",
+  recentlyCreated: "CAST(SUBSTRING(wp.numeric_id FROM 2) AS INTEGER)",
   wordCount: "wp.word_count",
   title: "wp.title",
 };


### PR DESCRIPTION
## Summary

- **Server**: `recentlyCreated` sort now uses `CAST(SUBSTRING(wp.numeric_id FROM 2) AS INTEGER)` instead of `wp.date_created`
- **Client**: fallback comparator now parses `numericId` (e.g. `E42` → `42`) and sorts numerically

EIDs are sequential integers assigned at entity creation time, making them a reliable and unambiguous proxy for creation order. The previous `date_created` field was derived from unreliable git history and was often `null`.

https://claude.ai/code/session_017rEstRTg5BFSXNgbB1eGpM
