### PR TITLE
feat(claims): UI polish — inline numeric badge, numeric filter, global stats

### DIFF
--- a/apps/web/src/app/claims/components/claims-filters.tsx
+++ b/apps/web/src/app/claims/components/claims-filters.tsx
@@ -7,6 +7,7 @@ export interface ClaimFilters {
   confidence: string;
   claimMode: string;
   multiEntity: boolean;
+  numericOnly: boolean;
 }
 
 export function ClaimsFilterBar({
@@ -26,7 +27,8 @@ export function ClaimsFilterBar({
     filters.category ||
     filters.confidence ||
     filters.claimMode ||
-    filters.multiEntity;
+    filters.multiEntity ||
+    filters.numericOnly;
 
   return (
     <div className="flex flex-wrap gap-2 mb-4">
@@ -89,6 +91,15 @@ export function ClaimsFilterBar({
         />
         Multi-entity only
       </label>
+      <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+        <input
+          type="checkbox"
+          checked={filters.numericOnly}
+          onChange={(e) => onFilterChange("numericOnly", e.target.checked)}
+          className="rounded"
+        />
+        Numeric only
+      </label>
       {hasFilters && (
         <button
           type="button"
@@ -99,6 +110,7 @@ export function ClaimsFilterBar({
             onFilterChange("confidence", "");
             onFilterChange("claimMode", "");
             onFilterChange("multiEntity", false);
+            onFilterChange("numericOnly", false);
           }}
           className="text-xs text-blue-600 hover:underline cursor-pointer"
         >

--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -43,10 +43,12 @@ function ExpandedClaimDetail({ claim }: { claim: ClaimRow }) {
         <p className="mt-0.5">{claim.claimText}</p>
       </div>
 
-      {/* Epistemic mode */}
-      {claim.claimMode && claim.claimMode !== "endorsed" && (
+      {/* Epistemic mode — show badge for attributed; always show asOf when set */}
+      {(claim.claimMode === "attributed" || claim.asOf) && (
         <div className="flex items-center gap-2">
-          <ClaimModeBadge mode={claim.claimMode} attributedTo={claim.attributedTo} />
+          {claim.claimMode === "attributed" && (
+            <ClaimModeBadge mode={claim.claimMode} attributedTo={claim.attributedTo} />
+          )}
           {claim.asOf && (
             <span className="text-[10px] text-muted-foreground">as of {claim.asOf}</span>
           )}
@@ -193,16 +195,33 @@ const columns: ColumnDef<ClaimRow>[] = [
   {
     accessorKey: "claimText",
     header: "Claim",
-    cell: ({ row }) => (
-      <span
-        className="text-xs leading-relaxed"
-        title={row.original.claimText}
-      >
-        {row.original.claimText.length > 200
-          ? row.original.claimText.slice(0, 200) + "..."
-          : row.original.claimText}
-      </span>
-    ),
+    cell: ({ row }) => {
+      const c = row.original;
+      const hasNumeric = c.valueNumeric != null || c.valueLow != null || c.valueHigh != null;
+      return (
+        <div className="space-y-0.5">
+          <span
+            className="text-xs leading-relaxed"
+            title={c.claimText}
+          >
+            {c.claimText.length > 200
+              ? c.claimText.slice(0, 200) + "..."
+              : c.claimText}
+          </span>
+          {hasNumeric && (
+            <div>
+              <NumericValueDisplay
+                value={c.valueNumeric}
+                low={c.valueLow}
+                high={c.valueHigh}
+                measure={c.measure}
+                compact
+              />
+            </div>
+          )}
+        </div>
+      );
+    },
     size: 400,
   },
   {

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -37,6 +37,9 @@ export default async function EntityClaimsPage({ params }: PageProps) {
   const withSources = claims.filter(
     (c) => c.sources && c.sources.length > 0
   ).length;
+  const withNumeric = claims.filter(
+    (c) => c.valueNumeric != null || c.valueLow != null || c.valueHigh != null
+  ).length;
 
   const byCategory: Record<string, number> = {};
   for (const c of claims) {
@@ -71,7 +74,7 @@ export default async function EntityClaimsPage({ params }: PageProps) {
 
       {claims.length > 0 && (
         <>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3 mb-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-6">
             <StatCard label="Total Claims" value={claims.length} />
             <StatCard label="Verified" value={verified} />
             <StatCard label="Multi-Entity" value={multiEntity} />
@@ -81,6 +84,7 @@ export default async function EntityClaimsPage({ params }: PageProps) {
             />
             <StatCard label="Attributed" value={attributed} />
             <StatCard label="With Sources" value={withSources} />
+            <StatCard label="Numeric" value={withNumeric} />
           </div>
 
           {Object.keys(byCategory).length > 1 && (

--- a/apps/web/src/app/claims/explore/claims-explorer.tsx
+++ b/apps/web/src/app/claims/explore/claims-explorer.tsx
@@ -26,6 +26,7 @@ export function ClaimsExplorer({
     confidence: searchParams.get("confidence") ?? "",
     claimMode: searchParams.get("claimMode") ?? "",
     multiEntity: searchParams.get("multiEntity") === "true",
+    numericOnly: searchParams.get("numericOnly") === "true",
   };
 
   function onFilterChange(key: string, value: string | boolean) {
@@ -70,6 +71,11 @@ export function ClaimsExplorer({
     if (filters.multiEntity) {
       result = result.filter(
         (c) => c.relatedEntities && c.relatedEntities.length > 0
+      );
+    }
+    if (filters.numericOnly) {
+      result = result.filter(
+        (c) => c.valueNumeric != null || c.valueLow != null || c.valueHigh != null
       );
     }
     return result;

--- a/apps/web/src/app/claims/page.tsx
+++ b/apps/web/src/app/claims/page.tsx
@@ -98,7 +98,7 @@ export default async function ClaimsOverviewPage() {
       </p>
 
       {/* Global stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3 mb-8">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-8">
         <StatCard label="Total Claims" value={stats.total} />
         <StatCard label="Entities" value={entityRows.length} />
         <StatCard label="Multi-Entity" value={stats.multiEntityClaims} />
@@ -110,6 +110,7 @@ export default async function ClaimsOverviewPage() {
             stats.total - (stats.byClaimCategory["uncategorized"] ?? 0)
           }
         />
+        <StatCard label="Numeric" value={stats.numericClaims ?? 0} />
       </div>
 
       {/* Category distribution */}

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -796,6 +796,7 @@ export interface ClaimStatsResult {
   factLinkedClaims: number;
   withSourcesClaims: number;
   attributedClaims: number;
+  numericClaims?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -318,6 +318,14 @@ claimsRoute.get("/stats", async (c) => {
     .from(claims)
     .where(eq(claims.claimMode, "attributed"));
 
+  // Claims with numeric value (central, low, or high)
+  const numericResult = await db
+    .select({ count: count() })
+    .from(claims)
+    .where(
+      sql`${claims.valueNumeric} IS NOT NULL OR ${claims.valueLow} IS NOT NULL OR ${claims.valueHigh} IS NOT NULL`
+    );
+
   return c.json({
     total,
     byClaimType: Object.fromEntries(byType.map((r) => [r.claimType, r.count])),
@@ -332,6 +340,7 @@ claimsRoute.get("/stats", async (c) => {
     factLinkedClaims: factLinkedResult[0].count,
     withSourcesClaims: withSourcesResult[0].count,
     attributedClaims: attributedResult[0].count,
+    numericClaims: numericResult[0].count,
   });
 });
 


### PR DESCRIPTION
## Summary

- **Inline numeric badge** in claims table: numeric values (value, range, measure) now appear directly in the Claim column without expanding the row
- **Numeric-only filter**: new "Numeric only" checkbox in the filter bar (wired up in URL params and claims-explorer)
- **asOf fix**: expanded claim detail now shows `asOf` for all claims (not just attributed ones)
- **Numeric stat cards**: both the entity claims page and global overview now show a "Numeric" stat card
- **Stats endpoint**: `GET /api/claims/stats` now returns `numericClaims` (optional field, `?? 0` fallback for backward compat with older server)

## Test plan

- [ ] Open `/claims` — global stat grid now has 7 cards including "Numeric"
- [ ] Open `/claims/entity/kalshi` (or similar) — entity stat grid has 7 cards including "Numeric"
- [ ] Open `/claims/explore` — "Numeric only" checkbox filters to claims with numeric values
- [ ] In claims table, claims with numeric values show a compact inline badge (no expand needed)
- [ ] Click to expand a claim with `asOf` set but mode=endorsed — `as of <date>` appears correctly
