### PR TITLE
feat: post-extraction quality gate for claims

### DIFF
--- a/crux/claims/extract.ts
+++ b/crux/claims/extract.ts
@@ -41,6 +41,7 @@ import { VALID_CLAIM_TYPES, claimTypeToCategory, parseNumericValue } from '../li
 import type { ClaimTypeValue } from '../lib/claim-utils.ts';
 import { getVariantPrompt, VARIANT_NAMES, type VariantName, type PageType } from './experiment-variants.ts';
 import { validateClaimBatch } from './validate-claim.ts';
+import { runExtractionQualityGate } from './extraction-quality-gate.ts';
 import { parseFootnotes, type ParsedFootnote } from '../lib/footnote-parser.ts';
 import { loadEntitySlugs, buildNormalizationMap, normalizeRelatedEntities } from '../lib/normalize-entity-slugs.ts';
 
@@ -410,6 +411,7 @@ async function main() {
   const args = parseCliArgs(process.argv.slice(2));
   const dryRun = args['dry-run'] === true;
   const strict = args['strict'] === true;
+  const noGate = args['no-gate'] === true;
   const model = typeof args.model === 'string' ? args.model : undefined;
   const variantArg = typeof args.variant === 'string' ? args.variant : 'baseline';
   const pageTypeArg = typeof args['page-type'] === 'string' ? args['page-type'] as PageType : undefined;
@@ -479,6 +481,9 @@ async function main() {
   if (strict) {
     console.log(`  ${c.yellow}STRICT MODE — claims failing validation will be rejected${c.reset}`);
   }
+  if (noGate) {
+    console.log(`  ${c.yellow}QUALITY GATE DISABLED — claims will not be quality-checked${c.reset}`);
+  }
   if (dryRun) {
     console.log(`  ${c.yellow}DRY RUN — claims will not be stored${c.reset}`);
   }
@@ -520,8 +525,43 @@ async function main() {
     }
   }
 
-  // Use validated claims going forward
-  const validatedClaims = accepted;
+  // --- Quality Gate: auto-fix and reject before insertion ---
+  const gateResult = runExtractionQualityGate(accepted, {
+    entityId: pageId,
+    entityName,
+    disabled: noGate,
+  });
+
+  if (!noGate && (gateResult.stats.autoFixedCount > 0 || gateResult.stats.rejected > 0)) {
+    console.log(`\n${c.bold}Quality Gate:${c.reset}`);
+    console.log(`  ${c.green}${gateResult.stats.accepted}${c.reset} accepted, ${c.yellow}${gateResult.stats.autoFixedCount}${c.reset} auto-fixed, ${c.red}${gateResult.stats.rejected}${c.reset} rejected`);
+
+    if (Object.keys(gateResult.stats.fixBreakdown).length > 0) {
+      console.log(`  ${c.dim}Auto-fixes:${c.reset}`);
+      for (const [fix, cnt] of Object.entries(gateResult.stats.fixBreakdown).sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${fix.padEnd(24)} ${cnt}`);
+      }
+    }
+    if (Object.keys(gateResult.stats.rejectBreakdown).length > 0) {
+      console.log(`  ${c.dim}Rejections:${c.reset}`);
+      for (const [reason, cnt] of Object.entries(gateResult.stats.rejectBreakdown).sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${reason.padEnd(24)} ${cnt}`);
+      }
+    }
+    if (gateResult.rejected.length > 0) {
+      console.log(`\n  ${c.yellow}Rejected claims:${c.reset}`);
+      for (const r of gateResult.rejected.slice(0, 5)) {
+        console.log(`    ${c.red}x${c.reset} ${r.claimText.slice(0, 80)}`);
+        console.log(`      ${c.dim}${r.rejectReasons.join('; ')}${c.reset}`);
+      }
+      if (gateResult.rejected.length > 5) {
+        console.log(`    ... and ${gateResult.rejected.length - 5} more`);
+      }
+    }
+  }
+
+  // Use gate-filtered claims going forward
+  const validatedClaims = gateResult.accepted;
 
   if (dryRun) {
     // Show type/category/mode breakdown

--- a/crux/claims/extraction-quality-gate.test.ts
+++ b/crux/claims/extraction-quality-gate.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripMarkup,
+  containsEntityReference,
+  fixSelfContainment,
+  isNonAtomic,
+  isTautologicalDefinition,
+  runExtractionQualityGate,
+  type GateInput,
+} from './extraction-quality-gate.ts';
+
+// ---------------------------------------------------------------------------
+// stripMarkup
+// ---------------------------------------------------------------------------
+
+describe('stripMarkup', () => {
+  it('strips EntityLink tags, keeping text content', () => {
+    const { cleaned, labels } = stripMarkup(
+      'Founded by <EntityLink id="dario-amodei">Dario Amodei</EntityLink>.',
+    );
+    expect(cleaned).toBe('Founded by Dario Amodei.');
+    expect(labels).toContain('EntityLink');
+  });
+
+  it('strips F tags entirely', () => {
+    const { cleaned } = stripMarkup('Revenue was <F id="revenue" />.');
+    expect(cleaned).toBe('Revenue was .');
+  });
+
+  it('strips MDX comments', () => {
+    const { cleaned, labels } = stripMarkup('Some text {/* NEEDS CITATION */} more.');
+    expect(cleaned).toBe('Some text more.');
+    expect(labels).toContain('MDX-comment');
+  });
+
+  it('strips bold markdown', () => {
+    const { cleaned } = stripMarkup('This is **very important** text.');
+    expect(cleaned).toBe('This is very important text.');
+  });
+
+  it('strips markdown links', () => {
+    const { cleaned } = stripMarkup('See [this article](https://example.com) for details.');
+    expect(cleaned).toBe('See this article for details.');
+  });
+
+  it('unescapes dollar signs', () => {
+    const { cleaned } = stripMarkup('The company raised \\$2 billion.');
+    expect(cleaned).toBe('The company raised $2 billion.');
+  });
+
+  it('returns original text if no markup', () => {
+    const { cleaned, labels } = stripMarkup('Anthropic was founded in 2021.');
+    expect(cleaned).toBe('Anthropic was founded in 2021.');
+    expect(labels).toHaveLength(0);
+  });
+
+  it('collapses multiple spaces after stripping', () => {
+    const { cleaned } = stripMarkup('Text <F id="x" /> with  gaps.');
+    expect(cleaned).toBe('Text with gaps.');
+    expect(cleaned).not.toContain('  ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// containsEntityReference
+// ---------------------------------------------------------------------------
+
+describe('containsEntityReference', () => {
+  it('detects entity name', () => {
+    expect(containsEntityReference('Anthropic raised $2B.', 'anthropic', 'Anthropic')).toBe(true);
+  });
+
+  it('detects entity slug', () => {
+    expect(containsEntityReference('anthropic raised $2B.', 'anthropic', 'Anthropic')).toBe(true);
+  });
+
+  it('detects hyphenated slug as space-separated words', () => {
+    expect(containsEntityReference('Sam Altman joined OpenAI.', 'sam-altman', 'Sam Altman')).toBe(true);
+  });
+
+  it('returns false when entity not mentioned', () => {
+    expect(containsEntityReference('The company raised $2B.', 'anthropic', 'Anthropic')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(containsEntityReference('ANTHROPIC raised money.', 'anthropic', 'Anthropic')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fixSelfContainment
+// ---------------------------------------------------------------------------
+
+describe('fixSelfContainment', () => {
+  it('replaces "the company" with entity name', () => {
+    const result = fixSelfContainment('The company raised $2 billion.', 'Anthropic');
+    expect(result).not.toBeNull();
+    expect(result!.fixed).toBe('Anthropic raised $2 billion.');
+    expect(result!.method).toBe('replace-the-company');
+  });
+
+  it('replaces "the platform" with entity name', () => {
+    const result = fixSelfContainment('The platform launched in 2020.', 'Kalshi');
+    expect(result).not.toBeNull();
+    expect(result!.fixed).toBe('Kalshi launched in 2020.');
+  });
+
+  it('replaces "It" pronoun with entity name', () => {
+    const result = fixSelfContainment('It was founded in 2021.', 'Anthropic');
+    expect(result).not.toBeNull();
+    expect(result!.fixed).toBe('Anthropic was founded in 2021.');
+    expect(result!.method).toBe('replace-it-pronoun');
+  });
+
+  it('replaces "They" pronoun with entity name', () => {
+    const result = fixSelfContainment('They raised $7 billion total.', 'Anthropic');
+    expect(result).not.toBeNull();
+    expect(result!.fixed).toBe('Anthropic raised $7 billion total.');
+    expect(result!.method).toBe('replace-they-pronoun');
+  });
+
+  it('returns null when no auto-fix strategy works', () => {
+    const result = fixSelfContainment('A major funding round occurred in 2023.', 'Anthropic');
+    expect(result).toBeNull();
+  });
+
+  it('strips relative starts like "However" when entity is present after', () => {
+    const result = fixSelfContainment('However, Anthropic grew rapidly.', 'Anthropic');
+    expect(result).not.toBeNull();
+    expect(result!.fixed).toBe('Anthropic grew rapidly.');
+    expect(result!.method).toBe('strip-relative-start');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isNonAtomic
+// ---------------------------------------------------------------------------
+
+describe('isNonAtomic', () => {
+  it('detects semicolon-split independent clauses', () => {
+    expect(isNonAtomic('Anthropic raised $2B; Google invested separately.')).toBe('semicolon-split');
+  });
+
+  it('detects compound-and pattern', () => {
+    expect(isNonAtomic('Anthropic was founded in 2021, and OpenAI launched GPT-4.')).toBe('compound-and');
+  });
+
+  it('detects connective multi-sentence claims', () => {
+    expect(isNonAtomic('Anthropic raised $2B. Additionally, they hired 500 people.')).toBe('connective-multi-sentence');
+  });
+
+  it('returns null for atomic claims', () => {
+    expect(isNonAtomic('Anthropic raised $2 billion in 2023.')).toBeNull();
+  });
+
+  it('allows "and" within a single assertion', () => {
+    expect(isNonAtomic('Anthropic was founded by Dario and Daniela Amodei.')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTautologicalDefinition
+// ---------------------------------------------------------------------------
+
+describe('isTautologicalDefinition', () => {
+  it('detects basic tautology', () => {
+    expect(isTautologicalDefinition('Kalshi is a prediction market platform.', 'kalshi', 'Kalshi')).toBe(true);
+  });
+
+  it('detects tautology with "was"', () => {
+    expect(isTautologicalDefinition('Anthropic was an AI safety company.', 'anthropic', 'Anthropic')).toBe(true);
+  });
+
+  it('does not flag claims with specifics', () => {
+    expect(isTautologicalDefinition('Kalshi is a prediction market founded in 2018.', 'kalshi', 'Kalshi')).toBe(false);
+  });
+
+  it('does not flag claims with location info', () => {
+    expect(isTautologicalDefinition('Anthropic is an AI company headquartered in San Francisco.', 'anthropic', 'Anthropic')).toBe(false);
+  });
+
+  it('does not flag non-definition claims', () => {
+    expect(isTautologicalDefinition('Anthropic raised $2 billion.', 'anthropic', 'Anthropic')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runExtractionQualityGate — full pipeline
+// ---------------------------------------------------------------------------
+
+describe('runExtractionQualityGate', () => {
+  const opts = { entityId: 'anthropic', entityName: 'Anthropic' };
+
+  function makeClaim(text: string, overrides: Partial<GateInput> = {}): GateInput {
+    return { claimText: text, claimType: 'factual', ...overrides };
+  }
+
+  it('accepts clean, self-contained claims', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic raised $2 billion in October 2023.')],
+      opts,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.stats.autoFixedCount).toBe(0);
+  });
+
+  it('auto-fixes markup in claims', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic was founded by <EntityLink id="dario-amodei">Dario Amodei</EntityLink>.')],
+      opts,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].claimText).toBe('Anthropic was founded by Dario Amodei.');
+    expect(result.stats.autoFixedCount).toBe(1);
+    expect(result.stats.fixBreakdown['strip-markup']).toBe(1);
+  });
+
+  it('auto-fixes self-containment by replacing generic references', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('The company raised $2 billion in 2023.')],
+      opts,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].claimText).toBe('Anthropic raised $2 billion in 2023.');
+    expect(result.stats.fixBreakdown['self-contain']).toBe(1);
+  });
+
+  it('auto-fixes missing terminal punctuation', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic raised $2 billion in 2023')],
+      opts,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].claimText).toBe('Anthropic raised $2 billion in 2023.');
+    expect(result.stats.fixBreakdown['add-period']).toBe(1);
+  });
+
+  it('rejects non-atomic claims', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic raised $2B; Google invested $300M separately.')],
+      opts,
+    );
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].rejectReasons).toContain('non-atomic(semicolon-split)');
+    expect(result.accepted).toHaveLength(0);
+  });
+
+  it('rejects tautological definitions', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic is an AI safety company.')],
+      opts,
+    );
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].rejectReasons).toContain('tautological');
+  });
+
+  it('rejects too-short claims', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('Anthropic exists.')],
+      opts,
+    );
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].rejectReasons).toContain('too-short');
+  });
+
+  it('rejects claims that cannot be made self-contained', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('A major funding round occurred in late October 2023.')],
+      opts,
+    );
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].rejectReasons).toContain('not-self-contained');
+  });
+
+  it('deduplicates near-identical claims within a batch', () => {
+    const result = runExtractionQualityGate(
+      [
+        makeClaim('Anthropic raised $2 billion in October 2023.'),
+        makeClaim('Anthropic raised $2 billion in October of 2023.'),
+      ],
+      opts,
+    );
+    // Second claim should be rejected as duplicate
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].rejectReasons).toContain('duplicate');
+  });
+
+  it('applies multiple fixes to a single claim', () => {
+    const result = runExtractionQualityGate(
+      [makeClaim('The company raised <F id="funding" /> in **October** 2023')],
+      opts,
+    );
+    expect(result.accepted).toHaveLength(1);
+    // Should strip markup, fix self-containment, and add period
+    expect(result.accepted[0].claimText).toContain('Anthropic');
+    expect(result.accepted[0].claimText).not.toContain('<F');
+    expect(result.accepted[0].claimText).not.toContain('**');
+    expect(result.accepted[0].claimText).toMatch(/\.$/);
+  });
+
+  it('passes everything through when disabled', () => {
+    const badClaims = [
+      makeClaim('Bad.'),
+      makeClaim('The company is great.'),
+    ];
+    const result = runExtractionQualityGate(badClaims, { ...opts, disabled: true });
+    expect(result.accepted).toHaveLength(2);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.stats.autoFixedCount).toBe(0);
+  });
+
+  it('handles empty claim list', () => {
+    const result = runExtractionQualityGate([], opts);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.stats.total).toBe(0);
+  });
+
+  it('preserves extra fields on accepted claims', () => {
+    const claim = makeClaim('Anthropic raised $2 billion in 2023.') as GateInput & { section: string };
+    claim.section = 'Funding';
+    const result = runExtractionQualityGate([claim], opts);
+    expect(result.accepted[0]).toHaveProperty('section', 'Funding');
+  });
+
+  it('counts fix and reject breakdowns correctly', () => {
+    const result = runExtractionQualityGate(
+      [
+        makeClaim('Anthropic raised $2B.'),                                    // clean accept
+        makeClaim('The company launched Claude.'),                              // auto-fix self-contain
+        makeClaim('Anthropic is an AI company.'),                               // reject tautological
+        makeClaim('Anthropic grew; OpenAI also grew significantly in 2023.'),   // reject non-atomic
+      ],
+      opts,
+    );
+    expect(result.stats.accepted).toBe(2);
+    expect(result.stats.rejected).toBe(2);
+    expect(result.stats.autoFixedCount).toBe(1);
+    expect(result.stats.fixBreakdown['self-contain']).toBe(1);
+    expect(result.stats.rejectBreakdown['tautological']).toBe(1);
+    expect(result.stats.rejectBreakdown['non-atomic']).toBe(1);
+  });
+});

--- a/crux/claims/extraction-quality-gate.ts
+++ b/crux/claims/extraction-quality-gate.ts
@@ -1,0 +1,409 @@
+/**
+ * Extraction Quality Gate — pre-insertion quality checks with auto-fix
+ *
+ * Runs between LLM extraction and DB insertion. Unlike validate-quality.ts
+ * (post-hoc auditor that reads from DB), this gate operates on in-memory
+ * claims before they're stored.
+ *
+ * Pipeline: LLM extraction → validate-claim.ts → **quality gate** → DB insert
+ *
+ * Auto-fixes:
+ *   - strip-markup:    Remove MDX/JSX artifacts from claim text
+ *   - add-entity-name: Prepend entity name to non-self-contained claims
+ *   - add-punctuation:  Add terminal period if missing
+ *
+ * Rejections (unfixable):
+ *   - non-atomic:       Multiple assertions in one claim
+ *   - tautological:     Merely defines what the entity is
+ *   - too-short:        Claim is under 20 chars after fixes
+ *   - duplicate:        Near-duplicate of another claim in the batch
+ */
+
+import { isClaimDuplicate } from '../lib/claim-utils.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GateInput {
+  claimText: string;
+  claimType: string;
+  section?: string;
+  [key: string]: unknown;
+}
+
+export interface GateResult<T extends GateInput> {
+  accepted: T[];
+  rejected: Array<T & { rejectReasons: string[] }>;
+  autoFixed: Array<{ claim: T; fixes: string[] }>;
+  stats: GateStats;
+}
+
+export interface GateStats {
+  total: number;
+  accepted: number;
+  rejected: number;
+  autoFixedCount: number;
+  fixBreakdown: Record<string, number>;
+  rejectBreakdown: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Markup stripping (reuses patterns from fix-quality.ts but operates inline)
+// ---------------------------------------------------------------------------
+
+const MARKUP_STRIP_RULES: Array<{ pattern: RegExp; replacement: string; label: string }> = [
+  // <EntityLink id="...">Text</EntityLink> → Text
+  { pattern: /<EntityLink\s+id="[^"]*"(?:\s+[^>]*)?>([^<]*)<\/EntityLink>/g, replacement: '$1', label: 'EntityLink' },
+  // <F id="..." /> or <F e="..." f="..." /> → empty
+  { pattern: /<F\s+[^>]*\/>/g, replacement: '', label: 'F-tag' },
+  // <R id="...">Text</R> → Text
+  { pattern: /<R\s+id="[^"]*">[^<]*<\/R>/g, replacement: '', label: 'R-tag' },
+  // <Calc>...</Calc> → empty
+  { pattern: /<Calc>[^<]*<\/Calc>/g, replacement: '', label: 'Calc' },
+  // Remaining self-closing JSX tags
+  { pattern: /<\w[\w.]*[^>]*\/>/g, replacement: '', label: 'JSX-self-closing' },
+  // Remaining JSX block tags (non-greedy, single-line)
+  { pattern: /<(\w[\w.]*)(?:\s[^>]*)?>([^<]*)<\/\1>/g, replacement: '$2', label: 'JSX-block' },
+  // MDX comments: {/* ... */}
+  { pattern: /\{\/\*[\s\S]*?\*\/\}/g, replacement: '', label: 'MDX-comment' },
+  // Curly brace expressions
+  { pattern: /\{[^}]+\}/g, replacement: '', label: 'curly-expr' },
+  // Escaped dollar signs: \$ → $
+  { pattern: /\\\$/g, replacement: '$', label: 'escaped-dollar' },
+  // Escaped angle brackets: \< → <
+  { pattern: /\\</g, replacement: '<', label: 'escaped-lt' },
+  // Bold markdown: **text** → text
+  { pattern: /\*\*([^*]+)\*\*/g, replacement: '$1', label: 'bold-markdown' },
+  // Markdown links: [text](url) → text
+  { pattern: /\[([^\]]+)\]\([^)]+\)/g, replacement: '$1', label: 'markdown-link' },
+];
+
+/** Has any MDX/markup content? */
+function hasMarkup(text: string): boolean {
+  for (const { pattern } of MARKUP_STRIP_RULES) {
+    pattern.lastIndex = 0;
+    if (pattern.test(text)) return true;
+  }
+  return false;
+}
+
+/** Strip markup and return cleaned text + list of what was stripped. */
+export function stripMarkup(text: string): { cleaned: string; labels: string[] } {
+  let cleaned = text;
+  const labels: string[] = [];
+
+  for (const { pattern, replacement, label } of MARKUP_STRIP_RULES) {
+    pattern.lastIndex = 0;
+    if (pattern.test(cleaned)) {
+      labels.push(label);
+      pattern.lastIndex = 0;
+      cleaned = cleaned.replace(pattern, replacement);
+    }
+  }
+
+  // Collapse multiple spaces and trim
+  cleaned = cleaned.replace(/\s{2,}/g, ' ').trim();
+  return { cleaned, labels };
+}
+
+// ---------------------------------------------------------------------------
+// Self-containment fix — prepend entity name if missing
+// ---------------------------------------------------------------------------
+
+/** Escape special regex characters. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Check if claim text mentions the entity. */
+export function containsEntityReference(
+  text: string,
+  entityId: string,
+  entityName: string,
+): boolean {
+  const lower = text.toLowerCase();
+
+  if (entityName.length > 0 && lower.includes(entityName.toLowerCase())) {
+    return true;
+  }
+  if (entityId.length > 0 && lower.includes(entityId.toLowerCase())) {
+    return true;
+  }
+  if (entityId.includes('-')) {
+    const slugWords = entityId.split('-').join(' ');
+    if (lower.includes(slugWords.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Try to fix a non-self-contained claim by replacing generic references
+ * ("the company", "the model", etc.) with the entity name, or by prepending
+ * the entity name.
+ */
+export function fixSelfContainment(
+  text: string,
+  entityName: string,
+): { fixed: string; method: string } | null {
+  // Strategy 1: Replace generic references with entity name
+  const genericReplacements: Array<{ pattern: RegExp; label: string }> = [
+    { pattern: /\bThe company\b/, label: 'the-company' },
+    { pattern: /\bthe company\b/, label: 'the-company' },
+    { pattern: /\bThe organization\b/, label: 'the-organization' },
+    { pattern: /\bthe organization\b/, label: 'the-organization' },
+    { pattern: /\bThe platform\b/, label: 'the-platform' },
+    { pattern: /\bthe platform\b/, label: 'the-platform' },
+    { pattern: /\bThe model\b/, label: 'the-model' },
+    { pattern: /\bthe model\b/, label: 'the-model' },
+    { pattern: /\bThe institute\b/, label: 'the-institute' },
+    { pattern: /\bthe institute\b/, label: 'the-institute' },
+    { pattern: /\bThe lab\b/, label: 'the-lab' },
+    { pattern: /\bthe lab\b/, label: 'the-lab' },
+    { pattern: /\bThe project\b/, label: 'the-project' },
+    { pattern: /\bthe project\b/, label: 'the-project' },
+  ];
+
+  for (const { pattern, label } of genericReplacements) {
+    if (pattern.test(text)) {
+      const fixed = text.replace(pattern, entityName);
+      return { fixed, method: `replace-${label}` };
+    }
+  }
+
+  // Strategy 2: If the claim starts with a relative phrase, try prepending
+  const relativeStarts = [
+    /^However,?\s+/i,
+    /^Additionally,?\s+/i,
+    /^Furthermore,?\s+/i,
+    /^Moreover,?\s+/i,
+    /^In contrast,?\s+/i,
+    /^In addition,?\s+/i,
+    /^Meanwhile,?\s+/i,
+    /^Similarly,?\s+/i,
+  ];
+
+  for (const pattern of relativeStarts) {
+    if (pattern.test(text)) {
+      // Remove the relative start and try again
+      const stripped = text.replace(pattern, '');
+      if (containsEntityReference(stripped, '', entityName)) {
+        return { fixed: stripped, method: 'strip-relative-start' };
+      }
+    }
+  }
+
+  // Strategy 3: If starts with "It " or "They ", replace pronoun
+  if (/^It\s+/i.test(text)) {
+    const fixed = text.replace(/^It\s+/i, `${entityName} `);
+    return { fixed, method: 'replace-it-pronoun' };
+  }
+  if (/^They\s+/i.test(text)) {
+    const fixed = text.replace(/^They\s+/i, `${entityName} `);
+    return { fixed, method: 'replace-they-pronoun' };
+  }
+
+  // Can't auto-fix
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Atomicity check — reject multi-fact claims
+// ---------------------------------------------------------------------------
+
+/** Check if a claim contains multiple assertions (non-atomic). */
+export function isNonAtomic(text: string): string | null {
+  // Semicolons splitting independent clauses
+  if (/;\s+[A-Z]/.test(text)) {
+    return 'semicolon-split';
+  }
+
+  // ", and [A-Z]" pattern suggesting multiple facts
+  if (/,\s+and\s+(?:also\s+)?[A-Z]/.test(text)) {
+    return 'compound-and';
+  }
+
+  // Multiple sentences joined by connective adverbs
+  if (/\.\s+(?:Additionally|Also|Furthermore|Moreover),?\s+/i.test(text)) {
+    return 'connective-multi-sentence';
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tautological definition check
+// ---------------------------------------------------------------------------
+
+/** Check if the claim merely defines the entity (e.g., "Kalshi is a prediction market"). */
+export function isTautologicalDefinition(
+  text: string,
+  entityId: string,
+  entityName: string,
+): boolean {
+  const lower = text.toLowerCase();
+  const entityLower = entityName.toLowerCase();
+  const idLower = entityId.toLowerCase();
+
+  const startsWithEntity =
+    lower.startsWith(entityLower + ' ') || lower.startsWith(idLower + ' ');
+  if (!startsWithEntity) return false;
+
+  const tautologyPattern = new RegExp(
+    `^(?:${escapeRegex(entityLower)}|${escapeRegex(idLower)})\\s+(?:is|was)\\s+(?:a|an|the)\\s+`,
+    'i',
+  );
+  if (!tautologyPattern.test(text)) return false;
+
+  const afterEntity = text.replace(tautologyPattern, '');
+  const hasSpecifics =
+    /\d/.test(afterEntity) ||
+    /\b(?:in|from|based|founded|headquartered|located)\b/i.test(afterEntity);
+
+  return !hasSpecifics;
+}
+
+// ---------------------------------------------------------------------------
+// Main gate function
+// ---------------------------------------------------------------------------
+
+export interface GateOptions {
+  entityId: string;
+  entityName: string;
+  /** If true, skip all checks and pass everything through. */
+  disabled?: boolean;
+}
+
+/**
+ * Run the extraction quality gate on a batch of claims.
+ *
+ * Auto-fixes what it can (markup, self-containment, punctuation).
+ * Rejects what it can't (non-atomic, tautological, too short, duplicates).
+ *
+ * @returns GateResult with accepted, rejected, auto-fixed lists and stats
+ */
+export function runExtractionQualityGate<T extends GateInput>(
+  claims: T[],
+  options: GateOptions,
+): GateResult<T> {
+  const { entityId, entityName, disabled } = options;
+
+  if (disabled) {
+    return {
+      accepted: [...claims],
+      rejected: [],
+      autoFixed: [],
+      stats: {
+        total: claims.length,
+        accepted: claims.length,
+        rejected: 0,
+        autoFixedCount: 0,
+        fixBreakdown: {},
+        rejectBreakdown: {},
+      },
+    };
+  }
+
+  const accepted: T[] = [];
+  const rejected: Array<T & { rejectReasons: string[] }> = [];
+  const autoFixed: Array<{ claim: T; fixes: string[] }> = [];
+  const fixBreakdown: Record<string, number> = {};
+  const rejectBreakdown: Record<string, number> = {};
+  const seenTexts: string[] = [];
+
+  for (const claim of claims) {
+    let text = claim.claimText;
+    const fixes: string[] = [];
+    const rejectReasons: string[] = [];
+
+    // --- Auto-fix phase ---
+
+    // Fix 1: Strip markup
+    if (hasMarkup(text)) {
+      const { cleaned, labels } = stripMarkup(text);
+      if (cleaned !== text && cleaned.length >= 10) {
+        text = cleaned;
+        const fixLabel = `strip-markup(${labels.join(',')})`;
+        fixes.push(fixLabel);
+        fixBreakdown['strip-markup'] = (fixBreakdown['strip-markup'] ?? 0) + 1;
+      }
+    }
+
+    // Fix 2: Self-containment — add entity name if missing
+    if (!containsEntityReference(text, entityId, entityName)) {
+      const result = fixSelfContainment(text, entityName);
+      if (result) {
+        text = result.fixed;
+        fixes.push(`self-contain(${result.method})`);
+        fixBreakdown['self-contain'] = (fixBreakdown['self-contain'] ?? 0) + 1;
+      } else {
+        rejectReasons.push('not-self-contained');
+      }
+    }
+
+    // Fix 3: Add terminal punctuation if missing
+    if (text.length > 0 && !/[.!?]$/.test(text.trim())) {
+      text = text.trim() + '.';
+      fixes.push('add-period');
+      fixBreakdown['add-period'] = (fixBreakdown['add-period'] ?? 0) + 1;
+    }
+
+    // --- Reject phase ---
+
+    // Check: non-atomic
+    const atomicIssue = isNonAtomic(text);
+    if (atomicIssue) {
+      rejectReasons.push(`non-atomic(${atomicIssue})`);
+    }
+
+    // Check: tautological definition
+    if (isTautologicalDefinition(text, entityId, entityName)) {
+      rejectReasons.push('tautological');
+    }
+
+    // Check: too short after fixes
+    if (text.trim().length < 20) {
+      rejectReasons.push('too-short');
+    }
+
+    // Check: duplicate of an already-accepted claim
+    const isDup = seenTexts.some(seen => isClaimDuplicate(text, seen));
+    if (isDup) {
+      rejectReasons.push('duplicate');
+    }
+
+    // --- Decision ---
+
+    if (rejectReasons.length > 0) {
+      for (const reason of rejectReasons) {
+        const key = reason.split('(')[0];
+        rejectBreakdown[key] = (rejectBreakdown[key] ?? 0) + 1;
+      }
+      rejected.push({ ...claim, rejectReasons });
+    } else {
+      // Apply fixes to the claim
+      const fixedClaim = { ...claim, claimText: text };
+      accepted.push(fixedClaim);
+      seenTexts.push(text);
+      if (fixes.length > 0) {
+        autoFixed.push({ claim: fixedClaim, fixes });
+      }
+    }
+  }
+
+  return {
+    accepted,
+    rejected,
+    autoFixed,
+    stats: {
+      total: claims.length,
+      accepted: accepted.length,
+      rejected: rejected.length,
+      autoFixedCount: autoFixed.length,
+      fixBreakdown,
+      rejectBreakdown,
+    },
+  };
+}

--- a/crux/commands/claims.ts
+++ b/crux/commands/claims.ts
@@ -17,13 +17,13 @@ const SCRIPTS = {
   pipeline: {
     script: 'claims/pipeline.ts',
     description: 'Run unified extract → link → verify pipeline for a page',
-    passthrough: ['dry-run', 'steps', 'model'],
+    passthrough: ['dry-run', 'steps', 'model', 'no-gate'],
     positional: true,
   },
   extract: {
     script: 'claims/extract.ts',
     description: 'Extract atomic claims from a wiki page using LLM',
-    passthrough: ['dry-run', 'model', 'variant', 'page-type'],
+    passthrough: ['dry-run', 'model', 'variant', 'page-type', 'no-gate', 'strict'],
     positional: true,
   },
   verify: {
@@ -185,6 +185,8 @@ Options:
   --batch=<file>        Process URLs from a file, one per line (from-resource)
   --no-auto-resource    Don't auto-create resource YAML for unknown URLs (from-resource)
   --apply               Write changes to database (integrate, backfill, migrate, cleanup; default: dry-run)
+  --no-gate             Disable quality gate (extract: skip auto-fix and rejection checks)
+  --strict              Strict mode (extract: reject claims that fail basic validation)
   --skip-extract        Skip claim extraction step (integrate: assumes claims already exist)
   --entity=E            Target entity filter (cleanup)
   --entity-id=E         Filter to single entity (backfill-related-entities)
@@ -200,6 +202,8 @@ Examples:
   crux claims pipeline kalshi --steps=extract,link    Run only extraction and linking steps
   crux claims extract kalshi                          Extract claims from the Kalshi page
   crux claims extract kalshi --dry-run                Preview without storing
+  crux claims extract kalshi --no-gate               Extract without quality gate
+  crux claims extract kalshi --strict                Reject claims that fail validation
   crux claims verify kalshi                           Verify claims against citation sources
   crux claims status kalshi                           Show verification breakdown
   crux claims status kalshi --json                    JSON output


### PR DESCRIPTION
## Summary
- Adds a quality gate that runs between LLM claim extraction and DB insertion
- Auto-fixes 3 common issues: MDX markup leakage, missing entity names (replaces generic references/pronouns), missing terminal punctuation
- Rejects 4 unfixable issue types: non-atomic claims (semicolons/compound-and), tautological definitions, too-short claims, batch duplicates
- `--no-gate` flag to bypass for debugging, `--strict` flag forwarded through CLI
- 43 unit tests covering all fix/reject paths and edge cases

## How it works

Pipeline: LLM extraction → `validateClaimBatch()` → **quality gate** → DB insert

The gate operates on in-memory claims before storage (unlike `validate-quality.ts` which audits existing DB claims post-hoc). It:
1. Strips markup (EntityLink, F-tags, MDX comments, bold, markdown links)
2. Fixes self-containment (replaces "the company" → entity name, "It" → entity name)
3. Adds terminal punctuation if missing
4. Rejects claims that can't be auto-fixed

## Test plan
- [x] 43 unit tests pass (`pnpm test`)
- [x] Full test suite: 2,392 tests pass (no regressions)
- [x] Production build succeeds (684 pages)
- [x] TypeScript clean (no errors)
- [x] Gate check: 5/5 checks pass

Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)