### PR TITLE
feat: add claims delete-by-ids server endpoint

### DIFF
--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -327,6 +327,29 @@ claimsRoute.post("/clear-by-section", async (c) => {
   return c.json({ deleted: deleted.length });
 });
 
+// ---- POST /delete-by-ids (batch delete claims by ID array) ----
+// Used by the cleanup command to remove low-quality claims in bulk.
+
+const DeleteByIdsSchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1).max(1000),
+});
+
+claimsRoute.post("/delete-by-ids", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = DeleteByIdsSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const db = getDrizzleDb();
+  const deleted = await db
+    .delete(claims)
+    .where(inArray(claims.id, parsed.data.ids))
+    .returning({ id: claims.id });
+
+  return c.json({ deleted: deleted.length });
+});
+
 // ---- GET /stats ----
 
 claimsRoute.get("/stats", async (c) => {


### PR DESCRIPTION
## Summary
- Adds `POST /api/claims/delete-by-ids` endpoint to the wiki-server claims route
- Accepts an array of claim IDs (1-1000) and deletes them in bulk
- Needed by the `crux claims cleanup` command to remove low-quality claims (duplicates, truncated, misattributed)

This is a prerequisite for running the claims cleanup (issue #1168). The endpoint is minimal — a single Zod-validated POST handler using drizzle's `inArray`.

## Test plan
- [ ] Verify endpoint accepts `{ ids: [1, 2, 3] }` and returns `{ deleted: N }`
- [ ] Verify validation rejects empty arrays and non-integer IDs
- [ ] After deployment, run `pnpm crux claims cleanup --apply` to verify end-to-end

Closes #1168