### PR TITLE
fix: correct bot email and add in-repo agent memory

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Longterm Wiki — Agent Memory
+
+## Critical Facts
+- **Website URL**: The production site is **longtermwiki.com** (specifically `https://www.longtermwiki.com`). Do NOT use `longterm.wiki`, `longtermwiki.org`, or any other domain when searching/fetching/referencing the site. The `longterm.wiki` domain does not exist.
+- **Org email domain**: `quantifieduncertainty.org` — bot emails use `bot@quantifieduncertainty.org`.

--- a/.github/workflows/job-worker.yml
+++ b/.github/workflows/job-worker.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Configure git
         run: |
           git config user.name "longterm-wiki-bot"
-          git config user.email "bot@longterm.wiki"
+          git config user.email "bot@quantifieduncertainty.org"
 
       - name: Run worker
         id: worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ AI safety wiki with ~700 MDX pages, Next.js frontend, YAML data layer, and CLI t
 
 **This is a routing document.** Detailed guides live in `content/docs/internal/` and `.claude/rules/`. Use `pnpm crux <domain> --help` for full CLI reference.
 
+**Agent memory**: Read `.claude/memory/MEMORY.md` at session start for cross-session facts and corrections. Update it when you learn stable new facts (confirmed URLs, naming conventions, recurring gotchas). This file is checked into git so all agents and worktrees share it.
+
 ## MANDATORY FIRST ACTION — Do this before anything else
 
 Before reading files, running commands, or writing any code, run:

--- a/crux/lib/job-handlers/batch-commit.ts
+++ b/crux/lib/job-handlers/batch-commit.ts
@@ -278,9 +278,9 @@ export async function handleBatchCommit(
       env: {
         ...process.env,
         GIT_AUTHOR_NAME: 'longterm-wiki-bot',
-        GIT_AUTHOR_EMAIL: 'bot@longterm.wiki',
+        GIT_AUTHOR_EMAIL: 'bot@quantifieduncertainty.org',
         GIT_COMMITTER_NAME: 'longterm-wiki-bot',
-        GIT_COMMITTER_EMAIL: 'bot@longterm.wiki',
+        GIT_COMMITTER_EMAIL: 'bot@quantifieduncertainty.org',
       },
     });
 


### PR DESCRIPTION
## Summary
- Fixed bot email from non-existent `bot@longterm.wiki` to `bot@quantifieduncertainty.org` in job-worker workflow and batch-commit handler
- Added `.claude/memory/MEMORY.md` — checked into git so all agents and worktrees share cross-session facts
- Updated CLAUDE.md to reference the memory file

## Test plan
- [x] Gate checks pass (all 13) — TS error is pre-existing on main from #1294 (missing @playwright/test)
- [x] No remaining references to `longterm.wiki` in codebase
- [ ] Verify bot commits on next job-worker run use correct email

🤖 Generated with [Claude Code](https://claude.com/claude-code)