### PR TITLE
fix: PR review quick fixes — wrong entity ref, dead code, unused param

### DIFF
--- a/content/docs/knowledge-base/organizations/far-ai.mdx
+++ b/content/docs/knowledge-base/organizations/far-ai.mdx
@@ -31,7 +31,7 @@ import { DataInfoBox, EntityLink } from '@components/wiki';
 
 FAR AI conducts technical research in areas including <EntityLink id="E1">adversarial robustness</EntityLink>, <EntityLink id="E174">Interpretability</EntityLink>, model evaluation, and alignment, focusing on fundamental AI safety challenges described as too large or resource-intensive for academia.[^rc-18d6] Notable results include adversarial policies that achieved a >99% win rate against the superhuman Go AI KataGo when it uses no tree search, and a >77% win rate even when KataGo uses superhuman-level search—policies that are themselves easily beaten by human amateur players, suggesting that high capability does not guarantee robustness in adversarial settings.[^rc-8f49] FAR AI co-authored the "Towards Guaranteed Safe AI" framework paper published in May 2024.[^rc-18d6] In early 2026, FAR AI was selected by the European Commission's AI Office to lead CBRN risk research under tender EC-CNECT/2025/OP/0032.[^rc-28ce]
 
-The organization has grown to <F e="anthropic" f="a1e87600">40</F>+ total staff as of early 2026, with a technical team of approximately 15 researchers and plans to scale to 30+ researchers.[^rc-a1d9] Financial details and program structure are described in the sections below.
+The organization has grown to 40+ total staff as of early 2026, with a technical team of approximately 15 researchers and plans to scale to 30+ researchers.[^rc-a1d9] Financial details and program structure are described in the sections below.
 
 ## Key Research Areas
 

--- a/crux/claims/gap-analysis.ts
+++ b/crux/claims/gap-analysis.ts
@@ -20,6 +20,7 @@
  */
 
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
@@ -153,7 +154,6 @@ function isClaimOnPage(claim: string, pageTextLower: string): boolean {
 function findContradictions(
   claim: ClaimWithSource,
   pageLines: string[],
-  pageTextLower: string,
 ): string | null {
   const claimNumbers = extractNumbers(claim.claimText);
   if (claimNumbers.length === 0) return null;
@@ -274,7 +274,7 @@ export async function runGapAnalysis(pageId: string): Promise<GapAnalysisResult 
       onPage++;
 
       // Even if on page, check for contradictions
-      const contradictingLine = findContradictions(claimWithSource, pageLines, pageTextLower);
+      const contradictingLine = findContradictions(claimWithSource, pageLines);
       if (contradictingLine) {
         contradictions.push({ claim: claimWithSource, pageText: contradictingLine });
       }
@@ -440,7 +440,7 @@ async function main() {
 }
 
 // Run CLI when invoked directly
-const isMain = process.argv[1]?.includes('gap-analysis');
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
   main().catch(err => {
     console.error('Error:', err instanceof Error ? err.message : String(err));

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -137,22 +137,6 @@ export async function clearClaimsBySection(
 // ---------------------------------------------------------------------------
 
 /**
- * Update the relatedEntities field on an existing claim.
- */
-export async function updateClaimRelatedEntities(
-  claimId: number,
-  relatedEntities: string[] | null,
-): Promise<ApiResult<ClaimRow>> {
-  return apiRequest<ClaimRow>(
-    'PATCH',
-    `/api/claims/${claimId}`,
-    { relatedEntities },
-    undefined,
-    'content',
-  );
-}
-
-/**
  * Batch update relatedEntities on multiple claims at once.
  * Max 500 items per call.
  */


### PR DESCRIPTION
## Summary

Quick fixes from a comprehensive review of the last 40 merged PRs (#1171–#1234):

- **Fix wrong entity reference on FAR AI page** — `<F e="anthropic" f="a1e87600">` was displaying Anthropic's gross margin (40%) as FAR AI's staff count. Replaced with plain text.
- **Remove unused `pageTextLower` parameter** from `findContradictions()` in gap-analysis.ts
- **Fix fragile `isMain` detection** — `process.argv[1]?.includes('gap-analysis')` would match test files too. Replaced with proper `fileURLToPath(import.meta.url)` comparison.
- **Remove dead `updateClaimRelatedEntities()`** function from wiki-server claims client (superseded by batch variant, zero callers)

## Related issues filed from the same review

- #1241 — Type safety sweep: eliminate `(r: any)` and `as unknown as T` casts
- #1242 — Batch UPDATE N+1 → bulk SQL
- #1243 — Destructive endpoints: audit logging + soft-delete
- #1244 — UI constants: extract shared row heights, verdict config, page sizes
- #1245 — Tech debt tracking checklist (10 lower-priority items)
- #1246 — Review guidelines: patterns to catch going forward

## Test plan

- [x] Gate passes (all 13 checks)
- [x] TypeScript compiles cleanly for both app and crux
- [x] No behavioral changes beyond fixing the incorrect fact reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)