### PR TITLE
fix: remove duplicate H1 titles from 15 MDX pages

### DIFF
--- a/content/docs/internal/about-this-wiki.mdx
+++ b/content/docs/internal/about-this-wiki.mdx
@@ -21,8 +21,6 @@ ratings:
 ---
 import {EntityLink} from '@components/wiki';
 
-# About the Longterm Wiki
-
 The Longterm Wiki is a strategic intelligence platform for AI safety prioritization. It serves as a **decision-support tool** for funders, researchers, and policymakers asking: *"Where should the next marginal dollar or researcher-hour go?"*
 
 This page documents the technical side—how the wiki is built, how content is organized, and how to contribute.

--- a/content/docs/internal/anthropic-pages-refactor-notes.mdx
+++ b/content/docs/internal/anthropic-pages-refactor-notes.mdx
@@ -11,8 +11,6 @@ lastEdited: "2026-02-04"
 evergreen: false
 ---
 
-# Anthropic Pages Refactor Notes
-
 This document captures ideas for future improvements to the Anthropic page cluster.
 
 ## Current Structure (as of Feb 2026)

--- a/content/docs/internal/gap-analysis-2026-02.mdx
+++ b/content/docs/internal/gap-analysis-2026-02.mdx
@@ -11,8 +11,6 @@ sidebar:
   label: "Gap Analysis (Feb 2026)"
 ---
 
-# Wiki Gap Analysis — February 2026
-
 Systematic review of coverage gaps across the wiki's 639 pages, combining `crux gaps list` output (existing pages needing insight extraction) with manual topic coverage analysis to identify both under-developed existing pages and entirely missing topics.
 
 ## Executive Summary

--- a/content/docs/internal/importance-ranking.mdx
+++ b/content/docs/internal/importance-ranking.mdx
@@ -13,8 +13,6 @@ lastEdited: "2026-02-17"
 update_frequency: 90
 ---
 
-# Importance Ranking System
-
 Page importance scores (0-100) are derived from ordered rankings — lists of all pages sorted by importance. The ranking is the source of truth; numeric scores are computed from position.
 
 ## Two Dimensions

--- a/content/docs/internal/longtermwiki-value-proposition.mdx
+++ b/content/docs/internal/longtermwiki-value-proposition.mdx
@@ -17,8 +17,6 @@ ratings:
 ---
 import {Mermaid, EntityLink} from '@components/wiki';
 
-# LongtermWiki Value Proposition
-
 **Status:** Working document, not polished
 **Purpose:** Explore ambitious pathways through which LongtermWiki could create substantial value
 **Last Updated:** 2026-02-04

--- a/content/docs/internal/page-types.mdx
+++ b/content/docs/internal/page-types.mdx
@@ -19,8 +19,6 @@ ratings:
   concreteness: 9
   actionability: 8
 ---
-# Page Type System
-
 LongtermWiki uses a two-level classification system to categorize content:
 
 1. **Page Type** (`pageType`): Controls validation behavior and quality scoring eligibility

--- a/content/docs/internal/rating-system.mdx
+++ b/content/docs/internal/rating-system.mdx
@@ -19,8 +19,6 @@ ratings:
 ---
 import {EntityLink} from '@components/wiki';
 
-# Rating System
-
 LongtermWiki uses a multi-dimensional rating system combining LLM-graded subscores with automated metrics to produce a derived quality score (0-100).
 
 ## Quick Reference

--- a/content/docs/internal/reports/cross-link-automation-proposal.mdx
+++ b/content/docs/internal/reports/cross-link-automation-proposal.mdx
@@ -17,8 +17,6 @@ ratings:
   concreteness: 8
   actionability: 7.5
 ---
-# Cross-Link Automation Proposal
-
 **Status:** Proposal
 **Author:** Claude Code
 **Date:** February 2026

--- a/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
+++ b/content/docs/internal/reports/website-consistency-audit-2026-02.mdx
@@ -7,8 +7,6 @@ lastEdited: "2026-02-20"
 evergreen: false
 ---
 
-# Website Consistency Audit — February 2026
-
 This report documents a systematic audit of the wiki's consistency, quality distribution, navigation structure, and cross-linking completeness. It covers **672 non-internal MDX pages** and identifies specific problems with prioritized recommendations.
 
 ---

--- a/content/docs/internal/response-style-guide.mdx
+++ b/content/docs/internal/response-style-guide.mdx
@@ -19,8 +19,6 @@ ratings:
 ---
 import {EntityLink} from '@components/wiki';
 
-# Response Pages Style Guide
-
 Response pages describe interventions, policies, and technical approaches that address AI risks. They explain how something works and assess its effectiveness.
 
 **Prerequisite**: All response pages must follow the <EntityLink id="common-writing-principles">Common Writing Principles</EntityLink> — epistemic honesty, language neutrality, and analytical tone. The **objectivity** rating dimension measures this.

--- a/content/docs/internal/risk-style-guide.mdx
+++ b/content/docs/internal/risk-style-guide.mdx
@@ -19,8 +19,6 @@ ratings:
 ---
 import {EntityLink} from '@components/wiki';
 
-# Risk Pages Style Guide
-
 This guide defines standards for risk analysis pages in the LongtermWiki knowledge base. Risk pages analyze potential negative outcomes from AI development.
 
 **Prerequisite**: All risk pages must follow the <EntityLink id="common-writing-principles">Common Writing Principles</EntityLink> — epistemic honesty, language neutrality, and analytical tone. The **objectivity** rating dimension measures this.

--- a/content/docs/knowledge-base/organizations/giving-what-we-can.mdx
+++ b/content/docs/knowledge-base/organizations/giving-what-we-can.mdx
@@ -24,8 +24,6 @@ update_frequency: 180
 ---
 import { EntityLink } from '@components/wiki';
 
-# Giving What We Can
-
 | | |
 |---|---|
 | **Founded** | November 2009 |

--- a/content/docs/project/index.mdx
+++ b/content/docs/project/index.mdx
@@ -8,8 +8,6 @@ entityType: internal
 ---
 import { EntityLink } from '@components/wiki';
 
-# LongtermWiki Project
-
 Planning and strategy documents for LongtermWiki — a strategic intelligence platform for AI safety prioritization.
 
 ## Documents

--- a/content/docs/project/strategy-brainstorm.mdx
+++ b/content/docs/project/strategy-brainstorm.mdx
@@ -18,8 +18,6 @@ ratings:
 ---
 import { Mermaid } from '@components/wiki';
 
-# LongtermWiki Strategy Brainstorm
-
 **Status:** Working document, not polished
 **Purpose:** Think through what could go wrong and what success looks like
 

--- a/content/docs/project/vision.mdx
+++ b/content/docs/project/vision.mdx
@@ -19,8 +19,6 @@ update_frequency: 180
 ---
 import { Mermaid } from '@components/wiki';
 
-# LongtermWiki Vision Document
-
 ## Vision Document (2-Person-Year Scope)
 
 **Version:** 0.1 Draft


### PR DESCRIPTION
## Summary

- Fixed 15 MDX pages where the page title appeared twice: once from the frontmatter `title` field (rendered by the page component as `<h1>`) and again from a redundant `# Title` heading in the MDX body
- Affected pages were mostly internal docs, project pages, and one knowledge-base page (giving-what-we-can)
- The fix removes the body H1 heading from each file, matching the convention used by ~624 other pages

## Root Cause

The wiki page component (`apps/web/src/app/wiki/[id]/page.tsx`, line 333) renders:
```tsx
{page.frontmatter.title && <h1>{page.frontmatter.title}</h1>}
```
Pages that also had a `# Title` in their MDX body got two `<h1>` elements rendered.

## Test plan
- [x] Ran detection script before fix: 15 pages with duplicate titles
- [x] Ran detection script after fix: 0 pages with duplicate titles
- [x] Gate passed: 288 tests green, all unified validation checks passed
- [x] Verified specific pages mentioned in the issue (E885, E883) are fixed

Closes #1118
