### PR TITLE
feat: implement backward propagation of claim verdicts to citation_quotes

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -888,6 +888,18 @@ export const LinkCitationsClaimsBatchSchema = z.object({
   })).min(1).max(200),
 });
 
+// -- Claims: Backward propagation (claim verdict → citation_quotes) -----------
+
+export const PropagateFromClaimsSchema = z.object({
+  pageId: z.string().min(1).max(300),
+});
+export type PropagateFromClaims = z.infer<typeof PropagateFromClaimsSchema>;
+
+export interface PropagateFromClaimsResult {
+  propagated: number;
+  skipped: number;
+}
+
 // ---------------------------------------------------------------------------
 // Similar Claims (trigram similarity)
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -22,6 +22,7 @@ import {
   type CitationHealthResult,
   LinkCitationClaimSchema,
   LinkCitationsClaimsBatchSchema,
+  PropagateFromClaimsSchema,
 } from "../api-types.js";
 
 export const citationsRoute = new Hono();
@@ -1148,4 +1149,87 @@ citationsRoute.post("/quotes/link-claims-batch", async (c) => {
   }
 
   return c.json({ linked: linkedCount });
+});
+
+// ---- POST /quotes/propagate-from-claims ----
+// Backward-propagate claim verdicts to linked citation_quotes.
+// For each citation_quote with a claim_id, copies the claim's verdict fields
+// to the citation's accuracy fields, using the mapping:
+//   claim verified → citation accurate
+//   claim unsupported → citation unsupported
+//   claim disputed → citation inaccurate
+//   claim unverified → skip (don't overwrite)
+
+citationsRoute.post("/quotes/propagate-from-claims", async (c) => {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = PropagateFromClaimsSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { pageId } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Find all citation_quotes for this page that have a linked claim
+  const linkedQuotes = await db
+    .select({
+      quoteId: citationQuotes.id,
+      claimVerdict: claims.claimVerdict,
+      claimVerdictScore: claims.claimVerdictScore,
+      claimVerdictIssues: claims.claimVerdictIssues,
+      claimVerdictQuotes: claims.claimVerdictQuotes,
+      claimVerdictDifficulty: claims.claimVerdictDifficulty,
+    })
+    .from(citationQuotes)
+    .innerJoin(claims, eq(citationQuotes.claimId, claims.id))
+    .where(
+      and(
+        eq(citationQuotes.pageId, pageId),
+        isNotNull(citationQuotes.claimId),
+      )
+    );
+
+  // Map claim verdict → citation accuracy verdict
+  const VERDICT_MAP: Record<string, string> = {
+    verified: "accurate",
+    unsupported: "unsupported",
+    disputed: "inaccurate",
+  };
+
+  let propagated = 0;
+  let skipped = 0;
+
+  for (const row of linkedQuotes) {
+    const claimVerdict = row.claimVerdict;
+
+    // Skip if claim has no verdict or verdict is 'unverified'
+    if (!claimVerdict || claimVerdict === "unverified") {
+      skipped++;
+      continue;
+    }
+
+    const mappedVerdict = VERDICT_MAP[claimVerdict];
+    if (!mappedVerdict) {
+      // Unknown verdict value — skip
+      skipped++;
+      continue;
+    }
+
+    await db
+      .update(citationQuotes)
+      .set({
+        accuracyVerdict: mappedVerdict,
+        accuracyScore: row.claimVerdictScore,
+        accuracyIssues: row.claimVerdictIssues ?? null,
+        accuracySupportingQuotes: row.claimVerdictQuotes ?? null,
+        verificationDifficulty: row.claimVerdictDifficulty ?? null,
+        accuracyCheckedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(citationQuotes.id, row.quoteId));
+
+    propagated++;
+  }
+
+  return c.json({ propagated, skipped });
 });

--- a/crux/claims/pipeline.ts
+++ b/crux/claims/pipeline.ts
@@ -30,7 +30,7 @@ import {
   addClaimPageReferencesBatch,
   type InsertClaimItem,
 } from '../lib/wiki-server/claims.ts';
-import { linkCitationsToClaimsBatch } from '../lib/wiki-server/citations.ts';
+import { linkCitationsToClaimsBatch, propagateClaimVerdictsToPage } from '../lib/wiki-server/citations.ts';
 import {
   isClaimDuplicate,
   claimTypeToCategory,
@@ -395,17 +395,30 @@ async function main() {
   // Step 3: Verify claims against sources
   // ------------------------------------------------------------------
   if (steps.includes('verify')) {
-    console.log(`\n${c.bold}Step 3: Verify claims against sources${c.reset}`);
+    console.log(`\n${c.bold}Step 3: Verify & propagate verdicts${c.reset}`);
 
     if (dryRun) {
-      console.log(`  ${c.yellow}[DRY RUN] Would run claim verification for all claims on this page${c.reset}`);
+      console.log(`  ${c.yellow}[DRY RUN] Would run claim verification and propagate to citation_quotes${c.reset}`);
     } else {
-      console.log(`  Verification delegates to the existing verify pipeline.`);
-      console.log(`  Run separately:`);
-      console.log(`    ${c.bold}pnpm crux claims verify ${pageId}${c.reset}`);
-      if (model) {
-        console.log(`    ${c.bold}pnpm crux claims verify ${pageId} --model=${model}${c.reset}`);
+      // Propagate any existing claim verdicts to citation_quotes
+      const propResult = await propagateClaimVerdictsToPage(pageId);
+      if (propResult.ok) {
+        const { propagated, skipped } = propResult.data;
+        if (propagated > 0) {
+          console.log(`  ${c.green}Propagated ${propagated} claim verdicts to citation_quotes${c.reset}`);
+        }
+        if (skipped > 0) {
+          console.log(`  ${c.dim}Skipped ${skipped} (unverified claims)${c.reset}`);
+        }
+        if (propagated === 0 && skipped === 0) {
+          console.log(`  ${c.dim}No linked claims found to propagate${c.reset}`);
+        }
+      } else {
+        console.log(`  ${c.yellow}Propagation failed: ${propResult.message}${c.reset}`);
       }
+
+      console.log(`\n  For full LLM-based verification, run separately:`);
+      console.log(`    ${c.bold}pnpm crux claims verify ${pageId}${c.reset}`);
     }
   }
 

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -28,6 +28,7 @@ import {
   type ClaimRow,
   type InsertClaimItem,
 } from '../lib/wiki-server/claims.ts';
+import { propagateClaimVerdictsToPage } from '../lib/wiki-server/citations.ts';
 import { extractCitationsFromContent } from '../lib/citation-archive.ts';
 import { resolveSource, MIN_SOURCE_CONTENT_LENGTH } from '../lib/citation-auditor.ts';
 import { findPageFile } from '../lib/file-utils.ts';
@@ -340,6 +341,19 @@ async function main() {
   }
 
   console.log(`  ${c.green}Updated ${inserted} claims${c.reset}`);
+
+  // Backward-propagate verdicts to linked citation_quotes
+  console.log(`\n  Propagating verdicts to citation_quotes...`);
+  const propResult = await propagateClaimVerdictsToPage(pageId);
+  if (propResult.ok) {
+    console.log(`  ${c.green}Propagated ${propResult.data.propagated} verdicts${c.reset}`);
+    if (propResult.data.skipped > 0) {
+      console.log(`  ${c.dim}Skipped ${propResult.data.skipped} (unverified claims)${c.reset}`);
+    }
+  } else {
+    console.log(`  ${c.yellow}Propagation failed: ${propResult.message}${c.reset}`);
+  }
+
   console.log(`\n  Run 'pnpm crux claims status ${pageId}' to see the full breakdown.\n`);
 }
 

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -22,6 +22,7 @@ import type {
   CitationContentListEntry,
   CitationContentListResult,
   CitationContentStatsResult,
+  PropagateFromClaimsResult,
 } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -177,6 +178,24 @@ export async function linkCitationsToClaimsBatch(
     'POST',
     '/api/citations/quotes/link-claims-batch',
     { items },
+    undefined,
+    'content',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Backward Propagation API functions
+// ---------------------------------------------------------------------------
+
+export type { PropagateFromClaimsResult };
+
+export async function propagateClaimVerdictsToPage(
+  pageId: string,
+): Promise<ApiResult<PropagateFromClaimsResult>> {
+  return apiRequest<PropagateFromClaimsResult>(
+    'POST',
+    '/api/citations/quotes/propagate-from-claims',
+    { pageId },
     undefined,
     'content',
   );


### PR DESCRIPTION
## Summary

Adds backward propagation of claim verdicts to citation_quotes table, bridging the claims and citations systems.

- `propagateClaimVerdictsToPage(pageId)` — copies claim verdicts to linked citation_quotes records
- Called automatically at the end of `crux claims verify`
- Maps claimVerdict values to accuracyVerdict values for citation_quotes compatibility

## Test plan
- [x] Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)