### PR TITLE
refactor: migrate all remaining wiki-server routes to Hono RPC

### DIFF
--- a/.claude/rules/wiki-server-rpc-migration.md
+++ b/.claude/rules/wiki-server-rpc-migration.md
@@ -4,8 +4,8 @@ All **new** wiki-server routes must use Hono RPC method-chaining. Existing route
 
 ## Status
 
-- **Migrated**: `facts.ts` (reference), `claims.ts`, `citations.ts`
-- **Not yet migrated**: remaining routes (~19 files in `apps/wiki-server/src/routes/`)
+- **Migrated**: All route files — `facts.ts`, `claims.ts`, `citations.ts`, `references.ts`, `health.ts`, `ids.ts`, `edit-logs.ts`, `summaries.ts`, `artifacts.ts`, `agent-sessions.ts`, `entities.ts`, `explore.ts`, `sessions.ts`, `pages.ts`, `links.ts`, `hallucination-risk.ts`, `jobs.ts`, `resources.ts`, `auto-update-news.ts`, `auto-update-runs.ts`, `integrity.ts`
+- **Utility files** (no migration needed): `ref-check.ts`, `utils.ts`
 
 ## Why
 
@@ -61,11 +61,9 @@ See `getFactsRpcClient()` for the ISR-compatible fetch wrapper pattern.
 
 Remove the old hand-written response interfaces from `api-types.ts` once all consumers use inferred types.
 
-## When NOT to migrate
+## Adding new routes
 
-- Don't convert a route just because you're reading it
-- Don't migrate as a side-effect of an unrelated bug fix
-- Do migrate when you're adding/changing endpoints on a route or restructuring it
+All new routes **must** use method-chaining from the start. Follow the pattern above.
 
 ## RPC path key gotchas
 

--- a/apps/wiki-server/src/routes/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/agent-sessions.ts
@@ -13,134 +13,132 @@ import {
   UpdateAgentSessionSchema,
 } from "../api-types.js";
 
-export const agentSessionsRoute = new Hono();
+const agentSessionsApp = new Hono()
+  // ---- POST / (create or update agent session by branch) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-// ---- POST / (create or update agent session by branch) ----
+    const parsed = CreateAgentSessionSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-agentSessionsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const d = parsed.data;
+    const db = getDrizzleDb();
 
-  const parsed = CreateAgentSessionSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    // Atomic upsert: wrap select+insert/update in a transaction.
+    // Note: this uses READ COMMITTED (Drizzle default), not serializable.
+    // Concurrent requests are unlikely in practice (one agent per branch).
+    const { row, isUpdate } = await db.transaction(async (tx) => {
+      const existing = await tx
+        .select()
+        .from(agentSessions)
+        .where(eq(agentSessions.branch, d.branch))
+        .orderBy(desc(agentSessions.startedAt))
+        .limit(1);
 
-  const d = parsed.data;
-  const db = getDrizzleDb();
+      if (existing.length > 0 && existing[0].status === "active") {
+        const updated = await tx
+          .update(agentSessions)
+          .set({
+            task: d.task,
+            sessionType: d.sessionType,
+            issueNumber: d.issueNumber ?? null,
+            checklistMd: d.checklistMd,
+            updatedAt: new Date(),
+          })
+          .where(eq(agentSessions.id, existing[0].id))
+          .returning();
+        return { row: firstOrThrow(updated, "agent session update"), isUpdate: true };
+      }
 
-  // Atomic upsert: wrap select+insert/update in a transaction.
-  // Note: this uses READ COMMITTED (Drizzle default), not serializable.
-  // Concurrent requests are unlikely in practice (one agent per branch).
-  const { row, isUpdate } = await db.transaction(async (tx) => {
-    const existing = await tx
-      .select()
-      .from(agentSessions)
-      .where(eq(agentSessions.branch, d.branch))
-      .orderBy(desc(agentSessions.startedAt))
-      .limit(1);
-
-    if (existing.length > 0 && existing[0].status === "active") {
-      const updated = await tx
-        .update(agentSessions)
-        .set({
+      const inserted = await tx
+        .insert(agentSessions)
+        .values({
+          branch: d.branch,
           task: d.task,
           sessionType: d.sessionType,
           issueNumber: d.issueNumber ?? null,
           checklistMd: d.checklistMd,
-          updatedAt: new Date(),
         })
-        .where(eq(agentSessions.id, existing[0].id))
         .returning();
-      return { row: firstOrThrow(updated, "agent session update"), isUpdate: true };
+      return { row: firstOrThrow(inserted, "agent session insert"), isUpdate: false };
+    });
+
+    return c.json(row, isUpdate ? 200 : 201);
+  })
+
+  // ---- GET /by-branch/:branch (get latest session for a branch) ----
+  .get("/by-branch/:branch", async (c) => {
+    const branch = c.req.param("branch");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(agentSessions)
+      .where(eq(agentSessions.branch, branch))
+      .orderBy(desc(agentSessions.startedAt))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return c.json({ error: "not_found", message: `No session for branch: ${branch}` }, 404);
     }
 
-    const inserted = await tx
-      .insert(agentSessions)
-      .values({
-        branch: d.branch,
-        task: d.task,
-        sessionType: d.sessionType,
-        issueNumber: d.issueNumber ?? null,
-        checklistMd: d.checklistMd,
-      })
+    return c.json(rows[0]);
+  })
+
+  // ---- PATCH /:id (update checklist or status) ----
+  .patch("/:id", async (c) => {
+    const raw = c.req.param("id");
+    const id = Number(raw);
+    if (!Number.isInteger(id) || id < 1) return validationError(c, "Invalid session ID");
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = UpdateAgentSessionSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { checklistMd, status } = parsed.data;
+    if (checklistMd === undefined && status === undefined) {
+      return validationError(c, "At least one of checklistMd or status must be provided");
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (checklistMd !== undefined) updates.checklistMd = checklistMd;
+    if (status !== undefined) {
+      updates.status = status;
+      if (status === "completed") {
+        updates.completedAt = new Date();
+      }
+    }
+
+    const db = getDrizzleDb();
+    const result = await db
+      .update(agentSessions)
+      .set(updates)
+      .where(eq(agentSessions.id, id))
       .returning();
-    return { row: firstOrThrow(inserted, "agent session insert"), isUpdate: false };
+
+    if (result.length === 0) {
+      return c.json({ error: "not_found", message: `No session with id: ${id}` }, 404);
+    }
+
+    return c.json(result[0]);
+  })
+
+  // ---- GET / (list recent sessions) ----
+  .get("/", async (c) => {
+    const limit = Math.min(Number(c.req.query("limit") || 50), 200);
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(agentSessions)
+      .orderBy(desc(agentSessions.startedAt))
+      .limit(limit);
+
+    return c.json({ sessions: rows });
   });
 
-  return c.json(row, isUpdate ? 200 : 201);
-});
-
-// ---- GET /by-branch/:branch (get latest session for a branch) ----
-
-agentSessionsRoute.get("/by-branch/:branch", async (c) => {
-  const branch = c.req.param("branch");
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(agentSessions)
-    .where(eq(agentSessions.branch, branch))
-    .orderBy(desc(agentSessions.startedAt))
-    .limit(1);
-
-  if (rows.length === 0) {
-    return c.json({ error: "not_found", message: `No session for branch: ${branch}` }, 404);
-  }
-
-  return c.json(rows[0]);
-});
-
-// ---- PATCH /:id (update checklist or status) ----
-
-agentSessionsRoute.patch("/:id", async (c) => {
-  const raw = c.req.param("id");
-  const id = Number(raw);
-  if (!Number.isInteger(id) || id < 1) return validationError(c, "Invalid session ID");
-
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = UpdateAgentSessionSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { checklistMd, status } = parsed.data;
-  if (checklistMd === undefined && status === undefined) {
-    return validationError(c, "At least one of checklistMd or status must be provided");
-  }
-
-  const updates: Record<string, unknown> = { updatedAt: new Date() };
-  if (checklistMd !== undefined) updates.checklistMd = checklistMd;
-  if (status !== undefined) {
-    updates.status = status;
-    if (status === "completed") {
-      updates.completedAt = new Date();
-    }
-  }
-
-  const db = getDrizzleDb();
-  const result = await db
-    .update(agentSessions)
-    .set(updates)
-    .where(eq(agentSessions.id, id))
-    .returning();
-
-  if (result.length === 0) {
-    return c.json({ error: "not_found", message: `No session with id: ${id}` }, 404);
-  }
-
-  return c.json(result[0]);
-});
-
-// ---- GET / (list recent sessions) ----
-
-agentSessionsRoute.get("/", async (c) => {
-  const limit = Math.min(Number(c.req.query("limit") || 50), 200);
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(agentSessions)
-    .orderBy(desc(agentSessions.startedAt))
-    .limit(limit);
-
-  return c.json({ sessions: rows });
-});
+export const agentSessionsRoute = agentSessionsApp;
+export type AgentSessionsRoute = typeof agentSessionsApp;

--- a/apps/wiki-server/src/routes/artifacts.ts
+++ b/apps/wiki-server/src/routes/artifacts.ts
@@ -11,8 +11,6 @@ import {
   notFoundError,
 } from "./utils.js";
 
-export const artifactsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 100;
@@ -56,150 +54,149 @@ function formatArtifactEntry(r: typeof pageImproveRuns.$inferSelect) {
   };
 }
 
-// ---- POST / (save artifacts from a run) ----
+const artifactsApp = new Hono()
+  // ---- POST / (save artifacts from a run) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-artifactsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const parsed = SaveArtifactsSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const parsed = SaveArtifactsSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const d = parsed.data;
+    const db = getDrizzleDb();
 
-  const d = parsed.data;
-  const db = getDrizzleDb();
+    const rows = await db
+      .insert(pageImproveRuns)
+      .values({
+        pageId: d.pageId,
+        engine: d.engine,
+        tier: d.tier,
+        directions: d.directions ?? null,
+        startedAt: new Date(d.startedAt),
+        completedAt: d.completedAt ? new Date(d.completedAt) : null,
+        durationS: d.durationS ?? null,
+        totalCost: d.totalCost ?? null,
+        sourceCache: d.sourceCache ?? null,
+        researchSummary: d.researchSummary ?? null,
+        citationAudit: d.citationAudit ?? null,
+        costEntries: d.costEntries ?? null,
+        costBreakdown: d.costBreakdown ?? null,
+        sectionDiffs: d.sectionDiffs ?? null,
+        qualityMetrics: d.qualityMetrics ?? null,
+        qualityGatePassed: d.qualityGatePassed ?? null,
+        qualityGaps: d.qualityGaps ?? null,
+        toolCallCount: d.toolCallCount ?? null,
+        refinementCycles: d.refinementCycles ?? null,
+        phasesRun: d.phasesRun ?? null,
+      })
+      .returning({
+        id: pageImproveRuns.id,
+        pageId: pageImproveRuns.pageId,
+        engine: pageImproveRuns.engine,
+        startedAt: pageImproveRuns.startedAt,
+        createdAt: pageImproveRuns.createdAt,
+      });
 
-  const rows = await db
-    .insert(pageImproveRuns)
-    .values({
-      pageId: d.pageId,
-      engine: d.engine,
-      tier: d.tier,
-      directions: d.directions ?? null,
-      startedAt: new Date(d.startedAt),
-      completedAt: d.completedAt ? new Date(d.completedAt) : null,
-      durationS: d.durationS ?? null,
-      totalCost: d.totalCost ?? null,
-      sourceCache: d.sourceCache ?? null,
-      researchSummary: d.researchSummary ?? null,
-      citationAudit: d.citationAudit ?? null,
-      costEntries: d.costEntries ?? null,
-      costBreakdown: d.costBreakdown ?? null,
-      sectionDiffs: d.sectionDiffs ?? null,
-      qualityMetrics: d.qualityMetrics ?? null,
-      qualityGatePassed: d.qualityGatePassed ?? null,
-      qualityGaps: d.qualityGaps ?? null,
-      toolCallCount: d.toolCallCount ?? null,
-      refinementCycles: d.refinementCycles ?? null,
-      phasesRun: d.phasesRun ?? null,
-    })
-    .returning({
-      id: pageImproveRuns.id,
-      pageId: pageImproveRuns.pageId,
-      engine: pageImproveRuns.engine,
-      startedAt: pageImproveRuns.startedAt,
-      createdAt: pageImproveRuns.createdAt,
+    return c.json(rows[0], 201);
+  })
+
+  // ---- GET /by-page?page_id=X&limit=N (artifacts for a specific page) ----
+  .get("/by-page", async (c) => {
+    const parsed = ByPageQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { page_id, limit } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(pageImproveRuns)
+      .where(eq(pageImproveRuns.pageId, page_id))
+      .orderBy(desc(pageImproveRuns.startedAt))
+      .limit(limit);
+
+    return c.json({ entries: rows.map(formatArtifactEntry) });
+  })
+
+  // ---- GET /all (paginated list of all artifacts) ----
+  .get("/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(pageImproveRuns)
+      .orderBy(desc(pageImproveRuns.startedAt))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(pageImproveRuns);
+    const total = countResult[0].count;
+
+    return c.json({
+      entries: rows.map(formatArtifactEntry),
+      total,
+      limit,
+      offset,
     });
+  })
 
-  return c.json(rows[0], 201);
-});
+  // ---- GET /stats (aggregate statistics) ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
 
-// ---- GET /by-page?page_id=X&limit=N (artifacts for a specific page) ----
+    const totalResult = await db
+      .select({ count: count() })
+      .from(pageImproveRuns);
+    const totalRuns = totalResult[0].count;
 
-artifactsRoute.get("/by-page", async (c) => {
-  const parsed = ByPageQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const byEngine = await db
+      .select({
+        engine: pageImproveRuns.engine,
+        count: count(),
+      })
+      .from(pageImproveRuns)
+      .groupBy(pageImproveRuns.engine);
 
-  const { page_id, limit } = parsed.data;
-  const db = getDrizzleDb();
+    const byTier = await db
+      .select({
+        tier: pageImproveRuns.tier,
+        count: count(),
+      })
+      .from(pageImproveRuns)
+      .groupBy(pageImproveRuns.tier);
 
-  const rows = await db
-    .select()
-    .from(pageImproveRuns)
-    .where(eq(pageImproveRuns.pageId, page_id))
-    .orderBy(desc(pageImproveRuns.startedAt))
-    .limit(limit);
+    return c.json({
+      totalRuns,
+      byEngine: Object.fromEntries(byEngine.map((r) => [r.engine, r.count])),
+      byTier: Object.fromEntries(byTier.map((r) => [r.tier, r.count])),
+    });
+  })
 
-  return c.json({ entries: rows.map(formatArtifactEntry) });
-});
+  // ---- GET /:id (single artifact by ID) ----
+  .get("/:id", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
 
-// ---- GET /all (paginated list of all artifacts) ----
+    const db = getDrizzleDb();
 
-artifactsRoute.get("/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const rows = await db
+      .select()
+      .from(pageImproveRuns)
+      .where(eq(pageImproveRuns.id, id));
 
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
+    if (rows.length === 0) {
+      return notFoundError(c, "Artifact not found");
+    }
 
-  const rows = await db
-    .select()
-    .from(pageImproveRuns)
-    .orderBy(desc(pageImproveRuns.startedAt))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(pageImproveRuns);
-  const total = countResult[0].count;
-
-  return c.json({
-    entries: rows.map(formatArtifactEntry),
-    total,
-    limit,
-    offset,
+    return c.json(formatArtifactEntry(rows[0]));
   });
-});
 
-// ---- GET /stats (aggregate statistics) ----
-
-artifactsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const totalResult = await db
-    .select({ count: count() })
-    .from(pageImproveRuns);
-  const totalRuns = totalResult[0].count;
-
-  const byEngine = await db
-    .select({
-      engine: pageImproveRuns.engine,
-      count: count(),
-    })
-    .from(pageImproveRuns)
-    .groupBy(pageImproveRuns.engine);
-
-  const byTier = await db
-    .select({
-      tier: pageImproveRuns.tier,
-      count: count(),
-    })
-    .from(pageImproveRuns)
-    .groupBy(pageImproveRuns.tier);
-
-  return c.json({
-    totalRuns,
-    byEngine: Object.fromEntries(byEngine.map((r) => [r.engine, r.count])),
-    byTier: Object.fromEntries(byTier.map((r) => [r.tier, r.count])),
-  });
-});
-
-// ---- GET /:id (single artifact by ID) ----
-
-artifactsRoute.get("/:id", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
-
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(pageImproveRuns)
-    .where(eq(pageImproveRuns.id, id));
-
-  if (rows.length === 0) {
-    return notFoundError(c, "Artifact not found");
-  }
-
-  return c.json(formatArtifactEntry(rows[0]));
-});
+export const artifactsRoute = artifactsApp;
+export type ArtifactsRoute = typeof artifactsApp;

--- a/apps/wiki-server/src/routes/auto-update-news.ts
+++ b/apps/wiki-server/src/routes/auto-update-news.ts
@@ -13,8 +13,6 @@ import {
   AutoUpdateNewsBatchSchema,
 } from "../api-types.js";
 
-export const autoUpdateNewsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 1000;
@@ -53,155 +51,156 @@ function mapNewsRow(r: typeof autoUpdateNewsItems.$inferSelect) {
   };
 }
 
-// ---- POST /batch (insert news items for a run) ----
+// ---- Routes ----
 
-autoUpdateNewsRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const autoUpdateNewsApp = new Hono()
+  // ---- POST /batch (insert news items for a run) ----
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = CreateBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = CreateBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { runId, items } = parsed.data;
-  const db = getDrizzleDb();
+    const { runId, items } = parsed.data;
+    const db = getDrizzleDb();
 
-  const results = await db.transaction(async (tx) => {
-    return await tx
-      .insert(autoUpdateNewsItems)
-      .values(
-        items.map((d) => ({
-          runId,
-          title: d.title,
-          url: d.url,
-          sourceId: d.sourceId,
-          publishedAt: d.publishedAt ?? null,
-          summary: d.summary ?? null,
-          relevanceScore: d.relevanceScore ?? null,
-          topicsJson: d.topics.length > 0 ? d.topics : null,
-          entitiesJson: d.entities.length > 0 ? d.entities : null,
-          routedToPageId: d.routedToPageId ?? null,
-          routedToPageTitle: d.routedToPageTitle ?? null,
-          routedTier: d.routedTier ?? null,
-        }))
-      )
-      .returning({ id: autoUpdateNewsItems.id });
+    const results = await db.transaction(async (tx) => {
+      return await tx
+        .insert(autoUpdateNewsItems)
+        .values(
+          items.map((d) => ({
+            runId,
+            title: d.title,
+            url: d.url,
+            sourceId: d.sourceId,
+            publishedAt: d.publishedAt ?? null,
+            summary: d.summary ?? null,
+            relevanceScore: d.relevanceScore ?? null,
+            topicsJson: d.topics.length > 0 ? d.topics : null,
+            entitiesJson: d.entities.length > 0 ? d.entities : null,
+            routedToPageId: d.routedToPageId ?? null,
+            routedToPageTitle: d.routedToPageTitle ?? null,
+            routedTier: d.routedTier ?? null,
+          }))
+        )
+        .returning({ id: autoUpdateNewsItems.id });
+    });
+
+    return c.json({ inserted: results.length }, 201);
+  })
+
+  // ---- GET /by-run/:runId (news items for a specific run) ----
+  .get("/by-run/:runId", async (c) => {
+    const runId = parseInt(c.req.param("runId"), 10);
+    if (isNaN(runId)) return validationError(c, "runId must be an integer");
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(autoUpdateNewsItems)
+      .where(eq(autoUpdateNewsItems.runId, runId))
+      .orderBy(desc(autoUpdateNewsItems.relevanceScore));
+
+    return c.json({ items: rows.map(mapNewsRow) });
+  })
+
+  // ---- GET /recent (recent news items across all runs) ----
+  .get("/recent", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Join with runs to get the run date
+    const rows = await db
+      .select({
+        item: autoUpdateNewsItems,
+        runDate: autoUpdateRuns.date,
+      })
+      .from(autoUpdateNewsItems)
+      .innerJoin(autoUpdateRuns, eq(autoUpdateNewsItems.runId, autoUpdateRuns.id))
+      .orderBy(desc(autoUpdateRuns.date), desc(autoUpdateNewsItems.relevanceScore))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(autoUpdateNewsItems);
+    const total = countResult[0].count;
+
+    return c.json({
+      items: rows.map((r) => ({
+        ...mapNewsRow(r.item),
+        runDate: r.runDate,
+      })),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /by-page/:pageId (news items routed to a specific page) ----
+  .get("/by-page/:pageId", async (c) => {
+    const pageId = c.req.param("pageId");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        item: autoUpdateNewsItems,
+        runDate: autoUpdateRuns.date,
+      })
+      .from(autoUpdateNewsItems)
+      .innerJoin(autoUpdateRuns, eq(autoUpdateNewsItems.runId, autoUpdateRuns.id))
+      .where(eq(autoUpdateNewsItems.routedToPageId, pageId))
+      .orderBy(desc(autoUpdateRuns.date), desc(autoUpdateNewsItems.relevanceScore));
+
+    return c.json({
+      items: rows.map((r) => ({
+        ...mapNewsRow(r.item),
+        runDate: r.runDate,
+      })),
+    });
+  })
+
+  // ---- GET /dashboard (optimized endpoint for news dashboard, last N runs) ----
+  .get("/dashboard", async (c) => {
+    const parsed = DashboardQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { runs: maxRuns } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Get the last N run IDs
+    const recentRuns = await db
+      .select({ id: autoUpdateRuns.id, date: autoUpdateRuns.date })
+      .from(autoUpdateRuns)
+      .orderBy(desc(autoUpdateRuns.startedAt))
+      .limit(maxRuns);
+
+    if (recentRuns.length === 0) {
+      return c.json({ items: [], runDates: [] });
+    }
+
+    const runIds = recentRuns.map((r) => r.id);
+    const runDateMap = new Map(recentRuns.map((r) => [r.id, r.date]));
+
+    // Fetch all news items for these runs
+    const rows = await db
+      .select()
+      .from(autoUpdateNewsItems)
+      .where(inArray(autoUpdateNewsItems.runId, runIds))
+      .orderBy(desc(autoUpdateNewsItems.relevanceScore));
+
+    return c.json({
+      items: rows.map((r) => ({
+        ...mapNewsRow(r),
+        runDate: runDateMap.get(r.runId) ?? null,
+      })),
+      runDates: [...new Set(recentRuns.map((r) => r.date))],
+    });
   });
 
-  return c.json({ inserted: results.length }, 201);
-});
-
-// ---- GET /by-run/:runId (news items for a specific run) ----
-
-autoUpdateNewsRoute.get("/by-run/:runId", async (c) => {
-  const runId = parseInt(c.req.param("runId"), 10);
-  if (isNaN(runId)) return validationError(c, "runId must be an integer");
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(autoUpdateNewsItems)
-    .where(eq(autoUpdateNewsItems.runId, runId))
-    .orderBy(desc(autoUpdateNewsItems.relevanceScore));
-
-  return c.json({ items: rows.map(mapNewsRow) });
-});
-
-// ---- GET /recent (recent news items across all runs) ----
-
-autoUpdateNewsRoute.get("/recent", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Join with runs to get the run date
-  const rows = await db
-    .select({
-      item: autoUpdateNewsItems,
-      runDate: autoUpdateRuns.date,
-    })
-    .from(autoUpdateNewsItems)
-    .innerJoin(autoUpdateRuns, eq(autoUpdateNewsItems.runId, autoUpdateRuns.id))
-    .orderBy(desc(autoUpdateRuns.date), desc(autoUpdateNewsItems.relevanceScore))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(autoUpdateNewsItems);
-  const total = countResult[0].count;
-
-  return c.json({
-    items: rows.map((r) => ({
-      ...mapNewsRow(r.item),
-      runDate: r.runDate,
-    })),
-    total,
-    limit,
-    offset,
-  });
-});
-
-// ---- GET /by-page/:pageId (news items routed to a specific page) ----
-
-autoUpdateNewsRoute.get("/by-page/:pageId", async (c) => {
-  const pageId = c.req.param("pageId");
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select({
-      item: autoUpdateNewsItems,
-      runDate: autoUpdateRuns.date,
-    })
-    .from(autoUpdateNewsItems)
-    .innerJoin(autoUpdateRuns, eq(autoUpdateNewsItems.runId, autoUpdateRuns.id))
-    .where(eq(autoUpdateNewsItems.routedToPageId, pageId))
-    .orderBy(desc(autoUpdateRuns.date), desc(autoUpdateNewsItems.relevanceScore));
-
-  return c.json({
-    items: rows.map((r) => ({
-      ...mapNewsRow(r.item),
-      runDate: r.runDate,
-    })),
-  });
-});
-
-// ---- GET /dashboard (optimized endpoint for news dashboard, last N runs) ----
-
-autoUpdateNewsRoute.get("/dashboard", async (c) => {
-  const parsed = DashboardQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { runs: maxRuns } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Get the last N run IDs
-  const recentRuns = await db
-    .select({ id: autoUpdateRuns.id, date: autoUpdateRuns.date })
-    .from(autoUpdateRuns)
-    .orderBy(desc(autoUpdateRuns.startedAt))
-    .limit(maxRuns);
-
-  if (recentRuns.length === 0) {
-    return c.json({ items: [], runDates: [] });
-  }
-
-  const runIds = recentRuns.map((r) => r.id);
-  const runDateMap = new Map(recentRuns.map((r) => [r.id, r.date]));
-
-  // Fetch all news items for these runs
-  const rows = await db
-    .select()
-    .from(autoUpdateNewsItems)
-    .where(inArray(autoUpdateNewsItems.runId, runIds))
-    .orderBy(desc(autoUpdateNewsItems.relevanceScore));
-
-  return c.json({
-    items: rows.map((r) => ({
-      ...mapNewsRow(r),
-      runDate: runDateMap.get(r.runId) ?? null,
-    })),
-    runDates: [...new Set(recentRuns.map((r) => r.date))],
-  });
-});
+export const autoUpdateNewsRoute = autoUpdateNewsApp;
+export type AutoUpdateNewsRoute = typeof autoUpdateNewsApp;

--- a/apps/wiki-server/src/routes/auto-update-runs.ts
+++ b/apps/wiki-server/src/routes/auto-update-runs.ts
@@ -5,8 +5,6 @@ import { getDrizzleDb } from "../db.js";
 import { autoUpdateRuns, autoUpdateResults } from "../schema.js";
 import { parseJsonBody, validationError, invalidJsonError, notFoundError, firstOrThrow } from "./utils.js";
 
-export const autoUpdateRunsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_BATCH_SIZE = 100;
@@ -93,207 +91,209 @@ function formatRunEntry(
   };
 }
 
-// ---- POST / (record a complete run with results) ----
+// ---- Route ----
 
-autoUpdateRunsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const autoUpdateRunsApp = new Hono()
+  // ---- POST / (record a complete run with results) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = RecordRunSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = RecordRunSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const d = parsed.data;
-  const db = getDrizzleDb();
+    const d = parsed.data;
+    const db = getDrizzleDb();
 
-  // Use a Drizzle transaction to ensure atomicity of run + results insert.
-  // ON CONFLICT DO NOTHING makes this idempotent: re-syncing the same run
-  // (e.g., from YAML files) returns the existing record rather than duplicating it.
-  const result = await db.transaction(async (tx) => {
-    const runRow = await tx
-      .insert(autoUpdateRuns)
-      .values({
-        date: d.date,
-        startedAt: new Date(d.startedAt),
-        completedAt: d.completedAt ? new Date(d.completedAt) : null,
-        trigger: d.trigger,
-        budgetLimit: d.budgetLimit ?? null,
-        budgetSpent: d.budgetSpent ?? null,
-        sourcesChecked: d.sourcesChecked ?? null,
-        sourcesFailed: d.sourcesFailed ?? null,
-        itemsFetched: d.itemsFetched ?? null,
-        itemsRelevant: d.itemsRelevant ?? null,
-        pagesPlanned: d.pagesPlanned ?? null,
-        pagesUpdated: d.pagesUpdated ?? null,
-        pagesFailed: d.pagesFailed ?? null,
-        pagesSkipped: d.pagesSkipped ?? null,
-        newPagesCreated: d.newPagesCreated?.length
-          ? JSON.stringify(d.newPagesCreated)
-          : null,
-      })
-      .onConflictDoNothing({ target: autoUpdateRuns.startedAt }) // idempotent: skip duplicate startedAt
-      .returning({
-        id: autoUpdateRuns.id,
-        date: autoUpdateRuns.date,
-        startedAt: autoUpdateRuns.startedAt,
-        createdAt: autoUpdateRuns.createdAt,
-      });
-
-    // If conflict (duplicate startedAt), fetch the existing run's id
-    if (runRow.length === 0) {
-      const existing = await tx
-        .select({
+    // Use a Drizzle transaction to ensure atomicity of run + results insert.
+    // ON CONFLICT DO NOTHING makes this idempotent: re-syncing the same run
+    // (e.g., from YAML files) returns the existing record rather than duplicating it.
+    const result = await db.transaction(async (tx) => {
+      const runRow = await tx
+        .insert(autoUpdateRuns)
+        .values({
+          date: d.date,
+          startedAt: new Date(d.startedAt),
+          completedAt: d.completedAt ? new Date(d.completedAt) : null,
+          trigger: d.trigger,
+          budgetLimit: d.budgetLimit ?? null,
+          budgetSpent: d.budgetSpent ?? null,
+          sourcesChecked: d.sourcesChecked ?? null,
+          sourcesFailed: d.sourcesFailed ?? null,
+          itemsFetched: d.itemsFetched ?? null,
+          itemsRelevant: d.itemsRelevant ?? null,
+          pagesPlanned: d.pagesPlanned ?? null,
+          pagesUpdated: d.pagesUpdated ?? null,
+          pagesFailed: d.pagesFailed ?? null,
+          pagesSkipped: d.pagesSkipped ?? null,
+          newPagesCreated: d.newPagesCreated?.length
+            ? JSON.stringify(d.newPagesCreated)
+            : null,
+        })
+        .onConflictDoNothing({ target: autoUpdateRuns.startedAt }) // idempotent: skip duplicate startedAt
+        .returning({
           id: autoUpdateRuns.id,
           date: autoUpdateRuns.date,
           startedAt: autoUpdateRuns.startedAt,
           createdAt: autoUpdateRuns.createdAt,
-        })
-        .from(autoUpdateRuns)
-        .where(eq(autoUpdateRuns.startedAt, new Date(d.startedAt)))
-        .limit(1);
-      const run = firstOrThrow(existing, "auto-update run lookup after conflict");
-      return { ...run, resultsInserted: 0 };
+        });
+
+      // If conflict (duplicate startedAt), fetch the existing run's id
+      if (runRow.length === 0) {
+        const existing = await tx
+          .select({
+            id: autoUpdateRuns.id,
+            date: autoUpdateRuns.date,
+            startedAt: autoUpdateRuns.startedAt,
+            createdAt: autoUpdateRuns.createdAt,
+          })
+          .from(autoUpdateRuns)
+          .where(eq(autoUpdateRuns.startedAt, new Date(d.startedAt)))
+          .limit(1);
+        const run = firstOrThrow(existing, "auto-update run lookup after conflict");
+        return { ...run, resultsInserted: 0 };
+      }
+
+      const run = runRow[0];
+      let resultsInserted = 0;
+
+      if (d.results && d.results.length > 0) {
+        await tx.insert(autoUpdateResults).values(
+          d.results.map((r) => ({
+            runId: run.id,
+            pageId: r.pageId,
+            status: r.status,
+            tier: r.tier ?? null,
+            durationMs: r.durationMs ?? null,
+            errorMessage: r.errorMessage ?? null,
+          }))
+        );
+        resultsInserted = d.results.length;
+      }
+
+      return { ...run, resultsInserted };
+    });
+
+    return c.json(result, 201);
+  })
+
+  // ---- GET /all (paginated list of runs) ----
+  .get("/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(autoUpdateRuns)
+      .orderBy(desc(autoUpdateRuns.startedAt))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(autoUpdateRuns);
+    const total = countResult[0].count;
+
+    // Fetch all results for the page of runs in a single query
+    const runIds = rows.map((r) => r.id);
+    const resultsByRun = new Map<number, (typeof autoUpdateResults.$inferSelect)[]>();
+
+    if (runIds.length > 0) {
+      const allResults = await db
+        .select()
+        .from(autoUpdateResults)
+        .where(inArray(autoUpdateResults.runId, runIds));
+
+      for (const result of allResults) {
+        const existing = resultsByRun.get(result.runId) || [];
+        existing.push(result);
+        resultsByRun.set(result.runId, existing);
+      }
     }
 
-    const run = runRow[0];
-    let resultsInserted = 0;
+    const entries = rows.map((r) =>
+      formatRunEntry(r, resultsByRun.get(r.id) || [])
+    );
 
-    if (d.results && d.results.length > 0) {
-      await tx.insert(autoUpdateResults).values(
-        d.results.map((r) => ({
-          runId: run.id,
-          pageId: r.pageId,
-          status: r.status,
-          tier: r.tier ?? null,
-          durationMs: r.durationMs ?? null,
-          errorMessage: r.errorMessage ?? null,
-        }))
-      );
-      resultsInserted = d.results.length;
+    return c.json({ entries, total, limit, offset });
+  })
+
+  // ---- GET /stats (aggregate statistics) ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const totalResult = await db
+      .select({ count: count() })
+      .from(autoUpdateRuns);
+    const totalRuns = totalResult[0].count;
+
+    const budgetResult = await db
+      .select({
+        total: sql<number>`coalesce(sum(${autoUpdateRuns.budgetSpent}), 0)`,
+      })
+      .from(autoUpdateRuns);
+    const totalBudgetSpent = Number(budgetResult[0].total);
+
+    const updatedResult = await db
+      .select({
+        total: sql<number>`coalesce(sum(${autoUpdateRuns.pagesUpdated}), 0)`,
+      })
+      .from(autoUpdateRuns);
+    const totalPagesUpdated = Number(updatedResult[0].total);
+
+    const failedResult = await db
+      .select({
+        total: sql<number>`coalesce(sum(${autoUpdateRuns.pagesFailed}), 0)`,
+      })
+      .from(autoUpdateRuns);
+    const totalPagesFailed = Number(failedResult[0].total);
+
+    const byTrigger = await db
+      .select({
+        trigger: autoUpdateRuns.trigger,
+        count: count(),
+      })
+      .from(autoUpdateRuns)
+      .groupBy(autoUpdateRuns.trigger);
+
+    return c.json({
+      totalRuns,
+      totalBudgetSpent,
+      totalPagesUpdated,
+      totalPagesFailed,
+      byTrigger: Object.fromEntries(
+        byTrigger.map((r) => [r.trigger, r.count])
+      ),
+    });
+  })
+
+  // ---- GET /:id (single run with results) ----
+  .get("/:id", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
+
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(autoUpdateRuns)
+      .where(eq(autoUpdateRuns.id, id));
+
+    if (rows.length === 0) {
+      return notFoundError(c, "Run not found");
     }
 
-    return { ...run, resultsInserted };
-  });
-
-  return c.json(result, 201);
-});
-
-// ---- GET /all (paginated list of runs) ----
-
-autoUpdateRunsRoute.get("/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(autoUpdateRuns)
-    .orderBy(desc(autoUpdateRuns.startedAt))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(autoUpdateRuns);
-  const total = countResult[0].count;
-
-  // Fetch all results for the page of runs in a single query
-  const runIds = rows.map((r) => r.id);
-  const resultsByRun = new Map<number, (typeof autoUpdateResults.$inferSelect)[]>();
-
-  if (runIds.length > 0) {
-    const allResults = await db
+    const r = rows[0];
+    const results = await db
       .select()
       .from(autoUpdateResults)
-      .where(inArray(autoUpdateResults.runId, runIds));
+      .where(eq(autoUpdateResults.runId, r.id));
 
-    for (const result of allResults) {
-      const existing = resultsByRun.get(result.runId) || [];
-      existing.push(result);
-      resultsByRun.set(result.runId, existing);
-    }
-  }
-
-  const entries = rows.map((r) =>
-    formatRunEntry(r, resultsByRun.get(r.id) || [])
-  );
-
-  return c.json({ entries, total, limit, offset });
-});
-
-// ---- GET /stats (aggregate statistics) ----
-
-autoUpdateRunsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const totalResult = await db
-    .select({ count: count() })
-    .from(autoUpdateRuns);
-  const totalRuns = totalResult[0].count;
-
-  const budgetResult = await db
-    .select({
-      total: sql<number>`coalesce(sum(${autoUpdateRuns.budgetSpent}), 0)`,
-    })
-    .from(autoUpdateRuns);
-  const totalBudgetSpent = Number(budgetResult[0].total);
-
-  const updatedResult = await db
-    .select({
-      total: sql<number>`coalesce(sum(${autoUpdateRuns.pagesUpdated}), 0)`,
-    })
-    .from(autoUpdateRuns);
-  const totalPagesUpdated = Number(updatedResult[0].total);
-
-  const failedResult = await db
-    .select({
-      total: sql<number>`coalesce(sum(${autoUpdateRuns.pagesFailed}), 0)`,
-    })
-    .from(autoUpdateRuns);
-  const totalPagesFailed = Number(failedResult[0].total);
-
-  const byTrigger = await db
-    .select({
-      trigger: autoUpdateRuns.trigger,
-      count: count(),
-    })
-    .from(autoUpdateRuns)
-    .groupBy(autoUpdateRuns.trigger);
-
-  return c.json({
-    totalRuns,
-    totalBudgetSpent,
-    totalPagesUpdated,
-    totalPagesFailed,
-    byTrigger: Object.fromEntries(
-      byTrigger.map((r) => [r.trigger, r.count])
-    ),
+    return c.json(formatRunEntry(r, results));
   });
-});
 
-// ---- GET /:id (single run with results) ----
-
-autoUpdateRunsRoute.get("/:id", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
-
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(autoUpdateRuns)
-    .where(eq(autoUpdateRuns.id, id));
-
-  if (rows.length === 0) {
-    return notFoundError(c, "Run not found");
-  }
-
-  const r = rows[0];
-  const results = await db
-    .select()
-    .from(autoUpdateResults)
-    .where(eq(autoUpdateResults.runId, r.id));
-
-  return c.json(formatRunEntry(r, results));
-});
+export const autoUpdateRunsRoute = autoUpdateRunsApp;
+export type AutoUpdateRunsRoute = typeof autoUpdateRunsApp;

--- a/apps/wiki-server/src/routes/edit-logs.ts
+++ b/apps/wiki-server/src/routes/edit-logs.ts
@@ -7,8 +7,6 @@ import { checkRefsExist } from "./ref-check.js";
 import { parseJsonBody, validationError, invalidJsonError, firstOrThrow } from "./utils.js";
 import { EditLogEntrySchema, EditLogBatchSchema } from "../api-types.js";
 
-export const editLogsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 1000;
@@ -27,208 +25,213 @@ const AllEntriesQuery = PaginationQuery.extend({
   since: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
 
-// ---- POST / (append single entry) ----
+const editLogsApp = new Hono()
 
-editLogsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+  // ---- POST / (append single entry) ----
 
-  const parsed = AppendSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const d = parsed.data;
-  const db = getDrizzleDb();
+    const parsed = AppendSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  // Validate page reference
-  const missing = await checkRefsExist(db, wikiPages, wikiPages.id, [d.pageId]);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced page not found: ${missing.join(", ")}`);
-  }
+    const d = parsed.data;
+    const db = getDrizzleDb();
 
-  const rows = await db
-    .insert(editLogs)
-    .values({
-      pageId: d.pageId,
-      date: d.date,
-      tool: d.tool,
-      agency: d.agency,
-      requestedBy: d.requestedBy ?? null,
-      note: d.note ?? null,
-    })
-    .returning({
-      id: editLogs.id,
-      pageId: editLogs.pageId,
-      date: editLogs.date,
-      createdAt: editLogs.createdAt,
+    // Validate page reference
+    const missing = await checkRefsExist(db, wikiPages, wikiPages.id, [d.pageId]);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced page not found: ${missing.join(", ")}`);
+    }
+
+    const rows = await db
+      .insert(editLogs)
+      .values({
+        pageId: d.pageId,
+        date: d.date,
+        tool: d.tool,
+        agency: d.agency,
+        requestedBy: d.requestedBy ?? null,
+        note: d.note ?? null,
+      })
+      .returning({
+        id: editLogs.id,
+        pageId: editLogs.pageId,
+        date: editLogs.date,
+        createdAt: editLogs.createdAt,
+      });
+
+    return c.json(firstOrThrow(rows, "edit log insert"), 201);
+  })
+
+  // ---- POST /batch (append multiple entries) ----
+
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = AppendBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Validate page references
+    const pageIds = [...new Set(items.map((d) => d.pageId))];
+    const missing = await checkRefsExist(db, wikiPages, wikiPages.id, pageIds);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced pages not found: ${missing.join(", ")}`);
+    }
+
+    const results = await db.transaction(async (tx) => {
+      return await tx
+        .insert(editLogs)
+        .values(
+          items.map((d) => ({
+            pageId: d.pageId,
+            date: d.date,
+            tool: d.tool,
+            agency: d.agency,
+            requestedBy: d.requestedBy ?? null,
+            note: d.note ?? null,
+          }))
+        )
+        .returning({ id: editLogs.id, pageId: editLogs.pageId });
     });
 
-  return c.json(firstOrThrow(rows, "edit log insert"), 201);
-});
+    return c.json({ inserted: results.length, results }, 201);
+  })
 
-// ---- POST /batch (append multiple entries) ----
+  // ---- GET /?page_id=X (entries for a page) ----
 
-editLogsRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+  .get("/", async (c) => {
+    const pageId = c.req.query("page_id");
+    if (!pageId) return validationError(c, "page_id query parameter is required");
 
-  const parsed = AppendBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Validate page references
-  const pageIds = [...new Set(items.map((d) => d.pageId))];
-  const missing = await checkRefsExist(db, wikiPages, wikiPages.id, pageIds);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced pages not found: ${missing.join(", ")}`);
-  }
-
-  const results = await db.transaction(async (tx) => {
-    return await tx
-      .insert(editLogs)
-      .values(
-        items.map((d) => ({
-          pageId: d.pageId,
-          date: d.date,
-          tool: d.tool,
-          agency: d.agency,
-          requestedBy: d.requestedBy ?? null,
-          note: d.note ?? null,
-        }))
-      )
-      .returning({ id: editLogs.id, pageId: editLogs.pageId });
-  });
-
-  return c.json({ inserted: results.length, results }, 201);
-});
-
-// ---- GET /?page_id=X (entries for a page) ----
-
-editLogsRoute.get("/", async (c) => {
-  const pageId = c.req.query("page_id");
-  if (!pageId) return validationError(c, "page_id query parameter is required");
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(editLogs)
-    .where(eq(editLogs.pageId, pageId))
-    .orderBy(asc(editLogs.date), asc(editLogs.id));
-
-  return c.json({
-    entries: rows.map((r) => ({
-      id: r.id,
-      pageId: r.pageId,
-      date: r.date,
-      tool: r.tool,
-      agency: r.agency,
-      requestedBy: r.requestedBy,
-      note: r.note,
-      createdAt: r.createdAt,
-    })),
-  });
-});
-
-// ---- GET /all (paginated, all entries) ----
-
-editLogsRoute.get("/all", async (c) => {
-  const parsed = AllEntriesQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset, since } = parsed.data;
-  const db = getDrizzleDb();
-
-  const whereClause = since ? gte(editLogs.date, since) : undefined;
-
-  const [rows, countResult] = await Promise.all([
-    db
+    const db = getDrizzleDb();
+    const rows = await db
       .select()
       .from(editLogs)
-      .where(whereClause)
-      .orderBy(desc(editLogs.date), desc(editLogs.id))
-      .limit(limit)
-      .offset(offset),
-    db.select({ count: count() }).from(editLogs).where(whereClause),
-  ]);
+      .where(eq(editLogs.pageId, pageId))
+      .orderBy(asc(editLogs.date), asc(editLogs.id));
 
-  const total = countResult[0].count;
+    return c.json({
+      entries: rows.map((r) => ({
+        id: r.id,
+        pageId: r.pageId,
+        date: r.date,
+        tool: r.tool,
+        agency: r.agency,
+        requestedBy: r.requestedBy,
+        note: r.note,
+        createdAt: r.createdAt,
+      })),
+    });
+  })
 
-  return c.json({
-    entries: rows.map((r) => ({
-      id: r.id,
-      pageId: r.pageId,
-      date: r.date,
-      tool: r.tool,
-      agency: r.agency,
-      requestedBy: r.requestedBy,
-      note: r.note,
-      createdAt: r.createdAt,
-    })),
-    total,
-    limit,
-    offset,
+  // ---- GET /all (paginated, all entries) ----
+
+  .get("/all", async (c) => {
+    const parsed = AllEntriesQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset, since } = parsed.data;
+    const db = getDrizzleDb();
+
+    const whereClause = since ? gte(editLogs.date, since) : undefined;
+
+    const [rows, countResult] = await Promise.all([
+      db
+        .select()
+        .from(editLogs)
+        .where(whereClause)
+        .orderBy(desc(editLogs.date), desc(editLogs.id))
+        .limit(limit)
+        .offset(offset),
+      db.select({ count: count() }).from(editLogs).where(whereClause),
+    ]);
+
+    const total = countResult[0].count;
+
+    return c.json({
+      entries: rows.map((r) => ({
+        id: r.id,
+        pageId: r.pageId,
+        date: r.date,
+        tool: r.tool,
+        agency: r.agency,
+        requestedBy: r.requestedBy,
+        note: r.note,
+        createdAt: r.createdAt,
+      })),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /latest-dates (latest edit date per page, for build-data) ----
+
+  .get("/latest-dates", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        pageId: editLogs.pageId,
+        latestDate: sql<string>`max(${editLogs.date})`,
+      })
+      .from(editLogs)
+      .groupBy(editLogs.pageId);
+
+    const dateMap: Record<string, string> = {};
+    for (const row of rows) {
+      dateMap[row.pageId] = row.latestDate;
+    }
+
+    return c.json({ dates: dateMap });
+  })
+
+  // ---- GET /stats ----
+
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const totalResult = await db.select({ count: count() }).from(editLogs);
+    const totalEntries = totalResult[0].count;
+
+    const pagesResult = await db
+      .select({
+        count: sql<number>`count(distinct ${editLogs.pageId})`,
+      })
+      .from(editLogs);
+    const pagesWithLogs = Number(pagesResult[0].count);
+
+    const byTool = await db
+      .select({
+        tool: editLogs.tool,
+        count: count(),
+      })
+      .from(editLogs)
+      .groupBy(editLogs.tool)
+      .orderBy(desc(count()));
+
+    const byAgency = await db
+      .select({
+        agency: editLogs.agency,
+        count: count(),
+      })
+      .from(editLogs)
+      .groupBy(editLogs.agency)
+      .orderBy(desc(count()));
+
+    return c.json({
+      totalEntries,
+      pagesWithLogs,
+      byTool: Object.fromEntries(byTool.map((r) => [r.tool, r.count])),
+      byAgency: Object.fromEntries(byAgency.map((r) => [r.agency, r.count])),
+    });
   });
-});
 
-// ---- GET /latest-dates (latest edit date per page, for build-data) ----
-
-editLogsRoute.get("/latest-dates", async (c) => {
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select({
-      pageId: editLogs.pageId,
-      latestDate: sql<string>`max(${editLogs.date})`,
-    })
-    .from(editLogs)
-    .groupBy(editLogs.pageId);
-
-  const dateMap: Record<string, string> = {};
-  for (const row of rows) {
-    dateMap[row.pageId] = row.latestDate;
-  }
-
-  return c.json({ dates: dateMap });
-});
-
-// ---- GET /stats ----
-
-editLogsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const totalResult = await db.select({ count: count() }).from(editLogs);
-  const totalEntries = totalResult[0].count;
-
-  const pagesResult = await db
-    .select({
-      count: sql<number>`count(distinct ${editLogs.pageId})`,
-    })
-    .from(editLogs);
-  const pagesWithLogs = Number(pagesResult[0].count);
-
-  const byTool = await db
-    .select({
-      tool: editLogs.tool,
-      count: count(),
-    })
-    .from(editLogs)
-    .groupBy(editLogs.tool)
-    .orderBy(desc(count()));
-
-  const byAgency = await db
-    .select({
-      agency: editLogs.agency,
-      count: count(),
-    })
-    .from(editLogs)
-    .groupBy(editLogs.agency)
-    .orderBy(desc(count()));
-
-  return c.json({
-    totalEntries,
-    pagesWithLogs,
-    byTool: Object.fromEntries(byTool.map((r) => [r.tool, r.count])),
-    byAgency: Object.fromEntries(byAgency.map((r) => [r.agency, r.count])),
-  });
-});
+export const editLogsRoute = editLogsApp;
+export type EditLogsRoute = typeof editLogsApp;

--- a/apps/wiki-server/src/routes/entities.ts
+++ b/apps/wiki-server/src/routes/entities.ts
@@ -15,8 +15,6 @@ import {
   SyncEntitiesBatchSchema,
 } from "../api-types.js";
 
-export const entitiesRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -64,204 +62,209 @@ function formatEntity(e: typeof entities.$inferSelect) {
   };
 }
 
-// ---- GET /search?q=...&limit=20 ----
+const entitiesApp = new Hono()
 
-entitiesRoute.get("/search", async (c) => {
-  const parsed = SearchQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+  // ---- GET /search?q=...&limit=20 ----
 
-  const { q, limit } = parsed.data;
-  const db = getDrizzleDb();
-  const pattern = `%${escapeIlike(q)}%`;
+  .get("/search", async (c) => {
+    const parsed = SearchQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const rows = await db
-    .select()
-    .from(entities)
-    .where(
-      or(
-        ilike(entities.title, pattern),
-        ilike(entities.id, pattern),
-        ilike(entities.description, pattern)
+    const { q, limit } = parsed.data;
+    const db = getDrizzleDb();
+    const pattern = `%${escapeIlike(q)}%`;
+
+    const rows = await db
+      .select()
+      .from(entities)
+      .where(
+        or(
+          ilike(entities.title, pattern),
+          ilike(entities.id, pattern),
+          ilike(entities.description, pattern)
+        )
       )
-    )
-    .orderBy(entities.id)
-    .limit(limit);
+      .orderBy(entities.id)
+      .limit(limit);
 
-  return c.json({
-    results: rows.map(formatEntity),
-    query: q,
-    total: rows.length,
-  });
-});
+    return c.json({
+      results: rows.map(formatEntity),
+      query: q,
+      total: rows.length,
+    });
+  })
 
-// ---- GET /stats ----
+  // ---- GET /stats ----
 
-entitiesRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
 
-  const totalResult = await db.select({ count: count() }).from(entities);
-  const total = totalResult[0].count;
+    const totalResult = await db.select({ count: count() }).from(entities);
+    const total = totalResult[0].count;
 
-  const byType = await db
-    .select({
-      entityType: entities.entityType,
-      count: count(),
-    })
-    .from(entities)
-    .groupBy(entities.entityType)
-    .orderBy(sql`count(*) DESC`);
+    const byType = await db
+      .select({
+        entityType: entities.entityType,
+        count: count(),
+      })
+      .from(entities)
+      .groupBy(entities.entityType)
+      .orderBy(sql`count(*) DESC`);
 
-  return c.json({
-    total,
-    byType: Object.fromEntries(
-      byType.map((r) => [r.entityType, r.count])
-    ),
-  });
-});
+    return c.json({
+      total,
+      byType: Object.fromEntries(
+        byType.map((r) => [r.entityType, r.count])
+      ),
+    });
+  })
 
-// ---- GET /:id ----
+  // ---- GET /:id ----
 
-entitiesRoute.get("/:id", async (c) => {
-  const id = c.req.param("id");
-  if (!id) return validationError(c, "Entity ID is required");
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Entity ID is required");
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  // Look up by slug or numeric ID
-  const rows = await db
-    .select()
-    .from(entities)
-    .where(or(eq(entities.id, id), eq(entities.numericId, id)));
+    // Look up by slug or numeric ID
+    const rows = await db
+      .select()
+      .from(entities)
+      .where(or(eq(entities.id, id), eq(entities.numericId, id)));
 
-  if (rows.length === 0) {
-    return notFoundError(c, `No entity found for id: ${id}`);
-  }
-
-  return c.json(formatEntity(rows[0]));
-});
-
-// ---- GET / (paginated listing) ----
-
-entitiesRoute.get("/", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset, entityType } = parsed.data;
-  const db = getDrizzleDb();
-
-  const conditions = [];
-  if (entityType) conditions.push(eq(entities.entityType, entityType));
-
-  const whereClause =
-    conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : and(...conditions)
-      : undefined;
-
-  const rows = await db
-    .select({
-      id: entities.id,
-      numericId: entities.numericId,
-      entityType: entities.entityType,
-      title: entities.title,
-      description: entities.description,
-      website: entities.website,
-      tags: entities.tags,
-      status: entities.status,
-      lastUpdated: entities.lastUpdated,
-    })
-    .from(entities)
-    .where(whereClause)
-    .orderBy(asc(entities.id))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(entities)
-    .where(whereClause);
-  const total = countResult[0].count;
-
-  return c.json({ entities: rows, total, limit, offset });
-});
-
-// ---- POST /sync ----
-
-entitiesRoute.post("/sync", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = SyncBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { entities: items } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Validate relatedEntries references: check that referenced entity IDs exist
-  // (excluding IDs being created in this same batch, which are valid self-refs)
-  const batchIds = new Set(items.map((e) => e.id));
-  const relatedIds = [
-    ...new Set(
-      items
-        .flatMap((e) => e.relatedEntries ?? [])
-        .map((r) => r.id)
-        .filter((id) => !batchIds.has(id))
-    ),
-  ];
-  if (relatedIds.length > 0) {
-    const missing = await checkRefsExist(db, entities, entities.id, relatedIds);
-    if (missing.length > 0) {
-      return validationError(
-        c,
-        `Referenced entities not found in relatedEntries: ${missing.join(", ")}`
-      );
+    if (rows.length === 0) {
+      return notFoundError(c, `No entity found for id: ${id}`);
     }
-  }
 
-  let upserted = 0;
+    return c.json(formatEntity(rows[0]));
+  })
 
-  await db.transaction(async (tx) => {
-    const allVals = items.map((e) => ({
-      id: e.id,
-      numericId: e.numericId ?? null,
-      entityType: e.entityType,
-      title: e.title,
-      description: e.description ?? null,
-      website: e.website ?? null,
-      tags: e.tags ?? null,
-      clusters: e.clusters ?? null,
-      status: e.status ?? null,
-      lastUpdated: e.lastUpdated ?? null,
-      customFields: e.customFields ?? null,
-      relatedEntries: e.relatedEntries ?? null,
-      sources: e.sources ?? null,
-    }));
+  // ---- GET / (paginated listing) ----
 
-    await tx
-      .insert(entities)
-      .values(allVals)
-      .onConflictDoUpdate({
-        target: entities.id,
-        set: {
-          numericId: sql`excluded.numeric_id`,
-          entityType: sql`excluded.entity_type`,
-          title: sql`excluded.title`,
-          description: sql`excluded.description`,
-          website: sql`excluded.website`,
-          tags: sql`excluded.tags`,
-          clusters: sql`excluded.clusters`,
-          status: sql`excluded.status`,
-          lastUpdated: sql`excluded.last_updated`,
-          customFields: sql`excluded.custom_fields`,
-          relatedEntries: sql`excluded.related_entries`,
-          sources: sql`excluded.sources`,
-          syncedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        },
-      });
-    upserted = allVals.length;
+  .get("/", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset, entityType } = parsed.data;
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (entityType) conditions.push(eq(entities.entityType, entityType));
+
+    const whereClause =
+      conditions.length > 0
+        ? conditions.length === 1
+          ? conditions[0]
+          : and(...conditions)
+        : undefined;
+
+    const rows = await db
+      .select({
+        id: entities.id,
+        numericId: entities.numericId,
+        entityType: entities.entityType,
+        title: entities.title,
+        description: entities.description,
+        website: entities.website,
+        tags: entities.tags,
+        status: entities.status,
+        lastUpdated: entities.lastUpdated,
+      })
+      .from(entities)
+      .where(whereClause)
+      .orderBy(asc(entities.id))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(entities)
+      .where(whereClause);
+    const total = countResult[0].count;
+
+    return c.json({ entities: rows, total, limit, offset });
+  })
+
+  // ---- POST /sync ----
+
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SyncBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { entities: items } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Validate relatedEntries references: check that referenced entity IDs exist
+    // (excluding IDs being created in this same batch, which are valid self-refs)
+    const batchIds = new Set(items.map((e) => e.id));
+    const relatedIds = [
+      ...new Set(
+        items
+          .flatMap((e) => e.relatedEntries ?? [])
+          .map((r) => r.id)
+          .filter((id) => !batchIds.has(id))
+      ),
+    ];
+    if (relatedIds.length > 0) {
+      const missing = await checkRefsExist(db, entities, entities.id, relatedIds);
+      if (missing.length > 0) {
+        return validationError(
+          c,
+          `Referenced entities not found in relatedEntries: ${missing.join(", ")}`
+        );
+      }
+    }
+
+    let upserted = 0;
+
+    await db.transaction(async (tx) => {
+      const allVals = items.map((e) => ({
+        id: e.id,
+        numericId: e.numericId ?? null,
+        entityType: e.entityType,
+        title: e.title,
+        description: e.description ?? null,
+        website: e.website ?? null,
+        tags: e.tags ?? null,
+        clusters: e.clusters ?? null,
+        status: e.status ?? null,
+        lastUpdated: e.lastUpdated ?? null,
+        customFields: e.customFields ?? null,
+        relatedEntries: e.relatedEntries ?? null,
+        sources: e.sources ?? null,
+      }));
+
+      await tx
+        .insert(entities)
+        .values(allVals)
+        .onConflictDoUpdate({
+          target: entities.id,
+          set: {
+            numericId: sql`excluded.numeric_id`,
+            entityType: sql`excluded.entity_type`,
+            title: sql`excluded.title`,
+            description: sql`excluded.description`,
+            website: sql`excluded.website`,
+            tags: sql`excluded.tags`,
+            clusters: sql`excluded.clusters`,
+            status: sql`excluded.status`,
+            lastUpdated: sql`excluded.last_updated`,
+            customFields: sql`excluded.custom_fields`,
+            relatedEntries: sql`excluded.related_entries`,
+            sources: sql`excluded.sources`,
+            syncedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          },
+        });
+      upserted = allVals.length;
+    });
+
+    return c.json({ upserted });
   });
 
-  return c.json({ upserted });
-});
+export const entitiesRoute = entitiesApp;
+export type EntitiesRoute = typeof entitiesApp;

--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -7,8 +7,6 @@ import {
   TRIGRAM_SIMILARITY_THRESHOLD,
 } from "../search-utils.js";
 
-export const exploreRoute = new Hono();
-
 // ---- Query Schema ----
 
 const ExploreQuery = z.object({
@@ -182,157 +180,61 @@ const SORT_COLUMNS: Record<string, string> = {
   title: "wp.title",
 };
 
-// ---- GET / (explore items with pagination, filtering, sorting, search, facets) ----
+// ---- Route ----
 
-exploreRoute.get("/", async (c) => {
-  const parsed = ExploreQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+const exploreApp = new Hono()
+  // ---- GET / (explore items with pagination, filtering, sorting, search, facets) ----
+  .get("/", async (c) => {
+    const parsed = ExploreQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const {
-    limit,
-    offset,
-    search,
-    entityType,
-    category,
-    cluster,
-    riskCategory,
-    sort,
-    sortDir,
-  } = parsed.data;
-  const rawDb = getDb();
+    const {
+      limit,
+      offset,
+      search,
+      entityType,
+      category,
+      cluster,
+      riskCategory,
+      sort,
+      sortDir,
+    } = parsed.data;
+    const rawDb = getDb();
 
-  // Build main query conditions (all filters applied)
-  const main = buildFilterConditions({
-    search,
-    cluster,
-    category,
-    entityType,
-    riskCategory,
-  });
-  const mainWhere = `WHERE ${main.conditions.join(" AND ")}`;
-
-  // Sort
-  const col = SORT_COLUMNS[sort] || SORT_COLUMNS.recommended;
-  const dir = sort === "title" ? "ASC" : sortDir.toUpperCase();
-  const nullsLast = dir === "DESC" ? "NULLS LAST" : "NULLS FIRST";
-
-  let searchRankSelect = "";
-  let orderBy = `${col} ${dir} ${nullsLast}`;
-
-  if (search) {
-    const prefixQuery = buildPrefixTsquery(search);
-    if (prefixQuery) {
-      searchRankSelect = `, ts_rank_cd(wp.search_vector, to_tsquery('english', $1), 1) AS search_rank`;
-      if (sort === "recommended") {
-        orderBy = `search_rank DESC, ${col} ${dir} ${nullsLast}`;
-      }
-    }
-  }
-
-  // Main data query
-  const limitParamIdx = main.paramIdx;
-  const offsetParamIdx = main.paramIdx + 1;
-  const dataParams = [...main.params, limit, offset];
-
-  const dataQuery = `
-    SELECT
-      wp.id, wp.numeric_id, wp.title, wp.entity_type, wp.content_format,
-      wp.category, COALESCE(wp.llm_summary, wp.description) AS description,
-      wp.tags AS page_tags, wp.clusters AS page_clusters,
-      wp.word_count, wp.quality, wp.reader_importance, wp.research_importance,
-      wp.tactical_value, wp.backlink_count, wp.risk_category,
-      wp.last_updated, wp.date_created, wp.recommended_score,
-      e.tags AS entity_tags, e.clusters AS entity_clusters
-      ${searchRankSelect}
-    FROM wiki_pages wp
-    LEFT JOIN entities e ON wp.id = e.id
-    ${mainWhere}
-    ORDER BY ${orderBy}
-    LIMIT $${limitParamIdx} OFFSET $${offsetParamIdx}
-  `;
-
-  // Count query (same filters, no pagination)
-  const countQuery = `
-    SELECT count(*) AS total
-    FROM wiki_pages wp
-    ${mainWhere}
-  `;
-
-  // Faceted counts — cascading:
-  // 1. Cluster counts: search only
-  // 2. Category counts: search + cluster
-  // 3. Entity type counts: search + cluster + category
-  // 4. Risk category counts: search + cluster + category + entity_type in risk types
-
-  const searchOnly = buildFilterConditions({ search });
-  const searchCluster = buildFilterConditions({ search, cluster });
-  const searchClusterCat = buildFilterConditions({ search, cluster, category });
-  const searchClusterCatRisk = buildFilterConditions({
-    search,
-    cluster,
-    category,
-    entityType: entityType === "risk" ? undefined : entityType,
-  });
-
-  const clusterCountQuery = `
-    SELECT val, count(*) AS cnt
-    FROM wiki_pages wp, jsonb_array_elements_text(wp.clusters) AS val
-    WHERE ${searchOnly.conditions.join(" AND ")}
-    GROUP BY val ORDER BY cnt DESC
-  `;
-
-  const categoryCountQuery = `
-    SELECT wp.category AS val, count(*) AS cnt
-    FROM wiki_pages wp
-    WHERE ${searchCluster.conditions.join(" AND ")} AND wp.category IS NOT NULL
-    GROUP BY wp.category ORDER BY cnt DESC
-  `;
-
-  const entityTypeCountQuery = `
-    SELECT (${DERIVED_TYPE_EXPR}) AS val, count(*) AS cnt
-    FROM wiki_pages wp
-    WHERE ${searchClusterCat.conditions.join(" AND ")}
-    GROUP BY val ORDER BY cnt DESC
-  `;
-
-  const riskCatCountQuery = `
-    SELECT wp.risk_category AS val, count(*) AS cnt
-    FROM wiki_pages wp
-    WHERE ${searchClusterCatRisk.conditions.join(" AND ")}
-      AND wp.entity_type = 'risk' AND wp.risk_category IS NOT NULL
-    GROUP BY wp.risk_category ORDER BY cnt DESC
-  `;
-
-  // Execute all queries in parallel
-  let [rows, countResult, clusterCounts, categoryCounts, entityTypeCounts, riskCatCounts] =
-    await Promise.all([
-      rawDb.unsafe(dataQuery, dataParams as any[]),
-      rawDb.unsafe(countQuery, main.params as any[]),
-      rawDb.unsafe(clusterCountQuery, searchOnly.params as any[]),
-      rawDb.unsafe(categoryCountQuery, searchCluster.params as any[]),
-      rawDb.unsafe(entityTypeCountQuery, searchClusterCat.params as any[]),
-      rawDb.unsafe(riskCatCountQuery, searchClusterCatRisk.params as any[]),
-    ]);
-
-  let total = parseInt(countResult[0]?.total ?? "0", 10);
-
-  // Trigram fallback: if FTS returned nothing and we have a search term,
-  // fall back to pg_trgm similarity on title for typo tolerance.
-  let searchMode: "fts" | "trigram" | null = search ? "fts" : null;
-  if (search && total === 0) {
-    searchMode = "trigram";
-    // Build trigram fallback query with same non-search filters
-    const noSearchFilters = buildFilterConditions({
+    // Build main query conditions (all filters applied)
+    const main = buildFilterConditions({
+      search,
       cluster,
       category,
       entityType,
       riskCategory,
     });
-    const trigramParamIdx = noSearchFilters.paramIdx;
-    const trigramWhere = `WHERE ${noSearchFilters.conditions.join(" AND ")} AND similarity(wp.title, $${trigramParamIdx}) > ${TRIGRAM_SIMILARITY_THRESHOLD}`;
-    const trigramParams = [...noSearchFilters.params, search, limit, offset];
+    const mainWhere = `WHERE ${main.conditions.join(" AND ")}`;
 
-    const trigramQuery = `
+    // Sort
+    const col = SORT_COLUMNS[sort] || SORT_COLUMNS.recommended;
+    const dir = sort === "title" ? "ASC" : sortDir.toUpperCase();
+    const nullsLast = dir === "DESC" ? "NULLS LAST" : "NULLS FIRST";
+
+    let searchRankSelect = "";
+    let orderBy = `${col} ${dir} ${nullsLast}`;
+
+    if (search) {
+      const prefixQuery = buildPrefixTsquery(search);
+      if (prefixQuery) {
+        searchRankSelect = `, ts_rank_cd(wp.search_vector, to_tsquery('english', $1), 1) AS search_rank`;
+        if (sort === "recommended") {
+          orderBy = `search_rank DESC, ${col} ${dir} ${nullsLast}`;
+        }
+      }
+    }
+
+    // Main data query
+    const limitParamIdx = main.paramIdx;
+    const offsetParamIdx = main.paramIdx + 1;
+    const dataParams = [...main.params, limit, offset];
+
+    const dataQuery = `
       SELECT
         wp.id, wp.numeric_id, wp.title, wp.entity_type, wp.content_format,
         wp.category, COALESCE(wp.llm_summary, wp.description) AS description,
@@ -340,74 +242,175 @@ exploreRoute.get("/", async (c) => {
         wp.word_count, wp.quality, wp.reader_importance, wp.research_importance,
         wp.tactical_value, wp.backlink_count, wp.risk_category,
         wp.last_updated, wp.date_created, wp.recommended_score,
-        e.tags AS entity_tags, e.clusters AS entity_clusters,
-        similarity(wp.title, $${trigramParamIdx}) AS search_rank
+        e.tags AS entity_tags, e.clusters AS entity_clusters
+        ${searchRankSelect}
       FROM wiki_pages wp
       LEFT JOIN entities e ON wp.id = e.id
-      ${trigramWhere}
-      ORDER BY similarity(wp.title, $${trigramParamIdx}) DESC
-      LIMIT $${trigramParamIdx + 1} OFFSET $${trigramParamIdx + 2}
-    `;
-    const trigramCountQuery = `
-      SELECT count(*) AS total FROM wiki_pages wp ${trigramWhere}
+      ${mainWhere}
+      ORDER BY ${orderBy}
+      LIMIT $${limitParamIdx} OFFSET $${offsetParamIdx}
     `;
 
-    const [trigramRows, trigramCount] = await Promise.all([
-      rawDb.unsafe(trigramQuery, trigramParams as any[]),
-      rawDb.unsafe(trigramCountQuery, [...noSearchFilters.params, search] as any[]),
-    ]);
-    rows = trigramRows;
-    total = parseInt(trigramCount[0]?.total ?? "0", 10);
-  }
+    // Count query (same filters, no pagination)
+    const countQuery = `
+      SELECT count(*) AS total
+      FROM wiki_pages wp
+      ${mainWhere}
+    `;
 
-  // Transform rows to ExploreItem shape
-  const items = rows.map((r: any) => {
-    const entityTags = Array.isArray(r.entity_tags) ? r.entity_tags : [];
-    const pageTags = parseTags(r.page_tags);
-    const tags = entityTags.length > 0 ? entityTags : pageTags;
+    // Faceted counts — cascading:
+    // 1. Cluster counts: search only
+    // 2. Category counts: search + cluster
+    // 3. Entity type counts: search + cluster + category
+    // 4. Risk category counts: search + cluster + category + entity_type in risk types
 
-    const entityClusters = parseClusters(r.entity_clusters);
-    const pageClusters = parseClusters(r.page_clusters);
-    const clusters =
-      pageClusters.length > 0 ? pageClusters : entityClusters;
+    const searchOnly = buildFilterConditions({ search });
+    const searchCluster = buildFilterConditions({ search, cluster });
+    const searchClusterCat = buildFilterConditions({ search, cluster, category });
+    const searchClusterCatRisk = buildFilterConditions({
+      search,
+      cluster,
+      category,
+      entityType: entityType === "risk" ? undefined : entityType,
+    });
 
-    return {
-      id: r.id,
-      numericId: r.numeric_id || r.id,
-      title: r.title,
-      type: deriveType(r.content_format, r.entity_type, r.category),
-      description: r.description || null,
-      tags,
-      clusters,
-      wordCount: r.word_count ?? null,
-      quality: r.quality ?? null,
-      readerImportance: r.reader_importance ?? null,
-      researchImportance: r.research_importance ?? null,
-      tacticalValue: r.tactical_value ?? null,
-      backlinkCount: r.backlink_count ?? null,
-      category: r.category || null,
-      riskCategory: r.risk_category || null,
-      lastUpdated: r.last_updated || null,
-      dateCreated: r.date_created || null,
-      contentFormat: r.content_format || null,
-      recommendedScore: r.recommended_score ?? null,
-    };
+    const clusterCountQuery = `
+      SELECT val, count(*) AS cnt
+      FROM wiki_pages wp, jsonb_array_elements_text(wp.clusters) AS val
+      WHERE ${searchOnly.conditions.join(" AND ")}
+      GROUP BY val ORDER BY cnt DESC
+    `;
+
+    const categoryCountQuery = `
+      SELECT wp.category AS val, count(*) AS cnt
+      FROM wiki_pages wp
+      WHERE ${searchCluster.conditions.join(" AND ")} AND wp.category IS NOT NULL
+      GROUP BY wp.category ORDER BY cnt DESC
+    `;
+
+    const entityTypeCountQuery = `
+      SELECT (${DERIVED_TYPE_EXPR}) AS val, count(*) AS cnt
+      FROM wiki_pages wp
+      WHERE ${searchClusterCat.conditions.join(" AND ")}
+      GROUP BY val ORDER BY cnt DESC
+    `;
+
+    const riskCatCountQuery = `
+      SELECT wp.risk_category AS val, count(*) AS cnt
+      FROM wiki_pages wp
+      WHERE ${searchClusterCatRisk.conditions.join(" AND ")}
+        AND wp.entity_type = 'risk' AND wp.risk_category IS NOT NULL
+      GROUP BY wp.risk_category ORDER BY cnt DESC
+    `;
+
+    // Execute all queries in parallel
+    let [rows, countResult, clusterCounts, categoryCounts, entityTypeCounts, riskCatCounts] =
+      await Promise.all([
+        rawDb.unsafe(dataQuery, dataParams as any[]),
+        rawDb.unsafe(countQuery, main.params as any[]),
+        rawDb.unsafe(clusterCountQuery, searchOnly.params as any[]),
+        rawDb.unsafe(categoryCountQuery, searchCluster.params as any[]),
+        rawDb.unsafe(entityTypeCountQuery, searchClusterCat.params as any[]),
+        rawDb.unsafe(riskCatCountQuery, searchClusterCatRisk.params as any[]),
+      ]);
+
+    let total = parseInt(countResult[0]?.total ?? "0", 10);
+
+    // Trigram fallback: if FTS returned nothing and we have a search term,
+    // fall back to pg_trgm similarity on title for typo tolerance.
+    let searchMode: "fts" | "trigram" | null = search ? "fts" : null;
+    if (search && total === 0) {
+      searchMode = "trigram";
+      // Build trigram fallback query with same non-search filters
+      const noSearchFilters = buildFilterConditions({
+        cluster,
+        category,
+        entityType,
+        riskCategory,
+      });
+      const trigramParamIdx = noSearchFilters.paramIdx;
+      const trigramWhere = `WHERE ${noSearchFilters.conditions.join(" AND ")} AND similarity(wp.title, $${trigramParamIdx}) > ${TRIGRAM_SIMILARITY_THRESHOLD}`;
+      const trigramParams = [...noSearchFilters.params, search, limit, offset];
+
+      const trigramQuery = `
+        SELECT
+          wp.id, wp.numeric_id, wp.title, wp.entity_type, wp.content_format,
+          wp.category, COALESCE(wp.llm_summary, wp.description) AS description,
+          wp.tags AS page_tags, wp.clusters AS page_clusters,
+          wp.word_count, wp.quality, wp.reader_importance, wp.research_importance,
+          wp.tactical_value, wp.backlink_count, wp.risk_category,
+          wp.last_updated, wp.date_created, wp.recommended_score,
+          e.tags AS entity_tags, e.clusters AS entity_clusters,
+          similarity(wp.title, $${trigramParamIdx}) AS search_rank
+        FROM wiki_pages wp
+        LEFT JOIN entities e ON wp.id = e.id
+        ${trigramWhere}
+        ORDER BY similarity(wp.title, $${trigramParamIdx}) DESC
+        LIMIT $${trigramParamIdx + 1} OFFSET $${trigramParamIdx + 2}
+      `;
+      const trigramCountQuery = `
+        SELECT count(*) AS total FROM wiki_pages wp ${trigramWhere}
+      `;
+
+      const [trigramRows, trigramCount] = await Promise.all([
+        rawDb.unsafe(trigramQuery, trigramParams as any[]),
+        rawDb.unsafe(trigramCountQuery, [...noSearchFilters.params, search] as any[]),
+      ]);
+      rows = trigramRows;
+      total = parseInt(trigramCount[0]?.total ?? "0", 10);
+    }
+
+    // Transform rows to ExploreItem shape
+    const items = rows.map((r: any) => {
+      const entityTags = Array.isArray(r.entity_tags) ? r.entity_tags : [];
+      const pageTags = parseTags(r.page_tags);
+      const tags = entityTags.length > 0 ? entityTags : pageTags;
+
+      const entityClusters = parseClusters(r.entity_clusters);
+      const pageClusters = parseClusters(r.page_clusters);
+      const clusters =
+        pageClusters.length > 0 ? pageClusters : entityClusters;
+
+      return {
+        id: r.id,
+        numericId: r.numeric_id || r.id,
+        title: r.title,
+        type: deriveType(r.content_format, r.entity_type, r.category),
+        description: r.description || null,
+        tags,
+        clusters,
+        wordCount: r.word_count ?? null,
+        quality: r.quality ?? null,
+        readerImportance: r.reader_importance ?? null,
+        researchImportance: r.research_importance ?? null,
+        tacticalValue: r.tactical_value ?? null,
+        backlinkCount: r.backlink_count ?? null,
+        category: r.category || null,
+        riskCategory: r.risk_category || null,
+        lastUpdated: r.last_updated || null,
+        dateCreated: r.date_created || null,
+        contentFormat: r.content_format || null,
+        recommendedScore: r.recommended_score ?? null,
+      };
+    });
+
+    const toCountMap = (rows: any[]) =>
+      Object.fromEntries(rows.map((r: any) => [r.val, parseInt(r.cnt, 10)]));
+
+    return c.json({
+      items,
+      total,
+      limit,
+      offset,
+      searchMode,
+      facets: {
+        clusters: toCountMap(clusterCounts),
+        categories: toCountMap(categoryCounts),
+        entityTypes: toCountMap(entityTypeCounts),
+        riskCategories: toCountMap(riskCatCounts),
+      },
+    });
   });
 
-  const toCountMap = (rows: any[]) =>
-    Object.fromEntries(rows.map((r: any) => [r.val, parseInt(r.cnt, 10)]));
-
-  return c.json({
-    items,
-    total,
-    limit,
-    offset,
-    searchMode,
-    facets: {
-      clusters: toCountMap(clusterCounts),
-      categories: toCountMap(categoryCounts),
-      entityTypes: toCountMap(entityTypeCounts),
-      riskCategories: toCountMap(riskCatCounts),
-    },
-  });
-});
+export const exploreRoute = exploreApp;
+export type ExploreRoute = typeof exploreApp;

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -14,8 +14,6 @@ import {
   RiskSnapshotBatchSchema,
 } from "../api-types.js";
 
-export const hallucinationRiskRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -39,188 +37,6 @@ const LatestQuery = z.object({
   level: z.enum(VALID_LEVELS).optional(),
 });
 
-// ---- POST / (record single snapshot) ----
-
-hallucinationRiskRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = SnapshotSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const d = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .insert(hallucinationRiskSnapshots)
-    .values({
-      pageId: d.pageId,
-      score: d.score,
-      level: d.level,
-      factors: d.factors ?? null,
-      integrityIssues: d.integrityIssues ?? null,
-    })
-    .returning({
-      id: hallucinationRiskSnapshots.id,
-      pageId: hallucinationRiskSnapshots.pageId,
-      score: hallucinationRiskSnapshots.score,
-      level: hallucinationRiskSnapshots.level,
-      computedAt: hallucinationRiskSnapshots.computedAt,
-    });
-
-  return c.json(firstOrThrow(rows, "hallucination risk snapshot insert"), 201);
-});
-
-// ---- POST /batch (record multiple snapshots) ----
-
-hallucinationRiskRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = BatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { snapshots } = parsed.data;
-  const db = getDrizzleDb();
-
-  const allVals = snapshots.map((d) => ({
-    pageId: d.pageId,
-    score: d.score,
-    level: d.level,
-    factors: d.factors ?? null,
-    integrityIssues: d.integrityIssues ?? null,
-  }));
-
-  const results = await db
-    .insert(hallucinationRiskSnapshots)
-    .values(allVals)
-    .returning({
-      id: hallucinationRiskSnapshots.id,
-      pageId: hallucinationRiskSnapshots.pageId,
-    });
-
-  return c.json({ inserted: results.length }, 201);
-});
-
-// ---- GET /history?page_id=X (history for a page) ----
-
-hallucinationRiskRoute.get("/history", async (c) => {
-  const parsed = HistoryQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { page_id, limit } = parsed.data;
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(hallucinationRiskSnapshots)
-    .where(eq(hallucinationRiskSnapshots.pageId, page_id))
-    .orderBy(desc(hallucinationRiskSnapshots.computedAt))
-    .limit(limit);
-
-  return c.json({
-    pageId: page_id,
-    snapshots: rows.map((r) => ({
-      id: r.id,
-      score: r.score,
-      level: r.level,
-      factors: r.factors,
-      integrityIssues: r.integrityIssues,
-      computedAt: r.computedAt,
-    })),
-  });
-});
-
-// ---- GET /stats (aggregate statistics) ----
-
-hallucinationRiskRoute.get("/stats", async (c) => {
-  const parsed = StatsQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const db = getDrizzleDb();
-  const rawDb = getDb();
-
-  // Total snapshots
-  const totalResult = await db
-    .select({ count: count() })
-    .from(hallucinationRiskSnapshots);
-  const totalSnapshots = totalResult[0].count;
-
-  // Unique pages
-  const pagesResult = await db
-    .select({
-      count: sql<number>`count(distinct ${hallucinationRiskSnapshots.pageId})`,
-    })
-    .from(hallucinationRiskSnapshots);
-  const uniquePages = Number(pagesResult[0].count);
-
-  // Level distribution (from latest snapshot per page) using DISTINCT ON
-  const levelDist = await rawDb`
-    SELECT level, count(*)::int AS count
-    FROM (
-      SELECT DISTINCT ON (page_id) level
-      FROM hallucination_risk_snapshots
-      ORDER BY page_id, computed_at DESC
-    ) latest
-    GROUP BY level
-  `;
-
-  return c.json({
-    totalSnapshots,
-    uniquePages,
-    levelDistribution: Object.fromEntries(
-      levelDist.map((r: any) => [r.level, r.count])
-    ),
-  });
-});
-
-// ---- GET /latest (latest score per page) ----
-
-hallucinationRiskRoute.get("/latest", async (c) => {
-  const parsed = LatestQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset, level } = parsed.data;
-  const rawDb = getDb();
-
-  // Use DISTINCT ON for efficient "latest per page" query
-  const rows = level
-    ? await rawDb`
-        SELECT page_id, score, level, factors, integrity_issues, computed_at
-        FROM (
-          SELECT DISTINCT ON (page_id) *
-          FROM hallucination_risk_snapshots
-          ORDER BY page_id, computed_at DESC
-        ) latest
-        WHERE level = ${level}
-        ORDER BY score DESC
-        LIMIT ${limit} OFFSET ${offset}
-      `
-    : await rawDb`
-        SELECT page_id, score, level, factors, integrity_issues, computed_at
-        FROM (
-          SELECT DISTINCT ON (page_id) *
-          FROM hallucination_risk_snapshots
-          ORDER BY page_id, computed_at DESC
-        ) latest
-        ORDER BY score DESC
-        LIMIT ${limit} OFFSET ${offset}
-      `;
-
-  return c.json({
-    pages: rows.map((r: any) => ({
-      pageId: r.page_id,
-      score: r.score,
-      level: r.level,
-      factors: r.factors,
-      integrityIssues: r.integrity_issues,
-      computedAt: r.computed_at,
-    })),
-  });
-});
-
-// ---- DELETE /cleanup (retention: keep latest N snapshots per page) ----
-
 const CleanupQuery = z.object({
   keep: z.coerce.number().int().min(1).max(1000).default(30),
   dry_run: z
@@ -229,18 +45,232 @@ const CleanupQuery = z.object({
     .default("false"),
 });
 
-hallucinationRiskRoute.delete("/cleanup", async (c) => {
-  const parsed = CleanupQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+const hallucinationRiskApp = new Hono()
 
-  const { keep, dry_run } = parsed.data;
-  const rawDb = getDb();
+  // ---- POST / (record single snapshot) ----
 
-  if (dry_run) {
-    // Count how many rows would be deleted
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SnapshotSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const d = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .insert(hallucinationRiskSnapshots)
+      .values({
+        pageId: d.pageId,
+        score: d.score,
+        level: d.level,
+        factors: d.factors ?? null,
+        integrityIssues: d.integrityIssues ?? null,
+      })
+      .returning({
+        id: hallucinationRiskSnapshots.id,
+        pageId: hallucinationRiskSnapshots.pageId,
+        score: hallucinationRiskSnapshots.score,
+        level: hallucinationRiskSnapshots.level,
+        computedAt: hallucinationRiskSnapshots.computedAt,
+      });
+
+    return c.json(firstOrThrow(rows, "hallucination risk snapshot insert"), 201);
+  })
+
+  // ---- POST /batch (record multiple snapshots) ----
+
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = BatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { snapshots } = parsed.data;
+    const db = getDrizzleDb();
+
+    const allVals = snapshots.map((d) => ({
+      pageId: d.pageId,
+      score: d.score,
+      level: d.level,
+      factors: d.factors ?? null,
+      integrityIssues: d.integrityIssues ?? null,
+    }));
+
+    const results = await db
+      .insert(hallucinationRiskSnapshots)
+      .values(allVals)
+      .returning({
+        id: hallucinationRiskSnapshots.id,
+        pageId: hallucinationRiskSnapshots.pageId,
+      });
+
+    return c.json({ inserted: results.length }, 201);
+  })
+
+  // ---- GET /history?page_id=X (history for a page) ----
+
+  .get("/history", async (c) => {
+    const parsed = HistoryQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { page_id, limit } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(hallucinationRiskSnapshots)
+      .where(eq(hallucinationRiskSnapshots.pageId, page_id))
+      .orderBy(desc(hallucinationRiskSnapshots.computedAt))
+      .limit(limit);
+
+    return c.json({
+      pageId: page_id,
+      snapshots: rows.map((r) => ({
+        id: r.id,
+        score: r.score,
+        level: r.level,
+        factors: r.factors,
+        integrityIssues: r.integrityIssues,
+        computedAt: r.computedAt,
+      })),
+    });
+  })
+
+  // ---- GET /stats (aggregate statistics) ----
+
+  .get("/stats", async (c) => {
+    const parsed = StatsQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const db = getDrizzleDb();
+    const rawDb = getDb();
+
+    // Total snapshots
+    const totalResult = await db
+      .select({ count: count() })
+      .from(hallucinationRiskSnapshots);
+    const totalSnapshots = totalResult[0].count;
+
+    // Unique pages
+    const pagesResult = await db
+      .select({
+        count: sql<number>`count(distinct ${hallucinationRiskSnapshots.pageId})`,
+      })
+      .from(hallucinationRiskSnapshots);
+    const uniquePages = Number(pagesResult[0].count);
+
+    // Level distribution (from latest snapshot per page) using DISTINCT ON
+    const levelDist = await rawDb`
+      SELECT level, count(*)::int AS count
+      FROM (
+        SELECT DISTINCT ON (page_id) level
+        FROM hallucination_risk_snapshots
+        ORDER BY page_id, computed_at DESC
+      ) latest
+      GROUP BY level
+    `;
+
+    return c.json({
+      totalSnapshots,
+      uniquePages,
+      levelDistribution: Object.fromEntries(
+        levelDist.map((r: any) => [r.level, r.count])
+      ),
+    });
+  })
+
+  // ---- GET /latest (latest score per page) ----
+
+  .get("/latest", async (c) => {
+    const parsed = LatestQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset, level } = parsed.data;
+    const rawDb = getDb();
+
+    // Use DISTINCT ON for efficient "latest per page" query
+    const rows = level
+      ? await rawDb`
+          SELECT page_id, score, level, factors, integrity_issues, computed_at
+          FROM (
+            SELECT DISTINCT ON (page_id) *
+            FROM hallucination_risk_snapshots
+            ORDER BY page_id, computed_at DESC
+          ) latest
+          WHERE level = ${level}
+          ORDER BY score DESC
+          LIMIT ${limit} OFFSET ${offset}
+        `
+      : await rawDb`
+          SELECT page_id, score, level, factors, integrity_issues, computed_at
+          FROM (
+            SELECT DISTINCT ON (page_id) *
+            FROM hallucination_risk_snapshots
+            ORDER BY page_id, computed_at DESC
+          ) latest
+          ORDER BY score DESC
+          LIMIT ${limit} OFFSET ${offset}
+        `;
+
+    return c.json({
+      pages: rows.map((r: any) => ({
+        pageId: r.page_id,
+        score: r.score,
+        level: r.level,
+        factors: r.factors,
+        integrityIssues: r.integrity_issues,
+        computedAt: r.computed_at,
+      })),
+    });
+  })
+
+  // ---- DELETE /cleanup (retention: keep latest N snapshots per page) ----
+
+  .delete("/cleanup", async (c) => {
+    const parsed = CleanupQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { keep, dry_run } = parsed.data;
+    const rawDb = getDb();
+
+    if (dry_run) {
+      // Count how many rows would be deleted
+      const result = await rawDb`
+        SELECT count(*)::int AS count
+        FROM hallucination_risk_snapshots hrs
+        WHERE id NOT IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              PARTITION BY page_id ORDER BY computed_at DESC
+            ) AS rn
+            FROM hallucination_risk_snapshots
+          ) ranked
+          WHERE rn <= ${keep}
+        )
+      `;
+      const wouldDelete = result[0]?.count ?? 0;
+
+      // Total count
+      const totalResult = await rawDb`
+        SELECT count(*)::int AS total FROM hallucination_risk_snapshots
+      `;
+      const total = totalResult[0]?.total ?? 0;
+
+      return c.json({
+        dryRun: true,
+        keep,
+        totalSnapshots: total,
+        wouldDelete,
+        wouldRetain: total - wouldDelete,
+      });
+    }
+
+    // Actually delete old snapshots, keeping latest `keep` per page
     const result = await rawDb`
-      SELECT count(*)::int AS count
-      FROM hallucination_risk_snapshots hrs
+      DELETE FROM hallucination_risk_snapshots
       WHERE id NOT IN (
         SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
@@ -251,38 +281,11 @@ hallucinationRiskRoute.delete("/cleanup", async (c) => {
         WHERE rn <= ${keep}
       )
     `;
-    const wouldDelete = result[0]?.count ?? 0;
 
-    // Total count
-    const totalResult = await rawDb`
-      SELECT count(*)::int AS total FROM hallucination_risk_snapshots
-    `;
-    const total = totalResult[0]?.total ?? 0;
+    const deleted = result.count;
 
-    return c.json({
-      dryRun: true,
-      keep,
-      totalSnapshots: total,
-      wouldDelete,
-      wouldRetain: total - wouldDelete,
-    });
-  }
+    return c.json({ deleted, keep });
+  });
 
-  // Actually delete old snapshots, keeping latest `keep` per page
-  const result = await rawDb`
-    DELETE FROM hallucination_risk_snapshots
-    WHERE id NOT IN (
-      SELECT id FROM (
-        SELECT id, ROW_NUMBER() OVER (
-          PARTITION BY page_id ORDER BY computed_at DESC
-        ) AS rn
-        FROM hallucination_risk_snapshots
-      ) ranked
-      WHERE rn <= ${keep}
-    )
-  `;
-
-  const deleted = result.count;
-
-  return c.json({ deleted, keep });
-});
+export const hallucinationRiskRoute = hallucinationRiskApp;
+export type HallucinationRiskRoute = typeof hallucinationRiskApp;

--- a/apps/wiki-server/src/routes/health.ts
+++ b/apps/wiki-server/src/routes/health.ts
@@ -6,92 +6,93 @@ import { resolveScopes, getKeyConfig, type ApiScope } from "../auth.js";
 
 const startTime = Date.now();
 
-export const healthRoute = new Hono();
+const healthApp = new Hono()
+  .get("/", async (c) => {
+    const db = getDrizzleDb();
 
-healthRoute.get("/", async (c) => {
-  const db = getDrizzleDb();
+    let dbStatus = "ok";
+    let totalIds = 0;
+    let nextId = 0;
+    let totalPages = 0;
+    let totalEntities = 0;
+    let totalFacts = 0;
 
-  let dbStatus = "ok";
-  let totalIds = 0;
-  let nextId = 0;
-  let totalPages = 0;
-  let totalEntities = 0;
-  let totalFacts = 0;
+    try {
+      const countResult = await db.select({ count: count() }).from(entityIds);
+      totalIds = countResult[0].count;
 
-  try {
-    const countResult = await db.select({ count: count() }).from(entityIds);
-    totalIds = countResult[0].count;
+      const pagesCountResult = await db
+        .select({ count: count() })
+        .from(wikiPages);
+      totalPages = pagesCountResult[0].count;
 
-    const pagesCountResult = await db
-      .select({ count: count() })
-      .from(wikiPages);
-    totalPages = pagesCountResult[0].count;
+      const entitiesCountResult = await db
+        .select({ count: count() })
+        .from(entities);
+      totalEntities = entitiesCountResult[0].count;
 
-    const entitiesCountResult = await db
-      .select({ count: count() })
-      .from(entities);
-    totalEntities = entitiesCountResult[0].count;
+      const factsCountResult = await db.select({ count: count() }).from(facts);
+      totalFacts = factsCountResult[0].count;
 
-    const factsCountResult = await db.select({ count: count() }).from(facts);
-    totalFacts = factsCountResult[0].count;
+      // Sequence query — no Drizzle equivalent, use raw SQL
+      const rawDb = getDb();
+      const seqResult =
+        await rawDb`SELECT last_value, is_called FROM entity_id_seq`;
+      const lastValue = Number(seqResult[0].last_value);
+      const isCalled = seqResult[0].is_called;
+      // If is_called is false, nextval will return last_value itself
+      nextId = isCalled ? lastValue + 1 : lastValue;
+    } catch (err) {
+      dbStatus = "error";
+      console.error("Health check DB error:", err);
+    }
 
-    // Sequence query — no Drizzle equivalent, use raw SQL
-    const rawDb = getDb();
-    const seqResult =
-      await rawDb`SELECT last_value, is_called FROM entity_id_seq`;
-    const lastValue = Number(seqResult[0].last_value);
-    const isCalled = seqResult[0].is_called;
-    // If is_called is false, nextval will return last_value itself
-    nextId = isCalled ? lastValue + 1 : lastValue;
-  } catch (err) {
-    dbStatus = "error";
-    console.error("Health check DB error:", err);
-  }
+    return c.json({
+      status: dbStatus === "ok" ? "healthy" : "degraded",
+      database: dbStatus,
+      totalIds,
+      totalPages,
+      totalEntities,
+      totalFacts,
+      nextId,
+      uptime: Math.floor((Date.now() - startTime) / 1000),
+    });
+  })
+  /**
+   * GET /auth — Check which scopes a Bearer token grants.
+   * Returns 401 if no token or invalid token.
+   * Returns { scopes, keyType } on success.
+   */
+  .get("/auth", (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return c.json({ error: "Bearer token required" }, 401);
+    }
 
-  return c.json({
-    status: dbStatus === "ok" ? "healthy" : "degraded",
-    database: dbStatus,
-    totalIds,
-    totalPages,
-    totalEntities,
-    totalFacts,
-    nextId,
-    uptime: Math.floor((Date.now() - startTime) / 1000),
+    const token = authHeader.slice(7);
+    const config = getKeyConfig();
+
+    if (!config.legacyKey && !config.projectKey && !config.contentKey) {
+      return c.json({ scopes: ["project", "content"], keyType: "none_configured" });
+    }
+
+    const scopes = resolveScopes(token, config);
+    if (scopes.length === 0) {
+      return c.json({ error: "Invalid API key" }, 401);
+    }
+
+    // Determine key type for diagnostics
+    let keyType: string;
+    if (config.legacyKey && token === config.legacyKey) {
+      keyType = "legacy";
+    } else if (config.projectKey && token === config.projectKey) {
+      keyType = "project";
+    } else {
+      keyType = "content";
+    }
+
+    return c.json({ scopes, keyType });
   });
-});
 
-/**
- * GET /auth — Check which scopes a Bearer token grants.
- * Returns 401 if no token or invalid token.
- * Returns { scopes, keyType } on success.
- */
-healthRoute.get("/auth", (c) => {
-  const authHeader = c.req.header("Authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
-    return c.json({ error: "Bearer token required" }, 401);
-  }
-
-  const token = authHeader.slice(7);
-  const config = getKeyConfig();
-
-  if (!config.legacyKey && !config.projectKey && !config.contentKey) {
-    return c.json({ scopes: ["project", "content"], keyType: "none_configured" });
-  }
-
-  const scopes = resolveScopes(token, config);
-  if (scopes.length === 0) {
-    return c.json({ error: "Invalid API key" }, 401);
-  }
-
-  // Determine key type for diagnostics
-  let keyType: string;
-  if (config.legacyKey && token === config.legacyKey) {
-    keyType = "legacy";
-  } else if (config.projectKey && token === config.projectKey) {
-    keyType = "project";
-  } else {
-    keyType = "content";
-  }
-
-  return c.json({ scopes, keyType });
-});
+export const healthRoute = healthApp;
+export type HealthRoute = typeof healthApp;

--- a/apps/wiki-server/src/routes/ids.ts
+++ b/apps/wiki-server/src/routes/ids.ts
@@ -10,8 +10,6 @@ import {
   notFoundError,
 } from "./utils.js";
 
-export const idsRoute = new Hono();
-
 // ---- Helpers ----
 
 type EntityIdRow = {
@@ -59,163 +57,165 @@ const AllocateBatchSchema = z.object({
     .max(50),
 });
 
-// ---- POST /allocate ----
-
-idsRoute.post("/allocate", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = AllocateSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { slug, description } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Check if slug already exists (avoids burning a sequence value on conflict)
-  const existing = await db
-    .select()
-    .from(entityIds)
-    .where(eq(entityIds.slug, slug));
-
-  if (existing.length > 0) {
-    return c.json(formatIdResponse(existing[0], false));
-  }
-
-  // Slug is new — allocate next sequence value
-  const inserted = await db
-    .insert(entityIds)
-    .values({
-      numericId: sql`nextval('entity_id_seq')`,
-      slug,
-      description: description ?? null,
-    })
-    .onConflictDoNothing({ target: entityIds.slug })
-    .returning();
-
-  if (inserted.length > 0) {
-    return c.json(formatIdResponse(inserted[0], true), 201);
-  }
-
-  // Race condition: another request inserted between our SELECT and INSERT.
-  // Re-fetch the existing row.
-  const raced = await db
-    .select()
-    .from(entityIds)
-    .where(eq(entityIds.slug, slug));
-
-  if (raced.length === 0) {
-    return c.json(
-      { error: "internal_error", message: "Unexpected: slug not found after conflict" },
-      500
-    );
-  }
-
-  return c.json(formatIdResponse(raced[0], false));
-});
-
-// ---- POST /allocate-batch ----
-
-idsRoute.post("/allocate-batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = AllocateBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-  const results: ReturnType<typeof formatIdResponse>[] = [];
-
-  // Run all allocations in a single transaction
-  await db.transaction(async (tx) => {
-    for (const item of items) {
-      // Check existence first to avoid burning sequence values
-      const existing = await tx
-        .select()
-        .from(entityIds)
-        .where(eq(entityIds.slug, item.slug));
-
-      if (existing.length > 0) {
-        results.push(formatIdResponse(existing[0], false));
-        continue;
-      }
-
-      const inserted = await tx
-        .insert(entityIds)
-        .values({
-          numericId: sql`nextval('entity_id_seq')`,
-          slug: item.slug,
-          description: item.description ?? null,
-        })
-        .onConflictDoNothing({ target: entityIds.slug })
-        .returning();
-
-      if (inserted.length > 0) {
-        results.push(formatIdResponse(inserted[0], true));
-      } else {
-        // Race condition: another request inserted between our SELECT and INSERT.
-        // Re-fetch the existing row.
-        const raced = await tx
-          .select()
-          .from(entityIds)
-          .where(eq(entityIds.slug, item.slug));
-        if (raced.length > 0) {
-          results.push(formatIdResponse(raced[0], false));
-        }
-      }
-    }
-  });
-
-  return c.json({ results });
-});
-
-// ---- GET / (list all, paginated) ----
-
 const ListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(1000).default(100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
-idsRoute.get("/", async (c) => {
-  const parsed = ListQuerySchema.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+// ---- Routes ----
 
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
+const idsApp = new Hono()
+  // ---- POST /allocate ----
+  .post("/allocate", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const rows = await db
-    .select()
-    .from(entityIds)
-    .orderBy(asc(entityIds.numericId))
-    .limit(limit)
-    .offset(offset);
+    const parsed = AllocateSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const countResult = await db.select({ count: count() }).from(entityIds);
-  const total = countResult[0].count;
+    const { slug, description } = parsed.data;
+    const db = getDrizzleDb();
 
-  return c.json({
-    ids: rows.map(formatIdSummary),
-    total,
-    limit,
-    offset,
+    // Check if slug already exists (avoids burning a sequence value on conflict)
+    const existing = await db
+      .select()
+      .from(entityIds)
+      .where(eq(entityIds.slug, slug));
+
+    if (existing.length > 0) {
+      return c.json(formatIdResponse(existing[0], false));
+    }
+
+    // Slug is new — allocate next sequence value
+    const inserted = await db
+      .insert(entityIds)
+      .values({
+        numericId: sql`nextval('entity_id_seq')`,
+        slug,
+        description: description ?? null,
+      })
+      .onConflictDoNothing({ target: entityIds.slug })
+      .returning();
+
+    if (inserted.length > 0) {
+      return c.json(formatIdResponse(inserted[0], true), 201);
+    }
+
+    // Race condition: another request inserted between our SELECT and INSERT.
+    // Re-fetch the existing row.
+    const raced = await db
+      .select()
+      .from(entityIds)
+      .where(eq(entityIds.slug, slug));
+
+    if (raced.length === 0) {
+      return c.json(
+        { error: "internal_error", message: "Unexpected: slug not found after conflict" },
+        500
+      );
+    }
+
+    return c.json(formatIdResponse(raced[0], false));
+  })
+
+  // ---- POST /allocate-batch ----
+  .post("/allocate-batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = AllocateBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+    const results: ReturnType<typeof formatIdResponse>[] = [];
+
+    // Run all allocations in a single transaction
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        // Check existence first to avoid burning sequence values
+        const existing = await tx
+          .select()
+          .from(entityIds)
+          .where(eq(entityIds.slug, item.slug));
+
+        if (existing.length > 0) {
+          results.push(formatIdResponse(existing[0], false));
+          continue;
+        }
+
+        const inserted = await tx
+          .insert(entityIds)
+          .values({
+            numericId: sql`nextval('entity_id_seq')`,
+            slug: item.slug,
+            description: item.description ?? null,
+          })
+          .onConflictDoNothing({ target: entityIds.slug })
+          .returning();
+
+        if (inserted.length > 0) {
+          results.push(formatIdResponse(inserted[0], true));
+        } else {
+          // Race condition: another request inserted between our SELECT and INSERT.
+          // Re-fetch the existing row.
+          const raced = await tx
+            .select()
+            .from(entityIds)
+            .where(eq(entityIds.slug, item.slug));
+          if (raced.length > 0) {
+            results.push(formatIdResponse(raced[0], false));
+          }
+        }
+      }
+    });
+
+    return c.json({ results });
+  })
+
+  // ---- GET / (list all, paginated) ----
+  .get("/", async (c) => {
+    const parsed = ListQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(entityIds)
+      .orderBy(asc(entityIds.numericId))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db.select({ count: count() }).from(entityIds);
+    const total = countResult[0].count;
+
+    return c.json({
+      ids: rows.map(formatIdSummary),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /by-slug?slug=... ----
+  .get("/by-slug", async (c) => {
+    const slug = c.req.query("slug");
+    if (!slug) return validationError(c, "slug query parameter is required");
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(entityIds)
+      .where(eq(entityIds.slug, slug));
+
+    if (rows.length === 0) {
+      return notFoundError(c, `No ID for slug: ${slug}`);
+    }
+
+    return c.json(formatIdSummary(rows[0]));
   });
-});
 
-// ---- GET /by-slug?slug=... ----
-
-idsRoute.get("/by-slug", async (c) => {
-  const slug = c.req.query("slug");
-  if (!slug) return validationError(c, "slug query parameter is required");
-
-  const db = getDrizzleDb();
-  const rows = await db
-    .select()
-    .from(entityIds)
-    .where(eq(entityIds.slug, slug));
-
-  if (rows.length === 0) {
-    return notFoundError(c, `No ID for slug: ${slug}`);
-  }
-
-  return c.json(formatIdSummary(rows[0]));
-});
+export const idsRoute = idsApp;
+export type IdsRoute = typeof idsApp;

--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -2,8 +2,6 @@ import { Hono } from "hono";
 import { sql } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 
-export const integrityRoute = new Hono();
-
 interface IntegrityIssue {
   table: string;
   column: string;
@@ -61,324 +59,328 @@ interface ClaimsAuditResult {
 
 // ---- GET /claims-audit ----
 
-integrityRoute.get("/claims-audit", async (c) => {
-  const db = getDrizzleDb();
-  const checks: ClaimsAuditCheck[] = [];
+const integrityApp = new Hono()
+  .get("/claims-audit", async (c) => {
+    const db = getDrizzleDb();
+    const checks: ClaimsAuditCheck[] = [];
 
-  // 1. Check claim_mode NOT NULL constraint (migration 0030 added DEFAULT 'endorsed')
-  const nullClaimMode = (await db.execute(
-    sql`SELECT COUNT(*) AS cnt FROM claims WHERE claim_mode IS NULL`
-  )) as Array<{ cnt: string }>;
-  const nullModeCount = parseInt(nullClaimMode[0]?.cnt ?? "0", 10);
-  checks.push({
-    name: "claim_mode_not_null",
-    description: "All claims have a non-null claim_mode (endorsed or attributed)",
-    status: nullModeCount === 0 ? "pass" : "fail",
-    count: nullModeCount,
-    ...(nullModeCount > 0 && {
-      details: `${nullModeCount} claims have NULL claim_mode — migration 0030 should have set DEFAULT 'endorsed'`,
-    }),
+    // 1. Check claim_mode NOT NULL constraint (migration 0030 added DEFAULT 'endorsed')
+    const nullClaimMode = (await db.execute(
+      sql`SELECT COUNT(*) AS cnt FROM claims WHERE claim_mode IS NULL`
+    )) as Array<{ cnt: string }>;
+    const nullModeCount = parseInt(nullClaimMode[0]?.cnt ?? "0", 10);
+    checks.push({
+      name: "claim_mode_not_null",
+      description: "All claims have a non-null claim_mode (endorsed or attributed)",
+      status: nullModeCount === 0 ? "pass" : "fail",
+      count: nullModeCount,
+      ...(nullModeCount > 0 && {
+        details: `${nullModeCount} claims have NULL claim_mode — migration 0030 should have set DEFAULT 'endorsed'`,
+      }),
+    });
+
+    // 2. Check claim_mode values are valid
+    const invalidClaimMode = (await db.execute(
+      sql`SELECT DISTINCT claim_mode AS val, COUNT(*) AS cnt FROM claims WHERE claim_mode NOT IN ('endorsed', 'attributed') GROUP BY claim_mode`
+    )) as Array<{ val: string; cnt: string }>;
+    const invalidModeCount = invalidClaimMode.reduce(
+      (sum, r) => sum + parseInt(r.cnt, 10),
+      0
+    );
+    checks.push({
+      name: "claim_mode_valid_values",
+      description: "All claim_mode values are 'endorsed' or 'attributed'",
+      status: invalidModeCount === 0 ? "pass" : "fail",
+      count: invalidModeCount,
+      ...(invalidModeCount > 0 && {
+        sample: invalidClaimMode.map((r) => ({ value: r.val, count: r.cnt })),
+      }),
+    });
+
+    // 3. Check is_primary in claim_sources (migration 0029 off-by-one bug)
+    // Each claim with sources should have exactly one primary source
+    const claimsWithoutPrimary = (await db.execute(
+      sql`SELECT cs.claim_id, COUNT(*) AS source_count
+          FROM claim_sources cs
+          GROUP BY cs.claim_id
+          HAVING COUNT(*) > 0 AND SUM(CASE WHEN cs.is_primary THEN 1 ELSE 0 END) = 0`
+    )) as Array<{ claim_id: string; source_count: string }>;
+    checks.push({
+      name: "claim_sources_has_primary",
+      description: "Every claim with sources has at least one marked is_primary=true",
+      status: claimsWithoutPrimary.length === 0 ? "pass" : "warn",
+      count: claimsWithoutPrimary.length,
+      ...(claimsWithoutPrimary.length > 0 && {
+        details: `${claimsWithoutPrimary.length} claims have sources but none marked as primary`,
+        sample: claimsWithoutPrimary.slice(0, 10).map((r) => ({
+          claimId: r.claim_id,
+          sourceCount: r.source_count,
+        })),
+      }),
+    });
+
+    // 4. Check for self-referential relatedEntities
+    const selfRefs = (await db.execute(
+      sql`SELECT id, entity_id FROM claims
+          WHERE related_entities IS NOT NULL
+          AND related_entities::text != 'null'
+          AND related_entities::text != '[]'
+          AND related_entities @> to_jsonb(entity_id)`
+    )) as Array<{ id: string; entity_id: string }>;
+    checks.push({
+      name: "no_self_referential_related_entities",
+      description: "No claims have their own entityId in relatedEntities",
+      status: selfRefs.length === 0 ? "pass" : "warn",
+      count: selfRefs.length,
+      ...(selfRefs.length > 0 && {
+        details: `${selfRefs.length} claims reference themselves in relatedEntities`,
+        sample: selfRefs.slice(0, 10).map((r) => ({
+          claimId: r.id,
+          entityId: r.entity_id,
+        })),
+      }),
+    });
+
+    // 5. Check for capitalization inconsistencies in entity_id
+    const capsIssues = (await db.execute(
+      sql`SELECT entity_id, COUNT(*) AS cnt FROM claims
+          WHERE entity_id != LOWER(entity_id)
+          GROUP BY entity_id`
+    )) as Array<{ entity_id: string; cnt: string }>;
+    const capsCount = capsIssues.reduce(
+      (sum, r) => sum + parseInt(r.cnt, 10),
+      0
+    );
+    checks.push({
+      name: "entity_id_lowercase",
+      description: "All entity_id values are lowercase (no capitalization variants)",
+      status: capsCount === 0 ? "pass" : "warn",
+      count: capsCount,
+      ...(capsCount > 0 && {
+        details: `${capsCount} claims have non-lowercase entity_id`,
+        sample: capsIssues.slice(0, 10).map((r) => ({
+          entityId: r.entity_id,
+          count: r.cnt,
+        })),
+      }),
+    });
+
+    // 6. Check for orphaned claim_sources (claim_id references deleted claims)
+    const orphanedSources = (await db.execute(
+      sql`SELECT cs.id, cs.claim_id FROM claim_sources cs
+          LEFT JOIN claims c ON cs.claim_id = c.id
+          WHERE c.id IS NULL`
+    )) as Array<{ id: string; claim_id: string }>;
+    checks.push({
+      name: "no_orphaned_claim_sources",
+      description: "All claim_sources reference existing claims (FK cascade should prevent this)",
+      status: orphanedSources.length === 0 ? "pass" : "fail",
+      count: orphanedSources.length,
+      ...(orphanedSources.length > 0 && {
+        sample: orphanedSources.slice(0, 10).map((r) => ({
+          sourceId: r.id,
+          claimId: r.claim_id,
+        })),
+      }),
+    });
+
+    // 7. Check numeric precision — values that lost precision from REAL→DOUBLE migration
+    // REAL has ~7 decimal digits; values like 7,300,000,000 would be stored as 7,299,999,744
+    const precisionIssues = (await db.execute(
+      sql`SELECT id, entity_id, value_numeric FROM claims
+          WHERE value_numeric IS NOT NULL
+          AND ABS(value_numeric) > 1000000
+          AND value_numeric != ROUND(value_numeric::numeric, 0)
+          AND ABS(value_numeric - ROUND(value_numeric::numeric, 0)) > 1`
+    )) as Array<{ id: string; entity_id: string; value_numeric: string }>;
+    checks.push({
+      name: "numeric_precision_clean",
+      description: "Large numeric values don't show REAL→DOUBLE precision artifacts (fractional cents on billions)",
+      status: precisionIssues.length === 0 ? "pass" : "warn",
+      count: precisionIssues.length,
+      ...(precisionIssues.length > 0 && {
+        details: `${precisionIssues.length} claims have numeric values with possible precision loss from old REAL storage`,
+        sample: precisionIssues.slice(0, 10).map((r) => ({
+          claimId: r.id,
+          entityId: r.entity_id,
+          valueNumeric: r.value_numeric,
+        })),
+      }),
+    });
+
+    // 8. Check for empty claim_text
+    const emptyText = (await db.execute(
+      sql`SELECT COUNT(*) AS cnt FROM claims WHERE TRIM(claim_text) = '' OR claim_text IS NULL`
+    )) as Array<{ cnt: string }>;
+    const emptyTextCount = parseInt(emptyText[0]?.cnt ?? "0", 10);
+    checks.push({
+      name: "no_empty_claim_text",
+      description: "All claims have non-empty claim_text",
+      status: emptyTextCount === 0 ? "pass" : "fail",
+      count: emptyTextCount,
+    });
+
+    // 9. Check for duplicate claims (same entity_id + claim_text)
+    const duplicates = (await db.execute(
+      sql`SELECT entity_id, claim_text, COUNT(*) AS cnt
+          FROM claims
+          GROUP BY entity_id, claim_text
+          HAVING COUNT(*) > 1
+          ORDER BY COUNT(*) DESC
+          LIMIT 20`
+    )) as Array<{ entity_id: string; claim_text: string; cnt: string }>;
+    const dupCount = duplicates.reduce(
+      (sum, r) => sum + parseInt(r.cnt, 10) - 1,
+      0
+    );
+    checks.push({
+      name: "no_exact_duplicate_claims",
+      description: "No exact duplicate claims (same entity_id + claim_text)",
+      status: dupCount === 0 ? "pass" : "warn",
+      count: dupCount,
+      ...(dupCount > 0 && {
+        details: `${dupCount} duplicate claim rows found across ${duplicates.length} unique texts`,
+        sample: duplicates.slice(0, 5).map((r) => ({
+          entityId: r.entity_id,
+          claimText:
+            r.claim_text.length > 80
+              ? r.claim_text.slice(0, 80) + "..."
+              : r.claim_text,
+          count: r.cnt,
+        })),
+      }),
+    });
+
+    // 10. Summary statistics
+    const totals = (await db.execute(
+      sql`SELECT
+            (SELECT COUNT(*) FROM claims) AS total_claims,
+            (SELECT COUNT(*) FROM claim_sources) AS total_sources`
+    )) as Array<{ total_claims: string; total_sources: string }>;
+    const totalClaims = parseInt(totals[0]?.total_claims ?? "0", 10);
+    const totalSources = parseInt(totals[0]?.total_sources ?? "0", 10);
+
+    const passed = checks.filter((c) => c.status === "pass").length;
+    const warnings = checks.filter((c) => c.status === "warn").length;
+    const failures = checks.filter((c) => c.status === "fail").length;
+
+    const result: ClaimsAuditResult = {
+      status: failures === 0 && warnings === 0 ? "clean" : "issues_found",
+      checked_at: new Date().toISOString(),
+      checks,
+      summary: {
+        total_claims: totalClaims,
+        total_sources: totalSources,
+        checks_run: checks.length,
+        passed,
+        warnings,
+        failures,
+      },
+    };
+
+    return c.json(result);
+  })
+
+  // ---- GET / ----
+
+  .get("/", async (c) => {
+    const db = getDrizzleDb();
+    const issues: IntegrityIssue[] = [];
+
+    const checks = [
+      // 1. facts.entity_id → entities
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT entity_id AS ref FROM facts WHERE entity_id NOT IN (SELECT id FROM entities)`,
+        "facts",
+        "entity_id",
+        "entities"
+      ),
+      // 2. facts.source_resource → resources
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT source_resource AS ref FROM facts WHERE source_resource IS NOT NULL AND source_resource NOT IN (SELECT id FROM resources)`,
+        "facts",
+        "source_resource",
+        "resources"
+      ),
+      // 3. claims.entity_id → entities
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT entity_id AS ref FROM claims WHERE entity_id NOT IN (SELECT id FROM entities)`,
+        "claims",
+        "entity_id",
+        "entities"
+      ),
+      // 4. summaries.entity_id → entities
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT entity_id AS ref FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities)`,
+        "summaries",
+        "entity_id",
+        "entities"
+      ),
+      // 5. citation_quotes.page_id → wiki_pages
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT page_id AS ref FROM citation_quotes WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
+        "citation_quotes",
+        "page_id",
+        "wiki_pages"
+      ),
+      // 6. citation_quotes.resource_id → resources
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT resource_id AS ref FROM citation_quotes WHERE resource_id IS NOT NULL AND resource_id NOT IN (SELECT id FROM resources)`,
+        "citation_quotes",
+        "resource_id",
+        "resources"
+      ),
+      // 7. edit_logs.page_id → wiki_pages
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT page_id AS ref FROM edit_logs WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
+        "edit_logs",
+        "page_id",
+        "wiki_pages"
+      ),
+      // 8. entities.relatedEntries JSONB → entities
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT elem->>'id' AS ref FROM entities, jsonb_array_elements(related_entries) AS elem WHERE related_entries IS NOT NULL AND (elem->>'id') NOT IN (SELECT id FROM entities)`,
+        "entities",
+        "related_entries[].id",
+        "entities"
+      ),
+      // 9. resource_citations.page_id → wiki_pages
+      checkDangling(
+        db,
+        sql`SELECT DISTINCT page_id AS ref FROM resource_citations WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
+        "resource_citations",
+        "page_id",
+        "wiki_pages"
+      ),
+    ];
+
+    const results = await Promise.all(checks);
+    for (const result of results) {
+      if (result) issues.push(result);
+    }
+
+    const tablesChecked = checks.length;
+    const totalDangling = issues.reduce((sum, i) => sum + i.count, 0);
+
+    return c.json({
+      status: issues.length === 0 ? "clean" : "issues_found",
+      checked_at: new Date().toISOString(),
+      issues,
+      summary: {
+        tables_checked: tablesChecked,
+        issues_found: issues.length,
+        total_dangling_refs: totalDangling,
+      },
+    });
   });
 
-  // 2. Check claim_mode values are valid
-  const invalidClaimMode = (await db.execute(
-    sql`SELECT DISTINCT claim_mode AS val, COUNT(*) AS cnt FROM claims WHERE claim_mode NOT IN ('endorsed', 'attributed') GROUP BY claim_mode`
-  )) as Array<{ val: string; cnt: string }>;
-  const invalidModeCount = invalidClaimMode.reduce(
-    (sum, r) => sum + parseInt(r.cnt, 10),
-    0
-  );
-  checks.push({
-    name: "claim_mode_valid_values",
-    description: "All claim_mode values are 'endorsed' or 'attributed'",
-    status: invalidModeCount === 0 ? "pass" : "fail",
-    count: invalidModeCount,
-    ...(invalidModeCount > 0 && {
-      sample: invalidClaimMode.map((r) => ({ value: r.val, count: r.cnt })),
-    }),
-  });
-
-  // 3. Check is_primary in claim_sources (migration 0029 off-by-one bug)
-  // Each claim with sources should have exactly one primary source
-  const claimsWithoutPrimary = (await db.execute(
-    sql`SELECT cs.claim_id, COUNT(*) AS source_count
-        FROM claim_sources cs
-        GROUP BY cs.claim_id
-        HAVING COUNT(*) > 0 AND SUM(CASE WHEN cs.is_primary THEN 1 ELSE 0 END) = 0`
-  )) as Array<{ claim_id: string; source_count: string }>;
-  checks.push({
-    name: "claim_sources_has_primary",
-    description: "Every claim with sources has at least one marked is_primary=true",
-    status: claimsWithoutPrimary.length === 0 ? "pass" : "warn",
-    count: claimsWithoutPrimary.length,
-    ...(claimsWithoutPrimary.length > 0 && {
-      details: `${claimsWithoutPrimary.length} claims have sources but none marked as primary`,
-      sample: claimsWithoutPrimary.slice(0, 10).map((r) => ({
-        claimId: r.claim_id,
-        sourceCount: r.source_count,
-      })),
-    }),
-  });
-
-  // 4. Check for self-referential relatedEntities
-  const selfRefs = (await db.execute(
-    sql`SELECT id, entity_id FROM claims
-        WHERE related_entities IS NOT NULL
-        AND related_entities::text != 'null'
-        AND related_entities::text != '[]'
-        AND related_entities @> to_jsonb(entity_id)`
-  )) as Array<{ id: string; entity_id: string }>;
-  checks.push({
-    name: "no_self_referential_related_entities",
-    description: "No claims have their own entityId in relatedEntities",
-    status: selfRefs.length === 0 ? "pass" : "warn",
-    count: selfRefs.length,
-    ...(selfRefs.length > 0 && {
-      details: `${selfRefs.length} claims reference themselves in relatedEntities`,
-      sample: selfRefs.slice(0, 10).map((r) => ({
-        claimId: r.id,
-        entityId: r.entity_id,
-      })),
-    }),
-  });
-
-  // 5. Check for capitalization inconsistencies in entity_id
-  const capsIssues = (await db.execute(
-    sql`SELECT entity_id, COUNT(*) AS cnt FROM claims
-        WHERE entity_id != LOWER(entity_id)
-        GROUP BY entity_id`
-  )) as Array<{ entity_id: string; cnt: string }>;
-  const capsCount = capsIssues.reduce(
-    (sum, r) => sum + parseInt(r.cnt, 10),
-    0
-  );
-  checks.push({
-    name: "entity_id_lowercase",
-    description: "All entity_id values are lowercase (no capitalization variants)",
-    status: capsCount === 0 ? "pass" : "warn",
-    count: capsCount,
-    ...(capsCount > 0 && {
-      details: `${capsCount} claims have non-lowercase entity_id`,
-      sample: capsIssues.slice(0, 10).map((r) => ({
-        entityId: r.entity_id,
-        count: r.cnt,
-      })),
-    }),
-  });
-
-  // 6. Check for orphaned claim_sources (claim_id references deleted claims)
-  const orphanedSources = (await db.execute(
-    sql`SELECT cs.id, cs.claim_id FROM claim_sources cs
-        LEFT JOIN claims c ON cs.claim_id = c.id
-        WHERE c.id IS NULL`
-  )) as Array<{ id: string; claim_id: string }>;
-  checks.push({
-    name: "no_orphaned_claim_sources",
-    description: "All claim_sources reference existing claims (FK cascade should prevent this)",
-    status: orphanedSources.length === 0 ? "pass" : "fail",
-    count: orphanedSources.length,
-    ...(orphanedSources.length > 0 && {
-      sample: orphanedSources.slice(0, 10).map((r) => ({
-        sourceId: r.id,
-        claimId: r.claim_id,
-      })),
-    }),
-  });
-
-  // 7. Check numeric precision — values that lost precision from REAL→DOUBLE migration
-  // REAL has ~7 decimal digits; values like 7,300,000,000 would be stored as 7,299,999,744
-  const precisionIssues = (await db.execute(
-    sql`SELECT id, entity_id, value_numeric FROM claims
-        WHERE value_numeric IS NOT NULL
-        AND ABS(value_numeric) > 1000000
-        AND value_numeric != ROUND(value_numeric::numeric, 0)
-        AND ABS(value_numeric - ROUND(value_numeric::numeric, 0)) > 1`
-  )) as Array<{ id: string; entity_id: string; value_numeric: string }>;
-  checks.push({
-    name: "numeric_precision_clean",
-    description: "Large numeric values don't show REAL→DOUBLE precision artifacts (fractional cents on billions)",
-    status: precisionIssues.length === 0 ? "pass" : "warn",
-    count: precisionIssues.length,
-    ...(precisionIssues.length > 0 && {
-      details: `${precisionIssues.length} claims have numeric values with possible precision loss from old REAL storage`,
-      sample: precisionIssues.slice(0, 10).map((r) => ({
-        claimId: r.id,
-        entityId: r.entity_id,
-        valueNumeric: r.value_numeric,
-      })),
-    }),
-  });
-
-  // 8. Check for empty claim_text
-  const emptyText = (await db.execute(
-    sql`SELECT COUNT(*) AS cnt FROM claims WHERE TRIM(claim_text) = '' OR claim_text IS NULL`
-  )) as Array<{ cnt: string }>;
-  const emptyTextCount = parseInt(emptyText[0]?.cnt ?? "0", 10);
-  checks.push({
-    name: "no_empty_claim_text",
-    description: "All claims have non-empty claim_text",
-    status: emptyTextCount === 0 ? "pass" : "fail",
-    count: emptyTextCount,
-  });
-
-  // 9. Check for duplicate claims (same entity_id + claim_text)
-  const duplicates = (await db.execute(
-    sql`SELECT entity_id, claim_text, COUNT(*) AS cnt
-        FROM claims
-        GROUP BY entity_id, claim_text
-        HAVING COUNT(*) > 1
-        ORDER BY COUNT(*) DESC
-        LIMIT 20`
-  )) as Array<{ entity_id: string; claim_text: string; cnt: string }>;
-  const dupCount = duplicates.reduce(
-    (sum, r) => sum + parseInt(r.cnt, 10) - 1,
-    0
-  );
-  checks.push({
-    name: "no_exact_duplicate_claims",
-    description: "No exact duplicate claims (same entity_id + claim_text)",
-    status: dupCount === 0 ? "pass" : "warn",
-    count: dupCount,
-    ...(dupCount > 0 && {
-      details: `${dupCount} duplicate claim rows found across ${duplicates.length} unique texts`,
-      sample: duplicates.slice(0, 5).map((r) => ({
-        entityId: r.entity_id,
-        claimText:
-          r.claim_text.length > 80
-            ? r.claim_text.slice(0, 80) + "..."
-            : r.claim_text,
-        count: r.cnt,
-      })),
-    }),
-  });
-
-  // 10. Summary statistics
-  const totals = (await db.execute(
-    sql`SELECT
-          (SELECT COUNT(*) FROM claims) AS total_claims,
-          (SELECT COUNT(*) FROM claim_sources) AS total_sources`
-  )) as Array<{ total_claims: string; total_sources: string }>;
-  const totalClaims = parseInt(totals[0]?.total_claims ?? "0", 10);
-  const totalSources = parseInt(totals[0]?.total_sources ?? "0", 10);
-
-  const passed = checks.filter((c) => c.status === "pass").length;
-  const warnings = checks.filter((c) => c.status === "warn").length;
-  const failures = checks.filter((c) => c.status === "fail").length;
-
-  const result: ClaimsAuditResult = {
-    status: failures === 0 && warnings === 0 ? "clean" : "issues_found",
-    checked_at: new Date().toISOString(),
-    checks,
-    summary: {
-      total_claims: totalClaims,
-      total_sources: totalSources,
-      checks_run: checks.length,
-      passed,
-      warnings,
-      failures,
-    },
-  };
-
-  return c.json(result);
-});
-
-// ---- GET / ----
-
-integrityRoute.get("/", async (c) => {
-  const db = getDrizzleDb();
-  const issues: IntegrityIssue[] = [];
-
-  const checks = [
-    // 1. facts.entity_id → entities
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT entity_id AS ref FROM facts WHERE entity_id NOT IN (SELECT id FROM entities)`,
-      "facts",
-      "entity_id",
-      "entities"
-    ),
-    // 2. facts.source_resource → resources
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT source_resource AS ref FROM facts WHERE source_resource IS NOT NULL AND source_resource NOT IN (SELECT id FROM resources)`,
-      "facts",
-      "source_resource",
-      "resources"
-    ),
-    // 3. claims.entity_id → entities
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT entity_id AS ref FROM claims WHERE entity_id NOT IN (SELECT id FROM entities)`,
-      "claims",
-      "entity_id",
-      "entities"
-    ),
-    // 4. summaries.entity_id → entities
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT entity_id AS ref FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities)`,
-      "summaries",
-      "entity_id",
-      "entities"
-    ),
-    // 5. citation_quotes.page_id → wiki_pages
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT page_id AS ref FROM citation_quotes WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
-      "citation_quotes",
-      "page_id",
-      "wiki_pages"
-    ),
-    // 6. citation_quotes.resource_id → resources
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT resource_id AS ref FROM citation_quotes WHERE resource_id IS NOT NULL AND resource_id NOT IN (SELECT id FROM resources)`,
-      "citation_quotes",
-      "resource_id",
-      "resources"
-    ),
-    // 7. edit_logs.page_id → wiki_pages
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT page_id AS ref FROM edit_logs WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
-      "edit_logs",
-      "page_id",
-      "wiki_pages"
-    ),
-    // 8. entities.relatedEntries JSONB → entities
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT elem->>'id' AS ref FROM entities, jsonb_array_elements(related_entries) AS elem WHERE related_entries IS NOT NULL AND (elem->>'id') NOT IN (SELECT id FROM entities)`,
-      "entities",
-      "related_entries[].id",
-      "entities"
-    ),
-    // 9. resource_citations.page_id → wiki_pages
-    checkDangling(
-      db,
-      sql`SELECT DISTINCT page_id AS ref FROM resource_citations WHERE page_id NOT IN (SELECT id FROM wiki_pages)`,
-      "resource_citations",
-      "page_id",
-      "wiki_pages"
-    ),
-  ];
-
-  const results = await Promise.all(checks);
-  for (const result of results) {
-    if (result) issues.push(result);
-  }
-
-  const tablesChecked = checks.length;
-  const totalDangling = issues.reduce((sum, i) => sum + i.count, 0);
-
-  return c.json({
-    status: issues.length === 0 ? "clean" : "issues_found",
-    checked_at: new Date().toISOString(),
-    issues,
-    summary: {
-      tables_checked: tablesChecked,
-      issues_found: issues.length,
-      total_dangling_refs: totalDangling,
-    },
-  });
-});
+export const integrityRoute = integrityApp;
+export type IntegrityRoute = typeof integrityApp;

--- a/apps/wiki-server/src/routes/jobs.ts
+++ b/apps/wiki-server/src/routes/jobs.ts
@@ -20,8 +20,6 @@ import {
   type JobStatus,
 } from "../api-types.js";
 
-export const jobsRoute = new Hono();
-
 // ---- Helpers ----
 
 function formatJob(row: typeof jobs.$inferSelect) {
@@ -63,102 +61,104 @@ function formatRawJobRow(row: Record<string, unknown>) {
   };
 }
 
-// ---- POST / (create job or batch) ----
+const jobsApp = new Hono()
 
-jobsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+  // ---- POST / (create job or batch) ----
 
-  const db = getDrizzleDb();
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  // Support both single object and array for batch creation
-  if (Array.isArray(body)) {
-    const parsed = CreateJobBatchSchema.safeParse(body);
+    const db = getDrizzleDb();
+
+    // Support both single object and array for batch creation
+    if (Array.isArray(body)) {
+      const parsed = CreateJobBatchSchema.safeParse(body);
+      if (!parsed.success) return validationError(c, parsed.error.message);
+
+      const rows = await db
+        .insert(jobs)
+        .values(
+          parsed.data.map((j) => ({
+            type: j.type,
+            params: j.params ?? null,
+            priority: j.priority,
+            maxRetries: j.maxRetries,
+          }))
+        )
+        .returning();
+
+      return c.json(rows.map(formatJob), 201);
+    }
+
+    const parsed = CreateJobSchema.safeParse(body);
     if (!parsed.success) return validationError(c, parsed.error.message);
 
+    const d = parsed.data;
     const rows = await db
       .insert(jobs)
-      .values(
-        parsed.data.map((j) => ({
-          type: j.type,
-          params: j.params ?? null,
-          priority: j.priority,
-          maxRetries: j.maxRetries,
-        }))
-      )
+      .values({
+        type: d.type,
+        params: d.params ?? null,
+        priority: d.priority,
+        maxRetries: d.maxRetries,
+      })
       .returning();
 
-    return c.json(rows.map(formatJob), 201);
-  }
+    return c.json(formatJob(firstOrThrow(rows, "job insert")), 201);
+  })
 
-  const parsed = CreateJobSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+  // ---- GET / (list jobs with filters) ----
 
-  const d = parsed.data;
-  const rows = await db
-    .insert(jobs)
-    .values({
-      type: d.type,
-      params: d.params ?? null,
-      priority: d.priority,
-      maxRetries: d.maxRetries,
-    })
-    .returning();
+  .get("/", async (c) => {
+    const parsed = ListJobsQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  return c.json(formatJob(firstOrThrow(rows, "job insert")), 201);
-});
+    const { status, type, limit, offset } = parsed.data;
+    const db = getDrizzleDb();
 
-// ---- GET / (list jobs with filters) ----
+    const conditions = [];
+    if (status) conditions.push(eq(jobs.status, status));
+    if (type) conditions.push(eq(jobs.type, type));
 
-jobsRoute.get("/", async (c) => {
-  const parsed = ListJobsQuerySchema.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const { status, type, limit, offset } = parsed.data;
-  const db = getDrizzleDb();
+    const [rows, countResult] = await Promise.all([
+      db
+        .select()
+        .from(jobs)
+        .where(whereClause)
+        .orderBy(desc(jobs.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ count: count() }).from(jobs).where(whereClause),
+    ]);
 
-  const conditions = [];
-  if (status) conditions.push(eq(jobs.status, status));
-  if (type) conditions.push(eq(jobs.type, type));
+    return c.json({
+      entries: rows.map(formatJob),
+      total: countResult[0].count,
+      limit,
+      offset,
+    });
+  })
 
-  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+  // ---- POST /claim (atomically claim next pending job) ----
 
-  const [rows, countResult] = await Promise.all([
-    db
-      .select()
-      .from(jobs)
-      .where(whereClause)
-      .orderBy(desc(jobs.createdAt))
-      .limit(limit)
-      .offset(offset),
-    db.select({ count: count() }).from(jobs).where(whereClause),
-  ]);
+  .post("/claim", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  return c.json({
-    entries: rows.map(formatJob),
-    total: countResult[0].count,
-    limit,
-    offset,
-  });
-});
+    const parsed = ClaimJobSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-// ---- POST /claim (atomically claim next pending job) ----
+    const { type, workerId } = parsed.data;
+    const pgClient = getDb();
 
-jobsRoute.post("/claim", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = ClaimJobSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { type, workerId } = parsed.data;
-  const pgClient = getDb();
-
-  // Use raw SQL for SELECT FOR UPDATE SKIP LOCKED (atomic claim).
-  // Two query variants to keep parameterization clean.
-  const result = type
-    ? await pgClient.unsafe(
-        `UPDATE "jobs"
+    // Use raw SQL for SELECT FOR UPDATE SKIP LOCKED (atomic claim).
+    // Two query variants to keep parameterization clean.
+    const result = type
+      ? await pgClient.unsafe(
+          `UPDATE "jobs"
          SET status = 'claimed', claimed_at = now(), worker_id = $1
          WHERE id = (
            SELECT id FROM "jobs"
@@ -168,10 +168,10 @@ jobsRoute.post("/claim", async (c) => {
            FOR UPDATE SKIP LOCKED
          )
          RETURNING *`,
-        [workerId, type]
-      )
-    : await pgClient.unsafe(
-        `UPDATE "jobs"
+          [workerId, type]
+        )
+      : await pgClient.unsafe(
+          `UPDATE "jobs"
          SET status = 'claimed', claimed_at = now(), worker_id = $1
          WHERE id = (
            SELECT id FROM "jobs"
@@ -181,96 +181,96 @@ jobsRoute.post("/claim", async (c) => {
            FOR UPDATE SKIP LOCKED
          )
          RETURNING *`,
-        [workerId]
-      );
+          [workerId]
+        );
 
-  if (result.length === 0) {
-    return c.json({ job: null }, 200);
-  }
+    if (result.length === 0) {
+      return c.json({ job: null }, 200);
+    }
 
-  return c.json({ job: formatRawJobRow(result[0] as Record<string, unknown>) });
-});
+    return c.json({ job: formatRawJobRow(result[0] as Record<string, unknown>) });
+  })
 
-// ---- POST /:id/start (mark as running) ----
+  // ---- POST /:id/start (mark as running) ----
 
-jobsRoute.post("/:id/start", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
+  .post("/:id/start", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  const rows = await db
-    .update(jobs)
-    .set({ status: "running" as JobStatus, startedAt: new Date() })
-    .where(and(eq(jobs.id, id), eq(jobs.status, "claimed")))
-    .returning();
+    const rows = await db
+      .update(jobs)
+      .set({ status: "running" as JobStatus, startedAt: new Date() })
+      .where(and(eq(jobs.id, id), eq(jobs.status, "claimed")))
+      .returning();
 
-  if (rows.length === 0) {
-    return notFoundError(c, "Job not found or not in 'claimed' status");
-  }
+    if (rows.length === 0) {
+      return notFoundError(c, "Job not found or not in 'claimed' status");
+    }
 
-  return c.json(formatJob(rows[0]));
-});
+    return c.json(formatJob(rows[0]));
+  })
 
-// ---- POST /:id/complete (mark as completed with result) ----
+  // ---- POST /:id/complete (mark as completed with result) ----
 
-jobsRoute.post("/:id/complete", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
+  .post("/:id/complete", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
 
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = CompleteJobSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = CompleteJobSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  const rows = await db
-    .update(jobs)
-    .set({
-      status: "completed" as JobStatus,
-      result: parsed.data.result ?? null,
-      completedAt: new Date(),
-    })
-    .where(and(eq(jobs.id, id), eq(jobs.status, "running")))
-    .returning();
+    const rows = await db
+      .update(jobs)
+      .set({
+        status: "completed" as JobStatus,
+        result: parsed.data.result ?? null,
+        completedAt: new Date(),
+      })
+      .where(and(eq(jobs.id, id), eq(jobs.status, "running")))
+      .returning();
 
-  if (rows.length === 0) {
-    return notFoundError(c, "Job not found or not in 'running' status");
-  }
+    if (rows.length === 0) {
+      return notFoundError(c, "Job not found or not in 'running' status");
+    }
 
-  return c.json(formatJob(rows[0]));
-});
+    return c.json(formatJob(rows[0]));
+  })
 
-// ---- POST /:id/fail (mark as failed; auto-retry if under max) ----
+  // ---- POST /:id/fail (mark as failed; auto-retry if under max) ----
 
-jobsRoute.post("/:id/fail", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
+  .post("/:id/fail", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
 
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = FailJobSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = FailJobSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const pgClient = getDb();
+    const pgClient = getDb();
 
-  // Single atomic UPDATE avoids the TOCTOU race between SELECT and UPDATE.
-  // The WHERE clause acts as an optimistic lock: only rows in 'running' or
-  // 'claimed' status are updated, and retries/max_retries are read and written
-  // in the same statement, so concurrent calls cannot double-increment retries.
-  //
-  // PostgreSQL evaluates all SET expressions against the *pre-update* row values,
-  // so `retries + 1` in each CASE expression is consistent (it always means
-  // old_retries + 1, not the value written by `retries = retries + 1`).
-  //
-  // Note: `error = $1` is always written, even on retry (same as the previous
-  // two-query implementation). A retried job carries the last failure's error
-  // message until it completes or fails permanently.
-  const result = await pgClient.unsafe(
-    `UPDATE "jobs"
+    // Single atomic UPDATE avoids the TOCTOU race between SELECT and UPDATE.
+    // The WHERE clause acts as an optimistic lock: only rows in 'running' or
+    // 'claimed' status are updated, and retries/max_retries are read and written
+    // in the same statement, so concurrent calls cannot double-increment retries.
+    //
+    // PostgreSQL evaluates all SET expressions against the *pre-update* row values,
+    // so `retries + 1` in each CASE expression is consistent (it always means
+    // old_retries + 1, not the value written by `retries = retries + 1`).
+    //
+    // Note: `error = $1` is always written, even on retry (same as the previous
+    // two-query implementation). A retried job carries the last failure's error
+    // message until it completes or fails permanently.
+    const result = await pgClient.unsafe(
+      `UPDATE "jobs"
      SET
        retries      = retries + 1,
        status       = CASE WHEN (retries + 1) < max_retries THEN 'pending' ELSE 'failed' END,
@@ -282,183 +282,186 @@ jobsRoute.post("/:id/fail", async (c) => {
      WHERE id = $2
        AND status IN ('running', 'claimed')
      RETURNING *`,
-    [parsed.data.error, id]
-  );
+      [parsed.data.error, id]
+    );
 
-  if (result.length === 0) {
-    // Distinguish "not found" from "wrong status" for accurate error messages.
+    if (result.length === 0) {
+      // Distinguish "not found" from "wrong status" for accurate error messages.
+      const db = getDrizzleDb();
+      const exists = await db
+        .select({ id: jobs.id, status: jobs.status })
+        .from(jobs)
+        .where(eq(jobs.id, id));
+      if (exists.length === 0) {
+        return notFoundError(c, "Job not found");
+      }
+      return validationError(
+        c,
+        `Job is in '${exists[0].status}' status, expected 'running' or 'claimed'`
+      );
+    }
+
+    const row = result[0] as Record<string, unknown>;
+    // `retried` is derived from the post-update status returned by RETURNING *.
+    const retried = row.status === "pending";
+
+    return c.json({ ...formatRawJobRow(row), retried });
+  })
+
+  // ---- POST /:id/cancel (cancel a pending or claimed job) ----
+
+  .post("/:id/cancel", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
+
     const db = getDrizzleDb();
-    const exists = await db
-      .select({ id: jobs.id, status: jobs.status })
+
+    const rows = await db
+      .update(jobs)
+      .set({
+        status: "cancelled" as JobStatus,
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(jobs.id, id),
+          sql`${jobs.status} IN ('pending', 'claimed')`
+        )
+      )
+      .returning();
+
+    if (rows.length === 0) {
+      return notFoundError(
+        c,
+        "Job not found or not in 'pending'/'claimed' status"
+      );
+    }
+
+    return c.json(formatJob(rows[0]));
+  })
+
+  // ---- GET /stats (aggregate counts by type and status) ----
+
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const byTypeStatus = await db
+      .select({
+        type: jobs.type,
+        status: jobs.status,
+        count: count(),
+      })
       .from(jobs)
-      .where(eq(jobs.id, id));
-    if (exists.length === 0) {
+      .groupBy(jobs.type, jobs.status);
+
+    // Compute average duration for completed jobs
+    const avgDuration = await db
+      .select({
+        type: jobs.type,
+        avgMs: sql<number>`avg(extract(epoch from (${jobs.completedAt} - ${jobs.startedAt})) * 1000)`,
+      })
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.status, "completed"),
+          sql`${jobs.startedAt} IS NOT NULL`,
+          sql`${jobs.completedAt} IS NOT NULL`
+        )
+      )
+      .groupBy(jobs.type);
+
+    // Failure rate per type
+    const failureRate = await db
+      .select({
+        type: jobs.type,
+        total: count(),
+        failed: sql<number>`sum(case when ${jobs.status} = 'failed' then 1 else 0 end)`,
+      })
+      .from(jobs)
+      .where(sql`${jobs.status} IN ('completed', 'failed')`)
+      .groupBy(jobs.type);
+
+    // Build summary
+    const typeSummary: Record<
+      string,
+      { byStatus: Record<string, number>; avgDurationMs?: number; failureRate?: number }
+    > = {};
+
+    for (const row of byTypeStatus) {
+      if (!typeSummary[row.type]) {
+        typeSummary[row.type] = { byStatus: {} };
+      }
+      typeSummary[row.type].byStatus[row.status] = row.count;
+    }
+
+    for (const row of avgDuration) {
+      if (typeSummary[row.type]) {
+        typeSummary[row.type].avgDurationMs = Math.round(Number(row.avgMs));
+      }
+    }
+
+    for (const row of failureRate) {
+      if (typeSummary[row.type] && row.total > 0) {
+        typeSummary[row.type].failureRate = Number(row.failed) / row.total;
+      }
+    }
+
+    const totalResult = await db.select({ count: count() }).from(jobs);
+
+    return c.json({
+      totalJobs: totalResult[0].count,
+      byType: typeSummary,
+    });
+  })
+
+  // ---- POST /sweep (reset stale claimed/running jobs) ----
+
+  .post("/sweep", async (c) => {
+    const body = (await parseJsonBody(c)) ?? {};
+    const parsed = SweepJobsSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+    const timeoutMinutes = parsed.data.timeoutMinutes;
+
+    const db = getDrizzleDb();
+
+    const result = await db
+      .update(jobs)
+      .set({
+        status: "pending" as JobStatus,
+        claimedAt: null,
+        startedAt: null,
+        workerId: null,
+      })
+      .where(
+        and(
+          sql`${jobs.status} IN ('claimed', 'running')`,
+          sql`${jobs.claimedAt} < now() - (${timeoutMinutes} * interval '1 minute')`
+        )
+      )
+      .returning({ id: jobs.id, type: jobs.type });
+
+    return c.json({
+      swept: result.length,
+      jobs: result,
+    });
+  })
+
+  // ---- GET /:id (single job details) ----
+
+  .get("/:id", async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) return validationError(c, "id must be a number");
+
+    const db = getDrizzleDb();
+
+    const rows = await db.select().from(jobs).where(eq(jobs.id, id));
+
+    if (rows.length === 0) {
       return notFoundError(c, "Job not found");
     }
-    return validationError(
-      c,
-      `Job is in '${exists[0].status}' status, expected 'running' or 'claimed'`
-    );
-  }
 
-  const row = result[0] as Record<string, unknown>;
-  // `retried` is derived from the post-update status returned by RETURNING *.
-  const retried = row.status === "pending";
-
-  return c.json({ ...formatRawJobRow(row), retried });
-});
-
-// ---- POST /:id/cancel (cancel a pending or claimed job) ----
-
-jobsRoute.post("/:id/cancel", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
-
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .update(jobs)
-    .set({
-      status: "cancelled" as JobStatus,
-      completedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(jobs.id, id),
-        sql`${jobs.status} IN ('pending', 'claimed')`
-      )
-    )
-    .returning();
-
-  if (rows.length === 0) {
-    return notFoundError(
-      c,
-      "Job not found or not in 'pending'/'claimed' status"
-    );
-  }
-
-  return c.json(formatJob(rows[0]));
-});
-
-// ---- GET /stats (aggregate counts by type and status) ----
-
-jobsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const byTypeStatus = await db
-    .select({
-      type: jobs.type,
-      status: jobs.status,
-      count: count(),
-    })
-    .from(jobs)
-    .groupBy(jobs.type, jobs.status);
-
-  // Compute average duration for completed jobs
-  const avgDuration = await db
-    .select({
-      type: jobs.type,
-      avgMs: sql<number>`avg(extract(epoch from (${jobs.completedAt} - ${jobs.startedAt})) * 1000)`,
-    })
-    .from(jobs)
-    .where(
-      and(
-        eq(jobs.status, "completed"),
-        sql`${jobs.startedAt} IS NOT NULL`,
-        sql`${jobs.completedAt} IS NOT NULL`
-      )
-    )
-    .groupBy(jobs.type);
-
-  // Failure rate per type
-  const failureRate = await db
-    .select({
-      type: jobs.type,
-      total: count(),
-      failed: sql<number>`sum(case when ${jobs.status} = 'failed' then 1 else 0 end)`,
-    })
-    .from(jobs)
-    .where(sql`${jobs.status} IN ('completed', 'failed')`)
-    .groupBy(jobs.type);
-
-  // Build summary
-  const typeSummary: Record<
-    string,
-    { byStatus: Record<string, number>; avgDurationMs?: number; failureRate?: number }
-  > = {};
-
-  for (const row of byTypeStatus) {
-    if (!typeSummary[row.type]) {
-      typeSummary[row.type] = { byStatus: {} };
-    }
-    typeSummary[row.type].byStatus[row.status] = row.count;
-  }
-
-  for (const row of avgDuration) {
-    if (typeSummary[row.type]) {
-      typeSummary[row.type].avgDurationMs = Math.round(Number(row.avgMs));
-    }
-  }
-
-  for (const row of failureRate) {
-    if (typeSummary[row.type] && row.total > 0) {
-      typeSummary[row.type].failureRate = Number(row.failed) / row.total;
-    }
-  }
-
-  const totalResult = await db.select({ count: count() }).from(jobs);
-
-  return c.json({
-    totalJobs: totalResult[0].count,
-    byType: typeSummary,
+    return c.json(formatJob(rows[0]));
   });
-});
 
-// ---- POST /sweep (reset stale claimed/running jobs) ----
-
-jobsRoute.post("/sweep", async (c) => {
-  const body = (await parseJsonBody(c)) ?? {};
-  const parsed = SweepJobsSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-  const timeoutMinutes = parsed.data.timeoutMinutes;
-
-  const db = getDrizzleDb();
-
-  const result = await db
-    .update(jobs)
-    .set({
-      status: "pending" as JobStatus,
-      claimedAt: null,
-      startedAt: null,
-      workerId: null,
-    })
-    .where(
-      and(
-        sql`${jobs.status} IN ('claimed', 'running')`,
-        sql`${jobs.claimedAt} < now() - (${timeoutMinutes} * interval '1 minute')`
-      )
-    )
-    .returning({ id: jobs.id, type: jobs.type });
-
-  return c.json({
-    swept: result.length,
-    jobs: result,
-  });
-});
-
-// ---- GET /:id (single job details) ----
-
-jobsRoute.get("/:id", async (c) => {
-  const id = parseInt(c.req.param("id"), 10);
-  if (isNaN(id)) return validationError(c, "id must be a number");
-
-  const db = getDrizzleDb();
-
-  const rows = await db.select().from(jobs).where(eq(jobs.id, id));
-
-  if (rows.length === 0) {
-    return notFoundError(c, "Job not found");
-  }
-
-  return c.json(formatJob(rows[0]));
-});
+export const jobsRoute = jobsApp;
+export type JobsRoute = typeof jobsApp;

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -8,8 +8,6 @@ import {
 } from "./utils.js";
 import { SyncLinksBatchSchema } from "../api-types.js";
 
-export const linksRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_RELATED = 25;
@@ -72,34 +70,35 @@ const RelatedQuery = z.object({
 // Prevents deadlocks when multiple callers (CI, local builds) sync concurrently.
 const PAGE_LINKS_SYNC_LOCK = 7_294_801;
 
-linksRoute.post("/sync", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const linksApp = new Hono()
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = SyncBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = SyncBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { links, replace } = parsed.data;
-  const rawDb = getDb();
+    const { links, replace } = parsed.data;
+    const rawDb = getDb();
 
-  let upserted = 0;
+    let upserted = 0;
 
-  // Use a raw postgres transaction with an advisory lock to serialize concurrent
-  // sync operations. Without this, two concurrent syncs deadlock on the unique
-  // index when inserting overlapping rows.
-  await rawDb.begin(async (txRaw) => {
-    const tx = txRaw as unknown as SqlQuery;
-    await tx`SELECT pg_advisory_xact_lock(${PAGE_LINKS_SYNC_LOCK})`;
+    // Use a raw postgres transaction with an advisory lock to serialize concurrent
+    // sync operations. Without this, two concurrent syncs deadlock on the unique
+    // index when inserting overlapping rows.
+    await rawDb.begin(async (txRaw) => {
+      const tx = txRaw as unknown as SqlQuery;
+      await tx`SELECT pg_advisory_xact_lock(${PAGE_LINKS_SYNC_LOCK})`;
 
-    if (replace) {
-      await tx`DELETE FROM page_links`;
-    }
+      if (replace) {
+        await tx`DELETE FROM page_links`;
+      }
 
-    // Batch upsert — on conflict (source, target, type) update weight + relationship
-    for (let i = 0; i < links.length; i += 500) {
-      const batch = links.slice(i, i + 500);
+      // Batch upsert — on conflict (source, target, type) update weight + relationship
+      for (let i = 0; i < links.length; i += 500) {
+        const batch = links.slice(i, i + 500);
 
-      await tx`
+        await tx`
         INSERT INTO page_links (source_id, target_id, link_type, relationship, weight)
         SELECT "sourceId", "targetId", "linkType", relationship, weight
         FROM jsonb_to_recordset(${JSON.stringify(batch)}::jsonb)
@@ -108,30 +107,30 @@ linksRoute.post("/sync", async (c) => {
         DO UPDATE SET weight = EXCLUDED.weight, relationship = EXCLUDED.relationship
       `;
 
-      upserted += batch.length;
-    }
-  });
+        upserted += batch.length;
+      }
+    });
 
-  return c.json({ upserted });
-});
+    return c.json({ upserted });
+  })
 
-// ---- GET /backlinks/:id ----
+  // ---- GET /backlinks/:id ----
 
-linksRoute.get("/backlinks/:id", async (c) => {
-  const targetId = c.req.param("id");
-  if (!targetId) return validationError(c, "Entity ID is required");
+  .get("/backlinks/:id", async (c) => {
+    const targetId = c.req.param("id");
+    if (!targetId) return validationError(c, "Entity ID is required");
 
-  const parsed = BacklinksQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = BacklinksQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { limit } = parsed.data;
-  const rawDb = getDb();
+    const { limit } = parsed.data;
+    const rawDb = getDb();
 
-  // Find all pages/entities that link TO this target.
-  // Join with wiki_pages to get title and entity_type for the source.
-  // Deduplicate by source_id (a source may link via multiple link_types),
-  // then order by weight descending (most relevant first).
-  const results = await rawDb`
+    // Find all pages/entities that link TO this target.
+    // Join with wiki_pages to get title and entity_type for the source.
+    // Deduplicate by source_id (a source may link via multiple link_types),
+    // then order by weight descending (most relevant first).
+    const results = await rawDb`
     SELECT * FROM (
       SELECT DISTINCT ON (pl.source_id)
         pl.source_id,
@@ -149,39 +148,39 @@ linksRoute.get("/backlinks/:id", async (c) => {
     LIMIT ${limit}
   `;
 
-  const backlinks = results.map((r: any) => ({
-    id: r.source_id,
-    type: r.source_type || "concept",
-    title: r.source_title || r.source_id,
-    relationship: r.relationship || undefined,
-    linkType: r.link_type,
-    weight: r.weight,
-  }));
+    const backlinks = results.map((r: any) => ({
+      id: r.source_id,
+      type: r.source_type || "concept",
+      title: r.source_title || r.source_id,
+      relationship: r.relationship || undefined,
+      linkType: r.link_type,
+      weight: r.weight,
+    }));
 
-  return c.json({
-    targetId,
-    backlinks,
-    total: backlinks.length,
-  });
-});
+    return c.json({
+      targetId,
+      backlinks,
+      total: backlinks.length,
+    });
+  })
 
-// ---- GET /related/:id ----
+  // ---- GET /related/:id ----
 
-linksRoute.get("/related/:id", async (c) => {
-  const entityId = c.req.param("id");
-  if (!entityId) return validationError(c, "Entity ID is required");
+  .get("/related/:id", async (c) => {
+    const entityId = c.req.param("id");
+    if (!entityId) return validationError(c, "Entity ID is required");
 
-  const parsed = RelatedQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = RelatedQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { limit } = parsed.data;
-  const rawDb = getDb();
+    const { limit } = parsed.data;
+    const rawDb = getDb();
 
-  // Compute related pages by aggregating all link signals bidirectionally.
-  // For each neighbor, sum the weights of all link types connecting them.
-  // Apply quality boost: 1 + quality/40 + reader_importance/400 (max ~1.45x).
-  // Relationship labels come from yaml_related links.
-  const results = await rawDb`
+    // Compute related pages by aggregating all link signals bidirectionally.
+    // For each neighbor, sum the weights of all link types connecting them.
+    // Apply quality boost: 1 + quality/40 + reader_importance/400 (max ~1.45x).
+    // Relationship labels come from yaml_related links.
+    const results = await rawDb`
     WITH bidirectional_links AS (
       -- Forward links: entityId is source (is_reverse = false)
       SELECT target_id AS neighbor_id, link_type, relationship, weight, false AS is_reverse
@@ -237,37 +236,37 @@ linksRoute.get("/related/:id", async (c) => {
     LIMIT ${limit * 3}
   `;
 
-  // Type-diverse selection: guarantee MIN_PER_TYPE from each entity type,
-  // then fill remaining slots with highest-scoring entries.
-  const scored = results.map((r: any) => ({
-    id: r.id as string,
-    type: (r.entity_type as string) || "concept",
-    title: (r.title as string) || r.id,
-    score: Math.round(parseFloat(r.score) * 100) / 100,
-    label: formatRelationshipLabel(r.relationship, !!r.relationship_is_reverse) || undefined,
-  }));
+    // Type-diverse selection: guarantee MIN_PER_TYPE from each entity type,
+    // then fill remaining slots with highest-scoring entries.
+    const scored = results.map((r: any) => ({
+      id: r.id as string,
+      type: (r.entity_type as string) || "concept",
+      title: (r.title as string) || r.id,
+      score: Math.round(parseFloat(r.score) * 100) / 100,
+      label: formatRelationshipLabel(r.relationship, !!r.relationship_is_reverse) || undefined,
+    }));
 
-  const selected = typeDiverseSelect(scored, limit);
+    const selected = typeDiverseSelect(scored, limit);
 
-  return c.json({
-    entityId,
-    related: selected,
-    total: selected.length,
-  });
-});
+    return c.json({
+      entityId,
+      related: selected,
+      total: selected.length,
+    });
+  })
 
-// ---- GET /graph/:id ----
+  // ---- GET /graph/:id ----
 
-linksRoute.get("/graph/:id", async (c) => {
-  const entityId = c.req.param("id");
-  if (!entityId) return validationError(c, "Entity ID is required");
+  .get("/graph/:id", async (c) => {
+    const entityId = c.req.param("id");
+    if (!entityId) return validationError(c, "Entity ID is required");
 
-  const rawDb = getDb();
-  const MAX_GRAPH_EDGES = 500;
+    const rawDb = getDb();
+    const MAX_GRAPH_EDGES = 500;
 
-  // Get all direct links (both directions) for the entity.
-  // This provides the raw graph data for visualization.
-  const results = await rawDb`
+    // Get all direct links (both directions) for the entity.
+    // This provides the raw graph data for visualization.
+    const results = await rawDb`
     SELECT
       pl.source_id,
       pl.target_id,
@@ -286,53 +285,53 @@ linksRoute.get("/graph/:id", async (c) => {
     LIMIT ${MAX_GRAPH_EDGES}
   `;
 
-  // Build node and edge sets
-  const nodeMap = new Map<string, { id: string; type: string; title: string }>();
-  const edges: Array<{
-    source: string;
-    target: string;
-    linkType: string;
-    relationship?: string;
-    weight: number;
-  }> = [];
+    // Build node and edge sets
+    const nodeMap = new Map<string, { id: string; type: string; title: string }>();
+    const edges: Array<{
+      source: string;
+      target: string;
+      linkType: string;
+      relationship?: string;
+      weight: number;
+    }> = [];
 
-  for (const r of results as any[]) {
-    if (!nodeMap.has(r.source_id)) {
-      nodeMap.set(r.source_id, {
-        id: r.source_id,
-        type: r.source_type || "concept",
-        title: r.source_title || r.source_id,
+    for (const r of results as any[]) {
+      if (!nodeMap.has(r.source_id)) {
+        nodeMap.set(r.source_id, {
+          id: r.source_id,
+          type: r.source_type || "concept",
+          title: r.source_title || r.source_id,
+        });
+      }
+      if (!nodeMap.has(r.target_id)) {
+        nodeMap.set(r.target_id, {
+          id: r.target_id,
+          type: r.target_type || "concept",
+          title: r.target_title || r.target_id,
+        });
+      }
+      edges.push({
+        source: r.source_id,
+        target: r.target_id,
+        linkType: r.link_type,
+        relationship: r.relationship || undefined,
+        weight: r.weight,
       });
     }
-    if (!nodeMap.has(r.target_id)) {
-      nodeMap.set(r.target_id, {
-        id: r.target_id,
-        type: r.target_type || "concept",
-        title: r.target_title || r.target_id,
-      });
-    }
-    edges.push({
-      source: r.source_id,
-      target: r.target_id,
-      linkType: r.link_type,
-      relationship: r.relationship || undefined,
-      weight: r.weight,
+
+    return c.json({
+      entityId,
+      nodes: Array.from(nodeMap.values()),
+      edges,
     });
-  }
+  })
 
-  return c.json({
-    entityId,
-    nodes: Array.from(nodeMap.values()),
-    edges,
-  });
-});
+  // ---- GET /stats ----
 
-// ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const rawDb = getDb();
 
-linksRoute.get("/stats", async (c) => {
-  const rawDb = getDb();
-
-  const stats = await rawDb`
+    const stats = await rawDb`
     SELECT
       link_type,
       COUNT(*)::int AS count,
@@ -342,27 +341,27 @@ linksRoute.get("/stats", async (c) => {
     ORDER BY count DESC
   `;
 
-  const totalResult = await rawDb`
+    const totalResult = await rawDb`
     SELECT COUNT(*)::int AS total FROM page_links
   `;
 
-  const uniquePagesResult = await rawDb`
+    const uniquePagesResult = await rawDb`
     SELECT COUNT(DISTINCT source_id)::int AS sources,
            COUNT(DISTINCT target_id)::int AS targets
     FROM page_links
   `;
 
-  return c.json({
-    total: (totalResult[0] as any)?.total || 0,
-    uniqueSources: (uniquePagesResult[0] as any)?.sources || 0,
-    uniqueTargets: (uniquePagesResult[0] as any)?.targets || 0,
-    byType: stats.map((s: any) => ({
-      linkType: s.link_type,
-      count: s.count,
-      avgWeight: parseFloat(s.avg_weight),
-    })),
+    return c.json({
+      total: (totalResult[0] as any)?.total || 0,
+      uniqueSources: (uniquePagesResult[0] as any)?.sources || 0,
+      uniqueTargets: (uniquePagesResult[0] as any)?.targets || 0,
+      byType: stats.map((s: any) => ({
+        linkType: s.link_type,
+        count: s.count,
+        avgWeight: parseFloat(s.avg_weight),
+      })),
+    });
   });
-});
 
 // ---- Helpers ----
 
@@ -419,3 +418,6 @@ function typeDiverseSelect(
   // Build final list in score order
   return scored.filter((e) => selected.has(e.id)).slice(0, maxItems);
 }
+
+export const linksRoute = linksApp;
+export type LinksRoute = typeof linksApp;

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -21,8 +21,6 @@ import {
   TS_HEADLINE_OPTIONS,
 } from "../search-utils.js";
 
-export const pagesRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -45,25 +43,25 @@ const PaginationQuery = z.object({
   entityType: z.string().max(100).optional(),
 });
 
-// ---- GET /search?q=...&limit=20 ----
+const pagesApp = new Hono()
+  // ---- GET /search?q=...&limit=20 ----
+  .get("/search", async (c) => {
+    const parsed = SearchQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-pagesRoute.get("/search", async (c) => {
-  const parsed = SearchQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const { q, limit } = parsed.data;
+    const rawDb = getDb();
 
-  const { q, limit } = parsed.data;
-  const rawDb = getDb();
+    // Phase 1: Prefix search with to_tsquery — supports search-as-you-type.
+    // Each word gets a :* suffix for prefix matching, ANDed together.
+    // Weighted ranking: title (A=1.0), description (B=0.4), llm_summary (C=0.2), tags+entityType (D=0.1).
+    const prefixQuery = buildPrefixTsquery(q);
 
-  // Phase 1: Prefix search with to_tsquery — supports search-as-you-type.
-  // Each word gets a :* suffix for prefix matching, ANDed together.
-  // Weighted ranking: title (A=1.0), description (B=0.4), llm_summary (C=0.2), tags+entityType (D=0.1).
-  const prefixQuery = buildPrefixTsquery(q);
+    let results: any[] = [];
 
-  let results: any[] = [];
-
-  if (prefixQuery) {
-    results = await rawDb.unsafe(
-      `SELECT
+    if (prefixQuery) {
+      results = await rawDb.unsafe(
+        `SELECT
         id, numeric_id, title, description, entity_type, category,
         reader_importance, quality,
         ts_rank_cd(search_vector, to_tsquery('english', $1), 1) AS rank,
@@ -75,15 +73,15 @@ pagesRoute.get("/search", async (c) => {
       WHERE search_vector @@ to_tsquery('english', $1)
       ORDER BY rank DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
-      [prefixQuery, limit],
-    );
-  }
+        [prefixQuery, limit],
+      );
+    }
 
-  // Phase 2: If FTS returned few results, fall back to pg_trgm similarity
-  // for typo tolerance (e.g. "antrhopic" → "anthropic").
-  if (results.length < TRIGRAM_FALLBACK_THRESHOLD) {
-    const trigramResults = await rawDb.unsafe(
-      `SELECT
+    // Phase 2: If FTS returned few results, fall back to pg_trgm similarity
+    // for typo tolerance (e.g. "antrhopic" → "anthropic").
+    if (results.length < TRIGRAM_FALLBACK_THRESHOLD) {
+      const trigramResults = await rawDb.unsafe(
+        `SELECT
         id, numeric_id, title, description, entity_type, category,
         reader_importance, quality,
         similarity(title, $1) AS rank,
@@ -94,260 +92,263 @@ pagesRoute.get("/search", async (c) => {
         AND id NOT IN (SELECT unnest($3::text[]))
       ORDER BY similarity(title, $1) DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
-      [q, limit - results.length, results.map((r: any) => r.id)],
-    );
-    results = [...results, ...trigramResults];
-  }
-
-  return c.json({
-    results: results.map((r: any) => ({
-      id: r.id,
-      numericId: r.numeric_id,
-      title: r.title,
-      description: r.description,
-      entityType: r.entity_type,
-      category: r.category,
-      readerImportance: r.reader_importance,
-      quality: r.quality,
-      score: parseFloat(r.rank),
-      snippet: r.snippet || null,
-    })),
-    query: q,
-    total: results.length,
-  });
-});
-
-// ---- GET /:id ----
-
-pagesRoute.get("/:id", async (c) => {
-  const id = c.req.param("id");
-  if (!id) return validationError(c, "Page ID is required");
-
-  const db = getDrizzleDb();
-
-  // If the ID looks like a numeric entity ID (E42), resolve to slug via entityIds table.
-  // The wiki_pages.numeric_id column is sparsely populated, so we use the authoritative
-  // entityIds table for the mapping and fall back to wiki_pages.numeric_id for legacy data.
-  let resolvedSlug: string | null = null;
-  if (/^E\d+$/i.test(id)) {
-    const numericValue = parseInt(id.slice(1), 10);
-    const idRows = await db
-      .select({ slug: entityIds.slug })
-      .from(entityIds)
-      .where(eq(entityIds.numericId, numericValue));
-    if (idRows.length > 0) {
-      resolvedSlug = idRows[0].slug;
+        [q, limit - results.length, results.map((r: any) => r.id)],
+      );
+      results = [...results, ...trigramResults];
     }
-  }
 
-  // Look up by resolved slug, original ID as slug, or legacy numericId column
-  const lookupSlug = resolvedSlug || id;
-  const rows = await db
-    .select()
-    .from(wikiPages)
-    .where(or(eq(wikiPages.id, lookupSlug), eq(wikiPages.numericId, id)));
+    return c.json({
+      results: results.map((r: any) => ({
+        id: r.id,
+        numericId: r.numeric_id,
+        title: r.title,
+        description: r.description,
+        entityType: r.entity_type,
+        category: r.category,
+        readerImportance: r.reader_importance,
+        quality: r.quality,
+        score: parseFloat(r.rank),
+        snippet: r.snippet || null,
+      })),
+      query: q,
+      total: results.length,
+    });
+  })
 
-  if (rows.length === 0) {
-    return notFoundError(c, `No page found for id: ${id}`);
-  }
+  // ---- GET /:id ----
 
-  const page = rows[0];
-  // Use the canonical numeric ID from the entityIds resolution if available,
-  // falling back to whatever is stored in wiki_pages
-  const numericId = resolvedSlug ? id.toUpperCase() : page.numericId;
-  return c.json({
-    id: page.id,
-    numericId,
-    title: page.title,
-    description: page.description,
-    llmSummary: page.llmSummary,
-    category: page.category,
-    subcategory: page.subcategory,
-    entityType: page.entityType,
-    tags: page.tags,
-    quality: page.quality,
-    readerImportance: page.readerImportance,
-    hallucinationRiskLevel: page.hallucinationRiskLevel,
-    hallucinationRiskScore: page.hallucinationRiskScore,
-    contentPlaintext: page.contentPlaintext,
-    wordCount: page.wordCount,
-    lastUpdated: page.lastUpdated,
-    contentFormat: page.contentFormat,
-    syncedAt: page.syncedAt,
-    createdAt: page.createdAt,
-    updatedAt: page.updatedAt,
-  });
-});
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Page ID is required");
 
-// ---- GET / (paginated listing) ----
+    const db = getDrizzleDb();
 
-pagesRoute.get("/", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    // If the ID looks like a numeric entity ID (E42), resolve to slug via entityIds table.
+    // The wiki_pages.numeric_id column is sparsely populated, so we use the authoritative
+    // entityIds table for the mapping and fall back to wiki_pages.numeric_id for legacy data.
+    let resolvedSlug: string | null = null;
+    if (/^E\d+$/i.test(id)) {
+      const numericValue = parseInt(id.slice(1), 10);
+      const idRows = await db
+        .select({ slug: entityIds.slug })
+        .from(entityIds)
+        .where(eq(entityIds.numericId, numericValue));
+      if (idRows.length > 0) {
+        resolvedSlug = idRows[0].slug;
+      }
+    }
 
-  const { limit, offset, category, entityType } = parsed.data;
-  const db = getDrizzleDb();
+    // Look up by resolved slug, original ID as slug, or legacy numericId column
+    const lookupSlug = resolvedSlug || id;
+    const rows = await db
+      .select()
+      .from(wikiPages)
+      .where(or(eq(wikiPages.id, lookupSlug), eq(wikiPages.numericId, id)));
 
-  // Build where conditions
-  const conditions = [];
-  if (category) conditions.push(eq(wikiPages.category, category));
-  if (entityType) conditions.push(eq(wikiPages.entityType, entityType));
+    if (rows.length === 0) {
+      return notFoundError(c, `No page found for id: ${id}`);
+    }
 
-  const whereClause =
-    conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : and(...conditions)
-      : undefined;
-
-  const rows = await db
-    .select({
-      id: wikiPages.id,
-      numericId: wikiPages.numericId,
-      title: wikiPages.title,
-      description: wikiPages.description,
-      category: wikiPages.category,
-      subcategory: wikiPages.subcategory,
-      entityType: wikiPages.entityType,
-      quality: wikiPages.quality,
-      readerImportance: wikiPages.readerImportance,
-      wordCount: wikiPages.wordCount,
-      lastUpdated: wikiPages.lastUpdated,
-      contentFormat: wikiPages.contentFormat,
-    })
-    .from(wikiPages)
-    .where(whereClause)
-    .orderBy(asc(wikiPages.id))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(wikiPages)
-    .where(whereClause);
-  const total = countResult[0].count;
-
-  return c.json({ pages: rows, total, limit, offset });
-});
-
-// ---- DELETE /:id ----
-
-pagesRoute.delete("/:id", async (c) => {
-  const id = c.req.param("id");
-  if (!id) return validationError(c, "Page ID is required");
-
-  const db = getDrizzleDb();
-
-  const deleted = await db
-    .delete(wikiPages)
-    .where(eq(wikiPages.id, id))
-    .returning({ id: wikiPages.id });
-
-  if (deleted.length === 0) {
-    return notFoundError(c, `No page found for id: ${id}`);
-  }
-
-  return c.json({ deleted: deleted.length });
-});
-
-// ---- POST /sync ----
-
-pagesRoute.post("/sync", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = SyncBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { pages, syncedFromBranch, syncedFromCommit } = parsed.data;
-  const db = getDrizzleDb();
-  let upserted = 0;
-
-  const pageIds = pages.map((p) => p.id);
-
-  try {
-   await db.transaction(async (tx) => {
-    const allVals = pages.map((page) => ({
+    const page = rows[0];
+    // Use the canonical numeric ID from the entityIds resolution if available,
+    // falling back to whatever is stored in wiki_pages
+    const numericId = resolvedSlug ? id.toUpperCase() : page.numericId;
+    return c.json({
       id: page.id,
-      numericId: page.numericId ?? null,
+      numericId,
       title: page.title,
-      description: page.description ?? null,
-      llmSummary: page.llmSummary ?? null,
-      category: page.category ?? null,
-      subcategory: page.subcategory ?? null,
-      entityType: page.entityType ?? null,
-      tags: page.tags ?? null,
-      quality: page.quality ?? null,
-      readerImportance: page.readerImportance ?? null,
-      researchImportance: page.researchImportance ?? null,
-      tacticalValue: page.tacticalValue ?? null,
-      backlinkCount: page.backlinkCount ?? null,
-      riskCategory: page.riskCategory ?? null,
-      dateCreated: page.dateCreated ?? null,
-      recommendedScore: page.recommendedScore ?? null,
-      clusters: page.clusters ?? null,
-      hallucinationRiskLevel: page.hallucinationRiskLevel ?? null,
-      hallucinationRiskScore: page.hallucinationRiskScore ?? null,
-      contentPlaintext: page.contentPlaintext ?? null,
-      wordCount: page.wordCount ?? null,
-      lastUpdated: page.lastUpdated ?? null,
-      contentFormat: page.contentFormat ?? null,
-      syncedFromBranch: syncedFromBranch ?? null,
-      syncedFromCommit: syncedFromCommit ?? null,
-    }));
+      description: page.description,
+      llmSummary: page.llmSummary,
+      category: page.category,
+      subcategory: page.subcategory,
+      entityType: page.entityType,
+      tags: page.tags,
+      quality: page.quality,
+      readerImportance: page.readerImportance,
+      hallucinationRiskLevel: page.hallucinationRiskLevel,
+      hallucinationRiskScore: page.hallucinationRiskScore,
+      contentPlaintext: page.contentPlaintext,
+      wordCount: page.wordCount,
+      lastUpdated: page.lastUpdated,
+      contentFormat: page.contentFormat,
+      syncedAt: page.syncedAt,
+      createdAt: page.createdAt,
+      updatedAt: page.updatedAt,
+    });
+  })
 
-    await tx
-      .insert(wikiPages)
-      .values(allVals)
-      .onConflictDoUpdate({
-        target: wikiPages.id,
-        set: {
-          numericId: sql`excluded.numeric_id`,
-          title: sql`excluded.title`,
-          description: sql`excluded.description`,
-          llmSummary: sql`excluded.llm_summary`,
-          category: sql`excluded.category`,
-          subcategory: sql`excluded.subcategory`,
-          entityType: sql`excluded.entity_type`,
-          tags: sql`excluded.tags`,
-          quality: sql`excluded.quality`,
-          readerImportance: sql`excluded.reader_importance`,
-          researchImportance: sql`excluded.research_importance`,
-          tacticalValue: sql`excluded.tactical_value`,
-          backlinkCount: sql`excluded.backlink_count`,
-          riskCategory: sql`excluded.risk_category`,
-          dateCreated: sql`excluded.date_created`,
-          recommendedScore: sql`excluded.recommended_score`,
-          clusters: sql`excluded.clusters`,
-          hallucinationRiskLevel: sql`excluded.hallucination_risk_level`,
-          hallucinationRiskScore: sql`excluded.hallucination_risk_score`,
-          contentPlaintext: sql`excluded.content_plaintext`,
-          wordCount: sql`excluded.word_count`,
-          lastUpdated: sql`excluded.last_updated`,
-          contentFormat: sql`excluded.content_format`,
-          syncedFromBranch: sql`excluded.synced_from_branch`,
-          syncedFromCommit: sql`excluded.synced_from_commit`,
-          syncedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        },
-      });
-    upserted = allVals.length;
+  // ---- GET / (paginated listing) ----
 
-    // Update search vectors inside the same transaction
-    const idList = sql.join(pageIds.map(id => sql`${id}`), sql`, `);
-    await tx.execute(sql`
-      UPDATE wiki_pages SET search_vector =
-        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(llm_summary, '')), 'C') ||
-        setweight(to_tsvector('english', coalesce(tags, '')), 'D') ||
-        setweight(to_tsvector('english', coalesce(entity_type, '')), 'D')
-      WHERE id IN (${idList})
-    `);
+  .get("/", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset, category, entityType } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Build where conditions
+    const conditions = [];
+    if (category) conditions.push(eq(wikiPages.category, category));
+    if (entityType) conditions.push(eq(wikiPages.entityType, entityType));
+
+    const whereClause =
+      conditions.length > 0
+        ? conditions.length === 1
+          ? conditions[0]
+          : and(...conditions)
+        : undefined;
+
+    const rows = await db
+      .select({
+        id: wikiPages.id,
+        numericId: wikiPages.numericId,
+        title: wikiPages.title,
+        description: wikiPages.description,
+        category: wikiPages.category,
+        subcategory: wikiPages.subcategory,
+        entityType: wikiPages.entityType,
+        quality: wikiPages.quality,
+        readerImportance: wikiPages.readerImportance,
+        wordCount: wikiPages.wordCount,
+        lastUpdated: wikiPages.lastUpdated,
+        contentFormat: wikiPages.contentFormat,
+      })
+      .from(wikiPages)
+      .where(whereClause)
+      .orderBy(asc(wikiPages.id))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(wikiPages)
+      .where(whereClause);
+    const total = countResult[0].count;
+
+    return c.json({ pages: rows, total, limit, offset });
+  })
+
+  // ---- DELETE /:id ----
+
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Page ID is required");
+
+    const db = getDrizzleDb();
+
+    const deleted = await db
+      .delete(wikiPages)
+      .where(eq(wikiPages.id, id))
+      .returning({ id: wikiPages.id });
+
+    if (deleted.length === 0) {
+      return notFoundError(c, `No page found for id: ${id}`);
+    }
+
+    return c.json({ deleted: deleted.length });
+  })
+
+  // ---- POST /sync ----
+
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SyncBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { pages, syncedFromBranch, syncedFromCommit } = parsed.data;
+    const db = getDrizzleDb();
+    let upserted = 0;
+
+    const pageIds = pages.map((p) => p.id);
+
+    try {
+     await db.transaction(async (tx) => {
+      const allVals = pages.map((page) => ({
+        id: page.id,
+        numericId: page.numericId ?? null,
+        title: page.title,
+        description: page.description ?? null,
+        llmSummary: page.llmSummary ?? null,
+        category: page.category ?? null,
+        subcategory: page.subcategory ?? null,
+        entityType: page.entityType ?? null,
+        tags: page.tags ?? null,
+        quality: page.quality ?? null,
+        readerImportance: page.readerImportance ?? null,
+        researchImportance: page.researchImportance ?? null,
+        tacticalValue: page.tacticalValue ?? null,
+        backlinkCount: page.backlinkCount ?? null,
+        riskCategory: page.riskCategory ?? null,
+        dateCreated: page.dateCreated ?? null,
+        recommendedScore: page.recommendedScore ?? null,
+        clusters: page.clusters ?? null,
+        hallucinationRiskLevel: page.hallucinationRiskLevel ?? null,
+        hallucinationRiskScore: page.hallucinationRiskScore ?? null,
+        contentPlaintext: page.contentPlaintext ?? null,
+        wordCount: page.wordCount ?? null,
+        lastUpdated: page.lastUpdated ?? null,
+        contentFormat: page.contentFormat ?? null,
+        syncedFromBranch: syncedFromBranch ?? null,
+        syncedFromCommit: syncedFromCommit ?? null,
+      }));
+
+      await tx
+        .insert(wikiPages)
+        .values(allVals)
+        .onConflictDoUpdate({
+          target: wikiPages.id,
+          set: {
+            numericId: sql`excluded.numeric_id`,
+            title: sql`excluded.title`,
+            description: sql`excluded.description`,
+            llmSummary: sql`excluded.llm_summary`,
+            category: sql`excluded.category`,
+            subcategory: sql`excluded.subcategory`,
+            entityType: sql`excluded.entity_type`,
+            tags: sql`excluded.tags`,
+            quality: sql`excluded.quality`,
+            readerImportance: sql`excluded.reader_importance`,
+            researchImportance: sql`excluded.research_importance`,
+            tacticalValue: sql`excluded.tactical_value`,
+            backlinkCount: sql`excluded.backlink_count`,
+            riskCategory: sql`excluded.risk_category`,
+            dateCreated: sql`excluded.date_created`,
+            recommendedScore: sql`excluded.recommended_score`,
+            clusters: sql`excluded.clusters`,
+            hallucinationRiskLevel: sql`excluded.hallucination_risk_level`,
+            hallucinationRiskScore: sql`excluded.hallucination_risk_score`,
+            contentPlaintext: sql`excluded.content_plaintext`,
+            wordCount: sql`excluded.word_count`,
+            lastUpdated: sql`excluded.last_updated`,
+            contentFormat: sql`excluded.content_format`,
+            syncedFromBranch: sql`excluded.synced_from_branch`,
+            syncedFromCommit: sql`excluded.synced_from_commit`,
+            syncedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          },
+        });
+      upserted = allVals.length;
+
+      // Update search vectors inside the same transaction
+      const idList = sql.join(pageIds.map(id => sql`${id}`), sql`, `);
+      await tx.execute(sql`
+        UPDATE wiki_pages SET search_vector =
+          setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+          setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(llm_summary, '')), 'C') ||
+          setweight(to_tsvector('english', coalesce(tags, '')), 'D') ||
+          setweight(to_tsvector('english', coalesce(entity_type, '')), 'D')
+        WHERE id IN (${idList})
+      `);
+    });
+    } catch (err) {
+      return dbError(c, "pages sync", err, { pageCount: pages.length });
+    }
+
+    return c.json({ upserted });
   });
-  } catch (err) {
-    return dbError(c, "pages sync", err, { pageCount: pages.length });
-  }
 
-  return c.json({ upserted });
-});
+export const pagesRoute = pagesApp;
+export type PagesRoute = typeof pagesApp;

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -27,8 +27,6 @@ import {
   type ResourceStatsResult,
 } from "../api-types.js";
 
-export const resourcesRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -192,106 +190,110 @@ function formatResource(r: typeof resources.$inferSelect) {
   };
 }
 
-// ---- POST / (upsert single resource) ----
+// ---- Route ----
 
-resourcesRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const resourcesApp = new Hono()
 
-  const parsed = UpsertResourceSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+  // ---- POST / (upsert single resource) ----
 
-  const db = getDrizzleDb();
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  // Validate citedBy page references (optional field)
-  if (parsed.data.citedBy && parsed.data.citedBy.length > 0) {
-    const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, parsed.data.citedBy);
-    if (missingPages.length > 0) {
-      return validationError(
-        c,
-        `Referenced pages not found in citedBy: ${missingPages.join(", ")}`
-      );
-    }
-  }
+    const parsed = UpsertResourceSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const result = await upsertResource(db, parsed.data);
-  return c.json(result, 201);
-});
+    const db = getDrizzleDb();
 
-// ---- POST /batch (upsert multiple resources) ----
-
-resourcesRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = UpsertBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-
-  const db = getDrizzleDb();
-
-  // Validate citedBy page references
-  const allCitedBy = [
-    ...new Set(items.flatMap((item) => item.citedBy ?? [])),
-  ];
-  if (allCitedBy.length > 0) {
-    const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, allCitedBy);
-    if (missingPages.length > 0) {
-      return validationError(
-        c,
-        `Referenced pages not found in citedBy: ${missingPages.join(", ")}`
-      );
-    }
-  }
-
-  const results: Array<{ id: string; url: string }> = [];
-  try {
-    await db.transaction(async (tx) => {
-      for (const item of items) {
-        // Skip per-row search_vector update; handled in bulk below
-        const result = await upsertResource(tx as unknown as DbClient, item, {
-          skipSearchVector: true,
-        });
-        results.push({ id: result.id, url: result.url });
+    // Validate citedBy page references (optional field)
+    if (parsed.data.citedBy && parsed.data.citedBy.length > 0) {
+      const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, parsed.data.citedBy);
+      if (missingPages.length > 0) {
+        return validationError(
+          c,
+          `Referenced pages not found in citedBy: ${missingPages.join(", ")}`
+        );
       }
+    }
 
-      // Bulk search_vector update for all upserted resources (one query)
-      const idList = sql.join(
-        results.map((r) => sql`${r.id}`),
-        sql`, `
-      );
-      await tx.execute(sql`
-        UPDATE resources SET search_vector =
-          setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-          setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
-          setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
-          setweight(to_tsvector('english', coalesce(review, '')), 'D')
-        WHERE id IN (${idList})
-      `);
-    });
-  } catch (err) {
-    return dbError(c, "resources batch upsert", err, { itemCount: items.length });
-  }
+    const result = await upsertResource(db, parsed.data);
+    return c.json(result, 201);
+  })
 
-  return c.json({ upserted: results.length, results }, 201);
-});
+  // ---- POST /batch (upsert multiple resources) ----
 
-// ---- GET /search?q=X (full-text search by title/summary/abstract/review) ----
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-resourcesRoute.get("/search", async (c) => {
-  const parsed = SearchQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = UpsertBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { q, limit } = parsed.data;
-  const rawDb = getDb();
+    const { items } = parsed.data;
 
-  // Full-text search with prefix matching (same pattern as wiki_pages search)
-  const prefixQuery = buildPrefixTsquery(q);
+    const db = getDrizzleDb();
 
-  const rows = prefixQuery
-    ? await rawDb.unsafe(
-        `SELECT
+    // Validate citedBy page references
+    const allCitedBy = [
+      ...new Set(items.flatMap((item) => item.citedBy ?? [])),
+    ];
+    if (allCitedBy.length > 0) {
+      const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, allCitedBy);
+      if (missingPages.length > 0) {
+        return validationError(
+          c,
+          `Referenced pages not found in citedBy: ${missingPages.join(", ")}`
+        );
+      }
+    }
+
+    const results: Array<{ id: string; url: string }> = [];
+    try {
+      await db.transaction(async (tx) => {
+        for (const item of items) {
+          // Skip per-row search_vector update; handled in bulk below
+          const result = await upsertResource(tx as unknown as DbClient, item, {
+            skipSearchVector: true,
+          });
+          results.push({ id: result.id, url: result.url });
+        }
+
+        // Bulk search_vector update for all upserted resources (one query)
+        const idList = sql.join(
+          results.map((r) => sql`${r.id}`),
+          sql`, `
+        );
+        await tx.execute(sql`
+          UPDATE resources SET search_vector =
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(summary, '')), 'B') ||
+            setweight(to_tsvector('english', coalesce(abstract, '')), 'C') ||
+            setweight(to_tsvector('english', coalesce(review, '')), 'D')
+          WHERE id IN (${idList})
+        `);
+      });
+    } catch (err) {
+      return dbError(c, "resources batch upsert", err, { itemCount: items.length });
+    }
+
+    return c.json({ upserted: results.length, results }, 201);
+  })
+
+  // ---- GET /search?q=X (full-text search by title/summary/abstract/review) ----
+
+  .get("/search", async (c) => {
+    const parsed = SearchQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { q, limit } = parsed.data;
+    const rawDb = getDb();
+
+    // Full-text search with prefix matching (same pattern as wiki_pages search)
+    const prefixQuery = buildPrefixTsquery(q);
+
+    const rows = prefixQuery
+      ? await rawDb.unsafe(
+          `SELECT
           id, url, title, type, summary, review, abstract,
           key_points, publication_id, authors, published_date,
           tags, local_filename, credibility_override,
@@ -301,254 +303,257 @@ resourcesRoute.get("/search", async (c) => {
         WHERE search_vector @@ to_tsquery('english', $1)
         ORDER BY rank DESC
         LIMIT $2`,
-        [prefixQuery, limit],
-      )
-    : [];
+          [prefixQuery, limit],
+        )
+      : [];
 
-  return c.json({
-    results: rows.map((r: any) => ({
-      id: r.id,
-      url: r.url,
-      title: r.title,
-      type: r.type,
-      summary: r.summary,
-      review: r.review,
-      abstract: r.abstract,
-      keyPoints: r.key_points,
-      publicationId: r.publication_id,
-      authors: r.authors,
-      publishedDate: r.published_date,
-      tags: r.tags,
-      localFilename: r.local_filename,
-      credibilityOverride: r.credibility_override,
-      fetchedAt: r.fetched_at,
-      contentHash: r.content_hash,
-      createdAt: r.created_at,
-      updatedAt: r.updated_at,
-    })),
-    count: rows.length,
-    query: q,
-  });
-});
+    return c.json({
+      results: rows.map((r: any) => ({
+        id: r.id,
+        url: r.url,
+        title: r.title,
+        type: r.type,
+        summary: r.summary,
+        review: r.review,
+        abstract: r.abstract,
+        keyPoints: r.key_points,
+        publicationId: r.publication_id,
+        authors: r.authors,
+        publishedDate: r.published_date,
+        tags: r.tags,
+        localFilename: r.local_filename,
+        credibilityOverride: r.credibility_override,
+        fetchedAt: r.fetched_at,
+        contentHash: r.content_hash,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      })),
+      count: rows.length,
+      query: q,
+    });
+  })
 
-// ---- GET /stats ----
+  // ---- GET /stats ----
 
-resourcesRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
 
-  const [totalResult, citationCountResult, citedPagesResult, byType] =
-    await Promise.all([
-      db.select({ count: count() }).from(resources),
-      db.select({ count: count() }).from(resourceCitations),
-      db
-        .select({
-          count: sql<number>`count(distinct ${resourceCitations.pageId})`,
-        })
-        .from(resourceCitations),
-      db
-        .select({ type: resources.type, count: count() })
-        .from(resources)
-        .groupBy(resources.type)
-        .orderBy(desc(count())),
-    ]);
+    const [totalResult, citationCountResult, citedPagesResult, byType] =
+      await Promise.all([
+        db.select({ count: count() }).from(resources),
+        db.select({ count: count() }).from(resourceCitations),
+        db
+          .select({
+            count: sql<number>`count(distinct ${resourceCitations.pageId})`,
+          })
+          .from(resourceCitations),
+        db
+          .select({ type: resources.type, count: count() })
+          .from(resources)
+          .groupBy(resources.type)
+          .orderBy(desc(count())),
+      ]);
 
-  const totalResources = totalResult[0].count;
-  const totalCitations = citationCountResult[0].count;
-  const citedPages = Number(citedPagesResult[0].count);
+    const totalResources = totalResult[0].count;
+    const totalCitations = citationCountResult[0].count;
+    const citedPages = Number(citedPagesResult[0].count);
 
-  // Extra stats: orphaned, metadata coverage, fetched count
-  const [orphanedResult, withMetadataResult, fetchedResult] = await Promise.all(
-    [
-      db.execute(sql`
+    // Extra stats: orphaned, metadata coverage, fetched count
+    const [orphanedResult, withMetadataResult, fetchedResult] = await Promise.all(
+      [
+        db.execute(sql`
         SELECT count(*) AS c FROM resources r
         LEFT JOIN resource_citations rc ON rc.resource_id = r.id
         WHERE rc.resource_id IS NULL
       `),
-      db.execute(sql`
+        db.execute(sql`
         SELECT count(*) AS c FROM resources
         WHERE summary IS NOT NULL OR review IS NOT NULL OR key_points IS NOT NULL
       `),
-      db.execute(sql`
+        db.execute(sql`
         SELECT count(*) AS c FROM resources WHERE fetched_at IS NOT NULL
       `),
-    ]
-  );
+      ]
+    );
 
-  const result: ResourceStatsResult = {
-    totalResources,
-    totalCitations,
-    citedPages,
-    byType: Object.fromEntries(
-      byType.map((r) => [r.type ?? "unknown", r.count])
-    ),
-    orphanedCount: Number((orphanedResult as any)[0]?.c ?? 0),
-    withMetadata: Number((withMetadataResult as any)[0]?.c ?? 0),
-    fetched: Number((fetchedResult as any)[0]?.c ?? 0),
-  };
+    const result: ResourceStatsResult = {
+      totalResources,
+      totalCitations,
+      citedPages,
+      byType: Object.fromEntries(
+        byType.map((r) => [r.type ?? "unknown", r.count])
+      ),
+      orphanedCount: Number((orphanedResult as any)[0]?.c ?? 0),
+      withMetadata: Number((withMetadataResult as any)[0]?.c ?? 0),
+      fetched: Number((fetchedResult as any)[0]?.c ?? 0),
+    };
 
-  return c.json(result);
-});
+    return c.json(result);
+  })
 
-// ---- GET /by-page/:pageId (resources cited by a page) ----
+  // ---- GET /by-page/:pageId (resources cited by a page) ----
 
-resourcesRoute.get("/by-page/:pageId", async (c) => {
-  const pageId = c.req.param("pageId");
-  const db = getDrizzleDb();
+  .get("/by-page/:pageId", async (c) => {
+    const pageId = c.req.param("pageId");
+    const db = getDrizzleDb();
 
-  const rows = await db
-    .select({
-      id: resources.id,
-      url: resources.url,
-      title: resources.title,
-      type: resources.type,
-      publicationId: resources.publicationId,
-      authors: resources.authors,
-      publishedDate: resources.publishedDate,
-    })
-    .from(resourceCitations)
-    .innerJoin(resources, eq(resourceCitations.resourceId, resources.id))
-    .where(eq(resourceCitations.pageId, pageId));
+    const rows = await db
+      .select({
+        id: resources.id,
+        url: resources.url,
+        title: resources.title,
+        type: resources.type,
+        publicationId: resources.publicationId,
+        authors: resources.authors,
+        publishedDate: resources.publishedDate,
+      })
+      .from(resourceCitations)
+      .innerJoin(resources, eq(resourceCitations.resourceId, resources.id))
+      .where(eq(resourceCitations.pageId, pageId));
 
-  return c.json({ resources: rows });
-});
+    return c.json({ resources: rows });
+  })
 
-// ---- GET /lookup?url=X (lookup by URL, with normalization) ----
+  // ---- GET /lookup?url=X (lookup by URL, with normalization) ----
 
-resourcesRoute.get("/lookup", async (c) => {
-  const url = c.req.query("url");
-  if (!url) return validationError(c, "url query parameter is required");
+  .get("/lookup", async (c) => {
+    const url = c.req.query("url");
+    if (!url) return validationError(c, "url query parameter is required");
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  // Try exact match first
-  let rows = await db
-    .select()
-    .from(resources)
-    .where(eq(resources.url, url))
-    .limit(1);
+    // Try exact match first
+    let rows = await db
+      .select()
+      .from(resources)
+      .where(eq(resources.url, url))
+      .limit(1);
 
-  // If not found, try normalized variants (www/no-www, trailing slash)
-  if (rows.length === 0) {
-    const variants = urlVariants(url);
-    if (variants.length > 1) {
-      const variantList = sql.join(
-        variants.map((v) => sql`${v}`),
-        sql`, `
-      );
-      rows = await db
-        .select()
-        .from(resources)
-        .where(sql`${resources.url} IN (${variantList})`)
-        .limit(1);
+    // If not found, try normalized variants (www/no-www, trailing slash)
+    if (rows.length === 0) {
+      const variants = urlVariants(url);
+      if (variants.length > 1) {
+        const variantList = sql.join(
+          variants.map((v) => sql`${v}`),
+          sql`, `
+        );
+        rows = await db
+          .select()
+          .from(resources)
+          .where(sql`${resources.url} IN (${variantList})`)
+          .limit(1);
+      }
     }
-  }
 
-  if (rows.length === 0) {
-    return notFoundError(c, `No resource found for URL: ${url}`);
-  }
+    if (rows.length === 0) {
+      return notFoundError(c, `No resource found for URL: ${url}`);
+    }
 
-  return c.json(formatResource(rows[0]));
-});
+    return c.json(formatResource(rows[0]));
+  })
 
-// ---- GET /all (paginated listing) ----
+  // ---- GET /all (paginated listing) ----
 
-resourcesRoute.get("/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+  .get("/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const { limit, offset, type } = parsed.data;
-  const db = getDrizzleDb();
+    const { limit, offset, type } = parsed.data;
+    const db = getDrizzleDb();
 
-  const conditions: SQL | undefined = type
-    ? eq(resources.type, type)
-    : undefined;
+    const conditions: SQL | undefined = type
+      ? eq(resources.type, type)
+      : undefined;
 
-  const rows = await db
-    .select()
-    .from(resources)
-    .where(conditions)
-    .orderBy(resources.id)
-    .limit(limit)
-    .offset(offset);
+    const rows = await db
+      .select()
+      .from(resources)
+      .where(conditions)
+      .orderBy(resources.id)
+      .limit(limit)
+      .offset(offset);
 
-  const countResult = await db
-    .select({ count: count() })
-    .from(resources)
-    .where(conditions);
-  const total = countResult[0].count;
+    const countResult = await db
+      .select({ count: count() })
+      .from(resources)
+      .where(conditions);
+    const total = countResult[0].count;
 
-  return c.json({
-    resources: rows.map(formatResource),
-    total,
-    limit,
-    offset,
+    return c.json({
+      resources: rows.map(formatResource),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /:id/content (resource + linked fetched content) ----
+
+  .get("/:id/content", async (c) => {
+    const id = c.req.param("id");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(resources)
+      .where(eq(resources.id, id))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return notFoundError(c, `Resource not found: ${id}`);
+    }
+
+    const resource = rows[0];
+
+    // Look up fetched content by exact URL match
+    const contentRows = await db
+      .select({
+        url: citationContent.url,
+        fetchedAt: citationContent.fetchedAt,
+        httpStatus: citationContent.httpStatus,
+        contentType: citationContent.contentType,
+        pageTitle: citationContent.pageTitle,
+        fullTextPreview: citationContent.fullTextPreview,
+        contentLength: citationContent.contentLength,
+        contentHash: citationContent.contentHash,
+      })
+      .from(citationContent)
+      .where(eq(citationContent.url, resource.url))
+      .limit(1);
+
+    return c.json({
+      ...formatResource(resource),
+      content: contentRows.length > 0 ? contentRows[0] : null,
+    });
+  })
+
+  // ---- GET /:id (get by ID) ----
+
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(resources)
+      .where(eq(resources.id, id))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return notFoundError(c, `Resource not found: ${id}`);
+    }
+
+    // Also fetch citations
+    const citations = await db
+      .select({ pageId: resourceCitations.pageId })
+      .from(resourceCitations)
+      .where(eq(resourceCitations.resourceId, id));
+
+    return c.json({
+      ...formatResource(rows[0]),
+      citedBy: citations.map((row) => row.pageId),
+    });
   });
-});
 
-// ---- GET /:id/content (resource + linked fetched content) ----
-
-resourcesRoute.get("/:id/content", async (c) => {
-  const id = c.req.param("id");
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(resources)
-    .where(eq(resources.id, id))
-    .limit(1);
-
-  if (rows.length === 0) {
-    return notFoundError(c, `Resource not found: ${id}`);
-  }
-
-  const resource = rows[0];
-
-  // Look up fetched content by exact URL match
-  const contentRows = await db
-    .select({
-      url: citationContent.url,
-      fetchedAt: citationContent.fetchedAt,
-      httpStatus: citationContent.httpStatus,
-      contentType: citationContent.contentType,
-      pageTitle: citationContent.pageTitle,
-      fullTextPreview: citationContent.fullTextPreview,
-      contentLength: citationContent.contentLength,
-      contentHash: citationContent.contentHash,
-    })
-    .from(citationContent)
-    .where(eq(citationContent.url, resource.url))
-    .limit(1);
-
-  return c.json({
-    ...formatResource(resource),
-    content: contentRows.length > 0 ? contentRows[0] : null,
-  });
-});
-
-// ---- GET /:id (get by ID) ----
-
-resourcesRoute.get("/:id", async (c) => {
-  const id = c.req.param("id");
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(resources)
-    .where(eq(resources.id, id))
-    .limit(1);
-
-  if (rows.length === 0) {
-    return notFoundError(c, `Resource not found: ${id}`);
-  }
-
-  // Also fetch citations
-  const citations = await db
-    .select({ pageId: resourceCitations.pageId })
-    .from(resourceCitations)
-    .where(eq(resourceCitations.resourceId, id));
-
-  return c.json({
-    ...formatResource(rows[0]),
-    citedBy: citations.map((row) => row.pageId),
-  });
-});
+export const resourcesRoute = resourcesApp;
+export type ResourcesRoute = typeof resourcesApp;

--- a/apps/wiki-server/src/routes/sessions.ts
+++ b/apps/wiki-server/src/routes/sessions.ts
@@ -10,8 +10,6 @@ import {
   DateStringSchema,
 } from "../api-types.js";
 
-export const sessionsRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 500;
@@ -89,68 +87,21 @@ const sessionConflictSet = {
   recommendationsJson: sql`excluded.recommendations_json`,
 };
 
-// ---- POST / (create or update single session) ----
+// ---- Routes ----
 
-sessionsRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const sessionsApp = new Hono()
+  // ---- POST / (create or update single session) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = CreateSessionSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = CreateSessionSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const d = parsed.data;
-  const db = getDrizzleDb();
+    const d = parsed.data;
+    const db = getDrizzleDb();
 
-  const result = await db.transaction(async (tx) => {
-    const rows = await tx
-      .insert(sessions)
-      .values(sessionValues(d))
-      .onConflictDoUpdate({
-        target: [sessions.date, sessions.title],
-        set: sessionConflictSet,
-      })
-      .returning({
-        id: sessions.id,
-        date: sessions.date,
-        title: sessions.title,
-        createdAt: sessions.createdAt,
-      });
-
-    const session = firstOrThrow(rows, "session upsert");
-
-    // Replace page associations: delete old, insert new
-    await tx
-      .delete(sessionPages)
-      .where(eq(sessionPages.sessionId, session.id));
-
-    if (d.pages.length > 0) {
-      await tx
-        .insert(sessionPages)
-        .values(d.pages.map((pageId) => ({ sessionId: session.id, pageId })));
-    }
-
-    return { ...session, pages: d.pages };
-  });
-
-  return c.json(result, 201);
-});
-
-// ---- POST /batch (create or update multiple sessions) ----
-
-sessionsRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
-
-  const parsed = CreateBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
-
-  const results = await db.transaction(async (tx) => {
-    const created: Array<{ id: number; title: string; pageCount: number }> = [];
-
-    for (const d of items) {
+    const result = await db.transaction(async (tx) => {
       const rows = await tx
         .insert(sessions)
         .values(sessionValues(d))
@@ -158,9 +109,14 @@ sessionsRoute.post("/batch", async (c) => {
           target: [sessions.date, sessions.title],
           set: sessionConflictSet,
         })
-        .returning({ id: sessions.id, title: sessions.title });
+        .returning({
+          id: sessions.id,
+          date: sessions.date,
+          title: sessions.title,
+          createdAt: sessions.createdAt,
+        });
 
-      const session = firstOrThrow(rows, `session batch upsert "${d.title}"`);
+      const session = firstOrThrow(rows, "session upsert");
 
       // Replace page associations: delete old, insert new
       await tx
@@ -173,197 +129,234 @@ sessionsRoute.post("/batch", async (c) => {
           .values(d.pages.map((pageId) => ({ sessionId: session.id, pageId })));
       }
 
-      created.push({
-        id: session.id,
-        title: session.title,
-        pageCount: d.pages.length,
-      });
+      return { ...session, pages: d.pages };
+    });
+
+    return c.json(result, 201);
+  })
+  // ---- POST /batch (create or update multiple sessions) ----
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = CreateBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    const results = await db.transaction(async (tx) => {
+      const created: Array<{ id: number; title: string; pageCount: number }> = [];
+
+      for (const d of items) {
+        const rows = await tx
+          .insert(sessions)
+          .values(sessionValues(d))
+          .onConflictDoUpdate({
+            target: [sessions.date, sessions.title],
+            set: sessionConflictSet,
+          })
+          .returning({ id: sessions.id, title: sessions.title });
+
+        const session = firstOrThrow(rows, `session batch upsert "${d.title}"`);
+
+        // Replace page associations: delete old, insert new
+        await tx
+          .delete(sessionPages)
+          .where(eq(sessionPages.sessionId, session.id));
+
+        if (d.pages.length > 0) {
+          await tx
+            .insert(sessionPages)
+            .values(d.pages.map((pageId) => ({ sessionId: session.id, pageId })));
+        }
+
+        created.push({
+          id: session.id,
+          title: session.title,
+          pageCount: d.pages.length,
+        });
+      }
+
+      return created;
+    });
+
+    return c.json({ upserted: results.length, results }, 201);
+  })
+  // ---- GET / (list sessions, paginated) ----
+  .get("/", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, offset } = parsed.data;
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(sessions)
+      .orderBy(desc(sessions.date), desc(sessions.id))
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db.select({ count: count() }).from(sessions);
+    const total = countResult[0].count;
+
+    // Fetch page associations for each session
+    const sessionIds = rows.map((r) => r.id);
+    let pageMap = new Map<number, string[]>();
+
+    if (sessionIds.length > 0) {
+      const pageRows = await db
+        .select()
+        .from(sessionPages)
+        .where(inArray(sessionPages.sessionId, sessionIds));
+
+      for (const row of pageRows) {
+        const existing = pageMap.get(row.sessionId) || [];
+        existing.push(row.pageId);
+        pageMap.set(row.sessionId, existing);
+      }
     }
 
-    return created;
-  });
+    return c.json({
+      sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
+      total,
+      limit,
+      offset,
+    });
+  })
+  // ---- GET /by-page?page_id=X (sessions that modified a specific page) ----
+  .get("/by-page", async (c) => {
+    const pageId = c.req.query("page_id");
+    if (!pageId) return validationError(c, "page_id query parameter is required");
 
-  return c.json({ upserted: results.length, results }, 201);
-});
+    const db = getDrizzleDb();
 
-// ---- GET / (list sessions, paginated) ----
+    // Find session IDs that include this page
+    const spRows = await db
+      .select({ sessionId: sessionPages.sessionId })
+      .from(sessionPages)
+      .where(eq(sessionPages.pageId, pageId));
 
-sessionsRoute.get("/", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    if (spRows.length === 0) {
+      return c.json({ sessions: [] });
+    }
 
-  const { limit, offset } = parsed.data;
-  const db = getDrizzleDb();
+    const sessionIds = spRows.map((r) => r.sessionId);
 
-  const rows = await db
-    .select()
-    .from(sessions)
-    .orderBy(desc(sessions.date), desc(sessions.id))
-    .limit(limit)
-    .offset(offset);
+    const rows = await db
+      .select()
+      .from(sessions)
+      .where(inArray(sessions.id, sessionIds))
+      .orderBy(desc(sessions.date), desc(sessions.id));
 
-  const countResult = await db.select({ count: count() }).from(sessions);
-  const total = countResult[0].count;
-
-  // Fetch page associations for each session
-  const sessionIds = rows.map((r) => r.id);
-  let pageMap = new Map<number, string[]>();
-
-  if (sessionIds.length > 0) {
-    const pageRows = await db
+    // Also fetch all pages for these sessions
+    const allPageRows = await db
       .select()
       .from(sessionPages)
       .where(inArray(sessionPages.sessionId, sessionIds));
 
+    const pageMap = new Map<number, string[]>();
+    for (const row of allPageRows) {
+      const existing = pageMap.get(row.sessionId) || [];
+      existing.push(row.pageId);
+      pageMap.set(row.sessionId, existing);
+    }
+
+    return c.json({
+      sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
+    });
+  })
+  // ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const totalResult = await db.select({ count: count() }).from(sessions);
+    const totalSessions = totalResult[0].count;
+
+    const pagesResult = await db
+      .select({
+        count: sql<number>`count(distinct ${sessionPages.pageId})`,
+      })
+      .from(sessionPages);
+    const uniquePages = Number(pagesResult[0].count);
+
+    const totalPageEditsResult = await db
+      .select({ count: count() })
+      .from(sessionPages);
+    const totalPageEdits = totalPageEditsResult[0].count;
+
+    const byModel = await db
+      .select({
+        model: sessions.model,
+        count: count(),
+      })
+      .from(sessions)
+      .groupBy(sessions.model)
+      .orderBy(desc(count()));
+
+    return c.json({
+      totalSessions,
+      uniquePages,
+      totalPageEdits,
+      byModel: Object.fromEntries(
+        byModel
+          .filter((r) => r.model !== null)
+          .map((r) => [r.model, r.count])
+      ),
+    });
+  })
+  // ---- GET /page-changes (optimized endpoint for page-changes dashboard) ----
+  .get("/page-changes", async (c) => {
+    const parsed = PageChangesQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { limit, since } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Step 1: Get the limited set of sessions that have at least one page,
+    // with optional date filter pushed into SQL (avoids fetching all rows).
+    const whereClause = since ? gte(sessions.date, since) : undefined;
+
+    const sessionIdRows = await db
+      .select({ id: sessions.id, date: sessions.date })
+      .from(sessions)
+      .innerJoin(sessionPages, eq(sessionPages.sessionId, sessions.id))
+      .where(whereClause)
+      .groupBy(sessions.id, sessions.date)
+      .orderBy(desc(sessions.date), desc(sessions.id))
+      .limit(limit);
+
+    if (sessionIdRows.length === 0) {
+      return c.json({ sessions: [] });
+    }
+
+    // Step 2: Fetch full session data and their page associations
+    const sessionIds = sessionIdRows.map((r) => r.id);
+
+    const [rows, pageRows] = await Promise.all([
+      db
+        .select()
+        .from(sessions)
+        .where(inArray(sessions.id, sessionIds))
+        .orderBy(desc(sessions.date), desc(sessions.id)),
+      db
+        .select()
+        .from(sessionPages)
+        .where(inArray(sessionPages.sessionId, sessionIds)),
+    ]);
+
+    const pageMap = new Map<number, string[]>();
     for (const row of pageRows) {
       const existing = pageMap.get(row.sessionId) || [];
       existing.push(row.pageId);
       pageMap.set(row.sessionId, existing);
     }
-  }
 
-  return c.json({
-    sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
-    total,
-    limit,
-    offset,
+    return c.json({
+      sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
+    });
   });
-});
 
-// ---- GET /by-page?page_id=X (sessions that modified a specific page) ----
-
-sessionsRoute.get("/by-page", async (c) => {
-  const pageId = c.req.query("page_id");
-  if (!pageId) return validationError(c, "page_id query parameter is required");
-
-  const db = getDrizzleDb();
-
-  // Find session IDs that include this page
-  const spRows = await db
-    .select({ sessionId: sessionPages.sessionId })
-    .from(sessionPages)
-    .where(eq(sessionPages.pageId, pageId));
-
-  if (spRows.length === 0) {
-    return c.json({ sessions: [] });
-  }
-
-  const sessionIds = spRows.map((r) => r.sessionId);
-
-  const rows = await db
-    .select()
-    .from(sessions)
-    .where(inArray(sessions.id, sessionIds))
-    .orderBy(desc(sessions.date), desc(sessions.id));
-
-  // Also fetch all pages for these sessions
-  const allPageRows = await db
-    .select()
-    .from(sessionPages)
-    .where(inArray(sessionPages.sessionId, sessionIds));
-
-  const pageMap = new Map<number, string[]>();
-  for (const row of allPageRows) {
-    const existing = pageMap.get(row.sessionId) || [];
-    existing.push(row.pageId);
-    pageMap.set(row.sessionId, existing);
-  }
-
-  return c.json({
-    sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
-  });
-});
-
-// ---- GET /stats ----
-
-sessionsRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
-
-  const totalResult = await db.select({ count: count() }).from(sessions);
-  const totalSessions = totalResult[0].count;
-
-  const pagesResult = await db
-    .select({
-      count: sql<number>`count(distinct ${sessionPages.pageId})`,
-    })
-    .from(sessionPages);
-  const uniquePages = Number(pagesResult[0].count);
-
-  const totalPageEditsResult = await db
-    .select({ count: count() })
-    .from(sessionPages);
-  const totalPageEdits = totalPageEditsResult[0].count;
-
-  const byModel = await db
-    .select({
-      model: sessions.model,
-      count: count(),
-    })
-    .from(sessions)
-    .groupBy(sessions.model)
-    .orderBy(desc(count()));
-
-  return c.json({
-    totalSessions,
-    uniquePages,
-    totalPageEdits,
-    byModel: Object.fromEntries(
-      byModel
-        .filter((r) => r.model !== null)
-        .map((r) => [r.model, r.count])
-    ),
-  });
-});
-
-// ---- GET /page-changes (optimized endpoint for page-changes dashboard) ----
-
-sessionsRoute.get("/page-changes", async (c) => {
-  const parsed = PageChangesQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, since } = parsed.data;
-  const db = getDrizzleDb();
-
-  // Step 1: Get the limited set of sessions that have at least one page,
-  // with optional date filter pushed into SQL (avoids fetching all rows).
-  const whereClause = since ? gte(sessions.date, since) : undefined;
-
-  const sessionIdRows = await db
-    .select({ id: sessions.id, date: sessions.date })
-    .from(sessions)
-    .innerJoin(sessionPages, eq(sessionPages.sessionId, sessions.id))
-    .where(whereClause)
-    .groupBy(sessions.id, sessions.date)
-    .orderBy(desc(sessions.date), desc(sessions.id))
-    .limit(limit);
-
-  if (sessionIdRows.length === 0) {
-    return c.json({ sessions: [] });
-  }
-
-  // Step 2: Fetch full session data and their page associations
-  const sessionIds = sessionIdRows.map((r) => r.id);
-
-  const [rows, pageRows] = await Promise.all([
-    db
-      .select()
-      .from(sessions)
-      .where(inArray(sessions.id, sessionIds))
-      .orderBy(desc(sessions.date), desc(sessions.id)),
-    db
-      .select()
-      .from(sessionPages)
-      .where(inArray(sessionPages.sessionId, sessionIds)),
-  ]);
-
-  const pageMap = new Map<number, string[]>();
-  for (const row of pageRows) {
-    const existing = pageMap.get(row.sessionId) || [];
-    existing.push(row.pageId);
-    pageMap.set(row.sessionId, existing);
-  }
-
-  return c.json({
-    sessions: rows.map((r) => mapSessionRow(r, pageMap.get(r.id) || [])),
-  });
-});
+export const sessionsRoute = sessionsApp;
+export type SessionsRoute = typeof sessionsApp;

--- a/apps/wiki-server/src/routes/summaries.ts
+++ b/apps/wiki-server/src/routes/summaries.ts
@@ -16,8 +16,6 @@ import {
   UpsertSummaryBatchSchema,
 } from "../api-types.js";
 
-export const summariesRoute = new Hono();
-
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -68,185 +66,186 @@ function formatSummary(r: typeof summaries.$inferSelect) {
   };
 }
 
-// ---- POST / (upsert single summary) ----
+// ---- Routes ----
 
-summariesRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+const summariesApp = new Hono()
+  // ---- POST / (upsert single summary) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
 
-  const parsed = UpsertSummarySchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const parsed = UpsertSummarySchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-  const db = getDrizzleDb();
+    const db = getDrizzleDb();
 
-  // Validate entity reference
-  const missing = await checkRefsExist(db, entities, entities.id, [parsed.data.entityId]);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced entity not found: ${missing.join(", ")}`);
-  }
+    // Validate entity reference
+    const missing = await checkRefsExist(db, entities, entities.id, [parsed.data.entityId]);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced entity not found: ${missing.join(", ")}`);
+    }
 
-  const vals = summaryValues(parsed.data);
+    const vals = summaryValues(parsed.data);
 
-  const rows = await db
-    .insert(summaries)
-    .values(vals)
-    .onConflictDoUpdate({
-      target: summaries.entityId,
-      set: {
-        entityType: vals.entityType,
-        oneLiner: vals.oneLiner,
-        summary: vals.summary,
-        review: vals.review,
-        keyPoints: vals.keyPoints,
-        keyClaims: vals.keyClaims,
-        model: vals.model,
-        tokensUsed: vals.tokensUsed,
-        generatedAt: sql`now()`,
-        updatedAt: sql`now()`,
-      },
-    })
-    .returning({
-      entityId: summaries.entityId,
-      entityType: summaries.entityType,
+    const rows = await db
+      .insert(summaries)
+      .values(vals)
+      .onConflictDoUpdate({
+        target: summaries.entityId,
+        set: {
+          entityType: vals.entityType,
+          oneLiner: vals.oneLiner,
+          summary: vals.summary,
+          review: vals.review,
+          keyPoints: vals.keyPoints,
+          keyClaims: vals.keyClaims,
+          model: vals.model,
+          tokensUsed: vals.tokensUsed,
+          generatedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({
+        entityId: summaries.entityId,
+        entityType: summaries.entityType,
+      });
+
+    return c.json(firstOrThrow(rows, "summary upsert"), 201);
+  })
+
+  // ---- POST /batch (upsert multiple summaries) ----
+  .post("/batch", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = UpsertBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    // Validate entity references
+    const entityIds = [...new Set(items.map((i) => i.entityId))];
+    const missing = await checkRefsExist(db, entities, entities.id, entityIds);
+    if (missing.length > 0) {
+      return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
+    }
+
+    const allVals = items.map(summaryValues);
+
+    const results = await db
+      .insert(summaries)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: summaries.entityId,
+        set: {
+          entityType: sql`excluded."entity_type"`,
+          oneLiner: sql`excluded."one_liner"`,
+          summary: sql`excluded."summary"`,
+          review: sql`excluded."review"`,
+          keyPoints: sql`excluded."key_points"`,
+          keyClaims: sql`excluded."key_claims"`,
+          model: sql`excluded."model"`,
+          tokensUsed: sql`excluded."tokens_used"`,
+          generatedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({
+        entityId: summaries.entityId,
+        entityType: summaries.entityType,
+      });
+
+    return c.json({ upserted: results.length, results }, 201);
+  })
+
+  // ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const totalResult = await db.select({ count: count() }).from(summaries);
+    const total = totalResult[0].count;
+
+    const byType = await db
+      .select({
+        entityType: summaries.entityType,
+        count: count(),
+      })
+      .from(summaries)
+      .groupBy(summaries.entityType)
+      .orderBy(desc(count()));
+
+    const byModel = await db
+      .select({
+        model: summaries.model,
+        count: count(),
+      })
+      .from(summaries)
+      .groupBy(summaries.model)
+      .orderBy(desc(count()));
+
+    return c.json({
+      total,
+      byType: Object.fromEntries(
+        byType.map((r) => [r.entityType, r.count])
+      ),
+      byModel: Object.fromEntries(
+        byModel.map((r) => [r.model ?? "unknown", r.count])
+      ),
     });
+  })
 
-  return c.json(firstOrThrow(rows, "summary upsert"), 201);
-});
+  // ---- GET /all (paginated listing) ----
+  .get("/all", async (c) => {
+    const parsed = PaginationQuery.safeParse(c.req.query());
+    if (!parsed.success) return validationError(c, parsed.error.message);
 
-// ---- POST /batch (upsert multiple summaries) ----
+    const { limit, offset, entityType } = parsed.data;
+    const db = getDrizzleDb();
 
-summariesRoute.post("/batch", async (c) => {
-  const body = await parseJsonBody(c);
-  if (!body) return invalidJsonError(c);
+    const conditions = entityType
+      ? eq(summaries.entityType, entityType)
+      : undefined;
 
-  const parsed = UpsertBatchSchema.safeParse(body);
-  if (!parsed.success) return validationError(c, parsed.error.message);
+    const rows = await db
+      .select()
+      .from(summaries)
+      .where(conditions)
+      .orderBy(asc(summaries.entityId))
+      .limit(limit)
+      .offset(offset);
 
-  const { items } = parsed.data;
-  const db = getDrizzleDb();
+    const countResult = await db
+      .select({ count: count() })
+      .from(summaries)
+      .where(conditions);
+    const total = countResult[0].count;
 
-  // Validate entity references
-  const entityIds = [...new Set(items.map((i) => i.entityId))];
-  const missing = await checkRefsExist(db, entities, entities.id, entityIds);
-  if (missing.length > 0) {
-    return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
-  }
-
-  const allVals = items.map(summaryValues);
-
-  const results = await db
-    .insert(summaries)
-    .values(allVals)
-    .onConflictDoUpdate({
-      target: summaries.entityId,
-      set: {
-        entityType: sql`excluded."entity_type"`,
-        oneLiner: sql`excluded."one_liner"`,
-        summary: sql`excluded."summary"`,
-        review: sql`excluded."review"`,
-        keyPoints: sql`excluded."key_points"`,
-        keyClaims: sql`excluded."key_claims"`,
-        model: sql`excluded."model"`,
-        tokensUsed: sql`excluded."tokens_used"`,
-        generatedAt: sql`now()`,
-        updatedAt: sql`now()`,
-      },
-    })
-    .returning({
-      entityId: summaries.entityId,
-      entityType: summaries.entityType,
+    return c.json({
+      summaries: rows.map(formatSummary),
+      total,
+      limit,
+      offset,
     });
+  })
 
-  return c.json({ upserted: results.length, results }, 201);
-});
+  // ---- GET /:entityId (get by entity ID) ----
+  .get("/:entityId", async (c) => {
+    const entityId = c.req.param("entityId");
+    const db = getDrizzleDb();
 
-// ---- GET /stats ----
+    const rows = await db
+      .select()
+      .from(summaries)
+      .where(eq(summaries.entityId, entityId))
+      .limit(1);
 
-summariesRoute.get("/stats", async (c) => {
-  const db = getDrizzleDb();
+    if (rows.length === 0) {
+      return notFoundError(c, `Summary not found: ${entityId}`);
+    }
 
-  const totalResult = await db.select({ count: count() }).from(summaries);
-  const total = totalResult[0].count;
-
-  const byType = await db
-    .select({
-      entityType: summaries.entityType,
-      count: count(),
-    })
-    .from(summaries)
-    .groupBy(summaries.entityType)
-    .orderBy(desc(count()));
-
-  const byModel = await db
-    .select({
-      model: summaries.model,
-      count: count(),
-    })
-    .from(summaries)
-    .groupBy(summaries.model)
-    .orderBy(desc(count()));
-
-  return c.json({
-    total,
-    byType: Object.fromEntries(
-      byType.map((r) => [r.entityType, r.count])
-    ),
-    byModel: Object.fromEntries(
-      byModel.map((r) => [r.model ?? "unknown", r.count])
-    ),
+    return c.json(formatSummary(rows[0]));
   });
-});
 
-// ---- GET /all (paginated listing) ----
-
-summariesRoute.get("/all", async (c) => {
-  const parsed = PaginationQuery.safeParse(c.req.query());
-  if (!parsed.success) return validationError(c, parsed.error.message);
-
-  const { limit, offset, entityType } = parsed.data;
-  const db = getDrizzleDb();
-
-  const conditions = entityType
-    ? eq(summaries.entityType, entityType)
-    : undefined;
-
-  const rows = await db
-    .select()
-    .from(summaries)
-    .where(conditions)
-    .orderBy(asc(summaries.entityId))
-    .limit(limit)
-    .offset(offset);
-
-  const countResult = await db
-    .select({ count: count() })
-    .from(summaries)
-    .where(conditions);
-  const total = countResult[0].count;
-
-  return c.json({
-    summaries: rows.map(formatSummary),
-    total,
-    limit,
-    offset,
-  });
-});
-
-// ---- GET /:entityId (get by entity ID) ----
-
-summariesRoute.get("/:entityId", async (c) => {
-  const entityId = c.req.param("entityId");
-  const db = getDrizzleDb();
-
-  const rows = await db
-    .select()
-    .from(summaries)
-    .where(eq(summaries.entityId, entityId))
-    .limit(1);
-
-  if (rows.length === 0) {
-    return notFoundError(c, `Summary not found: ${entityId}`);
-  }
-
-  return c.json(formatSummary(rows[0]));
-});
+export const summariesRoute = summariesApp;
+export type SummariesRoute = typeof summariesApp;


### PR DESCRIPTION
## Summary

- Convert all 15 remaining route files to Hono RPC method-chaining pattern
- Routes converted: health, ids, edit-logs, summaries, artifacts, agent-sessions, entities, explore, sessions, pages, links, hallucination-risk, jobs, resources, auto-update-news, auto-update-runs, integrity
- All route files now export their route type (`export type XxxRoute = typeof xxxApp`) for `InferResponseType<>` usage
- Update migration docs to reflect 100% completion — all 21 route files are now migrated

This continues the work from PR #1199 which migrated claims + citations. Pure syntactic refactor — all handler bodies are identical, only the route registration pattern changed.

## Test plan

- [x] All 409 wiki-server tests pass
- [x] TypeScript clean across all packages
- [x] Gate validation: 11/11 checks passed
