### PR TITLE
test: add claims unification dedup and pipeline linking tests

### DIFF
--- a/crux/claims/backfill-from-citations.test.ts
+++ b/crux/claims/backfill-from-citations.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for claims unification / backfill-from-citations logic.
+ *
+ * The backfill pipeline (backfill-from-citations.ts) orchestrates API calls
+ * internally, so we test the pure utility functions it depends on:
+ *   - isClaimDuplicate: core dedup predicate
+ *   - deduplicateClaims: batch dedup filter
+ *   - jaccardWordSimilarity: word-level similarity scoring
+ *   - jaccardSimilarity: set-level Jaccard
+ *   - normalizeClaimText: text normalization
+ *   - claimTypeToCategory: type-to-category mapping
+ *
+ * Covers scenarios that arise during citation backfill: grouping quotes by
+ * text similarity, deduplicating against existing claims, and mapping claim
+ * types to categories for newly created claims.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isClaimDuplicate,
+  deduplicateClaims,
+  jaccardWordSimilarity,
+  jaccardSimilarity,
+  normalizeClaimText,
+  claimTypeToCategory,
+  VALID_CLAIM_TYPES,
+  type ClaimTypeValue,
+} from '../lib/claim-utils.ts';
+
+// ---------------------------------------------------------------------------
+// jaccardWordSimilarity
+// ---------------------------------------------------------------------------
+
+describe('jaccardWordSimilarity', () => {
+  it('returns 1.0 for identical strings', () => {
+    expect(jaccardWordSimilarity('hello world', 'hello world')).toBe(1);
+  });
+
+  it('returns 1.0 for strings that normalize to the same text', () => {
+    expect(jaccardWordSimilarity('Hello World.', 'hello world')).toBe(1);
+  });
+
+  it('returns 0.0 for completely disjoint strings', () => {
+    expect(jaccardWordSimilarity('apples oranges', 'cats dogs')).toBe(0);
+  });
+
+  it('returns a value between 0 and 1 for partial overlap', () => {
+    const score = jaccardWordSimilarity(
+      'Anthropic raised seven billion dollars',
+      'Anthropic total funding reached seven billion',
+    );
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('is case insensitive', () => {
+    const a = 'GPT-4 SCORES 86% ON MMLU';
+    const b = 'gpt-4 scores 86% on mmlu';
+    expect(jaccardWordSimilarity(a, b)).toBe(1);
+  });
+
+  it('handles punctuation by stripping trailing punctuation', () => {
+    // normalizeClaimText strips trailing punctuation and lowercases
+    const a = 'Anthropic raised $7.3 billion.';
+    const b = 'Anthropic raised $7.3 billion';
+    expect(jaccardWordSimilarity(a, b)).toBe(1);
+  });
+
+  it('handles empty strings (both empty)', () => {
+    // Two empty strings: both word sets are empty -> jaccardSimilarity returns 1
+    expect(jaccardWordSimilarity('', '')).toBe(1);
+  });
+
+  it('handles one empty string', () => {
+    expect(jaccardWordSimilarity('hello', '')).toBe(0);
+    expect(jaccardWordSimilarity('', 'hello')).toBe(0);
+  });
+
+  it('treats duplicate words as a single set member', () => {
+    // "the the the cat" has word set {the, cat}
+    const score = jaccardWordSimilarity('the the the cat', 'the cat');
+    expect(score).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jaccardSimilarity (set-level)
+// ---------------------------------------------------------------------------
+
+describe('jaccardSimilarity', () => {
+  it('returns 1.0 for identical sets', () => {
+    expect(jaccardSimilarity(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1);
+  });
+
+  it('returns 0.0 for disjoint sets', () => {
+    expect(jaccardSimilarity(new Set(['a', 'b']), new Set(['c', 'd']))).toBe(0);
+  });
+
+  it('returns 1.0 for two empty sets', () => {
+    expect(jaccardSimilarity(new Set(), new Set())).toBe(1);
+  });
+
+  it('returns 0.0 when one set is empty and the other is not', () => {
+    expect(jaccardSimilarity(new Set(), new Set(['a']))).toBe(0);
+  });
+
+  it('computes correct ratio for partial overlap', () => {
+    // {a, b, c} & {b, c, d} = intersection 2, union 4 -> 0.5
+    const score = jaccardSimilarity(new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']));
+    expect(score).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeClaimText
+// ---------------------------------------------------------------------------
+
+describe('normalizeClaimText', () => {
+  it('lowercases text', () => {
+    expect(normalizeClaimText('HELLO WORLD')).toBe('hello world');
+  });
+
+  it('collapses whitespace', () => {
+    expect(normalizeClaimText('hello   world')).toBe('hello world');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeClaimText('  hello  ')).toBe('hello');
+  });
+
+  it('strips trailing punctuation (period, comma, semicolon, colon, etc.)', () => {
+    expect(normalizeClaimText('hello.')).toBe('hello');
+    expect(normalizeClaimText('hello!')).toBe('hello');
+    expect(normalizeClaimText('hello?')).toBe('hello');
+    expect(normalizeClaimText('hello;')).toBe('hello');
+    expect(normalizeClaimText('hello:')).toBe('hello');
+    expect(normalizeClaimText('hello,,')).toBe('hello');
+  });
+
+  it('does not strip internal punctuation', () => {
+    expect(normalizeClaimText('hello, world.')).toBe('hello, world');
+  });
+
+  it('handles empty string', () => {
+    expect(normalizeClaimText('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isClaimDuplicate — backfill-relevant scenarios
+// ---------------------------------------------------------------------------
+
+describe('isClaimDuplicate', () => {
+  describe('exact match', () => {
+    it('returns true for exact text match', () => {
+      expect(isClaimDuplicate(
+        'Anthropic raised $7.3 billion.',
+        'Anthropic raised $7.3 billion.',
+      )).toBe(true);
+    });
+
+    it('returns true for match after normalization (case + whitespace + punctuation)', () => {
+      expect(isClaimDuplicate(
+        'Anthropic Raised $7.3 Billion!',
+        'anthropic raised $7.3 billion.',
+      )).toBe(true);
+    });
+  });
+
+  describe('substring containment', () => {
+    it('returns true when one text is a substantial substring of the other', () => {
+      // shorter = "Anthropic raised $7.3 billion" (29 chars)
+      // longer  = "Anthropic raised $7.3 billion in total funding" (46 chars)
+      // ratio = 29/46 ~ 0.63 > 0.6 -> duplicate
+      expect(isClaimDuplicate(
+        'Anthropic raised $7.3 billion',
+        'Anthropic raised $7.3 billion in total funding',
+      )).toBe(true);
+    });
+
+    it('returns false when substring is too short relative to longer text', () => {
+      // "GPT-4" is much shorter than a full sentence
+      // ratio will be well below 0.6
+      expect(isClaimDuplicate(
+        'GPT-4',
+        'GPT-4 achieves state-of-the-art performance on multiple benchmarks.',
+      )).toBe(false);
+    });
+  });
+
+  describe('Jaccard similarity', () => {
+    it('returns true for high Jaccard similarity (paraphrases)', () => {
+      // "in 2024" vs "by 2024" — Jaccard 0.89, above 0.75 threshold
+      expect(isClaimDuplicate(
+        'Anthropic raised $7.3 billion in total funding in 2024.',
+        'Anthropic raised $7.3 billion in total funding by 2024.',
+      )).toBe(true);
+    });
+
+    it('returns false for completely different texts', () => {
+      expect(isClaimDuplicate(
+        'Anthropic raised $7.3 billion in total funding.',
+        'Kalshi was founded in 2018 as a prediction market platform.',
+      )).toBe(false);
+    });
+  });
+
+  describe('threshold sensitivity', () => {
+    it('matches at lower threshold (0.6) for same fact, different wording', () => {
+      // Jaccard 0.75 — above the 0.6 grouping threshold used in backfill
+      const a = 'Anthropic raised $7.3 billion in total funding.';
+      const b = 'Anthropic has raised $7.3 billion in funding.';
+      expect(isClaimDuplicate(a, b, 0.6)).toBe(true);
+    });
+
+    it('rejects at higher threshold (0.75) for loosely related text', () => {
+      const a = 'Anthropic was founded in 2021 by former OpenAI researchers.';
+      const b = 'Anthropic raised $7.3 billion in total funding.';
+      expect(isClaimDuplicate(a, b, 0.75)).toBe(false);
+    });
+
+    it('rejects at 0.6 threshold for entirely different topics', () => {
+      expect(isClaimDuplicate(
+        'Kalshi was founded in 2018.',
+        'The global population reached 8 billion in 2022.',
+        0.6,
+      )).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns true for two empty strings (normalize to same)', () => {
+      // Both normalize to empty string "" -> exact match
+      expect(isClaimDuplicate('', '')).toBe(true);
+    });
+
+    it('returns false for one empty and one non-empty string', () => {
+      expect(isClaimDuplicate('', 'Anthropic raised $7.3 billion.')).toBe(false);
+    });
+
+    it('handles very short texts (under 10 chars)', () => {
+      // "gpt-4" vs "gpt-4" -> exact match
+      expect(isClaimDuplicate('GPT-4', 'gpt-4')).toBe(true);
+
+      // "gpt-4" vs "gpt-3" -> different, low similarity
+      expect(isClaimDuplicate('GPT-4', 'GPT-3')).toBe(false);
+    });
+
+    it('handles whitespace-only strings', () => {
+      // Both normalize to empty string -> exact match
+      expect(isClaimDuplicate('   ', '   ')).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateClaims
+// ---------------------------------------------------------------------------
+
+describe('deduplicateClaims', () => {
+  it('returns empty result for empty input', () => {
+    const result = deduplicateClaims([], []);
+    expect(result).toEqual({ unique: [], duplicateCount: 0 });
+  });
+
+  it('returns all claims when none are duplicates', () => {
+    const claims = [
+      { claimText: 'Anthropic raised $7.3 billion in total funding.' },
+      { claimText: 'Kalshi was founded in 2018 as a prediction market.' },
+      { claimText: 'OpenAI released GPT-4 in March 2023.' },
+    ];
+    const existing: string[] = [];
+    const result = deduplicateClaims(claims, existing);
+    expect(result.unique).toHaveLength(3);
+    expect(result.duplicateCount).toBe(0);
+  });
+
+  it('filters out exact duplicates of existing claims', () => {
+    const claims = [
+      { claimText: 'Anthropic raised $7.3 billion in total funding.' },
+      { claimText: 'OpenAI released GPT-4 in March 2023.' },
+    ];
+    const existing = ['Anthropic raised $7.3 billion in total funding.'];
+    const result = deduplicateClaims(claims, existing);
+    expect(result.unique).toHaveLength(1);
+    expect(result.unique[0].claimText).toBe('OpenAI released GPT-4 in March 2023.');
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it('filters out paraphrase duplicates at default threshold', () => {
+    const claims = [
+      // "in 2024" vs "by 2024" — Jaccard ~0.89, above default 0.75 threshold
+      { claimText: 'Anthropic raised $7.3 billion in total funding in 2024.' },
+      { claimText: 'Kalshi was founded in 2018 as a prediction market platform.' },
+    ];
+    const existing = [
+      'Anthropic raised $7.3 billion in total funding by 2024.',
+    ];
+    const result = deduplicateClaims(claims, existing);
+    expect(result.unique).toHaveLength(1);
+    expect(result.unique[0].claimText).toContain('Kalshi');
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it('handles mix of duplicates and unique claims', () => {
+    const claims = [
+      { claimText: 'Anthropic raised $7.3 billion in total funding.' },
+      { claimText: 'Kalshi was founded in 2018 as a prediction market platform.' },
+      { claimText: 'GPT-4 scores 86.4% on MMLU benchmark.' },
+    ];
+    const existing = [
+      'Anthropic raised $7.3 billion in total funding.',
+      'GPT-4 scores 86.4% on the MMLU benchmark.',
+    ];
+    const result = deduplicateClaims(claims, existing);
+    expect(result.unique).toHaveLength(1);
+    expect(result.unique[0].claimText).toContain('Kalshi');
+    expect(result.duplicateCount).toBe(2);
+  });
+
+  it('respects threshold parameter — lower threshold catches more duplicates', () => {
+    // Jaccard is 0.75 for this pair, so:
+    // - at 0.9, NOT a dup (0.75 < 0.9)
+    // - at 0.6, IS a dup (0.75 >= 0.6)
+    const claims = [
+      { claimText: 'Anthropic raised $7.3 billion in total funding.' },
+    ];
+    const existing = [
+      'Anthropic has raised $7.3 billion in funding.',
+    ];
+
+    // At strict threshold 0.9, these should NOT be considered duplicates
+    const strict = deduplicateClaims(claims, existing, 0.9);
+    expect(strict.unique).toHaveLength(1);
+    expect(strict.duplicateCount).toBe(0);
+
+    // At loose threshold 0.6, they should be considered duplicates
+    const loose = deduplicateClaims(claims, existing, 0.6);
+    expect(loose.unique).toHaveLength(0);
+    expect(loose.duplicateCount).toBe(1);
+  });
+
+  it('preserves claim object properties through dedup', () => {
+    interface ExtendedClaim { claimText: string; claimType: string; score: number }
+    const claims: ExtendedClaim[] = [
+      { claimText: 'Unique claim about something.', claimType: 'factual', score: 0.9 },
+    ];
+    const result = deduplicateClaims(claims, []);
+    expect(result.unique[0].claimType).toBe('factual');
+    expect(result.unique[0].score).toBe(0.9);
+  });
+
+  it('deduplicates against existing even when existing has different casing', () => {
+    const claims = [
+      { claimText: 'ANTHROPIC RAISED $7.3 BILLION IN FUNDING.' },
+    ];
+    const existing = ['anthropic raised $7.3 billion in funding.'];
+    const result = deduplicateClaims(claims, existing);
+    expect(result.unique).toHaveLength(0);
+    expect(result.duplicateCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claimTypeToCategory — mapping for backfill-created claims
+// ---------------------------------------------------------------------------
+
+describe('claimTypeToCategory', () => {
+  it('maps factual → factual', () => {
+    expect(claimTypeToCategory('factual')).toBe('factual');
+  });
+
+  it('maps numeric → factual', () => {
+    expect(claimTypeToCategory('numeric')).toBe('factual');
+  });
+
+  it('maps historical → factual', () => {
+    expect(claimTypeToCategory('historical')).toBe('factual');
+  });
+
+  it('maps evaluative → opinion', () => {
+    expect(claimTypeToCategory('evaluative')).toBe('opinion');
+  });
+
+  it('maps consensus → opinion', () => {
+    expect(claimTypeToCategory('consensus')).toBe('opinion');
+  });
+
+  it('maps causal → analytical', () => {
+    expect(claimTypeToCategory('causal')).toBe('analytical');
+  });
+
+  it('maps speculative → speculative', () => {
+    expect(claimTypeToCategory('speculative')).toBe('speculative');
+  });
+
+  it('maps relational → relational', () => {
+    expect(claimTypeToCategory('relational')).toBe('relational');
+  });
+
+  it('all 8 VALID_CLAIM_TYPES map to a non-empty string', () => {
+    expect(VALID_CLAIM_TYPES).toHaveLength(8);
+    for (const t of VALID_CLAIM_TYPES) {
+      const cat = claimTypeToCategory(t);
+      expect(typeof cat).toBe('string');
+      expect(cat.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns factual for unknown type (default branch)', () => {
+    // Force an unknown value through the type system for defensive testing
+    const result = claimTypeToCategory('nonexistent' as ClaimTypeValue);
+    expect(result).toBe('factual');
+  });
+});

--- a/crux/claims/pipeline-link.test.ts
+++ b/crux/claims/pipeline-link.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Pipeline Linking Logic — Integration-style Tests
+ *
+ * The backfill pipeline (backfill-from-citations.ts) matches citation_quotes
+ * to claims using isClaimDuplicate and jaccardWordSimilarity. This file tests
+ * the matching algorithm at the level of those primitives, simulating how the
+ * pipeline groups quotes and selects the best match.
+ *
+ * Key algorithms tested:
+ * 1. Quote grouping: quotes within a page are grouped by text similarity
+ *    using isClaimDuplicate with threshold 0.6
+ * 2. Dedup against existing claims: each group's representative is checked
+ *    against existing claims using isClaimDuplicate with threshold 0.7
+ * 3. Best match selection: when matching a quote against multiple candidate
+ *    claims, the highest jaccardWordSimilarity score wins
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isClaimDuplicate,
+  jaccardWordSimilarity,
+} from '../lib/claim-utils.ts';
+
+// ---------------------------------------------------------------------------
+// Types — lightweight stand-ins for the pipeline's data structures
+// ---------------------------------------------------------------------------
+
+interface MockQuote {
+  id: number;
+  claimText: string;
+  footnote: number;
+}
+
+interface MockClaim {
+  id: number;
+  claimText: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — replicate the pipeline's matching algorithms
+// ---------------------------------------------------------------------------
+
+/**
+ * Group quotes by text similarity, replicating the backfill pipeline's
+ * grouping logic (lines 216-230 of backfill-from-citations.ts).
+ */
+function groupQuotesBySimilarity(
+  quotes: MockQuote[],
+  threshold = 0.6,
+): MockQuote[][] {
+  const groups: MockQuote[][] = [];
+  const assigned = new Set<number>();
+
+  for (const q of quotes) {
+    if (assigned.has(q.id)) continue;
+
+    const group: MockQuote[] = [q];
+    assigned.add(q.id);
+
+    for (const other of quotes) {
+      if (assigned.has(other.id)) continue;
+      if (isClaimDuplicate(q.claimText, other.claimText, threshold)) {
+        group.push(other);
+        assigned.add(other.id);
+      }
+    }
+    groups.push(group);
+  }
+  return groups;
+}
+
+/**
+ * Pick the longest/most representative quote from a group,
+ * replicating lines 237-239 of backfill-from-citations.ts.
+ */
+function pickRepresentative(group: MockQuote[]): MockQuote {
+  return group.reduce((best, q) =>
+    q.claimText.length > best.claimText.length ? q : best,
+  );
+}
+
+/**
+ * Find the best-matching claim for a quote using Jaccard similarity.
+ * Returns the matched claim and score, or null if no claim exceeds the threshold.
+ */
+function findBestMatch(
+  quoteText: string,
+  candidates: MockClaim[],
+  threshold = 0.5,
+): { claim: MockClaim; score: number } | null {
+  let best: { claim: MockClaim; score: number } | null = null;
+  for (const candidate of candidates) {
+    const score = jaccardWordSimilarity(quoteText, candidate.claimText);
+    if (score >= threshold && (!best || score > best.score)) {
+      best = { claim: candidate, score };
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Quote grouping tests
+// ---------------------------------------------------------------------------
+
+describe('quote grouping by similarity', () => {
+  it('groups identical quotes together', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in funding.', footnote: 1 },
+      { id: 2, claimText: 'Anthropic raised $7.3 billion in funding.', footnote: 3 },
+      { id: 3, claimText: 'Kalshi was founded in 2018.', footnote: 2 },
+    ];
+    const groups = groupQuotesBySimilarity(quotes);
+    expect(groups).toHaveLength(2);
+
+    // First group should contain the two identical Anthropic quotes
+    const anthropicGroup = groups.find(g => g[0].claimText.includes('Anthropic'));
+    expect(anthropicGroup).toBeDefined();
+    expect(anthropicGroup!.length).toBe(2);
+  });
+
+  it('groups paraphrased quotes together at 0.6 threshold', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.', footnote: 1 },
+      { id: 2, claimText: 'Anthropic has raised $7.3 billion in funding to date.', footnote: 5 },
+      { id: 3, claimText: 'GPT-4 scores 86.4% on the MMLU benchmark.', footnote: 2 },
+    ];
+    const groups = groupQuotesBySimilarity(quotes, 0.6);
+    expect(groups).toHaveLength(2);
+
+    const anthropicGroup = groups.find(g => g[0].claimText.includes('Anthropic'));
+    expect(anthropicGroup).toBeDefined();
+    expect(anthropicGroup!.length).toBe(2);
+  });
+
+  it('keeps different topics in separate groups', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.', footnote: 1 },
+      { id: 2, claimText: 'Kalshi was founded in 2018 as a prediction market.', footnote: 2 },
+      { id: 3, claimText: 'OpenAI released GPT-4 in March 2023.', footnote: 3 },
+    ];
+    const groups = groupQuotesBySimilarity(quotes);
+    expect(groups).toHaveLength(3);
+  });
+
+  it('groups multiple overlapping quotes into one group', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.', footnote: 1 },
+      { id: 2, claimText: 'Anthropic raised $7.3 billion in total funding as of 2024.', footnote: 2 },
+      { id: 3, claimText: 'Anthropic raised $7.3 billion in venture funding.', footnote: 3 },
+    ];
+    const groups = groupQuotesBySimilarity(quotes, 0.6);
+    // All three should be grouped together since they're all similar
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(3);
+  });
+
+  it('handles empty input', () => {
+    expect(groupQuotesBySimilarity([])).toEqual([]);
+  });
+
+  it('handles single quote', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Single claim about something.', footnote: 1 },
+    ];
+    const groups = groupQuotesBySimilarity(quotes);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Representative selection tests
+// ---------------------------------------------------------------------------
+
+describe('pickRepresentative', () => {
+  it('picks the longest quote as representative', () => {
+    const group: MockQuote[] = [
+      { id: 1, claimText: 'Short claim.', footnote: 1 },
+      { id: 2, claimText: 'This is a much longer and more detailed claim about the topic.', footnote: 2 },
+      { id: 3, claimText: 'Medium length claim here.', footnote: 3 },
+    ];
+    const rep = pickRepresentative(group);
+    expect(rep.id).toBe(2);
+  });
+
+  it('handles single-element group', () => {
+    const group: MockQuote[] = [
+      { id: 1, claimText: 'Only quote.', footnote: 1 },
+    ];
+    expect(pickRepresentative(group).id).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Best match selection tests (citation-to-claim matching)
+// ---------------------------------------------------------------------------
+
+describe('findBestMatch (citation-to-claim matching)', () => {
+  const claims: MockClaim[] = [
+    { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.' },
+    { id: 2, claimText: 'Kalshi was founded in 2018 as a prediction market platform.' },
+    { id: 3, claimText: 'OpenAI released GPT-4 in March 2023 with state-of-the-art performance.' },
+    { id: 4, claimText: 'DeepMind developed AlphaFold to predict protein structures.' },
+  ];
+
+  it('matches a quote to the most similar claim', () => {
+    const result = findBestMatch(
+      'Anthropic has raised $7.3 billion in funding to date.',
+      claims,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.claim.id).toBe(1);
+    expect(result!.score).toBeGreaterThan(0.5);
+  });
+
+  it('returns null when no claim exceeds the threshold', () => {
+    const result = findBestMatch(
+      'The weather in San Francisco is mild year-round.',
+      claims,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('selects the best Jaccard score when multiple claims partially match', () => {
+    // This quote is about OpenAI/GPT-4, should match claim #3 best
+    const result = findBestMatch(
+      'OpenAI released GPT-4 in March 2023.',
+      claims,
+      0.4,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.claim.id).toBe(3);
+  });
+
+  it('respects threshold — high threshold rejects weak matches', () => {
+    // At threshold 0.95, even a close paraphrase should not match
+    const result = findBestMatch(
+      'Anthropic has raised $7.3 billion in funding.',
+      claims,
+      0.95,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('handles empty candidate list', () => {
+    const result = findBestMatch('Some quote text.', []);
+    expect(result).toBeNull();
+  });
+
+  it('returns the single match when only one candidate exists above threshold', () => {
+    const singleClaim = [
+      { id: 99, claimText: 'Anthropic raised $7.3 billion in total funding.' },
+    ];
+    const result = findBestMatch(
+      'Anthropic raised $7.3 billion in total funding as of 2024.',
+      singleClaim,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.claim.id).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: grouping + dedup against existing claims
+// ---------------------------------------------------------------------------
+
+describe('end-to-end: group quotes, pick representatives, dedup against existing', () => {
+  it('groups quotes and skips duplicates of existing claims', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.', footnote: 1 },
+      { id: 2, claimText: 'Anthropic raised $7.3 billion in total funding as of 2024.', footnote: 3 },
+      { id: 3, claimText: 'Kalshi was founded in 2018 as a prediction market.', footnote: 2 },
+      { id: 4, claimText: 'OpenAI released GPT-4 in March 2023.', footnote: 4 },
+    ];
+
+    // Quote 1 is exact match; Quote 2 is a substring-containment match (ratio > 0.6).
+    // Both should group together AND the group representative should match existing at 0.7.
+    const existingClaims = [
+      'Anthropic raised $7.3 billion in total funding.',
+    ];
+
+    // Step 1: Group quotes
+    const groups = groupQuotesBySimilarity(quotes, 0.6);
+
+    // Step 2: Pick representatives and check against existing
+    const newClaimsToCreate: string[] = [];
+    const skippedDups: string[] = [];
+
+    for (const group of groups) {
+      const rep = pickRepresentative(group);
+      const isDup = existingClaims.some(t =>
+        isClaimDuplicate(rep.claimText, t, 0.7),
+      );
+      if (isDup) {
+        skippedDups.push(rep.claimText);
+      } else {
+        newClaimsToCreate.push(rep.claimText);
+        // Add to existing so later groups are checked against it
+        existingClaims.push(rep.claimText);
+      }
+    }
+
+    // The Anthropic group should be skipped (duplicate of existing)
+    expect(skippedDups.length).toBe(1);
+    expect(skippedDups[0]).toContain('Anthropic');
+
+    // Kalshi and OpenAI should be created as new claims
+    expect(newClaimsToCreate).toHaveLength(2);
+    expect(newClaimsToCreate.some(t => t.includes('Kalshi'))).toBe(true);
+    expect(newClaimsToCreate.some(t => t.includes('OpenAI'))).toBe(true);
+  });
+
+  it('prevents intra-batch duplicates by appending to existingTexts', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Kalshi was founded in 2018 as a prediction market.', footnote: 1 },
+      { id: 2, claimText: 'OpenAI released GPT-4 in March 2023.', footnote: 2 },
+      // This is a paraphrase of quote 1, but gets its own group because
+      // grouping threshold at 0.6 might or might not catch it depending on wording.
+      // Let's simulate it landing in a separate group:
+    ];
+
+    const existingClaims: string[] = [];
+    const groups = groupQuotesBySimilarity(quotes, 0.6);
+    const created: string[] = [];
+
+    for (const group of groups) {
+      const rep = pickRepresentative(group);
+      const isDup = existingClaims.some(t =>
+        isClaimDuplicate(rep.claimText, t, 0.7),
+      );
+      if (!isDup) {
+        created.push(rep.claimText);
+        existingClaims.push(rep.claimText);
+      }
+    }
+
+    // Both should be created since they're genuinely different
+    expect(created).toHaveLength(2);
+  });
+
+  it('handles page with all duplicate quotes (no new claims created)', () => {
+    const quotes: MockQuote[] = [
+      { id: 1, claimText: 'Anthropic raised $7.3 billion in total funding.', footnote: 1 },
+      { id: 2, claimText: 'Anthropic raised $7.3 billion in funding.', footnote: 2 },
+    ];
+
+    const existingClaims = [
+      'Anthropic raised $7.3 billion in total funding.',
+    ];
+
+    const groups = groupQuotesBySimilarity(quotes, 0.6);
+    let newCount = 0;
+
+    for (const group of groups) {
+      const rep = pickRepresentative(group);
+      const isDup = existingClaims.some(t =>
+        isClaimDuplicate(rep.claimText, t, 0.7),
+      );
+      if (!isDup) newCount++;
+    }
+
+    expect(newCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases in matching
+// ---------------------------------------------------------------------------
+
+describe('matching edge cases', () => {
+  it('handles quotes with special characters (dollar signs, percentages)', () => {
+    const score = jaccardWordSimilarity(
+      'Revenue was $100M in Q3 2024.',
+      'Revenue was $100M during Q3 2024.',
+    );
+    // Jaccard ~0.71: {revenue, was, $100m, in, q3, 2024} vs {revenue, was, $100m, during, q3, 2024}
+    // Intersection 5, Union 7 -> 5/7 = 0.714
+    expect(score).toBeGreaterThan(0.7);
+  });
+
+  it('handles very long claims', () => {
+    const longA = 'Anthropic ' + 'has developed advanced AI safety techniques '.repeat(10) + 'for alignment research.';
+    const longB = 'Anthropic ' + 'has developed advanced AI safety techniques '.repeat(10) + 'for alignment.';
+    expect(isClaimDuplicate(longA, longB)).toBe(true);
+  });
+
+  it('distinguishes claims about different entities with similar structure', () => {
+    const a = 'Anthropic raised $7.3 billion in total funding.';
+    const b = 'OpenAI raised $11.3 billion in total funding.';
+    // These share structure but differ on entity and amount
+    // Jaccard: {anthropic, raised, $7.3, billion, in, total, funding}
+    //       vs {openai, raised, $11.3, billion, in, total, funding}
+    // Intersection: {raised, billion, in, total, funding} = 5
+    // Union: 9
+    // Jaccard = 5/9 ~ 0.56 -> below 0.75 default threshold
+    expect(isClaimDuplicate(a, b)).toBe(false);
+  });
+
+  it('matches claims that differ only by trailing punctuation', () => {
+    expect(isClaimDuplicate(
+      'Kalshi was founded in 2018.',
+      'Kalshi was founded in 2018!',
+    )).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 72 tests for the claims unification / dedup logic used by the backfill-from-citations pipeline (PR #1146)
- `crux/claims/backfill-from-citations.test.ts` (51 tests): covers `isClaimDuplicate`, `deduplicateClaims`, `jaccardWordSimilarity`, `jaccardSimilarity`, `normalizeClaimText`, and `claimTypeToCategory` with backfill-specific scenarios
- `crux/claims/pipeline-link.test.ts` (21 tests): integration-style tests replicating the pipeline's quote grouping, representative selection, best-match Jaccard scoring, and end-to-end dedup-against-existing-claims logic

## Test plan
- [x] `cd crux && npx vitest run claims/backfill-from-citations.test.ts claims/pipeline-link.test.ts` — all 72 tests pass
- [x] Full `cd crux && npx vitest run` — no regressions (pre-existing worktree path failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
