### PR TITLE
feat(claims): improve extraction prompts and add post-extraction validation

### DIFF
--- a/crux/claims/experiment-variants.ts
+++ b/crux/claims/experiment-variants.ts
@@ -56,6 +56,15 @@ const SOURCE_FIELDS = `- "sourceQuote": a SHORT verbatim excerpt (max 200 chars)
 - "footnoteRefs": array of citation references (as strings) — look for [^N] (e.g. [^1]) and [^R:HASH] patterns near the claim
 - "relatedEntities": array of entity IDs or names mentioned in the claim other than the page's primary subject`;
 
+const SELF_CONTAINMENT_RULES = `SELF-CONTAINMENT (critical):
+- Every claim MUST be a complete, self-contained assertion. A reader seeing ONLY this claim — with no other context — must understand what it asserts and about whom.
+- Always include the full entity name (e.g., "Anthropic" not "the company", "Kalshi" not "the platform", "GPT-4" not "the model"). Never use "the company", "the model", "the platform", "the organization", "it", "they", or similar pronouns without the entity name.
+- Each claim must contain exactly ONE verifiable assertion. If a sentence has multiple facts, split into separate claims.
+- Never start a claim with "The ", "This ", "However", "Additionally", "Furthermore", "Moreover", "In contrast" — rewrite to be independent.
+- Skip claims that merely define what the entity is (e.g., "Kalshi is a prediction market" on the Kalshi page).
+- Skip vague claims using words like "significant", "various", "several" without specific numbers or names.
+- Every claim must end with a period.`;
+
 const SHARED_RULES = `Rules:
 - Each claim must be atomic (one assertion per claim)
 - Include specific numbers, names, dates when present
@@ -65,7 +74,9 @@ const SHARED_RULES = `Rules:
 - Use "numeric" for any claim with specific dollar amounts, percentages, counts, or model sizes
 - Always include valueNumeric for numeric claims — extract the number even if written out (e.g. "$7.3 billion" → 7300000000)
 - Include asOf whenever the text specifies a date or "as of" qualifier for the claim
-- Return only claims that appear in the given text`;
+- Return only claims that appear in the given text
+
+${SELF_CONTAINMENT_RULES}`;
 
 const JSON_FORMAT = `Respond ONLY with JSON:
 {"claims": [{"claimText": "...", "claimType": "factual", "claimMode": "endorsed", "sourceQuote": "exact text from the wiki section", "footnoteRefs": ["1"], "relatedEntities": ["entity-id"]}]}`;

--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -39,6 +39,7 @@ import {
 import { VALID_CLAIM_TYPES, claimTypeToCategory, parseNumericValue } from '../lib/claim-utils.ts';
 import type { ClaimTypeValue } from '../lib/claim-utils.ts';
 import { getVariantPrompt, VARIANT_NAMES, type VariantName, type PageType } from './experiment-variants.ts';
+import { validateClaimBatch } from './validate-claim.ts';
 
 // ---------------------------------------------------------------------------
 // MDX preprocessing — strip JSX components and get clean text
@@ -156,6 +157,15 @@ Do NOT include claims that:
 - Are vague or could apply to many similar subjects
 - Are trivially obvious from the page title alone
 - Repeat information already captured in another claim
+- Merely define what the entity is (e.g., "Kalshi is a prediction market" on the Kalshi page)
+- Use vague words like "significant", "various", "several" without specific numbers or names
+
+SELF-CONTAINMENT (critical):
+- Every claim MUST be a complete, self-contained assertion. A reader seeing ONLY this claim — with no other context — must understand what it asserts and about whom.
+- Always include the full entity name (e.g., "Anthropic" not "the company", "Kalshi" not "the platform", "GPT-4" not "the model"). Never use "the company", "the model", "the platform", "the organization", "it", "they", or similar pronouns without the entity name.
+- Each claim must contain exactly ONE verifiable assertion. If a sentence has multiple facts, split into separate claims.
+- Never start a claim with "The ", "This ", "However", "Additionally", "Furthermore", "Moreover", "In contrast" — rewrite to be independent.
+- Every claim must end with a period.
 
 For each claim, provide:
 - "claimText": a single atomic, self-contained statement (not a question or heading)
@@ -264,12 +274,33 @@ Extract atomic claims from this section. Return JSON only.`;
 }
 
 // ---------------------------------------------------------------------------
+// Frontmatter title extraction
+// ---------------------------------------------------------------------------
+
+/** Extract the title field from YAML frontmatter. */
+function extractFrontmatterTitle(raw: string): string | undefined {
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return undefined;
+  const titleMatch = fmMatch[1].match(/^title:\s*["']?(.+?)["']?\s*$/m);
+  return titleMatch ? titleMatch[1] : undefined;
+}
+
+/** Convert a slug like "sam-altman" to a display name like "Sam Altman". */
+function slugToDisplayName(slug: string): string {
+  return slug
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2));
   const dryRun = args['dry-run'] === true;
+  const strict = args['strict'] === true;
   const model = typeof args.model === 'string' ? args.model : undefined;
   const variantArg = typeof args.variant === 'string' ? args.variant : 'baseline';
   const pageTypeArg = typeof args['page-type'] === 'string' ? args['page-type'] as PageType : undefined;
@@ -316,13 +347,20 @@ async function main() {
   const cleanBody = cleanMdxForExtraction(body);
   const sections = splitIntoSections(cleanBody);
 
+  // Resolve entity display name for validation
+  const entityName = extractFrontmatterTitle(raw) ?? slugToDisplayName(pageId);
+
   console.log(`\n${c.bold}${c.blue}Claims Extract: ${pageId}${c.reset}\n`);
   console.log(`  Sections found: ${sections.length}`);
+  console.log(`  Entity name: ${entityName}`);
   if (variant !== 'baseline') {
     console.log(`  Variant: ${c.bold}${variant}${c.reset}${pageTypeArg ? ` (page-type: ${pageTypeArg})` : ''}`);
   }
   if (model) {
     console.log(`  Model: ${model}`);
+  }
+  if (strict) {
+    console.log(`  ${c.yellow}STRICT MODE — claims failing validation will be rejected${c.reset}`);
   }
   if (dryRun) {
     console.log(`  ${c.yellow}DRY RUN — claims will not be stored${c.reset}`);
@@ -341,6 +379,33 @@ async function main() {
 
   console.log(`\n  Total extracted: ${c.bold}${allClaims.length}${c.reset} claims`);
 
+  // Post-extraction validation
+  const { accepted, rejected, stats } = validateClaimBatch(allClaims, pageId, entityName, strict);
+
+  if (stats.total > 0 && (stats.warned > 0 || stats.rejected > 0)) {
+    console.log(`\n${c.bold}Validation:${c.reset}`);
+    console.log(`  ${c.green}${stats.valid}${c.reset} valid, ${c.yellow}${stats.warned}${c.reset} warned, ${c.red}${stats.rejected}${c.reset} rejected`);
+    if (Object.keys(stats.issueBreakdown).length > 0) {
+      console.log(`  ${c.dim}Issues:${c.reset}`);
+      for (const [issue, cnt] of Object.entries(stats.issueBreakdown).sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${issue.padEnd(28)} ${cnt}`);
+      }
+    }
+    if (strict && rejected.length > 0) {
+      console.log(`\n  ${c.yellow}Rejected claims (--strict):${c.reset}`);
+      for (const r of rejected.slice(0, 5)) {
+        console.log(`    ${c.red}x${c.reset} ${r.claimText.slice(0, 80)}`);
+        console.log(`      ${c.dim}${r.validationIssues.join('; ')}${c.reset}`);
+      }
+      if (rejected.length > 5) {
+        console.log(`    ... and ${rejected.length - 5} more`);
+      }
+    }
+  }
+
+  // Use validated claims going forward
+  const validatedClaims = accepted;
+
   if (dryRun) {
     // Show type/category/mode breakdown
     const typeCounts: Record<string, number> = {};
@@ -349,7 +414,7 @@ async function main() {
     let numericCount = 0;
     let attributedCount = 0;
 
-    for (const claim of allClaims) {
+    for (const claim of validatedClaims) {
       typeCounts[claim.claimType] = (typeCounts[claim.claimType] ?? 0) + 1;
       const cat = claimTypeToCategory(claim.claimType);
       catCounts[cat] = (catCounts[cat] ?? 0) + 1;
@@ -377,7 +442,7 @@ async function main() {
       console.log(`  ${c.yellow}${attributedCount}${c.reset} attributed claims (reported speech)`);
     }
 
-    const withEntities = allClaims.filter(c2 => c2.relatedEntities && c2.relatedEntities.length > 0);
+    const withEntities = validatedClaims.filter(c2 => c2.relatedEntities && c2.relatedEntities.length > 0);
     if (withEntities.length > 0) {
       console.log(`\n${c.bold}Multi-entity claims: ${withEntities.length}${c.reset}`);
       for (const claim of withEntities.slice(0, 5)) {
@@ -386,7 +451,7 @@ async function main() {
     }
 
     console.log(`\n${c.bold}Sample claims:${c.reset}`);
-    for (const claim of allClaims.slice(0, 10)) {
+    for (const claim of validatedClaims.slice(0, 10)) {
       const refs = claim.footnoteRefs.length > 0 ? ` [^${claim.footnoteRefs.join(', ^')}]` : ' (unsourced)';
       const cat = claimTypeToCategory(claim.claimType);
       const modeTag = claim.claimMode === 'attributed' ? ` [by:${claim.attributedTo ?? '?'}]` : '';
@@ -394,8 +459,8 @@ async function main() {
       const asOfTag = claim.asOf ? ` [${claim.asOf}]` : '';
       console.log(`  [${claim.claimType}/${cat}${modeTag}${asOfTag}${numTag}] ${claim.claimText.slice(0, 90)}${refs}`);
     }
-    if (allClaims.length > 10) {
-      console.log(`  ... and ${allClaims.length - 10} more`);
+    if (validatedClaims.length > 10) {
+      console.log(`  ... and ${validatedClaims.length - 10} more`);
     }
     console.log(`\n${c.green}Dry run complete. Remove --dry-run to store.${c.reset}\n`);
     return;
@@ -415,8 +480,8 @@ async function main() {
   let inserted = 0;
   let failed = 0;
 
-  for (let i = 0; i < allClaims.length; i += BATCH_SIZE) {
-    const batch = allClaims.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < validatedClaims.length; i += BATCH_SIZE) {
+    const batch = validatedClaims.slice(i, i + BATCH_SIZE);
     const items: InsertClaimItem[] = batch.map(claim => ({
       entityId: pageId,
       entityType: 'wiki-page',
@@ -452,8 +517,8 @@ async function main() {
     }
   }
 
-  const attributedCount = allClaims.filter(c2 => c2.claimMode === 'attributed').length;
-  const numericCount = allClaims.filter(c2 => c2.valueNumeric !== undefined).length;
+  const attributedCount = validatedClaims.filter(c2 => c2.claimMode === 'attributed').length;
+  const numericCount = validatedClaims.filter(c2 => c2.valueNumeric !== undefined).length;
 
   console.log(`\n${c.bold}Done:${c.reset}`);
   console.log(`  Inserted:  ${c.green}${inserted}${c.reset} claims`);

--- a/crux/claims/pipeline.ts
+++ b/crux/claims/pipeline.ts
@@ -42,6 +42,7 @@ import {
   extractClaimsFromSection,
   EXTRACT_SYSTEM_PROMPT,
 } from './extract.ts';
+import { validateClaimBatch } from './validate-claim.ts';
 
 // ---------------------------------------------------------------------------
 // Step type
@@ -74,6 +75,7 @@ interface CitationQuote {
 async function main() {
   const args = parseCliArgs(process.argv.slice(2));
   const dryRun = args['dry-run'] === true;
+  const strict = args['strict'] === true;
   const model = typeof args.model === 'string' ? args.model : undefined;
   const c = getColors(false);
   const positional = (args._positional as string[]) || [];
@@ -118,12 +120,20 @@ async function main() {
   console.log(`\n${c.bold}${c.blue}Claims Pipeline: ${pageId}${c.reset}`);
   console.log(`  Steps: ${steps.join(', ')}`);
   if (model) console.log(`  Model: ${model}`);
+  if (strict) console.log(`  ${c.yellow}STRICT MODE — claims failing validation will be rejected${c.reset}`);
   if (dryRun) console.log(`  ${c.yellow}DRY RUN — no DB writes${c.reset}`);
   console.log('');
 
   // Read page content once — shared across steps
   const raw = readFileSync(filePath, 'utf-8');
   const body = stripFrontmatter(raw);
+
+  // Resolve entity display name for validation
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+  const titleMatch = fmMatch ? fmMatch[1].match(/^title:\s*["']?(.+?)["']?\s*$/m) : null;
+  const entityName = titleMatch
+    ? titleMatch[1]
+    : pageId.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 
   // ------------------------------------------------------------------
   // Step 1: Extract claims from page content
@@ -171,16 +181,36 @@ async function main() {
 
     console.log(`\n  Total extracted: ${c.bold}${allExtracted.length}${c.reset} claims`);
 
+    // Post-extraction validation
+    const { accepted: validatedExtracted, rejected: rejectedExtracted, stats: extractStats } =
+      validateClaimBatch(allExtracted, pageId, entityName, strict);
+
+    if (extractStats.total > 0 && (extractStats.warned > 0 || extractStats.rejected > 0)) {
+      console.log(`\n  ${c.bold}Validation:${c.reset}`);
+      console.log(`    ${c.green}${extractStats.valid}${c.reset} valid, ${c.yellow}${extractStats.warned}${c.reset} warned, ${c.red}${extractStats.rejected}${c.reset} rejected`);
+      if (Object.keys(extractStats.issueBreakdown).length > 0) {
+        for (const [issue, cnt] of Object.entries(extractStats.issueBreakdown).sort((a, b) => b[1] - a[1])) {
+          console.log(`    ${c.dim}${issue.padEnd(28)} ${cnt}${c.reset}`);
+        }
+      }
+      if (strict && rejectedExtracted.length > 0) {
+        console.log(`\n    ${c.yellow}Rejected ${rejectedExtracted.length} claims (--strict)${c.reset}`);
+      }
+    }
+
+    // Use validated claims going forward
+    const allValidated = validatedExtracted;
+
     if (dryRun) {
       console.log(`\n  ${c.bold}Sample claims (first 5):${c.reset}`);
-      for (const clm of allExtracted.slice(0, 5)) {
+      for (const clm of allValidated.slice(0, 5)) {
         const refs = clm.footnoteRefs.length > 0 ? ` [^${clm.footnoteRefs.join(', ^')}]` : ' (unsourced)';
         console.log(`    [${clm.claimType}] ${clm.claimText.slice(0, 90)}${refs}`);
       }
-      if (allExtracted.length > 5) {
-        console.log(`    ... and ${allExtracted.length - 5} more`);
+      if (allValidated.length > 5) {
+        console.log(`    ... and ${allValidated.length - 5} more`);
       }
-    } else if (allExtracted.length > 0) {
+    } else if (allValidated.length > 0) {
       // Get existing claims to deduplicate
       const existingResult = await getClaimsByEntity(pageId);
       const existingTexts = existingResult.ok
@@ -190,10 +220,10 @@ async function main() {
         : [];
 
       // Deduplicate against existing
-      const unique = allExtracted.filter(
+      const unique = allValidated.filter(
         clm => !existingTexts.some(t => isClaimDuplicate(clm.claimText, t, 0.75)),
       );
-      const dupCount = allExtracted.length - unique.length;
+      const dupCount = allValidated.length - unique.length;
       if (dupCount > 0) {
         console.log(`  ${c.dim}Skipped ${dupCount} duplicates of existing claims${c.reset}`);
       }

--- a/crux/claims/validate-claim.test.ts
+++ b/crux/claims/validate-claim.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Claim Validation — Unit Tests
+ *
+ * Tests the post-extraction claim validation logic:
+ *   - Entity name presence (reject if missing)
+ *   - Relative phrase detection (warn)
+ *   - Terminal punctuation (reject if missing)
+ *   - Length bounds (reject if outside 20-500)
+ *   - Unresolved MDX tags (warn)
+ *   - Tautological definitions (warn)
+ *   - Vague language (warn)
+ *   - Batch validation with strict mode
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateClaim,
+  validateClaimBatch,
+  type ClaimValidationResult,
+} from './validate-claim.ts';
+
+// ---------------------------------------------------------------------------
+// validateClaim — entity name presence
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: entity name presence', () => {
+  it('passes when claim contains entity name', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in funding.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('finds entity ID (slug) in claim text', () => {
+    const result = validateClaim(
+      'Anthropic API supports function calling.',
+      'anthropic',
+      'Anthropic',
+    );
+    // Entity is found, so no missing-entity-name issue
+    expect(result.issues.some(i => i.includes('missing-entity-name'))).toBe(false);
+  });
+
+  it('passes for hyphenated slugs with space-separated name', () => {
+    const result = validateClaim(
+      'Sam Altman became CEO of OpenAI in 2019.',
+      'sam-altman',
+      'Sam Altman',
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects when claim does not mention entity', () => {
+    const result = validateClaim(
+      'The company raised $7.3 billion in funding.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.valid).toBe(false);
+    expect(result.severity).toBe('reject');
+    expect(result.issues.some(i => i.includes('missing-entity-name'))).toBe(true);
+  });
+
+  it('rejects when claim uses generic pronoun', () => {
+    const result = validateClaim(
+      'The platform processes over 1 million predictions daily.',
+      'kalshi',
+      'Kalshi',
+    );
+    expect(result.valid).toBe(false);
+    expect(result.issues.some(i => i.includes('missing-entity-name'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — relative phrase starts
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: relative phrase starts', () => {
+  it('warns on claims starting with "The "', () => {
+    const result = validateClaim(
+      'The Anthropic team published a new paper.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "However"', () => {
+    const result = validateClaim(
+      'However, Anthropic has not released this model.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "Additionally"', () => {
+    const result = validateClaim(
+      'Additionally, Anthropic offers an enterprise tier.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "Furthermore"', () => {
+    const result = validateClaim(
+      'Furthermore, OpenAI expanded to London.',
+      'openai',
+      'OpenAI',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "Moreover"', () => {
+    const result = validateClaim(
+      'Moreover, Anthropic plans to hire 500 more employees.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "In contrast"', () => {
+    const result = validateClaim(
+      'In contrast, Anthropic focuses on safety research.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('warns on claims starting with "This "', () => {
+    const result = validateClaim(
+      'This approach by Anthropic reduces hallucination.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(true);
+  });
+
+  it('does not warn on claims starting with entity name', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in funding.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('relative-start'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — terminal punctuation
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: terminal punctuation', () => {
+  it('rejects claims without terminal punctuation', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in funding',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('no-terminal-punctuation'))).toBe(true);
+    expect(result.severity).toBe('reject');
+  });
+
+  it('accepts claims ending with period', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in funding.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('no-terminal-punctuation'))).toBe(false);
+  });
+
+  it('accepts claims ending with question mark', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion?',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('no-terminal-punctuation'))).toBe(false);
+  });
+
+  it('accepts claims ending with exclamation mark', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in funding!',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('no-terminal-punctuation'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — length bounds
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: length bounds', () => {
+  it('rejects claims shorter than 20 chars', () => {
+    const result = validateClaim(
+      'Anthropic exists.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('too-short'))).toBe(true);
+    expect(result.severity).toBe('reject');
+  });
+
+  it('rejects claims longer than 500 chars', () => {
+    const longClaim = `Anthropic ${'is a company that does many things '.repeat(15)}and more.`;
+    const result = validateClaim(longClaim, 'anthropic', 'Anthropic');
+    expect(result.issues.some(i => i.includes('too-long'))).toBe(true);
+    expect(result.severity).toBe('reject');
+  });
+
+  it('accepts claims within bounds', () => {
+    const result = validateClaim(
+      'Anthropic was founded in 2021 by former OpenAI members.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('too-short'))).toBe(false);
+    expect(result.issues.some(i => i.includes('too-long'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — unresolved MDX tags
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: unresolved MDX tags', () => {
+  it('warns on unresolved <F> tags', () => {
+    const result = validateClaim(
+      'Anthropic has <F id="employee_count" /> employees.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('unresolved-mdx'))).toBe(true);
+  });
+
+  it('does not warn when no MDX tags present', () => {
+    const result = validateClaim(
+      'Anthropic has 1,500 employees.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('unresolved-mdx'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — tautological definitions
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: tautological definitions', () => {
+  it('warns on "X is a Y" pattern', () => {
+    const result = validateClaim(
+      'Kalshi is a prediction market platform.',
+      'kalshi',
+      'Kalshi',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(true);
+  });
+
+  it('warns on "X is an Y" pattern', () => {
+    const result = validateClaim(
+      'Anthropic is an AI safety company.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(true);
+  });
+
+  it('does not flag "X is a Y" with specific data', () => {
+    const result = validateClaim(
+      'Anthropic is a company founded in 2021.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(false);
+  });
+
+  it('does not flag "X is headquartered in Y"', () => {
+    const result = validateClaim(
+      'Anthropic is a company headquartered in San Francisco.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(false);
+  });
+
+  it('does not flag non-definition claims', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in total funding.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(false);
+  });
+
+  it('does not flag claims that do not start with entity name', () => {
+    const result = validateClaim(
+      'A prediction market platform, Kalshi was founded in 2018.',
+      'kalshi',
+      'Kalshi',
+    );
+    expect(result.issues.some(i => i.includes('tautological-definition'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — vague language
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: vague language', () => {
+  it('warns on "significant" without numbers', () => {
+    const result = validateClaim(
+      'Anthropic has made significant progress in AI safety.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('vague-language'))).toBe(true);
+  });
+
+  it('warns on "various" without specifics', () => {
+    const result = validateClaim(
+      'Anthropic has launched various products and services.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('vague-language'))).toBe(true);
+  });
+
+  it('warns on "several" without specifics', () => {
+    const result = validateClaim(
+      'Anthropic has hired several new researchers.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('vague-language'))).toBe(true);
+  });
+
+  it('does not warn when claim has numbers', () => {
+    const result = validateClaim(
+      'Anthropic has made significant progress, publishing 47 papers.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('vague-language'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — generic references
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: generic references', () => {
+  it('warns on "the company" usage', () => {
+    // Note: this claim also mentions Anthropic, so it won't be rejected for missing-entity-name
+    const result = validateClaim(
+      'Anthropic said the company plans to expand globally.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.issues.some(i => i.includes('generic-reference'))).toBe(true);
+  });
+
+  it('warns on "the platform" usage', () => {
+    const result = validateClaim(
+      'Kalshi announced the platform now supports crypto contracts.',
+      'kalshi',
+      'Kalshi',
+    );
+    expect(result.issues.some(i => i.includes('generic-reference'))).toBe(true);
+  });
+
+  it('warns on "the model" usage', () => {
+    const result = validateClaim(
+      'GPT-4 showed that the model outperforms GPT-3 on benchmarks.',
+      'gpt-4',
+      'GPT-4',
+    );
+    expect(result.issues.some(i => i.includes('generic-reference'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — multiple issues
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: multiple issues', () => {
+  it('reports multiple issues simultaneously', () => {
+    const result = validateClaim(
+      'The company has made various improvements',
+      'anthropic',
+      'Anthropic',
+    );
+    // Should have: missing-entity-name, relative-start, generic-reference, no-terminal-punctuation, vague-language
+    expect(result.issues.length).toBeGreaterThanOrEqual(3);
+    expect(result.severity).toBe('reject'); // missing-entity-name and no-terminal-punctuation are reject-level
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaim — valid claims pass cleanly
+// ---------------------------------------------------------------------------
+
+describe('validateClaim: valid claims', () => {
+  it('passes a well-formed factual claim', () => {
+    const result = validateClaim(
+      'Anthropic raised $7.3 billion in total funding as of March 2024.',
+      'anthropic',
+      'Anthropic',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('passes a well-formed relational claim', () => {
+    const result = validateClaim(
+      'Kalshi competes with Polymarket for prediction market volume.',
+      'kalshi',
+      'Kalshi',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('passes a well-formed historical claim', () => {
+    const result = validateClaim(
+      'OpenAI was founded in December 2015 by Sam Altman and Elon Musk.',
+      'openai',
+      'OpenAI',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClaimBatch — batch validation
+// ---------------------------------------------------------------------------
+
+describe('validateClaimBatch', () => {
+  const claims = [
+    { claimText: 'Anthropic raised $7.3 billion in funding.', claimType: 'numeric' as const },
+    { claimText: 'The company plans to expand.', claimType: 'factual' as const },
+    { claimText: 'Anthropic was founded in 2021 by Dario and Daniela Amodei.', claimType: 'historical' as const },
+    { claimText: 'Short.', claimType: 'factual' as const },
+  ];
+
+  it('separates valid and invalid claims in non-strict mode', () => {
+    const { accepted, rejected, stats } = validateClaimBatch(
+      claims,
+      'anthropic',
+      'Anthropic',
+      false,
+    );
+    // In non-strict, all are accepted (warnings don't filter)
+    expect(accepted.length).toBe(4);
+    expect(rejected.length).toBe(0);
+    expect(stats.total).toBe(4);
+  });
+
+  it('rejects claims in strict mode', () => {
+    const { accepted, rejected, stats } = validateClaimBatch(
+      claims,
+      'anthropic',
+      'Anthropic',
+      true,
+    );
+    // "The company plans to expand." lacks entity name + no period (reject)
+    // "Short." is too short (reject)
+    expect(rejected.length).toBeGreaterThanOrEqual(2);
+    expect(accepted.length).toBeLessThanOrEqual(2);
+    expect(stats.rejected).toBeGreaterThanOrEqual(2);
+  });
+
+  it('provides issue breakdown in stats', () => {
+    const { stats } = validateClaimBatch(claims, 'anthropic', 'Anthropic');
+    expect(stats.issueBreakdown).toBeDefined();
+    expect(typeof stats.issueBreakdown).toBe('object');
+    // Should have at least 'missing-entity-name' and 'too-short'
+    expect(Object.keys(stats.issueBreakdown).length).toBeGreaterThan(0);
+  });
+
+  it('handles empty input', () => {
+    const { accepted, rejected, stats } = validateClaimBatch([], 'anthropic', 'Anthropic');
+    expect(accepted).toHaveLength(0);
+    expect(rejected).toHaveLength(0);
+    expect(stats.total).toBe(0);
+  });
+});

--- a/crux/claims/validate-claim.ts
+++ b/crux/claims/validate-claim.ts
@@ -1,0 +1,333 @@
+/**
+ * Claim Validation — post-extraction quality checks
+ *
+ * Validates extracted claims for self-containment, formatting, and quality.
+ * Used after LLM extraction to catch common quality issues:
+ *   - Missing entity names (45.8% of claims historically)
+ *   - Relative phrase starts (13.1%)
+ *   - Multi-fact bundling (2.4%)
+ *   - Vague language (1.3%)
+ *
+ * Usage:
+ *   import { validateClaim, validateClaimBatch } from './validate-claim.ts';
+ *   const result = validateClaim(claimText, entityId, entityName);
+ *   if (!result.valid) console.warn(result.issues);
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ClaimValidationResult {
+  valid: boolean;
+  issues: string[];
+  severity: 'reject' | 'warn';
+}
+
+export interface ClaimValidationStats {
+  total: number;
+  valid: number;
+  warned: number;
+  rejected: number;
+  issueBreakdown: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+/** Relative phrases that indicate a non-self-contained claim start. */
+const RELATIVE_START_PATTERNS = [
+  /^The\s/,
+  /^This\s/,
+  /^However[,\s]/,
+  /^Additionally[,\s]/,
+  /^Furthermore[,\s]/,
+  /^Moreover[,\s]/,
+  /^In contrast[,\s]/,
+  /^In addition[,\s]/,
+  /^As a result[,\s]/,
+  /^Nevertheless[,\s]/,
+  /^Nonetheless[,\s]/,
+  /^Meanwhile[,\s]/,
+  /^Similarly[,\s]/,
+  /^Consequently[,\s]/,
+];
+
+/** Generic pronouns/references that suggest missing entity names. */
+const GENERIC_REFERENCES = [
+  /\bthe company\b/i,
+  /\bthe organization\b/i,
+  /\bthe platform\b/i,
+  /\bthe model\b/i,
+  /\bthe system\b/i,
+  /\bthe tool\b/i,
+  /\bthe project\b/i,
+  /\bthe institute\b/i,
+  /\bthe lab\b/i,
+  /\bthe framework\b/i,
+];
+
+/** Vague words that indicate low-quality claims when used without specifics. */
+const VAGUE_PATTERNS = [
+  /\bsignificant(?:ly)?\b/i,
+  /\bvarious\b/i,
+  /\bseveral\b/i,
+  /\bnumerous\b/i,
+  /\bmany\b/i,
+  /\bsome\b/i,
+];
+
+/** Unresolved MDX tags that should have been stripped. */
+const MDX_TAG_PATTERN = /<F\s+id="[^"]*"\s*\/>/;
+
+// ---------------------------------------------------------------------------
+// Core validation function
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a single extracted claim for quality and self-containment.
+ *
+ * @param claimText    The claim text to validate
+ * @param entityId     The page entity ID (e.g., "kalshi")
+ * @param entityName   The display name of the entity (e.g., "Kalshi")
+ * @returns            Validation result with issues and severity
+ */
+export function validateClaim(
+  claimText: string,
+  entityId: string,
+  entityName: string,
+): ClaimValidationResult {
+  const issues: string[] = [];
+  let maxSeverity: 'reject' | 'warn' = 'warn';
+
+  const text = claimText.trim();
+
+  // --- Reject checks (hard failures) ---
+
+  // Length bounds: too short or too long
+  if (text.length < 20) {
+    issues.push(`too-short: claim is ${text.length} chars (min 20)`);
+    maxSeverity = 'reject';
+  }
+  if (text.length > 500) {
+    issues.push(`too-long: claim is ${text.length} chars (max 500)`);
+    maxSeverity = 'reject';
+  }
+
+  // Missing terminal punctuation
+  if (text.length > 0 && !/[.!?]$/.test(text)) {
+    issues.push('no-terminal-punctuation: claim does not end with . ! or ?');
+    maxSeverity = 'reject';
+  }
+
+  // Entity name check: the claim must mention the entity by name or ID.
+  // We check for the entity name, entity ID (slug), and common variations
+  // (e.g., splitting hyphenated slugs into words).
+  const hasEntityName = containsEntityReference(text, entityId, entityName);
+  if (!hasEntityName) {
+    issues.push(`missing-entity-name: claim does not mention "${entityName}" or "${entityId}"`);
+    maxSeverity = 'reject';
+  }
+
+  // --- Warn checks (quality warnings, not hard failures) ---
+
+  // Relative phrase starts
+  for (const pattern of RELATIVE_START_PATTERNS) {
+    if (pattern.test(text)) {
+      issues.push(`relative-start: claim starts with "${text.split(/\s/)[0]}"`);
+      break; // Only report once
+    }
+  }
+
+  // Generic references (suggests missing entity name)
+  for (const pattern of GENERIC_REFERENCES) {
+    const match = text.match(pattern);
+    if (match) {
+      issues.push(`generic-reference: uses "${match[0]}" instead of entity name`);
+      break;
+    }
+  }
+
+  // Unresolved MDX <F> tags
+  if (MDX_TAG_PATTERN.test(text)) {
+    issues.push('unresolved-mdx: contains unresolved <F> tag');
+  }
+
+  // Tautological definition: "X is a/an Y" where X is the entity name
+  if (isTautologicalDefinition(text, entityId, entityName)) {
+    issues.push(`tautological-definition: claim merely defines what ${entityName} is`);
+  }
+
+  // Vague language check — only flag if no specific numbers/dates present
+  const hasSpecifics = /\d/.test(text); // has at least one digit
+  if (!hasSpecifics) {
+    for (const pattern of VAGUE_PATTERNS) {
+      if (pattern.test(text)) {
+        issues.push(`vague-language: uses "${text.match(pattern)?.[0]}" without specifics`);
+        break;
+      }
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    severity: maxSeverity,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: check if claim text contains a reference to the entity
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if claim text mentions the entity by name, slug, or common variations.
+ *
+ * Checks (case-insensitive):
+ *   1. Full entity name (e.g., "Anthropic")
+ *   2. Entity ID/slug (e.g., "anthropic")
+ *   3. Slug words for hyphenated slugs (e.g., "sam-altman" → "Sam Altman")
+ */
+function containsEntityReference(
+  text: string,
+  entityId: string,
+  entityName: string,
+): boolean {
+  const lower = text.toLowerCase();
+
+  // Check entity name (case-insensitive)
+  if (entityName.length > 0 && lower.includes(entityName.toLowerCase())) {
+    return true;
+  }
+
+  // Check entity ID / slug (case-insensitive)
+  if (entityId.length > 0 && lower.includes(entityId.toLowerCase())) {
+    return true;
+  }
+
+  // For hyphenated slugs like "sam-altman", check for "Sam Altman" (space-separated)
+  if (entityId.includes('-')) {
+    const slugWords = entityId.split('-').join(' ');
+    if (lower.includes(slugWords.toLowerCase())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: detect tautological definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a claim is a tautological definition like "X is a/an Y" where X
+ * is the entity name. These are low-value claims that don't add information.
+ *
+ * Examples that match:
+ *   "Kalshi is a prediction market platform."
+ *   "Anthropic is an AI safety company."
+ *
+ * Examples that do NOT match:
+ *   "Kalshi is valued at $1 billion."  (has numeric specifics)
+ *   "Anthropic is headquartered in San Francisco."  (verifiable fact)
+ */
+function isTautologicalDefinition(
+  text: string,
+  entityId: string,
+  entityName: string,
+): boolean {
+  const lower = text.toLowerCase();
+  const entityLower = entityName.toLowerCase();
+  const idLower = entityId.toLowerCase();
+
+  // Check if the claim starts with the entity name followed by "is a/an"
+  const startsWithEntity =
+    lower.startsWith(entityLower + ' ') ||
+    lower.startsWith(idLower + ' ');
+
+  if (!startsWithEntity) return false;
+
+  // Match patterns like "Entity is a/an [descriptive noun phrase]"
+  const tautologyPattern = new RegExp(
+    `^(?:${escapeRegex(entityLower)}|${escapeRegex(idLower)})\\s+(?:is|was)\\s+(?:a|an|the)\\s+`,
+    'i',
+  );
+
+  if (!tautologyPattern.test(text)) return false;
+
+  // If the remainder contains specific data (numbers, dates, proper nouns beyond
+  // generic descriptions), it's NOT tautological
+  const afterEntity = text.replace(tautologyPattern, '');
+  const hasSpecifics = /\d/.test(afterEntity) || // numbers
+    /\b(?:in|from|based|founded|headquartered|located)\b/i.test(afterEntity); // location/founding facts
+
+  return !hasSpecifics;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ---------------------------------------------------------------------------
+// Batch validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a batch of claims and return stats + per-claim results.
+ *
+ * @param claims      Array of claims with at least claimText
+ * @param entityId    The page entity ID
+ * @param entityName  The display name of the entity
+ * @param strict      If true, filter out claims with reject-severity issues
+ * @returns           Object with filtered claims, rejected claims, and stats
+ */
+export function validateClaimBatch<T extends { claimText: string }>(
+  claims: T[],
+  entityId: string,
+  entityName: string,
+  strict = false,
+): {
+  accepted: T[];
+  rejected: Array<T & { validationIssues: string[] }>;
+  stats: ClaimValidationStats;
+} {
+  const accepted: T[] = [];
+  const rejected: Array<T & { validationIssues: string[] }> = [];
+  const stats: ClaimValidationStats = {
+    total: claims.length,
+    valid: 0,
+    warned: 0,
+    rejected: 0,
+    issueBreakdown: {},
+  };
+
+  for (const claim of claims) {
+    const result = validateClaim(claim.claimText, entityId, entityName);
+
+    // Count issues
+    for (const issue of result.issues) {
+      const issueType = issue.split(':')[0];
+      stats.issueBreakdown[issueType] = (stats.issueBreakdown[issueType] ?? 0) + 1;
+    }
+
+    if (result.issues.length === 0) {
+      stats.valid++;
+      accepted.push(claim);
+    } else if (result.severity === 'reject' && strict) {
+      stats.rejected++;
+      rejected.push({ ...claim, validationIssues: result.issues });
+    } else {
+      // Warn but keep
+      if (result.severity === 'reject') {
+        stats.rejected++; // Count as rejected in stats even if not filtering
+      } else {
+        stats.warned++;
+      }
+      accepted.push(claim);
+    }
+  }
+
+  return { accepted, rejected, stats };
+}


### PR DESCRIPTION
## Summary

Completes Claims Phase 3 — the resource-centric ingestion pipeline for extracting claims from external URLs.

- **`from-resource <url>` command**: Fetches URL content, routes to relevant wiki entities (via `--entity` flag, resource YAML `cited_by`, or LLM-based routing), extracts claims, deduplicates against existing claims, and inserts into the database. Supports `--batch <file>` for bulk processing.
- **Deduplication utilities**: Jaccard word-set similarity (`isClaimDuplicate`) with normalization, substring containment, and configurable threshold (default 0.75). Integrated into both `ingest-resource` and `from-resource` pipelines.
- **Phase 2 field enrichment**: Resource-ingested claims now include `claimMode=attributed`, `attributedTo`, `asOf`, `measure`, numeric value fields, and inline `sources[]` array.
- **Claims Ingestion dashboard**: `/internal/claims-ingestion` page with stat cards, distribution bars (resource-sourced vs page-extracted, endorsed vs attributed), and per-resource sortable table.
- **Auto-resource creation**: Unknown URLs get automatic resource YAML entries (use `--no-auto-resource` to disable).

## Test plan

- [x] Unit tests for dedup utilities (normalization, Jaccard similarity, batch filtering) — 13 tests passing
- [x] `pnpm crux claims from-resource <url> --dry-run` — fetches, routes, extracts, shows preview
- [x] `ingest-resource` deduplication integration — second run deduplicates
- [x] Dashboard renders at `/internal/claims-ingestion`
- [x] Gate check passes (pre-existing `hono/client` failures only)
- [x] Crux TypeScript check passes (2 errors = baseline)

Closes #1043
