### PR TITLE
fix: repair broken Hono RPC chain in integrity route

### DIFF
--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -380,7 +380,7 @@ const integrityApp = new Hono()
         total_dangling_refs: totalDangling,
       },
     });
-  });
+  })
 
   // ---- GET /claims-citations-coverage ----
   // Coverage metrics for the citation_quotes → claims consolidation (#1194)


### PR DESCRIPTION
## Summary
- Fixes TypeScript error on main: `integrity.ts(388,3): error TS1128: Declaration or statement expected`
- A semicolon after `});` on line 383 broke the Hono method chain, preventing the `claims-citations-coverage` endpoint from compiling
- Changed `});` to `})` to continue the chain (matches the pattern on line 282)

Introduced by #1299.