### PR TITLE
perf: optimize CI pipeline — ~5 min faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  ci:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # --- Build data (once, shared by all subsequent steps) ---
+
       - name: Build data
         run: cd apps/web && node --import tsx/esm scripts/build-data.mjs
         env:
@@ -36,6 +38,63 @@ jobs:
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
+
+      # --- Validation (fail fast before expensive Next.js build) ---
+
+      - name: MDX syntax check (blocking)
+        run: pnpm crux validate unified --rules=comparison-operators,dollar-signs --errors-only
+
+      - name: YAML schema validation (blocking)
+        run: pnpm crux validate schema
+
+      - name: Frontmatter schema validation (blocking)
+        run: pnpm crux validate unified --rules=frontmatter-schema --errors-only
+
+      - name: Numeric ID integrity (blocking)
+        run: pnpm crux validate unified --rules=numeric-id-integrity --errors-only
+
+      - name: TypeScript type checks (parallel)
+        run: |
+          pids=()
+          (cd apps/web && npx tsc --noEmit) &
+          pids+=($!)
+          (cd apps/discord-bot && npx tsc --noEmit) &
+          pids+=($!)
+          (cd apps/wiki-server && npx tsc --noEmit) &
+          pids+=($!)
+          failed=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || failed=1
+          done
+          exit $failed
+
+      - name: TypeScript type check — crux (advisory, baseline-guarded)
+        continue-on-error: true
+        run: npx tsx crux/validate/validate-crux-tsc.ts --ci
+
+      - name: .returning() guard check (blocking)
+        run: npx tsx crux/validate/validate-returning-guard.ts
+
+      - name: Drizzle migration journal integrity (blocking)
+        run: npx tsx crux/validate/validate-drizzle-journal.ts
+
+      - name: Auto-update orchestrator smoke test (dry-run)
+        if: "!cancelled()"
+        continue-on-error: true
+        run: |
+          pnpm crux auto-update run --dry-run --skip-fetch --trigger=ci-check --budget=0 --count=0 \
+            || echo "::warning::Auto-update dry-run failed (advisory — check orchestrator for regressions)"
+
+      - name: Component reference validation (blocking)
+        run: pnpm crux validate refs
+
+      - name: Run validation suite (advisory)
+        if: "!cancelled()"
+        continue-on-error: true
+        run: |
+          pnpm crux validate || echo "::warning::Validation has pre-existing failures (non-blocking)"
+
+      # --- Tests ---
 
       - name: Run tests
         run: cd apps/web && pnpm test
@@ -49,16 +108,27 @@ jobs:
       - name: Run crux tests
         run: pnpm test:crux
 
+      # --- Next.js build (most expensive step — runs last) ---
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/web/.next/cache
+          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**', 'content/docs/**') }}
+          restore-keys: |
+            nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Build Next.js
         run: cd apps/web && pnpm build
         env:
+          SKIP_PREBUILD: "1"
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
 
   sync-content:
     # Sync wiki page content to wiki-server after build succeeds on main.
-    needs: [build-and-test]
+    needs: [ci]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -93,8 +163,7 @@ jobs:
     # Trigger a Vercel production deployment after CI passes on main.
     # This ensures prod is rebuilt exactly once per PR merge, naturally
     # capping deploys at ~1 per merged PR (<10/day in practice).
-    # The scheduled-deploy workflow provides a daily fallback for quiet periods.
-    needs: [build-and-test]
+    needs: [ci]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -121,79 +190,3 @@ jobs:
             echo "::error::Vercel deploy hook returned HTTP $RESPONSE"
             exit 1
           fi
-
-  validate:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build data (needed for validation)
-        id: build-data
-        run: cd apps/web && node --import tsx/esm scripts/build-data.mjs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
-          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
-          LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
-
-      - name: MDX syntax check (blocking)
-        run: pnpm crux validate unified --rules=comparison-operators,dollar-signs --errors-only
-
-      - name: YAML schema validation (blocking)
-        run: pnpm crux validate schema
-
-      - name: Frontmatter schema validation (blocking)
-        run: pnpm crux validate unified --rules=frontmatter-schema --errors-only
-
-      - name: Numeric ID integrity (blocking)
-        run: pnpm crux validate unified --rules=numeric-id-integrity --errors-only
-
-      - name: TypeScript type check — app (blocking)
-        run: cd apps/web && npx tsc --noEmit
-
-      - name: TypeScript type check — discord-bot (blocking)
-        run: cd apps/discord-bot && npx tsc --noEmit
-
-      - name: TypeScript type check — wiki-server (blocking)
-        run: cd apps/wiki-server && npx tsc --noEmit
-
-      - name: TypeScript type check — crux (advisory, baseline-guarded)
-        continue-on-error: true
-        run: npx tsx crux/validate/validate-crux-tsc.ts --ci
-
-      - name: .returning() guard check (blocking)
-        run: npx tsx crux/validate/validate-returning-guard.ts
-
-      - name: Drizzle migration journal integrity (blocking)
-        run: npx tsx crux/validate/validate-drizzle-journal.ts
-
-      - name: Auto-update orchestrator smoke test (dry-run)
-        # Verifies the orchestrator pipeline doesn't crash — specifically guards
-        # against missing mkdirSync before writeFileSync in saveRunDetails / saveRunReport.
-        # Uses --skip-fetch to avoid 9-minute RSS fetch; verifies code paths only.
-        # continue-on-error so failures show as warnings, not blockers.
-        if: "!cancelled()"
-        continue-on-error: true
-        run: |
-          pnpm crux auto-update run --dry-run --skip-fetch --trigger=ci-check --budget=0 --count=0 \
-            || echo "::warning::Auto-update dry-run failed (advisory — check orchestrator for regressions)"
-
-      - name: Component reference validation (blocking)
-        run: pnpm crux validate refs
-
-      - name: Run validation suite (advisory)
-        if: "!cancelled()"
-        continue-on-error: true
-        run: |
-          pnpm crux validate || echo "::warning::Validation has pre-existing failures (non-blocking)"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "assign-ids": "node scripts/assign-ids.mjs",
     "sync:data": "node scripts/assign-ids.mjs && NODE_USE_ENV_PROXY=1 node --import tsx/esm scripts/build-data.mjs",
     "sync:data:content": "node scripts/assign-ids.mjs --skip && NODE_USE_ENV_PROXY=1 node --import tsx/esm scripts/build-data.mjs --scope=content",
-    "prebuild": "node scripts/assign-ids.mjs && NODE_USE_ENV_PROXY=1 node --import tsx/esm scripts/build-data.mjs",
+    "prebuild": "if [ \"$SKIP_PREBUILD\" = '1' ]; then echo 'Skipping prebuild (data already built)'; else node scripts/assign-ids.mjs && NODE_USE_ENV_PROXY=1 node --import tsx/esm scripts/build-data.mjs; fi",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

Optimizes the CI pipeline to eliminate redundant work and improve parallelism:

- **Merge `build-and-test` + `validate` into single `ci` job** — eliminates duplicate checkout, pnpm install, and build-data (was running build-data 2x in parallel jobs, plus a 3rd time via prebuild)
- **Add Next.js build cache** — caches `.next/cache` between runs so only changed pages are recompiled (expected to cut ~7min build to ~2-3min on cache hits)
- **Add `SKIP_PREBUILD` env var** — prevents `pnpm build` from re-running build-data when CI already ran it (was silently doubling build-data time)
- **Parallelize 3 TypeScript type checks** — app, discord-bot, wiki-server now run concurrently instead of sequentially
- **Reorder steps** — validations run before tests, tests before Next.js build (fail fast on cheap checks)

### Expected savings

| Before | After (estimated) |
|---|---|
| ~10.5 min total | ~4-5 min total |
| build-data runs 3x | build-data runs 1x |
| Next.js build: ~7 min (no cache, includes redundant prebuild) | ~2-3 min (cached, no redundant prebuild) |
| tsc checks: sequential (~23s) | tsc checks: parallel (~13s) |

## Test plan

- [x] Local gate passes
- [ ] CI passes on this PR (first run won't have cache, but second push will)
- [ ] Verify `SKIP_PREBUILD` works (check "Build Next.js" step logs for "Skipping prebuild")
- [ ] Verify Next.js cache is populated (check "Post Restore Next.js build cache" step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)