### PR TITLE
Remove merge conflict marker from wiki-server.ts

### DIFF
--- a/apps/groundskeeper/src/wiki-server.ts
+++ b/apps/groundskeeper/src/wiki-server.ts
@@ -1,5 +1,3 @@
-Looking at the conflict, the HEAD side uses `console.log` with a JSON structure to log the exhaustion message, while origin/main uses `logger.warn` but references `result.error` which is out of scope at that point (it's inside the loop). The HEAD version's approach of logging the exhaustion event makes more semantic sense, but I should use `logger.warn` (consistent with the rest of the file) while keeping the structured log content from HEAD.
-
 /**
  * Lightweight wiki-server API client for the groundskeeper.
  *


### PR DESCRIPTION
## Summary
Removed a merge conflict resolution comment that was accidentally left in the source code during a previous merge.

## Changes
- Removed merge conflict marker and resolution notes from the top of `apps/groundskeeper/src/wiki-server.ts`

## Details
The diff shows the removal of a multi-line comment that documented a merge conflict resolution decision between logging approaches. This appears to be leftover documentation from resolving a conflict and should not be part of the final codebase.

https://claude.ai/code/session_01EPhEBcrWZng7UL61tnpBvU