### PR TITLE
Enhance claims system with multi-entity support and claim categories

### DIFF
--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -75,11 +75,49 @@ function ConfidenceBadge({ confidence }: { confidence: string | null }) {
     verified: "bg-green-100 text-green-800",
     unverified: "bg-yellow-100 text-yellow-800",
     unsourced: "bg-red-100 text-red-800",
+    unsupported: "bg-red-100 text-red-800",
   };
   const cls = colorMap[val] ?? "bg-gray-100 text-gray-800";
   return (
     <span className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium ${cls}`}>
       {val}
+    </span>
+  );
+}
+
+/** Badge for claim category (factual, opinion, analytical, speculative, relational) */
+function CategoryBadge({ category }: { category: string | null }) {
+  if (!category) return null;
+  const colorMap: Record<string, string> = {
+    factual: "bg-blue-50 text-blue-700 border-blue-200",
+    opinion: "bg-purple-50 text-purple-700 border-purple-200",
+    analytical: "bg-amber-50 text-amber-700 border-amber-200",
+    speculative: "bg-orange-50 text-orange-700 border-orange-200",
+    relational: "bg-teal-50 text-teal-700 border-teal-200",
+  };
+  const cls = colorMap[category] ?? "bg-gray-50 text-gray-600 border-gray-200";
+  return (
+    <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium border ${cls}`}>
+      {category}
+    </span>
+  );
+}
+
+/** Render related entity badges as links */
+function RelatedEntityBadges({ entities }: { entities: string[] | null }) {
+  if (!entities || entities.length === 0) return null;
+  return (
+    <span className="inline-flex gap-1 flex-wrap">
+      {entities.map(eid => (
+        <Link
+          key={eid}
+          href={`/wiki/${eid}`}
+          className="inline-block px-1 py-0.5 rounded text-[10px] bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-900"
+          title={`Related entity: ${eid}`}
+        >
+          {eid}
+        </Link>
+      ))}
     </span>
   );
 }
@@ -131,6 +169,16 @@ function CredDots({ level }: { level: number }) {
 type RefEntry = { title: string | null; url: string | null; resourceId?: string; domain?: string };
 type SourceEntry = RefEntry & { footnoteNum: number; credibility?: number; claimCount: number };
 
+/** Get the section name for a claim, preferring the new field over legacy */
+function getClaimSection(claim: ClaimRow): string {
+  return claim.section ?? claim.value ?? "Unknown";
+}
+
+/** Get footnote ref string, preferring new field over legacy */
+function getClaimFootnoteRefs(claim: ClaimRow): string | null {
+  return claim.footnoteRefs ?? claim.unit ?? null;
+}
+
 /** Build shared data structures from claims + footnote index */
 function buildClaimsData(claims: ClaimRow[], fnIndex?: FootnoteIndexEntry) {
   const byConfidence: Record<string, number> = {};
@@ -139,7 +187,13 @@ function buildClaimsData(claims: ClaimRow[], fnIndex?: FootnoteIndexEntry) {
     byConfidence[key] = (byConfidence[key] ?? 0) + 1;
   }
 
-  const sections = [...new Set(claims.map(c => c.value ?? "Unknown"))];
+  const byCategory: Record<string, number> = {};
+  for (const c of claims) {
+    const cat = c.claimCategory ?? "uncategorized";
+    byCategory[cat] = (byCategory[cat] ?? 0) + 1;
+  }
+
+  const sections = [...new Set(claims.map(c => getClaimSection(c)))];
 
   const refMap = new Map<number, RefEntry>();
   if (fnIndex) {
@@ -155,7 +209,7 @@ function buildClaimsData(claims: ClaimRow[], fnIndex?: FootnoteIndexEntry) {
 
   const allFootnoteNums = new Set<number>();
   for (const claim of claims) {
-    for (const n of parseFootnoteNums(claim.unit)) allFootnoteNums.add(n);
+    for (const n of parseFootnoteNums(getClaimFootnoteRefs(claim))) allFootnoteNums.add(n);
   }
 
   const seenUrls = new Set<string>();
@@ -168,29 +222,51 @@ function buildClaimsData(claims: ClaimRow[], fnIndex?: FootnoteIndexEntry) {
     seenUrls.add(key);
     const resource = entry.resourceId ? getResourceById(entry.resourceId) : undefined;
     const credibility = resource ? getResourceCredibility(resource) : undefined;
-    const claimCount = claims.filter(c => parseFootnoteNums(c.unit).includes(n)).length;
+    const claimCount = claims.filter(c => parseFootnoteNums(getClaimFootnoteRefs(c)).includes(n)).length;
     uniqueSources.push({ footnoteNum: n, ...entry, credibility, claimCount });
   }
   uniqueSources.sort((a, b) => b.claimCount - a.claimCount);
 
-  return { byConfidence, sections, refMap, uniqueSources };
+  // Count multi-entity claims
+  const multiEntityCount = claims.filter(c =>
+    c.relatedEntities && c.relatedEntities.length > 0
+  ).length;
+
+  return { byConfidence, byCategory, sections, refMap, uniqueSources, multiEntityCount };
 }
 
 function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: FootnoteIndexEntry }) {
-  const { byConfidence, sections, refMap } = buildClaimsData(claims, fnIndex);
+  const { byConfidence, byCategory, sections, refMap, multiEntityCount } = buildClaimsData(claims, fnIndex);
 
   return (
     <div>
-      {/* Summary bar */}
-      <div className="flex gap-3 mb-4 flex-wrap">
-        {Object.entries(byConfidence).map(([conf, count]) => (
+      {/* Summary bar: confidence distribution */}
+      <div className="flex gap-3 mb-3 flex-wrap">
+        {Object.entries(byConfidence).map(([conf, cnt]) => (
           <div key={conf} className="flex items-center gap-1">
             <ConfidenceBadge confidence={conf} />
-            <span className="text-xs text-gray-600">{count}</span>
+            <span className="text-xs text-gray-600">{cnt}</span>
           </div>
         ))}
         <span className="text-xs text-gray-500 ml-auto">{claims.length} total claims</span>
       </div>
+
+      {/* Category distribution bar */}
+      {Object.keys(byCategory).length > 1 && (
+        <div className="flex gap-3 mb-3 flex-wrap">
+          {Object.entries(byCategory).sort((a, b) => b[1] - a[1]).map(([cat, cnt]) => (
+            <div key={cat} className="flex items-center gap-1">
+              <CategoryBadge category={cat} />
+              <span className="text-xs text-gray-600">{cnt}</span>
+            </div>
+          ))}
+          {multiEntityCount > 0 && (
+            <span className="text-xs text-gray-500 ml-auto">
+              {multiEntityCount} multi-entity
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Section heatmap */}
       {sections.length > 1 && (
@@ -198,7 +274,7 @@ function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: Footno
           <p className="text-xs font-medium text-gray-600 mb-2">Section breakdown:</p>
           <div className="flex flex-wrap gap-2">
             {sections.map(section => {
-              const sectionClaims = claims.filter(c => (c.value ?? "Unknown") === section);
+              const sectionClaims = claims.filter(c => getClaimSection(c) === section);
               const verifiedCount = sectionClaims.filter(c => c.confidence === "verified").length;
               const pct = sectionClaims.length > 0 ? Math.round((verifiedCount / sectionClaims.length) * 100) : 0;
               const heatColor = pct >= 70 ? "bg-green-100 border-green-300"
@@ -217,56 +293,69 @@ function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: Footno
       <table className="text-xs w-full border-collapse">
         <thead>
           <tr className="border-b text-left bg-gray-50">
-            <th className="p-2 w-[28%]">Claim</th>
-            <th className="p-2 w-[22%]">Source Quote</th>
+            <th className="p-2 w-[26%]">Claim</th>
+            <th className="p-2 w-[18%]">Source Quote</th>
             <th className="p-2">Type</th>
+            <th className="p-2">Category</th>
             <th className="p-2">Confidence</th>
             <th className="p-2">Section</th>
-            <th className="p-2">Source</th>
+            <th className="p-2">Related</th>
             <th className="p-2">Citations</th>
           </tr>
         </thead>
         <tbody>
           {claims.map((claim) => {
-            const footnoteNums = parseFootnoteNums(claim.unit);
+            const footnoteNums = parseFootnoteNums(getClaimFootnoteRefs(claim));
             const firstRef = footnoteNums.length > 0 ? refMap.get(footnoteNums[0]) : null;
+            const sectionName = getClaimSection(claim);
             return (
               <tr key={claim.id} className="border-b hover:bg-gray-50 align-top">
-                <td className="p-2">{claim.claimText}</td>
+                <td className="p-2">
+                  {claim.claimText}
+                  {claim.factId && (
+                    <span className="block mt-0.5 text-[10px] text-gray-400 font-mono" title="Linked to fact system">
+                      fact: {claim.factId}
+                    </span>
+                  )}
+                </td>
                 <td className="p-2 text-gray-500 italic">
                   {claim.sourceQuote
-                    ? <span title={claim.sourceQuote}>&ldquo;{claim.sourceQuote.slice(0, 120)}{claim.sourceQuote.length > 120 ? "…" : ""}&rdquo;</span>
+                    ? <span title={claim.sourceQuote}>&ldquo;{claim.sourceQuote.slice(0, 100)}{claim.sourceQuote.length > 100 ? "…" : ""}&rdquo;</span>
                     : <span className="text-gray-300 not-italic">—</span>}
                 </td>
-                <td className="p-2 font-mono whitespace-nowrap">{claim.claimType}</td>
+                <td className="p-2 font-mono whitespace-nowrap text-[10px]">{claim.claimType}</td>
+                <td className="p-2 whitespace-nowrap">
+                  <CategoryBadge category={claim.claimCategory} />
+                </td>
                 <td className="p-2 whitespace-nowrap">
                   <ConfidenceBadge confidence={claim.confidence} />
                 </td>
-                <td className="p-2 text-gray-600 max-w-[110px] truncate" title={claim.value ?? ""}>
-                  {claim.value ?? "—"}
+                <td className="p-2 text-gray-600 max-w-[100px] truncate" title={sectionName}>
+                  {sectionName}
                 </td>
-                <td className="p-2 max-w-[140px]">
-                  {firstRef ? (
-                    firstRef.resourceId ? (
-                      <Link href={`/source/${firstRef.resourceId}`} className="text-blue-600 hover:underline truncate block" title={firstRef.title ?? ""}>
-                        {firstRef.domain ?? firstRef.title?.slice(0, 25) ?? "—"}
-                      </Link>
-                    ) : firstRef.url ? (
-                      <a href={firstRef.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline truncate block" title={firstRef.title ?? ""}>
-                        {firstRef.domain ?? "link"}
-                      </a>
-                    ) : (
-                      <span className="text-gray-400 truncate block">{firstRef.title?.slice(0, 25) ?? "—"}</span>
-                    )
-                  ) : "—"}
-                  {footnoteNums.length > 1 && (
-                    <span className="text-gray-400 text-[10px] block">+{footnoteNums.length - 1} more</span>
+                <td className="p-2 max-w-[120px]">
+                  <RelatedEntityBadges entities={claim.relatedEntities} />
+                  {(!claim.relatedEntities || claim.relatedEntities.length === 0) && (
+                    firstRef ? (
+                      firstRef.resourceId ? (
+                        <Link href={`/source/${firstRef.resourceId}`} className="text-blue-600 hover:underline truncate block text-[10px]" title={firstRef.title ?? ""}>
+                          {firstRef.domain ?? firstRef.title?.slice(0, 20) ?? "—"}
+                        </Link>
+                      ) : firstRef.url ? (
+                        <a href={firstRef.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline truncate block text-[10px]" title={firstRef.title ?? ""}>
+                          {firstRef.domain ?? "link"}
+                        </a>
+                      ) : <span className="text-gray-400 text-[10px]">—</span>
+                    ) : <span className="text-gray-400 text-[10px]">—</span>
                   )}
                 </td>
                 <td className="p-2 whitespace-nowrap">
                   {footnoteNums.length > 0
-                    ? footnoteNums.map(n => <CitationBadge key={n} num={n} fnIndex={fnIndex} />)
+                    ? footnoteNums.slice(0, 3).map(n => <CitationBadge key={n} num={n} fnIndex={fnIndex} />)
                     : "—"}
+                  {footnoteNums.length > 3 && (
+                    <span className="text-gray-400 text-[10px]">+{footnoteNums.length - 3}</span>
+                  )}
                 </td>
               </tr>
             );

--- a/apps/wiki-server/drizzle/0028_enhance_claims.sql
+++ b/apps/wiki-server/drizzle/0028_enhance_claims.sql
@@ -1,0 +1,24 @@
+-- Enhanced claims: multi-entity support, claim categories, fact linking, resource linking
+-- This migration adds columns to support:
+--   1. Claims relating to multiple entities (not just one page)
+--   2. Claim category taxonomy (factual, opinion, analytical, speculative, relational)
+--   3. Linking numeric claims to the facts system
+--   4. Linking claims directly to resource IDs
+
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS claim_category text;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS related_entities jsonb;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS fact_id text;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS resource_ids jsonb;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS section text;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS footnote_refs text;
+
+-- Migrate existing data: copy section name from overloaded 'value' column to 'section'
+UPDATE claims SET section = value WHERE section IS NULL AND value IS NOT NULL;
+
+-- Migrate existing data: copy footnote refs from overloaded 'unit' column to 'footnote_refs'
+UPDATE claims SET footnote_refs = unit WHERE footnote_refs IS NULL AND unit IS NOT NULL;
+
+-- Index for multi-entity queries using GIN on JSONB
+CREATE INDEX IF NOT EXISTS idx_cl_related_entities ON claims USING gin (related_entities);
+CREATE INDEX IF NOT EXISTS idx_cl_claim_category ON claims (claim_category);
+CREATE INDEX IF NOT EXISTS idx_cl_fact_id ON claims (fact_id);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1771902000000,
       "tag": "0027_resource_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1771902100000,
+      "tag": "0028_enhance_claims",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -26,7 +26,8 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   // ---- INSERT INTO claims ----
   if (q.includes("insert into") && q.includes('"claims"')) {
     const now = new Date();
-    const PARAMS_PER_ROW = 8;
+    // Count parameters per row: 8 original + 6 enhanced columns = 14
+    const PARAMS_PER_ROW = 14;
     const rowCount = Math.max(1, Math.floor(params.length / PARAMS_PER_ROW));
     const results: Record<string, unknown>[] = [];
 
@@ -43,6 +44,13 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         unit: params[off + 5],
         confidence: params[off + 6],
         source_quote: params[off + 7],
+        // Enhanced fields (migration 0028)
+        claim_category: params[off + 8],
+        related_entities: params[off + 9],
+        fact_id: params[off + 10],
+        resource_ids: params[off + 11],
+        section: params[off + 12],
+        footnote_refs: params[off + 13],
         created_at: now,
         updated_at: now,
       };
@@ -99,6 +107,52 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       .sort((a, b) => b.count - a.count);
   }
 
+  // ---- SELECT count(*) FROM claims with GROUP BY claim_category ----
+  if (
+    q.includes("count(*)") &&
+    q.includes('"claims"') &&
+    q.includes("group by") &&
+    q.includes("claim_category")
+  ) {
+    const counts: Record<string, number> = {};
+    for (const r of claimStore.values()) {
+      const t = (r.claim_category as string) ?? "uncategorized";
+      counts[t] = (counts[t] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([claim_category, count]) => ({ claim_category, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // ---- SELECT count(*) FROM claims WHERE related_entities IS NOT NULL (multi-entity) ----
+  if (
+    q.includes("count(*)") &&
+    q.includes('"claims"') &&
+    q.includes("related_entities") &&
+    q.includes("is not null")
+  ) {
+    let count = 0;
+    for (const r of claimStore.values()) {
+      const re = r.related_entities;
+      if (re && Array.isArray(re) && re.length > 0) count++;
+    }
+    return [{ count }];
+  }
+
+  // ---- SELECT count(*) FROM claims WHERE fact_id IS NOT NULL ----
+  if (
+    q.includes("count(*)") &&
+    q.includes('"claims"') &&
+    q.includes("fact_id") &&
+    q.includes("is not null")
+  ) {
+    let count = 0;
+    for (const r of claimStore.values()) {
+      if (r.fact_id) count++;
+    }
+    return [{ count }];
+  }
+
   // ---- SELECT count(*) FROM claims (no GROUP BY, with optional WHERE) ----
   if (
     q.includes("count(*)") &&
@@ -125,25 +179,29 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ count: claimStore.size }];
   }
 
-  // ---- SELECT ... FROM claims WHERE entity_id = $1 (by-entity) ----
+  // ---- SELECT ... FROM claims WHERE entity_id = $1 OR related_entities @> ... (by-entity) ----
   if (
     q.includes('"claims"') &&
     q.includes("where") &&
-    q.includes("order by")
+    q.includes("order by") &&
+    (q.includes('"entity_id"') || q.includes("related_entities"))
   ) {
-    const whereClause = q.split("where")[1] || "";
-    if (whereClause.includes('"entity_id"')) {
-      const entityId = params[0] as string;
-      return Array.from(claimStore.values())
-        .filter((r) => r.entity_id === entityId)
-        .sort((a, b) => {
-          const typeCompare = (a.claim_type as string).localeCompare(
-            b.claim_type as string
-          );
-          if (typeCompare !== 0) return typeCompare;
-          return (a.id as number) - (b.id as number);
-        });
-    }
+    const entityId = params[0] as string;
+    return Array.from(claimStore.values())
+      .filter((r) => {
+        if (r.entity_id === entityId) return true;
+        // Check relatedEntities JSONB array
+        const re = r.related_entities;
+        if (Array.isArray(re) && re.includes(entityId)) return true;
+        return false;
+      })
+      .sort((a, b) => {
+        const typeCompare = (a.claim_type as string).localeCompare(
+          b.claim_type as string
+        );
+        if (typeCompare !== 0) return typeCompare;
+        return (a.id as number) - (b.id as number);
+      });
   }
 
   // ---- SELECT ... FROM claims WHERE id = $1 (get by ID) ----

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -648,15 +648,54 @@ export interface UpsertSummaryBatchResult {
 // Claims
 // ---------------------------------------------------------------------------
 
+/**
+ * Claim category taxonomy — high-level grouping for how a claim should be
+ * treated, verified, and displayed.
+ */
+export const ClaimCategorySchema = z.enum([
+  "factual", // Verifiable against sources (dates, events, numbers)
+  "opinion", // Subjective evaluations, value judgments
+  "analytical", // Wiki's own inferences drawn from evidence
+  "speculative", // Uncertain projections, predictions
+  "relational", // Cross-entity comparisons or relationships
+]);
+export type ClaimCategory = z.infer<typeof ClaimCategorySchema>;
+
+/**
+ * Claim type — granular classification matching the claim-first architecture
+ * taxonomy (E892). These map to different verification strategies.
+ */
+export const ClaimTypeSchema = z.enum([
+  // Core types (existing)
+  "factual", // Verifiable against a single source
+  "evaluative", // Subjective assessments or judgments
+  "causal", // Cause-effect assertions
+  "historical", // Historical events with dates
+  // Extended types (from claim-first architecture)
+  "numeric", // Numeric values that should link to fact system
+  "consensus", // Claims requiring multiple source agreement
+  "speculative", // Explicit predictions or uncertain projections
+  "relational", // Cross-entity comparisons
+]);
+export type ClaimType = z.infer<typeof ClaimTypeSchema>;
+
 export const InsertClaimSchema = z.object({
   entityId: z.string().min(1).max(300),
   entityType: z.string().min(1).max(100),
   claimType: z.string().min(1).max(100),
   claimText: z.string().min(1).max(10000),
+  // Legacy fields — kept for backward compat
   value: z.string().max(1000).nullable().optional(),
   unit: z.string().max(100).nullable().optional(),
   confidence: z.string().max(100).nullable().optional(),
   sourceQuote: z.string().max(10000).nullable().optional(),
+  // Enhanced fields
+  claimCategory: ClaimCategorySchema.nullable().optional(),
+  relatedEntities: z.array(z.string().max(300)).nullable().optional(),
+  factId: z.string().max(300).nullable().optional(),
+  resourceIds: z.array(z.string().max(300)).nullable().optional(),
+  section: z.string().max(1000).nullable().optional(),
+  footnoteRefs: z.string().max(500).nullable().optional(),
 });
 export type InsertClaim = z.infer<typeof InsertClaimSchema>;
 
@@ -680,6 +719,13 @@ export interface ClaimRow {
   unit: string | null;
   confidence: string | null;
   sourceQuote: string | null;
+  // Enhanced fields
+  claimCategory: string | null;
+  relatedEntities: string[] | null;
+  factId: string | null;
+  resourceIds: string[] | null;
+  section: string | null;
+  footnoteRefs: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, desc, asc } from "drizzle-orm";
+import { eq, and, or, count, desc, asc, sql } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 import { claims } from "../schema.js";
 import {
@@ -32,6 +32,7 @@ const PaginationQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
   entityType: z.string().max(100).optional(),
   claimType: z.string().max(100).optional(),
+  claimCategory: z.string().max(100).optional(),
 });
 
 const DeleteByEntitySchema = ClearClaimsSchema;
@@ -50,6 +51,13 @@ function claimValues(d: ClaimInput) {
     unit: d.unit ?? null,
     confidence: d.confidence ?? null,
     sourceQuote: d.sourceQuote ?? null,
+    // Enhanced fields
+    claimCategory: d.claimCategory ?? null,
+    relatedEntities: d.relatedEntities ?? null,
+    factId: d.factId ?? null,
+    resourceIds: d.resourceIds ?? null,
+    section: d.section ?? d.value ?? null,
+    footnoteRefs: d.footnoteRefs ?? d.unit ?? null,
   };
 }
 
@@ -64,6 +72,13 @@ function formatClaim(r: typeof claims.$inferSelect) {
     unit: r.unit,
     confidence: r.confidence,
     sourceQuote: r.sourceQuote,
+    // Enhanced fields
+    claimCategory: r.claimCategory,
+    relatedEntities: r.relatedEntities as string[] | null,
+    factId: r.factId,
+    resourceIds: r.resourceIds as string[] | null,
+    section: r.section,
+    footnoteRefs: r.footnoteRefs,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   };
@@ -162,6 +177,29 @@ claimsRoute.get("/stats", async (c) => {
     .groupBy(claims.entityType)
     .orderBy(desc(count()));
 
+  const byCategory = await db
+    .select({
+      claimCategory: claims.claimCategory,
+      count: count(),
+    })
+    .from(claims)
+    .groupBy(claims.claimCategory)
+    .orderBy(desc(count()));
+
+  // Count claims that have relatedEntities (multi-entity claims)
+  const multiEntityResult = await db
+    .select({ count: count() })
+    .from(claims)
+    .where(sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`);
+  const multiEntityCount = multiEntityResult[0].count;
+
+  // Count claims linked to facts
+  const factLinkedResult = await db
+    .select({ count: count() })
+    .from(claims)
+    .where(sql`${claims.factId} IS NOT NULL`);
+  const factLinkedCount = factLinkedResult[0].count;
+
   return c.json({
     total,
     byClaimType: Object.fromEntries(
@@ -170,19 +208,31 @@ claimsRoute.get("/stats", async (c) => {
     byEntityType: Object.fromEntries(
       byEntityType.map((r) => [r.entityType, r.count])
     ),
+    byClaimCategory: Object.fromEntries(
+      byCategory.map((r) => [r.claimCategory ?? "uncategorized", r.count])
+    ),
+    multiEntityClaims: multiEntityCount,
+    factLinkedClaims: factLinkedCount,
   });
 });
 
 // ---- GET /by-entity/:entityId (claims for a specific entity) ----
+// Returns claims where entityId matches OR the entity appears in relatedEntities.
 
 claimsRoute.get("/by-entity/:entityId", async (c) => {
   const entityId = c.req.param("entityId");
   const db = getDrizzleDb();
 
+  // Query: primary entity match OR entity appears in the relatedEntities JSONB array
   const rows = await db
     .select()
     .from(claims)
-    .where(eq(claims.entityId, entityId))
+    .where(
+      or(
+        eq(claims.entityId, entityId),
+        sql`${claims.relatedEntities} @> ${JSON.stringify([entityId])}::jsonb`
+      )
+    )
     .orderBy(asc(claims.claimType), asc(claims.id));
 
   return c.json({ claims: rows.map(formatClaim) });
@@ -194,12 +244,13 @@ claimsRoute.get("/all", async (c) => {
   const parsed = PaginationQuery.safeParse(c.req.query());
   if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { limit, offset, entityType, claimType } = parsed.data;
+  const { limit, offset, entityType, claimType, claimCategory } = parsed.data;
   const db = getDrizzleDb();
 
   const conditions = [];
   if (entityType) conditions.push(eq(claims.entityType, entityType));
   if (claimType) conditions.push(eq(claims.claimType, claimType));
+  if (claimCategory) conditions.push(eq(claims.claimCategory, claimCategory));
 
   const whereClause =
     conditions.length > 0

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -340,22 +340,42 @@ export const summaries = pgTable(
 /**
  * Claims extracted from wiki pages.
  *
- * `entityId` is a logical reference to a wiki entity (page or data entity)
- * but is NOT enforced via FK — claims may reference entities from multiple
- * source tables (wikiPages, summaries, etc.) or entities not yet synced.
+ * `entityId` is the primary entity this claim was extracted from (page or data entity).
+ * `relatedEntities` is a JSONB array of other entity IDs this claim relates to,
+ * enabling claims to be independent of a single page.
+ *
+ * Claim taxonomy:
+ *   claimType: granular type (factual, evaluative, causal, historical, numeric, consensus, speculative, relational)
+ *   claimCategory: high-level category (factual, opinion, analytical, speculative, relational)
+ *
+ * Integration with other data layers:
+ *   factId: links numeric claims to data/facts/ entries (e.g. "anthropic.6796e194")
+ *   resourceIds: JSONB array of resource IDs from data/resources/ backing this claim
+ *
+ * Legacy columns (value, unit) are retained for backward compatibility but
+ * new code should use section + footnoteRefs instead.
  */
 export const claims = pgTable(
   "claims",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    entityId: text("entity_id").notNull(), // logical FK — see table comment above
+    entityId: text("entity_id").notNull(), // primary entity (extraction source)
     entityType: text("entity_type").notNull(),
     claimType: text("claim_type").notNull(),
     claimText: text("claim_text").notNull(),
+    // Legacy fields — kept for backward compat, prefer section/footnoteRefs
     value: text("value"),
     unit: text("unit"),
     confidence: text("confidence"),
     sourceQuote: text("source_quote"),
+    // --- Enhanced fields (migration 0028) ---
+    claimCategory: text("claim_category"), // factual | opinion | analytical | speculative | relational
+    relatedEntities: jsonb("related_entities"), // string[] — other entity IDs this claim relates to
+    factId: text("fact_id"), // link to facts system: "entity.factKey" (e.g. "anthropic.6796e194")
+    resourceIds: jsonb("resource_ids"), // string[] — resource IDs from data/resources/
+    section: text("section"), // section heading where claim appears
+    footnoteRefs: text("footnote_refs"), // comma-separated footnote refs (e.g. "1,3,7")
+    // --- Timestamps ---
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -367,6 +387,8 @@ export const claims = pgTable(
     index("idx_cl_entity_id").on(table.entityId),
     index("idx_cl_entity_type").on(table.entityType),
     index("idx_cl_claim_type").on(table.claimType),
+    index("idx_cl_claim_category").on(table.claimCategory),
+    index("idx_cl_fact_id").on(table.factId),
   ]
 );
 

--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -5,13 +5,15 @@
  * then stores them in PostgreSQL for verification and display.
  *
  * Claims are stored in the `claims` table with:
- *   entityId    = page slug (e.g., "kalshi")
- *   entityType  = "wiki-page"
- *   claimType   = "factual" | "evaluative" | "causal" | "historical"
- *   claimText   = the atomic claim
- *   value       = section name where claim appears
- *   unit        = footnote refs as comma-separated string (e.g. "1,3,7")
- *   confidence  = "unverified" (initial) | "verified" | "unsourced"
+ *   entityId       = page slug (e.g., "kalshi")
+ *   entityType     = "wiki-page"
+ *   claimType      = "factual" | "evaluative" | "causal" | "historical" | "numeric" | "consensus" | "speculative" | "relational"
+ *   claimCategory  = "factual" | "opinion" | "analytical" | "speculative" | "relational"
+ *   claimText      = the atomic claim
+ *   section        = section name where claim appears (also stored in legacy 'value')
+ *   footnoteRefs   = footnote refs as comma-separated string (also stored in legacy 'unit')
+ *   confidence     = "unverified" (initial) | "verified" | "unsourced"
+ *   relatedEntities = JSON array of entity IDs mentioned in the claim
  *
  * Usage:
  *   pnpm crux claims extract <page-id>
@@ -108,29 +110,72 @@ function splitIntoSections(body: string): Section[] {
 // LLM claim extraction
 // ---------------------------------------------------------------------------
 
-interface ExtractedClaim {
-  claimText: string;
-  claimType: 'factual' | 'evaluative' | 'causal' | 'historical';
-  footnoteRefs: string[];  // e.g. ["1", "3", "7"]
+/** Valid claim types — expanded taxonomy from claim-first architecture. */
+const VALID_CLAIM_TYPES = [
+  'factual', 'evaluative', 'causal', 'historical',
+  'numeric', 'consensus', 'speculative', 'relational',
+] as const;
+type ClaimTypeValue = (typeof VALID_CLAIM_TYPES)[number];
+
+/** Map from granular claimType → high-level claimCategory. */
+function claimTypeToCategory(claimType: ClaimTypeValue): string {
+  switch (claimType) {
+    case 'factual':
+    case 'numeric':
+    case 'historical':
+      return 'factual';
+    case 'evaluative':
+      return 'opinion';
+    case 'causal':
+      return 'analytical';
+    case 'consensus':
+      return 'opinion';
+    case 'speculative':
+      return 'speculative';
+    case 'relational':
+      return 'relational';
+    default:
+      return 'factual';
+  }
 }
 
-const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a section of a wiki article about AI safety, extract the specific, verifiable factual claims.
+interface ExtractedClaim {
+  claimText: string;
+  claimType: ClaimTypeValue;
+  footnoteRefs: string[];  // e.g. ["1", "3", "7"]
+  relatedEntities?: string[];  // entity IDs mentioned in the claim
+}
 
-For each claim:
+const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a section of a wiki article, extract specific, verifiable claims.
+
+For each claim, provide:
 - "claimText": a single atomic, self-contained statement (not a question or heading)
-- "claimType": one of "factual" (specific facts, numbers, dates), "evaluative" (assessments or judgments), "causal" (cause-effect statements), or "historical" (historical events or trends)
-- "footnoteRefs": array of citation references (as strings) that cite this claim — look for [^N] footnote patterns (e.g. [^1], [^3]) and [^R:HASH] resource references (e.g. [^R:abc123]) near the claim. Include both types.
+- "claimType": one of:
+    "factual" — specific facts, events, dates verifiable against a single source
+    "numeric" — claims with specific numbers, dollar amounts, percentages, counts
+    "historical" — historical events or timeline items
+    "evaluative" — subjective assessments, value judgments, or opinions
+    "causal" — cause-effect assertions or inferences
+    "consensus" — claims about what is "widely believed" or "generally accepted" (need multiple sources)
+    "speculative" — predictions, projections, or uncertain future claims
+    "relational" — comparisons between entities or cross-entity assertions
+- "footnoteRefs": array of citation references (as strings) — look for [^N] (e.g. [^1]) and [^R:HASH] (e.g. [^R:abc123]) patterns near the claim
+- "relatedEntities": array of entity IDs or names mentioned in the claim other than the page's primary subject (e.g., if a claim on the Kalshi page mentions "Polymarket", include ["polymarket"])
 
 Rules:
 - Each claim must be atomic (one assertion per claim)
 - Include specific numbers, names, dates when present
 - Skip headings, navigation text, and pure descriptions
-- Skip claims that are just definitions or explanations without verifiable content
-- Extract 3-8 claims per section (skip trivial or duplicate content)
+- Skip claims that are just definitions without verifiable content
+- Use "numeric" for any claim containing specific dollar amounts, percentages, or counts
+- Use "consensus" for claims using language like "widely", "generally", "most experts"
+- Use "speculative" for claims with hedging language: "may", "might", "could", "expected to"
+- Use "relational" for claims comparing two or more entities
+- Extract 3-10 claims per section (skip trivial or duplicate content)
 - Return only claims that appear in the given text
 
 Respond ONLY with JSON:
-{"claims": [{"claimText": "...", "claimType": "factual", "footnoteRefs": ["1", "R:abc123"]}]}`;
+{"claims": [{"claimText": "...", "claimType": "factual", "footnoteRefs": ["1"], "relatedEntities": ["entity-id"]}]}`;
 
 async function extractClaimsFromSection(
   section: Section,
@@ -162,11 +207,14 @@ Extract atomic claims from this section. Return JSON only.`;
       )
       .map(c => ({
         claimText: (c as ExtractedClaim).claimText,
-        claimType: (['factual', 'evaluative', 'causal', 'historical'].includes((c as ExtractedClaim).claimType)
+        claimType: (VALID_CLAIM_TYPES.includes((c as ExtractedClaim).claimType as ClaimTypeValue)
           ? (c as ExtractedClaim).claimType
-          : 'factual') as ExtractedClaim['claimType'],
+          : 'factual') as ClaimTypeValue,
         footnoteRefs: Array.isArray((c as ExtractedClaim).footnoteRefs)
           ? (c as ExtractedClaim).footnoteRefs.map(String)
+          : [],
+        relatedEntities: Array.isArray((c as ExtractedClaim).relatedEntities)
+          ? (c as ExtractedClaim).relatedEntities!.map(String).filter(s => s.length > 0)
           : [],
       }));
   } catch (err) {
@@ -236,10 +284,36 @@ async function main() {
   console.log(`\n  Total extracted: ${c.bold}${allClaims.length}${c.reset} claims`);
 
   if (dryRun) {
+    // Show type/category breakdown
+    const typeCounts: Record<string, number> = {};
+    const catCounts: Record<string, number> = {};
+    for (const claim of allClaims) {
+      typeCounts[claim.claimType] = (typeCounts[claim.claimType] ?? 0) + 1;
+      const cat = claimTypeToCategory(claim.claimType);
+      catCounts[cat] = (catCounts[cat] ?? 0) + 1;
+    }
+    console.log(`\n${c.bold}By type:${c.reset}`);
+    for (const [type, cnt] of Object.entries(typeCounts).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${type.padEnd(14)} ${cnt}`);
+    }
+    console.log(`\n${c.bold}By category:${c.reset}`);
+    for (const [cat, cnt] of Object.entries(catCounts).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${cat.padEnd(14)} ${cnt}`);
+    }
+
+    const withEntities = allClaims.filter(c2 => c2.relatedEntities && c2.relatedEntities.length > 0);
+    if (withEntities.length > 0) {
+      console.log(`\n${c.bold}Multi-entity claims: ${withEntities.length}${c.reset}`);
+      for (const claim of withEntities.slice(0, 5)) {
+        console.log(`  [${claim.claimType}] ${claim.claimText.slice(0, 80)} → {${claim.relatedEntities!.join(', ')}}`);
+      }
+    }
+
     console.log(`\n${c.bold}Sample claims:${c.reset}`);
     for (const claim of allClaims.slice(0, 10)) {
       const refs = claim.footnoteRefs.length > 0 ? ` [^${claim.footnoteRefs.join(', ^')}]` : ' (unsourced)';
-      console.log(`  [${claim.claimType}] ${claim.claimText.slice(0, 100)}${refs}`);
+      const cat = claimTypeToCategory(claim.claimType);
+      console.log(`  [${claim.claimType}/${cat}] ${claim.claimText.slice(0, 100)}${refs}`);
     }
     if (allClaims.length > 10) {
       console.log(`  ... and ${allClaims.length - 10} more`);
@@ -269,10 +343,18 @@ async function main() {
       entityType: 'wiki-page',
       claimType: claim.claimType,
       claimText: claim.claimText,
+      // Legacy fields (kept for backward compat)
       value: claim.section,
       unit: claim.footnoteRefs.length > 0 ? claim.footnoteRefs.join(',') : null,
       confidence: 'unverified',
       sourceQuote: null,
+      // Enhanced fields
+      claimCategory: claimTypeToCategory(claim.claimType),
+      relatedEntities: claim.relatedEntities && claim.relatedEntities.length > 0
+        ? claim.relatedEntities
+        : null,
+      section: claim.section,
+      footnoteRefs: claim.footnoteRefs.length > 0 ? claim.footnoteRefs.join(',') : null,
     }));
 
     const result = await insertClaimBatch(items);


### PR DESCRIPTION
## Summary
This PR significantly enhances the claims extraction and display system to support multi-entity relationships, granular claim categorization, and integration with the facts system. It introduces a new claim taxonomy that distinguishes between claim types (granular) and claim categories (high-level), enabling more sophisticated verification strategies and cross-entity claim tracking.

## Key Changes

### Claims Data Model (Schema & Migration)
- **New migration (0028)**: Adds 6 new columns to the `claims` table:
  - `claim_category`: High-level categorization (factual, opinion, analytical, speculative, relational)
  - `related_entities`: JSONB array of entity IDs mentioned in the claim (enables multi-entity claims)
  - `fact_id`: Links numeric claims to the facts system (e.g., "anthropic.6796e194")
  - `resource_ids`: JSONB array of resource IDs backing the claim
  - `section`: Replaces overloaded `value` field for section names
  - `footnote_refs`: Replaces overloaded `unit` field for footnote references
- Adds GIN index on `related_entities` for efficient multi-entity queries
- Migrates existing data from legacy columns to new columns

### Claim Extraction (crux/claims/extract.ts)
- **Expanded claim type taxonomy**: Adds `numeric`, `consensus`, `speculative`, and `relational` types alongside existing types
- **New `claimTypeToCategory()` function**: Maps granular claim types to high-level categories
  - `factual`, `numeric`, `historical` → "factual"
  - `evaluative`, `consensus` → "opinion"
  - `causal` → "analytical"
  - `speculative` → "speculative"
  - `relational` → "relational"
- **Enhanced LLM prompt**: Instructs the model to extract `relatedEntities` (other entity IDs mentioned in claims) and use the expanded claim type taxonomy
- **Improved dry-run output**: Shows breakdown by claim type and category, plus multi-entity claim examples
- **Database insertion**: Populates all new fields including `claimCategory`, `relatedEntities`, `section`, and `footnoteRefs`

### API & Routes (apps/wiki-server)
- **New query parameter**: `claimCategory` filter in `/all` endpoint
- **Enhanced `/stats` endpoint**: Returns `byClaimCategory`, `multiEntityClaims`, and `factLinkedClaims` counts
- **Updated `/by-entity/:entityId`**: Now returns claims where the entity is either the primary `entityId` OR appears in `relatedEntities` (using JSONB containment operator `@>`)
- **Helper functions**: `claimValues()` and `formatClaim()` now handle all new fields

### Wiki Data Page UI (apps/web)
- **New `CategoryBadge` component**: Displays claim categories with color-coded styling (blue for factual, purple for opinion, amber for analytical, orange for speculative, teal for relational)
- **New `RelatedEntityBadges` component**: Renders related entities as clickable links to their wiki pages
- **Enhanced summary bar**: Adds category distribution display alongside confidence distribution
- **Updated claims table**:
  - New "Category" column showing `CategoryBadge`
  - New "Related" column showing `RelatedEntityBadges` (or first source if no related entities)
  - Displays `factId` as a small gray label under claim text
  - Improved column widths and truncation
  - Limits citation badges to 3 with "+N more" indicator
- **Helper functions**: `getClaimSection()` and `getClaimFootnoteRefs()` provide backward-compatible access to legacy/new fields
- **Enhanced `buildClaimsData()`**: Tracks `byCategory` and `multiEntityCount` for summary display

### Type Definitions (api-types.ts)
- **New `ClaimCategorySchema`**: Zod schema for the 5 claim categories
- **New `ClaimTypeSchema`**: Zod schema for the 8 claim types (4 original + 4 new)
- **Updated `Ins

https://claude.ai/code/session_01Rcxui7VZZBT4VZNXxTJ5bx