### PR TITLE
feat: citation audit flags unsourced table cells with numeric claims

### DIFF
--- a/crux/authoring/orchestrator/tools/audit-citations.ts
+++ b/crux/authoring/orchestrator/tools/audit-citations.ts
@@ -39,6 +39,7 @@ export const tool: ToolRegistration = {
           failed: result.summary.failed,
           misattributed: result.summary.misattributed,
           unchecked: result.summary.unchecked,
+          unsourcedTableCells: result.summary.unsourcedTableCells,
           pass: result.pass,
           failedCitations: result.citations
             .filter((c) => c.verdict === 'unsupported' || c.verdict === 'misattributed')
@@ -47,7 +48,17 @@ export const tool: ToolRegistration = {
               claim: c.claim.slice(0, 100),
               verdict: c.verdict,
               explanation: c.explanation,
+              sourceContext: c.sourceContext,
             })),
+          ...(result.unsourcedTableCells.length > 0
+            ? {
+                unsourcedTableCellDetails: result.unsourcedTableCells.map((cell) => ({
+                  line: cell.line,
+                  column: cell.column,
+                  cellText: cell.cellText.slice(0, 80),
+                })),
+              }
+            : {}),
         },
         null,
         2,

--- a/crux/authoring/page-improver/phases/citation-audit.test.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.test.ts
@@ -60,8 +60,9 @@ const mockPage: PageData = {
 function makeAuditResult(overrides: Partial<AuditResult> = {}): AuditResult {
   return {
     citations: [],
-    summary: { total: 0, verified: 0, failed: 0, misattributed: 0, unchecked: 0 },
+    summary: { total: 0, verified: 0, failed: 0, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
     newUngroundedClaims: [],
+    unsourcedTableCells: [],
     pass: true,
     ...overrides,
   };
@@ -170,7 +171,7 @@ describe('citationAuditPhase', () => {
 
   it('returns the AuditResult from auditCitations', async () => {
     const expected = makeAuditResult({
-      summary: { total: 1, verified: 1, failed: 0, misattributed: 0, unchecked: 0 },
+      summary: { total: 1, verified: 1, failed: 0, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
       pass: true,
     });
     vi.mocked(auditCitations).mockResolvedValueOnce(expected);
@@ -190,7 +191,7 @@ describe('citationAuditPhase', () => {
 
   it('logs "Citation audit passed" when audit passes with citations', async () => {
     vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
-      summary: { total: 2, verified: 2, failed: 0, misattributed: 0, unchecked: 0 },
+      summary: { total: 2, verified: 2, failed: 0, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
       pass: true,
     }));
 
@@ -201,7 +202,7 @@ describe('citationAuditPhase', () => {
 
   it('logs [WARNING] in advisory mode when audit fails', async () => {
     vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
-      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0 },
+      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
       pass: false,
     }));
 
@@ -215,7 +216,7 @@ describe('citationAuditPhase', () => {
 
   it('logs [GATE] in gate mode when audit fails', async () => {
     vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
-      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0 },
+      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
       pass: false,
     }));
 

--- a/crux/authoring/page-improver/phases/citation-audit.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.ts
@@ -124,15 +124,27 @@ export async function citationAuditPhase(
     }
   }
 
+  // Unsourced table cell warnings (#1271)
+  if (result.unsourcedTableCells.length > 0) {
+    log(
+      'citation-audit',
+      `Found ${result.unsourcedTableCells.length} table cell(s) with numeric claims but no citation:`,
+    );
+    for (const cell of result.unsourcedTableCells) {
+      const colLabel = cell.column ? ` (${cell.column})` : '';
+      log('citation-audit', `  line ${cell.line}: "${cell.cellText}"${colLabel}`);
+    }
+  }
+
   if (total === 0) {
-    log('citation-audit', 'No citations found — skipping verification');
+    log('citation-audit', 'No citations found \u2014 skipping verification');
   } else if (result.pass) {
-    log('citation-audit', `✓ Citation audit passed`);
+    log('citation-audit', `\u2713 Citation audit passed`);
   } else {
     const mode = options.citationGate ? 'GATE' : 'WARNING';
     log(
       'citation-audit',
-      `⚠ [${mode}] Citation audit failed: pass rate below threshold (${verified}/${verified + failed} verified)`,
+      `\u26A0 [${mode}] Citation audit failed: pass rate below threshold (${verified}/${verified + failed} verified)`,
     );
   }
 

--- a/crux/authoring/page-improver/pipeline.ts
+++ b/crux/authoring/page-improver/pipeline.ts
@@ -350,8 +350,11 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
   }
 
   if (r.auditResult) {
-    const { total, verified, failed, unchecked } = r.auditResult.summary;
-    console.log(`Citations: ${total} total — ${verified} verified, ${failed} failed, ${unchecked} unchecked`);
+    const { total, verified, failed, unchecked, unsourcedTableCells } = r.auditResult.summary;
+    console.log(`Citations: ${total} total \u2014 ${verified} verified, ${failed} failed, ${unchecked} unchecked`);
+    if (unsourcedTableCells > 0) {
+      console.log(`Unsourced table cells: ${unsourcedTableCells} (numeric claims without citations)`);
+    }
     if (!r.auditResult.pass) {
       if (options.citationGate && dryRun) {
         console.log(`⚠ Citation audit FAILED (--citation-gate inactive in dry-run; would block --apply)`);

--- a/crux/citations/audit-check.ts
+++ b/crux/citations/audit-check.ts
@@ -142,6 +142,16 @@ async function main() {
     console.log('');
   }
 
+  // Unsourced table cells (#1271)
+  if (result.unsourcedTableCells.length > 0) {
+    console.log(`${c.bold}Unsourced Table Cells${c.reset}`);
+    for (const cell of result.unsourcedTableCells) {
+      const colLabel = cell.column ? ` (${cell.column})` : '';
+      console.log(`  ${c.red}!${c.reset} line ${cell.line}: "${cell.cellText}"${colLabel}`);
+    }
+    console.log('');
+  }
+
   // Summary
   console.log(`${c.bold}Summary${c.reset}`);
   console.log(`  Total citations:  ${result.summary.total}`);
@@ -151,6 +161,9 @@ async function main() {
   }
   if (result.summary.unchecked > 0) {
     console.log(`  ${c.dim}Unchecked:${c.reset}        ${result.summary.unchecked}  (url-dead, paywall, or no-fetch)`);
+  }
+  if (result.summary.unsourcedTableCells > 0) {
+    console.log(`  ${c.red}Unsourced cells:${c.reset}  ${result.summary.unsourcedTableCells}  (table cells with numeric claims, no citation)`);
   }
 
   // Pass/fail verdict

--- a/crux/lib/citation-auditor.test.ts
+++ b/crux/lib/citation-auditor.test.ts
@@ -13,6 +13,9 @@ import {
   parseVerifierResponse,
   parseBatchVerifierResponse,
   auditCitations,
+  inferSourceContext,
+  detectUnsourcedTableCells,
+  NUMERIC_CLAIM_PATTERN,
   type AuditRequest,
   type SourceCache,
   type ClaimMap,
@@ -708,5 +711,363 @@ First claim.[^1] Second claim.[^2]
     expect(result.summary.verified).toBe(3);
     // All 3 LLM calls should have been made (one per distinct URL)
     expect(timestamps).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferSourceContext (#1271)
+// ---------------------------------------------------------------------------
+
+describe('inferSourceContext', () => {
+  it('returns "table" when footnote appears in a table row', () => {
+    const body = `Some text.
+
+| Name | Value |
+| --- | --- |
+| Org A | 500 employees[^1] |
+
+[^1]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '1')).toBe('table');
+  });
+
+  it('returns "list" when footnote appears in an unordered list item', () => {
+    const body = `Some text.
+
+- First item with a claim.[^1]
+- Second item.
+
+[^1]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '1')).toBe('list');
+  });
+
+  it('returns "list" when footnote appears in an ordered list item', () => {
+    const body = `Some text.
+
+1. First ordered item with claim.[^2]
+2. Second item.
+
+[^2]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '2')).toBe('list');
+  });
+
+  it('returns "list" for * bullet list items', () => {
+    const body = `Some text.
+
+* A bullet point claim.[^3]
+
+[^3]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '3')).toBe('list');
+  });
+
+  it('returns "body" when footnote appears in regular paragraph text', () => {
+    const body = `This is a regular paragraph with a claim.[^1]
+
+[^1]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '1')).toBe('body');
+  });
+
+  it('returns "body" when footnote reference is not found', () => {
+    const body = `This is a paragraph without footnotes.`;
+    expect(inferSourceContext(body, '99')).toBe('body');
+  });
+
+  it('does not match footnote definition lines (only inline references)', () => {
+    // The definition line [^1]: ... should not be matched
+    const body = `[^1]: [Source](https://example.com)`;
+    expect(inferSourceContext(body, '1')).toBe('body');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectUnsourcedTableCells (#1271)
+// ---------------------------------------------------------------------------
+
+describe('detectUnsourcedTableCells', () => {
+  it('detects a numeric dollar amount in a table cell without footnote', () => {
+    const body = `Some text.
+
+| Company | Funding |
+| --- | --- |
+| Acme | $50M |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    expect(results[0].cellText).toBe('$50M');
+    expect(results[0].column).toBe('Funding');
+    expect(results[0].row).toBe(1);
+  });
+
+  it('detects percentages without footnotes', () => {
+    const body = `| Metric | Value |
+| --- | --- |
+| Growth | 25% |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    expect(results[0].cellText).toBe('25%');
+  });
+
+  it('detects comma-separated numbers', () => {
+    const body = `| Item | Count |
+| --- | --- |
+| Users | 1,500,000 |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    expect(results[0].cellText).toBe('1,500,000');
+  });
+
+  it('detects years in plausible range (19xx, 20xx)', () => {
+    const body = `| Event | Year |
+| --- | --- |
+| Founded | 2015 |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    expect(results[0].cellText).toBe('2015');
+  });
+
+  it('detects count + unit phrases like "50 employees"', () => {
+    const body = `| Org | Size |
+| --- | --- |
+| MIRI | 50 researchers |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    expect(results[0].cellText).toBe('50 researchers');
+  });
+
+  it('skips rows that have a footnote reference anywhere', () => {
+    const body = `| Company | Funding | Source |
+| --- | --- | --- |
+| Acme | $50M | Per report[^1] |
+
+[^1]: [Source](https://example.com)`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array for tables with no numeric claims', () => {
+    const body = `| Name | Status |
+| --- | --- |
+| Alice | Active |
+| Bob | Inactive |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array when content has no tables', () => {
+    const body = `Just a paragraph with $50M mentioned but not in a table.`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(0);
+  });
+
+  it('handles multiple tables in the same content', () => {
+    const body = `First table:
+
+| A | B |
+| --- | --- |
+| x | $10M |
+
+Some text.
+
+| C | D |
+| --- | --- |
+| y | 75% |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(2);
+    expect(results[0].cellText).toBe('$10M');
+    expect(results[1].cellText).toBe('75%');
+  });
+
+  it('reports correct line numbers', () => {
+    const body = `Line 1
+Line 2
+| Col |
+| --- |
+| $5M |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(1);
+    // Line 5 in 1-based indexing (index 4 in 0-based + offset for data row)
+    expect(results[0].line).toBe(5);
+  });
+
+  it('skips tables without a proper separator row', () => {
+    const body = `| A | B |
+| not a separator |
+| $10M | 50% |`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(0);
+  });
+
+  it('handles multiple data rows with mixed sourced/unsourced', () => {
+    const body = `| Org | Funding |
+| --- | --- |
+| Acme | $50M |
+| Beta | $20M[^1] |
+| Gamma | $30M |
+
+[^1]: [Source](https://example.com)`;
+    const results = detectUnsourcedTableCells(body);
+    expect(results).toHaveLength(2);
+    expect(results[0].cellText).toBe('$50M');
+    expect(results[1].cellText).toBe('$30M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NUMERIC_CLAIM_PATTERN (#1271)
+// ---------------------------------------------------------------------------
+
+describe('NUMERIC_CLAIM_PATTERN', () => {
+  const matches = (text: string) => NUMERIC_CLAIM_PATTERN.test(text);
+
+  it('matches dollar amounts', () => {
+    expect(matches('$100')).toBe(true);
+    expect(matches('$1.5M')).toBe(true);
+    expect(matches('$2 billion')).toBe(true);
+    expect(matches('$50,000')).toBe(true);
+  });
+
+  it('matches percentages', () => {
+    expect(matches('50%')).toBe(true);
+    expect(matches('3.5%')).toBe(true);
+    expect(matches('100%')).toBe(true);
+  });
+
+  it('matches comma-separated numbers', () => {
+    expect(matches('1,000')).toBe(true);
+    expect(matches('10,000,000')).toBe(true);
+  });
+
+  it('matches years', () => {
+    expect(matches('2015')).toBe(true);
+    expect(matches('1990')).toBe(true);
+    expect(matches('2025')).toBe(true);
+  });
+
+  it('matches count+unit phrases', () => {
+    expect(matches('50 employees')).toBe(true);
+    expect(matches('200 papers')).toBe(true);
+    expect(matches('10 researchers')).toBe(true);
+  });
+
+  it('does not match short plain numbers', () => {
+    // Single digits or small numbers without units should not match
+    expect(matches('5')).toBe(false);
+    expect(matches('42')).toBe(false);
+  });
+
+  it('does not match plain words', () => {
+    expect(matches('Active')).toBe(false);
+    expect(matches('hello world')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditCitations — sourceContext and unsourcedTableCells integration (#1271)
+// ---------------------------------------------------------------------------
+
+describe('auditCitations sourceContext and unsourcedTableCells', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('annotates citations with sourceContext', async () => {
+    mockCallOpenRouter.mockResolvedValue(
+      JSON.stringify({ verdict: 'verified', relevantQuote: '', explanation: 'ok' }),
+    );
+
+    const contentWithTable = `---
+title: Test
+---
+
+Body claim.[^1]
+
+| Col A | Col B |
+| --- | --- |
+| Data | Value[^2] |
+
+[^1]: [Source One](https://example.com/one)
+[^2]: [Source Two](https://example.com/two)
+`;
+
+    const sourceCache: SourceCache = new Map([
+      ['https://example.com/one', makeFetchedSource({ url: 'https://example.com/one' })],
+      ['https://example.com/two', makeFetchedSource({ url: 'https://example.com/two' })],
+    ]);
+
+    const result = await auditCitations({
+      content: contentWithTable,
+      sourceCache,
+      fetchMissing: false,
+      delayMs: 0,
+    });
+
+    const cit1 = result.citations.find(c => c.footnoteRef === '1');
+    const cit2 = result.citations.find(c => c.footnoteRef === '2');
+    expect(cit1?.sourceContext).toBe('body');
+    expect(cit2?.sourceContext).toBe('table');
+  });
+
+  it('detects unsourced table cells in audit result', async () => {
+    const contentWithUnsourcedTable = `---
+title: Test
+---
+
+Text with citation.[^1]
+
+| Org | Funding |
+| --- | --- |
+| Acme | $50M |
+
+[^1]: [Source](https://example.com/source)
+`;
+
+    mockCallOpenRouter.mockResolvedValue(
+      JSON.stringify({ verdict: 'verified', relevantQuote: '', explanation: 'ok' }),
+    );
+
+    const sourceCache: SourceCache = new Map([
+      ['https://example.com/source', makeFetchedSource({ url: 'https://example.com/source' })],
+    ]);
+
+    const result = await auditCitations({
+      content: contentWithUnsourcedTable,
+      sourceCache,
+      fetchMissing: false,
+      delayMs: 0,
+    });
+
+    expect(result.unsourcedTableCells).toHaveLength(1);
+    expect(result.unsourcedTableCells[0].cellText).toBe('$50M');
+    expect(result.unsourcedTableCells[0].column).toBe('Funding');
+    expect(result.summary.unsourcedTableCells).toBe(1);
+  });
+
+  it('returns empty unsourcedTableCells when all table data is sourced', async () => {
+    const sourcedContent = `---
+title: Test
+---
+
+| Org | Funding |
+| --- | --- |
+| Acme | $50M[^1] |
+
+[^1]: [Source](https://example.com/source)
+`;
+
+    mockCallOpenRouter.mockResolvedValue(
+      JSON.stringify({ verdict: 'verified', relevantQuote: '', explanation: 'ok' }),
+    );
+
+    const sourceCache: SourceCache = new Map([
+      ['https://example.com/source', makeFetchedSource({ url: 'https://example.com/source' })],
+    ]);
+
+    const result = await auditCitations({
+      content: sourcedContent,
+      sourceCache,
+      fetchMissing: false,
+      delayMs: 0,
+    });
+
+    expect(result.unsourcedTableCells).toHaveLength(0);
+    expect(result.summary.unsourcedTableCells).toBe(0);
   });
 });

--- a/crux/lib/citation-auditor.ts
+++ b/crux/lib/citation-auditor.ts
@@ -31,6 +31,41 @@ import { getCitationContentByUrl } from './wiki-server/citations.ts';
 /** Minimum source content length (chars) required to attempt LLM verification. */
 export const MIN_SOURCE_CONTENT_LENGTH = 50;
 
+// ---------------------------------------------------------------------------
+// Source context tracking (#1271)
+// ---------------------------------------------------------------------------
+
+/** Where in the page structure a citation (or unsourced claim) appears. */
+export type SourceContext = 'body' | 'table' | 'list';
+
+/**
+ * A table cell that contains a numeric claim but has no footnote reference
+ * in its row. Flagged as a potential unsourced factual assertion.
+ */
+export interface UnsourcedTableCell {
+  /** 1-based row index within the table (header = row 1). */
+  row: number;
+  /** Column header text (empty string if header is missing). */
+  column: string;
+  /** Raw text content of the cell. */
+  cellText: string;
+  /** 1-based line number in the original content. */
+  line: number;
+}
+
+/**
+ * Pattern matching numeric claims that should ideally have citations.
+ * Matches:
+ *   - Dollar amounts: $100, $1.5M, $2 billion
+ *   - Percentages: 50%, 3.5%
+ *   - Large comma-separated numbers: 1,000  10,000,000
+ *   - SI-suffixed numbers: 1.5B, 200M, 3K
+ *   - Years in plausible range: 2001, 2025
+ *   - Count + unit phrases: 50 employees, 200 papers
+ */
+export const NUMERIC_CLAIM_PATTERN =
+  /(?:\$[\d,.]+\s*(?:thousand|million|billion|trillion|[KMBT])?)|(?:\d+(?:[.,]\d+)*\s*%)|(?:(?<!\d)\d{1,3}(?:,\d{3})+(?:\.\d+)?)|(?:\d+(?:\.\d+)?\s*[KMBT](?:illion)?(?:\b))|(?:(?:19|20)\d{2}(?!\d))|(?:\d{2,}(?:\.\d+)?\s+(?:employees?|researchers?|staff|people|papers?|publications?|projects?|participants?|members?|users?|downloads?))/i;
+
 /**
  * Domains that commonly serve login walls, dynamic JS-rendered content,
  * or minimal snippets that cause false "unsupported" verdicts.
@@ -104,6 +139,8 @@ export interface CitationAudit {
   relevantQuote?: string;
   /** Human-readable explanation of the verdict. */
   explanation: string;
+  /** Where in the page this citation appears (#1271). */
+  sourceContext?: SourceContext;
 }
 
 /** Aggregate audit report for a page. */
@@ -121,6 +158,8 @@ export interface AuditResult {
     misattributed: number;
     /** Citations that could not be checked (url-dead, unchecked). */
     unchecked: number;
+    /** Number of table cells with numeric claims but no footnote reference (#1271). */
+    unsourcedTableCells: number;
   };
   /**
    * Placeholder for claims that make factual assertions without any citation.
@@ -128,6 +167,11 @@ export interface AuditResult {
    * Currently always returns [].
    */
   newUngroundedClaims: string[];
+  /**
+   * Table cells containing numeric claims without footnote references (#1271).
+   * These are potential unsourced factual assertions that should have citations.
+   */
+  unsourcedTableCells: UnsourcedTableCell[];
   /** True if the audit passes the passThreshold (enough citations verified). */
   pass: boolean;
 }
@@ -469,6 +513,114 @@ export async function resolveSource(
 }
 
 // ---------------------------------------------------------------------------
+// Source context & unsourced table cell detection (#1271)
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer where a footnote reference appears in the page structure.
+ *
+ * Finds the line containing `[^{footnoteRef}]` (inline reference, not the
+ * definition) and checks whether that line looks like a table row or list item.
+ */
+export function inferSourceContext(body: string, footnoteRef: string): SourceContext {
+  const lines = body.split('\n');
+  // Match inline usage [^N] but not definition lines that start with [^N]:
+  const refPattern = new RegExp(`\\[\\^${footnoteRef}\\](?!:)`);
+
+  for (const line of lines) {
+    if (!refPattern.test(line)) continue;
+    const trimmed = line.trimStart();
+    // Table row: starts with | or contains | delimiters
+    if (trimmed.startsWith('|') || /\|.*\|/.test(trimmed)) {
+      return 'table';
+    }
+    // List item: unordered (- or *) or ordered (1. 2. etc.)
+    if (/^[-*]\s/.test(trimmed) || /^\d+\.\s/.test(trimmed)) {
+      return 'list';
+    }
+  }
+  return 'body';
+}
+
+/**
+ * Detect table cells that contain numeric claims but have no footnote
+ * reference anywhere in their row.
+ *
+ * Parses markdown tables (sequences of `|`-delimited lines with a separator
+ * row) and checks each data cell against NUMERIC_CLAIM_PATTERN.
+ *
+ * A cell is considered "sourced" if any cell in the same row contains a
+ * `[^N]` footnote reference — this covers the common pattern where a single
+ * footnote at the end of a row sources the entire row.
+ */
+export function detectUnsourcedTableCells(body: string): UnsourcedTableCell[] {
+  const results: UnsourcedTableCell[] = [];
+  const lines = body.split('\n');
+
+  // Find table blocks: consecutive lines starting with |
+  let i = 0;
+  while (i < lines.length) {
+    // Look for a line that starts with |
+    if (!lines[i].trimStart().startsWith('|')) {
+      i++;
+      continue;
+    }
+
+    // Collect consecutive table lines
+    const tableStart = i;
+    const tableLines: string[] = [];
+    while (i < lines.length && lines[i].trimStart().startsWith('|')) {
+      tableLines.push(lines[i]);
+      i++;
+    }
+
+    // Need at least 3 lines: header, separator, and at least one data row
+    if (tableLines.length < 3) continue;
+
+    // Validate separator row (second line should be like |---|---|)
+    const separatorCells = tableLines[1].split('|').slice(1, -1);
+    const isSeparator = separatorCells.length > 0 &&
+      separatorCells.every(cell => /^\s*:?-+:?\s*$/.test(cell));
+    if (!isSeparator) continue;
+
+    // Parse header columns
+    const headers = tableLines[0]
+      .split('|')
+      .slice(1, -1)
+      .map(h => h.trim());
+
+    // Check each data row (skip header and separator)
+    for (let rowIdx = 2; rowIdx < tableLines.length; rowIdx++) {
+      const rowLine = tableLines[rowIdx];
+      const cells = rowLine.split('|').slice(1, -1);
+
+      // Check if the entire row has any footnote reference
+      const rowHasFootnote = /\[\^\d+\]/.test(rowLine);
+
+      for (let colIdx = 0; colIdx < cells.length; colIdx++) {
+        const cellText = cells[colIdx].trim();
+        if (!cellText) continue;
+
+        // Skip if the row already has a footnote somewhere
+        if (rowHasFootnote) continue;
+
+        // Check if this cell contains a numeric claim
+        if (NUMERIC_CLAIM_PATTERN.test(cellText)) {
+          results.push({
+            row: rowIdx - 1, // 1-based data row index (header excluded, separator excluded)
+            column: headers[colIdx] ?? '',
+            cellText,
+            line: tableStart + rowIdx + 1, // 1-based line number in original content
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
 // Core audit function
 // ---------------------------------------------------------------------------
 
@@ -655,6 +807,14 @@ export async function auditCitations(request: AuditRequest): Promise<AuditResult
   const citationAudits = [...nonLlmAudits, ...llmAudits]
     .sort((a, b) => parseInt(a.footnoteRef, 10) - parseInt(b.footnoteRef, 10));
 
+  // Annotate each citation with its source context (#1271)
+  for (const audit of citationAudits) {
+    audit.sourceContext = inferSourceContext(body, audit.footnoteRef);
+  }
+
+  // Detect unsourced table cells with numeric claims (#1271)
+  const unsourcedTableCells = detectUnsourcedTableCells(body);
+
   // Build summary
   const verified = citationAudits.filter((c) => c.verdict === 'verified').length;
   const misattributed = citationAudits.filter((c) => c.verdict === 'misattributed').length;
@@ -681,8 +841,16 @@ export async function auditCitations(request: AuditRequest): Promise<AuditResult
 
   return {
     citations: citationAudits,
-    summary: { total: citationAudits.length, verified, failed, misattributed, unchecked },
+    summary: {
+      total: citationAudits.length,
+      verified,
+      failed,
+      misattributed,
+      unchecked,
+      unsourcedTableCells: unsourcedTableCells.length,
+    },
     newUngroundedClaims: [],
+    unsourcedTableCells,
     pass,
   };
 }


### PR DESCRIPTION
## Summary
- Adds detection for markdown table cells containing numeric claims (dollar amounts, percentages, years, comma-separated numbers, count+unit phrases) that lack footnote references
- Tracks `sourceContext` (`'body' | 'table' | 'list'`) for each citation to indicate where it appears in the page structure
- Reports unsourced table cells in the audit-check CLI, improve pipeline output, and orchestrator tool results

Closes #1271

## Changes
- `crux/lib/citation-auditor.ts`: New types (`SourceContext`, `UnsourcedTableCell`), `NUMERIC_CLAIM_PATTERN` regex, `inferSourceContext()` and `detectUnsourcedTableCells()` functions; `AuditResult` now includes `unsourcedTableCells` array and summary count; `CitationAudit` now includes optional `sourceContext` field
- `crux/lib/citation-auditor.test.ts`: 29 new tests covering `inferSourceContext`, `detectUnsourcedTableCells`, `NUMERIC_CLAIM_PATTERN`, and integration tests for `sourceContext`/`unsourcedTableCells` in `auditCitations()`
- `crux/authoring/page-improver/phases/citation-audit.ts`: Logs unsourced table cell warnings during the citation audit phase
- `crux/authoring/page-improver/phases/citation-audit.test.ts`: Updated `makeAuditResult` helper and all summary overrides to include new `unsourcedTableCells` field
- `crux/authoring/orchestrator/tools/audit-citations.ts`: Includes unsourced table cell count and details in tool output
- `crux/citations/audit-check.ts`: Displays unsourced table cells section and summary line in CLI output
- `crux/authoring/page-improver/pipeline.ts`: Logs unsourced table cell count in pipeline summary

## Test plan
- [x] All existing 270+ tests continue to pass (no regressions)
- [x] 29 new tests added covering all new functions and integration
- [x] TypeScript compilation passes with zero errors
- [x] Pre-push gate checks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)