### PR TITLE
refactor: eliminate unsafe type casts in wiki-server and frontend

### DIFF
--- a/apps/web/src/app/internal/hallucination-risk/page.tsx
+++ b/apps/web/src/app/internal/hallucination-risk/page.tsx
@@ -30,6 +30,17 @@ export interface RiskPageData {
   factors: string[];
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_RISK_LEVELS = new Set<string>(["low", "medium", "high"]);
+
+/** Narrow a string to the RiskLevel union, defaulting to "medium" for unknown values. */
+function toRiskLevel(value: string): "low" | "medium" | "high" {
+  return VALID_RISK_LEVELS.has(value)
+    ? (value as "low" | "medium" | "high")
+    : "medium";
+}
+
 // ── Data loading ─────────────────────────────────────────────────────────────
 
 /**
@@ -97,7 +108,7 @@ async function loadRiskDataFromApi(): Promise<FetchResult<RiskPageData[]>> {
           entityType: meta?.entityType,
           quality: meta?.quality ?? null,
           wordCount: meta?.wordCount,
-          level: r.level as "low" | "medium" | "high",
+          level: toRiskLevel(r.level),
           score: r.score,
           factors: r.factors || [],
         };

--- a/apps/web/src/app/internal/improve-runs/page.tsx
+++ b/apps/web/src/app/internal/improve-runs/page.tsx
@@ -33,6 +33,17 @@ export interface ImproveRunRow {
   costBreakdown: Record<string, number> | null;
 }
 
+/** Narrow unknown jsonb value to Record<string, number> | null at runtime. */
+function toCostBreakdown(value: unknown): Record<string, number> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
+  const result: Record<string, number> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === "number") result[k] = v;
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
 async function loadRunsFromApi() {
   const result = await fetchDetailed<{
     entries: ArtifactRow[];
@@ -64,7 +75,7 @@ async function loadRunsFromApi() {
         hasCitationAudit: r.citationAudit != null,
         hasSectionDiffs:
           Array.isArray(r.sectionDiffs) && r.sectionDiffs.length > 0,
-        costBreakdown: r.costBreakdown as Record<string, number> | null,
+        costBreakdown: toCostBreakdown(r.costBreakdown),
       })
     ),
   };

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -7,7 +7,19 @@ import type {
 import type {
   AccuracyVerdict,
 } from "@wiki-server/api-types";
-import { ACCURACY_VERDICTS } from "@wiki-server/api-types";
+
+/**
+ * Valid accuracy verdict values — mirrors ACCURACY_VERDICTS from api-types.
+ * Inlined here to avoid a runtime import of @wiki-server/api-types
+ * (vitest can't resolve it as a runtime dependency).
+ */
+const ACCURACY_VERDICTS: readonly string[] = [
+  "accurate",
+  "inaccurate",
+  "unsupported",
+  "minor_issues",
+  "not_verifiable",
+];
 
 // Re-export the server type for consumers
 export type { CitationHealthResult } from "@wiki-server/api-response-types";
@@ -52,6 +64,17 @@ export interface CitationHealthSummary {
 }
 
 /**
+ * Narrow a string | null to AccuracyVerdict | null at runtime.
+ * Returns null for unrecognized values instead of silently mis-typing them.
+ */
+function toAccuracyVerdict(value: string | null): AccuracyVerdict | null {
+  if (value === null) return null;
+  return (ACCURACY_VERDICTS as readonly string[]).includes(value)
+    ? (value as AccuracyVerdict)
+    : null;
+}
+
+/**
  * Fetch citation verification data for a specific page from the wiki-server.
  * Returns an empty array if the server is unavailable or the page has no data.
  *
@@ -68,11 +91,27 @@ export async function getCitationQuotes(
   if (!result?.quotes) return [];
 
   // Only include quotes that have some verification data worth showing.
-  // Cast needed: server returns accuracyVerdict as string|null (DB row),
-  // but CitationQuote narrows it to AccuracyVerdict|null.
-  return result.quotes.filter(
-    (q) => q.quoteVerified || q.accuracyVerdict !== null
-  ) as unknown as CitationQuote[];
+  // Map server rows to CitationQuote, narrowing accuracyVerdict from string to the union type.
+  return result.quotes
+    .filter((q) => q.quoteVerified || q.accuracyVerdict !== null)
+    .map((q): CitationQuote => ({
+      footnote: q.footnote,
+      url: q.url,
+      resourceId: q.resourceId,
+      claimText: q.claimText,
+      sourceQuote: q.sourceQuote,
+      sourceTitle: q.sourceTitle,
+      sourceType: q.sourceType,
+      quoteVerified: q.quoteVerified,
+      verificationScore: q.verificationScore,
+      verifiedAt: q.verifiedAt,
+      accuracyVerdict: toAccuracyVerdict(q.accuracyVerdict),
+      accuracyScore: q.accuracyScore,
+      accuracyIssues: q.accuracyIssues,
+      accuracySupportingQuotes: q.accuracySupportingQuotes,
+      verificationDifficulty: q.verificationDifficulty,
+      accuracyCheckedAt: q.accuracyCheckedAt,
+    }));
 }
 
 /** Citation quote with page context — returned by quotes-by-url endpoint */

--- a/apps/wiki-server/src/__tests__/links.test.ts
+++ b/apps/wiki-server/src/__tests__/links.test.ts
@@ -346,6 +346,25 @@ function syncLinks(app: Hono, links: unknown[], replace = false) {
   return postJson(app, "/api/links/sync", { links, replace });
 }
 
+// ---- Response types (mirrors API response shapes for type-safe assertions) ----
+
+interface BacklinkItem {
+  id: string;
+  type: string;
+  title: string;
+  relationship?: string;
+  linkType: string;
+  weight: number;
+}
+
+interface RelatedItem {
+  id: string;
+  type: string;
+  title: string;
+  score: number;
+  label?: string;
+}
+
 // ---- Tests ----
 
 describe("Links API", () => {
@@ -484,7 +503,7 @@ describe("Links API", () => {
       const body = await res.json();
       expect(body.targetId).toBe("ai-safety");
       expect(body.backlinks).toHaveLength(2);
-      expect(body.backlinks.map((b: any) => b.id).sort()).toEqual([
+      expect(body.backlinks.map((b: BacklinkItem) => b.id).sort()).toEqual([
         "anthropic",
         "openai",
       ]);
@@ -587,11 +606,11 @@ describe("Links API", () => {
       // Both A and B should see each other as related
       const resA = await app.request("/api/links/related/a");
       const bodyA = await resA.json();
-      expect(bodyA.related.some((r: any) => r.id === "b")).toBe(true);
+      expect(bodyA.related.some((r: RelatedItem) => r.id === "b")).toBe(true);
 
       const resB = await app.request("/api/links/related/b");
       const bodyB = await resB.json();
-      expect(bodyB.related.some((r: any) => r.id === "a")).toBe(true);
+      expect(bodyB.related.some((r: RelatedItem) => r.id === "a")).toBe(true);
     });
   });
 

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -858,7 +858,7 @@ const claimsApp = new Hono()
 
     // Use raw SQL for the similarity() function (same pattern as pages.ts trigram fallback)
     const rawDb = getDb();
-    const rows = (await rawDb.unsafe(
+    const rows = await rawDb.unsafe<SimilarClaimDbRow[]>(
       `SELECT
       id, entity_id, entity_type, claim_text, claim_category, confidence,
       similarity(claim_text, $1) AS similarity_score
@@ -868,7 +868,7 @@ const claimsApp = new Hono()
     ORDER BY similarity(claim_text, $1) DESC
     LIMIT $3`,
       [targetText, id, limit],
-    )) as unknown as SimilarClaimDbRow[];
+    );
 
     return c.json({
       claims: rows.map((r) => ({

--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -151,9 +151,12 @@ const DERIVED_TYPE_EXPR = `
   END
 `;
 
+/** SQL parameter type compatible with postgres.js unsafe() */
+type SqlParam = string | number;
+
 /**
  * Build parameterized conditions and collect params.
- * Returns { conditions: string[], params: unknown[], paramIdx: number }.
+ * Returns { conditions: string[], params: SqlParam[], paramIdx: number }.
  */
 function buildFilterConditions(opts: {
   search?: string;
@@ -162,9 +165,9 @@ function buildFilterConditions(opts: {
   entityType?: string;
   riskCategory?: string;
   startParamIdx?: number;
-}): { conditions: string[]; params: unknown[]; paramIdx: number } {
+}): { conditions: string[]; params: SqlParam[]; paramIdx: number } {
   const conditions: string[] = [BASE_CONDITIONS];
-  const params: unknown[] = [];
+  const params: SqlParam[] = [];
   let paramIdx = opts.startParamIdx ?? 1;
 
   if (opts.search) {
@@ -345,12 +348,12 @@ const exploreApp = new Hono()
     // Execute all queries in parallel
     let [rows, countResult, clusterCounts, categoryCounts, entityTypeCounts, riskCatCounts] =
       await Promise.all([
-        rawDb.unsafe(dataQuery, dataParams as any[]),
-        rawDb.unsafe(countQuery, main.params as any[]),
-        rawDb.unsafe(clusterCountQuery, searchOnly.params as any[]),
-        rawDb.unsafe(categoryCountQuery, searchCluster.params as any[]),
-        rawDb.unsafe(entityTypeCountQuery, searchClusterCat.params as any[]),
-        rawDb.unsafe(riskCatCountQuery, searchClusterCatRisk.params as any[]),
+        rawDb.unsafe<ExploreDataRow[]>(dataQuery, dataParams),
+        rawDb.unsafe<{ total: string }[]>(countQuery, main.params),
+        rawDb.unsafe<FacetCountRow[]>(clusterCountQuery, searchOnly.params),
+        rawDb.unsafe<FacetCountRow[]>(categoryCountQuery, searchCluster.params),
+        rawDb.unsafe<FacetCountRow[]>(entityTypeCountQuery, searchClusterCat.params),
+        rawDb.unsafe<FacetCountRow[]>(riskCatCountQuery, searchClusterCatRisk.params),
       ]);
 
     let total = parseInt(countResult[0]?.total ?? "0", 10);
@@ -392,15 +395,15 @@ const exploreApp = new Hono()
       `;
 
       const [trigramRows, trigramCount] = await Promise.all([
-        rawDb.unsafe(trigramQuery, trigramParams as any[]),
-        rawDb.unsafe(trigramCountQuery, [...noSearchFilters.params, search] as any[]),
+        rawDb.unsafe<ExploreDataRow[]>(trigramQuery, trigramParams),
+        rawDb.unsafe<{ total: string }[]>(trigramCountQuery, [...noSearchFilters.params, search]),
       ]);
       rows = trigramRows;
       total = parseInt(trigramCount[0]?.total ?? "0", 10);
     }
 
     // Transform rows to ExploreItem shape
-    const items = (rows as unknown as ExploreDataRow[]).map((r) => {
+    const items = rows.map((r) => {
       const entityTags = Array.isArray(r.entity_tags) ? r.entity_tags : [];
       const pageTags = parseTags(r.page_tags);
       const tags = entityTags.length > 0 ? entityTags : pageTags;
@@ -412,7 +415,8 @@ const exploreApp = new Hono()
 
       return {
         id: r.id,
-        numericId: r.numeric_id as string,
+        // Safe non-null assertion: BASE_CONDITIONS includes `AND wp.numeric_id IS NOT NULL`
+        numericId: r.numeric_id!,
         title: r.title,
         type: deriveType(r.content_format, r.entity_type, r.category),
         description: r.description || null,
@@ -433,9 +437,9 @@ const exploreApp = new Hono()
       };
     });
 
-    const toCountMap = (rows: unknown[]) =>
+    const toCountMap = (rows: FacetCountRow[]) =>
       Object.fromEntries(
-        (rows as FacetCountRow[]).map((r) => [r.val, parseInt(r.cnt, 10)])
+        rows.map((r) => [r.val, parseInt(r.cnt, 10)])
       );
 
     return c.json({

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -179,7 +179,7 @@ const hallucinationRiskApp = new Hono()
     const uniquePages = Number(pagesResult[0].count);
 
     // Level distribution (from latest snapshot per page) using DISTINCT ON
-    const levelDist = await rawDb`
+    const levelDist = await rawDb<LevelDistRow[]>`
       SELECT level, count(*)::int AS count
       FROM (
         SELECT DISTINCT ON (page_id) level
@@ -193,7 +193,7 @@ const hallucinationRiskApp = new Hono()
       totalSnapshots,
       uniquePages,
       levelDistribution: Object.fromEntries(
-        (levelDist as unknown as LevelDistRow[]).map((r) => [r.level, r.count])
+        levelDist.map((r) => [r.level, r.count])
       ),
     });
   })
@@ -209,7 +209,7 @@ const hallucinationRiskApp = new Hono()
 
     // Use DISTINCT ON for efficient "latest per page" query
     const rows = level
-      ? await rawDb`
+      ? await rawDb<RiskPageDbRow[]>`
           SELECT page_id, score, level, factors, integrity_issues, computed_at
           FROM (
             SELECT DISTINCT ON (page_id) *
@@ -220,7 +220,7 @@ const hallucinationRiskApp = new Hono()
           ORDER BY score DESC
           LIMIT ${limit} OFFSET ${offset}
         `
-      : await rawDb`
+      : await rawDb<RiskPageDbRow[]>`
           SELECT page_id, score, level, factors, integrity_issues, computed_at
           FROM (
             SELECT DISTINCT ON (page_id) *
@@ -232,7 +232,7 @@ const hallucinationRiskApp = new Hono()
         `;
 
     return c.json({
-      pages: (rows as unknown as RiskPageDbRow[]).map((r) => ({
+      pages: rows.map((r) => ({
         pageId: r.page_id,
         score: r.score,
         level: r.level,

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -180,7 +180,7 @@ const linksApp = new Hono()
     // Join with wiki_pages to get title and entity_type for the source.
     // Deduplicate by source_id (a source may link via multiple link_types),
     // then order by weight descending (most relevant first).
-    const results = await rawDb`
+    const results = await rawDb<BacklinkDbRow[]>`
     SELECT * FROM (
       SELECT DISTINCT ON (pl.source_id)
         pl.source_id,
@@ -198,7 +198,7 @@ const linksApp = new Hono()
     LIMIT ${limit}
   `;
 
-    const backlinks = (results as unknown as BacklinkDbRow[]).map((r) => ({
+    const backlinks = results.map((r) => ({
       id: r.source_id,
       type: r.source_type || "concept",
       title: r.source_title || r.source_id,
@@ -230,7 +230,7 @@ const linksApp = new Hono()
     // For each neighbor, sum the weights of all link types connecting them.
     // Apply quality boost: 1 + quality/40 + reader_importance/400 (max ~1.45x).
     // Relationship labels come from yaml_related links.
-    const results = await rawDb`
+    const results = await rawDb<RelatedDbRow[]>`
     WITH bidirectional_links AS (
       -- Forward links: entityId is source (is_reverse = false)
       SELECT target_id AS neighbor_id, link_type, relationship, weight, false AS is_reverse
@@ -288,10 +288,10 @@ const linksApp = new Hono()
 
     // Type-diverse selection: guarantee MIN_PER_TYPE from each entity type,
     // then fill remaining slots with highest-scoring entries.
-    const scored = (results as unknown as RelatedDbRow[]).map((r) => ({
-      id: r.id as string,
-      type: (r.entity_type as string) || "concept",
-      title: (r.title as string) || r.id,
+    const scored = results.map((r) => ({
+      id: r.id,
+      type: r.entity_type || "concept",
+      title: r.title || r.id,
       score: Math.round(parseFloat(r.score) * 100) / 100,
       label: formatRelationshipLabel(r.relationship, !!r.relationship_is_reverse) || undefined,
     }));
@@ -316,7 +316,7 @@ const linksApp = new Hono()
 
     // Get all direct links (both directions) for the entity.
     // This provides the raw graph data for visualization.
-    const results = await rawDb`
+    const results = await rawDb<GraphEdgeDbRow[]>`
     SELECT
       pl.source_id,
       pl.target_id,
@@ -345,7 +345,7 @@ const linksApp = new Hono()
       weight: number;
     }> = [];
 
-    for (const r of results as unknown as GraphEdgeDbRow[]) {
+    for (const r of results) {
       if (!nodeMap.has(r.source_id)) {
         nodeMap.set(r.source_id, {
           id: r.source_id,
@@ -381,7 +381,7 @@ const linksApp = new Hono()
   .get("/stats", async (c) => {
     const rawDb = getDb();
 
-    const stats = await rawDb`
+    const stats = await rawDb<LinkStatsRow[]>`
     SELECT
       link_type,
       COUNT(*)::int AS count,
@@ -391,25 +391,24 @@ const linksApp = new Hono()
     ORDER BY count DESC
   `;
 
-    const totalResult = await rawDb`
+    const totalResult = await rawDb<TotalRow[]>`
     SELECT COUNT(*)::int AS total FROM page_links
   `;
 
-    const uniquePagesResult = await rawDb`
+    const uniquePagesResult = await rawDb<UniqueCountRow[]>`
     SELECT COUNT(DISTINCT source_id)::int AS sources,
            COUNT(DISTINCT target_id)::int AS targets
     FROM page_links
   `;
 
-    const total = (totalResult as unknown as TotalRow[])[0]?.total || 0;
-    const unique = (uniquePagesResult as unknown as UniqueCountRow[])[0];
-    const typedStats = stats as unknown as LinkStatsRow[];
+    const total = totalResult[0]?.total || 0;
+    const unique = uniquePagesResult[0];
 
     return c.json({
       total,
       uniqueSources: unique?.sources || 0,
       uniqueTargets: unique?.targets || 0,
-      byType: typedStats.map((s) => ({
+      byType: stats.map((s) => ({
         linkType: s.link_type,
         count: s.count,
         avgWeight: parseFloat(s.avg_weight),

--- a/apps/wiki-server/src/routes/pages.ts
+++ b/apps/wiki-server/src/routes/pages.ts
@@ -75,7 +75,7 @@ const pagesApp = new Hono()
     let results: PageSearchRow[] = [];
 
     if (prefixQuery) {
-      results = (await rawDb.unsafe(
+      results = await rawDb.unsafe<PageSearchRow[]>(
         `SELECT
         id, numeric_id, title, description, entity_type, category,
         reader_importance, quality,
@@ -90,13 +90,13 @@ const pagesApp = new Hono()
       ORDER BY rank DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
         [prefixQuery, limit],
-      )) as unknown as PageSearchRow[];
+      );
     }
 
     // Phase 2: If FTS returned few results, fall back to pg_trgm similarity
     // for typo tolerance (e.g. "antrhopic" → "anthropic").
     if (results.length < TRIGRAM_FALLBACK_THRESHOLD) {
-      const trigramResults = await rawDb.unsafe(
+      const trigramResults = await rawDb.unsafe<PageSearchRow[]>(
         `SELECT
         id, numeric_id, title, description, entity_type, category,
         reader_importance, quality,
@@ -111,7 +111,7 @@ const pagesApp = new Hono()
       LIMIT $2`,
         [q, limit - results.length, results.map((r) => r.id)],
       );
-      results = [...results, ...(trigramResults as unknown as PageSearchRow[])];
+      results = [...results, ...trigramResults];
     }
 
     return c.json({

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -321,8 +321,8 @@ const resourcesApp = new Hono()
     // Full-text search with prefix matching (same pattern as wiki_pages search)
     const prefixQuery = buildPrefixTsquery(q);
 
-    const rows = prefixQuery
-      ? await rawDb.unsafe(
+    const rows: ResourceSearchRow[] = prefixQuery
+      ? await rawDb.unsafe<ResourceSearchRow[]>(
           `SELECT
           id, url, title, type, summary, review, abstract,
           key_points, publication_id, authors, published_date,
@@ -338,7 +338,7 @@ const resourcesApp = new Hono()
       : [];
 
     return c.json({
-      results: (rows as ResourceSearchRow[]).map((r) => ({
+      results: rows.map((r) => ({
         id: r.id,
         url: r.url,
         title: r.title,
@@ -367,6 +367,7 @@ const resourcesApp = new Hono()
 
   .get("/stats", async (c) => {
     const db = getDrizzleDb();
+    const rawDb = getDb();
 
     const [totalResult, citationCountResult, citedPagesResult, byType] =
       await Promise.all([
@@ -389,20 +390,21 @@ const resourcesApp = new Hono()
     const citedPages = Number(citedPagesResult[0].count);
 
     // Extra stats: orphaned, metadata coverage, fetched count
+    // Use raw postgres client for type-parameterized queries (avoids double-cast from db.execute())
     const [orphanedResult, withMetadataResult, fetchedResult] = await Promise.all(
       [
-        db.execute(sql`
+        rawDb<CountRow[]>`
         SELECT count(*) AS c FROM resources r
         LEFT JOIN resource_citations rc ON rc.resource_id = r.id
         WHERE rc.resource_id IS NULL
-      `),
-        db.execute(sql`
+      `,
+        rawDb<CountRow[]>`
         SELECT count(*) AS c FROM resources
         WHERE summary IS NOT NULL OR review IS NOT NULL OR key_points IS NOT NULL
-      `),
-        db.execute(sql`
+      `,
+        rawDb<CountRow[]>`
         SELECT count(*) AS c FROM resources WHERE fetched_at IS NOT NULL
-      `),
+      `,
       ]
     );
 
@@ -413,9 +415,9 @@ const resourcesApp = new Hono()
       byType: Object.fromEntries(
         byType.map((r) => [r.type ?? "unknown", r.count])
       ),
-      orphanedCount: Number((orphanedResult as unknown as CountRow[])[0]?.c ?? 0),
-      withMetadata: Number((withMetadataResult as unknown as CountRow[])[0]?.c ?? 0),
-      fetched: Number((fetchedResult as unknown as CountRow[])[0]?.c ?? 0),
+      orphanedCount: Number(orphanedResult[0]?.c ?? 0),
+      withMetadata: Number(withMetadataResult[0]?.c ?? 0),
+      fetched: Number(fetchedResult[0]?.c ?? 0),
     };
 
     return c.json(result);


### PR DESCRIPTION
## Summary

- **Wiki-server routes**: Replace `as unknown as T[]` double-casts on raw SQL query results with postgres.js generic type parameters (`rawDb<T[]>` tagged templates and `rawDb.unsafe<T[]>()`) in `hallucination-risk.ts`, `pages.ts`, `resources.ts`, `explore.ts`, `claims.ts`, and `links.ts`
- **Frontend**: Replace `as unknown as CitationQuote[]` with a proper mapping function and runtime `toAccuracyVerdict()` validator; add `toRiskLevel()` type guard for hallucination risk levels; add `toCostBreakdown()` runtime validator for JSONB costBreakdown field
- **Explore route**: Type SQL params as `SqlParam` (= `string | number`) instead of `unknown[]` with `as any[]` casts
- **Test files**: Define `BacklinkItem` and `RelatedItem` interfaces to replace `(b: any)` and `(r: any)` in links.test.ts assertions

All 13 gate checks pass. No logic changes — only type annotations and runtime narrowing functions.

## Test plan

- [x] `pnpm crux validate gate --fix` passes all 13 checks
- [x] Wiki-server `tsc --noEmit` compiles cleanly (0 errors)
- [x] Wiki-server vitest: 409 tests pass, 21 skipped
- [x] Web vitest: 312 tests pass (including citation-data.test.ts with 17 tests)
- [ ] CI should pass — verify after push

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)