### PR TITLE
safety: replace git add -A with explicit file staging in CI workflows

### DIFF
--- a/.github/workflows/auto-update-review-gate.yml
+++ b/.github/workflows/auto-update-review-gate.yml
@@ -87,11 +87,25 @@ jobs:
           if git diff --quiet && git diff --staged --quiet; then
             echo "No changes from audit — nothing to commit."
           else
-            git add -A
-            git commit -m "audit: fix citation inaccuracies (automated)
+            # Security: stage only files the citation audit is expected to modify
+            # (MDX content pages and YAML data files), not everything in the tree.
+            CHANGED_FILES=$(git diff --name-only)
+            for file in $CHANGED_FILES; do
+              if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
+                git add -- "$file"
+              else
+                echo "::warning::Skipping unexpected modified file from audit: $file"
+              fi
+            done
+
+            if ! git diff --cached --quiet; then
+              git commit -m "audit: fix citation inaccuracies (automated)
 
           Automated citation audit fixes from the review gate pipeline."
-            git push
+              git push
+            else
+              echo "No expected audit changes to commit."
+            fi
           fi
 
       - name: Post audit summary

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -301,12 +301,34 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "auto-update: ${DATE} daily wiki refresh
+
+          # Security: stage only files the auto-update pipeline is expected to
+          # modify, not everything in the working tree.
+          CHANGED_FILES=$(git diff --name-only)
+          for file in $CHANGED_FILES; do
+            if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
+              git add -- "$file"
+            else
+              echo "::warning::Skipping unexpected modified file from auto-update: $file"
+            fi
+          done
+
+          # Also stage any new (untracked) files in expected directories
+          git ls-files --others --exclude-standard -- 'content/docs/' 'data/' | while IFS= read -r file; do
+            if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
+              git add -- "$file"
+            fi
+          done
+
+          if ! git diff --cached --quiet; then
+            git commit -m "auto-update: ${DATE} daily wiki refresh
 
           Automated news-driven wiki update.
           Run report: ${{ steps.report.outputs.path }}"
-          git push -u origin "$BRANCH"
+            git push -u origin "$BRANCH"
+          else
+            echo "No expected auto-update changes to commit."
+          fi
 
       - name: Create or update PR
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -141,6 +141,19 @@ jobs:
           PR_NUMBER: ${{ matrix.number }}
         run: node .github/scripts/resolve-conflicts.mjs --no-push
 
+      # Capture the set of files touched by the merge commit so we can
+      # restrict what gets staged later (security: prevents `git add -A`
+      # from picking up unrelated modifications).
+      - name: Record merge-affected files
+        if: always() && steps.fingerprint.outputs.skip != 'true' && steps.resolve.outcome == 'success'
+        id: merge_files
+        run: |
+          # The resolve script committed the merge — list files in that commit
+          MERGE_FILES=$(git diff --name-only HEAD~1 HEAD)
+          echo "$MERGE_FILES" > /tmp/merge-affected-files.txt
+          echo "Merge-affected files:"
+          cat /tmp/merge-affected-files.txt
+
       - uses: pnpm/action-setup@v4
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.resolve.outcome == 'success'
 
@@ -190,6 +203,14 @@ jobs:
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.validate.outcome == 'failure'
         run: npm install -g @anthropic-ai/claude-code@latest
 
+      - name: "Tier 2: Snapshot files before agent run"
+        if: always() && steps.fingerprint.outputs.skip != 'true' && steps.validate.outcome == 'failure'
+        run: |
+          # Record all tracked file states before the agent runs so we can
+          # detect exactly what it changed and reject unrelated modifications.
+          git diff --name-only > /tmp/pre-agent-unstaged.txt
+          git diff --name-only --cached > /tmp/pre-agent-staged.txt
+
       - name: "Tier 2: Agentic fix with Claude Code"
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.validate.outcome == 'failure'
         id: agentic
@@ -234,6 +255,36 @@ jobs:
             --dangerously-skip-permissions \
             --verbose
 
+      - name: "Tier 2: Restrict agent changes to merge-affected files"
+        if: always() && steps.fingerprint.outputs.skip != 'true' && steps.validate.outcome == 'failure' && steps.agentic.outcome == 'success'
+        run: |
+          # Security: the agent runs with --dangerously-skip-permissions and could
+          # modify anything. Only allow changes to files from the original merge.
+          ALLOWED_FILES=/tmp/merge-affected-files.txt
+
+          # Find every file the agent touched (new unstaged + new staged, minus pre-agent state)
+          git diff --name-only > /tmp/post-agent-unstaged.txt
+          git diff --name-only --cached > /tmp/post-agent-staged.txt
+          sort -u /tmp/post-agent-unstaged.txt /tmp/post-agent-staged.txt > /tmp/post-agent-all.txt
+          sort -u /tmp/pre-agent-unstaged.txt /tmp/pre-agent-staged.txt > /tmp/pre-agent-all.txt
+          comm -23 /tmp/post-agent-all.txt /tmp/pre-agent-all.txt > /tmp/agent-touched.txt
+
+          # Unstage and revert any file the agent modified that is NOT in the merge set
+          DISALLOWED=""
+          while IFS= read -r file; do
+            if [ -n "$file" ] && ! grep -qxF "$file" "$ALLOWED_FILES" 2>/dev/null; then
+              DISALLOWED="$DISALLOWED $file"
+              echo "::warning::Reverting unauthorized agent change: $file"
+              git checkout HEAD -- "$file" 2>/dev/null || true
+            fi
+          done < /tmp/agent-touched.txt
+
+          if [ -n "$DISALLOWED" ]; then
+            echo "Reverted unauthorized changes to:$DISALLOWED"
+          else
+            echo "All agent changes are within the merge-affected file set."
+          fi
+
       - name: "Tier 2: Validate after agentic fix"
         if: always() && steps.fingerprint.outputs.skip != 'true' && steps.validate.outcome == 'failure' && steps.agentic.outcome == 'success'
         id: revalidate
@@ -267,9 +318,23 @@ jobs:
         run: |
           if ! git diff --quiet || ! git diff --cached --quiet; then
             echo "Auto-fix produced changes — committing fixes..."
-            git add -A
-            TIER="${{ steps.validate.outcome == 'success' && 'Sonnet' || 'Claude Code' }}"
-            git commit -m "Auto-fix after conflict resolution ($TIER)"
+            # Security: stage only files that were part of the original merge,
+            # not everything in the working tree (avoids committing unrelated files).
+            CHANGED_FILES=$(git diff --name-only)
+            ALLOWED_FILES=/tmp/merge-affected-files.txt
+            for file in $CHANGED_FILES; do
+              if grep -qxF "$file" "$ALLOWED_FILES" 2>/dev/null; then
+                git add -- "$file"
+              else
+                echo "::warning::Skipping unexpected modified file: $file"
+              fi
+            done
+            # Also re-stage any already-staged files (from agent or fixers)
+            STAGED_FILES=$(git diff --name-only --cached)
+            if [ -n "$STAGED_FILES" ] || [ -n "$(git diff --cached --quiet 2>&1 || echo 'has staged')" ]; then
+              TIER="${{ steps.validate.outcome == 'success' && 'Sonnet' || 'Claude Code' }}"
+              git commit -m "Auto-fix after conflict resolution ($TIER)" || echo "Nothing to commit."
+            fi
           else
             echo "No auto-fix changes — merge commit is clean."
           fi


### PR DESCRIPTION
## Summary

- Replace `git add -A` with explicit file staging in all three CI workflows that commit code, preventing unrelated or unauthorized file modifications from being silently committed
- Add a file-restriction layer for the Tier 2 conflict resolver agent (which runs with `--dangerously-skip-permissions`), reverting any changes to files outside the original merge conflict set
- Stage only expected file types (MDX content pages and YAML data files) in the auto-update and citation audit workflows

## Security rationale

Three CI workflows committed code using `git add -A`, which stages *every* untracked and modified file in the working tree. This is dangerous because:

1. **resolve-conflicts.yml** — The Tier 2 agent runs with `--dangerously-skip-permissions` and could modify any file. With `git add -A`, those modifications would be silently committed and pushed. Now: changes are restricted to files from the original merge conflict set.

2. **auto-update-review-gate.yml** — The citation audit modifies only MDX content pages and YAML data files. With `git add -A`, any other modified file (e.g., from a build artifact or tool side effect) would also be committed. Now: only `content/docs/*.mdx` and `data/**/*.yaml` files are staged.

3. **auto-update.yml** — Same pattern as the review gate. The auto-update pipeline should only touch content and data files. Now: explicit allowlist with warnings for unexpected modifications.

## Changes by workflow

### resolve-conflicts.yml
- New "Record merge-affected files" step captures the file list from the merge commit
- New "Tier 2: Snapshot files before agent run" step records pre-agent state
- New "Tier 2: Restrict agent changes to merge-affected files" step compares before/after and reverts unauthorized changes
- "Commit auto-fix changes" now stages only merge-affected files instead of `git add -A`

### auto-update-review-gate.yml
- "Commit audit fixes" now stages only files matching `content/docs/*.mdx` and `data/**/*.yaml` patterns
- Unexpected modified files produce a `::warning` annotation instead of being silently committed

### auto-update.yml
- "Commit and push" now stages only files matching content/data patterns
- Handles both modified tracked files and new untracked files in expected directories
- Unexpected files produce warnings

## Test plan

- [x] YAML syntax validated (parsed successfully with Node.js yaml library)
- [x] `pnpm build` passes
- [ ] Verify resolve-conflicts workflow on a PR with actual merge conflicts
- [ ] Verify auto-update workflow on manual dispatch
- [ ] Verify review gate on an auto-update PR

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)