### PR TITLE
fix: resolve page_links deadlock with advisory lock

### DIFF
--- a/apps/wiki-server/src/__tests__/links.test.ts
+++ b/apps/wiki-server/src/__tests__/links.test.ts
@@ -40,13 +40,54 @@ function linkKey(sourceId: string, targetId: string, linkType: string) {
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
+  // --- pg_advisory_xact_lock (no-op in tests) ---
+  if (q.includes("pg_advisory_xact_lock")) {
+    return [];
+  }
+
   // --- page_links: DELETE all ---
   if (q.includes("delete from") && q.includes("page_links")) {
     linksStore.clear();
     return [];
   }
 
-  // --- page_links: INSERT ... ON CONFLICT DO UPDATE (multi-row) ---
+  // --- page_links: INSERT via jsonb_to_recordset (raw SQL sync endpoint) ---
+  if (q.includes("insert into") && q.includes("page_links") && q.includes("jsonb_to_recordset")) {
+    const jsonStr = params[0] as string;
+    const batch = JSON.parse(jsonStr) as Array<{
+      sourceId: string;
+      targetId: string;
+      linkType: string;
+      relationship?: string | null;
+      weight: number;
+    }>;
+    const rows: LinkRow[] = [];
+    const now = new Date();
+    for (const link of batch) {
+      const row: LinkRow = {
+        id: nextId++,
+        source_id: link.sourceId,
+        target_id: link.targetId,
+        link_type: link.linkType,
+        relationship: link.relationship || null,
+        weight: link.weight,
+        created_at: now,
+      };
+      const key = linkKey(row.source_id, row.target_id, row.link_type);
+      const existing = linksStore.get(key);
+      if (existing) {
+        existing.weight = row.weight;
+        existing.relationship = row.relationship;
+        rows.push(existing);
+      } else {
+        linksStore.set(key, row);
+        rows.push(row);
+      }
+    }
+    return rows;
+  }
+
+  // --- page_links: INSERT ... ON CONFLICT DO UPDATE (Drizzle multi-row, used by other tests) ---
   if (q.includes("insert into") && q.includes("page_links")) {
     const COLS = 5;
     const numRows = params.length / COLS;

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -1,17 +1,12 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { sql } from "drizzle-orm";
-import { getDrizzleDb, getDb } from "../db.js";
-import { pageLinks } from "../schema.js";
+import { getDb, type SqlQuery } from "../db.js";
 import {
   parseJsonBody,
   validationError,
   invalidJsonError,
 } from "./utils.js";
-import {
-  PageLinkSchema as SharedLinkSchema,
-  SyncLinksBatchSchema,
-} from "../api-types.js";
+import { SyncLinksBatchSchema } from "../api-types.js";
 
 export const linksRoute = new Hono();
 
@@ -61,7 +56,6 @@ const INVERSE_LABEL: Record<string, string> = {
 
 // ---- Schemas (from shared api-types) ----
 
-const LinkSchema = SharedLinkSchema;
 const SyncBatchSchema = SyncLinksBatchSchema;
 
 const BacklinksQuery = z.object({
@@ -74,6 +68,10 @@ const RelatedQuery = z.object({
 
 // ---- POST /sync ----
 
+// Advisory lock key for serializing page_links sync operations.
+// Prevents deadlocks when multiple callers (CI, local builds) sync concurrently.
+const PAGE_LINKS_SYNC_LOCK = 7_294_801;
+
 linksRoute.post("/sync", async (c) => {
   const body = await parseJsonBody(c);
   if (!body) return invalidJsonError(c);
@@ -82,38 +80,34 @@ linksRoute.post("/sync", async (c) => {
   if (!parsed.success) return validationError(c, parsed.error.message);
 
   const { links, replace } = parsed.data;
-  const db = getDrizzleDb();
+  const rawDb = getDb();
 
   let upserted = 0;
 
-  await db.transaction(async (tx) => {
+  // Use a raw postgres transaction with an advisory lock to serialize concurrent
+  // sync operations. Without this, two concurrent syncs deadlock on the unique
+  // index when inserting overlapping rows.
+  await rawDb.begin(async (txRaw) => {
+    const tx = txRaw as unknown as SqlQuery;
+    await tx`SELECT pg_advisory_xact_lock(${PAGE_LINKS_SYNC_LOCK})`;
+
     if (replace) {
-      await tx.delete(pageLinks);
+      await tx`DELETE FROM page_links`;
     }
 
     // Batch upsert — on conflict (source, target, type) update weight + relationship
     for (let i = 0; i < links.length; i += 500) {
       const batch = links.slice(i, i + 500);
-      const vals = batch.map((link) => ({
-        sourceId: link.sourceId,
-        targetId: link.targetId,
-        linkType: link.linkType,
-        relationship: link.relationship ?? null,
-        weight: link.weight,
-      }));
 
-      await tx
-        .insert(pageLinks)
-        .values(vals)
-        .onConflictDoUpdate({
-          target: [pageLinks.sourceId, pageLinks.targetId, pageLinks.linkType],
-          set: {
-            weight: sql`excluded.weight`,
-            relationship: sql`excluded.relationship`,
-          },
-        });
+      await tx`
+        INSERT INTO page_links (source_id, target_id, link_type, relationship, weight)
+        SELECT * FROM jsonb_to_recordset(${JSON.stringify(batch)}::jsonb)
+        AS t(source_id text, target_id text, link_type text, relationship text, weight real)
+        ON CONFLICT (source_id, target_id, link_type)
+        DO UPDATE SET weight = EXCLUDED.weight, relationship = EXCLUDED.relationship
+      `;
 
-      upserted += vals.length;
+      upserted += batch.length;
     }
   });
 


### PR DESCRIPTION
## Summary

- Fix PostgreSQL deadlock in wiki-server `POST /api/links/sync` endpoint that was crashing the production server
- Added `pg_advisory_xact_lock` to serialize concurrent sync operations — second caller waits instead of deadlocking
- Switched sync endpoint from Drizzle ORM to raw SQL with `jsonb_to_recordset` for cleaner bulk inserts
- Updated test mock dispatch to handle new SQL patterns

## Root cause

Two concurrent `POST /api/links/sync` requests (e.g., two CI builds) deadlocked on the `idx_pl_source_target_type` unique index when inserting overlapping rows in long-lived transactions. The unhandled error crashed the server, causing repeated pod restarts.

## Test plan
- [x] All 1904 tests pass (13 links-specific tests)
- [x] TypeScript compiles clean
- [x] Gate passes
- [ ] Verify prod server stabilizes after deploy
