### PR TITLE
fix: camelCase field names in jsonb_to_recordset link sync

### DIFF
--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -101,8 +101,9 @@ linksRoute.post("/sync", async (c) => {
 
       await tx`
         INSERT INTO page_links (source_id, target_id, link_type, relationship, weight)
-        SELECT * FROM jsonb_to_recordset(${JSON.stringify(batch)}::jsonb)
-        AS t(source_id text, target_id text, link_type text, relationship text, weight real)
+        SELECT "sourceId", "targetId", "linkType", relationship, weight
+        FROM jsonb_to_recordset(${JSON.stringify(batch)}::jsonb)
+        AS t("sourceId" text, "targetId" text, "linkType" text, relationship text, weight real)
         ON CONFLICT (source_id, target_id, link_type)
         DO UPDATE SET weight = EXCLUDED.weight, relationship = EXCLUDED.relationship
       `;


### PR DESCRIPTION
## Summary

- Fixes `null value in column "source_id"` error in the page links sync endpoint
- The `jsonb_to_recordset` AS clause used snake_case column names (`source_id`, `target_id`, `link_type`) but the JSON batch from the client uses camelCase keys (`sourceId`, `targetId`, `linkType`). PostgreSQL matches JSON keys to AS clause names, so the mismatch produced NULLs
- Uses quoted camelCase identifiers in the AS clause and SELECT list to match the JSON, mapped to snake_case table columns in the INSERT

## Context

This is a follow-up to PR #1111 (deadlock fix). The deadlock fix switched from Drizzle ORM to raw SQL with `jsonb_to_recordset`, but the field name casing was wrong. The deadlock is fixed but link sync has been silently failing due to this NOT NULL constraint violation.

## Test plan
- [x] All 13 links tests pass
- [x] Gate passes
