### PR TITLE
feat: normalize relatedEntities and surface cross-referenced entities in sidebar

### DIFF
--- a/apps/web/src/app/claims/components/claims-nav.ts
+++ b/apps/web/src/app/claims/components/claims-nav.ts
@@ -3,7 +3,7 @@ import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById, getEntityHref } from "@data";
 
 interface NetworkResponse {
-  nodes: { entityId: string; claimCount: number }[];
+  nodes: { entityId: string; claimCount: number; mentionCount?: number }[];
   edges: { source: string; target: string; weight: number }[];
 }
 
@@ -53,15 +53,26 @@ export async function getClaimsEntities(): Promise<ClaimsEntityItem[]> {
   if (!result) return [];
 
   return result.nodes
-    .filter((n) => n.claimCount > 0)
-    .sort((a, b) => b.claimCount - a.claimCount)
+    .filter((n) => {
+      // Include entities with primary claims
+      if (n.claimCount > 0) return true;
+      // Include mention-only entities if they're known wiki entities
+      if ((n.mentionCount ?? 0) > 0 && getEntityById(n.entityId)) return true;
+      return false;
+    })
+    .sort((a, b) => {
+      // Sort by total relevance (primary claims + mentions)
+      const totalA = a.claimCount + (a.mentionCount ?? 0);
+      const totalB = b.claimCount + (b.mentionCount ?? 0);
+      return totalB - totalA;
+    })
     .map((n) => {
       const entity = getEntityById(n.entityId);
       return {
         entityId: n.entityId,
         title: entity?.title ?? n.entityId,
         href: `/claims/entity/${n.entityId}`,
-        claimCount: n.claimCount,
+        claimCount: n.claimCount + (n.mentionCount ?? 0),
         entityType: entity?.type ?? "unknown",
       };
     });

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -131,8 +131,14 @@ export default async function EntityClaimsPage({ params }: PageProps) {
         </div>
         <p className="text-muted-foreground text-sm">
           {claims.length === 0
-            ? "No claims extracted for this entity yet."
-            : `${claims.length} claims extracted from this entity's wiki page.`}
+            ? "No claims found for this entity yet."
+            : (() => {
+                const primary = claims.filter((c) => c.entityId === entityId).length;
+                const mentioned = claims.length - primary;
+                if (mentioned === 0) return `${claims.length} claims extracted from this entity's wiki page.`;
+                if (primary === 0) return `${mentioned} claims mentioning this entity from other pages.`;
+                return `${primary} claims from this entity's page, ${mentioned} mentioning it from other pages.`;
+              })()}
         </p>
       </div>
 

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -724,6 +724,7 @@ const claimsApp = new Hono()
 
     const edgeMap = new Map<string, { source: string; target: string; weight: number }>();
     const nodeIds = new Set<string>();
+    const mentionCounts = new Map<string, number>();
 
     for (const row of rows) {
       nodeIds.add(row.entityId);
@@ -735,6 +736,7 @@ const claimsApp = new Hono()
         // Skip self-loops
         if (normalizedRel === row.entityId) continue;
         nodeIds.add(normalizedRel);
+        mentionCounts.set(normalizedRel, (mentionCounts.get(normalizedRel) ?? 0) + 1);
         const [source, target] = [row.entityId, normalizedRel].sort();
         const key = `${source}|||${target}`;
         if (!edgeMap.has(key)) {
@@ -750,6 +752,7 @@ const claimsApp = new Hono()
     const nodes = [...nodeIds].map((id) => ({
       entityId: id,
       claimCount: countMap[id] ?? 0,
+      mentionCount: mentionCounts.get(id) ?? 0,
     }));
     const edges = [...edgeMap.values()].sort((a, b) => b.weight - a.weight);
 

--- a/scripts/normalize-related-entities.mjs
+++ b/scripts/normalize-related-entities.mjs
@@ -1,0 +1,162 @@
+/**
+ * Normalize relatedEntities values in the claims database.
+ *
+ * Reads all claims with relatedEntities, applies normalization map,
+ * and batch-updates via the wiki-server API.
+ *
+ * Run:
+ *   node scripts/normalize-related-entities.mjs           # dry run
+ *   node scripts/normalize-related-entities.mjs --apply   # apply changes
+ */
+import { config } from "dotenv";
+config({ path: ".env" });
+
+const base = process.env.LONGTERMWIKI_SERVER_URL || "http://localhost:7778";
+const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+const dryRun = !process.argv.includes("--apply");
+
+const headers = { "Content-Type": "application/json" };
+if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+// Normalization map: unnormalized value -> canonical entity slug
+// Only includes mappings where we're confident about the match.
+const NORMALIZATION_MAP = {
+  // Space-to-hyphen (trivial)
+  "far ai": "far-ai",
+  "redwood research": "redwood-research",
+  "stuart russell": "stuart-russell",
+  "paul christiano": "paul-christiano",
+  "open philanthropy": "open-philanthropy",
+  "coefficient giving": "coefficient-giving",
+  "buck shlegeris": "buck-shlegeris",
+  "yann lecun": "yann-lecun",
+  "constitutional ai": "constitutional-ai",
+  "robin hanson": "robin-hanson",
+  "epoch ai": "epoch-ai",
+  "dario amodei": "dario-amodei",
+  "daniela amodei": "daniela-amodei",
+  "eliezer yudkowsky": "eliezer-yudkowsky",
+  "apollo research": "apollo-research",
+  "nate soares": "nate-soares",
+  "chris olah": "chris-olah",
+  "yoshua bengio": "yoshua-bengio",
+
+  // Dot/variant to hyphen
+  "far.ai": "far-ai",
+  "far.labs": "far-ai",
+
+  // Aliases (confident matches)
+  "nanda": "neel-nanda",
+  "christiano": "paul-christiano",
+  "redwood": "redwood-research",
+  "machine intelligence research institute": "miri",
+  "cotra": "ajeya-cotra",
+  "google deepmind": "deepmind",
+  "future of life institute": "fli",
+  "future-of-life-institute": "fli",
+  "russell": "stuart-russell",
+  "manifold markets": "manifold",
+  "metaculus aggregate": "metaculus",
+  "kwa/metr": "metr",
+  "open philanthropy project": "open-philanthropy",
+  "survival and flourishing fund": "sff",
+};
+
+// --- Main ---
+
+// 1. Fetch all claims with relatedEntities
+console.log("Fetching claims with relatedEntities...");
+let allClaims = [];
+let offset = 0;
+const limit = 200;
+while (true) {
+  const res = await fetch(
+    `${base}/api/claims/all?limit=${limit}&offset=${offset}&multiEntity=true`,
+    { headers }
+  );
+  const data = await res.json();
+  const claims = data.claims || [];
+  if (claims.length === 0) break;
+  allClaims.push(...claims);
+  offset += limit;
+  if (claims.length < limit) break;
+}
+console.log(`Found ${allClaims.length} claims with relatedEntities\n`);
+
+// 2. Build update batch
+const updates = []; // { id, relatedEntities }
+let totalNormalized = 0;
+const normCounts = {};
+
+for (const claim of allClaims) {
+  if (!claim.relatedEntities || claim.relatedEntities.length === 0) continue;
+
+  let changed = false;
+  const newEntities = claim.relatedEntities.map((re) => {
+    const normalized = NORMALIZATION_MAP[re];
+    if (normalized && normalized !== re) {
+      changed = true;
+      totalNormalized++;
+      normCounts[`"${re}" -> "${normalized}"`] =
+        (normCounts[`"${re}" -> "${normalized}"`] || 0) + 1;
+      return normalized;
+    }
+    return re;
+  });
+
+  if (changed) {
+    // Deduplicate (e.g. if "redwood" and "redwood-research" both existed)
+    const deduped = [...new Set(newEntities)];
+    updates.push({ id: claim.id, relatedEntities: deduped });
+  }
+}
+
+// 3. Report
+console.log(`Claims to update: ${updates.length}`);
+console.log(`Total values normalized: ${totalNormalized}`);
+console.log("\nNormalization breakdown:");
+const sortedCounts = Object.entries(normCounts).sort((a, b) => b[1] - a[1]);
+for (const [mapping, count] of sortedCounts) {
+  console.log(`  ${mapping}: ${count}`);
+}
+
+if (updates.length === 0) {
+  console.log("\nNothing to update.");
+  process.exit(0);
+}
+
+if (dryRun) {
+  console.log("\n[DRY RUN] No changes applied. Run with --apply to update.");
+  console.log("\nSample updates:");
+  for (const u of updates.slice(0, 5)) {
+    const original = allClaims.find((c) => c.id === u.id);
+    console.log(`  Claim #${u.id}:`);
+    console.log(`    Before: ${JSON.stringify(original.relatedEntities)}`);
+    console.log(`    After:  ${JSON.stringify(u.relatedEntities)}`);
+  }
+  process.exit(0);
+}
+
+// 4. Batch update
+console.log("\nApplying updates...");
+const batchSize = 200;
+let totalUpdated = 0;
+for (let i = 0; i < updates.length; i += batchSize) {
+  const batch = updates.slice(i, i + batchSize);
+  const res = await fetch(`${base}/api/claims/batch-update-related-entities`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ items: batch }),
+  });
+  const result = await res.json();
+  if (result.updated) {
+    totalUpdated += result.updated;
+    console.log(
+      `  Batch ${Math.floor(i / batchSize) + 1}: updated ${result.updated}/${batch.length}`
+    );
+  } else {
+    console.error(`  Batch ${Math.floor(i / batchSize) + 1} error:`, result);
+  }
+}
+
+console.log(`\nDone. Updated ${totalUpdated} claims.`);


### PR DESCRIPTION
## Summary

- Normalized 215 relatedEntities values across 205 claims in the database (e.g., "far ai" → "far-ai", "machine intelligence research institute" → "miri", "nanda" → "neel-nanda")
- Added `mentionCount` to the `/api/claims/network` endpoint so entities referenced only in other claims' relatedEntities (like constitutional-ai) appear in the claims sidebar
- Updated claims sidebar to include mention-only entities that are known wiki entities, sorted by total relevance
- Updated entity claims page to distinguish "N claims from this entity's page, M mentioning it from other pages"
- Included reusable normalization script at `scripts/normalize-related-entities.mjs` for future use

## Test plan
- [ ] Visit `/claims/entity/constitutional-ai` — should show 5 claims mentioning constitutional AI from other entity pages
- [ ] Check claims sidebar — constitutional-ai, neel-nanda, and other cross-referenced entities should now appear
- [ ] Visit `/claims/entity/anthropic` — description should say "X claims from this entity's page, Y mentioning it from other pages"
- [ ] Run `node scripts/normalize-related-entities.mjs` — should report 0 claims to update (already normalized)
