### PR TITLE
feat: add CI validation for orgType field in entity YAML

### DIFF
--- a/data/schema.ts
+++ b/data/schema.ts
@@ -716,6 +716,17 @@ export const Entity = z.object({
     'governance',   // Relevant for policy, regulation, international coordination
     'community',    // Relevant for field-building, funding, careers, orgs
   ])).optional(),
+  // Organization sub-type (only used when type is 'organization' or lab-* aliases)
+  orgType: z.enum([
+    'frontier-lab',   // OpenAI, Anthropic, DeepMind
+    'safety-org',     // MIRI, ARC, Redwood
+    'academic',       // FHI, CHAI, CAIS
+    'government',     // UK AISI, US AISI
+    'funder',         // Open Phil, SFF
+    'startup',        // Early-stage AI companies
+    'generic',        // General organizations
+    'other',          // Catch-all for unclassified orgs
+  ]).optional(),
   // InfoBox fields
   severity: z.enum([
     'low', 'medium', 'medium-high', 'high', 'critical', 'catastrophic',


### PR DESCRIPTION
## Summary

- Adds an optional `orgType` enum field to the `Entity` schema in `data/schema.ts`
- Valid values match `OrganizationEntitySchema` in `apps/web/src/data/entity-schemas.ts`: `frontier-lab`, `safety-org`, `academic`, `government`, `funder`, `startup`, `generic`, `other`
- Invalid `orgType` values in entity YAML files will now be caught by the CI gate's YAML schema validation check
- All 532 existing entities pass validation (values in use: `safety-org`, `funder`, `generic`, `frontier-lab`, `startup`, `academic`, `government`)

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
