### PR TITLE
safety: add global automation circuit breaker for cascading failures

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -26,7 +26,16 @@ concurrency:
   cancel-in-progress: true # newer run supersedes an in-progress rebase
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Automation is active"
+
   rebase-open-prs:
+    needs: [preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/auto-update-review-gate.yml
+++ b/.github/workflows/auto-update-review-gate.yml
@@ -16,9 +16,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    if: >-
+      vars.AUTOMATION_PAUSED != 'true' &&
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'auto-update')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   audit-gate:
-    # Only run on non-draft auto-update PRs
-    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-update')
+    needs: [preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -42,7 +42,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   auto-update:
+    needs: [preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -24,8 +24,10 @@ concurrency:
 
 jobs:
   autofix:
-    # Only run when CI failed on a claude/* branch (not main, not human branches)
+    # Only run when CI failed on a claude/* branch (not main, not human branches).
+    # Global circuit breaker — also skip when automation is paused.
     if: |
+      vars.AUTOMATION_PAUSED != 'true' &&
       github.event.workflow_run.conclusion == 'failure' &&
       startsWith(github.event.workflow_run.head_branch, 'claude/')
     runs-on: ubuntu-latest

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -20,6 +20,9 @@ on:
 
 jobs:
   backup:
+    # Global circuit breaker — skip when automation is paused.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
     name: Backup database
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -20,7 +20,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   backup:
+    needs: [preflight]
     name: Export wiki-server data
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/job-worker.yml
+++ b/.github/workflows/job-worker.yml
@@ -49,7 +49,22 @@ env:
   LONGTERMWIKI_CONTENT_KEY: ${{ secrets.LONGTERMWIKI_CONTENT_KEY }}
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   process-jobs:
+    needs: [preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -32,7 +32,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Automation is active"
+
   find-conflicted-prs:
+    needs: [preflight]
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -22,6 +22,9 @@ on:
 
 jobs:
   trigger-production-deploy:
+    # Global circuit breaker — skip when automation is paused.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -37,7 +37,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   maintain:
+    needs: [preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -11,7 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   sync-data:
+    needs: [preflight]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-entities-facts.yml
+++ b/.github/workflows/sync-entities-facts.yml
@@ -16,7 +16,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   sync-entities-facts:
+    needs: [preflight]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-resources.yml
+++ b/.github/workflows/sync-resources.yml
@@ -15,7 +15,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused or wiki-server is down.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki-server health
+        run: |
+          curl -sf --max-time 10 "${{ secrets.LONGTERMWIKI_SERVER_URL }}/health" || {
+            echo "::warning::Wiki-server unreachable — skipping workflow"
+            exit 1
+          }
+          echo "Wiki-server is healthy"
+
   sync-resources:
+    needs: [preflight]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/wellness-check.yml
+++ b/.github/workflows/wellness-check.yml
@@ -50,7 +50,17 @@ env:
 # ─────────────────────────────────────────
 
 jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused.
+    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
+    # Note: the server-health-monitor (5-min cadence) is exempt and keeps running.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Automation is active"
+
   server-health:
+    needs: [preflight]
     name: Server & DB health
     runs-on: ubuntu-latest
     outputs:
@@ -273,6 +283,7 @@ jobs:
 # ─────────────────────────────────────────
 
   github-actions-health:
+    needs: [preflight]
     name: GitHub Actions workflow health
     runs-on: ubuntu-latest
     permissions:
@@ -396,6 +407,7 @@ jobs:
 # ─────────────────────────────────────────
 
   frontend-health:
+    needs: [preflight]
     name: Frontend availability
     runs-on: ubuntu-latest
     outputs:
@@ -469,6 +481,7 @@ jobs:
 # ─────────────────────────────────────────
 
   data-freshness:
+    needs: [preflight]
     name: Data freshness
     runs-on: ubuntu-latest
     outputs:
@@ -581,6 +594,7 @@ jobs:
 # ─────────────────────────────────────────
 
   job-queue-health:
+    needs: [preflight]
     name: Job queue health
     runs-on: ubuntu-latest
     outputs:
@@ -673,6 +687,7 @@ jobs:
 # ─────────────────────────────────────────
 
   pr-issue-review:
+    needs: [preflight]
     name: PR & issue quality review
     runs-on: ubuntu-latest
     permissions:
@@ -834,6 +849,7 @@ jobs:
   report:
     name: Aggregate & report
     needs:
+      - preflight
       - server-health
       - api-smoke-tests
       - github-actions-health
@@ -841,7 +857,8 @@ jobs:
       - data-freshness
       - job-queue-health
       - pr-issue-review
-    if: always()
+    # Run if preflight passed (skip entire report when automation is paused)
+    if: always() && needs.preflight.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- Add a global `AUTOMATION_PAUSED` repository variable check to all 14 scheduled/automated workflows. Setting this variable to `true` cleanly skips all automated work — a single switch to pause everything during incidents.
- Add a wiki-server `/health` endpoint check to the 8 workflows that depend on the wiki-server. When the server is unreachable, the workflow skips instead of failing and retrying.
- Uses a `preflight` job pattern: downstream jobs declare `needs: [preflight]` so they are cleanly skipped (not failed) when the gate trips.
- The `server-health-monitor.yml` is deliberately exempt — it must keep running to detect and report outages.

### Workflows with both AUTOMATION_PAUSED + health guard (8)
`auto-update`, `auto-update-review-gate`, `scheduled-maintenance`, `job-worker`, `db-backup`, `sync-entities-facts`, `sync-resources`, `sync-data`

### Workflows with AUTOMATION_PAUSED only (6)
`resolve-conflicts`, `auto-rebase`, `ci-autofix`, `scheduled-deploy`, `database-backup`, `wellness-check`

### Deliberately exempt
`server-health-monitor` (must keep monitoring), `ci` / `claude-assistant` (human-triggered), Docker build workflows (push-triggered)

## Test plan

- [ ] Verify YAML syntax is valid (validated locally with `js-yaml`)
- [ ] Set `AUTOMATION_PAUSED=true` repo variable and confirm workflows skip
- [ ] Confirm `server-health-monitor.yml` still runs when paused
- [ ] Test that wiki-server health check correctly gates workflows

Closes #1408

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>