### PR TITLE
feat(claims): add public Resources browse page and sources column

### DIFF
--- a/apps/web/src/app/claims/components/claims-nav.ts
+++ b/apps/web/src/app/claims/components/claims-nav.ts
@@ -26,6 +26,7 @@ export async function getClaimsNav(): Promise<NavSection[]> {
         { label: "Browse Claims", href: "/claims/explore" },
         { label: "Relationships", href: "/claims/relationships" },
         { label: "Network", href: "/claims/network" },
+        { label: "Resources", href: "/claims/resources" },
       ],
     },
   ];

--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -250,6 +250,31 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
     size: 80,
   },
   {
+    id: "sources",
+    accessorFn: (row) => row.sources?.length ?? 0,
+    header: ({ column }) => (
+      <SortableHeader column={column}>Src</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const count = row.original.sources?.length ?? 0;
+      if (count === 0) return <span className="text-muted-foreground/40 text-xs">—</span>;
+      return (
+        <span
+          className={`inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded text-[10px] font-medium ${
+            count >= 3
+              ? "bg-emerald-100 text-emerald-700"
+              : count >= 1
+                ? "bg-blue-100 text-blue-700"
+                : ""
+          }`}
+        >
+          {count}
+        </span>
+      );
+    },
+    size: 45,
+  },
+  {
     accessorKey: "claimCategory",
     header: ({ column }) => (
       <SortableHeader column={column}>Category</SortableHeader>

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -51,6 +51,20 @@ export default async function EntityClaimsPage({ params }: PageProps) {
     .map((id) => getResourceById(id))
     .filter((r): r is NonNullable<typeof r> => r !== undefined);
 
+  // Count how many claims cite each resource (by resourceId or URL match)
+  const resourceCitationCounts = new Map<string, number>();
+  for (const claim of claims) {
+    if (!claim.sources) continue;
+    for (const source of claim.sources) {
+      if (source.resourceId) {
+        resourceCitationCounts.set(
+          source.resourceId,
+          (resourceCitationCounts.get(source.resourceId) ?? 0) + 1
+        );
+      }
+    }
+  }
+
   // Compute stats
   const verified = claims.filter((c) => c.confidence === "verified").length;
   const multiEntity = claims.filter(
@@ -144,6 +158,7 @@ export default async function EntityClaimsPage({ params }: PageProps) {
             <div className="mt-3 space-y-2">
               {resources.map((resource) => {
                 const credibility = getResourceCredibility(resource);
+                const citedInCount = resourceCitationCounts.get(resource.id) ?? 0;
                 return (
                   <div
                     key={resource.id}
@@ -153,15 +168,18 @@ export default async function EntityClaimsPage({ params }: PageProps) {
                       {getResourceTypeIcon(resource.type)}
                     </span>
                     <div className="flex-1 min-w-0">
-                      <a
-                        href={resource.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <Link
+                        href={`/source/${resource.id}`}
                         className="font-medium text-blue-600 hover:underline"
                       >
                         {resource.title}
-                      </a>
+                      </Link>
                     </div>
+                    {citedInCount > 0 && (
+                      <span className="text-[10px] text-muted-foreground shrink-0">
+                        {citedInCount} {citedInCount === 1 ? "claim" : "claims"}
+                      </span>
+                    )}
                     <span className="text-[10px] text-muted-foreground capitalize shrink-0">
                       {resource.type}
                     </span>

--- a/apps/web/src/app/claims/resources/page.tsx
+++ b/apps/web/src/app/claims/resources/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  getAllResources,
+  getPagesForResource,
+  getResourceCredibility,
+  getResourcePublication,
+} from "@data";
+import { getResourceTypeIcon } from "@/components/wiki/resource-utils";
+import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
+import { StatCard } from "../components/stat-card";
+import { DistributionBar } from "../components/distribution-bar";
+import { ResourcesTable } from "./resources-table";
+
+export const metadata: Metadata = {
+  title: "Resources — Claims Explorer",
+  description:
+    "Browse external resources (papers, articles, reports) referenced across the wiki.",
+};
+
+export interface PublicResourceRow {
+  id: string;
+  title: string;
+  url: string | undefined;
+  type: string;
+  publishedDate: string | null;
+  publicationName: string | null;
+  credibility: number | null;
+  citingPageCount: number;
+  hasSummary: boolean;
+}
+
+export default function ResourcesPage() {
+  const resources = getAllResources();
+
+  const rows: PublicResourceRow[] = resources
+    .map((r) => {
+      const publication = getResourcePublication(r);
+      const credibility = getResourceCredibility(r);
+      const citingPages = getPagesForResource(r.id);
+
+      return {
+        id: r.id,
+        title: r.title,
+        url: r.url,
+        type: r.type,
+        publishedDate: r.published_date ?? null,
+        publicationName: publication?.name ?? null,
+        credibility: credibility ?? null,
+        citingPageCount: citingPages.length,
+        hasSummary: !!r.summary,
+      };
+    })
+    .sort((a, b) => b.citingPageCount - a.citingPageCount);
+
+  // Stats
+  const cited = rows.filter((r) => r.citingPageCount > 0).length;
+  const withSummary = rows.filter((r) => r.hasSummary).length;
+
+  // Type distribution
+  const byType: Record<string, number> = {};
+  for (const r of rows) {
+    byType[r.type] = (byType[r.type] ?? 0) + 1;
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold mb-2">Resources</h1>
+        <p className="text-muted-foreground text-sm">
+          {resources.length.toLocaleString()} external resources (papers,
+          articles, reports) referenced across wiki pages.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+        <StatCard label="Total Resources" value={resources.length} />
+        <StatCard label="Cited by Pages" value={cited} />
+        <StatCard label="With Summary" value={withSummary} />
+        <StatCard
+          label="Resource Types"
+          value={Object.keys(byType).length}
+        />
+      </div>
+
+      {Object.keys(byType).length > 0 && (
+        <div className="rounded-lg border p-4 mb-6">
+          <h3 className="text-sm font-semibold mb-3">Type Distribution</h3>
+          <DistributionBar data={byType} total={resources.length} />
+        </div>
+      )}
+
+      <ResourcesTable resources={rows} />
+    </div>
+  );
+}

--- a/apps/web/src/app/claims/resources/resources-table.tsx
+++ b/apps/web/src/app/claims/resources/resources-table.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { Fragment, useState, useMemo } from "react";
+import Link from "next/link";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
+  getFilteredRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
+import { getResourceTypeIcon } from "@/components/wiki/resource-utils";
+import type { PublicResourceRow } from "./page";
+
+const TYPE_LABELS: Record<string, string> = {
+  paper: "Paper",
+  book: "Book",
+  blog: "Blog post",
+  report: "Report",
+  talk: "Talk",
+  podcast: "Podcast",
+  government: "Government",
+  reference: "Reference",
+  web: "Web",
+};
+
+const columns: ColumnDef<PublicResourceRow>[] = [
+  {
+    accessorKey: "title",
+    header: "Resource",
+    cell: ({ row }) => {
+      const r = row.original;
+      return (
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm leading-none shrink-0">
+            {getResourceTypeIcon(r.type)}
+          </span>
+          <div className="min-w-0">
+            <Link
+              href={`/source/${r.id}`}
+              className="text-xs font-medium text-blue-600 hover:underline leading-tight"
+            >
+              {r.title.length > 100 ? r.title.slice(0, 100) + "..." : r.title}
+            </Link>
+            {r.publicationName && (
+              <div className="text-[10px] text-muted-foreground">
+                {r.publicationName}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    },
+    size: 400,
+    filterFn: (row, _, filterValue) => {
+      const search = (filterValue as string).toLowerCase();
+      const r = row.original;
+      return (
+        r.title.toLowerCase().includes(search) ||
+        r.id.toLowerCase().includes(search) ||
+        (r.publicationName?.toLowerCase().includes(search) ?? false)
+      );
+    },
+  },
+  {
+    accessorKey: "type",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-[10px] text-muted-foreground capitalize">
+        {TYPE_LABELS[row.original.type] ?? row.original.type}
+      </span>
+    ),
+    size: 80,
+  },
+  {
+    accessorKey: "citingPageCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Pages</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const count = row.original.citingPageCount;
+      if (count === 0) return <span className="text-muted-foreground/40 text-xs">—</span>;
+      return (
+        <span className="text-xs tabular-nums font-medium">{count}</span>
+      );
+    },
+    size: 60,
+  },
+  {
+    accessorKey: "credibility",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Credibility</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const cred = row.original.credibility;
+      if (cred == null) return <span className="text-muted-foreground/40 text-xs">—</span>;
+      return <CredibilityBadge level={cred} />;
+    },
+    size: 80,
+  },
+  {
+    accessorKey: "publishedDate",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Published</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const date = row.original.publishedDate;
+      if (!date) return <span className="text-muted-foreground/40 text-xs">—</span>;
+      return <span className="text-xs text-muted-foreground tabular-nums">{date.slice(0, 10)}</span>;
+    },
+    size: 90,
+  },
+];
+
+export function ResourcesTable({
+  resources,
+}: {
+  resources: PublicResourceRow[];
+}) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "citingPageCount", desc: true },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+
+  const filteredResources = useMemo(() => {
+    if (typeFilter === "all") return resources;
+    return resources.filter((r) => r.type === typeFilter);
+  }, [resources, typeFilter]);
+
+  const types = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const r of resources) {
+      counts[r.type] = (counts[r.type] ?? 0) + 1;
+    }
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  }, [resources]);
+
+  const table = useReactTable({
+    data: filteredResources,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: (row, _, filterValue) => {
+      const search = (filterValue as string).toLowerCase();
+      const r = row.original;
+      return (
+        r.title.toLowerCase().includes(search) ||
+        r.id.toLowerCase().includes(search) ||
+        (r.publicationName?.toLowerCase().includes(search) ?? false)
+      );
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    initialState: { pagination: { pageSize: 30 } },
+  });
+
+  return (
+    <div>
+      {/* Search + filter bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <input
+          type="text"
+          placeholder="Search resources..."
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="flex-1 max-w-xs px-3 py-1.5 text-sm border rounded-md bg-background"
+        />
+        <div className="flex gap-1.5 flex-wrap">
+          <button
+            type="button"
+            onClick={() => setTypeFilter("all")}
+            className={`px-2 py-1 text-[10px] rounded cursor-pointer transition-colors ${
+              typeFilter === "all"
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            }`}
+          >
+            All ({resources.length})
+          </button>
+          {types.map(([type, count]) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => setTypeFilter(type === typeFilter ? "all" : type)}
+              className={`px-2 py-1 text-[10px] rounded cursor-pointer transition-colors ${
+                typeFilter === type
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              }`}
+            >
+              {TYPE_LABELS[type] ?? type} ({count})
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    style={{ width: header.getSize() }}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-center text-muted-foreground py-8"
+                >
+                  No resources found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {table.getPageCount() > 1 && (
+        <div className="flex items-center justify-between px-2 py-3 text-sm">
+          <span className="text-muted-foreground text-xs">
+            {table.getFilteredRowModel().rows.length} resources
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 cursor-pointer disabled:cursor-default"
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 cursor-pointer disabled:cursor-default"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="text-xs text-muted-foreground px-2 tabular-nums">
+              {table.getState().pagination.pageIndex + 1} /{" "}
+              {table.getPageCount()}
+            </span>
+            <button
+              type="button"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 cursor-pointer disabled:cursor-default"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+              disabled={!table.getCanNextPage()}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 cursor-pointer disabled:cursor-default"
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add public `/claims/resources` page with searchable, filterable resource table
- Add "Src" (sources) column to claims table showing source count per claim, color-coded by count
- Enhance entity claims page: resources now link to `/source/[id]` pages and show per-resource claim citation count
- Add "Resources" nav link to claims sidebar

## Changes
1. **New `/claims/resources` page** — Browse all wiki resources with type filters (Paper, Blog, Report, etc.), full-text search, and sorting by citing pages, credibility, or publication date
2. **Sources column in ClaimsTable** — Shows color-coded badge (blue for 1-2 sources, green for 3+, dash for 0)
3. **Entity page resources** — Resources now link to `/source/[id]` detail pages instead of external URLs, and show "N claims" badge indicating how many claims on that entity cite the resource
4. **Navigation** — "Resources" link added to claims sidebar for easy discoverability

## Test plan
- [ ] Visit `/claims/resources` — verify table loads with search and type filters
- [ ] Visit `/claims/explore` — verify new "Src" column appears with correct counts
- [ ] Visit `/claims/entity/kalshi` — verify resources section shows citation counts and links to `/source/`
- [ ] Verify sidebar shows "Resources" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
