### PR TITLE
fix: complete pino migration — replace remaining console.log/error calls

### DIFF
--- a/apps/discord-bot/src/logger.test.ts
+++ b/apps/discord-bot/src/logger.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { calculateCost, formatCost } from "./logger.js";
+import { logger } from "./log.js";
 
 describe("calculateCost", () => {
   afterEach(() => {
@@ -13,10 +14,11 @@ describe("calculateCost", () => {
   });
 
   it("uses default pricing and warns when unknown model is provided", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const cost = calculateCost(1_000_000, 1_000_000, "unknown-model");
     expect(cost).toBeCloseTo(18.0);
     expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "unknown-model" }),
       expect.stringContaining("Unknown model")
     );
   });

--- a/apps/discord-bot/src/pricing.ts
+++ b/apps/discord-bot/src/pricing.ts
@@ -1,3 +1,5 @@
+import { logger } from "./log.js";
+
 // Claude pricing per 1M tokens
 export interface ModelPricing {
   input: number;
@@ -16,9 +18,7 @@ export const PRICING: Record<string, ModelPricing> = {
 
 export function getPricing(model?: string): ModelPricing {
   if (model && !PRICING[model]) {
-    console.warn(
-      `[pricing] Unknown model "${model}" — using default pricing. Update pricing.ts if this model is new.`
-    );
+    logger.warn({ model }, "Unknown model — using default pricing. Update pricing.ts if this model is new.");
   }
   return (model && PRICING[model]) || PRICING["default"]!;
 }

--- a/apps/discord-bot/src/query.ts
+++ b/apps/discord-bot/src/query.ts
@@ -1,6 +1,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { WIKI_BASE_URL, TIMEOUT_MS, MAX_TOOL_CALLS } from "./config.js";
 import { wikiMcpServer } from "./wiki-tools.js";
+import { logger } from "./log.js";
 
 export interface QueryResult {
   result: string;
@@ -111,17 +112,13 @@ export async function runQuery(question: string): Promise<QueryResult> {
                 block.input?.page_id ||
                 "";
               toolCalls.push(`${block.name}: ${detail}`);
-              console.log(`${elapsed()} 🔧 Tool: ${block.name}`, detail);
+              logger.debug({ elapsed: elapsed(), tool: block.name, detail }, "Tool call");
             } else if (block.type === "text" && block.text) {
-              console.log(
-                `${elapsed()} 💬 Text: ${block.text.slice(0, 100)}...`
-              );
+              logger.debug({ elapsed: elapsed(), text: block.text.slice(0, 100) }, "Text block");
             }
           }
           if (toolCalls.length >= MAX_TOOL_CALLS) {
-            console.log(
-              `${elapsed()} ⚠️ Tool call limit reached (${MAX_TOOL_CALLS}), stopping query`
-            );
+            logger.warn({ elapsed: elapsed(), maxToolCalls: MAX_TOOL_CALLS }, "Tool call limit reached, stopping query");
             result =
               (lastResult || result) +
               `\n\n*(Stopped after ${MAX_TOOL_CALLS} tool calls to limit API usage)*`;
@@ -129,9 +126,9 @@ export async function runQuery(question: string): Promise<QueryResult> {
           }
         }
       } else if (msgType === "result") {
-        console.log(`${elapsed()} ✅ Got result`);
+        logger.debug({ elapsed: elapsed() }, "Got result");
       } else {
-        console.log(`${elapsed()} ${msgType} ${subtype}`);
+        logger.debug({ elapsed: elapsed(), msgType, subtype }, "Stream event");
       }
 
       if ("result" in msg) {

--- a/apps/discord-bot/src/wiki-api.ts
+++ b/apps/discord-bot/src/wiki-api.ts
@@ -9,6 +9,7 @@
  */
 
 import { WIKI_SERVER_URL, WIKI_SERVER_API_KEY } from "./config.js";
+import { logger } from "./log.js";
 
 // ---------------------------------------------------------------------------
 // Shared types — imported from crux/lib/wiki-server/
@@ -169,13 +170,13 @@ export async function searchWiki(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(`Wiki search failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "searchWiki" }, "Wiki search failed");
       return [];
     }
     const data = (await res.json()) as PageSearchResult;
     return data.results;
   } catch (error) {
-    console.error("Wiki search error:", error);
+    logger.error({ err: error, fn: "searchWiki" }, "Wiki search error");
     return [];
   }
 }
@@ -187,12 +188,12 @@ export async function getPage(id: string): Promise<PageDetail | null> {
     const res = await fetch(url.toString(), { headers: headers() });
     if (res.status === 404) return null;
     if (!res.ok) {
-      console.error(`Wiki getPage failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getPage", id }, "Wiki getPage failed");
       return null;
     }
     return (await res.json()) as PageDetail;
   } catch (error) {
-    console.error("Wiki getPage error:", error);
+    logger.error({ err: error, fn: "getPage", id }, "Wiki getPage error");
     return null;
   }
 }
@@ -211,12 +212,12 @@ export async function getRelatedPages(
     const res = await fetch(url.toString(), { headers: headers() });
     if (res.status === 404) return null;
     if (!res.ok) {
-      console.error(`getRelatedPages failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getRelatedPages", id }, "getRelatedPages failed");
       return null;
     }
     return (await res.json()) as RelatedResult;
   } catch (error) {
-    console.error("getRelatedPages error:", error);
+    logger.error({ err: error, fn: "getRelatedPages", id }, "getRelatedPages error");
     return null;
   }
 }
@@ -231,12 +232,12 @@ export async function getEntity(id: string): Promise<EntityEntry | null> {
     const res = await fetch(url.toString(), { headers: headers() });
     if (res.status === 404) return null;
     if (!res.ok) {
-      console.error(`getEntity failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getEntity", id }, "getEntity failed");
       return null;
     }
     return (await res.json()) as EntityEntry;
   } catch (error) {
-    console.error("getEntity error:", error);
+    logger.error({ err: error, fn: "getEntity", id }, "getEntity error");
     return null;
   }
 }
@@ -252,12 +253,12 @@ export async function searchEntities(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(`searchEntities failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "searchEntities", query }, "searchEntities failed");
       return null;
     }
     return (await res.json()) as EntitySearchResult;
   } catch (error) {
-    console.error("searchEntities error:", error);
+    logger.error({ err: error, fn: "searchEntities", query }, "searchEntities error");
     return null;
   }
 }
@@ -272,12 +273,12 @@ export async function getFacts(entityId: string): Promise<FactsByEntityResult | 
     const res = await fetch(url.toString(), { headers: headers() });
     if (res.status === 404) return null;
     if (!res.ok) {
-      console.error(`getFacts failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getFacts", entityId }, "getFacts failed");
       return null;
     }
     return (await res.json()) as FactsByEntityResult;
   } catch (error) {
-    console.error("getFacts error:", error);
+    logger.error({ err: error, fn: "getFacts", entityId }, "getFacts error");
     return null;
   }
 }
@@ -291,14 +292,12 @@ export async function getPageCitations(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(
-        `getPageCitations failed: ${res.status} ${res.statusText}`
-      );
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getPageCitations", pageId }, "getPageCitations failed");
       return null;
     }
     return (await res.json()) as CitationQuotesResult;
   } catch (error) {
-    console.error("getPageCitations error:", error);
+    logger.error({ err: error, fn: "getPageCitations", pageId }, "getPageCitations error");
     return null;
   }
 }
@@ -314,12 +313,12 @@ export async function searchResources(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(`searchResources failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "searchResources", query }, "searchResources failed");
       return null;
     }
     return (await res.json()) as ResourceSearchResponse;
   } catch (error) {
-    console.error("searchResources error:", error);
+    logger.error({ err: error, fn: "searchResources", query }, "searchResources error");
     return null;
   }
 }
@@ -338,12 +337,12 @@ export async function getBacklinks(
     const res = await fetch(url.toString(), { headers: headers() });
     if (res.status === 404) return null;
     if (!res.ok) {
-      console.error(`getBacklinks failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getBacklinks", id }, "getBacklinks failed");
       return null;
     }
     return (await res.json()) as BacklinksResult;
   } catch (error) {
-    console.error("getBacklinks error:", error);
+    logger.error({ err: error, fn: "getBacklinks", id }, "getBacklinks error");
     return null;
   }
 }
@@ -360,11 +359,11 @@ export async function getWikiStats(): Promise<WikiStats | null> {
     ]);
 
     if (!healthRes.ok) {
-      console.error(`getWikiStats /health failed: ${healthRes.status} ${healthRes.statusText}`);
+      logger.error({ status: healthRes.status, statusText: healthRes.statusText, fn: "getWikiStats", endpoint: "/health" }, "getWikiStats /health failed");
       return null;
     }
     if (!citationsRes.ok) {
-      console.error(`getWikiStats /api/citations/stats failed: ${citationsRes.status} ${citationsRes.statusText}`);
+      logger.error({ status: citationsRes.status, statusText: citationsRes.statusText, fn: "getWikiStats", endpoint: "/api/citations/stats" }, "getWikiStats /api/citations/stats failed");
       return null;
     }
 
@@ -372,7 +371,7 @@ export async function getWikiStats(): Promise<WikiStats | null> {
     const citations = (await citationsRes.json()) as CitationStats;
     return { health, citations };
   } catch (error) {
-    console.error("getWikiStats error:", error);
+    logger.error({ err: error, fn: "getWikiStats" }, "getWikiStats error");
     return null;
   }
 }
@@ -390,12 +389,12 @@ export async function getRecentChanges(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(`getRecentChanges failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getRecentChanges" }, "getRecentChanges failed");
       return null;
     }
     return (await res.json()) as RecentChangesResponse;
   } catch (error) {
-    console.error("getRecentChanges error:", error);
+    logger.error({ err: error, fn: "getRecentChanges" }, "getRecentChanges error");
     return null;
   }
 }
@@ -409,14 +408,12 @@ export async function getAutoUpdateStatus(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(
-        `getAutoUpdateStatus failed: ${res.status} ${res.statusText}`
-      );
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getAutoUpdateStatus" }, "getAutoUpdateStatus failed");
       return null;
     }
     return (await res.json()) as AutoUpdateStatusResponse;
   } catch (error) {
-    console.error("getAutoUpdateStatus error:", error);
+    logger.error({ err: error, fn: "getAutoUpdateStatus" }, "getAutoUpdateStatus error");
     return null;
   }
 }
@@ -427,14 +424,12 @@ export async function getCitationHealth(): Promise<CitationHealthResponse | null
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(
-        `getCitationHealth failed: ${res.status} ${res.statusText}`
-      );
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getCitationHealth" }, "getCitationHealth failed");
       return null;
     }
     return (await res.json()) as CitationHealthResponse;
   } catch (error) {
-    console.error("getCitationHealth error:", error);
+    logger.error({ err: error, fn: "getCitationHealth" }, "getCitationHealth error");
     return null;
   }
 }
@@ -450,12 +445,12 @@ export async function getRiskReport(
   try {
     const res = await fetch(url.toString(), { headers: headers() });
     if (!res.ok) {
-      console.error(`getRiskReport failed: ${res.status} ${res.statusText}`);
+      logger.error({ status: res.status, statusText: res.statusText, fn: "getRiskReport", level }, "getRiskReport failed");
       return null;
     }
     return (await res.json()) as RiskReportResponse;
   } catch (error) {
-    console.error("getRiskReport error:", error);
+    logger.error({ err: error, fn: "getRiskReport", level }, "getRiskReport error");
     return null;
   }
 }

--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -24,6 +24,8 @@ export interface Config {
 function envOrDie(name: string): string {
   const value = process.env[name];
   if (!value) {
+    // Use console.error here intentionally: logger may not be initialized
+    // yet since config is loaded first during startup.
     console.error(`Missing required environment variable: ${name}`);
     process.exit(1);
   }

--- a/apps/groundskeeper/src/wiki-server.ts
+++ b/apps/groundskeeper/src/wiki-server.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Config } from "./config.js";
+import { logger } from "./logger.js";
 
 interface ApiResult<T> {
   ok: boolean;
@@ -82,13 +83,9 @@ export async function recordRunToServer(
     payload,
   );
   if (!result.ok) {
-    console.log(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        event: "wiki_server_sync_failed",
-        endpoint: "/api/groundskeeper-runs",
-        error: result.error,
-      }),
+    logger.warn(
+      { event: "wiki_server_sync_failed", endpoint: "/api/groundskeeper-runs", error: result.error },
+      "Failed to record run to wiki-server",
     );
   }
 }
@@ -124,12 +121,9 @@ export async function registerAsActiveAgent(
     return result.data.id;
   }
 
-  console.log(
-    JSON.stringify({
-      timestamp: new Date().toISOString(),
-      event: "active_agent_registration_failed",
-      error: result.error,
-    }),
+  logger.warn(
+    { event: "active_agent_registration_failed", error: result.error },
+    "Failed to register as active agent",
   );
   return null;
 }
@@ -149,12 +143,9 @@ export async function updateActiveAgent(
     updates,
   );
   if (!result.ok) {
-    console.log(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        event: "active_agent_update_failed",
-        error: result.error,
-      }),
+    logger.warn(
+      { event: "active_agent_update_failed", error: result.error },
+      "Failed to update active agent",
     );
   }
 }
@@ -187,13 +178,9 @@ export async function recordIncident(
     payload,
   );
   if (!result.ok) {
-    console.log(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        event: "incident_recording_failed",
-        endpoint: "/api/monitoring/incidents",
-        error: result.error,
-      }),
+    logger.warn(
+      { event: "incident_recording_failed", endpoint: "/api/monitoring/incidents", error: result.error },
+      "Failed to record incident to wiki-server",
     );
   }
 }

--- a/apps/wiki-server/src/routes/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/agent-sessions.ts
@@ -12,6 +12,7 @@ import {
   CreateAgentSessionSchema,
   UpdateAgentSessionSchema,
 } from "../api-types.js";
+import { logger } from "../logger.js";
 
 const agentSessionsApp = new Hono()
   // ---- POST / (create or update agent session by branch) ----
@@ -160,7 +161,7 @@ const agentSessionsApp = new Hono()
       )
       .returning({ id: agentSessions.id, branch: agentSessions.branch });
 
-    console.log(`[agent-sessions] Sweep: marked ${stale.length} stale sessions as completed (cutoff: ${cutoff.toISOString()})`);
+    logger.info({ swept: stale.length, cutoff: cutoff.toISOString() }, "Sweep: marked stale sessions as completed");
 
     return c.json({ swept: stale.length, sessions: stale });
   });

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -18,6 +18,7 @@ import {
   RecordIncidentSchema,
   UpdateIncidentSchema,
 } from "../api-types.js";
+import { logger } from "../logger.js";
 
 // Static service registry — no DB table needed
 const SERVICES = [
@@ -282,9 +283,9 @@ const monitoringApp = new Hono()
           maxRetries: 1,
         })
         .catch((err: unknown) => {
-          console.error(
-            "[monitoring] Failed to create monitoring-alert job:",
-            err instanceof Error ? err.message : String(err)
+          logger.error(
+            { err: err instanceof Error ? err.message : String(err) },
+            "Failed to create monitoring-alert job",
           );
         });
     }


### PR DESCRIPTION
## Summary

Completes the pino structured logging migration started in PR #1355. Replaces all remaining `console.log`/`console.error`/`console.warn` calls in the groundskeeper, discord-bot, and wiki-server routes with their pino logger equivalents.

- **groundskeeper/wiki-server.ts**: 4 `console.log` (manual JSON.stringify) -> `logger.warn` with structured objects
- **discord-bot/wiki-api.ts**: 26 `console.error` -> `logger.error` with HTTP status, function name, and request context
- **discord-bot/query.ts**: 5 `console.log` -> `logger.debug`/`logger.warn` for query execution tracing
- **discord-bot/pricing.ts**: 1 `console.warn` -> `logger.warn` with model context
- **wiki-server/agent-sessions.ts**: 1 `console.log` -> `logger.info` for session sweep
- **wiki-server/monitoring.ts**: 1 `console.error` -> `logger.error` for job creation failures
- **discord-bot/logger.test.ts**: Updated test to spy on pino `logger.warn` instead of `console.warn`

### Intentionally left as console

- `config.ts` `console.error` — pre-logger startup fatal (process.exit)
- `run-migrate.ts` `console.log` — standalone CLI migration script
- `test-query.ts`, `test-suite.ts`, `view-logs.ts` — CLI test/diagnostic tools that write to stdout for humans

## Test plan

- [x] `pnpm --filter groundskeeper exec tsc --noEmit` — clean
- [x] `pnpm --filter discord-bot exec tsc --noEmit` — clean
- [x] `pnpm --filter wiki-server exec tsc --noEmit` — clean
- [x] `pnpm --filter groundskeeper test` — 35/35 passed
- [x] `pnpm --filter discord-bot test` — 128/128 passed
- [x] `pnpm --filter wiki-server test` — 445/445 passed
- [x] Verified structured log output in test runs (pino JSON visible in test stderr)

Closes #1365

Generated with [Claude Code](https://claude.com/claude-code)