### PR TITLE
fix: pin Claude CLI version and defer dailyAiCount increment

### DIFF
--- a/apps/groundskeeper/Dockerfile
+++ b/apps/groundskeeper/Dockerfile
@@ -7,7 +7,8 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 RUN apk add --no-cache git github-cli openssh
 
 # Install Claude Code CLI globally (needed for Phase 2+ AI tasks)
-RUN npm install -g @anthropic-ai/claude-code
+# Pin version to avoid silent breakage from upstream updates
+RUN npm install -g @anthropic-ai/claude-code@2.1.63
 
 WORKDIR /repo
 

--- a/apps/groundskeeper/src/claude.ts
+++ b/apps/groundskeeper/src/claude.ts
@@ -35,7 +35,6 @@ export async function runClaude(
     };
   }
 
-  incrementDailyAiCount(config);
   const start = Date.now();
 
   return new Promise<ClaudeResult>((resolve) => {
@@ -57,6 +56,11 @@ export async function runClaude(
         // Ensure Claude Code uses the API key from our env
         ANTHROPIC_API_KEY: process.env["ANTHROPIC_API_KEY"],
       },
+    });
+
+    // Increment daily count only after spawn succeeds (not on spawn error)
+    proc.on("spawn", () => {
+      incrementDailyAiCount(config);
     });
 
     let stdout = "";


### PR DESCRIPTION
## Summary
Two reliability fixes for the groundskeeper service:

1. **Pin Claude CLI version** in Dockerfile to v2.1.63 (was unpinned `npm install -g @anthropic-ai/claude-code`). Prevents silent breakage from upstream releases. Follows the same pattern as the pnpm version pin on line 4.

2. **Defer dailyAiCount increment** until after the claude process successfully spawns. Previously, `incrementDailyAiCount()` was called before `spawn()`, so if the binary was missing or unexecutable (ENOENT), a daily cap slot was wasted without any work being done. Now uses the Node.js `"spawn"` event to increment only on successful process creation.

## Test plan
- [x] Dockerfile change is syntactically correct
- [x] claude.ts logic verified: `spawn` event only fires after successful process creation
- [ ] Manual: rebuild groundskeeper Docker image to verify Claude CLI installs at pinned version

https://claude.ai/code/session_014Vcui7uPW1L5A3Z6LWfSro