### PR TITLE
fix: resolve crux TypeScript errors from structured claims merge

### DIFF
--- a/crux/lib/page-coverage.test.ts
+++ b/crux/lib/page-coverage.test.ts
@@ -555,8 +555,8 @@ describe('computePageCoverage — actuals passthrough', () => {
   it('output does NOT contain backlinkCount', () => {
     const result = computePageCoverage(makeInput());
     // PageCoverage type has no backlinkCount field — verify it's absent at runtime
-    expect((result as Record<string, unknown>).backlinkCount).toBeUndefined();
-    expect((result.actuals as Record<string, unknown>).backlinkCount).toBeUndefined();
+    expect((result as unknown as Record<string, unknown>).backlinkCount).toBeUndefined();
+    expect((result.actuals as unknown as Record<string, unknown>).backlinkCount).toBeUndefined();
     expect((result.items as Record<string, unknown>).backlinkCount).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Fix 2 TypeScript errors in `crux/lib/page-coverage.test.ts` introduced by recent merges
- Cast through `unknown` before `Record<string, unknown>` to satisfy TS2352 (missing index signatures on `PageCoverage` and `CoverageActuals`)
- This is blocking CI on main

## Test plan
- [x] `tsc --noEmit -p crux/tsconfig.json` passes with 0 errors
- [x] `npx tsx crux/validate/validate-crux-tsc.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)