### PR TITLE
fix: verify migration renames (PR #1372) are safe, add idempotency warnings

### DIFF
--- a/crux/validate/validate-drizzle-journal.ts
+++ b/crux/validate/validate-drizzle-journal.ts
@@ -12,6 +12,24 @@
  *    Duplicate prefixes arise from branch merges and make the migration order
  *    ambiguous. Known historical duplicates are grandfathered; new ones fail.
  *
+ * 3. Journal `idx` values must be sequential and `when` values strictly increasing.
+ *    Duplicate `when` values cause the Drizzle migrator to silently skip migrations.
+ *
+ * ## How Drizzle tracks applied migrations
+ *
+ * The `__drizzle_migrations` table stores `hash` (SHA-256 of SQL content) and
+ * `created_at` (the `when` timestamp from the journal). The migrator selects the
+ * most recent `created_at` and applies any journal entry where
+ * `lastDbMigration.created_at < migration.folderMillis`.
+ *
+ * IMPORTANT: Drizzle does NOT track by filename/tag. Renaming a migration file
+ * (and updating the journal tag) is safe as long as the `when` timestamp is
+ * preserved. The SQL content hash is stored but never used for skip/apply decisions.
+ *
+ * This was verified in issue #1392 when PR #1372 renamed four migration files
+ * (0020->0041, 0022->0042, 0024->0043, 0026->0044) without changing their
+ * `when` values. Existing databases correctly skip these already-applied migrations.
+ *
  * The journal uses sequential `idx` values and `tag` = filename without .sql.
  *
  * Usage: npx tsx crux/validate/validate-drizzle-journal.ts
@@ -195,6 +213,55 @@ export function runCheck(): CheckResult {
   } else {
     console.log(
       `${c.green}Journal ordering is correct (sequential idx, strictly increasing when)${c.reset}`
+    );
+  }
+
+  // Check for non-idempotent SQL patterns in migration files.
+  // While Drizzle's timestamp-based tracking prevents accidental re-application,
+  // idempotent migrations are safer as defense-in-depth. This is a warning, not an error.
+  const idempotencyWarnings: string[] = [];
+  const NON_IDEMPOTENT_PATTERNS = [
+    { pattern: /\bCREATE\s+TABLE\b(?!\s+IF\s+NOT\s+EXISTS)/gi, fix: 'CREATE TABLE IF NOT EXISTS' },
+    { pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b(?!\s+(?:IF\s+NOT\s+EXISTS|CONCURRENTLY))/gi, fix: 'CREATE INDEX IF NOT EXISTS' },
+    { pattern: /\bALTER\s+TABLE\s+\S+\s+ADD\s+COLUMN\b(?!\s+IF\s+NOT\s+EXISTS)/gi, fix: 'ADD COLUMN IF NOT EXISTS' },
+  ];
+
+  for (const tag of sqlFiles) {
+    const filePath = join(DRIZZLE_DIR, `${tag}.sql`);
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+    // Strip SQL comments to avoid false positives on commented-out code
+    const stripped = content.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const { pattern, fix } of NON_IDEMPOTENT_PATTERNS) {
+      // Reset lastIndex for global regex
+      pattern.lastIndex = 0;
+      if (pattern.test(stripped)) {
+        idempotencyWarnings.push(`${tag}.sql: consider using ${fix}`);
+      }
+    }
+  }
+
+  if (idempotencyWarnings.length > 0) {
+    console.log(
+      `\n${c.yellow}Found ${idempotencyWarnings.length} non-idempotent SQL pattern(s) (warning only):${c.reset}\n`
+    );
+    for (const warn of idempotencyWarnings) {
+      console.log(`  ${c.yellow}${warn}${c.reset}`);
+    }
+    console.log();
+    console.log(
+      `${c.dim}Idempotent migrations (IF NOT EXISTS / IF EXISTS) are preferred for safety.${c.reset}`
+    );
+    console.log(
+      `${c.dim}Drizzle tracks by timestamp so re-application is unlikely, but idempotency is defense-in-depth.${c.reset}`
+    );
+  } else {
+    console.log(
+      `${c.green}All migration files use idempotent SQL patterns${c.reset}`
     );
   }
 


### PR DESCRIPTION
## Summary

Investigated whether the migration file renames in PR #1372 are compatible with existing databases. **Finding: the renames are safe.**

### How Drizzle tracks applied migrations

Drizzle's `__drizzle_migrations` table stores `hash` (SHA-256 of SQL content) and `created_at` (the `when` timestamp from the journal). The migrator determines which migrations to apply by:

1. Selecting the most recent `created_at` from `__drizzle_migrations` (`ORDER BY created_at DESC LIMIT 1`)
2. Applying any journal entry where `lastDbMigration.created_at < migration.folderMillis`

**Drizzle does NOT track by filename/tag.** The tag is only used to locate the `.sql` file on disk. The `hash` is stored but never used for skip/apply decisions.

### Why the renames in PR #1372 are safe

PR #1372 renamed four files (0020->0041, 0022->0042, 0024->0043, 0026->0044) and updated the journal tags to match, but preserved the `when` timestamps. Since Drizzle uses only the timestamp for comparison, existing databases will correctly skip these already-applied migrations.

### Changes in this PR

- Documented Drizzle's timestamp-based migration tracking mechanism in `validate-drizzle-journal.ts`
- Added a non-blocking idempotency check that warns about migration SQL files missing `IF NOT EXISTS` / `IF EXISTS` guards (17 existing files flagged as warnings, no errors)
- The idempotency check is advisory only -- it does not block the gate

## Test plan

- [x] `pnpm test` passes (2451 tests, 97 files)
- [x] `pnpm crux validate gate --fix` passes (all 14 checks)
- [x] TypeScript compiles clean
- [x] Drizzle journal validator correctly shows idempotency warnings without failing

Closes #1392

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>