### PR TITLE
refactor: remove backward propagation and deprecate citation_quotes writes

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -674,12 +674,9 @@ export const LinkCitationsClaimsBatchSchema = z.object({
   })).min(1).max(200),
 });
 
-// -- Claims: Backward propagation (claim verdict → citation_quotes) -----------
-
-export const PropagateFromClaimsSchema = z.object({
-  pageId: z.string().min(1).max(300),
-});
-export type PropagateFromClaims = z.infer<typeof PropagateFromClaimsSchema>;
+// -- Claims: Backward propagation — REMOVED in #1310 -----------
+// PropagateFromClaimsSchema was deleted. Claims are now the single source of truth.
+// The old endpoint POST /quotes/propagate-from-claims no longer exists.
 
 // ---------------------------------------------------------------------------
 // Page Links

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -22,12 +22,18 @@ import {
   CITATION_CONTENT_PREVIEW_MAX,
   LinkCitationClaimSchema,
   LinkCitationsClaimsBatchSchema,
-  PropagateFromClaimsSchema,
 } from "../api-types.js";
 // ---- Constants ----
 
 const BROKEN_SCORE_THRESHOLD = 0.5;
 const MAX_PAGE_SIZE = 5000;
+
+// ---- Deprecation helper (#1310) ----
+// Citation_quotes write endpoints are deprecated. Use claims + claim_sources instead.
+// These endpoints will be removed when the citation_quotes table is dropped (#1311).
+function deprecationWarning(endpoint: string): void {
+  console.warn(`[DEPRECATED] ${endpoint} — use claims API instead. Will be removed in #1311.`);
+}
 
 // ---- Schemas (from shared api-types) ----
 
@@ -174,8 +180,9 @@ const citationsApp = new Hono()
     return c.json(computePageHealth(pageId, rows));
   })
 
-  // ---- POST /quotes/upsert ----
+  // ---- POST /quotes/upsert ---- [DEPRECATED: use POST /api/claims + POST /api/claims/:id/sources]
   .post("/quotes/upsert", async (c) => {
+    deprecationWarning("POST /quotes/upsert");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -210,8 +217,9 @@ const citationsApp = new Hono()
     }, 200);
   })
 
-  // ---- POST /quotes/upsert-batch ----
+  // ---- POST /quotes/upsert-batch ---- [DEPRECATED: use POST /api/claims/batch]
   .post("/quotes/upsert-batch", async (c) => {
+    deprecationWarning("POST /quotes/upsert-batch");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -322,8 +330,9 @@ const citationsApp = new Hono()
     return c.json({ quotes: rows, total, limit, offset });
   })
 
-  // ---- POST /quotes/mark-verified ----
+  // ---- POST /quotes/mark-verified ---- [DEPRECATED: update claim_sources.sourceVerdict instead]
   .post("/quotes/mark-verified", async (c) => {
+    deprecationWarning("POST /quotes/mark-verified");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -361,8 +370,9 @@ const citationsApp = new Hono()
     return c.json({ updated: true, pageId, footnote });
   })
 
-  // ---- POST /quotes/mark-unverified ----
+  // ---- POST /quotes/mark-unverified ---- [DEPRECATED: update claim_sources.sourceVerdict instead]
   .post("/quotes/mark-unverified", async (c) => {
+    deprecationWarning("POST /quotes/mark-unverified");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -399,8 +409,9 @@ const citationsApp = new Hono()
     return c.json({ updated: true, pageId, footnote });
   })
 
-  // ---- POST /quotes/mark-accuracy ----
+  // ---- POST /quotes/mark-accuracy ---- [DEPRECATED: update claims.claimVerdict instead]
   .post("/quotes/mark-accuracy", async (c) => {
+    deprecationWarning("POST /quotes/mark-accuracy");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -590,8 +601,9 @@ const citationsApp = new Hono()
     return c.json({ url: d.url });
   })
 
-  // ---- POST /quotes/mark-accuracy-batch ----
+  // ---- POST /quotes/mark-accuracy-batch ---- [DEPRECATED: batch update claims.claimVerdict instead]
   .post("/quotes/mark-accuracy-batch", async (c) => {
+    deprecationWarning("POST /quotes/mark-accuracy-batch");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -1086,9 +1098,10 @@ const citationsApp = new Hono()
     });
   })
 
-  // ---- PATCH /quotes/:id/link-claim ----
+  // ---- PATCH /quotes/:id/link-claim ---- [DEPRECATED: claims are now the source of truth]
   // Links a citation_quote to a claim via the claim_id FK.
   .patch("/quotes/:id/link-claim", async (c) => {
+    deprecationWarning("PATCH /quotes/:id/link-claim");
     const idStr = c.req.param("id");
     const id = Number(idStr);
     if (!Number.isInteger(id) || id <= 0) {
@@ -1118,8 +1131,9 @@ const citationsApp = new Hono()
     return c.json({ linked: true, quoteId: Number(rows[0].id), claimId: parsed.data.claimId });
   })
 
-  // ---- POST /quotes/link-claims-batch ----
+  // ---- POST /quotes/link-claims-batch ---- [DEPRECATED: claims are now the source of truth]
   .post("/quotes/link-claims-batch", async (c) => {
+    deprecationWarning("POST /quotes/link-claims-batch");
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
 
@@ -1161,96 +1175,9 @@ const citationsApp = new Hono()
     return c.json({ linked: linkedCount });
   })
 
-  // ---- POST /quotes/propagate-from-claims ----
-  // Backward-propagate claim verdicts to linked citation_quotes.
-  // For each citation_quote with a claim_id, copies the claim's verdict fields
-  // to the citation's accuracy fields, using the mapping:
-  //   claim verified → citation accurate
-  //   claim unsupported → citation unsupported
-  //   claim disputed → citation inaccurate
-  //   claim unverified → skip (don't overwrite)
-  .post("/quotes/propagate-from-claims", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = PropagateFromClaimsSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { pageId } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Find all citation_quotes for this page that have a linked claim
-    const linkedQuotes = await db
-      .select({
-        quoteId: citationQuotes.id,
-        claimVerdict: claims.claimVerdict,
-        claimVerdictScore: claims.claimVerdictScore,
-        claimVerdictIssues: claims.claimVerdictIssues,
-        claimVerdictQuotes: claims.claimVerdictQuotes,
-        claimVerdictDifficulty: claims.claimVerdictDifficulty,
-      })
-      .from(citationQuotes)
-      .innerJoin(claims, eq(citationQuotes.claimId, claims.id))
-      .where(
-        and(
-          eq(citationQuotes.pageId, pageId),
-          isNotNull(citationQuotes.claimId),
-        )
-      );
-
-    // Map claim verdict → citation accuracy verdict
-    const VERDICT_MAP: Record<string, string> = {
-      verified: "accurate",
-      unsupported: "unsupported",
-      disputed: "inaccurate",
-    };
-
-    // Partition rows into those we can propagate vs those we skip
-    const toPropagateRows: Array<typeof linkedQuotes[number] & { mappedVerdict: string }> = [];
-    let skipped = 0;
-
-    for (const row of linkedQuotes) {
-      const claimVerdict = row.claimVerdict;
-
-      // Skip if claim has no verdict or verdict is 'unverified'
-      if (!claimVerdict || claimVerdict === "unverified") {
-        skipped++;
-        continue;
-      }
-
-      const mappedVerdict = VERDICT_MAP[claimVerdict];
-      if (!mappedVerdict) {
-        // Unknown verdict value — skip
-        skipped++;
-        continue;
-      }
-
-      toPropagateRows.push({ ...row, mappedVerdict });
-    }
-
-    // Bulk-update all propagatable rows inside a single transaction
-    const propagated = await db.transaction(async (tx) => {
-      let count = 0;
-      for (const row of toPropagateRows) {
-        await tx
-          .update(citationQuotes)
-          .set({
-            accuracyVerdict: row.mappedVerdict,
-            accuracyScore: row.claimVerdictScore,
-            accuracyIssues: row.claimVerdictIssues ?? null,
-            accuracySupportingQuotes: row.claimVerdictQuotes ?? null,
-            verificationDifficulty: row.claimVerdictDifficulty ?? null,
-            accuracyCheckedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          })
-          .where(eq(citationQuotes.id, row.quoteId));
-        count++;
-      }
-      return count;
-    });
-
-    return c.json({ propagated, skipped });
-  })
+  // NOTE: POST /quotes/propagate-from-claims was removed in #1310.
+  // Backward propagation from claims → citation_quotes is no longer needed
+  // since claims is now the single source of truth for verification data.
 
   // ---- GET /source-type-stats ----
   .get("/source-type-stats", async (c) => {

--- a/crux/claims/integrate.ts
+++ b/crux/claims/integrate.ts
@@ -6,9 +6,10 @@
  *
  * Steps:
  *   1. Extract claims from the page (if not already done)
- *   2. Link citation_quotes to claims
- *   3. Migrate [^rc-XXXX] → [^cr-XXXX] for claim-backed footnotes
- *   4. Create claim_page_references in DB
+ *   2. Migrate [^rc-XXXX] → [^cr-XXXX] for claim-backed footnotes + create claim_page_references
+ *
+ * Note: Steps 2 (link citation_quotes) and 4 (propagate verdicts) were removed in #1310.
+ * Claims are now the single source of truth.
  *
  * Usage:
  *   pnpm crux claims integrate <page-id>           # dry-run
@@ -21,16 +22,12 @@ import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
-import { isServerAvailable, apiRequest } from '../lib/wiki-server/client.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { findPageFile } from '../lib/file-utils.ts';
 import {
   getClaimsByEntity,
-  addClaimPageReferencesBatch,
 } from '../lib/wiki-server/claims.ts';
-import {
-  linkCitationsToClaimsBatch,
-  propagateClaimVerdictsToPage,
-} from '../lib/wiki-server/citations.ts';
+// linkCitationsToClaimsBatch removed — citation_quotes linking eliminated in #1310
 import { createClaimReference } from '../lib/wiki-server/references.ts';
 import { generateReferenceId } from './migrate-footnotes.ts';
 import type { ClaimPageReferenceInsert } from '../../apps/wiki-server/src/api-types.ts';
@@ -57,8 +54,6 @@ interface IntegrationResult {
   steps: StepResult[];
   summary: {
     claimsTotal: number;
-    quotesTotal: number;
-    quotesLinked: number;
     footnotesConverted: number;
     claimRefsCreated: number;
   };
@@ -125,103 +120,8 @@ async function ensureClaims(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Step 2: Link citation_quotes to claims
-// ---------------------------------------------------------------------------
-
-async function linkQuotesToClaims(
-  pageId: string,
-  apply: boolean,
-): Promise<StepResult & { quotesTotal: number; linked: number }> {
-  const quotes = await fetchQuotesForPage(pageId);
-  if (quotes.length === 0) {
-    return {
-      name: 'link-quotes',
-      status: 'skipped',
-      message: 'No citation_quotes found for this page',
-      quotesTotal: 0,
-      linked: 0,
-    };
-  }
-
-  const unlinked = quotes.filter(q => q.claimId === null);
-  const alreadyLinked = quotes.filter(q => q.claimId !== null);
-
-  if (unlinked.length === 0) {
-    return {
-      name: 'link-quotes',
-      status: 'ok',
-      message: `All ${quotes.length} quotes already linked to claims`,
-      quotesTotal: quotes.length,
-      linked: alreadyLinked.length,
-    };
-  }
-
-  // Get claims for this entity to find matches
-  const claimsResult = await getClaimsByEntity(pageId);
-  if (!claimsResult.ok || claimsResult.data.claims.length === 0) {
-    return {
-      name: 'link-quotes',
-      status: 'skipped',
-      message: `${unlinked.length} unlinked quotes, but no claims to link to`,
-      quotesTotal: quotes.length,
-      linked: alreadyLinked.length,
-    };
-  }
-
-  // Match unlinked quotes to claims by text similarity
-  const claims = claimsResult.data.claims;
-  const linkItems: Array<{ quoteId: number; claimId: number }> = [];
-
-  for (const quote of unlinked) {
-    const quoteLower = quote.claimText.toLowerCase().trim();
-    // Try exact match first, then substring match
-    let bestClaim = claims.find(c =>
-      c.claimText.toLowerCase().trim() === quoteLower
-    );
-    if (!bestClaim) {
-      // Try substring containment
-      bestClaim = claims.find(c =>
-        quoteLower.includes(c.claimText.toLowerCase().trim()) ||
-        c.claimText.toLowerCase().trim().includes(quoteLower)
-      );
-    }
-    if (bestClaim) {
-      linkItems.push({ quoteId: quote.id, claimId: bestClaim.id });
-    }
-  }
-
-  if (linkItems.length === 0) {
-    return {
-      name: 'link-quotes',
-      status: 'ok',
-      message: `${unlinked.length} unlinked quotes, no text matches found`,
-      quotesTotal: quotes.length,
-      linked: alreadyLinked.length,
-    };
-  }
-
-  if (apply) {
-    const result = await linkCitationsToClaimsBatch(linkItems);
-    if (result.ok) {
-      return {
-        name: 'link-quotes',
-        status: 'ok',
-        message: `Linked ${result.data.linked} quotes to claims (${alreadyLinked.length} already linked)`,
-        quotesTotal: quotes.length,
-        linked: alreadyLinked.length + result.data.linked,
-      };
-    }
-  }
-
-  return {
-    name: 'link-quotes',
-    status: 'ok',
-    message: `Would link ${linkItems.length} quotes to claims (${alreadyLinked.length} already linked)`,
-    quotesTotal: quotes.length,
-    linked: alreadyLinked.length,
-  };
-}
+// Step 2 (link citation_quotes to claims) was removed in #1310.
+// Claims are now the single source of truth — no backward linking needed.
 
 // ---------------------------------------------------------------------------
 // Step 3: Convert rc- footnotes to cr- where claims are linked
@@ -384,36 +284,8 @@ async function convertFootnotes(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Step 4: Propagate claim verdicts
-// ---------------------------------------------------------------------------
-
-async function propagateVerdicts(
-  pageId: string,
-  apply: boolean,
-): Promise<StepResult> {
-  if (!apply) {
-    return {
-      name: 'propagate-verdicts',
-      status: 'skipped',
-      message: 'Skipped in dry-run',
-    };
-  }
-
-  const result = await propagateClaimVerdictsToPage(pageId);
-  if (result.ok) {
-    return {
-      name: 'propagate-verdicts',
-      status: 'ok',
-      message: `Propagated verdicts: ${result.data.updated ?? 0} quotes updated`,
-    };
-  }
-  return {
-    name: 'propagate-verdicts',
-    status: 'error',
-    message: `Failed to propagate: ${(result as { message?: string }).message ?? 'unknown error'}`,
-  };
-}
+// Step 4 (propagate claim verdicts to citation_quotes) was removed in #1310.
+// Claims are now the single source of truth — no backward propagation needed.
 
 // ---------------------------------------------------------------------------
 // Main orchestrator
@@ -445,25 +317,15 @@ export async function integrateClaims(
     };
   }
 
-  // Step 2: Link citation_quotes to claims
-  const linkResult = await linkQuotesToClaims(pageId, apply);
-  steps.push(linkResult);
-
-  // Step 3: Convert rc- footnotes to cr-
+  // Step 2: Convert rc- footnotes to cr-
   const convertResult = await convertFootnotes(pageId, apply);
   steps.push(convertResult);
-
-  // Step 4: Propagate verdicts
-  const verdictResult = await propagateVerdicts(pageId, apply);
-  steps.push(verdictResult);
 
   return {
     pageId,
     steps,
     summary: {
       claimsTotal: claimResult.claimCount,
-      quotesTotal: linkResult.quotesTotal,
-      quotesLinked: linkResult.linked,
       footnotesConverted: convertResult.converted,
       claimRefsCreated: convertResult.refsCreated,
     },
@@ -517,12 +379,10 @@ async function main() {
   console.log();
   console.log(`${c.bold}Summary${c.reset}`);
   console.log(`  Claims:             ${result.summary.claimsTotal}`);
-  console.log(`  Citation quotes:    ${result.summary.quotesTotal}`);
-  console.log(`  Quotes linked:      ${result.summary.quotesLinked}`);
   console.log(`  Footnotes converted: ${result.summary.footnotesConverted}`);
   console.log(`  Claim refs created: ${result.summary.claimRefsCreated}`);
 
-  if (!apply && (result.summary.footnotesConverted > 0 || result.summary.quotesLinked > 0)) {
+  if (!apply && result.summary.footnotesConverted > 0) {
     console.log(`\n${c.yellow}Dry run — no changes written. Use --apply to integrate.${c.reset}`);
   }
   console.log();

--- a/crux/claims/pipeline.ts
+++ b/crux/claims/pipeline.ts
@@ -3,15 +3,17 @@
  * linking, and verification.
  *
  * Runs in sequence:
- *   Step 1: Extract claims from page content → claims records
- *   Step 2: Link citation_quotes to claims → claim_id FK + claim_page_references
- *   Step 3: Verify claims against sources → verdict fields (delegates to crux claims verify)
+ *   Step 1: Extract claims from page content → claims records + claim_page_references
+ *   Step 2: Verify claims against sources → verdict fields (delegates to crux claims verify)
+ *
+ * Note: The 'link' step (backward-link citation_quotes to claims) was removed in #1310.
+ * Claims are now the single source of truth.
  *
  * Usage:
  *   pnpm crux claims pipeline <page-id>
  *   pnpm crux claims pipeline <page-id> --dry-run
- *   pnpm crux claims pipeline <page-id> --steps=extract,link
- *   pnpm crux claims pipeline <page-id> --steps=link,verify --model=google/gemini-2.0-flash-001
+ *   pnpm crux claims pipeline <page-id> --steps=extract
+ *   pnpm crux claims pipeline <page-id> --steps=verify --model=google/gemini-2.0-flash-001
  *
  * Requires: OPENROUTER_API_KEY or ANTHROPIC_API_KEY
  * Optional: LONGTERMWIKI_SERVER_URL (for DB writes)
@@ -23,18 +25,17 @@ import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
-import { isServerAvailable, apiRequest } from '../lib/wiki-server/client.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import {
   insertClaimBatch,
   getClaimsByEntity,
   addClaimPageReferencesBatch,
   type InsertClaimItem,
 } from '../lib/wiki-server/claims.ts';
-import { linkCitationsToClaimsBatch, propagateClaimVerdictsToPage } from '../lib/wiki-server/citations.ts';
+// linkCitationsToClaimsBatch removed — citation_quotes linking eliminated in #1310
 import {
   isClaimDuplicate,
   claimTypeToCategory,
-  jaccardWordSimilarity,
 } from '../lib/claim-utils.ts';
 import {
   cleanMdxForExtraction,
@@ -48,25 +49,12 @@ import { validateClaimBatch } from './validate-claim.ts';
 // Step type
 // ---------------------------------------------------------------------------
 
-const ALL_STEPS = ['extract', 'link', 'verify'] as const;
+// 'link' step was removed in #1310 — claims are now the source of truth,
+// no need to backward-link citation_quotes to claims.
+const ALL_STEPS = ['extract', 'verify'] as const;
 type Step = (typeof ALL_STEPS)[number];
 
-// ---------------------------------------------------------------------------
-// Citation quote shape (from /api/citations/quotes endpoint)
-// ---------------------------------------------------------------------------
-
-interface CitationQuote {
-  id: number;
-  pageId: string;
-  footnote: number | null;
-  claimText: string;
-  claimContext: string | null;
-  sourceQuote: string | null;
-  url: string | null;
-  resourceId: string | null;
-  accuracyVerdict: string | null;
-  claimId: number | null;
-}
+// CitationQuote interface removed — citation_quotes linking eliminated in #1310
 
 // ---------------------------------------------------------------------------
 // Main
@@ -83,7 +71,7 @@ async function main() {
 
   if (!pageId) {
     console.error(`${c.red}Error: provide a page ID${c.reset}`);
-    console.error(`  Usage: pnpm crux claims pipeline <page-id> [--dry-run] [--steps=extract,link,verify] [--model=X]`);
+    console.error(`  Usage: pnpm crux claims pipeline <page-id> [--dry-run] [--steps=extract,verify] [--model=X]`);
     process.exit(1);
   }
 
@@ -296,145 +284,20 @@ async function main() {
     }
   }
 
-  // ------------------------------------------------------------------
-  // Step 2: Link citation_quotes to claims
-  // ------------------------------------------------------------------
-  if (steps.includes('link')) {
-    console.log(`\n${c.bold}Step 2: Link citation_quotes to claims${c.reset}`);
-
-    // Fetch citation quotes for this page
-    const quotesResult = await apiRequest<{ quotes: CitationQuote[] }>(
-      'GET',
-      `/api/citations/quotes?page_id=${encodeURIComponent(pageId)}&limit=500`,
-      undefined,
-      30_000,
-    );
-
-    if (!quotesResult.ok) {
-      console.error(`  ${c.red}Failed to fetch citation quotes: ${quotesResult.message}${c.reset}`);
-    } else {
-      const quotes = quotesResult.data.quotes;
-      const unlinked = quotes.filter(q => q.claimId == null);
-      console.log(`  ${quotes.length} total quotes, ${unlinked.length} unlinked`);
-
-      if (unlinked.length === 0) {
-        console.log(`  ${c.green}All quotes already linked${c.reset}`);
-      } else {
-        // Fetch claims for this entity
-        const claimsResult = await getClaimsByEntity(pageId);
-        if (!claimsResult.ok) {
-          console.error(`  ${c.red}Failed to fetch claims: ${claimsResult.message}${c.reset}`);
-        } else {
-          const existingClaims = claimsResult.data.claims.filter(cl => cl.entityId === pageId);
-          console.log(`  ${existingClaims.length} claims to match against`);
-
-          const linkItems: Array<{ quoteId: number; claimId: number }> = [];
-
-          for (const q of unlinked) {
-            // Find best matching claim by text similarity using Jaccard word similarity
-            let bestMatch: { id: number; score: number } | null = null;
-
-            for (const claim of existingClaims) {
-              if (isClaimDuplicate(q.claimText, claim.claimText, 0.5)) {
-                const score = jaccardWordSimilarity(q.claimText, claim.claimText);
-                if (!bestMatch || score > bestMatch.score) {
-                  bestMatch = { id: claim.id, score };
-                }
-              }
-            }
-
-            if (bestMatch) {
-              linkItems.push({ quoteId: q.id, claimId: bestMatch.id });
-            }
-          }
-
-          console.log(`  Matched ${linkItems.length} of ${unlinked.length} unlinked quotes`);
-
-          if (dryRun) {
-            console.log(`\n  ${c.bold}Sample links (first 3):${c.reset}`);
-            for (const item of linkItems.slice(0, 3)) {
-              const q = unlinked.find(uq => uq.id === item.quoteId);
-              console.log(`    Quote #${item.quoteId} → Claim #${item.claimId}: "${q?.claimText.slice(0, 60)}..."`);
-            }
-            if (linkItems.length > 3) {
-              console.log(`    ... and ${linkItems.length - 3} more`);
-            }
-          } else if (linkItems.length > 0) {
-            // Batch link in chunks of 200
-            const LINK_BATCH_SIZE = 200;
-            let totalLinked = 0;
-
-            for (let i = 0; i < linkItems.length; i += LINK_BATCH_SIZE) {
-              const batch = linkItems.slice(i, i + LINK_BATCH_SIZE);
-              const result = await linkCitationsToClaimsBatch(batch);
-              if (result.ok) {
-                totalLinked += result.data.linked;
-              } else {
-                console.error(`  ${c.red}Batch link failed: ${result.message}${c.reset}`);
-              }
-            }
-
-            console.log(`  ${c.green}Linked ${totalLinked} quotes to claims${c.reset}`);
-
-            // Create claim_page_references for each newly linked claim
-            const claimPageRefMap = new Map<number, Array<{ pageId: string; footnote: number | null; section: string | null }>>();
-            for (const item of linkItems) {
-              const quote = unlinked.find(q => q.id === item.quoteId);
-              if (!quote) continue;
-              if (!claimPageRefMap.has(item.claimId)) {
-                claimPageRefMap.set(item.claimId, []);
-              }
-              claimPageRefMap.get(item.claimId)!.push({
-                pageId: quote.pageId,
-                footnote: quote.footnote,
-                section: quote.claimContext ?? null,
-              });
-            }
-
-            let totalRefs = 0;
-            for (const [claimId, refs] of claimPageRefMap) {
-              const result = await addClaimPageReferencesBatch(claimId, refs);
-              if (result.ok) {
-                totalRefs += result.data.inserted;
-              }
-            }
-
-            if (totalRefs > 0) {
-              console.log(`  ${c.green}Created ${totalRefs} claim_page_references${c.reset}`);
-            }
-          }
-        }
-      }
-    }
-  }
+  // Step 2 (link citation_quotes to claims) was removed in #1310.
+  // Claims are now the single source of truth — no backward linking needed.
+  // Claim_page_references are created during extraction (Step 1).
 
   // ------------------------------------------------------------------
-  // Step 3: Verify claims against sources
+  // Step 2: Verify claims against sources
   // ------------------------------------------------------------------
   if (steps.includes('verify')) {
-    console.log(`\n${c.bold}Step 3: Verify & propagate verdicts${c.reset}`);
+    console.log(`\n${c.bold}Step 3: Verify claims${c.reset}`);
 
     if (dryRun) {
-      console.log(`  ${c.yellow}[DRY RUN] Would run claim verification and propagate to citation_quotes${c.reset}`);
+      console.log(`  ${c.yellow}[DRY RUN] Would run claim verification${c.reset}`);
     } else {
-      // Propagate any existing claim verdicts to citation_quotes
-      const propResult = await propagateClaimVerdictsToPage(pageId);
-      if (propResult.ok) {
-        const { propagated, skipped } = propResult.data;
-        if (propagated > 0) {
-          console.log(`  ${c.green}Propagated ${propagated} claim verdicts to citation_quotes${c.reset}`);
-        }
-        if (skipped > 0) {
-          console.log(`  ${c.dim}Skipped ${skipped} (unverified claims)${c.reset}`);
-        }
-        if (propagated === 0 && skipped === 0) {
-          console.log(`  ${c.dim}No linked claims found to propagate${c.reset}`);
-        }
-      } else {
-        console.log(`  ${c.yellow}Propagation failed: ${propResult.message}${c.reset}`);
-      }
-
-      console.log(`\n  For full LLM-based verification, run separately:`);
+      console.log(`  For full LLM-based verification, run separately:`);
       console.log(`    ${c.bold}pnpm crux claims verify ${pageId}${c.reset}`);
     }
   }

--- a/crux/claims/verify.ts
+++ b/crux/claims/verify.ts
@@ -28,7 +28,7 @@ import {
   type ClaimRow,
   type InsertClaimItem,
 } from '../lib/wiki-server/claims.ts';
-import { propagateClaimVerdictsToPage } from '../lib/wiki-server/citations.ts';
+// propagateClaimVerdictsToPage removed — backward propagation eliminated in #1310
 import { extractCitationsFromContent } from '../lib/citation-archive.ts';
 import { resolveSource, MIN_SOURCE_CONTENT_LENGTH } from '../lib/citation-auditor.ts';
 import { findPageFile } from '../lib/file-utils.ts';
@@ -351,18 +351,6 @@ async function main() {
   }
 
   console.log(`  ${c.green}Updated ${inserted} claims${c.reset}`);
-
-  // Backward-propagate verdicts to linked citation_quotes
-  console.log(`\n  Propagating verdicts to citation_quotes...`);
-  const propResult = await propagateClaimVerdictsToPage(pageId);
-  if (propResult.ok) {
-    console.log(`  ${c.green}Propagated ${propResult.data.propagated} verdicts${c.reset}`);
-    if (propResult.data.skipped > 0) {
-      console.log(`  ${c.dim}Skipped ${propResult.data.skipped} (unverified claims)${c.reset}`);
-    }
-  } else {
-    console.log(`  ${c.yellow}Propagation failed: ${propResult.message}${c.reset}`);
-  }
 
   console.log(`\n  Run 'pnpm crux claims status ${pageId}' to see the full breakdown.\n`);
 }

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -32,7 +32,7 @@ type CitationContentRow = InferResponseType<RpcClient['content']['$get'], 200>;
 type CitationContentListResult = InferResponseType<RpcClient['content']['list']['$get'], 200>;
 type CitationContentListEntry = CitationContentListResult['entries'][number];
 type CitationContentStatsResult = InferResponseType<RpcClient['content']['stats']['$get'], 200>;
-type PropagateFromClaimsResult = InferResponseType<RpcClient['quotes']['propagate-from-claims']['$post'], 200>;
+// PropagateFromClaimsResult removed — backward propagation eliminated in #1310
 
 // New query types
 type CitationStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
@@ -93,12 +93,14 @@ export type { MarkAccuracyResult, MarkAccuracyBatchResult, SnapshotResult, Accur
 // Citation Quotes API functions
 // ---------------------------------------------------------------------------
 
+/** @deprecated Use `insertClaim()` + claim_sources instead. Will be removed in #1311. */
 export async function upsertCitationQuote(
   item: UpsertCitationQuoteItem,
 ): Promise<ApiResult<UpsertCitationQuoteResult>> {
   return apiRequest<UpsertCitationQuoteResult>('POST', '/api/citations/quotes/upsert', item, undefined, 'content');
 }
 
+/** @deprecated Use `insertClaimBatch()` + claim_sources instead. Will be removed in #1311. */
 export async function upsertCitationQuoteBatch(
   items: UpsertCitationQuoteItem[],
 ): Promise<ApiResult<UpsertCitationQuoteBatchResult>> {
@@ -128,12 +130,14 @@ export async function getPageCitationHealth(
 // Citation Accuracy API functions
 // ---------------------------------------------------------------------------
 
+/** @deprecated Update claims.claimVerdict instead. Will be removed in #1311. */
 export async function markCitationAccuracy(
   item: MarkAccuracyItem,
 ): Promise<ApiResult<MarkAccuracyResult>> {
   return apiRequest<MarkAccuracyResult>('POST', '/api/citations/quotes/mark-accuracy', item, undefined, 'content');
 }
 
+/** @deprecated Batch update claims.claimVerdict instead. Will be removed in #1311. */
 export async function markCitationAccuracyBatch(
   items: MarkAccuracyItem[],
 ): Promise<ApiResult<MarkAccuracyBatchResult>> {
@@ -195,6 +199,7 @@ export async function getCitationContentStats(): Promise<ApiResult<CitationConte
 // Citation-Claim Linking API functions
 // ---------------------------------------------------------------------------
 
+/** @deprecated Claims are now the source of truth — no need to backward-link. Will be removed in #1311. */
 export async function linkCitationToClaim(
   quoteId: number,
   claimId: number,
@@ -208,6 +213,7 @@ export async function linkCitationToClaim(
   );
 }
 
+/** @deprecated Claims are now the source of truth — no need to backward-link. Will be removed in #1311. */
 export async function linkCitationsToClaimsBatch(
   items: Array<{ quoteId: number; claimId: number }>,
 ): Promise<ApiResult<{ linked: number }>> {
@@ -220,23 +226,9 @@ export async function linkCitationsToClaimsBatch(
   );
 }
 
-// ---------------------------------------------------------------------------
-// Backward Propagation API functions
-// ---------------------------------------------------------------------------
-
-export type { PropagateFromClaimsResult };
-
-export async function propagateClaimVerdictsToPage(
-  pageId: string,
-): Promise<ApiResult<PropagateFromClaimsResult>> {
-  return apiRequest<PropagateFromClaimsResult>(
-    'POST',
-    '/api/citations/quotes/propagate-from-claims',
-    { pageId },
-    undefined,
-    'content',
-  );
-}
+// NOTE: propagateClaimVerdictsToPage() was removed in #1310.
+// Backward propagation from claims → citation_quotes is no longer needed
+// since claims is now the single source of truth for verification data.
 
 // ---------------------------------------------------------------------------
 // Citation Quotes Query API functions (replacing SQLite DAO reads)
@@ -293,6 +285,7 @@ export async function getQuote(
   );
 }
 
+/** @deprecated Update claim_sources.sourceVerdict instead. Will be removed in #1311. */
 export async function markQuoteVerified(
   pageId: string,
   footnote: number,
@@ -308,6 +301,7 @@ export async function markQuoteVerified(
   );
 }
 
+/** @deprecated Update claim_sources.sourceVerdict instead. Will be removed in #1311. */
 export async function markQuoteUnverified(
   pageId: string,
   footnote: number,


### PR DESCRIPTION
## Summary

Phase 1 of rerouting write pipelines from citation_quotes → claims system (issue #1310, Epic #1313).

**Core change**: Claims are now the single source of truth for verification data. The backward propagation pattern (copying claim verdicts back to citation_quotes) is eliminated entirely, and all citation_quotes write endpoints are deprecated.

## Key Changes

- **Delete `propagateClaimVerdictsToPage()`** — Removed the server endpoint (`POST /quotes/propagate-from-claims`), the client function, and all 3 call sites in `pipeline.ts`, `verify.ts`, `integrate.ts`
- **Remove 'link' step from claims pipeline** — The step that backward-linked citation_quotes to claims via `claimId` FK is no longer needed since claims are primary
- **Remove link-quotes and propagate-verdicts steps from integrate.ts** — Both wrote to citation_quotes; now the integrate command just handles claims + footnote conversion
- **Deprecate all 7 citation_quotes write endpoints** — Added server-side deprecation warnings and `@deprecated` JSDoc to all client write functions
- **Remove `PropagateFromClaimsSchema`** from api-types.ts

## What's NOT in this PR (follow-up work)

The remaining citation pipeline scripts (`extract-quotes.ts`, `check-accuracy.ts`, `verify-quotes.ts`, `fix-inaccuracies.ts`, `backfill-resource-ids.ts`) still write to citation_quotes. Their migration to write directly to claims + claim_sources is more complex (each needs claim-matching logic) and is planned for a follow-up session. All their write functions are now marked `@deprecated`.

## Stats

- 6 files changed, 75 insertions, 446 deletions (net -371 lines)
- All 14 gate checks pass
- All 2349 tests pass
- TypeScript clean (both crux/ and wiki-server/)

## Test plan

- [x] `pnpm crux validate gate --fix` — all 14 checks pass
- [x] `pnpm test` — 93 test files, 2349 tests pass
- [x] TypeScript `tsc --noEmit` clean for both crux/ and apps/wiki-server/
- [x] Verified no remaining references to `propagateClaimVerdictsToPage` (grep confirmed)
- [x] `claims pipeline` command no longer has a 'link' step (only extract + verify)

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)