### PR TITLE
fix: remove dead code and fix bugs in claims integrate/pipeline

### DIFF
--- a/crux/claims/integrate.ts
+++ b/crux/claims/integrate.ts
@@ -27,7 +27,7 @@ import { findPageFile } from '../lib/file-utils.ts';
 import {
   getClaimsByEntity,
 } from '../lib/wiki-server/claims.ts';
-// linkCitationsToClaimsBatch removed — citation_quotes linking eliminated in #1310
+import { getQuotesByPage } from '../lib/wiki-server/citations.ts';
 import { createClaimReference } from '../lib/wiki-server/references.ts';
 import { generateReferenceId } from './migrate-footnotes.ts';
 import type { ClaimPageReferenceInsert } from '../../apps/wiki-server/src/api-types.ts';
@@ -35,19 +35,6 @@ import type { ClaimPageReferenceInsert } from '../../apps/wiki-server/src/api-ty
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface CitationQuoteRow {
-  id: number;
-  pageId: string;
-  footnote: number | null;
-  claimText: string;
-  claimContext: string | null;
-  sourceQuote: string | null;
-  url: string | null;
-  resourceId: string | null;
-  accuracyVerdict: string | null;
-  claimId: number | null;
-}
 
 interface IntegrationResult {
   pageId: string;
@@ -63,19 +50,6 @@ interface StepResult {
   name: string;
   status: 'ok' | 'skipped' | 'error';
   message: string;
-}
-
-// ---------------------------------------------------------------------------
-// Fetch citation_quotes for a page
-// ---------------------------------------------------------------------------
-
-async function fetchQuotesForPage(pageId: string): Promise<CitationQuoteRow[]> {
-  const result = await apiRequest<{ quotes: CitationQuoteRow[] }>(
-    'GET',
-    `/api/citations/quotes?page_id=${encodeURIComponent(pageId)}&limit=500`,
-  );
-  if (!result.ok) return [];
-  return result.data.quotes;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,8 +137,9 @@ async function convertFootnotes(
   }
 
   // Fetch quotes with linked claims
-  const quotes = await fetchQuotesForPage(pageId);
-  const linkedQuotes = quotes.filter(q => q.claimId !== null);
+  const quotesResult = await getQuotesByPage(pageId, 500);
+  const quotes = quotesResult.ok ? quotesResult.data.quotes : [];
+  const linkedQuotes = quotes.filter((q: { claimId: number | null }) => q.claimId !== null);
 
   if (linkedQuotes.length === 0) {
     return {
@@ -309,8 +284,6 @@ export async function integrateClaims(
       steps,
       summary: {
         claimsTotal: 0,
-        quotesTotal: 0,
-        quotesLinked: 0,
         footnotesConverted: 0,
         claimRefsCreated: 0,
       },

--- a/crux/claims/pipeline.ts
+++ b/crux/claims/pipeline.ts
@@ -292,7 +292,7 @@ async function main() {
   // Step 2: Verify claims against sources
   // ------------------------------------------------------------------
   if (steps.includes('verify')) {
-    console.log(`\n${c.bold}Step 3: Verify claims${c.reset}`);
+    console.log(`\n${c.bold}Step 2: Verify claims${c.reset}`);
 
     if (dryRun) {
       console.log(`  ${c.yellow}[DRY RUN] Would run claim verification${c.reset}`);


### PR DESCRIPTION
## Summary
- Remove dead `fetchQuotesForPage` function that references missing `apiRequest` import — would crash at runtime if the `convertFootnotes` step was reached
- Remove dead `CitationQuoteRow` interface (only consumer was deleted function)
- Remove stale `quotesTotal`/`quotesLinked` fields from error-path summary that don't exist on `IntegrationResult` type
- Replace with proper `getQuotesByPage` import from wiki-server/citations.ts
- Fix pipeline step numbering: verify step printed "Step 3" but should be "Step 2" after link step was removed in #1310

## Test plan
- [x] Verified dead code is removed and proper import replaces it
- [x] Verified error-path summary matches `IntegrationResult` type
- [x] Verified pipeline step numbering is sequential

https://claude.ai/code/session_014Vcui7uPW1L5A3Z6LWfSro