### PR TITLE
fix: consistent error handling in wiki-server route transaction blocks

### DIFF
--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -9,6 +9,7 @@ import {
   invalidJsonError,
   notFoundError,
   firstOrThrow,
+  dbError,
 } from "./utils.js";
 import {
   UpsertCitationQuoteSchema,
@@ -209,34 +210,39 @@ citationsRoute.post("/quotes/upsert-batch", async (c) => {
   const { items } = parsed.data;
   const db = getDrizzleDb();
 
-  const results = await db.transaction(async (tx) => {
-    return await tx
-      .insert(citationQuotes)
-      .values(items.map((d) => quoteValues(d)))
-      .onConflictDoUpdate({
-        target: [citationQuotes.pageId, citationQuotes.footnote],
-        set: {
-          url: sql`excluded.url`,
-          resourceId: sql`excluded.resource_id`,
-          claimText: sql`excluded.claim_text`,
-          claimContext: sql`excluded.claim_context`,
-          sourceQuote: sql`excluded.source_quote`,
-          sourceLocation: sql`excluded.source_location`,
-          quoteVerified: sql`excluded.quote_verified`,
-          verificationMethod: sql`excluded.verification_method`,
-          verificationScore: sql`excluded.verification_score`,
-          sourceTitle: sql`excluded.source_title`,
-          sourceType: sql`excluded.source_type`,
-          extractionModel: sql`excluded.extraction_model`,
-          updatedAt: sql`now()`,
-        },
-      })
-      .returning({
-        id: citationQuotes.id,
-        pageId: citationQuotes.pageId,
-        footnote: citationQuotes.footnote,
-      });
-  });
+  let results;
+  try {
+    results = await db.transaction(async (tx) => {
+      return await tx
+        .insert(citationQuotes)
+        .values(items.map((d) => quoteValues(d)))
+        .onConflictDoUpdate({
+          target: [citationQuotes.pageId, citationQuotes.footnote],
+          set: {
+            url: sql`excluded.url`,
+            resourceId: sql`excluded.resource_id`,
+            claimText: sql`excluded.claim_text`,
+            claimContext: sql`excluded.claim_context`,
+            sourceQuote: sql`excluded.source_quote`,
+            sourceLocation: sql`excluded.source_location`,
+            quoteVerified: sql`excluded.quote_verified`,
+            verificationMethod: sql`excluded.verification_method`,
+            verificationScore: sql`excluded.verification_score`,
+            sourceTitle: sql`excluded.source_title`,
+            sourceType: sql`excluded.source_type`,
+            extractionModel: sql`excluded.extraction_model`,
+            updatedAt: sql`now()`,
+          },
+        })
+        .returning({
+          id: citationQuotes.id,
+          pageId: citationQuotes.pageId,
+          footnote: citationQuotes.footnote,
+        });
+    });
+  } catch (err) {
+    return dbError(c, "citation quotes upsert-batch", err, { itemCount: items.length });
+  }
 
   return c.json({ results });
 });
@@ -533,35 +539,39 @@ citationsRoute.post("/quotes/mark-accuracy-batch", async (c) => {
   const db = getDrizzleDb();
   const results: Array<{ pageId: string; footnote: number; verdict: string }> = [];
 
-  await db.transaction(async (tx) => {
-    for (const d of items) {
-      const rows = await tx
-        .update(citationQuotes)
-        .set({
-          accuracyVerdict: d.verdict,
-          accuracyScore: d.score,
-          accuracyIssues: d.issues ?? null,
-          accuracySupportingQuotes: d.supportingQuotes ?? null,
-          verificationDifficulty: d.verificationDifficulty ?? null,
-          accuracyCheckedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        })
-        .where(
-          and(
-            eq(citationQuotes.pageId, d.pageId),
-            eq(citationQuotes.footnote, d.footnote)
+  try {
+    await db.transaction(async (tx) => {
+      for (const d of items) {
+        const rows = await tx
+          .update(citationQuotes)
+          .set({
+            accuracyVerdict: d.verdict,
+            accuracyScore: d.score,
+            accuracyIssues: d.issues ?? null,
+            accuracySupportingQuotes: d.supportingQuotes ?? null,
+            verificationDifficulty: d.verificationDifficulty ?? null,
+            accuracyCheckedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          })
+          .where(
+            and(
+              eq(citationQuotes.pageId, d.pageId),
+              eq(citationQuotes.footnote, d.footnote)
+            )
           )
-        )
-        .returning({
-          pageId: citationQuotes.pageId,
-          footnote: citationQuotes.footnote,
-        });
+          .returning({
+            pageId: citationQuotes.pageId,
+            footnote: citationQuotes.footnote,
+          });
 
-      if (rows.length > 0) {
-        results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
+        if (rows.length > 0) {
+          results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
+        }
       }
-    }
-  });
+    });
+  } catch (err) {
+    return dbError(c, "citation quotes mark-accuracy-batch", err, { itemCount: items.length });
+  }
 
   return c.json({ updated: results.length, results });
 });
@@ -954,13 +964,18 @@ citationsRoute.post("/content/link-resources", async (c) => {
 
   // Find all citation_content rows that have no resource_id
   // and match a resource by URL.
-  const result = await db.execute(sql`
-    UPDATE citation_content cc
-    SET resource_id = r.id
-    FROM resources r
-    WHERE cc.url = r.url
-      AND cc.resource_id IS NULL
-  `);
+  let result;
+  try {
+    result = await db.execute(sql`
+      UPDATE citation_content cc
+      SET resource_id = r.id
+      FROM resources r
+      WHERE cc.url = r.url
+        AND cc.resource_id IS NULL
+    `);
+  } catch (err) {
+    return dbError(c, "citation content link-resources", err);
+  }
 
   const linked = Number((result as any).count ?? 0);
   return c.json({ linked });

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  dbError,
 } from "./utils.js";
 import {
   SyncPageSchema as SharedSyncPageSchema,
@@ -245,85 +246,89 @@ pagesRoute.post("/sync", async (c) => {
 
   const pageIds = pages.map((p) => p.id);
 
-  await db.transaction(async (tx) => {
-    const allVals = pages.map((page) => ({
-      id: page.id,
-      numericId: page.numericId ?? null,
-      title: page.title,
-      description: page.description ?? null,
-      llmSummary: page.llmSummary ?? null,
-      category: page.category ?? null,
-      subcategory: page.subcategory ?? null,
-      entityType: page.entityType ?? null,
-      tags: page.tags ?? null,
-      quality: page.quality ?? null,
-      readerImportance: page.readerImportance ?? null,
-      researchImportance: page.researchImportance ?? null,
-      tacticalValue: page.tacticalValue ?? null,
-      backlinkCount: page.backlinkCount ?? null,
-      riskCategory: page.riskCategory ?? null,
-      dateCreated: page.dateCreated ?? null,
-      recommendedScore: page.recommendedScore ?? null,
-      clusters: page.clusters ?? null,
-      hallucinationRiskLevel: page.hallucinationRiskLevel ?? null,
-      hallucinationRiskScore: page.hallucinationRiskScore ?? null,
-      contentPlaintext: page.contentPlaintext ?? null,
-      wordCount: page.wordCount ?? null,
-      lastUpdated: page.lastUpdated ?? null,
-      contentFormat: page.contentFormat ?? null,
-      syncedFromBranch: syncedFromBranch ?? null,
-      syncedFromCommit: syncedFromCommit ?? null,
-    }));
+  try {
+    await db.transaction(async (tx) => {
+      const allVals = pages.map((page) => ({
+        id: page.id,
+        numericId: page.numericId ?? null,
+        title: page.title,
+        description: page.description ?? null,
+        llmSummary: page.llmSummary ?? null,
+        category: page.category ?? null,
+        subcategory: page.subcategory ?? null,
+        entityType: page.entityType ?? null,
+        tags: page.tags ?? null,
+        quality: page.quality ?? null,
+        readerImportance: page.readerImportance ?? null,
+        researchImportance: page.researchImportance ?? null,
+        tacticalValue: page.tacticalValue ?? null,
+        backlinkCount: page.backlinkCount ?? null,
+        riskCategory: page.riskCategory ?? null,
+        dateCreated: page.dateCreated ?? null,
+        recommendedScore: page.recommendedScore ?? null,
+        clusters: page.clusters ?? null,
+        hallucinationRiskLevel: page.hallucinationRiskLevel ?? null,
+        hallucinationRiskScore: page.hallucinationRiskScore ?? null,
+        contentPlaintext: page.contentPlaintext ?? null,
+        wordCount: page.wordCount ?? null,
+        lastUpdated: page.lastUpdated ?? null,
+        contentFormat: page.contentFormat ?? null,
+        syncedFromBranch: syncedFromBranch ?? null,
+        syncedFromCommit: syncedFromCommit ?? null,
+      }));
 
-    await tx
-      .insert(wikiPages)
-      .values(allVals)
-      .onConflictDoUpdate({
-        target: wikiPages.id,
-        set: {
-          numericId: sql`excluded.numeric_id`,
-          title: sql`excluded.title`,
-          description: sql`excluded.description`,
-          llmSummary: sql`excluded.llm_summary`,
-          category: sql`excluded.category`,
-          subcategory: sql`excluded.subcategory`,
-          entityType: sql`excluded.entity_type`,
-          tags: sql`excluded.tags`,
-          quality: sql`excluded.quality`,
-          readerImportance: sql`excluded.reader_importance`,
-          researchImportance: sql`excluded.research_importance`,
-          tacticalValue: sql`excluded.tactical_value`,
-          backlinkCount: sql`excluded.backlink_count`,
-          riskCategory: sql`excluded.risk_category`,
-          dateCreated: sql`excluded.date_created`,
-          recommendedScore: sql`excluded.recommended_score`,
-          clusters: sql`excluded.clusters`,
-          hallucinationRiskLevel: sql`excluded.hallucination_risk_level`,
-          hallucinationRiskScore: sql`excluded.hallucination_risk_score`,
-          contentPlaintext: sql`excluded.content_plaintext`,
-          wordCount: sql`excluded.word_count`,
-          lastUpdated: sql`excluded.last_updated`,
-          contentFormat: sql`excluded.content_format`,
-          syncedFromBranch: sql`excluded.synced_from_branch`,
-          syncedFromCommit: sql`excluded.synced_from_commit`,
-          syncedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        },
-      });
-    upserted = allVals.length;
+      await tx
+        .insert(wikiPages)
+        .values(allVals)
+        .onConflictDoUpdate({
+          target: wikiPages.id,
+          set: {
+            numericId: sql`excluded.numeric_id`,
+            title: sql`excluded.title`,
+            description: sql`excluded.description`,
+            llmSummary: sql`excluded.llm_summary`,
+            category: sql`excluded.category`,
+            subcategory: sql`excluded.subcategory`,
+            entityType: sql`excluded.entity_type`,
+            tags: sql`excluded.tags`,
+            quality: sql`excluded.quality`,
+            readerImportance: sql`excluded.reader_importance`,
+            researchImportance: sql`excluded.research_importance`,
+            tacticalValue: sql`excluded.tactical_value`,
+            backlinkCount: sql`excluded.backlink_count`,
+            riskCategory: sql`excluded.risk_category`,
+            dateCreated: sql`excluded.date_created`,
+            recommendedScore: sql`excluded.recommended_score`,
+            clusters: sql`excluded.clusters`,
+            hallucinationRiskLevel: sql`excluded.hallucination_risk_level`,
+            hallucinationRiskScore: sql`excluded.hallucination_risk_score`,
+            contentPlaintext: sql`excluded.content_plaintext`,
+            wordCount: sql`excluded.word_count`,
+            lastUpdated: sql`excluded.last_updated`,
+            contentFormat: sql`excluded.content_format`,
+            syncedFromBranch: sql`excluded.synced_from_branch`,
+            syncedFromCommit: sql`excluded.synced_from_commit`,
+            syncedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          },
+        });
+      upserted = allVals.length;
 
-    // Update search vectors inside the same transaction
-    const idList = sql.join(pageIds.map(id => sql`${id}`), sql`, `);
-    await tx.execute(sql`
-      UPDATE wiki_pages SET search_vector =
-        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(llm_summary, '')), 'C') ||
-        setweight(to_tsvector('english', coalesce(tags, '')), 'D') ||
-        setweight(to_tsvector('english', coalesce(entity_type, '')), 'D')
-      WHERE id IN (${idList})
-    `);
-  });
+      // Update search vectors inside the same transaction
+      const idList = sql.join(pageIds.map(id => sql`${id}`), sql`, `);
+      await tx.execute(sql`
+        UPDATE wiki_pages SET search_vector =
+          setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+          setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(llm_summary, '')), 'C') ||
+          setweight(to_tsvector('english', coalesce(tags, '')), 'D') ||
+          setweight(to_tsvector('english', coalesce(entity_type, '')), 'D')
+        WHERE id IN (${idList})
+      `);
+    });
+  } catch (err) {
+    return dbError(c, "pages sync", err, { pageCount: pages.length });
+  }
 
   return c.json({ upserted });
 });

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -18,6 +18,7 @@ import {
   invalidJsonError,
   notFoundError,
   firstOrThrow,
+  dbError,
 } from "./utils.js";
 import {
   UpsertResourceSchema as SharedUpsertResourceSchema,
@@ -217,29 +218,33 @@ resourcesRoute.post("/batch", async (c) => {
   const results: Array<{ id: string; url: string }> = [];
 
   const db = getDrizzleDb();
-  await db.transaction(async (tx) => {
-    for (const item of items) {
-      // Skip per-row search_vector update; handled in bulk below
-      const result = await upsertResource(tx as unknown as DbClient, item, {
-        skipSearchVector: true,
-      });
-      results.push({ id: result.id, url: result.url });
-    }
+  try {
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        // Skip per-row search_vector update; handled in bulk below
+        const result = await upsertResource(tx as unknown as DbClient, item, {
+          skipSearchVector: true,
+        });
+        results.push({ id: result.id, url: result.url });
+      }
 
-    // Bulk search_vector update for all upserted resources (one query)
-    const idList = sql.join(
-      results.map((r) => sql`${r.id}`),
-      sql`, `
-    );
-    await tx.execute(sql`
-      UPDATE resources SET search_vector =
-        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-        setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
-        setweight(to_tsvector('english', coalesce(review, '')), 'D')
-      WHERE id IN (${idList})
-    `);
-  });
+      // Bulk search_vector update for all upserted resources (one query)
+      const idList = sql.join(
+        results.map((r) => sql`${r.id}`),
+        sql`, `
+      );
+      await tx.execute(sql`
+        UPDATE resources SET search_vector =
+          setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+          setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
+          setweight(to_tsvector('english', coalesce(review, '')), 'D')
+        WHERE id IN (${idList})
+      `);
+    });
+  } catch (err) {
+    return dbError(c, "resources batch upsert", err, { itemCount: items.length });
+  }
 
   return c.json({ upserted: results.length, results }, 201);
 });
@@ -256,8 +261,10 @@ resourcesRoute.get("/search", async (c) => {
   // Full-text search with prefix matching (same pattern as wiki_pages search)
   const prefixQuery = buildPrefixTsquery(q);
 
-  const rows = prefixQuery
-    ? await rawDb.unsafe(
+  let rows: any[] = [];
+  if (prefixQuery) {
+    try {
+      rows = await rawDb.unsafe(
         `SELECT
           id, url, title, type, summary, review, abstract,
           key_points, publication_id, authors, published_date,
@@ -269,8 +276,11 @@ resourcesRoute.get("/search", async (c) => {
         ORDER BY rank DESC
         LIMIT $2`,
         [prefixQuery, limit],
-      )
-    : [];
+      );
+    } catch (err) {
+      return dbError(c, "resources search", err, { q });
+    }
+  }
 
   return c.json({
     results: rows.map((r: any) => ({

--- a/apps/wiki-server/src/routes/utils.ts
+++ b/apps/wiki-server/src/routes/utils.ts
@@ -30,3 +30,23 @@ export function firstOrThrow<T>(rows: T[], context: string): T {
   }
   return rows[0];
 }
+
+/**
+ * Return a 500 database error response and log context for debugging.
+ * Use this inside catch blocks around transaction or DB operations.
+ */
+export function dbError(
+  c: Context,
+  operation: string,
+  err: unknown,
+  context?: Record<string, unknown>
+) {
+  console.error(`[db] ${operation} failed:`, {
+    ...(context ?? {}),
+    error: err instanceof Error ? err.message : String(err),
+  });
+  return c.json(
+    { error: "database_error", message: `${operation} failed` },
+    500
+  );
+}


### PR DESCRIPTION
## Summary

Adds a `dbError()` helper to `routes/utils.ts` and wraps bare transaction blocks in `try/catch` across the route files that were missing it.

**Before:** unhandled DB errors in batch/transaction endpoints would bubble up to the global error handler with no route-specific context — impossible to know which operation, which page IDs, or how many items were involved.

**After:** each catch block logs the operation name + relevant context (item count, page count, etc.) and returns a structured `{ error: "database_error", message }` response — consistent with the existing `validationError` and `notFoundError` shape used throughout.

### Files changed

**`routes/utils.ts`** — adds `dbError(c, operation, err, context?)` helper

**`routes/resources.ts`**
- `/batch` — wraps transaction in try/catch, logs itemCount on failure
- `/search` — wraps `rawDb.unsafe()` in try/catch (was swallowing errors silently)

**`routes/citations.ts`**
- `/quotes/upsert-batch` — wraps transaction, logs itemCount
- `/quotes/mark-accuracy-batch` — wraps transaction, logs itemCount
- `/content/link-resources` — wraps `db.execute()` in try/catch

**`routes/pages.ts`**
- `/sync` — wraps transaction, logs pageCount (highest-traffic endpoint in CI)

## Test plan

- [ ] `cd apps/wiki-server && npx tsc --noEmit` — clean ✅
- [ ] Gate passes (9 checks) ✅
- [ ] No existing tests broken (wiki-server tests pass) ✅

Closes #1011
