### PR TITLE
fix: dateCreated field unreliable — detect and discard bulk-import git dates

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -25,6 +25,7 @@ import { parse } from 'yaml';
 import { extractMetrics, suggestQuality, getQualityDiscrepancy } from '../../../crux/lib/metrics-extractor.ts';
 import { computeHallucinationRisk as computeCanonicalRisk, resolveEntityType } from '../../../crux/lib/hallucination-risk.ts';
 import { syncPageLinks } from './lib/links-client.mjs';
+import { filterBulkImportDates } from './lib/git-date-utils.mjs';
 import { computeRedundancy } from './lib/redundancy.mjs';
 import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, PROJECT_ROOT, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
 import { generateLLMFiles } from './generate-llm-files.mjs';
@@ -605,9 +606,14 @@ function maxDate(a, b) {
  *   - gitCreatedMap: path → YYYY-MM-DD of first commit (approximate, when file was added)
  *   - gitModifiedMap: path → YYYY-MM-DD of last commit
  * Falls back to empty maps if git is unavailable (e.g. shallow clones, no git installed).
+ *
+ * Bulk-import detection: uses filterBulkImportDates() to remove entries where
+ * more than 50 files share the same git-created date. This prevents mass
+ * restructures (e.g. an import that touched 650 files) from giving every page
+ * an identical, meaningless creation date.
  */
 function buildGitDateMaps() {
-  const gitCreatedMap = new Map();
+  let gitCreatedMap = new Map();
   const gitModifiedMap = new Map();
 
   try {
@@ -647,7 +653,19 @@ function buildGitDateMaps() {
       }
     }
 
-    console.log(`  gitDateMaps: ${gitModifiedMap.size} files tracked`);
+    // Filter out bulk-import dates using the extracted utility
+    const { filtered, discardedDates } = filterBulkImportDates(gitCreatedMap);
+    const removed = gitCreatedMap.size - filtered.size;
+    gitCreatedMap = filtered;
+
+    if (discardedDates.length > 0) {
+      for (const { date, fileCount } of discardedDates) {
+        console.log(`  gitDateMaps: discarded bulk-import date ${date} (${fileCount} files)`);
+      }
+      console.log(`  gitDateMaps: ${gitModifiedMap.size} files tracked, ${removed} bulk-import created dates discarded`);
+    } else {
+      console.log(`  gitDateMaps: ${gitModifiedMap.size} files tracked`);
+    }
   } catch (err) {
     console.log(`  gitDateMaps: skipped (${err.message || 'unknown error'})`);
   }
@@ -690,6 +708,47 @@ async function buildEditLogDateMap() {
     return dateMap;
   } catch (err) {
     console.log(`  editLogDates: skipped (${err.message || 'server unavailable'})`);
+    return new Map();
+  }
+}
+
+/**
+ * Fetch earliest edit dates per page from the wiki-server API.
+ * Used as a fallback for dateCreated when git dates were discarded (bulk import)
+ * and no frontmatter createdAt exists.
+ * Falls back to an empty map if the server is unavailable.
+ */
+async function buildEarliestEditLogDateMap() {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl) {
+    console.log('  earliestEditLogDates: skipped (LONGTERMWIKI_SERVER_URL not set)');
+    return new Map();
+  }
+
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+    const res = await fetch(`${serverUrl}/api/edit-logs/earliest-dates`, {
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      console.log(`  earliestEditLogDates: skipped (server returned ${res.status})`);
+      return new Map();
+    }
+
+    const data = await res.json();
+    const dateMap = new Map();
+    for (const [pageId, dateStr] of Object.entries(data.dates)) {
+      dateMap.set(pageId, dateStr);
+    }
+    console.log(`  earliestEditLogDates: ${dateMap.size} pages fetched from API`);
+    return dateMap;
+  } catch (err) {
+    console.log(`  earliestEditLogDates: skipped (${err.message || 'server unavailable'})`);
     return new Map();
   }
 }
@@ -799,8 +858,9 @@ function extractFrontmatter(content) {
  * Extracts frontmatter including quality, lastUpdated, title, etc.
  * Also detects unconverted links (markdown links with matching resources)
  */
-function buildPagesRegistry(urlToResource, editLogDates, gitDateMaps) {
+function buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEditLogDates) {
   const { gitCreatedMap = new Map(), gitModifiedMap = new Map() } = gitDateMaps || {};
+  const earliestDates = earliestEditLogDates || new Map();
   const pages = [];
 
   function scanDirectory(dir, urlPrefix = '') {
@@ -861,8 +921,11 @@ function buildPagesRegistry(urlToResource, editLogDates, gitDateMaps) {
               maxDate(toDateString(fm.lastUpdated), toDateString(fm.lastEdited))
             )
           ),
-          // Derive creation date from git first-commit; fall back to frontmatter for legacy pages.
-          dateCreated: gitCreatedMap.get(relative(REPO_ROOT, fullPath)) || toDateString(fm.createdAt) || toDateString(fm.dateCreated) || null,
+          // Derive creation date: prefer explicit frontmatter, then non-bulk git
+          // first-commit, then earliest edit log from wiki-server, then legacy
+          // frontmatter. Bulk-import git dates are already filtered out of
+          // gitCreatedMap by buildGitDateMaps().
+          dateCreated: toDateString(fm.createdAt) || gitCreatedMap.get(relative(REPO_ROOT, fullPath)) || earliestDates.get(isIndexFile ? null : id) || toDateString(fm.dateCreated) || null,
           llmSummary: fm.llmSummary || null,
           description: fm.description || null,
           // Extract ratings for model pages
@@ -1133,18 +1196,19 @@ async function main() {
   const urlToResource = buildUrlToResourceMap(resources);
   console.log(`  urlToResource: ${urlToResource.size} URL variations mapped`);
 
-  // Fetch edit log dates and citation stats from wiki-server (parallel)
-  // Also build git-based date maps (synchronous, fast).
+  // Fetch edit log dates, earliest edit log dates, and citation stats from
+  // wiki-server (parallel). Also build git-based date maps (synchronous, fast).
   const gitDateMaps = CONTENT_ONLY ? { gitCreatedMap: new Map(), gitModifiedMap: new Map() } : buildGitDateMaps();
-  const [editLogDates, citationStats] = CONTENT_ONLY
-    ? [new Map(), new Map()]
+  const [editLogDates, earliestEditLogDates, citationStats] = CONTENT_ONLY
+    ? [new Map(), new Map(), new Map()]
     : await Promise.all([
         buildEditLogDateMap(),
+        buildEarliestEditLogDateMap(),
         buildCitationStatsMap(),
       ]);
 
   // Build pages registry with frontmatter data (quality, etc.)
-  const pages = buildPagesRegistry(urlToResource, editLogDates, gitDateMaps);
+  const pages = buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEditLogDates);
 
   // =========================================================================
   // CONTENT ENTITY LINKS — scan MDX for <EntityLink> references

--- a/apps/web/scripts/lib/__tests__/git-date-utils.test.mjs
+++ b/apps/web/scripts/lib/__tests__/git-date-utils.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { filterBulkImportDates, resolveDateCreated, BULK_IMPORT_THRESHOLD } from '../git-date-utils.mjs';
+
+describe('filterBulkImportDates', () => {
+  it('returns all entries when no date exceeds the threshold', () => {
+    const map = new Map([
+      ['content/docs/page-a.mdx', '2026-02-15'],
+      ['content/docs/page-b.mdx', '2026-02-16'],
+      ['content/docs/page-c.mdx', '2026-02-15'],
+    ]);
+
+    const { filtered, discardedDates } = filterBulkImportDates(map);
+    expect(filtered.size).toBe(3);
+    expect(discardedDates).toHaveLength(0);
+  });
+
+  it('removes entries whose date exceeds the threshold', () => {
+    // Use a small threshold for testing
+    const map = new Map();
+    // 10 files all with the same date (simulating bulk import)
+    for (let i = 0; i < 10; i++) {
+      map.set(`content/docs/bulk-${i}.mdx`, '2026-02-09');
+    }
+    // 3 files with unique dates (legitimate)
+    map.set('content/docs/new-a.mdx', '2026-02-15');
+    map.set('content/docs/new-b.mdx', '2026-02-16');
+    map.set('content/docs/new-c.mdx', '2026-02-17');
+
+    const { filtered, discardedDates } = filterBulkImportDates(map, 5);
+    expect(filtered.size).toBe(3);
+    expect(filtered.has('content/docs/new-a.mdx')).toBe(true);
+    expect(filtered.has('content/docs/new-b.mdx')).toBe(true);
+    expect(filtered.has('content/docs/new-c.mdx')).toBe(true);
+    expect(filtered.has('content/docs/bulk-0.mdx')).toBe(false);
+    expect(discardedDates).toHaveLength(1);
+    expect(discardedDates[0]).toEqual({ date: '2026-02-09', fileCount: 10 });
+  });
+
+  it('removes multiple bulk-import dates', () => {
+    const map = new Map();
+    // First bulk import
+    for (let i = 0; i < 8; i++) {
+      map.set(`content/docs/import1-${i}.mdx`, '2026-01-01');
+    }
+    // Second bulk import
+    for (let i = 0; i < 6; i++) {
+      map.set(`content/docs/import2-${i}.mdx`, '2026-02-01');
+    }
+    // Legitimate pages
+    map.set('content/docs/real.mdx', '2026-03-01');
+
+    const { filtered, discardedDates } = filterBulkImportDates(map, 5);
+    expect(filtered.size).toBe(1);
+    expect(filtered.get('content/docs/real.mdx')).toBe('2026-03-01');
+    expect(discardedDates).toHaveLength(2);
+  });
+
+  it('keeps entries at exactly the threshold (not strictly greater)', () => {
+    const map = new Map();
+    // Exactly 5 files with the same date
+    for (let i = 0; i < 5; i++) {
+      map.set(`content/docs/page-${i}.mdx`, '2026-02-09');
+    }
+
+    const { filtered, discardedDates } = filterBulkImportDates(map, 5);
+    // 5 is not > 5, so these should be kept
+    expect(filtered.size).toBe(5);
+    expect(discardedDates).toHaveLength(0);
+  });
+
+  it('handles empty map', () => {
+    const { filtered, discardedDates } = filterBulkImportDates(new Map());
+    expect(filtered.size).toBe(0);
+    expect(discardedDates).toHaveLength(0);
+  });
+
+  it('does not mutate the original map', () => {
+    const map = new Map();
+    for (let i = 0; i < 10; i++) {
+      map.set(`content/docs/page-${i}.mdx`, '2026-02-09');
+    }
+
+    filterBulkImportDates(map, 5);
+    expect(map.size).toBe(10); // original unchanged
+  });
+
+  it('uses the default threshold constant', () => {
+    expect(BULK_IMPORT_THRESHOLD).toBe(50);
+  });
+});
+
+describe('resolveDateCreated', () => {
+  it('prefers frontmatter createdAt over all others', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: '2025-01-01',
+      gitCreatedDate: '2026-02-15',
+      earliestEditLogDate: '2026-02-20',
+      fmDateCreated: '2025-06-01',
+    });
+    expect(result).toBe('2025-01-01');
+  });
+
+  it('falls back to git date when createdAt is null', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: null,
+      gitCreatedDate: '2026-02-15',
+      earliestEditLogDate: '2026-02-20',
+      fmDateCreated: '2025-06-01',
+    });
+    expect(result).toBe('2026-02-15');
+  });
+
+  it('falls back to earliest edit log when git date is null', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: null,
+      gitCreatedDate: null,
+      earliestEditLogDate: '2026-02-20',
+      fmDateCreated: '2025-06-01',
+    });
+    expect(result).toBe('2026-02-20');
+  });
+
+  it('falls back to legacy dateCreated when edit log is null', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: null,
+      gitCreatedDate: null,
+      earliestEditLogDate: null,
+      fmDateCreated: '2025-06-01',
+    });
+    expect(result).toBe('2025-06-01');
+  });
+
+  it('returns null when all sources are null', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: null,
+      gitCreatedDate: null,
+      earliestEditLogDate: null,
+      fmDateCreated: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('skips empty strings (falsy values)', () => {
+    const result = resolveDateCreated({
+      fmCreatedAt: '',
+      gitCreatedDate: '',
+      earliestEditLogDate: '2026-02-20',
+      fmDateCreated: null,
+    });
+    expect(result).toBe('2026-02-20');
+  });
+});

--- a/apps/web/scripts/lib/git-date-utils.mjs
+++ b/apps/web/scripts/lib/git-date-utils.mjs
@@ -1,0 +1,77 @@
+/**
+ * Git Date Utilities
+ *
+ * Pure functions for processing git-based date maps, including
+ * bulk-import detection and dateCreated fallback chain logic.
+ */
+
+/**
+ * Threshold for bulk-import detection: if more than this many files share the
+ * same git-created date, that date is treated as a bulk import/restructure and
+ * discarded from gitCreatedMap so it doesn't produce misleading dateCreated
+ * values. Individual files with legitimate creation dates are unaffected.
+ */
+export const BULK_IMPORT_THRESHOLD = 50;
+
+/**
+ * Filter out bulk-import dates from a gitCreatedMap.
+ *
+ * If more than BULK_IMPORT_THRESHOLD files share the same git-created date,
+ * those entries are removed. This prevents mass restructures (e.g. an import
+ * that touched 650 files) from giving every page an identical, meaningless
+ * creation date.
+ *
+ * @param {Map<string, string>} gitCreatedMap - Map of file path → YYYY-MM-DD
+ * @param {number} [threshold] - Override default threshold (for testing)
+ * @returns {{ filtered: Map<string, string>, discardedDates: Array<{ date: string, fileCount: number }> }}
+ */
+export function filterBulkImportDates(gitCreatedMap, threshold = BULK_IMPORT_THRESHOLD) {
+  // Count how many files share each created date
+  const dateFileCounts = new Map();
+  for (const date of gitCreatedMap.values()) {
+    dateFileCounts.set(date, (dateFileCounts.get(date) || 0) + 1);
+  }
+
+  // Identify bulk-import dates
+  const discardedDates = [];
+  for (const [date, fileCount] of dateFileCounts) {
+    if (fileCount > threshold) {
+      discardedDates.push({ date, fileCount });
+    }
+  }
+
+  if (discardedDates.length === 0) {
+    return { filtered: new Map(gitCreatedMap), discardedDates: [] };
+  }
+
+  // Filter out entries with bulk-import dates
+  const bulkDateSet = new Set(discardedDates.map(b => b.date));
+  const filtered = new Map();
+  for (const [filePath, date] of gitCreatedMap) {
+    if (!bulkDateSet.has(date)) {
+      filtered.set(filePath, date);
+    }
+  }
+
+  return { filtered, discardedDates };
+}
+
+/**
+ * Resolve the dateCreated value for a page using the standard fallback chain:
+ *
+ * 1. Frontmatter `createdAt` (explicit, highest priority)
+ * 2. Git first-commit date (with bulk-import dates already filtered)
+ * 3. Earliest edit-log date from wiki-server
+ * 4. Frontmatter `dateCreated` (legacy field)
+ * 5. null (honest about missing data)
+ *
+ * @param {object} options
+ * @param {string|null} options.fmCreatedAt - frontmatter createdAt value
+ * @param {string|null} options.gitCreatedDate - git first-commit date (already filtered for bulk imports)
+ * @param {string|null} options.earliestEditLogDate - earliest edit log from wiki-server
+ * @param {string|null} options.fmDateCreated - legacy frontmatter dateCreated value
+ * @returns {string|null}
+ */
+export function resolveDateCreated({ fmCreatedAt, gitCreatedDate, earliestEditLogDate, fmDateCreated }) {
+  return fmCreatedAt || gitCreatedDate || earliestEditLogDate || fmDateCreated || null;
+}

--- a/apps/wiki-server/src/__tests__/edit-logs.test.ts
+++ b/apps/wiki-server/src/__tests__/edit-logs.test.ts
@@ -158,6 +158,28 @@ function createMockSql() {
         .sort((a, b) => b.count - a.count);
     }
 
+    // ---- SELECT page_id, max(date) FROM edit_logs GROUP BY page_id ----
+    if (q.includes("edit_logs") && q.includes("group by") && q.includes("page_id") && q.includes("max(")) {
+      const grouped: Record<string, string> = {};
+      for (const e of editStore) {
+        if (!grouped[e.page_id] || e.date > grouped[e.page_id]) {
+          grouped[e.page_id] = e.date;
+        }
+      }
+      return Object.entries(grouped).map(([page_id, date]) => ({ page_id, date }));
+    }
+
+    // ---- SELECT page_id, min(date) FROM edit_logs GROUP BY page_id ----
+    if (q.includes("edit_logs") && q.includes("group by") && q.includes("page_id") && q.includes("min(")) {
+      const grouped: Record<string, string> = {};
+      for (const e of editStore) {
+        if (!grouped[e.page_id] || e.date < grouped[e.page_id]) {
+          grouped[e.page_id] = e.date;
+        }
+      }
+      return Object.entries(grouped).map(([page_id, date]) => ({ page_id, date }));
+    }
+
     // ---- SELECT agency, count FROM edit_logs GROUP BY agency ----
     if (q.includes("edit_logs") && q.includes("group by") && q.includes('"agency"')) {
       const counts: Record<string, number> = {};
@@ -464,6 +486,68 @@ describe("Edit Logs API", () => {
       // Should be sorted descending
       expect(body.entries[0].date).toBe("2026-02-21");
       expect(body.entries[2].date).toBe("2026-02-18");
+    });
+  });
+
+  describe("GET /api/edit-logs/latest-dates", () => {
+    it("returns latest edit date per page", async () => {
+      for (const entry of [
+        { pageId: "page-a", date: "2026-02-10", tool: "crux-create", agency: "ai-directed" },
+        { pageId: "page-a", date: "2026-02-15", tool: "crux-improve", agency: "ai-directed" },
+        { pageId: "page-a", date: "2026-02-20", tool: "crux-fix", agency: "automated" },
+        { pageId: "page-b", date: "2026-02-12", tool: "crux-create", agency: "ai-directed" },
+        { pageId: "page-b", date: "2026-02-18", tool: "crux-fix", agency: "automated" },
+      ]) {
+        await app.request("/api/edit-logs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(entry),
+        });
+      }
+
+      const res = await app.request("/api/edit-logs/latest-dates");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.dates["page-a"]).toBe("2026-02-20");
+      expect(body.dates["page-b"]).toBe("2026-02-18");
+    });
+
+    it("returns empty object when no entries exist", async () => {
+      const res = await app.request("/api/edit-logs/latest-dates");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.dates).toEqual({});
+    });
+  });
+
+  describe("GET /api/edit-logs/earliest-dates", () => {
+    it("returns earliest edit date per page", async () => {
+      for (const entry of [
+        { pageId: "page-a", date: "2026-02-10", tool: "crux-create", agency: "ai-directed" },
+        { pageId: "page-a", date: "2026-02-15", tool: "crux-improve", agency: "ai-directed" },
+        { pageId: "page-a", date: "2026-02-20", tool: "crux-fix", agency: "automated" },
+        { pageId: "page-b", date: "2026-02-12", tool: "crux-create", agency: "ai-directed" },
+        { pageId: "page-b", date: "2026-02-18", tool: "crux-fix", agency: "automated" },
+      ]) {
+        await app.request("/api/edit-logs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(entry),
+        });
+      }
+
+      const res = await app.request("/api/edit-logs/earliest-dates");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.dates["page-a"]).toBe("2026-02-10");
+      expect(body.dates["page-b"]).toBe("2026-02-12");
+    });
+
+    it("returns empty object when no entries exist", async () => {
+      const res = await app.request("/api/edit-logs/earliest-dates");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.dates).toEqual({});
     });
   });
 });

--- a/apps/wiki-server/src/routes/edit-logs.ts
+++ b/apps/wiki-server/src/routes/edit-logs.ts
@@ -189,6 +189,27 @@ const editLogsApp = new Hono()
     return c.json({ dates: dateMap });
   })
 
+  // ---- GET /earliest-dates (earliest edit date per page, for dateCreated fallback) ----
+
+  .get("/earliest-dates", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        pageId: editLogs.pageId,
+        earliestDate: sql<string>`min(${editLogs.date})`,
+      })
+      .from(editLogs)
+      .groupBy(editLogs.pageId);
+
+    const dateMap: Record<string, string> = {};
+    for (const row of rows) {
+      dateMap[row.pageId] = row.earliestDate;
+    }
+
+    return c.json({ dates: dateMap });
+  })
+
   // ---- GET /stats ----
 
   .get("/stats", async (c) => {

--- a/crux/authoring/creator/synthesis.ts
+++ b/crux/authoring/creator/synthesis.ts
@@ -237,6 +237,8 @@ Include proper frontmatter:
 ---
 title: "${topic}"
 description: "..."${destPath ? `\nentityType: "${inferEntityType(destPath) || 'concept'}"` : ''}
+createdAt: "${new Date().toISOString().split('T')[0]}"
+lastEdited: "${new Date().toISOString().split('T')[0]}"
 importance: 50
 sidebar:
   order: 50


### PR DESCRIPTION
## Summary

- Fixes the `dateCreated` field that was giving 650 of 769 pages the identical date `2026-02-09` because the bulk import commit was treated as the page creation date
- Adds bulk-import detection: if >50 files share a git-created date, discard those entries
- Inverts `dateCreated` priority: explicit frontmatter `createdAt` now takes precedence over git dates
- Adds `/earliest-dates` endpoint to edit-logs for additional dateCreated fallback
- Ensures new pages get `createdAt` in frontmatter via the content creation pipeline

## Key changes

1. **`apps/web/scripts/lib/git-date-utils.mjs`** (new) -- Extracted `filterBulkImportDates()` utility with `BULK_IMPORT_THRESHOLD = 50`
2. **`apps/web/scripts/build-data.mjs`** -- Uses the utility to discard bulk-import dates; inverted priority to `createdAt > git > earliestEditLog > dateCreated`; fetches earliest edit log dates from wiki-server
3. **`apps/wiki-server/src/routes/edit-logs.ts`** -- New `GET /earliest-dates` endpoint (mirrors existing `/latest-dates`)
4. **`crux/authoring/creator/synthesis.ts`** -- Adds `createdAt` and `lastEdited` to new page frontmatter template

## Test plan

- [x] 13 new unit tests for `filterBulkImportDates()` and `resolveDateCreated()` -- all pass
- [x] 4 new tests for `/latest-dates` and `/earliest-dates` endpoints -- all pass
- [x] Wiki-server full test suite: 449 passed
- [x] Crux full test suite: 2450/2451 passed (1 pre-existing timeout)
- [x] Gate check: all 7 checks passed
- [x] Build-data output confirms: `gitDateMaps: discarded bulk-import date 2026-02-09 (650 files)`

Closes #1358

Generated with [Claude Code](https://claude.com/claude-code)