### PR TITLE
feat(claims): Phase 2A — claim_sources join table, claim_mode, as_of, numeric values

### DIFF
--- a/apps/wiki-server/drizzle/0029_claim_sources_and_modes.sql
+++ b/apps/wiki-server/drizzle/0029_claim_sources_and_modes.sql
@@ -1,0 +1,84 @@
+-- Phase 2: claim_sources join table, claim_mode, attributed_to, as_of, measure, numeric values
+--
+-- This migration adds:
+--   1. claim_sources join table — proper relational multi-source provenance
+--      (replaces the JSONB resource_ids array with per-row source quotes and is_primary flag)
+--   2. claim_mode — epistemic mode: "endorsed" (wiki asserts) vs "attributed" (entity X claims)
+--   3. attributed_to — entity_id of person/org making the claim (when claim_mode = attributed)
+--   4. as_of — temporal indexing for time-sensitive claims
+--   5. measure — links numeric claims to the facts taxonomy (e.g., "valuation", "employee_count")
+--   6. value_numeric / value_low / value_high — machine-readable quantitative values
+--      (enables trend queries, range display, and fact-claim reconciliation)
+
+-- Add new columns to claims table
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS claim_mode text;         -- 'endorsed' | 'attributed'
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS attributed_to text;      -- entity_id of claim author
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS as_of text;              -- YYYY-MM or YYYY-MM-DD
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS measure text;            -- measure ID (links to facts taxonomy)
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS value_numeric real;      -- central numeric value
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS value_low real;          -- lower bound for range values
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS value_high real;         -- upper bound for range values
+
+-- Default existing claims to 'endorsed' (wiki-authored page claims are endorsements)
+UPDATE claims SET claim_mode = 'endorsed' WHERE claim_mode IS NULL;
+
+-- Indexes for new columns
+CREATE INDEX IF NOT EXISTS idx_cl_claim_mode ON claims (claim_mode);
+CREATE INDEX IF NOT EXISTS idx_cl_attributed_to ON claims (attributed_to);
+CREATE INDEX IF NOT EXISTS idx_cl_as_of ON claims (as_of);
+CREATE INDEX IF NOT EXISTS idx_cl_measure ON claims (measure);
+
+-- claim_sources join table
+-- Stores the N sources backing each claim, with per-source quote and primary flag.
+-- Replaces the JSONB resource_ids array approach.
+CREATE TABLE IF NOT EXISTS claim_sources (
+  id          bigserial PRIMARY KEY,
+  claim_id    bigint    NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+  resource_id text      REFERENCES resources(id) ON DELETE SET NULL,
+  url         text,                          -- fallback if resource_id not known
+  source_quote text,                         -- exact excerpt from this source supporting the claim
+  is_primary  boolean   NOT NULL DEFAULT false,
+  added_at    timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cs_claim_id    ON claim_sources (claim_id);
+CREATE INDEX IF NOT EXISTS idx_cs_resource_id ON claim_sources (resource_id);
+CREATE INDEX IF NOT EXISTS idx_cs_is_primary  ON claim_sources (is_primary);
+
+-- Migrate existing data: convert resource_ids JSONB array → claim_sources rows
+-- Each resource_id becomes a claim_sources row with is_primary=true for the first one.
+INSERT INTO claim_sources (claim_id, resource_id, is_primary)
+SELECT
+  c.id,
+  r_id.resource_id,
+  (r_id.idx = 0) AS is_primary
+FROM claims c,
+     jsonb_array_elements_text(c.resource_ids) WITH ORDINALITY AS r_id(resource_id, idx)
+WHERE c.resource_ids IS NOT NULL
+  AND jsonb_array_length(c.resource_ids) > 0
+  -- Only insert if the resource actually exists
+  AND EXISTS (SELECT 1 FROM resources r WHERE r.id = r_id.resource_id)
+ON CONFLICT DO NOTHING;
+
+-- Migrate existing sourceQuote from citation_quotes to claim_sources
+-- Match claims to citation quotes via their footnoteRefs
+-- (Best-effort: for claims with exactly one footnote ref, link the quote)
+INSERT INTO claim_sources (claim_id, resource_id, url, source_quote, is_primary)
+SELECT
+  c.id,
+  cq.resource_id,
+  cq.url,
+  cq.source_quote,
+  true
+FROM claims c
+JOIN citation_quotes cq
+  ON cq.page_id = c.entity_id
+  AND cq.footnote::text = trim(c.footnote_refs)  -- single footnote ref
+WHERE c.source_quote IS NULL
+  AND c.footnote_refs IS NOT NULL
+  AND c.footnote_refs NOT LIKE '%,%'             -- only single-footnote claims
+  AND cq.source_quote IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM claim_sources cs WHERE cs.claim_id = c.id
+  )
+ON CONFLICT DO NOTHING;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1771902100000,
       "tag": "0028_enhance_claims",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1771902200000,
+      "tag": "0029_claim_sources_and_modes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -5,11 +5,15 @@ import { mockDbModule, postJson } from "./test-utils.js";
 // ---- In-memory store ----
 
 let claimStore: Map<number, Record<string, unknown>>;
+let claimSourceStore: Map<number, Record<string, unknown>>;
 let nextId: number;
+let nextSourceId: number;
 
 function resetStores() {
   claimStore = new Map();
+  claimSourceStore = new Map();
   nextId = 1;
+  nextSourceId = 1;
 }
 
 /** Parse a JSONB param that may arrive as a JSON string from Drizzle */
@@ -37,11 +41,61 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return params.map((p) => ({ id: p }));
   }
 
+  // ---- INSERT INTO claim_sources ----
+  if (q.includes("insert into") && q.includes('"claim_sources"')) {
+    const now = new Date();
+    // Columns: claim_id, resource_id, url, source_quote, is_primary
+    const PARAMS_PER_ROW = 5;
+    const rowCount = Math.max(1, Math.floor(params.length / PARAMS_PER_ROW));
+    const results: Record<string, unknown>[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const off = i * PARAMS_PER_ROW;
+      const id = nextSourceId++;
+      const row: Record<string, unknown> = {
+        id,
+        claim_id: params[off],
+        resource_id: params[off + 1],
+        url: params[off + 2],
+        source_quote: params[off + 3],
+        is_primary: params[off + 4],
+        added_at: now,
+      };
+      claimSourceStore.set(id, row);
+      results.push(row);
+    }
+    return results;
+  }
+
+  // ---- SELECT FROM claim_sources WHERE claim_id = $1 ----
+  if (q.includes('"claim_sources"') && q.includes("where") && q.includes("claim_id")) {
+    const claimId = Number(params[0]);
+    return Array.from(claimSourceStore.values()).filter(
+      (s) => Number(s.claim_id) === claimId
+    );
+  }
+
+  // ---- SELECT FROM claim_sources WHERE claim_id IN (...) ----
+  if (q.includes('"claim_sources"') && q.includes("in (")) {
+    const ids = params.map(Number);
+    return Array.from(claimSourceStore.values()).filter(
+      (s) => ids.includes(Number(s.claim_id))
+    );
+  }
+
+  // ---- EXISTS subquery for claim_sources in stats ----
+  if (q.includes("count(*)") && q.includes("exists") && q.includes("claim_sources")) {
+    // Count claims that have at least one claim_source
+    const claimIdsWithSources = new Set(
+      Array.from(claimSourceStore.values()).map((s) => Number(s.claim_id))
+    );
+    return [{ count: claimIdsWithSources.size }];
+  }
+
   // ---- INSERT INTO claims ----
   if (q.includes("insert into") && q.includes('"claims"')) {
     const now = new Date();
-    // Count parameters per row: 8 original + 6 enhanced columns = 14
-    const PARAMS_PER_ROW = 14;
+    // Count parameters per row: 8 original + 6 enhanced + 7 phase2 = 21
+    const PARAMS_PER_ROW = 21;
     const rowCount = Math.max(1, Math.floor(params.length / PARAMS_PER_ROW));
     const results: Record<string, unknown>[] = [];
 
@@ -59,13 +113,20 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         confidence: params[off + 6],
         source_quote: params[off + 7],
         // Enhanced fields (migration 0028)
-        // JSONB values arrive as JSON strings from Drizzle — parse them back
         claim_category: params[off + 8],
         related_entities: parseJsonbParam(params[off + 9]),
         fact_id: params[off + 10],
         resource_ids: parseJsonbParam(params[off + 11]),
         section: params[off + 12],
         footnote_refs: params[off + 13],
+        // Phase 2 fields (migration 0029)
+        claim_mode: params[off + 14] ?? "endorsed",
+        attributed_to: params[off + 15],
+        as_of: params[off + 16],
+        measure: params[off + 17],
+        value_numeric: params[off + 18],
+        value_low: params[off + 19],
+        value_high: params[off + 20],
         created_at: now,
         updated_at: now,
       };
@@ -168,6 +229,36 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ count }];
   }
 
+  // ---- SELECT count(*) FROM claims with GROUP BY claim_mode ----
+  if (
+    q.includes("count(*)") &&
+    q.includes('"claims"') &&
+    q.includes("group by") &&
+    q.includes("claim_mode")
+  ) {
+    const counts: Record<string, number> = {};
+    for (const r of claimStore.values()) {
+      const t = (r.claim_mode as string) ?? "endorsed";
+      counts[t] = (counts[t] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([claim_mode, count]) => ({ claim_mode, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // ---- SELECT count(*) FROM claims WHERE claim_mode = 'attributed' ----
+  if (
+    q.includes("count(*)") &&
+    q.includes('"claims"') &&
+    q.includes("claim_mode")
+  ) {
+    let count = 0;
+    for (const r of claimStore.values()) {
+      if (r.claim_mode === "attributed") count++;
+    }
+    return [{ count }];
+  }
+
   // ---- SELECT count(*) FROM claims (no GROUP BY, with optional WHERE) ----
   if (
     q.includes("count(*)") &&
@@ -225,6 +316,18 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         if (typeCompare !== 0) return typeCompare;
         return (a.id as number) - (b.id as number);
       });
+  }
+
+  // ---- SELECT FROM claim_sources WHERE claim_id = $1 ORDER BY ... (for GET /:id) ----
+  if (
+    q.includes('"claim_sources"') &&
+    q.includes("where") &&
+    q.includes("order by")
+  ) {
+    const claimId = Number(params[0]);
+    return Array.from(claimSourceStore.values()).filter(
+      (s) => Number(s.claim_id) === claimId
+    );
   }
 
   // ---- SELECT ... FROM claims WHERE id = $1 (get by ID) ----
@@ -554,6 +657,13 @@ describe("Claims API", () => {
     resourceIds: ["res-bloomberg-2024"],
     section: "Funding History",
     footnoteRefs: "1,3",
+    // Phase 2 fields
+    claimMode: "endorsed",
+    asOf: "2024-09",
+    measure: "total_funding",
+    valueNumeric: 7300000000,
+    valueLow: 7000000000,
+    valueHigh: 7500000000,
   };
 
   describe("Enhanced fields round-trip", () => {
@@ -697,6 +807,105 @@ describe("Claims API", () => {
       const res = await app.request("/api/claims/stats");
       const body = await res.json();
       expect(body.factLinkedClaims).toBe(1);
+    });
+  });
+
+  // =======================================================================
+  // Phase 2 tests (migration 0029): claim_mode, as_of, numeric values, claim_sources
+  // =======================================================================
+
+  describe("Phase 2 — claim_mode and attributed claims", () => {
+    it("stores and returns claimMode via GET by ID", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "neel-nanda",
+        entityType: "person",
+        claimType: "evaluative",
+        claimText: "Mechanistic interpretability is crucial for AI safety",
+        claimMode: "attributed",
+        attributedTo: "neel-nanda",
+        asOf: "2023-06",
+      });
+      expect(createRes.status).toBe(201);
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.claimMode).toBe("attributed");
+      expect(body.attributedTo).toBe("neel-nanda");
+      expect(body.asOf).toBe("2023-06");
+    });
+
+    it("defaults claim_mode to endorsed when not specified", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "Anthropic was founded in 2021",
+      });
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}`);
+      const body = await res.json();
+      expect(body.claimMode).toBe("endorsed");
+    });
+
+    it("stores numeric value fields", async () => {
+      const createRes = await postJson(app, "/api/claims", enhancedClaim);
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}`);
+      const body = await res.json();
+      expect(body.valueNumeric).toBe(7300000000);
+      expect(body.valueLow).toBe(7000000000);
+      expect(body.valueHigh).toBe(7500000000);
+      expect(body.measure).toBe("total_funding");
+      expect(body.asOf).toBe("2024-09");
+    });
+  });
+
+  describe("Phase 2 — claim_sources inline insert", () => {
+    it("creates claim_sources when sources array is provided", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "Anthropic raised $7.3B from Google and Amazon",
+        sources: [
+          {
+            resourceId: "res-bloomberg-2024",
+            sourceQuote: "Google has committed to invest up to $2 billion",
+            isPrimary: true,
+          },
+          {
+            url: "https://example.com/amazon-investment",
+            sourceQuote: "Amazon invested $4 billion in Anthropic",
+            isPrimary: false,
+          },
+        ],
+      });
+      expect(createRes.status).toBe(201);
+      const created = await createRes.json();
+
+      // Check sources are in the store
+      expect(claimSourceStore.size).toBe(2);
+      const sources = Array.from(claimSourceStore.values());
+      expect(sources.some((s) => s.resource_id === "res-bloomberg-2024")).toBe(true);
+      expect(sources.some((s) => s.url === "https://example.com/amazon-investment")).toBe(true);
+    });
+
+    it("GET /:id always includes sources array", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "A claim without sources",
+      });
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}`);
+      const body = await res.json();
+      expect(Array.isArray(body.sources)).toBe(true);
     });
   });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -679,6 +679,9 @@ export const ClaimTypeSchema = z.enum([
 ]);
 export type ClaimType = z.infer<typeof ClaimTypeSchema>;
 
+export const ClaimModeSchema = z.enum(["endorsed", "attributed"]);
+export type ClaimMode = z.infer<typeof ClaimModeSchema>;
+
 export const InsertClaimSchema = z.object({
   entityId: z.string().min(1).max(300),
   entityType: z.string().min(1).max(100),
@@ -689,13 +692,28 @@ export const InsertClaimSchema = z.object({
   unit: z.string().max(100).nullable().optional(),
   confidence: z.string().max(100).nullable().optional(),
   sourceQuote: z.string().max(10000).nullable().optional(),
-  // Enhanced fields
+  // Enhanced fields (migration 0028)
   claimCategory: ClaimCategorySchema.nullable().optional(),
   relatedEntities: z.array(z.string().max(300)).nullable().optional(),
   factId: z.string().max(300).nullable().optional(),
   resourceIds: z.array(z.string().max(300)).nullable().optional(),
   section: z.string().max(1000).nullable().optional(),
   footnoteRefs: z.string().max(500).nullable().optional(),
+  // Phase 2 fields (migration 0029)
+  claimMode: ClaimModeSchema.nullable().optional(),
+  attributedTo: z.string().max(300).nullable().optional(),
+  asOf: z.string().max(20).nullable().optional(), // YYYY-MM or YYYY-MM-DD
+  measure: z.string().max(200).nullable().optional(),
+  valueNumeric: z.number().nullable().optional(),
+  valueLow: z.number().nullable().optional(),
+  valueHigh: z.number().nullable().optional(),
+  // Inline sources — optional list of sources to create in claim_sources table
+  sources: z.array(z.object({
+    resourceId: z.string().max(300).nullable().optional(),
+    url: z.string().max(2000).nullable().optional(),
+    sourceQuote: z.string().max(10000).nullable().optional(),
+    isPrimary: z.boolean().optional(),
+  })).nullable().optional(),
 });
 export type InsertClaim = z.infer<typeof InsertClaimSchema>;
 
@@ -709,6 +727,16 @@ export const ClearClaimsSchema = z.object({
 
 // -- Claims: Response types ---------------------------------------------------
 
+export interface ClaimSourceRow {
+  id: number;
+  claimId: number;
+  resourceId: string | null;
+  url: string | null;
+  sourceQuote: string | null;
+  isPrimary: boolean;
+  addedAt: string;
+}
+
 export interface ClaimRow {
   id: number;
   entityId: string;
@@ -719,13 +747,22 @@ export interface ClaimRow {
   unit: string | null;
   confidence: string | null;
   sourceQuote: string | null;
-  // Enhanced fields
+  // Enhanced fields (migration 0028)
   claimCategory: string | null;
   relatedEntities: string[] | null;
   factId: string | null;
   resourceIds: string[] | null;
   section: string | null;
   footnoteRefs: string | null;
+  // Phase 2 fields (migration 0029)
+  claimMode: string | null;       // 'endorsed' | 'attributed'
+  attributedTo: string | null;    // entity_id of person/org making claim
+  asOf: string | null;            // YYYY-MM or YYYY-MM-DD
+  measure: string | null;         // measure ID from facts taxonomy
+  valueNumeric: number | null;    // central numeric value
+  valueLow: number | null;        // lower bound
+  valueHigh: number | null;       // upper bound
+  sources: ClaimSourceRow[];      // populated when ?includeSources=true
   createdAt: string;
   updatedAt: string;
 }
@@ -754,8 +791,11 @@ export interface ClaimStatsResult {
   byClaimType: Record<string, number>;
   byEntityType: Record<string, number>;
   byClaimCategory: Record<string, number>;
+  byClaimMode: Record<string, number>;
   multiEntityClaims: number;
   factLinkedClaims: number;
+  withSourcesClaims: number;
+  attributedClaims: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, or, count, desc, asc, sql } from "drizzle-orm";
+import { eq, and, or, count, desc, asc, sql, inArray } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
-import { claims, entities } from "../schema.js";
+import { claims, claimSources, entities } from "../schema.js";
 import { checkRefsExist } from "./ref-check.js";
 import {
   parseJsonBody,
@@ -34,11 +34,16 @@ const PaginationQuery = z.object({
   entityType: z.string().max(100).optional(),
   claimType: z.string().max(100).optional(),
   claimCategory: z.string().max(100).optional(),
+  claimMode: z.string().max(50).optional(),
   search: z.string().max(500).optional(),
   confidence: z.string().max(50).optional(),
   entityId: z.string().max(200).optional(),
+  attributedTo: z.string().max(300).optional(),
+  measure: z.string().max(200).optional(),
   multiEntity: z.coerce.boolean().optional(),
-  sort: z.enum(["newest", "entity", "confidence"]).optional(),
+  hasNumericValue: z.coerce.boolean().optional(),
+  includeSources: z.coerce.boolean().optional(),
+  sort: z.enum(["newest", "entity", "confidence", "as_of"]).optional(),
 });
 
 const DeleteByEntitySchema = ClearClaimsSchema;
@@ -53,23 +58,49 @@ function claimValues(d: ClaimInput) {
     entityType: d.entityType,
     claimType: d.claimType,
     claimText: d.claimText,
+    // Legacy fields (kept for backward compat)
     value: d.value ?? null,
     unit: d.unit ?? null,
     confidence: d.confidence ?? null,
     sourceQuote: d.sourceQuote ?? null,
-    // Enhanced fields
+    // Enhanced fields (migration 0028)
     claimCategory: d.claimCategory ?? null,
     relatedEntities: d.relatedEntities ?? null,
     factId: d.factId ?? null,
     resourceIds: d.resourceIds ?? null,
     section: d.section ?? d.value ?? null,
     footnoteRefs: d.footnoteRefs ?? d.unit ?? null,
+    // Phase 2 fields (migration 0029)
+    claimMode: d.claimMode ?? "endorsed",
+    attributedTo: d.attributedTo ?? null,
+    asOf: d.asOf ?? null,
+    measure: d.measure ?? null,
+    valueNumeric: d.valueNumeric ?? null,
+    valueLow: d.valueLow ?? null,
+    valueHigh: d.valueHigh ?? null,
   };
 }
 
-function formatClaim(r: typeof claims.$inferSelect) {
+type ClaimSourceRow = typeof claimSources.$inferSelect;
+
+function formatClaimSource(s: ClaimSourceRow) {
   return {
-    id: r.id,
+    id: Number(s.id),
+    claimId: Number(s.claimId),
+    resourceId: s.resourceId,
+    url: s.url,
+    sourceQuote: s.sourceQuote,
+    isPrimary: s.isPrimary,
+    addedAt: s.addedAt,
+  };
+}
+
+function formatClaim(
+  r: typeof claims.$inferSelect,
+  sourcesRows: ClaimSourceRow[] = []
+) {
+  return {
+    id: Number(r.id),
     entityId: r.entityId,
     entityType: r.entityType,
     claimType: r.claimType,
@@ -78,13 +109,22 @@ function formatClaim(r: typeof claims.$inferSelect) {
     unit: r.unit,
     confidence: r.confidence,
     sourceQuote: r.sourceQuote,
-    // Enhanced fields
+    // Enhanced fields (migration 0028)
     claimCategory: r.claimCategory,
     relatedEntities: r.relatedEntities as string[] | null,
     factId: r.factId,
     resourceIds: r.resourceIds as string[] | null,
     section: r.section,
     footnoteRefs: r.footnoteRefs,
+    // Phase 2 fields (migration 0029)
+    claimMode: r.claimMode,
+    attributedTo: r.attributedTo,
+    asOf: r.asOf,
+    measure: r.measure,
+    valueNumeric: r.valueNumeric,
+    valueLow: r.valueLow,
+    valueHigh: r.valueHigh,
+    sources: sourcesRows.map(formatClaimSource),
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   };
@@ -118,7 +158,21 @@ claimsRoute.post("/", async (c) => {
       claimType: claims.claimType,
     });
 
-  return c.json(firstOrThrow(rows, "claim insert"), 201);
+  const inserted = firstOrThrow(rows, "claim insert");
+
+  // Insert claim_sources if provided
+  if (parsed.data.sources && parsed.data.sources.length > 0) {
+    const sourceVals = parsed.data.sources.map((s) => ({
+      claimId: inserted.id,
+      resourceId: s.resourceId ?? null,
+      url: s.url ?? null,
+      sourceQuote: s.sourceQuote ?? null,
+      isPrimary: s.isPrimary ?? false,
+    }));
+    await db.insert(claimSources).values(sourceVals);
+  }
+
+  return c.json(inserted, 201);
 });
 
 // ---- POST /batch (insert multiple claims) ----
@@ -150,6 +204,35 @@ claimsRoute.post("/batch", async (c) => {
       entityId: claims.entityId,
       claimType: claims.claimType,
     });
+
+  // Insert claim_sources for any items that include inline sources
+  const sourcesToInsert: Array<{
+    claimId: number;
+    resourceId: string | null;
+    url: string | null;
+    sourceQuote: string | null;
+    isPrimary: boolean;
+  }> = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const result = results[i];
+    if (item.sources && item.sources.length > 0 && result) {
+      for (const s of item.sources) {
+        sourcesToInsert.push({
+          claimId: result.id,
+          resourceId: s.resourceId ?? null,
+          url: s.url ?? null,
+          sourceQuote: s.sourceQuote ?? null,
+          isPrimary: s.isPrimary ?? false,
+        });
+      }
+    }
+  }
+
+  if (sourcesToInsert.length > 0) {
+    await db.insert(claimSources).values(sourcesToInsert);
+  }
 
   return c.json({ inserted: results.length, results }, 201);
 });
@@ -186,59 +269,69 @@ claimsRoute.get("/stats", async (c) => {
   const total = totalResult[0].count;
 
   const byType = await db
-    .select({
-      claimType: claims.claimType,
-      count: count(),
-    })
+    .select({ claimType: claims.claimType, count: count() })
     .from(claims)
     .groupBy(claims.claimType)
     .orderBy(desc(count()));
 
   const byEntityType = await db
-    .select({
-      entityType: claims.entityType,
-      count: count(),
-    })
+    .select({ entityType: claims.entityType, count: count() })
     .from(claims)
     .groupBy(claims.entityType)
     .orderBy(desc(count()));
 
   const byCategory = await db
-    .select({
-      claimCategory: claims.claimCategory,
-      count: count(),
-    })
+    .select({ claimCategory: claims.claimCategory, count: count() })
     .from(claims)
     .groupBy(claims.claimCategory)
     .orderBy(desc(count()));
 
-  // Count claims that have relatedEntities (multi-entity claims)
+  const byMode = await db
+    .select({ claimMode: claims.claimMode, count: count() })
+    .from(claims)
+    .groupBy(claims.claimMode)
+    .orderBy(desc(count()));
+
+  // Multi-entity claims
   const multiEntityResult = await db
     .select({ count: count() })
     .from(claims)
     .where(sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`);
-  const multiEntityCount = multiEntityResult[0].count;
 
-  // Count claims linked to facts
+  // Fact-linked claims
   const factLinkedResult = await db
     .select({ count: count() })
     .from(claims)
     .where(sql`${claims.factId} IS NOT NULL`);
-  const factLinkedCount = factLinkedResult[0].count;
+
+  // Claims with claim_sources entries
+  const withSourcesResult = await db
+    .select({ count: count() })
+    .from(claims)
+    .where(
+      sql`EXISTS (SELECT 1 FROM claim_sources cs WHERE cs.claim_id = ${claims.id})`
+    );
+
+  // Attributed claims
+  const attributedResult = await db
+    .select({ count: count() })
+    .from(claims)
+    .where(eq(claims.claimMode, "attributed"));
 
   return c.json({
     total,
-    byClaimType: Object.fromEntries(
-      byType.map((r) => [r.claimType, r.count])
-    ),
-    byEntityType: Object.fromEntries(
-      byEntityType.map((r) => [r.entityType, r.count])
-    ),
+    byClaimType: Object.fromEntries(byType.map((r) => [r.claimType, r.count])),
+    byEntityType: Object.fromEntries(byEntityType.map((r) => [r.entityType, r.count])),
     byClaimCategory: Object.fromEntries(
       byCategory.map((r) => [r.claimCategory ?? "uncategorized", r.count])
     ),
-    multiEntityClaims: multiEntityCount,
-    factLinkedClaims: factLinkedCount,
+    byClaimMode: Object.fromEntries(
+      byMode.map((r) => [r.claimMode ?? "uncategorized", r.count])
+    ),
+    multiEntityClaims: multiEntityResult[0].count,
+    factLinkedClaims: factLinkedResult[0].count,
+    withSourcesClaims: withSourcesResult[0].count,
+    attributedClaims: attributedResult[0].count,
   });
 });
 
@@ -247,6 +340,7 @@ claimsRoute.get("/stats", async (c) => {
 
 claimsRoute.get("/by-entity/:entityId", async (c) => {
   const entityId = c.req.param("entityId");
+  const includeSources = c.req.query("includeSources") === "true";
   const db = getDrizzleDb();
 
   // Query: primary entity match OR entity appears in the relatedEntities JSONB array
@@ -261,7 +355,23 @@ claimsRoute.get("/by-entity/:entityId", async (c) => {
     )
     .orderBy(asc(claims.claimType), asc(claims.id));
 
-  return c.json({ claims: rows.map(formatClaim) });
+  let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
+  if (includeSources && rows.length > 0) {
+    const claimIds = rows.map((r) => r.id);
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(inArray(claimSources.claimId, claimIds));
+    for (const s of sourcesRows) {
+      const id = Number(s.claimId);
+      if (!sourcesMap.has(id)) sourcesMap.set(id, []);
+      sourcesMap.get(id)!.push(s);
+    }
+  }
+
+  return c.json({
+    claims: rows.map((r) => formatClaim(r, sourcesMap.get(Number(r.id)) ?? [])),
+  });
 });
 
 // ---- GET /all (paginated listing) ----
@@ -271,8 +381,9 @@ claimsRoute.get("/all", async (c) => {
   if (!parsed.success) return validationError(c, parsed.error.message);
 
   const {
-    limit, offset, entityType, claimType, claimCategory,
-    search, confidence, entityId, multiEntity, sort,
+    limit, offset, entityType, claimType, claimCategory, claimMode,
+    search, confidence, entityId, attributedTo, measure,
+    multiEntity, hasNumericValue, includeSources, sort,
   } = parsed.data;
   const db = getDrizzleDb();
 
@@ -280,10 +391,20 @@ claimsRoute.get("/all", async (c) => {
   if (entityType) conditions.push(eq(claims.entityType, entityType));
   if (claimType) conditions.push(eq(claims.claimType, claimType));
   if (claimCategory) conditions.push(eq(claims.claimCategory, claimCategory));
+  if (claimMode) conditions.push(eq(claims.claimMode, claimMode));
   if (search) conditions.push(sql`${claims.claimText} ILIKE ${"%" + search + "%"}`);
   if (confidence) conditions.push(eq(claims.confidence, confidence));
   if (entityId) conditions.push(eq(claims.entityId, entityId));
-  if (multiEntity) conditions.push(sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`);
+  if (attributedTo) conditions.push(eq(claims.attributedTo, attributedTo));
+  if (measure) conditions.push(eq(claims.measure, measure));
+  if (multiEntity) {
+    conditions.push(
+      sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
+    );
+  }
+  if (hasNumericValue) {
+    conditions.push(sql`${claims.valueNumeric} IS NOT NULL`);
+  }
 
   const whereClause =
     conditions.length > 0
@@ -296,6 +417,7 @@ claimsRoute.get("/all", async (c) => {
     sort === "newest" ? desc(claims.id)
     : sort === "entity" ? asc(claims.entityId)
     : sort === "confidence" ? asc(claims.confidence)
+    : sort === "as_of" ? desc(claims.asOf)
     : asc(claims.id);
 
   const rows = await db
@@ -312,8 +434,22 @@ claimsRoute.get("/all", async (c) => {
     .where(whereClause);
   const total = countResult[0].count;
 
+  let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
+  if (includeSources && rows.length > 0) {
+    const claimIds = rows.map((r) => r.id);
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(inArray(claimSources.claimId, claimIds));
+    for (const s of sourcesRows) {
+      const id = Number(s.claimId);
+      if (!sourcesMap.has(id)) sourcesMap.set(id, []);
+      sourcesMap.get(id)!.push(s);
+    }
+  }
+
   return c.json({
-    claims: rows.map(formatClaim),
+    claims: rows.map((r) => formatClaim(r, sourcesMap.get(Number(r.id)) ?? [])),
     total,
     limit,
     offset,
@@ -404,6 +540,74 @@ claimsRoute.get("/network", async (c) => {
   return c.json({ nodes, edges });
 });
 
+// ---- GET /:id/sources (sources for a specific claim) ----
+
+claimsRoute.get("/:id/sources", async (c) => {
+  const idStr = c.req.param("id");
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return validationError(c, "Claim ID must be a positive integer");
+  }
+
+  const db = getDrizzleDb();
+  const rows = await db
+    .select()
+    .from(claimSources)
+    .where(eq(claimSources.claimId, id))
+    .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+  return c.json({ sources: rows.map(formatClaimSource) });
+});
+
+// ---- POST /:id/sources (add a source to a claim) ----
+
+const AddClaimSourceSchema = z.object({
+  resourceId: z.string().max(300).nullable().optional(),
+  url: z.string().max(2000).nullable().optional(),
+  sourceQuote: z.string().max(10000).nullable().optional(),
+  isPrimary: z.boolean().optional(),
+});
+
+claimsRoute.post("/:id/sources", async (c) => {
+  const idStr = c.req.param("id");
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return validationError(c, "Claim ID must be a positive integer");
+  }
+
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = AddClaimSourceSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const db = getDrizzleDb();
+
+  // Verify claim exists
+  const claimRows = await db
+    .select({ id: claims.id })
+    .from(claims)
+    .where(eq(claims.id, id))
+    .limit(1);
+
+  if (claimRows.length === 0) {
+    return notFoundError(c, `Claim not found: ${id}`);
+  }
+
+  const rows = await db
+    .insert(claimSources)
+    .values({
+      claimId: id,
+      resourceId: parsed.data.resourceId ?? null,
+      url: parsed.data.url ?? null,
+      sourceQuote: parsed.data.sourceQuote ?? null,
+      isPrimary: parsed.data.isPrimary ?? false,
+    })
+    .returning();
+
+  return c.json(formatClaimSource(firstOrThrow(rows, "claim_source insert")), 201);
+});
+
 // ---- GET /:id (get by ID) ----
 
 claimsRoute.get("/:id", async (c) => {
@@ -424,5 +628,12 @@ claimsRoute.get("/:id", async (c) => {
     return notFoundError(c, `Claim not found: ${id}`);
   }
 
-  return c.json(formatClaim(rows[0]));
+  // Always include sources for single claim fetches
+  const sourcesRows = await db
+    .select()
+    .from(claimSources)
+    .where(eq(claimSources.claimId, id))
+    .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+  return c.json(formatClaim(rows[0], sourcesRows));
 });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -394,6 +394,14 @@ export const claims = pgTable(
     resourceIds: jsonb("resource_ids"), // string[] — resource IDs from data/resources/
     section: text("section"), // section heading where claim appears
     footnoteRefs: text("footnote_refs"), // comma-separated footnote refs (e.g. "1,3,7")
+    // --- Phase 2 fields (migration 0029) ---
+    claimMode: text("claim_mode"),      // 'endorsed' | 'attributed'
+    attributedTo: text("attributed_to"), // entity_id of person/org making the claim
+    asOf: text("as_of"),                // temporal index: YYYY-MM or YYYY-MM-DD
+    measure: text("measure"),           // measure ID linking to facts taxonomy
+    valueNumeric: real("value_numeric"), // central numeric value (machine-readable)
+    valueLow: real("value_low"),        // lower bound for range values
+    valueHigh: real("value_high"),      // upper bound for range values
     // --- Timestamps ---
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
@@ -408,8 +416,46 @@ export const claims = pgTable(
     index("idx_cl_claim_type").on(table.claimType),
     index("idx_cl_claim_category").on(table.claimCategory),
     index("idx_cl_fact_id").on(table.factId),
+    index("idx_cl_claim_mode").on(table.claimMode),
+    index("idx_cl_attributed_to").on(table.attributedTo),
+    index("idx_cl_as_of").on(table.asOf),
+    index("idx_cl_measure").on(table.measure),
     // GIN index on relatedEntities is created in migration 0028
     // (Drizzle doesn't support GIN index declarations on JSONB)
+  ]
+);
+
+/**
+ * Claim sources — join table linking claims to their supporting resources.
+ *
+ * Each row represents one resource backing a claim.
+ * Replaces the JSONB resource_ids array with proper relational rows,
+ * enabling per-source quotes, primary source flags, and JOIN queries.
+ *
+ * claim_mode on the parent claim tells you whether the wiki endorses the claim
+ * or is attributing it to another entity (e.g., "Anthropic claims that...").
+ */
+export const claimSources = pgTable(
+  "claim_sources",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    claimId: bigint("claim_id", { mode: "number" })
+      .notNull()
+      .references(() => claims.id, { onDelete: "cascade" }),
+    resourceId: text("resource_id").references(() => resources.id, {
+      onDelete: "set null",
+    }),
+    url: text("url"), // fallback if resourceId not known
+    sourceQuote: text("source_quote"), // exact excerpt supporting the claim
+    isPrimary: boolean("is_primary").notNull().default(false),
+    addedAt: timestamp("added_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cs_claim_id").on(table.claimId),
+    index("idx_cs_resource_id").on(table.resourceId),
+    index("idx_cs_is_primary").on(table.isPrimary),
   ]
 );
 

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -12,7 +12,9 @@ import type {
   InsertClaimBatchResult,
   ClearClaimsResult,
   ClaimRow,
+  ClaimSourceRow,
   GetClaimsResult,
+  ClaimStatsResult,
 } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -25,7 +27,15 @@ export type InsertClaimItem = InsertClaim;
 // Types — response (re-exported from canonical api-types.ts)
 // ---------------------------------------------------------------------------
 
-export type { InsertClaimResult, InsertClaimBatchResult, ClearClaimsResult, ClaimRow, GetClaimsResult };
+export type {
+  InsertClaimResult,
+  InsertClaimBatchResult,
+  ClearClaimsResult,
+  ClaimRow,
+  ClaimSourceRow,
+  GetClaimsResult,
+  ClaimStatsResult,
+};
 
 // ---------------------------------------------------------------------------
 // API functions
@@ -33,11 +43,44 @@ export type { InsertClaimResult, InsertClaimBatchResult, ClearClaimsResult, Clai
 
 export async function getClaimsByEntity(
   entityId: string,
+  options?: { includeSources?: boolean },
 ): Promise<ApiResult<GetClaimsResult>> {
+  const params = options?.includeSources ? '?includeSources=true' : '';
   return apiRequest<GetClaimsResult>(
     'GET',
-    `/api/claims/by-entity/${encodeURIComponent(entityId)}`,
+    `/api/claims/by-entity/${encodeURIComponent(entityId)}${params}`,
   );
+}
+
+export async function getClaimSources(
+  claimId: number,
+): Promise<ApiResult<{ sources: ClaimSourceRow[] }>> {
+  return apiRequest<{ sources: ClaimSourceRow[] }>(
+    'GET',
+    `/api/claims/${claimId}/sources`,
+  );
+}
+
+export async function addClaimSource(
+  claimId: number,
+  source: {
+    resourceId?: string | null;
+    url?: string | null;
+    sourceQuote?: string | null;
+    isPrimary?: boolean;
+  },
+): Promise<ApiResult<ClaimSourceRow>> {
+  return apiRequest<ClaimSourceRow>(
+    'POST',
+    `/api/claims/${claimId}/sources`,
+    source,
+    undefined,
+    'content',
+  );
+}
+
+export async function getClaimStats(): Promise<ApiResult<ClaimStatsResult>> {
+  return apiRequest<ClaimStatsResult>('GET', '/api/claims/stats');
 }
 
 export async function insertClaim(


### PR DESCRIPTION
## Summary

Phase 2A of the claims system — proper relational multi-source provenance and epistemic metadata.

**New DB objects (migration 0029):**
- `claim_sources` join table: replaces JSONB `resource_ids` with proper relational rows. Each source has `resource_id`, `url`, `source_quote`, and `is_primary` flag. Migrates existing data on deploy.
- `claim_mode` column: `endorsed` (wiki asserts this) vs `attributed` (entity X claims this). Existing claims default to `endorsed`.
- `attributed_to` column: entity_id of the person/org making the claim (for attributed mode)
- `as_of` column: temporal index (YYYY-MM or YYYY-MM-DD) for time-sensitive claims
- `measure` column: links numeric claims to the facts taxonomy
- `value_numeric`, `value_low`, `value_high`: machine-readable quantitative values for range display and trend queries

**API changes:**
- `InsertClaim` schema accepts inline `sources[]` array — creates `claim_sources` rows atomically with the claim
- `GET /api/claims/:id` always includes `sources[]` in response
- New `POST /api/claims/:id/sources` to add individual sources
- New `GET /api/claims/:id/sources` to list sources
- `GET /api/claims/by-entity/:id` and `/all` accept `?includeSources=true`
- New filter params: `claimMode`, `attributedTo`, `measure`, `hasNumericValue`
- New sort option: `sort=as_of`
- Stats endpoint now returns `byClaimMode`, `withSourcesClaims`, `attributedClaims`

**Crux client updates:**
- `addClaimSource()`, `getClaimSources()`, `getClaimStats()` helpers added

## Test plan
- [x] All 1863 tests pass (82 test files)
- [x] 32 claims tests including Phase 2 round-trips (claim_mode, numeric values, claim_sources)
- [x] TypeScript clean (apps/web, apps/wiki-server)
- [ ] After merge: deploy DB migration, verify claim_sources backfill from resource_ids

Closes #1043 (Phase 3 issue created separately)
