### PR TITLE
security: add session expiration to admin auth tokens

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE } from "@/lib/auth";
+import {
+  ADMIN_COOKIE_NAME,
+  generateAdminToken,
+  getTokenMaxAge,
+} from "@/lib/admin-token";
 
 export async function POST(request: NextRequest) {
   const adminPassword = process.env.ADMIN_PASSWORD;
@@ -17,14 +21,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid password" }, { status: 401 });
   }
 
+  const token = await generateAdminToken(adminPassword);
+  const maxAge = getTokenMaxAge();
+
   const response = NextResponse.json({ ok: true });
-  response.cookies.set(ADMIN_COOKIE_NAME, ADMIN_TOKEN_VALUE, {
+  response.cookies.set(ADMIN_COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     path: "/",
-    // 30 days
-    maxAge: 60 * 60 * 24 * 30,
+    maxAge,
   });
 
   return response;

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { isSafeRedirect } from "@/lib/safe-redirect";
 
 function LoginForm() {
   const [password, setPassword] = useState("");
@@ -23,7 +24,8 @@ function LoginForm() {
       });
 
       if (res.ok) {
-        const redirectTo = searchParams.get("from") || "/internal";
+        const from = searchParams.get("from");
+        const redirectTo = from && isSafeRedirect(from) ? from : "/internal";
         router.push(redirectTo);
         router.refresh();
       } else {

--- a/apps/web/src/lib/__tests__/admin-token.test.ts
+++ b/apps/web/src/lib/__tests__/admin-token.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  generateAdminToken,
+  verifyAdminToken,
+  getTokenMaxAge,
+  TOKEN_MAX_AGE_SECONDS,
+} from "../admin-token";
+
+const TEST_PASSWORD = "test-secret-password-123";
+
+describe("generateAdminToken", () => {
+  it("produces a token in the format timestamp:nonce:hmac", async () => {
+    const token = await generateAdminToken(TEST_PASSWORD);
+    const parts = token.split(":");
+    expect(parts).toHaveLength(3);
+
+    const [timestamp, nonce, hmac] = parts;
+
+    // Timestamp should be a valid Unix timestamp
+    expect(parseInt(timestamp, 10)).toBeGreaterThan(0);
+
+    // Nonce should be 64 hex chars (32 bytes)
+    expect(nonce).toMatch(/^[0-9a-f]{64}$/);
+
+    // HMAC should be 64 hex chars (SHA-256 = 32 bytes)
+    expect(hmac).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("uses the provided timestamp when given", async () => {
+    const now = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, now);
+    const parts = token.split(":");
+    expect(parts[0]).toBe("1700000000");
+  });
+
+  it("generates unique tokens each time (different nonces)", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token1 = await generateAdminToken(TEST_PASSWORD, now);
+    const token2 = await generateAdminToken(TEST_PASSWORD, now);
+    expect(token1).not.toBe(token2);
+  });
+});
+
+describe("verifyAdminToken", () => {
+  it("accepts a freshly generated token", async () => {
+    const token = await generateAdminToken(TEST_PASSWORD);
+    const valid = await verifyAdminToken(token, TEST_PASSWORD);
+    expect(valid).toBe(true);
+  });
+
+  it("accepts a token with a known timestamp within the max age", async () => {
+    const now = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, now);
+    // Verify at the same time
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, now);
+    expect(valid).toBe(true);
+  });
+
+  it("accepts a token just before expiration", async () => {
+    const issueTime = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, issueTime);
+    // Check 1 second before expiration
+    const checkTime = issueTime + TOKEN_MAX_AGE_SECONDS - 1;
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, checkTime);
+    expect(valid).toBe(true);
+  });
+
+  it("rejects an expired token", async () => {
+    const issueTime = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, issueTime);
+    // Check 1 second after expiration
+    const checkTime = issueTime + TOKEN_MAX_AGE_SECONDS + 1;
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, checkTime);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects a token exactly at the expiration boundary", async () => {
+    const issueTime = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, issueTime);
+    // Check exactly at expiration + 1 second
+    const checkTime = issueTime + TOKEN_MAX_AGE_SECONDS + 1;
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, checkTime);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects tokens with future timestamps beyond clock skew tolerance", async () => {
+    const futureTime = Math.floor(Date.now() / 1000) + 120; // 2 minutes in the future
+    const token = await generateAdminToken(TEST_PASSWORD, futureTime);
+    const now = Math.floor(Date.now() / 1000);
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, now);
+    expect(valid).toBe(false);
+  });
+
+  it("accepts tokens with small future timestamps (within 60s clock skew)", async () => {
+    const now = 1700000000;
+    const slightFuture = now + 30; // 30 seconds in the future
+    const token = await generateAdminToken(TEST_PASSWORD, slightFuture);
+    const valid = await verifyAdminToken(token, TEST_PASSWORD, now);
+    expect(valid).toBe(true);
+  });
+
+  it("rejects tokens with wrong password", async () => {
+    const token = await generateAdminToken(TEST_PASSWORD);
+    const valid = await verifyAdminToken(token, "wrong-password");
+    expect(valid).toBe(false);
+  });
+
+  it("rejects empty token", async () => {
+    const valid = await verifyAdminToken("", TEST_PASSWORD);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects empty password", async () => {
+    const token = await generateAdminToken(TEST_PASSWORD);
+    const valid = await verifyAdminToken(token, "");
+    expect(valid).toBe(false);
+  });
+
+  it("rejects malformed token (too few parts)", async () => {
+    const valid = await verifyAdminToken("only-one-part", TEST_PASSWORD);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects malformed token (too many parts)", async () => {
+    const valid = await verifyAdminToken("a:b:c:d", TEST_PASSWORD);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with non-numeric timestamp", async () => {
+    const valid = await verifyAdminToken(
+      `abc:${"a".repeat(64)}:${"b".repeat(64)}`,
+      TEST_PASSWORD,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with negative timestamp", async () => {
+    const valid = await verifyAdminToken(
+      `-1:${"a".repeat(64)}:${"b".repeat(64)}`,
+      TEST_PASSWORD,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with invalid nonce (wrong length)", async () => {
+    const valid = await verifyAdminToken(
+      `1700000000:abcdef:${"b".repeat(64)}`,
+      TEST_PASSWORD,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with invalid hmac (wrong length)", async () => {
+    const valid = await verifyAdminToken(
+      `1700000000:${"a".repeat(64)}:abcdef`,
+      TEST_PASSWORD,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with tampered timestamp", async () => {
+    const now = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, now);
+    const parts = token.split(":");
+    // Change the timestamp
+    const tampered = `${now + 1}:${parts[1]}:${parts[2]}`;
+    const valid = await verifyAdminToken(tampered, TEST_PASSWORD, now);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with tampered nonce", async () => {
+    const now = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, now);
+    const parts = token.split(":");
+    // Flip a bit in the nonce
+    const tamperedNonce =
+      parts[1][0] === "a" ? "b" + parts[1].slice(1) : "a" + parts[1].slice(1);
+    const tampered = `${parts[0]}:${tamperedNonce}:${parts[2]}`;
+    const valid = await verifyAdminToken(tampered, TEST_PASSWORD, now);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects token with tampered hmac", async () => {
+    const now = 1700000000;
+    const token = await generateAdminToken(TEST_PASSWORD, now);
+    const parts = token.split(":");
+    // Flip a bit in the hmac
+    const tamperedHmac =
+      parts[2][0] === "a" ? "b" + parts[2].slice(1) : "a" + parts[2].slice(1);
+    const tampered = `${parts[0]}:${parts[1]}:${tamperedHmac}`;
+    const valid = await verifyAdminToken(tampered, TEST_PASSWORD, now);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects the old hardcoded 'authenticated' value", async () => {
+    const valid = await verifyAdminToken("authenticated", TEST_PASSWORD);
+    expect(valid).toBe(false);
+  });
+});
+
+describe("Node.js and Edge Runtime consistency", () => {
+  it("tokens generated at a specific time verify correctly at that time", async () => {
+    // This test verifies that the same crypto operations produce consistent
+    // results, which is the key property needed for Node.js/Edge Runtime parity.
+    const times = [1700000000, 1700086400, 1700172800];
+    for (const t of times) {
+      const token = await generateAdminToken(TEST_PASSWORD, t);
+      const valid = await verifyAdminToken(token, TEST_PASSWORD, t);
+      expect(valid).toBe(true);
+    }
+  });
+
+  it("token format is deterministic (same structure) across invocations", async () => {
+    const tokens = await Promise.all(
+      Array.from({ length: 10 }, () => generateAdminToken(TEST_PASSWORD)),
+    );
+
+    for (const token of tokens) {
+      const parts = token.split(":");
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toMatch(/^\d+$/);
+      expect(parts[1]).toMatch(/^[0-9a-f]{64}$/);
+      expect(parts[2]).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});
+
+describe("getTokenMaxAge", () => {
+  const envBackup: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    envBackup.ADMIN_TOKEN_MAX_AGE_SECONDS =
+      process.env.ADMIN_TOKEN_MAX_AGE_SECONDS;
+  });
+
+  afterEach(() => {
+    if (envBackup.ADMIN_TOKEN_MAX_AGE_SECONDS === undefined) {
+      delete process.env.ADMIN_TOKEN_MAX_AGE_SECONDS;
+    } else {
+      process.env.ADMIN_TOKEN_MAX_AGE_SECONDS =
+        envBackup.ADMIN_TOKEN_MAX_AGE_SECONDS;
+    }
+  });
+
+  it("returns the default when env var is not set", () => {
+    delete process.env.ADMIN_TOKEN_MAX_AGE_SECONDS;
+    expect(getTokenMaxAge()).toBe(TOKEN_MAX_AGE_SECONDS);
+  });
+
+  it("returns the env var value when set to a valid number", () => {
+    process.env.ADMIN_TOKEN_MAX_AGE_SECONDS = "3600";
+    expect(getTokenMaxAge()).toBe(3600);
+  });
+
+  it("returns the default when env var is not a valid number", () => {
+    process.env.ADMIN_TOKEN_MAX_AGE_SECONDS = "not-a-number";
+    expect(getTokenMaxAge()).toBe(TOKEN_MAX_AGE_SECONDS);
+  });
+
+  it("returns the default when env var is zero", () => {
+    process.env.ADMIN_TOKEN_MAX_AGE_SECONDS = "0";
+    expect(getTokenMaxAge()).toBe(TOKEN_MAX_AGE_SECONDS);
+  });
+
+  it("returns the default when env var is negative", () => {
+    process.env.ADMIN_TOKEN_MAX_AGE_SECONDS = "-100";
+    expect(getTokenMaxAge()).toBe(TOKEN_MAX_AGE_SECONDS);
+  });
+});

--- a/apps/web/src/lib/__tests__/safe-redirect.test.ts
+++ b/apps/web/src/lib/__tests__/safe-redirect.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { isSafeRedirect, safeRedirectOr } from "../safe-redirect";
+
+describe("isSafeRedirect", () => {
+  describe("valid paths", () => {
+    it("accepts simple relative paths", () => {
+      expect(isSafeRedirect("/internal")).toBe(true);
+      expect(isSafeRedirect("/internal/pages")).toBe(true);
+      expect(isSafeRedirect("/wiki/E42")).toBe(true);
+      expect(isSafeRedirect("/login")).toBe(true);
+    });
+
+    it("accepts paths with query strings", () => {
+      expect(isSafeRedirect("/internal?tab=pages")).toBe(true);
+      expect(isSafeRedirect("/wiki?entity=risks")).toBe(true);
+    });
+
+    it("accepts paths with fragments", () => {
+      expect(isSafeRedirect("/wiki/E42#overview")).toBe(true);
+    });
+
+    it("accepts root path", () => {
+      expect(isSafeRedirect("/")).toBe(true);
+    });
+  });
+
+  describe("protocol-relative URLs (//evil.com)", () => {
+    it("rejects protocol-relative URLs", () => {
+      expect(isSafeRedirect("//evil.com")).toBe(false);
+      expect(isSafeRedirect("//evil.com/path")).toBe(false);
+    });
+
+    it("rejects URL-encoded protocol-relative URLs", () => {
+      // %2F = /
+      expect(isSafeRedirect("/%2Fevil.com")).toBe(false);
+      expect(isSafeRedirect("/%2fevil.com")).toBe(false);
+    });
+
+    it("rejects double-encoded protocol-relative URLs", () => {
+      // %252F = %2F (after first decode) = / (after second decode)
+      expect(isSafeRedirect("/%252Fevil.com")).toBe(false);
+      expect(isSafeRedirect("/%252fevil.com")).toBe(false);
+    });
+  });
+
+  describe("backslash bypass", () => {
+    it("rejects paths with backslashes", () => {
+      expect(isSafeRedirect("/\\evil.com")).toBe(false);
+      expect(isSafeRedirect("\\evil.com")).toBe(false);
+    });
+
+    it("rejects URL-encoded backslashes", () => {
+      // %5C = backslash
+      expect(isSafeRedirect("/%5Cevil.com")).toBe(false);
+      expect(isSafeRedirect("/%5cevil.com")).toBe(false);
+    });
+
+    it("rejects double-encoded backslashes", () => {
+      // %255C = %5C (after first decode) = \ (after second decode)
+      expect(isSafeRedirect("/%255Cevil.com")).toBe(false);
+      expect(isSafeRedirect("/%255cevil.com")).toBe(false);
+    });
+  });
+
+  describe("absolute URLs", () => {
+    it("rejects http URLs", () => {
+      expect(isSafeRedirect("http://evil.com")).toBe(false);
+    });
+
+    it("rejects https URLs", () => {
+      expect(isSafeRedirect("https://evil.com")).toBe(false);
+    });
+
+    it("rejects URL-encoded scheme", () => {
+      // http%3A%2F%2F = http://
+      expect(isSafeRedirect("http%3A%2F%2Fevil.com")).toBe(false);
+    });
+  });
+
+  describe("CRLF injection", () => {
+    it("rejects paths with carriage return", () => {
+      expect(isSafeRedirect("/internal\r\nSet-Cookie: evil=true")).toBe(false);
+    });
+
+    it("rejects paths with newline", () => {
+      expect(isSafeRedirect("/internal\nevil")).toBe(false);
+    });
+
+    it("rejects URL-encoded CRLF", () => {
+      // %0D%0A = \r\n
+      expect(isSafeRedirect("/internal%0D%0ASet-Cookie:%20evil=true")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("rejects empty string", () => {
+      expect(isSafeRedirect("")).toBe(false);
+    });
+
+    it("rejects null/undefined coerced to string", () => {
+      // @ts-expect-error testing runtime behavior
+      expect(isSafeRedirect(null)).toBe(false);
+      // @ts-expect-error testing runtime behavior
+      expect(isSafeRedirect(undefined)).toBe(false);
+    });
+
+    it("rejects paths not starting with /", () => {
+      expect(isSafeRedirect("evil.com")).toBe(false);
+      expect(isSafeRedirect("internal")).toBe(false);
+    });
+
+    it("rejects javascript: scheme", () => {
+      expect(isSafeRedirect("javascript:alert(1)")).toBe(false);
+    });
+
+    it("rejects data: scheme", () => {
+      expect(isSafeRedirect("data:text/html,<h1>evil</h1>")).toBe(false);
+    });
+
+    it("handles malformed percent encoding gracefully", () => {
+      // %ZZ is not valid percent encoding — should be rejected safely
+      expect(isSafeRedirect("/%ZZ")).toBe(false);
+    });
+  });
+});
+
+describe("safeRedirectOr", () => {
+  it("returns the path when it's safe", () => {
+    expect(safeRedirectOr("/internal", "/fallback")).toBe("/internal");
+  });
+
+  it("returns the fallback for unsafe paths", () => {
+    expect(safeRedirectOr("//evil.com", "/fallback")).toBe("/fallback");
+  });
+
+  it("returns the fallback for null", () => {
+    expect(safeRedirectOr(null, "/fallback")).toBe("/fallback");
+  });
+
+  it("returns the fallback for undefined", () => {
+    expect(safeRedirectOr(undefined, "/fallback")).toBe("/fallback");
+  });
+
+  it("returns the fallback for empty string", () => {
+    expect(safeRedirectOr("", "/fallback")).toBe("/fallback");
+  });
+});

--- a/apps/web/src/lib/admin-token.ts
+++ b/apps/web/src/lib/admin-token.ts
@@ -1,0 +1,177 @@
+/**
+ * Admin session token generation and verification.
+ *
+ * Token format: `timestamp:nonce:hmac`
+ *   - timestamp: Unix seconds when the token was issued
+ *   - nonce: 32 hex chars of random data
+ *   - hmac: SHA-256 HMAC of "timestamp:nonce" keyed with ADMIN_PASSWORD
+ *
+ * Uses the Web Crypto API so it works in both Node.js and Edge Runtime.
+ *
+ * This module has NO dependency on next/headers or any server-only APIs,
+ * making it safe to import from middleware.ts (Edge Runtime).
+ */
+
+/** Cookie name for the admin session. */
+export const ADMIN_COOKIE_NAME = "admin_session";
+
+/**
+ * Default token lifetime in seconds (24 hours).
+ * Override via the ADMIN_TOKEN_MAX_AGE_SECONDS environment variable.
+ */
+export const TOKEN_MAX_AGE_SECONDS = 24 * 60 * 60;
+
+/** Get the configured token max age, falling back to the default. */
+export function getTokenMaxAge(): number {
+  const envVal = typeof process !== "undefined"
+    ? process.env?.ADMIN_TOKEN_MAX_AGE_SECONDS
+    : undefined;
+  if (envVal) {
+    const parsed = parseInt(envVal, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return TOKEN_MAX_AGE_SECONDS;
+}
+
+// ---------------------------------------------------------------------------
+// Web Crypto helpers
+// ---------------------------------------------------------------------------
+
+/** Encode a string to Uint8Array. */
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+/** Convert an ArrayBuffer to a hex string. */
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Import a password string as an HMAC CryptoKey. */
+async function getHmacKey(password: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    encode(password).buffer as ArrayBuffer,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/** Compute HMAC-SHA256 and return as hex. */
+async function hmacHex(password: string, message: string): Promise<string> {
+  const key = await getHmacKey(password);
+  const data = encode(message);
+  const sig = await crypto.subtle.sign("HMAC", key, data.buffer as ArrayBuffer);
+  return bufToHex(sig);
+}
+
+/** Constant-time comparison of two hex strings. */
+async function hmacEqual(
+  password: string,
+  message: string,
+  expectedHex: string,
+): Promise<boolean> {
+  const key = await getHmacKey(password);
+  // Re-compute and use subtle.verify for constant-time comparison
+  const sig = hexToUint8Array(expectedHex);
+  if (!sig) return false;
+  const data = encode(message);
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    sig.buffer as ArrayBuffer,
+    data.buffer as ArrayBuffer,
+  );
+}
+
+/** Convert a hex string to Uint8Array, or null if invalid. */
+function hexToUint8Array(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  if (!/^[0-9a-f]+$/i.test(hex)) return null;
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Generate 32 bytes of random hex (64 chars). */
+function randomNonce(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return bufToHex(bytes.buffer as ArrayBuffer);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a new admin session token.
+ *
+ * @param password - The ADMIN_PASSWORD value
+ * @param nowSeconds - Current Unix timestamp in seconds (for testing)
+ * @returns A token string in the format "timestamp:nonce:hmac"
+ */
+export async function generateAdminToken(
+  password: string,
+  nowSeconds?: number,
+): Promise<string> {
+  const timestamp = nowSeconds ?? Math.floor(Date.now() / 1000);
+  const nonce = randomNonce();
+  const message = `${timestamp}:${nonce}`;
+  const mac = await hmacHex(password, message);
+  return `${timestamp}:${nonce}:${mac}`;
+}
+
+/**
+ * Verify an admin session token.
+ *
+ * Checks:
+ * 1. Token format is valid (timestamp:nonce:hmac)
+ * 2. HMAC is correct for the given password
+ * 3. Token has not expired (based on configurable max age)
+ *
+ * @param token - The token string from the cookie
+ * @param password - The ADMIN_PASSWORD value
+ * @param nowSeconds - Current Unix timestamp in seconds (for testing)
+ * @returns true if the token is valid and not expired
+ */
+export async function verifyAdminToken(
+  token: string,
+  password: string,
+  nowSeconds?: number,
+): Promise<boolean> {
+  if (!token || !password) return false;
+
+  // Parse token format: "timestamp:nonce:hmac"
+  const parts = token.split(":");
+  if (parts.length !== 3) return false;
+
+  const [timestampStr, nonce, mac] = parts;
+
+  // Validate timestamp is a number
+  const timestamp = parseInt(timestampStr, 10);
+  if (isNaN(timestamp) || timestamp <= 0) return false;
+
+  // Validate nonce is hex and reasonable length (64 hex chars = 32 bytes)
+  if (!/^[0-9a-f]{64}$/i.test(nonce)) return false;
+
+  // Validate HMAC is hex and correct length (64 hex chars = 32 bytes SHA-256)
+  if (!/^[0-9a-f]{64}$/i.test(mac)) return false;
+
+  // Check expiration
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+  const maxAge = getTokenMaxAge();
+  if (now - timestamp > maxAge) return false;
+
+  // Reject tokens with future timestamps (clock skew tolerance: 60 seconds)
+  if (timestamp > now + 60) return false;
+
+  // Verify HMAC (constant-time via Web Crypto subtle.verify)
+  const message = `${timestampStr}:${nonce}`;
+  return hmacEqual(password, message, mac);
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,17 +1,27 @@
 import { cookies } from "next/headers";
 
-/** Cookie name for the admin session. */
-export const ADMIN_COOKIE_NAME = "admin_session";
-/** Simple token value stored in the cookie when authenticated. */
-export const ADMIN_TOKEN_VALUE = "authenticated";
+// Re-export shared token utilities so consumers can import from one place.
+// The core crypto lives in admin-token.ts (no next/headers dependency, Edge-safe).
+export {
+  ADMIN_COOKIE_NAME,
+  generateAdminToken,
+  verifyAdminToken,
+  TOKEN_MAX_AGE_SECONDS,
+} from "./admin-token";
 
 /**
  * Check whether the current request has a valid admin session.
  * Call from Server Components or Route Handlers (uses next/headers).
  */
 export async function isAdmin(): Promise<boolean> {
-  if (!process.env.ADMIN_PASSWORD) return false;
+  const password = process.env.ADMIN_PASSWORD;
+  if (!password) return false;
 
   const cookieStore = await cookies();
-  return cookieStore.get(ADMIN_COOKIE_NAME)?.value === ADMIN_TOKEN_VALUE;
+  const token = cookieStore.get("admin_session")?.value;
+  if (!token) return false;
+
+  // Dynamic import to avoid top-level await issues in some Next.js contexts
+  const { verifyAdminToken } = await import("./admin-token");
+  return verifyAdminToken(token, password);
 }

--- a/apps/web/src/lib/safe-redirect.ts
+++ b/apps/web/src/lib/safe-redirect.ts
@@ -1,0 +1,74 @@
+/**
+ * Validate that a redirect target is safe (same-origin, relative path).
+ *
+ * Prevents open-redirect attacks where an attacker crafts a login URL like:
+ *   /login?from=https://evil.com
+ *   /login?from=%2F%2Fevil.com   (URL-encoded //evil.com)
+ *   /login?from=/\evil.com       (backslash trick)
+ *
+ * This module has no server dependencies and can be used in both
+ * client components and Edge Runtime middleware.
+ */
+
+/**
+ * Returns true if the given path is a safe same-origin redirect target.
+ *
+ * Safe means:
+ * - Starts with a single "/" (relative path)
+ * - Does not start with "//" (protocol-relative URL)
+ * - Does not contain backslashes (which some browsers treat as forward slashes)
+ * - Does not contain CRLF characters (header injection)
+ * - After URL decoding, still satisfies all the above rules
+ *
+ * @param path - The redirect target to validate
+ * @returns true if the path is safe to redirect to
+ */
+export function isSafeRedirect(path: string): boolean {
+  if (!path || typeof path !== "string") return false;
+
+  // Decode the path to catch URL-encoded bypass attempts
+  let decoded: string;
+  try {
+    // Decode iteratively to handle double-encoding
+    decoded = path;
+    let prev = "";
+    let iterations = 0;
+    while (decoded !== prev && iterations < 5) {
+      prev = decoded;
+      decoded = decodeURIComponent(decoded);
+      iterations++;
+    }
+  } catch {
+    // If decoding fails (e.g., malformed %XX), reject
+    return false;
+  }
+
+  // Check both the original and decoded versions
+  for (const p of [path, decoded]) {
+    // Must start with exactly one forward slash
+    if (!p.startsWith("/")) return false;
+
+    // Reject protocol-relative URLs (//evil.com)
+    if (p.startsWith("//")) return false;
+
+    // Reject backslashes (some browsers normalize \ to /)
+    if (p.includes("\\")) return false;
+
+    // Reject CRLF (header injection)
+    if (p.includes("\r") || p.includes("\n")) return false;
+
+    // Reject @ in authority position (//@evil.com or /foo@evil.com before first /)
+    // This catches edge cases like //user@evil.com
+    if (p.startsWith("/@") || p.startsWith("//@")) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Return the redirect path if it's safe, or a fallback otherwise.
+ */
+export function safeRedirectOr(path: string | null | undefined, fallback: string): string {
+  if (path && isSafeRedirect(path)) return path;
+  return fallback;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-
-// Duplicated from @/lib/auth to avoid pulling in next/headers in Edge runtime.
-const ADMIN_COOKIE_NAME = "admin_session";
-const ADMIN_TOKEN_VALUE = "authenticated";
+import { ADMIN_COOKIE_NAME, verifyAdminToken } from "./lib/admin-token";
+import { isSafeRedirect } from "./lib/safe-redirect";
 
 /**
  * Middleware handles two concerns:
@@ -32,20 +30,23 @@ const KB_CATEGORIES = new Set([
   "worldviews",
 ]);
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // --- Admin auth gate ---
   // When ADMIN_PASSWORD is set, /internal/* requires a valid session cookie.
   // If not set, internal pages remain open (dev mode / no-auth deployments).
   if (pathname.startsWith("/internal")) {
-    const hasPassword = !!process.env.ADMIN_PASSWORD;
-    if (hasPassword) {
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    if (adminPassword) {
       const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
-      if (token !== ADMIN_TOKEN_VALUE) {
+      const valid = token ? await verifyAdminToken(token, adminPassword) : false;
+      if (!valid) {
         const loginUrl = request.nextUrl.clone();
         loginUrl.pathname = "/login";
-        loginUrl.searchParams.set("from", pathname);
+        if (isSafeRedirect(pathname)) {
+          loginUrl.searchParams.set("from", pathname);
+        }
         return NextResponse.redirect(loginUrl);
       }
     }
@@ -53,11 +54,15 @@ export function middleware(request: NextRequest) {
 
   // If already logged in and visiting /login, redirect to /internal
   if (pathname === "/login") {
-    const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
-    if (token === ADMIN_TOKEN_VALUE) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/internal";
-      return NextResponse.redirect(url);
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    if (adminPassword) {
+      const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+      const valid = token ? await verifyAdminToken(token, adminPassword) : false;
+      if (valid) {
+        const url = request.nextUrl.clone();
+        url.pathname = "/internal";
+        return NextResponse.redirect(url);
+      }
     }
     return NextResponse.next();
   }
@@ -70,8 +75,8 @@ export function middleware(request: NextRequest) {
 
   const segments = path.split("/").filter(Boolean);
 
-  // /browse → /wiki (legacy browse pages merged into wiki)
-  // /browse/resources → /wiki/resources, /browse/tags → /wiki/tags
+  // /browse -> /wiki (legacy browse pages merged into wiki)
+  // /browse/resources -> /wiki/resources, /browse/tags -> /wiki/tags
   if (segments[0] === "browse") {
     const url = request.nextUrl.clone();
     if (segments.length <= 1) {
@@ -82,9 +87,9 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(url, 308);
   }
 
-  // /knowledge-base → /wiki (root index page)
-  // /knowledge-base/risks → /wiki (category index — no standalone page in new site)
-  // /knowledge-base/[category/]slug → /wiki/slug
+  // /knowledge-base -> /wiki (root index page)
+  // /knowledge-base/risks -> /wiki (category index -- no standalone page in new site)
+  // /knowledge-base/[category/]slug -> /wiki/slug
   if (segments[0] === "knowledge-base") {
     const url = request.nextUrl.clone();
     if (segments.length <= 1) {
@@ -94,7 +99,7 @@ export function middleware(request: NextRequest) {
     }
     const slug = segments[segments.length - 1];
     if (segments.length === 2 && KB_CATEGORIES.has(slug)) {
-      // Category index: /knowledge-base/risks → /wiki?entity=risks
+      // Category index: /knowledge-base/risks -> /wiki?entity=risks
       // Preserve category context so the explore grid can pre-filter by type.
       url.pathname = "/wiki";
       url.searchParams.set("entity", slug);
@@ -104,7 +109,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(url, 308);
   }
 
-  // /ai-transition-model* → /wiki (ATM section removed; redirect old URLs)
+  // /ai-transition-model* -> /wiki (ATM section removed; redirect old URLs)
   if (segments[0] === "ai-transition-model" || segments[0] === "ai-transition-model-views") {
     const url = request.nextUrl.clone();
     url.pathname = "/wiki";


### PR DESCRIPTION
## Summary

- Replace hardcoded `"authenticated"` cookie value with HMAC-SHA256 tokens containing a Unix timestamp
- Tokens expire after 24 hours by default (configurable via `ADMIN_TOKEN_MAX_AGE_SECONDS` env var)
- Token format: `timestamp:nonce:hmac` where the HMAC covers both timestamp and nonce, preventing tampering
- Uses Web Crypto API (`crypto.subtle`) for consistent behavior across Node.js and Edge Runtime
- Extract `isSafeRedirect` to a shared utility with protection against URL-encoded bypass attacks (`%2F`, `%5C`, double-encoding, CRLF injection)
- Cookie `maxAge` now matches the server-side token lifetime instead of using a hardcoded 30-day value

## Changes

| File | Description |
|------|-------------|
| `apps/web/src/lib/admin-token.ts` | **New** - Core HMAC token generation/verification (Edge-safe, no next/headers) |
| `apps/web/src/lib/safe-redirect.ts` | **New** - Shared redirect validation utility |
| `apps/web/src/lib/auth.ts` | Rewritten to use `admin-token.ts` for verification |
| `apps/web/src/middleware.ts` | Uses async `verifyAdminToken()` instead of string comparison |
| `apps/web/src/app/api/auth/login/route.ts` | Generates HMAC tokens, syncs cookie maxAge with token lifetime |
| `apps/web/src/app/login/page.tsx` | Uses `isSafeRedirect()` for redirect validation |
| `apps/web/src/lib/__tests__/admin-token.test.ts` | **New** - 30 tests for token generation, expiration, tampering |
| `apps/web/src/lib/__tests__/safe-redirect.test.ts` | **New** - 27 tests including URL-encoded bypass attempts |

## Test plan

- [x] 57 new tests covering token generation, verification, expiration, tampering, and redirect validation
- [x] TypeScript type-checks pass (`npx tsc --noEmit` -- no new errors)
- [x] Existing tests pass (380 tests, 2 pre-existing failures from missing build artifacts in worktree)
- [ ] Manual testing: login flow works with new HMAC tokens
- [ ] Verify expired tokens redirect to login page

Closes #1388

---
Generated with [Claude Code](https://claude.com/claude-code)