### PR TITLE
feat(claims): surface wiki resources in Claims Explorer

### DIFF
--- a/apps/web/src/app/claims/components/claim-sources-list.tsx
+++ b/apps/web/src/app/claims/components/claim-sources-list.tsx
@@ -1,9 +1,15 @@
 /**
  * ClaimSourcesList — displays the sources backing a claim.
  * Shows resource links, URLs, and source quotes.
+ * Resolves resourceId → full resource metadata (title, type, credibility).
+ * Falls back to URL matching via normalizeUrl() when only a URL is known.
  */
 import Link from "next/link";
 import type { ClaimSourceRow } from "@wiki-server/api-types";
+import { getResourceById, getAllResources, getResourceCredibility } from "@data";
+import type { Resource } from "@data";
+import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
+import { normalizeUrl, getResourceTypeIcon } from "@/components/wiki/resource-utils";
 
 interface Props {
   sources: ClaimSourceRow[];
@@ -21,49 +27,91 @@ export function ClaimSourcesList({ sources, compact = false }: Props) {
     );
   }
 
+  // Build URL index for fuzzy matching (normalised URL → Resource).
+  // Only built when there are sources without a resourceId to resolve.
+  const needsUrlLookup = sources.some((s) => !s.resourceId && s.url);
+  const urlIndex = new Map<string, Resource>();
+  if (needsUrlLookup) {
+    for (const r of getAllResources()) {
+      if (r.url) urlIndex.set(normalizeUrl(r.url), r);
+    }
+  }
+
   return (
     <div className="space-y-2">
-      {sources.map((source) => (
-        <div
-          key={source.id}
-          className={`rounded border p-3 text-sm ${
-            source.isPrimary
-              ? "border-blue-200 bg-blue-50/30"
-              : "border-gray-200 bg-gray-50/30"
-          }`}
-        >
-          <div className="flex items-center gap-2 mb-1">
-            {source.isPrimary && (
-              <span className="text-[10px] font-medium bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">
-                primary
-              </span>
-            )}
-            {source.resourceId && (
-              <Link
-                href={`/source/${source.resourceId}`}
-                className="text-xs font-mono text-blue-600 hover:underline"
-              >
-                {source.resourceId}
-              </Link>
-            )}
-            {!source.resourceId && source.url && (
-              <a
-                href={source.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline truncate max-w-xs"
-              >
-                {source.url}
-              </a>
+      {sources.map((source) => {
+        // Resolve to a full resource
+        let resource: Resource | undefined;
+        if (source.resourceId) {
+          resource = getResourceById(source.resourceId);
+        } else if (source.url) {
+          resource = urlIndex.get(normalizeUrl(source.url));
+        }
+
+        const credibility =
+          resource != null ? getResourceCredibility(resource) : undefined;
+
+        return (
+          <div
+            key={source.id}
+            className={`rounded border p-3 text-sm ${
+              source.isPrimary
+                ? "border-blue-200 bg-blue-50/30"
+                : "border-gray-200 bg-gray-50/30"
+            }`}
+          >
+            <div className="flex items-center gap-2 flex-wrap mb-1">
+              {source.isPrimary && (
+                <span className="text-[10px] font-medium bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">
+                  primary
+                </span>
+              )}
+              {resource ? (
+                <>
+                  <span className="text-sm leading-none">
+                    {getResourceTypeIcon(resource.type)}
+                  </span>
+                  <a
+                    href={resource.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-medium text-blue-600 hover:underline"
+                  >
+                    {resource.title}
+                  </a>
+                  <span className="text-[10px] text-muted-foreground capitalize">
+                    {resource.type}
+                  </span>
+                  {credibility !== undefined && (
+                    <CredibilityBadge level={credibility} />
+                  )}
+                </>
+              ) : source.resourceId ? (
+                <Link
+                  href={`/source/${source.resourceId}`}
+                  className="text-xs font-mono text-blue-600 hover:underline"
+                >
+                  {source.resourceId}
+                </Link>
+              ) : source.url ? (
+                <a
+                  href={source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline truncate max-w-xs"
+                >
+                  {source.url}
+                </a>
+              ) : null}
+            </div>
+            {source.sourceQuote && (
+              <p className="text-xs italic text-muted-foreground">
+                &ldquo;{source.sourceQuote}&rdquo;
+              </p>
             )}
           </div>
-          {source.sourceQuote && (
-            <p className="text-xs italic text-muted-foreground">
-              &ldquo;{source.sourceQuote}&rdquo;
-            </p>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
-import { getEntityById } from "@data";
+import {
+  getEntityById,
+  getResourcesForPage,
+  getResourceById,
+  getResourceCredibility,
+} from "@data";
 import type { GetClaimsResult } from "@wiki-server/api-types";
 import { StatCard } from "../../components/stat-card";
 import { ClaimsTable } from "../../components/claims-table";
@@ -10,6 +15,8 @@ import {
   collectEntitySlugs,
   buildEntityNameMap,
 } from "../../components/claims-data";
+import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
+import { getResourceTypeIcon } from "@/components/wiki/resource-utils";
 
 interface PageProps {
   params: Promise<{ entityId: string }>;
@@ -37,6 +44,12 @@ export default async function EntityClaimsPage({ params }: PageProps) {
   const entity = getEntityById(entityId);
   const displayName = entity?.title ?? entityId;
   const entityNames = buildEntityNameMap(collectEntitySlugs(claims));
+
+  // Resolve page resources for the "Page Resources" section
+  const resourceIds = getResourcesForPage(entityId);
+  const resources = resourceIds
+    .map((id) => getResourceById(id))
+    .filter((r): r is NonNullable<typeof r> => r !== undefined);
 
   // Compute stats
   const verified = claims.filter((c) => c.confidence === "verified").length;
@@ -112,6 +125,55 @@ export default async function EntityClaimsPage({ params }: PageProps) {
 
           <ClaimsTable claims={claims} entityNames={entityNames} />
         </>
+      )}
+
+      {resources.length > 0 && (
+        <div className="mt-8">
+          <details open={resources.length <= 5}>
+            <summary className="text-sm font-semibold cursor-pointer select-none list-none flex items-center gap-2">
+              <span>Page Resources</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                ({resources.length})
+              </span>
+              {resources.length > 5 && (
+                <span className="text-xs text-muted-foreground">
+                  — click to expand
+                </span>
+              )}
+            </summary>
+            <div className="mt-3 space-y-2">
+              {resources.map((resource) => {
+                const credibility = getResourceCredibility(resource);
+                return (
+                  <div
+                    key={resource.id}
+                    className="flex items-center gap-3 rounded border px-3 py-2 text-sm"
+                  >
+                    <span className="text-base leading-none shrink-0">
+                      {getResourceTypeIcon(resource.type)}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <a
+                        href={resource.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-medium text-blue-600 hover:underline"
+                      >
+                        {resource.title}
+                      </a>
+                    </div>
+                    <span className="text-[10px] text-muted-foreground capitalize shrink-0">
+                      {resource.type}
+                    </span>
+                    {credibility !== undefined && (
+                      <CredibilityBadge level={credibility} />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </details>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Page Resources section** on entity claims pages (`/claims/entity/<id>`): shows all resources associated with the wiki page via `getResourcesForPage()`. Each resource displays its type icon, title (linked to URL), type label, and credibility badge. Collapsed by default when >5 resources.
- **Enriched ClaimSourcesList**: when a claim source has a `resourceId`, resolves it to the full resource record and shows title, type icon, type label, and credibility badge instead of just the raw ID. When a source has only a URL, tries fuzzy URL matching via `normalizeUrl()` against all wiki resources.
- **Performance guard**: URL index (6000 entries) is only built when at least one source lacks a `resourceId`; empty-URL guard added.

## Test plan

- [ ] Visit `/claims/entity/anthropic` (or any entity with resources) — confirm "Page Resources" section appears with titles, icons, and credibility badges
- [ ] Entities with ≤5 resources: section is open by default
- [ ] Entities with >6 resources: section is collapsed with "click to expand" hint
- [ ] Visit `/claims/<id>` for a claim with structured sources that have `resourceId` — confirm sources show resource titles instead of raw IDs
- [ ] Visit a claim where sources have URLs only — confirm URL-matched resources show enriched metadata
- [ ] Entity with no page resources: "Page Resources" section does not appear

Closes #1096
