### PR TITLE
feat: adopt resource page pattern for entity claims display

### DIFF
--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -429,33 +429,6 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
     size: 100,
   },
   {
-    id: "structured",
-    accessorFn: (row) => row.property,
-    header: ({ column }) => (
-      <SortableHeader column={column}>Structured</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const c = row.original;
-      if (!c.property) return <span className="text-muted-foreground/40 text-xs">&mdash;</span>;
-      const parts: string[] = [c.property];
-      if (c.structuredValue) {
-        parts.push(`= ${c.structuredValue}`);
-      }
-      if (c.valueUnit) {
-        parts.push(`[${c.valueUnit}]`);
-      }
-      return (
-        <span
-          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono bg-violet-100 text-violet-700 max-w-[180px] truncate"
-          title={`${c.property}${c.structuredValue ? ` = ${c.structuredValue}` : ""}${c.valueUnit ? ` [${c.valueUnit}]` : ""}${c.valueDate ? ` @ ${c.valueDate}` : ""}`}
-        >
-          {parts.join(" ")}
-        </span>
-      );
-    },
-    size: 160,
-  },
-  {
     id: "sourceQuote",
     /** @deprecated Prefer sources[] from claim_sources table */
     accessorFn: (row) => {
@@ -466,7 +439,7 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
       }
       return row.sourceQuote || null;
     },
-    header: "Source Quote",
+    header: "Excerpt",
     cell: ({ row }) => {
       // Prefer quote from claim_sources, fall back to legacy sourceQuote
       let quote: string | null = null;

--- a/apps/web/src/app/claims/entity/[entityId]/entity-claims-list.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/entity-claims-list.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  HelpCircle,
+  Clock,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Hash,
+} from "lucide-react";
+import { cn } from "@lib/utils";
+import { renderInlineMarkdown } from "@/lib/inline-markdown";
+import type { ClaimRow } from "@wiki-server/api-types";
+import { VerdictBadge } from "../../components/verdict-badge";
+import { CategoryBadge } from "../../components/category-badge";
+
+const VERDICT_CONFIG: Record<
+  string,
+  { icon: typeof CheckCircle2; label: string; color: string; bg: string }
+> = {
+  verified: {
+    icon: CheckCircle2,
+    label: "Verified",
+    color: "text-emerald-700 dark:text-emerald-400",
+    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+  },
+  disputed: {
+    icon: AlertTriangle,
+    label: "Disputed",
+    color: "text-amber-700 dark:text-amber-400",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+  },
+  unsupported: {
+    icon: XCircle,
+    label: "Unsupported",
+    color: "text-red-700 dark:text-red-400",
+    bg: "bg-red-50 dark:bg-red-950/30",
+  },
+  not_verifiable: {
+    icon: HelpCircle,
+    label: "Not verifiable",
+    color: "text-muted-foreground",
+    bg: "bg-muted/30",
+  },
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface SectionGroup {
+  section: string;
+  claims: ClaimRow[];
+}
+
+function groupClaimsBySection(claims: ClaimRow[]): SectionGroup[] {
+  const map = new Map<string, ClaimRow[]>();
+  for (const claim of claims) {
+    const section = claim.section || "General";
+    if (!map.has(section)) map.set(section, []);
+    map.get(section)!.push(claim);
+  }
+  return Array.from(map.entries()).map(([section, claims]) => ({
+    section,
+    claims,
+  }));
+}
+
+/** Number of section groups visible before "Show more" */
+const INITIAL_VISIBLE = 5;
+
+function ClaimCard({ claim }: { claim: ClaimRow }) {
+  const verdict = claim.claimVerdict
+    ? VERDICT_CONFIG[claim.claimVerdict]
+    : null;
+  const Icon = verdict?.icon;
+
+  // Get the best available source quote
+  let sourceQuote: string | null = null;
+  if (claim.sources && claim.sources.length > 0) {
+    const primary = claim.sources.find((s) => s.isPrimary);
+    sourceQuote =
+      (primary || claim.sources[0]).sourceQuote || claim.sourceQuote || null;
+  } else {
+    sourceQuote = claim.sourceQuote || null;
+  }
+
+  const hasSources = claim.sources && claim.sources.length > 0;
+
+  return (
+    <div className={cn("px-4 py-2.5", verdict?.bg)}>
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-foreground leading-snug mb-1">
+            {renderInlineMarkdown(claim.claimText)}
+          </p>
+
+          {sourceQuote && (
+            <blockquote className="text-xs text-muted-foreground border-l-2 border-border pl-2.5 mb-1.5 italic leading-snug line-clamp-2">
+              &ldquo;{sourceQuote}&rdquo;
+            </blockquote>
+          )}
+
+          <div className="flex items-center flex-wrap gap-2 text-xs">
+            {verdict && Icon && (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1",
+                  verdict.color
+                )}
+              >
+                <Icon className="w-3 h-3" />
+                {verdict.label}
+              </span>
+            )}
+            {claim.claimVerdictScore != null && (
+              <span className="text-muted-foreground tabular-nums">
+                {Math.round(claim.claimVerdictScore * 100)}%
+              </span>
+            )}
+            {claim.claimVerdictIssues && (
+              <span className="text-amber-600 dark:text-amber-400 line-clamp-1">
+                {claim.claimVerdictIssues}
+              </span>
+            )}
+            {claim.claimCategory && (
+              <CategoryBadge category={claim.claimCategory} />
+            )}
+            {hasSources && (
+              <span className="inline-flex items-center gap-0.5 text-blue-600">
+                <FileText className="w-3 h-3" />
+                {claim.sources!.length} source
+                {claim.sources!.length !== 1 ? "s" : ""}
+              </span>
+            )}
+            {claim.claimVerifiedAt && (
+              <span className="text-muted-foreground/60 ml-auto flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {formatDate(claim.claimVerifiedAt)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <Link
+          href={`/claims/claim/${claim.id}`}
+          className="text-[10px] text-muted-foreground hover:text-blue-600 shrink-0 mt-0.5"
+          title="View claim detail"
+        >
+          <Hash className="w-3 h-3 inline" />
+          {claim.id}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function EntityClaimsList({ claims }: { claims: ClaimRow[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
+    new Set()
+  );
+
+  const groups = groupClaimsBySection(claims);
+  const visibleGroups =
+    showAll || groups.length <= INITIAL_VISIBLE
+      ? groups
+      : groups.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = groups.length - INITIAL_VISIBLE;
+
+  const toggleSection = (section: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(section)) {
+        next.delete(section);
+      } else {
+        next.add(section);
+      }
+      return next;
+    });
+  };
+
+  // Summary stats for header
+  const verdictCounts: Record<string, number> = {};
+  for (const claim of claims) {
+    const v = claim.claimVerdict ?? "unchecked";
+    verdictCounts[v] = (verdictCounts[v] || 0) + 1;
+  }
+
+  return (
+    <div>
+      {/* Summary badges */}
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground mb-4">
+        <span>
+          {claims.length} claim{claims.length !== 1 ? "s" : ""} across{" "}
+          {groups.length} section{groups.length !== 1 ? "s" : ""}
+        </span>
+        {verdictCounts.verified && verdictCounts.verified > 0 && (
+          <span className="inline-flex items-center gap-1 text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="w-3 h-3" />
+            {verdictCounts.verified} verified
+          </span>
+        )}
+        {((verdictCounts.disputed ?? 0) > 0 ||
+          (verdictCounts.unsupported ?? 0) > 0) && (
+          <span className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="w-3 h-3" />
+            {(verdictCounts.disputed ?? 0) + (verdictCounts.unsupported ?? 0)}{" "}
+            flagged
+          </span>
+        )}
+      </div>
+
+      {/* Section groups */}
+      <div className="space-y-3">
+        {visibleGroups.map((group) => {
+          const isCollapsed = collapsedSections.has(group.section);
+          return (
+            <div
+              key={group.section}
+              className="border border-border rounded-lg overflow-hidden"
+            >
+              <button
+                onClick={() => toggleSection(group.section)}
+                className="flex items-center gap-2 w-full text-left px-4 py-2 bg-muted/50 border-b border-border hover:bg-muted/70 transition-colors"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                ) : (
+                  <ChevronDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                )}
+                <span className="text-sm font-medium text-accent-foreground">
+                  {group.section}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {group.claims.length} claim
+                  {group.claims.length !== 1 ? "s" : ""}
+                </span>
+              </button>
+
+              {!isCollapsed && (
+                <div className="divide-y divide-border">
+                  {group.claims.map((claim) => (
+                    <ClaimCard key={claim.id} claim={claim} />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Show more / less toggle */}
+      {groups.length > INITIAL_VISIBLE && (
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors mt-3"
+        >
+          {showAll
+            ? "Show fewer sections"
+            : `Show ${hiddenCount} more section${hiddenCount !== 1 ? "s" : ""}...`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/claims/entity/[entityId]/entity-claims-views.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/entity-claims-views.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { List, Table2 } from "lucide-react";
+import { cn } from "@lib/utils";
+import type { ClaimRow } from "@wiki-server/api-types";
+import { EntityClaimsList } from "./entity-claims-list";
+import { ClaimsTable } from "../../components/claims-table";
+
+export function EntityClaimsViews({
+  claims,
+  entityNames,
+}: {
+  claims: ClaimRow[];
+  entityNames: Record<string, string>;
+}) {
+  const [view, setView] = useState<"sections" | "table">("sections");
+
+  return (
+    <div>
+      {/* View toggle */}
+      <div className="flex items-center gap-1 mb-4">
+        <button
+          onClick={() => setView("sections")}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+            view === "sections"
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <List className="w-3.5 h-3.5" />
+          Sections
+        </button>
+        <button
+          onClick={() => setView("table")}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+            view === "table"
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <Table2 className="w-3.5 h-3.5" />
+          Table
+        </button>
+      </div>
+
+      {view === "sections" ? (
+        <EntityClaimsList claims={claims} />
+      ) : (
+        <ClaimsTable claims={claims} entityNames={entityNames} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -10,12 +10,12 @@ import {
 } from "@data";
 import type { GetClaimsResult } from "@wiki-server/api-types";
 import { StatCard } from "../../components/stat-card";
-import { ClaimsTable } from "../../components/claims-table";
 import { DistributionBar } from "../../components/distribution-bar";
 import {
   collectEntitySlugs,
   buildEntityNameMap,
 } from "../../components/claims-data";
+import { EntityClaimsViews } from "./entity-claims-views";
 import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
 import { getResourceTypeIcon } from "@/components/wiki/resource-utils";
 
@@ -150,7 +150,7 @@ export default async function EntityClaimsPage({ params }: PageProps) {
             </div>
           )}
 
-          <ClaimsTable claims={claims} entityNames={entityNames} />
+          <EntityClaimsViews claims={claims} entityNames={entityNames} />
         </>
       )}
 


### PR DESCRIPTION
## Summary
- Adds a new **section-grouped collapsible claims view** as the default display on entity claims pages (e.g., `/claims/entity/anthropic`), adapting the pattern from the resource page's `CollapsibleClaims` component
- Provides a **Sections/Table toggle** so users can switch between the new grouped view and the existing flat table
- Each section card shows claims with verdict badges, source quotes, category badges, source counts, and links to individual claim detail pages
- Also fixes the **duplicate "Structured" column** and renames "Source Quote" → "Excerpt" in the table view (fixes that were lost during the RPC migration merge)

Closes #1208

## Test plan
- [x] Gate passes (all 7 checks)
- [x] Production build succeeds
- [ ] Visit `/claims/entity/anthropic` — verify section-grouped view shows by default
- [ ] Toggle to Table view — verify table loads correctly without duplicate columns
- [ ] Verify claims are grouped by section with collapsible headers
- [ ] Verify verdict badges, source quotes, and claim links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)