### PR TITLE
fix: move Structured column earlier in claims explorer table

### DIFF
--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -310,6 +310,33 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
     size: 400,
   },
   {
+    id: "structured",
+    accessorFn: (row) => row.property,
+    header: ({ column }) => (
+      <SortableHeader column={column}>Structured</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const c = row.original;
+      if (!c.property) return <span className="text-muted-foreground/40 text-xs">&mdash;</span>;
+      const parts: string[] = [c.property];
+      if (c.structuredValue) {
+        parts.push(`= ${c.structuredValue}`);
+      }
+      if (c.valueUnit) {
+        parts.push(`[${c.valueUnit}]`);
+      }
+      return (
+        <span
+          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono bg-violet-100 text-violet-700 max-w-[180px] truncate"
+          title={`${c.property}${c.structuredValue ? ` = ${c.structuredValue}` : ""}${c.valueUnit ? ` [${c.valueUnit}]` : ""}${c.valueDate ? ` @ ${c.valueDate}` : ""}`}
+        >
+          {parts.join(" ")}
+        </span>
+      );
+    },
+    size: 160,
+  },
+  {
     accessorKey: "claimType",
     header: ({ column }) => (
       <SortableHeader column={column}>Type</SortableHeader>
@@ -398,33 +425,6 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
       />
     ),
     size: 100,
-  },
-  {
-    id: "structured",
-    accessorFn: (row) => row.property,
-    header: ({ column }) => (
-      <SortableHeader column={column}>Structured</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const c = row.original;
-      if (!c.property) return <span className="text-muted-foreground/40 text-xs">&mdash;</span>;
-      const parts: string[] = [c.property];
-      if (c.structuredValue) {
-        parts.push(`= ${c.structuredValue}`);
-      }
-      if (c.valueUnit) {
-        parts.push(`[${c.valueUnit}]`);
-      }
-      return (
-        <span
-          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono bg-violet-100 text-violet-700 max-w-[180px] truncate"
-          title={`${c.property}${c.structuredValue ? ` = ${c.structuredValue}` : ""}${c.valueUnit ? ` [${c.valueUnit}]` : ""}${c.valueDate ? ` @ ${c.valueDate}` : ""}`}
-        >
-          {parts.join(" ")}
-        </span>
-      );
-    },
-    size: 160,
   },
   {
     accessorKey: "sourceQuote",


### PR DESCRIPTION
## Summary

- Move the Structured column from position 11 (after Verdict, requiring horizontal scroll) to position 5 (right after Claim text) in the claims explorer table
- This makes structured claim data (property/value badges) immediately visible without scrolling

## Context

PR #1192 added structured claims enrichment and a Structured column to the claims explorer. However, the column was placed as the 11th of 13 columns in a ~1565px-wide table, making it invisible without horizontal scrolling. This fix promotes it to a prominent position right after the claim text.

## Test plan
- [ ] Visit `/claims/explore?entity=anthropic` — Structured column should be visible without scrolling
- [ ] Filter with `structuredOnly=true` checkbox — should show ~111 claims with violet badges
- [ ] Existing columns (Type, Sources, Category, etc.) still render correctly after the Structured column
