### PR TITLE
fix: remove literal EntityLink tag breaking CI refs validator

### DIFF
--- a/content/docs/internal/coverage-guide.mdx
+++ b/content/docs/internal/coverage-guide.mdx
@@ -143,4 +143,4 @@ The number of other wiki pages that link to this page. Shown as an informational
 
 **Why it matters:** A page with many backlinks is well-integrated into the knowledge graph. Low backlink counts suggest the page is an orphan that readers can't easily discover.
 
-**How to increase:** Add `<EntityLink id="this-page">` references to it from related pages. Improve the page quality so other pages naturally reference it.
+**How to increase:** Add EntityLink references (pointing to this page) from related pages. Improve the page quality so other pages naturally reference it.


### PR DESCRIPTION
## Summary
- The `coverage-guide.mdx` page used a literal `<EntityLink id="this-page">` tag inside backticks as a prose example
- The refs validator (`validate-component-refs.ts`) uses raw regex matching on file content, so backticks don't prevent detection
- It treated `this-page` as a real entity reference, which doesn't exist, causing the `validate` CI check to fail
- Rewrote the sentence to describe the component without using the literal tag syntax

## Test plan
- [x] `pnpm crux validate refs` passes with 0 missing references
- [x] `pnpm crux validate gate --scope=content --fix` all checks pass
- [x] Full pre-push gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)