### PR TITLE
fix: clean up dead and redundant frontmatter fields

### DIFF
--- a/content/docs/internal/about-this-wiki.mdx
+++ b/content/docs/internal/about-this-wiki.mdx
@@ -11,7 +11,6 @@ readerImportance: 11.5
 researchImportance: 9
 lastEdited: "2026-02-17"
 update_frequency: 30
-evergreen: true
 llmSummary: "Technical documentation for the Longterm Wiki platform covering content architecture (~550 MDX pages, ~100 entities), quality scoring system (6 dimensions on 0-10 scale), data layer (YAML databases generating JSON artifacts), cross-linking system with stable entity IDs, and development workflows using unified CLI tools. Provides comprehensive reference for contributors on page types, validation rules, and automation commands."
 ratings:
   focus: 8.5

--- a/content/docs/internal/architecture.mdx
+++ b/content/docs/internal/architecture.mdx
@@ -11,7 +11,6 @@ readerImportance: 9.5
 researchImportance: 9
 lastEdited: "2026-02-15"
 update_frequency: 60
-evergreen: true
 ---
 import { Mermaid } from '@components/wiki';
 

--- a/content/docs/internal/automation-tools.mdx
+++ b/content/docs/internal/automation-tools.mdx
@@ -10,7 +10,6 @@ readerImportance: 10
 researchImportance: 9
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "Comprehensive technical documentation for wiki maintenance automation, covering page improvement workflows (Q5 standards requiring 10+ citations, 800+ words), content grading via Claude API (~$0.02/page), validation suite, and knowledge base system. Provides detailed command reference, cost estimates, and common workflows for maintaining content quality."
 ratings:
   novelty: 0

--- a/content/docs/internal/canonical-facts.mdx
+++ b/content/docs/internal/canonical-facts.mdx
@@ -10,7 +10,6 @@ readerImportance: 12
 researchImportance: 15
 lastEdited: "2026-02-18"
 update_frequency: 90
-evergreen: true
 ratings:
   novelty: 3
   rigor: 6

--- a/content/docs/internal/cause-effect-diagrams.mdx
+++ b/content/docs/internal/cause-effect-diagrams.mdx
@@ -10,7 +10,6 @@ readerImportance: 9.5
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Technical documentation for creating cause-effect diagrams in YAML format, covering node types (leaf/cause/intermediate/effect), edge properties (strength/confidence/effect), semantic color coding, scoring dimensions (novelty/sensitivity/changeability/certainty), and layout best practices with 15-20 node limits."
 ratings:
   novelty: 0

--- a/content/docs/internal/common-writing-principles.md
+++ b/content/docs/internal/common-writing-principles.md
@@ -10,7 +10,6 @@ readerImportance: 73.5
 researchImportance: 71
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Shared writing principles referenced by all domain-specific style guides. Three pillars: epistemic honesty (hedge uncertain claims, use ranges, source confidence levels), language neutrality (avoid insider jargon, describe things by what they are), and analytical tone (present tradeoffs rather than prescribe). Includes concrete word substitution tables and anti-patterns."
 ratings:
   novelty: 3

--- a/content/docs/internal/content-database.mdx
+++ b/content/docs/internal/content-database.mdx
@@ -10,7 +10,6 @@ readerImportance: 10.5
 researchImportance: 9
 lastEdited: "2026-02-04"
 update_frequency: 60
-evergreen: true
 llmSummary: "Documentation for an internal SQLite-based content management system that indexes MDX articles, tracks citations to external sources, and generates AI summaries using Claude models. The system provides CLI tools for scanning content (~311 articles), generating summaries (estimated $2-3 for full corpus using Haiku), and exporting data to YAML for site builds."
 ratings:
   novelty: 0

--- a/content/docs/internal/coverage-guide.mdx
+++ b/content/docs/internal/coverage-guide.mdx
@@ -9,7 +9,6 @@ quality: 40
 readerImportance: 10
 researchImportance: 5
 lastEdited: "2026-02-23"
-evergreen: true
 ---
 
 The **Content** checklist in PageStatus tracks content enrichment layers that a page can have. Pages with more layers are better sourced, more useful, and easier to maintain. This guide explains each layer.

--- a/content/docs/internal/documentation-maintenance.mdx
+++ b/content/docs/internal/documentation-maintenance.mdx
@@ -11,7 +11,6 @@ readerImportance: 9.5
 researchImportance: 8.5
 lastEdited: "2026-02-04"
 update_frequency: 60
-evergreen: true
 ---
 import {EntityLink} from '@components/wiki';
 

--- a/content/docs/internal/enhancement-queue.mdx
+++ b/content/docs/internal/enhancement-queue.mdx
@@ -10,7 +10,6 @@ readerImportance: 9
 researchImportance: 8.5
 lastEdited: "2025-12-27"
 update_frequency: 30
-evergreen: true
 llmSummary: "Internal project management page tracking editorial work across ~100 wiki pages, organizing them by completion status and content type. Provides checklists for applying style guide requirements."
 ratings:
   novelty: 0

--- a/content/docs/internal/fact-system-strategy.mdx
+++ b/content/docs/internal/fact-system-strategy.mdx
@@ -10,7 +10,6 @@ readerImportance: 10
 researchImportance: 30
 lastEdited: "2026-02-23"
 update_frequency: 90
-evergreen: true
 ratings:
   novelty: 6
   rigor: 7

--- a/content/docs/internal/importance-ranking.mdx
+++ b/content/docs/internal/importance-ranking.mdx
@@ -11,7 +11,6 @@ readerImportance: 7
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 ---
 
 # Importance Ranking System

--- a/content/docs/internal/index.md
+++ b/content/docs/internal/index.md
@@ -6,7 +6,6 @@ sidebar:
   order: 0
   label: Overview
 entityType: internal
-evergreen: true
 ---
 import {EntityLink} from '@components/wiki';
 

--- a/content/docs/internal/knowledge-base.mdx
+++ b/content/docs/internal/knowledge-base.mdx
@@ -10,7 +10,6 @@ readerImportance: 11.5
 researchImportance: 10
 lastEdited: "2025-12-26"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for wiki content creation, emphasizing flexible hierarchical structure over rigid templates, integrated arguments over sparse sections, and selective use of visualizations. Provides concrete examples of good/bad practices for risk and response pages."
 ratings:
   novelty: 1

--- a/content/docs/internal/longterm-strategy.md
+++ b/content/docs/internal/longterm-strategy.md
@@ -9,7 +9,6 @@ readerImportance: 47.5
 researchImportance: 15.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal strategic planning document for LongtermWiki project development, exploring five failure modes (becoming just another wiki, generating non-insights, building unwanted features, maintenance hell, being too unusual) and five strategic options (narrow/deep focus, broad/shallow wiki, opinionated synthesis, crux laboratory, living assessment). Proposes four 2-week validation tests (user interviews, crux prototype, page quality test, insight generation) before committing resources."
 ratings:
   novelty: 0

--- a/content/docs/internal/longterm-vision.md
+++ b/content/docs/internal/longterm-vision.md
@@ -9,7 +9,6 @@ readerImportance: 58.5
 researchImportance: 12.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal strategic planning document for the LongtermWiki project itself, outlining a 2-person-year scope to build a knowledge platform focused on AI safety prioritization cruxes. Proposes ~250 pages across risks, interventions, and causal models with worldview-based priority mapping."
 ratings:
   novelty: 0

--- a/content/docs/internal/longtermwiki-value-proposition.mdx
+++ b/content/docs/internal/longtermwiki-value-proposition.mdx
@@ -9,7 +9,6 @@ readerImportance: 11.5
 researchImportance: 14
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal strategy document exploring ambitious value pathways for LongtermWiki, including improving longtermist prioritization (Coefficient integration, cross-funder coordination), attracting new capital (billionaires, governments), demonstrating epistemic infrastructure to Anthropic, enabling field coordination, and accelerating researcher onboarding. Includes causal diagrams mapping value creation mechanisms."
 ratings:
   novelty: 0

--- a/content/docs/internal/mermaid-diagrams.mdx
+++ b/content/docs/internal/mermaid-diagrams.mdx
@@ -10,7 +10,6 @@ readerImportance: 12
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for creating Mermaid diagrams in the wiki, recommending vertical layouts over horizontal (max 3-4 parallel nodes), providing semantic color palette, and advocating tables over diagrams for taxonomies. Includes practical width limits and anti-patterns for common diagram issues."
 ratings:
   novelty: 1

--- a/content/docs/internal/models-style-guide.md
+++ b/content/docs/internal/models-style-guide.md
@@ -9,7 +9,6 @@ readerImportance: 45
 researchImportance: 70.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide prescribing dense, quantified content structure for model pages: minimum 800 words, 2+ tables (4x3+), 1+ Mermaid diagram, mathematical formulations, and <30% bullets. Requires specific sections (overview, framework, quantitative analysis, cases, limitations) with probability ranges and scenario weighting throughout."
 ratings:
   novelty: 2

--- a/content/docs/internal/models.mdx
+++ b/content/docs/internal/models.mdx
@@ -10,7 +10,6 @@ readerImportance: 12
 researchImportance: 13
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "This internal style guide establishes format requirements and methodological principles for analytical models in the knowledge base, emphasizing executive summaries that state both methodology and conclusions, strategic prioritization content, and diagram selection criteria. It provides comprehensive formatting standards but represents internal infrastructure rather than substantive analysis."
 ratings:
   novelty: 2

--- a/content/docs/internal/page-types.mdx
+++ b/content/docs/internal/page-types.mdx
@@ -10,7 +10,6 @@ readerImportance: 11
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "Documents LongtermWiki's four-level page classification system (content, stub, documentation, overview) with explicit validation rules for each type, where content pages receive full quality grading while stubs/documentation are excluded from validation pipelines."
 ratings:
   focus: 9

--- a/content/docs/internal/parameters-strategy.md
+++ b/content/docs/internal/parameters-strategy.md
@@ -9,7 +9,6 @@ readerImportance: 39
 researchImportance: 69.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal project management document providing implementation instructions for creating parameter pages in a knowledge base. Outlines workflow, templates, and batch assignments for parallel development work."
 ratings:
   novelty: 0

--- a/content/docs/internal/project-roadmap.md
+++ b/content/docs/internal/project-roadmap.md
@@ -10,7 +10,6 @@ readerImportance: 14
 researchImportance: 8.5
 lastEdited: "2026-01-02"
 update_frequency: 30
-evergreen: true
 llmSummary: "Internal project roadmap tracking wiki infrastructure status (14 validators, quality grading, dashboard all complete as of Jan 2026) and future priorities including batch content improvement for high-importance/low-quality pages and increased citation coverage. Emphasizes pragmatic approach: avoid over-engineering, adapt style guidelines to content."
 ratings:
   novelty: 0

--- a/content/docs/internal/rating-system.mdx
+++ b/content/docs/internal/rating-system.mdx
@@ -10,7 +10,6 @@ readerImportance: 11
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "This page documents LongtermWiki's content rating system, which combines LLM-graded subscores (focus, novelty, rigor, completeness, objectivity, concreteness, actionability on 0-10 scales) with automated metrics (word count, citations) to derive quality scores (0-100) and importance ratings for prioritization decisions."
 ratings:
   novelty: 2

--- a/content/docs/internal/reports/index.mdx
+++ b/content/docs/internal/reports/index.mdx
@@ -6,7 +6,6 @@ sidebar:
   label: Overview
   order: 0
 entityType: internal
-evergreen: true
 ---
 
 Internal reports document **technical research and design decisions** for the project infrastructure.

--- a/content/docs/internal/research-reports.mdx
+++ b/content/docs/internal/research-reports.mdx
@@ -10,7 +10,6 @@ readerImportance: 12.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for deprecated research report format, specifying table-based layouts, escaped dollar signs, YAML schema, and causal factor documentation for diagram creation. Provides comprehensive formatting rules and validation checklists but addresses an obsolete content structure."
 ratings:
   novelty: 0.5

--- a/content/docs/internal/response-style-guide.mdx
+++ b/content/docs/internal/response-style-guide.mdx
@@ -10,7 +10,6 @@ readerImportance: 8.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide specifying structure for response/intervention pages, including required sections (overview, assessment table, mechanism diagrams, limitations), frontmatter format, and Claude workflow templates. Provides concrete formatting requirements and examples but no original methodology for intervention assessment."
 ratings:
   novelty: 2

--- a/content/docs/internal/risk-style-guide.mdx
+++ b/content/docs/internal/risk-style-guide.mdx
@@ -10,7 +10,6 @@ readerImportance: 12.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Comprehensive style guide defining standards for risk analysis pages, including required sections (overview, risk assessment table, mechanism diagrams, contributing factors, responses, uncertainties), quality criteria (0-10 scoring on novelty/rigor/actionability/completeness), and Claude workflows for creation/improvement. Prescribes specific formats like Mermaid diagrams for mechanisms and tables for assessments."
 ratings:
   novelty: 4

--- a/content/docs/internal/schema/diagrams.mdx
+++ b/content/docs/internal/schema/diagrams.mdx
@@ -9,7 +9,6 @@ readerImportance: 11
 researchImportance: 14
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 ---
 
 import {Mermaid} from '@components/wiki';

--- a/content/docs/internal/schema/entities.mdx
+++ b/content/docs/internal/schema/entities.mdx
@@ -9,7 +9,6 @@ readerImportance: 9
 researchImportance: 13
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 ---
 
 ;

--- a/content/docs/internal/schema/index.md
+++ b/content/docs/internal/schema/index.md
@@ -6,7 +6,6 @@ sidebar:
   label: Schema Overview
   order: 0
 entityType: internal
-evergreen: true
 ---
 
 import {Mermaid, EntityLink} from '@components/wiki';

--- a/content/docs/internal/stub-style-guide.md
+++ b/content/docs/internal/stub-style-guide.md
@@ -10,7 +10,6 @@ readerImportance: 14
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal documentation providing guidelines for creating minimal placeholder pages (stubs) in the knowledge base, including when to use them, required formatting, and when to convert them to full pages. Covers basic content structure and validation procedures."
 ratings:
   novelty: 0.5

--- a/content/docs/internal/wiki-server-architecture.mdx
+++ b/content/docs/internal/wiki-server-architecture.mdx
@@ -9,7 +9,6 @@ entityType: internal
 pageType: documentation
 lastEdited: "2026-02-24"
 update_frequency: 90
-evergreen: true
 ---
 
 This document analyzes how the wiki-server handles (or fails to handle) environment isolation between development, preview, and production. It identifies the core architectural tension — entity ID allocation must be globally shared, but content data should not — and proposes a tiered remediation plan.

--- a/content/docs/knowledge-base/capabilities/large-language-models.mdx
+++ b/content/docs/knowledge-base/capabilities/large-language-models.mdx
@@ -18,7 +18,6 @@ ratings:
   actionability: 5.5
   completeness: 7.5
 clusters: ["ai-safety", "governance"]
-todos: []
 ---
 import {R, Mermaid, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/ai-acceleration-tradeoff.mdx
+++ b/content/docs/knowledge-base/models/ai-acceleration-tradeoff.mdx
@@ -21,7 +21,6 @@ ratings:
 clusters:
   - ai-safety
   - governance
-contentType: analysis
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/anthropic-pledge-enforcement.mdx
+++ b/content/docs/knowledge-base/models/anthropic-pledge-enforcement.mdx
@@ -30,7 +30,6 @@ todos:
   - Get external review of probability estimates from philanthropic professionals
   - Model selection bias more rigorously — what % of impact is counterfactual?
   - Research how Mackenzie Scott's giving was structured (irrevocable or discretionary?)
-contentType: analysis
 ---
 import {EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/bioweapons-ai-uplift.mdx
+++ b/content/docs/knowledge-base/models/bioweapons-ai-uplift.mdx
@@ -22,7 +22,6 @@ clusters:
   - ai-safety
   - biorisks
   - governance
-contentType: analysis
 ---
 import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/intervention-effectiveness-matrix.mdx
+++ b/content/docs/knowledge-base/models/intervention-effectiveness-matrix.mdx
@@ -28,7 +28,6 @@ todos:
   - Complete 'Quantitative Analysis' section (8 placeholders)
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
-contentType: analysis
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/public-opinion-evolution.mdx
+++ b/content/docs/knowledge-base/models/public-opinion-evolution.mdx
@@ -25,7 +25,6 @@ clusters:
 todos:
   - Complete 'Quantitative Analysis' section (8 placeholders)
   - Complete 'Limitations' section (6 placeholders)
-contentType: analysis
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/safety-capability-tradeoff.mdx
+++ b/content/docs/knowledge-base/models/safety-capability-tradeoff.mdx
@@ -22,7 +22,6 @@ ratings:
 clusters:
   - ai-safety
   - governance
-contentType: analysis
 ---
 import {DataInfoBox, KeyQuestions, Mermaid, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/scheming-likelihood-model.mdx
+++ b/content/docs/knowledge-base/models/scheming-likelihood-model.mdx
@@ -23,7 +23,6 @@ todos:
   - Complete 'Quantitative Analysis' section (8 placeholders)
   - Complete 'Strategic Importance' section
   - Complete 'Limitations' section (6 placeholders)
-contentType: analysis
 ---
 import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/models/short-timeline-policy-implications.mdx
+++ b/content/docs/knowledge-base/models/short-timeline-policy-implications.mdx
@@ -22,7 +22,6 @@ ratings:
 clusters:
   - ai-safety
   - governance
-contentType: analysis
 ---
 import { EntityLink } from '@components/wiki';
 

--- a/content/docs/knowledge-base/responses/nist-ai-rmf.mdx
+++ b/content/docs/knowledge-base/responses/nist-ai-rmf.mdx
@@ -22,7 +22,6 @@ ratings:
 clusters:
   - "ai-safety"
   - "governance"
-todos: []
 ---
 import { DataInfoBox, Mermaid } from '@components/wiki';
 

--- a/content/docs/knowledge-base/responses/scheming-detection.mdx
+++ b/content/docs/knowledge-base/responses/scheming-detection.mdx
@@ -18,7 +18,6 @@ ratings:
   completeness: 7.5
 clusters:
   - ai-safety
-todos: []
 ---
 import {Mermaid, EntityLink} from '@components/wiki';
 

--- a/content/docs/knowledge-base/risks/treacherous-turn.mdx
+++ b/content/docs/knowledge-base/risks/treacherous-turn.mdx
@@ -20,7 +20,6 @@ ratings:
   completeness: 8
 clusters:
   - ai-safety
-todos: []
 ---
 import {DataInfoBox, Mermaid, R, EntityLink} from '@components/wiki';
 


### PR DESCRIPTION
## Summary

Clean up dead and redundant frontmatter fields across wiki pages:

- Remove redundant `contentType: analysis` from 8 `/models/` pages — path-based detection already returns `analysis` for this directory, so the explicit field is a no-op
- Keep `contentType` on 4 non-`/models/` pages (`/responses/` and `/organizations/`) where it overrides path detection to `analysis` — these are meaningful
- Remove empty `todos: []` arrays from 4 pages (pure noise with no functional effect)
- Remove redundant `evergreen: true` from 33 pages — `true` is the default value, so explicit declaration is clutter

No logic or content changed — only frontmatter metadata cleanup. The `contentType` field is only used by the grading/improve pipeline, not by the build pipeline or frontend display.

## Test plan

- [x] `pnpm crux validate unified --rules=frontmatter-schema` passes (all 641 files)
- [x] `pnpm crux validate schema` passes (all 6611 items)
- [x] `pnpm crux fix escaping` finds no fixable issues
- [x] No content or functionality changed, only frontmatter metadata removed/cleaned
