### PR TITLE
feat: add Drizzle migration journal validation to gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
       - name: .returning() guard check (blocking)
         run: npx tsx crux/validate/validate-returning-guard.ts
 
+      - name: Drizzle migration journal integrity (blocking)
+        run: npx tsx crux/validate/validate-drizzle-journal.ts
+
       - name: Auto-update orchestrator smoke test (dry-run)
         # Verifies the orchestrator pipeline doesn't crash — specifically guards
         # against missing mkdirSync before writeFileSync in saveRunDetails / saveRunReport.

--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -111,6 +111,11 @@ const SCRIPTS = {
     description: 'Cross-page numeric claim consistency checker — flag contradictory facts about the same entity',
     passthrough: ['ci', 'json', 'entity', 'top', 'limit'],
   },
+  'drizzle-journal': {
+    script: 'validate/validate-drizzle-journal.ts',
+    description: 'Verify all migration SQL files are registered in Drizzle journal',
+    passthrough: ['ci'],
+  },
   gate: {
     script: 'validate/validate-gate.ts',
     description: 'CI-blocking checks (pre-push gate)',

--- a/crux/validate/validate-drizzle-journal.ts
+++ b/crux/validate/validate-drizzle-journal.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that every Drizzle migration SQL file is registered in the journal.
+ *
+ * drizzle-kit generate creates the .sql file automatically but never updates
+ * _journal.json. This causes migrations to be silently skipped on every server
+ * restart/deploy. This check catches that before push.
+ *
+ * The journal uses sequential `idx` values and `tag` = filename without .sql.
+ * Duplicate-numbered files (e.g. two 0022_* files from branch merges) are
+ * handled correctly: both must have journal entries; only missing tags fail.
+ *
+ * Usage: npx tsx crux/validate/validate-drizzle-journal.ts
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { getColors } from '../lib/output.ts';
+
+const DRIZZLE_DIR = 'apps/wiki-server/drizzle';
+const JOURNAL_PATH = join(DRIZZLE_DIR, 'meta/_journal.json');
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  missing: string[];
+  sqlFiles: string[];
+  journalTags: string[];
+}
+
+export function runCheck(): CheckResult {
+  const c = getColors();
+  console.log(`${c.blue}Checking Drizzle migration journal integrity...${c.reset}\n`);
+
+  // Read SQL files
+  let sqlFiles: string[];
+  try {
+    sqlFiles = readdirSync(DRIZZLE_DIR)
+      .filter((f) => f.endsWith('.sql'))
+      .map((f) => f.replace(/\.sql$/, ''))
+      .sort();
+  } catch {
+    console.log(`${c.dim}Skipping: ${DRIZZLE_DIR} not found${c.reset}`);
+    return { passed: true, errors: 0, missing: [], sqlFiles: [], journalTags: [] };
+  }
+
+  // Read journal
+  let journal: Journal;
+  try {
+    journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8')) as Journal;
+  } catch (err) {
+    console.log(`${c.red}Failed to read journal at ${JOURNAL_PATH}: ${err}${c.reset}`);
+    return { passed: false, errors: 1, missing: [JOURNAL_PATH], sqlFiles, journalTags: [] };
+  }
+
+  const journalTags = new Set(journal.entries.map((e) => e.tag));
+
+  // Find SQL files with no matching journal entry
+  const missing = sqlFiles.filter((tag) => !journalTags.has(tag));
+
+  if (missing.length === 0) {
+    console.log(
+      `${c.green}All ${sqlFiles.length} migration files are registered in the journal${c.reset}`
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${missing.length} migration file${missing.length > 1 ? 's' : ''} not registered in ${JOURNAL_PATH}:${c.reset}\n`
+    );
+    for (const tag of missing) {
+      console.log(`  ${c.red}${tag}.sql${c.reset}`);
+    }
+    console.log();
+    console.log(
+      `${c.dim}Fix: add an entry for each missing tag to ${JOURNAL_PATH}${c.reset}`
+    );
+    console.log(
+      `${c.dim}Each entry needs: idx (next sequential), version, when (epoch ms), tag, breakpoints: true${c.reset}`
+    );
+    console.log(
+      `${c.dim}Without this, the Drizzle migrator will silently skip these migrations on every deploy.${c.reset}`
+    );
+  }
+
+  return {
+    passed: missing.length === 0,
+    errors: missing.length,
+    missing,
+    sqlFiles,
+    journalTags: [...journalTags],
+  };
+}
+
+if (process.argv[1]?.includes('validate-drizzle-journal')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -232,6 +232,13 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'drizzle-journal',
+    name: 'Drizzle migration journal integrity',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-drizzle-journal.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     id: 'mdx-compile',
     name: 'MDX compilation smoke-test (advisory)',
     command: 'npx',


### PR DESCRIPTION
## Summary

Adds `crux/validate/validate-drizzle-journal.ts` — a blocking check that fails if any `.sql` file in `apps/wiki-server/drizzle/` has no matching entry in `_journal.json`.

**Why:** `drizzle-kit generate` creates the `.sql` file automatically but never updates the journal. Drizzle's migrator reads the journal to decide which migrations to run — if an entry is missing, the migration is silently skipped on every server restart. This caused two separate production incidents:
- PR #989 fixed 4 missing journal entries
- Commit 1e266d20 (from the PR review session) fixed 2 more (migrations 0026 and 0027 from PRs #998 and #999)

**What the check does:**
- Reads all `*.sql` files from `apps/wiki-server/drizzle/`
- Reads `meta/_journal.json`
- Fails with a clear message listing each unregistered file if any tag is missing
- Handles the existing duplicate-numbered files (`0022_*`, `0024_*`) correctly — validates by tag name, not sequential number

**Integrated in 3 places:**
1. `pnpm crux validate drizzle-journal` — standalone command
2. `pnpm crux validate gate` — pre-push blocking check (was 8 checks, now 9)
3. CI validate job (`.github/workflows/ci.yml`) — blocks PR merges

**Tested:**
- Passes cleanly on current repo (31 SQL files, 31 journal entries)
- Correctly returns exit code 1 when a migration file is present but not in the journal

## Test plan

- [ ] Gate passes (10 checks all green) ✅
- [ ] `pnpm crux validate drizzle-journal` outputs "All 31 migration files are registered" ✅
- [ ] Check CI on this PR passes the new "Drizzle migration journal integrity" step

Closes #1008
