### PR TITLE
fix: claims pipeline bugs from Sprint 2 prep review

### DIFF
--- a/crux/claims/evaluate-baseline.ts
+++ b/crux/claims/evaluate-baseline.ts
@@ -237,8 +237,8 @@ const HEADER = `  ${'Type'.padEnd(22)} ${'N'.padStart(3)}  ${'Accur'.padStart(5)
 export async function runEvaluation() {
   const c = getColors();
   const args = parseCliArgs(process.argv.slice(2));
-  const fromLogs = args.options['from-logs'] === true;
-  const sampleSize = Number(args.options['sample']) || DEFAULT_SAMPLE_SIZE;
+  const fromLogs = args['from-logs'] === true;
+  const sampleSize = typeof args['sample'] === 'string' ? parseInt(args['sample'], 10) || DEFAULT_SAMPLE_SIZE : DEFAULT_SAMPLE_SIZE;
   const client = createClient();
   const allEvals: ClaimEval[] = [];
 

--- a/crux/claims/ingest-resource.ts
+++ b/crux/claims/ingest-resource.ts
@@ -30,7 +30,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
-import { callOpenRouter, stripCodeFences, DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
+import { callOpenRouter, stripCodeFences, parseJsonWithRepair, DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import {
   insertClaimBatch,
@@ -184,7 +184,7 @@ export async function extractClaimsForEntity(
     });
 
     const json = stripCodeFences(raw);
-    const parsed = JSON.parse(json) as { claims?: unknown[] };
+    const parsed = parseJsonWithRepair<{ claims?: unknown[] }>(json);
 
     if (!Array.isArray(parsed.claims)) return [];
 

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -109,7 +109,7 @@ async function verifyClaim(
   try {
     const raw = await callOpenRouter(VERIFY_SYSTEM_PROMPT, userPrompt, {
       model: opts.model ?? DEFAULT_CITATION_MODEL,
-      maxTokens: 400,
+      maxTokens: 800,
       title: 'LongtermWiki Claim Verification',
     });
 
@@ -192,7 +192,7 @@ async function main() {
   let noSource = 0;
 
   for (const claim of claims) {
-    const footnoteRefs = (claim.footnoteRefs ?? claim.unit) ? (claim.footnoteRefs ?? claim.unit)!.split(',').map(s => s.trim()) : [];
+    const footnoteRefs = claim.footnoteRefs ? claim.footnoteRefs.split(',').map(s => s.trim()) : [];
 
     // If no footnote refs, mark as unsourced
     if (footnoteRefs.length === 0) {
@@ -295,7 +295,15 @@ async function main() {
       factId: claim.factId ?? null,
       resourceIds: claim.resourceIds ?? null,
       section: claim.section ?? claim.value ?? null,
-      footnoteRefs: claim.footnoteRefs ?? claim.unit ?? null,
+      footnoteRefs: claim.footnoteRefs ?? null,
+      // Phase 2 fields — preserve from original claim
+      claimMode: claim.claimMode ?? null,
+      attributedTo: claim.attributedTo ?? null,
+      asOf: claim.asOf ?? null,
+      measure: claim.measure ?? null,
+      valueNumeric: claim.valueNumeric ?? null,
+      valueLow: claim.valueLow ?? null,
+      valueHigh: claim.valueHigh ?? null,
     }));
 
     const result = await insertClaimBatch(items);

--- a/crux/commands/claims.ts
+++ b/crux/commands/claims.ts
@@ -23,7 +23,7 @@ const SCRIPTS = {
   verify: {
     script: 'claims/verify.ts',
     description: 'Verify extracted claims against citation_content full text',
-    passthrough: ['dry-run', 'model'],
+    passthrough: ['dry-run', 'model', 'fetch'],
     positional: true,
   },
   status: {

--- a/crux/lib/quote-extractor.test.ts
+++ b/crux/lib/quote-extractor.test.ts
@@ -4,8 +4,73 @@ import {
   parseAccuracyCheckResponse,
   truncateSource,
   stripCodeFences,
+  repairJson,
+  parseJsonWithRepair,
   VALID_ACCURACY_VERDICTS,
 } from './quote-extractor.ts';
+
+describe('repairJson', () => {
+  it('removes trailing comma before }', () => {
+    expect(repairJson('{"a": 1,}')).toBe('{"a": 1}');
+  });
+
+  it('removes trailing comma before ]', () => {
+    expect(repairJson('[1, 2,]')).toBe('[1, 2]');
+  });
+
+  it('removes trailing comma with whitespace and parses cleanly', () => {
+    const result = repairJson('{"a": 1 , }');
+    expect(() => JSON.parse(result)).not.toThrow();
+    expect(JSON.parse(result)).toEqual({ a: 1 });
+  });
+
+  it('escapes raw newlines inside strings', () => {
+    const input = '{"a": "line1\nline2"}';
+    const result = repairJson(input);
+    expect(() => JSON.parse(result)).not.toThrow();
+    expect(JSON.parse(result).a).toBe('line1\nline2');
+  });
+
+  it('escapes raw tabs inside strings', () => {
+    const input = '{"a": "col1\tcol2"}';
+    const result = repairJson(input);
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('leaves already-valid JSON unchanged', () => {
+    const valid = '{"a": 1, "b": [2, 3]}';
+    expect(repairJson(valid)).toBe(valid);
+  });
+
+  it('preserves already-escaped sequences', () => {
+    const input = '{"a": "already\\nescaped"}';
+    const result = repairJson(input);
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+});
+
+describe('parseJsonWithRepair', () => {
+  it('parses valid JSON directly', () => {
+    expect(parseJsonWithRepair('{"a": 1}')).toEqual({ a: 1 });
+  });
+
+  it('repairs and parses JSON with trailing comma', () => {
+    expect(parseJsonWithRepair('{"a": 1,}')).toEqual({ a: 1 });
+  });
+
+  it('repairs and parses array with trailing comma', () => {
+    expect(parseJsonWithRepair('[1, 2, 3,]')).toEqual([1, 2, 3]);
+  });
+
+  it('throws on completely invalid input', () => {
+    expect(() => parseJsonWithRepair('not json at all')).toThrow();
+  });
+
+  it('supports generic type parameter', () => {
+    const result = parseJsonWithRepair<{ verdict: string }>('{"verdict": "verified"}');
+    expect(result.verdict).toBe('verified');
+  });
+});
 
 describe('stripCodeFences', () => {
   it('strips ```json prefix and ``` suffix', () => {


### PR DESCRIPTION
## Summary

Fixes 7 bugs found by the paranoid review of PR #1073 (Sprint 2 prep):

- **evaluate-baseline: broken CLI flags** — `args.options['from-logs']` should be `args['from-logs']` (`parseCliArgs` returns a flat object, not nested). `--from-logs` and `--sample` were silently ignored.
- **verify: Phase 2 field data loss** — Re-inserting claims after verification dropped `claimMode`, `attributedTo`, `asOf`, `measure`, `valueNumeric`, `valueLow`, `valueHigh`. All Phase 2 metadata was silently destroyed on every verify run.
- **verify: wrong footnoteRef fallback** — Fell back to `claim.unit` (which stores relevance strings like `"direct"`) when `footnoteRefs` was null, causing bogus lookups.
- **verify: response truncation** — `maxTokens: 400` was too low for responses with long quotes. Bumped to 800.
- **verify: --fetch flag not forwarded** — The CLI dispatcher's `passthrough` list was missing `fetch`, so `--fetch` was silently dropped.
- **ingest-resource: raw JSON.parse** — The whole point of the Sprint 2 prep was to add `parseJsonWithRepair`, but `ingest-resource.ts` was missed.
- **Missing tests** — Added 10 test cases for `repairJson` and `parseJsonWithRepair`.

## Test plan

- [x] 42 quote-extractor tests pass (10 new)
- [x] Gate passes (4 checks, 6 skipped by triage)
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)