### PR TITLE
fix: resolve 4 frontend audit bugs (Tailwind, NaN, import, empty section)

### DIFF
--- a/apps/web/src/app/claims/page.tsx
+++ b/apps/web/src/app/claims/page.tsx
@@ -163,40 +163,42 @@ export default async function ClaimsOverviewPage() {
       )}
 
       {/* Top entities */}
-      <div className="rounded-lg border p-4 mb-6">
-        <h3 className="text-sm font-semibold mb-3">Top Entities by Claims</h3>
-        <div className="space-y-2">
-          {entityRows.slice(0, 10).map((row) => (
-              <div key={row.entityId} className="flex items-center gap-3">
-                <Link
-                  href={`/claims/entity/${row.entityId}`}
-                  className="text-sm text-blue-600 hover:underline w-40 truncate"
-                >
-                  {entityNames[row.entityId] ?? row.entityId}
-                </Link>
-                <div className="flex-1 flex items-center gap-2">
-                  <div className="flex-1 h-4 bg-gray-100 rounded overflow-hidden">
-                    <div
-                      className="h-full bg-blue-400 rounded-l"
-                      style={{
-                        width: `${(row.total / entityRows[0].total) * 100}%`,
-                      }}
-                    />
+      {entityRows.length > 0 && (
+        <div className="rounded-lg border p-4 mb-6">
+          <h3 className="text-sm font-semibold mb-3">Top Entities by Claims</h3>
+          <div className="space-y-2">
+            {entityRows.slice(0, 10).map((row) => (
+                <div key={row.entityId} className="flex items-center gap-3">
+                  <Link
+                    href={`/claims/entity/${row.entityId}`}
+                    className="text-sm text-blue-600 hover:underline w-40 truncate"
+                  >
+                    {entityNames[row.entityId] ?? row.entityId}
+                  </Link>
+                  <div className="flex-1 flex items-center gap-2">
+                    <div className="flex-1 h-4 bg-gray-100 rounded overflow-hidden">
+                      <div
+                        className="h-full bg-blue-400 rounded-l"
+                        style={{
+                          width: `${(row.total / entityRows[0].total) * 100}%`,
+                        }}
+                      />
+                    </div>
+                    <span className="text-xs tabular-nums w-8 text-right">
+                      {row.total}
+                    </span>
                   </div>
-                  <span className="text-xs tabular-nums w-8 text-right">
-                    {row.total}
-                  </span>
+                  {row.multiEntity > 0 && (
+                    <span className="text-[10px] text-teal-600 whitespace-nowrap">
+                      {row.multiEntity} linked
+                    </span>
+                  )}
                 </div>
-                {row.multiEntity > 0 && (
-                  <span className="text-[10px] text-teal-600 whitespace-nowrap">
-                    {row.multiEntity} linked
-                  </span>
-                )}
-              </div>
-            )
-          )}
+              )
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Top relationships */}
       {relationshipRows.length > 0 && (

--- a/apps/web/src/app/claims/resources/resources-table.tsx
+++ b/apps/web/src/app/claims/resources/resources-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import {

--- a/apps/web/src/app/internal/resources/page.tsx
+++ b/apps/web/src/app/internal/resources/page.tsx
@@ -79,6 +79,15 @@ export default function ResourcesPage() {
   );
 }
 
+const colorClasses: Record<string, string> = {
+  emerald: "text-emerald-600",
+  amber: "text-amber-600",
+  red: "text-red-600",
+  blue: "text-blue-600",
+  purple: "text-purple-600",
+  teal: "text-teal-600",
+};
+
 function StatCard({
   label,
   value,
@@ -93,7 +102,7 @@ function StatCard({
   const pct = total > 0 ? Math.round((value / total) * 100) : 0;
   return (
     <div className="rounded-lg border border-border p-3 text-center">
-      <div className={`text-2xl font-bold tabular-nums text-${color}-600`}>
+      <div className={`text-2xl font-bold tabular-nums ${colorClasses[color] ?? ""}`}>
         {value.toLocaleString()}
       </div>
       <div className="text-[11px] text-muted-foreground mt-0.5">{label}</div>

--- a/apps/web/src/app/source/[id]/page.tsx
+++ b/apps/web/src/app/source/[id]/page.tsx
@@ -479,7 +479,7 @@ export default async function SourcePage({ params }: PageProps) {
               {contentData.fullTextPreview.slice(0, 3000)}
               {contentData.fullTextPreview.length > 3000 && (
                 <span className="text-muted-foreground/50">
-                  {"\n\n"}... (truncated, {Math.round(contentData.contentLength! / 1024)} KB total)
+                  {"\n\n"}... (truncated{contentData.contentLength != null ? `, ${Math.round(contentData.contentLength / 1024)} KB total` : ""})
                 </span>
               )}
             </pre>


### PR DESCRIPTION
## Summary
- **Critical**: Fix dynamic Tailwind class names in `internal/resources/page.tsx` — `text-${color}-600` can't be detected by Tailwind v4's static analysis. Replaced with a mapping object of complete class strings.
- Fix potential `NaN` display on source page when `contentLength` is null
- Remove unused `Fragment` import from resources table
- Hide empty "Top Entities by Claims" section when no entity rows exist

## Test plan
- [x] `/internal/resources` stat cards show correct colors (emerald, amber, red, etc.)
- [x] `/source/<id>` with long content doesn't show "NaN KB total"
- [x] `/claims` page with no claims doesn't show empty bordered box
- [x] No lint warnings from unused imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)