### PR TITLE
fix: claims batch insert reliability + extract 5,410 new claims across 25 pages

### DIFF
--- a/apps/wiki-server/src/routes/claims.ts
+++ b/apps/wiki-server/src/routes/claims.ts
@@ -376,51 +376,54 @@ const claimsApp = new Hono()
         .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
       allResults.push(...rows);
     } else {
-      // Safe path: insert one at a time to guarantee ID correlation for source rows
-      const sourcesToInsert: Array<{
-        claimId: number;
-        resourceId: string | null;
-        url: string | null;
-        sourceQuote: string | null;
-        isPrimary: boolean;
-        sourceTitle: string | null;
-        sourceType: string | null;
-        sourceLocation: string | null;
-        sourceVerdict: string | null;
-        sourceVerdictScore: number | null;
-        sourceCheckedAt: Date | null;
-      }> = [];
+      // Safe path: insert one at a time to guarantee ID correlation for source rows.
+      // Wrapped in a transaction for atomicity and reduced connection hold time.
+      await db.transaction(async (tx) => {
+        const sourcesToInsert: Array<{
+          claimId: number;
+          resourceId: string | null;
+          url: string | null;
+          sourceQuote: string | null;
+          isPrimary: boolean;
+          sourceTitle: string | null;
+          sourceType: string | null;
+          sourceLocation: string | null;
+          sourceVerdict: string | null;
+          sourceVerdictScore: number | null;
+          sourceCheckedAt: Date | null;
+        }> = [];
 
-      for (const item of items) {
-        const [row] = await db
-          .insert(claims)
-          .values(claimValues(item))
-          .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
+        for (const item of items) {
+          const [row] = await tx
+            .insert(claims)
+            .values(claimValues(item))
+            .returning({ id: claims.id, entityId: claims.entityId, claimType: claims.claimType });
 
-        allResults.push(row);
+          allResults.push(row);
 
-        if (item.sources && item.sources.length > 0) {
-          for (const s of item.sources) {
-            sourcesToInsert.push({
-              claimId: row.id,
-              resourceId: s.resourceId ?? null,
-              url: s.url ?? null,
-              sourceQuote: s.sourceQuote ?? null,
-              isPrimary: s.isPrimary ?? false,
-              sourceTitle: s.sourceTitle ?? null,
-              sourceType: s.sourceType ?? null,
-              sourceLocation: s.sourceLocation ?? null,
-              sourceVerdict: s.sourceVerdict ?? null,
-              sourceVerdictScore: s.sourceVerdictScore ?? null,
-              sourceCheckedAt: s.sourceCheckedAt ? new Date(s.sourceCheckedAt) : null,
-            });
+          if (item.sources && item.sources.length > 0) {
+            for (const s of item.sources) {
+              sourcesToInsert.push({
+                claimId: row.id,
+                resourceId: s.resourceId ?? null,
+                url: s.url ?? null,
+                sourceQuote: s.sourceQuote ?? null,
+                isPrimary: s.isPrimary ?? false,
+                sourceTitle: s.sourceTitle ?? null,
+                sourceType: s.sourceType ?? null,
+                sourceLocation: s.sourceLocation ?? null,
+                sourceVerdict: s.sourceVerdict ?? null,
+                sourceVerdictScore: s.sourceVerdictScore ?? null,
+                sourceCheckedAt: s.sourceCheckedAt ? new Date(s.sourceCheckedAt) : null,
+              });
+            }
           }
         }
-      }
 
-      if (sourcesToInsert.length > 0) {
-        await db.insert(claimSources).values(sourcesToInsert);
-      }
+        if (sourcesToInsert.length > 0) {
+          await tx.insert(claimSources).values(sourcesToInsert);
+        }
+      });
     }
 
     return c.json({ inserted: allResults.length, results: allResults }, 201);

--- a/crux/lib/wiki-server/claims.ts
+++ b/crux/lib/wiki-server/claims.ts
@@ -6,7 +6,7 @@
  * stay in sync automatically when the server shape changes.
  */
 
-import { apiRequest, type ApiResult } from './client.ts';
+import { apiRequest, BATCH_TIMEOUT_MS, type ApiResult } from './client.ts';
 import type { InsertClaim } from '../../../apps/wiki-server/src/api-types.ts';
 import type { ClaimPageReferenceRow } from './references.ts';
 import type { hc, InferResponseType } from 'hono/client';
@@ -97,7 +97,7 @@ export async function insertClaimBatch(
     'POST',
     '/api/claims/batch',
     { items },
-    undefined,
+    BATCH_TIMEOUT_MS,
     'content',
   );
 }


### PR DESCRIPTION
## Summary

- **Extracted 5,410 new claims** across 25 wiki pages (up from 3,018 → 8,428 total), covering major pages like Microsoft AI, OpenAI Foundation, Epoch AI, Scheming, Agentic AI, FLI, Language Models, and more
- **Fixed batch insert reliability**: the `insertClaimBatch` client was using the default 5s timeout (`TIMEOUT_MS`) instead of the already-defined `BATCH_TIMEOUT_MS` (30s), causing timeouts under load that led to server crashes
- **Wrapped slow-path batch inserts in a transaction**: the sequential single-row INSERT loop (used when claims have sources) now runs inside `db.transaction()` for atomicity and reduced connection hold time

## Pages with new claims

microsoft (379), openai-foundation (327), deep-learning-era (353), epoch-ai (302), fli (261), language-models (274), scheming (219), agentic-ai (201), alignment (187), metr (171), scaling-laws (154), rethink-priorities (138), chris-olah (136), goodfire (122), jan-leike (116), elicit (108), cais (108), dan-hendrycks (105), pause-ai, why-alignment-hard, nick-bostrom (88), seldon-lab, palisade-research, existential-risk (57), superintelligence (42), evan-hubinger, max-tegmark, frontier-model-forum, ai-futures-project, case-against-xrisk

## Test plan

- [x] TypeScript type-check passes for both `apps/wiki-server` and `crux/`
- [x] Gate check passes (`pnpm crux validate gate`)
- [x] Claims successfully inserted and visible via `/api/claims/stats` (8,428 total)
- [x] Server recovered after crash and all pre-crash data persisted

https://claude.ai/code/session_01Uh89L6dusxcynXFkKYFfCh
