### PR TITLE
fix: add claims/ to crux tsconfig include list

### DIFF
--- a/crux/claims/extraction-quality-gate.ts
+++ b/crux/claims/extraction-quality-gate.ts
@@ -29,7 +29,6 @@ export interface GateInput {
   claimText: string;
   claimType: string;
   section?: string;
-  [key: string]: unknown;
 }
 
 export interface GateResult<T extends GateInput> {

--- a/crux/claims/from-resource.ts
+++ b/crux/claims/from-resource.ts
@@ -293,6 +293,7 @@ async function main() {
     if (!existsSync(batchFile)) {
       console.error(`${c.red}Error: batch file not found: ${batchFile}${c.reset}`);
       process.exit(1);
+      return; // unreachable, helps tsc
     }
     const content = readFileSync(batchFile, 'utf-8');
     urls = content
@@ -306,6 +307,7 @@ async function main() {
     console.error(`  Usage: pnpm crux claims from-resource <url>`);
     console.error(`         pnpm crux claims from-resource --batch urls.txt`);
     process.exit(1);
+    return; // unreachable, helps tsc
   }
 
   // Apply limit

--- a/crux/tsconfig.json
+++ b/crux/tsconfig.json
@@ -12,5 +12,5 @@
     "allowJs": true,
     "checkJs": false
   },
-  "include": ["lib/**/*.ts", "validate/**/*.ts", "commands/**/*.ts", "analyze/**/*.ts", "fix/**/*.ts", "generate/**/*.ts", "authoring/**/*.ts", "citations/**/*.ts", "evals/**/*.ts", "enrich/**/*.ts", "*.ts", "*.d.ts"]
+  "include": ["lib/**/*.ts", "validate/**/*.ts", "commands/**/*.ts", "analyze/**/*.ts", "fix/**/*.ts", "generate/**/*.ts", "authoring/**/*.ts", "citations/**/*.ts", "claims/**/*.ts", "evals/**/*.ts", "enrich/**/*.ts", "*.ts", "*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- The entire crux/claims/ directory was missing from crux/tsconfig.json include list, meaning none of the claims code was type-checked
- Removes index signature from GateInput that caused type widening through the quality gate generic
- Adds unreachable return after process.exit() in from-resource.ts for control flow analysis

## Test plan
- [x] Verified npx tsc --noEmit now includes claims/ files
- [x] Verified extract.ts type errors (footnoteRefs as unknown) are resolved
- [x] Verified from-resource.ts variable-before-assigned error is resolved

https://claude.ai/code/session_014Vcui7uPW1L5A3Z6LWfSro