### PR TITLE
infra: enable GitHub merge queue support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 # Cancel superseded runs for the same PR/branch (saves ~3 min per cancelled run).
-# Runs on main are never cancelled (each SHA produces a unique group).
+# Runs on main and merge queue are never cancelled (each SHA produces a unique group).
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds `merge_group` event trigger to `.github/workflows/ci.yml` so CI runs against merge queue commits
- The concurrency group already handles merge queue runs correctly (falls back to `github.sha` for non-PR events)
- The `sync-content` and `deploy` jobs are gated on `push` to `main`, so they correctly skip merge queue runs

## Admin setup required

A repo admin needs to complete the following steps to activate the merge queue:

1. Go to **Settings > Rules > Rulesets** (or **Settings > Branches > Branch protection rules** for `main`)
2. Enable **"Require merge queue"** under the branch protection settings
3. Configure merge queue settings:
   - **Merge method**: Squash (recommended, matches current workflow)
   - **Build concurrency**: 1-3 (start with 1 to be safe)
   - **Maximum queue size**: 20 (reasonable default)
   - **Minimum/Maximum group size**: 1/1 (no batching initially)
   - **Wait time**: 0 seconds (merge as soon as CI passes)
   - **Status check timeout**: 60 minutes (matches the CI run time)
4. Ensure the `ci` job is listed as a **required status check**

## How the merge queue works

Without a merge queue, PRs A and B can both pass CI independently against the same `main`. When A merges, B's CI result is stale -- B might fail against the updated main but gets merged anyway, breaking `main`.

With a merge queue enabled, GitHub:
1. Tests each PR against a temporary merge commit that includes all preceding queued changes
2. Only merges if this combined-state CI passes
3. Automatically removes PRs from the queue if they cause failures

## What this PR changes

Only the CI workflow trigger -- adding `merge_group` alongside the existing `push` and `pull_request` triggers. This is a prerequisite for enabling the merge queue; without it, the queue would have no CI status to gate on.

Closes #1399

---
Generated with [Claude Code](https://claude.com/claude-code)