### PR TITLE
feat: scaffold groundskeeper service with health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           pids+=($!)
           (cd apps/wiki-server && npx tsc --noEmit) &
           pids+=($!)
+          (cd apps/groundskeeper && npx tsc --noEmit) &
+          pids+=($!)
           failed=0
           for pid in "${pids[@]}"; do
             wait "$pid" || failed=1

--- a/.github/workflows/groundskeeper-docker.yml
+++ b/.github/workflows/groundskeeper-docker.yml
@@ -1,0 +1,83 @@
+name: Groundskeeper — Build & Push Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/groundskeeper/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/groundskeeper-docker.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: groundskeeper-docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build & push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/quantified-uncertainty/longterm-wiki-groundskeeper
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=long
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/groundskeeper/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=groundskeeper
+          cache-to: type=gha,scope=groundskeeper,mode=max
+
+      - name: Update ArgoCD image tag
+        if: github.ref == 'refs/heads/main'
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+        run: |
+          IMAGE_TAG="sha-${{ github.sha }}"
+          echo "Deploying image tag: $IMAGE_TAG"
+
+          # Download ArgoCD CLI from pinned GitHub release
+          ARGOCD_VERSION="v3.3.1"
+          curl -sSL -o /usr/local/bin/argocd \
+            "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+          chmod +x /usr/local/bin/argocd
+
+          argocd app set longterm-wiki-groundskeeper \
+            --helm-set image.tag="${IMAGE_TAG}" \
+            --auth-token "${ARGOCD_AUTH_TOKEN}" \
+            --server "${ARGOCD_SERVER}" \
+            --grpc-web
+
+          argocd app wait longterm-wiki-groundskeeper \
+            --health \
+            --timeout 300 \
+            --auth-token "${ARGOCD_AUTH_TOKEN}" \
+            --server "${ARGOCD_SERVER}" \
+            --grpc-web

--- a/apps/groundskeeper/Dockerfile
+++ b/apps/groundskeeper/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+
+# Install system dependencies needed for Claude Code and git operations
+RUN apk add --no-cache git github-cli openssh
+
+# Install Claude Code CLI globally (needed for Phase 2+ AI tasks)
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /repo
+
+# Copy workspace manifests and lockfile first for layer caching
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/groundskeeper/package.json ./apps/groundskeeper/
+
+# Install only groundskeeper dependencies
+RUN pnpm install --frozen-lockfile --filter groundskeeper
+
+# Copy groundskeeper source
+COPY apps/groundskeeper/ ./apps/groundskeeper/
+
+# Create data directory for run log
+RUN mkdir -p /data
+
+ENV NODE_ENV=production
+
+WORKDIR /repo/apps/groundskeeper
+CMD ["pnpm", "start"]

--- a/apps/groundskeeper/package.json
+++ b/apps/groundskeeper/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "groundskeeper",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@octokit/auth-app": "^7.1.4",
+    "dotenv": "^16.4.7",
+    "node-cron": "^3.0.3",
+    "octokit": "^4.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/node-cron": "^3.0.11",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/groundskeeper/src/claude.ts
+++ b/apps/groundskeeper/src/claude.ts
@@ -1,0 +1,91 @@
+import { spawn } from "child_process";
+import type { Config } from "./config.js";
+import { incrementDailyAiCount, isDailyCapReached } from "./run-tracker.js";
+import { sendDiscordNotification } from "./notify.js";
+
+export interface ClaudeResult {
+  success: boolean;
+  output: string;
+  durationMs: number;
+}
+
+interface ClaudeOptions {
+  prompt: string;
+  timeoutMs?: number;
+  maxTurns?: number;
+  cwd?: string;
+}
+
+export async function runClaude(
+  config: Config,
+  options: ClaudeOptions
+): Promise<ClaudeResult> {
+  const { prompt, timeoutMs = 300_000, maxTurns = 20, cwd } = options;
+
+  // Check daily cap before running
+  if (isDailyCapReached(config)) {
+    await sendDiscordNotification(
+      config,
+      "⚠️ **Daily AI run cap reached** — skipping Claude Code invocation. Non-AI tasks continue."
+    );
+    return {
+      success: false,
+      output: "Daily run cap reached",
+      durationMs: 0,
+    };
+  }
+
+  incrementDailyAiCount(config);
+  const start = Date.now();
+
+  return new Promise<ClaudeResult>((resolve) => {
+    const args = [
+      "-p",
+      prompt,
+      "--max-turns",
+      String(maxTurns),
+      "--output-format",
+      "text",
+    ];
+
+    const proc = spawn("claude", args, {
+      cwd,
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        // Ensure Claude Code uses the API key from our env
+        ANTHROPIC_API_KEY: process.env["ANTHROPIC_API_KEY"],
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      const durationMs = Date.now() - start;
+      resolve({
+        success: code === 0,
+        output: stdout || stderr,
+        durationMs,
+      });
+    });
+
+    proc.on("error", (err) => {
+      const durationMs = Date.now() - start;
+      resolve({
+        success: false,
+        output: `Process error: ${err.message}`,
+        durationMs,
+      });
+    });
+  });
+}

--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -1,0 +1,71 @@
+export interface TaskConfig {
+  enabled: boolean;
+  schedule: string; // cron expression
+}
+
+export interface Config {
+  githubAppId: string;
+  githubInstallationId: string;
+  githubAppPrivateKey: string;
+  githubRepo: string;
+  wikiServerUrl: string;
+  discordWebhookUrl: string;
+  dailyRunCap: number;
+  runLogPath: string;
+  tasks: {
+    healthCheck: TaskConfig;
+    resolveConflicts: TaskConfig;
+    codeReview: TaskConfig;
+  };
+}
+
+function envOrDie(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function envBool(name: string, defaultValue: boolean): boolean {
+  const value = process.env[name];
+  if (value === undefined) return defaultValue;
+  return value === "true" || value === "1";
+}
+
+function envInt(name: string, defaultValue: number): number {
+  const value = process.env[name];
+  if (value === undefined) return defaultValue;
+  const parsed = parseInt(value, 10);
+  if (isNaN(parsed)) return defaultValue;
+  return parsed;
+}
+
+export function loadConfig(): Config {
+  return {
+    githubAppId: envOrDie("GITHUB_APP_ID"),
+    githubInstallationId: envOrDie("GITHUB_INSTALLATION_ID"),
+    githubAppPrivateKey: envOrDie("GITHUB_APP_PRIVATE_KEY"),
+    githubRepo: envOrDie("GITHUB_REPO"),
+    wikiServerUrl: envOrDie("WIKI_SERVER_URL"),
+    discordWebhookUrl: envOrDie("DISCORD_WEBHOOK_URL"),
+    dailyRunCap: envInt("DAILY_RUN_CAP", 20),
+    runLogPath: process.env["RUN_LOG_PATH"] ?? "/data/run-log.json",
+    tasks: {
+      healthCheck: {
+        enabled: envBool("TASK_HEALTH_CHECK_ENABLED", true),
+        schedule: process.env["TASK_HEALTH_CHECK_SCHEDULE"] ?? "*/5 * * * *",
+      },
+      resolveConflicts: {
+        enabled: envBool("TASK_RESOLVE_CONFLICTS_ENABLED", false),
+        schedule:
+          process.env["TASK_RESOLVE_CONFLICTS_SCHEDULE"] ?? "0 */2 * * *",
+      },
+      codeReview: {
+        enabled: envBool("TASK_CODE_REVIEW_ENABLED", false),
+        schedule: process.env["TASK_CODE_REVIEW_SCHEDULE"] ?? "0 9 * * 1",
+      },
+    },
+  };
+}

--- a/apps/groundskeeper/src/github.ts
+++ b/apps/groundskeeper/src/github.ts
@@ -1,0 +1,25 @@
+import { Octokit } from "octokit";
+import { createAppAuth } from "@octokit/auth-app";
+import type { Config } from "./config.js";
+
+let octokitInstance: Octokit | null = null;
+
+export function getOctokit(config: Config): Octokit {
+  if (octokitInstance) return octokitInstance;
+
+  octokitInstance = new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: config.githubAppId,
+      installationId: config.githubInstallationId,
+      privateKey: config.githubAppPrivateKey,
+    },
+  });
+
+  return octokitInstance;
+}
+
+export function parseRepo(config: Config): { owner: string; repo: string } {
+  const [owner, repo] = config.githubRepo.split("/");
+  return { owner, repo };
+}

--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -1,0 +1,68 @@
+import "dotenv/config";
+import { loadConfig } from "./config.js";
+import { registerTask } from "./scheduler.js";
+import { sendDiscordNotification } from "./notify.js";
+import { healthCheck } from "./tasks/health-check.js";
+import { resolveConflicts } from "./tasks/resolve-conflicts.js";
+import { codeReview } from "./tasks/code-review.js";
+
+const config = loadConfig();
+
+console.log(
+  JSON.stringify({
+    timestamp: new Date().toISOString(),
+    event: "startup",
+    dailyRunCap: config.dailyRunCap,
+    tasks: {
+      healthCheck: {
+        enabled: config.tasks.healthCheck.enabled,
+        schedule: config.tasks.healthCheck.schedule,
+      },
+      resolveConflicts: {
+        enabled: config.tasks.resolveConflicts.enabled,
+        schedule: config.tasks.resolveConflicts.schedule,
+      },
+      codeReview: {
+        enabled: config.tasks.codeReview.enabled,
+        schedule: config.tasks.codeReview.schedule,
+      },
+    },
+  })
+);
+
+// Register tasks
+registerTask(
+  config,
+  "health-check",
+  config.tasks.healthCheck.schedule,
+  config.tasks.healthCheck.enabled,
+  () => healthCheck(config)
+);
+
+registerTask(
+  config,
+  "resolve-conflicts",
+  config.tasks.resolveConflicts.schedule,
+  config.tasks.resolveConflicts.enabled,
+  () => resolveConflicts(config)
+);
+
+registerTask(
+  config,
+  "code-review",
+  config.tasks.codeReview.schedule,
+  config.tasks.codeReview.enabled,
+  () => codeReview(config)
+);
+
+await sendDiscordNotification(
+  config,
+  "🟢 **Groundskeeper started** — health check active, monitoring wiki server."
+);
+
+console.log(
+  JSON.stringify({
+    timestamp: new Date().toISOString(),
+    event: "ready",
+  })
+);

--- a/apps/groundskeeper/src/notify.ts
+++ b/apps/groundskeeper/src/notify.ts
@@ -1,0 +1,24 @@
+import type { Config } from "./config.js";
+
+export async function sendDiscordNotification(
+  config: Config,
+  message: string
+): Promise<void> {
+  try {
+    const response = await fetch(config.discordWebhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: message.slice(0, 2000), // Discord message limit
+      }),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Discord webhook failed: ${response.status} ${response.statusText}`
+      );
+    }
+  } catch (error) {
+    console.error("Failed to send Discord notification:", error);
+  }
+}

--- a/apps/groundskeeper/src/run-tracker.ts
+++ b/apps/groundskeeper/src/run-tracker.ts
@@ -1,0 +1,89 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import type { Config } from "./config.js";
+
+export interface RunRecord {
+  taskName: string;
+  timestamp: string;
+  durationMs: number;
+  success: boolean;
+  error?: string;
+  summary?: string;
+}
+
+interface RunLog {
+  runs: RunRecord[];
+  dailyCounts: Record<string, number>; // date string -> count of AI invocations
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD in UTC
+}
+
+function loadLog(path: string): RunLog {
+  if (!existsSync(path)) {
+    return { runs: [], dailyCounts: {} };
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return { runs: [], dailyCounts: {} };
+  }
+}
+
+function saveLog(path: string, log: RunLog): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(path, JSON.stringify(log, null, 2));
+}
+
+export function recordRun(config: Config, record: RunRecord): void {
+  const log = loadLog(config.runLogPath);
+
+  // Keep last 200 runs to avoid unbounded growth
+  log.runs.push(record);
+  if (log.runs.length > 200) {
+    log.runs = log.runs.slice(-200);
+  }
+
+  saveLog(config.runLogPath, log);
+}
+
+export function incrementDailyAiCount(config: Config): void {
+  const log = loadLog(config.runLogPath);
+  const key = todayKey();
+  log.dailyCounts[key] = (log.dailyCounts[key] ?? 0) + 1;
+
+  // Clean up old date entries (keep last 7 days)
+  const keys = Object.keys(log.dailyCounts).sort();
+  while (keys.length > 7) {
+    const oldKey = keys.shift()!;
+    delete log.dailyCounts[oldKey];
+  }
+
+  saveLog(config.runLogPath, log);
+}
+
+export function getDailyAiCount(config: Config): number {
+  const log = loadLog(config.runLogPath);
+  return log.dailyCounts[todayKey()] ?? 0;
+}
+
+export function isDailyCapReached(config: Config): boolean {
+  return getDailyAiCount(config) >= config.dailyRunCap;
+}
+
+export function getRecentRuns(
+  config: Config,
+  taskName?: string,
+  limit = 10
+): RunRecord[] {
+  const log = loadLog(config.runLogPath);
+  let runs = log.runs;
+  if (taskName) {
+    runs = runs.filter((r) => r.taskName === taskName);
+  }
+  return runs.slice(-limit);
+}

--- a/apps/groundskeeper/src/scheduler.ts
+++ b/apps/groundskeeper/src/scheduler.ts
@@ -1,0 +1,167 @@
+import cron from "node-cron";
+import type { Config } from "./config.js";
+import { sendDiscordNotification } from "./notify.js";
+import { recordRun } from "./run-tracker.js";
+
+export type TaskFn = () => Promise<{ success: boolean; summary?: string }>;
+
+interface TaskState {
+  name: string;
+  consecutiveFailures: number;
+  disabled: boolean;
+  running: boolean;
+}
+
+const taskStates = new Map<string, TaskState>();
+
+function getState(name: string): TaskState {
+  let state = taskStates.get(name);
+  if (!state) {
+    state = { name, consecutiveFailures: 0, disabled: false, running: false };
+    taskStates.set(name, state);
+  }
+  return state;
+}
+
+function log(taskName: string, data: Record<string, unknown>): void {
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      task: taskName,
+      ...data,
+    })
+  );
+}
+
+export function registerTask(
+  config: Config,
+  name: string,
+  schedule: string,
+  enabled: boolean,
+  fn: TaskFn
+): void {
+  if (!enabled) {
+    log(name, { event: "skipped", reason: "disabled" });
+    return;
+  }
+
+  if (!cron.validate(schedule)) {
+    log(name, { event: "error", reason: `Invalid cron: ${schedule}` });
+    return;
+  }
+
+  log(name, { event: "registered", schedule });
+
+  cron.schedule(schedule, async () => {
+    const state = getState(name);
+
+    // Guard: don't run if already running
+    if (state.running) {
+      log(name, { event: "skipped", reason: "already running" });
+      return;
+    }
+
+    // Guard: circuit breaker
+    if (state.disabled) {
+      log(name, { event: "skipped", reason: "circuit breaker tripped" });
+      return;
+    }
+
+    state.running = true;
+    const start = Date.now();
+
+    try {
+      const result = await fn();
+      const durationMs = Date.now() - start;
+
+      if (result.success) {
+        state.consecutiveFailures = 0;
+        log(name, {
+          event: "success",
+          durationMs,
+          summary: result.summary,
+        });
+      } else {
+        state.consecutiveFailures++;
+        log(name, {
+          event: "failure",
+          durationMs,
+          consecutiveFailures: state.consecutiveFailures,
+          summary: result.summary,
+        });
+
+        await sendDiscordNotification(
+          config,
+          `❌ **${name}** failed (${state.consecutiveFailures}/3): ${result.summary ?? "no details"}`
+        );
+
+        // Trip circuit breaker after 3 consecutive failures
+        if (state.consecutiveFailures >= 3) {
+          state.disabled = true;
+          await sendDiscordNotification(
+            config,
+            `🔴 **Circuit breaker tripped** for **${name}** after 3 consecutive failures. Task disabled until pod restart or manual reset.`
+          );
+          log(name, { event: "circuit_breaker_tripped" });
+        }
+      }
+
+      recordRun(config, {
+        taskName: name,
+        timestamp: new Date().toISOString(),
+        durationMs,
+        success: result.success,
+        summary: result.summary,
+      });
+    } catch (error) {
+      const durationMs = Date.now() - start;
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      state.consecutiveFailures++;
+      log(name, {
+        event: "error",
+        durationMs,
+        error: errorMessage,
+        consecutiveFailures: state.consecutiveFailures,
+      });
+
+      await sendDiscordNotification(
+        config,
+        `❌ **${name}** threw an error (${state.consecutiveFailures}/3): ${errorMessage}`
+      );
+
+      if (state.consecutiveFailures >= 3) {
+        state.disabled = true;
+        await sendDiscordNotification(
+          config,
+          `🔴 **Circuit breaker tripped** for **${name}** after 3 consecutive failures. Task disabled until pod restart or manual reset.`
+        );
+        log(name, { event: "circuit_breaker_tripped" });
+      }
+
+      recordRun(config, {
+        taskName: name,
+        timestamp: new Date().toISOString(),
+        durationMs,
+        success: false,
+        error: errorMessage,
+      });
+    } finally {
+      state.running = false;
+    }
+  });
+}
+
+export function resetCircuitBreaker(name: string): boolean {
+  const state = taskStates.get(name);
+  if (!state) return false;
+  state.disabled = false;
+  state.consecutiveFailures = 0;
+  log(name, { event: "circuit_breaker_reset" });
+  return true;
+}
+
+export function getTaskStates(): Map<string, TaskState> {
+  return taskStates;
+}

--- a/apps/groundskeeper/src/tasks/code-review.ts
+++ b/apps/groundskeeper/src/tasks/code-review.ts
@@ -1,0 +1,12 @@
+import type { Config } from "../config.js";
+
+// Phase 3: Weekly code review using Claude Code
+// Will review recent changes and post findings to Discord.
+export async function codeReview(
+  _config: Config
+): Promise<{ success: boolean; summary?: string }> {
+  return {
+    success: true,
+    summary: "Not yet implemented (Phase 3)",
+  };
+}

--- a/apps/groundskeeper/src/tasks/health-check.ts
+++ b/apps/groundskeeper/src/tasks/health-check.ts
@@ -1,0 +1,91 @@
+import type { Config } from "../config.js";
+import { getOctokit, parseRepo } from "../github.js";
+
+const ISSUE_TITLE = "[Groundskeeper] Wiki server health check failure";
+
+async function findOpenHealthIssue(config: Config) {
+  const octokit = getOctokit(config);
+  const { owner, repo } = parseRepo(config);
+
+  const { data: issues } = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: "open",
+    labels: "groundskeeper",
+    per_page: 100,
+  });
+
+  return issues.find((issue) => issue.title === ISSUE_TITLE);
+}
+
+export async function healthCheck(
+  config: Config
+): Promise<{ success: boolean; summary?: string }> {
+  let serverUp = false;
+
+  try {
+    const response = await fetch(config.wikiServerUrl, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    serverUp = response.ok;
+  } catch {
+    serverUp = false;
+  }
+
+  const octokit = getOctokit(config);
+  const { owner, repo } = parseRepo(config);
+  const existingIssue = await findOpenHealthIssue(config);
+
+  if (serverUp) {
+    // Server is up — close any existing issue
+    if (existingIssue) {
+      await octokit.rest.issues.update({
+        owner,
+        repo,
+        issue_number: existingIssue.number,
+        state: "closed",
+        state_reason: "completed",
+      });
+      await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: existingIssue.number,
+        body: `✅ Wiki server is back up at ${new Date().toISOString()}.`,
+      });
+      return {
+        success: true,
+        summary: `Server up, closed issue #${existingIssue.number}`,
+      };
+    }
+    return { success: true, summary: "Server up" };
+  }
+
+  // Server is down
+  if (existingIssue) {
+    // Already tracked — add a comment with the latest check time
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: existingIssue.number,
+      body: `⚠️ Wiki server still down at ${new Date().toISOString()}.`,
+    });
+    return {
+      success: false,
+      summary: `Server down, updated issue #${existingIssue.number}`,
+    };
+  }
+
+  // Create a new issue
+  const { data: newIssue } = await octokit.rest.issues.create({
+    owner,
+    repo,
+    title: ISSUE_TITLE,
+    body: `The wiki server at \`${config.wikiServerUrl}\` is not responding.\n\nDetected at: ${new Date().toISOString()}\n\nThis issue will be closed automatically when the server recovers.`,
+    labels: ["groundskeeper"],
+  });
+
+  return {
+    success: false,
+    summary: `Server down, created issue #${newIssue.number}`,
+  };
+}

--- a/apps/groundskeeper/src/tasks/resolve-conflicts.ts
+++ b/apps/groundskeeper/src/tasks/resolve-conflicts.ts
@@ -1,0 +1,12 @@
+import type { Config } from "../config.js";
+
+// Phase 2: Conflict resolution using Claude Code
+// Will find PRs with merge conflicts and use Claude Code CLI to resolve them.
+export async function resolveConflicts(
+  _config: Config
+): Promise<{ success: boolean; summary?: string }> {
+  return {
+    success: true,
+    summary: "Not yet implemented (Phase 2)",
+  };
+}

--- a/apps/groundskeeper/tsconfig.json
+++ b/apps/groundskeeper/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,34 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  apps/groundskeeper:
+    dependencies:
+      '@octokit/auth-app':
+        specifier: ^7.1.4
+        version: 7.2.2
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      node-cron:
+        specifier: ^3.0.3
+        version: 3.0.3
+      octokit:
+        specifier: ^4.1.2
+        version: 4.1.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.10
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@dagrejs/dagre':
@@ -497,9 +525,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1374,6 +1404,113 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@octokit/app@15.1.6':
+    resolution: {integrity: sha512-WELCamoCJo9SN0lf3SWZccf68CF0sBNPQuLYmZ/n87p5qvBJDe9aBtr5dHkh7T9nxWZ608pizwsUbypSzZAiUw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-app@7.2.2':
+    resolution: {integrity: sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-app@8.1.4':
+    resolution: {integrity: sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-device@7.1.5':
+    resolution: {integrity: sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-user@5.1.6':
+    resolution: {integrity: sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-token@5.1.2':
+    resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-unauthenticated@6.1.3':
+    resolution: {integrity: sha512-d5gWJla3WdSl1yjbfMpET+hUSFCE15qM0KVSB0H1shyuJihf/RL1KqWoZMIaonHvlNojkL9XtLFp8QeLe+1iwA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@6.1.6':
+    resolution: {integrity: sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@10.1.4':
+    resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@8.2.2':
+    resolution: {integrity: sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-app@7.1.6':
+    resolution: {integrity: sha512-OMcMzY2WFARg80oJNFwWbY51TBUfLH4JGTy119cqiDawSFXSIBujxmpXiKbGWQlvfn0CxE6f7/+c6+Kr5hI2YA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-authorization-url@7.1.1':
+    resolution: {integrity: sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-methods@5.1.5':
+    resolution: {integrity: sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/openapi-webhooks-types@11.0.0':
+    resolution: {integrity: sha512-ZBzCFj98v3SuRM7oBas6BHZMJRadlnDoeFfvm1olVxZnYeU6Vh97FhPxyS5aLh5pN51GYv2I51l/hVUAVkGBlA==}
+
+  '@octokit/plugin-paginate-graphql@5.2.4':
+    resolution: {integrity: sha512-pLZES1jWaOynXKHOqdnwZ5ULeVR6tVVCMm+AUbp0htdcyXDU95WbkYdU4R2ej1wKj5Tu94Mee2Ne0PjPO9cCyA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@12.0.0':
+    resolution: {integrity: sha512-MPd6WK1VtZ52lFrgZ0R2FlaoiWllzgqFHaSZxvp72NmoDeZ0m8GeJdg4oB6ctqMTYyrnDYp592Xma21mrgiyDA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@14.0.0':
+    resolution: {integrity: sha512-iQt6ovem4b7zZYZQtdv+PwgbL5VPq37th1m2x2TdkgimIDJpsi2A6Q/OI/23i/hR6z5mL0EgisNR4dcbmckSZQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@7.2.1':
+    resolution: {integrity: sha512-wUc3gv0D6vNHpGxSaR3FlqJpTXGWgqmk607N9L3LvPL4QjaxDgX/1nY2mGpT37Khn+nlIXdljczkRnNdTTV3/A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-throttling@10.0.0':
+    resolution: {integrity: sha512-Kuq5/qs0DVYTHZuBAzCZStCzo2nKvVRo/TDNhCcpC2TKiOGz/DisXMCvjt3/b5kr6SCI1Y8eeeJTHBxxpFvZEg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': ^6.1.3
+
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@9.2.4':
+    resolution: {integrity: sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@octokit/webhooks-methods@5.1.1':
+    resolution: {integrity: sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/webhooks@13.9.1':
+    resolution: {integrity: sha512-Nss2b4Jyn4wB3EAqAPJypGuCJFalz/ZujKBQQ5934To7Xw9xjf4hkr/EAByxQY7hp7MKd790bWGz7XYSTsHmaw==}
+    engines: {node: '>= 18'}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
@@ -2094,6 +2231,9 @@ packages:
   '@tanstack/virtual-core@3.13.18':
     resolution: {integrity: sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==}
 
+  '@types/aws-lambda@8.10.161':
+    resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -2228,6 +2368,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node-cron@3.0.11':
+    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
   '@types/node@22.19.10':
     resolution: {integrity: sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==}
@@ -2376,6 +2519,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  before-after-hook@3.0.2:
+    resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
   better-sqlite3@12.6.2:
     resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
@@ -2385,6 +2531,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2996,6 +3145,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-content-type-parse@2.0.1:
+    resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3720,12 +3872,20 @@ packages:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
+  node-cron@3.0.3:
+    resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
+    engines: {node: '>=6.0.0'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  octokit@4.1.4:
+    resolution: {integrity: sha512-cRvxRte6FU3vAHRC9+PMSY3D+mRAs2Rd9emMoqp70UGRvJRM3sbAoim2IXRZNNsf8wVfn4sGxVBHRAP+JBVX/g==}
+    engines: {node: '>= 18'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -4097,9 +4257,11 @@ packages:
 
   shikiji-core@0.10.2:
     resolution: {integrity: sha512-9Of8HMlF96usXJHmCL3Gd0Fcf0EcyJUF9m8EoAKKd98mHXi0La2AZl1h6PegSFGtiYcBDK/fLuKbDa1l16r1fA==}
+    deprecated: Deprecated, use @shikijs/core instead
 
   shikiji@0.10.2:
     resolution: {integrity: sha512-wtZg3T0vtYV2PnqusWQs3mDaJBdCPWxFDrBM/SE5LfrX92gjUvfEMlc+vJnoKY6Z/S44OWaCRzNIsdBRWcTAiw==}
+    deprecated: Deprecated, use shiki instead
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4269,6 +4431,10 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
@@ -4364,6 +4530,12 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4421,6 +4593,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -5496,6 +5672,153 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
+  '@octokit/app@15.1.6':
+    dependencies:
+      '@octokit/auth-app': 7.2.2
+      '@octokit/auth-unauthenticated': 6.1.3
+      '@octokit/core': 6.1.6
+      '@octokit/oauth-app': 7.1.6
+      '@octokit/plugin-paginate-rest': 12.0.0(@octokit/core@6.1.6)
+      '@octokit/types': 14.1.0
+      '@octokit/webhooks': 13.9.1
+
+  '@octokit/auth-app@7.2.2':
+    dependencies:
+      '@octokit/auth-oauth-app': 8.1.4
+      '@octokit/auth-oauth-user': 5.1.6
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@8.1.4':
+    dependencies:
+      '@octokit/auth-oauth-device': 7.1.5
+      '@octokit/auth-oauth-user': 5.1.6
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@7.1.5':
+    dependencies:
+      '@octokit/oauth-methods': 5.1.5
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@5.1.6':
+    dependencies:
+      '@octokit/auth-oauth-device': 7.1.5
+      '@octokit/oauth-methods': 5.1.5
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@5.1.2': {}
+
+  '@octokit/auth-unauthenticated@6.1.3':
+    dependencies:
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+
+  '@octokit/core@6.1.6':
+    dependencies:
+      '@octokit/auth-token': 5.1.2
+      '@octokit/graphql': 8.2.2
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      before-after-hook: 3.0.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@10.1.4':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@8.2.2':
+    dependencies:
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-app@7.1.6':
+    dependencies:
+      '@octokit/auth-oauth-app': 8.1.4
+      '@octokit/auth-oauth-user': 5.1.6
+      '@octokit/auth-unauthenticated': 6.1.3
+      '@octokit/core': 6.1.6
+      '@octokit/oauth-authorization-url': 7.1.1
+      '@octokit/oauth-methods': 5.1.5
+      '@types/aws-lambda': 8.10.161
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@7.1.1': {}
+
+  '@octokit/oauth-methods@5.1.5':
+    dependencies:
+      '@octokit/oauth-authorization-url': 7.1.1
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/openapi-webhooks-types@11.0.0': {}
+
+  '@octokit/plugin-paginate-graphql@5.2.4(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+
+  '@octokit/plugin-paginate-rest@12.0.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 14.1.0
+
+  '@octokit/plugin-rest-endpoint-methods@14.0.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 14.1.0
+
+  '@octokit/plugin-retry@7.2.1(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@10.0.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 14.1.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@6.1.8':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request@9.2.4':
+    dependencies:
+      '@octokit/endpoint': 10.1.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 2.0.1
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
+
+  '@octokit/webhooks-methods@5.1.1': {}
+
+  '@octokit/webhooks@13.9.1':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 11.0.0
+      '@octokit/request-error': 6.1.8
+      '@octokit/webhooks-methods': 5.1.1
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
@@ -6238,6 +6561,8 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.18': {}
 
+  '@types/aws-lambda@8.10.161': {}
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.10
@@ -6396,6 +6721,8 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node-cron@3.0.11': {}
 
   '@types/node@22.19.10':
     dependencies:
@@ -6562,6 +6889,8 @@ snapshots:
   base64-js@1.5.1:
     optional: true
 
+  before-after-hook@3.0.2: {}
+
   better-sqlite3@12.6.2:
     dependencies:
       bindings: 1.5.0
@@ -6579,6 +6908,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  bottleneck@2.19.5: {}
 
   buffer-from@1.1.2: {}
 
@@ -7214,6 +7545,8 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fast-content-type-parse@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -8299,9 +8632,27 @@ snapshots:
       semver: 7.7.4
     optional: true
 
+  node-cron@3.0.3:
+    dependencies:
+      uuid: 8.3.2
+
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
+
+  octokit@4.1.4:
+    dependencies:
+      '@octokit/app': 15.1.6
+      '@octokit/core': 6.1.6
+      '@octokit/oauth-app': 7.1.6
+      '@octokit/plugin-paginate-graphql': 5.2.4(@octokit/core@6.1.6)
+      '@octokit/plugin-paginate-rest': 12.0.0(@octokit/core@6.1.6)
+      '@octokit/plugin-rest-endpoint-methods': 14.0.0(@octokit/core@6.1.6)
+      '@octokit/plugin-retry': 7.2.1(@octokit/core@6.1.6)
+      '@octokit/plugin-throttling': 10.0.0(@octokit/core@6.1.6)
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      '@octokit/webhooks': 13.9.1
 
   once@1.4.0:
     dependencies:
@@ -9046,6 +9397,8 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  toad-cache@3.7.0: {}
+
   toggle-selection@1.0.6: {}
 
   toml@3.0.0: {}
@@ -9154,6 +9507,10 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.13)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -9195,6 +9552,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
+
+  uuid@8.3.2: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "apps/web"
   - "apps/discord-bot"
   - "apps/wiki-server"
+  - "apps/groundskeeper"


### PR DESCRIPTION
## Summary

- Adds new `apps/groundskeeper` workspace package — an automated maintenance service to replace expensive GitHub Actions workflows
- Phase 1: cron scheduler with circuit breakers, daily AI run cap, Discord notifications, and wiki server health check task
- Stubs for Phase 2 (conflict resolution via Claude Code) and Phase 3 (code review)
- Dockerfile with git, gh CLI, and Claude Code CLI for future AI tasks
- GitHub Actions workflow for GHCR image builds + ArgoCD deployment

## Infrastructure (ops repo)

Companion changes in the ops repo (to be committed separately):
- Helm chart: `k8s/apps/longterm-wiki-groundskeeper/`
- ArgoCD registration in `k8s/app-manifests/values.yaml`
- Terraform secret `longtermwiki-groundskeeper-env` in `terraform/stacks/longtermwiki/secrets.tf`

## Test plan

- [ ] Verify TypeScript compiles (`cd apps/groundskeeper && npx tsc --noEmit`)
- [ ] Verify Docker image builds locally
- [ ] After deploy: pod starts and logs structured JSON
- [ ] After deploy: health check runs on schedule, creates GitHub issue when server is down
- [ ] After deploy: circuit breaker trips after 3 consecutive failures
- [ ] After deploy: Discord notifications arrive in #agent-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)