### PR TITLE
fix: correct stop_reason mapping in OpenRouter adapter

### DIFF
--- a/crux/lib/llm.ts
+++ b/crux/lib/llm.ts
@@ -226,7 +226,7 @@ async function callOpenRouterAsAnthropic(
     role: 'assistant',
     content: [{ type: 'text', text }],
     model: data.model || model,
-    stop_reason: data.choices[0]?.finish_reason === 'stop' ? 'end_turn' : 'end_turn',
+    stop_reason: data.choices[0]?.finish_reason === 'length' ? 'max_tokens' : 'end_turn',
     stop_sequence: null,
     usage,
   } as Anthropic.Messages.Message;


### PR DESCRIPTION
## Summary

- Fix no-op ternary in `callOpenRouterAsAnthropic()` where both branches returned `'end_turn'`
- Now properly maps OpenRouter's `'length'` finish_reason to Anthropic's `'max_tokens'` stop_reason, so truncated responses are correctly identified

Found by paranoid code review of PR #1126.

## Test plan

- [x] TypeScript compiles cleanly
- [x] Gate passes (4 checks, 6 skipped by triage)
- [x] One-line fix, logic verified by inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)