### PR TITLE
refactor: fix (r: any) type regressions + dead code cleanup in RPC migration

### DIFF
--- a/apps/web/src/app/internal/hallucination-risk/page.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/page.tsx
@@ -97,7 +97,7 @@ async function loadRiskDataFromApi(): Promise<FetchResult<RiskPageData[]>> {
           entityType: meta?.entityType,
           quality: meta?.quality ?? null,
           wordCount: meta?.wordCount,
-          level: r.level,
+          level: r.level as "low" | "medium" | "high",
           score: r.score,
           factors: r.factors || [],
         };

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -65,46 +65,6 @@ export const EditLogBatchSchema = z.object({
 });
 export type EditLogBatch = z.infer<typeof EditLogBatchSchema>;
 
-// -- Edit Logs: Response types ------------------------------------------------
-
-export interface EditLogAppendResult {
-  id: number;
-  pageId: string;
-  date: string;
-  createdAt: string;
-}
-
-export interface EditLogBatchResult {
-  inserted: number;
-  results: Array<{ id: number; pageId: string }>;
-}
-
-export interface EditLogRow {
-  id: number;
-  pageId: string;
-  date: string;
-  tool: string;
-  agency: string;
-  requestedBy: string | null;
-  note: string | null;
-  createdAt: string;
-}
-
-export interface EditLogEntriesResult {
-  entries: EditLogRow[];
-}
-
-export interface EditLogStatsResult {
-  totalEntries: number;
-  pagesWithLogs: number;
-  byTool: Record<string, number>;
-  byAgency: Record<string, number>;
-}
-
-export interface EditLogLatestDatesResult {
-  dates: Record<string, string>;
-}
-
 // ---------------------------------------------------------------------------
 // Citation Quotes
 // ---------------------------------------------------------------------------
@@ -130,60 +90,6 @@ export type UpsertCitationQuote = z.infer<typeof UpsertCitationQuoteSchema>;
 export const UpsertCitationQuoteBatchSchema = z.object({
   items: z.array(UpsertCitationQuoteSchema).min(1).max(100),
 });
-
-// -- Citation Quotes: Response types ------------------------------------------
-
-export interface CitationQuoteRow {
-  id: number;
-  pageId: string;
-  footnote: number;
-  url: string | null;
-  resourceId: string | null;
-  claimText: string;
-  claimContext: string | null;
-  sourceQuote: string | null;
-  sourceLocation: string | null;
-  quoteVerified: boolean;
-  verificationScore: number | null;
-  sourceTitle: string | null;
-  sourceType: string | null;
-  accuracyVerdict: string | null;
-  accuracyScore: number | null;
-}
-
-export interface UpsertCitationQuoteResult {
-  id: number;
-  pageId: string;
-  footnote: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface UpsertCitationQuoteBatchResult {
-  results: Array<{ id: number; pageId: string; footnote: number }>;
-}
-
-export interface CitationQuotesResult {
-  quotes: CitationQuoteRow[];
-  pageId: string;
-  total: number;
-}
-
-// -- Citation Health: per-page summary ----------------------------------------
-
-export interface CitationHealthResult {
-  pageId: string;
-  total: number;
-  withQuotes: number;
-  verified: number;
-  accuracyChecked: number;
-  accurate: number;
-  inaccurate: number;
-  unsupported: number;
-  minorIssues: number;
-  notVerifiable: number;
-  avgScore: number | null;
-}
 
 // ---------------------------------------------------------------------------
 // Citation Accuracy
@@ -218,25 +124,6 @@ export type MarkAccuracy = z.infer<typeof MarkAccuracySchema>;
 export const MarkAccuracyBatchSchema = z.object({
   items: z.array(MarkAccuracySchema).min(1).max(100),
 });
-
-// -- Citation Accuracy: Response types ----------------------------------------
-
-export interface MarkAccuracyResult {
-  updated: true;
-  pageId: string;
-  footnote: number;
-  verdict: string;
-}
-
-export interface MarkAccuracyBatchResult {
-  updated: number;
-  results: Array<{ pageId: string; footnote: number; verdict: string }>;
-}
-
-export interface AccuracySnapshotResult {
-  snapshotCount: number;
-  pages: string[];
-}
 
 export interface AccuracyDashboardData {
   exportedAt: string;
@@ -388,61 +275,6 @@ export const CreateSessionBatchSchema = z.object({
   items: z.array(CreateSessionSchema).min(1).max(MAX_BATCH_SIZE),
 });
 
-// -- Sessions: Response types -------------------------------------------------
-
-export interface SessionRow {
-  id: number;
-  date: string;
-  branch: string | null;
-  title: string;
-  summary: string | null;
-  model: string | null;
-  duration: string | null;
-  cost: string | null;
-  prUrl: string | null;
-  checksYaml: string | null;
-  issuesJson: unknown;
-  learningsJson: unknown;
-  recommendationsJson: unknown;
-  pages: string[];
-  createdAt: string;
-}
-
-export interface CreateSessionResult {
-  id: number;
-  date: string;
-  title: string;
-  pages: string[];
-  createdAt: string;
-}
-
-export interface SessionBatchResult {
-  upserted: number;
-  results: Array<{ id: number; title: string; pageCount: number }>;
-}
-
-export interface SessionListResult {
-  sessions: SessionRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-export interface SessionByPageResult {
-  sessions: SessionRow[];
-}
-
-export interface SessionStatsResult {
-  totalSessions: number;
-  uniquePages: number;
-  totalPageEdits: number;
-  byModel: Record<string, number>;
-}
-
-export interface SessionPageChangesResult {
-  sessions: SessionRow[];
-}
-
 // ---------------------------------------------------------------------------
 // Auto-Update Runs
 // ---------------------------------------------------------------------------
@@ -476,52 +308,6 @@ export const RecordAutoUpdateRunSchema = z.object({
 });
 export type RecordAutoUpdateRun = z.infer<typeof RecordAutoUpdateRunSchema>;
 
-// -- Auto-Update Runs: Response types -----------------------------------------
-
-export interface RecordAutoUpdateRunResult {
-  id: number;
-  date: string;
-  startedAt: string;
-  createdAt: string;
-  resultsInserted: number;
-}
-
-export interface AutoUpdateRunRow {
-  id: number;
-  date: string;
-  startedAt: string;
-  completedAt: string | null;
-  trigger: string;
-  budgetLimit: number | null;
-  budgetSpent: number | null;
-  sourcesChecked: number | null;
-  sourcesFailed: number | null;
-  itemsFetched: number | null;
-  itemsRelevant: number | null;
-  pagesPlanned: number | null;
-  pagesUpdated: number | null;
-  pagesFailed: number | null;
-  pagesSkipped: number | null;
-  newPagesCreated: string[];
-  results: AutoUpdateResult[];
-  createdAt: string;
-}
-
-export interface AutoUpdateRunsListResult {
-  entries: AutoUpdateRunRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-export interface AutoUpdateStatsResult {
-  totalRuns: number;
-  totalBudgetSpent: number;
-  totalPagesUpdated: number;
-  totalPagesFailed: number;
-  byTrigger: Record<string, number>;
-}
-
 // ---------------------------------------------------------------------------
 // Auto-Update News Items
 // ---------------------------------------------------------------------------
@@ -546,35 +332,6 @@ export const AutoUpdateNewsBatchSchema = z.object({
   items: z.array(AutoUpdateNewsItemSchema).min(1).max(500),
 });
 
-// -- Auto-Update News: Response types -----------------------------------------
-
-export interface AutoUpdateNewsRow {
-  id: number;
-  runId: number;
-  title: string;
-  url: string;
-  sourceId: string;
-  publishedAt: string | null;
-  summary: string | null;
-  relevanceScore: number | null;
-  topics: string[];
-  entities: string[];
-  routedToPageId: string | null;
-  routedToPageTitle: string | null;
-  routedTier: string | null;
-  runDate?: string | null;
-  createdAt: string;
-}
-
-export interface AutoUpdateNewsBatchResult {
-  inserted: number;
-}
-
-export interface AutoUpdateNewsDashboardResult {
-  items: AutoUpdateNewsRow[];
-  runDates: string[];
-}
-
 // ---------------------------------------------------------------------------
 // Hallucination Risk
 // ---------------------------------------------------------------------------
@@ -591,25 +348,6 @@ export type RiskSnapshotInput = z.infer<typeof RiskSnapshotSchema>;
 export const RiskSnapshotBatchSchema = z.object({
   snapshots: z.array(RiskSnapshotSchema).min(1).max(700),
 });
-
-// -- Hallucination Risk: Response types ---------------------------------------
-
-export interface RiskBatchResult {
-  inserted: number;
-}
-
-export interface RiskPageRow {
-  pageId: string;
-  score: number;
-  level: "low" | "medium" | "high";
-  factors: string[] | null;
-  integrityIssues: string[] | null;
-  computedAt: string;
-}
-
-export interface RiskLatestResult {
-  pages: RiskPageRow[];
-}
 
 // ---------------------------------------------------------------------------
 // Summaries
@@ -631,18 +369,6 @@ export type UpsertSummary = z.infer<typeof UpsertSummarySchema>;
 export const UpsertSummaryBatchSchema = z.object({
   items: z.array(UpsertSummarySchema).min(1).max(MAX_BATCH_SIZE),
 });
-
-// -- Summaries: Response types ------------------------------------------------
-
-export interface UpsertSummaryResult {
-  entityId: string;
-  entityType: string;
-}
-
-export interface UpsertSummaryBatchResult {
-  upserted: number;
-  results: Array<{ entityId: string; entityType: string }>;
-}
 
 // ---------------------------------------------------------------------------
 // Claims
@@ -760,107 +486,6 @@ export const ClearClaimsBySectionSchema = z.object({
   section: z.string().min(1).max(500),
 });
 
-// -- Claims: Response types ---------------------------------------------------
-
-export interface ClaimSourceRow {
-  id: number;
-  claimId: number;
-  resourceId: string | null;
-  url: string | null;
-  sourceQuote: string | null;
-  isPrimary: boolean;
-  addedAt: string;
-  sourceVerdict: string | null;
-  sourceVerdictScore: number | null;
-  sourceVerdictIssues: string | null;
-  sourceCheckedAt: string | null;
-}
-
-export interface ClaimRow {
-  id: number;
-  entityId: string;
-  entityType: string;
-  claimType: string;
-  claimText: string;
-  /** @deprecated Use valueNumeric/valueLow/valueHigh instead */
-  value: string | null;
-  /** @deprecated Use measure instead */
-  unit: string | null;
-  /** @deprecated Use claimVerdict instead. */
-  confidence: string | null;
-  /** @deprecated Use sources[] (from claim_sources table) instead. */
-  sourceQuote: string | null;
-  // Enhanced fields (migration 0028)
-  claimCategory: string | null;
-  relatedEntities: string[] | null;
-  factId: string | null;
-  resourceIds: string[] | null;
-  section: string | null;
-  /** @deprecated Use claim_page_references table instead. Kept for backward compat. */
-  footnoteRefs: string | null;
-  // Phase 2 fields (migration 0029)
-  claimMode: string | null;       // 'endorsed' | 'attributed'
-  attributedTo: string | null;    // entity_id of person/org making claim
-  asOf: string | null;            // YYYY-MM or YYYY-MM-DD
-  measure: string | null;         // measure ID from facts taxonomy
-  valueNumeric: number | null;    // central numeric value
-  valueLow: number | null;        // lower bound
-  valueHigh: number | null;       // upper bound
-  // Verdict fields (migration 0031)
-  claimVerdict: string | null;
-  claimVerdictScore: number | null;
-  claimVerdictIssues: string | null;
-  claimVerdictQuotes: string | null;
-  claimVerdictDifficulty: string | null;
-  claimVerifiedAt: string | null;
-  claimVerdictModel: string | null;
-  // Structured claim fields (migration 0032)
-  subjectEntity: string | null;
-  property: string | null;
-  structuredValue: string | null;
-  valueUnit: string | null;
-  valueDate: string | null;
-  qualifiers: Record<string, string> | null;
-  sources: ClaimSourceRow[];      // populated when ?includeSources=true
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface InsertClaimResult {
-  id: number;
-  entityId: string;
-  claimType: string;
-}
-
-export interface InsertClaimBatchResult {
-  inserted: number;
-  results: Array<{ id: number; entityId: string; claimType: string }>;
-}
-
-export interface ClearClaimsResult {
-  deleted: number;
-}
-
-export interface GetClaimsResult {
-  claims: ClaimRow[];
-}
-
-export interface ClaimStatsResult {
-  total: number;
-  byClaimType: Record<string, number>;
-  byEntityType: Record<string, number>;
-  byClaimCategory: Record<string, number>;
-  byClaimMode: Record<string, number>;
-  byClaimVerdict: Record<string, number>;
-  multiEntityClaims: number;
-  factLinkedClaims: number;
-  withSourcesClaims: number;
-  attributedClaims: number;
-  numericClaims?: number;
-  structuredClaims?: number;
-  byProperty?: Record<string, number>;
-}
-
 // -- Claims: Page References types -------------------------------------------
 
 export interface ClaimPageReferenceRow {
@@ -936,29 +561,6 @@ export const PropagateFromClaimsSchema = z.object({
 });
 export type PropagateFromClaims = z.infer<typeof PropagateFromClaimsSchema>;
 
-export interface PropagateFromClaimsResult {
-  propagated: number;
-  skipped: number;
-}
-
-// ---------------------------------------------------------------------------
-// Similar Claims (trigram similarity)
-// ---------------------------------------------------------------------------
-
-export interface SimilarClaimItem {
-  id: number;
-  entityId: string;
-  entityType: string;
-  claimText: string;
-  claimCategory: string | null;
-  confidence: string | null;
-  similarityScore: number;
-}
-
-export interface SimilarClaimsResult {
-  claims: SimilarClaimItem[];
-}
-
 // ---------------------------------------------------------------------------
 // Page Links
 // ---------------------------------------------------------------------------
@@ -984,23 +586,6 @@ export const SyncLinksBatchSchema = z.object({
   links: z.array(PageLinkSchema).min(1).max(5000),
   replace: z.boolean().optional().default(false),
 });
-
-// -- Page Links: Response types -----------------------------------------------
-
-export interface SyncLinksResult {
-  upserted: number;
-}
-
-export interface LinksStatsResult {
-  total: number;
-  uniqueSources: number;
-  uniqueTargets: number;
-  byType: Array<{
-    linkType: string;
-    count: number;
-    avgWeight: number;
-  }>;
-}
 
 export interface PageSearchResult {
   results: Array<{
@@ -1225,49 +810,6 @@ export const SyncEntitiesBatchSchema = z.object({
   entities: z.array(SyncEntitySchema).min(1).max(MAX_BATCH_SIZE),
 });
 
-// -- Entities: Response types -------------------------------------------------
-
-export interface SyncEntitiesResult {
-  upserted: number;
-}
-
-export interface EntityRow {
-  id: string;
-  numericId: string | null;
-  entityType: string;
-  title: string;
-  description: string | null;
-  website: string | null;
-  tags: string[] | null;
-  clusters: string[] | null;
-  status: string | null;
-  lastUpdated: string | null;
-  customFields: Array<{ label: string; value: string; link?: string }> | null;
-  relatedEntries: Array<{ id: string; type: string; relationship?: string }> | null;
-  sources: Array<{ title: string; url?: string; author?: string; date?: string }> | null;
-  syncedAt: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface EntityListResult {
-  entities: EntityRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-export interface EntitySearchResult {
-  results: EntityRow[];
-  query: string;
-  total: number;
-}
-
-export interface EntityStatsResult {
-  total: number;
-  byType: Record<string, number>;
-}
-
 // ---------------------------------------------------------------------------
 // Facts
 // ---------------------------------------------------------------------------
@@ -1373,53 +915,6 @@ export const SweepJobsSchema = z.object({
 });
 export type SweepJobs = z.infer<typeof SweepJobsSchema>;
 
-// -- Jobs: Response types -----------------------------------------------------
-
-export interface JobRow {
-  id: number;
-  type: string;
-  status: string;
-  params: Record<string, unknown> | null;
-  result: Record<string, unknown> | null;
-  error: string | null;
-  priority: number;
-  retries: number;
-  maxRetries: number;
-  createdAt: string;
-  claimedAt: string | null;
-  startedAt: string | null;
-  completedAt: string | null;
-  workerId: string | null;
-}
-
-export interface ListJobsResult {
-  entries: JobRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-export interface ClaimJobResult {
-  job: JobRow | null;
-}
-
-export interface JobStatsResult {
-  totalJobs: number;
-  byType: Record<
-    string,
-    {
-      byStatus: Record<string, number>;
-      avgDurationMs?: number;
-      failureRate?: number;
-    }
-  >;
-}
-
-export interface SweepJobsResult {
-  swept: number;
-  jobs: Array<{ id: number; type: string }>;
-}
-
 // ---------------------------------------------------------------------------
 // Improve Run Artifacts
 // ---------------------------------------------------------------------------
@@ -1477,58 +972,6 @@ export const SaveArtifactsSchema = z.object({
   phasesRun: z.array(z.string().max(100)).max(20).nullable().optional(),
 });
 export type SaveArtifacts = z.infer<typeof SaveArtifactsSchema>;
-
-// -- Artifacts: Response types ------------------------------------------------
-
-export interface SaveArtifactsResult {
-  id: number;
-  pageId: string;
-  engine: string;
-  startedAt: string;
-  createdAt: string;
-}
-
-export interface ArtifactRow {
-  id: number;
-  pageId: string;
-  engine: string;
-  tier: string;
-  directions: string | null;
-  startedAt: string;
-  completedAt: string | null;
-  durationS: number | null;
-  totalCost: number | null;
-  sourceCache: unknown;
-  researchSummary: string | null;
-  citationAudit: unknown;
-  costEntries: unknown;
-  costBreakdown: Record<string, number> | null;
-  sectionDiffs: unknown;
-  qualityMetrics: unknown;
-  qualityGatePassed: boolean | null;
-  qualityGaps: string[] | null;
-  toolCallCount: number | null;
-  refinementCycles: number | null;
-  phasesRun: string[] | null;
-  createdAt: string;
-}
-
-export interface GetArtifactsResult {
-  entries: ArtifactRow[];
-}
-
-export interface GetArtifactsPagedResult {
-  entries: ArtifactRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
-
-export interface ArtifactStatsResult {
-  totalRuns: number;
-  byEngine: Record<string, number>;
-  byTier: Record<string, number>;
-}
 
 // ---------------------------------------------------------------------------
 // Pages
@@ -1595,18 +1038,3 @@ export const UpdateAgentSessionSchema = z.object({
 });
 export type UpdateAgentSession = z.infer<typeof UpdateAgentSessionSchema>;
 
-// -- Agent Sessions: Response types -------------------------------------------
-
-export interface AgentSessionRow {
-  id: number;
-  branch: string;
-  task: string;
-  sessionType: "content" | "infrastructure" | "bugfix" | "refactor" | "commands";
-  issueNumber: number | null;
-  checklistMd: string;
-  status: "active" | "completed";
-  startedAt: string;
-  completedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-}

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -19,12 +19,10 @@ import {
   MarkAccuracyBatchSchema as SharedMarkAccuracyBatchSchema,
   UpsertCitationContentSchema,
   CITATION_CONTENT_PREVIEW_MAX,
-  type CitationHealthResult,
   LinkCitationClaimSchema,
   LinkCitationsClaimsBatchSchema,
   PropagateFromClaimsSchema,
 } from "../api-types.js";
-
 // ---- Constants ----
 
 const BROKEN_SCORE_THRESHOLD = 0.5;
@@ -111,7 +109,7 @@ function computePageHealth(
     accuracyVerdict: string | null;
     accuracyScore: number | null;
   }>
-): CitationHealthResult {
+) {
   let withQuotes = 0;
   let verified = 0;
   let accuracyChecked = 0;

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -107,6 +107,17 @@ function claimValues(d: ClaimInput) {
 
 type ClaimSourceRowType = typeof claimSources.$inferSelect;
 
+/** Raw row shape returned by the `/:id/similar` raw SQL query (pg_trgm similarity). */
+interface SimilarClaimDbRow {
+  id: number;
+  entity_id: string;
+  entity_type: string;
+  claim_text: string;
+  claim_category: string | null;
+  confidence: number | null;
+  similarity_score: string; // pg returns numeric as string
+}
+
 function formatClaimSource(s: ClaimSourceRowType) {
   return {
     id: Number(s.id),
@@ -786,7 +797,7 @@ const claimsApp = new Hono()
 
     // Use raw SQL for the similarity() function (same pattern as pages.ts trigram fallback)
     const rawDb = getDb();
-    const rows = await rawDb.unsafe(
+    const rows = (await rawDb.unsafe(
       `SELECT
       id, entity_id, entity_type, claim_text, claim_category, confidence,
       similarity(claim_text, $1) AS similarity_score
@@ -796,10 +807,10 @@ const claimsApp = new Hono()
     ORDER BY similarity(claim_text, $1) DESC
     LIMIT $3`,
       [targetText, id, limit],
-    );
+    )) as unknown as SimilarClaimDbRow[];
 
     return c.json({
-      claims: rows.map((r: any) => ({
+      claims: rows.map((r) => ({
         id: Number(r.id),
         entityId: r.entity_id,
         entityType: r.entity_type,

--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -7,6 +7,40 @@ import {
   TRIGRAM_SIMILARITY_THRESHOLD,
 } from "../search-utils.js";
 
+// ---- Row types returned by raw SQL queries ----
+
+/** Row shape from the main explore data query (both FTS and trigram paths). */
+interface ExploreDataRow {
+  id: string;
+  numeric_id: string | null;
+  title: string;
+  entity_type: string | null;
+  content_format: string | null;
+  category: string | null;
+  description: string | null;
+  page_tags: string | null;
+  page_clusters: string[] | null;
+  word_count: number | null;
+  quality: number | null;
+  reader_importance: number | null;
+  research_importance: number | null;
+  tactical_value: number | null;
+  backlink_count: number | null;
+  risk_category: string | null;
+  last_updated: string | null;
+  date_created: string | null;
+  recommended_score: number | null;
+  entity_tags: string[] | null;
+  entity_clusters: string[] | null;
+  search_rank?: number;
+}
+
+/** Row shape from faceted count queries (cluster, category, entityType, riskCategory). */
+interface FacetCountRow {
+  val: string;
+  cnt: string;
+}
+
 // ---- Query Schema ----
 
 const ExploreQuery = z.object({
@@ -361,7 +395,7 @@ const exploreApp = new Hono()
     }
 
     // Transform rows to ExploreItem shape
-    const items = rows.map((r: any) => {
+    const items = (rows as unknown as ExploreDataRow[]).map((r) => {
       const entityTags = Array.isArray(r.entity_tags) ? r.entity_tags : [];
       const pageTags = parseTags(r.page_tags);
       const tags = entityTags.length > 0 ? entityTags : pageTags;
@@ -394,8 +428,10 @@ const exploreApp = new Hono()
       };
     });
 
-    const toCountMap = (rows: any[]) =>
-      Object.fromEntries(rows.map((r: any) => [r.val, parseInt(r.cnt, 10)]));
+    const toCountMap = (rows: unknown[]) =>
+      Object.fromEntries(
+        (rows as FacetCountRow[]).map((r) => [r.val, parseInt(r.cnt, 10)])
+      );
 
     return c.json({
       items,

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -14,6 +14,22 @@ import {
   RiskSnapshotBatchSchema,
 } from "../api-types.js";
 
+// ---- Raw SQL row types ----
+
+interface LevelDistRow {
+  level: string;
+  count: number;
+}
+
+interface RiskPageDbRow {
+  page_id: string;
+  score: number;
+  level: string;
+  factors: string[] | null;
+  integrity_issues: string[] | null;
+  computed_at: string;
+}
+
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -177,7 +193,7 @@ const hallucinationRiskApp = new Hono()
       totalSnapshots,
       uniquePages,
       levelDistribution: Object.fromEntries(
-        levelDist.map((r: any) => [r.level, r.count])
+        (levelDist as unknown as LevelDistRow[]).map((r) => [r.level, r.count])
       ),
     });
   })
@@ -216,7 +232,7 @@ const hallucinationRiskApp = new Hono()
         `;
 
     return c.json({
-      pages: rows.map((r: any) => ({
+      pages: (rows as unknown as RiskPageDbRow[]).map((r) => ({
         pageId: r.page_id,
         score: r.score,
         level: r.level,

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -64,6 +64,29 @@ const RelatedQuery = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(MAX_RELATED),
 });
 
+// ---- Raw SQL row types ----
+
+interface BacklinkDbRow {
+  source_id: string;
+  relationship: string | null;
+  link_type: string;
+  weight: number;
+  source_title: string | null;
+  source_type: string | null;
+}
+
+interface RelatedDbRow {
+  id: string;
+  raw_score: number;
+  relationship: string | null;
+  relationship_is_reverse: boolean | null;
+  title: string | null;
+  entity_type: string | null;
+  quality: number | null;
+  reader_importance: number | null;
+  score: string;
+}
+
 // ---- POST /sync ----
 
 // Advisory lock key for serializing page_links sync operations.
@@ -148,7 +171,7 @@ const linksApp = new Hono()
     LIMIT ${limit}
   `;
 
-    const backlinks = results.map((r: any) => ({
+    const backlinks = (results as unknown as BacklinkDbRow[]).map((r) => ({
       id: r.source_id,
       type: r.source_type || "concept",
       title: r.source_title || r.source_id,
@@ -238,7 +261,7 @@ const linksApp = new Hono()
 
     // Type-diverse selection: guarantee MIN_PER_TYPE from each entity type,
     // then fill remaining slots with highest-scoring entries.
-    const scored = results.map((r: any) => ({
+    const scored = (results as unknown as RelatedDbRow[]).map((r) => ({
       id: r.id as string,
       type: (r.entity_type as string) || "concept",
       title: (r.title as string) || r.id,

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -21,6 +21,22 @@ import {
   TS_HEADLINE_OPTIONS,
 } from "../search-utils.js";
 
+// ---- Raw SQL row types ----
+
+/** Row shape returned by the FTS and trigram search queries. */
+interface PageSearchRow {
+  id: string;
+  numeric_id: string | null;
+  title: string;
+  description: string | null;
+  entity_type: string | null;
+  category: string | null;
+  reader_importance: number | null;
+  quality: number | null;
+  rank: number;
+  snippet: string | null;
+}
+
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -57,10 +73,10 @@ const pagesApp = new Hono()
     // Weighted ranking: title (A=1.0), description (B=0.4), llm_summary (C=0.2), tags+entityType (D=0.1).
     const prefixQuery = buildPrefixTsquery(q);
 
-    let results: any[] = [];
+    let results: PageSearchRow[] = [];
 
     if (prefixQuery) {
-      results = await rawDb.unsafe(
+      results = (await rawDb.unsafe(
         `SELECT
         id, numeric_id, title, description, entity_type, category,
         reader_importance, quality,
@@ -74,7 +90,7 @@ const pagesApp = new Hono()
       ORDER BY rank DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
         [prefixQuery, limit],
-      );
+      )) as unknown as PageSearchRow[];
     }
 
     // Phase 2: If FTS returned few results, fall back to pg_trgm similarity
@@ -92,13 +108,13 @@ const pagesApp = new Hono()
         AND id NOT IN (SELECT unnest($3::text[]))
       ORDER BY similarity(title, $1) DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
-        [q, limit - results.length, results.map((r: any) => r.id)],
+        [q, limit - results.length, results.map((r) => r.id)],
       );
-      results = [...results, ...trigramResults];
+      results = [...results, ...(trigramResults as unknown as PageSearchRow[])];
     }
 
     return c.json({
-      results: results.map((r: any) => ({
+      results: results.map((r) => ({
         id: r.id,
         numericId: r.numeric_id,
         title: r.title,
@@ -107,7 +123,7 @@ const pagesApp = new Hono()
         category: r.category,
         readerImportance: r.reader_importance,
         quality: r.quality,
-        score: parseFloat(r.rank),
+        score: parseFloat(String(r.rank)),
         snippet: r.snippet || null,
       })),
       query: q,

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -27,6 +27,36 @@ import {
   type ResourceStatsResult,
 } from "../api-types.js";
 
+// ---- Raw SQL row types ----
+
+/** Row shape returned by the resource FTS search query. */
+interface ResourceSearchRow {
+  id: string;
+  url: string;
+  title: string | null;
+  type: string | null;
+  summary: string | null;
+  review: string | null;
+  abstract: string | null;
+  key_points: string[] | null;
+  publication_id: string | null;
+  authors: string[] | null;
+  published_date: string | null;
+  tags: string[] | null;
+  local_filename: string | null;
+  credibility_override: number | null;
+  fetched_at: string | null;
+  content_hash: string | null;
+  created_at: string;
+  updated_at: string;
+  rank: number;
+}
+
+/** Row shape returned by COUNT(*) aggregate queries via db.execute(). */
+interface CountRow {
+  c: string | number;
+}
+
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
@@ -308,7 +338,7 @@ const resourcesApp = new Hono()
       : [];
 
     return c.json({
-      results: rows.map((r: any) => ({
+      results: (rows as ResourceSearchRow[]).map((r) => ({
         id: r.id,
         url: r.url,
         title: r.title,
@@ -383,9 +413,9 @@ const resourcesApp = new Hono()
       byType: Object.fromEntries(
         byType.map((r) => [r.type ?? "unknown", r.count])
       ),
-      orphanedCount: Number((orphanedResult as any)[0]?.c ?? 0),
-      withMetadata: Number((withMetadataResult as any)[0]?.c ?? 0),
-      fetched: Number((fetchedResult as any)[0]?.c ?? 0),
+      orphanedCount: Number((orphanedResult as unknown as CountRow[])[0]?.c ?? 0),
+      withMetadata: Number((withMetadataResult as unknown as CountRow[])[0]?.c ?? 0),
+      fetched: Number((fetchedResult as unknown as CountRow[])[0]?.c ?? 0),
     };
 
     return c.json(result);

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -34,10 +34,8 @@ import {
   getBacklinks,
   getCitationQuotes,
 } from '../lib/wiki-server/pages.ts';
-import type {
-  SessionPageChangesResult,
-  RiskLatestResult,
-} from '../../apps/wiki-server/src/api-types.ts';
+import type { SessionPageChangesResult } from '../lib/wiki-server/sessions.ts';
+import type { RiskLatestResult } from '../lib/wiki-server/risk.ts';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -7,10 +7,8 @@
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
-import type {
-  InsertClaim,
-  ClaimPageReferenceRow,
-} from '../../../apps/wiki-server/src/api-types.ts';
+import type { InsertClaim } from '../../../apps/wiki-server/src/api-types.ts';
+import type { ClaimPageReferenceRow } from './references.ts';
 import type { hc, InferResponseType } from 'hono/client';
 import type { ClaimsRoute } from '../../../apps/wiki-server/src/routes/claims.ts';
 

--- a/crux/lib/wiki-server/index.ts
+++ b/crux/lib/wiki-server/index.ts
@@ -22,7 +22,7 @@ export { apiOk, apiErr, unwrap } from './client.ts';
 
 export type { EditLogApiEntry } from './edit-logs.ts';
 export type { UpsertCitationQuoteItem, AccuracyVerdict, MarkAccuracyItem, AccuracyDashboardData } from './citations.ts';
-export type { SessionApiEntry, SessionEntry } from './sessions.ts';
+export type { SessionApiEntry, SessionEntry, SessionPageChangesResult } from './sessions.ts';
 export type {
   AutoUpdateRunResultEntry,
   RecordAutoUpdateRunInput,
@@ -30,7 +30,7 @@ export type {
   AutoUpdateNewsItem,
   AutoUpdateNewsItemEntry,
 } from './auto-update.ts';
-export type { RiskSnapshot } from './risk.ts';
+export type { RiskSnapshot, RiskLatestResult } from './risk.ts';
 export type { UpsertSummaryItem } from './summaries.ts';
 export type { InsertClaimItem } from './claims.ts';
 export type { PageLinkItem } from './links.ts';
@@ -132,6 +132,19 @@ export {
 
 // Resources
 export { upsertResource } from './resources.ts';
+
+// References
+export {
+  getPageReferences,
+  createClaimReference,
+  createCitation,
+  createCitationsBatch,
+} from './references.ts';
+export type {
+  GetPageReferencesResult,
+  ClaimPageReferenceRow,
+  PageCitationRow,
+} from './references.ts';
 
 
 // Entities

--- a/crux/lib/wiki-server/risk.ts
+++ b/crux/lib/wiki-server/risk.ts
@@ -11,6 +11,7 @@ import type { HallucinationRiskRoute } from '../../../apps/wiki-server/src/route
 
 type RpcClient = ReturnType<typeof hc<HallucinationRiskRoute>>;
 export type RiskBatchResult = InferResponseType<RpcClient['batch']['$post'], 201>;
+export type RiskLatestResult = InferResponseType<RpcClient['latest']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)


### PR DESCRIPTION
## Summary

Server-side RPC type cleanup — fixes type regressions, removes dead code, and resolves import issues.

- **Fix `(r: any)` type regressions in 6 route files**: Replace untyped raw SQL mappings with typed `interface` DB row shapes, so `InferResponseType<>` produces proper `string`/`number` field types instead of `any`. Affected: links.ts, claims.ts, hallucination-risk.ts, explore.ts, pages.ts, resources.ts
- **Remove 57 dead response interfaces from api-types.ts** (~550 lines): All were superseded by `InferResponseType<>` in crux clients and `api-response-types.ts`
- **Resolve `CitationHealthResult` name collision**: Remove hand-written version from api-types.ts; let citations.ts infer its return type naturally (avoids circular import)
- **Fix stale crux imports**: `query.ts` and `claims.ts` now import response types from InferResponseType sources instead of api-types.ts
- **Add `RiskLatestResult` export** to crux risk module; re-export references module from barrel

## Test plan
- [x] TypeScript compiles cleanly (wiki-server, frontend, crux — all zero errors)
- [x] All 312 tests pass
- [x] Full gate check passes (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
