### PR TITLE
feat: add audit logging to bulk claim deletion endpoint

### DIFF
--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -409,6 +409,16 @@ const claimsApp = new Hono()
     const parsed = DeleteByIdsSchema.safeParse(body);
     if (!parsed.success) return validationError(c, parsed.error.message);
 
+    // Audit log: record bulk deletion before executing it
+    console.log(
+      JSON.stringify({
+        audit: "bulk-claim-delete",
+        timestamp: new Date().toISOString(),
+        count: parsed.data.ids.length,
+        claimIds: parsed.data.ids,
+      })
+    );
+
     const db = getDrizzleDb();
     const deleted = await db
       .delete(claims)


### PR DESCRIPTION
## Summary

- Added structured JSON audit logging to the `POST /api/claims/delete-by-ids` endpoint in the wiki-server
- Before executing the bulk delete, the endpoint now logs the claim IDs, count, and timestamp via `console.log` as a JSON object with `audit: "bulk-claim-delete"`
- This provides an audit trail for destructive operations without requiring database schema changes

## Test plan

- [ ] Verify the wiki-server starts without errors
- [ ] Call `POST /api/claims/delete-by-ids` with a test payload and confirm the structured JSON audit line appears in server logs
- [ ] Confirm existing bulk delete functionality still works correctly (claims are deleted, response includes count)

Closes #1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)