### PR TITLE
feat: add local data mode to eliminate runtime wiki-server API calls

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -802,6 +802,76 @@ async function buildCitationStatsMap() {
 }
 
 /**
+ * Fetch all citation quotes from wiki-server, grouped by pageId.
+ * Used by the frontend to render citation health banners and footnote tooltips
+ * without making per-page API calls at runtime.
+ * Returns { [pageId]: CitationQuote[] } or empty object if unavailable.
+ */
+async function buildCitationQuotesBundle() {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl) {
+    console.log('  citationQuotes: skipped (LONGTERMWIKI_SERVER_URL not set)');
+    return {};
+  }
+
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+    // Paginate through all quotes (max 5000 per page)
+    const allQuotes = [];
+    let offset = 0;
+    const limit = 5000;
+
+    while (true) {
+      const res = await fetch(
+        `${serverUrl}/api/citations/quotes/all?limit=${limit}&offset=${offset}`,
+        { headers, signal: AbortSignal.timeout(30_000) }
+      );
+      if (!res.ok) {
+        console.log(`  citationQuotes: skipped (server returned ${res.status})`);
+        return {};
+      }
+      const data = await res.json();
+      allQuotes.push(...(data.quotes || []));
+      if (data.quotes.length < limit) break;
+      offset += limit;
+    }
+
+    // Group by pageId
+    const byPage = {};
+    for (const q of allQuotes) {
+      if (!byPage[q.pageId]) byPage[q.pageId] = [];
+      byPage[q.pageId].push({
+        footnote: q.footnote,
+        url: q.url,
+        resourceId: q.resourceId,
+        claimText: q.claimText,
+        sourceQuote: q.sourceQuote,
+        sourceTitle: q.sourceTitle,
+        sourceType: q.sourceType,
+        quoteVerified: q.quoteVerified,
+        verificationScore: q.verificationScore,
+        verifiedAt: q.verifiedAt,
+        accuracyVerdict: q.accuracyVerdict,
+        accuracyScore: q.accuracyScore,
+        accuracyIssues: q.accuracyIssues,
+        accuracySupportingQuotes: q.accuracySupportingQuotes,
+        verificationDifficulty: q.verificationDifficulty,
+        accuracyCheckedAt: q.accuracyCheckedAt,
+      });
+    }
+
+    console.log(`  citationQuotes: ${allQuotes.length} quotes across ${Object.keys(byPage).length} pages`);
+    return byPage;
+  } catch (err) {
+    console.log(`  citationQuotes: skipped (${err.message || 'server unavailable'})`);
+    return {};
+  }
+}
+
+/**
  * Fetch all page references (claim refs + citations) from the wiki-server.
  * Returns a map of pageId → { claimReferences, citations } for the reference preprocessor.
  * Falls back to an empty object if the server is unavailable.
@@ -1199,13 +1269,15 @@ async function main() {
   // Fetch edit log dates, earliest edit log dates, and citation stats from
   // wiki-server (parallel). Also build git-based date maps (synchronous, fast).
   const gitDateMaps = CONTENT_ONLY ? { gitCreatedMap: new Map(), gitModifiedMap: new Map() } : buildGitDateMaps();
-  const [editLogDates, earliestEditLogDates, citationStats] = CONTENT_ONLY
-    ? [new Map(), new Map(), new Map()]
+  const [editLogDates, earliestEditLogDates, citationStats, citationQuotesBundle] = CONTENT_ONLY
+    ? [new Map(), new Map(), new Map(), {}]
     : await Promise.all([
         buildEditLogDateMap(),
         buildEarliestEditLogDateMap(),
         buildCitationStatsMap(),
+        buildCitationQuotesBundle(),
       ]);
+  database.citationQuotes = citationQuotesBundle;
 
   // Build pages registry with frontmatter data (quality, etc.)
   const pages = buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEditLogDates);

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -210,6 +210,25 @@ interface DatabaseShape {
     avgScore: number;
     topFactors: Array<{ factor: string; count: number }>;
   };
+  /** Citation quotes bundled at build time, keyed by pageId */
+  citationQuotes?: Record<string, Array<{
+    footnote: number;
+    url: string | null;
+    resourceId: string | null;
+    claimText: string;
+    sourceQuote: string | null;
+    sourceTitle: string | null;
+    sourceType: string | null;
+    quoteVerified: boolean;
+    verificationScore: number | null;
+    verifiedAt: string | null;
+    accuracyVerdict: string | null;
+    accuracyScore: number | null;
+    accuracyIssues: string | null;
+    accuracySupportingQuotes: string | null;
+    verificationDifficulty: string | null;
+    accuracyCheckedAt: string | null;
+  }>>;
 }
 
 // ============================================================================
@@ -1053,6 +1072,14 @@ export async function getRiskStats(): Promise<RiskStats | null> {
     () => getDatabase().riskStats ?? null
   );
   return result.data;
+}
+
+/**
+ * Get build-time citation quotes for a page from database.json.
+ * Returns undefined if no citation data was bundled at build time.
+ */
+export function getLocalCitationQuotes(pageId: string) {
+  return getDatabase().citationQuotes?.[pageId];
 }
 
 export function getResourceCredibility(

--- a/apps/web/src/lib/__tests__/citation-data.test.ts
+++ b/apps/web/src/lib/__tests__/citation-data.test.ts
@@ -126,12 +126,25 @@ describe("computeCitationHealth", () => {
   });
 });
 
+/** Shared mock setup for getCitationQuotes tests */
+function mockCitationDeps(overrides: {
+  fetchFromWikiServer?: ReturnType<typeof vi.fn>;
+  isLocalDataMode?: () => boolean;
+  getLocalCitationQuotes?: () => unknown;
+}) {
+  vi.doMock("../wiki-server", () => ({
+    fetchFromWikiServer: overrides.fetchFromWikiServer ?? vi.fn().mockResolvedValue(null),
+    isLocalDataMode: overrides.isLocalDataMode ?? (() => false),
+  }));
+  vi.doMock("@/data", () => ({
+    getLocalCitationQuotes: overrides.getLocalCitationQuotes ?? (() => undefined),
+  }));
+}
+
 describe("getCitationQuotes", () => {
   it("returns empty array when server returns null", async () => {
     vi.resetModules();
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: vi.fn().mockResolvedValue(null),
-    }));
+    mockCitationDeps({ fetchFromWikiServer: vi.fn().mockResolvedValue(null) });
     const mod = await import("../citation-data");
     const result = await mod.getCitationQuotes("test-page");
     expect(result).toEqual([]);
@@ -139,9 +152,7 @@ describe("getCitationQuotes", () => {
 
   it("returns empty array when quotes field is missing", async () => {
     vi.resetModules();
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: vi.fn().mockResolvedValue({}),
-    }));
+    mockCitationDeps({ fetchFromWikiServer: vi.fn().mockResolvedValue({}) });
     const mod = await import("../citation-data");
     const result = await mod.getCitationQuotes("test-page");
     expect(result).toEqual([]);
@@ -154,9 +165,7 @@ describe("getCitationQuotes", () => {
       makeQuote({ footnote: 2 }), // no verification data — should be filtered
       makeQuote({ footnote: 3, accuracyVerdict: "accurate" }), // has accuracy
     ];
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: vi.fn().mockResolvedValue({ quotes: mockQuotes }),
-    }));
+    mockCitationDeps({ fetchFromWikiServer: vi.fn().mockResolvedValue({ quotes: mockQuotes }) });
     const mod = await import("../citation-data");
     const result = await mod.getCitationQuotes("test-page");
     expect(result).toHaveLength(2);
@@ -167,9 +176,7 @@ describe("getCitationQuotes", () => {
   it("calls the claims by-page endpoint (not deprecated citations/quotes)", async () => {
     vi.resetModules();
     const mockFetch = vi.fn().mockResolvedValue({ quotes: [] });
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: mockFetch,
-    }));
+    mockCitationDeps({ fetchFromWikiServer: mockFetch });
     const mod = await import("../citation-data");
     await mod.getCitationQuotes("test-page");
     expect(mockFetch).toHaveBeenCalledWith(
@@ -177,15 +184,31 @@ describe("getCitationQuotes", () => {
       { revalidate: 600 }
     );
   });
+
+  it("uses local data in local mode", async () => {
+    vi.resetModules();
+    const localQuotes = [
+      makeQuote({ footnote: 1, quoteVerified: true }),
+      makeQuote({ footnote: 2, accuracyVerdict: "accurate" }),
+    ];
+    const mockFetch = vi.fn();
+    mockCitationDeps({
+      fetchFromWikiServer: mockFetch,
+      isLocalDataMode: () => true,
+      getLocalCitationQuotes: () => localQuotes,
+    });
+    const mod = await import("../citation-data");
+    const result = await mod.getCitationQuotes("test-page");
+    expect(result).toHaveLength(2);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("getCitationQuotesByUrl", () => {
   it("calls the claims by-source-url endpoint (not deprecated citations/quotes-by-url)", async () => {
     vi.resetModules();
     const mockFetch = vi.fn().mockResolvedValue({ quotes: [], stats: {} });
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: mockFetch,
-    }));
+    mockCitationDeps({ fetchFromWikiServer: mockFetch });
     const mod = await import("../citation-data");
     await mod.getCitationQuotesByUrl("https://example.com/test");
     expect(mockFetch).toHaveBeenCalledWith(
@@ -196,9 +219,7 @@ describe("getCitationQuotesByUrl", () => {
 
   it("returns null when server is unavailable", async () => {
     vi.resetModules();
-    vi.doMock("../wiki-server", () => ({
-      fetchFromWikiServer: vi.fn().mockResolvedValue(null),
-    }));
+    mockCitationDeps({ fetchFromWikiServer: vi.fn().mockResolvedValue(null) });
     const mod = await import("../citation-data");
     const result = await mod.getCitationQuotesByUrl("https://example.com/test");
     expect(result).toBeNull();

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -1,4 +1,5 @@
-import { fetchFromWikiServer } from "./wiki-server";
+import { fetchFromWikiServer, isLocalDataMode } from "./wiki-server";
+import { getLocalCitationQuotes } from "@/data";
 import type {
   CitationHealthResult,
   ClaimsByPageResult,
@@ -75,24 +76,32 @@ function toAccuracyVerdict(value: string | null): AccuracyVerdict | null {
 }
 
 /**
- * Fetch citation verification data for a specific page from the wiki-server.
- * Returns an empty array if the server is unavailable or the page has no data.
+ * Fetch citation verification data for a specific page.
  *
- * Reads from the claims system (claims + claim_page_references + claim_sources)
- * via the /api/claims/by-page endpoint, which replaced the deprecated
- * /api/citations/quotes endpoint (#1311).
+ * In local data mode (WIKI_DATA_MODE=local), reads from the build-time
+ * citation bundle in database.json — zero API calls. Otherwise fetches
+ * from the claims system via /api/claims/by-page.
  *
- * Revalidates every 10 minutes — citation data changes infrequently.
+ * Returns an empty array if no data is available.
  */
 export async function getCitationQuotes(
   pageId: string
 ): Promise<CitationQuote[]> {
+  // Local-first: use build-time bundle if available and in local mode,
+  // or if the server URL is not configured.
+  if (isLocalDataMode()) {
+    return getLocalCitationQuotesForPage(pageId);
+  }
+
   const result = await fetchFromWikiServer<ClaimsByPageResult>(
     `/api/claims/by-page?page_id=${encodeURIComponent(pageId)}`,
     { revalidate: 600 }
   );
 
-  if (!result?.quotes) return [];
+  if (!result?.quotes) {
+    // API unavailable — fall back to local bundle
+    return getLocalCitationQuotesForPage(pageId);
+  }
 
   // Only include quotes that have some verification data worth showing.
   // Map server rows to CitationQuote, narrowing accuracyVerdict from string to the union type.
@@ -115,6 +124,36 @@ export async function getCitationQuotes(
       accuracySupportingQuotes: q.accuracySupportingQuotes,
       verificationDifficulty: q.verificationDifficulty,
       accuracyCheckedAt: q.accuracyCheckedAt,
+    }));
+}
+
+/**
+ * Read citation quotes for a page from the build-time database.json bundle.
+ * Returns an empty array if no data was bundled.
+ */
+function getLocalCitationQuotesForPage(pageId: string): CitationQuote[] {
+  const localQuotes = getLocalCitationQuotes(pageId);
+  if (!localQuotes) return [];
+
+  return localQuotes
+    .filter((q: Record<string, unknown>) => q.quoteVerified || q.accuracyVerdict !== null)
+    .map((q: Record<string, unknown>): CitationQuote => ({
+      footnote: q.footnote as number,
+      url: q.url as string | null,
+      resourceId: q.resourceId as string | null,
+      claimText: q.claimText as string,
+      sourceQuote: q.sourceQuote as string | null,
+      sourceTitle: q.sourceTitle as string | null,
+      sourceType: q.sourceType as string | null,
+      quoteVerified: q.quoteVerified as boolean,
+      verificationScore: q.verificationScore as number | null,
+      verifiedAt: q.verifiedAt as string | null,
+      accuracyVerdict: toAccuracyVerdict(q.accuracyVerdict as string | null),
+      accuracyScore: q.accuracyScore as number | null,
+      accuracyIssues: q.accuracyIssues as string | null,
+      accuracySupportingQuotes: q.accuracySupportingQuotes as string | null,
+      verificationDifficulty: q.verificationDifficulty as string | null,
+      accuracyCheckedAt: q.accuracyCheckedAt as string | null,
     }));
 }
 

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -80,10 +80,21 @@ export async function fetchFromWikiServer<T>(
  * Useful for dashboards that need custom fetch logic (e.g. pagination).
  * Returns null if the server URL is not configured.
  */
+/**
+ * When WIKI_DATA_MODE=local, all API calls are skipped and data is read
+ * from local database.json instead. This eliminates runtime wiki-server
+ * requests from content pages, avoiding rate-limit pressure.
+ */
+export function isLocalDataMode(): boolean {
+  return process.env.WIKI_DATA_MODE === "local";
+}
+
 export function getWikiServerConfig(): {
   serverUrl: string;
   headers: Record<string, string>;
 } | null {
+  if (isLocalDataMode()) return null;
+
   const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
   if (!serverUrl) return null;
 


### PR DESCRIPTION
## Summary

- Add `WIKI_DATA_MODE=local` env var that makes content pages read entirely from `database.json` instead of making live API calls to the wiki-server
- Bundle citation quotes into `database.json` at build time, closing the last data gap that required runtime API calls
- Add local fallback in `getCitationQuotes()` so citation data works without API access

## Problem

The wiki-server was being rate-limited (429s) because all traffic appeared from `127.0.0.1` (ingress IP forwarding issue), exhausting the 100 req/min limit. Each wiki page render makes 4-5 API calls during ISR revalidation — with ~700 pages this generates hundreds of requests per minute.

## Solution

**Option 1 — Local data mode:** When `WIKI_DATA_MODE=local` is set, `getWikiServerConfig()` returns null, causing all `fetchFromWikiServer`/`fetchDetailed`/RPC calls to short-circuit. The existing `withApiFallback` pattern already falls back to `database.json` for all content data (facts, backlinks, related pages, resources, risk stats).

**Option 2 — Citation data bundling:** The one gap was citation quotes (only in PostgreSQL). `build-data.mjs` now fetches all citation quotes at build time via `/api/citations/quotes/all` and includes them in `database.json`. `getCitationQuotes()` reads from this local bundle when the API is unavailable.

## To deploy

Set `WIKI_DATA_MODE=local` in the Next.js deployment environment. Content pages will use `database.json` exclusively — zero runtime API calls. Data freshness matches the last deploy/rebuild.

## Test plan

- [x] TypeScript compiles cleanly (no new errors)
- [x] All 21 citation-data tests pass, including new local mode test
- [x] Full test suite: no new failures (2 pre-existing wiki-nav failures unrelated)
- [ ] Verify `pnpm build` succeeds
- [ ] Test with `WIKI_DATA_MODE=local` set locally

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)