### PR TITLE
feat: switch frontend citation reads from citation_quotes to claims

### DIFF
--- a/apps/web/src/lib/__tests__/citation-data.test.ts
+++ b/apps/web/src/lib/__tests__/citation-data.test.ts
@@ -163,6 +163,46 @@ describe("getCitationQuotes", () => {
     expect(result[0].footnote).toBe(1);
     expect(result[1].footnote).toBe(3);
   });
+
+  it("calls the claims by-page endpoint (not deprecated citations/quotes)", async () => {
+    vi.resetModules();
+    const mockFetch = vi.fn().mockResolvedValue({ quotes: [] });
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: mockFetch,
+    }));
+    const mod = await import("../citation-data");
+    await mod.getCitationQuotes("test-page");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/claims/by-page?page_id=test-page",
+      { revalidate: 600 }
+    );
+  });
+});
+
+describe("getCitationQuotesByUrl", () => {
+  it("calls the claims by-source-url endpoint (not deprecated citations/quotes-by-url)", async () => {
+    vi.resetModules();
+    const mockFetch = vi.fn().mockResolvedValue({ quotes: [], stats: {} });
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: mockFetch,
+    }));
+    const mod = await import("../citation-data");
+    await mod.getCitationQuotesByUrl("https://example.com/test");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/claims/by-source-url?url=https%3A%2F%2Fexample.com%2Ftest",
+      { revalidate: 600 }
+    );
+  });
+
+  it("returns null when server is unavailable", async () => {
+    vi.resetModules();
+    vi.doMock("../wiki-server", () => ({
+      fetchFromWikiServer: vi.fn().mockResolvedValue(null),
+    }));
+    const mod = await import("../citation-data");
+    const result = await mod.getCitationQuotesByUrl("https://example.com/test");
+    expect(result).toBeNull();
+  });
 });
 
 describe("isSafeUrl", () => {

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -1,8 +1,8 @@
 import { fetchFromWikiServer } from "./wiki-server";
 import type {
   CitationHealthResult,
-  CitationQuotesResult,
-  CitationQuotesByUrlResult,
+  ClaimsByPageResult,
+  ClaimsBySourceUrlResult,
 } from "@wiki-server/api-response-types";
 import type {
   AccuracyVerdict,
@@ -78,13 +78,17 @@ function toAccuracyVerdict(value: string | null): AccuracyVerdict | null {
  * Fetch citation verification data for a specific page from the wiki-server.
  * Returns an empty array if the server is unavailable or the page has no data.
  *
+ * Reads from the claims system (claims + claim_page_references + claim_sources)
+ * via the /api/claims/by-page endpoint, which replaced the deprecated
+ * /api/citations/quotes endpoint (#1311).
+ *
  * Revalidates every 10 minutes — citation data changes infrequently.
  */
 export async function getCitationQuotes(
   pageId: string
 ): Promise<CitationQuote[]> {
-  const result = await fetchFromWikiServer<CitationQuotesResult>(
-    `/api/citations/quotes?page_id=${encodeURIComponent(pageId)}`,
+  const result = await fetchFromWikiServer<ClaimsByPageResult>(
+    `/api/claims/by-page?page_id=${encodeURIComponent(pageId)}`,
     { revalidate: 600 }
   );
 
@@ -114,20 +118,23 @@ export async function getCitationQuotes(
     }));
 }
 
-/** Citation quote with page context — returned by quotes-by-url endpoint */
+/** Citation quote with page context — returned by by-source-url endpoint */
 export interface CrossPageCitationQuote extends CitationQuote {
   pageId: string;
 }
 
 /**
- * Fetch all citation quotes across all pages for a given source URL.
+ * Fetch all claims across all pages for a given source URL.
  * Used by /source/[id] pages to show cross-page citation data.
+ *
+ * Reads from the claims system via the /api/claims/by-source-url endpoint,
+ * which replaced the deprecated /api/citations/quotes-by-url endpoint (#1311).
  */
 export async function getCitationQuotesByUrl(
   url: string
-): Promise<CitationQuotesByUrlResult | null> {
-  return fetchFromWikiServer<CitationQuotesByUrlResult>(
-    `/api/citations/quotes-by-url?url=${encodeURIComponent(url)}`,
+): Promise<ClaimsBySourceUrlResult | null> {
+  return fetchFromWikiServer<ClaimsBySourceUrlResult>(
+    `/api/claims/by-source-url?url=${encodeURIComponent(url)}`,
     { revalidate: 600 }
   );
 }

--- a/apps/wiki-server/src/api-response-types.ts
+++ b/apps/wiki-server/src/api-response-types.ts
@@ -93,6 +93,18 @@ export type PageReferencesResult = InferResponseType<ClaimsRpc[':id']['page-refe
 /** A single page reference row. */
 export type PageReferenceRow = PageReferencesResult['references'][number];
 
+/** Claims for a specific page, with footnote-level citation data (replaces citation_quotes). */
+export type ClaimsByPageResult = InferResponseType<ClaimsRpc['by-page']['$get'], 200>;
+
+/** A single claim quote row from the by-page endpoint (CitationQuote-compatible). */
+export type ClaimQuoteRow = ClaimsByPageResult['quotes'][number];
+
+/** Claims citing a specific source URL, across all pages (replaces quotes-by-url). */
+export type ClaimsBySourceUrlResult = InferResponseType<ClaimsRpc['by-source-url']['$get'], 200>;
+
+/** A single cross-page claim quote from the by-source-url endpoint. */
+export type CrossPageClaimQuoteRow = ClaimsBySourceUrlResult['quotes'][number];
+
 // ---------------------------------------------------------------------------
 // Citations
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -1300,6 +1300,248 @@ const claimsApp = new Hono()
       .returning();
 
     return c.json({ inserted: rows.length }, 201);
+  })
+
+  // ---- GET /by-page — claims for a specific wiki page, grouped by footnote ----
+  // Replaces the deprecated GET /api/citations/quotes endpoint (#1311).
+  // Joins claims → claim_page_references (for footnote) → claim_sources (for source data).
+  // Returns a CitationQuote-compatible shape for the frontend CitationOverlay.
+  .get("/by-page", async (c) => {
+    const pageId = c.req.query("page_id");
+    if (!pageId) return validationError(c, "page_id query parameter is required");
+
+    const limitParam = c.req.query("limit");
+    const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 500, 1), 1000) : 500;
+
+    const db = getDrizzleDb();
+
+    // Step 1: Get all claim_page_references for this page (with footnote info)
+    const refs = await db
+      .select({
+        claimId: claimPageReferences.claimId,
+        footnote: claimPageReferences.footnote,
+        section: claimPageReferences.section,
+      })
+      .from(claimPageReferences)
+      .where(eq(claimPageReferences.pageId, pageId))
+      .orderBy(asc(claimPageReferences.footnote))
+      .limit(limit);
+
+    if (refs.length === 0) {
+      return c.json({ quotes: [] as Array<{
+        footnote: number;
+        url: string | null;
+        resourceId: string | null;
+        claimText: string;
+        sourceQuote: string | null;
+        sourceTitle: string | null;
+        sourceType: string | null;
+        quoteVerified: boolean;
+        verificationScore: number | null;
+        verifiedAt: string | null;
+        accuracyVerdict: string | null;
+        accuracyScore: number | null;
+        accuracyIssues: string | null;
+        accuracySupportingQuotes: string | null;
+        verificationDifficulty: string | null;
+        accuracyCheckedAt: string | null;
+      }> });
+    }
+
+    const claimIds = [...new Set(refs.map((r) => r.claimId))];
+
+    // Step 2: Fetch the claims themselves
+    const claimRows = await db
+      .select()
+      .from(claims)
+      .where(inArray(claims.id, claimIds));
+
+    const claimMap = new Map(claimRows.map((r) => [Number(r.id), r]));
+
+    // Step 3: Fetch primary sources for these claims (limit to primary or first source)
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(inArray(claimSources.claimId, claimIds))
+      .orderBy(desc(claimSources.isPrimary), asc(claimSources.addedAt));
+
+    // Build a map: claimId → primary source (first one, preferring isPrimary)
+    const sourceMap = new Map<number, typeof claimSources.$inferSelect>();
+    for (const s of sourcesRows) {
+      const cid = Number(s.claimId);
+      if (!sourceMap.has(cid)) {
+        sourceMap.set(cid, s);
+      }
+    }
+
+    // Step 4: Build CitationQuote-compatible output
+    const quotes = refs
+      .filter((ref) => ref.footnote !== null && claimMap.has(Number(ref.claimId)))
+      .map((ref) => {
+        const claim = claimMap.get(Number(ref.claimId))!;
+        const source = sourceMap.get(Number(ref.claimId));
+
+        // Map claim verdict fields to the CitationQuote shape
+        // claim_verdict → accuracyVerdict
+        // claim_verdict_score → accuracyScore
+        // claim_verdict_issues → accuracyIssues
+        // claim_verdict_quotes → accuracySupportingQuotes
+        // claim_verdict_difficulty → verificationDifficulty
+        // claim_verified_at → accuracyCheckedAt
+        // source_verdict → quoteVerified (true if source_verdict exists)
+        // source_verdict_score → verificationScore
+        // source_checked_at → verifiedAt
+        return {
+          footnote: ref.footnote as number,
+          url: source?.url ?? null,
+          resourceId: source?.resourceId ?? null,
+          claimText: claim.claimText,
+          sourceQuote: source?.sourceQuote ?? claim.sourceQuote ?? null,
+          sourceTitle: source?.sourceTitle ?? null,
+          sourceType: source?.sourceType ?? null,
+          quoteVerified: source?.sourceVerdict != null,
+          verificationScore: source?.sourceVerdictScore ?? null,
+          verifiedAt: source?.sourceCheckedAt?.toISOString() ?? null,
+          accuracyVerdict: claim.claimVerdict ?? null,
+          accuracyScore: claim.claimVerdictScore ?? null,
+          accuracyIssues: claim.claimVerdictIssues ?? null,
+          accuracySupportingQuotes: claim.claimVerdictQuotes ?? null,
+          verificationDifficulty: claim.claimVerdictDifficulty ?? null,
+          accuracyCheckedAt: claim.claimVerifiedAt?.toISOString() ?? null,
+        };
+      });
+
+    return c.json({ quotes });
+  })
+
+  // ---- GET /by-source-url — claims citing a specific source URL, across all pages ----
+  // Replaces the deprecated GET /api/citations/quotes-by-url endpoint (#1311).
+  // Returns cross-page citation data grouped by URL for the /source/[id] page.
+  .get("/by-source-url", async (c) => {
+    const url = c.req.query("url");
+    if (!url) return validationError(c, "url query parameter is required");
+
+    const limitParam = c.req.query("limit");
+    const limit = limitParam
+      ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500)
+      : 100;
+
+    const db = getDrizzleDb();
+
+    // Step 1: Find all claim_sources matching this URL
+    const sourcesRows = await db
+      .select()
+      .from(claimSources)
+      .where(eq(claimSources.url, url))
+      .limit(limit);
+
+    if (sourcesRows.length === 0) {
+      return c.json({
+        quotes: [] as Array<{
+          pageId: string;
+          footnote: number;
+          url: string | null;
+          resourceId: string | null;
+          claimText: string;
+          sourceQuote: string | null;
+          sourceTitle: string | null;
+          sourceType: string | null;
+          quoteVerified: boolean;
+          verificationScore: number | null;
+          verifiedAt: string | null;
+          accuracyVerdict: string | null;
+          accuracyScore: number | null;
+          accuracyIssues: string | null;
+          accuracySupportingQuotes: string | null;
+          verificationDifficulty: string | null;
+          accuracyCheckedAt: string | null;
+        }>,
+        stats: {
+          totalPages: 0 as number,
+          totalQuotes: 0 as number,
+          verified: 0 as number,
+          accurate: 0 as number,
+          inaccurate: 0 as number,
+          unsupported: 0 as number,
+          minorIssues: 0 as number,
+        },
+      });
+    }
+
+    const claimIds = [...new Set(sourcesRows.map((s) => s.claimId))];
+
+    // Step 2: Fetch claims
+    const claimRows = await db
+      .select()
+      .from(claims)
+      .where(inArray(claims.id, claimIds));
+
+    const claimMap = new Map(claimRows.map((r) => [Number(r.id), r]));
+
+    // Step 3: Fetch page references for these claims
+    const pageRefs = await db
+      .select()
+      .from(claimPageReferences)
+      .where(inArray(claimPageReferences.claimId, claimIds))
+      .orderBy(asc(claimPageReferences.pageId), asc(claimPageReferences.footnote));
+
+    // Build source map: claimId → source row that matched our URL
+    const sourceByClaimId = new Map<number, typeof claimSources.$inferSelect>();
+    for (const s of sourcesRows) {
+      sourceByClaimId.set(Number(s.claimId), s);
+    }
+
+    // Step 4: Build cross-page quotes. Each page reference generates one quote entry.
+    const quotes = pageRefs
+      .filter((pr) => claimMap.has(Number(pr.claimId)))
+      .map((pr) => {
+        const claim = claimMap.get(Number(pr.claimId))!;
+        const source = sourceByClaimId.get(Number(pr.claimId));
+
+        return {
+          pageId: pr.pageId,
+          footnote: pr.footnote ?? 0,
+          url: source?.url ?? null,
+          resourceId: source?.resourceId ?? null,
+          claimText: claim.claimText,
+          sourceQuote: source?.sourceQuote ?? claim.sourceQuote ?? null,
+          sourceTitle: source?.sourceTitle ?? null,
+          sourceType: source?.sourceType ?? null,
+          quoteVerified: source?.sourceVerdict != null,
+          verificationScore: source?.sourceVerdictScore ?? null,
+          verifiedAt: source?.sourceCheckedAt?.toISOString() ?? null,
+          accuracyVerdict: claim.claimVerdict ?? null,
+          accuracyScore: claim.claimVerdictScore ?? null,
+          accuracyIssues: claim.claimVerdictIssues ?? null,
+          accuracySupportingQuotes: claim.claimVerdictQuotes ?? null,
+          verificationDifficulty: claim.claimVerdictDifficulty ?? null,
+          accuracyCheckedAt: claim.claimVerifiedAt?.toISOString() ?? null,
+        };
+      });
+
+    // Step 5: Compute aggregate stats
+    const pageIds = new Set(quotes.map((q) => q.pageId));
+    let verified = 0, accurate = 0, inaccurate = 0, unsupported = 0, minorIssues = 0;
+    for (const q of quotes) {
+      if (q.accuracyVerdict === "accurate") accurate++;
+      else if (q.accuracyVerdict === "inaccurate") inaccurate++;
+      else if (q.accuracyVerdict === "unsupported") unsupported++;
+      else if (q.accuracyVerdict === "minor_issues") minorIssues++;
+      if (q.quoteVerified) verified++;
+    }
+
+    return c.json({
+      quotes,
+      stats: {
+        totalPages: pageIds.size,
+        totalQuotes: quotes.length,
+        verified,
+        accurate,
+        inaccurate,
+        unsupported,
+        minorIssues,
+      },
+    });
   });
 
 export const claimsRoute = claimsApp;


### PR DESCRIPTION
## Summary

- Add `GET /api/claims/by-page` endpoint that joins claims + claim_page_references + claim_sources to reconstruct per-footnote citation data, replacing reads from the deprecated citation_quotes table
- Add `GET /api/claims/by-source-url` endpoint that provides cross-page citation data for source pages, replacing the deprecated `/api/citations/quotes-by-url`
- Update `getCitationQuotes()` and `getCitationQuotesByUrl()` in the frontend to call the new claims endpoints
- Add inferred response types (`ClaimsByPageResult`, `ClaimsBySourceUrlResult`) to api-response-types.ts
- Add 3 new tests verifying correct endpoint URLs and null handling

The CitationQuote interface, CitationOverlay component, wiki page, and source page all remain unchanged -- only the data source switched from citation_quotes to claims.

The old `/api/citations/quotes` endpoints are preserved for backward compatibility with the discord-bot and crux CLI consumers that still reference `CitationQuotesResult`.

## Data Flow (before vs after)

**Before:** `citation_quotes` table -> `/api/citations/quotes` -> `getCitationQuotes()` -> CitationOverlay
**After:** `claims` + `claim_page_references` + `claim_sources` tables -> `/api/claims/by-page` -> `getCitationQuotes()` -> CitationOverlay

## Test plan

- [x] TypeScript compilation passes (both wiki-server and web app)
- [x] All 20 citation-data tests pass (including 3 new endpoint URL verification tests)
- [x] Full production build compiles and generates all 881 static pages
- [x] Pre-push gate checks pass
- [ ] Manual verification: wiki pages with citation overlays still show correct verdict badges
- [ ] Manual verification: `/source/[id]` pages still show cross-page claims data

Closes #1311

Generated with [Claude Code](https://claude.com/claude-code)
