### PR TITLE
perf: cache matViewExists() and use reltuples for stats count

### DIFF
--- a/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
+++ b/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
@@ -18,10 +18,14 @@ let riskStore: Array<{
 /** Whether to simulate the materialized view existing. */
 let simulateMatView = false;
 
+/** Count how many times pg_matviews is actually queried (for caching tests). */
+let pgMatviewsQueryCount = 0;
+
 function resetStore() {
   riskStore = [];
   nextId = 1;
   simulateMatView = false;
+  pgMatviewsQueryCount = 0;
 }
 
 /** Get latest snapshot per page (shared logic for stats/latest mock queries). */
@@ -41,12 +45,18 @@ function dispatch(query: string, params: unknown[]): unknown[] {
 
   // ---- pg_matviews check (materialized view existence) ----
   if (q.includes("pg_matviews") && q.includes("hallucination_risk_latest")) {
+    pgMatviewsQueryCount++;
     return [{ exists: simulateMatView }];
   }
 
   // ---- REFRESH MATERIALIZED VIEW (no-op in tests) ----
   if (q.includes("refresh materialized view")) {
     return [];
+  }
+
+  // ---- pg_class.reltuples (approximate count for stats) ----
+  if (q.includes("reltuples") && q.includes("pg_class") && q.includes("hallucination_risk_snapshots")) {
+    return [{ reltuples: riskStore.length }];
   }
 
   // ---- entity_ids (for health check) ----
@@ -288,6 +298,9 @@ function dispatch(query: string, params: unknown[]): unknown[] {
 vi.mock("../db.js", () => mockDbModule(dispatch));
 
 const { createApp } = await import("../app.js");
+const { clearMatViewCache } = await import(
+  "../routes/hallucination-risk.js"
+);
 
 // ---- Tests ----
 
@@ -296,6 +309,7 @@ describe("Hallucination Risk API", () => {
 
   beforeEach(() => {
     resetStore();
+    clearMatViewCache();
     delete process.env.LONGTERMWIKI_SERVER_API_KEY;
     app = createApp();
   });
@@ -616,6 +630,59 @@ describe("Hallucination Risk API", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.keep).toBe(30);
+    });
+  });
+
+  describe("matViewExists() caching", () => {
+    it("caches pg_matviews result across multiple requests", async () => {
+      simulateMatView = true;
+
+      // First request — should query pg_matviews
+      await app.request("/api/hallucination-risk/stats");
+      const firstCount = pgMatviewsQueryCount;
+      expect(firstCount).toBe(1);
+
+      // Second request — should use cached result, no new pg_matviews query
+      await app.request("/api/hallucination-risk/stats");
+      expect(pgMatviewsQueryCount).toBe(1); // unchanged — cache hit
+
+      // Third request to a different endpoint — still uses cache
+      await app.request("/api/hallucination-risk/latest");
+      expect(pgMatviewsQueryCount).toBe(1); // still unchanged
+    });
+
+    it("re-queries pg_matviews after cache is cleared", async () => {
+      simulateMatView = false;
+
+      // First request — queries pg_matviews, caches false
+      await app.request("/api/hallucination-risk/stats");
+      expect(pgMatviewsQueryCount).toBe(1);
+
+      // Clear cache, change simulated state
+      clearMatViewCache();
+      simulateMatView = true;
+
+      // Next request — should re-query pg_matviews since cache was cleared
+      await app.request("/api/hallucination-risk/stats");
+      expect(pgMatviewsQueryCount).toBe(2);
+    });
+
+    it("re-queries pg_matviews after TTL expires", async () => {
+      simulateMatView = true;
+
+      // First request — populates cache
+      await app.request("/api/hallucination-risk/stats");
+      expect(pgMatviewsQueryCount).toBe(1);
+
+      // Advance time past TTL (5 minutes = 300000ms)
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 300_001);
+
+      // Next request — TTL expired, should re-query
+      await app.request("/api/hallucination-risk/stats");
+      expect(pgMatviewsQueryCount).toBe(2);
+
+      vi.useRealTimers();
     });
   });
 });

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -33,12 +33,12 @@ interface RiskPageDbRow {
   computed_at: string;
 }
 
-interface TotalCountRow {
+interface UniqueCountRow {
   count: number;
 }
 
-interface UniqueCountRow {
-  count: number;
+interface ReltuplesRow {
+  reltuples: number;
 }
 
 // ---- Constants ----
@@ -72,6 +72,22 @@ const CleanupQuery = z.object({
     .default("false"),
 });
 
+// ---- Materialized view existence cache ----
+
+/** Cache TTL in milliseconds (5 minutes). */
+const MAT_VIEW_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let matViewCachedResult: boolean | null = null;
+let matViewCachedAt = 0;
+
+/**
+ * Clear the matViewExists cache. Exported for testing.
+ */
+export function clearMatViewCache(): void {
+  matViewCachedResult = null;
+  matViewCachedAt = 0;
+}
+
 // ---- Helpers ----
 
 /**
@@ -94,15 +110,26 @@ async function refreshMaterializedView(): Promise<void> {
 /**
  * Check if the materialized view exists. Returns false during tests
  * or before the migration has been applied.
+ *
+ * Results are cached for MAT_VIEW_CACHE_TTL_MS (5 minutes) to avoid
+ * querying pg_matviews on every request. The view existence only changes
+ * during migrations, not between requests.
  */
 async function matViewExists(): Promise<boolean> {
+  const now = Date.now();
+  if (matViewCachedResult !== null && now - matViewCachedAt < MAT_VIEW_CACHE_TTL_MS) {
+    return matViewCachedResult;
+  }
+
   const rawDb = getDb();
   const result = await rawDb<{ exists: boolean }[]>`
     SELECT EXISTS (
       SELECT 1 FROM pg_matviews WHERE matviewname = 'hallucination_risk_latest'
     ) AS exists
   `;
-  return result[0]?.exists ?? false;
+  matViewCachedResult = result[0]?.exists ?? false;
+  matViewCachedAt = now;
+  return matViewCachedResult;
 }
 
 const hallucinationRiskApp = new Hono()
@@ -228,11 +255,13 @@ const hallucinationRiskApp = new Hono()
     const rawDb = getDb();
     const useMatView = await matViewExists();
 
-    // Total snapshots (from base table — always accurate)
-    const totalResult = await rawDb<TotalCountRow[]>`
-      SELECT count(*)::int AS count FROM hallucination_risk_snapshots
+    // Total snapshots — use pg_class.reltuples for a fast approximate count
+    // instead of a full count(*) sequential scan on the base table.
+    // reltuples is updated by VACUUM/ANALYZE and is accurate enough for stats display.
+    const totalResult = await rawDb<ReltuplesRow[]>`
+      SELECT reltuples::int AS reltuples FROM pg_class WHERE relname = 'hallucination_risk_snapshots'
     `;
-    const totalSnapshots = totalResult[0]?.count ?? 0;
+    const totalSnapshots = Math.max(0, totalResult[0]?.reltuples ?? 0);
 
     if (useMatView) {
       // Use materialized view for unique pages and level distribution — instant


### PR DESCRIPTION
## Summary

- Cache `matViewExists()` result in a module-level variable with a 5-minute TTL, eliminating a `pg_matviews` catalog query on every request to `/stats`, `/latest`, `/batch`, `/refresh`, and `/cleanup` endpoints
- Replace `count(*)` full sequential scan with `pg_class.reltuples` for the `totalSnapshots` statistic in `/stats` — accurate enough for display, avoids a table scan
- Export `clearMatViewCache()` for test isolation and add 3 new tests covering cache hits, manual cache invalidation, and TTL expiry

## Motivation

The materialized view either exists or doesn't — this state only changes during migrations, not between requests. Querying `pg_matviews` on every request was an unnecessary round-trip.

Similarly, `count(*)` on the base table triggers a full sequential scan. `pg_class.reltuples` (maintained by VACUUM/ANALYZE) is a fast O(1) approximation suitable for stats display.

## Test plan

- [x] All 23 hallucination-risk tests pass (20 existing + 3 new caching tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New tests verify: cache hit across requests, re-query after clear, re-query after TTL expiry

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)