### PR TITLE
refactor: deduplicate entity normalization between claims frontend and backend

### DIFF
--- a/apps/web/src/app/claims/claim/[id]/page.tsx
+++ b/apps/web/src/app/claims/claim/[id]/page.tsx
@@ -51,7 +51,8 @@ export default async function ClaimDetailPage({ params }: PageProps) {
   const similarClaims = similarResult?.claims ?? [];
   const entity = getEntityById(claim.entityId);
   const entityDisplayName = entity?.title ?? claim.entityId;
-  const allSlugs = [claim.entityId, ...(claim.relatedEntities ?? []).map(s => s.toLowerCase())];
+  // relatedEntities are already normalized (lowercased) by the server
+  const allSlugs = [claim.entityId, ...(claim.relatedEntities ?? [])];
   const entityNames = buildEntityNameMap(allSlugs);
 
   return (
@@ -340,10 +341,10 @@ export default async function ClaimDetailPage({ params }: PageProps) {
             {claim.relatedEntities.map((eid) => (
               <Link
                 key={eid}
-                href={`/claims/entity/${eid.toLowerCase()}`}
+                href={`/claims/entity/${eid}`}
                 className="inline-block px-2 py-1 rounded text-xs bg-gray-100 text-gray-700 hover:bg-gray-200"
               >
-                {entityNames[eid.toLowerCase()] ?? eid}
+                {entityNames[eid] ?? eid}
               </Link>
             ))}
           </div>

--- a/apps/web/src/app/claims/components/claims-data.ts
+++ b/apps/web/src/app/claims/components/claims-data.ts
@@ -20,14 +20,15 @@ export function buildEntityNameMap(slugs: string[]): Record<string, string> {
   return map;
 }
 
-/** Collect all unique entity slugs from claims (both entityId and relatedEntities) */
+/** Collect all unique entity slugs from claims (both entityId and relatedEntities).
+ *  relatedEntities are already normalized (lowercased) by the server. */
 export function collectEntitySlugs(claims: ClaimRow[]): string[] {
   const slugs = new Set<string>();
   for (const claim of claims) {
     slugs.add(claim.entityId);
     if (claim.relatedEntities) {
       for (const rel of claim.relatedEntities) {
-        slugs.add(rel.toLowerCase());
+        slugs.add(rel);
       }
     }
   }

--- a/apps/web/src/app/claims/components/claims-table.tsx
+++ b/apps/web/src/app/claims/components/claims-table.tsx
@@ -213,10 +213,10 @@ function ExpandedClaimDetail({ claim, entityNames = {} }: { claim: ClaimRow; ent
             {claim.relatedEntities.map((eid) => (
               <Link
                 key={eid}
-                href={`/claims/entity/${eid.toLowerCase()}`}
+                href={`/claims/entity/${eid}`}
                 className="text-blue-600 hover:underline ml-1"
               >
-                {entityNames[eid.toLowerCase()] ?? eid}
+                {entityNames[eid] ?? eid}
               </Link>
             ))}
           </span>
@@ -483,10 +483,10 @@ function getColumns(entityNames: Record<string, string>): ColumnDef<ClaimRow>[] 
           {entities.slice(0, 3).map((eid) => (
             <Link
               key={eid}
-              href={`/claims/entity/${eid.toLowerCase()}`}
+              href={`/claims/entity/${eid}`}
               className="inline-block px-1 py-0.5 rounded text-[10px] bg-gray-100 text-gray-600 hover:bg-gray-200"
             >
-              {entityNames[eid.toLowerCase()] ?? eid}
+              {entityNames[eid] ?? eid}
             </Link>
           ))}
           {entities.length > 3 && (

--- a/apps/web/src/app/claims/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/claims/entity/[entityId]/page.tsx
@@ -83,14 +83,13 @@ function ConnectedEntities({
   entityId: string;
   entityNames: Record<string, string>;
 }) {
-  const eidLower = entityId.toLowerCase();
+  // relatedEntities are already normalized (lowercased) by the server
   const relatedStats = new Map<string, number>();
   for (const c of claims) {
     if (!c.relatedEntities) continue;
     for (const rel of c.relatedEntities) {
-      const normalized = rel.toLowerCase();
-      if (normalized === eidLower) continue;
-      relatedStats.set(normalized, (relatedStats.get(normalized) ?? 0) + 1);
+      if (rel === entityId) continue;
+      relatedStats.set(rel, (relatedStats.get(rel) ?? 0) + 1);
     }
   }
   // Also count claims where this entity appears as a relatedEntity (not primary)

--- a/apps/web/src/app/claims/page.tsx
+++ b/apps/web/src/app/claims/page.tsx
@@ -64,7 +64,8 @@ export default async function ClaimsOverviewPage() {
   // Build entity name map for display
   const entityNames = buildEntityNameMap(collectEntitySlugs(claims));
 
-  // Build relationship counts (skip self-referential)
+  // Build relationship counts (skip self-referential).
+  // relatedEntities are already normalized (lowercased) by the server.
   const pairCounts = new Map<
     string,
     { from: string; to: string; count: number; sample: string }
@@ -72,9 +73,8 @@ export default async function ClaimsOverviewPage() {
   for (const claim of claims) {
     if (!claim.relatedEntities || claim.relatedEntities.length === 0) continue;
     for (const related of claim.relatedEntities) {
-      const normalizedRel = related.toLowerCase();
-      if (normalizedRel === claim.entityId) continue;
-      const [a, b] = [claim.entityId, normalizedRel].sort();
+      if (related === claim.entityId) continue;
+      const [a, b] = [claim.entityId, related].sort();
       const pair = `${a} <-> ${b}`;
       if (!pairCounts.has(pair)) {
         pairCounts.set(pair, {

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -135,6 +135,28 @@ function formatClaimSource(s: ClaimSourceRowType) {
   };
 }
 
+/**
+ * Normalize a relatedEntities array: lowercase all slugs and deduplicate.
+ * This is the single source of truth for entity slug normalization in claims.
+ * Frontend consumers receive already-normalized data and should NOT re-lowercase.
+ */
+function normalizeRelatedEntitiesSlugs(
+  entities: unknown
+): string[] | null {
+  if (!Array.isArray(entities) || entities.length === 0) return null;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const e of entities) {
+    if (typeof e !== "string") continue;
+    const normalized = e.toLowerCase();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+  return result.length > 0 ? result : null;
+}
+
 function formatClaim(
   r: typeof claims.$inferSelect,
   sourcesRows: ClaimSourceRowType[] = []
@@ -152,7 +174,7 @@ function formatClaim(
     sourceQuote: r.sourceQuote,
     // Enhanced fields (migration 0028)
     claimCategory: r.claimCategory,
-    relatedEntities: r.relatedEntities as string[] | null,
+    relatedEntities: normalizeRelatedEntitiesSlugs(r.relatedEntities),
     factId: r.factId,
     resourceIds: r.resourceIds as string[] | null,
     section: r.section,
@@ -718,11 +740,9 @@ const claimsApp = new Hono()
     >();
 
     for (const row of rows) {
-      const related = row.relatedEntities as string[] | null;
+      const related = normalizeRelatedEntitiesSlugs(row.relatedEntities);
       if (!related) continue;
-      for (const rel of related) {
-        // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
-        const normalizedRel = rel.toLowerCase();
+      for (const normalizedRel of related) {
         // Skip self-referential pairs
         if (normalizedRel === row.entityId) continue;
         const [a, b] = [row.entityId, normalizedRel].sort();
@@ -763,11 +783,9 @@ const claimsApp = new Hono()
 
     for (const row of rows) {
       nodeIds.add(row.entityId);
-      const related = row.relatedEntities as string[] | null;
+      const related = normalizeRelatedEntitiesSlugs(row.relatedEntities);
       if (!related) continue;
-      for (const rel of related) {
-        // Normalize to lowercase slug to merge capitalized variants (e.g. "Anthropic" → "anthropic")
-        const normalizedRel = rel.toLowerCase();
+      for (const normalizedRel of related) {
         // Skip self-loops
         if (normalizedRel === row.entityId) continue;
         nodeIds.add(normalizedRel);


### PR DESCRIPTION
## Summary
- Extract entity slug normalization (lowercasing, deduplication) into a single `normalizeRelatedEntitiesSlugs()` function in the wiki-server claims route
- All claims API responses now return already-normalized `relatedEntities`, so frontend components no longer duplicate `.toLowerCase()` calls
- Remove 8 separate `.toLowerCase()` call sites across 5 frontend files that were duplicating the same normalization the backend was doing

## Details

**Before:** Entity slug normalization was duplicated in both:
- Backend: inline `rel.toLowerCase()` in `/relationships` and `/network` endpoints, but `formatClaim()` returned raw DB values
- Frontend: `.toLowerCase()` scattered across `claims-data.ts`, `claims/page.tsx`, `claims/entity/[entityId]/page.tsx`, `claims/claim/[id]/page.tsx`, and `claims-table.tsx`

**After:** Single normalization point in `normalizeRelatedEntitiesSlugs()` used by:
1. `formatClaim()` -- normalizes all API response `relatedEntities`
2. `/relationships` endpoint -- normalizes before pair-building
3. `/network` endpoint -- normalizes before graph-building

Frontend components now receive pre-normalized data and use slugs directly without transformation.

## Test plan
- [ ] Verify claims explorer page loads correctly with entity names resolving
- [ ] Verify `/claims/entity/<id>` connected entities section renders
- [ ] Verify `/claims/claim/<id>` related entities links work
- [ ] Verify `/claims/network` graph renders with merged entity variants
- [ ] Verify `/claims/relationships` table shows correct counts

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)