### PR TITLE
fix: resolve wiki page lookups by numeric ID via entityIds table

### DIFF
--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { mockDbModule, postJson } from "./test-utils.js";
 
-// ---- In-memory store simulating Postgres wiki_pages table ----
+// ---- In-memory stores simulating Postgres tables ----
 
 let pagesStore: Map<string, Record<string, unknown>>;
+let entityIdsStore: Map<number, { slug: string; description: string | null; created_at: Date }>;
 
 function resetStores() {
   pagesStore = new Map();
+  entityIdsStore = new Map();
 }
 
 /**
@@ -190,9 +192,19 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
+  // --- entity_ids: SELECT slug WHERE numeric_id = ? (numeric ID resolution) ---
+  if (q.includes("entity_ids") && q.includes("where") && q.includes("numeric_id") && !q.includes("count(*)")) {
+    const numericId = params[0] as number;
+    const entry = entityIdsStore.get(numericId);
+    if (entry) {
+      return [{ slug: entry.slug }];
+    }
+    return [];
+  }
+
   // --- entity_ids: COUNT (for health check) ---
   if (q.includes("count(*)") && !q.includes("wiki_pages")) {
-    return [{ count: 0 }];
+    return [{ count: entityIdsStore.size }];
   }
 
   // --- sequence health check ---
@@ -333,10 +345,34 @@ describe("Pages API", () => {
       expect(body.numericId).toBe("E42");
     });
 
-    it("returns page by numeric ID", async () => {
+    it("returns page by numeric ID (legacy wiki_pages.numericId)", async () => {
       await seedPage(app, "anthropic", "Anthropic", { numericId: "E42" });
 
       const res = await app.request("/api/pages/E42");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.id).toBe("anthropic");
+    });
+
+    it("returns page by numeric ID via entityIds table when wiki_pages.numericId is null", async () => {
+      // Seed a page WITHOUT numericId (as most pages are in production)
+      await seedPage(app, "anthropic", "Anthropic", { numericId: null });
+      // Seed the entityIds mapping: E22 → anthropic
+      entityIdsStore.set(22, { slug: "anthropic", description: null, created_at: new Date() });
+
+      const res = await app.request("/api/pages/E22");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.id).toBe("anthropic");
+      expect(body.numericId).toBe("E22");
+    });
+
+    it("returns page by case-insensitive numeric ID", async () => {
+      await seedPage(app, "anthropic", "Anthropic", { numericId: null });
+      entityIdsStore.set(22, { slug: "anthropic", description: null, created_at: new Date() });
+
+      // Lowercase e22 should also work
+      const res = await app.request("/api/pages/e22");
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.id).toBe("anthropic");

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, or, and, count, asc, sql } from "drizzle-orm";
 import { getDrizzleDb, getDb } from "../db.js";
-import { wikiPages } from "../schema.js";
+import { wikiPages, entityIds } from "../schema.js";
 import {
   parseJsonBody,
   validationError,
@@ -125,20 +125,39 @@ pagesRoute.get("/:id", async (c) => {
 
   const db = getDrizzleDb();
 
-  // Look up by slug or numeric ID
+  // If the ID looks like a numeric entity ID (E42), resolve to slug via entityIds table.
+  // The wiki_pages.numeric_id column is sparsely populated, so we use the authoritative
+  // entityIds table for the mapping and fall back to wiki_pages.numeric_id for legacy data.
+  let resolvedSlug: string | null = null;
+  if (/^E\d+$/i.test(id)) {
+    const numericValue = parseInt(id.slice(1), 10);
+    const idRows = await db
+      .select({ slug: entityIds.slug })
+      .from(entityIds)
+      .where(eq(entityIds.numericId, numericValue));
+    if (idRows.length > 0) {
+      resolvedSlug = idRows[0].slug;
+    }
+  }
+
+  // Look up by resolved slug, original ID as slug, or legacy numericId column
+  const lookupSlug = resolvedSlug || id;
   const rows = await db
     .select()
     .from(wikiPages)
-    .where(or(eq(wikiPages.id, id), eq(wikiPages.numericId, id)));
+    .where(or(eq(wikiPages.id, lookupSlug), eq(wikiPages.numericId, id)));
 
   if (rows.length === 0) {
     return notFoundError(c, `No page found for id: ${id}`);
   }
 
   const page = rows[0];
+  // Use the canonical numeric ID from the entityIds resolution if available,
+  // falling back to whatever is stored in wiki_pages
+  const numericId = resolvedSlug ? id.toUpperCase() : page.numericId;
   return c.json({
     id: page.id,
-    numericId: page.numericId,
+    numericId,
     title: page.title,
     description: page.description,
     llmSummary: page.llmSummary,


### PR DESCRIPTION
## Summary

- Fixed `GET /api/pages/:id` failing to find pages when queried by numeric ID (e.g. `E22`) because `wiki_pages.numeric_id` is `NULL` for ~95% of pages
- The route now resolves numeric IDs through the authoritative `entityIds` table first, then falls back to the legacy `wiki_pages.numeric_id` column
- Added 2 regression tests: entityIds-based resolution and case-insensitive numeric IDs

## Root cause

The `entityIds` table is the source of truth for slug↔numericId mappings (814 entries), but the `GET /api/pages/:id` route only checked `wiki_pages.numeric_id`, which is `NULL` for 647 of 680 pages. Requesting `/api/pages/E22` returned 404 even though the `entityIds` table correctly maps `E22 → anthropic`.

## Test plan

- [x] Verified on live wiki-server: `GET /api/pages/E22` returns 404 before fix
- [x] All 21 pages tests pass (including 2 new regression tests)
- [x] All 383 wiki-server tests pass (20 files, 0 failures)
- [x] Gate checks pass (6/6)

https://claude.ai/code/session_011fRBgKSHTjpcQxDbghDJdu
