### PR TITLE
fix: validate EntityLinks against pages as well as YAML entities

### DIFF
--- a/crux/validate/validate-component-refs.ts
+++ b/crux/validate/validate-component-refs.ts
@@ -116,6 +116,13 @@ function loadEntities(): Set<string> {
       ids.add(eid);
     }
 
+    // Page IDs — EntityLinks may also reference pages that lack a YAML entity definition
+    // (internal docs, overview pages, style guides, etc.)
+    const pages = (database as Record<string, unknown>).pages as Array<{ id: string }> | undefined;
+    for (const p of pages ?? []) {
+      ids.add(p.id);
+    }
+
     return ids;
   } catch {
     log.warn('Warning: Could not load entities database. Data layer may need manual rebuild.');
@@ -132,20 +139,6 @@ function loadExternalLinks(): Set<string> {
       pageIds.add(match[1].trim());
     }
     return pageIds;
-  } catch {
-    return new Set();
-  }
-}
-
-function loadSafetyApproaches(): Set<string> {
-  try {
-    const content: string = readFileSync(`${DATA_DIR}/tables/safety-approaches.ts`, 'utf-8');
-    const ids = new Set<string>();
-    const matches = content.matchAll(/id: ['"]([^'"]+)['"]/g);
-    for (const match of matches) {
-      ids.add(match[1]);
-    }
-    return ids;
   } catch {
     return new Set();
   }
@@ -234,7 +227,6 @@ function findComponentRefs(content: string): ComponentRef[] {
 export async function runCheck(options: ValidatorOptions = {}): Promise<ValidatorResult> {
   const entities: Set<string> = loadEntities();
   const externalLinks: Set<string> = loadExternalLinks();
-  const safetyApproaches: Set<string> = loadSafetyApproaches();
 
   const files: string[] = findMdxFiles(CONTENT_DIR);
 
@@ -264,9 +256,8 @@ export async function runCheck(options: ValidatorOptions = {}): Promise<Validato
       switch (ref.component) {
         case 'EntityLink':
           isValid = entities.has(ref.value) ||
-                    safetyApproaches.has(ref.value) ||
                     ref.value.startsWith('__index__/');
-          dataSource = 'entities/safety-approaches';
+          dataSource = 'entities/pages';
           break;
 
         case 'DataInfoBox':
@@ -318,11 +309,9 @@ async function main(): Promise<void> {
   log.dim('Loading data sources...');
   const entities: Set<string> = loadEntities();
   const externalLinks: Set<string> = loadExternalLinks();
-  const safetyApproaches: Set<string> = loadSafetyApproaches();
 
-  log.dim(`  Entities: ${entities.size}`);
+  log.dim(`  Entities + Pages: ${entities.size}`);
   log.dim(`  External Links: ${externalLinks.size}`);
-  log.dim(`  Safety Approaches: ${safetyApproaches.size}`);
   console.log();
 
   const files: string[] = findMdxFiles(CONTENT_DIR);
@@ -357,9 +346,8 @@ async function main(): Promise<void> {
       switch (ref.component) {
         case 'EntityLink':
           isValid = entities.has(ref.value) ||
-                    safetyApproaches.has(ref.value) ||
                     ref.value.startsWith('__index__/');
-          dataSource = 'entities/safety-approaches';
+          dataSource = 'entities/pages';
           break;
 
         case 'DataInfoBox':


### PR DESCRIPTION
## Summary

- Fixed 143 false-positive CI failures in the component-refs validator where `EntityLink` components referencing valid wiki pages (internal docs, overview pages, style guides) were reported as missing
- Root cause: `loadEntities()` only loaded YAML entity definitions, but many valid `EntityLink` targets are pages without YAML entities. Fixed by also loading page IDs from `database.json`'s `pages` array.
- Removed dead `loadSafetyApproaches()` function (tried to read `data/tables/safety-approaches.ts` which never existed; always returned an empty Set)
- Updated the error message label from the misleading `'entities/safety-approaches'` to `'entities/pages'`

## Test plan

- [x] `pnpm crux validate refs` → 0 missing references (was 143)
- [x] `pnpm crux validate gate --fix --no-cache` → ✅ All 13 gate checks pass
