### PR TITLE
docs: update internal wiki pages for SQLite → PostgreSQL migration

### DIFF
--- a/content/docs/internal/about-this-wiki.mdx
+++ b/content/docs/internal/about-this-wiki.mdx
@@ -368,7 +368,7 @@ npm run validate         # Full validation
 - <EntityLink id="architecture">System Architecture</EntityLink> — Data flow, pipelines, design decisions
 - <EntityLink id="page-types">Page Type System</EntityLink> — Complete classification reference
 - <EntityLink id="rating-system">Rating System</EntityLink> — Quality scoring system
-- <EntityLink id="content-database">Content Database</EntityLink> — SQLite caching, source fetching, AI summaries
+- <EntityLink id="content-database">Content Database</EntityLink> — Storage architecture (PostgreSQL, caching, YAML)
 - <EntityLink id="automation-tools">Automation Tools</EntityLink> — All scripts and workflows
 - <EntityLink id="cause-effect-diagrams">Cause-Effect Diagrams</EntityLink> — Graph schema and examples
 - <EntityLink id="mermaid-diagrams">Mermaid Diagrams</EntityLink> — Diagram guidelines

--- a/content/docs/internal/architecture.mdx
+++ b/content/docs/internal/architecture.mdx
@@ -329,48 +329,25 @@ A tag shared by 3 entities is more informative than one shared by 300. This prev
 **Key files generated**:
 - `database.json` — All entities, pages, relations, facts, search data, statistics (includes ID registry)
 
-### Knowledge Database (SQLite)
+### Wiki-Server (PostgreSQL)
 
-**Purpose**: Index content for analysis, cache external sources, and support AI-assisted workflows.
+**Purpose**: Durable storage for citation content, audit results, claims, facts, and other structured data. Provides full-text search and typed API access.
 
-**Location**: `.cache/knowledge.db` (gitignored, regenerated per machine)
+**Location**: Remote PostgreSQL database accessed via the wiki-server's Hono RPC API.
 
-<Mermaid chart={`
-erDiagram
-    articles ||--o{ article_sources : "cites"
-    sources ||--o{ article_sources : "cited_by"
-    articles ||--o| summaries : "has"
-    sources ||--o| summaries : "has"
+| Table | Purpose |
+|-------|---------|
+| `citation_content` | Full text of fetched source URLs |
+| `citation_audits` | Per-page citation verification results |
+| `claims` | Extracted atomic claims with source references |
+| `facts` | Canonical facts with values |
+| `resources` | External resource metadata |
+| `entities` | Entity metadata (synced from YAML) |
+| `agent_sessions` | Claude Code session logs |
 
-    articles {
-        text id PK
-        text path
-        text title
-        text content
-        int word_count
-        int quality
-        text content_hash
-    }
+CLI tools access the database through `apiRequest()` in `crux/lib/wiki-server/`. The frontend uses typed RPC clients with `InferResponseType<>` for compile-time type safety.
 
-    sources {
-        text id PK
-        text url
-        text title
-        text content
-        text fetch_status
-        text fetched_at
-    }
-
-    summaries {
-        text entity_id PK
-        text entity_type
-        text one_liner
-        text summary
-        text key_points
-    }
-`} />
-
-**See**: <EntityLink id="content-database">Content Database</EntityLink> for full schema and API reference.
+**See**: <EntityLink id="content-database">Content Database</EntityLink> for the full storage architecture.
 
 ### Page Creation Pipeline
 
@@ -467,18 +444,18 @@ sequenceDiagram
     participant PageCreator
     participant Perplexity
     participant Firecrawl
-    participant SQLite
+    participant WikiServer
     participant Claude
 
     User->>PageCreator: Create page "Topic"
     PageCreator->>Perplexity: Research queries
     Perplexity-->>PageCreator: Content + citation URLs
-    PageCreator->>SQLite: Register source URLs
+    PageCreator->>WikiServer: Register source URLs
     PageCreator->>Firecrawl: Fetch page content
-    Firecrawl-->>SQLite: Store fetched content
+    Firecrawl-->>WikiServer: Store fetched content
     PageCreator->>Claude: Synthesize with research
     Claude-->>PageCreator: Draft MDX
-    PageCreator->>SQLite: Load fetched content
+    PageCreator->>WikiServer: Load fetched content
     PageCreator->>PageCreator: Verify quotes against sources
     PageCreator->>Claude: Validation loop
     Claude-->>PageCreator: Fixed MDX
@@ -612,7 +589,7 @@ This architecture documentation should be updated when:
 ## Related Documentation
 
 - <EntityLink id="about-this-wiki">About This Wiki</EntityLink> — Contributor overview
-- <EntityLink id="content-database">Content Database</EntityLink> — SQLite schema and API
+- <EntityLink id="content-database">Content Database</EntityLink> — Storage architecture (PostgreSQL, caching, YAML)
 - <EntityLink id="automation-tools">Automation Tools</EntityLink> — CLI reference
 - <EntityLink id="page-creator-pipeline">Page Creator Pipeline</EntityLink> — Generation experiments
 - [Schema Overview](/internal/schema/) — Entity types and data relationships

--- a/content/docs/internal/automation-tools.mdx
+++ b/content/docs/internal/automation-tools.mdx
@@ -288,52 +288,49 @@ npm run validate:ci
 
 ---
 
-## Knowledge Base System
+## Citation & Content Tools
 
-SQLite-based system for managing content, sources, and AI summaries.
+Tools for verifying citations, fetching source content, and scanning wiki pages. Data is stored in the wiki-server PostgreSQL database and accessed via Hono RPC API.
 
-### Setup
-
-Requires `.env` file:
-```
-ANTHROPIC_API_KEY=sk-ant-...
-```
-
-### Commands
+### Citation Verification
 
 ```bash
-npm run crux -- analyze scan                   # Scan MDX files, extract sources
-npm run crux -- generate summaries             # Generate AI summaries
-node scripts/scan-content.mjs --stats          # Show database statistics
+# Verify all citations on a page (fetches URLs, checks quotes)
+pnpm crux citations verify <page-id>
+
+# Run citation audits across multiple pages
+pnpm crux citations audit
+
+# View citation archive for a page
+pnpm crux citations show <page-id>
 ```
 
-### Detailed Usage
+Citation results are stored in two places:
+- **YAML archive** (`data/citation-archive/<page-id>.yaml`) — per-page verification records, checked into git
+- **PostgreSQL** (`citation_content` table) — full fetched text for quote verification, accessed via wiki-server API
+
+### Content Scanning
 
 ```bash
-# Scan content (run after editing MDX files)
-node scripts/scan-content.mjs
-node scripts/scan-content.mjs --force    # Rescan all files
-node scripts/scan-content.mjs --verbose  # Show per-file progress
-
-# Generate summaries via crux
-npm run crux -- generate summaries --batch 50
-npm run crux -- generate summaries --model sonnet
-npm run crux -- generate summaries --id deceptive-alignment
-npm run crux -- generate summaries --dry-run
+# Scan MDX files for content analysis
+pnpm crux scan-content
 ```
 
-### Database Location
+### Source Fetching
 
-All cached data is in `.cache/` (gitignored):
-- `.cache/knowledge.db` - SQLite database
-- `.cache/sources/` - Fetched source documents
+When verifying citations, the system fetches source URLs through a multi-layer cache:
+1. **In-memory LRU cache** (500 entries, session-scoped)
+2. **PostgreSQL `citation_content`** (durable, cross-machine)
+3. **Network fetch** via Firecrawl API or built-in fallback
 
-### Cost Estimates
+Fetched content is cached in `.cache/sources/` locally and persisted to PostgreSQL for future sessions.
 
-| Task | Model | Cost |
-|------|-------|------|
-| Summarize all 311 articles | Haiku | ≈\$2-3 |
-| Summarize all 793 sources | Haiku | ≈\$10-15 |
+### Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Claude API for summaries and grading |
+| `FIRECRAWL_KEY` | Web page fetching (optional, has built-in fallback) |
 
 ---
 

--- a/content/docs/internal/claim-first-architecture.mdx
+++ b/content/docs/internal/claim-first-architecture.mdx
@@ -1598,11 +1598,11 @@ The migration is additive — the claim layer sits on top of existing citation i
 
 The wiki-first experiment (Parts 9–10) extracted claims from the existing Kalshi wiki page, then verified them against sources. This has a fundamental flaw: we're extracting claims from prose that was already synthesized by an LLM, then checking if those synthesized claims match sources. The knowledge is filtered twice.
 
-**Source-first extraction** inverts this: extract claims directly from the 32 raw source documents cached in the SQLite `citation_content` table (379K chars total), compose a wiki page from those claims, and never reference the existing wiki page. This tests whether the claim-first architecture can build knowledge from primary sources.
+**Source-first extraction** inverts this: extract claims directly from the 32 raw source documents cached in the PostgreSQL `citation_content` table (379K chars total), compose a wiki page from those claims, and never reference the existing wiki page. This tests whether the claim-first architecture can build knowledge from primary sources.
 
 ### Method
 
-1. **Load sources** — Read full text from SQLite `citation_content` cache for all Kalshi-related URLs. Rank by importance (from citation archive YAML).
+1. **Load sources** — Read full text from PostgreSQL `citation_content` cache for all Kalshi-related URLs. Rank by importance (from citation archive YAML).
 2. **Extract claims per source** — Each source processed independently. Claims tagged with topics (founding, funding, regulatory, operations, partnerships, competition, market-data, community-reception, consumer-concerns).
 3. **Cross-source deduplication** — Jaccard similarity ≥0.65 on word sets. Lower threshold than wiki-first (0.8) because cross-source claims use different phrasing for the same fact. Track `sourceCount` and `allSources` for multi-source confidence.
 4. **Editorial direction** — Generate section structure and map topics to sections.

--- a/content/docs/internal/content-database.mdx
+++ b/content/docs/internal/content-database.mdx
@@ -1,15 +1,15 @@
 ---
 numericId: E759
 title: "Content Database System"
-description: "SQLite-based system for indexing articles, tracking sources, and generating AI summaries"
+description: "Data storage architecture: PostgreSQL wiki-server, in-memory caching, YAML files, and build artifacts"
 sidebar:
   order: 5
 quality: 44
 readerImportance: 10.5
 researchImportance: 9
-lastEdited: "2026-02-04"
+lastEdited: "2026-02-27"
 update_frequency: 60
-llmSummary: "Documentation for an internal SQLite-based content management system that indexes MDX articles, tracks citations to external sources, and generates AI summaries using Claude models. The system provides CLI tools for scanning content (~311 articles), generating summaries (estimated $2-3 for full corpus using Haiku), and exporting data to YAML for site builds."
+llmSummary: "Documentation for the wiki's multi-layer data storage architecture. The wiki-server PostgreSQL database stores citation content, audit results, claims, facts, and structured data accessed via Hono RPC API. An in-memory LRU cache provides session-local caching for source fetching. YAML files in data/ define entities, facts, and resources. The build pipeline compiles YAML + MDX into database.json for the Next.js frontend."
 ratings:
   novelty: 0
   rigor: 6.5
@@ -18,547 +18,201 @@ ratings:
 ---
 import { Mermaid } from '@components/wiki';
 
-This project includes a SQLite-based content database for managing article metadata, tracking external source references, and generating AI-powered summaries. The database is stored locally in `.cache/knowledge.db` (gitignored) and serves as a foundation for content quality tooling.
+The wiki uses a multi-layer storage architecture. There is no single database — different kinds of data live in the storage layer best suited for them.
 
 ---
 
-## Quick Start
-
-```bash
-# Scan all content files and populate database
-npm run crux -- analyze scan
-
-# Generate AI summaries for articles
-npm run crux -- generate summaries
-
-# Export sources to resources.yaml
-node scripts/utils/export-resources.mjs
-
-# View database statistics
-node scripts/scan-content.mjs --stats
-```
-
-<Aside type="note">
-Requires `ANTHROPIC_API_KEY` in `.env` file for summary generation.
-</Aside>
-
----
-
-## Architecture
+## Storage Layers
 
 <Mermaid chart={`
 flowchart TD
-    subgraph Content["Content Layer"]
-        MDX[MDX Files]
-        YAML[entities.yaml]
+    subgraph Durable["Durable Storage"]
+        PG[("PostgreSQL\n(wiki-server)")]
+        YAML[("YAML Files\ndata/")]
+        MDX[("MDX Pages\ncontent/docs/")]
     end
-    subgraph Processing["Processing Layer"]
-        SCAN[scan-content.mjs]
-        SUMM[generate-summaries.mjs]
+
+    subgraph Transient["Transient / Session"]
+        LRU["In-Memory LRU Cache\n(500 entries, per-process)"]
+        SOURCES[".cache/sources/\n(fetched HTML/text)"]
+        HASHES[".cache/content-hashes.json\n(change detection)"]
     end
-    subgraph Storage["Storage Layer"]
-        DB[(knowledge.db)]
-        CACHE[.cache/sources/]
+
+    subgraph Build["Build Artifacts"]
+        JSON[("database.json\nYAML + MDX → JSON")]
     end
-    subgraph API["External"]
-        ANTH[Anthropic API]
+
+    YAML --> JSON
+    MDX --> JSON
+    PG -.->|"Hono RPC API"| LRU
+    LRU -.->|"cache miss"| PG
+`} />
+
+### 1. PostgreSQL (wiki-server)
+
+The wiki-server runs a PostgreSQL database that stores all structured data requiring durability and cross-machine access. This replaced the earlier local SQLite database (`.cache/knowledge.db`), which was retired in February 2026.
+
+**What it stores:**
+
+| Table | Purpose |
+|-------|---------|
+| `citation_content` | Full text of fetched source URLs (for quote verification) |
+| `citation_audits` | Per-page citation verification results |
+| `claims` | Extracted atomic claims with source references |
+| `facts` | Canonical facts with values and computed expressions |
+| `resources` | External resource metadata (papers, blogs, reports) |
+| `entities` | Entity metadata synced from YAML |
+| `agent_sessions` | Claude Code session logs |
+| `edit_logs` | Per-page edit history |
+| `hallucination_evals` | Hallucination detection results |
+
+**Access pattern:** All access goes through the wiki-server's Hono RPC API. CLI tools use `apiRequest()` from `crux/lib/wiki-server/`. The frontend uses typed RPC clients (e.g., `getFactsRpcClient()`).
+
+```bash
+# Example CLI commands that read/write PostgreSQL
+pnpm crux citations verify <page-id>    # Verify citations → writes audit results
+pnpm crux query entity <id>             # Read entity data
+pnpm crux query search "topic"          # Full-text search
+```
+
+### 2. In-Memory LRU Cache
+
+Source fetching uses a session-scoped in-memory cache (`crux/lib/citation-content-cache.ts`) to avoid redundant network requests and database lookups within a single process.
+
+| Property | Value |
+|----------|-------|
+| Max entries | 500 |
+| Eviction | Least Recently Used |
+| Scope | Per-process (cleared on exit) |
+| Persistence | None — purely ephemeral |
+
+When fetching a URL, the system checks:
+1. In-memory LRU cache (fastest)
+2. PostgreSQL `citation_content` table (durable)
+3. Network fetch via Firecrawl or built-in fallback (slowest)
+
+Results are written back to both the LRU cache and PostgreSQL.
+
+### 3. YAML Files (data/)
+
+Human-editable YAML files are the source of truth for content metadata:
+
+| Directory | Content |
+|-----------|---------|
+| `data/entities/` | Entity definitions (type, description, relations) |
+| `data/facts/` | Canonical facts with values and expressions |
+| `data/resources/` | External resource metadata |
+| `data/graphs/` | Cause-effect graph data |
+| `data/edit-logs/` | Per-page edit history |
+| `data/citation-archive/` | Per-page citation verification YAML |
+| `data/auto-update/` | Auto-update system configuration and state |
+
+YAML files are checked into git and are the canonical source for everything they contain. PostgreSQL mirrors some of this data for API access and full-text search.
+
+### 4. File-System Caches (.cache/)
+
+Temporary files for local development workflows:
+
+| Path | Purpose |
+|------|---------|
+| `.cache/sources/` | Fetched source documents (HTML, text, PDF) |
+| `.cache/content-hashes.json` | MD5 hashes for change detection during scans |
+
+These are gitignored and can be deleted without data loss.
+
+### 5. Build Artifact (database.json)
+
+The build pipeline (`apps/web/scripts/build-data.mjs`) compiles YAML + MDX frontmatter into `apps/web/src/data/database.json`. This single JSON file contains all entities, pages, relations, facts, search data, and statistics needed by the Next.js frontend.
+
+```bash
+pnpm build-data           # Full build (~2 min)
+pnpm build-data:content   # Content-only rebuild (~15s)
+```
+
+The JSON is loaded at server startup with lazy-built indexes (see <EntityLink id="architecture">Architecture</EntityLink>).
+
+---
+
+## Data Flow
+
+<Mermaid chart={`
+flowchart LR
+    subgraph Edit["Authoring"]
+        AUTHOR["Human or AI\nedits YAML/MDX"]
     end
-    MDX --> SCAN
-    YAML --> SCAN
-    SCAN --> DB
-    DB --> SUMM
-    SUMM --> ANTH
-    ANTH --> DB
-    SUMM --> CACHE
+
+    subgraph Pipeline["Build Pipeline"]
+        BUILD["build-data.mjs"]
+    end
+
+    subgraph Serve["Runtime"]
+        NEXT["Next.js\nreads database.json"]
+        API["Wiki-server API\nreads PostgreSQL"]
+    end
+
+    AUTHOR -->|"git push"| BUILD
+    BUILD -->|"database.json"| NEXT
+    AUTHOR -->|"crux citations verify"| API
+    API -->|"search, facts, claims"| NEXT
+`} />
+
+### Source Fetching Flow
+
+When verifying citations or fetching content for page improvement:
+
+<Mermaid chart={`
+sequenceDiagram
+    participant CLI as Crux CLI
+    participant Cache as LRU Cache
+    participant PG as PostgreSQL
+    participant Net as Network
+
+    CLI->>Cache: getCachedContent(url)
+    alt Cache hit
+        Cache-->>CLI: cached content
+    else Cache miss
+        CLI->>PG: query citation_content
+        alt DB hit
+            PG-->>CLI: stored content
+            CLI->>Cache: setCachedContent(url)
+        else DB miss
+            CLI->>Net: fetch via Firecrawl / fallback
+            Net-->>CLI: raw content
+            CLI->>PG: saveFetchResultToPostgres(url)
+            CLI->>Cache: setCachedContent(url)
+        end
+    end
 `} />
 
 ---
 
-## Database Schema
-
-### articles
-
-Stores content extracted from MDX files.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | TEXT PRIMARY KEY | Entity ID from filename |
-| `path` | TEXT | Relative path to source file |
-| `title` | TEXT | Article title from frontmatter |
-| `description` | TEXT | Article description |
-| `content` | TEXT | Plain text content (JSX removed) |
-| `word_count` | INTEGER | Word count for prioritization |
-| `quality` | INTEGER | Quality rating from frontmatter |
-| `content_hash` | TEXT | MD5 hash for change detection |
-| `created_at` | TEXT | When article was first indexed |
-| `updated_at` | TEXT | When article was last updated |
-
-### sources
-
-Stores metadata about external references discovered in articles.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | TEXT PRIMARY KEY | SHA256 hash of URL/DOI (16 chars) |
-| `url` | TEXT | Full URL of external source |
-| `doi` | TEXT | Digital Object Identifier (if paper) |
-| `title` | TEXT | Source title/headline |
-| `authors` | TEXT (JSON) | Array of author names |
-| `year` | INTEGER | Publication year |
-| `source_type` | TEXT | Type: paper, blog, report, web, etc. |
-| `content` | TEXT | Fetched source content |
-| `fetch_status` | TEXT | pending, fetched, failed, manual |
-| `fetched_at` | TEXT | When source was last fetched |
-
-### article_sources
-
-Junction table linking articles to their cited sources.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `article_id` | TEXT | Foreign key to articles |
-| `source_id` | TEXT | Foreign key to sources |
-| `citation_context` | TEXT | Quote where source is cited |
-
-### summaries
-
-Stores AI-generated summaries of articles and sources.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `entity_id` | TEXT PRIMARY KEY | ID of summarized entity |
-| `entity_type` | TEXT | 'article' or 'source' |
-| `one_liner` | TEXT | Single-sentence summary (max 25 words) |
-| `summary` | TEXT | 2-3 paragraph summary |
-| `key_points` | TEXT (JSON) | 3-5 bullet points |
-| `key_claims` | TEXT (JSON) | Claims with values |
-| `model` | TEXT | Model used (e.g., claude-3-5-haiku) |
-| `tokens_used` | INTEGER | Total tokens consumed |
-| `generated_at` | TEXT | When summary was generated |
-
-### entity_relations
-
-Entity relationships loaded from `entities.yaml`.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `from_id` | TEXT | Source entity ID |
-| `to_id` | TEXT | Target entity ID |
-| `relationship` | TEXT | Relationship type |
-
----
-
-## Commands Reference
-
-### Scan Content
-
-Scans all MDX files and populates the database.
-
-```bash
-# Standard scan (skips unchanged files)
-npm run crux -- analyze scan
-
-# Force rescan all files
-node scripts/scan-content.mjs --force
-
-# Show per-file progress
-node scripts/scan-content.mjs --verbose
-
-# Show database stats only
-node scripts/scan-content.mjs --stats
-```
-
-**What it does:**
-
-1. Finds all `.mdx` and `.md` files in `src/content/docs/`
-2. Extracts frontmatter (title, description, quality, sources)
-3. Extracts plain text content (removes imports, JSX, HTML comments)
-4. Discovers URLs from markdown links and DOIs
-5. Infers source types from domains (arxiv.org → paper, lesswrong.com → blog)
-6. Loads entity relations from `entities.yaml`
-7. Skips unchanged files via content hash comparison
-
-### Generate Summaries
-
-Generates AI summaries using the Anthropic API.
-
-```bash
-# Summarize 10 articles (default)
-npm run crux -- generate summaries
-
-# Summarize specific count
-npm run crux -- generate summaries --batch 50
-
-# Use higher-quality model
-npm run crux -- generate summaries --model sonnet
-
-# Summarize specific article
-npm run crux -- generate summaries --id deceptive-alignment
-
-# Re-summarize changed content
-npm run crux -- generate summaries --resummary
-
-# Preview without API calls
-npm run crux -- generate summaries --dry-run
-```
-
-**Models available:**
-
-| Model | ID | Cost (per 1M input tokens) | Use case |
-|-------|----|-----------------------------|----------|
-| haiku | claude-haiku-4-5-20251001 | ≈\$0.25 | Bulk summarization |
-| sonnet | claude-sonnet-4-6 | ≈\$3.00 | Higher quality |
-| opus | claude-opus-4-6 | ≈\$5.00 | Best quality |
-
-**Cost estimates:**
-
-| Task | Model | Estimated Cost |
-|------|-------|----------------|
-| Summarize 311 articles | Haiku | ≈\$2-3 |
-| Summarize 793 sources | Haiku | ≈\$10-15 |
-| Single article improvement | Sonnet | ≈\$0.20 |
-
-### Database Statistics
-
-Display database statistics.
-
-```bash
-node scripts/scan-content.mjs --stats
-```
-
----
-
-## Core Module API
-
-The database is accessed via `scripts/lib/knowledge-db.mjs`.
-
-### Import
-
-```javascript
-import {
-  db,                    // Better-sqlite3 instance
-  articles,              // Article operations
-  sources,               // Source operations
-  summaries,             // Summary operations
-  relations,             // Entity relation operations
-  getResearchContext,    // Full context for article
-  getStats,              // Database statistics
-  CACHE_DIR,             // Path to .cache/
-  SOURCES_DIR,           // Path to .cache/sources/
-} from './scripts/lib/knowledge-db.mjs';
-```
-
-### articles API
-
-```javascript
-// Get article by ID
-const article = articles.get('deceptive-alignment');
-
-// Get article with its summary
-const withSummary = articles.getWithSummary('deceptive-alignment');
-
-// Get all articles
-const all = articles.getAll();
-
-// Find articles needing summaries
-const unsummarized = articles.needingSummary();
-
-// Search articles
-const results = articles.search('reward hacking');
-
-// Check if content changed
-const changed = articles.hasChanged('id', newHash);
-
-// Insert/update article
-articles.upsert({
-  id: 'my-article',
-  path: 'knowledge-base/risks/my-article.mdx',
-  title: 'My Article',
-  description: 'Description here',
-  content: 'Full text content...',
-  word_count: 1500,
-  quality: 3,
-  content_hash: 'abc123...'
-});
-```
-
-### sources API
-
-```javascript
-// Get source by ID or URL
-const source = sources.get('abc123def456');
-const byUrl = sources.getByUrl('https://arxiv.org/...');
-
-// Get sources for an article
-const articleSources = sources.getForArticle('deceptive-alignment');
-
-// Get pending sources for fetching
-const pending = sources.getPending(100);
-
-// Link source to article
-sources.linkToArticle('article-id', 'source-id', 'citation context');
-
-// Mark source fetch status
-sources.markFetched('source-id', 'content...');
-sources.markFailed('source-id', 'Error message');
-
-// Get statistics
-const stats = sources.stats();
-// { total: 793, pending: 793, fetched: 0, failed: 0, manual: 0 }
-```
-
-### summaries API
-
-```javascript
-// Get summary by entity ID
-const summary = summaries.get('deceptive-alignment');
-
-// Get all summaries of a type
-const articleSummaries = summaries.getAll('article');
-
-// Insert/update summary
-summaries.upsert('entity-id', 'article', {
-  oneLiner: 'Single sentence...',
-  summary: 'Full summary...',
-  keyPoints: ['Point 1', 'Point 2'],
-  keyClaims: [{ claim: '...', value: '...' }],
-  model: 'claude-haiku-4-5-20251001',
-  tokensUsed: 1247
-});
-
-// Get statistics
-const stats = summaries.stats();
-// { article: { count: 311, tokens: 387000 }, source: { count: 0, tokens: 0 } }
-```
-
-### Research Context
-
-Get comprehensive context for improving an article:
-
-```javascript
-const context = getResearchContext('deceptive-alignment');
-// Returns:
-// {
-//   article: { ...article, summary: {...} },
-//   relatedArticles: [...],
-//   sources: [...],
-//   claims: [...],
-//   stats: { relatedCount, sourcesTotal, sourcesFetched, claimsCount }
-// }
-```
-
----
-
-## Source Type Inference
-
-When scanning content, source types are inferred from domains:
-
-| Domain Pattern | Inferred Type |
-|----------------|---------------|
-| arxiv.org, doi.org, nature.com | paper |
-| lesswrong.com, alignmentforum.org | blog |
-| substack.com | blog |
-| .gov, congress.gov, whitehouse.gov | government |
-| wikipedia.org | reference |
-| .pdf (any domain) | report |
-| (default) | web |
-
----
-
-## Directory Structure
-
-```
-project/
-├── .cache/                         # Gitignored
-│   ├── knowledge.db               # SQLite database
-│   └── sources/                   # Cached source documents
-│       ├── pdf/
-│       ├── html/
-│       └── text/
-├── scripts/
-│   ├── lib/
-│   │   ├── knowledge-db.mjs       # Core DB module
-│   │   ├── file-utils.mjs         # File discovery
-│   │   ├── mdx-utils.mjs          # MDX parsing
-│   │   └── output.mjs             # Terminal formatting
-│   ├── scan-content.mjs           # Content scanner
-│   └── generate-summaries.mjs     # AI summarization
-├── src/content/docs/              # Source MDX files
-└── .env                           # API credentials
-```
-
----
-
-## Workflow Examples
-
-### After Editing Content
-
-```bash
-# 1. Scan for changes (fast, uses hash comparison)
-npm run crux -- analyze scan
-
-# 2. Generate summaries for new/changed articles
-npm run crux -- generate summaries --resummary
-```
-
-### Bulk Initial Setup
-
-```bash
-# 1. Scan all content
-node scripts/scan-content.mjs --force
-
-# 2. Generate summaries in batches
-npm run crux -- generate summaries --batch 100
-npm run crux -- generate summaries --batch 100
-npm run crux -- generate summaries --batch 100
-# ... repeat until done
-```
-
-### Check Database State
-
-```bash
-# View statistics
-node scripts/scan-content.mjs --stats
-
-# Or programmatically
-node -e "
-import { getStats } from './scripts/lib/knowledge-db.mjs';
-console.log(JSON.stringify(getStats(), null, 2));
-"
-```
-
----
-
-## Exporting to YAML (Resources System)
-
-The database serves as a processing layer. Canonical data is exported to YAML files for the site build.
-
-### Export Resources
-
-```bash
-# Export cited sources to resources.yaml
-node scripts/export-resources.mjs
-
-# Export ALL sources (including uncited)
-node scripts/export-resources.mjs --all
-
-# Preview without writing
-node scripts/export-resources.mjs --dry-run
-```
-
-The export script:
-- Reads sources from SQLite with their AI summaries
-- Merges with existing `src/data/resources.yaml` (preserves manual edits)
-- Includes `cited_by` references showing which articles cite each source
-
-### Using Resources in MDX
-
-Once resources are in `resources.yaml`, you can reference them semantically:
-
-```mdx
-import { ResourceLink, ResourceList, ResourceCite } from '@components/wiki';
-
-Recent work on AI control <ResourceCite id="ai-control-2023" /> shows...
-
-See also: <ResourceLink id="superintelligence-2014" />
-
-## Key Papers
-
-<ResourceList
-  ids={["ai-control-2023", "concrete-problems-2016"]}
-  showSummaries
-/>
-```
-
-### Resource Schema
-
-Resources in `resources.yaml` have this structure:
-
-```yaml
-- id: ai-control-2023
-  url: https://arxiv.org/abs/2312.06942
-  title: "AI Control: Improving Safety..."
-  authors: ["Ryan Greenblatt", "Buck Shlegeris"]
-  published_date: "2023-12"
-  type: paper  # paper, blog, book, report, talk, podcast, government, reference, web
-  summary: "AI-generated summary..."
-  key_points:
-    - "Point 1"
-    - "Point 2"
-  cited_by:
-    - agentic-ai
-    - ai-control
-```
-
----
-
-## Source Fetching
-
-The system now includes automatic source fetching via the Firecrawl API. This enables:
-
-1. **Citation verification** - Check that quoted text actually appears in sources
-2. **Content caching** - Store fetched pages for offline access
-3. **Quote validation** - Catch hallucinated quotes during page creation
-
-### Standalone Fetching
-
-```bash
-# Fetch pending sources (up to 20)
-node scripts/utils/fetch-sources.mjs --batch 20
-
-# Fetch a specific source by ID
-node scripts/utils/fetch-sources.mjs --id abc123def456
-
-# Retry failed sources
-node scripts/utils/fetch-sources.mjs --retry-failed
-
-# Preview without fetching
-node scripts/utils/fetch-sources.mjs --dry-run
-```
-
-### Integrated with Page Creation
-
-The page creator pipeline automatically:
-1. Extracts citation URLs from Perplexity research
-2. Registers them in the sources table
-3. Fetches content via Firecrawl (up to 15 per page)
-4. Uses fetched content for quote verification
-
-```bash
-# Standard tier includes source fetching
-node scripts/content/page-creator.mjs "Topic" --tier standard
-```
-
-### Rate Limiting
-
-Firecrawl free tier allows ~10 requests/minute. The system waits 7 seconds between requests to stay under limits.
-
-### Fetch Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `pending` | Not yet attempted |
-| `fetched` | Successfully retrieved and stored |
-| `failed` | Fetch attempted but failed (error stored) |
-| `manual` | Requires manual handling (paywalled, etc.) |
+## CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm crux citations verify <page-id>` | Verify all citations on a page |
+| `pnpm crux citations audit` | Run citation audits across pages |
+| `pnpm crux scan-content` | Scan MDX files for content analysis |
+| `pnpm crux query search "topic"` | Full-text search via wiki-server |
+| `pnpm crux query entity <id>` | Look up entity data |
+| `pnpm crux query related <id>` | Find related pages |
+| `pnpm crux context for-page <id>` | Full research context for a page |
+| `pnpm build-data` | Rebuild database.json from YAML + MDX |
+| `pnpm build-data:content` | Content-only rebuild (≈15s) |
 
 ---
 
 ## Limitations
 
-1. **Claims extraction minimal**: The claims table exists but extraction is not fully implemented
-2. **Local only**: Database is gitignored and must be regenerated on each machine
-3. **No incremental summary updates**: Summaries are regenerated from scratch, not updated
-4. **Firecrawl API key required**: Source fetching requires `FIRECRAWL_KEY` in `.env`
+1. **No offline PostgreSQL access**: CLI commands that query the wiki-server require network connectivity
+2. **LRU cache is session-scoped**: Restarting a process loses cached content (by design — PostgreSQL is the durable tier)
+3. **database.json must be rebuilt**: Changes to YAML or MDX frontmatter are not visible to the frontend until `build-data` runs
+4. **Citation content is append-mostly**: Old fetched content is not automatically refreshed
 
 ---
 
-## Future Enhancements
+## Related
 
-Potential improvements to the system:
-
-- PDF parsing for academic papers
-- Claims extraction and consistency checking across articles
-- Similarity search using embeddings
-- Migration of entity `sources` to use resource IDs
-- Integration with content validation tools
+- <EntityLink id="architecture">Architecture</EntityLink> — System overview and design patterns
+- <EntityLink id="automation-tools">Automation Tools</EntityLink> — Full CLI reference
+- <EntityLink id="claim-first-architecture">Claim-First Architecture</EntityLink> — Future direction for structured claims

--- a/content/docs/internal/documentation-maintenance.mdx
+++ b/content/docs/internal/documentation-maintenance.mdx
@@ -62,7 +62,7 @@ Some documentation can be auto-generated from code:
 | Content Type | Generation Method |
 |--------------|-------------------|
 | CLI help text | `npm run crux -- --help` |
-| Database schema | Extract from `knowledge-db.mjs` |
+| Database schema | Extract from wiki-server API types |
 | Validation rules | List from `scripts/validate/` |
 | Cost estimates | Pull from actual API usage |
 
@@ -215,7 +215,7 @@ When reviewing a PR that touches `/scripts/`:
 | Changed File | Update These Docs |
 |--------------|-------------------|
 | `scripts/content/page-creator.mjs` | <EntityLink id="architecture">Architecture</EntityLink>, <EntityLink id="automation-tools">Automation Tools</EntityLink> |
-| `scripts/lib/knowledge-db.mjs` | <EntityLink id="content-database">Content Database</EntityLink>, <EntityLink id="architecture">Architecture</EntityLink> |
+| `apps/wiki-server/src/routes/*` | <EntityLink id="content-database">Content Database</EntityLink>, <EntityLink id="architecture">Architecture</EntityLink> |
 | `scripts/crux.mjs` or `commands/*` | <EntityLink id="automation-tools">Automation Tools</EntityLink> |
 | `src/content.config.ts` | <EntityLink id="page-types">Page Types</EntityLink> |
 | Any validation script | <EntityLink id="automation-tools">Automation Tools</EntityLink> |

--- a/content/docs/internal/index.md
+++ b/content/docs/internal/index.md
@@ -18,7 +18,7 @@ This section contains internal documentation for maintaining and contributing to
 ## Automation and Tools
 
 - <EntityLink id="automation-tools">Automation Tools</EntityLink> - Complete reference for all scripts and CLI workflows
-- <EntityLink id="content-database">Content Database</EntityLink> - SQLite-based system for indexing and AI summaries
+- <EntityLink id="content-database">Content Database</EntityLink> - Storage architecture (PostgreSQL, caching, YAML)
 
 ## Style Guides
 

--- a/content/docs/internal/project-roadmap.md
+++ b/content/docs/internal/project-roadmap.md
@@ -32,7 +32,7 @@ The project has mature infrastructure:
 | Validation Suite | ✅ Complete | 14 validators covering style, links, MDX, Mermaid, staleness, redundancy |
 | Quality Grading | ✅ Complete | Claude API-powered grading (0-100 quality/importance) |
 | Dashboard | ✅ Complete | `/dashboard/` with quality distribution, `/dashboard/graph/` for relationships |
-| Knowledge Base | ✅ Complete | SQLite cache with article/source extraction and AI summaries |
+| Knowledge Base | ✅ Complete | PostgreSQL-backed article/source extraction and AI summaries |
 | Resource Linking | ✅ Complete | `<R>` component with bidirectional tracking, metadata extraction |
 | Page Type System | ✅ Complete | overview/content/stub classification |
 | Freshness Tracking | ✅ Complete | `reviewBy`, `contentDependencies`, staleness validator |


### PR DESCRIPTION
## Summary
- Rewrite `content-database.mdx` to document current architecture (PostgreSQL + in-memory LRU cache + YAML + database.json)
- Update `architecture.mdx`: replace SQLite section with wiki-server PostgreSQL section, update sequence diagram, fix link text
- Update `automation-tools.mdx`: replace Knowledge Base System section with Citation & Content Tools section documenting current CLI commands
- Fix `documentation-maintenance.mdx`: replace `knowledge-db.mjs` references with current equivalents
- Fix `claim-first-architecture.mdx`: SQLite → PostgreSQL table references (lines 1601, 1605)
- Fix `about-this-wiki.mdx`, `index.md`, `project-roadmap.md`: update stale SQLite link descriptions

## Test plan
- [x] `pnpm crux fix escaping` and `pnpm crux fix markdown` run clean
- [x] `pnpm crux validate gate --scope=content --fix` passes
- [x] All 11 gate checks pass on push (including tests, TypeScript, unified rules)
- [x] No remaining SQLite references in core internal documentation pages (remaining refs are in archived reports and third-party architecture descriptions which are correct)

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)