### PR TITLE
fix(explore): show internal pages in /wiki search

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -1541,6 +1541,10 @@ async function main() {
     const entity = entityMap.get(page.id);
     if (entity?.type) {
       page.entityType = resolveEntityType(entity.type);
+    } else if (page.category === 'internal') {
+      // Internal pages don't have YAML entities, but still need entityType
+      // so the explore page can filter them correctly.
+      page.entityType = 'internal';
     }
 
     if (risk.level === 'high') riskHigh++;

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -1810,6 +1810,7 @@ const CATEGORY_TO_TYPE: Record<string, string> = {
   forecasting: "model",
   "foundation-models": "capability",
   incidents: "historical",
+  internal: "internal",
   other: "concept",
 };
 

--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -51,6 +51,7 @@ const CATEGORY_TO_TYPE: Record<string, string> = {
   forecasting: "model",
   "foundation-models": "capability",
   incidents: "historical",
+  internal: "internal",
   other: "concept",
 };
 
@@ -108,6 +109,7 @@ const DERIVED_TYPE_EXPR = `
     WHEN wp.content_format = 'table' THEN 'table'
     WHEN wp.content_format = 'diagram' THEN 'diagram'
     WHEN wp.entity_type IS NOT NULL THEN wp.entity_type
+    WHEN wp.category = 'internal' THEN 'internal'
     ELSE 'concept'
   END
 `;


### PR DESCRIPTION
## Summary

Completes Claims Phase 3 — the resource-centric ingestion pipeline for extracting claims from external URLs.

- **`from-resource <url>` command**: Fetches URL content, routes to relevant wiki entities (via `--entity` flag, resource YAML `cited_by`, or LLM-based routing), extracts claims, deduplicates against existing claims, and inserts into the database. Supports `--batch <file>` for bulk processing.
- **Deduplication utilities**: Jaccard word-set similarity (`isClaimDuplicate`) with normalization, substring containment, and configurable threshold (default 0.75). Integrated into both `ingest-resource` and `from-resource` pipelines.
- **Phase 2 field enrichment**: Resource-ingested claims now include `claimMode=attributed`, `attributedTo`, `asOf`, `measure`, numeric value fields, and inline `sources[]` array.
- **Claims Ingestion dashboard**: `/internal/claims-ingestion` page with stat cards, distribution bars (resource-sourced vs page-extracted, endorsed vs attributed), and per-resource sortable table.
- **Auto-resource creation**: Unknown URLs get automatic resource YAML entries (use `--no-auto-resource` to disable).

## Test plan

- [x] Unit tests for dedup utilities (normalization, Jaccard similarity, batch filtering) — 13 tests passing
- [x] `pnpm crux claims from-resource <url> --dry-run` — fetches, routes, extracts, shows preview
- [x] `ingest-resource` deduplication integration — second run deduplicates
- [x] Dashboard renders at `/internal/claims-ingestion`
- [x] Gate check passes (pre-existing `hono/client` failures only)
- [x] Crux TypeScript check passes (2 errors = baseline)

Closes #1043
