### PR TITLE
fix: expanded claim row background now spans full table width

### DIFF
--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -35,7 +35,7 @@ import { NumericValueDisplay } from "./numeric-value-display";
 
 function ExpandedClaimDetail({ claim, entityNames = {} }: { claim: ClaimRow; entityNames?: Record<string, string> }) {
   return (
-    <div className="px-4 py-3 bg-muted/30 space-y-2 text-sm">
+    <div className="px-4 py-3 space-y-2 text-sm">
       <div>
         <span className="font-medium text-xs text-muted-foreground">
           Full Claim:
@@ -184,7 +184,7 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
     cell: ({ row }) => (
       <Link
         href={`/claims/claim/${row.original.id}`}
-        className="font-mono text-[10px] text-muted-foreground hover:text-blue-600 hover:underline"
+        className="font-mono text-xs text-blue-600 hover:underline"
         onClick={(e) => e.stopPropagation()}
       >
         {row.original.id}
@@ -408,7 +408,7 @@ export function ClaimsTable({
                   </TableRow>
                   {row.getIsExpanded() && (
                     <TableRow>
-                      <TableCell colSpan={columns.length} className="p-0">
+                      <TableCell colSpan={columns.length} className="p-0 bg-muted/30">
                         <ExpandedClaimDetail claim={row.original} entityNames={entityNames} />
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
## Summary

- Move `bg-muted/30` from the inner `<div>` in `ExpandedClaimDetail` to the `<TableCell colSpan={...}>` wrapper — the background now fills the full cell width instead of stopping at the `px-4` padding boundary
- Also make claim ID links permanently blue (`text-blue-600`) instead of muted-until-hover, improving discoverability

Closes #1094

## Test plan

- [ ] Expand any row in the Claims Explorer table and verify the `bg-muted/30` background spans edge-to-edge
- [ ] Verify claim ID links in the `#` column are visibly blue (not muted gray)
