### PR TITLE
feat: add conflict marker detection to CI gate pipeline

### DIFF
--- a/crux/validate/validate-conflict-markers.test.ts
+++ b/crux/validate/validate-conflict-markers.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the conflict marker detection validator.
+ *
+ * Uses unit tests against the exported detection logic rather than
+ * subprocess integration tests, since the validator's core logic is
+ * pure file scanning.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+
+// We test by importing the module's exported function
+// But since runCheck() calls git ls-files and readFileSync internally,
+// we test at the integration level by running the script as a subprocess.
+
+const REPO_ROOT = `${__dirname}/../..`;
+
+function run(cmd: string): { stdout: string; exitCode: number } {
+  const fullCmd = `${cmd} 2>&1`;
+  try {
+    const stdout = execSync(fullCmd, {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout || '', exitCode: e.status ?? 1 };
+  }
+}
+
+describe('validate-conflict-markers', () => {
+  it('passes on the current codebase (no conflict markers)', () => {
+    const result = run('npx tsx crux/validate/validate-conflict-markers.ts');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No conflict markers found');
+  }, 30_000);
+
+  it('correctly excludes resolve-conflicts.mjs from scanning', () => {
+    // resolve-conflicts.mjs legitimately contains conflict marker strings
+    // Verify the validator passes despite that file existing
+    const result = run('npx tsx crux/validate/validate-conflict-markers.ts');
+    expect(result.exitCode).toBe(0);
+    // Should not report resolve-conflicts.mjs
+    expect(result.stdout).not.toContain('resolve-conflicts.mjs');
+  }, 30_000);
+
+  describe('conflict marker pattern matching', () => {
+    // Test the regex patterns directly to verify they match correctly
+    const patterns = [
+      { pattern: /^<{7}(?:\s|$)/, label: '<<<<<<<' },
+      { pattern: /^={7}(?:\s|$)/, label: '=======' },
+      { pattern: /^>{7}(?:\s|$)/, label: '>>>>>>>' },
+    ];
+
+    it('matches standard git conflict markers', () => {
+      expect(patterns[0].pattern.test('<<<<<<< HEAD')).toBe(true);
+      expect(patterns[1].pattern.test('=======')).toBe(true);
+      expect(patterns[2].pattern.test('>>>>>>> origin/main')).toBe(true);
+    });
+
+    it('matches markers with no trailing content', () => {
+      expect(patterns[0].pattern.test('<<<<<<<')).toBe(true);
+      expect(patterns[1].pattern.test('=======')).toBe(true);
+      expect(patterns[2].pattern.test('>>>>>>>')).toBe(true);
+    });
+
+    it('does not match shorter sequences', () => {
+      // 6 characters should not match
+      expect(patterns[0].pattern.test('<<<<<<')).toBe(false);
+      expect(patterns[1].pattern.test('======')).toBe(false);
+      expect(patterns[2].pattern.test('>>>>>>')).toBe(false);
+    });
+
+    it('does not match markers embedded in text', () => {
+      // Markers must be at start of line
+      expect(patterns[0].pattern.test('  <<<<<<< HEAD')).toBe(false);
+      expect(patterns[0].pattern.test('text <<<<<<< HEAD')).toBe(false);
+    });
+
+    it('does not match longer sequences without space separator', () => {
+      // 8+ characters followed by non-space should not match
+      expect(patterns[0].pattern.test('<<<<<<<<text')).toBe(false);
+      expect(patterns[2].pattern.test('>>>>>>>>text')).toBe(false);
+    });
+
+    it('does not match 8+ character sequences (non-standard markers)', () => {
+      // Standard git conflict markers are exactly 7 characters
+      // 8+ without a space after the 7th should not match
+      expect(patterns[0].pattern.test('<<<<<<<< HEAD')).toBe(false);
+      expect(patterns[2].pattern.test('>>>>>>>> branch')).toBe(false);
+    });
+  });
+});

--- a/crux/validate/validate-conflict-markers.ts
+++ b/crux/validate/validate-conflict-markers.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that no git merge conflict markers remain in committed files.
+ *
+ * Scans all git-tracked files for leftover `<<<<<<<`, `=======`, and
+ * `>>>>>>>` markers that can slip through automated merge conflict
+ * resolution. Only flags lines where a full conflict marker pattern is
+ * present (marker at start of line), not incidental uses of those
+ * characters.
+ *
+ * Excludes:
+ *   - The conflict resolver script itself (.github/scripts/resolve-conflicts.mjs)
+ *   - Test fixtures and snapshot files
+ *   - Binary files (images, fonts, etc.)
+ *
+ * Usage: npx tsx crux/validate/validate-conflict-markers.ts
+ */
+
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { getColors } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+/** Files that legitimately reference conflict markers (e.g., the resolver script). */
+const EXCLUDED_FILES = new Set([
+  '.github/scripts/resolve-conflicts.mjs',
+]);
+
+/** File extensions to skip (binary or irrelevant). */
+const EXCLUDED_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.webp',
+  '.woff', '.woff2', '.ttf', '.eot',
+  '.pdf', '.zip', '.tar', '.gz',
+  '.lock',
+]);
+
+/**
+ * Conflict marker patterns. Each must appear at the start of a line
+ * (after optional whitespace) to count as a real conflict marker.
+ *
+ * We require at least 7 consecutive characters to match git's default
+ * conflict marker format:
+ *   <<<<<<< HEAD
+ *   =======
+ *   >>>>>>> branch-name
+ */
+const CONFLICT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /^<{7}(?:\s|$)/, label: '<<<<<<<' },
+  { pattern: /^={7}(?:\s|$)/, label: '=======' },
+  { pattern: /^>{7}(?:\s|$)/, label: '>>>>>>>' },
+];
+
+export interface ConflictViolation {
+  file: string;
+  line: number;
+  marker: string;
+  text: string;
+}
+
+function isExcluded(filePath: string): boolean {
+  if (EXCLUDED_FILES.has(filePath)) return true;
+
+  // Skip binary extensions
+  const extMatch = filePath.match(/\.[^.]+$/);
+  if (extMatch && EXCLUDED_EXTENSIONS.has(extMatch[0].toLowerCase())) return true;
+
+  // Skip test fixtures and snapshots
+  if (filePath.includes('__fixtures__/') || filePath.includes('__snapshots__/')) return true;
+  if (filePath.endsWith('.snap')) return true;
+
+  return false;
+}
+
+function checkFile(filePath: string): ConflictViolation[] {
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch {
+    return []; // File can't be read — skip silently
+  }
+
+  // Quick check: skip files that don't contain any marker substring
+  if (!content.includes('<<<<<<<') && !content.includes('=======') && !content.includes('>>>>>>>')) {
+    return [];
+  }
+
+  const lines = content.split('\n');
+  const violations: ConflictViolation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const { pattern, label } of CONFLICT_PATTERNS) {
+      if (pattern.test(line)) {
+        violations.push({
+          file: filePath,
+          line: i + 1,
+          marker: label,
+          text: line.trim(),
+        });
+        break; // One violation per line is enough
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: ConflictViolation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking for leftover merge conflict markers...${c.reset}\n`);
+
+  // Get list of tracked files from git
+  let trackedFiles: string[];
+  try {
+    const output = execSync('git ls-files', {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024, // 10 MB — repo has ~2000 files
+    });
+    trackedFiles = output.trim().split('\n').filter(Boolean);
+  } catch {
+    console.log(`${c.dim}Skipping: could not list git-tracked files${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const filesToCheck = trackedFiles.filter(f => !isExcluded(f));
+  const allViolations: ConflictViolation[] = [];
+
+  for (const file of filesToCheck) {
+    const violations = checkFile(file);
+    allViolations.push(...violations);
+  }
+
+  if (allViolations.length === 0) {
+    console.log(`${c.green}No conflict markers found (${filesToCheck.length} files checked)${c.reset}`);
+  } else {
+    console.log(`${c.red}Found ${allViolations.length} conflict marker(s):${c.reset}\n`);
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}`);
+      console.log(`    ${c.dim}${v.marker}: ${v.text}${c.reset}\n`);
+    }
+    console.log(`${c.dim}Fix: remove leftover merge conflict markers and commit the resolved file.${c.reset}`);
+  }
+
+  return { passed: allViolations.length === 0, errors: allViolations.length, violations: allViolations };
+}
+
+if (process.argv[1]?.includes('validate-conflict-markers')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -260,6 +260,13 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'conflict-markers',
+    name: 'Conflict marker detection',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-conflict-markers.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     id: 'mdx-compile',
     name: 'MDX compilation smoke-test (advisory)',
     command: 'npx',


### PR DESCRIPTION
## Summary

- Adds a new `validate-conflict-markers.ts` validator that scans all git-tracked files for leftover merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
- Registers the check as a blocking step in the gate pipeline (`validate-gate.ts`), running in parallel with other checks
- Includes 8 tests covering integration (passes on current codebase, excludes legitimate files) and unit-level pattern matching

## Why

The repo uses an automated merge conflict resolver (`.github/scripts/resolve-conflicts.mjs`). If resolution fails silently or leaves partial markers, these slip into committed files and cause build failures or corrupted content. This check catches them early at the gate level.

## Design decisions

- **Standalone validator** (not a unified engine rule) since it scans all file types, not just MDX
- **Exact 7-character match** at start of line avoids false positives from decorative uses of `=` or `>` characters
- **Excludes** `resolve-conflicts.mjs` (which legitimately references marker strings), binary files, test fixtures, and snapshots
- **Non-advisory** (blocking) since conflict markers in committed files are always a bug

## Test plan

- [x] Validator passes on current codebase (no false positives)
- [x] `resolve-conflicts.mjs` is correctly excluded
- [x] Pattern matching correctly identifies standard git conflict markers
- [x] Pattern matching rejects shorter sequences, embedded markers, and non-standard lengths
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (2460 tests, 99 suites)

Closes #1400

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>