### PR TITLE
fix: harden rate limiter against security red-team findings

### DIFF
--- a/apps/wiki-server/src/__tests__/rate-limit.test.ts
+++ b/apps/wiki-server/src/__tests__/rate-limit.test.ts
@@ -4,8 +4,58 @@ import {
   RateLimiter,
   rateLimitMiddleware,
   createDefaultRateLimiters,
+  normalizeIPv6,
   type RateLimitConfig,
 } from "../rate-limit.js";
+
+// ---------------------------------------------------------------------------
+// normalizeIPv6 unit tests
+// ---------------------------------------------------------------------------
+
+describe("normalizeIPv6", () => {
+  it("returns IPv4 addresses unchanged", () => {
+    expect(normalizeIPv6("1.2.3.4")).toBe("1.2.3.4");
+    expect(normalizeIPv6("192.168.1.1")).toBe("192.168.1.1");
+    expect(normalizeIPv6("10.0.0.1")).toBe("10.0.0.1");
+  });
+
+  it("extracts IPv4 from IPv4-mapped IPv6", () => {
+    expect(normalizeIPv6("::ffff:1.2.3.4")).toBe("1.2.3.4");
+    expect(normalizeIPv6("::FFFF:192.168.1.1")).toBe("192.168.1.1");
+  });
+
+  it("normalizes full IPv6 addresses to /64 prefix", () => {
+    const result = normalizeIPv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+    expect(result).toBe("2001:0db8:85a3:0000::/64");
+  });
+
+  it("normalizes abbreviated IPv6 addresses to /64 prefix", () => {
+    const result = normalizeIPv6("2001:db8:85a3::8a2e:370:7334");
+    expect(result).toBe("2001:0db8:85a3:0000::/64");
+  });
+
+  it("groups addresses in the same /64 to the same key", () => {
+    const addr1 = normalizeIPv6("2001:db8:85a3:0:1111:2222:3333:4444");
+    const addr2 = normalizeIPv6("2001:db8:85a3:0:aaaa:bbbb:cccc:dddd");
+    expect(addr1).toBe(addr2);
+  });
+
+  it("distinguishes addresses in different /64 prefixes", () => {
+    const addr1 = normalizeIPv6("2001:db8:85a3:0001::");
+    const addr2 = normalizeIPv6("2001:db8:85a3:0002::");
+    expect(addr1).not.toBe(addr2);
+  });
+
+  it("handles loopback (::1)", () => {
+    const result = normalizeIPv6("::1");
+    expect(result).toBe("0000:0000:0000:0000::/64");
+  });
+
+  it("returns unparseable strings as-is", () => {
+    expect(normalizeIPv6("not-an-ip")).toBe("not-an-ip");
+    expect(normalizeIPv6("1:2:3:4:5:6:7:8:9")).toBe("1:2:3:4:5:6:7:8:9");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // RateLimiter core unit tests
@@ -124,6 +174,77 @@ describe("RateLimiter", () => {
     limiter.reset();
     expect(limiter.size).toBe(0);
   });
+
+  // -------------------------------------------------------------------------
+  // maxKeys cap
+  // -------------------------------------------------------------------------
+
+  describe("maxKeys cap", () => {
+    it("denies new keys when maxKeys is reached", () => {
+      const limiter = new RateLimiter(
+        { maxRequests: 10, windowMs: 60_000 },
+        3 // maxKeys = 3
+      );
+
+      expect(limiter.check("ip-1").allowed).toBe(true);
+      expect(limiter.check("ip-2").allowed).toBe(true);
+      expect(limiter.check("ip-3").allowed).toBe(true);
+      expect(limiter.size).toBe(3);
+
+      const result = limiter.check("ip-4");
+      expect(result.allowed).toBe(false);
+      expect(result.remaining).toBe(0);
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it("still allows existing keys when maxKeys is reached", () => {
+      const limiter = new RateLimiter(
+        { maxRequests: 10, windowMs: 60_000 },
+        2 // maxKeys = 2
+      );
+
+      limiter.check("ip-1");
+      limiter.check("ip-2");
+
+      const r1 = limiter.check("ip-1");
+      expect(r1.allowed).toBe(true);
+
+      const r2 = limiter.check("ip-2");
+      expect(r2.allowed).toBe(true);
+    });
+
+    it("allows new keys again after cleanup frees slots", () => {
+      const windowMs = 1000;
+      const limiter = new RateLimiter(
+        { maxRequests: 10, windowMs },
+        2 // maxKeys = 2
+      );
+
+      const now = Date.now();
+      limiter.check("ip-1", now);
+      limiter.check("ip-2", now);
+
+      expect(limiter.check("ip-3", now + 100).allowed).toBe(false);
+
+      limiter.cleanup(now + windowMs + 1);
+      expect(limiter.size).toBe(0);
+
+      expect(limiter.check("ip-3", now + windowMs + 2).allowed).toBe(true);
+    });
+
+    it("exposes maxKeys on the instance", () => {
+      const limiter = new RateLimiter(
+        { maxRequests: 10, windowMs: 60_000 },
+        5000
+      );
+      expect(limiter.maxKeys).toBe(5000);
+    });
+
+    it("defaults maxKeys to 10000", () => {
+      const limiter = new RateLimiter({ maxRequests: 10, windowMs: 60_000 });
+      expect(limiter.maxKeys).toBe(10_000);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -131,7 +252,10 @@ describe("RateLimiter", () => {
 // ---------------------------------------------------------------------------
 
 describe("rateLimitMiddleware", () => {
-  function buildApp(readConfig: RateLimitConfig, writeConfig: RateLimitConfig) {
+  function buildApp(
+    readConfig: RateLimitConfig,
+    writeConfig: RateLimitConfig
+  ) {
     const readLimiter = new RateLimiter(readConfig);
     const writeLimiter = new RateLimiter(writeConfig);
 
@@ -151,6 +275,7 @@ describe("rateLimitMiddleware", () => {
     app.put("/api/pages/1", (c) => c.json({ ok: true }));
     app.delete("/api/pages/1", (c) => c.json({ ok: true }));
     app.get("/health", (c) => c.json({ status: "ok" }));
+    app.get("/health/extra", (c) => c.json({ status: "ok" }));
 
     return { app, readLimiter, writeLimiter };
   }
@@ -272,18 +397,41 @@ describe("rateLimitMiddleware", () => {
     expect(res2.status).toBe(429);
   });
 
-  it("skips rate limiting for exempt paths", async () => {
+  // -------------------------------------------------------------------------
+  // skipPaths: exact match (not prefix)
+  // -------------------------------------------------------------------------
+
+  it("skips rate limiting for exact skipPaths match", async () => {
     const { app } = buildApp(
       { maxRequests: 1, windowMs: 60_000 },
       { maxRequests: 1, windowMs: 60_000 }
     );
 
-    // Health endpoint should always work, even after limit is reached
+    // /health should always work, even after limit is reached
     for (let i = 0; i < 5; i++) {
       const res = await app.request("/health");
       expect(res.status).toBe(200);
     }
   });
+
+  it("does NOT skip rate limiting for paths that start with a skip path", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 1, windowMs: 60_000 }
+    );
+
+    // /health/extra is NOT in skipPaths — it should be rate limited
+    const res1 = await app.request("/health/extra");
+    expect(res1.status).toBe(200);
+
+    // Second request should be rate limited
+    const res2 = await app.request("/health/extra");
+    expect(res2.status).toBe(429);
+  });
+
+  // -------------------------------------------------------------------------
+  // X-Forwarded-For and IPv6 normalization in middleware
+  // -------------------------------------------------------------------------
 
   it("uses X-Forwarded-For header for client identification", async () => {
     const { app } = buildApp(
@@ -328,6 +476,47 @@ describe("rateLimitMiddleware", () => {
     });
     expect(res2.status).toBe(429);
   });
+
+  it("normalizes IPv6 addresses from X-Forwarded-For to /64 prefix", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    // First request with one IPv6 address
+    const res1 = await app.request("/api/pages", {
+      headers: {
+        "X-Forwarded-For": "2001:db8:85a3:0:1111:2222:3333:4444",
+      },
+    });
+    expect(res1.status).toBe(200);
+
+    // Second request with a different address in the same /64 — should be
+    // rate limited because both normalize to the same /64 prefix
+    const res2 = await app.request("/api/pages", {
+      headers: {
+        "X-Forwarded-For": "2001:db8:85a3:0:aaaa:bbbb:cccc:dddd",
+      },
+    });
+    expect(res2.status).toBe(429);
+  });
+
+  it("does not share bucket between no-proxy fallback and real IPs", async () => {
+    const { app } = buildApp(
+      { maxRequests: 1, windowMs: 60_000 },
+      { maxRequests: 10, windowMs: 60_000 }
+    );
+
+    // Request without proxy headers — uses fallback key
+    const res1 = await app.request("/api/pages");
+    expect(res1.status).toBe(200);
+
+    // Request with a real IP should still succeed (different bucket)
+    const res2 = await app.request("/api/pages", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+    expect(res2.status).toBe(200);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -352,5 +541,19 @@ describe("createDefaultRateLimiters", () => {
     expect(readLimiter.config.windowMs).toBe(60_000); // default preserved
     expect(writeLimiter.config.maxRequests).toBe(20); // default preserved
     expect(writeLimiter.config.windowMs).toBe(30_000);
+  });
+
+  it("passes maxKeys to both limiters", () => {
+    const { readLimiter, writeLimiter } = createDefaultRateLimiters({
+      maxKeys: 500,
+    });
+    expect(readLimiter.maxKeys).toBe(500);
+    expect(writeLimiter.maxKeys).toBe(500);
+  });
+
+  it("defaults maxKeys to 10000", () => {
+    const { readLimiter, writeLimiter } = createDefaultRateLimiters();
+    expect(readLimiter.maxKeys).toBe(10_000);
+    expect(writeLimiter.maxKeys).toBe(10_000);
   });
 });

--- a/apps/wiki-server/src/rate-limit.ts
+++ b/apps/wiki-server/src/rate-limit.ts
@@ -9,10 +9,94 @@
  *   - "write" (POST/PUT/DELETE/PATCH): stricter limits (default 20 req/min)
  *
  * Returns 429 Too Many Requests with a Retry-After header when limits are exceeded.
+ *
+ * SECURITY NOTE — X-Forwarded-For Trust
+ * ======================================
+ * This middleware extracts the client IP from X-Forwarded-For / X-Real-IP /
+ * CF-Connecting-IP headers. These headers are trivially spoofable by end users.
+ *
+ * **This server MUST be deployed behind a trusted reverse proxy** (e.g., Fly.io,
+ * Cloudflare, nginx) that overwrites X-Forwarded-For with the real client IP
+ * before forwarding. If the server is exposed directly to the internet without
+ * a trusted proxy, an attacker can rotate the X-Forwarded-For value on every
+ * request to bypass rate limiting entirely.
+ *
+ * As a defense-in-depth measure, the RateLimiter enforces a `maxKeys` cap
+ * (default 10,000). When the number of tracked keys exceeds this threshold,
+ * new keys are denied immediately — preventing unbounded memory growth from
+ * key-flooding attacks even if header spoofing occurs.
  */
 
 import type { Context, MiddlewareHandler } from "hono";
 import { logger } from "./logger.js";
+
+// ---------------------------------------------------------------------------
+// IPv6 normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an IPv6 address to its /64 prefix for rate limiting.
+ *
+ * IPv6 allocates /64 prefixes to end sites, so different addresses within
+ * the same /64 likely belong to the same user. Normalizing to /64 prevents
+ * an attacker from rotating through addresses within their allocation.
+ *
+ * IPv4 addresses (and IPv4-mapped IPv6 like ::ffff:1.2.3.4) are returned
+ * unchanged.
+ */
+export function normalizeIPv6(ip: string): string {
+  // IPv4 — return as-is
+  if (!ip.includes(":")) {
+    return ip;
+  }
+
+  // IPv4-mapped IPv6 (::ffff:1.2.3.4) — return the IPv4 portion
+  const v4MappedMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (v4MappedMatch) {
+    return v4MappedMatch[1];
+  }
+
+  // Full IPv6 — normalize to /64 prefix (first 4 groups)
+  const expanded = expandIPv6(ip);
+  if (!expanded) {
+    // If we can't parse it, return as-is rather than silently misclassifying
+    return ip;
+  }
+
+  // Take the first 4 groups (64 bits) and zero out the rest
+  const groups = expanded.split(":");
+  const prefix = groups.slice(0, 4).join(":") + "::/64";
+  return prefix;
+}
+
+/**
+ * Expand an IPv6 address to its full 8-group representation.
+ * Returns null if the address doesn't look like valid IPv6.
+ */
+function expandIPv6(ip: string): string | null {
+  let parts: string[];
+
+  if (ip.includes("::")) {
+    const [left, right] = ip.split("::");
+    const leftParts = left ? left.split(":") : [];
+    const rightParts = right ? right.split(":") : [];
+    const missing = 8 - leftParts.length - rightParts.length;
+
+    if (missing < 0) return null;
+
+    parts = [
+      ...leftParts,
+      ...(Array(missing).fill("0000") as string[]),
+      ...rightParts,
+    ];
+  } else {
+    parts = ip.split(":");
+  }
+
+  if (parts.length !== 8) return null;
+
+  return parts.map((p) => p.padStart(4, "0")).join(":");
+}
 
 // ---------------------------------------------------------------------------
 // Rate limiter core
@@ -33,14 +117,20 @@ interface WindowEntry {
 /**
  * Sliding-window rate limiter. Tracks request timestamps per key and checks
  * whether the key has exceeded its allowed request count within the window.
+ *
+ * The `maxKeys` parameter caps the number of distinct keys tracked. Once
+ * the cap is reached, requests from unknown keys are denied. This prevents
+ * memory exhaustion from key-flooding attacks (e.g., spoofed X-Forwarded-For).
  */
 export class RateLimiter {
   private windows = new Map<string, WindowEntry>();
   private cleanupInterval: ReturnType<typeof setInterval> | null = null;
   readonly config: RateLimitConfig;
+  readonly maxKeys: number;
 
-  constructor(config: RateLimitConfig) {
+  constructor(config: RateLimitConfig, maxKeys = 10_000) {
     this.config = config;
+    this.maxKeys = maxKeys;
   }
 
   /**
@@ -73,6 +163,22 @@ export class RateLimiter {
     const windowStart = now - this.config.windowMs;
 
     let entry = this.windows.get(key);
+
+    // If this is a new key and we've hit the maxKeys cap, deny immediately.
+    // This prevents unbounded memory growth from key-flooding attacks.
+    if (!entry && this.windows.size >= this.maxKeys) {
+      logger.warn(
+        { key, maxKeys: this.maxKeys, currentKeys: this.windows.size },
+        "Rate limiter maxKeys cap reached — denying new key"
+      );
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs: Math.ceil(this.config.windowMs / 2),
+        resetMs: Math.ceil(this.config.windowMs / 2),
+      };
+    }
+
     if (!entry) {
       entry = { timestamps: [] };
       this.windows.set(key, entry);
@@ -144,6 +250,9 @@ export interface RateLimitResult {
 /** Extract a client identifier from the request for rate limiting. */
 function getClientKey(c: Context): string {
   // Check standard proxy headers first (Fly.io, Cloudflare, nginx, etc.)
+  //
+  // IMPORTANT: These headers are only trustworthy when the server sits behind
+  // a reverse proxy that overwrites them. See the module-level security note.
   const forwarded =
     c.req.header("x-forwarded-for") ||
     c.req.header("x-real-ip") ||
@@ -151,11 +260,21 @@ function getClientKey(c: Context): string {
 
   if (forwarded) {
     // x-forwarded-for may contain "client, proxy1, proxy2" — use the first
-    return forwarded.split(",")[0].trim();
+    const clientIp = forwarded.split(",")[0].trim();
+    return normalizeIPv6(clientIp);
   }
 
-  // Fallback: not ideal in production but fine for dev/local
-  return "unknown";
+  // No proxy headers available. This typically means the server is running
+  // locally or is directly exposed without a reverse proxy. Log a warning
+  // because all requests will share the same rate-limit bucket, which both
+  // degrades service for legitimate users and makes rate limiting ineffective.
+  logger.warn(
+    { path: c.req.path, method: c.req.method },
+    "Rate limiter: no proxy headers found — falling back to shared 'no-proxy-ip' key. " +
+      "Ensure the server is behind a trusted reverse proxy in production."
+  );
+
+  return "no-proxy-ip";
 }
 
 export interface RateLimitMiddlewareOptions {
@@ -165,7 +284,7 @@ export interface RateLimitMiddlewareOptions {
   writeLimiter: RateLimiter;
   /** Methods treated as "read". Defaults to ["GET", "HEAD", "OPTIONS"]. */
   readMethods?: string[];
-  /** Paths to skip rate limiting entirely (exact prefix match). */
+  /** Paths to skip rate limiting entirely (exact match, not prefix). */
   skipPaths?: string[];
 }
 
@@ -181,15 +300,15 @@ export function rateLimitMiddleware(
   const readMethods = new Set(
     options.readMethods ?? ["GET", "HEAD", "OPTIONS"]
   );
-  const skipPaths = options.skipPaths ?? [];
+  const skipPaths = new Set(options.skipPaths ?? []);
 
   return async (c, next) => {
-    // Check if this path should skip rate limiting
-    for (const prefix of skipPaths) {
-      if (c.req.path.startsWith(prefix)) {
-        await next();
-        return;
-      }
+    // Check if this path should skip rate limiting (exact match only).
+    // Using exact match prevents bypass via path traversal tricks like
+    // "/health/../../api/secret" that would match a prefix check.
+    if (skipPaths.has(c.req.path)) {
+      await next();
+      return;
     }
 
     const clientKey = getClientKey(c);
@@ -247,6 +366,9 @@ export const DEFAULT_WRITE_LIMIT: RateLimitConfig = {
   windowMs: 60_000,
 };
 
+/** Default maximum number of distinct IP keys tracked per limiter. */
+export const DEFAULT_MAX_KEYS = 10_000;
+
 /**
  * Create preconfigured rate limiters with default settings.
  * Override individual limits via the options parameter.
@@ -254,15 +376,23 @@ export const DEFAULT_WRITE_LIMIT: RateLimitConfig = {
 export function createDefaultRateLimiters(overrides?: {
   read?: Partial<RateLimitConfig>;
   write?: Partial<RateLimitConfig>;
+  maxKeys?: number;
 }) {
-  const readLimiter = new RateLimiter({
-    ...DEFAULT_READ_LIMIT,
-    ...overrides?.read,
-  });
-  const writeLimiter = new RateLimiter({
-    ...DEFAULT_WRITE_LIMIT,
-    ...overrides?.write,
-  });
+  const maxKeys = overrides?.maxKeys ?? DEFAULT_MAX_KEYS;
+  const readLimiter = new RateLimiter(
+    {
+      ...DEFAULT_READ_LIMIT,
+      ...overrides?.read,
+    },
+    maxKeys
+  );
+  const writeLimiter = new RateLimiter(
+    {
+      ...DEFAULT_WRITE_LIMIT,
+      ...overrides?.write,
+    },
+    maxKeys
+  );
 
   return { readLimiter, writeLimiter };
 }


### PR DESCRIPTION
## Summary
- Address all critical/high/medium/low findings from the security red-team review of PR #1424 (rate limiting)
- Add `maxKeys` cap (default 10,000) to `RateLimiter` to prevent unbounded memory growth from key-flooding / X-Forwarded-For spoofing attacks
- Add `normalizeIPv6()` helper that collapses IPv6 addresses to /64 prefix for rate limiting
- Replace `"unknown"` fallback key with `"no-proxy-ip"` and log a warning when no proxy headers are found
- Change health endpoint skip from prefix match to exact match to prevent path traversal bypass
- Add prominent security documentation about X-Forwarded-For trust requirements

## Test plan
- [x] All 39 rate-limit tests pass (17 new tests added)
- [x] Full wiki-server test suite passes (529 tests)
- [ ] Verify CI passes

Closes #1424

:robot: Generated with [Claude Code](https://claude.com/claude-code)