### PR TITLE
feat: expand system health dashboard with CI, integrity, and more

### DIFF
--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -53,11 +53,78 @@ export interface IncidentDisplayRow {
   checkSource: string | null;
 }
 
+interface CiCheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+interface ExtendedHealthData {
+  ci: {
+    sha: string;
+    totalChecks: number;
+    allCompleted: boolean;
+    allPassed: boolean;
+    anyFailed: boolean;
+    checks: CiCheckRun[];
+  } | null;
+  groundskeeperTasks: Array<{
+    taskName: string;
+    totalRuns: number;
+    successCount: number;
+    failureCount: number;
+    successRate: number | null;
+    avgDurationMs: number | null;
+    lastRun: string;
+  }>;
+  integrity: {
+    totalDanglingRefs: number;
+    status: string;
+    breakdown: {
+      facts: number;
+      claims: number;
+      summaries: number;
+      citations: number;
+      editLogs: number;
+    };
+  };
+  autoUpdate: {
+    totalRuns: number;
+    recentRuns: Array<{
+      id: number;
+      date: string;
+      trigger: string;
+      pagesUpdated: number;
+      pagesFailed: number;
+      budgetSpent: number;
+      completed: boolean;
+    }>;
+  };
+  recentSessions: Array<{
+    id: number;
+    sessionId: string;
+    branch: string | null;
+    task: string | null;
+    status: string;
+    issueNumber: number | null;
+    prNumber: number | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    model: string | null;
+  }>;
+}
+
 // ── Data Loading ──────────────────────────────────────────────────────────
 
 async function loadFromApi(): Promise<FetchResult<MonitoringStatusData>> {
   return fetchDetailed<MonitoringStatusData>("/api/monitoring/status", {
     revalidate: 30,
+  });
+}
+
+async function loadExtendedData(): Promise<FetchResult<ExtendedHealthData>> {
+  return fetchDetailed<ExtendedHealthData>("/api/monitoring/extended", {
+    revalidate: 60,
   });
 }
 
@@ -198,13 +265,424 @@ function OverallBanner({ status }: { status: string }) {
   );
 }
 
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-sm font-semibold text-muted-foreground mb-3 mt-8">
+      {children}
+    </h3>
+  );
+}
+
+function CiStatusSection({ ci }: { ci: ExtendedHealthData["ci"] }) {
+  if (!ci) {
+    return (
+      <>
+        <SectionHeader>CI Pipeline (main branch)</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          CI status unavailable (GITHUB_TOKEN not configured on server)
+        </div>
+      </>
+    );
+  }
+
+  const statusColor = ci.allPassed
+    ? "text-green-600"
+    : ci.anyFailed
+      ? "text-red-500"
+      : "text-yellow-600";
+  const statusLabel = ci.allPassed
+    ? "All checks passed"
+    : ci.anyFailed
+      ? "Some checks failed"
+      : "Checks in progress";
+  const statusBg = ci.allPassed
+    ? "bg-green-500/15"
+    : ci.anyFailed
+      ? "bg-red-500/15"
+      : "bg-yellow-500/15";
+
+  return (
+    <>
+      <SectionHeader>CI Pipeline (main branch)</SectionHeader>
+      <div className={`rounded-lg border border-border/60 p-4 mb-4 ${statusBg}`}>
+        <div className="flex items-center justify-between mb-2">
+          <span className={`text-sm font-semibold ${statusColor}`}>
+            {statusLabel}
+          </span>
+          <span className="text-xs text-muted-foreground font-mono">
+            {ci.sha}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {ci.totalChecks} check{ci.totalChecks !== 1 ? "s" : ""}
+          {ci.allCompleted ? " completed" : " running"}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-6">
+        {ci.checks.map((check) => {
+          const isSuccess = check.conclusion === "success";
+          const isFailed = check.conclusion === "failure";
+          const isRunning = check.status !== "completed";
+          const bgClass = isFailed
+            ? "bg-red-500/10"
+            : isSuccess
+              ? ""
+              : isRunning
+                ? "bg-yellow-500/10"
+                : "";
+          return (
+            <div
+              key={check.name}
+              className={`rounded border border-border/60 px-3 py-2 flex items-center justify-between ${bgClass}`}
+            >
+              <span className="text-xs truncate mr-2">{check.name}</span>
+              <span
+                className={`text-xs font-medium shrink-0 ${
+                  isFailed
+                    ? "text-red-500"
+                    : isSuccess
+                      ? "text-green-600"
+                      : "text-yellow-600"
+                }`}
+              >
+                {isRunning
+                  ? check.status
+                  : check.conclusion ?? "unknown"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function GroundskeeperSection({
+  tasks,
+}: {
+  tasks: ExtendedHealthData["groundskeeperTasks"];
+}) {
+  if (tasks.length === 0) {
+    return (
+      <>
+        <SectionHeader>Groundskeeper Tasks (last 24h)</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          No task runs recorded in the last 24 hours.
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SectionHeader>Groundskeeper Tasks (last 24h)</SectionHeader>
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60">
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 pr-4">
+                Task
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                Runs
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                Success Rate
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                Avg Duration
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 pl-3">
+                Last Run
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((task) => {
+              const rateColor =
+                task.successRate === null
+                  ? ""
+                  : task.successRate >= 95
+                    ? "text-green-600"
+                    : task.successRate >= 80
+                      ? "text-yellow-600"
+                      : "text-red-500";
+              return (
+                <tr
+                  key={task.taskName}
+                  className="border-b border-border/30"
+                >
+                  <td className="py-2 pr-4 font-mono text-xs">
+                    {task.taskName}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {task.totalRuns}
+                    {task.failureCount > 0 && (
+                      <span className="text-red-500 ml-1">
+                        ({task.failureCount} failed)
+                      </span>
+                    )}
+                  </td>
+                  <td
+                    className={`py-2 px-3 text-right tabular-nums ${rateColor}`}
+                  >
+                    {task.successRate !== null
+                      ? `${task.successRate}%`
+                      : "-"}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums text-muted-foreground">
+                    {task.avgDurationMs !== null
+                      ? task.avgDurationMs > 1000
+                        ? `${(task.avgDurationMs / 1000).toFixed(1)}s`
+                        : `${task.avgDurationMs}ms`
+                      : "-"}
+                  </td>
+                  <td className="py-2 pl-3 text-right text-xs text-muted-foreground">
+                    {formatRelativeTime(task.lastRun)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function IntegritySection({
+  integrity,
+}: {
+  integrity: ExtendedHealthData["integrity"];
+}) {
+  const isClean = integrity.status === "clean";
+
+  return (
+    <>
+      <SectionHeader>Data Integrity</SectionHeader>
+      <div
+        className={`rounded-lg border border-border/60 p-4 mb-6 ${
+          isClean ? "bg-green-500/10" : "bg-yellow-500/10"
+        }`}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <span
+            className={`text-sm font-semibold ${
+              isClean ? "text-green-600" : "text-yellow-600"
+            }`}
+          >
+            {isClean
+              ? "No dangling references"
+              : `${integrity.totalDanglingRefs} dangling reference${integrity.totalDanglingRefs !== 1 ? "s" : ""}`}
+          </span>
+        </div>
+        {!isClean && (
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 mt-2">
+            {Object.entries(integrity.breakdown).map(([key, count]) =>
+              count > 0 ? (
+                <div
+                  key={key}
+                  className="text-xs text-muted-foreground"
+                >
+                  <span className="font-medium text-yellow-700">
+                    {count}
+                  </span>{" "}
+                  in {key}
+                </div>
+              ) : null
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function AutoUpdateSection({
+  autoUpdate,
+}: {
+  autoUpdate: ExtendedHealthData["autoUpdate"];
+}) {
+  return (
+    <>
+      <SectionHeader>Auto-Update System</SectionHeader>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
+        <StatCard label="Total runs" value={autoUpdate.totalRuns} />
+        <StatCard
+          label="Recent updates"
+          value={autoUpdate.recentRuns.reduce(
+            (sum, r) => sum + r.pagesUpdated,
+            0
+          )}
+          subtext="pages (last 5 runs)"
+        />
+        <StatCard
+          label="Recent failures"
+          value={autoUpdate.recentRuns.reduce(
+            (sum, r) => sum + r.pagesFailed,
+            0
+          )}
+          subtext="pages (last 5 runs)"
+          colorClass={
+            autoUpdate.recentRuns.some((r) => r.pagesFailed > 0)
+              ? "text-yellow-600"
+              : "text-green-600"
+          }
+        />
+      </div>
+      {autoUpdate.recentRuns.length > 0 && (
+        <div className="overflow-x-auto mb-6">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60">
+                <th className="text-left text-xs text-muted-foreground font-medium py-2 pr-4">
+                  Date
+                </th>
+                <th className="text-left text-xs text-muted-foreground font-medium py-2 px-3">
+                  Trigger
+                </th>
+                <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                  Updated
+                </th>
+                <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                  Failed
+                </th>
+                <th className="text-right text-xs text-muted-foreground font-medium py-2 pl-3">
+                  Cost
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {autoUpdate.recentRuns.map((run) => (
+                <tr
+                  key={run.id}
+                  className="border-b border-border/30"
+                >
+                  <td className="py-2 pr-4 text-xs">{run.date}</td>
+                  <td className="py-2 px-3 text-xs">{run.trigger}</td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {run.pagesUpdated}
+                  </td>
+                  <td
+                    className={`py-2 px-3 text-right tabular-nums ${
+                      run.pagesFailed > 0 ? "text-red-500" : ""
+                    }`}
+                  >
+                    {run.pagesFailed}
+                  </td>
+                  <td className="py-2 pl-3 text-right tabular-nums text-muted-foreground">
+                    {"$"}{run.budgetSpent.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
+function RecentSessionsSection({
+  sessions,
+}: {
+  sessions: ExtendedHealthData["recentSessions"];
+}) {
+  if (sessions.length === 0) return null;
+
+  const activeSessions = sessions.filter((s) => s.status === "active");
+  const completedSessions = sessions.filter((s) => s.status === "completed");
+
+  return (
+    <>
+      <SectionHeader>
+        Agent Sessions ({activeSessions.length} active, {completedSessions.length} recent)
+      </SectionHeader>
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60">
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 pr-4">
+                Status
+              </th>
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 px-3">
+                Branch
+              </th>
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 px-3">
+                Task
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">
+                Issue
+              </th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 pl-3">
+                Started
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map((s) => (
+              <tr
+                key={s.id}
+                className="border-b border-border/30"
+              >
+                <td className="py-2 pr-4">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      s.status === "active"
+                        ? "bg-blue-500/15 text-blue-600"
+                        : s.status === "completed"
+                          ? "bg-green-500/15 text-green-600"
+                          : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {s.status}
+                  </span>
+                </td>
+                <td className="py-2 px-3 text-xs font-mono truncate max-w-[200px]">
+                  {s.branch ?? "-"}
+                </td>
+                <td className="py-2 px-3 text-xs truncate max-w-[250px]">
+                  {s.task ?? "-"}
+                </td>
+                <td className="py-2 px-3 text-right text-xs tabular-nums">
+                  {s.issueNumber ? `#${s.issueNumber}` : "-"}
+                </td>
+                <td className="py-2 pl-3 text-right text-xs text-muted-foreground">
+                  {s.startedAt ? formatRelativeTime(s.startedAt) : "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function formatRelativeTime(isoString: string): string {
+  const now = Date.now();
+  const then = new Date(isoString).getTime();
+  const diffMs = now - then;
+
+  if (diffMs < 0) return "just now";
+  if (diffMs < 60_000) return "just now";
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+}
+
 // ── Content Component ────────────────────────────────────────────────────
 
 export async function SystemHealthContent() {
-  const { data, source, apiError } = await withApiFallback(
-    loadFromApi,
-    noLocalFallback
-  );
+  const [
+    { data, source, apiError },
+    extendedResult,
+  ] = await Promise.all([
+    withApiFallback(loadFromApi, noLocalFallback),
+    loadExtendedData(),
+  ]);
+
+  const extended = extendedResult.ok ? extendedResult.data : null;
 
   const { overall, services, dbCounts, recentIncidents, jobsQueue, activeAgents } =
     data;
@@ -285,10 +763,14 @@ export async function SystemHealthContent() {
         />
       </div>
 
+      {/* CI Pipeline Status */}
+      {extended && <CiStatusSection ci={extended.ci} />}
+
+      {/* Data Integrity */}
+      {extended && <IntegritySection integrity={extended.integrity} />}
+
       {/* Recent incidents */}
-      <h3 className="text-sm font-semibold text-muted-foreground mb-3">
-        Recent incidents (last 24h)
-      </h3>
+      <SectionHeader>Recent incidents (last 24h)</SectionHeader>
       {incidentRows.length === 0 ? (
         <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground mb-6">
           <p className="text-lg font-medium mb-2">No recent incidents</p>
@@ -299,6 +781,19 @@ export async function SystemHealthContent() {
         </div>
       ) : (
         <SystemHealthTable data={incidentRows} />
+      )}
+
+      {/* Groundskeeper Tasks */}
+      {extended && (
+        <GroundskeeperSection tasks={extended.groundskeeperTasks} />
+      )}
+
+      {/* Auto-Update System */}
+      {extended && <AutoUpdateSection autoUpdate={extended.autoUpdate} />}
+
+      {/* Agent Sessions */}
+      {extended && (
+        <RecentSessionsSection sessions={extended.recentSessions} />
       )}
 
       <DataSourceBanner source={source} apiError={apiError} />

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
-import { eq, desc, and, count, gte } from "drizzle-orm";
+import { eq, desc, and, count, gte, sql } from "drizzle-orm";
 import { getDrizzleDb, getDb } from "../db.js";
 import {
   serviceHealthIncidents,
   activeAgents,
   groundskeeperRuns,
   jobs,
+  autoUpdateRuns,
 } from "../schema.js";
 import {
   parseJsonBody,
@@ -325,7 +326,246 @@ const monitoringApp = new Hono()
 
     if (result.length === 0) return notFoundError(c, "Incident not found");
     return c.json(result[0]);
+  })
+
+  // ---- GET /extended — additional health data for the dashboard ----
+  .get("/extended", async (c) => {
+    const db = getDrizzleDb();
+    const rawDb = getDb();
+
+    // Run all queries in parallel
+    const [
+      ciResult,
+      gkStatsResult,
+      integrityResult,
+      autoUpdateResult,
+      recentSessionsResult,
+    ] = await Promise.all([
+      // 1. GitHub CI status for main branch
+      fetchCiStatus().catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch CI status");
+        return null;
+      }),
+
+      // 2. Groundskeeper task stats (last 24h)
+      fetchGroundskeeperStats(db),
+
+      // 3. Data integrity summary (dangling refs)
+      fetchIntegritySummary(rawDb),
+
+      // 4. Auto-update system stats
+      fetchAutoUpdateStats(db),
+
+      // 5. Recent agent sessions
+      fetchRecentSessions(rawDb),
+    ]);
+
+    return c.json({
+      ci: ciResult,
+      groundskeeperTasks: gkStatsResult,
+      integrity: integrityResult,
+      autoUpdate: autoUpdateResult,
+      recentSessions: recentSessionsResult,
+    });
   });
+
+// ---- Helper functions for /extended endpoint ----
+
+const GITHUB_REPO = "quantified-uncertainty/longterm-wiki";
+
+interface CiCheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+async function fetchCiStatus() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return null;
+
+  // Get the latest commit on main
+  const branchResp = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/branches/main`,
+    {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(8000),
+    }
+  );
+  if (!branchResp.ok) return null;
+
+  const branch = (await branchResp.json()) as {
+    commit: { sha: string };
+  };
+  const sha = branch.commit.sha;
+
+  // Get check runs for that commit
+  const checksResp = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/commits/${sha}/check-runs`,
+    {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(8000),
+    }
+  );
+  if (!checksResp.ok) return null;
+
+  const checksData = (await checksResp.json()) as {
+    total_count: number;
+    check_runs: Array<{
+      name: string;
+      status: string;
+      conclusion: string | null;
+      completed_at: string | null;
+    }>;
+  };
+
+  const checks: CiCheckRun[] = checksData.check_runs.map((r) => ({
+    name: r.name,
+    status: r.status,
+    conclusion: r.conclusion,
+  }));
+
+  const allCompleted = checks.every((ch) => ch.status === "completed");
+  const anyFailed = checks.some((ch) => ch.conclusion === "failure");
+  const allPassed = allCompleted && !anyFailed;
+
+  return {
+    sha: sha.slice(0, 8),
+    totalChecks: checksData.total_count,
+    allCompleted,
+    allPassed,
+    anyFailed,
+    checks,
+  };
+}
+
+async function fetchGroundskeeperStats(db: ReturnType<typeof getDrizzleDb>) {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .select({
+      taskName: groundskeeperRuns.taskName,
+      totalRuns: sql<number>`count(*)::int`,
+      successCount: sql<number>`count(*) filter (where ${groundskeeperRuns.success} = true)::int`,
+      failureCount: sql<number>`count(*) filter (where ${groundskeeperRuns.success} = false)::int`,
+      avgDurationMs: sql<number>`avg(${groundskeeperRuns.durationMs})::int`,
+      lastRun: sql<string>`max(${groundskeeperRuns.timestamp})`,
+    })
+    .from(groundskeeperRuns)
+    .where(gte(groundskeeperRuns.timestamp, since))
+    .groupBy(groundskeeperRuns.taskName);
+
+  return rows.map((r) => ({
+    taskName: r.taskName,
+    totalRuns: r.totalRuns,
+    successCount: r.successCount,
+    failureCount: r.failureCount,
+    successRate: r.totalRuns > 0 ? Math.round((r.successCount / r.totalRuns) * 100) : null,
+    avgDurationMs: r.avgDurationMs,
+    lastRun: r.lastRun,
+  }));
+}
+
+async function fetchIntegritySummary(rawDb: ReturnType<typeof getDb>) {
+  // Quick count of dangling refs across key tables
+  const result = await rawDb`
+    SELECT
+      (SELECT count(*) FROM facts WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_facts,
+      (SELECT count(*) FROM claims WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_claims,
+      (SELECT count(*) FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_summaries,
+      (SELECT count(*) FROM citation_quotes WHERE page_id NOT IN (SELECT id FROM wiki_pages))::int AS dangling_citations,
+      (SELECT count(*) FROM edit_logs WHERE page_id NOT IN (SELECT id FROM wiki_pages))::int AS dangling_edit_logs
+  `;
+
+  const row = result[0] as {
+    dangling_facts: number;
+    dangling_claims: number;
+    dangling_summaries: number;
+    dangling_citations: number;
+    dangling_edit_logs: number;
+  };
+
+  const totalDangling =
+    row.dangling_facts +
+    row.dangling_claims +
+    row.dangling_summaries +
+    row.dangling_citations +
+    row.dangling_edit_logs;
+
+  return {
+    totalDanglingRefs: totalDangling,
+    status: totalDangling === 0 ? "clean" : "issues_found",
+    breakdown: {
+      facts: row.dangling_facts,
+      claims: row.dangling_claims,
+      summaries: row.dangling_summaries,
+      citations: row.dangling_citations,
+      editLogs: row.dangling_edit_logs,
+    },
+  };
+}
+
+async function fetchAutoUpdateStats(db: ReturnType<typeof getDrizzleDb>) {
+  const [totalResult, recentRuns] = await Promise.all([
+    db.select({ count: count() }).from(autoUpdateRuns),
+    db
+      .select({
+        id: autoUpdateRuns.id,
+        date: autoUpdateRuns.date,
+        trigger: autoUpdateRuns.trigger,
+        pagesUpdated: autoUpdateRuns.pagesUpdated,
+        pagesFailed: autoUpdateRuns.pagesFailed,
+        budgetSpent: autoUpdateRuns.budgetSpent,
+        completedAt: autoUpdateRuns.completedAt,
+      })
+      .from(autoUpdateRuns)
+      .orderBy(desc(autoUpdateRuns.startedAt))
+      .limit(5),
+  ]);
+
+  return {
+    totalRuns: totalResult[0]?.count ?? 0,
+    recentRuns: recentRuns.map((r) => ({
+      id: r.id,
+      date: r.date,
+      trigger: r.trigger,
+      pagesUpdated: r.pagesUpdated ?? 0,
+      pagesFailed: r.pagesFailed ?? 0,
+      budgetSpent: r.budgetSpent ?? 0,
+      completed: r.completedAt !== null,
+    })),
+  };
+}
+
+async function fetchRecentSessions(rawDb: ReturnType<typeof getDb>) {
+  const rows = await rawDb`
+    SELECT
+      id, session_id, branch, task, status, issue_number, pr_number,
+      started_at, completed_at, model
+    FROM active_agents
+    WHERE status != 'stale'
+    ORDER BY started_at DESC NULLS LAST
+    LIMIT 10
+  `;
+
+  return rows.map((r) => ({
+    id: r.id as number,
+    sessionId: r.session_id as string,
+    branch: (r.branch as string | null) ?? null,
+    task: (r.task as string | null) ?? null,
+    status: r.status as string,
+    issueNumber: (r.issue_number as number | null) ?? null,
+    prNumber: (r.pr_number as number | null) ?? null,
+    startedAt: r.started_at ? String(r.started_at) : null,
+    completedAt: r.completed_at ? String(r.completed_at) : null,
+    model: (r.model as string | null) ?? null,
+  }));
+}
 
 export const monitoringRoute = monitoringApp;
 export type MonitoringRoute = typeof monitoringApp;


### PR DESCRIPTION
## Summary
- Adds a `/monitoring/extended` endpoint to the wiki-server that aggregates five new data sources in one call
- Expands the System Health dashboard (E927) frontend with five new sections:
  - **CI Pipeline Status**: Shows GitHub Actions check run status for the `main` branch — individual check names, pass/fail/running state, and overall summary
  - **Data Integrity**: Dangling reference count across key tables (facts, claims, summaries, citations, edit_logs), with a clean/issues-found banner
  - **Groundskeeper Tasks**: Table of all tasks run in the last 24h with run counts, success rates, avg duration, and last run time
  - **Auto-Update System**: Stats on total runs, recent pages updated/failed, costs — with a table of the last 5 runs
  - **Agent Sessions**: Recent active and completed agent sessions with branch, task, issue number, and timing

## Test plan
- [x] TypeScript type checks pass (both wiki-server and web app)
- [x] Next.js build succeeds (700+ pages)
- [x] All 360 existing tests pass
- [x] Pre-push gate checks pass (all 8 checks)
- [ ] Verify on staging that the new sections render correctly with live data
- [ ] Confirm CI status shows accurate check run information

https://claude.ai/code/session_01Csi2JyE9ThNh69vsGYJGmZ
