### PR TITLE
feat: add gate checks and code review guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,16 @@ For non-trivial changes (>5 files or >300 lines), run `/review-pr` before shippi
 - **Hono RPC**: Mandatory for all new wiki-server routes; convert existing routes when modifying them. See `.claude/rules/wiki-server-rpc-migration.md`.
 - **Entity IDs**: **Never manually invent numericIds** (E42, E886, etc.). Always allocate from the wiki-server: `pnpm crux ids allocate <slug>`. The gate runs `assign-ids.mjs` automatically as a safety net, but allocating early prevents conflicts between concurrent agents. Use `pnpm crux ids check <slug>` to look up existing IDs.
 
+## Code Review Guidelines
+
+Rules enforced by gate checks and PR review. See [#1246](https://github.com/quantified-uncertainty/longterm-wiki/issues/1246) for full context.
+
+- **No `(r: any)` in wiki-server routes** — define typed row interfaces for raw SQL results (enforced by gate)
+- **No `as unknown as T` double-casts** — use runtime type narrowing or proper generics
+- **Batch endpoints must use transactions or bulk SQL** — never sequential per-row updates
+- **Migration file prefixes must be unique** — no two `.sql` files with the same numeric prefix (enforced by gate)
+- **Destructive endpoints (DELETE, bulk UPDATE) must log actions** before executing
+
 ## Detailed Guides (loaded automatically by Claude Code)
 
 - `.claude/rules/agent-session-workflow.md` — Session start/end workflow

--- a/crux/validate/validate-drizzle-journal.ts
+++ b/crux/validate/validate-drizzle-journal.ts
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Validate that every Drizzle migration SQL file is registered in the journal.
+ * Validate Drizzle migration journal integrity:
  *
- * drizzle-kit generate creates the .sql file automatically but never updates
- * _journal.json. This causes migrations to be silently skipped on every server
- * restart/deploy. This check catches that before push.
+ * 1. Every migration SQL file must be registered in the journal.
+ *    drizzle-kit generate creates the .sql file automatically but never updates
+ *    _journal.json. This causes migrations to be silently skipped on every
+ *    server restart/deploy. This check catches that before push.
+ *
+ * 2. Migration file prefixes (the numeric part, e.g. 0032) must be unique.
+ *    Duplicate prefixes arise from branch merges and make the migration order
+ *    ambiguous. Known historical duplicates are grandfathered; new ones fail.
  *
  * The journal uses sequential `idx` values and `tag` = filename without .sql.
- * Duplicate-numbered files (e.g. two 0022_* files from branch merges) are
- * handled correctly: both must have journal entries; only missing tags fail.
  *
  * Usage: npx tsx crux/validate/validate-drizzle-journal.ts
  */
@@ -35,13 +38,25 @@ interface Journal {
   entries: JournalEntry[];
 }
 
+interface DuplicatePrefix {
+  prefix: string;
+  files: string[];
+}
+
 interface CheckResult {
   passed: boolean;
   errors: number;
   missing: string[];
+  duplicatePrefixes: DuplicatePrefix[];
   sqlFiles: string[];
   journalTags: string[];
 }
+
+// Historical duplicate prefixes that already exist in the codebase.
+// These are grandfathered — only NEW duplicates will fail the check.
+const KNOWN_DUPLICATE_PREFIXES = new Set([
+  '0020', '0022', '0024', '0026', '0032', '0034',
+]);
 
 export function runCheck(): CheckResult {
   const c = getColors();
@@ -56,7 +71,7 @@ export function runCheck(): CheckResult {
       .sort();
   } catch {
     console.log(`${c.dim}Skipping: ${DRIZZLE_DIR} not found${c.reset}`);
-    return { passed: true, errors: 0, missing: [], sqlFiles: [], journalTags: [] };
+    return { passed: true, errors: 0, missing: [], duplicatePrefixes: [], sqlFiles: [], journalTags: [] };
   }
 
   // Read journal
@@ -65,7 +80,7 @@ export function runCheck(): CheckResult {
     journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8')) as Journal;
   } catch (err) {
     console.log(`${c.red}Failed to read journal at ${JOURNAL_PATH}: ${err}${c.reset}`);
-    return { passed: false, errors: 1, missing: [JOURNAL_PATH], sqlFiles, journalTags: [] };
+    return { passed: false, errors: 1, missing: [JOURNAL_PATH], duplicatePrefixes: [], sqlFiles, journalTags: [] };
   }
 
   const journalTags = new Set(journal.entries.map((e) => e.tag));
@@ -96,10 +111,56 @@ export function runCheck(): CheckResult {
     );
   }
 
+  // Check for duplicate migration prefixes (the numeric part like "0032")
+  const prefixMap = new Map<string, string[]>();
+  for (const tag of sqlFiles) {
+    const match = tag.match(/^(\d+)_/);
+    if (match) {
+      const prefix = match[1];
+      if (!prefixMap.has(prefix)) prefixMap.set(prefix, []);
+      prefixMap.get(prefix)!.push(tag);
+    }
+  }
+
+  const newDuplicates: DuplicatePrefix[] = [];
+  for (const [prefix, files] of prefixMap) {
+    if (files.length > 1 && !KNOWN_DUPLICATE_PREFIXES.has(prefix)) {
+      newDuplicates.push({ prefix, files });
+    }
+  }
+
+  if (newDuplicates.length > 0) {
+    console.log(
+      `\n${c.red}Found ${newDuplicates.length} new duplicate migration prefix(es):${c.reset}\n`
+    );
+    for (const dup of newDuplicates) {
+      console.log(`  ${c.red}Prefix ${dup.prefix}:${c.reset}`);
+      for (const file of dup.files) {
+        console.log(`    ${c.red}${file}.sql${c.reset}`);
+      }
+    }
+    console.log();
+    console.log(
+      `${c.dim}Fix: renumber one of the conflicting migrations to the next available prefix.${c.reset}`
+    );
+    console.log(
+      `${c.dim}Duplicate prefixes make migration order ambiguous across environments.${c.reset}`
+    );
+  } else {
+    const knownCount = [...prefixMap.values()].filter(f => f.length > 1).length;
+    const knownNote = knownCount > 0 ? ` (${knownCount} known historical duplicates grandfathered)` : '';
+    console.log(
+      `${c.green}No new duplicate migration prefixes${c.reset}${c.dim}${knownNote}${c.reset}`
+    );
+  }
+
+  const totalErrors = missing.length + newDuplicates.length;
+
   return {
-    passed: missing.length === 0,
-    errors: missing.length,
+    passed: totalErrors === 0,
+    errors: totalErrors,
     missing,
+    duplicatePrefixes: newDuplicates,
     sqlFiles,
     journalTags: [...journalTags],
   };

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -253,6 +253,13 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'untyped-rows',
+    name: 'No untyped row casts in routes',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-untyped-rows.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     id: 'mdx-compile',
     name: 'MDX compilation smoke-test (advisory)',
     command: 'npx',

--- a/crux/validate/validate-untyped-rows.ts
+++ b/crux/validate/validate-untyped-rows.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that wiki-server routes don't use `(r: any)` casts for row results.
+ *
+ * Raw SQL queries should use typed row interfaces instead of casting to `any`,
+ * which hides type errors and makes refactoring unsafe. This check scans route
+ * files for the pattern and fails if any are found.
+ *
+ * Usage: npx tsx crux/validate/validate-untyped-rows.ts
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { getColors } from '../lib/output.ts';
+
+const ROUTES_DIR = 'apps/wiki-server/src/routes';
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function checkFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Match (r: any), (row: any), (rows: any), etc. — any single-letter or
+    // common variable name followed by `: any` inside parens
+    if (/\(\s*\w+\s*:\s*any\s*\)/.test(line)) {
+      violations.push({
+        file: filePath,
+        line: i + 1,
+        text: line.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: Violation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking for untyped row casts in wiki-server routes...${c.reset}\n`);
+
+  let files: string[];
+  try {
+    files = readdirSync(ROUTES_DIR)
+      .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+      .map((f) => join(ROUTES_DIR, f));
+  } catch {
+    console.log(`${c.dim}Skipping: ${ROUTES_DIR} not found${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: Violation[] = [];
+
+  for (const file of files) {
+    const violations = checkFile(file);
+    allViolations.push(...violations);
+  }
+
+  if (allViolations.length === 0) {
+    console.log(`${c.green}No untyped row casts found (${files.length} files checked)${c.reset}`);
+  } else {
+    console.log(`${c.red}Found ${allViolations.length} untyped row cast(s):${c.reset}\n`);
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}`);
+      console.log(`    ${c.dim}${v.text}${c.reset}`);
+      console.log(`    ${c.dim}Fix: define a typed row interface instead of using (r: any)${c.reset}\n`);
+    }
+  }
+
+  return { passed: allViolations.length === 0, errors: allViolations.length, violations: allViolations };
+}
+
+if (process.argv[1]?.includes('validate-untyped-rows')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

- Extends the Drizzle migration journal validator (`validate-drizzle-journal.ts`) to detect duplicate numeric prefixes (e.g., two `0032_*.sql` files). Historical duplicates are grandfathered via a known-set; only new duplicates fail the gate.
- Adds a new `validate-untyped-rows.ts` gate check that scans `apps/wiki-server/src/routes/*.ts` for `(r: any)` patterns and fails with file:line details. Registered as a parallel step in the gate.
- Documents five code review guidelines in `CLAUDE.md`: no untyped row casts, no double-casts, batch endpoints must use transactions, unique migration prefixes, and destructive endpoints must log actions.

## Test plan

- [x] Both new checks pass on current codebase (`npx tsx crux/validate/validate-drizzle-journal.ts` and `npx tsx crux/validate/validate-untyped-rows.ts`)
- [x] Full gate passes: `pnpm crux validate gate --fix --no-cache` (14 checks, all green)
- [ ] CI passes on this branch

Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)