### PR TITLE
fix: auto-update workflow exit code 5 and wellness check flaky tolerance

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -242,7 +242,10 @@ jobs:
         id: citations
         if: success() && steps.report.outputs.path != ''
         run: |
-          RESULT=$(pnpm crux auto-update verify-citations --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
+          RESULT_RAW=$(pnpm --silent crux auto-update verify-citations --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
+          # Extract just the JSON object (guards against pnpm/dotenv preamble on stdout)
+          RESULT=$(echo "$RESULT_RAW" | grep -E '^\{' | tail -1)
+          RESULT="${RESULT:-{}}"
           SUMMARY=$(echo "$RESULT" | jq -r '.markdownSummary // ""')
           HAS_BROKEN=$(echo "$RESULT" | jq -r '.hasBroken // false')
 
@@ -264,7 +267,10 @@ jobs:
           cd apps/web && node --import tsx/esm scripts/build-data.mjs 2>/dev/null
           cd "$GITHUB_WORKSPACE"
 
-          RESULT=$(pnpm crux auto-update risk-scores --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
+          RESULT_RAW=$(pnpm --silent crux auto-update risk-scores --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
+          # Extract just the JSON object (guards against pnpm/dotenv preamble on stdout)
+          RESULT=$(echo "$RESULT_RAW" | grep -E '^\{' | tail -1)
+          RESULT="${RESULT:-{}}"
           SUMMARY=$(echo "$RESULT" | jq -r '.markdownSummary // ""')
           HAS_HIGH=$(echo "$RESULT" | jq -r '.hasHighRisk // false')
 

--- a/.github/workflows/wellness-check.yml
+++ b/.github/workflows/wellness-check.yml
@@ -298,12 +298,18 @@ jobs:
           NOW_EPOCH=$(date -u +%s)
 
           # Check a workflow's most recent completed run.
-          # Args: display_name  workflow_filename  max_age_hours  require_success
+          # Args: display_name  workflow_filename  max_age_hours  require_success  allow_any_recent_success
+          #
+          # When allow_any_recent_success=true, the check passes if ANY of the
+          # last 5 completed runs succeeded (tolerates transient failures in
+          # flaky pipelines like auto-update that depend on LLMs/external URLs).
+          # It only fails if ALL recent runs failed persistently.
           check_workflow() {
             local name="$1"
             local workflow="$2"
             local max_age_h="$3"
             local require_success="${4:-true}"
+            local allow_any_recent="${5:-false}"
 
             local runs
             runs=$(gh run list \
@@ -339,15 +345,32 @@ jobs:
               detail_cell="Last run ${age_h}h ago — stale (max ${max_age_h}h)"
               FAILURES="$FAILURES\n- $name: last run ${age_h}h ago (max ${max_age_h}h)"
             elif [ "$require_success" = "true" ] && [ "$conclusion" != "success" ]; then
-              status_cell="FAIL"
-              detail_cell="Last run concluded '${conclusion}' ${age_h}h ago"
-              FAILURES="$FAILURES\n- $name: last run concluded '${conclusion}'"
+              # For flaky workflows, check if ANY recent run succeeded
+              if [ "$allow_any_recent" = "true" ]; then
+                local any_success
+                any_success=$(echo "$runs" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
+                if [ "$any_success" -gt 0 ]; then
+                  status_cell="WARN"
+                  detail_cell="Last run failed but ${any_success}/5 recent runs succeeded"
+                  # WARN — not added to FAILURES so it doesn't trigger an issue
+                else
+                  status_cell="FAIL"
+                  detail_cell="All recent runs failed (latest: '${conclusion}' ${age_h}h ago)"
+                  FAILURES="$FAILURES\n- $name: all recent runs concluded '${conclusion}'"
+                fi
+              else
+                status_cell="FAIL"
+                detail_cell="Last run concluded '${conclusion}' ${age_h}h ago"
+                FAILURES="$FAILURES\n- $name: last run concluded '${conclusion}'"
+              fi
             fi
 
             RESULTS="$RESULTS\n| $name | $status_cell | $detail_cell |"
           }
 
-          check_workflow "auto-update"          "auto-update.yml"          "$MAX_AUTO_UPDATE_AGE_H"
+          # auto-update is inherently flaky (depends on LLMs, external URLs,
+          # citation verification) — tolerate transient failures
+          check_workflow "auto-update"          "auto-update.yml"          "$MAX_AUTO_UPDATE_AGE_H"  true  true
           check_workflow "database-backup"      "database-backup.yml"      "$MAX_BACKUP_AGE_H"
           check_workflow "scheduled-maintenance" "scheduled-maintenance.yml" "$MAX_MAINTENANCE_AGE_H"
           check_workflow "server-health-monitor" "server-health-monitor.yml" "$MAX_HEALTH_MONITOR_AGE_H"

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -239,6 +239,11 @@ interface WorkflowRunsResponse {
   workflow_runs: WorkflowRun[];
 }
 
+// Workflows that are inherently flaky — depends on LLMs, external URLs,
+// citation verification. For these, we check if ANY of the last 5 runs
+// succeeded rather than requiring the most recent one to succeed.
+const FLAKY_WORKFLOWS = new Set(['auto-update.yml']);
+
 async function checkActions(): Promise<CheckResult> {
   const name = 'GitHub Actions';
   const detail: string[] = [];
@@ -279,8 +284,21 @@ async function checkActions(): Promise<CheckResult> {
         detail.push(`FAIL  ${wf}: last run ${ageH}h ago (max ${maxAgeH}h)`);
         failures.push(`${wf}: stale (${ageH}h ago, max ${maxAgeH}h)`);
       } else if (requireSuccess && latest.conclusion !== 'success') {
-        detail.push(`FAIL  ${wf}: last run concluded '${latest.conclusion}' (${ageH}h ago)`);
-        failures.push(`${wf}: last run '${latest.conclusion}'`);
+        // For flaky workflows, check if ANY recent run succeeded
+        if (FLAKY_WORKFLOWS.has(wf)) {
+          const anySuccess = runs.some(r => r.conclusion === 'success');
+          if (anySuccess) {
+            const successCount = runs.filter(r => r.conclusion === 'success').length;
+            detail.push(`WARN  ${wf}: last run failed but ${successCount}/${runs.length} recent runs succeeded`);
+            // WARN — not added to failures, so it won't trigger an issue
+          } else {
+            detail.push(`FAIL  ${wf}: all ${runs.length} recent runs failed (latest: '${latest.conclusion}' ${ageH}h ago)`);
+            failures.push(`${wf}: all recent runs failed ('${latest.conclusion}')`);
+          }
+        } else {
+          detail.push(`FAIL  ${wf}: last run concluded '${latest.conclusion}' (${ageH}h ago)`);
+          failures.push(`${wf}: last run '${latest.conclusion}'`);
+        }
       } else {
         detail.push(`PASS  ${wf}: ${ageH}h ago (${latest.conclusion})`);
       }


### PR DESCRIPTION
## Summary

- **Fix auto-update workflow crash**: The `verify-citations` and `risk-scores` steps were failing with exit code 5 because `jq` received non-JSON output (pnpm banner + dotenv messages mixed with the JSON result). Fixed by using `pnpm --silent` and extracting only the JSON object line via `grep`, matching the pattern already used by the paranoid review step in the same workflow.
- **Make wellness check tolerant of transient failures**: The auto-update workflow is inherently flaky (depends on LLMs, external citation URLs, content quality checks). Instead of requiring the single most recent run to succeed, the wellness check now looks at the last 5 runs. It only flags FAIL if ALL recent runs failed (persistent problem). If some succeeded, it shows WARN without creating a wellness issue.

## Root cause analysis

The `Verify citations on updated pages` step ran:
```bash
RESULT=$(pnpm crux auto-update verify-citations ... --json 2>/dev/null || echo '{}')
SUMMARY=$(echo "$RESULT" | jq -r '.markdownSummary // ""')
```

`pnpm` outputs its banner line to stdout even with `2>/dev/null`. This caused `$RESULT` to contain both the pnpm banner and the JSON, which made `jq` fail with exit code 5 ("parse error: Invalid numeric literal"). With GitHub Actions' default `set -e`, this crashed the entire step.

## Test plan

- [x] Verified `crux health --check=actions` runs with the new logic and correctly shows `FAIL  auto-update.yml: all 5 recent runs failed` (since all 5 are currently failures)
- [ ] After merge, the next auto-update daily run should pass the verify-citations step
- [ ] Once an auto-update succeeds, the wellness check should show WARN instead of FAIL for subsequent transient failures

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)