### PR TITLE
feat: source verdict support + backfill pagination for citation_quotes→claims migration

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -482,6 +482,9 @@ export const InsertClaimSchema = z.object({
     sourceTitle: z.string().max(1000).nullable().optional(),
     sourceType: z.string().max(100).nullable().optional(),
     sourceLocation: z.string().max(1000).nullable().optional(),
+    sourceVerdict: z.string().max(100).nullable().optional(),
+    sourceVerdictScore: z.number().min(0).max(1).nullable().optional(),
+    sourceCheckedAt: z.string().nullable().optional(),
   })).nullable().optional(),
 });
 export type InsertClaim = z.infer<typeof InsertClaimSchema>;

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -229,6 +229,9 @@ const AddClaimSourceSchema = z.object({
   sourceTitle: z.string().max(1000).nullable().optional(),
   sourceType: z.string().max(100).nullable().optional(),
   sourceLocation: z.string().max(1000).nullable().optional(),
+  sourceVerdict: z.string().max(100).nullable().optional(),
+  sourceVerdictScore: z.number().min(0).max(1).nullable().optional(),
+  sourceCheckedAt: z.string().nullable().optional(),
 });
 
 const BatchUpdateRelatedEntitiesSchema = z.object({
@@ -312,6 +315,9 @@ const claimsApp = new Hono()
         sourceTitle: s.sourceTitle ?? null,
         sourceType: s.sourceType ?? null,
         sourceLocation: s.sourceLocation ?? null,
+        sourceVerdict: s.sourceVerdict ?? null,
+        sourceVerdictScore: s.sourceVerdictScore ?? null,
+        sourceCheckedAt: s.sourceCheckedAt ? new Date(s.sourceCheckedAt) : null,
       }));
       await db.insert(claimSources).values(sourceVals);
     }
@@ -367,6 +373,9 @@ const claimsApp = new Hono()
         sourceTitle: string | null;
         sourceType: string | null;
         sourceLocation: string | null;
+        sourceVerdict: string | null;
+        sourceVerdictScore: number | null;
+        sourceCheckedAt: Date | null;
       }> = [];
 
       for (const item of items) {
@@ -388,6 +397,9 @@ const claimsApp = new Hono()
               sourceTitle: s.sourceTitle ?? null,
               sourceType: s.sourceType ?? null,
               sourceLocation: s.sourceLocation ?? null,
+              sourceVerdict: s.sourceVerdict ?? null,
+              sourceVerdictScore: s.sourceVerdictScore ?? null,
+              sourceCheckedAt: s.sourceCheckedAt ? new Date(s.sourceCheckedAt) : null,
             });
           }
         }
@@ -970,6 +982,9 @@ const claimsApp = new Hono()
         sourceTitle: parsed.data.sourceTitle ?? null,
         sourceType: parsed.data.sourceType ?? null,
         sourceLocation: parsed.data.sourceLocation ?? null,
+        sourceVerdict: parsed.data.sourceVerdict ?? null,
+        sourceVerdictScore: parsed.data.sourceVerdictScore ?? null,
+        sourceCheckedAt: parsed.data.sourceCheckedAt ? new Date(parsed.data.sourceCheckedAt) : null,
       })
       .returning();
 

--- a/crux/claims/backfill-from-citations.ts
+++ b/crux/claims/backfill-from-citations.ts
@@ -45,6 +45,10 @@ interface CitationQuote {
   sourceTitle: string | null;
   sourceType: string | null;
   sourceLocation: string | null;
+  // Fields for source-level verification
+  quoteVerified: boolean;
+  verificationScore: number | null;
+  verifiedAt: string | null;
   // Fields for claim verdict enrichment
   accuracyIssues: string | null;
   accuracySupportingQuotes: string | null;
@@ -103,6 +107,25 @@ function detectClaimType(text: string): ClaimTypeValue {
 }
 
 /**
+ * Map quote verification status to a source verdict for claim_sources.
+ * quoteVerified=true → "verified" (quote exists in source).
+ * quoteVerified=false + score → "unverified".
+ * No data at all → null (don't populate).
+ */
+function mapVerificationToSourceVerdict(
+  quoteVerified: boolean,
+  verificationScore: number | null,
+): { sourceVerdict: string | null; sourceVerdictScore: number | null } {
+  if (!quoteVerified && verificationScore == null) {
+    return { sourceVerdict: null, sourceVerdictScore: null };
+  }
+  return {
+    sourceVerdict: quoteVerified ? 'verified' : 'unverified',
+    sourceVerdictScore: verificationScore,
+  };
+}
+
+/**
  * Map an accuracy verdict from citation_quotes to a claim verdict.
  */
 function mapAccuracyToClaimVerdict(
@@ -127,7 +150,7 @@ async function main() {
   const args = parseCliArgs(process.argv.slice(2));
   const dryRun = args['dry-run'] === true;
   const pageIdFilter = typeof args['page-id'] === 'string' ? args['page-id'] : null;
-  const limit = parseIntOpt(args.limit, 1000);
+  const limit = parseIntOpt(args.limit, 10000);
   const c = getColors(false);
 
   console.log(`\n${c.bold}${c.blue}Backfill claims from citation_quotes${c.reset}`);
@@ -143,7 +166,7 @@ async function main() {
     }
   }
 
-  // Step 1: Fetch citation quotes
+  // Step 1: Fetch citation quotes (paginated to handle full dataset)
   let allQuotes: CitationQuote[];
 
   if (pageIdFilter) {
@@ -155,13 +178,24 @@ async function main() {
     }
     allQuotes = result.data.quotes;
   } else {
-    const url = `/api/citations/quotes/all?limit=${limit}&offset=0`;
-    const result = await apiRequest<QuotesAllResponse>('GET', url, undefined, BATCH_TIMEOUT_MS);
-    if (!result.ok) {
-      console.error(`${c.red}Failed to fetch citation quotes: ${result.message}${c.reset}`);
-      process.exit(1);
+    // Paginate through all quotes — the API allows up to 5000 per request
+    allQuotes = [];
+    const pageSize = 5000;
+    let offset = 0;
+    let total = Infinity;
+
+    while (offset < total && allQuotes.length < limit) {
+      const url = `/api/citations/quotes/all?limit=${pageSize}&offset=${offset}`;
+      const result = await apiRequest<QuotesAllResponse>('GET', url, undefined, BATCH_TIMEOUT_MS);
+      if (!result.ok) {
+        console.error(`${c.red}Failed to fetch citation quotes (offset=${offset}): ${result.message}${c.reset}`);
+        process.exit(1);
+      }
+      allQuotes.push(...result.data.quotes);
+      total = result.data.total;
+      offset += pageSize;
+      if (result.data.quotes.length === 0) break;
     }
-    allQuotes = result.data.quotes;
   }
 
   // Filter out already-linked quotes and those without claim text
@@ -305,6 +339,11 @@ async function main() {
                 sourceTitle: representative.sourceTitle ?? null,
                 sourceType: representative.sourceType ?? null,
                 sourceLocation: representative.sourceLocation ?? null,
+                ...mapVerificationToSourceVerdict(
+                  representative.quoteVerified,
+                  representative.verificationScore,
+                ),
+                sourceCheckedAt: representative.verifiedAt ?? null,
               }],
             }
           : {}),


### PR DESCRIPTION
## Summary

Step 1 of retiring the `citation_quotes` table (#1194). This PR completes the remaining schema and pipeline gaps needed to run the full backfill:

- **Source verdict passthrough**: Add `sourceVerdict`/`sourceVerdictScore`/`sourceCheckedAt` to the inline sources schema in `InsertClaimSchema` and `AddClaimSourceSchema`, and pass them through all 3 claim source insertion paths (single insert, batch insert, POST `:id/sources`)
- **Backfill pagination**: The backfill command now paginates through all 4,935 citation_quotes (was limited to 1,000) using 5,000-item pages
- **Verification→verdict mapping**: During backfill, `quoteVerified`/`verificationScore` from citation_quotes are now mapped to `sourceVerdict`/`sourceVerdictScore` on `claim_sources`

## What's NOT in this PR

The actual backfill execution. The wiki-server database is currently in a degraded state (`"database":"error"` on `/health`). Once the server recovers and this PR is deployed:

```bash
pnpm crux claims coverage-audit          # Check current state
pnpm crux claims backfill-from-citations  # Run the full backfill
pnpm crux claims coverage-audit          # Verify completeness
```

## Test plan

- [x] wiki-server TypeScript compiles clean
- [x] crux TypeScript compiles clean  
- [x] All 5 gate checks pass
- [x] Backfill module imports without errors
- [ ] Run `backfill-from-citations` after server recovery and verify ≥95% linkage rate

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)