### PR TITLE
infra: add pre-deploy smoke test and automatic rollback

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -107,17 +107,18 @@ jobs:
             fi
           done
 
-          # Always clean up the container regardless of test outcome.
-          echo "Stopping and removing smoke-test container..."
-          docker stop "$CONTAINER_NAME" || true
-          docker rm "$CONTAINER_NAME" || true
-
           if [ "$STATUS" != "healthy" ]; then
             echo "::error::Pre-deploy smoke test failed — container did not become healthy within $((MAX_ATTEMPTS * DELAY))s. Aborting deploy to prevent serving broken traffic."
             exit 1
           fi
 
           echo "Pre-deploy smoke test passed — container is healthy. Proceeding with deploy."
+
+      - name: Clean up smoke test container
+        if: always()
+        run: |
+          docker stop "smoke-test-${{ github.run_id }}" 2>/dev/null || true
+          docker rm "smoke-test-${{ github.run_id }}" 2>/dev/null || true
 
   pre-deploy-backup:
     name: Pre-deploy database backup
@@ -131,10 +132,13 @@ jobs:
   deploy:
     name: Deploy to ArgoCD
     needs: [build-and-push, pre-deploy-smoke-test, pre-deploy-backup]
-    if: github.ref == 'refs/heads/main' && !cancelled()
+    if: >-
+      github.ref == 'refs/heads/main'
+      && !cancelled()
+      && needs.pre-deploy-smoke-test.result == 'success'
     # Deploy proceeds even if backup fails (DATABASE_URL may not be configured yet).
     # Once DATABASE_URL is added, backup failures will be visible but non-blocking.
-    # Pre-deploy smoke test failure DOES block the deploy (job dependency enforces this).
+    # Pre-deploy smoke test failure explicitly blocks the deploy (checked in the `if` condition above).
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Adds new `pre-deploy-smoke-test` job that runs the new Docker image in isolation (port 3099) before routing any traffic to it
- Container starts with production `DATABASE_URL`; idempotent migrations run and health check must return `healthy` within 30s
- If pre-deploy smoke test fails, `deploy` job is blocked — the bad image never serves user traffic
- Adds `id: post-deploy-smoke` to the existing post-deploy smoke test step for step reference
- Adds automatic rollback step: triggers `argocd app rollback` when the post-deploy smoke test fails, then waits for rollback to become healthy
- Container is always cleaned up (stop + rm) regardless of test outcome

## Design decisions
- Pre-deploy uses production `DATABASE_URL`: migrations are idempotent (Drizzle skips already-applied migrations), so connecting to the real DB is safe and validates the actual schema
- Timeout: 10 retries × 3s = 30s max — fast enough for most startup times, sufficient for migration execution
- Container name includes `github.run_id` to avoid collisions on concurrent runs
- Rollback step only runs if the smoke test step specifically failed (not if upstream steps like SHA verification failed)

## Test plan
- [ ] Gate passes
- [ ] Workflow runs `pre-deploy-smoke-test` job after `build-and-push` and before `deploy`
- [ ] Deploy is blocked when pre-deploy smoke test fails
- [ ] Post-deploy smoke test failure triggers ArgoCD rollback
- [ ] Cleanup runs even on test failure

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)