### PR TITLE
refactor: replace unsafe casts with proper types in ingest-resource.ts

### DIFF
--- a/crux/claims/ingest-resource.ts
+++ b/crux/claims/ingest-resource.ts
@@ -88,23 +88,21 @@ export function buildResourceText(resource: Resource & { localFilename?: string 
   if (resource.authors && resource.authors.length > 0) {
     parts.push(`Authors: ${resource.authors.join(', ')}`);
   }
-  if (resource.published_date || (resource as unknown as { date?: string }).date) {
-    const d = resource.published_date ?? (resource as unknown as { date?: string }).date;
+  if (resource.published_date || resource.date) {
+    const d = resource.published_date ?? resource.date;
     parts.push(`Published: ${d}`);
   }
   if (resource.abstract) {
     parts.push(`\n## Abstract\n${resource.abstract}`);
   }
-  if ((resource as unknown as { summary?: string }).summary) {
-    parts.push(`\n## Summary\n${(resource as unknown as { summary?: string }).summary}`);
+  if (resource.summary) {
+    parts.push(`\n## Summary\n${resource.summary}`);
   }
-  const keyPoints = (resource as unknown as { key_points?: string[] }).key_points;
-  if (keyPoints && keyPoints.length > 0) {
-    parts.push(`\n## Key Points\n${keyPoints.map(p => `- ${p}`).join('\n')}`);
+  if (resource.key_points && resource.key_points.length > 0) {
+    parts.push(`\n## Key Points\n${resource.key_points.map(p => `- ${p}`).join('\n')}`);
   }
-  const review = (resource as unknown as { review?: string }).review;
-  if (review) {
-    parts.push(`\n## Review\n${review}`);
+  if (resource.review) {
+    parts.push(`\n## Review\n${resource.review}`);
   }
 
   return parts.join('\n').trim();

--- a/crux/resource-types.ts
+++ b/crux/resource-types.ts
@@ -20,6 +20,8 @@ export interface Resource {
   published_date?: string;
   abstract?: string;
   summary?: string;
+  review?: string;
+  key_points?: string[];
   publication_id?: string;
   tags?: string[];
   cited_by?: string[];

--- a/crux/vitest.config.ts
+++ b/crux/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       'facts/**/*.test.ts',
       'entity/**/*.test.ts',
       'citations/**/*.test.ts',
+      'claims/**/*.test.ts',
       'validate/**/*.test.ts',
       'wiki-server/**/*.test.ts',
       'evals/**/*.test.ts',


### PR DESCRIPTION
## Summary

- Adds `review` and `key_points` fields to the `Resource` interface in `crux/resource-types.ts` so all YAML-sourced fields used in `buildResourceText` are properly typed
- Removes all 6 `as unknown as` casts from `crux/claims/ingest-resource.ts` — `summary`, `date`, `key_points`, and `review` fields are now accessed directly via the typed interface
- Adds `claims/**/*.test.ts` to the crux vitest config so the existing claims pipeline tests (`extract-pipeline.test.ts`, `source-linking.test.ts`, `validate-claim.test.ts`) are included in every `pnpm test` run

## Why

The `Resource` interface in `resource-types.ts` was missing `review` and `key_points` fields that are present in the YAML files and used in `buildResourceText`. TypeScript didn't know about these fields, so the code worked around the gap with unsafe `as unknown as` casts. The fix is to add the missing fields to the interface, making the type accurate and eliminating the need for casts.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
