### PR TITLE
test: add tests for groundskeeper scheduler and run-tracker

### DIFF
--- a/apps/groundskeeper/package.json
+++ b/apps/groundskeeper/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@octokit/auth-app": "^7.1.4",
@@ -19,6 +20,7 @@
     "@types/node": "^22.10.0",
     "@types/node-cron": "^3.0.11",
     "tsx": "^4.19.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/groundskeeper/src/run-tracker.test.ts
+++ b/apps/groundskeeper/src/run-tracker.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  recordRun,
+  incrementDailyAiCount,
+  getDailyAiCount,
+  isDailyCapReached,
+  getRecentRuns,
+  type RunRecord,
+} from "./run-tracker.js";
+import type { Config } from "./config.js";
+
+function makeConfig(runLogPath: string): Config {
+  return {
+    githubAppId: "test",
+    githubInstallationId: "test",
+    githubAppPrivateKey: "test",
+    githubRepo: "test/test",
+    wikiServerUrl: "http://localhost:3000",
+    discordWebhookUrl: "http://localhost/webhook",
+    dailyRunCap: 5,
+    runLogPath,
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      resolveConflicts: { enabled: false, schedule: "0 */2 * * *" },
+      codeReview: { enabled: false, schedule: "0 9 * * 1" },
+    },
+  };
+}
+
+describe("run-tracker", () => {
+  let tempDir: string;
+  let config: Config;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "groundskeeper-test-"));
+    config = makeConfig(join(tempDir, "run-log.json"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("recordRun", () => {
+    it("records a successful run", () => {
+      recordRun(config, {
+        taskName: "health-check",
+        timestamp: new Date().toISOString(),
+        durationMs: 100,
+        success: true,
+        summary: "All good",
+      });
+
+      const runs = getRecentRuns(config);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].taskName).toBe("health-check");
+      expect(runs[0].success).toBe(true);
+    });
+
+    it("records a failed run with error", () => {
+      recordRun(config, {
+        taskName: "health-check",
+        timestamp: new Date().toISOString(),
+        durationMs: 500,
+        success: false,
+        error: "Connection refused",
+      });
+
+      const runs = getRecentRuns(config);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].success).toBe(false);
+      expect(runs[0].error).toBe("Connection refused");
+    });
+
+    it("trims to 200 runs maximum", () => {
+      for (let i = 0; i < 210; i++) {
+        recordRun(config, {
+          taskName: "health-check",
+          timestamp: new Date().toISOString(),
+          durationMs: 10,
+          success: true,
+          summary: `Run ${i}`,
+        });
+      }
+
+      const runs = getRecentRuns(config, undefined, 300);
+      expect(runs.length).toBeLessThanOrEqual(200);
+    });
+
+    it("creates parent directory if missing", () => {
+      const nestedPath = join(tempDir, "subdir", "nested", "run-log.json");
+      const nestedConfig = makeConfig(nestedPath);
+
+      recordRun(nestedConfig, {
+        taskName: "test",
+        timestamp: new Date().toISOString(),
+        durationMs: 10,
+        success: true,
+      });
+
+      expect(existsSync(nestedPath)).toBe(true);
+    });
+  });
+
+  describe("getRecentRuns", () => {
+    it("returns empty array when no runs exist", () => {
+      const runs = getRecentRuns(config);
+      expect(runs).toEqual([]);
+    });
+
+    it("filters by task name", () => {
+      recordRun(config, {
+        taskName: "health-check",
+        timestamp: new Date().toISOString(),
+        durationMs: 100,
+        success: true,
+      });
+      recordRun(config, {
+        taskName: "code-review",
+        timestamp: new Date().toISOString(),
+        durationMs: 200,
+        success: true,
+      });
+      recordRun(config, {
+        taskName: "health-check",
+        timestamp: new Date().toISOString(),
+        durationMs: 150,
+        success: false,
+      });
+
+      const healthRuns = getRecentRuns(config, "health-check");
+      expect(healthRuns).toHaveLength(2);
+      expect(healthRuns.every((r) => r.taskName === "health-check")).toBe(true);
+    });
+
+    it("respects limit parameter", () => {
+      for (let i = 0; i < 10; i++) {
+        recordRun(config, {
+          taskName: "test",
+          timestamp: new Date().toISOString(),
+          durationMs: 10,
+          success: true,
+          summary: `Run ${i}`,
+        });
+      }
+
+      const runs = getRecentRuns(config, undefined, 3);
+      expect(runs).toHaveLength(3);
+      // Should return the last 3
+      expect(runs[2].summary).toBe("Run 9");
+    });
+  });
+
+  describe("daily AI count", () => {
+    it("starts at zero", () => {
+      expect(getDailyAiCount(config)).toBe(0);
+    });
+
+    it("increments daily count", () => {
+      incrementDailyAiCount(config);
+      expect(getDailyAiCount(config)).toBe(1);
+
+      incrementDailyAiCount(config);
+      expect(getDailyAiCount(config)).toBe(2);
+    });
+
+    it("respects daily cap", () => {
+      expect(isDailyCapReached(config)).toBe(false);
+
+      for (let i = 0; i < 5; i++) {
+        incrementDailyAiCount(config);
+      }
+      expect(isDailyCapReached(config)).toBe(true);
+    });
+
+    it("cap is not reached at count less than cap", () => {
+      for (let i = 0; i < 4; i++) {
+        incrementDailyAiCount(config);
+      }
+      expect(isDailyCapReached(config)).toBe(false);
+    });
+  });
+
+  describe("corrupted log file", () => {
+    it("handles malformed JSON gracefully", () => {
+      const { writeFileSync } = require("fs");
+      writeFileSync(config.runLogPath, "not valid json{{{", "utf-8");
+
+      // Should not throw — returns empty state
+      const runs = getRecentRuns(config);
+      expect(runs).toEqual([]);
+      expect(getDailyAiCount(config)).toBe(0);
+    });
+  });
+});

--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock node-cron before importing scheduler
+const scheduledCallbacks: Array<() => Promise<void>> = [];
+vi.mock("node-cron", () => ({
+  default: {
+    validate: (expr: string) => expr.includes("*") || /^\d/.test(expr),
+    schedule: (_expr: string, fn: () => Promise<void>) => {
+      scheduledCallbacks.push(fn);
+    },
+  },
+}));
+
+// Mock notify to prevent actual Discord calls
+vi.mock("./notify.js", () => ({
+  sendDiscordNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock run-tracker to prevent file writes
+vi.mock("./run-tracker.js", () => ({
+  recordRun: vi.fn(),
+}));
+
+import {
+  registerTask,
+  resetCircuitBreaker,
+  getTaskStates,
+  type TaskFn,
+} from "./scheduler.js";
+import type { Config } from "./config.js";
+
+function makeConfig(): Config {
+  return {
+    githubAppId: "test",
+    githubInstallationId: "test",
+    githubAppPrivateKey: "test",
+    githubRepo: "test/test",
+    wikiServerUrl: "http://localhost:3000",
+    discordWebhookUrl: "http://localhost/webhook",
+    dailyRunCap: 20,
+    runLogPath: "/tmp/test-run-log.json",
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      resolveConflicts: { enabled: false, schedule: "0 */2 * * *" },
+      codeReview: { enabled: false, schedule: "0 9 * * 1" },
+    },
+  };
+}
+
+describe("scheduler", () => {
+  let config: Config;
+
+  beforeEach(() => {
+    config = makeConfig();
+    scheduledCallbacks.length = 0;
+    // Clear task states between tests
+    getTaskStates().clear();
+  });
+
+  describe("registerTask", () => {
+    it("does not schedule disabled tasks", () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: true });
+      registerTask(config, "disabled-task", "*/5 * * * *", false, fn);
+      expect(scheduledCallbacks).toHaveLength(0);
+    });
+
+    it("does not schedule tasks with invalid cron", () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: true });
+      registerTask(config, "bad-cron", "not a cron expression", true, fn);
+      expect(scheduledCallbacks).toHaveLength(0);
+    });
+
+    it("schedules enabled tasks with valid cron", () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: true });
+      registerTask(config, "test-task", "*/5 * * * *", true, fn);
+      expect(scheduledCallbacks).toHaveLength(1);
+    });
+  });
+
+  describe("circuit breaker", () => {
+    it("resets consecutive failures on success", async () => {
+      let callCount = 0;
+      const fn: TaskFn = vi.fn().mockImplementation(async () => {
+        callCount++;
+        return callCount <= 2
+          ? { success: false, summary: "fail" }
+          : { success: true, summary: "ok" };
+      });
+
+      registerTask(config, "breaker-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Two failures
+      await callback();
+      await callback();
+
+      const states = getTaskStates();
+      const state = states.get("breaker-test");
+      expect(state?.consecutiveFailures).toBe(2);
+      expect(state?.disabled).toBe(false);
+
+      // Third call succeeds — resets counter
+      await callback();
+      expect(state?.consecutiveFailures).toBe(0);
+      expect(state?.disabled).toBe(false);
+    });
+
+    it("trips after 3 consecutive failures", async () => {
+      const fn: TaskFn = vi
+        .fn()
+        .mockResolvedValue({ success: false, summary: "down" });
+
+      registerTask(config, "trip-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      await callback();
+      await callback();
+      await callback();
+
+      const state = getTaskStates().get("trip-test");
+      expect(state?.disabled).toBe(true);
+      expect(state?.consecutiveFailures).toBe(3);
+    });
+
+    it("skips execution when circuit breaker is tripped", async () => {
+      const fn: TaskFn = vi
+        .fn()
+        .mockResolvedValue({ success: false, summary: "fail" });
+
+      registerTask(config, "skip-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip the breaker
+      await callback();
+      await callback();
+      await callback();
+      expect(fn).toHaveBeenCalledTimes(3);
+
+      // Fourth call should be skipped (breaker tripped)
+      await callback();
+      expect(fn).toHaveBeenCalledTimes(3); // Not called again
+    });
+
+    it("trips on thrown errors too", async () => {
+      const fn: TaskFn = vi.fn().mockRejectedValue(new Error("crash"));
+
+      registerTask(config, "error-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      await callback();
+      await callback();
+      await callback();
+
+      const state = getTaskStates().get("error-test");
+      expect(state?.disabled).toBe(true);
+    });
+  });
+
+  describe("resetCircuitBreaker", () => {
+    it("resets a tripped breaker", async () => {
+      const fn: TaskFn = vi
+        .fn()
+        .mockResolvedValue({ success: false, summary: "fail" });
+
+      registerTask(config, "reset-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip breaker
+      await callback();
+      await callback();
+      await callback();
+      expect(getTaskStates().get("reset-test")?.disabled).toBe(true);
+
+      // Reset
+      const result = resetCircuitBreaker("reset-test");
+      expect(result).toBe(true);
+
+      const state = getTaskStates().get("reset-test");
+      expect(state?.disabled).toBe(false);
+      expect(state?.consecutiveFailures).toBe(0);
+    });
+
+    it("returns false for unknown tasks", () => {
+      expect(resetCircuitBreaker("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("concurrent execution guard", () => {
+    it("prevents overlapping executions", async () => {
+      let resolveFirst: (() => void) | undefined;
+      let callCount = 0;
+
+      const fn: TaskFn = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: hang until we resolve
+          return new Promise<{ success: boolean }>((resolve) => {
+            resolveFirst = () => resolve({ success: true });
+          });
+        }
+        return Promise.resolve({ success: true });
+      });
+
+      registerTask(config, "concurrent-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Start first execution (will hang)
+      const first = callback();
+
+      // Attempt second execution while first is running
+      await callback();
+
+      // fn should only have been called once (second was skipped)
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      // Clean up: resolve first
+      resolveFirst?.();
+      await first;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 22 tests for the groundskeeper service which had zero test coverage
- 12 tests for run-tracker: recording runs, trim limit, daily AI count/cap, corrupted file handling
- 10 tests for scheduler: circuit breaker (trips after 3 failures, resets on success, skips when tripped, trips on errors), concurrent execution guard, disabled tasks, invalid cron rejection
- Add vitest as devDependency and test script to package.json

## Test plan
- [x] All 22 tests pass via `npx vitest run apps/groundskeeper/src/`
- [x] run-tracker tests use real temp directories (cleaned up in afterEach)
- [x] scheduler tests mock node-cron, notify, and run-tracker to isolate logic

https://claude.ai/code/session_014Vcui7uPW1L5A3Z6LWfSro