### PR TITLE
security: fix new-file bypass and word-splitting in CI workflows

### DIFF
--- a/.github/workflows/auto-update-review-gate.yml
+++ b/.github/workflows/auto-update-review-gate.yml
@@ -98,8 +98,7 @@ jobs:
           else
             # Security: stage only files the citation audit is expected to modify
             # (MDX content pages and YAML data files), not everything in the tree.
-            CHANGED_FILES=$(git diff --name-only)
-            for file in $CHANGED_FILES; do
+            git diff --name-only | while IFS= read -r file; do
               if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
                 git add -- "$file"
               else

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -315,8 +315,7 @@ jobs:
 
           # Security: stage only files the auto-update pipeline is expected to
           # modify, not everything in the working tree.
-          CHANGED_FILES=$(git diff --name-only)
-          for file in $CHANGED_FILES; do
+          git diff --name-only | while IFS= read -r file; do
             if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
               git add -- "$file"
             else

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -275,7 +275,14 @@ jobs:
             if [ -n "$file" ] && ! grep -qxF "$file" "$ALLOWED_FILES" 2>/dev/null; then
               DISALLOWED="$DISALLOWED $file"
               echo "::warning::Reverting unauthorized agent change: $file"
-              git checkout HEAD -- "$file" 2>/dev/null || true
+              # For files that exist in HEAD, restore them to their original state
+              if git checkout HEAD -- "$file" 2>/dev/null; then
+                : # successfully reverted
+              else
+                # File is newly created (not in HEAD) — unstage and remove it
+                git reset HEAD -- "$file" 2>/dev/null || true
+                git clean -f -- "$file" 2>/dev/null || true
+              fi
             fi
           done < /tmp/agent-touched.txt
 
@@ -320,9 +327,8 @@ jobs:
             echo "Auto-fix produced changes — committing fixes..."
             # Security: stage only files that were part of the original merge,
             # not everything in the working tree (avoids committing unrelated files).
-            CHANGED_FILES=$(git diff --name-only)
             ALLOWED_FILES=/tmp/merge-affected-files.txt
-            for file in $CHANGED_FILES; do
+            git diff --name-only | while IFS= read -r file; do
               if grep -qxF "$file" "$ALLOWED_FILES" 2>/dev/null; then
                 git add -- "$file"
               else


### PR DESCRIPTION
## Summary

Fixes two security issues identified in red-team review of PR #1422 (explicit file staging):

- **[HIGH] New-file bypass in Tier 2 agent restriction**: `git checkout HEAD -- "$file"` fails silently for newly created files (not in HEAD), leaving them staged. The `2>/dev/null || true` suppressed the error. Now falls back to `git reset HEAD` + `git clean -f` to properly unstage and remove unauthorized new files.

- **[MEDIUM] Word-splitting in filename iteration**: `for file in $CHANGED_FILES` breaks on filenames with spaces. Replaced with `git diff --name-only | while IFS= read -r file` pattern across all three affected workflow files.

### Files changed

- `.github/workflows/resolve-conflicts.yml` — both fixes
- `.github/workflows/auto-update-review-gate.yml` — word-splitting fix
- `.github/workflows/auto-update.yml` — word-splitting fix

## Test plan

- [x] Verify `git checkout HEAD` failure path now properly handles new files via `git reset HEAD` + `git clean -f`
- [x] Verify all `for file in $CHANGED_FILES` patterns replaced with `while IFS= read -r` across all workflow files
- [x] Confirm no remaining `for file in $` patterns in workflow directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)