### PR TITLE
fix: consistent error handling in wiki-server route transaction blocks

### DIFF
--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -10,6 +10,7 @@ import {
   invalidJsonError,
   notFoundError,
   firstOrThrow,
+  dbError,
 } from "./utils.js";
 import {
   UpsertCitationQuoteSchema,
@@ -249,34 +250,39 @@ citationsRoute.post("/quotes/upsert-batch", async (c) => {
     }
   }
 
-  const results = await db.transaction(async (tx) => {
-    return await tx
-      .insert(citationQuotes)
-      .values(items.map((d) => quoteValues(d)))
-      .onConflictDoUpdate({
-        target: [citationQuotes.pageId, citationQuotes.footnote],
-        set: {
-          url: sql`excluded.url`,
-          resourceId: sql`excluded.resource_id`,
-          claimText: sql`excluded.claim_text`,
-          claimContext: sql`excluded.claim_context`,
-          sourceQuote: sql`excluded.source_quote`,
-          sourceLocation: sql`excluded.source_location`,
-          quoteVerified: sql`excluded.quote_verified`,
-          verificationMethod: sql`excluded.verification_method`,
-          verificationScore: sql`excluded.verification_score`,
-          sourceTitle: sql`excluded.source_title`,
-          sourceType: sql`excluded.source_type`,
-          extractionModel: sql`excluded.extraction_model`,
-          updatedAt: sql`now()`,
-        },
-      })
-      .returning({
-        id: citationQuotes.id,
-        pageId: citationQuotes.pageId,
-        footnote: citationQuotes.footnote,
-      });
-  });
+  let results;
+  try {
+    results = await db.transaction(async (tx) => {
+      return await tx
+        .insert(citationQuotes)
+        .values(items.map((d) => quoteValues(d)))
+        .onConflictDoUpdate({
+          target: [citationQuotes.pageId, citationQuotes.footnote],
+          set: {
+            url: sql`excluded.url`,
+            resourceId: sql`excluded.resource_id`,
+            claimText: sql`excluded.claim_text`,
+            claimContext: sql`excluded.claim_context`,
+            sourceQuote: sql`excluded.source_quote`,
+            sourceLocation: sql`excluded.source_location`,
+            quoteVerified: sql`excluded.quote_verified`,
+            verificationMethod: sql`excluded.verification_method`,
+            verificationScore: sql`excluded.verification_score`,
+            sourceTitle: sql`excluded.source_title`,
+            sourceType: sql`excluded.source_type`,
+            extractionModel: sql`excluded.extraction_model`,
+            updatedAt: sql`now()`,
+          },
+        })
+        .returning({
+          id: citationQuotes.id,
+          pageId: citationQuotes.pageId,
+          footnote: citationQuotes.footnote,
+        });
+    });
+  } catch (err) {
+    return dbError(c, "citation quotes upsert-batch", err, { itemCount: items.length });
+  }
 
   return c.json({ results });
 });
@@ -573,35 +579,39 @@ citationsRoute.post("/quotes/mark-accuracy-batch", async (c) => {
   const db = getDrizzleDb();
   const results: Array<{ pageId: string; footnote: number; verdict: string }> = [];
 
-  await db.transaction(async (tx) => {
-    for (const d of items) {
-      const rows = await tx
-        .update(citationQuotes)
-        .set({
-          accuracyVerdict: d.verdict,
-          accuracyScore: d.score,
-          accuracyIssues: d.issues ?? null,
-          accuracySupportingQuotes: d.supportingQuotes ?? null,
-          verificationDifficulty: d.verificationDifficulty ?? null,
-          accuracyCheckedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        })
-        .where(
-          and(
-            eq(citationQuotes.pageId, d.pageId),
-            eq(citationQuotes.footnote, d.footnote)
+  try {
+    await db.transaction(async (tx) => {
+      for (const d of items) {
+        const rows = await tx
+          .update(citationQuotes)
+          .set({
+            accuracyVerdict: d.verdict,
+            accuracyScore: d.score,
+            accuracyIssues: d.issues ?? null,
+            accuracySupportingQuotes: d.supportingQuotes ?? null,
+            verificationDifficulty: d.verificationDifficulty ?? null,
+            accuracyCheckedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          })
+          .where(
+            and(
+              eq(citationQuotes.pageId, d.pageId),
+              eq(citationQuotes.footnote, d.footnote)
+            )
           )
-        )
-        .returning({
-          pageId: citationQuotes.pageId,
-          footnote: citationQuotes.footnote,
-        });
+          .returning({
+            pageId: citationQuotes.pageId,
+            footnote: citationQuotes.footnote,
+          });
 
-      if (rows.length > 0) {
-        results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
+        if (rows.length > 0) {
+          results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
+        }
       }
-    }
-  });
+    });
+  } catch (err) {
+    return dbError(c, "citation quotes mark-accuracy-batch", err, { itemCount: items.length });
+  }
 
   return c.json({ updated: results.length, results });
 });
@@ -994,13 +1004,18 @@ citationsRoute.post("/content/link-resources", async (c) => {
 
   // Find all citation_content rows that have no resource_id
   // and match a resource by URL.
-  const result = await db.execute(sql`
-    UPDATE citation_content cc
-    SET resource_id = r.id
-    FROM resources r
-    WHERE cc.url = r.url
-      AND cc.resource_id IS NULL
-  `);
+  let result;
+  try {
+    result = await db.execute(sql`
+      UPDATE citation_content cc
+      SET resource_id = r.id
+      FROM resources r
+      WHERE cc.url = r.url
+        AND cc.resource_id IS NULL
+    `);
+  } catch (err) {
+    return dbError(c, "citation content link-resources", err);
+  }
 
   const linked = Number((result as any).count ?? 0);
   return c.json({ linked });

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  dbError,
 } from "./utils.js";
 import {
   SyncPageSchema as SharedSyncPageSchema,
@@ -245,7 +246,8 @@ pagesRoute.post("/sync", async (c) => {
 
   const pageIds = pages.map((p) => p.id);
 
-  await db.transaction(async (tx) => {
+  try {
+   await db.transaction(async (tx) => {
     const allVals = pages.map((page) => ({
       id: page.id,
       numericId: page.numericId ?? null,
@@ -324,6 +326,9 @@ pagesRoute.post("/sync", async (c) => {
       WHERE id IN (${idList})
     `);
   });
+  } catch (err) {
+    return dbError(c, "pages sync", err, { pageCount: pages.length });
+  }
 
   return c.json({ upserted });
 });

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -19,6 +19,7 @@ import {
   invalidJsonError,
   notFoundError,
   firstOrThrow,
+  dbError,
 } from "./utils.js";
 import {
   UpsertResourceSchema as SharedUpsertResourceSchema,
@@ -245,29 +246,33 @@ resourcesRoute.post("/batch", async (c) => {
   }
 
   const results: Array<{ id: string; url: string }> = [];
-  await db.transaction(async (tx) => {
-    for (const item of items) {
-      // Skip per-row search_vector update; handled in bulk below
-      const result = await upsertResource(tx as unknown as DbClient, item, {
-        skipSearchVector: true,
-      });
-      results.push({ id: result.id, url: result.url });
-    }
+  try {
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        // Skip per-row search_vector update; handled in bulk below
+        const result = await upsertResource(tx as unknown as DbClient, item, {
+          skipSearchVector: true,
+        });
+        results.push({ id: result.id, url: result.url });
+      }
 
-    // Bulk search_vector update for all upserted resources (one query)
-    const idList = sql.join(
-      results.map((r) => sql`${r.id}`),
-      sql`, `
-    );
-    await tx.execute(sql`
-      UPDATE resources SET search_vector =
-        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-        setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
-        setweight(to_tsvector('english', coalesce(review, '')), 'D')
-      WHERE id IN (${idList})
-    `);
-  });
+      // Bulk search_vector update for all upserted resources (one query)
+      const idList = sql.join(
+        results.map((r) => sql`${r.id}`),
+        sql`, `
+      );
+      await tx.execute(sql`
+        UPDATE resources SET search_vector =
+          setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+          setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
+          setweight(to_tsvector('english', coalesce(review, '')), 'D')
+        WHERE id IN (${idList})
+      `);
+    });
+  } catch (err) {
+    return dbError(c, "resources batch upsert", err, { itemCount: items.length });
+  }
 
   return c.json({ upserted: results.length, results }, 201);
 });

--- a/apps/wiki-server/src/routes/utils.ts
+++ b/apps/wiki-server/src/routes/utils.ts
@@ -23,6 +23,20 @@ export function notFoundError(c: Context, message: string) {
   return c.json({ error: "not_found", message }, 404);
 }
 
+/** Return a 500 database error response, logging the underlying error. */
+export function dbError(
+  c: Context,
+  operation: string,
+  err: unknown,
+  context?: Record<string, unknown>
+) {
+  console.error(`[db] ${operation} failed:`, {
+    ...(context ?? {}),
+    error: err instanceof Error ? err.message : String(err),
+  });
+  return c.json({ error: "database_error", message: `${operation} failed` }, 500);
+}
+
 /** Extract the first row from a query result, throwing if empty. */
 export function firstOrThrow<T>(rows: T[], context: string): T {
   if (rows.length === 0) {


### PR DESCRIPTION
## Summary

- Add `dbError()` helper to `routes/utils.ts` for structured 500 responses with server-side logging (operation name, context, error message)
- Wrap bare transactions in try/catch in `pages/sync`, `citations/quotes/upsert-batch`, `citations/quotes/mark-accuracy-batch`, `citations/content/link-resources`, and `resources/batch`
- DB failures now return `{"error":"database_error","message":"<operation> failed"}` (500) instead of uncaught runtime exceptions that crash the request handler

Re-implements the work from the previously closed #1033.

Closes #1011
