### PR TITLE
feat: add simple admin login for /internal/* pages

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE } from "@/lib/auth";
+
+export async function POST(request: NextRequest) {
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  if (!adminPassword) {
+    return NextResponse.json(
+      { error: "Admin login is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const password = body?.password;
+
+  if (typeof password !== "string" || password !== adminPassword) {
+    return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+  }
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    // 30 days
+    maxAge: 60 * 60 * 24 * 30,
+  });
+
+  return response;
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { ADMIN_COOKIE_NAME } from "@/lib/auth";
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(ADMIN_COOKIE_NAME, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return response;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { AdminBadge } from "@/components/AdminBadge";
 import { DevModeToggle } from "@/components/DevModeToggle";
 import { SearchButton, SearchDialog } from "@/components/SearchDialog";
 import { MobileNav } from "@/components/MobileNav";
+import { isAdmin } from "@/lib/auth";
 import { SITE_URL } from "@/lib/site-config";
 import "./globals.css";
 import "katex/dist/katex.min.css";
@@ -28,11 +30,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const admin = await isAdmin();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -77,6 +81,7 @@ export default function RootLayout({
               </Link>
               <SearchButton />
               <DevModeToggle />
+              {admin && <AdminBadge />}
               <MobileNav />
             </nav>
           </div>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function LoginForm() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        const redirectTo = searchParams.get("from") || "/internal";
+        router.push(redirectTo);
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.error ?? "Login failed");
+      }
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="w-full max-w-sm space-y-4 rounded-lg border border-border bg-card p-6"
+    >
+      <h1 className="text-xl font-semibold">Admin Login</h1>
+      <div>
+        <label
+          htmlFor="password"
+          className="block text-sm font-medium text-muted-foreground mb-1"
+        >
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoFocus
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full rounded-md bg-foreground px-3 py-2 text-sm font-medium text-background hover:opacity-90 disabled:opacity-50"
+      >
+        {loading ? "Logging in..." : "Log in"}
+      </button>
+    </form>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Suspense>
+        <LoginForm />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/components/AdminBadge.tsx
+++ b/apps/web/src/components/AdminBadge.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function AdminBadge() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch("/api/auth/logout", { method: "POST" });
+    router.push("/");
+    router.refresh();
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
+        Admin
+      </span>
+      <button
+        onClick={handleLogout}
+        className="underline hover:text-foreground transition-colors"
+      >
+        Logout
+      </button>
+    </span>
+  );
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,17 @@
+import { cookies } from "next/headers";
+
+/** Cookie name for the admin session. */
+export const ADMIN_COOKIE_NAME = "admin_session";
+/** Simple token value stored in the cookie when authenticated. */
+export const ADMIN_TOKEN_VALUE = "authenticated";
+
+/**
+ * Check whether the current request has a valid admin session.
+ * Call from Server Components or Route Handlers (uses next/headers).
+ */
+export async function isAdmin(): Promise<boolean> {
+  if (!process.env.ADMIN_PASSWORD) return false;
+
+  const cookieStore = await cookies();
+  return cookieStore.get(ADMIN_COOKIE_NAME)?.value === ADMIN_TOKEN_VALUE;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+// Duplicated from @/lib/auth to avoid pulling in next/headers in Edge runtime.
+const ADMIN_COOKIE_NAME = "admin_session";
+const ADMIN_TOKEN_VALUE = "authenticated";
+
 /**
- * Redirects old-style content URLs to the new /wiki/:slug canonical URLs.
- *
- * Old site (longtermwiki.com) used paths like:
- *   /knowledge-base/risks/deceptive-alignment
- *   /knowledge-base/organizations/anthropic
- *
- * New site serves all wiki content through /wiki/:id (numeric E42 or slug).
- * The /wiki/[id] route handles slug → numeric ID resolution internally.
+ * Middleware handles two concerns:
+ * 1. Admin auth gating for /internal/* routes
+ * 2. Redirecting old-style content URLs to /wiki/:slug
  */
 
 // Knowledge-base category directories that had index pages in the old site.
@@ -35,6 +34,33 @@ const KB_CATEGORIES = new Set([
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // --- Admin auth gate ---
+  // When ADMIN_PASSWORD is set, /internal/* requires a valid session cookie.
+  // If not set, internal pages remain open (dev mode / no-auth deployments).
+  if (pathname.startsWith("/internal")) {
+    const hasPassword = !!process.env.ADMIN_PASSWORD;
+    if (hasPassword) {
+      const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+      if (token !== ADMIN_TOKEN_VALUE) {
+        const loginUrl = request.nextUrl.clone();
+        loginUrl.pathname = "/login";
+        loginUrl.searchParams.set("from", pathname);
+        return NextResponse.redirect(loginUrl);
+      }
+    }
+  }
+
+  // If already logged in and visiting /login, redirect to /internal
+  if (pathname === "/login") {
+    const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+    if (token === ADMIN_TOKEN_VALUE) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/internal";
+      return NextResponse.redirect(url);
+    }
+    return NextResponse.next();
+  }
 
   // Normalize: strip trailing slash
   const path =
@@ -90,6 +116,9 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/internal",
+    "/internal/:path+",
+    "/login",
     "/browse",
     "/browse/:path+",
     "/knowledge-base",


### PR DESCRIPTION
## Summary
- Adds a shared-password admin login system gated by the `ADMIN_PASSWORD` environment variable
- When `ADMIN_PASSWORD` is set, visiting `/internal/*` redirects unauthenticated users to `/login`
- When not set, internal pages remain publicly accessible (current behavior preserved)
- Session stored as an HTTP-only cookie (30-day expiry)

## What's included
- `POST /api/auth/login` — validates password, sets session cookie
- `POST /api/auth/logout` — clears session cookie
- `/login` page with redirect-back support (`?from=` param)
- Middleware auth gate on `/internal/*` routes
- `AdminBadge` + logout button in the header when logged in
- `isAdmin()` server-side helper in `@/lib/auth` for future use

## How to use
1. Set `ADMIN_PASSWORD=your-secret` in your `.env` file
2. Visit `/internal/*` — you'll be redirected to `/login`
3. Enter the password — you'll be redirected back to where you were going

If `ADMIN_PASSWORD` is not set, nothing changes — internal pages remain open.

## Test plan
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Next.js build passes (`pnpm build`)
- [x] Existing tests pass (96/97 suites — 1 pre-existing failure in source-fetcher unrelated to changes)
- [ ] Manual: verify `/internal` accessible without `ADMIN_PASSWORD` set
- [ ] Manual: set `ADMIN_PASSWORD`, verify `/internal` redirects to `/login`
- [ ] Manual: enter correct password, verify redirect back
- [ ] Manual: enter wrong password, verify error message
- [ ] Manual: verify Admin badge + Logout in header
- [ ] Manual: click Logout, verify cookie cleared

https://claude.ai/code/session_01ScgMbJLaAR3bbCGCX5odgR
