### PR TITLE
refactor: replace frontend local types with canonical api-response-types

### DIFF
--- a/apps/web/src/app/claims/claim/[id]/page.tsx
+++ b/apps/web/src/app/claims/claim/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById, getEntityHref } from "@data";
-import type { ClaimRow, SimilarClaimsResult } from "@wiki-server/api-response-types";
+import type { ClaimRow, SimilarClaimsResult, PageReferencesResult } from "@wiki-server/api-response-types";
 import { buildEntityNameMap } from "../../components/claims-data";
 import { CategoryBadge } from "../../components/category-badge";
 import { ConfidenceBadge } from "../../components/confidence-badge";
@@ -12,10 +12,7 @@ import { NumericValueDisplay } from "../../components/numeric-value-display";
 import { formatStructuredValue } from "@lib/format-value";
 import { ClaimSourcesList } from "../../components/claim-sources-list";
 import { VerdictBadge } from "../../components/verdict-badge";
-import {
-  ClaimPageReferences,
-  type PageReference,
-} from "../../components/claim-page-references";
+import { ClaimPageReferences } from "../../components/claim-page-references";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -39,7 +36,7 @@ export default async function ClaimDetailPage({ params }: PageProps) {
     fetchFromWikiServer<ClaimRow>(`/api/claims/${id}?includeSources=true`, {
       revalidate: 300,
     }),
-    fetchFromWikiServer<{ references: PageReference[] }>(
+    fetchFromWikiServer<PageReferencesResult>(
       `/api/claims/${id}/page-references`,
       { revalidate: 300 }
     ),

--- a/apps/web/src/app/claims/components/claim-page-references.tsx
+++ b/apps/web/src/app/claims/components/claim-page-references.tsx
@@ -2,15 +2,9 @@
 
 import Link from "next/link";
 import { FileText } from "lucide-react";
+import type { PageReferenceRow } from "@wiki-server/api-response-types";
 
-export interface PageReference {
-  id: number;
-  claimId: number;
-  pageId: string;
-  footnote: number | null;
-  section: string | null;
-  createdAt: string;
-}
+export type PageReference = PageReferenceRow;
 
 export function ClaimPageReferences({
   references,

--- a/apps/web/src/app/claims/components/claims-data.ts
+++ b/apps/web/src/app/claims/components/claims-data.ts
@@ -1,13 +1,6 @@
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById } from "@data";
-import type { ClaimRow } from "@wiki-server/api-response-types";
-
-interface PaginatedClaimsResponse {
-  claims: ClaimRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+import type { ClaimRow, GetAllClaimsResult } from "@wiki-server/api-response-types";
 
 /** Convert a slug like "open-philanthropy" to "Open Philanthropy" as fallback */
 function formatSlugAsTitle(slug: string): string {
@@ -49,7 +42,7 @@ export async function fetchAllClaims(): Promise<ClaimRow[]> {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const page = await fetchFromWikiServer<PaginatedClaimsResponse>(
+    const page = await fetchFromWikiServer<GetAllClaimsResult>(
       `/api/claims/all?limit=${PAGE_SIZE}&offset=${offset}&includeSources=true`,
       { revalidate: 300 }
     );

--- a/apps/web/src/app/claims/components/claims-nav.ts
+++ b/apps/web/src/app/claims/components/claims-nav.ts
@@ -1,11 +1,7 @@
 import type { NavSection } from "@/lib/internal-nav";
 import { fetchFromWikiServer } from "@lib/wiki-server";
 import { getEntityById, getEntityHref } from "@data";
-
-interface NetworkResponse {
-  nodes: { entityId: string; claimCount: number; mentionCount?: number }[];
-  edges: { source: string; target: string; weight: number }[];
-}
+import type { ClaimsNetworkResult } from "@wiki-server/api-response-types";
 
 export interface ClaimsEntityItem {
   entityId: string;
@@ -45,7 +41,7 @@ export async function getClaimsNav(): Promise<NavSection[]> {
  * Returns ALL entities with claims, sorted by claim count descending.
  */
 export async function getClaimsEntities(): Promise<ClaimsEntityItem[]> {
-  const result = await fetchFromWikiServer<NetworkResponse>(
+  const result = await fetchFromWikiServer<ClaimsNetworkResult>(
     "/api/claims/network",
     { revalidate: 300 }
   );

--- a/apps/web/src/app/claims/network/page.tsx
+++ b/apps/web/src/app/claims/network/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { fetchFromWikiServer } from "@lib/wiki-server";
+import type { ClaimsNetworkResult } from "@wiki-server/api-response-types";
 import { buildEntityNameMap } from "../components/claims-data";
 import { NetworkGraph } from "../components/network-graph";
 
@@ -9,13 +10,8 @@ export const metadata: Metadata = {
     "Interactive network graph showing entity relationships via shared claims.",
 };
 
-interface NetworkResponse {
-  nodes: { entityId: string; claimCount: number }[];
-  edges: { source: string; target: string; weight: number }[];
-}
-
 export default async function NetworkPage() {
-  const result = await fetchFromWikiServer<NetworkResponse>(
+  const result = await fetchFromWikiServer<ClaimsNetworkResult>(
     "/api/claims/network",
     { revalidate: 300 }
   );

--- a/apps/web/src/app/claims/relationships/page.tsx
+++ b/apps/web/src/app/claims/relationships/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 import { fetchFromWikiServer } from "@lib/wiki-server";
+import type { ClaimsRelationshipsResult } from "@wiki-server/api-response-types";
 import { buildEntityNameMap } from "../components/claims-data";
-import {
-  RelationshipsTable,
-  type RelationshipRow,
-} from "./relationships-table";
+import { RelationshipsTable } from "./relationships-table";
 
 export const metadata: Metadata = {
   title: "Entity Relationships",
@@ -12,12 +10,8 @@ export const metadata: Metadata = {
     "Entity pairs connected by shared claims across wiki pages.",
 };
 
-interface RelationshipsResponse {
-  relationships: RelationshipRow[];
-}
-
 export default async function RelationshipsPage() {
-  const result = await fetchFromWikiServer<RelationshipsResponse>(
+  const result = await fetchFromWikiServer<ClaimsRelationshipsResult>(
     "/api/claims/relationships",
     { revalidate: 300 }
   );

--- a/apps/web/src/app/claims/relationships/relationships-table.tsx
+++ b/apps/web/src/app/claims/relationships/relationships-table.tsx
@@ -25,13 +25,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { RelationshipRow } from "@wiki-server/api-response-types";
 
-export interface RelationshipRow {
-  entityA: string;
-  entityB: string;
-  claimCount: number;
-  sampleClaims: string[];
-}
+export type { RelationshipRow };
 
 function getColumns(entityNames: Record<string, string>): ColumnDef<RelationshipRow>[] {
   return [

--- a/apps/web/src/app/source/[id]/page.tsx
+++ b/apps/web/src/app/source/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@data";
 import { getCitationQuotesByUrl } from "@/lib/citation-data";
 import { fetchFromWikiServer } from "@/lib/wiki-server";
+import type { CitationContentResult } from "@wiki-server/api-response-types";
 import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
 import { getDomain } from "@/components/wiki/resource-utils";
 import { renderInlineMarkdown } from "@/lib/inline-markdown";
@@ -42,15 +43,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     description: resource.summary || `Citation source: ${resource.title}`,
     robots: { index: false, follow: false },
   };
-}
-
-interface CitationContentData {
-  url: string;
-  fetchedAt: string;
-  httpStatus: number | null;
-  pageTitle: string | null;
-  fullTextPreview: string | null;
-  contentLength: number | null;
 }
 
 function formatDate(iso: string): string {
@@ -93,7 +85,7 @@ export default async function SourcePage({ params }: PageProps) {
   const [quotesData, contentData] = await Promise.all([
     resource.url ? getCitationQuotesByUrl(resource.url) : null,
     resource.url
-      ? fetchFromWikiServer<CitationContentData>(
+      ? fetchFromWikiServer<CitationContentResult>(
           `/api/citations/content?url=${encodeURIComponent(resource.url)}`,
           { revalidate: 3600 }
         )

--- a/apps/web/src/app/wiki/page.tsx
+++ b/apps/web/src/app/wiki/page.tsx
@@ -1,25 +1,12 @@
 import { Suspense } from "react";
 import { getExploreItems } from "@/data";
-import type { ExploreItem } from "@/data";
 import { ExploreGrid } from "@/components/explore/ExploreGrid";
 import { fetchFromWikiServer } from "@/lib/wiki-server";
-
-interface ExploreResponse {
-  items: ExploreItem[];
-  total: number;
-  limit: number;
-  offset: number;
-  facets: {
-    clusters: Record<string, number>;
-    categories: Record<string, number>;
-    entityTypes: Record<string, number>;
-    riskCategories: Record<string, number>;
-  };
-}
+import type { ExploreResult } from "@wiki-server/api-response-types";
 
 export default async function WikiIndex() {
   // Try fetching first page from wiki-server for a smaller initial payload
-  const serverData = await fetchFromWikiServer<ExploreResponse>(
+  const serverData = await fetchFromWikiServer<ExploreResult>(
     "/api/explore?limit=50&offset=0&sort=recommended",
     { revalidate: 300 }
   );

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -1,6 +1,8 @@
 import { fetchFromWikiServer } from "./wiki-server";
 import type {
   CitationHealthResult,
+  CitationQuotesResult,
+  CitationQuotesByUrlResult,
 } from "@wiki-server/api-response-types";
 import type {
   AccuracyVerdict,
@@ -49,10 +51,6 @@ export interface CitationHealthSummary {
   unchecked: number;
 }
 
-interface QuotesApiResponse {
-  quotes: CitationQuote[];
-}
-
 /**
  * Fetch citation verification data for a specific page from the wiki-server.
  * Returns an empty array if the server is unavailable or the page has no data.
@@ -62,35 +60,24 @@ interface QuotesApiResponse {
 export async function getCitationQuotes(
   pageId: string
 ): Promise<CitationQuote[]> {
-  const result = await fetchFromWikiServer<QuotesApiResponse>(
+  const result = await fetchFromWikiServer<CitationQuotesResult>(
     `/api/citations/quotes?page_id=${encodeURIComponent(pageId)}`,
     { revalidate: 600 }
   );
 
   if (!result?.quotes) return [];
 
-  // Only include quotes that have some verification data worth showing
+  // Only include quotes that have some verification data worth showing.
+  // Cast needed: server returns accuracyVerdict as string|null (DB row),
+  // but CitationQuote narrows it to AccuracyVerdict|null.
   return result.quotes.filter(
     (q) => q.quoteVerified || q.accuracyVerdict !== null
-  );
+  ) as unknown as CitationQuote[];
 }
 
 /** Citation quote with page context — returned by quotes-by-url endpoint */
 export interface CrossPageCitationQuote extends CitationQuote {
   pageId: string;
-}
-
-interface QuotesByUrlResponse {
-  quotes: CrossPageCitationQuote[];
-  stats: {
-    totalPages: number;
-    totalQuotes: number;
-    verified: number;
-    accurate: number;
-    inaccurate: number;
-    unsupported: number;
-    minorIssues: number;
-  };
 }
 
 /**
@@ -99,8 +86,8 @@ interface QuotesByUrlResponse {
  */
 export async function getCitationQuotesByUrl(
   url: string
-): Promise<QuotesByUrlResponse | null> {
-  return fetchFromWikiServer<QuotesByUrlResponse>(
+): Promise<CitationQuotesByUrlResult | null> {
+  return fetchFromWikiServer<CitationQuotesByUrlResult>(
     `/api/citations/quotes-by-url?url=${encodeURIComponent(url)}`,
     { revalidate: 600 }
   );

--- a/apps/wiki-server/src/api-response-types.ts
+++ b/apps/wiki-server/src/api-response-types.ts
@@ -24,6 +24,7 @@ import type { AutoUpdateRunsRoute } from './routes/auto-update-runs.js';
 import type { AutoUpdateNewsRoute } from './routes/auto-update-news.js';
 import type { LinksRoute } from './routes/links.js';
 import type { HallucinationRiskRoute } from './routes/hallucination-risk.js';
+import type { ExploreRoute } from './routes/explore.js';
 
 // ---------------------------------------------------------------------------
 // RPC client phantom types (compile-time only)
@@ -38,6 +39,7 @@ type AutoUpdateRunsRpc = ReturnType<typeof hc<AutoUpdateRunsRoute>>;
 type AutoUpdateNewsRpc = ReturnType<typeof hc<AutoUpdateNewsRoute>>;
 type LinksRpc = ReturnType<typeof hc<LinksRoute>>;
 type HallucinationRiskRpc = ReturnType<typeof hc<HallucinationRiskRoute>>;
+type ExploreRpc = ReturnType<typeof hc<ExploreRoute>>;
 
 // ---------------------------------------------------------------------------
 // Claims
@@ -61,6 +63,24 @@ export type SimilarClaimsResult = InferResponseType<ClaimsRpc[':id']['similar'][
 /** A single similar claim item. */
 export type SimilarClaimItem = SimilarClaimsResult['claims'][number];
 
+/** Paginated claims list response from /all. */
+export type GetAllClaimsResult = InferResponseType<ClaimsRpc['all']['$get'], 200>;
+
+/** Claims network graph response. */
+export type ClaimsNetworkResult = InferResponseType<ClaimsRpc['network']['$get'], 200>;
+
+/** Claims relationships response. */
+export type ClaimsRelationshipsResult = InferResponseType<ClaimsRpc['relationships']['$get'], 200>;
+
+/** A single relationship row. */
+export type RelationshipRow = ClaimsRelationshipsResult['relationships'][number];
+
+/** Page references for a claim. */
+export type PageReferencesResult = InferResponseType<ClaimsRpc[':id']['page-references']['$get'], 200>;
+
+/** A single page reference row. */
+export type PageReferenceRow = PageReferencesResult['references'][number];
+
 // ---------------------------------------------------------------------------
 // Citations
 // ---------------------------------------------------------------------------
@@ -79,6 +99,18 @@ export type CitationContentListEntry = CitationContentListResult['entries'][numb
 
 /** Citation content stats response. */
 export type CitationContentStatsResult = InferResponseType<CitationsRpc['content']['stats']['$get'], 200>;
+
+/** Citation quotes for a page. */
+export type CitationQuotesResult = InferResponseType<CitationsRpc['quotes']['$get'], 200>;
+
+/** A single citation quote row (full DB shape). */
+export type CitationQuoteDbRow = CitationQuotesResult['quotes'][number];
+
+/** Citation quotes grouped by URL. */
+export type CitationQuotesByUrlResult = InferResponseType<CitationsRpc['quotes-by-url']['$get'], 200>;
+
+/** Single citation content record. */
+export type CitationContentResult = InferResponseType<CitationsRpc['content']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Sessions
@@ -145,3 +177,13 @@ type RiskLatestResult = InferResponseType<HallucinationRiskRpc['latest']['$get']
 
 /** A single risk page row. */
 export type RiskPageRow = RiskLatestResult['pages'][number];
+
+// ---------------------------------------------------------------------------
+// Explore
+// ---------------------------------------------------------------------------
+
+/** Explore page response. */
+export type ExploreResult = InferResponseType<ExploreRpc['index']['$get'], 200>;
+
+/** A single explore item. */
+export type ExploreItem = ExploreResult['items'][number];


### PR DESCRIPTION
## Summary

- Add 15 new `InferResponseType` exports to `api-response-types.ts` covering claims (paginated, network, relationships, page-references), citations (quotes, quotes-by-url, content), and explore endpoints
- Replace 10 hand-written local interfaces across frontend files with these canonical types, ensuring compile-time type safety derived directly from route handlers
- Net -26 lines: removes drift-prone duplicated type definitions

**Part 2 of RPC migration cleanup** (Part 1: #1229 — server-side `(r: any)` fixes and dead code removal)

## Files changed

| File | Change |
|------|--------|
| `api-response-types.ts` | +15 new type exports (GetAllClaimsResult, ClaimsNetworkResult, etc.) |
| `claims-data.ts` | `PaginatedClaimsResponse` → `GetAllClaimsResult` |
| `claims-nav.ts` | `NetworkResponse` → `ClaimsNetworkResult` |
| `network/page.tsx` | `NetworkResponse` → `ClaimsNetworkResult` |
| `relationships/page.tsx` | `RelationshipsResponse` → `ClaimsRelationshipsResult` |
| `claim/[id]/page.tsx` | Local `PageReference` → `PageReferenceRow` |
| `claim-page-references.tsx` | Local `PageReference` → `PageReferenceRow` |
| `relationships-table.tsx` | Local `RelationshipRow` → canonical import |
| `wiki/page.tsx` | `ExploreResponse` → `ExploreResult` |
| `citation-data.ts` | `QuotesApiResponse` → `CitationQuotesResult`, `QuotesByUrlResponse` → `CitationQuotesByUrlResult` |
| `source/[id]/page.tsx` | `CitationContentData` → `CitationContentResult` |

## Test plan

- [x] TypeScript compiles cleanly (wiki-server, frontend, crux)
- [x] All 312 tests pass
- [x] All 13 gate checks pass
