### PR TITLE
fix: populate sourceQuote during claims extraction

### DIFF
--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -44,7 +44,7 @@ import type { ClaimTypeValue } from '../lib/claim-utils.ts';
 // ---------------------------------------------------------------------------
 
 /** Strip MDX/JSX components and return plain text suitable for LLM analysis. */
-function cleanMdxForExtraction(body: string): string {
+export function cleanMdxForExtraction(body: string): string {
   return body
     // Remove import/export statements
     .replace(/^(import|export)\s+.*$/gm, '')
@@ -67,14 +67,14 @@ function cleanMdxForExtraction(body: string): string {
 // Section splitting
 // ---------------------------------------------------------------------------
 
-interface Section {
+export interface Section {
   heading: string;
   content: string;
   level: number;
 }
 
 /** Split MDX body into sections by H2/H3 headings. */
-function splitIntoSections(body: string): Section[] {
+export function splitIntoSections(body: string): Section[] {
   const lines = body.split('\n');
   const sections: Section[] = [];
   let currentHeading = 'Introduction';
@@ -122,11 +122,12 @@ interface ExtractedClaim {
   valueNumeric?: number;                  // Phase 2: central numeric value
   valueLow?: number;                      // Phase 2: lower bound
   valueHigh?: number;                     // Phase 2: upper bound
+  sourceQuote?: string;                   // Verbatim excerpt from wiki text supporting the claim
   footnoteRefs: string[];
   relatedEntities?: string[];
 }
 
-const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a section of a wiki article, extract specific, verifiable claims.
+export const EXTRACT_SYSTEM_PROMPT = `You are a fact-extraction assistant. Given a section of a wiki article, extract specific, verifiable claims.
 
 For each claim, provide:
 - "claimText": a single atomic, self-contained statement (not a question or heading)
@@ -151,6 +152,7 @@ For each claim, provide:
 - "valueNumeric": (optional, only for numeric claims) the central numeric value as a plain number (e.g. 7300000000 for $7.3B, 0.92 for 92%)
 - "valueLow": (optional) lower bound if a range is given
 - "valueHigh": (optional) upper bound if a range is given
+- "sourceQuote": a SHORT verbatim excerpt (max 200 chars) copied exactly from the wiki text that contains or directly supports this claim. Must be an exact substring of the input text.
 - "footnoteRefs": array of citation references (as strings) — look for [^N] (e.g. [^1]) and [^R:HASH] patterns near the claim
 - "relatedEntities": array of entity IDs or names mentioned in the claim other than the page's primary subject
 
@@ -168,7 +170,7 @@ Rules:
 - Return only claims that appear in the given text
 
 Respond ONLY with JSON:
-{"claims": [{"claimText": "...", "claimType": "factual", "claimMode": "endorsed", "footnoteRefs": ["1"], "relatedEntities": ["entity-id"]}]}`;
+{"claims": [{"claimText": "...", "claimType": "factual", "claimMode": "endorsed", "sourceQuote": "exact text from the wiki section", "footnoteRefs": ["1"], "relatedEntities": ["entity-id"]}]}`;
 
 async function extractClaimsFromSection(
   section: Section,
@@ -216,6 +218,9 @@ Extract atomic claims from this section. Return JSON only.`;
         valueNumeric: parseNumericValue(c.valueNumeric),
         valueLow: parseNumericValue(c.valueLow),
         valueHigh: parseNumericValue(c.valueHigh),
+        sourceQuote: typeof c.sourceQuote === 'string' && c.sourceQuote.length > 5
+          ? c.sourceQuote.slice(0, 500)
+          : undefined,
         footnoteRefs: Array.isArray(c.footnoteRefs)
           ? (c.footnoteRefs as unknown[]).map(String)
           : [],
@@ -374,7 +379,7 @@ async function main() {
       value: claim.section,
       unit: claim.footnoteRefs.length > 0 ? claim.footnoteRefs.join(',') : null,
       confidence: 'unverified',
-      sourceQuote: null,
+      sourceQuote: claim.sourceQuote ?? null,
       // Enhanced fields (migration 0028)
       claimCategory: claimTypeToCategory(claim.claimType),
       relatedEntities: claim.relatedEntities && claim.relatedEntities.length > 0

--- a/crux/claims/ingest-resource.ts
+++ b/crux/claims/ingest-resource.ts
@@ -150,7 +150,7 @@ For each claim, provide:
 - "valueNumeric": (optional) central numeric value as plain number (e.g. 7300000000 for $7.3B, 0.92 for 92%)
 - "valueLow": (optional) lower bound if a range is given
 - "valueHigh": (optional) upper bound if a range is given
-- "sourceQuote": a SHORT verbatim quote (max 200 chars) from the resource text that supports this claim, if available
+- "sourceQuote": REQUIRED — a SHORT verbatim quote (max 200 chars) copied exactly from the resource text that supports this claim. Every claim MUST include a sourceQuote.
 - "relatedEntities": other entity IDs/names mentioned alongside ${targetEntity} in the claim
 
 Rules:
@@ -162,6 +162,7 @@ Rules:
 - Prefer "direct" relevance claims
 - Use "numeric" claimType for any claim with specific dollar amounts, percentages, counts, or sizes
 - Always include valueNumeric for numeric claims — extract the number even if written out (e.g. "$7.3 billion" → 7300000000)
+- ALWAYS include sourceQuote — every claim must be grounded with an exact verbatim excerpt from the resource text
 
 Respond ONLY with JSON:
 {"claims": [{"claimText": "...", "claimType": "factual", "relevance": "direct", "claimMode": "endorsed", "sourceQuote": "...", "relatedEntities": []}]}`;

--- a/crux/claims/source-linking.test.ts
+++ b/crux/claims/source-linking.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for source linking in claims extraction pipelines.
+ *
+ * Validates that:
+ * - Page extraction prompt requests sourceQuote from wiki text
+ * - Resource extraction prompt requires sourceQuote from resource text
+ * - LLM responses with sourceQuote are properly parsed and stored
+ * - buildInsertItem preserves sourceQuote through to DB insertion
+ *
+ * Addresses issue #1084: all claims had sourceQuote: null and confidence: unverified.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EXTRACT_SYSTEM_PROMPT,
+  cleanMdxForExtraction,
+  splitIntoSections,
+} from './extract.ts';
+import {
+  buildExtractionPrompt,
+  buildInsertItem,
+  type ExtractedResourceClaim,
+} from './ingest-resource.ts';
+
+// ---------------------------------------------------------------------------
+// Page extraction prompt tests
+// ---------------------------------------------------------------------------
+
+describe('page extraction prompt (EXTRACT_SYSTEM_PROMPT)', () => {
+  it('requests sourceQuote from the wiki text', () => {
+    expect(EXTRACT_SYSTEM_PROMPT).toContain('sourceQuote');
+    expect(EXTRACT_SYSTEM_PROMPT).toContain('verbatim excerpt');
+  });
+
+  it('includes sourceQuote in the example JSON response', () => {
+    // The example JSON at the end should show sourceQuote
+    expect(EXTRACT_SYSTEM_PROMPT).toContain('"sourceQuote"');
+  });
+
+  it('specifies max 200 char limit for sourceQuote', () => {
+    expect(EXTRACT_SYSTEM_PROMPT).toContain('max 200 chars');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource extraction prompt tests
+// ---------------------------------------------------------------------------
+
+describe('resource extraction prompt (buildExtractionPrompt)', () => {
+  const resource = {
+    id: 'test-resource-id',
+    title: 'Test Resource',
+    url: 'https://example.com/article',
+    authors: ['Jane Doe'],
+    type: 'article' as const,
+  };
+
+  it('requires sourceQuote (not just optional)', () => {
+    const prompt = buildExtractionPrompt(resource, 'kalshi');
+    expect(prompt).toContain('REQUIRED');
+    expect(prompt).toContain('sourceQuote');
+  });
+
+  it('emphasizes sourceQuote in the rules section', () => {
+    const prompt = buildExtractionPrompt(resource, 'kalshi');
+    expect(prompt).toContain('ALWAYS include sourceQuote');
+  });
+
+  it('includes sourceQuote in the example JSON', () => {
+    const prompt = buildExtractionPrompt(resource, 'kalshi');
+    expect(prompt).toContain('"sourceQuote": "...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInsertItem — sourceQuote propagation
+// ---------------------------------------------------------------------------
+
+describe('buildInsertItem sourceQuote propagation', () => {
+  const baseResource = {
+    id: 'resource-123',
+    title: 'Example',
+    url: 'https://example.com',
+    type: 'article' as const,
+  };
+
+  const baseClaim: ExtractedResourceClaim = {
+    claimText: 'Kalshi was founded in 2018.',
+    claimType: 'factual',
+    relevance: 'direct',
+    claimMode: 'endorsed',
+    relatedEntities: [],
+  };
+
+  it('stores sourceQuote when present in extracted claim', () => {
+    const claim: ExtractedResourceClaim = {
+      ...baseClaim,
+      sourceQuote: 'Kalshi, founded in 2018, is an event-based trading platform.',
+    };
+
+    const item = buildInsertItem(claim, 'kalshi', baseResource);
+    expect(item.sourceQuote).toBe('Kalshi, founded in 2018, is an event-based trading platform.');
+  });
+
+  it('stores null when sourceQuote is undefined', () => {
+    const item = buildInsertItem(baseClaim, 'kalshi', baseResource);
+    expect(item.sourceQuote).toBeNull();
+  });
+
+  it('creates claim_sources with sourceQuote when available', () => {
+    const claim: ExtractedResourceClaim = {
+      ...baseClaim,
+      sourceQuote: 'The company raised $30M in Series B.',
+    };
+
+    const item = buildInsertItem(claim, 'kalshi', baseResource);
+    expect(item.sources).toBeDefined();
+    expect(item.sources!.length).toBe(1);
+    expect(item.sources![0].sourceQuote).toBe('The company raised $30M in Series B.');
+    expect(item.sources![0].isPrimary).toBe(true);
+    expect(item.sources![0].resourceId).toBe('resource-123');
+  });
+
+  it('creates claim_sources without sourceQuote when not available', () => {
+    const item = buildInsertItem(baseClaim, 'kalshi', baseResource);
+    expect(item.sources).toBeDefined();
+    expect(item.sources!.length).toBe(1);
+    expect(item.sources![0].sourceQuote).toBeUndefined();
+    expect(item.sources![0].isPrimary).toBe(true);
+  });
+
+  it('always sets confidence to unverified on initial extraction', () => {
+    const claim: ExtractedResourceClaim = {
+      ...baseClaim,
+      sourceQuote: 'Some quote.',
+    };
+    const item = buildInsertItem(claim, 'kalshi', baseResource);
+    expect(item.confidence).toBe('unverified');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanMdxForExtraction
+// ---------------------------------------------------------------------------
+
+describe('cleanMdxForExtraction', () => {
+  it('converts <R> tags to footnote markers', () => {
+    const input = 'See <R id="abc123">Source Title</R> for details.';
+    const result = cleanMdxForExtraction(input);
+    expect(result).toContain('[^R:abc123]');
+    expect(result).not.toContain('<R');
+  });
+
+  it('removes JSX self-closing tags', () => {
+    const input = 'The company <EntityLink id="kalshi" /> was founded in 2018.';
+    const result = cleanMdxForExtraction(input);
+    expect(result).not.toContain('<EntityLink');
+  });
+
+  it('removes import/export statements', () => {
+    const input = 'import { Component } from "react";\nexport default Page;\nSome text.';
+    const result = cleanMdxForExtraction(input);
+    expect(result).not.toContain('import');
+    expect(result).not.toContain('export');
+    expect(result).toContain('Some text.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitIntoSections
+// ---------------------------------------------------------------------------
+
+describe('splitIntoSections', () => {
+  it('splits by H2 headings', () => {
+    const body = `Some intro text that is long enough to be kept as a section here we go with fifty chars.
+
+## History
+
+Kalshi was founded in 2018. It has grown significantly since its early days as a platform.
+
+## Products
+
+Kalshi offers event-based contracts. Users can trade on the outcome of real-world events.`;
+
+    const sections = splitIntoSections(body);
+    expect(sections).toHaveLength(3);
+    expect(sections[0].heading).toBe('Introduction');
+    expect(sections[1].heading).toBe('History');
+    expect(sections[2].heading).toBe('Products');
+  });
+
+  it('skips sections with less than 50 chars of content', () => {
+    const body = `## Good Section
+
+This section has enough content to be included in the extraction process and analyzed.
+
+## Short
+
+Too short.`;
+
+    const sections = splitIntoSections(body);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('Good Section');
+  });
+});


### PR DESCRIPTION
## Summary
- Page extraction prompt now requests a verbatim `sourceQuote` excerpt from the wiki text (was hardcoded `null`)
- Resource extraction prompt now **requires** `sourceQuote` (was "if available")
- Both pipelines parse and store the LLM-provided sourceQuote instead of discarding it
- Exported `cleanMdxForExtraction`, `splitIntoSections`, and `EXTRACT_SYSTEM_PROMPT` for testability

## What changed
| File | Change |
|------|--------|
| `crux/claims/extract.ts` | Added `sourceQuote` to prompt, `ExtractedClaim` type, parsing, and DB insertion |
| `crux/claims/ingest-resource.ts` | Changed sourceQuote from optional to required in prompt |
| `crux/claims/source-linking.test.ts` | 16 new tests covering prompts, propagation, and helpers |

## Test plan
- [x] 16 unit tests pass covering prompt content, sourceQuote propagation, cleanMdxForExtraction, splitIntoSections
- [x] TypeScript compiles clean
- [x] Full gate passes

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)