### PR TITLE
feat: add CI check that flags PRs modifying agent rules for human review

### DIFF
--- a/.github/workflows/protected-paths-check.yml
+++ b/.github/workflows/protected-paths-check.yml
@@ -24,9 +24,15 @@ jobs:
               /^\.claude\/rules\//,
               /^\.claude\/memory\//,
               /^\.claude\/commands\//,
+              /^\.claude\/settings\.json$/,
+              /^\.claude\/hooks\//,
               /^\.github\/workflows\//,
               /^\.githooks\//,
               /^crux\/validate\//,
+              /^crux\/commands\//,
+              /^crux\/lib\/session-checklist\.ts$/,
+              /^crux\/lib\/page-templates\.ts$/,
+              /^crux\/auto-update\//,
             ];
 
             const REVIEW_LABEL = 'rules-change-reviewed';
@@ -59,9 +65,15 @@ jobs:
               'Agent rules (.claude/rules/)': [],
               'Agent memory (.claude/memory/)': [],
               'Agent commands (.claude/commands/)': [],
+              'Agent settings (.claude/settings.json)': [],
+              'Agent hooks (.claude/hooks/)': [],
               'CI workflows (.github/workflows/)': [],
               'Git hooks (.githooks/)': [],
               'Validation code (crux/validate/)': [],
+              'CLI commands (crux/commands/)': [],
+              'Session checklist (crux/lib/session-checklist.ts)': [],
+              'Page templates (crux/lib/page-templates.ts)': [],
+              'Auto-update system (crux/auto-update/)': [],
             };
 
             for (const file of protectedFiles) {
@@ -69,12 +81,18 @@ jobs:
               else if (/^\.claude\/rules\//.test(file)) categories['Agent rules (.claude/rules/)'].push(file);
               else if (/^\.claude\/memory\//.test(file)) categories['Agent memory (.claude/memory/)'].push(file);
               else if (/^\.claude\/commands\//.test(file)) categories['Agent commands (.claude/commands/)'].push(file);
+              else if (/^\.claude\/settings\.json$/.test(file)) categories['Agent settings (.claude/settings.json)'].push(file);
+              else if (/^\.claude\/hooks\//.test(file)) categories['Agent hooks (.claude/hooks/)'].push(file);
               else if (/^\.github\/workflows\//.test(file)) categories['CI workflows (.github/workflows/)'].push(file);
               else if (/^\.githooks\//.test(file)) categories['Git hooks (.githooks/)'].push(file);
               else if (/^crux\/validate\//.test(file)) categories['Validation code (crux/validate/)'].push(file);
+              else if (/^crux\/commands\//.test(file)) categories['CLI commands (crux/commands/)'].push(file);
+              else if (/^crux\/lib\/session-checklist\.ts$/.test(file)) categories['Session checklist (crux/lib/session-checklist.ts)'].push(file);
+              else if (/^crux\/lib\/page-templates\.ts$/.test(file)) categories['Page templates (crux/lib/page-templates.ts)'].push(file);
+              else if (/^crux\/auto-update\//.test(file)) categories['Auto-update system (crux/auto-update/)'].push(file);
             }
 
-            // Check if the review label is present
+            // Check if the review label is present AND was added by a human
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -82,11 +100,67 @@ jobs:
             });
             const hasReviewLabel = labels.some(l => l.name === REVIEW_LABEL);
 
+            // If the label is present, verify it was added by a human (not a bot or agent)
+            // This prevents agents from self-applying the label to bypass review.
+            const DISALLOWED_LABEL_ACTORS = [
+              'github-actions[bot]',
+              'dependabot[bot]',
+            ];
+            const DISALLOWED_ACTOR_PATTERNS = [
+              /^claude-/i,
+            ];
+
+            function isDisallowedActor(login) {
+              if (DISALLOWED_LABEL_ACTORS.includes(login)) return true;
+              return DISALLOWED_ACTOR_PATTERNS.some(p => p.test(login));
+            }
+
+            let labelAddedByHuman = false;
+            let labelActorName = null;
+
+            if (hasReviewLabel) {
+              // Fetch timeline events to find who added the label
+              const events = await github.paginate(
+                github.rest.issues.listEvents,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  per_page: 100,
+                }
+              );
+
+              // Find the most recent 'labeled' event for our review label
+              const labelEvents = events.filter(
+                e => e.event === 'labeled' && e.label?.name === REVIEW_LABEL
+              );
+              const mostRecent = labelEvents[labelEvents.length - 1];
+
+              if (mostRecent && mostRecent.actor) {
+                labelActorName = mostRecent.actor.login;
+                labelAddedByHuman = !isDisallowedActor(labelActorName);
+              }
+
+              if (!labelAddedByHuman) {
+                console.log(`Label "${REVIEW_LABEL}" was added by "${labelActorName || 'unknown'}" which is not an allowed reviewer.`);
+              } else {
+                console.log(`Label "${REVIEW_LABEL}" was added by "${labelActorName}" — accepted as human reviewer.`);
+              }
+            }
+
+            // The label counts only if it exists AND was added by an allowed actor
+            const reviewApproved = hasReviewLabel && labelAddedByHuman;
+
             // Build the comment body
-            const statusIcon = hasReviewLabel ? '✅' : '🛑';
-            const statusText = hasReviewLabel
-              ? `The \`${REVIEW_LABEL}\` label is present. A human has acknowledged these changes.`
-              : `**Action required**: Add the \`${REVIEW_LABEL}\` label after a human has reviewed the protected file changes.`;
+            const statusIcon = reviewApproved ? '✅' : '🛑';
+            let statusText;
+            if (reviewApproved) {
+              statusText = `The \`${REVIEW_LABEL}\` label is present (added by \`${labelActorName}\`). A human has acknowledged these changes.`;
+            } else if (hasReviewLabel && !labelAddedByHuman) {
+              statusText = `**Action required**: The \`${REVIEW_LABEL}\` label was added by \`${labelActorName || 'unknown'}\`, which is not recognized as a human reviewer. A human must remove and re-add the label for it to count.`;
+            } else {
+              statusText = `**Action required**: Add the \`${REVIEW_LABEL}\` label after a human has reviewed the protected file changes.`;
+            }
 
             const fileList = Object.entries(categories)
               .filter(([, files]) => files.length > 0)
@@ -111,12 +185,16 @@ jobs:
               `> **Why this check exists**: Agents have write access to their own behavioral rules. Without human review, a rule change buried in a large PR could weaken validation, bypass gates, or modify agent instructions. See [#1405](https://github.com/quantified-uncertainty/longterm-wiki/issues/1405).`,
             ].join('\n');
 
-            // Post or update the comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            // Post or update the comment (paginated to handle PRs with many comments)
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              }
+            );
             const existing = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
 
             if (existing) {
@@ -137,12 +215,19 @@ jobs:
               console.log('Posted protected-paths comment.');
             }
 
-            // Fail the check if the review label is missing
-            if (!hasReviewLabel) {
-              core.setFailed(
-                `This PR modifies ${protectedFiles.length} protected file(s) but is missing the "${REVIEW_LABEL}" label. ` +
-                `A human must review the changes to agent rules, CI workflows, or validation code and add the label before this PR can merge.`
-              );
+            // Fail the check if the review label is missing or was not added by a human
+            if (!reviewApproved) {
+              if (hasReviewLabel && !labelAddedByHuman) {
+                core.setFailed(
+                  `This PR modifies ${protectedFiles.length} protected file(s). The "${REVIEW_LABEL}" label is present but was added by "${labelActorName || 'unknown'}", ` +
+                  `which is not recognized as a human reviewer. A human must remove and re-add the label for it to count.`
+                );
+              } else {
+                core.setFailed(
+                  `This PR modifies ${protectedFiles.length} protected file(s) but is missing the "${REVIEW_LABEL}" label. ` +
+                  `A human must review the changes to agent rules, CI workflows, or validation code and add the label before this PR can merge.`
+                );
+              }
             } else {
-              console.log(`Protected files modified but "${REVIEW_LABEL}" label is present. Check passes.`);
+              console.log(`Protected files modified but "${REVIEW_LABEL}" label is present (added by "${labelActorName}"). Check passes.`);
             }


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow (`protected-paths-check.yml`) that runs on all PRs targeting `main`
- Detects when PRs modify protected paths that control agent behavior, CI pipelines, or validation logic
- Posts a categorized PR comment listing all modified protected files
- Requires the `rules-change-reviewed` label before the check passes — without it, the check fails and the PR cannot merge

### Protected paths covered

| Category | Pattern |
|----------|---------|
| Agent instructions | `CLAUDE.md` |
| Agent rules | `.claude/rules/**` |
| Agent memory | `.claude/memory/**` |
| Agent commands | `.claude/commands/**` |
| CI workflows | `.github/workflows/**` |
| Git hooks | `.githooks/**` |
| Validation code | `crux/validate/**` |

### How it works

1. On PR open/sync/label/unlabel, the workflow lists all changed files
2. Matches against the protected path patterns
3. If no protected files changed, the check passes silently
4. If protected files are found:
   - Posts (or updates) a comment grouping files by category
   - Checks for the `rules-change-reviewed` label
   - If label is missing: check **fails** with a clear error message
   - If label is present: check **passes** (human has acknowledged the changes)

### Admin action needed

To make this check effective, a repo admin should add `check-protected-paths` as a **required status check** in the branch protection rules for `main`.

### Note about this PR

This PR itself modifies `.github/workflows/` (adding the new workflow file), so it will trigger the very check it introduces. A human reviewer should add the `rules-change-reviewed` label after reviewing.

Closes #1405

## Test plan

- [ ] Verify the workflow YAML is valid (validated locally with yaml-lint)
- [ ] After merge, open a test PR that modifies a `.claude/rules/` file and confirm the check runs and fails without the label
- [ ] Add the `rules-change-reviewed` label and confirm the check re-runs and passes
- [ ] Open a PR that does NOT touch protected paths and confirm the check passes silently