### PR TITLE
fix: address PR review issues from #1146 and #1147

### DIFF
--- a/apps/web/src/app/wiki/[id]/claims/page.tsx
+++ b/apps/web/src/app/wiki/[id]/claims/page.tsx
@@ -127,12 +127,13 @@ export default async function WikiClaimsPage({ params }: PageProps) {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
             <StatCard label="Total Claims" value={claims.length} />
             {hasVerdicts ? (
               <>
                 <StatCard label="Verdict: Verified" value={verdictVerified} />
-                <StatCard label="Verdict: Disputed" value={verdictDisputed + verdictUnsupported} />
+                <StatCard label="Verdict: Disputed" value={verdictDisputed} />
+                <StatCard label="Verdict: Unsupported" value={verdictUnsupported} />
                 <StatCard
                   label="Verdict Rate"
                   value={`${Math.round(claims.length > 0 ? ((verdictVerified + verdictDisputed + verdictUnsupported) / claims.length) * 100 : 0)}%`}

--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -89,7 +89,16 @@ function ConfidenceBadge({ confidence }: { confidence: string | null }) {
   );
 }
 
-/** Server-compatible verdict badge (no "use client" dependency) */
+/**
+ * Server-compatible verdict badge — intentionally duplicates the styling from
+ * `@/app/claims/components/verdict-badge.tsx` (VerdictBadge).
+ *
+ * The canonical VerdictBadge is a "use client" component (uses Lucide icons
+ * + shadcn Badge), but this page is a React Server Component and cannot import
+ * client components without a wrapper. Since the inline version is just a tiny
+ * styled <span> with no interactivity, duplicating it here avoids the overhead
+ * of a client boundary for a purely visual element.
+ */
 function VerdictBadgeInline({ verdict, score }: { verdict: string | null; score?: number | null }) {
   if (!verdict) return <span className="text-gray-300">—</span>;
   const colorMap: Record<string, string> = {

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -828,6 +828,7 @@ export interface ClaimStatsResult {
   byEntityType: Record<string, number>;
   byClaimCategory: Record<string, number>;
   byClaimMode: Record<string, number>;
+  byClaimVerdict: Record<string, number>;
   multiEntityClaims: number;
   factLinkedClaims: number;
   withSourcesClaims: number;

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -1117,6 +1117,19 @@ citationsRoute.post("/quotes/link-claims-batch", async (c) => {
 
   const { items } = parsed.data;
   const db = getDrizzleDb();
+
+  // Pre-validate that all referenced claim IDs exist (mirrors the single-item endpoint)
+  const uniqueClaimIds = [...new Set(items.map((i) => i.claimId))];
+  const existingClaims = await db
+    .select({ id: claims.id })
+    .from(claims)
+    .where(sql`${claims.id} = ANY(${uniqueClaimIds})`);
+  const existingClaimIdSet = new Set(existingClaims.map((r) => r.id));
+  const missingClaimIds = uniqueClaimIds.filter((id) => !existingClaimIdSet.has(id));
+  if (missingClaimIds.length > 0) {
+    return validationError(c, `Referenced claims not found: ${missingClaimIds.join(", ")}`);
+  }
+
   let linkedCount = 0;
 
   try {

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -501,10 +501,13 @@ export const claimPageReferences = pgTable(
   (table) => [
     index("idx_cpr_claim_id").on(table.claimId),
     index("idx_cpr_page_id").on(table.pageId),
-    // The COALESCE-based unique index is managed by migration 0031 SQL;
-    // Drizzle doesn't support expressions in uniqueIndex, so we declare
-    // a simpler version here for schema awareness.
-    uniqueIndex("idx_cpr_claim_page_footnote").on(
+    // The real unique constraint is a COALESCE-based expression index in
+    // migration 0031_unify_claims_citations.sql:
+    //   CREATE UNIQUE INDEX idx_cpr_claim_page_footnote
+    //     ON claim_page_references (claim_id, page_id, COALESCE(footnote, -1));
+    // Drizzle doesn't support expression indexes, so we declare a plain
+    // index here for query-planning awareness only.
+    index("idx_cpr_claim_page_footnote").on(
       table.claimId,
       table.pageId,
     ),

--- a/crux/claims/backfill-from-citations.ts
+++ b/crux/claims/backfill-from-citations.ts
@@ -22,7 +22,7 @@ import {
   addClaimPageReferencesBatch,
 } from '../lib/wiki-server/claims.ts';
 import { linkCitationsToClaimsBatch } from '../lib/wiki-server/citations.ts';
-import { isClaimDuplicate, claimTypeToCategory } from '../lib/claim-utils.ts';
+import { isClaimDuplicate, claimTypeToCategory, type ClaimTypeValue } from '../lib/claim-utils.ts';
 import type { ClaimVerdict } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -55,6 +55,44 @@ interface QuotesByPageResponse {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Heuristic claim type detection from claim text.
+ *
+ * Tries to detect numeric, evaluative, causal, historical, and relational
+ * claims based on surface patterns. Falls back to 'factual' when no pattern
+ * matches. This replaces the previous blanket 'factual' default.
+ */
+function detectClaimType(text: string): ClaimTypeValue {
+  const lower = text.toLowerCase();
+
+  // Numeric: contains numbers with units, percentages, dollar amounts, or quantities
+  if (/\$[\d,.]+|\d+%|\d[\d,.]*\s*(billion|million|thousand|trillion|percent|employees|users|people|dollars|usd|eur|gbp)/i.test(text)) {
+    return 'numeric';
+  }
+
+  // Evaluative: subjective assessments, rankings, opinions
+  if (/\b(best|worst|leading|top|most important|considered|regarded|viewed as|believed to|arguably|widely seen)\b/i.test(lower)) {
+    return 'evaluative';
+  }
+
+  // Causal: cause-effect relationships
+  if (/\b(caused|led to|resulted in|because|due to|as a result|contribut(ed|es|ing) to|impact(ed|s|ing) on)\b/i.test(lower)) {
+    return 'causal';
+  }
+
+  // Historical: past events with dates or temporal markers
+  if (/\b(in \d{4}|was founded|established|launched|published|released|announced|merged|acquired)\b/i.test(lower)) {
+    return 'historical';
+  }
+
+  // Relational: relationships between entities
+  if (/\b(partner(ed|ship)|collaborat|subsidiary|acquired by|funded by|member of|affiliated with|part of)\b/i.test(lower)) {
+    return 'relational';
+  }
+
+  return 'factual';
+}
 
 /**
  * Map an accuracy verdict from citation_quotes to a claim verdict.
@@ -223,11 +261,12 @@ async function main() {
 
       // Create the claim
       const claimVerdict = mapAccuracyToClaimVerdict(representative.accuracyVerdict);
+      const detectedType = detectClaimType(representative.claimText);
       const claimResult = await insertClaim({
         entityId: pageId,
         entityType: 'wiki-page',
-        claimType: 'factual',
-        claimCategory: claimTypeToCategory('factual'),
+        claimType: detectedType,
+        claimCategory: claimTypeToCategory(detectedType),
         claimText: representative.claimText,
         sourceQuote: representative.sourceQuote ?? null,
         section: representative.claimContext ?? null,

--- a/crux/claims/pipeline.ts
+++ b/crux/claims/pipeline.ts
@@ -32,9 +32,9 @@ import {
 } from '../lib/wiki-server/claims.ts';
 import { linkCitationsToClaimsBatch } from '../lib/wiki-server/citations.ts';
 import {
-  normalizeClaimText,
   isClaimDuplicate,
   claimTypeToCategory,
+  jaccardWordSimilarity,
 } from '../lib/claim-utils.ts';
 import {
   cleanMdxForExtraction,
@@ -284,14 +284,12 @@ async function main() {
           const linkItems: Array<{ quoteId: number; claimId: number }> = [];
 
           for (const q of unlinked) {
-            // Find best matching claim by text similarity
+            // Find best matching claim by text similarity using Jaccard word similarity
             let bestMatch: { id: number; score: number } | null = null;
 
             for (const claim of existingClaims) {
               if (isClaimDuplicate(q.claimText, claim.claimText, 0.5)) {
-                const normQ = normalizeClaimText(q.claimText);
-                const normC = normalizeClaimText(claim.claimText);
-                const score = normQ === normC ? 1.0 : 0.7;
+                const score = jaccardWordSimilarity(q.claimText, claim.claimText);
                 if (!bestMatch || score > bestMatch.score) {
                   bestMatch = { id: claim.id, score };
                 }

--- a/crux/lib/claim-utils.ts
+++ b/crux/lib/claim-utils.ts
@@ -62,7 +62,7 @@ export function normalizeClaimText(text: string): string {
  * Compute Jaccard similarity between two sets of words.
  * Returns a value in [0, 1].
  */
-function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
   if (a.size === 0 && b.size === 0) return 1;
   let intersection = 0;
   for (const word of a) {
@@ -70,6 +70,17 @@ function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
   }
   const union = a.size + b.size - intersection;
   return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Compute Jaccard word-level similarity between two text strings.
+ * Normalizes both strings first, then computes Jaccard on word sets.
+ * Returns a value in [0, 1].
+ */
+export function jaccardWordSimilarity(a: string, b: string): number {
+  const wordsA = new Set(normalizeClaimText(a).split(' ').filter(w => w.length > 0));
+  const wordsB = new Set(normalizeClaimText(b).split(' ').filter(w => w.length > 0));
+  return jaccardSimilarity(wordsA, wordsB);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes issues identified in PR review of #1146 and #1147:

**Medium priority:**
- Downgrade Drizzle `uniqueIndex` to plain `index` on claim_page_references (real COALESCE constraint lives in migration SQL)
- Add `byClaimVerdict` to `ClaimStatsResult` interface in api-types.ts
- Add batch claim FK pre-validation in `link-claims-batch` endpoint

**Low priority:**
- Heuristic claim type detection in backfill (was hardcoded to `factual`)
- Use actual Jaccard similarity for pipeline link scoring (was coarse 1.0/0.7)
- Add explanatory comment on `VerdictBadgeInline` server component duplicate
- Split merged "Verdict: Disputed" stat card into separate disputed/unsupported cards

## Test plan
- [ ] Wiki-server compiles cleanly
- [ ] Crux CLI compiles cleanly
- [ ] Backfill detects claim types correctly (dry-run)
- [ ] Pipeline link step scores similarity properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)