### PR TITLE
fix: add View claims link to UnifiedReferences section

### DIFF
--- a/apps/web/src/components/wiki/UnifiedReferences.tsx
+++ b/apps/web/src/components/wiki/UnifiedReferences.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import {
   getResourceById,
   getResourceCredibility,
@@ -326,18 +327,26 @@ export function UnifiedReferences({ pageId, className }: UnifiedReferencesProps)
       className={cn("mt-10 pt-5 border-t border-border", className)}
       aria-label="References"
     >
-      <h2
-        className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2 mt-0 pb-0 border-b-0"
-        id="references"
-      >
-        References
-        <span className="text-xs font-normal ml-2 opacity-60">
-          {totalSources} source{totalSources !== 1 ? "s" : ""}
-          {withResources.length > 0 &&
-            withResources.length < totalSources &&
-            ` \u00b7 ${withResources.length} with metadata`}
-        </span>
-      </h2>
+      <div className="flex items-baseline justify-between mb-2">
+        <h2
+          className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mt-0 pb-0 border-b-0"
+          id="references"
+        >
+          References
+          <span className="text-xs font-normal ml-2 opacity-60">
+            {totalSources} source{totalSources !== 1 ? "s" : ""}
+            {withResources.length > 0 &&
+              withResources.length < totalSources &&
+              ` \u00b7 ${withResources.length} with metadata`}
+          </span>
+        </h2>
+        <Link
+          href={`/claims/entity/${pageId}`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View claims →
+        </Link>
+      </div>
 
       {entries.length > 0 && (
         <div>


### PR DESCRIPTION
## Summary
- Add "View claims →" link to `UnifiedReferences.tsx` heading, matching the link already added to `References.tsx` in PR #1102
- `UnifiedReferences` is used by ~153 well-cited pages (vs ~12 for `References`), so this was a significant gap

## Context
PR #1102 added the claims link to `References.tsx` but missed `UnifiedReferences.tsx`. Testing with Playwright confirmed the link was missing on major pages like Kalshi, Anthropic, etc.

## Test plan
- [x] TypeScript passes
- [ ] Verify link appears on pages using UnifiedReferences (e.g., /wiki/E67, /wiki/E1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
