### PR TITLE
fix: remove CONCURRENTLY from Drizzle migration

### DIFF
--- a/apps/wiki-server/drizzle/0045_hallucination_risk_perf.sql
+++ b/apps/wiki-server/drizzle/0045_hallucination_risk_perf.sql
@@ -1,7 +1,7 @@
 -- Covering index for DISTINCT ON (page_id) queries on hallucination_risk_snapshots.
 -- Enables index-only scans by including all columns read by /latest and /stats endpoints.
 -- Replaces the basic (page_id, computed_at DESC) index from 0014_query_performance.sql.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_hrs_page_computed_covering
+CREATE INDEX IF NOT EXISTS idx_hrs_page_computed_covering
   ON hallucination_risk_snapshots (page_id, computed_at DESC)
   INCLUDE (id, score, level, factors, integrity_issues);
 --> statement-breakpoint


### PR DESCRIPTION
## Summary
- Remove `CONCURRENTLY` keyword from `CREATE INDEX` in migration `0045_hallucination_risk_perf.sql`
- PostgreSQL forbids `CREATE INDEX CONCURRENTLY` within transaction blocks, and Drizzle runs migrations inside transactions, causing this migration to fail

## Test plan
- [x] Gate check passes
- [x] Drizzle migration journal integrity check passes
- [x] All 373 tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)