### PR TITLE
feat: add rate limiting to wiki-server API endpoints

### DIFF
--- a/apps/wiki-server/src/__tests__/rate-limit.test.ts
+++ b/apps/wiki-server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import {
+  RateLimiter,
+  rateLimitMiddleware,
+  createDefaultRateLimiters,
+  type RateLimitConfig,
+} from "../rate-limit.js";
+
+// ---------------------------------------------------------------------------
+// RateLimiter core unit tests
+// ---------------------------------------------------------------------------
+
+describe("RateLimiter", () => {
+  it("allows requests under the limit", () => {
+    const limiter = new RateLimiter({ maxRequests: 3, windowMs: 60_000 });
+    const r1 = limiter.check("ip-1");
+    expect(r1.allowed).toBe(true);
+    expect(r1.remaining).toBe(2);
+
+    const r2 = limiter.check("ip-1");
+    expect(r2.allowed).toBe(true);
+    expect(r2.remaining).toBe(1);
+
+    const r3 = limiter.check("ip-1");
+    expect(r3.allowed).toBe(true);
+    expect(r3.remaining).toBe(0);
+  });
+
+  it("blocks requests over the limit", () => {
+    const limiter = new RateLimiter({ maxRequests: 2, windowMs: 60_000 });
+    limiter.check("ip-1");
+    limiter.check("ip-1");
+
+    const r3 = limiter.check("ip-1");
+    expect(r3.allowed).toBe(false);
+    expect(r3.remaining).toBe(0);
+    expect(r3.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("tracks different keys independently", () => {
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    const r1 = limiter.check("ip-1");
+    expect(r1.allowed).toBe(true);
+
+    const r2 = limiter.check("ip-2");
+    expect(r2.allowed).toBe(true);
+
+    // ip-1 is now over limit
+    const r3 = limiter.check("ip-1");
+    expect(r3.allowed).toBe(false);
+
+    // ip-2 is also over limit
+    const r4 = limiter.check("ip-2");
+    expect(r4.allowed).toBe(false);
+  });
+
+  it("allows requests again after the window expires", () => {
+    const windowMs = 1000;
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs });
+
+    const now = Date.now();
+    const r1 = limiter.check("ip-1", now);
+    expect(r1.allowed).toBe(true);
+
+    // Still within window
+    const r2 = limiter.check("ip-1", now + 500);
+    expect(r2.allowed).toBe(false);
+
+    // After window expires
+    const r3 = limiter.check("ip-1", now + windowMs + 1);
+    expect(r3.allowed).toBe(true);
+  });
+
+  it("provides correct retryAfterMs", () => {
+    const windowMs = 10_000;
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs });
+
+    const now = 1000000;
+    limiter.check("ip-1", now);
+
+    const result = limiter.check("ip-1", now + 3000);
+    expect(result.allowed).toBe(false);
+    // The oldest request was at `now`, so it expires at `now + windowMs`.
+    // retryAfterMs = (now + windowMs) - (now + 3000) = windowMs - 3000 = 7000
+    expect(result.retryAfterMs).toBe(7000);
+  });
+
+  it("cleanup removes expired entries", () => {
+    const windowMs = 1000;
+    const limiter = new RateLimiter({ maxRequests: 10, windowMs });
+
+    const now = Date.now();
+    limiter.check("ip-1", now);
+    limiter.check("ip-2", now);
+    expect(limiter.size).toBe(2);
+
+    // After window expires, cleanup should remove both
+    const removed = limiter.cleanup(now + windowMs + 1);
+    expect(removed).toBe(2);
+    expect(limiter.size).toBe(0);
+  });
+
+  it("cleanup keeps entries with recent timestamps", () => {
+    const windowMs = 10_000;
+    const limiter = new RateLimiter({ maxRequests: 10, windowMs });
+
+    const now = Date.now();
+    limiter.check("ip-1", now);
+    limiter.check("ip-2", now - 5000);
+
+    // Cleanup at `now` — both are within window
+    const removed = limiter.cleanup(now);
+    expect(removed).toBe(0);
+    expect(limiter.size).toBe(2);
+  });
+
+  it("reset clears all state", () => {
+    const limiter = new RateLimiter({ maxRequests: 10, windowMs: 60_000 });
+    limiter.check("ip-1");
+    limiter.check("ip-2");
+    expect(limiter.size).toBe(2);
+
+    limiter.reset();
+    expect(limiter.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware integration tests
+// ---------------------------------------------------------------------------
+
+describe("rateLimitMiddleware", () => {
+  function buildApp(readConfig: RateLimitConfig, writeConfig: RateLimitConfig) {
+    const readLimiter = new RateLimiter(readConfig);
+    const writeLimiter = new RateLimiter(writeConfig);
+
+    const app = new Hono();
+
+    app.use(
+      "*",
+      rateLimitMiddleware({
+        readLimiter,
+        writeLimiter,
+        skipPaths: ["/health"],
+      })
+    );
+
+    app.get("/api/pages", (c) => c.json({ ok: true }));
+    app.post("/api/pages", (c) => c.json({ ok: true }));
+    app.put("/api/pages/1", (c) => c.json({ ok: true }));
+    app.delete("/api/pages/1", (c) => c.json({ ok: true }));
+    app.get("/health", (c) => c.json({ status: "ok" }));
+
+    return { app, readLimiter, writeLimiter };
+  }
+
+  it("allows GET requests under the read limit", async () => {
+    const { app } = buildApp(
+      { maxRequests: 3, windowMs: 60_000 },
+      { maxRequests: 1, windowMs: 60_000 }
+    );
+
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/api/pages");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 429 for GET requests over the read limit", async () => {
+    const { app } = buildApp(
+      { maxRequests: 2, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    await app.request("/api/pages");
+    await app.request("/api/pages");
+
+    const res = await app.request("/api/pages");
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.error).toBe("rate_limit_exceeded");
+    expect(body.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("returns 429 for POST requests over the write limit", async () => {
+    const { app } = buildApp(
+      { maxRequests: 100, windowMs: 60_000 },
+      { maxRequests: 1, windowMs: 60_000 }
+    );
+
+    // First POST succeeds
+    const res1 = await app.request("/api/pages", { method: "POST" });
+    expect(res1.status).toBe(200);
+
+    // Second POST is rate limited
+    const res2 = await app.request("/api/pages", { method: "POST" });
+    expect(res2.status).toBe(429);
+  });
+
+  it("applies different limits for read vs. write", async () => {
+    const { app } = buildApp(
+      { maxRequests: 5, windowMs: 60_000 },
+      { maxRequests: 2, windowMs: 60_000 }
+    );
+
+    // Use up write limit
+    await app.request("/api/pages", { method: "POST" });
+    await app.request("/api/pages", { method: "POST" });
+
+    // Write is blocked
+    const writeRes = await app.request("/api/pages", { method: "POST" });
+    expect(writeRes.status).toBe(429);
+
+    // But read still works (different limiter)
+    const readRes = await app.request("/api/pages");
+    expect(readRes.status).toBe(200);
+  });
+
+  it("includes Retry-After header on 429 responses", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    await app.request("/api/pages");
+    const res = await app.request("/api/pages");
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThan(0);
+  });
+
+  it("includes X-RateLimit-* headers on successful responses", async () => {
+    const { app } = buildApp(
+      { maxRequests: 10, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    const res = await app.request("/api/pages");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("9");
+    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Category")).toBe("read");
+  });
+
+  it("sets category to 'write' for POST requests", async () => {
+    const { app } = buildApp(
+      { maxRequests: 10, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    const res = await app.request("/api/pages", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Category")).toBe("write");
+  });
+
+  it("treats PUT and DELETE as write requests", async () => {
+    const { app } = buildApp(
+      { maxRequests: 100, windowMs: 60_000 },
+      { maxRequests: 1, windowMs: 60_000 }
+    );
+
+    // First write request (PUT) succeeds
+    const res1 = await app.request("/api/pages/1", { method: "PUT" });
+    expect(res1.status).toBe(200);
+    expect(res1.headers.get("X-RateLimit-Category")).toBe("write");
+
+    // Second write request (DELETE) is rate limited
+    const res2 = await app.request("/api/pages/1", { method: "DELETE" });
+    expect(res2.status).toBe(429);
+  });
+
+  it("skips rate limiting for exempt paths", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 1, windowMs: 60_000 }
+    );
+
+    // Health endpoint should always work, even after limit is reached
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/health");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("uses X-Forwarded-For header for client identification", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    // First request from IP-A succeeds
+    const res1 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+    expect(res1.status).toBe(200);
+
+    // Second request from IP-A is rate limited
+    const res2 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+    expect(res2.status).toBe(429);
+
+    // Request from IP-B still succeeds
+    const res3 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "5.6.7.8" },
+    });
+    expect(res3.status).toBe(200);
+  });
+
+  it("uses first IP from X-Forwarded-For chain", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    // Request with proxy chain — should use 1.2.3.4 as the key
+    const res1 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "1.2.3.4, 10.0.0.1, 10.0.0.2" },
+    });
+    expect(res1.status).toBe(200);
+
+    // Same client IP through different proxy chain — should be rate limited
+    const res2 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "1.2.3.4, 10.0.0.99" },
+    });
+    expect(res2.status).toBe(429);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDefaultRateLimiters
+// ---------------------------------------------------------------------------
+
+describe("createDefaultRateLimiters", () => {
+  it("creates limiters with default config", () => {
+    const { readLimiter, writeLimiter } = createDefaultRateLimiters();
+    expect(readLimiter.config.maxRequests).toBe(100);
+    expect(readLimiter.config.windowMs).toBe(60_000);
+    expect(writeLimiter.config.maxRequests).toBe(20);
+    expect(writeLimiter.config.windowMs).toBe(60_000);
+  });
+
+  it("allows overriding individual limits", () => {
+    const { readLimiter, writeLimiter } = createDefaultRateLimiters({
+      read: { maxRequests: 50 },
+      write: { windowMs: 30_000 },
+    });
+    expect(readLimiter.config.maxRequests).toBe(50);
+    expect(readLimiter.config.windowMs).toBe(60_000); // default preserved
+    expect(writeLimiter.config.maxRequests).toBe(20); // default preserved
+    expect(writeLimiter.config.windowMs).toBe(30_000);
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -2,6 +2,10 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "./logger.js";
 import { validateApiKey, requireWriteScope } from "./auth.js";
+import {
+  rateLimitMiddleware,
+  createDefaultRateLimiters,
+} from "./rate-limit.js";
 import { healthRoute } from "./routes/health.js";
 import { idsRoute } from "./routes/ids.js";
 import { citationsRoute } from "./routes/citations.js";
@@ -54,6 +58,22 @@ export function createApp() {
       logger.info(logData, "request");
     }
   });
+
+  // Rate limiting middleware — applied before auth so that abusive traffic
+  // is rejected early without touching the database or auth layer.
+  // Health endpoint is exempt so monitoring probes are never throttled.
+  const { readLimiter, writeLimiter } = createDefaultRateLimiters();
+  readLimiter.startCleanup();
+  writeLimiter.startCleanup();
+
+  app.use(
+    "*",
+    rateLimitMiddleware({
+      readLimiter,
+      writeLimiter,
+      skipPaths: ["/health"],
+    })
+  );
 
   // Error handler — re-throw HTTPExceptions (auth failures etc.) so Hono
   // returns the proper status code; only catch unexpected errors as 500.

--- a/apps/wiki-server/src/rate-limit.ts
+++ b/apps/wiki-server/src/rate-limit.ts
@@ -1,0 +1,268 @@
+/**
+ * In-memory sliding-window rate limiter middleware for Hono.
+ *
+ * Provides per-IP rate limiting with configurable limits by endpoint category.
+ * Uses a simple sliding window algorithm with automatic cleanup of expired entries.
+ *
+ * Categories:
+ *   - "read"  (GET requests): generous limits (default 100 req/min)
+ *   - "write" (POST/PUT/DELETE/PATCH): stricter limits (default 20 req/min)
+ *
+ * Returns 429 Too Many Requests with a Retry-After header when limits are exceeded.
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import { logger } from "./logger.js";
+
+// ---------------------------------------------------------------------------
+// Rate limiter core
+// ---------------------------------------------------------------------------
+
+export interface RateLimitConfig {
+  /** Maximum number of requests allowed in the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+interface WindowEntry {
+  /** Timestamps of requests within the current window. */
+  timestamps: number[];
+}
+
+/**
+ * Sliding-window rate limiter. Tracks request timestamps per key and checks
+ * whether the key has exceeded its allowed request count within the window.
+ */
+export class RateLimiter {
+  private windows = new Map<string, WindowEntry>();
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  readonly config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Start periodic cleanup of expired window entries.
+   * Call this once when the server starts. Not required for tests.
+   */
+  startCleanup(intervalMs = 60_000): void {
+    this.cleanupInterval = setInterval(() => this.cleanup(), intervalMs);
+    // Don't block process exit
+    if (this.cleanupInterval.unref) {
+      this.cleanupInterval.unref();
+    }
+  }
+
+  /** Stop periodic cleanup. */
+  stopCleanup(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+  }
+
+  /**
+   * Check whether a request from `key` should be allowed.
+   *
+   * @returns `{ allowed: true, remaining, resetMs }` if under limit,
+   *          `{ allowed: false, remaining: 0, retryAfterMs }` if over limit.
+   */
+  check(key: string, now = Date.now()): RateLimitResult {
+    const windowStart = now - this.config.windowMs;
+
+    let entry = this.windows.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      this.windows.set(key, entry);
+    }
+
+    // Slide window: discard timestamps outside the current window
+    entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+
+    if (entry.timestamps.length >= this.config.maxRequests) {
+      // Over limit — calculate how long until the oldest request in the window
+      // falls out, making room for a new one.
+      const oldestInWindow = entry.timestamps[0];
+      const retryAfterMs = oldestInWindow + this.config.windowMs - now;
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs: Math.max(retryAfterMs, 1),
+        resetMs: oldestInWindow + this.config.windowMs - now,
+      };
+    }
+
+    // Under limit — record this request
+    entry.timestamps.push(now);
+    const remaining = this.config.maxRequests - entry.timestamps.length;
+    const resetMs =
+      entry.timestamps.length > 0
+        ? entry.timestamps[0] + this.config.windowMs - now
+        : this.config.windowMs;
+
+    return { allowed: true, remaining, resetMs };
+  }
+
+  /** Remove all expired entries to prevent memory growth. */
+  cleanup(now = Date.now()): number {
+    const windowStart = now - this.config.windowMs;
+    let removed = 0;
+    for (const [key, entry] of this.windows) {
+      entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+      if (entry.timestamps.length === 0) {
+        this.windows.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /** Reset all tracked state. Useful for testing. */
+  reset(): void {
+    this.windows.clear();
+  }
+
+  /** Number of tracked keys. Useful for monitoring. */
+  get size(): number {
+    return this.windows.size;
+  }
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs?: number;
+  resetMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hono middleware factory
+// ---------------------------------------------------------------------------
+
+/** Extract a client identifier from the request for rate limiting. */
+function getClientKey(c: Context): string {
+  // Check standard proxy headers first (Fly.io, Cloudflare, nginx, etc.)
+  const forwarded =
+    c.req.header("x-forwarded-for") ||
+    c.req.header("x-real-ip") ||
+    c.req.header("cf-connecting-ip");
+
+  if (forwarded) {
+    // x-forwarded-for may contain "client, proxy1, proxy2" — use the first
+    return forwarded.split(",")[0].trim();
+  }
+
+  // Fallback: not ideal in production but fine for dev/local
+  return "unknown";
+}
+
+export interface RateLimitMiddlewareOptions {
+  /** Rate limiter for GET requests. */
+  readLimiter: RateLimiter;
+  /** Rate limiter for non-GET (write) requests. */
+  writeLimiter: RateLimiter;
+  /** Methods treated as "read". Defaults to ["GET", "HEAD", "OPTIONS"]. */
+  readMethods?: string[];
+  /** Paths to skip rate limiting entirely (exact prefix match). */
+  skipPaths?: string[];
+}
+
+/**
+ * Create a Hono middleware that applies per-IP rate limiting.
+ *
+ * Uses separate limiters for read vs. write requests, allowing generous
+ * GET limits while restricting mutating operations more tightly.
+ */
+export function rateLimitMiddleware(
+  options: RateLimitMiddlewareOptions
+): MiddlewareHandler {
+  const readMethods = new Set(
+    options.readMethods ?? ["GET", "HEAD", "OPTIONS"]
+  );
+  const skipPaths = options.skipPaths ?? [];
+
+  return async (c, next) => {
+    // Check if this path should skip rate limiting
+    for (const prefix of skipPaths) {
+      if (c.req.path.startsWith(prefix)) {
+        await next();
+        return;
+      }
+    }
+
+    const clientKey = getClientKey(c);
+    const isRead = readMethods.has(c.req.method);
+    const limiter = isRead ? options.readLimiter : options.writeLimiter;
+    const category = isRead ? "read" : "write";
+
+    const result = limiter.check(clientKey);
+
+    // Always set informational headers
+    c.header("X-RateLimit-Limit", String(limiter.config.maxRequests));
+    c.header("X-RateLimit-Remaining", String(result.remaining));
+    c.header(
+      "X-RateLimit-Reset",
+      String(Math.ceil((Date.now() + result.resetMs) / 1000))
+    );
+    c.header("X-RateLimit-Category", category);
+
+    if (!result.allowed) {
+      const retryAfterSec = Math.ceil((result.retryAfterMs ?? 1000) / 1000);
+      c.header("Retry-After", String(retryAfterSec));
+
+      logger.warn(
+        { clientKey, category, path: c.req.path },
+        "Rate limit exceeded"
+      );
+
+      return c.json(
+        {
+          error: "rate_limit_exceeded",
+          message: `Too many ${category} requests. Retry after ${retryAfterSec} seconds.`,
+          retryAfter: retryAfterSec,
+        },
+        429
+      );
+    }
+
+    await next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default configuration
+// ---------------------------------------------------------------------------
+
+/** Default rate limit: 100 GET requests per minute per IP. */
+export const DEFAULT_READ_LIMIT: RateLimitConfig = {
+  maxRequests: 100,
+  windowMs: 60_000,
+};
+
+/** Default rate limit: 20 write requests per minute per IP. */
+export const DEFAULT_WRITE_LIMIT: RateLimitConfig = {
+  maxRequests: 20,
+  windowMs: 60_000,
+};
+
+/**
+ * Create preconfigured rate limiters with default settings.
+ * Override individual limits via the options parameter.
+ */
+export function createDefaultRateLimiters(overrides?: {
+  read?: Partial<RateLimitConfig>;
+  write?: Partial<RateLimitConfig>;
+}) {
+  const readLimiter = new RateLimiter({
+    ...DEFAULT_READ_LIMIT,
+    ...overrides?.read,
+  });
+  const writeLimiter = new RateLimiter({
+    ...DEFAULT_WRITE_LIMIT,
+    ...overrides?.write,
+  });
+
+  return { readLimiter, writeLimiter };
+}


### PR DESCRIPTION
## Summary

- Add in-memory sliding-window rate limiter middleware to the wiki-server, preventing abuse by limiting requests per IP
- Read endpoints (GET/HEAD/OPTIONS): 100 requests per minute per IP
- Write endpoints (POST/PUT/DELETE/PATCH): 20 requests per minute per IP
- Health endpoint (`/health`) is exempt so monitoring probes are never throttled
- Returns 429 Too Many Requests with `Retry-After` header and `X-RateLimit-*` informational headers

## Implementation details

- `RateLimiter` class with configurable sliding window, periodic cleanup of expired entries, and per-key tracking
- Client IP identification via `X-Forwarded-For`, `X-Real-IP`, or `CF-Connecting-IP` headers (first IP in proxy chain)
- Middleware is applied before auth so abusive traffic is rejected early
- No external dependencies needed (pure in-memory, suitable for single-instance deployment)

## Test plan

- [x] 21 tests covering core limiter logic and middleware integration
- [x] Requests under limit succeed with correct `X-RateLimit-*` headers
- [x] Requests over limit return 429 with `Retry-After` header
- [x] Read and write endpoints use independent rate limiters
- [x] PUT/DELETE treated as write requests
- [x] Health endpoint exempt from rate limiting
- [x] IP identification via X-Forwarded-For proxy chain
- [x] Window expiration allows requests again
- [x] Cleanup removes expired entries to prevent memory growth
- [x] All 466 existing wiki-server tests pass (no regressions)
- [x] TypeScript type check passes clean

Closes #1415

Generated with [Claude Code](https://claude.com/claude-code)