### PR TITLE
fix: data page fallbacks, entity badge URLs, and footnote anchor alignment

### DIFF
--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -14,6 +14,7 @@ import {
   getFootnoteIndex,
   getResourceById,
   getResourceCredibility,
+  getEntityHref,
 } from "@/data";
 import type { FootnoteIndexEntry } from "@/data";
 import { fetchFromWikiServer } from "@lib/wiki-server";
@@ -114,7 +115,7 @@ function RelatedEntityBadges({ entities }: { entities: string[] | null }) {
       {entities.map(eid => (
         <Link
           key={eid}
-          href={`/wiki/${eid}`}
+          href={getEntityHref(eid)}
           className="inline-block px-1 py-0.5 rounded text-[10px] bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-900"
           title={`Related entity: ${eid}`}
         >
@@ -172,14 +173,14 @@ function CredDots({ level }: { level: number }) {
 type RefEntry = { title: string | null; url: string | null; resourceId?: string; domain?: string };
 type SourceEntry = RefEntry & { footnoteNum: number; credibility?: number; claimCount: number };
 
-/** Get the section name for a claim, preferring the new field over legacy */
+/** Get the section name for a claim */
 function getClaimSection(claim: ClaimRow): string {
-  return claim.section ?? claim.value ?? "Unknown";
+  return claim.section ?? "Unknown";
 }
 
-/** Get footnote ref string, preferring new field over legacy */
+/** Get footnote ref string for a claim */
 function getClaimFootnoteRefs(claim: ClaimRow): string | null {
-  return claim.footnoteRefs ?? claim.unit ?? null;
+  return claim.footnoteRefs ?? null;
 }
 
 /** Build shared data structures from claims + footnote index */

--- a/apps/web/src/components/wiki/References.tsx
+++ b/apps/web/src/components/wiki/References.tsx
@@ -6,6 +6,7 @@ import {
   getResourcePublication,
   getPageCitationHealth,
   getResourcesForPage,
+  getFootnoteIndex,
 } from "@data";
 import type { Resource } from "@data";
 import { CredibilityBadge } from "./CredibilityBadge";
@@ -42,12 +43,35 @@ interface ResolvedRef {
   credibility: number | undefined;
   publicationName: string | undefined;
   peerReviewed: boolean;
+  /** Actual footnote numbers from the page that reference this resource */
+  footnoteNumbers: number[];
 }
 
-function resolveRefs(ids: string[]): {
+function resolveRefs(ids: string[], pageId?: string): {
   refs: ResolvedRef[];
   missing: string[];
 } {
+  // Build a map from resource ID → footnote numbers using the footnote index
+  const resourceFootnotes = new Map<string, number[]>();
+  if (pageId) {
+    const fnIndex = getFootnoteIndex(pageId);
+    if (fnIndex) {
+      for (const source of fnIndex.sources) {
+        if (source.resourceId) {
+          resourceFootnotes.set(source.resourceId, source.footnoteNumbers);
+        }
+      }
+      // Also check individual footnotes for resourceId matches not in sources
+      for (const [numStr, entry] of Object.entries(fnIndex.footnotes)) {
+        if (entry.resourceId && !resourceFootnotes.has(entry.resourceId)) {
+          const existing = resourceFootnotes.get(entry.resourceId) ?? [];
+          existing.push(parseInt(numStr, 10));
+          resourceFootnotes.set(entry.resourceId, existing);
+        }
+      }
+    }
+  }
+
   const refs: ResolvedRef[] = [];
   const missing: string[] = [];
   const seen = new Set<string>();
@@ -69,6 +93,7 @@ function resolveRefs(ids: string[]): {
       credibility: getResourceCredibility(resource),
       publicationName: publication?.name,
       peerReviewed: publication?.peer_reviewed ?? false,
+      footnoteNumbers: resourceFootnotes.get(id) ?? [],
     });
   }
 
@@ -149,14 +174,30 @@ function ReferenceEntry({ entry }: { entry: ResolvedRef }) {
     </div>
   );
 
+  // Build anchor elements for actual footnote numbers (for links from claim pages)
+  const { footnoteNumbers } = entry;
+  const fnAnchors = footnoteNumbers.length > 0
+    ? footnoteNumbers.map((n) => (
+        <React.Fragment key={`fn-anchor-${n}`}>
+          <span id={`user-content-fn-${n}`} className="scroll-mt-4" />
+          <span id={`fn-${n}`} />
+        </React.Fragment>
+      ))
+    : (
+      // Fallback: use sequential index when no footnote numbers are available
+      <React.Fragment>
+        <span id={`user-content-fn-${index}`} className="scroll-mt-4" />
+        <span id={`fn-${index}`} />
+      </React.Fragment>
+    );
+
   if (!hasExpandableContent) {
     return (
       <div
         id={`ref-${index}`}
         className="py-1 border-b border-border last:border-b-0"
       >
-        <span id={`user-content-fn-${index}`} className="scroll-mt-4" />
-        <span id={`fn-${index}`} />
+        {fnAnchors}
         <div className="-mx-1.5 px-1.5 py-0.5">
           {titleRow}
         </div>
@@ -169,8 +210,7 @@ function ReferenceEntry({ entry }: { entry: ResolvedRef }) {
       id={`ref-${index}`}
       className="py-1 border-b border-border last:border-b-0"
     >
-      <span id={`user-content-fn-${index}`} className="scroll-mt-4" />
-      <span id={`fn-${index}`} />
+      {fnAnchors}
       <details className="ref-details group">
         <summary className="ref-summary cursor-pointer select-none hover:bg-muted/50 -mx-1.5 px-1.5 py-0.5 rounded transition-colors">
           {titleRow}
@@ -247,7 +287,7 @@ export function References({
 
   if (resolvedIds.length === 0) return null;
 
-  const { refs, missing } = resolveRefs(resolvedIds);
+  const { refs, missing } = resolveRefs(resolvedIds, pageId);
 
   return (
     <section


### PR DESCRIPTION
## Summary
- **Major**: Remove incorrect fallbacks in data page — `getClaimSection()` was showing claim text values as section headings, `getClaimFootnoteRefs()` was using measurement units as footnote refs
- **Major**: Fix `RelatedEntityBadges` to use `getEntityHref()` for canonical URLs instead of raw slugs that trigger redirects
- Fix inconsistent footnote anchor IDs between `References.tsx` (sequential index) and `UnifiedReferences.tsx` (actual footnote numbers) — claim page links now scroll to the correct reference

## Test plan
- [x] `/wiki/E<id>/data` section headings show "Unknown" instead of claim text when section is null
- [x] Related entity badges link to `/wiki/E<id>` canonical URLs
- [x] Footnote links from claim detail pages scroll to correct reference in both References and UnifiedReferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)