### PR TITLE
feat: expand PageStatus content checklist — overview, facts, backlinks (#868)

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -1855,6 +1855,8 @@ async function main() {
       accuracyTotal: page.citationHealth?.total ?? 0,
       ratings: page.ratings,
       factCount: entityFactCounts[page.id] || 0,
+      hasOverview: page.metrics?.hasOverview,
+      entityType: page.entityType ?? null,
     });
     page.coverage = coverage;
     const pct = coverage.passing / coverage.total;

--- a/apps/web/src/app/wiki/[id]/page.tsx
+++ b/apps/web/src/app/wiki/[id]/page.tsx
@@ -315,6 +315,7 @@ async function ContentView({
         pathname={entityPath}
         contentFormat={contentFormat}
         hasEntity={!!entity}
+        entityType={pageData?.entityType ?? undefined}
         resourceCount={getResourcesForPage(slug).length}
         citationHealth={liveCitationHealth}
         ratings={pageData?.ratings ?? undefined}

--- a/apps/web/src/components/PageStatus.tsx
+++ b/apps/web/src/components/PageStatus.tsx
@@ -9,7 +9,7 @@ import {
   type ContentFormat,
 } from "@/lib/page-types";
 import type { ChangeEntry, Page } from "@/data";
-import { getRatioStatus } from "@/lib/coverage";
+import { getRatioStatus, getMetricStatus as getCoverageMetricStatus, ENTITY_LIKE_TYPES, FACTS_GREEN_THRESHOLD } from "@/lib/coverage";
 import type { CoverageStatus } from "@/lib/coverage";
 import styles from "@/components/wiki/tooltip.module.css";
 
@@ -80,6 +80,7 @@ export interface PageStatusProps {
   pathname?: string;
   contentFormat?: ContentFormat;
   hasEntity?: boolean;
+  entityType?: string;
   resourceCount?: number;
   citationHealth?: CitationHealth;
   ratings?: PageRatings;
@@ -687,14 +688,9 @@ function getRecommendedMetrics(
   };
 }
 
-function getMetricStatus(actual: number, target?: number): CoverageStatus {
-  if (target === undefined || target === 0) {
-    return actual > 0 ? "green" : "red";
-  }
-  if (actual >= target) return "green";
-  if (actual > 0) return "amber";
-  return "red";
-}
+// getMetricStatus is imported from @/lib/coverage as getCoverageMetricStatus
+// Use the alias to avoid breaking other references in this file
+const getMetricStatus = getCoverageMetricStatus;
 
 const statusIcons = {
   green: <IconCheck className="shrink-0 text-emerald-500" />,
@@ -719,6 +715,8 @@ function ContentCoverageSection({
   ratings,
   factCount,
   coverage,
+  entityType,
+  backlinkCount,
 }: {
   llmSummary?: string;
   updateFrequency?: number;
@@ -732,9 +730,17 @@ function ContentCoverageSection({
   ratings?: PageRatings;
   factCount?: number;
   coverage?: Page["coverage"];
+  entityType?: string;
+  backlinkCount?: number;
 }) {
   // Use pre-computed coverage targets when available, else compute from scratch
   const recommended = coverage?.targets ?? getRecommendedMetrics(wordCount || 0, contentFormat || "article");
+
+  // Entity types where canonical facts are scored (real-world people and organizations)
+  const isEntityLike = entityType && ENTITY_LIKE_TYPES.has(entityType);
+
+  // Overview is scored for article and diagram formats
+  const isOverviewFormat = !contentFormat || contentFormat === "article" || contentFormat === "diagram";
 
   // --- Boolean items (yes/no chips) ---
   const booleanItems: BooleanCoverageItem[] = [
@@ -767,6 +773,13 @@ function ContentCoverageSection({
       description: "Tracked changes from improve pipeline runs and manual edits.",
       anchor: "edit-history",
     },
+    ...(isOverviewFormat && metrics !== undefined ? [{
+      label: "Overview",
+      present: !!(metrics?.hasOverview),
+      hint: "Add a ## Overview section at the top of the page",
+      description: "A ## Overview heading section that orients readers. Helps with search and AI summaries.",
+      anchor: "overview-section",
+    }] : []),
   ];
 
   // --- Numeric metrics (table rows) ---
@@ -846,6 +859,15 @@ function ContentCoverageSection({
       description: "Citations verified against their sources for factual accuracy.",
       anchor: "accuracy-checked",
     },
+    // Facts — scored for person and organization pages only
+    ...(isEntityLike ? [{
+      label: "Facts",
+      actual: factCount ?? 0,
+      target: FACTS_GREEN_THRESHOLD,
+      hint: "Add canonical facts in data/facts/ YAML",
+      description: "Canonical facts for this entity defined in data/facts/ YAML. Used by <F> components for structured data access.",
+      anchor: "entity-facts",
+    }] : []),
   ];
 
   // --- Info-only items (no pass/fail, just data) ---
@@ -866,11 +888,20 @@ function ContentCoverageSection({
     }
   }
 
-  if (factCount != null && factCount > 0) {
+  // Facts as info-only for non-entity-like pages (e.g. concept, risk, analysis)
+  if (!isEntityLike && factCount != null && factCount > 0) {
     infoItems.push({
       label: "Facts",
       value: `${factCount}`,
       description: "Canonical facts defined for this entity in data/facts/ YAML. Used by <F> components.",
+    });
+  }
+
+  if (backlinkCount != null && backlinkCount > 0) {
+    infoItems.push({
+      label: "Backlinks",
+      value: `${backlinkCount}`,
+      description: "Number of other wiki pages that link to this page. Higher backlink count means better integration into the knowledge graph.",
     });
   }
 
@@ -1148,6 +1179,7 @@ export function PageStatus({
   pathname,
   contentFormat,
   hasEntity,
+  entityType,
   resourceCount,
   citationHealth,
   ratings,
@@ -1258,6 +1290,8 @@ export function PageStatus({
         ratings={ratings}
         factCount={factCount}
         coverage={coverage}
+        entityType={entityType}
+        backlinkCount={backlinkCount}
       />
 
       {/* Change history */}

--- a/apps/web/src/lib/coverage.ts
+++ b/apps/web/src/lib/coverage.ts
@@ -19,3 +19,23 @@ export function getRatioStatus(
   if (numerator > 0) return 'amber';
   return 'red';
 }
+
+/** Status for a numeric metric vs. its target */
+export function getMetricStatus(actual: number, target?: number): CoverageStatus {
+  if (target === undefined || target === 0) {
+    return actual > 0 ? 'green' : 'red';
+  }
+  if (actual >= target) return 'green';
+  if (actual > 0) return 'amber';
+  return 'red';
+}
+
+/**
+ * Entity types where canonical facts are scored. Limited to real-world entities
+ * (people and organizations) where biographical/organizational facts are applicable.
+ * Keep in sync with ENTITY_LIKE_TYPES in crux/lib/page-coverage.ts.
+ */
+export const ENTITY_LIKE_TYPES = new Set(['person', 'organization']);
+
+/** Facts target threshold: pages with >= this many facts score green. */
+export const FACTS_GREEN_THRESHOLD = 5;

--- a/content/docs/internal/coverage-guide.mdx
+++ b/content/docs/internal/coverage-guide.mdx
@@ -12,9 +12,11 @@ lastEdited: "2026-02-23"
 evergreen: true
 ---
 
-The **Content** checklist in PageStatus tracks eleven data enrichment layers that a page can have. Pages with more layers are better sourced, more useful, and easier to maintain. This guide explains each layer.
+The **Content** checklist in PageStatus tracks content enrichment layers that a page can have. Pages with more layers are better sourced, more useful, and easier to maintain. This guide explains each layer.
 
-Numeric metrics (tables, diagrams, links, footnotes, references) show a **target** that scales with page word count — a 5,000-word article is expected to have more tables and citations than a 500-word stub. Targets also vary by content format (table-format pages expect more tables; index pages expect more links). Boolean items (summary, schedule, entity, edit history) are simply present or absent.
+Some items are **type-specific**: the Overview check only applies to article and diagram format pages; the Facts check only applies to person and organization pages. Other items appear on all pages.
+
+Numeric metrics (tables, diagrams, links, footnotes, references) show a **target** that scales with page word count — a 5,000-word article is expected to have more tables and citations than a 500-word stub. Targets also vary by content format (table-format pages expect more tables; index pages expect more links). Boolean items (summary, schedule, entity, edit history, overview) are simply present or absent.
 
 ## Structured Summary
 
@@ -42,6 +44,16 @@ A YAML entity definition in `data/entities/` with type, description, related ent
 **Why it matters:** Pages without entity data are invisible to the wiki's graph — they don't appear in related pages, can't be linked via `<EntityLink>`, and lack structured metadata.
 
 **How to add:** Create a YAML file in the appropriate `data/entities/*.yaml` file for the entity's type. See existing entities for the schema.
+
+## Overview Section
+
+A `## Overview` heading section that introduces the page's topic and scope. Detected by the presence of a heading literally named "Overview" in the page content. Scored for article and diagram format pages only.
+
+**Why it matters:** An overview section helps readers orient themselves quickly and improves AI-generated summaries and search snippets. Structural quality scoring rewards pages that clearly introduce their topic.
+
+**How to add:** Add `## Overview` as the first or second heading in the MDX file, followed by 1-3 paragraphs that summarize the topic. Many high-quality wiki pages use this pattern.
+
+**Anchor:** `overview-section`
 
 ## Tables
 
@@ -112,3 +124,23 @@ Tracked changes from improve pipeline runs and manual editing sessions. Stored i
 **Why it matters:** Edit history creates accountability — you can see when a page was last improved, by which model, and what changed. It also helps identify pages that haven't been touched in a long time.
 
 **How to add:** Edit history is created automatically by the improve pipeline (`--apply` flag) and by manual session logs. Use `pnpm crux edit-log view <page-id>` to inspect.
+
+## Entity Facts
+
+Canonical facts defined for this entity in `data/facts/` YAML files. Used by `<F>` components in the page content to render structured data inline. Scored for **person and organization pages only** (not concept, approach, risk, or analysis pages).
+
+Scoring: green = 5+ facts, amber = 1-4 facts, red = 0 facts.
+
+**Why it matters:** Canonical facts make entity data machine-readable and maintainable. Instead of burying numbers in prose (where they go stale), facts are defined once and updated in a single YAML file.
+
+**How to add:** Create or update the entity's entry in `data/facts/` YAML files. Example: `data/facts/organizations.yaml` for organization pages. Use `<F entity="slug" fact="founded">` in the page content to render values.
+
+**Anchor:** `entity-facts`
+
+## Backlinks (info-only)
+
+The number of other wiki pages that link to this page. Shown as an informational item — not scored (it's not directly under the page author's control).
+
+**Why it matters:** A page with many backlinks is well-integrated into the knowledge graph. Low backlink counts suggest the page is an orphan that readers can't easily discover.
+
+**How to increase:** Add `<EntityLink id="this-page">` references to it from related pages. Improve the page quality so other pages naturally reference it.

--- a/crux/lib/page-coverage.ts
+++ b/crux/lib/page-coverage.ts
@@ -43,7 +43,7 @@ export interface CoverageActuals {
 export interface PageCoverage {
   /** Number of items with 'green' status */
   passing: number;
-  /** Total scored items (5 boolean + 8 numeric = 13) */
+  /** Total scored items — varies by page type and format */
   total: number;
   /** Recommended targets based on wordCount + contentFormat */
   targets: CoverageTargets;
@@ -58,6 +58,20 @@ export interface PageCoverage {
   /** Number of canonical facts for this entity */
   factCount?: number;
 }
+
+/**
+ * Entity types that benefit from canonical facts. Limited to real-world entities
+ * (people and organizations) where biographical/organizational facts are applicable.
+ * Excludes analytical model pages, research approach pages, etc.
+ * Keep in sync with ENTITY_LIKE_TYPES in apps/web/src/lib/coverage.ts.
+ */
+export const ENTITY_LIKE_TYPES = new Set([
+  'person',
+  'organization',
+]);
+
+/** Facts threshold: pages with >= this many facts score green. */
+export const FACTS_GREEN_THRESHOLD = 5;
 
 export interface CoverageInput {
   wordCount: number;
@@ -83,6 +97,10 @@ export interface CoverageInput {
     completeness?: number;
   } | null;
   factCount?: number;
+  /** Whether the page has a ## Overview heading section */
+  hasOverview?: boolean;
+  /** Entity type slug (e.g. 'person', 'organization', 'model') for type-specific scoring */
+  entityType?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -176,11 +194,18 @@ export function computePageCoverage(input: CoverageInput): PageCoverage {
 
   const items: Record<string, CoverageStatus> = {};
 
-  // Boolean items (4)
+  // Boolean items (4 core)
   items.llmSummary = input.llmSummary ? 'green' : 'red';
   items.schedule = input.updateFrequency != null ? 'green' : 'red';
   items.entity = input.hasEntity ? 'green' : 'red';
   items.editHistory = input.changeHistoryCount > 0 ? 'green' : 'red';
+
+  // Overview section — scored for article and diagram formats
+  // Index/table/dashboard pages don't need a prose overview
+  const isOverviewFormat = input.contentFormat === 'article' || input.contentFormat === 'diagram' || !input.contentFormat;
+  if (isOverviewFormat && input.hasOverview !== undefined) {
+    items.overview = input.hasOverview ? 'green' : 'red';
+  }
 
   // Numeric metrics (6 target-based)
   items.tables = getMetricStatus(input.tableCount, targets.tables);
@@ -190,12 +215,20 @@ export function computePageCoverage(input: CoverageInput): PageCoverage {
   items.footnotes = getMetricStatus(input.footnoteCount, targets.footnotes);
   items.references = getMetricStatus(input.resourceCount, targets.references);
 
+  // Facts — scored only for person and organization pages
+  // For concept/risk/analysis/approach/model pages, facts are tracked as info-only via factCount
+  const isEntityLike = input.entityType && ENTITY_LIKE_TYPES.has(input.entityType);
+  if (isEntityLike) {
+    const facts = input.factCount ?? 0;
+    items.facts = facts >= FACTS_GREEN_THRESHOLD ? 'green' : facts >= 1 ? 'amber' : 'red';
+  }
+
   // Ratio metrics (2)
   items.quotes = getRatioStatus(input.quotesWithQuotes, input.quotesTotal);
   items.accuracy = getRatioStatus(input.accuracyChecked, input.accuracyTotal);
 
   const passing = Object.values(items).filter((s) => s === 'green').length;
-  const total = Object.keys(items).length; // 13
+  const total = Object.keys(items).length;
 
   // Build compact ratings string
   let ratingsString: string | undefined;


### PR DESCRIPTION
## Summary

- **Overview section** (new scored boolean): Pages now show a green/red chip for whether they have a `## Overview` heading. Scored for article and diagram format pages only. 79% of current pages already pass.
- **Facts** (new scored numeric): Person and organization pages now get a Facts item scored against a target of 5 canonical facts (green ≥5, amber ≥1, red =0). Concept/risk/model/approach pages skip this item. Currently 9/144 eligible pages pass — intentionally aspirational.
- **Backlinks** (new info-only item): Pages with backlinks now show a count in the ContentCoverageSection alongside Ratings and Facts.
- **DRY fixes**: `ENTITY_LIKE_TYPES`, `getMetricStatus`, and `FACTS_GREEN_THRESHOLD` are now exported from `apps/web/src/lib/coverage.ts` (the frontend shim), eliminating duplicate definitions in PageStatus.tsx.
- **Coverage guide updated**: `content/docs/internal/coverage-guide.mdx` documents all three new items with accurate descriptions of what `hasOverview` actually measures (a `## Overview` heading, not a prose paragraph).

## Design decisions

- Facts scoring is limited to `person` and `organization` types. In this wiki, `model` = analytical risk model and `approach` = research method — neither has meaningful canonical facts. Calibrated against actual usage (only 13/308 entity-like pages have any facts at all, so this is intentionally pushing toward a new standard).
- Targets remain unchanged (aspirational 75th-percentile). The 46% table pass rate among quality≥70 pages is correctly identifying a real gap, not a miscalibration.
- `backlinkCount` is shown as info-only (not scored) because page authors don't directly control incoming links.

## Test plan

- [x] Gate passes locally: 14 gate checks, 263 tests pass
- [x] `pnpm crux fix escaping` and `pnpm crux fix markdown` — no issues
- [x] Rebuilt `database.json` and verified: anthropic (org, 33 facts) → facts green; AI timelines (concept) → no facts item; person pages → facts red (0 facts)
- [x] TypeScript compiles clean in both app and crux
- [x] Tooling gap filed: #1053 (add unit tests for computePageCoverage conditional scoring)

Closes #868
