### PR TITLE
feat: add verdict display to all claims UI surfaces

### DIFF
--- a/apps/web/src/app/claims/components/stat-card.tsx
+++ b/apps/web/src/app/claims/components/stat-card.tsx
@@ -3,12 +3,12 @@ export function StatCard({
   value,
 }: {
   label: string;
-  value: number;
+  value: number | string;
 }) {
   return (
     <div className="rounded-lg border border-border p-3 text-center">
       <div className="text-2xl font-bold tabular-nums">
-        {value.toLocaleString()}
+        {typeof value === "number" ? value.toLocaleString() : value}
       </div>
       <div className="text-[11px] text-muted-foreground mt-0.5">{label}</div>
     </div>

--- a/apps/web/src/app/internal/claims-ingestion/page.tsx
+++ b/apps/web/src/app/internal/claims-ingestion/page.tsx
@@ -24,6 +24,7 @@ interface ClaimStats {
   total: number;
   byClaimType: Record<string, number>;
   byClaimMode: Record<string, number>;
+  byClaimVerdict?: Record<string, number>;
   withSourcesClaims: number;
   attributedClaims: number;
 }
@@ -138,6 +139,13 @@ export default async function ClaimsIngestionPage() {
   const contestedCount = stats?.byClaimMode?.contested ?? 0;
   const noModeCount = Math.max(0, (stats?.total ?? 0) - endorsedCount - attributedCount - contestedCount);
 
+  // Verdict counts
+  const verdictVerified = stats?.byClaimVerdict?.verified ?? 0;
+  const verdictDisputed = stats?.byClaimVerdict?.disputed ?? 0;
+  const verdictUnsupported = stats?.byClaimVerdict?.unsupported ?? 0;
+  const verdictUnverified = (stats?.total ?? 0) - verdictVerified - verdictDisputed - verdictUnsupported;
+  const hasVerdicts = verdictVerified + verdictDisputed + verdictUnsupported > 0;
+
   return (
     <article className="prose max-w-none">
       <h1>Claims Ingestion</h1>
@@ -168,6 +176,20 @@ export default async function ClaimsIngestionPage() {
         />
       </div>
 
+      {/* Verdict stat cards — only shown if any claims have verdicts */}
+      {hasVerdicts && (
+        <div className="not-prose grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
+          <StatCard label="Verdict: Verified" value={verdictVerified} />
+          <StatCard label="Verdict: Disputed" value={verdictDisputed} />
+          <StatCard label="Verdict: Unsupported" value={verdictUnsupported} />
+          <StatCard
+            label="Verdict Rate"
+            value={`${stats?.total ? (((verdictVerified + verdictDisputed + verdictUnsupported) / stats.total) * 100).toFixed(0) : 0}%`}
+            sub={`${verdictUnverified} remaining`}
+          />
+        </div>
+      )}
+
       {/* Distribution bars */}
       <div className="not-prose space-y-4 my-6">
         <DistributionBar
@@ -194,6 +216,17 @@ export default async function ClaimsIngestionPage() {
             { name: "Unset", count: noModeCount, color: "bg-gray-400" },
           ]}
         />
+        {hasVerdicts && (
+          <DistributionBar
+            label="Claim Verdict"
+            items={[
+              { name: "Verified", count: verdictVerified, color: "bg-green-500" },
+              { name: "Disputed", count: verdictDisputed, color: "bg-amber-500" },
+              { name: "Unsupported", count: verdictUnsupported, color: "bg-red-500" },
+              { name: "Unverified", count: verdictUnverified, color: "bg-gray-400" },
+            ]}
+          />
+        )}
       </div>
 
       {/* Per-resource table */}

--- a/apps/web/src/app/wiki/[id]/claims/page.tsx
+++ b/apps/web/src/app/wiki/[id]/claims/page.tsx
@@ -72,6 +72,11 @@ export default async function WikiClaimsPage({ params }: PageProps) {
     (c) => c.relatedEntities && c.relatedEntities.length > 0
   ).length;
 
+  const verdictVerified = claims.filter((c) => c.claimVerdict === "verified").length;
+  const verdictDisputed = claims.filter((c) => c.claimVerdict === "disputed").length;
+  const verdictUnsupported = claims.filter((c) => c.claimVerdict === "unsupported").length;
+  const hasVerdicts = verdictVerified + verdictDisputed + verdictUnsupported > 0;
+
   const byCategory: Record<string, number> = {};
   for (const c of claims) {
     const cat = c.claimCategory ?? "uncategorized";
@@ -124,14 +129,25 @@ export default async function WikiClaimsPage({ params }: PageProps) {
         <>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
             <StatCard label="Total Claims" value={claims.length} />
-            <StatCard label="Verified" value={verified} />
-            <StatCard label="Multi-Entity" value={multiEntity} />
-            <StatCard
-              label="Verification Rate"
-              value={Math.round(
-                claims.length > 0 ? (verified / claims.length) * 100 : 0
-              )}
-            />
+            {hasVerdicts ? (
+              <>
+                <StatCard label="Verdict: Verified" value={verdictVerified} />
+                <StatCard label="Verdict: Disputed" value={verdictDisputed + verdictUnsupported} />
+                <StatCard
+                  label="Verdict Rate"
+                  value={`${Math.round(claims.length > 0 ? ((verdictVerified + verdictDisputed + verdictUnsupported) / claims.length) * 100 : 0)}%`}
+                />
+              </>
+            ) : (
+              <>
+                <StatCard label="Confidence: Verified" value={verified} />
+                <StatCard label="Multi-Entity" value={multiEntity} />
+                <StatCard
+                  label="Verification Rate"
+                  value={`${Math.round(claims.length > 0 ? (verified / claims.length) * 100 : 0)}%`}
+                />
+              </>
+            )}
           </div>
 
           {Object.keys(byCategory).length > 1 && (

--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -89,6 +89,24 @@ function ConfidenceBadge({ confidence }: { confidence: string | null }) {
   );
 }
 
+/** Server-compatible verdict badge (no "use client" dependency) */
+function VerdictBadgeInline({ verdict, score }: { verdict: string | null; score?: number | null }) {
+  if (!verdict) return <span className="text-gray-300">—</span>;
+  const colorMap: Record<string, string> = {
+    verified: "bg-green-100 text-green-800 border-green-200",
+    unsupported: "bg-red-100 text-red-800 border-red-200",
+    disputed: "bg-amber-100 text-amber-800 border-amber-200",
+    unverified: "bg-gray-100 text-gray-500 border-gray-200",
+  };
+  const cls = colorMap[verdict] ?? "bg-gray-100 text-gray-500 border-gray-200";
+  return (
+    <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium border ${cls}`}>
+      {verdict}
+      {score != null && <span className="ml-0.5 opacity-70">({Math.round(score * 100)}%)</span>}
+    </span>
+  );
+}
+
 /** Badge for claim category (factual, opinion, analytical, speculative, relational) */
 function CategoryBadge({ category }: { category: string | null }) {
   if (!category) return null;
@@ -236,11 +254,17 @@ function buildClaimsData(claims: ClaimRow[], fnIndex?: FootnoteIndexEntry) {
     c.relatedEntities && c.relatedEntities.length > 0
   ).length;
 
-  return { byConfidence, byCategory, sections, refMap, uniqueSources, multiEntityCount };
+  const byVerdict: Record<string, number> = {};
+  for (const c of claims) {
+    const v = c.claimVerdict ?? "unverified";
+    byVerdict[v] = (byVerdict[v] ?? 0) + 1;
+  }
+
+  return { byConfidence, byCategory, byVerdict, sections, refMap, uniqueSources, multiEntityCount };
 }
 
 function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: FootnoteIndexEntry }) {
-  const { byConfidence, byCategory, sections, refMap, multiEntityCount } = buildClaimsData(claims, fnIndex);
+  const { byConfidence, byCategory, byVerdict, sections, refMap, multiEntityCount } = buildClaimsData(claims, fnIndex);
 
   return (
     <div>
@@ -254,6 +278,18 @@ function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: Footno
         ))}
         <span className="text-xs text-gray-500 ml-auto">{claims.length} total claims</span>
       </div>
+
+      {/* Verdict distribution */}
+      {Object.keys(byVerdict).some(v => v !== "unverified") && (
+        <div className="flex gap-3 mb-3 flex-wrap">
+          {Object.entries(byVerdict).map(([v, cnt]) => (
+            <div key={v} className="flex items-center gap-1">
+              <VerdictBadgeInline verdict={v} />
+              <span className="text-xs text-gray-600">{cnt}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Category distribution bar */}
       {Object.keys(byCategory).length > 1 && (
@@ -297,11 +333,12 @@ function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: Footno
       <table className="text-xs w-full border-collapse">
         <thead>
           <tr className="border-b text-left bg-gray-50">
-            <th className="p-2 w-[26%]">Claim</th>
-            <th className="p-2 w-[18%]">Source Quote</th>
+            <th className="p-2 w-[24%]">Claim</th>
+            <th className="p-2 w-[16%]">Source Quote</th>
             <th className="p-2">Type</th>
             <th className="p-2">Category</th>
             <th className="p-2">Confidence</th>
+            <th className="p-2">Verdict</th>
             <th className="p-2">Section</th>
             <th className="p-2">Sources</th>
             <th className="p-2">Related</th>
@@ -334,6 +371,9 @@ function ClaimsTable({ claims, fnIndex }: { claims: ClaimRow[]; fnIndex?: Footno
                 </td>
                 <td className="p-2 whitespace-nowrap">
                   <ConfidenceBadge confidence={claim.confidence} />
+                </td>
+                <td className="p-2 whitespace-nowrap">
+                  <VerdictBadgeInline verdict={claim.claimVerdict} score={claim.claimVerdictScore} />
                 </td>
                 <td className="p-2 text-gray-600 max-w-[100px] truncate" title={sectionName}>
                   {sectionName}

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -393,6 +393,13 @@ claimsRoute.get("/stats", async (c) => {
       sql`${claims.valueNumeric} IS NOT NULL OR ${claims.valueLow} IS NOT NULL OR ${claims.valueHigh} IS NOT NULL`
     );
 
+  // Verdict distribution
+  const byVerdict = await db
+    .select({ claimVerdict: claims.claimVerdict, count: count() })
+    .from(claims)
+    .groupBy(claims.claimVerdict)
+    .orderBy(desc(count()));
+
   return c.json({
     total,
     byClaimType: Object.fromEntries(byType.map((r) => [r.claimType, r.count])),
@@ -402,6 +409,9 @@ claimsRoute.get("/stats", async (c) => {
     ),
     byClaimMode: Object.fromEntries(
       byMode.map((r) => [r.claimMode ?? "uncategorized", r.count])
+    ),
+    byClaimVerdict: Object.fromEntries(
+      byVerdict.map((r) => [r.claimVerdict ?? "unverified", r.count])
     ),
     multiEntityClaims: multiEntityResult[0].count,
     factLinkedClaims: factLinkedResult[0].count,


### PR DESCRIPTION
## Summary
- **Data tab** (`/wiki/[id]/data`): Adds Verdict column and verdict distribution bar to the custom inline ClaimsTable
- **Claims tab** (`/wiki/[id]/claims`): Shows verdict-based stat cards (verified/disputed/rate) when verdicts exist, falls back to confidence-based stats otherwise
- **Claims ingestion dashboard** (`/internal/claims-ingestion`): Adds verdict stat cards, verdict distribution bar, and `byClaimVerdict` to the stats API endpoint
- **StatCard**: Widens value type to accept strings for percentage display
- **Wiki-server stats API**: Adds `byClaimVerdict` field to `/api/claims/stats` response

These changes ensure all 3 UI surfaces that display claims data properly reflect the verdict system added in #1146.

## Test plan
- [ ] Verify `/wiki/[id]/data` page shows Verdict column in claims table
- [ ] Verify `/wiki/[id]/claims` page shows verdict stats when claims have verdicts
- [ ] Verify `/internal/claims-ingestion` shows verdict distribution bar when claims have verdicts
- [ ] Verify all pages gracefully degrade when no verdicts exist (show dashes or hide sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)