### PR TITLE
fix: phase 2 cleanup — minor_issues bug, dead code, stale SQLite comments, tests

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -169,6 +169,7 @@ export interface AccuracyDashboardData {
     accurate: number;
     inaccurate: number;
     unsupported: number;
+    minorIssues: number;
     inaccuracyRate: number | null;
   }>;
 }

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -776,7 +776,7 @@ const citationsApp = new Hono()
     // Domain aggregation
     const domainMap = new Map<string, {
       total: number; checked: number; accurate: number;
-      inaccurate: number; unsupported: number;
+      inaccurate: number; unsupported: number; minorIssues: number;
     }>();
 
     // Flagged citations
@@ -811,7 +811,7 @@ const citationsApp = new Hono()
       // Domain aggregation
       if (domain) {
         if (!domainMap.has(domain)) {
-          domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0 });
+          domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0, minorIssues: 0 });
         }
         const d = domainMap.get(domain)!;
         d.total++;
@@ -846,6 +846,7 @@ const citationsApp = new Hono()
           if (domain) domainMap.get(domain)!.unsupported++;
         } else if (verdict === 'minor_issues') {
           minorIssueCount++; page.minorIssues++;
+          if (domain) domainMap.get(domain)!.minorIssues++;
         }
 
         // Flag problematic citations
@@ -893,6 +894,7 @@ const citationsApp = new Hono()
         accurate: d.accurate,
         inaccurate: d.inaccurate,
         unsupported: d.unsupported,
+        minorIssues: d.minorIssues,
         inaccuracyRate: d.checked > 0 ? Math.round(((d.inaccurate + d.unsupported) / d.checked) * 100) / 100 : null,
       }));
     domainAnalysis.sort((a, b) => {

--- a/crux/authoring/creator/source-fetching.ts
+++ b/crux/authoring/creator/source-fetching.ts
@@ -3,7 +3,7 @@
  *
  * Handles registration and fetching of source URLs from research results.
  * Uses resource YAML files for existence checks and local cache files for
- * fetched content (no SQLite dependency).
+ * fetched content.
  */
 
 import fs from 'fs';

--- a/crux/auto-update/ci-audit.ts
+++ b/crux/auto-update/ci-audit.ts
@@ -103,7 +103,7 @@ function runAuditForPage(pageId: string, apply: boolean, verbose: boolean): numb
   }
 }
 
-// ── Final accuracy check (reads cached results from SQLite) ──────────────────
+// ── Final accuracy check (reads cached results from PostgreSQL) ──────────────
 
 async function getFinalAccuracy(pageId: string): Promise<AccuracyResult | null> {
   const filePath = findPageFile(pageId);
@@ -115,7 +115,7 @@ async function getFinalAccuracy(pageId: string): Promise<AccuracyResult | null> 
 
   if (citations.length === 0) return null;
 
-  // Read cached results (no LLM calls — just reads from SQLite)
+  // Read cached results (no LLM calls — just reads from PostgreSQL)
   return checkAccuracyForPage(pageId, { verbose: false, recheck: false });
 }
 
@@ -266,7 +266,7 @@ export async function runAuditGate(options: {
     // Run the full audit pipeline as a subprocess
     const exitCode = runAuditForPage(pageId, apply, verbose);
 
-    // Get the final accuracy state from SQLite (cached, no LLM calls)
+    // Get the final accuracy state from PostgreSQL (cached, no LLM calls)
     const accuracy = await getFinalAccuracy(pageId);
 
     results.push({

--- a/crux/auto-update/ci-verify-citations.ts
+++ b/crux/auto-update/ci-verify-citations.ts
@@ -5,9 +5,9 @@
  * summary for CI/PR use. Calls the citation archive library directly
  * instead of shelling out to CLI commands and parsing JSON with jq.
  *
- * SQLite note: verifyCitationsForPage stores full HTML content in SQLite
- * as a best-effort cache. Works fine when SQLite is unavailable — metadata
- * is always saved to YAML in data/citation-archive/.
+ * Note: verifyCitationsForPage stores full HTML content in the in-memory cache
+ * and PostgreSQL as a best-effort cache. Metadata is always saved to YAML
+ * in data/citation-archive/.
  *
  * Usage (via crux CLI):
  *   pnpm crux auto-update verify-citations <page-id> [page-id...]

--- a/crux/citations/audit-check.ts
+++ b/crux/citations/audit-check.ts
@@ -2,13 +2,13 @@
  * Citation Audit Check — independent post-hoc verification CLI
  *
  * Stateless citation verification for a single wiki page. Extracts citations
- * from the page content, fetches source URLs (or uses the SQLite cache via the
- * source-fetcher module), and independently verifies each claim with a cheap
+ * from the page content, fetches source URLs (or uses the in-memory cache via
+ * the source-fetcher module), and independently verifies each claim with a cheap
  * LLM call.
  *
- * Note: when --no-fetch is not set, fetched source content is cached in SQLite
- * (via source-fetcher) for cross-session reuse. Page content files are never
- * modified — this command only reads and reports.
+ * Note: when --no-fetch is not set, fetched source content is cached in memory
+ * and PostgreSQL (via source-fetcher) for cross-session reuse. Page content
+ * files are never modified — this command only reads and reports.
  *
  * Unlike `crux citations audit` (which is a full extract→check→fix pipeline),
  * this command only verifies — it does not write fixes to any wiki page.

--- a/crux/citations/audit.ts
+++ b/crux/citations/audit.ts
@@ -301,7 +301,7 @@ async function main() {
   }
 
   // ── Step 4: Re-extract + Re-verify ─────────────────────────────────────
-  // After fixing the page, claim_text in SQLite is stale (from Step 1).
+  // After fixing the page, claim_text in PostgreSQL is stale (from Step 1).
   // Re-extract quotes to update claim_text before re-verifying accuracy.
   // Skip re-extract if Step 3c already did it and no further changes were made.
   console.log(`\n${c.bold}Step 4: Re-extract & Re-verify${c.reset}\n`);

--- a/crux/citations/export-dashboard.ts
+++ b/crux/citations/export-dashboard.ts
@@ -78,6 +78,7 @@ export interface DomainSummary {
   accurate: number;
   inaccurate: number;
   unsupported: number;
+  minorIssues: number;
   inaccuracyRate: number | null;
 }
 
@@ -136,6 +137,7 @@ export async function buildDashboardExport(): Promise<DashboardExport | null> {
     accurate: number;
     inaccurate: number;
     unsupported: number;
+    minorIssues: number;
   }>();
 
   // Flagged citations
@@ -159,7 +161,7 @@ export async function buildDashboardExport(): Promise<DashboardExport | null> {
     // Domain aggregation
     if (domain) {
       if (!domainMap.has(domain)) {
-        domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0 });
+        domainMap.set(domain, { total: 0, checked: 0, accurate: 0, inaccurate: 0, unsupported: 0, minorIssues: 0 });
       }
       const d = domainMap.get(domain)!;
       d.total++;
@@ -200,7 +202,7 @@ export async function buildDashboardExport(): Promise<DashboardExport | null> {
       } else if (verdict === 'minor_issues') {
         minorIssueCount++;
         page.minorIssues++;
-        if (domain) domainMap.get(domain)!.accurate++;
+        if (domain) domainMap.get(domain)!.minorIssues++;
       }
 
       // Flag problematic citations
@@ -256,6 +258,7 @@ export async function buildDashboardExport(): Promise<DashboardExport | null> {
       accurate: d.accurate,
       inaccurate: d.inaccurate,
       unsupported: d.unsupported,
+      minorIssues: d.minorIssues,
       inaccuracyRate: d.checked > 0 ? (d.inaccurate + d.unsupported) / d.checked : null,
     });
   }

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -2,7 +2,7 @@
  * Citation Inaccuracy Auto-Fixer
  *
  * Reads flagged citations from the dashboard YAML (for discovery), then
- * enriches each with full source text from SQLite before generating fixes.
+ * enriches each with full source text from the wiki-server API before generating fixes.
  *
  * Usage:
  *   pnpm crux citations fix-inaccuracies                        # Dry run all
@@ -494,7 +494,7 @@ export interface SecondOpinionResult {
 /**
  * Second opinion check using Claude Haiku to reduce false positives.
  * Re-checks flagged citations with a different model; demotes false positives
- * by updating SQLite verdicts.
+ * by updating PostgreSQL verdicts.
  */
 export async function secondOpinionCheck(
   pageId: string,
@@ -694,7 +694,7 @@ export function loadFlaggedCitations(opts: {
 }
 
 // ---------------------------------------------------------------------------
-// SQLite enrichment — pull full source text for better fix generation
+// API enrichment — pull full source text for better fix generation
 // ---------------------------------------------------------------------------
 
 export interface EnrichedFlaggedCitation extends FlaggedCitation {
@@ -832,7 +832,7 @@ function buildUserPrompt(
     }
     parts.push(`Source: ${c.sourceTitle ?? 'unknown'}`);
 
-    // Use full claim text from SQLite when available (YAML version is truncated)
+    // Use full claim text from PostgreSQL when available (YAML version is truncated)
     const claimText = c.fullClaimText || c.claimText;
     parts.push(`\nClaim text: ${claimText}`);
 
@@ -1327,7 +1327,7 @@ async function main() {
 
   const c = getColors(json);
 
-  // Load flagged citations from YAML, then enrich with SQLite source data
+  // Load flagged citations from YAML, then enrich with API source data
   let enriched: EnrichedFlaggedCitation[];
   try {
     const flagged = loadFlaggedCitations({
@@ -1591,7 +1591,7 @@ async function main() {
           process.stdout.write(`  ${pageId}: re-extracting claims... `);
         }
 
-        // Re-extract claims from the updated page to update claim_text in SQLite
+        // Re-extract claims from the updated page to update claim_text in PostgreSQL
         const filePath = findPageFile(pageId);
         if (filePath) {
           const updatedRaw = readFileSync(filePath, 'utf-8');

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -1,10 +1,10 @@
 /**
  * Claims Verify — verify extracted claims against citation_content full text
  *
- * Reads claims stored in PG for a page, looks up source text from SQLite
- * (local, fast) then PG (cross-machine), and verifies each claim using an LLM.
+ * Reads claims stored in PG for a page, looks up source text from the in-memory
+ * cache (fast) then PG (cross-machine), and verifies each claim using an LLM.
  * Uses the shared resolveSource() from citation-auditor for consistent
- * 3-tier source resolution (sourceCache → SQLite → PG → optional network).
+ * 3-tier source resolution (sourceCache → in-memory cache → PG → optional network).
  *
  * Usage:
  *   pnpm crux claims verify <page-id>
@@ -13,7 +13,7 @@
  *   pnpm crux claims verify <page-id> --dry-run       # report only, no DB writes
  *
  * Requires: OPENROUTER_API_KEY or ANTHROPIC_API_KEY
- * Optional: LONGTERMWIKI_SERVER_URL (for PG fallback when SQLite is empty)
+ * Optional: LONGTERMWIKI_SERVER_URL
  */
 
 import { fileURLToPath } from 'url';

--- a/crux/commands/citations.ts
+++ b/crux/commands/citations.ts
@@ -93,7 +93,7 @@ const SCRIPTS = {
   },
   'content-coverage': {
     script: 'citations/citation-content-coverage.ts',
-    description: 'Show citation content coverage stats (SQLite vs PostgreSQL)',
+    description: 'Show citation content coverage stats (PostgreSQL)',
     passthrough: ['json'],
   },
   'register-resources': {
@@ -147,7 +147,7 @@ Examples:
   crux citations normalize-footnotes --fix          Auto-fix to [Title](URL) format
   crux citations normalize-footnotes --fix <id>     Fix one page
   crux citations export-dashboard                  Export data for web dashboard (prefers PG)
-  crux citations export-dashboard --local-only     Force local SQLite only
+  crux citations export-dashboard --local-only     Force local data only (skip wiki-server)
   crux citations backfill-resource-ids               Backfill resource_id for existing quotes
   crux citations backfill-resource-ids --dry-run    Preview matches without writing
   crux citations fix-inaccuracies                   Dry-run fix proposals for all flagged

--- a/crux/lib/citation-archive.test.ts
+++ b/crux/lib/citation-archive.test.ts
@@ -5,7 +5,7 @@ import { extractClaimSentence, extractCitationsFromContent, verifyCitationsForPa
 // Mocks for verifyCitationsForPage tests
 // ---------------------------------------------------------------------------
 
-// Mock citation-content-cache (in-memory cache, replaces SQLite)
+// Mock citation-content-cache (in-memory cache)
 vi.mock('./citation-content-cache.ts', () => ({
   getCachedContent: vi.fn(() => null),
   setCachedContent: vi.fn(),

--- a/crux/lib/citation-archive.ts
+++ b/crux/lib/citation-archive.ts
@@ -586,13 +586,11 @@ export async function fetchCitationUrl(url: string): Promise<FetchResult> {
 
 /**
  * Store full fetched content in the in-memory session cache.
- * This replaces the SQLite tier — PG is the durable store.
+ * PG is the durable store; this avoids redundant API calls within a session.
  * Best-effort: errors are swallowed so verification isn't blocked.
  */
 function storeCitationContent(
   url: string,
-  _pageId: string,
-  _footnote: number,
   result: FetchResult,
 ) {
   try {
@@ -630,9 +628,7 @@ export function saveFetchResultToPostgres(url: string, result: FetchResult): voi
     pageTitle: result.pageTitle ?? null,
     fullText: text,
     contentLength: result.contentLength,
-  }).catch(() => {
-    // Best-effort — don't fail verification if wiki-server is unavailable
-  });
+  }).catch((e) => console.warn('[citation-archive] PG write failed:', e.message));
 }
 
 /**
@@ -694,7 +690,7 @@ export async function verifyCitationsForPage(
             note: result.error ? `Academic publisher: ${result.error}` : 'Academic publisher — URL accessible',
           };
           // Store whatever content we got from academic publishers
-          storeCitationContent(ext.url, pageId, ext.footnote, result);
+          storeCitationContent(ext.url, result);
           saveFetchResultToPostgres(ext.url, result);
         } else {
           const result = await fetchCitationUrl(ext.url);
@@ -718,7 +714,7 @@ export async function verifyCitationsForPage(
           };
           // Store full HTML + text content in memory cache + PostgreSQL
           if (result.fullHtml || result.fullText) {
-            storeCitationContent(ext.url, pageId, ext.footnote, result);
+            storeCitationContent(ext.url, result);
             saveFetchResultToPostgres(ext.url, result);
           }
         }

--- a/crux/lib/citation-auditor.ts
+++ b/crux/lib/citation-auditor.ts
@@ -416,7 +416,7 @@ export async function resolveSource(
   const cached = sourceCache?.get(url);
   if (cached !== undefined) return cached;
 
-  // Fetch (with caches) if allowed — fetchSource checks SQLite then PG then network
+  // Fetch (with caches) if allowed — fetchSource checks in-memory cache then PG then network
   if (fetchMissing) {
     try {
       return await fetchSource({ url, extractMode: 'full' });

--- a/crux/lib/citation-content-cache.test.ts
+++ b/crux/lib/citation-content-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getCachedContent,
+  setCachedContent,
+  clearContentCache,
+  contentCacheSize,
+  contentCacheEvictions,
+} from './citation-content-cache.ts';
+
+function makeEntry(url: string, text = 'content') {
+  return {
+    url,
+    fetchedAt: new Date().toISOString(),
+    httpStatus: 200,
+    contentType: 'text/html',
+    pageTitle: `Title for ${url}`,
+    fullText: text,
+    contentLength: text.length,
+  };
+}
+
+describe('citation-content-cache', () => {
+  beforeEach(() => {
+    clearContentCache();
+  });
+
+  it('returns null for unknown URL', () => {
+    expect(getCachedContent('https://unknown.example.com')).toBeNull();
+  });
+
+  it('returns cached content after setCachedContent', () => {
+    const entry = makeEntry('https://example.com/a');
+    setCachedContent('https://example.com/a', entry);
+    const result = getCachedContent('https://example.com/a');
+    expect(result).not.toBeNull();
+    expect(result!.url).toBe('https://example.com/a');
+    expect(result!.fullText).toBe('content');
+  });
+
+  it('LRU refresh: accessing an entry moves it to most-recently-used', () => {
+    // Insert A, B, C
+    setCachedContent('a', makeEntry('a'));
+    setCachedContent('b', makeEntry('b'));
+    setCachedContent('c', makeEntry('c'));
+
+    // Access A (moves it to end)
+    getCachedContent('a');
+
+    // Now fill cache to 500 to trigger eviction
+    for (let i = 0; i < 498; i++) {
+      setCachedContent(`fill-${i}`, makeEntry(`fill-${i}`));
+    }
+    // Cache now has 501 entries — B should be evicted (oldest after A was refreshed)
+    expect(contentCacheSize()).toBe(500);
+    expect(getCachedContent('b')).toBeNull(); // B was evicted
+    expect(getCachedContent('a')).not.toBeNull(); // A survived (was refreshed)
+  });
+
+  it('evicts oldest entry when exceeding 500 entries', () => {
+    for (let i = 0; i < 501; i++) {
+      setCachedContent(`url-${i}`, makeEntry(`url-${i}`));
+    }
+    expect(contentCacheSize()).toBe(500);
+    expect(contentCacheEvictions()).toBe(1);
+    // The first entry (url-0) should have been evicted
+    expect(getCachedContent('url-0')).toBeNull();
+    // The last entry should still be present
+    expect(getCachedContent('url-500')).not.toBeNull();
+  });
+
+  it('cumulative eviction counter increments across multiple evictions', () => {
+    // Fill cache to 500
+    for (let i = 0; i < 500; i++) {
+      setCachedContent(`url-${i}`, makeEntry(`url-${i}`));
+    }
+    expect(contentCacheEvictions()).toBe(0);
+
+    // Add 5 more to trigger 5 evictions
+    for (let i = 500; i < 505; i++) {
+      setCachedContent(`url-${i}`, makeEntry(`url-${i}`));
+    }
+    expect(contentCacheEvictions()).toBe(5);
+    expect(contentCacheSize()).toBe(500);
+  });
+
+  it('clearContentCache resets size and eviction counter', () => {
+    for (let i = 0; i < 505; i++) {
+      setCachedContent(`url-${i}`, makeEntry(`url-${i}`));
+    }
+    expect(contentCacheSize()).toBe(500);
+    expect(contentCacheEvictions()).toBe(5);
+
+    clearContentCache();
+    expect(contentCacheSize()).toBe(0);
+    expect(contentCacheEvictions()).toBe(0);
+  });
+
+  it('updating existing entry replaces content', () => {
+    setCachedContent('https://example.com/x', makeEntry('https://example.com/x', 'old'));
+    setCachedContent('https://example.com/x', makeEntry('https://example.com/x', 'new'));
+
+    const result = getCachedContent('https://example.com/x');
+    expect(result!.fullText).toBe('new');
+    expect(contentCacheSize()).toBe(1); // no duplicate
+  });
+});

--- a/crux/lib/citation-content-cache.ts
+++ b/crux/lib/citation-content-cache.ts
@@ -1,8 +1,8 @@
 /**
- * In-Memory Citation Content Cache
+ * Session-local in-memory cache for citation content.
  *
- * Replaces the SQLite citation_content tier. PG (wiki-server) is the
- * durable store; this avoids redundant API calls within a single CLI session.
+ * PG (wiki-server) is the durable store; this avoids redundant API calls
+ * within a single CLI session.
  *
  * The cache is a simple Map keyed by URL with LRU eviction.
  */

--- a/crux/lib/hash-utils.test.ts
+++ b/crux/lib/hash-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { hashId, contentHash } from './hash-utils.ts';
+
+describe('hashId', () => {
+  it('returns a 16-character hex string', () => {
+    const result = hashId('https://example.com');
+    expect(result).toHaveLength(16);
+    expect(result).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic (same input = same output)', () => {
+    expect(hashId('test-input')).toBe(hashId('test-input'));
+  });
+
+  it('produces different outputs for different inputs', () => {
+    expect(hashId('input-a')).not.toBe(hashId('input-b'));
+  });
+
+  it('matches known SHA256 prefix for "https://example.com"', () => {
+    expect(hashId('https://example.com')).toBe('100680ad546ce6a5');
+  });
+});
+
+describe('contentHash', () => {
+  it('returns a 32-character hex string', () => {
+    const result = contentHash('hello world');
+    expect(result).toHaveLength(32);
+    expect(result).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('is deterministic (same input = same output)', () => {
+    expect(contentHash('test content')).toBe(contentHash('test content'));
+  });
+
+  it('produces different outputs for different inputs', () => {
+    expect(contentHash('content-a')).not.toBe(contentHash('content-b'));
+  });
+
+  it('matches known MD5 hash for "hello world"', () => {
+    expect(contentHash('hello world')).toBe('5eb63bbbe01eeed093cb22bb8f5acdc3');
+  });
+});

--- a/crux/lib/hash-utils.ts
+++ b/crux/lib/hash-utils.ts
@@ -2,7 +2,6 @@
  * Hash Utilities
  *
  * Simple hash functions for generating IDs and detecting content changes.
- * Previously lived in knowledge-db.ts alongside the SQLite DAOs.
  */
 
 import { createHash } from 'crypto';

--- a/crux/lib/source-fetcher.ts
+++ b/crux/lib/source-fetcher.ts
@@ -138,13 +138,13 @@ const sessionCache = new Map<string, FetchedSource>();
 const inFlightFetches = new Map<string, Promise<FetchedSource>>();
 
 /** Cumulative eviction counter (for diagnostics). */
-let _evictionCount = 0;
+let evictionCount = 0;
 
 /** Clear the in-memory cache and in-flight map (useful in tests). */
 export function clearSessionCache(): void {
   sessionCache.clear();
   inFlightFetches.clear();
-  _evictionCount = 0;
+  evictionCount = 0;
 }
 
 /** Number of entries in the session cache (for tests and diagnostics). */
@@ -154,7 +154,7 @@ export function sessionCacheSize(): number {
 
 /** Number of LRU evictions since last cache clear (for diagnostics). */
 export function sessionCacheEvictions(): number {
-  return _evictionCount;
+  return evictionCount;
 }
 
 /**
@@ -173,7 +173,7 @@ function sessionCacheSet(url: string, value: FetchedSource): void {
     const oldest = sessionCache.keys().next().value;
     if (oldest !== undefined) {
       sessionCache.delete(oldest);
-      _evictionCount++;
+      evictionCount++;
     }
   }
 }
@@ -508,7 +508,7 @@ function mimeToContentType(mime: string | null): FetchedSourceContentType {
   return 'html';
 }
 
-/** Store fetched content in the in-memory session cache (replaces SQLite tier). */
+/** Store fetched content in the in-memory session cache. */
 function saveToMemoryCache(url: string, title: string, content: string, httpStatus: number, contentType: FetchedSourceContentType = 'html'): void {
   setCachedContent(url, {
     url,
@@ -557,9 +557,7 @@ function saveToPostgres(url: string, title: string, content: string, httpStatus:
     pageTitle: title || null,
     fullText: content,
     contentLength: content.length,
-  }).catch(() => {
-    // Best-effort — don't fail if server unavailable
-  });
+  }).catch((e) => console.warn('[source-fetcher] PG write failed:', e.message));
 }
 
 // ---------------------------------------------------------------------------
@@ -636,7 +634,7 @@ async function _fetchSourceCore(
     return result;
   }
 
-  // ---- 2. In-memory content cache (replaces SQLite tier) ----
+  // ---- 2. In-memory content cache ----
   const memoryCached = getCachedContent(url);
   if (memoryCached?.fullText && memoryCached.fullText.length > 0) {
     // Check TTL — skip stale entries so sources are periodically re-fetched.

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -239,7 +239,7 @@ export async function propagateClaimVerdictsToPage(
 }
 
 // ---------------------------------------------------------------------------
-// Citation Quotes Query API functions (replacing SQLite DAO reads)
+// Citation Quotes Query API functions
 // ---------------------------------------------------------------------------
 
 export async function getCitationStats(): Promise<ApiResult<CitationStatsResult>> {

--- a/crux/scan-content.ts
+++ b/crux/scan-content.ts
@@ -7,7 +7,7 @@
  * - Article count, word counts
  * - Source references (URLs, DOIs) found in content
  *
- * Uses a JSON hash cache for change detection (no SQLite).
+ * Uses a JSON hash cache for change detection.
  *
  * Usage:
  *   node crux/scan-content.ts [options]
@@ -35,7 +35,7 @@ const VERBOSE = args.includes('--verbose');
 const colors = getColors();
 
 // ---------------------------------------------------------------------------
-// Hash cache for change detection (replaces SQLite articles.hasChanged)
+// Hash cache for change detection
 // ---------------------------------------------------------------------------
 
 const CACHE_DIR = join(PROJECT_ROOT, '.cache');


### PR DESCRIPTION
## Summary
- Fix `minor_issues` verdict being silently mapped to `accurate` in domain stats (both CLI and wiki-server)
- Replace silent `.catch(() => {})` with `console.warn` on PG write failures
- Remove unused `_pageId` and `_footnote` params from `storeCitationContent`
- Rename `_evictionCount` → `evictionCount` (exported, not unused)
- Update ~22 stale SQLite references across 14 files to reflect PostgreSQL/in-memory cache
- Add tests for `citation-content-cache` (LRU eviction, hit/miss, reset)
- Add tests for `hash-utils` (hashId, contentHash determinism and format)

## Test plan
- [x] `npx vitest run --config crux/vitest.config.ts` passes (including new tests)
- [x] `pnpm crux validate gate --fix` passes
- [x] No remaining SQLite references in crux/ code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)