### PR TITLE
fix: repair internal page frontmatter and add missing subcategories

### DIFF
--- a/content/docs/internal/anthropic-pages-refactor-notes.mdx
+++ b/content/docs/internal/anthropic-pages-refactor-notes.mdx
@@ -4,7 +4,6 @@ title: "Anthropic Pages Refactor Notes"
 description: "Internal notes on potential future refactoring of the Anthropic page cluster"
 sidebar:
   order: 90
-entityType: internal
 subcategory: style-guides
 readerImportance: 8.5
 researchImportance: 8

--- a/content/docs/internal/architecture.mdx
+++ b/content/docs/internal/architecture.mdx
@@ -5,14 +5,12 @@ description: "Technical architecture of the Longterm Wiki — data pipeline, cle
 sidebar:
   order: 0
   label: "Architecture"
-entityType: internal
 subcategory: architecture
 pageType: documentation
 readerImportance: 9.5
 researchImportance: 9
 lastEdited: "2026-02-15"
 update_frequency: 60
-evergreen: true
 ---
 import { Mermaid } from '@components/wiki';
 

--- a/content/docs/internal/canonical-facts.mdx
+++ b/content/docs/internal/canonical-facts.mdx
@@ -4,14 +4,12 @@ title: "Canonical Facts & Calc Usage Guide"
 description: "Strategy and conventions for using the F (fact) and Calc (computed value) components across wiki pages — when to make a number a fact, how to use showDate for temporal claims, and scaling guidelines."
 sidebar:
   order: 10
-entityType: internal
 subcategory: style-guides
 quality: 50
 readerImportance: 12
 researchImportance: 15
 lastEdited: "2026-02-18"
 update_frequency: 90
-evergreen: true
 ratings:
   novelty: 3
   rigor: 6

--- a/content/docs/internal/cause-effect-diagrams.mdx
+++ b/content/docs/internal/cause-effect-diagrams.mdx
@@ -4,14 +4,12 @@ title: "Cause-Effect Diagram Style Guide"
 description: "Guidelines for creating cause-effect diagrams in YAML format"
 sidebar:
   order: 4
-entityType: internal
 subcategory: style-guides
 quality: 44
 readerImportance: 9.5
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Technical documentation for creating cause-effect diagrams in YAML format, covering node types (leaf/cause/intermediate/effect), edge properties (strength/confidence/effect), semantic color coding, scoring dimensions (novelty/sensitivity/changeability/certainty), and layout best practices with 15-20 node limits."
 ratings:
   novelty: 0

--- a/content/docs/internal/citation-architecture.mdx
+++ b/content/docs/internal/citation-architecture.mdx
@@ -5,7 +5,6 @@ description: "Analysis of the wiki's four overlapping citation systems and a con
 sidebar:
   order: 15
   label: "Citation Architecture"
-entityType: internal
 subcategory: architecture
 pageType: documentation
 quality: 70

--- a/content/docs/internal/claim-first-architecture.mdx
+++ b/content/docs/internal/claim-first-architecture.mdx
@@ -4,7 +4,6 @@ title: "Claim-First Wiki Architecture: Data Layer as Primary Artifact"
 description: "Architecture brainstorm for inverting the wiki generation pipeline — researching and verifying atomic claims first, then composing pages as derived views from a verified claim store"
 sidebar:
   order: 36
-entityType: internal
 subcategory: architecture
 quality: 40
 readerImportance: 80

--- a/content/docs/internal/claims-architecture-decisions.mdx
+++ b/content/docs/internal/claims-architecture-decisions.mdx
@@ -4,7 +4,6 @@ title: "Claims System: Architecture Decisions, Cruxes, and Worked Examples"
 description: "Synthesizes an extended design session on the claims system — covering the core data model, integration with facts and resources, red-team failure modes, worked examples for person/org pages, and phased implementation path."
 sidebar:
   order: 37
-entityType: internal
 subcategory: architecture
 quality: 60
 readerImportance: 85

--- a/content/docs/internal/common-writing-principles.md
+++ b/content/docs/internal/common-writing-principles.md
@@ -4,14 +4,12 @@ title: "Common Writing Principles"
 description: "Cross-cutting writing standards that apply to all content types. Covers epistemic honesty, language neutrality, and analytical tone."
 sidebar:
   order: 9
-entityType: internal
 subcategory: style-guides
 quality: 0
 readerImportance: 73.5
 researchImportance: 71
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Shared writing principles referenced by all domain-specific style guides. Three pillars: epistemic honesty (hedge uncertain claims, use ranges, source confidence levels), language neutrality (avoid insider jargon, describe things by what they are), and analytical tone (present tradeoffs rather than prescribe). Includes concrete word substitution tables and anti-patterns."
 ratings:
   novelty: 3

--- a/content/docs/internal/content-pipeline-architecture.mdx
+++ b/content/docs/internal/content-pipeline-architecture.mdx
@@ -4,7 +4,6 @@ title: "Content Pipeline Architecture: Faster Page Creation"
 description: "Design document analyzing options for reducing the time it takes an AI agent to create and publish a wiki page — from the current 15-30 minutes down to seconds"
 sidebar:
   order: 36
-entityType: internal
 subcategory: architecture
 quality: 50
 readerImportance: 80

--- a/content/docs/internal/coverage-guide.mdx
+++ b/content/docs/internal/coverage-guide.mdx
@@ -4,13 +4,11 @@ title: "Page Coverage Guide"
 description: "What each content layer means, why it matters, and how to add it to a wiki page."
 sidebar:
   order: 11
-entityType: internal
 subcategory: style-guides
 quality: 40
 readerImportance: 10
 researchImportance: 5
 lastEdited: "2026-02-23"
-evergreen: true
 ---
 
 The **Content** checklist in PageStatus tracks content enrichment layers that a page can have. Pages with more layers are better sourced, more useful, and easier to maintain. This guide explains each layer.

--- a/content/docs/internal/documentation-maintenance.mdx
+++ b/content/docs/internal/documentation-maintenance.mdx
@@ -5,14 +5,12 @@ description: "Guidelines for keeping internal documentation accurate and up-to-d
 sidebar:
   order: 99
   label: "Doc Maintenance"
-entityType: internal
 subcategory: style-guides
 pageType: documentation
 readerImportance: 9.5
 researchImportance: 8.5
 lastEdited: "2026-02-04"
 update_frequency: 60
-evergreen: true
 ---
 import {EntityLink} from '@components/wiki';
 

--- a/content/docs/internal/fact-dashboard.mdx
+++ b/content/docs/internal/fact-dashboard.mdx
@@ -2,7 +2,6 @@
 numericId: E898
 title: "Canonical Facts Dashboard"
 description: "Browse and filter canonical facts across all wiki entities"
-entityType: internal
 subcategory: dashboards
 contentFormat: dashboard
 lastEdited: "2026-02-25"

--- a/content/docs/internal/fact-system-strategy.mdx
+++ b/content/docs/internal/fact-system-strategy.mdx
@@ -4,14 +4,12 @@ title: "Fact System Strategy"
 description: "Research-backed strategy for the canonical facts system — what to keep, what to prune, and how to make facts genuinely useful for wiki maintenance."
 sidebar:
   order: 11
-entityType: internal
 subcategory: architecture
 quality: 55
 readerImportance: 10
 researchImportance: 30
 lastEdited: "2026-02-23"
 update_frequency: 90
-evergreen: true
 ratings:
   novelty: 6
   rigor: 7

--- a/content/docs/internal/gap-analysis-2026-02.mdx
+++ b/content/docs/internal/gap-analysis-2026-02.mdx
@@ -2,13 +2,13 @@
 numericId: E762
 title: "Wiki Gap Analysis — February 2026"
 description: "Systematic identification of coverage gaps across the wiki, prioritized by importance for AI safety coverage."
-entityType: internal
 subcategory: research
 readerImportance: 12.5
 researchImportance: 14
 lastEdited: "2026-02-17"
 evergreen: false
-sidebar_label: "Gap Analysis (Feb 2026)"
+sidebar:
+  label: "Gap Analysis (Feb 2026)"
 ---
 
 # Wiki Gap Analysis — February 2026

--- a/content/docs/internal/importance-ranking.mdx
+++ b/content/docs/internal/importance-ranking.mdx
@@ -4,7 +4,6 @@ title: "Importance Ranking System"
 description: "How wiki page importance scores are derived from ordered rankings using LLM-assisted comparison"
 sidebar:
   order: 7
-entityType: internal
 subcategory: research
 pageType: "documentation"
 quality: 40
@@ -12,7 +11,6 @@ readerImportance: 7
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 ---
 
 # Importance Ranking System

--- a/content/docs/internal/knowledge-base.mdx
+++ b/content/docs/internal/knowledge-base.mdx
@@ -4,14 +4,12 @@ title: "Knowledge Base Style Guide"
 description: "Guidelines for knowledge base pages (risks, responses, etc.)"
 sidebar:
   order: 1
-entityType: internal
 subcategory: style-guides
 quality: 34
 readerImportance: 11.5
 researchImportance: 10
 lastEdited: "2025-12-26"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for wiki content creation, emphasizing flexible hierarchical structure over rigid templates, integrated arguments over sparse sections, and selective use of visualizations. Provides concrete examples of good/bad practices for risk and response pages."
 ratings:
   novelty: 1

--- a/content/docs/internal/knowledge-graph-ontology.mdx
+++ b/content/docs/internal/knowledge-graph-ontology.mdx
@@ -4,7 +4,6 @@ title: "Knowledge Graph Ontology: From Facts to Structured Claims"
 description: "Design document for extending the wiki's data layer from numeric facts to a full knowledge graph with typed properties, entity relationships, and structured claims — including a concrete refactoring of the Kalshi page as a worked example"
 sidebar:
   order: 37
-entityType: internal
 subcategory: architecture
 quality: 45
 readerImportance: 85

--- a/content/docs/internal/mermaid-diagrams.mdx
+++ b/content/docs/internal/mermaid-diagrams.mdx
@@ -4,14 +4,12 @@ title: "Mermaid Diagram Style Guide"
 description: "Guidelines for creating effective Mermaid diagrams in this wiki"
 sidebar:
   order: 3
-entityType: internal
 subcategory: style-guides
 quality: 37
 readerImportance: 12
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for creating Mermaid diagrams in the wiki, recommending vertical layouts over horizontal (max 3-4 parallel nodes), providing semantic color palette, and advocating tables over diagrams for taxonomies. Includes practical width limits and anti-patterns for common diagram issues."
 ratings:
   novelty: 1

--- a/content/docs/internal/models-style-guide.md
+++ b/content/docs/internal/models-style-guide.md
@@ -2,7 +2,6 @@
 numericId: E736
 title: "Models Style Guide"
 description: "Style guide for writing model and analysis pages"
-entityType: internal
 subcategory: style-guides
 pageType: "documentation"
 quality: 38
@@ -10,7 +9,6 @@ readerImportance: 45
 researchImportance: 70.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide prescribing dense, quantified content structure for model pages: minimum 800 words, 2+ tables (4x3+), 1+ Mermaid diagram, mathematical formulations, and <30% bullets. Requires specific sections (overview, framework, quantitative analysis, cases, limitations) with probability ranges and scenario weighting throughout."
 ratings:
   novelty: 2

--- a/content/docs/internal/models.mdx
+++ b/content/docs/internal/models.mdx
@@ -4,14 +4,12 @@ title: "Model Style Guide"
 description: "Format requirements and methodological considerations for analytical models"
 sidebar:
   order: 2
-entityType: internal
 subcategory: style-guides
 quality: 32
 readerImportance: 12
 researchImportance: 13
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "This internal style guide establishes format requirements and methodological principles for analytical models in the knowledge base, emphasizing executive summaries that state both methodology and conclusions, strategic prioritization content, and diagram selection criteria. It provides comprehensive formatting standards but represents internal infrastructure rather than substantive analysis."
 ratings:
   novelty: 2

--- a/content/docs/internal/page-coverage-dashboard.mdx
+++ b/content/docs/internal/page-coverage-dashboard.mdx
@@ -2,7 +2,6 @@
 numericId: E899
 title: "Pages"
 description: "Comprehensive admin view of all wiki pages — quality, coverage, citations, risk, and update status"
-entityType: internal
 subcategory: dashboards
 contentFormat: dashboard
 lastEdited: "2026-02-25"

--- a/content/docs/internal/page-length-research.mdx
+++ b/content/docs/internal/page-length-research.mdx
@@ -4,7 +4,6 @@ title: "Research: Adaptive Page Length & Summary Systems"
 description: "Analysis of approaches for handling variable page lengths, better summaries, and progressive disclosure on the wiki"
 sidebar:
   order: 18
-entityType: internal
 subcategory: research
 readerImportance: 10
 researchImportance: 14.5

--- a/content/docs/internal/page-types.mdx
+++ b/content/docs/internal/page-types.mdx
@@ -4,14 +4,12 @@ title: "Page Type System"
 description: "Comprehensive reference for LongtermWiki's page classification system"
 sidebar:
   order: 5
-entityType: internal
 subcategory: style-guides
 quality: 65
 readerImportance: 11
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "Documents LongtermWiki's four-level page classification system (content, stub, documentation, overview) with explicit validation rules for each type, where content pages receive full quality grading while stubs/documentation are excluded from validation pipelines."
 ratings:
   focus: 9

--- a/content/docs/internal/parameters-strategy.md
+++ b/content/docs/internal/parameters-strategy.md
@@ -2,7 +2,6 @@
 numericId: E740
 title: "Parameters Strategy"
 description: "Strategy for AI transition model parameters"
-entityType: internal
 subcategory: research
 pageType: "documentation"
 quality: 3
@@ -10,7 +9,6 @@ readerImportance: 39
 researchImportance: 69.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal project management document providing implementation instructions for creating parameter pages in a knowledge base. Outlines workflow, templates, and batch assignments for parallel development work."
 ratings:
   novelty: 0

--- a/content/docs/internal/rating-system.mdx
+++ b/content/docs/internal/rating-system.mdx
@@ -4,14 +4,12 @@ title: "Rating System"
 description: "Reference documentation for LongtermWiki's content quality and importance rating system"
 sidebar:
   order: 6
-entityType: internal
 subcategory: style-guides
 quality: 48
 readerImportance: 11
 researchImportance: 10
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 llmSummary: "This page documents LongtermWiki's content rating system, which combines LLM-graded subscores (focus, novelty, rigor, completeness, objectivity, concreteness, actionability on 0-10 scales) with automated metrics (word count, citations) to derive quality scores (0-100) and importance ratings for prioritization decisions."
 ratings:
   novelty: 2

--- a/content/docs/internal/reports/ai-research-workflows.mdx
+++ b/content/docs/internal/reports/ai-research-workflows.mdx
@@ -4,7 +4,6 @@ title: "AI-Assisted Research Workflows: Best Practices"
 description: "A guide to using Claude Code, deep research APIs, and multi-agent pipelines for producing high-quality research articles efficiently"
 sidebar:
   order: 25
-entityType: internal
 subcategory: research
 quality: 46
 readerImportance: 11

--- a/content/docs/internal/reports/causal-diagram-visualization.mdx
+++ b/content/docs/internal/reports/causal-diagram-visualization.mdx
@@ -4,7 +4,6 @@ title: "Causal Diagram Visualization: Tools & Best Practices"
 description: "Research on complex interactive causal diagram tools, academic literature, and best practices for large-scale graph visualization"
 sidebar:
   order: 10
-entityType: internal
 subcategory: research
 quality: 46
 readerImportance: 12

--- a/content/docs/internal/reports/controlled-vocabulary.mdx
+++ b/content/docs/internal/reports/controlled-vocabulary.mdx
@@ -4,7 +4,6 @@ title: "Controlled Vocabulary for Longtermist Analysis"
 description: "A standardized terminology system for categorizing risks, interventions, and concepts in longtermist discourse, designed for consistent use across diagrams and documentation"
 sidebar:
   order: 30
-entityType: internal
 subcategory: research
 quality: 55
 readerImportance: 13

--- a/content/docs/internal/reports/cross-link-automation-proposal.mdx
+++ b/content/docs/internal/reports/cross-link-automation-proposal.mdx
@@ -2,7 +2,6 @@
 numericId: E745
 title: "Cross-Link Automation Proposal"
 description: "Technical proposal for automated cross-linking improvements using vector embeddings and LLM verification"
-entityType: internal
 subcategory: research
 quality: 54
 readerImportance: 10

--- a/content/docs/internal/reports/diagram-naming-research.mdx
+++ b/content/docs/internal/reports/diagram-naming-research.mdx
@@ -4,7 +4,6 @@ title: "Factor Diagram Naming: Research Report"
 description: "Research on naming alternatives for cause-effect diagrams, surveying influence diagrams, crux maps, argument maps, and related frameworks across decision analysis, systems thinking, and philosophy"
 sidebar:
   order: 20
-entityType: internal
 subcategory: research
 quality: 31
 readerImportance: 10.5

--- a/content/docs/internal/reports/github-integrations-for-agents.mdx
+++ b/content/docs/internal/reports/github-integrations-for-agents.mdx
@@ -4,7 +4,6 @@ title: "GitHub Integrations for Multi-Agent Coordination"
 description: "Research report evaluating GitHub Sub-Issues, Discussions, Gists, and external tools (Linear, Redis, LangGraph) for coordinating multiple AI agents working on shared codebases"
 sidebar:
   order: 30
-entityType: internal
 subcategory: research
 readerImportance: 15
 researchImportance: 20

--- a/content/docs/internal/reports/page-creator-pipeline.mdx
+++ b/content/docs/internal/reports/page-creator-pipeline.mdx
@@ -4,7 +4,6 @@ title: "Research-First Page Creation Pipeline"
 description: "Experiment results from a multi-phase article generation pipeline that enforces citation discipline through structured research, extraction, and synthesis phases"
 sidebar:
   order: 30
-entityType: internal
 subcategory: research
 quality: 49
 readerImportance: 10

--- a/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
+++ b/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
@@ -2,7 +2,6 @@
 numericId: E885
 title: "Website Consistency Audit (February 2026)"
 description: "Comprehensive audit of page quality, structural consistency, navigation, and cross-linking across the wiki's ~625 pages"
-entityType: internal
 subcategory: research
 lastEdited: "2026-02-20"
 evergreen: false

--- a/content/docs/internal/research-reports.mdx
+++ b/content/docs/internal/research-reports.mdx
@@ -4,14 +4,12 @@ title: "Research Report Style Guide"
 description: "Guidelines for creating research reports on AI safety topics"
 sidebar:
   order: 5
-entityType: internal
 subcategory: style-guides
 quality: 36
 readerImportance: 12.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide for deprecated research report format, specifying table-based layouts, escaped dollar signs, YAML schema, and causal factor documentation for diagram creation. Provides comprehensive formatting rules and validation checklists but addresses an obsolete content structure."
 ratings:
   novelty: 0.5

--- a/content/docs/internal/response-style-guide.mdx
+++ b/content/docs/internal/response-style-guide.mdx
@@ -4,14 +4,12 @@ title: "Response Pages Style Guide"
 description: "Style guide for writing intervention and response pages"
 sidebar:
   order: 11
-entityType: internal
 subcategory: style-guides
 quality: 34
 readerImportance: 8.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal style guide specifying structure for response/intervention pages, including required sections (overview, assessment table, mechanism diagrams, limitations), frontmatter format, and Claude workflow templates. Provides concrete formatting requirements and examples but no original methodology for intervention assessment."
 ratings:
   novelty: 2

--- a/content/docs/internal/risk-style-guide.mdx
+++ b/content/docs/internal/risk-style-guide.mdx
@@ -4,14 +4,12 @@ title: "Risk Pages Style Guide"
 description: "Style guide for writing risk analysis pages in the knowledge base"
 sidebar:
   order: 10
-entityType: internal
 subcategory: style-guides
 quality: 53
 readerImportance: 12.5
 researchImportance: 10.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Comprehensive style guide defining standards for risk analysis pages, including required sections (overview, risk assessment table, mechanism diagrams, contributing factors, responses, uncertainties), quality criteria (0-10 scoring on novelty/rigor/actionability/completeness), and Claude workflows for creation/improvement. Prescribes specific formats like Mermaid diagrams for mechanisms and tables for assessments."
 ratings:
   novelty: 4

--- a/content/docs/internal/schema/diagrams.mdx
+++ b/content/docs/internal/schema/diagrams.mdx
@@ -4,13 +4,11 @@ title: "Schema Diagrams"
 description: "Visual documentation of entity types, relationships, data flow, and the full entity-relationship model"
 sidebar:
   order: 2
-entityType: internal
 subcategory: architecture
 readerImportance: 11
 researchImportance: 14
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 ---
 
 import {Mermaid} from '@components/wiki';

--- a/content/docs/internal/schema/entities.mdx
+++ b/content/docs/internal/schema/entities.mdx
@@ -4,13 +4,11 @@ title: "Entity Type Reference"
 description: "Complete field-level reference for every entity type, standalone data type, and their enums"
 sidebar:
   order: 1
-entityType: internal
 subcategory: architecture
 readerImportance: 9
 researchImportance: 13
 lastEdited: "2026-02-17"
 update_frequency: 60
-evergreen: true
 ---
 
 ;

--- a/content/docs/internal/server-communication-investigation.md
+++ b/content/docs/internal/server-communication-investigation.md
@@ -2,7 +2,6 @@
 numericId: E890
 title: "Server Communication Investigation"
 description: "Evaluation of wiki-server client/server architecture — pain points, framework options (Hono RPC, ts-rest, oRPC), and pragmatic improvement plan for type-safe API communication."
-entityType: internal
 subcategory: architecture
 readerImportance: 15
 researchImportance: 20

--- a/content/docs/internal/stub-style-guide.md
+++ b/content/docs/internal/stub-style-guide.md
@@ -4,14 +4,12 @@ title: "Stub Pages Style Guide"
 description: "Guidelines for minimal placeholder pages"
 sidebar:
   order: 13
-entityType: internal
 subcategory: style-guides
 quality: 19
 readerImportance: 14
 researchImportance: 9.5
 lastEdited: "2026-02-17"
 update_frequency: 90
-evergreen: true
 llmSummary: "Internal documentation providing guidelines for creating minimal placeholder pages (stubs) in the knowledge base, including when to use them, required formatting, and when to convert them to full pages. Covers basic content structure and validation procedures."
 ratings:
   novelty: 0.5

--- a/content/docs/internal/update-schedule-dashboard.mdx
+++ b/content/docs/internal/update-schedule-dashboard.mdx
@@ -2,7 +2,6 @@
 numericId: E900
 title: "Update Schedule"
 description: "Pages ranked by update priority based on staleness and importance"
-entityType: internal
 subcategory: dashboards
 contentFormat: dashboard
 lastEdited: "2026-02-25"

--- a/content/docs/internal/wiki-generation-architecture.mdx
+++ b/content/docs/internal/wiki-generation-architecture.mdx
@@ -4,7 +4,6 @@ title: "Wiki Generation Architecture: Multi-Agent Multi-Pass Design"
 description: "Architecture proposal for scalable, high-quality wiki page generation using specialist agents, multi-pass refinement, knowledge graph integration, and dynamic computation"
 sidebar:
   order: 35
-entityType: internal
 subcategory: architecture
 quality: 55
 readerImportance: 75

--- a/content/docs/internal/wiki-server-architecture.mdx
+++ b/content/docs/internal/wiki-server-architecture.mdx
@@ -5,12 +5,10 @@ description: "Analysis of environment isolation in the wiki-server — the ID al
 sidebar:
   order: 5
   label: "Server Environments"
-entityType: internal
 subcategory: architecture
 pageType: documentation
 lastEdited: "2026-02-24"
 update_frequency: 90
-evergreen: true
 ---
 
 This document analyzes how the wiki-server handles (or fails to handle) environment isolation between development, preview, and production. It identifies the core architectural tension — entity ID allocation must be globally shared, but content data should not — and proposes a tiered remediation plan.

--- a/crux/lib/valid-subcategories.ts
+++ b/crux/lib/valid-subcategories.ts
@@ -85,6 +85,12 @@ export const VALID_SUBCATEGORIES = [
   'ea-history',
   'ai-history',
   'applications',
+
+  // internal pages
+  'style-guides',
+  'architecture',
+  'research',
+  'dashboards',
 ] as const;
 
 export type ValidSubcategory = typeof VALID_SUBCATEGORIES[number];


### PR DESCRIPTION
Add style-guides, architecture, research, dashboards to the valid subcategory enum. Remove redundant entityType: internal (sourced from YAML when numericId is set), evergreen: true (schema only allows false), and fix sidebar_label to nested sidebar.label format. These issues were introduced by #1110 and broke the frontmatter-schema and scope-flag tests.