### PR TITLE
fix: use /health endpoint for wiki server health check

### DIFF
--- a/apps/groundskeeper/src/tasks/health-check.ts
+++ b/apps/groundskeeper/src/tasks/health-check.ts
@@ -24,7 +24,8 @@ export async function healthCheck(
   let serverUp = false;
 
   try {
-    const response = await fetch(config.wikiServerUrl, {
+    const healthUrl = config.wikiServerUrl.replace(/\/$/, "") + "/health";
+    const response = await fetch(healthUrl, {
       signal: AbortSignal.timeout(10_000),
     });
     serverUp = response.ok;


### PR DESCRIPTION
The wiki server returns 404 on `/` — use the dedicated `/health` endpoint.

Without this fix, the groundskeeper creates false-alarm GitHub issues every 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)