### PR TITLE
fix: record half-open circuit breaker events to wiki-server

### DIFF
--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -21,6 +21,13 @@ vi.mock("./run-tracker.js", () => ({
   recordRun: vi.fn(),
 }));
 
+// Mock wiki-server to capture recordRunToServer calls
+const mockRecordRunToServer = vi.fn().mockResolvedValue(undefined);
+vi.mock("./wiki-server.js", () => ({
+  recordRunToServer: (...args: unknown[]) => mockRecordRunToServer(...args),
+  updateActiveAgent: vi.fn().mockResolvedValue(undefined),
+}));
+
 import {
   registerTask,
   resetCircuitBreaker,
@@ -57,6 +64,7 @@ describe("scheduler", () => {
     scheduledCallbacks.length = 0;
     // Clear task states between tests
     getTaskStates().clear();
+    mockRecordRunToServer.mockClear();
   });
 
   describe("registerTask", () => {
@@ -324,6 +332,140 @@ describe("scheduler", () => {
       expect(state.disabled).toBe(true);
       expect(state.trippedAt).toBeGreaterThanOrEqual(beforeTrip);
       expect(state.trippedAt).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe("wiki-server event recording for half-open probes", () => {
+    it("records half_open_attempt when probe starts", async () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: false, summary: "down" });
+
+      registerTask(config, "attempt-event-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip the breaker
+      await callback();
+      await callback();
+      await callback();
+      mockRecordRunToServer.mockClear();
+
+      const state = getTaskStates().get("attempt-event-test")!;
+      // Advance time past cooldown
+      state.trippedAt = Date.now() - 61_000;
+
+      // Trigger half-open probe
+      await callback();
+
+      // Should have recorded half_open_attempt event
+      const attemptCall = mockRecordRunToServer.mock.calls.find(
+        (call: unknown[]) => (call[1] as { event: string }).event === "half_open_attempt"
+      );
+      expect(attemptCall).toBeDefined();
+      expect((attemptCall![1] as { taskName: string }).taskName).toBe("attempt-event-test");
+    });
+
+    it("records half_open_success when probe succeeds", async () => {
+      let callCount = 0;
+      const fn: TaskFn = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 3) return { success: false, summary: "down" };
+        return { success: true, summary: "recovered" };
+      });
+
+      registerTask(config, "success-event-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip the breaker
+      await callback();
+      await callback();
+      await callback();
+      mockRecordRunToServer.mockClear();
+
+      const state = getTaskStates().get("success-event-test")!;
+      // Advance time past cooldown
+      state.trippedAt = Date.now() - 61_000;
+
+      // Probe succeeds
+      await callback();
+
+      // The main run event should be "half_open_success", not plain "success"
+      const runCalls = mockRecordRunToServer.mock.calls.filter(
+        (call: unknown[]) => {
+          const evt = (call[1] as { event: string }).event;
+          return evt === "half_open_success" || evt === "success";
+        }
+      );
+      expect(runCalls.length).toBeGreaterThanOrEqual(1);
+      const hasHalfOpenSuccess = runCalls.some(
+        (call: unknown[]) => (call[1] as { event: string }).event === "half_open_success"
+      );
+      expect(hasHalfOpenSuccess).toBe(true);
+    });
+
+    it("does not record half_open_success for normal successful runs", async () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: true, summary: "ok" });
+
+      registerTask(config, "normal-success-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      await callback();
+
+      const hasHalfOpenSuccess = mockRecordRunToServer.mock.calls.some(
+        (call: unknown[]) => (call[1] as { event: string }).event === "half_open_success"
+      );
+      expect(hasHalfOpenSuccess).toBe(false);
+
+      // Should have recorded a plain "success" event
+      const hasSuccess = mockRecordRunToServer.mock.calls.some(
+        (call: unknown[]) => (call[1] as { event: string }).event === "success"
+      );
+      expect(hasSuccess).toBe(true);
+    });
+  });
+
+  describe("wiki-server event recording for manual reset", () => {
+    it("records circuit_breaker_reset when config is provided", async () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: false, summary: "fail" });
+
+      registerTask(config, "manual-reset-test", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip the breaker
+      await callback();
+      await callback();
+      await callback();
+      mockRecordRunToServer.mockClear();
+
+      // Manual reset with config
+      resetCircuitBreaker("manual-reset-test", config);
+
+      // Should have recorded circuit_breaker_reset event
+      const resetCall = mockRecordRunToServer.mock.calls.find(
+        (call: unknown[]) => (call[1] as { event: string }).event === "circuit_breaker_reset"
+      );
+      expect(resetCall).toBeDefined();
+      expect((resetCall![1] as { taskName: string }).taskName).toBe("manual-reset-test");
+    });
+
+    it("does not record to wiki-server when config is omitted", async () => {
+      const fn: TaskFn = vi.fn().mockResolvedValue({ success: false, summary: "fail" });
+
+      registerTask(config, "no-config-reset", "*/5 * * * *", true, fn);
+      const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+      // Trip the breaker
+      await callback();
+      await callback();
+      await callback();
+      mockRecordRunToServer.mockClear();
+
+      // Manual reset without config
+      resetCircuitBreaker("no-config-reset");
+
+      // Should NOT have recorded circuit_breaker_reset event
+      const resetCall = mockRecordRunToServer.mock.calls.find(
+        (call: unknown[]) => (call[1] as { event: string }).event === "circuit_breaker_reset"
+      );
+      expect(resetCall).toBeUndefined();
     });
   });
 

--- a/apps/groundskeeper/src/scheduler.ts
+++ b/apps/groundskeeper/src/scheduler.ts
@@ -81,6 +81,15 @@ export function registerTask(
           config,
           `🟡 **${name}** circuit breaker cooldown elapsed — attempting recovery probe...`
         );
+        // Record half-open attempt to wiki-server
+        recordRunToServer(config, {
+          taskName: name,
+          event: "half_open_attempt",
+          success: false,
+          consecutiveFailures: state.consecutiveFailures,
+          circuitBreakerActive: true,
+          timestamp: new Date().toISOString(),
+        }).catch(() => {});
       } else {
         logger.warn({ event: "skipped", reason: "circuit breaker tripped" }, "Task skipped");
         state.running = false;
@@ -152,7 +161,10 @@ export function registerTask(
       }
 
       const runTs = new Date().toISOString();
-      const event = result.success ? "success" : "failure";
+      let event = result.success ? "success" : "failure";
+      if (isHalfOpenProbe && result.success) {
+        event = "half_open_success";
+      }
 
       recordRun(config, {
         taskName: name,
@@ -269,13 +281,26 @@ export function registerTask(
   });
 }
 
-export function resetCircuitBreaker(name: string): boolean {
+export function resetCircuitBreaker(name: string, config?: Config): boolean {
   const state = taskStates.get(name);
   if (!state) return false;
   state.disabled = false;
   state.trippedAt = null;
   state.consecutiveFailures = 0;
   rootLogger.child({ task: name }).info({ event: "circuit_breaker_reset" }, "Circuit breaker reset");
+
+  // Record manual reset to wiki-server if config is provided
+  if (config) {
+    recordRunToServer(config, {
+      taskName: name,
+      event: "circuit_breaker_reset",
+      success: true,
+      consecutiveFailures: 0,
+      circuitBreakerActive: false,
+      timestamp: new Date().toISOString(),
+    }).catch(() => {});
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Successful half-open probes now record `"half_open_success"` instead of plain `"success"` to the wiki-server, enabling the groundskeeper-runs dashboard (E926) to distinguish recovery probes from normal executions
- Half-open attempt start now sends a `"half_open_attempt"` event to the wiki-server (was only logged locally before)
- Manual circuit breaker resets via `resetCircuitBreaker()` now record `"circuit_breaker_reset"` when a `Config` is provided (backward-compatible optional parameter)

## Root cause
The `event` variable at line 155 of `scheduler.ts` was always computed as `result.success ? "success" : "failure"`, without considering whether the run was a half-open probe. Additionally, `half_open_attempt` and `circuit_breaker_reset` events were logged locally but never sent to the wiki-server via `recordRunToServer()`.

## Test plan
- [x] 5 new tests added covering all 3 fix areas (half_open_attempt recording, half_open_success recording, normal success unaffected, manual reset with config, manual reset without config)
- [x] All 20 scheduler tests pass
- [x] All 40 groundskeeper tests pass
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] No changes to wiki-server schema needed (event types already defined in `VALID_GK_EVENTS`)

Closes #1366

Generated with [Claude Code](https://claude.com/claude-code)