### PR TITLE
refactor: migrate frontend types to Hono RPC InferResponseType

### DIFF
--- a/apps/web/src/app/claims/claim/[id]/page.tsx
+++ b/apps/web/src/app/claims/claim/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById, getEntityHref } from "@data";
-import type { ClaimRow, SimilarClaimsResult } from "@wiki-server/api-types";
+import type { ClaimRow, SimilarClaimsResult } from "@wiki-server/api-response-types";
 import { buildEntityNameMap } from "../../components/claims-data";
 import { CategoryBadge } from "../../components/category-badge";
 import { ConfidenceBadge } from "../../components/confidence-badge";

--- a/apps/web/src/app/claims/components/claim-sources-list.tsx
+++ b/apps/web/src/app/claims/components/claim-sources-list.tsx
@@ -5,7 +5,7 @@
  * Falls back to URL matching via normalizeUrl() when only a URL is known.
  */
 import Link from "next/link";
-import type { ClaimSourceRow } from "@wiki-server/api-types";
+import type { ClaimSourceRow } from "@wiki-server/api-response-types";
 import { getResourceById, getAllResources, getResourceCredibility } from "@data";
 import type { Resource } from "@data";
 import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";

--- a/apps/web/src/app/claims/components/claims-data.ts
+++ b/apps/web/src/app/claims/components/claims-data.ts
@@ -1,6 +1,6 @@
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById } from "@data";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 
 interface PaginatedClaimsResponse {
   claims: ClaimRow[];

--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -27,7 +27,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 import { CategoryBadge } from "./category-badge";
 import { ConfidenceBadge } from "./confidence-badge";
 import { ClaimModeBadge } from "./claim-mode-badge";

--- a/apps/web/src/app/claims/components/structured-claims-table.tsx
+++ b/apps/web/src/app/claims/components/structured-claims-table.tsx
@@ -19,7 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 import { formatStructuredValue } from "@lib/format-value";
 
 interface Props {

--- a/apps/web/src/app/claims/entity/[entityId]/entity-claims-list.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/entity-claims-list.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@lib/utils";
 import { renderInlineMarkdown } from "@/lib/inline-markdown";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 import { VerdictBadge } from "../../components/verdict-badge";
 import { CategoryBadge } from "../../components/category-badge";
 

--- a/apps/web/src/app/claims/entity/[entityId]/entity-claims-views.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/entity-claims-views.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { List, Table2 } from "lucide-react";
 import { cn } from "@lib/utils";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 import { EntityClaimsList } from "./entity-claims-list";
 import { ClaimsTable } from "../../components/claims-table";
 

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -8,7 +8,7 @@ import {
   getResourceById,
   getResourceCredibility,
 } from "@data";
-import type { GetClaimsResult } from "@wiki-server/api-types";
+import type { GetClaimsResult } from "@wiki-server/api-response-types";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { parse } from "yaml";

--- a/apps/web/src/app/claims/explore/claims-explorer.tsx
+++ b/apps/web/src/app/claims/explore/claims-explorer.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import type { ClaimRow } from "@wiki-server/api-types";
+import type { ClaimRow } from "@wiki-server/api-response-types";
 import { ClaimsFilterBar } from "../components/claims-filters";
 import { ClaimsTable } from "../components/claims-table";
 

--- a/apps/web/src/app/claims/page.tsx
+++ b/apps/web/src/app/claims/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
-import type { ClaimStatsResult } from "@wiki-server/api-types";
+import type { ClaimStatsResult } from "@wiki-server/api-response-types";
 import { StatCard } from "./components/stat-card";
 import { DistributionBar } from "./components/distribution-bar";
 import {

--- a/apps/web/src/app/internal/agent-sessions/page.tsx
+++ b/apps/web/src/app/internal/agent-sessions/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 import type {
   AgentSessionRow as CanonicalAgentSessionRow,
   SessionRow,
-} from "@wiki-server/api-types";
+} from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Agent Sessions | Longterm Wiki Internal",

--- a/apps/web/src/app/internal/auto-update-news/page.tsx
+++ b/apps/web/src/app/internal/auto-update-news/page.tsx
@@ -10,7 +10,7 @@ import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { NewsTable } from "./news-table";
 import { SourcesTable } from "./sources-table";
 import type { Metadata } from "next";
-import type { AutoUpdateNewsRow } from "@wiki-server/api-types";
+import type { AutoUpdateNewsRow } from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Auto-Update News | Longterm Wiki Internal",

--- a/apps/web/src/app/internal/auto-update-runs/page.tsx
+++ b/apps/web/src/app/internal/auto-update-runs/page.tsx
@@ -8,7 +8,7 @@ import {
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { RunsTable } from "./runs-table";
 import type { Metadata } from "next";
-import type { AutoUpdateRunRow } from "@wiki-server/api-types";
+import type { AutoUpdateRunRow } from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Auto-Update Runs | Longterm Wiki Internal",

--- a/apps/web/src/app/internal/citation-accuracy/page.tsx
+++ b/apps/web/src/app/internal/citation-accuracy/page.tsx
@@ -9,7 +9,7 @@ import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { CitationAccuracyDashboard } from "./citation-accuracy-dashboard";
 import { VERDICT_COLORS } from "./verdict-colors";
 import type { Metadata } from "next";
-import type { AccuracyDashboardData } from "@wiki-server/api-types";
+import type { AccuracyDashboardData } from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Citation Accuracy | Longterm Wiki Internal",

--- a/apps/web/src/app/internal/citation-content/page.tsx
+++ b/apps/web/src/app/internal/citation-content/page.tsx
@@ -6,7 +6,7 @@ import type {
   CitationContentListEntry,
   CitationContentListResult,
   CitationContentStatsResult,
-} from "@wiki-server/api-types";
+} from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Citation Content | Longterm Wiki Internal",

--- a/apps/web/src/app/internal/hallucination-risk/page.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/page.tsx
@@ -8,7 +8,7 @@ import {
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { HallucinationRiskDashboard } from "./hallucination-risk-dashboard";
 import type { Metadata } from "next";
-import type { RiskPageRow } from "@wiki-server/api-types";
+import type { RiskPageRow } from "@wiki-server/api-response-types";
 
 // Render on-demand — avoid build-time timeout when wiki-server is unreachable
 export const dynamic = "force-dynamic";

--- a/apps/web/src/app/internal/improve-runs/page.tsx
+++ b/apps/web/src/app/internal/improve-runs/page.tsx
@@ -4,7 +4,7 @@ import {
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { RunsTable } from "./runs-table";
 import type { Metadata } from "next";
-import type { ArtifactRow } from "@wiki-server/api-types";
+import type { ArtifactRow } from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Improve Runs | Longterm Wiki Internal",
@@ -64,7 +64,7 @@ async function loadRunsFromApi() {
         hasCitationAudit: r.citationAudit != null,
         hasSectionDiffs:
           Array.isArray(r.sectionDiffs) && r.sectionDiffs.length > 0,
-        costBreakdown: r.costBreakdown,
+        costBreakdown: r.costBreakdown as Record<string, number> | null,
       })
     ),
   };

--- a/apps/web/src/app/internal/page-changes/page.tsx
+++ b/apps/web/src/app/internal/page-changes/page.tsx
@@ -11,7 +11,7 @@ import {
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { PageChangesSessions } from "./page-changes-sessions";
 import type { Metadata } from "next";
-import type { SessionRow } from "@wiki-server/api-types";
+import type { SessionRow } from "@wiki-server/api-response-types";
 
 export const metadata: Metadata = {
   title: "Page Changes | Longterm Wiki Internal",

--- a/apps/web/src/app/wiki/[id]/claims/page.tsx
+++ b/apps/web/src/app/wiki/[id]/claims/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/mdx";
 import { getPageById } from "@/data";
 import { fetchFromWikiServer } from "@lib/wiki-server";
-import type { ClaimRow, GetClaimsResult } from "@wiki-server/api-types";
+import type { ClaimRow, GetClaimsResult } from "@wiki-server/api-response-types";
 import { StatCard } from "@/app/claims/components/stat-card";
 import { DistributionBar } from "@/app/claims/components/distribution-bar";
 import { ClaimsTable } from "@/app/claims/components/claims-table";

--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/data";
 import type { FootnoteIndexEntry } from "@/data";
 import { fetchFromWikiServer } from "@lib/wiki-server";
-import type { ClaimRow, GetClaimsResult } from "@wiki-server/api-types";
+import type { ClaimRow, GetClaimsResult } from "@wiki-server/api-response-types";
 
 interface PageProps {
   params: Promise<{ id: string }>;

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -12,7 +12,7 @@ import fs from "fs";
 import path from "path";
 import { loadYaml } from "@lib/yaml";
 import { fetchFromWikiServer, withApiFallback, getFactsRpcClient, type WithSource, type RpcFactsByEntityResult, type RpcTimeseriesResult } from "@lib/wiki-server";
-import type { BacklinkEntry as ServerBacklinkEntry, RelatedEntry as ServerRelatedEntry, CitationHealthResult } from "@wiki-server/api-types";
+import type { BacklinkEntry as ServerBacklinkEntry, RelatedEntry as ServerRelatedEntry, CitationHealthResult } from "@wiki-server/api-response-types";
 import {
   TypedEntitySchema,
   type TypedEntity,
@@ -1164,8 +1164,8 @@ export function getBacklinksFor(
   }));
 }
 
-/** Server response shape for backlinks endpoint — imported from shared api-types */
-type ServerBacklink = ServerBacklinkEntry;
+/** Backlink shape used by both the API and local fallback paths. */
+type NormalizedBacklink = { id: string; type: string; title: string; href: string; relationship?: string };
 
 /**
  * Fetch backlinks from wiki-server with fallback to local database.json.
@@ -1173,24 +1173,21 @@ type ServerBacklink = ServerBacklinkEntry;
  */
 export async function getBacklinksWithFallback(
   entityId: string
-): Promise<WithSource<Array<{
-  id: string;
-  type: string;
-  title: string;
-  href: string;
-  relationship?: string;
-}>>> {
+): Promise<WithSource<NormalizedBacklink[]>> {
   const slug = resolveId(entityId);
 
-  return withApiFallback(
+  return withApiFallback<NormalizedBacklink[]>(
     async () => {
-      const data = await fetchFromWikiServer<{ backlinks: ServerBacklink[] }>(
+      const data = await fetchFromWikiServer<{ backlinks: ServerBacklinkEntry[] }>(
         `/api/links/backlinks/${encodeURIComponent(slug)}`
       );
       if (!data) return null;
-      return data.backlinks.map((link) => ({
-        ...link,
-        href: getEntityHref(link.id, link.type),
+      return data.backlinks.map(({ id, type, title, relationship }): NormalizedBacklink => ({
+        id: String(id),
+        type: String(type),
+        title: String(title),
+        relationship: relationship ? String(relationship) : undefined,
+        href: getEntityHref(String(id), String(type)),
       }));
     },
     () => getBacklinksFor(entityId)

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -1,12 +1,14 @@
 import { fetchFromWikiServer } from "./wiki-server";
 import type {
   CitationHealthResult,
+} from "@wiki-server/api-response-types";
+import type {
   AccuracyVerdict,
 } from "@wiki-server/api-types";
 import { ACCURACY_VERDICTS } from "@wiki-server/api-types";
 
 // Re-export the server type for consumers
-export type { CitationHealthResult } from "@wiki-server/api-types";
+export type { CitationHealthResult } from "@wiki-server/api-response-types";
 
 /**
  * Citation quote data from the wiki-server API.

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,6 +22,7 @@
       "@data/*": ["./src/data/*"],
       "@lib/*": ["./src/lib/*"],
       "@wiki-server/api-types": ["../wiki-server/src/api-types.ts"],
+      "@wiki-server/api-response-types": ["../wiki-server/src/api-response-types.ts"],
       "@wiki-server/facts-route": ["../wiki-server/src/routes/facts.ts"]
     }
   },

--- a/apps/wiki-server/src/api-response-types.ts
+++ b/apps/wiki-server/src/api-response-types.ts
@@ -1,0 +1,147 @@
+/**
+ * API Response Types — Inferred from Hono RPC route types.
+ *
+ * This file re-exports response types derived via InferResponseType<> from the
+ * server route handlers, which are the single source of truth. These types are
+ * consumed by the frontend (apps/web/) via the @wiki-server/api-response-types
+ * path alias.
+ *
+ * Input types (Zod schemas, request body shapes) remain in api-types.ts.
+ * Runtime constants (ACCURACY_VERDICTS, etc.) remain in api-types.ts.
+ *
+ * All imports here are type-only — zero runtime cost.
+ */
+
+import type { hc, InferResponseType } from 'hono/client';
+
+// Route type imports
+import type { ClaimsRoute } from './routes/claims.js';
+import type { CitationsRoute } from './routes/citations.js';
+import type { SessionsRoute } from './routes/sessions.js';
+import type { AgentSessionsRoute } from './routes/agent-sessions.js';
+import type { ArtifactsRoute } from './routes/artifacts.js';
+import type { AutoUpdateRunsRoute } from './routes/auto-update-runs.js';
+import type { AutoUpdateNewsRoute } from './routes/auto-update-news.js';
+import type { LinksRoute } from './routes/links.js';
+import type { HallucinationRiskRoute } from './routes/hallucination-risk.js';
+
+// ---------------------------------------------------------------------------
+// RPC client phantom types (compile-time only)
+// ---------------------------------------------------------------------------
+
+type ClaimsRpc = ReturnType<typeof hc<ClaimsRoute>>;
+type CitationsRpc = ReturnType<typeof hc<CitationsRoute>>;
+type SessionsRpc = ReturnType<typeof hc<SessionsRoute>>;
+type AgentSessionsRpc = ReturnType<typeof hc<AgentSessionsRoute>>;
+type ArtifactsRpc = ReturnType<typeof hc<ArtifactsRoute>>;
+type AutoUpdateRunsRpc = ReturnType<typeof hc<AutoUpdateRunsRoute>>;
+type AutoUpdateNewsRpc = ReturnType<typeof hc<AutoUpdateNewsRoute>>;
+type LinksRpc = ReturnType<typeof hc<LinksRoute>>;
+type HallucinationRiskRpc = ReturnType<typeof hc<HallucinationRiskRoute>>;
+
+// ---------------------------------------------------------------------------
+// Claims
+// ---------------------------------------------------------------------------
+
+/** Full claims-by-entity response. */
+export type GetClaimsResult = InferResponseType<ClaimsRpc['by-entity'][':entityId']['$get'], 200>;
+
+/** A single claim row from the by-entity endpoint. */
+export type ClaimRow = GetClaimsResult['claims'][number];
+
+/** Claim stats response. */
+export type ClaimStatsResult = InferResponseType<ClaimsRpc['stats']['$get'], 200>;
+
+/** A single claim source row. */
+export type ClaimSourceRow = InferResponseType<ClaimsRpc[':id']['sources']['$get'], 200>['sources'][number];
+
+/** Similar claims response from /:id/similar. */
+export type SimilarClaimsResult = InferResponseType<ClaimsRpc[':id']['similar']['$get'], 200>;
+
+/** A single similar claim item. */
+export type SimilarClaimItem = SimilarClaimsResult['claims'][number];
+
+// ---------------------------------------------------------------------------
+// Citations
+// ---------------------------------------------------------------------------
+
+/** Citation health response for a page. */
+export type CitationHealthResult = InferResponseType<CitationsRpc['health'][':pageId']['$get'], 200>;
+
+/** Accuracy dashboard data. */
+export type AccuracyDashboardData = InferResponseType<CitationsRpc['accuracy-dashboard']['$get'], 200>;
+
+/** Citation content list response. */
+export type CitationContentListResult = InferResponseType<CitationsRpc['content']['list']['$get'], 200>;
+
+/** A single citation content list entry. */
+export type CitationContentListEntry = CitationContentListResult['entries'][number];
+
+/** Citation content stats response. */
+export type CitationContentStatsResult = InferResponseType<CitationsRpc['content']['stats']['$get'], 200>;
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+/** Session list response. */
+type SessionListResult = InferResponseType<SessionsRpc['index']['$get'], 200>;
+
+/** A single session row. */
+export type SessionRow = SessionListResult['sessions'][number];
+
+// ---------------------------------------------------------------------------
+// Agent Sessions
+// ---------------------------------------------------------------------------
+
+/** A single agent session row. */
+export type AgentSessionRow = InferResponseType<AgentSessionsRpc['by-branch'][':branch']['$get'], 200>;
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+/** A single artifact row (from by-ID endpoint). */
+export type ArtifactRow = InferResponseType<ArtifactsRpc[':id']['$get'], 200>;
+
+// ---------------------------------------------------------------------------
+// Auto-Update
+// ---------------------------------------------------------------------------
+
+/** Auto-update runs list response. */
+type AutoUpdateRunsListResult = InferResponseType<AutoUpdateRunsRpc['all']['$get'], 200>;
+
+/** A single auto-update run row. */
+export type AutoUpdateRunRow = AutoUpdateRunsListResult['entries'][number];
+
+/** Auto-update news dashboard response. */
+type AutoUpdateNewsDashboardResult = InferResponseType<AutoUpdateNewsRpc['dashboard']['$get'], 200>;
+
+/** A single auto-update news row. */
+export type AutoUpdateNewsRow = AutoUpdateNewsDashboardResult['items'][number];
+
+// ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+/** Backlinks response. */
+type BacklinksResult = InferResponseType<LinksRpc['backlinks'][':id']['$get'], 200>;
+
+/** A single backlink entry. */
+export type BacklinkEntry = BacklinksResult['backlinks'][number];
+
+/** Related pages response. */
+type RelatedPagesResult = InferResponseType<LinksRpc['related'][':id']['$get'], 200>;
+
+/** A single related entry. */
+export type RelatedEntry = RelatedPagesResult['related'][number];
+
+// ---------------------------------------------------------------------------
+// Hallucination Risk
+// ---------------------------------------------------------------------------
+
+/** Hallucination risk latest response. */
+type RiskLatestResult = InferResponseType<HallucinationRiskRpc['latest']['$get'], 200>;
+
+/** A single risk page row. */
+export type RiskPageRow = RiskLatestResult['pages'][number];


### PR DESCRIPTION
## Summary

Completes Claims Phase 3 — the resource-centric ingestion pipeline for extracting claims from external URLs.

- **`from-resource <url>` command**: Fetches URL content, routes to relevant wiki entities (via `--entity` flag, resource YAML `cited_by`, or LLM-based routing), extracts claims, deduplicates against existing claims, and inserts into the database. Supports `--batch <file>` for bulk processing.
- **Deduplication utilities**: Jaccard word-set similarity (`isClaimDuplicate`) with normalization, substring containment, and configurable threshold (default 0.75). Integrated into both `ingest-resource` and `from-resource` pipelines.
- **Phase 2 field enrichment**: Resource-ingested claims now include `claimMode=attributed`, `attributedTo`, `asOf`, `measure`, numeric value fields, and inline `sources[]` array.
- **Claims Ingestion dashboard**: `/internal/claims-ingestion` page with stat cards, distribution bars (resource-sourced vs page-extracted, endorsed vs attributed), and per-resource sortable table.
- **Auto-resource creation**: Unknown URLs get automatic resource YAML entries (use `--no-auto-resource` to disable).

## Test plan

- [x] Unit tests for dedup utilities (normalization, Jaccard similarity, batch filtering) — 13 tests passing
- [x] `pnpm crux claims from-resource <url> --dry-run` — fetches, routes, extracts, shows preview
- [x] `ingest-resource` deduplication integration — second run deduplicates
- [x] Dashboard renders at `/internal/claims-ingestion`
- [x] Gate check passes (pre-existing `hono/client` failures only)
- [x] Crux TypeScript check passes (2 errors = baseline)

Closes #1043
