### PR TITLE
fix: render EntityLink tags as clickable links in claim text

### DIFF
--- a/apps/web/src/lib/inline-markdown.tsx
+++ b/apps/web/src/lib/inline-markdown.tsx
@@ -1,14 +1,19 @@
 import React from "react";
+import Link from "next/link";
+import { getEntityHref, getEntityById } from "@data";
 
 /**
- * Render basic inline markdown: **bold**, *italic*, `code`.
+ * Render basic inline markdown: **bold**, *italic*, `code`, and
+ * `<EntityLink id="...">text</EntityLink>` tags as clickable links.
  *
  * Useful for displaying short user-facing text that may contain
  * lightweight formatting without pulling in a full MDX pipeline.
  */
 export function renderInlineMarkdown(text: string): React.ReactNode {
   const parts: React.ReactNode[] = [];
-  const pattern = /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`)/g;
+  // Combined pattern: bold, italic, code, and EntityLink tags
+  const pattern =
+    /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`|<EntityLink\s+id="([^"]+)"[^>]*>([^<]+)<\/EntityLink>)/g;
   let lastIndex = 0;
   let key = 0;
   let matched = false;
@@ -20,14 +25,36 @@ export function renderInlineMarkdown(text: string): React.ReactNode {
       parts.push(text.slice(lastIndex, match.index));
     }
     if (match[2]) {
-      parts.push(<strong key={key++} className="font-semibold">{match[2]}</strong>);
+      // **bold**
+      parts.push(
+        <strong key={key++} className="font-semibold">
+          {match[2]}
+        </strong>
+      );
     } else if (match[3]) {
+      // *italic*
       parts.push(<em key={key++}>{match[3]}</em>);
     } else if (match[4]) {
+      // `code`
       parts.push(
         <code key={key++} className="text-[0.9em] px-0.5 bg-muted rounded">
           {match[4]}
         </code>
+      );
+    } else if (match[5]) {
+      // <EntityLink id="...">text</EntityLink>
+      const entityId = match[5];
+      const displayText = match[6];
+      const entity = getEntityById(entityId);
+      const href = getEntityHref(entityId, entity?.type);
+      parts.push(
+        <Link
+          key={key++}
+          href={href}
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-muted rounded text-sm text-accent-foreground no-underline transition-colors hover:bg-muted/80"
+        >
+          {displayText}
+        </Link>
       );
     }
     lastIndex = match.index + match[0].length;


### PR DESCRIPTION
## Summary
On source detail pages, claim text from wiki pages contained raw `<EntityLink id="anthropic">Anthropic</EntityLink>` markup displayed as plain text. 

Extended `renderInlineMarkdown()` to parse EntityLink tags and render them as clickable pill-styled links (matching the EntityLink component style) using `getEntityById()` and `getEntityHref()` for proper URL resolution.

Affects all uses of `renderInlineMarkdown()`:
- Source page claims, abstract, summary, key points, review
- Reference citation details component

## Test plan
- [x] EntityLink tags in claim text render as clickable links, not raw markup
- [x] Links resolve to canonical `/wiki/E<id>` URLs
- [x] Pill styling matches existing EntityLink component appearance
- [x] Bold, italic, code formatting still works alongside EntityLinks
- [x] 288 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)