### PR TITLE
fix: shorten vercel.json ignoreCommand to under 256 chars

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,5 @@
   "framework": "nextjs",
   "installCommand": "cd .. && npx pnpm@9 install",
   "buildCommand": "node scripts/build-data.mjs && next build",
-  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == \"main\" ]]; then echo \"Skipping Git-triggered build on main (production deploys via scheduled hook only)\"; exit 0; fi; if [[ \"$VERCEL_GIT_COMMIT_REF\" == claude/* ]]; then echo \"Skipping build: claude/* branch (automated PR)\"; exit 0; fi; exit 1"
+  "ignoreCommand": "bash -c '[[ $VERCEL_GIT_COMMIT_REF == main || $VERCEL_GIT_COMMIT_REF == claude/* ]] && exit 0; exit 1'"
 }


### PR DESCRIPTION
## Summary

- Vercel's schema validation rejects `ignoreCommand` over 256 characters
- The existing command was 277 chars — condensed to 102 chars
- Same behavior: skip builds for `main` and `claude/*` branches, build everything else

## Test plan

- [x] New command is 102 chars (under 256 limit)
- [x] Logic preserved: `main` → skip, `claude/*` → skip, other branches → build
- [ ] Vercel deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)