### PR TITLE
fix: backfill incidents on recovery when wiki-server was down

### DIFF
--- a/apps/groundskeeper/src/incident-buffer.test.ts
+++ b/apps/groundskeeper/src/incident-buffer.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the wiki-server module before importing anything that uses it
+vi.mock("./wiki-server.js", () => ({
+  recordIncident: vi.fn(),
+}));
+
+// Mock the logger to avoid pino output in tests
+vi.mock("./logger.js", () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+import {
+  recordFailure,
+  getCurrentOutage,
+  clearOutage,
+  addToBuffer,
+  getBufferSize,
+  getBufferSnapshot,
+  flushBuffer,
+  backfillOutageIncident,
+  _resetForTesting,
+  type BufferedIncident,
+} from "./incident-buffer.js";
+import { recordIncident } from "./wiki-server.js";
+import type { Config } from "./config.js";
+
+const mockRecordIncident = vi.mocked(recordIncident);
+
+function makeConfig(): Config {
+  return {
+    githubAppId: "test",
+    githubInstallationId: "test",
+    githubAppPrivateKey: "test",
+    githubRepo: "test/test",
+    wikiServerUrl: "http://localhost:3000",
+    discordWebhookUrl: "http://localhost/webhook",
+    dailyRunCap: 20,
+    runLogPath: "/tmp/test-run-log.json",
+    circuitBreakerCooldownMs: 60_000,
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      resolveConflicts: { enabled: false, schedule: "0 */2 * * *" },
+      codeReview: { enabled: false, schedule: "0 9 * * 1" },
+      issueResponder: { enabled: false, schedule: "*/10 * * * *" },
+    },
+  };
+}
+
+describe("incident-buffer", () => {
+  let config: Config;
+
+  beforeEach(() => {
+    config = makeConfig();
+    _resetForTesting();
+    vi.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // Outage tracking
+  // -----------------------------------------------------------------------
+  describe("outage tracking", () => {
+    it("starts with no active outage", () => {
+      expect(getCurrentOutage()).toBeNull();
+    });
+
+    it("creates an outage window on first failure", () => {
+      recordFailure();
+      const outage = getCurrentOutage();
+      expect(outage).not.toBeNull();
+      expect(outage!.consecutiveFailures).toBe(1);
+      expect(outage!.detectedAt).toBeTruthy();
+    });
+
+    it("increments consecutive failures on subsequent failures", () => {
+      recordFailure();
+      recordFailure();
+      recordFailure();
+      const outage = getCurrentOutage();
+      expect(outage!.consecutiveFailures).toBe(3);
+    });
+
+    it("preserves detectedAt across multiple failures", () => {
+      recordFailure();
+      const firstDetectedAt = getCurrentOutage()!.detectedAt;
+
+      recordFailure();
+      recordFailure();
+
+      expect(getCurrentOutage()!.detectedAt).toBe(firstDetectedAt);
+    });
+
+    it("clears outage window", () => {
+      recordFailure();
+      expect(getCurrentOutage()).not.toBeNull();
+
+      clearOutage();
+      expect(getCurrentOutage()).toBeNull();
+    });
+
+    it("starts a new outage window after clearing", () => {
+      recordFailure();
+      recordFailure();
+      clearOutage();
+
+      recordFailure();
+      const outage = getCurrentOutage();
+      expect(outage!.consecutiveFailures).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Buffer operations
+  // -----------------------------------------------------------------------
+  describe("buffer operations", () => {
+    const sampleIncident: BufferedIncident = {
+      service: "wiki-server",
+      severity: "critical",
+      title: "Test incident",
+      detail: "Some detail",
+      checkSource: "test",
+      timestamp: "2026-02-28T00:00:00.000Z",
+    };
+
+    it("starts with empty buffer", () => {
+      expect(getBufferSize()).toBe(0);
+      expect(getBufferSnapshot()).toEqual([]);
+    });
+
+    it("accumulates incidents during outage", () => {
+      addToBuffer({ ...sampleIncident, title: "Incident 1" });
+      addToBuffer({ ...sampleIncident, title: "Incident 2" });
+      addToBuffer({ ...sampleIncident, title: "Incident 3" });
+
+      expect(getBufferSize()).toBe(3);
+
+      const snapshot = getBufferSnapshot();
+      expect(snapshot).toHaveLength(3);
+      expect(snapshot[0].title).toBe("Incident 1");
+      expect(snapshot[2].title).toBe("Incident 3");
+    });
+
+    it("respects max buffer size (100 entries)", () => {
+      // Add 110 entries
+      for (let i = 0; i < 110; i++) {
+        addToBuffer({
+          ...sampleIncident,
+          title: `Incident ${i}`,
+          timestamp: `2026-02-28T00:${String(i).padStart(2, "0")}:00.000Z`,
+        });
+      }
+
+      expect(getBufferSize()).toBe(100);
+
+      // Should keep the newest 100, dropping the oldest 10
+      const snapshot = getBufferSnapshot();
+      expect(snapshot[0].title).toBe("Incident 10");
+      expect(snapshot[99].title).toBe("Incident 109");
+    });
+
+    it("returns a defensive copy from getBufferSnapshot", () => {
+      addToBuffer(sampleIncident);
+      const snapshot = getBufferSnapshot();
+      // Mutating the snapshot should not affect the internal buffer
+      (snapshot as BufferedIncident[]).push({
+        ...sampleIncident,
+        title: "Injected",
+      });
+      expect(getBufferSize()).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Buffer flushing
+  // -----------------------------------------------------------------------
+  describe("flushBuffer", () => {
+    const sampleIncident: BufferedIncident = {
+      service: "wiki-server",
+      severity: "critical",
+      title: "Buffered failure",
+      detail: "Server was down",
+      checkSource: "groundskeeper",
+      timestamp: "2026-02-28T12:00:00.000Z",
+    };
+
+    it("returns 0 when buffer is empty", async () => {
+      const flushed = await flushBuffer(config);
+      expect(flushed).toBe(0);
+      expect(mockRecordIncident).not.toHaveBeenCalled();
+    });
+
+    it("flushes all buffered incidents on recovery", async () => {
+      mockRecordIncident.mockResolvedValue(true);
+
+      addToBuffer({ ...sampleIncident, title: "Incident A" });
+      addToBuffer({ ...sampleIncident, title: "Incident B" });
+
+      const flushed = await flushBuffer(config);
+
+      expect(flushed).toBe(2);
+      expect(mockRecordIncident).toHaveBeenCalledTimes(2);
+      expect(getBufferSize()).toBe(0);
+    });
+
+    it("marks flushed incidents with buffered=true metadata", async () => {
+      mockRecordIncident.mockResolvedValue(true);
+
+      addToBuffer(sampleIncident);
+      await flushBuffer(config);
+
+      expect(mockRecordIncident).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            buffered: true,
+            originalTimestamp: sampleIncident.timestamp,
+          }),
+        })
+      );
+    });
+
+    it("counts partial successes correctly", async () => {
+      // First call succeeds, second fails
+      mockRecordIncident
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      addToBuffer({ ...sampleIncident, title: "Success" });
+      addToBuffer({ ...sampleIncident, title: "Failure" });
+
+      const flushed = await flushBuffer(config);
+
+      expect(flushed).toBe(1);
+      expect(getBufferSize()).toBe(0); // Buffer is cleared regardless
+    });
+
+    it("empties the buffer even if all flushes fail", async () => {
+      mockRecordIncident.mockResolvedValue(false);
+
+      addToBuffer(sampleIncident);
+      addToBuffer(sampleIncident);
+
+      const flushed = await flushBuffer(config);
+
+      expect(flushed).toBe(0);
+      expect(getBufferSize()).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Backfill on recovery
+  // -----------------------------------------------------------------------
+  describe("backfillOutageIncident", () => {
+    it("posts a backfill incident with detectedAt and resolvedAt", async () => {
+      mockRecordIncident.mockResolvedValue(true);
+
+      const outage = {
+        detectedAt: "2026-02-28T10:00:00.000Z",
+        consecutiveFailures: 5,
+      };
+
+      await backfillOutageIncident(config, outage);
+
+      expect(mockRecordIncident).toHaveBeenCalledTimes(1);
+      const call = mockRecordIncident.mock.calls[0];
+      expect(call[0]).toBe(config);
+
+      const payload = call[1];
+      expect(payload.service).toBe("wiki-server");
+      expect(payload.severity).toBe("critical");
+      expect(payload.title).toContain("backfilled");
+      expect(payload.detail).toContain(outage.detectedAt);
+      expect(payload.detail).toContain("5");
+      expect(payload.metadata).toMatchObject({
+        backfilled: true,
+        detectedAt: outage.detectedAt,
+        consecutiveFailures: 5,
+      });
+      // resolvedAt should be a recent ISO timestamp
+      expect(payload.metadata!.resolvedAt).toBeTruthy();
+    });
+
+    it("handles backfill failure gracefully (no throw)", async () => {
+      mockRecordIncident.mockResolvedValue(false);
+
+      const outage = {
+        detectedAt: "2026-02-28T10:00:00.000Z",
+        consecutiveFailures: 3,
+      };
+
+      // Should not throw
+      await expect(
+        backfillOutageIncident(config, outage)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Integration: full outage-to-recovery cycle
+  // -----------------------------------------------------------------------
+  describe("full outage-to-recovery cycle", () => {
+    it("tracks failures, buffers incidents, backfills on recovery, and flushes", async () => {
+      // Phase 1: Outage starts — failures accumulate
+      recordFailure();
+      addToBuffer({
+        service: "wiki-server",
+        severity: "critical",
+        title: "Check 1 failed",
+        timestamp: "2026-02-28T10:00:00.000Z",
+      });
+
+      recordFailure();
+      addToBuffer({
+        service: "wiki-server",
+        severity: "critical",
+        title: "Check 2 failed",
+        timestamp: "2026-02-28T10:05:00.000Z",
+      });
+
+      expect(getCurrentOutage()!.consecutiveFailures).toBe(2);
+      expect(getBufferSize()).toBe(2);
+
+      // Phase 2: Recovery — backfill + flush
+      mockRecordIncident.mockResolvedValue(true);
+
+      const outage = getCurrentOutage()!;
+      await backfillOutageIncident(config, outage);
+      clearOutage();
+
+      const flushed = await flushBuffer(config);
+
+      // 1 backfill + 2 buffered = 3 total calls
+      expect(mockRecordIncident).toHaveBeenCalledTimes(3);
+      expect(flushed).toBe(2);
+      expect(getCurrentOutage()).toBeNull();
+      expect(getBufferSize()).toBe(0);
+    });
+  });
+});

--- a/apps/groundskeeper/src/incident-buffer.ts
+++ b/apps/groundskeeper/src/incident-buffer.ts
@@ -1,0 +1,212 @@
+/**
+ * In-memory incident buffer for the groundskeeper.
+ *
+ * When the wiki-server is down, incident data cannot be POSTed. This module
+ * buffers incidents locally and flushes them once the server recovers. It also
+ * tracks outage windows so that a single backfill incident (with detectedAt /
+ * resolvedAt) can be created on recovery.
+ */
+
+import type { Config } from "./config.js";
+import { recordIncident } from "./wiki-server.js";
+import { logger as rootLogger } from "./logger.js";
+
+const logger = rootLogger.child({ module: "incident-buffer" });
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BufferedIncident {
+  service: string;
+  severity: string;
+  title: string;
+  detail?: string;
+  checkSource?: string;
+  metadata?: Record<string, unknown>;
+  /** ISO timestamp of when this incident was originally detected. */
+  timestamp: string;
+}
+
+export interface OutageWindow {
+  /** ISO timestamp of the first failure in the current streak. */
+  detectedAt: string;
+  /** Number of consecutive health-check failures (mirrors scheduler state). */
+  consecutiveFailures: number;
+}
+
+// ---------------------------------------------------------------------------
+// Buffer state (module-level singleton — one per process)
+// ---------------------------------------------------------------------------
+
+const MAX_BUFFER_SIZE = 100;
+
+let incidentBuffer: BufferedIncident[] = [];
+let currentOutage: OutageWindow | null = null;
+
+// ---------------------------------------------------------------------------
+// Outage tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * Call when a health-check failure occurs. Records the start of an outage
+ * window if one is not already in progress.
+ */
+export function recordFailure(): void {
+  if (!currentOutage) {
+    currentOutage = {
+      detectedAt: new Date().toISOString(),
+      consecutiveFailures: 1,
+    };
+    logger.info(
+      { detectedAt: currentOutage.detectedAt },
+      "Outage window started"
+    );
+  } else {
+    currentOutage.consecutiveFailures++;
+  }
+}
+
+/**
+ * Returns the current outage window, or null if no outage is in progress.
+ */
+export function getCurrentOutage(): OutageWindow | null {
+  return currentOutage;
+}
+
+/**
+ * Clear the outage window (called after recovery handling is complete).
+ */
+export function clearOutage(): void {
+  currentOutage = null;
+}
+
+// ---------------------------------------------------------------------------
+// Incident buffer
+// ---------------------------------------------------------------------------
+
+/**
+ * Add an incident to the in-memory buffer. Drops oldest entries when the
+ * buffer exceeds MAX_BUFFER_SIZE.
+ */
+export function addToBuffer(incident: BufferedIncident): void {
+  incidentBuffer.push(incident);
+  if (incidentBuffer.length > MAX_BUFFER_SIZE) {
+    const dropped = incidentBuffer.length - MAX_BUFFER_SIZE;
+    incidentBuffer = incidentBuffer.slice(-MAX_BUFFER_SIZE);
+    logger.warn(
+      { dropped, bufferSize: incidentBuffer.length },
+      "Buffer overflow — dropped oldest entries"
+    );
+  }
+}
+
+/**
+ * Returns the current buffer size.
+ */
+export function getBufferSize(): number {
+  return incidentBuffer.length;
+}
+
+/**
+ * Returns a snapshot of the current buffer (for testing).
+ */
+export function getBufferSnapshot(): readonly BufferedIncident[] {
+  return [...incidentBuffer];
+}
+
+/**
+ * Flush all buffered incidents to the wiki-server. Best-effort: incidents
+ * that fail to POST are logged and discarded (the server is presumably back
+ * up, so transient failures here are unlikely to recur).
+ *
+ * Returns the number of incidents successfully flushed.
+ */
+export async function flushBuffer(config: Config): Promise<number> {
+  if (incidentBuffer.length === 0) return 0;
+
+  const toFlush = [...incidentBuffer];
+  incidentBuffer = [];
+
+  let flushed = 0;
+  for (const incident of toFlush) {
+    const ok = await recordIncident(config, {
+      service: incident.service,
+      severity: incident.severity,
+      title: incident.title,
+      detail: incident.detail,
+      checkSource: incident.checkSource,
+      metadata: {
+        ...incident.metadata,
+        buffered: true,
+        originalTimestamp: incident.timestamp,
+      },
+    });
+    if (ok) {
+      flushed++;
+    } else {
+      logger.error(
+        { title: incident.title, timestamp: incident.timestamp },
+        "Failed to flush buffered incident — discarding"
+      );
+    }
+  }
+
+  logger.info(
+    { flushed, total: toFlush.length },
+    "Buffer flush complete"
+  );
+  return flushed;
+}
+
+/**
+ * Backfill an incident record for a completed outage window. Called on
+ * recovery when the wiki-server is available again.
+ */
+export async function backfillOutageIncident(
+  config: Config,
+  outage: OutageWindow
+): Promise<void> {
+  const resolvedAt = new Date().toISOString();
+
+  const ok = await recordIncident(config, {
+    service: "wiki-server",
+    severity: "critical",
+    title: "Wiki server outage (backfilled on recovery)",
+    detail: [
+      `Server was unreachable from ${outage.detectedAt} to ${resolvedAt}.`,
+      `Total consecutive failures: ${outage.consecutiveFailures}.`,
+      `This incident was recorded retroactively after recovery.`,
+    ].join(" "),
+    checkSource: "groundskeeper",
+    metadata: {
+      backfilled: true,
+      detectedAt: outage.detectedAt,
+      resolvedAt,
+      consecutiveFailures: outage.consecutiveFailures,
+    },
+  });
+  if (ok) {
+    logger.info(
+      { detectedAt: outage.detectedAt, resolvedAt },
+      "Outage incident backfilled successfully"
+    );
+  } else {
+    logger.error(
+      { detectedAt: outage.detectedAt, resolvedAt },
+      "Failed to backfill outage incident"
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset all module state. Only intended for use in tests.
+ */
+export function _resetForTesting(): void {
+  incidentBuffer = [];
+  currentOutage = null;
+}

--- a/apps/groundskeeper/src/tasks/health-check.ts
+++ b/apps/groundskeeper/src/tasks/health-check.ts
@@ -1,6 +1,17 @@
 import type { Config } from "../config.js";
 import { getOctokit, parseRepo } from "../github.js";
+import {
+  recordFailure,
+  getCurrentOutage,
+  clearOutage,
+  addToBuffer,
+  flushBuffer,
+  backfillOutageIncident,
+} from "../incident-buffer.js";
+import { logger as rootLogger } from "../logger.js";
 import { recordIncident } from "../wiki-server.js";
+
+const logger = rootLogger.child({ task: "health-check" });
 
 const ISSUE_TITLE = "[Groundskeeper] Wiki server health check failure";
 
@@ -71,6 +82,21 @@ export async function healthCheck(
   const existingIssue = await findOpenHealthIssue(config);
 
   if (serverUp) {
+    // Recovery path: if there was an active outage, backfill the incident
+    // and flush any buffered incidents now that the server is reachable.
+    const outage = getCurrentOutage();
+    if (outage) {
+      await backfillOutageIncident(config, outage);
+      clearOutage();
+      logger.info("Outage window closed — backfill incident recorded");
+    }
+
+    // Flush any incidents that were buffered while the server was down
+    const flushed = await flushBuffer(config);
+    if (flushed > 0) {
+      logger.info({ flushed }, "Flushed buffered incidents on recovery");
+    }
+
     // Server is up — close any existing issue
     if (existingIssue) {
       await octokit.rest.issues.update({
@@ -84,7 +110,7 @@ export async function healthCheck(
         owner,
         repo,
         issue_number: existingIssue.number,
-        body: `✅ Wiki server is back up at ${new Date().toISOString()}.`,
+        body: `Wiki server is back up at ${new Date().toISOString()}.`,
       });
       return {
         success: true,
@@ -94,14 +120,27 @@ export async function healthCheck(
     return { success: true, summary: "Server up" };
   }
 
-  // Server is down — record incident (best-effort; will fail if wiki-server is what's down)
-  await recordIncident(config, {
+  // Server is down — track the failure for outage window detection
+  recordFailure();
+
+  // Try to record incident to wiki-server; if it fails (expected when the
+  // wiki-server itself is down), buffer it locally for later flushing.
+  const incidentPayload = {
     service: "wiki-server",
     severity: "critical",
     title: "Wiki server health check failure",
     detail: `Server at ${config.wikiServerUrl} is not responding to /health endpoint`,
     checkSource: "groundskeeper",
-  }).catch(() => {});
+  };
+
+  const recorded = await recordIncident(config, incidentPayload);
+  if (!recorded) {
+    addToBuffer({
+      ...incidentPayload,
+      timestamp: new Date().toISOString(),
+    });
+    logger.info("Incident buffered locally (wiki-server unreachable)");
+  }
 
   // Add comment to existing open issue instead of creating duplicates
   if (existingIssue) {

--- a/apps/groundskeeper/src/wiki-server.ts
+++ b/apps/groundskeeper/src/wiki-server.ts
@@ -191,6 +191,8 @@ export async function updateActiveAgent(
  * If wiki-server is the thing that's down, this call will also fail — that's
  * expected. The groundskeeper health-check task also creates GitHub issues
  * as a fallback notification channel.
+ *
+ * Returns true if the incident was recorded successfully, false otherwise.
  */
 export async function recordIncident(
   config: Config,
@@ -202,7 +204,7 @@ export async function recordIncident(
     checkSource?: string;
     metadata?: Record<string, unknown>;
   },
-): Promise<void> {
+): Promise<boolean> {
   const result = await apiRequest(
     config,
     "POST",
@@ -214,7 +216,9 @@ export async function recordIncident(
       { event: "incident_recording_failed", endpoint: "/api/monitoring/incidents", error: result.error },
       "Failed to record incident to wiki-server",
     );
+    return false;
   }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the chicken-and-egg problem where incident recording fails when the wiki-server is down, causing the monitoring dashboard to show "0 open incidents" during active outages.

- **Outage window tracking**: Records when the first failure occurs. On recovery, retroactively creates a single backfill incident with `detectedAt` and `resolvedAt` timestamps spanning the full outage.
- **In-memory incident buffer**: When `recordIncident()` fails (wiki-server unreachable), buffers incident data locally (max 100 entries, drops oldest on overflow). Flushes to wiki-server on the next successful health check.
- **`recordIncident()` return type**: Changed from `Promise<void>` to `Promise<boolean>` so callers can detect failures without relying on exceptions.
- **18 new tests**: Outage tracking, buffer accumulation, overflow handling, flush behavior, backfill on recovery, and a full outage-to-recovery integration cycle.

Closes #1418

## Test plan

- [x] New `incident-buffer.test.ts` covers all buffer and outage tracking logic (18 tests)
- [x] All 58 groundskeeper tests pass (verified in main repo with full deps)
- [x] Full project build passes (`pnpm build`)
- [x] Full test suite passes (`pnpm test` — 2422 tests across 97 files)
- [ ] CI green after push

Generated with [Claude Code](https://claude.com/claude-code)