### PR TITLE
feat: enforce test plan validation and add /review-pr command

### DIFF
--- a/.claude/commands/agent-session-ready-PR.md
+++ b/.claude/commands/agent-session-ready-PR.md
@@ -19,7 +19,7 @@ For each unchecked item in the checklist:
 3. **Blocked?** Note why next to the item.
 
 Pay special attention to:
-- **Paranoid review** (`paranoid-review`): Use the Task tool to spawn a fresh subagent with the full diff (`git diff main`) and this prompt: *"You are a paranoid code reviewer with no prior context. Find every bug, DRY violation, dead code, missing export, test coverage gap, hardcoded constant, and deferred work item in this diff. Be adversarial — assume something is wrong."* Paste findings here. Fix or document every issue before checking the item off.
+- **Paranoid review** (`paranoid-review`): Run `/review-pr` — this handles diff review (fresh subagent), test plan validation, execution-based verification, and edge case testing. Fix or document every finding before checking the item off.
 - **Self-audit**: Re-run commands you claimed to run. Verify outputs match your claims.
 - **Gate check**: `pnpm crux validate gate --fix` — record the exact test count.
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,103 @@
+# Review PR
+
+Comprehensive paranoid review of the current branch's changes. Combines diff review with execution-based verification.
+
+**When to use:** Before shipping any non-trivial PR. Called automatically by `/agent-session-ready-PR`.
+
+## Phase 1: Diff Review (spawn subagent)
+
+Use the Task tool to spawn a fresh subagent (subagent_type: "general-purpose") with NO prior context.
+
+Provide it with the full diff (`git diff main...HEAD`) and this prompt:
+
+> You are a paranoid code reviewer with fresh eyes. You have no context about why these changes were made — evaluate purely on correctness and quality.
+>
+> Review this diff for:
+> 1. **Bugs**: Logic errors, off-by-one, null/undefined access, race conditions
+> 2. **Security**: Injection, XSS, secrets in code, unsafe shell commands
+> 3. **Dead code**: Unused imports, unreachable branches, commented-out code
+> 4. **Missing exports**: New functions/types not exported where needed
+> 5. **Test gaps**: New behavior without test coverage
+> 6. **DRY violations**: Copy-pasted logic that should be extracted
+> 7. **Hardcoded values**: Magic numbers, URLs, paths that should be constants
+> 8. **Shell safety**: Unquoted variables, missing error handling in bash/workflow files
+>
+> For each finding, rate severity (CRITICAL / HIGH / MEDIUM / LOW) and give a confidence score (0-100).
+> Only report findings with confidence >= 70.
+> Output format: `[SEVERITY] (confidence: N) file:line — description`
+
+If the subagent reports CRITICAL or HIGH findings (confidence >= 80), fix them before proceeding.
+
+## Phase 2: Test Plan Validation
+
+Run `pnpm crux pr validate-test-plan` on the current PR.
+
+If the test plan fails validation:
+- Add missing test plan section to PR body
+- Execute the tests described in the plan
+- Check off items as they pass
+
+## Phase 3: Execution-Based Verification
+
+This is the most important phase. Do NOT skip it. Actually run the code and verify it works.
+
+### 3a. Unit/Integration Tests
+
+```bash
+# Run the full test suite
+pnpm test
+
+# If new test files were added, verify they actually run
+npx vitest run --config crux/vitest.config.ts <new-test-files>
+```
+
+### 3b. Type Checking
+
+```bash
+# Verify no type errors
+npx tsc --noEmit -p apps/web/tsconfig.json
+npx tsc --noEmit -p crux/tsconfig.json
+```
+
+### 3c. Feature-Specific Verification
+
+Based on what changed, do targeted verification:
+
+- **CLI commands**: Run the new/modified command with `--help`, then with real arguments. Verify output is correct.
+- **API routes**: If a wiki-server route changed, test it against the dev server if available.
+- **UI components**: If a React component changed, check that the dev server renders it (`pnpm dev` then describe what you see, or check for build errors).
+- **Data pipeline**: If build-data scripts changed, run `pnpm build-data:content` and verify output.
+- **Validation rules**: If validators changed, run `pnpm crux validate gate --fix` and verify the expected behavior.
+- **GitHub Actions**: Review the YAML carefully. Verify all referenced commands exist and work locally.
+
+### 3d. Edge Case / Fuzz Testing
+
+For new functions or significant logic changes:
+
+1. Identify 3-5 edge cases not covered by existing tests
+2. Test them manually or write quick throwaway test cases
+3. Try unexpected inputs: empty strings, null, very long inputs, special characters
+
+### 3e. Regression Check
+
+```bash
+# Ensure nothing existing broke
+pnpm crux validate gate --fix
+```
+
+## Phase 4: Update Test Plan
+
+After executing all verification steps:
+
+1. Update the PR body's test plan section with checked items reflecting what was actually verified
+2. Add any additional test items that were performed beyond the original plan
+3. Use `pnpm crux pr validate-test-plan` to confirm it passes
+
+## Output
+
+Summarize findings:
+- Issues found and fixed (from diff review)
+- Tests executed and results
+- Edge cases verified
+- Regressions checked
+- Overall confidence: HIGH / MEDIUM / LOW

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeClosesSyntax } from './pr.ts';
+import { normalizeClosesSyntax, validateTestPlan, bigramSimilarity } from './pr.ts';
 
 describe('normalizeClosesSyntax', () => {
   it('rewrites comma-separated Closes to one-per-line', () => {
@@ -46,5 +46,103 @@ describe('normalizeClosesSyntax', () => {
   it('handles numbers without # prefix', () => {
     const { result } = normalizeClosesSyntax('Closes #1, 2, 3');
     expect(result).toBe('Closes #1\nCloses #2\nCloses #3');
+  });
+});
+
+describe('validateTestPlan', () => {
+  it('blocks when test plan section is missing', () => {
+    const result = validateTestPlan('## Summary\nSome changes\n');
+    expect(result.status).toBe('block');
+    expect(result.hasTestPlanSection).toBe(false);
+  });
+
+  it('blocks when test plan section has no checkbox items', () => {
+    const result = validateTestPlan('## Summary\nChanges\n\n## Test plan\nJust some text, no checkboxes.\n');
+    expect(result.status).toBe('block');
+    expect(result.hasTestPlanSection).toBe(true);
+    expect(result.totalItems).toBe(0);
+  });
+
+  it('blocks when all items are unchecked (tests listed but not executed)', () => {
+    const body = `## Summary\nChanges\n\n## Test plan\n- [ ] Run unit tests\n- [ ] Manual verification\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('block');
+    expect(result.checkedItems).toBe(0);
+    expect(result.uncheckedItems).toBe(2);
+  });
+
+  it('warns when some items are unchecked', () => {
+    const body = `## Summary\nChanges\n\n## Test plan\n- [x] Run unit tests\n- [ ] Manual verification\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('warn');
+    expect(result.checkedItems).toBe(1);
+    expect(result.uncheckedItems).toBe(1);
+  });
+
+  it('passes when all items are checked', () => {
+    const body = `## Summary\nChanges\n\n## Test plan\n- [x] Run unit tests\n- [x] Manual verification\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('ok');
+    expect(result.checkedItems).toBe(2);
+    expect(result.uncheckedItems).toBe(0);
+  });
+
+  it('handles ### heading level', () => {
+    const body = `## Summary\nChanges\n\n### Test plan\n- [x] Verified\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('ok');
+  });
+
+  it('is case-insensitive for heading', () => {
+    const body = `## Summary\n\n## TEST PLAN\n- [x] Done\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('ok');
+  });
+
+  it('stops at the next heading', () => {
+    const body = `## Test plan\n- [x] Done\n\n## Notes\n- [ ] This is not a test item\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('ok');
+    expect(result.totalItems).toBe(1);
+  });
+
+  it('handles [X] (uppercase) as checked', () => {
+    const body = `## Test plan\n- [X] Verified\n`;
+    const result = validateTestPlan(body);
+    expect(result.status).toBe('ok');
+    expect(result.checkedItems).toBe(1);
+  });
+
+  it('handles empty body', () => {
+    const result = validateTestPlan('');
+    expect(result.status).toBe('block');
+    expect(result.hasTestPlanSection).toBe(false);
+  });
+});
+
+describe('bigramSimilarity', () => {
+  it('returns 1.0 for identical strings', () => {
+    expect(bigramSimilarity('hello world foo bar', 'hello world foo bar')).toBe(1.0);
+  });
+
+  it('returns 0.0 for completely different strings', () => {
+    expect(bigramSimilarity('alpha beta gamma', 'delta epsilon zeta')).toBe(0);
+  });
+
+  it('returns 0 for empty strings', () => {
+    expect(bigramSimilarity('', 'hello world')).toBe(0);
+    expect(bigramSimilarity('hello world', '')).toBe(0);
+  });
+
+  it('returns high similarity for near-identical strings', () => {
+    const a = 'add new feature for user authentication with JWT tokens';
+    const b = 'add new feature for user authentication with session tokens';
+    const sim = bigramSimilarity(a, b);
+    expect(sim).toBeGreaterThan(0.5);
+  });
+
+  it('ignores punctuation', () => {
+    const sim = bigramSimilarity('hello, world!', 'hello world');
+    expect(sim).toBe(1.0);
   });
 });

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -18,6 +18,97 @@ import type { CommandResult } from '../lib/cli.ts';
 
 type CommandOptions = Record<string, unknown>;
 
+// ── Test plan validation ─────────────────────────────────────────────────────
+
+export interface TestPlanValidation {
+  hasTestPlanSection: boolean;
+  totalItems: number;
+  checkedItems: number;
+  uncheckedItems: number;
+  status: 'ok' | 'warn' | 'block';
+  message: string;
+}
+
+/**
+ * Validate the test plan section in a PR body.
+ *
+ * Rules:
+ * - A "## Test plan" section must exist (blocks if missing).
+ * - Test plan must have at least one checkbox item (blocks if empty).
+ * - All checkbox items should be checked (warns if unchecked items remain).
+ *   Unchecked items mean testing was planned but not executed.
+ */
+export function validateTestPlan(body: string): TestPlanValidation {
+  // Find the test plan section (case-insensitive, allow ## or ###)
+  const testPlanMatch = body.match(/^#{2,3}\s+test\s+plan\b/im);
+
+  if (!testPlanMatch) {
+    return {
+      hasTestPlanSection: false,
+      totalItems: 0,
+      checkedItems: 0,
+      uncheckedItems: 0,
+      status: 'block',
+      message: 'PR body is missing a "## Test plan" section.',
+    };
+  }
+
+  // Extract the test plan section content (up to next ## heading or end of body)
+  const sectionStart = testPlanMatch.index! + testPlanMatch[0].length;
+  const nextHeading = body.slice(sectionStart).match(/^#{2,3}\s+/m);
+  const sectionEnd = nextHeading
+    ? sectionStart + nextHeading.index!
+    : body.length;
+  const section = body.slice(sectionStart, sectionEnd);
+
+  // Count checkbox items
+  const checked = [...section.matchAll(/^[\s]*-\s+\[x\]/gim)];
+  const unchecked = [...section.matchAll(/^[\s]*-\s+\[\s\]/gm)];
+  const totalItems = checked.length + unchecked.length;
+
+  if (totalItems === 0) {
+    return {
+      hasTestPlanSection: true,
+      totalItems: 0,
+      checkedItems: 0,
+      uncheckedItems: 0,
+      status: 'block',
+      message: 'Test plan section exists but has no checkbox items (- [ ] or - [x]).',
+    };
+  }
+
+  if (unchecked.length > 0 && checked.length === 0) {
+    return {
+      hasTestPlanSection: true,
+      totalItems,
+      checkedItems: checked.length,
+      uncheckedItems: unchecked.length,
+      status: 'block',
+      message: `Test plan has ${unchecked.length} item(s) but none are checked. Tests were listed but not executed.`,
+    };
+  }
+
+  if (unchecked.length > 0) {
+    return {
+      hasTestPlanSection: true,
+      totalItems,
+      checkedItems: checked.length,
+      uncheckedItems: unchecked.length,
+      status: 'warn',
+      message: `Test plan has ${unchecked.length} unchecked item(s) out of ${totalItems}. Consider completing or removing unexecuted items.`,
+    };
+  }
+
+  return {
+    hasTestPlanSection: true,
+    totalItems,
+    checkedItems: checked.length,
+    uncheckedItems: 0,
+    status: 'ok',
+    message: `Test plan: ${checked.length}/${totalItems} items verified.`,
+  };
+}
+
 /**
  * Bigram Jaccard similarity between two text strings.
  * Returns 0.0 (no overlap) to 1.0 (identical).
@@ -216,6 +307,25 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
     } catch {
       // Quality checks are best-effort — don't block PR creation if they fail
     }
+
+    // Check 3: Test plan validation
+    if (!(options.skipTestPlan ?? options['skip-test-plan'])) {
+      const testPlanResult = validateTestPlan(body);
+      if (testPlanResult.status === 'block') {
+        return {
+          output:
+            `${c.red}✗ Test plan validation failed:${c.reset} ${testPlanResult.message}\n` +
+            `  PRs must include a "## Test plan" section with checked items (- [x]).\n` +
+            `  Pass --skip-test-plan to bypass this check.\n`,
+          exitCode: 1,
+        };
+      }
+      if (testPlanResult.status === 'warn') {
+        log.warn(testPlanResult.message);
+      } else {
+        log.info(testPlanResult.message);
+      }
+    }
   }
 
   // Check for existing PR first
@@ -345,6 +455,52 @@ async function fixBody(args: string[], options: CommandOptions): Promise<Command
   return { output, exitCode: 0 };
 }
 
+/**
+ * Validate the test plan section of the current branch's PR.
+ *
+ * Reads the PR body from GitHub and checks that the test plan section
+ * has checkbox items and that they are checked (indicating tests were executed).
+ *
+ * Options:
+ *   --pr=N    Target a specific PR number instead of auto-detecting
+ *   --json    JSON output
+ */
+async function validateTestPlanCmd(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+  const json = Boolean(options.json);
+
+  let prNum: number | null = options.pr ? parseInt(String(options.pr), 10) : null;
+
+  if (!prNum) {
+    const branch = currentBranch();
+    const prs = await githubApi<GitHubPR[]>(
+      `/repos/${REPO}/pulls?head=quantified-uncertainty:${branch}&state=open`
+    );
+    if (!prs.length) {
+      if (json) return { output: JSON.stringify({ error: 'no PR found' }) + '\n', exitCode: 1 };
+      return {
+        output: `${c.yellow}No open PR found for branch ${currentBranch()}.${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+    prNum = prs[0].number;
+  }
+
+  const pr = await githubApi<GitHubPR>(`/repos/${REPO}/pulls/${prNum}`);
+  const result = validateTestPlan(pr.body ?? '');
+
+  if (json) {
+    return { output: JSON.stringify({ pr: prNum, ...result }) + '\n', exitCode: result.status === 'block' ? 1 : 0 };
+  }
+
+  const icon = result.status === 'ok' ? `${c.green}✓` : result.status === 'warn' ? `${c.yellow}⚠` : `${c.red}✗`;
+  return {
+    output: `${icon}${c.reset} PR #${prNum}: ${result.message}\n`,
+    exitCode: result.status === 'block' ? 1 : 0,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Domain entry point (required by crux.mjs dispatch)
 // ---------------------------------------------------------------------------
@@ -353,6 +509,7 @@ export const commands = {
   create,
   detect,
   'fix-body': fixBody,
+  'validate-test-plan': validateTestPlanCmd,
 };
 
 export function getHelp(): string {
@@ -360,9 +517,10 @@ export function getHelp(): string {
 PR Domain — GitHub Pull Request utilities
 
 Commands:
-  create              Create a PR for the current branch (corruption-safe).
-  detect              Detect open PR for current branch (returns URL + number).
-  fix-body [--pr=N]   Detect and repair literal \\n in the current branch's PR body.
+  create                        Create a PR for the current branch (corruption-safe).
+  detect                        Detect open PR for current branch (returns URL + number).
+  fix-body [--pr=N]             Detect and repair literal \\n in the current branch's PR body.
+  validate-test-plan [--pr=N]   Check that the PR's test plan section is complete.
 
 Options (create):
   --title="..."       Required. PR title.
@@ -371,19 +529,24 @@ Options (create):
   --base=main         Base branch (default: main).
   --draft             Create as draft PR.
   --allow-empty-body  Allow creating PR without a description (not recommended).
+  --skip-test-plan    Skip test plan validation (not recommended).
   (stdin)             If --body and --body-file are absent and stdin is a pipe, body is read from stdin.
 
 Options (detect):
   --ci                JSON output.
 
-Options (fix-body):
+Options (fix-body / validate-test-plan):
   --pr=N              Target a specific PR number instead of auto-detecting.
+  --json              JSON output (validate-test-plan only).
 
 Examples:
   # Multi-line body via heredoc (recommended — avoids sh/dash heredoc issues):
   pnpm crux pr create --title="Add feature X" <<'EOF'
   ## Summary
   - Added X
+
+  ## Test plan
+  - [x] Ran unit tests
   EOF
 
   # Multi-line body via file (also recommended):
@@ -396,5 +559,7 @@ Examples:
   pnpm crux pr detect --ci               # JSON output for scripts
   pnpm crux pr fix-body                  # Fix PR for current branch
   pnpm crux pr fix-body --pr=42          # Fix a specific PR
+  pnpm crux pr validate-test-plan        # Check test plan on current PR
+  pnpm crux pr validate-test-plan --pr=42 --json  # Check specific PR (JSON)
 `.trim();
 }


### PR DESCRIPTION
## Summary

- **Test plan enforcement in `crux pr create`**: Validates that PR bodies include a `## Test plan` section with checked checkbox items (`- [x]`). Blocks creation when the section is missing, empty, or has zero checked items. Warns when some items remain unchecked. Bypass with `--skip-test-plan`.
- **`crux pr validate-test-plan` command**: Standalone validation for checking existing PRs. Supports `--pr=N` and `--json` flags.
- **`/review-pr` slash command**: Multi-phase review process:
  1. **Diff review** — fresh-context subagent with adversarial prompt, confidence scoring (only reports findings >= 70 confidence)
  2. **Test plan validation** — calls `crux pr validate-test-plan`
  3. **Execution-based verification** — unit tests, type checking, feature-specific testing, edge case/fuzz testing
  4. **Regression check** — `crux validate gate --fix`
- **`/agent-session-ready-PR` updated** — now calls `/review-pr` instead of inline paranoid review prompt

Closes #1252

## Test plan
- [x] 23 unit tests pass (10 validateTestPlan, 5 bigramSimilarity, 8 normalizeClosesSyntax)
- [x] validateTestPlan correctly blocks: missing section, empty section, all-unchecked items
- [x] validateTestPlan correctly warns: partial unchecked items
- [x] validateTestPlan correctly passes: all checked, case-insensitive heading, ### heading level
- [x] validateTestPlan stops parsing at next heading (doesn't count items from other sections)
- [x] [X] (uppercase) treated as checked
- [x] `--skip-test-plan` flag wired into create function
- [x] `/review-pr.md` created with execution-based testing phases