### PR TITLE
docs: add .env.example for wiki-server

### DIFF
--- a/apps/wiki-server/.env.example
+++ b/apps/wiki-server/.env.example
@@ -1,0 +1,20 @@
+# wiki-server environment variables
+# Copy to .env and fill in values for local development.
+
+# Required: PostgreSQL connection string
+DATABASE_URL=postgresql://user:password@localhost:5432/longterm_wiki
+
+# Legacy superkey — grants all scopes; still accepted but prefer scoped keys below
+LONGTERMWIKI_SERVER_API_KEY=your-legacy-api-key-here
+
+# Scoped keys (introduced in PR #972 — set as GitHub secrets for CI workflows)
+# LONGTERMWIKI_PROJECT_KEY grants: coordination operations (IDs, sessions, edit logs,
+#   jobs, agent sessions, auto-update tracking)
+LONGTERMWIKI_PROJECT_KEY=your-project-key-here
+
+# LONGTERMWIKI_CONTENT_KEY grants: destructive content sync (pages, entities, facts,
+#   citations, resources, links, etc.)
+LONGTERMWIKI_CONTENT_KEY=your-content-key-here
+
+# Optional: HTTP port (default: 3100)
+PORT=3100


### PR DESCRIPTION
## Summary

Adds `apps/wiki-server/.env.example` documenting all five environment variables referenced in the wiki-server source code.

Previously there was no documentation of required env vars in the wiki-server directory — you had to grep the source to discover them. This was flagged in the PR review session as an onboarding/deploy setup gap.

**Variables documented:**
- `DATABASE_URL` — PostgreSQL connection string (required)
- `LONGTERMWIKI_SERVER_API_KEY` — legacy superkey, still accepted
- `LONGTERMWIKI_PROJECT_KEY` — scoped key for coordination ops (added PR #972)
- `LONGTERMWIKI_CONTENT_KEY` — scoped key for content sync (added PR #972)
- `PORT` — HTTP port, optional (default 3100)

## Test plan

- [ ] File exists and is readable
- [ ] All env vars match what `grep process.env` finds in `apps/wiki-server/src/`
