### PR TITLE
refactor: migrate claims & citations routes to Hono RPC method-chaining

### DIFF
--- a/.claude/rules/wiki-server-rpc-migration.md
+++ b/.claude/rules/wiki-server-rpc-migration.md
@@ -1,11 +1,11 @@
-# Wiki-Server: Hono RPC Migration (Opportunistic)
+# Wiki-Server: Hono RPC Migration (Mandatory for New Routes)
 
-We are incrementally migrating wiki-server routes from hand-written response types to Hono RPC type inference. **Do not batch-migrate** — convert routes when you are already modifying them.
+All **new** wiki-server routes must use Hono RPC method-chaining. Existing routes should be converted when you are already modifying them.
 
 ## Status
 
-- **Migrated**: `facts.ts` (reference implementation)
-- **Not yet migrated**: all other routes (~21 files in `apps/wiki-server/src/routes/`)
+- **Migrated**: `facts.ts` (reference), `claims.ts`, `citations.ts`
+- **Not yet migrated**: remaining routes (~19 files in `apps/wiki-server/src/routes/`)
 
 ## Why
 
@@ -66,3 +66,9 @@ Remove the old hand-written response interfaces from `api-types.ts` once all con
 - Don't convert a route just because you're reading it
 - Don't migrate as a side-effect of an unrelated bug fix
 - Do migrate when you're adding/changing endpoints on a route or restructuring it
+
+## RPC path key gotchas
+
+- Root route `/` maps to `'index'` in the RPC client type (not `'/'`)
+- Path params like `/:id` map to `':id'`
+- Hyphenated paths like `/by-entity` map to `'by-entity'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Do not consider work complete until CI is green.
 - **GitHub API**: Use `crux issues/pr/ci/epic` commands for writes. Use MCP GitHub tools for ad-hoc reads. Never raw `curl`.
 - **Epics**: Use `crux epic` for multi-issue coordination via GitHub Discussions. Individual tasks stay as Issues.
 - **API keys**: In environment variables, NOT `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`
+- **Hono RPC**: Mandatory for all new wiki-server routes; convert existing routes when modifying them. See `.claude/rules/wiki-server-rpc-migration.md`.
 - **Entity IDs**: **Never manually invent numericIds** (E42, E886, etc.). Always allocate from the wiki-server: `pnpm crux ids allocate <slug>`. The gate runs `assign-ids.mjs` automatically as a safety net, but allocating early prevents conflicts between concurrent agents. Use `pnpm crux ids check <slug>` to look up existing IDs.
 
 ## Detailed Guides (loaded automatically by Claude Code)

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -25,8 +25,6 @@ import {
   PropagateFromClaimsSchema,
 } from "../api-types.js";
 
-export const citationsRoute = new Hono();
-
 // ---- Constants ----
 
 const BROKEN_SCORE_THRESHOLD = 0.5;
@@ -159,1077 +157,1057 @@ function computePageHealth(
   };
 }
 
-// ---- GET /health/:pageId ----
-// Per-page citation health summary — used by the Next.js frontend.
+const citationsApp = new Hono()
+  // ---- GET /health/:pageId ----
+  // Per-page citation health summary — used by the Next.js frontend.
+  .get("/health/:pageId", async (c) => {
+    const pageId = c.req.param("pageId");
+    const db = getDrizzleDb();
 
-citationsRoute.get("/health/:pageId", async (c) => {
-  const pageId = c.req.param("pageId");
-  const db = getDrizzleDb();
+    const rows = await db
+      .select({
+        sourceQuote: citationQuotes.sourceQuote,
+        quoteVerified: citationQuotes.quoteVerified,
+        verificationScore: citationQuotes.verificationScore,
+        accuracyVerdict: citationQuotes.accuracyVerdict,
+        accuracyScore: citationQuotes.accuracyScore,
+      })
+      .from(citationQuotes)
+      .where(eq(citationQuotes.pageId, pageId));
 
-  const rows = await db
-    .select({
-      sourceQuote: citationQuotes.sourceQuote,
-      quoteVerified: citationQuotes.quoteVerified,
-      verificationScore: citationQuotes.verificationScore,
-      accuracyVerdict: citationQuotes.accuracyVerdict,
-      accuracyScore: citationQuotes.accuracyScore,
-    })
-    .from(citationQuotes)
-    .where(eq(citationQuotes.pageId, pageId));
+    return c.json(computePageHealth(pageId, rows));
+  })
 
-  return c.json(computePageHealth(pageId, rows));
-});
+  // ---- POST /quotes/upsert ----
+  .post("/quotes/upsert", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-// ---- POST /quotes/upsert ----
+    const parsed = UpsertQuoteSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-citationsRoute.post("/quotes/upsert", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const db = getDrizzleDb();
 
-  const parsed = UpsertQuoteSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-
-  // Validate page reference
-  const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, [parsed.data.pageId]);
-  if (missingPages.length > 0) {
-    return validationError(c, `Referenced page not found: ${missingPages.join(", ")}`);
-  }
-
-  // Validate resource reference (optional)
-  if (parsed.data.resourceId) {
-    const missingRes = await checkRefsExist(db, resources, resources.id, [parsed.data.resourceId]);
-    if (missingRes.length > 0) {
-      return validationError(c, `Referenced resource not found: ${missingRes.join(", ")}`);
+    // Validate page reference
+    const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, [parsed.data.pageId]);
+    if (missingPages.length > 0) {
+      return validationError(c, `Referenced page not found: ${missingPages.join(", ")}`);
     }
-  }
 
-  const rows = await upsertQuote(db, parsed.data);
+    // Validate resource reference (optional)
+    if (parsed.data.resourceId) {
+      const missingRes = await checkRefsExist(db, resources, resources.id, [parsed.data.resourceId]);
+      if (missingRes.length > 0) {
+        return validationError(c, `Referenced resource not found: ${missingRes.join(", ")}`);
+      }
+    }
 
-  const row = firstOrThrow(rows, "citation quote upsert");
-  return c.json({
-    id: row.id,
-    pageId: row.pageId,
-    footnote: row.footnote,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  }, 200);
-});
+    const rows = await upsertQuote(db, parsed.data);
 
-// ---- POST /quotes/upsert-batch ----
+    const row = firstOrThrow(rows, "citation quote upsert");
+    return c.json({
+      id: row.id,
+      pageId: row.pageId,
+      footnote: row.footnote,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }, 200);
+  })
 
-citationsRoute.post("/quotes/upsert-batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+  // ---- POST /quotes/upsert-batch ----
+  .post("/quotes/upsert-batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = UpsertBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = UpsertBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
 
-  // Validate page references
-  const pageIds = [...new Set(items.map((d) => d.pageId))];
-  const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, pageIds);
-  if (missingPages.length > 0) {
-    return validationError(
-      c,
-      `Referenced pages not found: ${missingPages.join(", ")}`
-    );
-  }
-
-  // Validate resource references (optional field)
-  const resourceIds = [
-    ...new Set(items.map((d) => d.resourceId).filter((r): r is string => r != null)),
-  ];
-  if (resourceIds.length > 0) {
-    const missingResources = await checkRefsExist(db, resources, resources.id, resourceIds);
-    if (missingResources.length > 0) {
+    // Validate page references
+    const pageIds = [...new Set(items.map((d) => d.pageId))];
+    const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, pageIds);
+    if (missingPages.length > 0) {
       return validationError(
         c,
-        `Referenced resources not found: ${missingResources.join(", ")}`
+        `Referenced pages not found: ${missingPages.join(", ")}`
       );
     }
-  }
 
-  let results;
-  try {
-    results = await db.transaction(async (tx) => {
-      return await tx
-        .insert(citationQuotes)
-        .values(items.map((d) => quoteValues(d)))
-        .onConflictDoUpdate({
-          target: [citationQuotes.pageId, citationQuotes.footnote],
-          set: {
-            url: sql`excluded.url`,
-            resourceId: sql`excluded.resource_id`,
-            claimText: sql`excluded.claim_text`,
-            claimContext: sql`excluded.claim_context`,
-            sourceQuote: sql`excluded.source_quote`,
-            sourceLocation: sql`excluded.source_location`,
-            quoteVerified: sql`excluded.quote_verified`,
-            verificationMethod: sql`excluded.verification_method`,
-            verificationScore: sql`excluded.verification_score`,
-            sourceTitle: sql`excluded.source_title`,
-            sourceType: sql`excluded.source_type`,
-            extractionModel: sql`excluded.extraction_model`,
-            updatedAt: sql`now()`,
-          },
-        })
-        .returning({
-          id: citationQuotes.id,
-          pageId: citationQuotes.pageId,
-          footnote: citationQuotes.footnote,
-        });
-    });
-  } catch (err) {
-    return dbError(c, "citation quotes upsert-batch", err, { itemCount: items.length });
-  }
+    // Validate resource references (optional field)
+    const resourceIds = [
+      ...new Set(items.map((d) => d.resourceId).filter((r): r is string => r != null)),
+    ];
+    if (resourceIds.length > 0) {
+      const missingResources = await checkRefsExist(db, resources, resources.id, resourceIds);
+      if (missingResources.length > 0) {
+        return validationError(
+          c,
+          `Referenced resources not found: ${missingResources.join(", ")}`
+        );
+      }
+    }
 
-  return c.json({ results });
-});
-
-// ---- GET /quotes?page_id=X ----
-
-citationsRoute.get("/quotes", async (c) => {
-  const pageId = c.req.query("page_id");
-  if (!pageId) return validationError(c, "page_id query parameter is required");
-
-  const limitParam = c.req.query("limit");
-  const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500) : 100;
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(citationQuotes)
-    .where(eq(citationQuotes.pageId, pageId))
-    .orderBy(asc(citationQuotes.footnote))
-    .limit(limit);
-
-  return c.json({ quotes: rows });
-});
-
-// ---- GET /quotes/all (paginated) ----
-
-citationsRoute.get("/quotes/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(citationQuotes)
-    .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db.select({ count: count() }).from(citationQuotes);
-  const total = countResult[0].count;
-
-  return c.json({ quotes: rows, total, limit, offset });
-});
-
-// ---- POST /quotes/mark-verified ----
-
-citationsRoute.post("/quotes/mark-verified", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = MarkVerifiedSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { pageId, footnote, method, score } = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .update(citationQuotes)
-    .set({
-      quoteVerified: true,
-      verificationMethod: method,
-      verificationScore: score,
-      verifiedAt: sql`now()`,
-      updatedAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(citationQuotes.pageId, pageId),
-        eq(citationQuotes.footnote, footnote)
-      )
-    )
-    .returning({
-      id: citationQuotes.id,
-      pageId: citationQuotes.pageId,
-      footnote: citationQuotes.footnote,
-    });
-
-  if (rows.length === 0) {
-    return notFoundError(c, `No quote for page=${pageId} footnote=${footnote}`);
-  }
-
-  return c.json({ updated: true, pageId, footnote });
-});
-
-// ---- POST /quotes/mark-accuracy ----
-
-citationsRoute.post("/quotes/mark-accuracy", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = MarkAccuracySchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { pageId, footnote, verdict, score, issues, supportingQuotes, verificationDifficulty } = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .update(citationQuotes)
-    .set({
-      accuracyVerdict: verdict,
-      accuracyScore: score,
-      accuracyIssues: issues ?? null,
-      accuracySupportingQuotes: supportingQuotes ?? null,
-      verificationDifficulty: verificationDifficulty ?? null,
-      accuracyCheckedAt: sql`now()`,
-      updatedAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(citationQuotes.pageId, pageId),
-        eq(citationQuotes.footnote, footnote)
-      )
-    )
-    .returning({
-      id: citationQuotes.id,
-      pageId: citationQuotes.pageId,
-      footnote: citationQuotes.footnote,
-    });
-
-  if (rows.length === 0) {
-    return notFoundError(c, `No quote for page=${pageId} footnote=${footnote}`);
-  }
-
-  return c.json({ updated: true, pageId, footnote, verdict });
-});
-
-// ---- GET /stats ----
-
-citationsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const rows = await db.select({
-    totalQuotes: count(),
-    withQuotes: sql<number>`count(case when ${citationQuotes.sourceQuote} is not null then 1 end)`,
-    verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
-    unverified: sql<number>`count(case when ${citationQuotes.quoteVerified} = false or ${citationQuotes.quoteVerified} is null then 1 end)`,
-    totalPages: sql<number>`count(distinct ${citationQuotes.pageId})`,
-    averageScore: avg(citationQuotes.verificationScore),
-  }).from(citationQuotes);
-
-  const r = rows[0];
-  return c.json({
-    totalQuotes: r.totalQuotes,
-    withQuotes: Number(r.withQuotes),
-    verified: Number(r.verified),
-    unverified: Number(r.unverified),
-    totalPages: Number(r.totalPages),
-    averageScore: r.averageScore != null ? Number(r.averageScore) : null,
-  });
-});
-
-// ---- GET /page-stats ----
-
-citationsRoute.get("/page-stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const rows = await db.select({
-    pageId: citationQuotes.pageId,
-    total: count(),
-    withQuotes: sql<number>`count(case when ${citationQuotes.sourceQuote} is not null then 1 end)`,
-    verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
-    avgScore: avg(citationQuotes.verificationScore),
-    accuracyChecked: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
-    accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
-    inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
-  })
-    .from(citationQuotes)
-    .groupBy(citationQuotes.pageId)
-    .orderBy(asc(citationQuotes.pageId));
-
-  return c.json({
-    pages: rows.map((r) => ({
-      pageId: r.pageId,
-      total: r.total,
-      withQuotes: Number(r.withQuotes),
-      verified: Number(r.verified),
-      avgScore: r.avgScore != null ? Number(r.avgScore) : null,
-      accuracyChecked: Number(r.accuracyChecked),
-      accurate: Number(r.accurate),
-      inaccurate: Number(r.inaccurate),
-    })),
-  });
-});
-
-// ---- GET /accuracy-summary ----
-
-citationsRoute.get("/accuracy-summary", async (c) => {
-  const db = getDrizzleDb();
-
-  const rows = await db.select({
-    pageId: citationQuotes.pageId,
-    checked: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
-    accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
-    inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
-    unsupported: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
-  })
-    .from(citationQuotes)
-    .groupBy(citationQuotes.pageId)
-    .having(sql`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end) > 0`)
-    .orderBy(asc(citationQuotes.pageId));
-
-  return c.json({
-    pages: rows.map((r) => ({
-      pageId: r.pageId,
-      checked: Number(r.checked),
-      accurate: Number(r.accurate),
-      inaccurate: Number(r.inaccurate),
-      unsupported: Number(r.unsupported),
-    })),
-  });
-});
-
-// ---- GET /broken ----
-
-citationsRoute.get("/broken", async (c) => {
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select({
-      pageId: citationQuotes.pageId,
-      footnote: citationQuotes.footnote,
-      url: citationQuotes.url,
-      claimText: citationQuotes.claimText,
-      verificationScore: citationQuotes.verificationScore,
-    })
-    .from(citationQuotes)
-    .where(
-      and(
-        eq(citationQuotes.quoteVerified, true),
-        isNotNull(citationQuotes.verificationScore),
-        lt(citationQuotes.verificationScore, BROKEN_SCORE_THRESHOLD)
-      )
-    )
-    .orderBy(
-      asc(citationQuotes.verificationScore),
-      asc(citationQuotes.pageId),
-      asc(citationQuotes.footnote)
-    );
-
-  return c.json({ broken: rows });
-});
-
-// ---- POST /content/upsert ----
-// BREAKING CHANGE (PR #476): This endpoint no longer accepts `pageId` or
-// `footnote` fields. Citation content is now keyed by URL only. External
-// scripts that previously sent pageId/footnote need updating.
-
-citationsRoute.post("/content/upsert", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = UpsertContentSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const d = parsed.data;
-  const db = getDrizzleDb();
-
-  const vals = {
-    url: d.url,
-    resourceId: d.resourceId ?? null,
-    fetchedAt: new Date(d.fetchedAt),
-    httpStatus: d.httpStatus ?? null,
-    contentType: d.contentType ?? null,
-    pageTitle: d.pageTitle ?? null,
-    fullTextPreview: d.fullTextPreview ?? (d.fullText ? d.fullText.slice(0, CITATION_CONTENT_PREVIEW_MAX) : null),
-    fullText: d.fullText ?? null,
-    contentLength: d.contentLength ?? null,
-    contentHash: d.contentHash ?? null,
-  };
-
-  await db
-    .insert(citationContent)
-    .values(vals)
-    .onConflictDoUpdate({
-      target: citationContent.url,
-      set: { ...vals, updatedAt: sql`now()` },
-    });
-
-  return c.json({ url: d.url });
-});
-
-// ---- POST /quotes/mark-accuracy-batch ----
-
-citationsRoute.post("/quotes/mark-accuracy-batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = MarkAccuracyBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-  const results: Array<{ pageId: string; footnote: number; verdict: string }> = [];
-
-  try {
-    await db.transaction(async (tx) => {
-      for (const d of items) {
-        const rows = await tx
-          .update(citationQuotes)
-          .set({
-            accuracyVerdict: d.verdict,
-            accuracyScore: d.score,
-            accuracyIssues: d.issues ?? null,
-            accuracySupportingQuotes: d.supportingQuotes ?? null,
-            verificationDifficulty: d.verificationDifficulty ?? null,
-            accuracyCheckedAt: sql`now()`,
-            updatedAt: sql`now()`,
+    let results;
+    try {
+      results = await db.transaction(async (tx) => {
+        return await tx
+          .insert(citationQuotes)
+          .values(items.map((d) => quoteValues(d)))
+          .onConflictDoUpdate({
+            target: [citationQuotes.pageId, citationQuotes.footnote],
+            set: {
+              url: sql`excluded.url`,
+              resourceId: sql`excluded.resource_id`,
+              claimText: sql`excluded.claim_text`,
+              claimContext: sql`excluded.claim_context`,
+              sourceQuote: sql`excluded.source_quote`,
+              sourceLocation: sql`excluded.source_location`,
+              quoteVerified: sql`excluded.quote_verified`,
+              verificationMethod: sql`excluded.verification_method`,
+              verificationScore: sql`excluded.verification_score`,
+              sourceTitle: sql`excluded.source_title`,
+              sourceType: sql`excluded.source_type`,
+              extractionModel: sql`excluded.extraction_model`,
+              updatedAt: sql`now()`,
+            },
           })
-          .where(
-            and(
-              eq(citationQuotes.pageId, d.pageId),
-              eq(citationQuotes.footnote, d.footnote)
-            )
-          )
           .returning({
+            id: citationQuotes.id,
             pageId: citationQuotes.pageId,
             footnote: citationQuotes.footnote,
           });
-
-        if (rows.length > 0) {
-          results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
-        }
-      }
-    });
-  } catch (err) {
-    return dbError(c, "citation quotes mark-accuracy-batch", err, { itemCount: items.length });
-  }
-
-  return c.json({ updated: results.length, results });
-});
-
-// ---- POST /accuracy-snapshot ----
-
-citationsRoute.post("/accuracy-snapshot", async (c) => {
-  const db = getDrizzleDb();
-
-  // Compute per-page accuracy stats from current citation_quotes data
-  const pageStats = await db.select({
-    pageId: citationQuotes.pageId,
-    totalCitations: count(),
-    checkedCitations: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
-    accurateCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
-    minorIssuesCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'minor_issues' then 1 end)`,
-    inaccurateCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
-    unsupportedCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
-    notVerifiableCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'not_verifiable' then 1 end)`,
-    averageScore: avg(citationQuotes.accuracyScore),
-  })
-    .from(citationQuotes)
-    .groupBy(citationQuotes.pageId)
-    .having(sql`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end) > 0`);
-
-  // Insert snapshots for all pages with accuracy data
-  let inserted: Array<{ id: number; pageId: string }> = [];
-  if (pageStats.length > 0) {
-    inserted = await db
-      .insert(citationAccuracySnapshots)
-      .values(
-        pageStats.map((ps) => ({
-          pageId: ps.pageId,
-          totalCitations: ps.totalCitations,
-          checkedCitations: Number(ps.checkedCitations),
-          accurateCount: Number(ps.accurateCount),
-          minorIssuesCount: Number(ps.minorIssuesCount),
-          inaccurateCount: Number(ps.inaccurateCount),
-          unsupportedCount: Number(ps.unsupportedCount),
-          notVerifiableCount: Number(ps.notVerifiableCount),
-          averageScore: ps.averageScore != null ? Number(ps.averageScore) : null,
-        }))
-      )
-      .returning({
-        id: citationAccuracySnapshots.id,
-        pageId: citationAccuracySnapshots.pageId,
       });
-  }
+    } catch (err) {
+      return dbError(c, "citation quotes upsert-batch", err, { itemCount: items.length });
+    }
 
-  return c.json({
-    snapshotCount: inserted.length,
-    pages: inserted.map((r) => r.pageId),
-  }, 201);
-});
+    return c.json({ results });
+  })
 
-// ---- GET /accuracy-trends?page_id=X&limit=N ----
+  // ---- GET /quotes?page_id=X ----
+  .get("/quotes", async (c) => {
+    const pageId = c.req.query("page_id");
+    if (!pageId) return validationError(c, "page_id query parameter is required");
 
-citationsRoute.get("/accuracy-trends", async (c) => {
-  const pageId = c.req.query("page_id");
-  const limitStr = c.req.query("limit");
-  const limit = limitStr ? Math.min(Math.max(parseInt(limitStr, 10) || 50, 1), 500) : 50;
+    const limitParam = c.req.query("limit");
+    const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500) : 100;
 
-  const db = getDrizzleDb();
-
-  if (pageId) {
-    // Trends for a specific page
+    const db = getDrizzleDb();
     const rows = await db
       .select()
+      .from(citationQuotes)
+      .where(eq(citationQuotes.pageId, pageId))
+      .orderBy(asc(citationQuotes.footnote))
+      .limit(limit);
+
+    return c.json({ quotes: rows });
+  })
+
+  // ---- GET /quotes/all (paginated) ----
+  .get("/quotes/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(citationQuotes)
+      .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db.select({ count: count() }).from(citationQuotes);
+    const total = countResult[0].count;
+
+    return c.json({ quotes: rows, total, limit, offset });
+  })
+
+  // ---- POST /quotes/mark-verified ----
+  .post("/quotes/mark-verified", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = MarkVerifiedSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { pageId, footnote, method, score } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .update(citationQuotes)
+      .set({
+        quoteVerified: true,
+        verificationMethod: method,
+        verificationScore: score,
+        verifiedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(citationQuotes.pageId, pageId),
+          eq(citationQuotes.footnote, footnote)
+        )
+      )
+      .returning({
+        id: citationQuotes.id,
+        pageId: citationQuotes.pageId,
+        footnote: citationQuotes.footnote,
+      });
+
+    if (rows.length === 0) {
+      return notFoundError(c, `No quote for page=${pageId} footnote=${footnote}`);
+    }
+
+    return c.json({ updated: true, pageId, footnote });
+  })
+
+  // ---- POST /quotes/mark-accuracy ----
+  .post("/quotes/mark-accuracy", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = MarkAccuracySchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { pageId, footnote, verdict, score, issues, supportingQuotes, verificationDifficulty } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .update(citationQuotes)
+      .set({
+        accuracyVerdict: verdict,
+        accuracyScore: score,
+        accuracyIssues: issues ?? null,
+        accuracySupportingQuotes: supportingQuotes ?? null,
+        verificationDifficulty: verificationDifficulty ?? null,
+        accuracyCheckedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(citationQuotes.pageId, pageId),
+          eq(citationQuotes.footnote, footnote)
+        )
+      )
+      .returning({
+        id: citationQuotes.id,
+        pageId: citationQuotes.pageId,
+        footnote: citationQuotes.footnote,
+      });
+
+    if (rows.length === 0) {
+      return notFoundError(c, `No quote for page=${pageId} footnote=${footnote}`);
+    }
+
+    return c.json({ updated: true, pageId, footnote, verdict });
+  })
+
+  // ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db.select({
+      totalQuotes: count(),
+      withQuotes: sql<number>`count(case when ${citationQuotes.sourceQuote} is not null then 1 end)`,
+      verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
+      unverified: sql<number>`count(case when ${citationQuotes.quoteVerified} = false or ${citationQuotes.quoteVerified} is null then 1 end)`,
+      totalPages: sql<number>`count(distinct ${citationQuotes.pageId})`,
+      averageScore: avg(citationQuotes.verificationScore),
+    }).from(citationQuotes);
+
+    const r = rows[0];
+    return c.json({
+      totalQuotes: r.totalQuotes,
+      withQuotes: Number(r.withQuotes),
+      verified: Number(r.verified),
+      unverified: Number(r.unverified),
+      totalPages: Number(r.totalPages),
+      averageScore: r.averageScore != null ? Number(r.averageScore) : null,
+    });
+  })
+
+  // ---- GET /page-stats ----
+  .get("/page-stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db.select({
+      pageId: citationQuotes.pageId,
+      total: count(),
+      withQuotes: sql<number>`count(case when ${citationQuotes.sourceQuote} is not null then 1 end)`,
+      verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
+      avgScore: avg(citationQuotes.verificationScore),
+      accuracyChecked: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
+      accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
+      inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
+    })
+      .from(citationQuotes)
+      .groupBy(citationQuotes.pageId)
+      .orderBy(asc(citationQuotes.pageId));
+
+    return c.json({
+      pages: rows.map((r) => ({
+        pageId: r.pageId,
+        total: r.total,
+        withQuotes: Number(r.withQuotes),
+        verified: Number(r.verified),
+        avgScore: r.avgScore != null ? Number(r.avgScore) : null,
+        accuracyChecked: Number(r.accuracyChecked),
+        accurate: Number(r.accurate),
+        inaccurate: Number(r.inaccurate),
+      })),
+    });
+  })
+
+  // ---- GET /accuracy-summary ----
+  .get("/accuracy-summary", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db.select({
+      pageId: citationQuotes.pageId,
+      checked: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
+      accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
+      inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
+      unsupported: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
+    })
+      .from(citationQuotes)
+      .groupBy(citationQuotes.pageId)
+      .having(sql`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end) > 0`)
+      .orderBy(asc(citationQuotes.pageId));
+
+    return c.json({
+      pages: rows.map((r) => ({
+        pageId: r.pageId,
+        checked: Number(r.checked),
+        accurate: Number(r.accurate),
+        inaccurate: Number(r.inaccurate),
+        unsupported: Number(r.unsupported),
+      })),
+    });
+  })
+
+  // ---- GET /broken ----
+  .get("/broken", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        pageId: citationQuotes.pageId,
+        footnote: citationQuotes.footnote,
+        url: citationQuotes.url,
+        claimText: citationQuotes.claimText,
+        verificationScore: citationQuotes.verificationScore,
+      })
+      .from(citationQuotes)
+      .where(
+        and(
+          eq(citationQuotes.quoteVerified, true),
+          isNotNull(citationQuotes.verificationScore),
+          lt(citationQuotes.verificationScore, BROKEN_SCORE_THRESHOLD)
+        )
+      )
+      .orderBy(
+        asc(citationQuotes.verificationScore),
+        asc(citationQuotes.pageId),
+        asc(citationQuotes.footnote)
+      );
+
+    return c.json({ broken: rows });
+  })
+
+  // ---- POST /content/upsert ----
+  // BREAKING CHANGE (PR #476): This endpoint no longer accepts `pageId` or
+  // `footnote` fields. Citation content is now keyed by URL only. External
+  // scripts that previously sent pageId/footnote need updating.
+  .post("/content/upsert", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = UpsertContentSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const d = parsed.data;
+    const db = getDrizzleDb();
+
+    const vals = {
+      url: d.url,
+      resourceId: d.resourceId ?? null,
+      fetchedAt: new Date(d.fetchedAt),
+      httpStatus: d.httpStatus ?? null,
+      contentType: d.contentType ?? null,
+      pageTitle: d.pageTitle ?? null,
+      fullTextPreview: d.fullTextPreview ?? (d.fullText ? d.fullText.slice(0, CITATION_CONTENT_PREVIEW_MAX) : null),
+      fullText: d.fullText ?? null,
+      contentLength: d.contentLength ?? null,
+      contentHash: d.contentHash ?? null,
+    };
+
+    await db
+      .insert(citationContent)
+      .values(vals)
+      .onConflictDoUpdate({
+        target: citationContent.url,
+        set: { ...vals, updatedAt: sql`now()` },
+      });
+
+    return c.json({ url: d.url });
+  })
+
+  // ---- POST /quotes/mark-accuracy-batch ----
+  .post("/quotes/mark-accuracy-batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = MarkAccuracyBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+    const results: Array<{ pageId: string; footnote: number; verdict: string }> = [];
+
+    try {
+      await db.transaction(async (tx) => {
+        for (const d of items) {
+          const rows = await tx
+            .update(citationQuotes)
+            .set({
+              accuracyVerdict: d.verdict,
+              accuracyScore: d.score,
+              accuracyIssues: d.issues ?? null,
+              accuracySupportingQuotes: d.supportingQuotes ?? null,
+              verificationDifficulty: d.verificationDifficulty ?? null,
+              accuracyCheckedAt: sql`now()`,
+              updatedAt: sql`now()`,
+            })
+            .where(
+              and(
+                eq(citationQuotes.pageId, d.pageId),
+                eq(citationQuotes.footnote, d.footnote)
+              )
+            )
+            .returning({
+              pageId: citationQuotes.pageId,
+              footnote: citationQuotes.footnote,
+            });
+
+          if (rows.length > 0) {
+            results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
+          }
+        }
+      });
+    } catch (err) {
+      return dbError(c, "citation quotes mark-accuracy-batch", err, { itemCount: items.length });
+    }
+
+    return c.json({ updated: results.length, results });
+  })
+
+  // ---- POST /accuracy-snapshot ----
+  .post("/accuracy-snapshot", async (c) => {
+    const db = getDrizzleDb();
+
+    // Compute per-page accuracy stats from current citation_quotes data
+    const pageStats = await db.select({
+      pageId: citationQuotes.pageId,
+      totalCitations: count(),
+      checkedCitations: sql<number>`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end)`,
+      accurateCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
+      minorIssuesCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'minor_issues' then 1 end)`,
+      inaccurateCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
+      unsupportedCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
+      notVerifiableCount: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'not_verifiable' then 1 end)`,
+      averageScore: avg(citationQuotes.accuracyScore),
+    })
+      .from(citationQuotes)
+      .groupBy(citationQuotes.pageId)
+      .having(sql`count(case when ${citationQuotes.accuracyVerdict} is not null then 1 end) > 0`);
+
+    // Insert snapshots for all pages with accuracy data
+    let inserted: Array<{ id: number; pageId: string }> = [];
+    if (pageStats.length > 0) {
+      inserted = await db
+        .insert(citationAccuracySnapshots)
+        .values(
+          pageStats.map((ps) => ({
+            pageId: ps.pageId,
+            totalCitations: ps.totalCitations,
+            checkedCitations: Number(ps.checkedCitations),
+            accurateCount: Number(ps.accurateCount),
+            minorIssuesCount: Number(ps.minorIssuesCount),
+            inaccurateCount: Number(ps.inaccurateCount),
+            unsupportedCount: Number(ps.unsupportedCount),
+            notVerifiableCount: Number(ps.notVerifiableCount),
+            averageScore: ps.averageScore != null ? Number(ps.averageScore) : null,
+          }))
+        )
+        .returning({
+          id: citationAccuracySnapshots.id,
+          pageId: citationAccuracySnapshots.pageId,
+        });
+    }
+
+    return c.json({
+      snapshotCount: inserted.length,
+      pages: inserted.map((r) => r.pageId),
+    }, 201);
+  })
+
+  // ---- GET /accuracy-trends?page_id=X&limit=N ----
+  .get("/accuracy-trends", async (c) => {
+    const pageId = c.req.query("page_id");
+    const limitStr = c.req.query("limit");
+    const limit = limitStr ? Math.min(Math.max(parseInt(limitStr, 10) || 50, 1), 500) : 50;
+
+    const db = getDrizzleDb();
+
+    if (pageId) {
+      // Trends for a specific page
+      const rows = await db
+        .select()
+        .from(citationAccuracySnapshots)
+        .where(eq(citationAccuracySnapshots.pageId, pageId))
+        .orderBy(desc(citationAccuracySnapshots.snapshotAt))
+        .limit(limit);
+
+      return c.json({ pageId, snapshots: rows });
+    }
+
+    // Global trends: aggregate all snapshots by timestamp
+    const rows = await db
+      .select({
+        snapshotAt: citationAccuracySnapshots.snapshotAt,
+        totalPages: sql<number>`count(distinct ${citationAccuracySnapshots.pageId})`,
+        totalCitations: sql<number>`sum(${citationAccuracySnapshots.totalCitations})`,
+        checkedCitations: sql<number>`sum(${citationAccuracySnapshots.checkedCitations})`,
+        accurateCount: sql<number>`sum(${citationAccuracySnapshots.accurateCount})`,
+        minorIssuesCount: sql<number>`sum(${citationAccuracySnapshots.minorIssuesCount})`,
+        inaccurateCount: sql<number>`sum(${citationAccuracySnapshots.inaccurateCount})`,
+        unsupportedCount: sql<number>`sum(${citationAccuracySnapshots.unsupportedCount})`,
+        notVerifiableCount: sql<number>`sum(${citationAccuracySnapshots.notVerifiableCount})`,
+        averageScore: avg(citationAccuracySnapshots.averageScore),
+      })
       .from(citationAccuracySnapshots)
-      .where(eq(citationAccuracySnapshots.pageId, pageId))
+      .groupBy(citationAccuracySnapshots.snapshotAt)
       .orderBy(desc(citationAccuracySnapshots.snapshotAt))
       .limit(limit);
 
-    return c.json({ pageId, snapshots: rows });
-  }
+    return c.json({
+      snapshots: rows.map((r) => ({
+        ...r,
+        totalPages: Number(r.totalPages),
+        totalCitations: Number(r.totalCitations),
+        checkedCitations: Number(r.checkedCitations),
+        accurateCount: Number(r.accurateCount),
+        minorIssuesCount: Number(r.minorIssuesCount),
+        inaccurateCount: Number(r.inaccurateCount),
+        unsupportedCount: Number(r.unsupportedCount),
+        notVerifiableCount: Number(r.notVerifiableCount),
+        averageScore: r.averageScore != null ? Number(r.averageScore) : null,
+      })),
+    });
+  })
 
-  // Global trends: aggregate all snapshots by timestamp
-  const rows = await db
-    .select({
-      snapshotAt: citationAccuracySnapshots.snapshotAt,
-      totalPages: sql<number>`count(distinct ${citationAccuracySnapshots.pageId})`,
-      totalCitations: sql<number>`sum(${citationAccuracySnapshots.totalCitations})`,
-      checkedCitations: sql<number>`sum(${citationAccuracySnapshots.checkedCitations})`,
-      accurateCount: sql<number>`sum(${citationAccuracySnapshots.accurateCount})`,
-      minorIssuesCount: sql<number>`sum(${citationAccuracySnapshots.minorIssuesCount})`,
-      inaccurateCount: sql<number>`sum(${citationAccuracySnapshots.inaccurateCount})`,
-      unsupportedCount: sql<number>`sum(${citationAccuracySnapshots.unsupportedCount})`,
-      notVerifiableCount: sql<number>`sum(${citationAccuracySnapshots.notVerifiableCount})`,
-      averageScore: avg(citationAccuracySnapshots.averageScore),
-    })
-    .from(citationAccuracySnapshots)
-    .groupBy(citationAccuracySnapshots.snapshotAt)
-    .orderBy(desc(citationAccuracySnapshots.snapshotAt))
-    .limit(limit);
+  // ---- GET /accuracy-dashboard ----
+  .get("/accuracy-dashboard", async (c) => {
+    const db = getDrizzleDb();
 
-  return c.json({
-    snapshots: rows.map((r) => ({
-      ...r,
-      totalPages: Number(r.totalPages),
-      totalCitations: Number(r.totalCitations),
-      checkedCitations: Number(r.checkedCitations),
-      accurateCount: Number(r.accurateCount),
-      minorIssuesCount: Number(r.minorIssuesCount),
-      inaccurateCount: Number(r.inaccurateCount),
-      unsupportedCount: Number(r.unsupportedCount),
-      notVerifiableCount: Number(r.notVerifiableCount),
-      averageScore: r.averageScore != null ? Number(r.averageScore) : null,
-    })),
-  });
-});
+    // Get all quotes with accuracy data
+    const allQuotes = await db
+      .select()
+      .from(citationQuotes)
+      .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote));
 
-// ---- GET /accuracy-dashboard ----
+    // Compute summary stats
+    let checkedCount = 0;
+    let accurateCount = 0;
+    let inaccurateCount = 0;
+    let unsupportedCount = 0;
+    let minorIssueCount = 0;
+    let scoreSum = 0;
+    let scoreCount = 0;
 
-citationsRoute.get("/accuracy-dashboard", async (c) => {
-  const db = getDrizzleDb();
-
-  // Get all quotes with accuracy data
-  const allQuotes = await db
-    .select()
-    .from(citationQuotes)
-    .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote));
-
-  // Compute summary stats
-  let checkedCount = 0;
-  let accurateCount = 0;
-  let inaccurateCount = 0;
-  let unsupportedCount = 0;
-  let minorIssueCount = 0;
-  let scoreSum = 0;
-  let scoreCount = 0;
-
-  const verdictDist: Record<string, number> = {};
-  const difficultyDist: Record<string, number> = {};
-
-  // Page aggregation
-  const pageMap = new Map<string, {
-    total: number; checked: number; accurate: number;
-    inaccurate: number; unsupported: number; minorIssues: number;
-    scoreSum: number; scoreCount: number;
-  }>();
-
-  // Domain aggregation
-  const domainMap = new Map<string, {
-    total: number; checked: number; accurate: number;
-    inaccurate: number; unsupported: number;
-  }>();
-
-  // Flagged citations
-  const flagged: Array<{
-    pageId: string; footnote: number; claimText: string;
-    sourceTitle: string | null; url: string | null;
-    verdict: string; score: number | null;
-    issues: string | null; difficulty: string | null;
-    checkedAt: string | null;
-  }> = [];
-
-  for (const q of allQuotes) {
-    const pageId = q.pageId;
-    const verdict = q.accuracyVerdict;
-    const score = q.accuracyScore;
-    const difficulty = q.verificationDifficulty;
-    const url = q.url;
-
-    // Extract domain
-    let domain: string | null = null;
-    if (url) {
-      try { domain = new URL(url).hostname.replace(/^www\./, ''); } catch { /* invalid URL */ }
-    }
+    const verdictDist: Record<string, number> = {};
+    const difficultyDist: Record<string, number> = {};
 
     // Page aggregation
-    if (!pageMap.has(pageId)) {
-      pageMap.set(pageId, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0, minorIssues: 0, scoreSum: 0, scoreCount: 0 });
-    }
-    const page = pageMap.get(pageId)!;
-    page.total++;
+    const pageMap = new Map<string, {
+      total: number; checked: number; accurate: number;
+      inaccurate: number; unsupported: number; minorIssues: number;
+      scoreSum: number; scoreCount: number;
+    }>();
 
     // Domain aggregation
-    if (domain) {
-      if (!domainMap.has(domain)) {
-        domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0 });
+    const domainMap = new Map<string, {
+      total: number; checked: number; accurate: number;
+      inaccurate: number; unsupported: number;
+    }>();
+
+    // Flagged citations
+    const flagged: Array<{
+      pageId: string; footnote: number; claimText: string;
+      sourceTitle: string | null; url: string | null;
+      verdict: string; score: number | null;
+      issues: string | null; difficulty: string | null;
+      checkedAt: string | null;
+    }> = [];
+
+    for (const q of allQuotes) {
+      const pageId = q.pageId;
+      const verdict = q.accuracyVerdict;
+      const score = q.accuracyScore;
+      const difficulty = q.verificationDifficulty;
+      const url = q.url;
+
+      // Extract domain
+      let domain: string | null = null;
+      if (url) {
+        try { domain = new URL(url).hostname.replace(/^www\./, ''); } catch { /* invalid URL */ }
       }
-      const d = domainMap.get(domain)!;
-      d.total++;
+
+      // Page aggregation
+      if (!pageMap.has(pageId)) {
+        pageMap.set(pageId, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0, minorIssues: 0, scoreSum: 0, scoreCount: 0 });
+      }
+      const page = pageMap.get(pageId)!;
+      page.total++;
+
+      // Domain aggregation
+      if (domain) {
+        if (!domainMap.has(domain)) {
+          domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0 });
+        }
+        const d = domainMap.get(domain)!;
+        d.total++;
+      }
+
+      if (verdict) {
+        checkedCount++;
+        page.checked++;
+        verdictDist[verdict] = (verdictDist[verdict] || 0) + 1;
+
+        if (domain) domainMap.get(domain)!.checked++;
+
+        if (score !== null) {
+          scoreSum += score;
+          scoreCount++;
+          page.scoreSum += score;
+          page.scoreCount++;
+        }
+
+        if (difficulty) {
+          difficultyDist[difficulty] = (difficultyDist[difficulty] || 0) + 1;
+        }
+
+        if (verdict === 'accurate') {
+          accurateCount++; page.accurate++;
+          if (domain) domainMap.get(domain)!.accurate++;
+        } else if (verdict === 'inaccurate') {
+          inaccurateCount++; page.inaccurate++;
+          if (domain) domainMap.get(domain)!.inaccurate++;
+        } else if (verdict === 'unsupported') {
+          unsupportedCount++; page.unsupported++;
+          if (domain) domainMap.get(domain)!.unsupported++;
+        } else if (verdict === 'minor_issues') {
+          minorIssueCount++; page.minorIssues++;
+        }
+
+        // Flag problematic citations
+        if (verdict === 'inaccurate' || verdict === 'unsupported') {
+          const claimText = q.claimText.length > 150 ? q.claimText.slice(0, 150) + '...' : q.claimText;
+          flagged.push({
+            pageId, footnote: q.footnote, claimText,
+            sourceTitle: q.sourceTitle, url,
+            verdict, score,
+            issues: q.accuracyIssues,
+            difficulty,
+            checkedAt: q.accuracyCheckedAt?.toISOString() ?? null,
+          });
+        }
+      }
     }
 
-    if (verdict) {
-      checkedCount++;
-      page.checked++;
-      verdictDist[verdict] = (verdictDist[verdict] || 0) + 1;
-
-      if (domain) domainMap.get(domain)!.checked++;
-
-      if (score !== null) {
-        scoreSum += score;
-        scoreCount++;
-        page.scoreSum += score;
-        page.scoreCount++;
-      }
-
-      if (difficulty) {
-        difficultyDist[difficulty] = (difficultyDist[difficulty] || 0) + 1;
-      }
-
-      if (verdict === 'accurate') {
-        accurateCount++; page.accurate++;
-        if (domain) domainMap.get(domain)!.accurate++;
-      } else if (verdict === 'inaccurate') {
-        inaccurateCount++; page.inaccurate++;
-        if (domain) domainMap.get(domain)!.inaccurate++;
-      } else if (verdict === 'unsupported') {
-        unsupportedCount++; page.unsupported++;
-        if (domain) domainMap.get(domain)!.unsupported++;
-      } else if (verdict === 'minor_issues') {
-        minorIssueCount++; page.minorIssues++;
-      }
-
-      // Flag problematic citations
-      if (verdict === 'inaccurate' || verdict === 'unsupported') {
-        const claimText = q.claimText.length > 150 ? q.claimText.slice(0, 150) + '...' : q.claimText;
-        flagged.push({
-          pageId, footnote: q.footnote, claimText,
-          sourceTitle: q.sourceTitle, url,
-          verdict, score,
-          issues: q.accuracyIssues,
-          difficulty,
-          checkedAt: q.accuracyCheckedAt?.toISOString() ?? null,
-        });
-      }
-    }
-  }
-
-  // Build page summaries
-  const pages = Array.from(pageMap.entries()).map(([pageId, p]) => ({
-    pageId,
-    totalCitations: p.total,
-    checked: p.checked,
-    accurate: p.accurate,
-    inaccurate: p.inaccurate,
-    unsupported: p.unsupported,
-    minorIssues: p.minorIssues,
-    accuracyRate: p.checked > 0 ? Math.round(((p.accurate + p.minorIssues) / p.checked) * 100) / 100 : null,
-    avgScore: p.scoreCount > 0 ? Math.round((p.scoreSum / p.scoreCount) * 100) / 100 : null,
-  }));
-  pages.sort((a, b) => {
-    const aInacc = a.checked > 0 ? (a.inaccurate + a.unsupported) / a.checked : 0;
-    const bInacc = b.checked > 0 ? (b.inaccurate + b.unsupported) / b.checked : 0;
-    if (bInacc !== aInacc) return bInacc - aInacc;
-    return b.totalCitations - a.totalCitations;
-  });
-
-  // Build domain summaries
-  const MIN_DOMAIN_CITATIONS = 2;
-  const domainAnalysis = Array.from(domainMap.entries())
-    .filter(([, d]) => d.total >= MIN_DOMAIN_CITATIONS)
-    .map(([domain, d]) => ({
-      domain,
-      totalCitations: d.total,
-      checked: d.checked,
-      accurate: d.accurate,
-      inaccurate: d.inaccurate,
-      unsupported: d.unsupported,
-      inaccuracyRate: d.checked > 0 ? Math.round(((d.inaccurate + d.unsupported) / d.checked) * 100) / 100 : null,
+    // Build page summaries
+    const pages = Array.from(pageMap.entries()).map(([pageId, p]) => ({
+      pageId,
+      totalCitations: p.total,
+      checked: p.checked,
+      accurate: p.accurate,
+      inaccurate: p.inaccurate,
+      unsupported: p.unsupported,
+      minorIssues: p.minorIssues,
+      accuracyRate: p.checked > 0 ? Math.round(((p.accurate + p.minorIssues) / p.checked) * 100) / 100 : null,
+      avgScore: p.scoreCount > 0 ? Math.round((p.scoreSum / p.scoreCount) * 100) / 100 : null,
     }));
-  domainAnalysis.sort((a, b) => {
-    const aRate = a.inaccuracyRate ?? 0;
-    const bRate = b.inaccuracyRate ?? 0;
-    if (bRate !== aRate) return bRate - aRate;
-    return b.totalCitations - a.totalCitations;
-  });
+    pages.sort((a, b) => {
+      const aInacc = a.checked > 0 ? (a.inaccurate + a.unsupported) / a.checked : 0;
+      const bInacc = b.checked > 0 ? (b.inaccurate + b.unsupported) / b.checked : 0;
+      if (bInacc !== aInacc) return bInacc - aInacc;
+      return b.totalCitations - a.totalCitations;
+    });
 
-  // Sort flagged by score (worst first)
-  flagged.sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
+    // Build domain summaries
+    const MIN_DOMAIN_CITATIONS = 2;
+    const domainAnalysis = Array.from(domainMap.entries())
+      .filter(([, d]) => d.total >= MIN_DOMAIN_CITATIONS)
+      .map(([domain, d]) => ({
+        domain,
+        totalCitations: d.total,
+        checked: d.checked,
+        accurate: d.accurate,
+        inaccurate: d.inaccurate,
+        unsupported: d.unsupported,
+        inaccuracyRate: d.checked > 0 ? Math.round(((d.inaccurate + d.unsupported) / d.checked) * 100) / 100 : null,
+      }));
+    domainAnalysis.sort((a, b) => {
+      const aRate = a.inaccuracyRate ?? 0;
+      const bRate = b.inaccuracyRate ?? 0;
+      if (bRate !== aRate) return bRate - aRate;
+      return b.totalCitations - a.totalCitations;
+    });
 
-  return c.json({
-    exportedAt: new Date().toISOString(),
-    summary: {
-      totalCitations: allQuotes.length,
-      checkedCitations: checkedCount,
-      accurateCitations: accurateCount,
-      inaccurateCitations: inaccurateCount,
-      unsupportedCitations: unsupportedCount,
-      minorIssueCitations: minorIssueCount,
-      uncheckedCitations: allQuotes.length - checkedCount,
-      averageScore: scoreCount > 0 ? Math.round((scoreSum / scoreCount) * 100) / 100 : null,
-    },
-    verdictDistribution: verdictDist,
-    difficultyDistribution: difficultyDist,
-    pages,
-    flaggedCitations: flagged,
-    domainAnalysis,
-  });
-});
+    // Sort flagged by score (worst first)
+    flagged.sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
 
-// ---- GET /content?url=X ----
+    return c.json({
+      exportedAt: new Date().toISOString(),
+      summary: {
+        totalCitations: allQuotes.length,
+        checkedCitations: checkedCount,
+        accurateCitations: accurateCount,
+        inaccurateCitations: inaccurateCount,
+        unsupportedCitations: unsupportedCount,
+        minorIssueCitations: minorIssueCount,
+        uncheckedCitations: allQuotes.length - checkedCount,
+        averageScore: scoreCount > 0 ? Math.round((scoreSum / scoreCount) * 100) / 100 : null,
+      },
+      verdictDistribution: verdictDist,
+      difficultyDistribution: difficultyDist,
+      pages,
+      flaggedCitations: flagged,
+      domainAnalysis,
+    });
+  })
 
-citationsRoute.get("/content", async (c) => {
-  const url = c.req.query("url");
-  if (!url) return validationError(c, "url query parameter is required");
+  // ---- GET /content?url=X ----
+  .get("/content", async (c) => {
+    const url = c.req.query("url");
+    if (!url) return validationError(c, "url query parameter is required");
 
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(citationContent)
-    .where(eq(citationContent.url, url));
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(citationContent)
+      .where(eq(citationContent.url, url));
 
-  if (rows.length === 0) {
-    return notFoundError(c, `No content for url: ${url}`);
-  }
+    if (rows.length === 0) {
+      return notFoundError(c, `No content for url: ${url}`);
+    }
 
-  return c.json(rows[0]);
-});
+    return c.json(rows[0]);
+  })
 
-// ---- GET /content/list (paginated, metadata only — no full_text) ----
+  // ---- GET /content/list (paginated, metadata only — no full_text) ----
+  .get("/content/list", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-citationsRoute.get("/content/list", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
 
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
+    const rows = await db
+      .select({
+        url: citationContent.url,
+        fetchedAt: citationContent.fetchedAt,
+        httpStatus: citationContent.httpStatus,
+        contentType: citationContent.contentType,
+        pageTitle: citationContent.pageTitle,
+        contentLength: citationContent.contentLength,
+        contentHash: citationContent.contentHash,
+        hasFullText: sql<boolean>`(${citationContent.fullText} IS NOT NULL)`,
+        hasPreview: sql<boolean>`(${citationContent.fullTextPreview} IS NOT NULL)`,
+        createdAt: citationContent.createdAt,
+        updatedAt: citationContent.updatedAt,
+      })
+      .from(citationContent)
+      .orderBy(desc(citationContent.fetchedAt))
+      .limit(limit)
+      .offset(offset);
 
-  const rows = await db
-    .select({
-      url: citationContent.url,
-      fetchedAt: citationContent.fetchedAt,
-      httpStatus: citationContent.httpStatus,
-      contentType: citationContent.contentType,
-      pageTitle: citationContent.pageTitle,
-      contentLength: citationContent.contentLength,
-      contentHash: citationContent.contentHash,
-      hasFullText: sql<boolean>`(${citationContent.fullText} IS NOT NULL)`,
-      hasPreview: sql<boolean>`(${citationContent.fullTextPreview} IS NOT NULL)`,
-      createdAt: citationContent.createdAt,
-      updatedAt: citationContent.updatedAt,
-    })
-    .from(citationContent)
-    .orderBy(desc(citationContent.fetchedAt))
-    .limit(limit)
-    .offset(offset);
+    // Single aggregate query — avoids 3 separate round-trips and is consistent
+    const aggregates = await db.select({
+      total: count(),
+      withFullText: sql<number>`count(case when ${citationContent.fullText} is not null then 1 end)`,
+      withPreview: sql<number>`count(case when ${citationContent.fullTextPreview} is not null then 1 end)`,
+    }).from(citationContent);
 
-  // Single aggregate query — avoids 3 separate round-trips and is consistent
-  const aggregates = await db.select({
-    total: count(),
-    withFullText: sql<number>`count(case when ${citationContent.fullText} is not null then 1 end)`,
-    withPreview: sql<number>`count(case when ${citationContent.fullTextPreview} is not null then 1 end)`,
-  }).from(citationContent);
+    return c.json({
+      entries: rows,
+      total: aggregates[0].total,
+      withFullText: Number(aggregates[0].withFullText),
+      withPreview: Number(aggregates[0].withPreview),
+      limit,
+      offset,
+    });
+  })
 
-  return c.json({
-    entries: rows,
-    total: aggregates[0].total,
-    withFullText: Number(aggregates[0].withFullText),
-    withPreview: Number(aggregates[0].withPreview),
-    limit,
-    offset,
-  });
-});
+  // ---- GET /content/stats ----
+  .get("/content/stats", async (c) => {
+    const db = getDrizzleDb();
 
-// ---- GET /content/stats ----
+    const rows = await db.select({
+      total: count(),
+      withFullText: sql<number>`count(case when ${citationContent.fullText} is not null then 1 end)`,
+      withPreview: sql<number>`count(case when ${citationContent.fullTextPreview} is not null then 1 end)`,
+      okCount: sql<number>`count(case when ${citationContent.httpStatus} = 200 then 1 end)`,
+      deadCount: sql<number>`count(case when ${citationContent.httpStatus} >= 400 then 1 end)`,
+      avgContentLength: avg(citationContent.contentLength),
+    }).from(citationContent);
 
-citationsRoute.get("/content/stats", async (c) => {
-  const db = getDrizzleDb();
+    const r = rows[0];
+    return c.json({
+      total: r.total,
+      withFullText: Number(r.withFullText),
+      withPreview: Number(r.withPreview),
+      coverage: r.total > 0 ? Math.round((Number(r.withFullText) / r.total) * 100) : 0,
+      okCount: Number(r.okCount),
+      deadCount: Number(r.deadCount),
+      avgContentLength: r.avgContentLength != null ? Math.round(Number(r.avgContentLength)) : null,
+    });
+  })
 
-  const rows = await db.select({
-    total: count(),
-    withFullText: sql<number>`count(case when ${citationContent.fullText} is not null then 1 end)`,
-    withPreview: sql<number>`count(case when ${citationContent.fullTextPreview} is not null then 1 end)`,
-    okCount: sql<number>`count(case when ${citationContent.httpStatus} = 200 then 1 end)`,
-    deadCount: sql<number>`count(case when ${citationContent.httpStatus} >= 400 then 1 end)`,
-    avgContentLength: avg(citationContent.contentLength),
-  }).from(citationContent);
+  // ---- POST /content/link-resources ----
+  // Batch-links citation_content rows to their matching resources by URL.
+  // This bridges the gap between fetched content (URL-keyed) and curated resources (ID-keyed).
+  .post("/content/link-resources", async (c) => {
+    const db = getDrizzleDb();
 
-  const r = rows[0];
-  return c.json({
-    total: r.total,
-    withFullText: Number(r.withFullText),
-    withPreview: Number(r.withPreview),
-    coverage: r.total > 0 ? Math.round((Number(r.withFullText) / r.total) * 100) : 0,
-    okCount: Number(r.okCount),
-    deadCount: Number(r.deadCount),
-    avgContentLength: r.avgContentLength != null ? Math.round(Number(r.avgContentLength)) : null,
-  });
-});
-
-// ---- POST /content/link-resources ----
-// Batch-links citation_content rows to their matching resources by URL.
-// This bridges the gap between fetched content (URL-keyed) and curated resources (ID-keyed).
-
-citationsRoute.post("/content/link-resources", async (c) => {
-  const db = getDrizzleDb();
-
-  // Find all citation_content rows that have no resource_id
-  // and match a resource by URL.
-  let result;
-  try {
-    result = await db.execute(sql`
+    // Find all citation_content rows that have no resource_id
+    // and match a resource by URL.
+    let result;
+    try {
+      result = await db.execute(sql`
       UPDATE citation_content cc
       SET resource_id = r.id
       FROM resources r
       WHERE cc.url = r.url
         AND cc.resource_id IS NULL
     `);
-  } catch (err) {
-    return dbError(c, "citation content link-resources", err);
-  }
-
-  const linked = Number((result as any).count ?? 0);
-  return c.json({ linked });
-});
-
-// ---- GET /quotes-by-url?url=X ----
-// Returns all citation quotes across all pages for a given source URL.
-// Used by resource pages to show cross-page citations.
-
-citationsRoute.get("/quotes-by-url", async (c) => {
-  const url = c.req.query("url");
-  if (!url) return validationError(c, "url query parameter is required");
-
-  const limitParam = c.req.query("limit");
-  const limit = limitParam
-    ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500)
-    : 100;
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(citationQuotes)
-    .where(eq(citationQuotes.url, url))
-    .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote))
-    .limit(limit);
-
-  // Also get aggregate stats
-  const stats = await db
-    .select({
-      totalPages: sql<number>`count(distinct ${citationQuotes.pageId})`,
-      totalQuotes: count(),
-      verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
-      accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
-      inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
-      unsupported: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
-      minorIssues: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'minor_issues' then 1 end)`,
-    })
-    .from(citationQuotes)
-    .where(eq(citationQuotes.url, url));
-
-  const s = stats[0];
-  return c.json({
-    quotes: rows,
-    stats: {
-      totalPages: Number(s.totalPages),
-      totalQuotes: s.totalQuotes,
-      verified: Number(s.verified),
-      accurate: Number(s.accurate),
-      inaccurate: Number(s.inaccurate),
-      unsupported: Number(s.unsupported),
-      minorIssues: Number(s.minorIssues),
-    },
-  });
-});
-
-// ---- PATCH /quotes/:id/link-claim ----
-// Links a citation_quote to a claim via the claim_id FK.
-
-citationsRoute.patch("/quotes/:id/link-claim", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Quote ID must be a positive integer");
-  }
-
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = LinkCitationClaimSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-
-  // Verify claim exists
-  const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, parsed.data.claimId)).limit(1);
-  if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${parsed.data.claimId}`);
-
-  const rows = await db
-    .update(citationQuotes)
-    .set({ claimId: parsed.data.claimId, updatedAt: sql`now()` })
-    .where(eq(citationQuotes.id, id))
-    .returning({ id: citationQuotes.id, pageId: citationQuotes.pageId, footnote: citationQuotes.footnote });
-
-  if (rows.length === 0) return notFoundError(c, `Citation quote not found: ${id}`);
-
-  return c.json({ linked: true, quoteId: Number(rows[0].id), claimId: parsed.data.claimId });
-});
-
-// ---- POST /quotes/link-claims-batch ----
-
-citationsRoute.post("/quotes/link-claims-batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = LinkCitationsClaimsBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Pre-validate that all referenced claim IDs exist (mirrors the single-item endpoint)
-  const uniqueClaimIds = [...new Set(items.map((i) => i.claimId))];
-  const existingClaims = await db
-    .select({ id: claims.id })
-    .from(claims)
-    .where(sql`${claims.id} = ANY(${uniqueClaimIds})`);
-  const existingClaimIdSet = new Set(existingClaims.map((r) => r.id));
-  const missingClaimIds = uniqueClaimIds.filter((id) => !existingClaimIdSet.has(id));
-  if (missingClaimIds.length > 0) {
-    return validationError(c, `Referenced claims not found: ${missingClaimIds.join(", ")}`);
-  }
-
-  let linkedCount = 0;
-
-  try {
-    await db.transaction(async (tx) => {
-      for (const item of items) {
-        const rows = await tx
-          .update(citationQuotes)
-          .set({ claimId: item.claimId, updatedAt: sql`now()` })
-          .where(eq(citationQuotes.id, item.quoteId))
-          .returning({ id: citationQuotes.id });
-        if (rows.length > 0) linkedCount++;
-      }
-    });
-  } catch (err) {
-    return dbError(c, "citation quotes link-claims-batch", err, { itemCount: items.length });
-  }
-
-  return c.json({ linked: linkedCount });
-});
-
-// ---- POST /quotes/propagate-from-claims ----
-// Backward-propagate claim verdicts to linked citation_quotes.
-// For each citation_quote with a claim_id, copies the claim's verdict fields
-// to the citation's accuracy fields, using the mapping:
-//   claim verified → citation accurate
-//   claim unsupported → citation unsupported
-//   claim disputed → citation inaccurate
-//   claim unverified → skip (don't overwrite)
-
-citationsRoute.post("/quotes/propagate-from-claims", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = PropagateFromClaimsSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { pageId } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Find all citation_quotes for this page that have a linked claim
-  const linkedQuotes = await db
-    .select({
-      quoteId: citationQuotes.id,
-      claimVerdict: claims.claimVerdict,
-      claimVerdictScore: claims.claimVerdictScore,
-      claimVerdictIssues: claims.claimVerdictIssues,
-      claimVerdictQuotes: claims.claimVerdictQuotes,
-      claimVerdictDifficulty: claims.claimVerdictDifficulty,
-    })
-    .from(citationQuotes)
-    .innerJoin(claims, eq(citationQuotes.claimId, claims.id))
-    .where(
-      and(
-        eq(citationQuotes.pageId, pageId),
-        isNotNull(citationQuotes.claimId),
-      )
-    );
-
-  // Map claim verdict → citation accuracy verdict
-  const VERDICT_MAP: Record<string, string> = {
-    verified: "accurate",
-    unsupported: "unsupported",
-    disputed: "inaccurate",
-  };
-
-  let propagated = 0;
-  let skipped = 0;
-
-  for (const row of linkedQuotes) {
-    const claimVerdict = row.claimVerdict;
-
-    // Skip if claim has no verdict or verdict is 'unverified'
-    if (!claimVerdict || claimVerdict === "unverified") {
-      skipped++;
-      continue;
+    } catch (err) {
+      return dbError(c, "citation content link-resources", err);
     }
 
-    const mappedVerdict = VERDICT_MAP[claimVerdict];
-    if (!mappedVerdict) {
-      // Unknown verdict value — skip
-      skipped++;
-      continue;
-    }
+    const linked = Number((result as any).count ?? 0);
+    return c.json({ linked });
+  })
 
-    await db
-      .update(citationQuotes)
-      .set({
-        accuracyVerdict: mappedVerdict,
-        accuracyScore: row.claimVerdictScore,
-        accuracyIssues: row.claimVerdictIssues ?? null,
-        accuracySupportingQuotes: row.claimVerdictQuotes ?? null,
-        verificationDifficulty: row.claimVerdictDifficulty ?? null,
-        accuracyCheckedAt: sql`now()`,
-        updatedAt: sql`now()`,
+  // ---- GET /quotes-by-url?url=X ----
+  // Returns all citation quotes across all pages for a given source URL.
+  // Used by resource pages to show cross-page citations.
+  .get("/quotes-by-url", async (c) => {
+    const url = c.req.query("url");
+    if (!url) return validationError(c, "url query parameter is required");
+
+    const limitParam = c.req.query("limit");
+    const limit = limitParam
+      ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500)
+      : 100;
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(citationQuotes)
+      .where(eq(citationQuotes.url, url))
+      .orderBy(asc(citationQuotes.pageId), asc(citationQuotes.footnote))
+      .limit(limit);
+
+    // Also get aggregate stats
+    const stats = await db
+      .select({
+        totalPages: sql<number>`count(distinct ${citationQuotes.pageId})`,
+        totalQuotes: count(),
+        verified: sql<number>`count(case when ${citationQuotes.quoteVerified} = true then 1 end)`,
+        accurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'accurate' then 1 end)`,
+        inaccurate: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'inaccurate' then 1 end)`,
+        unsupported: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'unsupported' then 1 end)`,
+        minorIssues: sql<number>`count(case when ${citationQuotes.accuracyVerdict} = 'minor_issues' then 1 end)`,
       })
-      .where(eq(citationQuotes.id, row.quoteId));
+      .from(citationQuotes)
+      .where(eq(citationQuotes.url, url));
 
-    propagated++;
-  }
+    const s = stats[0];
+    return c.json({
+      quotes: rows,
+      stats: {
+        totalPages: Number(s.totalPages),
+        totalQuotes: s.totalQuotes,
+        verified: Number(s.verified),
+        accurate: Number(s.accurate),
+        inaccurate: Number(s.inaccurate),
+        unsupported: Number(s.unsupported),
+        minorIssues: Number(s.minorIssues),
+      },
+    });
+  })
 
-  return c.json({ propagated, skipped });
-});
+  // ---- PATCH /quotes/:id/link-claim ----
+  // Links a citation_quote to a claim via the claim_id FK.
+  .patch("/quotes/:id/link-claim", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Quote ID must be a positive integer");
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = LinkCitationClaimSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+
+    // Verify claim exists
+    const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, parsed.data.claimId)).limit(1);
+    if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${parsed.data.claimId}`);
+
+    const rows = await db
+      .update(citationQuotes)
+      .set({ claimId: parsed.data.claimId, updatedAt: sql`now()` })
+      .where(eq(citationQuotes.id, id))
+      .returning({ id: citationQuotes.id, pageId: citationQuotes.pageId, footnote: citationQuotes.footnote });
+
+    if (rows.length === 0) return notFoundError(c, `Citation quote not found: ${id}`);
+
+    return c.json({ linked: true, quoteId: Number(rows[0].id), claimId: parsed.data.claimId });
+  })
+
+  // ---- POST /quotes/link-claims-batch ----
+  .post("/quotes/link-claims-batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = LinkCitationsClaimsBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Pre-validate that all referenced claim IDs exist (mirrors the single-item endpoint)
+    const uniqueClaimIds = [...new Set(items.map((i) => i.claimId))];
+    const existingClaims = await db
+      .select({ id: claims.id })
+      .from(claims)
+      .where(sql`${claims.id} = ANY(${uniqueClaimIds})`);
+    const existingClaimIdSet = new Set(existingClaims.map((r) => r.id));
+    const missingClaimIds = uniqueClaimIds.filter((id) => !existingClaimIdSet.has(id));
+    if (missingClaimIds.length > 0) {
+      return validationError(c, `Referenced claims not found: ${missingClaimIds.join(", ")}`);
+    }
+
+    let linkedCount = 0;
+
+    try {
+      await db.transaction(async (tx) => {
+        for (const item of items) {
+          const rows = await tx
+            .update(citationQuotes)
+            .set({ claimId: item.claimId, updatedAt: sql`now()` })
+            .where(eq(citationQuotes.id, item.quoteId))
+            .returning({ id: citationQuotes.id });
+          if (rows.length > 0) linkedCount++;
+        }
+      });
+    } catch (err) {
+      return dbError(c, "citation quotes link-claims-batch", err, { itemCount: items.length });
+    }
+
+    return c.json({ linked: linkedCount });
+  })
+
+  // ---- POST /quotes/propagate-from-claims ----
+  // Backward-propagate claim verdicts to linked citation_quotes.
+  // For each citation_quote with a claim_id, copies the claim's verdict fields
+  // to the citation's accuracy fields, using the mapping:
+  //   claim verified → citation accurate
+  //   claim unsupported → citation unsupported
+  //   claim disputed → citation inaccurate
+  //   claim unverified → skip (don't overwrite)
+  .post("/quotes/propagate-from-claims", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = PropagateFromClaimsSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { pageId } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Find all citation_quotes for this page that have a linked claim
+    const linkedQuotes = await db
+      .select({
+        quoteId: citationQuotes.id,
+        claimVerdict: claims.claimVerdict,
+        claimVerdictScore: claims.claimVerdictScore,
+        claimVerdictIssues: claims.claimVerdictIssues,
+        claimVerdictQuotes: claims.claimVerdictQuotes,
+        claimVerdictDifficulty: claims.claimVerdictDifficulty,
+      })
+      .from(citationQuotes)
+      .innerJoin(claims, eq(citationQuotes.claimId, claims.id))
+      .where(
+        and(
+          eq(citationQuotes.pageId, pageId),
+          isNotNull(citationQuotes.claimId),
+        )
+      );
+
+    // Map claim verdict → citation accuracy verdict
+    const VERDICT_MAP: Record<string, string> = {
+      verified: "accurate",
+      unsupported: "unsupported",
+      disputed: "inaccurate",
+    };
+
+    let propagated = 0;
+    let skipped = 0;
+
+    for (const row of linkedQuotes) {
+      const claimVerdict = row.claimVerdict;
+
+      // Skip if claim has no verdict or verdict is 'unverified'
+      if (!claimVerdict || claimVerdict === "unverified") {
+        skipped++;
+        continue;
+      }
+
+      const mappedVerdict = VERDICT_MAP[claimVerdict];
+      if (!mappedVerdict) {
+        // Unknown verdict value — skip
+        skipped++;
+        continue;
+      }
+
+      await db
+        .update(citationQuotes)
+        .set({
+          accuracyVerdict: mappedVerdict,
+          accuracyScore: row.claimVerdictScore,
+          accuracyIssues: row.claimVerdictIssues ?? null,
+          accuracySupportingQuotes: row.claimVerdictQuotes ?? null,
+          verificationDifficulty: row.claimVerdictDifficulty ?? null,
+          accuracyCheckedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        })
+        .where(eq(citationQuotes.id, row.quoteId));
+
+      propagated++;
+    }
+
+    return c.json({ propagated, skipped });
+  });
+
+export const citationsRoute = citationsApp;
+export type CitationsRoute = typeof citationsApp;

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -25,8 +25,6 @@ import { TRIGRAM_SIMILARITY_THRESHOLD } from "../search-utils.js";
 /** Pre-computed schema for single page-reference insertion (omits claimId from URL param). */
 const PageRefInsertBodySchema = ClaimPageReferenceInsertSchema.omit({ claimId: true });
 
-export const claimsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -107,9 +105,9 @@ function claimValues(d: ClaimInput) {
   };
 }
 
-type ClaimSourceRow = typeof claimSources.$inferSelect;
+type ClaimSourceRowType = typeof claimSources.$inferSelect;
 
-function formatClaimSource(s: ClaimSourceRow) {
+function formatClaimSource(s: ClaimSourceRowType) {
   return {
     id: Number(s.id),
     claimId: Number(s.claimId),
@@ -127,7 +125,7 @@ function formatClaimSource(s: ClaimSourceRow) {
 
 function formatClaim(
   r: typeof claims.$inferSelect,
-  sourcesRows: ClaimSourceRow[] = []
+  sourcesRows: ClaimSourceRowType[] = []
 ) {
   return {
     id: Number(r.id),
@@ -176,640 +174,11 @@ function formatClaim(
   };
 }
 
-// ---- POST / (insert single claim) ----
-
-claimsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = InsertClaimSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-
-  // Validate entity reference
-  const missing = await checkRefsExist(db, entities, entities.id, [parsed.data.entityId]);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced entity not found: ${missing.join(", ")}`);
-  }
-
-  const vals = claimValues(parsed.data);
-
-  const rows = await db
-    .insert(claims)
-    .values(vals)
-    .returning({
-      id: claims.id,
-      entityId: claims.entityId,
-      claimType: claims.claimType,
-    });
-
-  const inserted = firstOrThrow(rows, "claim insert");
-
-  // Insert claim_sources if provided
-  if (parsed.data.sources && parsed.data.sources.length > 0) {
-    const sourceVals = parsed.data.sources.map((s) => ({
-      claimId: inserted.id,
-      resourceId: s.resourceId ?? null,
-      url: s.url ?? null,
-      sourceQuote: s.sourceQuote ?? null,
-      isPrimary: s.isPrimary ?? false,
-    }));
-    await db.insert(claimSources).values(sourceVals);
-  }
-
-  return c.json(inserted, 201);
-});
-
-// ---- POST /batch (insert multiple claims) ----
-
-claimsRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = InsertBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Validate entity references
-  const entityIds = [...new Set(items.map((i) => i.entityId))];
-  const missing = await checkRefsExist(db, entities, entities.id, entityIds);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
-  }
-
-  const itemsWithSources = items.filter(
-    (item) => item.sources && item.sources.length > 0
-  );
-
-  // PostgreSQL's RETURNING clause does not guarantee row ordering matches
-  // insertion order, so we cannot safely correlate results[i] with items[i]
-  // when sources need to be attached to specific claims.
-  //
-  // Strategy: if no item has sources, use a fast multi-row batch insert.
-  // If any item has sources, insert one-at-a-time so each claim's ID is known.
-  const allResults: Array<{ id: number; entityId: string; claimType: string }> = [];
-
-  if (itemsWithSources.length === 0) {
-    // Fast path: bulk insert, no source correlation needed
-    const allVals = items.map(claimValues);
-    const rows = await db
-      .insert(claims)
-      .values(allVals)
-      .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
-    allResults.push(...rows);
-  } else {
-    // Safe path: insert one at a time to guarantee ID correlation for source rows
-    const sourcesToInsert: Array<{
-      claimId: number;
-      resourceId: string | null;
-      url: string | null;
-      sourceQuote: string | null;
-      isPrimary: boolean;
-    }> = [];
-
-    for (const item of items) {
-      const [row] = await db
-        .insert(claims)
-        .values(claimValues(item))
-        .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
-
-      allResults.push(row);
-
-      if (item.sources && item.sources.length > 0) {
-        for (const s of item.sources) {
-          sourcesToInsert.push({
-            claimId: row.id,
-            resourceId: s.resourceId ?? null,
-            url: s.url ?? null,
-            sourceQuote: s.sourceQuote ?? null,
-            isPrimary: s.isPrimary ?? false,
-          });
-        }
-      }
-    }
-
-    if (sourcesToInsert.length > 0) {
-      await db.insert(claimSources).values(sourcesToInsert);
-    }
-  }
-
-  return c.json({ inserted: allResults.length, results: allResults }, 201);
-});
-
-// ---- POST /clear (delete all claims for an entity) ----
-// NOTE: This deletes claims where `entityId` matches (primary entity only).
-// Claims where the entity appears in `relatedEntities` are NOT deleted.
-// This is intentional — relatedEntities are secondary references owned by
-// the primary entity's extraction, and should only be removed when that
-// primary entity's claims are cleared.
-
-claimsRoute.post("/clear", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = DeleteByEntitySchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const deleted = await db
-    .delete(claims)
-    .where(eq(claims.entityId, parsed.data.entityId))
-    .returning({ id: claims.id });
-
-  return c.json({ deleted: deleted.length });
-});
-
-// ---- POST /clear-by-section (delete only claims matching entity+section) ----
-// Used by resource ingestion --force to re-ingest a single resource without
-// clobbering claims from page extraction or other resources.
-
-claimsRoute.post("/clear-by-section", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = ClearClaimsBySectionSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const deleted = await db
-    .delete(claims)
-    .where(
-      and(
-        eq(claims.entityId, parsed.data.entityId),
-        eq(claims.section, parsed.data.section)
-      )
-    )
-    .returning({ id: claims.id });
-
-  return c.json({ deleted: deleted.length });
-});
-
-// ---- POST /delete-by-ids (batch delete claims by ID array) ----
-// Used by the cleanup command to remove low-quality claims in bulk.
+// ---- Schemas defined before the route (must be above method chain) ----
 
 const DeleteByIdsSchema = z.object({
   ids: z.array(z.number().int().positive()).min(1).max(1000),
 });
-
-claimsRoute.post("/delete-by-ids", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = DeleteByIdsSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const deleted = await db
-    .delete(claims)
-    .where(inArray(claims.id, parsed.data.ids))
-    .returning({ id: claims.id });
-
-  return c.json({ deleted: deleted.length });
-});
-
-// ---- GET /stats ----
-
-claimsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const totalResult = await db.select({ count: count() }).from(claims);
-  const total = totalResult[0].count;
-
-  const byType = await db
-    .select({ claimType: claims.claimType, count: count() })
-    .from(claims)
-    .groupBy(claims.claimType)
-    .orderBy(desc(count()));
-
-  const byEntityType = await db
-    .select({ entityType: claims.entityType, count: count() })
-    .from(claims)
-    .groupBy(claims.entityType)
-    .orderBy(desc(count()));
-
-  const byCategory = await db
-    .select({ claimCategory: claims.claimCategory, count: count() })
-    .from(claims)
-    .groupBy(claims.claimCategory)
-    .orderBy(desc(count()));
-
-  const byMode = await db
-    .select({ claimMode: claims.claimMode, count: count() })
-    .from(claims)
-    .groupBy(claims.claimMode)
-    .orderBy(desc(count()));
-
-  // Multi-entity claims
-  const multiEntityResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`);
-
-  // Fact-linked claims
-  const factLinkedResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(sql`${claims.factId} IS NOT NULL`);
-
-  // Claims with claim_sources entries
-  const withSourcesResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(
-      sql`EXISTS (SELECT 1 FROM claim_sources cs WHERE cs.claim_id = ${claims.id})`
-    );
-
-  // Attributed claims
-  const attributedResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(eq(claims.claimMode, "attributed"));
-
-  // Claims with numeric value (central, low, or high)
-  const numericResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(
-      sql`${claims.valueNumeric} IS NOT NULL OR ${claims.valueLow} IS NOT NULL OR ${claims.valueHigh} IS NOT NULL`
-    );
-
-  // Structured claims (with property set)
-  const structuredResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(sql`${claims.property} IS NOT NULL`);
-
-  // Property distribution (for structured claims)
-  const byProperty = await db
-    .select({ property: claims.property, count: count() })
-    .from(claims)
-    .where(sql`${claims.property} IS NOT NULL`)
-    .groupBy(claims.property)
-    .orderBy(desc(count()));
-
-  // Verdict distribution
-  const byVerdict = await db
-    .select({ claimVerdict: claims.claimVerdict, count: count() })
-    .from(claims)
-    .groupBy(claims.claimVerdict)
-    .orderBy(desc(count()));
-
-  return c.json({
-    total,
-    byClaimType: Object.fromEntries(byType.map((r) => [r.claimType, r.count])),
-    byEntityType: Object.fromEntries(byEntityType.map((r) => [r.entityType, r.count])),
-    byClaimCategory: Object.fromEntries(
-      byCategory.map((r) => [r.claimCategory ?? "uncategorized", r.count])
-    ),
-    byClaimMode: Object.fromEntries(
-      byMode.map((r) => [r.claimMode ?? "uncategorized", r.count])
-    ),
-    byClaimVerdict: Object.fromEntries(
-      byVerdict.map((r) => [r.claimVerdict ?? "unverified", r.count])
-    ),
-    multiEntityClaims: multiEntityResult[0].count,
-    factLinkedClaims: factLinkedResult[0].count,
-    withSourcesClaims: withSourcesResult[0].count,
-    attributedClaims: attributedResult[0].count,
-    numericClaims: numericResult[0].count,
-    structuredClaims: structuredResult[0].count,
-    byProperty: Object.fromEntries(
-      byProperty.map((r) => [r.property ?? "unknown", r.count])
-    ),
-  });
-});
-
-// ---- GET /by-entity/:entityId (claims for a specific entity) ----
-// Returns claims where entityId matches OR the entity appears in relatedEntities.
-
-claimsRoute.get("/by-entity/:entityId", async (c) => {
-  const entityId = c.req.param("entityId");
-  const includeSources = c.req.query("includeSources") === "true";
-  const db = getDrizzleDb();
-
-  // Query: primary entity match OR entity appears in the relatedEntities JSONB array
-  const rows = await db
-    .select()
-    .from(claims)
-    .where(
-      or(
-        eq(claims.entityId, entityId),
-        sql`${claims.relatedEntities} @> ${JSON.stringify([entityId])}::jsonb`
-      )
-    )
-    .orderBy(asc(claims.claimType), asc(claims.id));
-
-  let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
-  if (includeSources && rows.length > 0) {
-    const claimIds = rows.map((r) => r.id);
-    const sourcesRows = await db
-      .select()
-      .from(claimSources)
-      .where(inArray(claimSources.claimId, claimIds));
-    for (const s of sourcesRows) {
-      const id = Number(s.claimId);
-      if (!sourcesMap.has(id)) sourcesMap.set(id, []);
-      sourcesMap.get(id)!.push(s);
-    }
-  }
-
-  const includePageReferences = c.req.query("includePageReferences") === "true";
-
-  let pageRefsMap = new Map<number, typeof claimPageReferences.$inferSelect[]>();
-  if (includePageReferences && rows.length > 0) {
-    const claimIds = rows.map((r) => r.id);
-    const pageRefRows = await db
-      .select()
-      .from(claimPageReferences)
-      .where(inArray(claimPageReferences.claimId, claimIds));
-    for (const pr of pageRefRows) {
-      const cid = Number(pr.claimId);
-      if (!pageRefsMap.has(cid)) pageRefsMap.set(cid, []);
-      pageRefsMap.get(cid)!.push(pr);
-    }
-  }
-
-  return c.json({
-    claims: rows.map((r) => {
-      const claim: ReturnType<typeof formatClaim> & { pageReferences?: ClaimPageReferenceRow[] } =
-        formatClaim(r, sourcesMap.get(Number(r.id)) ?? []);
-      if (includePageReferences) {
-        claim.pageReferences = (pageRefsMap.get(Number(r.id)) ?? []).map((pr) => ({
-          id: Number(pr.id),
-          claimId: Number(pr.claimId),
-          pageId: pr.pageId,
-          footnote: pr.footnote,
-          section: pr.section,
-          quoteText: pr.quoteText,
-          referenceId: pr.referenceId,
-          createdAt: pr.createdAt?.toISOString() ?? new Date().toISOString(),
-        }));
-      }
-      return claim;
-    }),
-  });
-});
-
-// ---- GET /all (paginated listing) ----
-
-claimsRoute.get("/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const {
-    limit, offset, entityType, claimType, claimCategory, claimMode,
-    search, confidence, claimVerdict, entityId, attributedTo, measure,
-    multiEntity, hasNumericValue, hasStructuredFields,
-    subjectEntity, property,
-    includeSources, sort,
-  } = parsed.data;
-  const db = getDrizzleDb();
-
-  const conditions = [];
-  if (entityType) conditions.push(eq(claims.entityType, entityType));
-  if (claimType) conditions.push(eq(claims.claimType, claimType));
-  if (claimCategory) conditions.push(eq(claims.claimCategory, claimCategory));
-  if (claimMode) conditions.push(eq(claims.claimMode, claimMode));
-  if (search) conditions.push(sql`${claims.claimText} ILIKE ${"%" + search + "%"}`);
-  if (confidence) conditions.push(eq(claims.confidence, confidence)); // @deprecated Use claimVerdict filter instead
-  if (claimVerdict) conditions.push(eq(claims.claimVerdict, claimVerdict));
-  if (entityId) conditions.push(eq(claims.entityId, entityId));
-  if (attributedTo) conditions.push(eq(claims.attributedTo, attributedTo));
-  if (measure) conditions.push(eq(claims.measure, measure));
-  if (multiEntity) {
-    conditions.push(
-      sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
-    );
-  }
-  if (hasNumericValue) {
-    conditions.push(sql`${claims.valueNumeric} IS NOT NULL`);
-  }
-  if (hasStructuredFields) {
-    conditions.push(sql`${claims.property} IS NOT NULL`);
-  }
-  if (subjectEntity) conditions.push(eq(claims.subjectEntity, subjectEntity));
-  if (property) conditions.push(eq(claims.property, property));
-
-  const whereClause =
-    conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : and(...conditions)
-      : undefined;
-
-  const orderBy =
-    sort === "newest" ? desc(claims.id)
-    : sort === "entity" ? asc(claims.entityId)
-    : sort === "confidence" ? asc(claims.confidence) // @deprecated Use sort=verdict instead
-    : sort === "verdict" ? asc(claims.claimVerdict)
-    : sort === "as_of" ? desc(claims.asOf)
-    : asc(claims.id);
-
-  const rows = await db
-    .select()
-    .from(claims)
-    .where(whereClause)
-    .orderBy(orderBy)
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(claims)
-    .where(whereClause);
-  const total = countResult[0].count;
-
-  let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
-  if (includeSources && rows.length > 0) {
-    const claimIds = rows.map((r) => r.id);
-    const sourcesRows = await db
-      .select()
-      .from(claimSources)
-      .where(inArray(claimSources.claimId, claimIds));
-    for (const s of sourcesRows) {
-      const id = Number(s.claimId);
-      if (!sourcesMap.has(id)) sourcesMap.set(id, []);
-      sourcesMap.get(id)!.push(s);
-    }
-  }
-
-  return c.json({
-    claims: rows.map((r) => formatClaim(r, sourcesMap.get(Number(r.id)) ?? [])),
-    total,
-    limit,
-    offset,
-  });
-});
-
-// ---- GET /relationships (entity-pair relationships) ----
-
-claimsRoute.get("/relationships", async (c) => {
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(claims)
-    .where(
-      sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
-    );
-
-  const pairMap = new Map<
-    string,
-    { entityA: string; entityB: string; claimCount: number; sampleClaims: string[] }
-  >();
-
-  for (const row of rows) {
-    const related = row.relatedEntities as string[] | null;
-    if (!related) continue;
-    for (const rel of related) {
-      // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
-      const normalizedRel = rel.toLowerCase();
-      // Skip self-referential pairs
-      if (normalizedRel === row.entityId) continue;
-      const [a, b] = [row.entityId, normalizedRel].sort();
-      const key = `${a}|||${b}`;
-      if (!pairMap.has(key)) {
-        pairMap.set(key, { entityA: a, entityB: b, claimCount: 0, sampleClaims: [] });
-      }
-      const entry = pairMap.get(key)!;
-      entry.claimCount++;
-      if (entry.sampleClaims.length < 3) {
-        entry.sampleClaims.push(row.claimText.slice(0, 150));
-      }
-    }
-  }
-
-  const relationships = [...pairMap.values()].sort((a, b) => b.claimCount - a.claimCount);
-  return c.json({ relationships });
-});
-
-// ---- GET /network (graph-ready node/edge data) ----
-
-claimsRoute.get("/network", async (c) => {
-  const db = getDrizzleDb();
-
-  const entityCounts = await db
-    .select({ entityId: claims.entityId, count: count() })
-    .from(claims)
-    .groupBy(claims.entityId);
-
-  const rows = await db
-    .select()
-    .from(claims)
-    .where(
-      sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
-    );
-
-  const edgeMap = new Map<string, { source: string; target: string; weight: number }>();
-  const nodeIds = new Set<string>();
-
-  for (const row of rows) {
-    nodeIds.add(row.entityId);
-    const related = row.relatedEntities as string[] | null;
-    if (!related) continue;
-    for (const rel of related) {
-      // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
-      const normalizedRel = rel.toLowerCase();
-      // Skip self-loops
-      if (normalizedRel === row.entityId) continue;
-      nodeIds.add(normalizedRel);
-      const [source, target] = [row.entityId, normalizedRel].sort();
-      const key = `${source}|||${target}`;
-      if (!edgeMap.has(key)) {
-        edgeMap.set(key, { source, target, weight: 0 });
-      }
-      edgeMap.get(key)!.weight++;
-    }
-  }
-
-  const countMap = Object.fromEntries(
-    entityCounts.map((r) => [r.entityId, r.count])
-  );
-  const nodes = [...nodeIds].map((id) => ({
-    entityId: id,
-    claimCount: countMap[id] ?? 0,
-  }));
-  const edges = [...edgeMap.values()].sort((a, b) => b.weight - a.weight);
-
-  return c.json({ nodes, edges });
-});
-
-// ---- GET /:id/similar (find similar claims via pg_trgm) ----
-
-claimsRoute.get("/:id/similar", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
-
-  const limitParam = c.req.query("limit");
-  const limit = Math.min(Math.max(Number(limitParam) || 5, 1), 20);
-
-  const db = getDrizzleDb();
-
-  // Fetch the target claim's text
-  const targetRows = await db
-    .select({ claimText: claims.claimText })
-    .from(claims)
-    .where(eq(claims.id, id))
-    .limit(1);
-
-  if (targetRows.length === 0) {
-    return notFoundError(c, `Claim not found: ${id}`);
-  }
-
-  const targetText = targetRows[0].claimText;
-
-  // Use raw SQL for the similarity() function (same pattern as pages.ts trigram fallback)
-  const rawDb = getDb();
-  const rows = await rawDb.unsafe(
-    `SELECT
-      id, entity_id, entity_type, claim_text, claim_category, confidence,
-      similarity(claim_text, $1) AS similarity_score
-    FROM claims
-    WHERE id != $2
-      AND similarity(claim_text, $1) > ${TRIGRAM_SIMILARITY_THRESHOLD}
-    ORDER BY similarity(claim_text, $1) DESC
-    LIMIT $3`,
-    [targetText, id, limit],
-  );
-
-  return c.json({
-    claims: rows.map((r: any) => ({
-      id: Number(r.id),
-      entityId: r.entity_id,
-      entityType: r.entity_type,
-      claimText: r.claim_text,
-      claimCategory: r.claim_category,
-      confidence: r.confidence,
-      similarityScore: parseFloat(r.similarity_score) || 0,
-    })),
-  });
-});
-
-// ---- GET /:id/sources (sources for a specific claim) ----
-
-claimsRoute.get("/:id/sources", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(claimSources)
-    .where(eq(claimSources.claimId, id))
-    .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
-
-  return c.json({ sources: rows.map(formatClaimSource) });
-});
-
-// ---- POST /:id/sources (add a source to a claim) ----
 
 const AddClaimSourceSchema = z.object({
   resourceId: z.string().max(300).nullable().optional(),
@@ -818,83 +187,12 @@ const AddClaimSourceSchema = z.object({
   isPrimary: z.boolean().optional(),
 });
 
-claimsRoute.post("/:id/sources", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
-
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = AddClaimSourceSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-
-  // Verify claim exists
-  const claimRows = await db
-    .select({ id: claims.id })
-    .from(claims)
-    .where(eq(claims.id, id))
-    .limit(1);
-
-  if (claimRows.length === 0) {
-    return notFoundError(c, `Claim not found: ${id}`);
-  }
-
-  const rows = await db
-    .insert(claimSources)
-    .values({
-      claimId: id,
-      resourceId: parsed.data.resourceId ?? null,
-      url: parsed.data.url ?? null,
-      sourceQuote: parsed.data.sourceQuote ?? null,
-      isPrimary: parsed.data.isPrimary ?? false,
-    })
-    .returning();
-
-  return c.json(formatClaimSource(firstOrThrow(rows, "claim_source insert")), 201);
-});
-
-// ---- PATCH /batch-update-related-entities (bulk update relatedEntities) ----
-// Accepts an array of {id, relatedEntities} pairs and updates them all.
-// IMPORTANT: Must be defined before PATCH /:id to avoid wildcard matching.
-
 const BatchUpdateRelatedEntitiesSchema = z.object({
   items: z.array(z.object({
     id: z.number().int().positive(),
     relatedEntities: z.array(z.string().max(300)).nullable(),
   })).min(1).max(500),
 });
-
-claimsRoute.patch("/batch-update-related-entities", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = BatchUpdateRelatedEntitiesSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const now = new Date();
-  let updated = 0;
-
-  for (const item of parsed.data.items) {
-    const result = await db
-      .update(claims)
-      .set({ relatedEntities: item.relatedEntities, updatedAt: now })
-      .where(eq(claims.id, item.id))
-      .returning({ id: claims.id });
-    if (result.length > 0) updated++;
-  }
-
-  return c.json({ updated, total: parsed.data.items.length });
-});
-
-// ---- PATCH /batch-update-structured (bulk update structured fields) ----
-// Accepts an array of {id, subjectEntity, property, ...} pairs.
-// IMPORTANT: Must be defined before PATCH /:id to avoid wildcard matching.
 
 const BatchUpdateStructuredSchema = z.object({
   items: z.array(z.object({
@@ -908,40 +206,6 @@ const BatchUpdateStructuredSchema = z.object({
   })).min(1).max(500),
 });
 
-claimsRoute.patch("/batch-update-structured", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = BatchUpdateStructuredSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const now = new Date();
-  let updated = 0;
-
-  for (const item of parsed.data.items) {
-    const updates: Record<string, unknown> = { updatedAt: now };
-    if (item.subjectEntity !== undefined) updates.subjectEntity = item.subjectEntity;
-    if (item.property !== undefined) updates.property = item.property;
-    if (item.structuredValue !== undefined) updates.structuredValue = item.structuredValue;
-    if (item.valueUnit !== undefined) updates.valueUnit = item.valueUnit;
-    if (item.valueDate !== undefined) updates.valueDate = item.valueDate;
-    if (item.qualifiers !== undefined) updates.qualifiers = item.qualifiers;
-
-    const result = await db
-      .update(claims)
-      .set(updates)
-      .where(eq(claims.id, item.id))
-      .returning({ id: claims.id });
-    if (result.length > 0) updated++;
-  }
-
-  return c.json({ updated, total: parsed.data.items.length });
-});
-
-// ---- PATCH /:id (partial update) ----
-// Supports updating relatedEntities and structured fields.
-
 const PatchClaimSchema = z.object({
   relatedEntities: z.array(z.string().max(300)).nullable().optional(),
   subjectEntity: z.string().max(300).nullable().optional(),
@@ -952,207 +216,910 @@ const PatchClaimSchema = z.object({
   qualifiers: z.record(z.string()).nullable().optional(),
 });
 
-claimsRoute.patch("/:id", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
+// ---- Route definition (method-chained for Hono RPC type inference) ----
 
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const claimsApp = new Hono()
+  // ---- POST / (insert single claim) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = PatchClaimSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = InsertClaimSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  // Verify claim exists
-  const existing = await db
-    .select({ id: claims.id })
-    .from(claims)
-    .where(eq(claims.id, id))
-    .limit(1);
+    // Validate entity reference
+    const missing = await checkRefsExist(db, entities, entities.id, [parsed.data.entityId]);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced entity not found: ${missing.join(", ")}`);
+    }
 
-  if (existing.length === 0) {
-    return notFoundError(c, `Claim not found: ${id}`);
-  }
+    const vals = claimValues(parsed.data);
 
-  // Build update set — only include fields that were provided
-  const updates: Record<string, unknown> = {};
-  if (parsed.data.relatedEntities !== undefined) {
-    updates.relatedEntities = parsed.data.relatedEntities;
-  }
-  if (parsed.data.subjectEntity !== undefined) updates.subjectEntity = parsed.data.subjectEntity;
-  if (parsed.data.property !== undefined) updates.property = parsed.data.property;
-  if (parsed.data.structuredValue !== undefined) updates.structuredValue = parsed.data.structuredValue;
-  if (parsed.data.valueUnit !== undefined) updates.valueUnit = parsed.data.valueUnit;
-  if (parsed.data.valueDate !== undefined) updates.valueDate = parsed.data.valueDate;
-  if (parsed.data.qualifiers !== undefined) updates.qualifiers = parsed.data.qualifiers;
+    const rows = await db
+      .insert(claims)
+      .values(vals)
+      .returning({
+        id: claims.id,
+        entityId: claims.entityId,
+        claimType: claims.claimType,
+      });
 
-  if (Object.keys(updates).length === 0) {
-    return validationError(c, "No fields to update");
-  }
+    const inserted = firstOrThrow(rows, "claim insert");
 
-  updates.updatedAt = new Date();
+    // Insert claim_sources if provided
+    if (parsed.data.sources && parsed.data.sources.length > 0) {
+      const sourceVals = parsed.data.sources.map((s) => ({
+        claimId: inserted.id,
+        resourceId: s.resourceId ?? null,
+        url: s.url ?? null,
+        sourceQuote: s.sourceQuote ?? null,
+        isPrimary: s.isPrimary ?? false,
+      }));
+      await db.insert(claimSources).values(sourceVals);
+    }
 
-  const rows = await db
-    .update(claims)
-    .set(updates)
-    .where(eq(claims.id, id))
-    .returning();
+    return c.json(inserted, 201);
+  })
+  // ---- POST /batch (insert multiple claims) ----
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const sourcesRows = await db
-    .select()
-    .from(claimSources)
-    .where(eq(claimSources.claimId, id))
-    .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+    const parsed = InsertBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const row = firstOrThrow(rows, "claim update");
-  return c.json(formatClaim(row, sourcesRows));
-});
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
 
-// ---- GET /:id (get by ID) ----
+    // Validate entity references
+    const entityIds = [...new Set(items.map((i) => i.entityId))];
+    const missing = await checkRefsExist(db, entities, entities.id, entityIds);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
+    }
 
-claimsRoute.get("/:id", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
+    const itemsWithSources = items.filter(
+      (item) => item.sources && item.sources.length > 0
+    );
 
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(claims)
-    .where(eq(claims.id, id))
-    .limit(1);
+    // PostgreSQL's RETURNING clause does not guarantee row ordering matches
+    // insertion order, so we cannot safely correlate results[i] with items[i]
+    // when sources need to be attached to specific claims.
+    //
+    // Strategy: if no item has sources, use a fast multi-row batch insert.
+    // If any item has sources, insert one-at-a-time so each claim's ID is known.
+    const allResults: Array<{ id: number; entityId: string; claimType: string }> = [];
 
-  if (rows.length === 0) {
-    return notFoundError(c, `Claim not found: ${id}`);
-  }
+    if (itemsWithSources.length === 0) {
+      // Fast path: bulk insert, no source correlation needed
+      const allVals = items.map(claimValues);
+      const rows = await db
+        .insert(claims)
+        .values(allVals)
+        .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
+      allResults.push(...rows);
+    } else {
+      // Safe path: insert one at a time to guarantee ID correlation for source rows
+      const sourcesToInsert: Array<{
+        claimId: number;
+        resourceId: string | null;
+        url: string | null;
+        sourceQuote: string | null;
+        isPrimary: boolean;
+      }> = [];
 
-  // Always include sources for single claim fetches
-  const sourcesRows = await db
-    .select()
-    .from(claimSources)
-    .where(eq(claimSources.claimId, id))
-    .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+      for (const item of items) {
+        const [row] = await db
+          .insert(claims)
+          .values(claimValues(item))
+          .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
 
-  return c.json(formatClaim(rows[0], sourcesRows));
-});
+        allResults.push(row);
 
-// ---- GET /:id/page-references ----
+        if (item.sources && item.sources.length > 0) {
+          for (const s of item.sources) {
+            sourcesToInsert.push({
+              claimId: row.id,
+              resourceId: s.resourceId ?? null,
+              url: s.url ?? null,
+              sourceQuote: s.sourceQuote ?? null,
+              isPrimary: s.isPrimary ?? false,
+            });
+          }
+        }
+      }
 
-claimsRoute.get("/:id/page-references", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
+      if (sourcesToInsert.length > 0) {
+        await db.insert(claimSources).values(sourcesToInsert);
+      }
+    }
 
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(claimPageReferences)
-    .where(eq(claimPageReferences.claimId, id))
-    .orderBy(asc(claimPageReferences.pageId), asc(claimPageReferences.footnote));
+    return c.json({ inserted: allResults.length, results: allResults }, 201);
+  })
+  // ---- POST /clear (delete all claims for an entity) ----
+  // NOTE: This deletes claims where `entityId` matches (primary entity only).
+  // Claims where the entity appears in `relatedEntities` are NOT deleted.
+  // This is intentional — relatedEntities are secondary references owned by
+  // the primary entity's extraction, and should only be removed when that
+  // primary entity's claims are cleared.
+  .post("/clear", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  return c.json({
-    references: rows.map((r) => ({
-      id: Number(r.id),
-      claimId: Number(r.claimId),
-      pageId: r.pageId,
-      footnote: r.footnote,
-      section: r.section,
-      createdAt: r.createdAt?.toISOString() ?? new Date().toISOString(),
-    })),
-  });
-});
+    const parsed = DeleteByEntitySchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-// ---- POST /:id/page-references ----
+    const db = getDrizzleDb();
+    const deleted = await db
+      .delete(claims)
+      .where(eq(claims.entityId, parsed.data.entityId))
+      .returning({ id: claims.id });
 
-claimsRoute.post("/:id/page-references", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
+    return c.json({ deleted: deleted.length });
+  })
+  // ---- POST /clear-by-section (delete only claims matching entity+section) ----
+  // Used by resource ingestion --force to re-ingest a single resource without
+  // clobbering claims from page extraction or other resources.
+  .post("/clear-by-section", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const parsed = ClearClaimsBySectionSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const parsed = PageRefInsertBodySchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const db = getDrizzleDb();
+    const deleted = await db
+      .delete(claims)
+      .where(
+        and(
+          eq(claims.entityId, parsed.data.entityId),
+          eq(claims.section, parsed.data.section)
+        )
+      )
+      .returning({ id: claims.id });
 
-  const db = getDrizzleDb();
+    return c.json({ deleted: deleted.length });
+  })
+  // ---- POST /delete-by-ids (batch delete claims by ID array) ----
+  // Used by the cleanup command to remove low-quality claims in bulk.
+  .post("/delete-by-ids", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  // Verify claim exists
-  const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, id)).limit(1);
-  if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${id}`);
+    const parsed = DeleteByIdsSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const rows = await db
-    .insert(claimPageReferences)
-    .values({
+    const db = getDrizzleDb();
+    const deleted = await db
+      .delete(claims)
+      .where(inArray(claims.id, parsed.data.ids))
+      .returning({ id: claims.id });
+
+    return c.json({ deleted: deleted.length });
+  })
+  // ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const totalResult = await db.select({ count: count() }).from(claims);
+    const total = totalResult[0].count;
+
+    const byType = await db
+      .select({ claimType: claims.claimType, count: count() })
+      .from(claims)
+      .groupBy(claims.claimType)
+      .orderBy(desc(count()));
+
+    const byEntityType = await db
+      .select({ entityType: claims.entityType, count: count() })
+      .from(claims)
+      .groupBy(claims.entityType)
+      .orderBy(desc(count()));
+
+    const byCategory = await db
+      .select({ claimCategory: claims.claimCategory, count: count() })
+      .from(claims)
+      .groupBy(claims.claimCategory)
+      .orderBy(desc(count()));
+
+    const byMode = await db
+      .select({ claimMode: claims.claimMode, count: count() })
+      .from(claims)
+      .groupBy(claims.claimMode)
+      .orderBy(desc(count()));
+
+    // Multi-entity claims
+    const multiEntityResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`);
+
+    // Fact-linked claims
+    const factLinkedResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(sql`${claims.factId} IS NOT NULL`);
+
+    // Claims with claim_sources entries
+    const withSourcesResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(
+        sql`EXISTS (SELECT 1 FROM claim_sources cs WHERE cs.claim_id = ${claims.id})`
+      );
+
+    // Attributed claims
+    const attributedResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(eq(claims.claimMode, "attributed"));
+
+    // Claims with numeric value (central, low, or high)
+    const numericResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(
+        sql`${claims.valueNumeric} IS NOT NULL OR ${claims.valueLow} IS NOT NULL OR ${claims.valueHigh} IS NOT NULL`
+      );
+
+    // Structured claims (with property set)
+    const structuredResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(sql`${claims.property} IS NOT NULL`);
+
+    // Property distribution (for structured claims)
+    const byProperty = await db
+      .select({ property: claims.property, count: count() })
+      .from(claims)
+      .where(sql`${claims.property} IS NOT NULL`)
+      .groupBy(claims.property)
+      .orderBy(desc(count()));
+
+    // Verdict distribution
+    const byVerdict = await db
+      .select({ claimVerdict: claims.claimVerdict, count: count() })
+      .from(claims)
+      .groupBy(claims.claimVerdict)
+      .orderBy(desc(count()));
+
+    return c.json({
+      total,
+      byClaimType: Object.fromEntries(byType.map((r) => [r.claimType, r.count])),
+      byEntityType: Object.fromEntries(byEntityType.map((r) => [r.entityType, r.count])),
+      byClaimCategory: Object.fromEntries(
+        byCategory.map((r) => [r.claimCategory ?? "uncategorized", r.count])
+      ),
+      byClaimMode: Object.fromEntries(
+        byMode.map((r) => [r.claimMode ?? "uncategorized", r.count])
+      ),
+      byClaimVerdict: Object.fromEntries(
+        byVerdict.map((r) => [r.claimVerdict ?? "unverified", r.count])
+      ),
+      multiEntityClaims: multiEntityResult[0].count,
+      factLinkedClaims: factLinkedResult[0].count,
+      withSourcesClaims: withSourcesResult[0].count,
+      attributedClaims: attributedResult[0].count,
+      numericClaims: numericResult[0].count,
+      structuredClaims: structuredResult[0].count,
+      byProperty: Object.fromEntries(
+        byProperty.map((r) => [r.property ?? "unknown", r.count])
+      ),
+    });
+  })
+  // ---- GET /by-entity/:entityId (claims for a specific entity) ----
+  // Returns claims where entityId matches OR the entity appears in relatedEntities.
+  .get("/by-entity/:entityId", async (c) => {
+    const entityId = c.req.param("entityId");
+    const includeSources = c.req.query("includeSources") === "true";
+    const db = getDrizzleDb();
+
+    // Query: primary entity match OR entity appears in the relatedEntities JSONB array
+    const rows = await db
+      .select()
+      .from(claims)
+      .where(
+        or(
+          eq(claims.entityId, entityId),
+          sql`${claims.relatedEntities} @> ${JSON.stringify([entityId])}::jsonb`
+        )
+      )
+      .orderBy(asc(claims.claimType), asc(claims.id));
+
+    let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
+    if (includeSources && rows.length > 0) {
+      const claimIds = rows.map((r) => r.id);
+      const sourcesRows = await db
+        .select()
+        .from(claimSources)
+        .where(inArray(claimSources.claimId, claimIds));
+      for (const s of sourcesRows) {
+        const id = Number(s.claimId);
+        if (!sourcesMap.has(id)) sourcesMap.set(id, []);
+        sourcesMap.get(id)!.push(s);
+      }
+    }
+
+    const includePageReferences = c.req.query("includePageReferences") === "true";
+
+    let pageRefsMap = new Map<number, typeof claimPageReferences.$inferSelect[]>();
+    if (includePageReferences && rows.length > 0) {
+      const claimIds = rows.map((r) => r.id);
+      const pageRefRows = await db
+        .select()
+        .from(claimPageReferences)
+        .where(inArray(claimPageReferences.claimId, claimIds));
+      for (const pr of pageRefRows) {
+        const cid = Number(pr.claimId);
+        if (!pageRefsMap.has(cid)) pageRefsMap.set(cid, []);
+        pageRefsMap.get(cid)!.push(pr);
+      }
+    }
+
+    return c.json({
+      claims: rows.map((r) => {
+        const claim: ReturnType<typeof formatClaim> & { pageReferences?: ClaimPageReferenceRow[] } =
+          formatClaim(r, sourcesMap.get(Number(r.id)) ?? []);
+        if (includePageReferences) {
+          claim.pageReferences = (pageRefsMap.get(Number(r.id)) ?? []).map((pr) => ({
+            id: Number(pr.id),
+            claimId: Number(pr.claimId),
+            pageId: pr.pageId,
+            footnote: pr.footnote,
+            section: pr.section,
+            quoteText: pr.quoteText,
+            referenceId: pr.referenceId,
+            createdAt: pr.createdAt?.toISOString() ?? new Date().toISOString(),
+          }));
+        }
+        return claim;
+      }),
+    });
+  })
+  // ---- GET /all (paginated listing) ----
+  .get("/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const {
+      limit, offset, entityType, claimType, claimCategory, claimMode,
+      search, confidence, claimVerdict, entityId, attributedTo, measure,
+      multiEntity, hasNumericValue, hasStructuredFields,
+      subjectEntity, property,
+      includeSources, sort,
+    } = parsed.data;
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (entityType) conditions.push(eq(claims.entityType, entityType));
+    if (claimType) conditions.push(eq(claims.claimType, claimType));
+    if (claimCategory) conditions.push(eq(claims.claimCategory, claimCategory));
+    if (claimMode) conditions.push(eq(claims.claimMode, claimMode));
+    if (search) conditions.push(sql`${claims.claimText} ILIKE ${"%" + search + "%"}`);
+    if (confidence) conditions.push(eq(claims.confidence, confidence)); // @deprecated Use claimVerdict filter instead
+    if (claimVerdict) conditions.push(eq(claims.claimVerdict, claimVerdict));
+    if (entityId) conditions.push(eq(claims.entityId, entityId));
+    if (attributedTo) conditions.push(eq(claims.attributedTo, attributedTo));
+    if (measure) conditions.push(eq(claims.measure, measure));
+    if (multiEntity) {
+      conditions.push(
+        sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
+      );
+    }
+    if (hasNumericValue) {
+      conditions.push(sql`${claims.valueNumeric} IS NOT NULL`);
+    }
+    if (hasStructuredFields) {
+      conditions.push(sql`${claims.property} IS NOT NULL`);
+    }
+    if (subjectEntity) conditions.push(eq(claims.subjectEntity, subjectEntity));
+    if (property) conditions.push(eq(claims.property, property));
+
+    const whereClause =
+      conditions.length > 0
+        ? conditions.length === 1
+          ? conditions[0]
+          : and(...conditions)
+        : undefined;
+
+    const orderBy =
+      sort === "newest" ? desc(claims.id)
+      : sort === "entity" ? asc(claims.entityId)
+      : sort === "confidence" ? asc(claims.confidence) // @deprecated Use sort=verdict instead
+      : sort === "verdict" ? asc(claims.claimVerdict)
+      : sort === "as_of" ? desc(claims.asOf)
+      : asc(claims.id);
+
+    const rows = await db
+      .select()
+      .from(claims)
+      .where(whereClause)
+      .orderBy(orderBy)
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(claims)
+      .where(whereClause);
+    const total = countResult[0].count;
+
+    let sourcesMap = new Map<number, typeof claimSources.$inferSelect[]>();
+    if (includeSources && rows.length > 0) {
+      const claimIds = rows.map((r) => r.id);
+      const sourcesRows = await db
+        .select()
+        .from(claimSources)
+        .where(inArray(claimSources.claimId, claimIds));
+      for (const s of sourcesRows) {
+        const id = Number(s.claimId);
+        if (!sourcesMap.has(id)) sourcesMap.set(id, []);
+        sourcesMap.get(id)!.push(s);
+      }
+    }
+
+    return c.json({
+      claims: rows.map((r) => formatClaim(r, sourcesMap.get(Number(r.id)) ?? [])),
+      total,
+      limit,
+      offset,
+    });
+  })
+  // ---- GET /relationships (entity-pair relationships) ----
+  .get("/relationships", async (c) => {
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(claims)
+      .where(
+        sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
+      );
+
+    const pairMap = new Map<
+      string,
+      { entityA: string; entityB: string; claimCount: number; sampleClaims: string[] }
+    >();
+
+    for (const row of rows) {
+      const related = row.relatedEntities as string[] | null;
+      if (!related) continue;
+      for (const rel of related) {
+        // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
+        const normalizedRel = rel.toLowerCase();
+        // Skip self-referential pairs
+        if (normalizedRel === row.entityId) continue;
+        const [a, b] = [row.entityId, normalizedRel].sort();
+        const key = `${a}|||${b}`;
+        if (!pairMap.has(key)) {
+          pairMap.set(key, { entityA: a, entityB: b, claimCount: 0, sampleClaims: [] });
+        }
+        const entry = pairMap.get(key)!;
+        entry.claimCount++;
+        if (entry.sampleClaims.length < 3) {
+          entry.sampleClaims.push(row.claimText.slice(0, 150));
+        }
+      }
+    }
+
+    const relationships = [...pairMap.values()].sort((a, b) => b.claimCount - a.claimCount);
+    return c.json({ relationships });
+  })
+  // ---- GET /network (graph-ready node/edge data) ----
+  .get("/network", async (c) => {
+    const db = getDrizzleDb();
+
+    const entityCounts = await db
+      .select({ entityId: claims.entityId, count: count() })
+      .from(claims)
+      .groupBy(claims.entityId);
+
+    const rows = await db
+      .select()
+      .from(claims)
+      .where(
+        sql`${claims.relatedEntities} IS NOT NULL AND jsonb_array_length(${claims.relatedEntities}) > 0`
+      );
+
+    const edgeMap = new Map<string, { source: string; target: string; weight: number }>();
+    const nodeIds = new Set<string>();
+
+    for (const row of rows) {
+      nodeIds.add(row.entityId);
+      const related = row.relatedEntities as string[] | null;
+      if (!related) continue;
+      for (const rel of related) {
+        // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
+        const normalizedRel = rel.toLowerCase();
+        // Skip self-loops
+        if (normalizedRel === row.entityId) continue;
+        nodeIds.add(normalizedRel);
+        const [source, target] = [row.entityId, normalizedRel].sort();
+        const key = `${source}|||${target}`;
+        if (!edgeMap.has(key)) {
+          edgeMap.set(key, { source, target, weight: 0 });
+        }
+        edgeMap.get(key)!.weight++;
+      }
+    }
+
+    const countMap = Object.fromEntries(
+      entityCounts.map((r) => [r.entityId, r.count])
+    );
+    const nodes = [...nodeIds].map((id) => ({
+      entityId: id,
+      claimCount: countMap[id] ?? 0,
+    }));
+    const edges = [...edgeMap.values()].sort((a, b) => b.weight - a.weight);
+
+    return c.json({ nodes, edges });
+  })
+  // ---- GET /:id/similar (find similar claims via pg_trgm) ----
+  .get("/:id/similar", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const limitParam = c.req.query("limit");
+    const limit = Math.min(Math.max(Number(limitParam) || 5, 1), 20);
+
+    const db = getDrizzleDb();
+
+    // Fetch the target claim's text
+    const targetRows = await db
+      .select({ claimText: claims.claimText })
+      .from(claims)
+      .where(eq(claims.id, id))
+      .limit(1);
+
+    if (targetRows.length === 0) {
+      return notFoundError(c, `Claim not found: ${id}`);
+    }
+
+    const targetText = targetRows[0].claimText;
+
+    // Use raw SQL for the similarity() function (same pattern as pages.ts trigram fallback)
+    const rawDb = getDb();
+    const rows = await rawDb.unsafe(
+      `SELECT
+      id, entity_id, entity_type, claim_text, claim_category, confidence,
+      similarity(claim_text, $1) AS similarity_score
+    FROM claims
+    WHERE id != $2
+      AND similarity(claim_text, $1) > ${TRIGRAM_SIMILARITY_THRESHOLD}
+    ORDER BY similarity(claim_text, $1) DESC
+    LIMIT $3`,
+      [targetText, id, limit],
+    );
+
+    return c.json({
+      claims: rows.map((r: any) => ({
+        id: Number(r.id),
+        entityId: r.entity_id,
+        entityType: r.entity_type,
+        claimText: r.claim_text,
+        claimCategory: r.claim_category,
+        confidence: r.confidence,
+        similarityScore: parseFloat(r.similarity_score) || 0,
+      })),
+    });
+  })
+  // ---- GET /:id/sources (sources for a specific claim) ----
+  .get("/:id/sources", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(claimSources)
+      .where(eq(claimSources.claimId, id))
+      .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+    return c.json({ sources: rows.map(formatClaimSource) });
+  })
+  // ---- POST /:id/sources (add a source to a claim) ----
+  .post("/:id/sources", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = AddClaimSourceSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+
+    // Verify claim exists
+    const claimRows = await db
+      .select({ id: claims.id })
+      .from(claims)
+      .where(eq(claims.id, id))
+      .limit(1);
+
+    if (claimRows.length === 0) {
+      return notFoundError(c, `Claim not found: ${id}`);
+    }
+
+    const rows = await db
+      .insert(claimSources)
+      .values({
+        claimId: id,
+        resourceId: parsed.data.resourceId ?? null,
+        url: parsed.data.url ?? null,
+        sourceQuote: parsed.data.sourceQuote ?? null,
+        isPrimary: parsed.data.isPrimary ?? false,
+      })
+      .returning();
+
+    return c.json(formatClaimSource(firstOrThrow(rows, "claim_source insert")), 201);
+  })
+  // ---- PATCH /batch-update-related-entities (bulk update relatedEntities) ----
+  // Accepts an array of {id, relatedEntities} pairs and updates them all.
+  // IMPORTANT: Must be defined before PATCH /:id to avoid wildcard matching.
+  .patch("/batch-update-related-entities", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = BatchUpdateRelatedEntitiesSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+    const now = new Date();
+    let updated = 0;
+
+    for (const item of parsed.data.items) {
+      const result = await db
+        .update(claims)
+        .set({ relatedEntities: item.relatedEntities, updatedAt: now })
+        .where(eq(claims.id, item.id))
+        .returning({ id: claims.id });
+      if (result.length > 0) updated++;
+    }
+
+    return c.json({ updated, total: parsed.data.items.length });
+  })
+  // ---- PATCH /batch-update-structured (bulk update structured fields) ----
+  // Accepts an array of {id, subjectEntity, property, ...} pairs.
+  // IMPORTANT: Must be defined before PATCH /:id to avoid wildcard matching.
+  .patch("/batch-update-structured", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = BatchUpdateStructuredSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+    const now = new Date();
+    let updated = 0;
+
+    for (const item of parsed.data.items) {
+      const updates: Record<string, unknown> = { updatedAt: now };
+      if (item.subjectEntity !== undefined) updates.subjectEntity = item.subjectEntity;
+      if (item.property !== undefined) updates.property = item.property;
+      if (item.structuredValue !== undefined) updates.structuredValue = item.structuredValue;
+      if (item.valueUnit !== undefined) updates.valueUnit = item.valueUnit;
+      if (item.valueDate !== undefined) updates.valueDate = item.valueDate;
+      if (item.qualifiers !== undefined) updates.qualifiers = item.qualifiers;
+
+      const result = await db
+        .update(claims)
+        .set(updates)
+        .where(eq(claims.id, item.id))
+        .returning({ id: claims.id });
+      if (result.length > 0) updated++;
+    }
+
+    return c.json({ updated, total: parsed.data.items.length });
+  })
+  // ---- PATCH /:id (partial update) ----
+  // Supports updating relatedEntities and structured fields.
+  .patch("/:id", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = PatchClaimSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+
+    // Verify claim exists
+    const existing = await db
+      .select({ id: claims.id })
+      .from(claims)
+      .where(eq(claims.id, id))
+      .limit(1);
+
+    if (existing.length === 0) {
+      return notFoundError(c, `Claim not found: ${id}`);
+    }
+
+    // Build update set — only include fields that were provided
+    const updates: Record<string, unknown> = {};
+    if (parsed.data.relatedEntities !== undefined) {
+      updates.relatedEntities = parsed.data.relatedEntities;
+    }
+    if (parsed.data.subjectEntity !== undefined) updates.subjectEntity = parsed.data.subjectEntity;
+    if (parsed.data.property !== undefined) updates.property = parsed.data.property;
+    if (parsed.data.structuredValue !== undefined) updates.structuredValue = parsed.data.structuredValue;
+    if (parsed.data.valueUnit !== undefined) updates.valueUnit = parsed.data.valueUnit;
+    if (parsed.data.valueDate !== undefined) updates.valueDate = parsed.data.valueDate;
+    if (parsed.data.qualifiers !== undefined) updates.qualifiers = parsed.data.qualifiers;
+
+    if (Object.keys(updates).length === 0) {
+      return validationError(c, "No fields to update");
+    }
+
+    updates.updatedAt = new Date();
+
+    const rows = await db
+      .update(claims)
+      .set(updates)
+      .where(eq(claims.id, id))
+      .returning();
+
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(eq(claimSources.claimId, id))
+      .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+    const row = firstOrThrow(rows, "claim update");
+    return c.json(formatClaim(row, sourcesRows));
+  })
+  // ---- GET /:id (get by ID) ----
+  .get("/:id", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(claims)
+      .where(eq(claims.id, id))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return notFoundError(c, `Claim not found: ${id}`);
+    }
+
+    // Always include sources for single claim fetches
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(eq(claimSources.claimId, id))
+      .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+    return c.json(formatClaim(rows[0], sourcesRows));
+  })
+  // ---- GET /:id/page-references ----
+  .get("/:id/page-references", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(claimPageReferences)
+      .where(eq(claimPageReferences.claimId, id))
+      .orderBy(asc(claimPageReferences.pageId), asc(claimPageReferences.footnote));
+
+    return c.json({
+      references: rows.map((r) => ({
+        id: Number(r.id),
+        claimId: Number(r.claimId),
+        pageId: r.pageId,
+        footnote: r.footnote,
+        section: r.section,
+        createdAt: r.createdAt?.toISOString() ?? new Date().toISOString(),
+      })),
+    });
+  })
+  // ---- POST /:id/page-references ----
+  .post("/:id/page-references", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = PageRefInsertBodySchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+
+    // Verify claim exists
+    const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, id)).limit(1);
+    if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${id}`);
+
+    const rows = await db
+      .insert(claimPageReferences)
+      .values({
+        claimId: id,
+        pageId: parsed.data.pageId,
+        footnote: parsed.data.footnote ?? null,
+        section: parsed.data.section ?? null,
+        quoteText: parsed.data.quoteText ?? null,
+        referenceId: parsed.data.referenceId ?? null,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (rows.length === 0) {
+      return c.json({ message: "Reference already exists" }, 200);
+    }
+
+    return c.json({
+      id: Number(rows[0].id),
+      claimId: Number(rows[0].claimId),
+      pageId: rows[0].pageId,
+      footnote: rows[0].footnote,
+      section: rows[0].section,
+      quoteText: rows[0].quoteText,
+      referenceId: rows[0].referenceId,
+      createdAt: rows[0].createdAt?.toISOString() ?? new Date().toISOString(),
+    }, 201);
+  })
+  // ---- POST /:id/page-references/batch ----
+  .post("/:id/page-references/batch", async (c) => {
+    const idStr = c.req.param("id");
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id <= 0) {
+      return validationError(c, "Claim ID must be a positive integer");
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = ClaimPageReferenceBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+
+    // Verify claim exists
+    const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, id)).limit(1);
+    if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${id}`);
+
+    const values = parsed.data.items.map((item) => ({
       claimId: id,
-      pageId: parsed.data.pageId,
-      footnote: parsed.data.footnote ?? null,
-      section: parsed.data.section ?? null,
-      quoteText: parsed.data.quoteText ?? null,
-      referenceId: parsed.data.referenceId ?? null,
-    })
-    .onConflictDoNothing()
-    .returning();
+      pageId: item.pageId,
+      footnote: item.footnote ?? null,
+      section: item.section ?? null,
+    }));
 
-  if (rows.length === 0) {
-    return c.json({ message: "Reference already exists" }, 200);
-  }
+    const rows = await db
+      .insert(claimPageReferences)
+      .values(values)
+      .onConflictDoNothing()
+      .returning();
 
-  return c.json({
-    id: Number(rows[0].id),
-    claimId: Number(rows[0].claimId),
-    pageId: rows[0].pageId,
-    footnote: rows[0].footnote,
-    section: rows[0].section,
-    quoteText: rows[0].quoteText,
-    referenceId: rows[0].referenceId,
-    createdAt: rows[0].createdAt?.toISOString() ?? new Date().toISOString(),
-  }, 201);
-});
+    return c.json({ inserted: rows.length }, 201);
+  });
 
-// ---- POST /:id/page-references/batch ----
-
-claimsRoute.post("/:id/page-references/batch", async (c) => {
-  const idStr = c.req.param("id");
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return validationError(c, "Claim ID must be a positive integer");
-  }
-
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = ClaimPageReferenceBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-
-  // Verify claim exists
-  const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, id)).limit(1);
-  if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${id}`);
-
-  const values = parsed.data.items.map((item) => ({
-    claimId: id,
-    pageId: item.pageId,
-    footnote: item.footnote ?? null,
-    section: item.section ?? null,
-  }));
-
-  const rows = await db
-    .insert(claimPageReferences)
-    .values(values)
-    .onConflictDoNothing()
-    .returning();
-
-  return c.json({ inserted: rows.length }, 201);
-});
+export const claimsRoute = claimsApp;
+export type ClaimsRoute = typeof claimsApp;

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -2,28 +2,37 @@
  * Citation Quotes & Accuracy API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from the Hono RPC route types (single source of truth).
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { CitationsRoute } from '../../../apps/wiki-server/src/routes/citations.ts';
 import type {
   UpsertCitationQuote,
   AccuracyVerdict as AccuracyVerdictType,
   MarkAccuracy,
   UpsertCitationContent,
-  UpsertCitationQuoteResult,
-  UpsertCitationQuoteBatchResult,
-  MarkAccuracyResult,
-  MarkAccuracyBatchResult,
-  AccuracySnapshotResult,
-  AccuracyDashboardData,
-  CitationHealthResult,
-  CitationContentRow,
-  CitationContentListEntry,
-  CitationContentListResult,
-  CitationContentStatsResult,
-  PropagateFromClaimsResult,
 } from '../../../apps/wiki-server/src/api-types.ts';
+
+// ---------------------------------------------------------------------------
+// RPC type inference — response shapes derived from the route handler
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<CitationsRoute>>;
+
+type UpsertCitationQuoteResult = InferResponseType<RpcClient['quotes']['upsert']['$post'], 200>;
+type UpsertCitationQuoteBatchResult = InferResponseType<RpcClient['quotes']['upsert-batch']['$post'], 200>;
+type MarkAccuracyResult = InferResponseType<RpcClient['quotes']['mark-accuracy']['$post'], 200>;
+type MarkAccuracyBatchResult = InferResponseType<RpcClient['quotes']['mark-accuracy-batch']['$post'], 200>;
+type SnapshotResult = InferResponseType<RpcClient['accuracy-snapshot']['$post'], 201>;
+type AccuracyDashboardData = InferResponseType<RpcClient['accuracy-dashboard']['$get'], 200>;
+type CitationHealthResult = InferResponseType<RpcClient['health'][':pageId']['$get'], 200>;
+type CitationContentRow = InferResponseType<RpcClient['content']['$get'], 200>;
+type CitationContentListResult = InferResponseType<RpcClient['content']['list']['$get'], 200>;
+type CitationContentListEntry = CitationContentListResult['entries'][number];
+type CitationContentStatsResult = InferResponseType<RpcClient['content']['stats']['$get'], 200>;
+type PropagateFromClaimsResult = InferResponseType<RpcClient['quotes']['propagate-from-claims']['$post'], 200>;
 
 // ---------------------------------------------------------------------------
 // Citation Quotes Types — input (derived from server Zod schemas)
@@ -32,7 +41,7 @@ import type {
 export type UpsertCitationQuoteItem = UpsertCitationQuote;
 
 // ---------------------------------------------------------------------------
-// Citation Quotes Types — response (re-exported from canonical api-types.ts)
+// Citation Quotes Types — response (re-exported for consumers)
 // ---------------------------------------------------------------------------
 
 export type { UpsertCitationQuoteResult, UpsertCitationQuoteBatchResult };
@@ -46,11 +55,10 @@ export type AccuracyVerdict = AccuracyVerdictType;
 export type MarkAccuracyItem = MarkAccuracy;
 
 // ---------------------------------------------------------------------------
-// Citation Accuracy Types — response (re-exported from canonical api-types.ts)
+// Citation Accuracy Types — response (re-exported for consumers)
 // ---------------------------------------------------------------------------
 
-export type { MarkAccuracyResult, MarkAccuracyBatchResult, AccuracyDashboardData, CitationHealthResult };
-export type SnapshotResult = AccuracySnapshotResult;
+export type { MarkAccuracyResult, MarkAccuracyBatchResult, SnapshotResult, AccuracyDashboardData, CitationHealthResult };
 
 // ---------------------------------------------------------------------------
 // Citation Quotes API functions

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -2,21 +2,31 @@
  * Claims API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from the canonical api-types.ts definitions.
+ * Response types are inferred from the Hono RPC route type (ClaimsRoute) to
+ * stay in sync automatically when the server shape changes.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
 import type {
   InsertClaim,
-  InsertClaimResult,
-  InsertClaimBatchResult,
-  ClearClaimsResult,
-  ClaimRow,
-  ClaimSourceRow,
-  GetClaimsResult,
-  ClaimStatsResult,
   ClaimPageReferenceRow,
 } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ClaimsRoute } from '../../../apps/wiki-server/src/routes/claims.ts';
+
+// ---------------------------------------------------------------------------
+// RPC type inference — response shapes derived from the server route
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<ClaimsRoute>>;
+
+export type InsertClaimResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type InsertClaimBatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
+export type ClearClaimsResult = InferResponseType<RpcClient['clear']['$post'], 200>;
+export type GetClaimsResult = InferResponseType<RpcClient['by-entity'][':entityId']['$get'], 200>;
+export type ClaimStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type ClaimRow = GetClaimsResult['claims'][number];
+export type ClaimSourceRow = InferResponseType<RpcClient[':id']['sources']['$get'], 200>['sources'][number];
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -25,19 +35,10 @@ import type {
 export type InsertClaimItem = InsertClaim;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — re-exported for consumers
 // ---------------------------------------------------------------------------
 
-export type {
-  InsertClaimResult,
-  InsertClaimBatchResult,
-  ClearClaimsResult,
-  ClaimRow,
-  ClaimSourceRow,
-  GetClaimsResult,
-  ClaimStatsResult,
-  ClaimPageReferenceRow,
-};
+export type { ClaimPageReferenceRow };
 
 // ---------------------------------------------------------------------------
 // API functions


### PR DESCRIPTION
## Summary

- Convert `claims.ts` (20 endpoints) and `citations.ts` (24 endpoints) from standalone `route.get()/post()` calls to Hono RPC method-chaining pattern (`.get().post()...`)
- Update crux CLI client types (`crux/lib/wiki-server/claims.ts`, `citations.ts`) to use `InferResponseType<>` instead of hand-written response interfaces
- Update `.claude/rules/wiki-server-rpc-migration.md` to mark claims/citations as migrated and make RPC mandatory for new routes
- Add Hono RPC convention note to root `CLAUDE.md`

This is a pure type-level refactor — all handler bodies, API behavior, and runtime code are identical. The method-chaining enables TypeScript to infer the full route type, allowing compile-time type safety between server and client via `InferResponseType<>`.

Note: hand-written types in `api-types.ts` are intentionally kept for now — removing them would create circular imports (routes import Zod input schemas from api-types). A future PR can split api-types into separate input/output schema files.

## Test plan

- [x] All 409 wiki-server tests pass
- [x] TypeScript clean across all 3 packages (wiki-server, web, crux)
- [x] Gate validation: 11/11 checks passed
- [x] Paranoid code review confirmed all 44 endpoints preserved with identical behavior

Closes #1197
