### PR TITLE
fix: maintenance sweep — consistency regex crash + stale labels cleanup

### DIFF
--- a/content/docs/knowledge-base/models/short-timeline-policy-implications.mdx
+++ b/content/docs/knowledge-base/models/short-timeline-policy-implications.mdx
@@ -11,7 +11,7 @@ researchImportance: 74
 tacticalValue: 75
 lastEdited: "2026-02-02"
 update_frequency: 90
-llmSummary: Analyzes how AI policy priorities shift under 1-5 year timelines to transformative AI, arguing that interventions requiring <2 years (lab safety practices, compute monitoring, emergency coordination) become much more valuable than longer-term efforts (institution building, comprehensive legislation, public campaigns). Provides actor-specific recommendations prioritizing speed over thoroughness, with concrete guidance on what becomes more/less tractable.
+llmSummary: Analyzes how AI policy priorities shift under 1-5 year timelines to transformative AI, arguing that interventions requiring less than 2 years (lab safety practices, compute monitoring, emergency coordination) become much more valuable than longer-term efforts (institution building, comprehensive legislation, public campaigns). Provides actor-specific recommendations prioritizing speed over thoroughness, with concrete guidance on what becomes more or less tractable.
 ratings:
   focus: 8.5
   novelty: 5

--- a/crux/validate/validate-consistency.ts
+++ b/crux/validate/validate-consistency.ts
@@ -370,10 +370,12 @@ function checkCausalConsistency(allContent: FileContent[], entities: Entity[]): 
   }
 
   // Causal claim patterns
+  // Use \w+(?:\s+\w+){0,5} instead of [\w\s]{2,30} to avoid catastrophic backtracking
+  // ([\w\s] overlaps with \s+, causing exponential regex engine paths on large text)
   const causalPatterns: CausalPattern[] = [
-    { regex: /(\w[\w\s]{2,30}?)\s+(?:causes?|leads?\s+to|results?\s+in)\s+(\w[\w\s]{2,30})/gi, type: 'causes' },
-    { regex: /(\w[\w\s]{2,30}?)\s+(?:mitigates?|prevents?|reduces?)\s+(\w[\w\s]{2,30})/gi, type: 'mitigates' },
-    { regex: /(\w[\w\s]{2,30}?)\s+(?:enables?|allows?)\s+(\w[\w\s]{2,30})/gi, type: 'enables' },
+    { regex: /(\w+(?:\s+\w+){0,5})\s+(?:causes?|leads?\s+to|results?\s+in)\s+(\w+(?:\s+\w+){0,5})/gi, type: 'causes' },
+    { regex: /(\w+(?:\s+\w+){0,5})\s+(?:mitigates?|prevents?|reduces?)\s+(\w+(?:\s+\w+){0,5})/gi, type: 'mitigates' },
+    { regex: /(\w+(?:\s+\w+){0,5})\s+(?:enables?|allows?)\s+(\w+(?:\s+\w+){0,5})/gi, type: 'enables' },
   ];
 
   for (const { content, filePath } of allContent) {


### PR DESCRIPTION
## Summary

Periodic maintenance sweep covering bug fixes, issue triage, and cleanup.

### Code fixes
- **Fix consistency validation stack overflow**: The causal consistency checker's regex patterns used `[\w\s]{2,30}?` which causes catastrophic backtracking because `[\w\s]` overlaps with `\s+`. Replaced with `\w+(?:\s+\w+){0,5}` — unambiguous pattern matching 1-6 words.
- **Fix unescaped `<` in frontmatter**: `short-timeline-policy-implications.mdx` had `<2 years` in `llmSummary` — replaced with plain text.

### Issue triage
- Removed stale `claude-working` labels from 3 issues (#1085, #1278, #1284) where sessions started but no PRs were created
- Verified 4 recently closed issues (#1276, #1274, #1017, #1215) are properly resolved
- Filed #1287: validate-quality.ts split (725 lines → 4 modules)

### Maintenance signals reviewed
- 94 merged PRs, 89 session logs, 56 open issues, 70 cruft items
- No P0 blockers remaining after the regex fix

## Test plan

- [x] `pnpm crux validate gate --fix --no-cache` passes (14/14 checks)
- [x] Consistency validator completes without stack overflow (was crashing before)
- [x] All 327 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)