### PR TITLE
fix(claims): paranoid review fixes — migration off-by-one, batch ordering, /sources tests

### DIFF
--- a/apps/wiki-server/drizzle/0029_claim_sources_and_modes.sql
+++ b/apps/wiki-server/drizzle/0029_claim_sources_and_modes.sql
@@ -51,7 +51,7 @@ INSERT INTO claim_sources (claim_id, resource_id, is_primary)
 SELECT
   c.id,
   r_id.resource_id,
-  (r_id.idx = 0) AS is_primary
+  (r_id.idx = 1) AS is_primary   -- WITH ORDINALITY starts at 1, not 0
 FROM claims c,
      jsonb_array_elements_text(c.resource_ids) WITH ORDINALITY AS r_id(resource_id, idx)
 WHERE c.resource_ids IS NOT NULL

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -909,6 +909,171 @@ describe("Claims API", () => {
     });
   });
 
+  // =======================================================================
+  // GET /:id/sources and POST /:id/sources
+  // =======================================================================
+
+  describe("GET /api/claims/:id/sources", () => {
+    it("returns empty sources array for claim with no sources", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "No sources here",
+      });
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}/sources`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.sources).toEqual([]);
+    });
+
+    it("returns sources for a claim that has them", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "Anthropic raised $7.3B",
+        sources: [
+          { resourceId: "res-001", sourceQuote: "raised $7.3B", isPrimary: true },
+          { url: "https://example.com", isPrimary: false },
+        ],
+      });
+      const created = await createRes.json();
+
+      const res = await app.request(`/api/claims/${created.id}/sources`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.sources).toHaveLength(2);
+      // Primary source should be present
+      expect(body.sources.some((s: { resourceId?: string }) => s.resourceId === "res-001")).toBe(true);
+    });
+
+    it("returns 400 for non-numeric claim ID", async () => {
+      const res = await app.request("/api/claims/not-a-number/sources");
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for zero claim ID", async () => {
+      const res = await app.request("/api/claims/0/sources");
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/claims/:id/sources", () => {
+    it("adds a source to an existing claim", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "Anthropic was founded in 2021",
+      });
+      const created = await createRes.json();
+
+      const addRes = await postJson(app, `/api/claims/${created.id}/sources`, {
+        resourceId: "res-techcrunch-2021",
+        sourceQuote: "The company was founded in 2021",
+        isPrimary: true,
+      });
+      expect(addRes.status).toBe(201);
+      const source = await addRes.json();
+      expect(source.resourceId).toBe("res-techcrunch-2021");
+      expect(source.isPrimary).toBe(true);
+      expect(source.sourceQuote).toBe("The company was founded in 2021");
+    });
+
+    it("adds a URL-only source (no resourceId)", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "anthropic",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "A claim",
+      });
+      const created = await createRes.json();
+
+      const addRes = await postJson(app, `/api/claims/${created.id}/sources`, {
+        url: "https://example.com/article",
+        isPrimary: false,
+      });
+      expect(addRes.status).toBe(201);
+      const source = await addRes.json();
+      expect(source.url).toBe("https://example.com/article");
+      expect(source.resourceId).toBeNull();
+    });
+
+    it("returns 404 when adding source to non-existent claim", async () => {
+      const res = await postJson(app, "/api/claims/99999/sources", {
+        url: "https://example.com",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for non-numeric claim ID", async () => {
+      const res = await postJson(app, "/api/claims/abc/sources", {
+        url: "https://example.com",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("source appears in GET /:id/sources after being added", async () => {
+      const createRes = await postJson(app, "/api/claims", {
+        entityId: "openai",
+        entityType: "organization",
+        claimType: "factual",
+        claimText: "OpenAI released GPT-4",
+      });
+      const created = await createRes.json();
+
+      await postJson(app, `/api/claims/${created.id}/sources`, {
+        resourceId: "res-openai-gpt4",
+        sourceQuote: "GPT-4 was released in March 2023",
+        isPrimary: true,
+      });
+
+      const sourcesRes = await app.request(`/api/claims/${created.id}/sources`);
+      expect(sourcesRes.status).toBe(200);
+      const body = await sourcesRes.json();
+      expect(body.sources).toHaveLength(1);
+      expect(body.sources[0].resourceId).toBe("res-openai-gpt4");
+    });
+  });
+
+  // =======================================================================
+  // Phase 2 batch with sources (safe path — one at a time to avoid ordering bug)
+  // =======================================================================
+
+  describe("POST /api/claims/batch with sources", () => {
+    it("inserts batch items with inline sources — each claim gets correct sources", async () => {
+      const res = await postJson(app, "/api/claims/batch", {
+        items: [
+          {
+            entityId: "anthropic",
+            entityType: "organization",
+            claimType: "factual",
+            claimText: "Anthropic raised from Google",
+            sources: [{ resourceId: "res-google", isPrimary: true }],
+          },
+          {
+            entityId: "openai",
+            entityType: "organization",
+            claimType: "factual",
+            claimText: "OpenAI raised from Microsoft",
+            sources: [{ resourceId: "res-msft", isPrimary: true }],
+          },
+        ],
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.inserted).toBe(2);
+      // Both sets of sources should be present
+      expect(claimSourceStore.size).toBe(2);
+      const sources = Array.from(claimSourceStore.values());
+      expect(sources.some((s) => s.resource_id === "res-google")).toBe(true);
+      expect(sources.some((s) => s.resource_id === "res-msft")).toBe(true);
+    });
+  });
+
   describe("Filtering by claimCategory", () => {
     it("filters /all endpoint by claimCategory", async () => {
       await postJson(app, "/api/claims", {

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -194,47 +194,63 @@ claimsRoute.post("/batch", async (c) => {
     return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
   }
 
-  const allVals = items.map(claimValues);
+  const itemsWithSources = items.filter(
+    (item) => item.sources && item.sources.length > 0
+  );
 
-  const results = await db
-    .insert(claims)
-    .values(allVals)
-    .returning({
-      id: claims.id,
-      entityId: claims.entityId,
-      claimType: claims.claimType,
-    });
+  // PostgreSQL's RETURNING clause does not guarantee row ordering matches
+  // insertion order, so we cannot safely correlate results[i] with items[i]
+  // when sources need to be attached to specific claims.
+  //
+  // Strategy: if no item has sources, use a fast multi-row batch insert.
+  // If any item has sources, insert one-at-a-time so each claim's ID is known.
+  const allResults: Array<{ id: number; entityId: string; claimType: string }> = [];
 
-  // Insert claim_sources for any items that include inline sources
-  const sourcesToInsert: Array<{
-    claimId: number;
-    resourceId: string | null;
-    url: string | null;
-    sourceQuote: string | null;
-    isPrimary: boolean;
-  }> = [];
+  if (itemsWithSources.length === 0) {
+    // Fast path: bulk insert, no source correlation needed
+    const allVals = items.map(claimValues);
+    const rows = await db
+      .insert(claims)
+      .values(allVals)
+      .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
+    allResults.push(...rows);
+  } else {
+    // Safe path: insert one at a time to guarantee ID correlation for source rows
+    const sourcesToInsert: Array<{
+      claimId: number;
+      resourceId: string | null;
+      url: string | null;
+      sourceQuote: string | null;
+      isPrimary: boolean;
+    }> = [];
 
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    const result = results[i];
-    if (item.sources && item.sources.length > 0 && result) {
-      for (const s of item.sources) {
-        sourcesToInsert.push({
-          claimId: result.id,
-          resourceId: s.resourceId ?? null,
-          url: s.url ?? null,
-          sourceQuote: s.sourceQuote ?? null,
-          isPrimary: s.isPrimary ?? false,
-        });
+    for (const item of items) {
+      const [row] = await db
+        .insert(claims)
+        .values(claimValues(item))
+        .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
+
+      allResults.push(row);
+
+      if (item.sources && item.sources.length > 0) {
+        for (const s of item.sources) {
+          sourcesToInsert.push({
+            claimId: row.id,
+            resourceId: s.resourceId ?? null,
+            url: s.url ?? null,
+            sourceQuote: s.sourceQuote ?? null,
+            isPrimary: s.isPrimary ?? false,
+          });
+        }
       }
+    }
+
+    if (sourcesToInsert.length > 0) {
+      await db.insert(claimSources).values(sourcesToInsert);
     }
   }
 
-  if (sourcesToInsert.length > 0) {
-    await db.insert(claimSources).values(sourcesToInsert);
-  }
-
-  return c.json({ inserted: results.length, results }, 201);
+  return c.json({ inserted: allResults.length, results: allResults }, 201);
 });
 
 // ---- POST /clear (delete all claims for an entity) ----


### PR DESCRIPTION
## Summary

Paranoid review fixes for Phase 2 schema and batch endpoint:

- **Fix SQL migration off-by-one** (`WITH ORDINALITY` starts at 1, not 0): `(r_id.idx = 0)` was always `false`, so no migrated resource would ever be marked `is_primary`. Fixed to `(r_id.idx = 1)`.
- **Fix batch insert ordering**: PostgreSQL `RETURNING` doesn't guarantee row order matches input order. When any item has `sources[]`, fall back to serial inserts to ensure each claim ID correlates correctly with its sources array before inserting into `claim_sources`.
- **Add 10 new tests**: Full coverage of `GET /:id/sources` and `POST /:id/sources` endpoints — empty array, round-trip add, 404 for missing claim, 400 for invalid IDs, URL-only source, source persists after add, batch-with-sources propagation.

## Test plan
- [x] `pnpm test` — 42 claims tests passing (up from 32)
- [x] `pnpm crux validate gate --fix` — all 9 checks pass
- [x] Off-by-one verified: `WITH ORDINALITY` documented behavior confirmed

## Notes
- This PR targets the epic branch `claude/claims-phase2-epic` (not main)
- These are post-merge fixes identified during paranoid review of the original Phase 2 PRs

Part of Phase 2 epic.
