### PR TITLE
fix(claims): add missing sources, use canonical IDs, fix date hydration

### DIFF
--- a/apps/web/src/app/claims/claim/[id]/page.tsx
+++ b/apps/web/src/app/claims/claim/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
-import { getEntityById } from "@data";
+import { getEntityById, getEntityHref } from "@data";
 import type { ClaimRow } from "@wiki-server/api-types";
 import { buildEntityNameMap } from "../../components/claims-data";
 import { CategoryBadge } from "../../components/category-badge";
@@ -29,9 +29,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ClaimDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const claim = await fetchFromWikiServer<ClaimRow>(`/api/claims/${id}`, {
-    revalidate: 300,
-  });
+  const claim = await fetchFromWikiServer<ClaimRow>(
+    `/api/claims/${id}?includeSources=true`,
+    { revalidate: 300 }
+  );
 
   if (!claim) notFound();
 
@@ -92,7 +93,7 @@ export default async function ClaimDetailPage({ params }: PageProps) {
               Source Quote
             </span>
             <Link
-              href={`/wiki/${claim.entityId}`}
+              href={getEntityHref(claim.entityId)}
               className="text-xs text-amber-600 hover:underline"
             >
               From wiki page &rarr;
@@ -243,7 +244,7 @@ export default async function ClaimDetailPage({ params }: PageProps) {
               return (
                 <Link
                   key={num}
-                  href={`/wiki/${claim.entityId}#fn-${num}`}
+                  href={`${getEntityHref(claim.entityId)}#fn-${num}`}
                   className="font-mono text-xs px-1.5 py-0.5 rounded bg-gray-100 text-blue-600 hover:bg-gray-200 hover:underline"
                 >
                   [{num}]
@@ -260,11 +261,11 @@ export default async function ClaimDetailPage({ params }: PageProps) {
       {/* Timestamps */}
       <div className="border-t pt-4 text-xs text-muted-foreground">
         <span>
-          Created: {claim.createdAt ? new Date(claim.createdAt).toLocaleString() : "-"}
+          Created: {claim.createdAt ? new Date(claim.createdAt).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "-"}
         </span>
         {claim.updatedAt && (
           <span className="ml-4">
-            Updated: {new Date(claim.updatedAt).toLocaleString()}
+            Updated: {new Date(claim.updatedAt).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
           </span>
         )}
       </div>
@@ -272,13 +273,13 @@ export default async function ClaimDetailPage({ params }: PageProps) {
       {/* Actions */}
       <div className="mt-4 flex gap-3">
         <Link
-          href={`/wiki/${claim.entityId}`}
+          href={getEntityHref(claim.entityId)}
           className="text-xs text-blue-600 hover:underline"
         >
           View wiki page &rarr;
         </Link>
         <Link
-          href={`/wiki/${claim.entityId}/data`}
+          href={`${getEntityHref(claim.entityId)}/data`}
           className="text-xs text-muted-foreground hover:underline"
         >
           View data page

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import {
   getEntityById,
+  getEntityHref,
   getResourcesForPage,
   getResourceById,
   getResourceCredibility,
@@ -90,13 +91,13 @@ export default async function EntityClaimsPage({ params }: PageProps) {
         <div className="flex items-center gap-3 mb-2">
           <h1 className="text-2xl font-bold">{displayName}</h1>
           <Link
-            href={`/wiki/${entityId}`}
+            href={getEntityHref(entityId)}
             className="text-xs text-blue-600 hover:underline"
           >
             View wiki page &rarr;
           </Link>
           <Link
-            href={`/wiki/${entityId}/data`}
+            href={`${getEntityHref(entityId)}/data`}
             className="text-xs text-muted-foreground hover:underline"
           >
             Data page


### PR DESCRIPTION
## Summary
- **Major**: Add `?includeSources=true` to claim detail page fetch — sources section was always empty
- **Major**: Replace slug-based wiki links with `getEntityHref()` canonical IDs — eliminates 302 redirects on every click from claims pages
- Fix `toLocaleString()` hydration mismatches — use explicit `en-US` locale for deterministic server/client output

## Test plan
- [x] `/claims/claim/<id>` Sources section now shows source data
- [x] "View wiki page" links from claim pages go directly to `/wiki/E<id>` without redirect
- [x] Date formatting is consistent between server and client renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)