### PR TITLE
fix: close admin auth bypass, open redirect, and timing attack vulnerabilities

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE } from "@/lib/auth";
+import {
+  ADMIN_COOKIE_NAME,
+  generateSessionToken,
+  verifyPassword,
+} from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
   const adminPassword = process.env.ADMIN_PASSWORD;
@@ -13,12 +17,14 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null);
   const password = body?.password;
 
-  if (typeof password !== "string" || password !== adminPassword) {
+  if (typeof password !== "string" || !verifyPassword(password, adminPassword)) {
     return NextResponse.json({ error: "Invalid password" }, { status: 401 });
   }
 
+  const token = generateSessionToken(adminPassword);
+
   const response = NextResponse.json({ ok: true });
-  response.cookies.set(ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE, {
+  response.cookies.set(ADMIN_COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -23,7 +23,15 @@ function LoginForm() {
       });
 
       if (res.ok) {
-        const redirectTo = searchParams.get("from") || "/internal";
+        const from = searchParams.get("from") || "/internal";
+        // Validate redirect to prevent open redirect attacks:
+        // only allow relative paths, block protocol-relative and absolute URLs
+        const isSafe =
+          from.startsWith("/") &&
+          !from.startsWith("//") &&
+          !from.includes("://") &&
+          !from.includes("\\");
+        const redirectTo = isSafe ? from : "/internal";
         router.push(redirectTo);
         router.refresh();
       } else {

--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateSessionToken,
+  verifySessionToken,
+  verifyPassword,
+  isSafeRedirect,
+} from "../auth";
+
+describe("auth", () => {
+  const SECRET = "test-admin-password-123";
+
+  describe("generateSessionToken", () => {
+    it("produces a token with nonce.hmac format", () => {
+      const token = generateSessionToken(SECRET);
+      const parts = token.split(".");
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatch(/^[0-9a-f]{64}$/); // 32 bytes = 64 hex chars
+      expect(parts[1]).toMatch(/^[0-9a-f]{64}$/); // SHA-256 HMAC = 64 hex chars
+    });
+
+    it("generates unique tokens each time", () => {
+      const t1 = generateSessionToken(SECRET);
+      const t2 = generateSessionToken(SECRET);
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe("verifySessionToken", () => {
+    it("accepts a token generated with the same secret", () => {
+      const token = generateSessionToken(SECRET);
+      expect(verifySessionToken(token, SECRET)).toBe(true);
+    });
+
+    it("rejects a token generated with a different secret", () => {
+      const token = generateSessionToken(SECRET);
+      expect(verifySessionToken(token, "wrong-secret")).toBe(false);
+    });
+
+    it("rejects the old hardcoded 'authenticated' value", () => {
+      expect(verifySessionToken("authenticated", SECRET)).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      expect(verifySessionToken("", SECRET)).toBe(false);
+    });
+
+    it("rejects token with tampered nonce", () => {
+      const token = generateSessionToken(SECRET);
+      const [, hmac] = token.split(".");
+      const tampered = "00".repeat(32) + "." + hmac;
+      expect(verifySessionToken(tampered, SECRET)).toBe(false);
+    });
+
+    it("rejects token with tampered HMAC", () => {
+      const token = generateSessionToken(SECRET);
+      const [nonce] = token.split(".");
+      const tampered = nonce + "." + "00".repeat(32);
+      expect(verifySessionToken(tampered, SECRET)).toBe(false);
+    });
+
+    it("rejects token without dot separator", () => {
+      expect(verifySessionToken("abcdef1234567890", SECRET)).toBe(false);
+    });
+  });
+
+  describe("verifyPassword", () => {
+    it("accepts matching passwords", () => {
+      expect(verifyPassword("correct-password", "correct-password")).toBe(true);
+    });
+
+    it("rejects non-matching passwords of same length", () => {
+      expect(verifyPassword("password-aaa", "password-bbb")).toBe(false);
+    });
+
+    it("rejects non-matching passwords of different length", () => {
+      expect(verifyPassword("short", "a-much-longer-password")).toBe(false);
+    });
+
+    it("rejects empty password against non-empty", () => {
+      expect(verifyPassword("", "secret")).toBe(false);
+    });
+  });
+
+  describe("isSafeRedirect", () => {
+    it("allows simple relative paths", () => {
+      expect(isSafeRedirect("/internal")).toBe(true);
+      expect(isSafeRedirect("/internal/dashboard")).toBe(true);
+      expect(isSafeRedirect("/")).toBe(true);
+    });
+
+    it("blocks protocol-relative URLs", () => {
+      expect(isSafeRedirect("//evil.com")).toBe(false);
+      expect(isSafeRedirect("//evil.com/steal")).toBe(false);
+    });
+
+    it("blocks absolute URLs with protocol", () => {
+      expect(isSafeRedirect("https://evil.com")).toBe(false);
+      expect(isSafeRedirect("http://evil.com")).toBe(false);
+    });
+
+    it("blocks non-path strings", () => {
+      expect(isSafeRedirect("evil.com")).toBe(false);
+      expect(isSafeRedirect("javascript:alert(1)")).toBe(false);
+    });
+
+    it("blocks embedded protocol indicators", () => {
+      expect(isSafeRedirect("/foo://bar")).toBe(false);
+    });
+
+    it("blocks backslash variants", () => {
+      expect(isSafeRedirect("/\\evil.com")).toBe(false);
+      expect(isSafeRedirect("\\\\evil.com")).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,17 +1,100 @@
 import { cookies } from "next/headers";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 
 /** Cookie name for the admin session. */
 export const ADMIN_COOKIE_NAME = "admin_session";
-/** Simple token value stored in the cookie when authenticated. */
-export const ADMIN_TOKEN_VALUE = "authenticated";
+
+/**
+ * Generate a signed session token: `<random-hex>.<hmac-hex>`.
+ * The HMAC is keyed with ADMIN_PASSWORD so tokens can't be forged
+ * without knowing the password.
+ */
+export function generateSessionToken(secret: string): string {
+  const nonce = randomBytes(32).toString("hex");
+  const hmac = createHmac("sha256", secret).update(nonce).digest("hex");
+  return `${nonce}.${hmac}`;
+}
+
+/**
+ * Verify a session token's HMAC signature.
+ * Returns true only if the token has a valid format and its HMAC
+ * matches re-computation with the given secret.
+ */
+export function verifySessionToken(
+  token: string,
+  secret: string,
+): boolean {
+  const dotIndex = token.indexOf(".");
+  if (dotIndex === -1) return false;
+
+  const nonce = token.slice(0, dotIndex);
+  const providedHmac = token.slice(dotIndex + 1);
+
+  // Reject obviously malformed tokens
+  if (!nonce || !providedHmac) return false;
+
+  const expectedHmac = createHmac("sha256", secret)
+    .update(nonce)
+    .digest("hex");
+
+  // Timing-safe comparison to prevent timing attacks on the HMAC
+  try {
+    const a = Buffer.from(providedHmac, "hex");
+    const b = Buffer.from(expectedHmac, "hex");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Timing-safe password comparison.
+ * Prevents timing attacks that could reveal password length or content.
+ */
+export function verifyPassword(
+  provided: string,
+  expected: string,
+): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    // Still do a comparison to avoid short-circuiting timing leak,
+    // but always return false for length mismatch.
+    timingSafeEqual(a, Buffer.alloc(a.length));
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Validate a redirect URL to prevent open redirect attacks.
+ * Only allows relative paths (starting with /) that don't contain
+ * protocol indicators.
+ */
+export function isSafeRedirect(url: string): boolean {
+  // Must start with / (relative path)
+  if (!url.startsWith("/")) return false;
+  // Block protocol-relative URLs (//evil.com)
+  if (url.startsWith("//")) return false;
+  // Block any embedded protocol indicators
+  if (url.includes("://")) return false;
+  // Block backslash variants (some browsers normalize \ to /)
+  if (url.includes("\\")) return false;
+  return true;
+}
 
 /**
  * Check whether the current request has a valid admin session.
  * Call from Server Components or Route Handlers (uses next/headers).
  */
 export async function isAdmin(): Promise<boolean> {
-  if (!process.env.ADMIN_PASSWORD) return false;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  if (!adminPassword) return false;
 
   const cookieStore = await cookies();
-  return cookieStore.get(ADMIN_COOKIE_NAME)?.value === ADMIN_TOKEN_VALUE;
+  const token = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
+  if (!token) return false;
+
+  return verifySessionToken(token, adminPassword);
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,9 +1,79 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Duplicated from @/lib/auth to avoid pulling in next/headers in Edge runtime.
+// Cookie name duplicated from @/lib/auth to avoid pulling in next/headers in Edge runtime.
 const ADMIN_COOKIE_NAME = "admin_session";
-const ADMIN_TOKEN_VALUE = "authenticated";
+
+/** Convert a hex string to a Uint8Array. */
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Convert a Uint8Array to a hex string. */
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Constant-time comparison of two hex strings.
+ * Prevents timing attacks by always comparing the full length.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const aBuf = hexToBytes(a);
+  const bBuf = hexToBytes(b);
+  let result = 0;
+  for (let i = 0; i < aBuf.length; i++) {
+    result |= aBuf[i] ^ bBuf[i];
+  }
+  return result === 0;
+}
+
+/**
+ * Verify a session token's HMAC signature (Edge-compatible version).
+ * Uses Web Crypto API (SubtleCrypto) which is available in Edge Runtime.
+ * Duplicated from @/lib/auth because middleware runs in Edge runtime
+ * and cannot import next/headers or Node.js crypto.
+ */
+async function verifySessionToken(
+  token: string,
+  secret: string,
+): Promise<boolean> {
+  const dotIndex = token.indexOf(".");
+  if (dotIndex === -1) return false;
+
+  const nonce = token.slice(0, dotIndex);
+  const providedHmac = token.slice(dotIndex + 1);
+
+  if (!nonce || !providedHmac) return false;
+
+  try {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      encoder.encode(nonce),
+    );
+    const expectedHmac = bytesToHex(new Uint8Array(signature));
+
+    return constantTimeEqual(providedHmac, expectedHmac);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Middleware handles two concerns:
@@ -32,17 +102,17 @@ const KB_CATEGORIES = new Set([
   "worldviews",
 ]);
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // --- Admin auth gate ---
   // When ADMIN_PASSWORD is set, /internal/* requires a valid session cookie.
   // If not set, internal pages remain open (dev mode / no-auth deployments).
   if (pathname.startsWith("/internal")) {
-    const hasPassword = !!process.env.ADMIN_PASSWORD;
-    if (hasPassword) {
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    if (adminPassword) {
       const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
-      if (token !== ADMIN_TOKEN_VALUE) {
+      if (!token || !(await verifySessionToken(token, adminPassword))) {
         const loginUrl = request.nextUrl.clone();
         loginUrl.pathname = "/login";
         loginUrl.searchParams.set("from", pathname);
@@ -53,8 +123,13 @@ export function middleware(request: NextRequest) {
 
   // If already logged in and visiting /login, redirect to /internal
   if (pathname === "/login") {
+    const adminPassword = process.env.ADMIN_PASSWORD;
     const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
-    if (token === ADMIN_TOKEN_VALUE) {
+    if (
+      adminPassword &&
+      token &&
+      (await verifySessionToken(token, adminPassword))
+    ) {
       const url = request.nextUrl.clone();
       url.pathname = "/internal";
       return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary

Fixes three security vulnerabilities in the admin authentication system:

- **Auth bypass**: The session cookie was the hardcoded string `"authenticated"`, visible in public source code. Anyone could bypass auth with `curl -b "admin_session=authenticated"`. Now uses HMAC-signed random tokens (`nonce.hmac` format) keyed with `ADMIN_PASSWORD`, so tokens cannot be forged without knowing the password.
- **Open redirect**: `searchParams.get("from")` was passed directly to `router.push()` with no validation. An attacker could craft `?from=https://evil.com` to redirect users after login. Now validates that the redirect URL is a relative path (starts with `/`, no `://`, no `//`, no `\`).
- **Timing attack on password**: `password !== adminPassword` allows timing-based password extraction. Now uses `crypto.timingSafeEqual` for constant-time comparison.

### Implementation notes

- The middleware runs in Edge Runtime (no Node.js `crypto`), so it uses the Web Crypto API (`crypto.subtle.importKey` + `crypto.subtle.sign`) for HMAC verification. The `auth.ts` library uses Node.js `crypto` since it runs in Server Components/Route Handlers.
- Both implementations produce identical HMAC-SHA256 signatures, so tokens generated by the login route are valid in the middleware.
- Existing sessions will be invalidated after deploy (the old `"authenticated"` cookie value will fail HMAC verification). Users just need to log in again.

## Test plan

- [x] 19 new tests covering `generateSessionToken`, `verifySessionToken`, `verifyPassword`, and `isSafeRedirect`
- [x] All tests pass (`vitest run`)
- [x] Build compiles successfully (pre-existing type error in `claims/claim/[id]/page.tsx` is unrelated)
- [ ] Manual: Log in, verify cookie is a random token (not `"authenticated"`)
- [ ] Manual: Verify `curl -b "admin_session=authenticated" /internal` redirects to `/login`
- [ ] Manual: Verify `?from=https://evil.com` falls back to `/internal`

Closes #1362

Generated with [Claude Code](https://claude.com/claude-code)