### PR TITLE
refactor: migrate all crux client types to Hono RPC InferResponseType

### DIFF
--- a/crux/authoring/orchestrator/tools/suggest-cross-links.ts
+++ b/crux/authoring/orchestrator/tools/suggest-cross-links.ts
@@ -62,11 +62,12 @@ export const tool: ToolRegistration = {
 
       if (backlinksResult.ok) {
         for (const bl of backlinksResult.data.backlinks) {
-          if (bl.id === ctx.page.id || existingRelated.has(bl.id)) continue;
-          const existing = candidates.get(bl.id) || { score: 0, reasons: [], title: bl.title, type: bl.type };
-          existing.score += bl.weight || 1;
+          const blId = String(bl.id);
+          if (blId === ctx.page.id || existingRelated.has(blId)) continue;
+          const existing = candidates.get(blId) || { score: 0, reasons: [], title: bl.title as string, type: bl.type as string };
+          existing.score += (bl.weight as number) || 1;
           existing.reasons.push(`Backlink (${bl.linkType}${bl.relationship ? `: ${bl.relationship}` : ''})`);
-          candidates.set(bl.id, existing);
+          candidates.set(blId, existing);
         }
       }
 

--- a/crux/commands/context.ts
+++ b/crux/commands/context.ts
@@ -392,7 +392,7 @@ async function forPage(
   }
 
   if (citationsResult.ok) {
-    bundle += citationHealthBlock(citationsResult.data.quotes, citationsResult.data.total);
+    bundle += citationHealthBlock(citationsResult.data.quotes, citationsResult.data.quotes.length);
   }
 
   const print = options.print as boolean;
@@ -407,7 +407,7 @@ async function forPage(
     `  Page: ${p.title} (${pageId})`,
     relatedResult.ok ? `  Related pages: ${relatedResult.data.related.length}` : '',
     backlinksResult.ok ? `  Backlinks: ${backlinksResult.data.backlinks.length}` : '',
-    citationsResult.ok ? `  Citations: ${citationsResult.data.total} total` : '',
+    citationsResult.ok ? `  Citations: ${citationsResult.data.quotes.length} total` : '',
   ]
     .filter(Boolean)
     .join('\n');

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -556,7 +556,8 @@ export async function citations(args: string[], options: Record<string, unknown>
     return { output: JSON.stringify(result.data, null, 2), exitCode: 0 };
   }
 
-  const { quotes, total } = result.data;
+  const { quotes } = result.data;
+  const total = quotes.length;
 
   if (quotes.length === 0) {
     return { output: `${c.dim}No citations found for "${pageId}"${c.reset}`, exitCode: 0 };

--- a/crux/lib/wiki-server/agent-sessions.ts
+++ b/crux/lib/wiki-server/agent-sessions.ts
@@ -3,22 +3,34 @@
  *
  * Stores and retrieves agent checklist state in PostgreSQL,
  * replacing the previous pattern of committing .claude/wip-checklist.md to git.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from the Hono route via InferResponseType<>.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { AgentSessionsRoute } from '../../../apps/wiki-server/src/routes/agent-sessions.ts';
 import type {
   CreateAgentSession,
   UpdateAgentSession,
-  AgentSessionRow,
 } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-/** Backward-compatible alias for AgentSessionRow. */
-export type AgentSessionEntry = AgentSessionRow;
+type RpcClient = ReturnType<typeof hc<AgentSessionsRoute>>;
+
+/** Shape returned by GET /by-branch/:branch (200 success). */
+export type AgentSessionEntry = InferResponseType<
+  RpcClient['by-branch'][':branch']['$get'],
+  200
+>;
+
+/** Shape returned by GET / (200 success). */
+export type AgentSessionListResponse = InferResponseType<
+  RpcClient['index']['$get'],
+  200
+>;
 
 // ---------------------------------------------------------------------------
 // API functions
@@ -62,8 +74,8 @@ export async function updateAgentSession(
  */
 export async function listAgentSessions(
   limit = 50,
-): Promise<ApiResult<{ sessions: AgentSessionEntry[] }>> {
-  return apiRequest<{ sessions: AgentSessionEntry[] }>(
+): Promise<ApiResult<AgentSessionListResponse>> {
+  return apiRequest<AgentSessionListResponse>(
     'GET',
     `/api/agent-sessions?limit=${limit}`,
   );

--- a/crux/lib/wiki-server/artifacts.ts
+++ b/crux/lib/wiki-server/artifacts.ts
@@ -3,18 +3,19 @@
  *
  * Saves and retrieves intermediate artifacts from V2 orchestrator
  * and page-improver pipeline runs. See GitHub issue #826.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred via Hono RPC InferResponseType<>.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  SaveArtifacts,
-  SaveArtifactsResult,
-  ArtifactRow,
-  GetArtifactsResult,
-  GetArtifactsPagedResult,
-  ArtifactStatsResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ArtifactsRoute } from '../../../apps/wiki-server/src/routes/artifacts.ts';
+import type { SaveArtifacts } from '../../../apps/wiki-server/src/api-types.ts';
+
+// ---------------------------------------------------------------------------
+// RPC client type (used only for response type inference)
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<ArtifactsRoute>>;
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -23,13 +24,16 @@ import type {
 export type SaveArtifactsInput = SaveArtifacts;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type { SaveArtifactsResult, GetArtifactsResult, GetArtifactsPagedResult, ArtifactStatsResult };
+export type SaveArtifactsResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type GetArtifactsResult = InferResponseType<RpcClient['by-page']['$get'], 200>;
+export type GetArtifactsPagedResult = InferResponseType<RpcClient['all']['$get'], 200>;
+export type ArtifactStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
 
-/** Backward-compatible alias for ArtifactRow. */
-export type ArtifactEntry = ArtifactRow;
+/** ArtifactEntry inferred from the single-artifact endpoint. */
+export type ArtifactEntry = InferResponseType<RpcClient[':id']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // API functions

--- a/crux/lib/wiki-server/auto-update.ts
+++ b/crux/lib/wiki-server/auto-update.ts
@@ -2,23 +2,22 @@
  * Auto-Update Runs & News Items API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from Hono RPC route types (single source of truth).
  */
 
 import { apiRequest, getServerUrl, type ApiResult } from './client.ts';
 import type { z } from 'zod';
+import type { hc, InferResponseType } from 'hono/client';
+import type { AutoUpdateRunsRoute } from '../../../apps/wiki-server/src/routes/auto-update-runs.ts';
+import type { AutoUpdateNewsRoute } from '../../../apps/wiki-server/src/routes/auto-update-news.ts';
 import type {
   AutoUpdateResult,
   RecordAutoUpdateRun,
   AutoUpdateNewsItemSchema,
-  RecordAutoUpdateRunResult,
-  AutoUpdateRunRow,
-  AutoUpdateRunsListResult,
-  AutoUpdateStatsResult,
-  AutoUpdateNewsBatchResult,
-  AutoUpdateNewsRow,
-  AutoUpdateNewsDashboardResult,
 } from '../../../apps/wiki-server/src/api-types.ts';
+
+type RunsRpcClient = ReturnType<typeof hc<AutoUpdateRunsRoute>>;
+type NewsRpcClient = ReturnType<typeof hc<AutoUpdateNewsRoute>>;
 
 // ---------------------------------------------------------------------------
 // Auto-Update Runs Types — input (derived from server Zod schemas)
@@ -29,13 +28,13 @@ export type AutoUpdateRunResultEntry = AutoUpdateResult;
 export type RecordAutoUpdateRunInput = RecordAutoUpdateRun;
 
 // ---------------------------------------------------------------------------
-// Auto-Update Runs Types — response (re-exported from canonical api-types.ts)
+// Auto-Update Runs Types — response (inferred from Hono RPC route types)
 // ---------------------------------------------------------------------------
 
-export type RecordRunResult = RecordAutoUpdateRunResult;
-export type AutoUpdateRunEntry = AutoUpdateRunRow;
-export type GetRunsResult = AutoUpdateRunsListResult;
-export type { AutoUpdateStatsResult };
+export type RecordRunResult = InferResponseType<RunsRpcClient['index']['$post'], 201>;
+export type GetRunsResult = InferResponseType<RunsRpcClient['all']['$get'], 200>;
+export type AutoUpdateRunEntry = GetRunsResult['entries'][number];
+export type AutoUpdateStatsResult = InferResponseType<RunsRpcClient['stats']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Auto-Update News Items Types
@@ -44,9 +43,9 @@ export type { AutoUpdateStatsResult };
 /** Uses z.input (not z.infer) because the schema has .default([]) on topics/entities. */
 export type AutoUpdateNewsItem = z.input<typeof AutoUpdateNewsItemSchema>;
 
-export type NewsItemBatchResult = AutoUpdateNewsBatchResult;
-export type AutoUpdateNewsItemEntry = AutoUpdateNewsRow;
-export type NewsDashboardResult = AutoUpdateNewsDashboardResult;
+export type NewsItemBatchResult = InferResponseType<NewsRpcClient['batch']['$post'], 201>;
+export type NewsDashboardResult = InferResponseType<NewsRpcClient['dashboard']['$get'], 200>;
+export type AutoUpdateNewsItemEntry = NewsDashboardResult['items'][number];
 
 // ---------------------------------------------------------------------------
 // Auto-Update Runs API functions

--- a/crux/lib/wiki-server/edit-logs.ts
+++ b/crux/lib/wiki-server/edit-logs.ts
@@ -2,33 +2,33 @@
  * Edit Logs API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
+ * Response types are inferred from the Hono RPC route type (EditLogsRoute) to
+ * stay in sync automatically when the server shape changes.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  EditLogEntry,
-  EditLogAppendResult,
-  EditLogBatchResult,
-  EditLogEntriesResult,
-  EditLogStatsResult,
-  EditLogLatestDatesResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { EditLogEntry } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { EditLogsRoute } from '../../../apps/wiki-server/src/routes/edit-logs.ts';
+
+// ---------------------------------------------------------------------------
+// RPC type inference — response shapes derived from the server route
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<EditLogsRoute>>;
+
+export type AppendResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type BatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
+export type GetEntriesResult = InferResponseType<RpcClient['index']['$get'], 200>;
+export type GetAllEntriesResult = InferResponseType<RpcClient['all']['$get'], 200>;
+export type StatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type LatestDatesResult = InferResponseType<RpcClient['latest-dates']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
 // ---------------------------------------------------------------------------
 
 export type EditLogApiEntry = EditLogEntry;
-
-// ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
-// ---------------------------------------------------------------------------
-
-export type AppendResult = EditLogAppendResult;
-export type BatchResult = EditLogBatchResult;
-export type GetEntriesResult = EditLogEntriesResult;
-export type StatsResult = EditLogStatsResult;
-export type LatestDatesResult = EditLogLatestDatesResult;
 
 // ---------------------------------------------------------------------------
 // API functions (return ApiResult<T>)

--- a/crux/lib/wiki-server/entities.ts
+++ b/crux/lib/wiki-server/entities.ts
@@ -1,19 +1,39 @@
 /**
  * Entities API — wiki-server client module
  *
+ * Response types are inferred from the server route via Hono RPC type system,
+ * eliminating hand-written response interfaces and preventing type drift.
+ * All imports from hono/client are type-only — zero runtime cost.
+ *
+ * Runtime HTTP still uses `apiRequest` (for mock compatibility in tests).
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
  */
 
+import type { hc, InferResponseType } from 'hono/client';
 import { batchedRequest, getServerUrl, apiRequest, type ApiResult } from './client.ts';
-import type {
-  SyncEntity,
-  SyncEntitiesResult,
-  EntityRow,
-  EntityListResult,
-  EntitySearchResult,
-  EntityStatsResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { EntitiesRoute } from '../../../apps/wiki-server/src/routes/entities.ts';
+import type { SyncEntity } from '../../../apps/wiki-server/src/api-types.ts';
+
+// ---------------------------------------------------------------------------
+// RPC type inference (compile-time only — no runtime cost)
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<EntitiesRoute>>;
+
+/** Response type for POST /api/entities/sync (inferred from server). */
+export type SyncEntitiesResult = InferResponseType<RpcClient['sync']['$post'], 200>;
+
+/** Response type for GET /api/entities/:id (inferred from server). */
+type EntityRow = InferResponseType<RpcClient[':id']['$get'], 200>;
+
+/** Response type for GET /api/entities (inferred from server). */
+export type EntityListResult = InferResponseType<RpcClient['index']['$get'], 200>;
+
+/** Response type for GET /api/entities/search (inferred from server). */
+export type EntitySearchResult = InferResponseType<RpcClient['search']['$get'], 200>;
+
+/** Response type for GET /api/entities/stats (inferred from server). */
+export type EntityStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -22,10 +42,8 @@ import type {
 export type SyncEntityItem = SyncEntity;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response aliases
 // ---------------------------------------------------------------------------
-
-export type { SyncEntitiesResult, EntityListResult, EntitySearchResult, EntityStatsResult };
 
 /** Backward-compatible alias for EntityRow. */
 export type EntityEntry = EntityRow;

--- a/crux/lib/wiki-server/ids.ts
+++ b/crux/lib/wiki-server/ids.ts
@@ -8,30 +8,24 @@
  * The server guarantees uniqueness via PostgreSQL sequences.
  */
 
+import type { hc, InferResponseType } from 'hono/client';
+import type { IdsRoute } from '../../../apps/wiki-server/src/routes/ids.ts';
 import { apiRequest, getServerUrl, type ApiResult } from './client.ts';
 
 // ---------------------------------------------------------------------------
-// Types
+// Types (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export interface AllocatedId {
-  numericId: string;
-  slug: string;
-  description: string | null;
-  created: boolean;
-  createdAt: string;
-}
+type RpcClient = ReturnType<typeof hc<IdsRoute>>;
 
-export interface AllocateBatchResult {
-  results: AllocatedId[];
-}
+export type AllocatedId = InferResponseType<RpcClient['allocate']['$post'], 200>;
 
-export interface IdListResult {
-  ids: AllocatedId[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+export type AllocateBatchResult = InferResponseType<
+  RpcClient['allocate-batch']['$post'],
+  200
+>;
+
+export type IdListResult = InferResponseType<RpcClient['index']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/crux/lib/wiki-server/jobs.ts
+++ b/crux/lib/wiki-server/jobs.ts
@@ -3,21 +3,18 @@
  *
  * Client functions for the job queue system.
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from the Hono RPC route type (single source of truth).
  */
 
 import { apiRequest, batchedRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { JobsRoute } from '../../../apps/wiki-server/src/routes/jobs.ts';
 import type {
   CreateJobInput,
   ClaimJob,
   CompleteJob,
   FailJob,
   SweepJobs,
-  JobRow,
-  ListJobsResult,
-  ClaimJobResult,
-  JobStatsResult,
-  SweepJobsResult,
 } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -31,19 +28,22 @@ export type { FailJob as FailJobInput };
 export type { SweepJobs as SweepJobsInput };
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type { ListJobsResult, JobStatsResult };
+type RpcClient = ReturnType<typeof hc<JobsRoute>>;
 
-/** Backward-compatible alias for JobRow. */
-export type JobEntry = JobRow;
+export type ListJobsResult = InferResponseType<RpcClient['index']['$get'], 200>;
+export type JobStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
 
-/** Backward-compatible alias for ClaimJobResult. */
-export type ClaimResult = ClaimJobResult;
+/** Backward-compatible alias for the inferred job row shape. */
+export type JobEntry = InferResponseType<RpcClient[':id']['$get'], 200>;
 
-/** Backward-compatible alias for SweepJobsResult. */
-export type SweepResult = SweepJobsResult;
+/** Backward-compatible alias for the inferred claim result shape. */
+export type ClaimResult = InferResponseType<RpcClient['claim']['$post'], 200>;
+
+/** Backward-compatible alias for the inferred sweep result shape. */
+export type SweepResult = InferResponseType<RpcClient['sweep']['$post'], 200>;
 
 // ---------------------------------------------------------------------------
 // API functions

--- a/crux/lib/wiki-server/links.ts
+++ b/crux/lib/wiki-server/links.ts
@@ -2,12 +2,14 @@
  * Page Links API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from the canonical api-types.ts definitions.
+ * Response types are inferred via Hono RPC InferResponseType<>.
  */
 
 import type { z } from 'zod';
+import type { hc, InferResponseType } from 'hono/client';
+import type { LinksRoute } from '../../../apps/wiki-server/src/routes/links.ts';
 import { batchedRequest, getServerUrl, type ApiResult } from './client.ts';
-import type { PageLinkSchema, SyncLinksResult } from '../../../apps/wiki-server/src/api-types.ts';
+import type { PageLinkSchema } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -17,10 +19,12 @@ import type { PageLinkSchema, SyncLinksResult } from '../../../apps/wiki-server/
 export type PageLinkItem = z.input<typeof PageLinkSchema>;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type { SyncLinksResult };
+type RpcClient = ReturnType<typeof hc<LinksRoute>>;
+
+export type SyncLinksResult = InferResponseType<RpcClient['sync']['$post'], 200>;
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/crux/lib/wiki-server/pages.ts
+++ b/crux/lib/wiki-server/pages.ts
@@ -3,26 +3,45 @@
  *
  * Shared types and wrapper functions for page-related API endpoints.
  * Consumed by crux/commands/context.ts and crux/commands/query.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from server routes via Hono RPC type system,
+ * eliminating hand-written response interfaces and preventing type drift.
+ * All imports from hono/client are type-only — zero runtime cost.
  */
 
+import type { hc, InferResponseType } from 'hono/client';
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  PageSearchResult,
-  PageDetailRow,
-  RelatedPagesResult,
-  BacklinksResult,
-  BacklinkEntry,
-  RelatedEntry,
-  CitationQuoteRow,
-  CitationQuotesResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { PagesRoute } from '../../../apps/wiki-server/src/routes/pages.ts';
+import type { LinksRoute } from '../../../apps/wiki-server/src/routes/links.ts';
+import type { CitationsRoute } from '../../../apps/wiki-server/src/routes/citations.ts';
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// RPC type inference (compile-time only — no runtime cost)
 // ---------------------------------------------------------------------------
 
-export type { PageSearchResult, BacklinksResult, CitationQuotesResult, BacklinkEntry, RelatedEntry };
+type PagesRpcClient = ReturnType<typeof hc<PagesRoute>>;
+type LinksRpcClient = ReturnType<typeof hc<LinksRoute>>;
+type CitationsRpcClient = ReturnType<typeof hc<CitationsRoute>>;
+
+/** Response type for GET /api/pages/search (inferred from server). */
+export type PageSearchResult = InferResponseType<PagesRpcClient['search']['$get'], 200>;
+
+/** Response type for GET /api/pages/:id (inferred from server). */
+export type PageDetailRow = InferResponseType<PagesRpcClient[':id']['$get'], 200>;
+
+/** Response type for GET /api/links/related/:id (inferred from server). */
+export type RelatedPagesResult = InferResponseType<LinksRpcClient['related'][':id']['$get'], 200>;
+
+/** Response type for GET /api/links/backlinks/:id (inferred from server). */
+export type BacklinksResult = InferResponseType<LinksRpcClient['backlinks'][':id']['$get'], 200>;
+
+/** Response type for GET /api/citations/quotes (inferred from server). */
+export type CitationQuotesResult = InferResponseType<CitationsRpcClient['quotes']['$get'], 200>;
+
+/** A single entry from the related pages list. */
+export type RelatedEntry = RelatedPagesResult['related'][number];
+
+/** A single entry from the backlinks list. */
+export type BacklinkEntry = BacklinksResult['backlinks'][number];
 
 /** Backward-compatible alias for PageDetailRow. */
 export type PageDetail = PageDetailRow;
@@ -30,8 +49,8 @@ export type PageDetail = PageDetailRow;
 /** Backward-compatible alias for RelatedPagesResult. */
 export type RelatedResult = RelatedPagesResult;
 
-/** Backward-compatible alias for CitationQuoteRow. */
-export type CitationQuote = CitationQuoteRow;
+/** A single citation quote row from the server. */
+export type CitationQuote = CitationQuotesResult['quotes'][number];
 
 // ---------------------------------------------------------------------------
 // API functions

--- a/crux/lib/wiki-server/references.ts
+++ b/crux/lib/wiki-server/references.ts
@@ -3,47 +3,37 @@
  *
  * Unified API for both claim-backed and regular page citations.
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from the Hono route via InferResponseType<>.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
 import type {
   ClaimPageReferenceInsert,
-  ClaimPageReferenceRow,
   PageCitationInsert,
-  PageCitationRow,
 } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ReferencesRoute } from '../../../apps/wiki-server/src/routes/references.ts';
 
 // ---------------------------------------------------------------------------
-// Types — re-exported from canonical api-types.ts
+// Inferred response types from Hono RPC
 // ---------------------------------------------------------------------------
 
-export type {
-  ClaimPageReferenceRow,
-  PageCitationRow,
-};
+type RpcClient = ReturnType<typeof hc<ReferencesRoute>>;
 
-// ---------------------------------------------------------------------------
-// Response shapes
-// ---------------------------------------------------------------------------
+export type GetPageReferencesResult = InferResponseType<
+  RpcClient['by-page'][':pageId']['$get'],
+  200
+>;
 
-interface ClaimReferenceItem extends ClaimPageReferenceRow {
-  type: 'claim';
-  claimText: string;
-  claimVerdict: string | null;
-}
+export type ClaimPageReferenceRow = InferResponseType<
+  RpcClient['claim']['$post'],
+  201
+>;
 
-interface CitationItem extends PageCitationRow {
-  type: 'citation';
-}
-
-type UnifiedReference = ClaimReferenceItem | CitationItem;
-
-export interface GetPageReferencesResult {
-  references: UnifiedReference[];
-  totalClaim: number;
-  totalCitation: number;
-}
+export type PageCitationRow = InferResponseType<
+  RpcClient['citation']['$post'],
+  201
+>;
 
 // ---------------------------------------------------------------------------
 // API functions

--- a/crux/lib/wiki-server/resources.ts
+++ b/crux/lib/wiki-server/resources.ts
@@ -2,18 +2,13 @@
  * Resources API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from the canonical api-types.ts definitions.
+ * Response types are inferred from the Hono RPC route type via InferResponseType<>.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  UpsertResource,
-  UpsertResourceResult,
-  ResourceRow,
-  ResourceStatsResult,
-  ResourceSearchResult,
-  ResourceListResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { UpsertResource } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ResourcesRoute } from '../../../apps/wiki-server/src/routes/resources.ts';
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -22,10 +17,16 @@ import type {
 export type UpsertResourceItem = UpsertResource;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type { UpsertResourceResult, ResourceRow, ResourceStatsResult, ResourceSearchResult, ResourceListResult };
+type RpcClient = ReturnType<typeof hc<ResourcesRoute>>;
+
+export type UpsertResourceResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type ResourceRow = InferResponseType<RpcClient['lookup']['$get'], 200>;
+export type ResourceStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type ResourceSearchResult = InferResponseType<RpcClient['search']['$get'], 200>;
+export type ResourceListResult = InferResponseType<RpcClient['all']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // API functions

--- a/crux/lib/wiki-server/risk.ts
+++ b/crux/lib/wiki-server/risk.ts
@@ -5,10 +5,12 @@
  */
 
 import { batchedRequest, getServerUrl, type ApiResult } from './client.ts';
-import type {
-  RiskSnapshotInput,
-  RiskBatchResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { RiskSnapshotInput } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { HallucinationRiskRoute } from '../../../apps/wiki-server/src/routes/hallucination-risk.ts';
+
+type RpcClient = ReturnType<typeof hc<HallucinationRiskRoute>>;
+export type RiskBatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)

--- a/crux/lib/wiki-server/sessions.ts
+++ b/crux/lib/wiki-server/sessions.ts
@@ -2,21 +2,14 @@
  * Sessions API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from api-types.ts (single source of truth).
+ * Response types are inferred from the Hono RPC route type (single source of truth).
  */
 
 import type { z } from 'zod';
+import type { hc, InferResponseType } from 'hono/client';
+import type { SessionsRoute } from '../../../apps/wiki-server/src/routes/sessions.ts';
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  CreateSessionSchema,
-  CreateSessionResult,
-  SessionBatchResult,
-  SessionRow,
-  SessionListResult,
-  SessionByPageResult,
-  SessionStatsResult,
-  SessionPageChangesResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { CreateSessionSchema } from '../../../apps/wiki-server/src/api-types.ts';
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -26,17 +19,20 @@ import type {
 export type SessionApiEntry = z.input<typeof CreateSessionSchema>;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type {
-  CreateSessionResult,
-  SessionBatchResult,
-  SessionListResult,
-  SessionByPageResult,
-  SessionStatsResult,
-  SessionPageChangesResult,
-};
+type RpcClient = ReturnType<typeof hc<SessionsRoute>>;
+
+export type CreateSessionResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type SessionBatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
+export type SessionListResult = InferResponseType<RpcClient['index']['$get'], 200>;
+export type SessionByPageResult = InferResponseType<RpcClient['by-page']['$get'], 200>;
+export type SessionStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type SessionPageChangesResult = InferResponseType<RpcClient['page-changes']['$get'], 200>;
+
+/** SessionRow — extracted from the list result (sessions array element). */
+export type SessionRow = SessionListResult['sessions'][number];
 
 /** Backward-compatible alias for SessionRow. */
 export type SessionEntry = SessionRow;

--- a/crux/lib/wiki-server/summaries.ts
+++ b/crux/lib/wiki-server/summaries.ts
@@ -2,15 +2,13 @@
  * Summaries API — wiki-server client module
  *
  * Input types are derived from the canonical Zod schemas in api-types.ts.
- * Response types are imported from the canonical api-types.ts definitions.
+ * Response types are inferred from the Hono route via InferResponseType<>.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  UpsertSummary,
-  UpsertSummaryResult,
-  UpsertSummaryBatchResult,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { UpsertSummary } from '../../../apps/wiki-server/src/api-types.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { SummariesRoute } from '../../../apps/wiki-server/src/routes/summaries.ts';
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
@@ -19,10 +17,13 @@ import type {
 export type UpsertSummaryItem = UpsertSummary;
 
 // ---------------------------------------------------------------------------
-// Types — response (re-exported from canonical api-types.ts)
+// Types — response (inferred from Hono RPC route)
 // ---------------------------------------------------------------------------
 
-export type { UpsertSummaryResult, UpsertSummaryBatchResult };
+type RpcClient = ReturnType<typeof hc<SummariesRoute>>;
+
+export type UpsertSummaryResult = InferResponseType<RpcClient['index']['$post'], 201>;
+export type UpsertSummaryBatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
 
 // ---------------------------------------------------------------------------
 // API functions


### PR DESCRIPTION
## Summary

- Replace hand-written response type imports from `api-types.ts` with `InferResponseType<>` in all 14 remaining crux CLI client files
- All crux client modules now derive response types from the server route types at compile-time, eliminating type drift
- Fixed real bug caught by migration: `GET /api/citations/quotes` returns `{ quotes }` without a `total` field — the hand-written `CitationQuotesResult` type incorrectly included `total`, which was never returned by the server. Consumers (`context.ts`, `query.ts`) now use `quotes.length` instead
- Added type casts in `suggest-cross-links.ts` for backlink fields (raw SQL `(r: any)` mapping produces `any`-typed fields in RPC inference)

**Files migrated:** `edit-logs.ts`, `agent-sessions.ts`, `artifacts.ts`, `auto-update.ts`, `entities.ts`, `jobs.ts`, `links.ts`, `pages.ts`, `resources.ts`, `sessions.ts`, `summaries.ts`, `references.ts`, `risk.ts`, `ids.ts`

Combined with the previous PRs (#1199, #1210), the full Hono RPC migration is now complete for both server routes and crux CLI clients.

## Test plan

- [x] All 409 wiki-server tests pass
- [x] TypeScript clean across all packages including crux
- [x] Gate validation: 13/13 checks passed
- [x] Real type-drift bug caught and fixed (missing `total` field)
