### PR TITLE
safety: add semantic diff and scope enforcement for AI content changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ scripts/fact-id-mapping.json
 
 # Eval results (ephemeral — regenerated on each run)
 crux/evals/results/
+
+# Semantic diff snapshots (audit trail — not source code, stored locally)
+.claude/snapshots/

--- a/crux/authoring/page-improver/pipeline.ts
+++ b/crux/authoring/page-improver/pipeline.ts
@@ -29,6 +29,7 @@ import {
   validatePhase, gapFillPhase, triagePhase, adversarialLoopPhase,
   citationAuditPhase,
 } from './phases.ts';
+import { runSemanticDiff } from '../../lib/semantic-diff/index.ts';
 
 // ── Session log helpers ───────────────────────────────────────────────────────
 
@@ -138,6 +139,9 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
     console.error(`File not found: ${filePath}`);
     process.exit(1);
   }
+
+  // Capture original content for semantic diff (before any modifications)
+  const originalContent = fs.readFileSync(filePath, 'utf-8');
 
   // Handle triage tier: run news check to auto-select the real tier
   let triageResult: TriageResult | undefined;
@@ -396,6 +400,28 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
 
     fs.writeFileSync(filePath, contentToApply);
     console.log(`\nChanges applied to ${filePath}`);
+
+    // Semantic diff: analyze factual claim changes for safety audit
+    // Non-blocking: runs after write, warns but never blocks on analysis failure
+    try {
+      const semanticDiff = await runSemanticDiff(
+        page.id,
+        originalContent,
+        contentToApply,
+        { agent: 'crux-improve', tier, verbose: false },
+      );
+      if (semanticDiff.assessment !== 'safe') {
+        log('semantic-diff', `Assessment: ${semanticDiff.assessment.toUpperCase()}`);
+        for (const issue of semanticDiff.issues) {
+          log('semantic-diff', `  ${issue}`);
+        }
+      } else {
+        log('semantic-diff', `Safe (${semanticDiff.diff.summary.added} added, ${semanticDiff.diff.summary.removed} removed, ${semanticDiff.diff.summary.changed} changed claims)`);
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      log('semantic-diff', `Warning: semantic diff failed (non-blocking): ${error.message}`);
+    }
 
     // Post-apply cleanup: run auto-fixers on the written file
     const cleanupResult = await runPostApplyCleanup(filePath);

--- a/crux/lib/semantic-diff/claim-extractor.ts
+++ b/crux/lib/semantic-diff/claim-extractor.ts
@@ -1,0 +1,269 @@
+/**
+ * Claim Extractor
+ *
+ * Uses Haiku (lightweight, fast) to extract structured factual claims
+ * from MDX page content. Claims are the atomic factual assertions
+ * that can be verified, contradicted, or tracked across versions.
+ *
+ * This is intentionally kept cheap and fast — Haiku is ~20x cheaper
+ * than Sonnet and fast enough for real-time use during the improve pipeline.
+ */
+
+import { createLlmClient, callLlm, MODELS } from '../llm.ts';
+import { parseJsonFromLlm } from '../json-parsing.ts';
+import type { ExtractedClaim, ClaimType, ExtractionConfidence } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// MDX content preprocessing
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip MDX frontmatter, JSX components, and markdown formatting from content
+ * to produce cleaner prose for claim extraction.
+ *
+ * We strip:
+ * - YAML frontmatter (--- ... ---)
+ * - JSX/MDX component tags (<Component ... />)
+ * - Footnote definitions ([^N]: ...)
+ * - Import/export statements
+ * - Markdown headings (# ## ###)
+ * - Code blocks
+ */
+export function preprocessMdxForExtraction(content: string): string {
+  let text = content;
+
+  // Strip frontmatter
+  text = text.replace(/^---[\s\S]*?---\n/, '');
+
+  // Strip code blocks (they contain code, not prose claims)
+  text = text.replace(/```[\s\S]*?```/g, '');
+
+  // Strip inline code
+  text = text.replace(/`[^`]+`/g, '');
+
+  // Strip import/export statements
+  text = text.replace(/^(?:import|export)\s+.*$/gm, '');
+
+  // Strip JSX/MDX component tags (self-closing and opening)
+  text = text.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
+  text = text.replace(/<[A-Z][a-zA-Z]*[^>]*>/g, '');
+  text = text.replace(/<\/[A-Z][a-zA-Z]*>/g, '');
+
+  // Strip HTML comments
+  text = text.replace(/\{\/\*[\s\S]*?\*\/\}/g, '');
+
+  // Strip footnote definitions (we want claims from prose, not references)
+  text = text.replace(/^\[\^\d+\]:.*$/gm, '');
+
+  // Strip footnote references inline (keep the surrounding text)
+  text = text.replace(/\[\^(\d+)\]/g, '');
+
+  // Strip markdown link syntax, keep text
+  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+  // Strip heading markers (keep the text)
+  text = text.replace(/^#{1,6}\s+/gm, '');
+
+  // Strip bold/italic
+  text = text.replace(/\*\*([^*]+)\*\*/g, '$1');
+  text = text.replace(/\*([^*]+)\*/g, '$1');
+  text = text.replace(/__([^_]+)__/g, '$1');
+  text = text.replace(/_([^_]+)_/g, '$1');
+
+  // Collapse multiple blank lines
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+}
+
+/**
+ * Split content into chunks of approximately maxChars characters,
+ * breaking on paragraph boundaries to preserve context.
+ */
+export function splitIntoChunks(text: string, maxChars = 3000): string[] {
+  const paragraphs = text.split(/\n\n+/);
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const para of paragraphs) {
+    if (current.length + para.length + 2 > maxChars && current.length > 0) {
+      chunks.push(current.trim());
+      current = para;
+    } else {
+      current = current ? current + '\n\n' + para : para;
+    }
+  }
+
+  if (current.trim()) {
+    chunks.push(current.trim());
+  }
+
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// LLM extraction
+// ---------------------------------------------------------------------------
+
+const EXTRACTION_SYSTEM_PROMPT = `You are a factual claim extractor for an AI safety wiki. Your job is to identify discrete, verifiable factual claims from wiki page content.
+
+Extract only concrete, assertable facts — not opinions, speculation, or general descriptions. Focus on:
+- Numbers, statistics, percentages
+- Dates, years, founding dates, event timings
+- Attributions ("X said Y", "X founded Y", "X employs N people")
+- Causal relationships with specific evidence
+- Comparisons with specific values
+- Existence claims ("X was created", "X published Y")
+
+Do NOT extract:
+- Vague descriptions ("X is an important organization")
+- Opinions or evaluations ("X is considered excellent")
+- Future predictions
+- Hypothetical statements
+
+Output must be valid JSON with this exact structure:
+{
+  "claims": [
+    {
+      "text": "One-sentence assertable factual claim",
+      "type": "numeric|temporal|causal|attribution|existence|comparison|definition|other",
+      "confidence": "high|medium|low",
+      "sourceContext": "The sentence or phrase this was extracted from",
+      "keyValue": "The specific value (number, date, name) that is the core of this claim, if applicable"
+    }
+  ]
+}
+
+Extract only claims you can clearly identify. Quality over quantity. Return an empty claims array if there are no clear factual claims.`;
+
+interface RawClaimData {
+  text?: unknown;
+  type?: unknown;
+  confidence?: unknown;
+  sourceContext?: unknown;
+  keyValue?: unknown;
+}
+
+interface LlmExtractionResult {
+  claims: RawClaimData[];
+}
+
+/**
+ * Extract claims from a single chunk of text using Haiku.
+ */
+async function extractClaimsFromChunk(
+  chunk: string,
+): Promise<ExtractedClaim[]> {
+  const client = createLlmClient();
+
+  const prompt = `Extract all verifiable factual claims from this wiki page content:
+
+${chunk}
+
+Return the claims as a JSON object with a "claims" array.`;
+
+  const result = await callLlm(client, {
+    system: EXTRACTION_SYSTEM_PROMPT,
+    user: prompt,
+  }, {
+    model: MODELS.haiku,
+    maxTokens: 2000,
+    retryLabel: 'claim-extraction',
+  });
+
+  const parsed = parseJsonFromLlm<LlmExtractionResult>(
+    result.text,
+    'claim-extraction',
+    (raw, err) => {
+      // Log the parse failure with context for debugging
+      console.warn(
+        `[semantic-diff] Failed to parse claim extraction response: ${err ?? 'unknown error'}. Raw (first 200): ${raw.slice(0, 200)}`
+      );
+      return { claims: [] };
+    },
+  );
+
+  if (!parsed.claims || !Array.isArray(parsed.claims)) {
+    return [];
+  }
+
+  const validTypes = new Set<ClaimType>([
+    'numeric', 'temporal', 'causal', 'attribution',
+    'existence', 'comparison', 'definition', 'other',
+  ]);
+  const validConfidence = new Set<ExtractionConfidence>(['high', 'medium', 'low']);
+
+  return parsed.claims
+    .filter((c): c is RawClaimData => c !== null && typeof c === 'object')
+    .map(c => ({
+      text: typeof c.text === 'string' ? c.text.trim() : '',
+      type: (validTypes.has(c.type as ClaimType) ? c.type : 'other') as ClaimType,
+      confidence: (validConfidence.has(c.confidence as ExtractionConfidence)
+        ? c.confidence : 'low') as ExtractionConfidence,
+      sourceContext: typeof c.sourceContext === 'string' ? c.sourceContext.trim() : '',
+      keyValue: typeof c.keyValue === 'string' ? c.keyValue.trim() : undefined,
+    }))
+    .filter(c => c.text.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract factual claims from MDX page content.
+ *
+ * Preprocesses the content, splits into chunks, and runs Haiku extraction
+ * on each chunk. Deduplicates the resulting claims.
+ *
+ * @param content - Raw MDX page content (including frontmatter)
+ * @param maxChunkChars - Max characters per chunk for LLM calls (default: 3000)
+ * @returns Array of extracted factual claims
+ */
+export async function extractClaims(
+  content: string,
+  maxChunkChars = 3000,
+): Promise<ExtractedClaim[]> {
+  const prose = preprocessMdxForExtraction(content);
+
+  if (prose.length < 50) {
+    // Too little content to extract claims from
+    return [];
+  }
+
+  const chunks = splitIntoChunks(prose, maxChunkChars);
+  const allClaims: ExtractedClaim[] = [];
+
+  for (const chunk of chunks) {
+    if (chunk.trim().length < 20) continue;
+    try {
+      const claims = await extractClaimsFromChunk(chunk);
+      allClaims.push(...claims);
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.warn(`[semantic-diff] Claim extraction failed for chunk: ${error.message}`);
+      // Continue with other chunks — partial extraction is better than none
+    }
+  }
+
+  return deduplicateExtractedClaims(allClaims);
+}
+
+/**
+ * Remove duplicate claims from an array.
+ * Uses normalized text comparison to identify near-duplicates.
+ */
+function deduplicateExtractedClaims(claims: ExtractedClaim[]): ExtractedClaim[] {
+  const seen = new Set<string>();
+  const unique: ExtractedClaim[] = [];
+
+  for (const claim of claims) {
+    const normalized = claim.text.toLowerCase().replace(/\s+/g, ' ').trim();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      unique.push(claim);
+    }
+  }
+
+  return unique;
+}

--- a/crux/lib/semantic-diff/contradiction-checker.ts
+++ b/crux/lib/semantic-diff/contradiction-checker.ts
@@ -1,0 +1,321 @@
+/**
+ * Contradiction Checker
+ *
+ * Detects factual contradictions between new claims added to a page
+ * and the existing claims on the same page (or cross-page).
+ *
+ * Uses two strategies:
+ * 1. Rule-based: numeric contradiction detection using keyValue comparison
+ *    (fast, deterministic, catches obvious cases like "50 employees" vs "200 employees")
+ * 2. LLM-based: Haiku semantic contradiction detection for complex contradictions
+ *    (slower, catches nuanced contradictions)
+ *
+ * The LLM check only runs on added/changed claims, keeping cost minimal.
+ */
+
+import { jaccardWordSimilarity } from '../claim-utils.ts';
+import { createLlmClient, callLlm, MODELS } from '../llm.ts';
+import { parseJsonFromLlm } from '../json-parsing.ts';
+import type {
+  ExtractedClaim,
+  Contradiction,
+  ContradictionResult,
+  ContradictionSeverity,
+} from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Rule-based contradiction detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a numeric value from a claim's keyValue or text.
+ * Returns undefined if no numeric value can be parsed.
+ */
+function parseNumericFromClaim(claim: ExtractedClaim): number | undefined {
+  const source = claim.keyValue ?? '';
+  if (!source) return undefined;
+
+  // Remove commas and try to parse
+  const cleaned = source.replace(/[$,]/g, '').trim();
+  const value = parseFloat(cleaned);
+  return isFinite(value) ? value : undefined;
+}
+
+/**
+ * Check if two claims are about the same subject based on text similarity.
+ * Higher threshold means we only flag contradictions when claims are clearly
+ * talking about the same thing.
+ */
+function areClainsAboutSameSubject(a: ExtractedClaim, b: ExtractedClaim): boolean {
+  return jaccardWordSimilarity(a.text, b.text) >= 0.4;
+}
+
+/**
+ * Detect rule-based numeric contradictions.
+ * If two similar claims have different numeric keyValues, that's likely a contradiction.
+ */
+function detectNumericContradictions(
+  newClaims: ExtractedClaim[],
+  existingClaims: ExtractedClaim[],
+): Contradiction[] {
+  const contradictions: Contradiction[] = [];
+
+  const numericNew = newClaims.filter(c => c.type === 'numeric' && c.keyValue);
+  const numericExisting = existingClaims.filter(c => c.type === 'numeric' && c.keyValue);
+
+  for (const newClaim of numericNew) {
+    for (const existing of numericExisting) {
+      if (!areClainsAboutSameSubject(newClaim, existing)) continue;
+
+      const newVal = parseNumericFromClaim(newClaim);
+      const existVal = parseNumericFromClaim(existing);
+
+      if (newVal !== undefined && existVal !== undefined && newVal !== existVal) {
+        // Calculate how different the values are
+        const ratio = Math.max(newVal, existVal) / Math.min(newVal, existVal);
+        const severity: ContradictionSeverity =
+          ratio >= 2 ? 'high' : ratio >= 1.2 ? 'medium' : 'low';
+
+        contradictions.push({
+          newClaim,
+          existingClaim: existing,
+          reason: `Numeric value mismatch: new claim has "${newClaim.keyValue}", existing has "${existing.keyValue}"`,
+          severity,
+        });
+      }
+    }
+  }
+
+  return contradictions;
+}
+
+/**
+ * Detect temporal contradictions (different years/dates for the same event).
+ */
+function detectTemporalContradictions(
+  newClaims: ExtractedClaim[],
+  existingClaims: ExtractedClaim[],
+): Contradiction[] {
+  const contradictions: Contradiction[] = [];
+
+  const temporalNew = newClaims.filter(c => c.type === 'temporal' && c.keyValue);
+  const temporalExisting = existingClaims.filter(c => c.type === 'temporal' && c.keyValue);
+
+  for (const newClaim of temporalNew) {
+    for (const existing of temporalExisting) {
+      if (!areClainsAboutSameSubject(newClaim, existing)) continue;
+      if (newClaim.keyValue === existing.keyValue) continue;
+
+      // Year-based comparison for temporal claims
+      const newYear = parseInt(newClaim.keyValue ?? '', 10);
+      const existYear = parseInt(existing.keyValue ?? '', 10);
+
+      if (!isNaN(newYear) && !isNaN(existYear) && newYear !== existYear) {
+        contradictions.push({
+          newClaim,
+          existingClaim: existing,
+          reason: `Temporal mismatch: new claim says "${newClaim.keyValue}", existing says "${existing.keyValue}"`,
+          severity: 'high',
+        });
+      }
+    }
+  }
+
+  return contradictions;
+}
+
+// ---------------------------------------------------------------------------
+// LLM-based contradiction detection
+// ---------------------------------------------------------------------------
+
+const CONTRADICTION_SYSTEM_PROMPT = `You are a fact-checker for an AI safety wiki. Your job is to detect factual contradictions between new claims and existing claims.
+
+A contradiction is when two claims assert incompatible facts about the same subject:
+- "OpenAI was founded in 2015" contradicts "OpenAI was founded in 2019"
+- "The organization has 300 employees" contradicts "The organization employs 50 people"
+- "X is the CEO of Y" contradicts "X was fired from Y in 2023"
+
+NOT contradictions:
+- Claims about different time periods ("had 50 employees in 2020" vs "has 300 employees now")
+- Claims about different subjects
+- Vague vs specific statements (vague doesn't contradict specific)
+- Complementary information
+
+Output valid JSON:
+{
+  "contradictions": [
+    {
+      "newClaimIndex": 0,
+      "existingClaimIndex": 1,
+      "reason": "Why these contradict",
+      "severity": "high|medium|low"
+    }
+  ]
+}
+
+Return an empty contradictions array if no contradictions are found.`;
+
+interface RawContradiction {
+  newClaimIndex?: unknown;
+  existingClaimIndex?: unknown;
+  reason?: unknown;
+  severity?: unknown;
+}
+
+interface LlmContradictionResult {
+  contradictions: RawContradiction[];
+}
+
+/**
+ * Use Haiku to detect semantic contradictions between new and existing claims.
+ * Only called for added/changed claims to keep costs low.
+ */
+async function detectLlmContradictions(
+  newClaims: ExtractedClaim[],
+  existingClaims: ExtractedClaim[],
+): Promise<Contradiction[]> {
+  if (newClaims.length === 0 || existingClaims.length === 0) return [];
+
+  // Limit claim counts to keep prompt size manageable
+  const limitedNew = newClaims.slice(0, 20);
+  const limitedExisting = existingClaims.slice(0, 30);
+
+  const client = createLlmClient();
+
+  const prompt = `Check these NEW claims against EXISTING claims for contradictions.
+
+NEW CLAIMS (just added/changed):
+${limitedNew.map((c, i) => `[${i}] ${c.text}${c.keyValue ? ` (key value: ${c.keyValue})` : ''}`).join('\n')}
+
+EXISTING CLAIMS (already in the page):
+${limitedExisting.map((c, i) => `[${i}] ${c.text}${c.keyValue ? ` (key value: ${c.keyValue})` : ''}`).join('\n')}
+
+Find any contradictions between the NEW claims and EXISTING claims. Return JSON.`;
+
+  const result = await callLlm(client, {
+    system: CONTRADICTION_SYSTEM_PROMPT,
+    user: prompt,
+  }, {
+    model: MODELS.haiku,
+    maxTokens: 1500,
+    retryLabel: 'contradiction-check',
+  });
+
+  const parsed = parseJsonFromLlm<LlmContradictionResult>(
+    result.text,
+    'contradiction-check',
+    (raw, err) => {
+      console.warn(
+        `[semantic-diff] Failed to parse contradiction check response: ${err ?? 'unknown error'}. Raw (first 200): ${raw.slice(0, 200)}`
+      );
+      return { contradictions: [] };
+    },
+  );
+
+  if (!parsed.contradictions || !Array.isArray(parsed.contradictions)) {
+    return [];
+  }
+
+  const validSeverities = new Set<ContradictionSeverity>(['high', 'medium', 'low']);
+
+  return parsed.contradictions
+    .filter((c): c is RawContradiction =>
+      typeof c.newClaimIndex === 'number' &&
+      typeof c.existingClaimIndex === 'number' &&
+      typeof c.reason === 'string',
+    )
+    .map(c => {
+      const newClaimIdx = c.newClaimIndex as number;
+      const existingClaimIdx = c.existingClaimIndex as number;
+
+      const newClaim = limitedNew[newClaimIdx];
+      const existingClaim = limitedExisting[existingClaimIdx];
+
+      if (!newClaim || !existingClaim) return null;
+
+      const severity: ContradictionSeverity = validSeverities.has(c.severity as ContradictionSeverity)
+        ? (c.severity as ContradictionSeverity)
+        : 'medium';
+
+      return {
+        newClaim,
+        existingClaim,
+        reason: c.reason as string,
+        severity,
+      };
+    })
+    .filter((c): c is Contradiction => c !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ContradictionCheckOptions {
+  /** Whether to use LLM-based semantic contradiction detection. Default: true. */
+  useLlm?: boolean;
+  /** Whether to use rule-based numeric contradiction detection. Default: true. */
+  useRules?: boolean;
+}
+
+/**
+ * Check for contradictions between new claims and existing claims.
+ *
+ * Runs both rule-based and LLM-based checks (by default) and merges results.
+ * Deduplicates any contradictions caught by both methods.
+ *
+ * @param newClaims - Claims that were added or changed in the new version
+ * @param existingClaims - Claims from the existing (before) version of the page
+ * @param options - Configuration for which checks to run
+ */
+export async function checkContradictions(
+  newClaims: ExtractedClaim[],
+  existingClaims: ExtractedClaim[],
+  options: ContradictionCheckOptions = {},
+): Promise<ContradictionResult> {
+  const { useLlm = true, useRules = true } = options;
+
+  const allContradictions: Contradiction[] = [];
+
+  // Rule-based checks (fast, free)
+  if (useRules) {
+    const numericContradictions = detectNumericContradictions(newClaims, existingClaims);
+    const temporalContradictions = detectTemporalContradictions(newClaims, existingClaims);
+    allContradictions.push(...numericContradictions, ...temporalContradictions);
+  }
+
+  // LLM-based checks (slower, costs Haiku tokens)
+  if (useLlm) {
+    try {
+      const llmContradictions = await detectLlmContradictions(newClaims, existingClaims);
+
+      // Deduplicate: skip LLM findings that already caught by rule-based
+      for (const llmContra of llmContradictions) {
+        const alreadyCaught = allContradictions.some(
+          existing =>
+            existing.newClaim.text === llmContra.newClaim.text &&
+            existing.existingClaim.text === llmContra.existingClaim.text,
+        );
+        if (!alreadyCaught) {
+          allContradictions.push(llmContra);
+        }
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.warn(`[semantic-diff] LLM contradiction check failed: ${error.message}`);
+      // Continue with rule-based results only
+    }
+  }
+
+  const summary = {
+    high: allContradictions.filter(c => c.severity === 'high').length,
+    medium: allContradictions.filter(c => c.severity === 'medium').length,
+    low: allContradictions.filter(c => c.severity === 'low').length,
+  };
+
+  return {
+    contradictions: allContradictions,
+    hasHighSeverity: summary.high > 0,
+    summary,
+  };
+}

--- a/crux/lib/semantic-diff/diff-engine.ts
+++ b/crux/lib/semantic-diff/diff-engine.ts
@@ -1,0 +1,180 @@
+/**
+ * Semantic Diff Engine
+ *
+ * Compares two sets of extracted claims (before and after page modification)
+ * and produces a structured diff of what changed.
+ *
+ * Uses Jaccard word-similarity (already present in claim-utils.ts) to match
+ * semantically similar claims across versions, then identifies which values
+ * actually changed.
+ *
+ * Design decisions:
+ * - No LLM calls in the diff step (pure computation, fast and cheap)
+ * - Uses the existing Jaccard similarity from claim-utils.ts for consistency
+ * - A claim is "changed" when it matches an existing claim but has a different keyValue
+ */
+
+import { jaccardWordSimilarity } from '../claim-utils.ts';
+import type {
+  ExtractedClaim,
+  ClaimDiffEntry,
+  ClaimDiffStatus,
+  SemanticDiff,
+} from './types.ts';
+
+// Threshold for two claims to be considered "the same claim with different values"
+// vs "two unrelated claims". At 0.5, claims must share half their vocabulary.
+const MATCH_THRESHOLD = 0.5;
+
+// ---------------------------------------------------------------------------
+// Internal matching
+// ---------------------------------------------------------------------------
+
+interface ClaimMatch {
+  beforeIndex: number;
+  afterIndex: number;
+  similarity: number;
+}
+
+/**
+ * Find the best matching pairs between before and after claims.
+ * Uses a greedy matching algorithm: highest-similarity pairs are matched first.
+ */
+function findBestMatches(
+  beforeClaims: ExtractedClaim[],
+  afterClaims: ExtractedClaim[],
+): ClaimMatch[] {
+  // Build all potential matches above threshold
+  const candidates: ClaimMatch[] = [];
+
+  for (let i = 0; i < beforeClaims.length; i++) {
+    for (let j = 0; j < afterClaims.length; j++) {
+      const sim = jaccardWordSimilarity(beforeClaims[i].text, afterClaims[j].text);
+      if (sim >= MATCH_THRESHOLD) {
+        candidates.push({ beforeIndex: i, afterIndex: j, similarity: sim });
+      }
+    }
+  }
+
+  // Sort by similarity descending
+  candidates.sort((a, b) => b.similarity - a.similarity);
+
+  // Greedy assignment: each before/after claim can be matched at most once
+  const usedBefore = new Set<number>();
+  const usedAfter = new Set<number>();
+  const matches: ClaimMatch[] = [];
+
+  for (const candidate of candidates) {
+    if (!usedBefore.has(candidate.beforeIndex) && !usedAfter.has(candidate.afterIndex)) {
+      matches.push(candidate);
+      usedBefore.add(candidate.beforeIndex);
+      usedAfter.add(candidate.afterIndex);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Determine what changed between two matched claims.
+ * Returns a description if the claim actually changed, or undefined if unchanged.
+ */
+function describeChange(before: ExtractedClaim, after: ExtractedClaim): string | undefined {
+  // Key value changed (most important change)
+  if (before.keyValue !== undefined && after.keyValue !== undefined) {
+    if (before.keyValue !== after.keyValue) {
+      return `Key value changed: "${before.keyValue}" → "${after.keyValue}"`;
+    }
+  } else if (before.keyValue !== undefined && after.keyValue === undefined) {
+    return `Key value removed: was "${before.keyValue}"`;
+  } else if (before.keyValue === undefined && after.keyValue !== undefined) {
+    return `Key value added: "${after.keyValue}"`;
+  }
+
+  // Text changed significantly despite high similarity
+  // (e.g., "X raised $100M" → "X raised $200M" when keyValue is not set)
+  const normBefore = before.text.toLowerCase().trim();
+  const normAfter = after.text.toLowerCase().trim();
+  if (normBefore !== normAfter) {
+    // Only flag if the texts are different enough to matter
+    const sim = jaccardWordSimilarity(before.text, after.text);
+    if (sim < 0.95) {
+      return `Claim text updated`;
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a structured semantic diff between two sets of claims.
+ *
+ * @param beforeClaims - Claims extracted from the page before modification
+ * @param afterClaims - Claims extracted from the page after modification
+ * @returns A SemanticDiff with categorized entries
+ */
+export function diffClaims(
+  beforeClaims: ExtractedClaim[],
+  afterClaims: ExtractedClaim[],
+): SemanticDiff {
+  const matches = findBestMatches(beforeClaims, afterClaims);
+
+  const matchedBeforeIndices = new Set(matches.map(m => m.beforeIndex));
+  const matchedAfterIndices = new Set(matches.map(m => m.afterIndex));
+
+  const entries: ClaimDiffEntry[] = [];
+
+  // Process matched pairs
+  for (const match of matches) {
+    const before = beforeClaims[match.beforeIndex];
+    const after = afterClaims[match.afterIndex];
+    const changeDescription = describeChange(before, after);
+
+    const status: ClaimDiffStatus = changeDescription ? 'changed' : 'unchanged';
+
+    entries.push({
+      status,
+      oldClaim: before,
+      newClaim: after,
+      changeDescription,
+    });
+  }
+
+  // Unmatched before claims = removed
+  for (let i = 0; i < beforeClaims.length; i++) {
+    if (!matchedBeforeIndices.has(i)) {
+      entries.push({
+        status: 'removed',
+        oldClaim: beforeClaims[i],
+      });
+    }
+  }
+
+  // Unmatched after claims = added
+  for (let j = 0; j < afterClaims.length; j++) {
+    if (!matchedAfterIndices.has(j)) {
+      entries.push({
+        status: 'added',
+        newClaim: afterClaims[j],
+      });
+    }
+  }
+
+  const summary = {
+    added: entries.filter(e => e.status === 'added').length,
+    removed: entries.filter(e => e.status === 'removed').length,
+    changed: entries.filter(e => e.status === 'changed').length,
+    unchanged: entries.filter(e => e.status === 'unchanged').length,
+  };
+
+  return {
+    claimsBefore: beforeClaims.length,
+    claimsAfter: afterClaims.length,
+    entries,
+    summary,
+  };
+}

--- a/crux/lib/semantic-diff/index.ts
+++ b/crux/lib/semantic-diff/index.ts
@@ -1,0 +1,270 @@
+/**
+ * Semantic Diff — Main Module
+ *
+ * Orchestrates the full semantic diff pipeline for AI-generated content changes:
+ * 1. Extract factual claims from before and after content (via Haiku LLM)
+ * 2. Diff claims to find added/removed/changed facts
+ * 3. Check for contradictions between new claims and existing page content
+ * 4. Store before/after snapshots for audit trail
+ *
+ * Design principles:
+ * - Non-blocking by default: returns 'warn' assessment rather than 'block'
+ *   until confidence in the system is established
+ * - Fail-open for analysis (if LLM fails, still write the page with a warning)
+ * - Fail-closed for scope checks (scope violations always block)
+ * - Cost-conscious: uses Haiku for all LLM calls
+ *
+ * Usage:
+ *   import { runSemanticDiff, checkScope } from './lib/semantic-diff/index.ts';
+ *
+ *   // After AI modifies page content:
+ *   const result = await runSemanticDiff(pageId, beforeContent, afterContent, {
+ *     agent: 'auto-update',
+ *     tier: 'standard',
+ *   });
+ *   if (result.assessment !== 'safe') {
+ *     console.warn('[semantic-diff]', result.issues.join('\n'));
+ *   }
+ */
+
+import { extractClaims } from './claim-extractor.ts';
+import { diffClaims } from './diff-engine.ts';
+import { checkContradictions } from './contradiction-checker.ts';
+import { storeSnapshot } from './snapshot-store.ts';
+import type { SemanticDiffResult, ExtractedClaim } from './types.ts';
+
+// Re-export sub-modules for direct use
+export { extractClaims } from './claim-extractor.ts';
+export { diffClaims } from './diff-engine.ts';
+export { checkContradictions } from './contradiction-checker.ts';
+export { checkScope, checkContentScope, filterContentFiles, detectModifiedFiles } from './scope-checker.ts';
+export { storeSnapshot, loadSnapshot, listSnapshots, getLatestSnapshot, getSnapshotsDir } from './snapshot-store.ts';
+export type * from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface SemanticDiffOptions {
+  /** Agent or pipeline that made the change. Default: 'auto-update'. */
+  agent?: string;
+  /** Tier used for the improvement (e.g., 'polish', 'standard', 'deep'). */
+  tier?: string;
+  /** Whether to run contradiction checking. Default: true. */
+  checkContradictions?: boolean;
+  /** Whether to use LLM for contradiction checking. Default: true. */
+  useLlmContradictions?: boolean;
+  /** Whether to store a snapshot. Default: true. */
+  storeSnapshot?: boolean;
+  /** Whether to output progress logs. Default: false. */
+  verbose?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Assessment logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the overall assessment level based on diff and contradiction results.
+ *
+ * Currently:
+ * - 'safe': No high-severity contradictions, reasonable claim changes
+ * - 'warn': Medium-severity contradictions or unusual claim change ratio
+ * - 'block': High-severity contradictions (reserved for future use when
+ *            confidence in the system is established)
+ *
+ * The system starts in non-blocking mode: 'block' is not returned in the
+ * initial implementation to avoid false positives. Callers should treat
+ * 'warn' as informational for now.
+ */
+function computeAssessment(
+  diff: SemanticDiffResult['diff'],
+  contradictions: SemanticDiffResult['contradictions'],
+): { assessment: 'safe' | 'warn' | 'block'; issues: string[] } {
+  const issues: string[] = [];
+
+  // High-severity contradictions = warn (not block yet, non-blocking mode)
+  if (contradictions.hasHighSeverity) {
+    issues.push(
+      `${contradictions.summary.high} high-severity contradiction(s) detected. ` +
+      `Review before publishing.`
+    );
+  }
+
+  // Medium-severity contradictions = warn
+  if (contradictions.summary.medium > 0) {
+    issues.push(
+      `${contradictions.summary.medium} medium-severity contradiction(s) detected.`
+    );
+  }
+
+  // Unusual change ratio: more than 50% of claims changed
+  const totalClaims = Math.max(diff.claimsBefore, diff.claimsAfter, 1);
+  const changedRatio = (diff.summary.added + diff.summary.removed + diff.summary.changed) / totalClaims;
+  if (changedRatio > 0.5 && totalClaims > 5) {
+    issues.push(
+      `${Math.round(changedRatio * 100)}% of claims changed ` +
+      `(${diff.summary.added} added, ${diff.summary.removed} removed, ${diff.summary.changed} modified). ` +
+      `Consider reviewing scope of changes.`
+    );
+  }
+
+  // Many claims removed = potential content loss
+  if (diff.summary.removed > 5) {
+    issues.push(`${diff.summary.removed} claims removed. Verify important information was not lost.`);
+  }
+
+  const assessment = issues.length === 0 ? 'safe' : 'warn';
+
+  return { assessment, issues };
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full semantic diff pipeline on a page change.
+ *
+ * Extracts claims from before/after content, diffs them, checks for
+ * contradictions, and stores a snapshot. Returns a structured result
+ * with an overall assessment.
+ *
+ * This function is designed to be non-blocking — it will always return
+ * a result even if individual steps fail (with appropriate warnings).
+ *
+ * @param pageId - The page entity ID (e.g., 'anthropic', 'miri')
+ * @param beforeContent - Raw MDX content before the AI modification
+ * @param afterContent - Raw MDX content after the AI modification
+ * @param options - Configuration options
+ */
+export async function runSemanticDiff(
+  pageId: string,
+  beforeContent: string,
+  afterContent: string,
+  options: SemanticDiffOptions = {},
+): Promise<SemanticDiffResult> {
+  const {
+    agent = 'auto-update',
+    tier,
+    checkContradictions: doCheckContradictions = true,
+    useLlmContradictions = true,
+    storeSnapshot: doStoreSnapshot = true,
+    verbose = false,
+  } = options;
+
+  const timestamp = new Date().toISOString();
+
+  if (verbose) {
+    console.log(`[semantic-diff] Analyzing changes for ${pageId}...`);
+  }
+
+  // Step 1: Extract claims from both versions
+  let beforeClaims: ExtractedClaim[] = [];
+  let afterClaims: ExtractedClaim[] = [];
+
+  try {
+    if (verbose) console.log('[semantic-diff] Extracting claims from before content...');
+    beforeClaims = await extractClaims(beforeContent);
+    if (verbose) console.log(`[semantic-diff] Found ${beforeClaims.length} claims in before content`);
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.warn(`[semantic-diff] Before-content claim extraction failed: ${error.message}`);
+  }
+
+  try {
+    if (verbose) console.log('[semantic-diff] Extracting claims from after content...');
+    afterClaims = await extractClaims(afterContent);
+    if (verbose) console.log(`[semantic-diff] Found ${afterClaims.length} claims in after content`);
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.warn(`[semantic-diff] After-content claim extraction failed: ${error.message}`);
+  }
+
+  // Step 2: Diff the claims
+  const diff = diffClaims(beforeClaims, afterClaims);
+
+  if (verbose) {
+    console.log(
+      `[semantic-diff] Diff: +${diff.summary.added} added, -${diff.summary.removed} removed, ` +
+      `~${diff.summary.changed} changed, =${diff.summary.unchanged} unchanged`
+    );
+  }
+
+  // Step 3: Check for contradictions (only on added/changed claims)
+  let contradictionResult: SemanticDiffResult['contradictions'] = {
+    contradictions: [],
+    hasHighSeverity: false,
+    summary: { high: 0, medium: 0, low: 0 },
+  };
+
+  if (doCheckContradictions) {
+    // Only check new/changed claims against existing claims
+    const newAndChangedClaims = [
+      ...diff.entries
+        .filter(e => e.status === 'added')
+        .map(e => e.newClaim!),
+      ...diff.entries
+        .filter(e => e.status === 'changed')
+        .map(e => e.newClaim!),
+    ];
+
+    if (newAndChangedClaims.length > 0 && beforeClaims.length > 0) {
+      try {
+        if (verbose) console.log(`[semantic-diff] Checking ${newAndChangedClaims.length} new/changed claims for contradictions...`);
+        contradictionResult = await checkContradictions(
+          newAndChangedClaims,
+          beforeClaims,
+          { useLlm: useLlmContradictions },
+        );
+        if (verbose) {
+          console.log(
+            `[semantic-diff] Contradictions: ${contradictionResult.summary.high} high, ` +
+            `${contradictionResult.summary.medium} medium, ${contradictionResult.summary.low} low`
+          );
+        }
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.warn(`[semantic-diff] Contradiction check failed: ${error.message}`);
+      }
+    }
+  }
+
+  // Step 4: Compute assessment
+  const { assessment, issues } = computeAssessment(diff, contradictionResult);
+
+  // Step 5: Store snapshot
+  let snapshotPath: string | undefined;
+  if (doStoreSnapshot) {
+    const stored = storeSnapshot(pageId, beforeContent, afterContent, {
+      agent,
+      tier,
+      diff,
+      contradictions: contradictionResult,
+    });
+    snapshotPath = stored ?? undefined;
+
+    if (verbose && snapshotPath) {
+      console.log(`[semantic-diff] Snapshot stored: ${snapshotPath}`);
+    }
+  }
+
+  const result: SemanticDiffResult = {
+    pageId,
+    timestamp,
+    diff,
+    contradictions: contradictionResult,
+    snapshotPath,
+    assessment,
+    issues,
+  };
+
+  // Always log issues at warn level so they appear in pipeline output
+  if (issues.length > 0) {
+    console.warn(`[semantic-diff] ${pageId}: ${assessment.toUpperCase()} — ${issues.join(' | ')}`);
+  } else if (verbose) {
+    console.log(`[semantic-diff] ${pageId}: SAFE`);
+  }
+
+  return result;
+}

--- a/crux/lib/semantic-diff/scope-checker.ts
+++ b/crux/lib/semantic-diff/scope-checker.ts
@@ -1,0 +1,163 @@
+/**
+ * Scope Checker
+ *
+ * Enforces file scope constraints for AI-generated content changes.
+ *
+ * Primary use case: Tier 2 agent (conflict resolver) should ONLY modify
+ * files that were identified as having merge conflicts. Any modification
+ * to other files is a scope violation.
+ *
+ * This is a pure function module — no LLM calls, no side effects.
+ * Takes lists of changed files and allowed files, returns violations.
+ */
+
+import path from 'path';
+import type { ScopeCheckResult, ScopeViolation } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Path normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a file path for comparison.
+ * Resolves relative paths, normalizes separators.
+ */
+function normalizePath(filePath: string, basePath?: string): string {
+  if (basePath && !path.isAbsolute(filePath)) {
+    return path.resolve(basePath, filePath);
+  }
+  return path.resolve(filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Scope rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Paths that are always allowed to be modified (meta-files, not content).
+ * These are relative path fragments — any file containing these is allowed.
+ */
+const ALWAYS_ALLOWED_PATTERNS = [
+  // Edit log — always safe to update
+  'data/edit-log.yaml',
+  // Auto-graded quality fields
+  'data/entities/',
+  // Session files
+  '.claude/sessions/',
+  // Temp files
+  '.claude/temp/',
+];
+
+/**
+ * Check if a file path matches any always-allowed pattern.
+ */
+function isAlwaysAllowed(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, '/');
+  return ALWAYS_ALLOWED_PATTERNS.some(pattern => normalized.includes(pattern));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if all changed files are within the allowed scope.
+ *
+ * @param changedFiles - Files that were modified
+ * @param allowedFiles - Files that are permitted to be modified
+ * @param basePath - Optional base path for resolving relative paths
+ * @returns Scope check result with violations
+ */
+export function checkScope(
+  changedFiles: string[],
+  allowedFiles: string[],
+  basePath?: string,
+): ScopeCheckResult {
+  const normalizedAllowed = new Set(
+    allowedFiles.map(f => normalizePath(f, basePath)),
+  );
+
+  const allowedChanges: string[] = [];
+  const violations: ScopeViolation[] = [];
+
+  for (const file of changedFiles) {
+    const normalized = normalizePath(file, basePath);
+
+    // Always-allowed meta-files
+    if (isAlwaysAllowed(file)) {
+      allowedChanges.push(file);
+      continue;
+    }
+
+    // Check if in allowed list
+    if (normalizedAllowed.has(normalized)) {
+      allowedChanges.push(file);
+    } else {
+      violations.push({
+        file,
+        reason: `File "${file}" was not in the allowed scope for this operation`,
+      });
+    }
+  }
+
+  return {
+    valid: violations.length === 0,
+    allowedChanges,
+    violations,
+  };
+}
+
+/**
+ * Check if a set of changed content files (MDX/YAML) are within scope.
+ * Specialized version for content pipeline — auto-generates allowed set from
+ * a list of page IDs and their corresponding file paths.
+ *
+ * @param changedFiles - Files that were actually modified
+ * @param allowedPagePaths - MDX file paths for pages that are allowed to be changed
+ */
+export function checkContentScope(
+  changedFiles: string[],
+  allowedPagePaths: string[],
+): ScopeCheckResult {
+  return checkScope(changedFiles, allowedPagePaths);
+}
+
+/**
+ * Filter a list of changed files to only return content files (MDX, YAML).
+ * Useful for narrowing scope checks to just the content changes.
+ */
+export function filterContentFiles(files: string[]): string[] {
+  return files.filter(f => /\.(mdx|yaml|yml)$/.test(f));
+}
+
+/**
+ * Compute which MDX files were modified by comparing before/after directory state.
+ * Returns relative paths from basePath.
+ *
+ * This is a utility for callers that need to detect file changes programmatically
+ * rather than from git. For git-based workflows, use `git diff --name-only` instead.
+ */
+export function detectModifiedFiles(
+  beforeFiles: Map<string, string>,  // path → content hash
+  afterFiles: Map<string, string>,   // path → content hash
+): { modified: string[]; added: string[]; deleted: string[] } {
+  const modified: string[] = [];
+  const added: string[] = [];
+  const deleted: string[] = [];
+
+  for (const [path, hash] of afterFiles) {
+    if (!beforeFiles.has(path)) {
+      added.push(path);
+    } else if (beforeFiles.get(path) !== hash) {
+      modified.push(path);
+    }
+  }
+
+  for (const path of beforeFiles.keys()) {
+    if (!afterFiles.has(path)) {
+      deleted.push(path);
+    }
+  }
+
+  return { modified, added, deleted };
+}

--- a/crux/lib/semantic-diff/semantic-diff.test.ts
+++ b/crux/lib/semantic-diff/semantic-diff.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Tests for the semantic diff system.
+ *
+ * Tests cover:
+ * 1. MDX preprocessing for claim extraction
+ * 2. Claim diff engine (pure, no LLM)
+ * 3. Scope checker (pure, no LLM)
+ * 4. Snapshot storage
+ * 5. Assessment logic
+ * 6. Adversarial cases (hallucination, scope violation attempts)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { preprocessMdxForExtraction, splitIntoChunks } from './claim-extractor.ts';
+import { diffClaims } from './diff-engine.ts';
+import { checkScope, checkContentScope, filterContentFiles, detectModifiedFiles } from './scope-checker.ts';
+import { storeSnapshot, loadSnapshot, listSnapshots } from './snapshot-store.ts';
+import type { ExtractedClaim } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeClaim(
+  text: string,
+  type: ExtractedClaim['type'] = 'numeric',
+  keyValue?: string,
+): ExtractedClaim {
+  return {
+    text,
+    type,
+    confidence: 'high',
+    sourceContext: text,
+    keyValue,
+  };
+}
+
+const SAMPLE_MDX = `---
+numericId: E42
+title: Test Organization
+description: A test organization
+lastEdited: "2024-01-01"
+---
+
+import { EntityLink } from '@/components/entity-link';
+
+# Overview
+
+Test Organization was founded in 2015 by Jane Smith. The organization has raised \\$500 million in total funding and employs approximately 300 researchers.
+
+<EntityLink id="some-entity">Some Entity</EntityLink>
+
+## Research Areas
+
+The organization focuses on AI safety research. In 2023, they published 45 papers on alignment.
+
+[^1]: https://example.com/source1
+[^2]: https://example.com/source2
+`;
+
+// ---------------------------------------------------------------------------
+// 1. MDX Preprocessing Tests
+// ---------------------------------------------------------------------------
+
+describe('preprocessMdxForExtraction', () => {
+  it('strips frontmatter', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).not.toContain('numericId:');
+    expect(result).not.toContain('lastEdited:');
+  });
+
+  it('strips import statements', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).not.toContain('import {');
+    expect(result).not.toContain('EntityLink');
+  });
+
+  it('strips JSX component tags', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).not.toContain('<EntityLink');
+    expect(result).not.toContain('</EntityLink>');
+  });
+
+  it('strips footnote definitions but keeps prose', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).not.toContain('[^1]:');
+    expect(result).not.toContain('[^2]:');
+    // Prose should remain
+    expect(result).toContain('founded in 2015');
+  });
+
+  it('strips heading markers but keeps text', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).not.toContain('## Research Areas');
+    expect(result).toContain('Research Areas');
+  });
+
+  it('strips inline footnote references from prose', () => {
+    const content = 'The organization has 300 researchers[^1] working on alignment[^2].';
+    const result = preprocessMdxForExtraction(content);
+    expect(result).not.toContain('[^1]');
+    expect(result).not.toContain('[^2]');
+    expect(result).toContain('300 researchers');
+  });
+
+  it('preserves factual content', () => {
+    const result = preprocessMdxForExtraction(SAMPLE_MDX);
+    expect(result).toContain('500 million');
+    expect(result).toContain('300 researchers');
+    expect(result).toContain('2015');
+    expect(result).toContain('AI safety research');
+  });
+
+  it('handles empty content gracefully', () => {
+    const result = preprocessMdxForExtraction('');
+    expect(result).toBe('');
+  });
+
+  it('handles content with only frontmatter', () => {
+    const onlyFm = '---\ntitle: Test\n---\n';
+    const result = preprocessMdxForExtraction(onlyFm);
+    expect(result).toBe('');
+  });
+});
+
+describe('splitIntoChunks', () => {
+  it('returns single chunk for short content', () => {
+    const text = 'Short paragraph.';
+    const chunks = splitIntoChunks(text, 3000);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
+  });
+
+  it('splits on paragraph boundaries', () => {
+    const text = 'Para one.\n\nPara two.\n\nPara three.';
+    const chunks = splitIntoChunks(text, 15);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should not exceed maxChars + one paragraph
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThan(200);
+    }
+  });
+
+  it('handles empty string', () => {
+    const chunks = splitIntoChunks('', 3000);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('preserves all content across chunks', () => {
+    const paragraphs = Array.from({ length: 10 }, (_, i) => `Paragraph ${i} with some content.`);
+    const text = paragraphs.join('\n\n');
+    const chunks = splitIntoChunks(text, 100);
+    const rejoined = chunks.join('\n\n');
+    // All paragraphs should be preserved
+    for (const para of paragraphs) {
+      expect(rejoined).toContain(para);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Claim Diff Engine Tests
+// ---------------------------------------------------------------------------
+
+describe('diffClaims', () => {
+  it('detects added claims', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+    ];
+    const after: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+      makeClaim('Organization raised $500 million', 'numeric', '500 million'),
+    ];
+
+    const diff = diffClaims(before, after);
+    expect(diff.summary.added).toBe(1);
+    expect(diff.summary.unchanged).toBe(1);
+    expect(diff.summary.removed).toBe(0);
+    expect(diff.claimsAfter).toBe(2);
+    expect(diff.claimsBefore).toBe(1);
+  });
+
+  it('detects removed claims', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+      makeClaim('Organization has 200 employees', 'numeric', '200'),
+    ];
+    const after: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+    ];
+
+    const diff = diffClaims(before, after);
+    expect(diff.summary.removed).toBe(1);
+    expect(diff.summary.unchanged).toBe(1);
+    expect(diff.summary.added).toBe(0);
+  });
+
+  it('detects changed claims with different key values', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('Organization has 200 employees', 'numeric', '200'),
+    ];
+    const after: ExtractedClaim[] = [
+      makeClaim('Organization has 500 employees', 'numeric', '500'),
+    ];
+
+    const diff = diffClaims(before, after);
+    expect(diff.summary.changed).toBe(1);
+    expect(diff.summary.added).toBe(0);
+    expect(diff.summary.removed).toBe(0);
+
+    const changedEntry = diff.entries.find(e => e.status === 'changed');
+    expect(changedEntry).toBeDefined();
+    expect(changedEntry?.changeDescription).toContain('200');
+    expect(changedEntry?.changeDescription).toContain('500');
+  });
+
+  it('handles empty claim sets', () => {
+    const diff = diffClaims([], []);
+    expect(diff.summary.added).toBe(0);
+    expect(diff.summary.removed).toBe(0);
+    expect(diff.summary.changed).toBe(0);
+    expect(diff.summary.unchanged).toBe(0);
+    expect(diff.entries).toHaveLength(0);
+  });
+
+  it('marks all claims as added when no before claims', () => {
+    const after: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+      makeClaim('Organization raised $500M', 'numeric', '500'),
+    ];
+
+    const diff = diffClaims([], after);
+    expect(diff.summary.added).toBe(2);
+    expect(diff.summary.removed).toBe(0);
+    expect(diff.summary.unchanged).toBe(0);
+  });
+
+  it('marks all claims as removed when no after claims', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('Organization was founded in 2015', 'temporal', '2015'),
+    ];
+
+    const diff = diffClaims(before, []);
+    expect(diff.summary.removed).toBe(1);
+    expect(diff.summary.added).toBe(0);
+  });
+
+  it('matches semantically similar claims despite minor wording differences', () => {
+    // Claims that differ only in minor wording should be matched via Jaccard similarity
+    // The threshold is 0.5, so the two strings must share ≥50% of their word vocabulary
+    const before: ExtractedClaim[] = [
+      makeClaim('OpenAI employs approximately 1000 researchers', 'numeric', '1000'),
+    ];
+    const after: ExtractedClaim[] = [
+      // Same subject, same number, very similar verb — should match
+      makeClaim('OpenAI employs approximately 2000 researchers', 'numeric', '2000'),
+    ];
+
+    const diff = diffClaims(before, after);
+    // Should be matched as changed (same claim structure, different value)
+    expect(diff.summary.unchanged + diff.summary.changed).toBe(1);
+    expect(diff.summary.added).toBe(0);
+    expect(diff.summary.removed).toBe(0);
+
+    const changedEntry = diff.entries.find(e => e.status === 'changed');
+    expect(changedEntry).toBeDefined();
+  });
+
+  it('does not match unrelated claims', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('OpenAI was founded in 2015', 'temporal', '2015'),
+    ];
+    const after: ExtractedClaim[] = [
+      makeClaim('Anthropic focuses on constitutional AI research', 'existence'),
+    ];
+
+    const diff = diffClaims(before, after);
+    expect(diff.summary.added).toBe(1);
+    expect(diff.summary.removed).toBe(1);
+    expect(diff.summary.unchanged).toBe(0);
+  });
+
+  it('summary counts are consistent with entries', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('Claim A with unique text about topic X', 'numeric', '100'),
+      makeClaim('Claim B with unique text about topic Y', 'temporal', '2020'),
+    ];
+    const after: ExtractedClaim[] = [
+      makeClaim('Claim A with unique text about topic X', 'numeric', '200'),
+      makeClaim('New claim Z about topic Z', 'existence'),
+    ];
+
+    const diff = diffClaims(before, after);
+    const total = diff.summary.added + diff.summary.removed + diff.summary.changed + diff.summary.unchanged;
+    expect(total).toBe(diff.entries.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Scope Checker Tests
+// ---------------------------------------------------------------------------
+
+describe('checkScope', () => {
+  it('returns valid when all files are in allowed list', () => {
+    const changed = ['content/docs/anthropic.mdx', 'content/docs/openai.mdx'];
+    const allowed = ['content/docs/anthropic.mdx', 'content/docs/openai.mdx'];
+
+    const result = checkScope(changed, allowed);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.allowedChanges).toHaveLength(2);
+  });
+
+  it('returns invalid when files are outside allowed list', () => {
+    const changed = ['content/docs/anthropic.mdx', 'content/docs/deepmind.mdx'];
+    const allowed = ['content/docs/anthropic.mdx'];
+
+    const result = checkScope(changed, allowed);
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].file).toBe('content/docs/deepmind.mdx');
+  });
+
+  it('always allows data/edit-log.yaml changes', () => {
+    const changed = ['data/edit-log.yaml'];
+    const allowed: string[] = [];
+
+    const result = checkScope(changed, allowed);
+    expect(result.valid).toBe(true);
+    expect(result.allowedChanges).toContain('data/edit-log.yaml');
+  });
+
+  it('always allows data/entities/ changes', () => {
+    const changed = ['data/entities/anthropic.yaml'];
+    const allowed: string[] = [];
+
+    const result = checkScope(changed, allowed);
+    expect(result.valid).toBe(true);
+  });
+
+  it('handles empty changed files list', () => {
+    const result = checkScope([], ['content/docs/anthropic.mdx']);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.allowedChanges).toHaveLength(0);
+  });
+
+  it('handles empty allowed list with non-meta files', () => {
+    const changed = ['content/docs/anthropic.mdx'];
+    const result = checkScope(changed, []);
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(1);
+  });
+});
+
+describe('checkContentScope', () => {
+  it('validates content files against allowed paths', () => {
+    const changed = ['content/docs/anthropic.mdx'];
+    const allowed = ['content/docs/anthropic.mdx'];
+
+    const result = checkContentScope(changed, allowed);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('filterContentFiles', () => {
+  it('filters to only MDX and YAML files', () => {
+    const files = [
+      'content/docs/page.mdx',
+      'data/entities/org.yaml',
+      'apps/web/src/component.tsx',
+      '.github/workflows/ci.yml',
+      'README.md',
+    ];
+
+    const content = filterContentFiles(files);
+    expect(content).toContain('content/docs/page.mdx');
+    expect(content).toContain('data/entities/org.yaml');
+    expect(content).toContain('.github/workflows/ci.yml');
+    expect(content).not.toContain('apps/web/src/component.tsx');
+  });
+
+  it('handles empty file list', () => {
+    expect(filterContentFiles([])).toHaveLength(0);
+  });
+});
+
+describe('detectModifiedFiles', () => {
+  it('detects added files', () => {
+    const before = new Map([['file-a.mdx', 'hash1']]);
+    const after = new Map([['file-a.mdx', 'hash1'], ['file-b.mdx', 'hash2']]);
+
+    const result = detectModifiedFiles(before, after);
+    expect(result.added).toContain('file-b.mdx');
+    expect(result.modified).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+  });
+
+  it('detects deleted files', () => {
+    const before = new Map([['file-a.mdx', 'hash1'], ['file-b.mdx', 'hash2']]);
+    const after = new Map([['file-a.mdx', 'hash1']]);
+
+    const result = detectModifiedFiles(before, after);
+    expect(result.deleted).toContain('file-b.mdx');
+    expect(result.modified).toHaveLength(0);
+    expect(result.added).toHaveLength(0);
+  });
+
+  it('detects modified files (same path, different hash)', () => {
+    const before = new Map([['file-a.mdx', 'hash1']]);
+    const after = new Map([['file-a.mdx', 'hash2-changed']]);
+
+    const result = detectModifiedFiles(before, after);
+    expect(result.modified).toContain('file-a.mdx');
+    expect(result.added).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+  });
+
+  it('handles no changes', () => {
+    const before = new Map([['file-a.mdx', 'hash1']]);
+    const after = new Map([['file-a.mdx', 'hash1']]);
+
+    const result = detectModifiedFiles(before, after);
+    expect(result.modified).toHaveLength(0);
+    expect(result.added).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Snapshot Store Tests
+// ---------------------------------------------------------------------------
+
+describe('storeSnapshot and loadSnapshot', () => {
+  let tempDir: string;
+
+  // We need to patch the SNAPSHOTS_DIR — since it's a module-level const,
+  // we use a workaround by mocking the fs path. In practice, we test
+  // via the public API but mock the fs operations.
+
+  // For simplicity, we directly test that the functions don't throw
+  // and return appropriate types.
+
+  it('storeSnapshot returns a path string or null', () => {
+    // Should not throw; may return null if filesystem write fails
+    const result = storeSnapshot('test-page-id', 'before content', 'after content', {
+      agent: 'test',
+      tier: 'standard',
+    });
+
+    // Result is either a path string or null (null = filesystem error, acceptable in test env)
+    expect(typeof result === 'string' || result === null).toBe(true);
+  });
+
+  it('loadSnapshot returns null for non-existent page', () => {
+    const result = loadSnapshot('definitely-nonexistent-page-xyz', '2024-01-01T00:00:00.000Z');
+    expect(result).toBeNull();
+  });
+
+  it('listSnapshots returns empty array for non-existent page', () => {
+    const result = listSnapshots('definitely-nonexistent-page-xyz');
+    expect(result).toEqual([]);
+  });
+
+  it('stores and retrieves a snapshot', () => {
+    const pageId = `test-snapshot-${Date.now()}`;
+    const beforeContent = 'Before: Organization was founded in 2015 with 100 employees.';
+    const afterContent = 'After: Organization was founded in 2015 with 500 employees.';
+
+    const storedPath = storeSnapshot(pageId, beforeContent, afterContent, {
+      agent: 'test-agent',
+      tier: 'polish',
+    });
+
+    // If storage succeeded (may fail in restricted envs)
+    if (storedPath !== null) {
+      const snapshots = listSnapshots(pageId);
+      expect(snapshots.length).toBeGreaterThan(0);
+      expect(snapshots[0].agent).toBe('test-agent');
+      expect(snapshots[0].tier).toBe('polish');
+
+      // Clean up
+      try {
+        const dir = path.dirname(storedPath);
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best effort cleanup
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Adversarial/edge cases
+// ---------------------------------------------------------------------------
+
+describe('adversarial cases — diff engine', () => {
+  it('handles a claim that changes from a small number to a very large number (hallucination pattern)', () => {
+    // An LLM might hallucinate a larger number to seem more impressive
+    const before: ExtractedClaim[] = [
+      makeClaim('OpenAI employs 1500 researchers', 'numeric', '1500'),
+    ];
+    const after: ExtractedClaim[] = [
+      // LLM hallucinated 10x more employees
+      makeClaim('OpenAI employs 15000 researchers', 'numeric', '15000'),
+    ];
+
+    const diff = diffClaims(before, after);
+    // Should be detected as changed, not as new claim
+    expect(diff.summary.changed).toBe(1);
+    const change = diff.entries.find(e => e.status === 'changed');
+    expect(change?.changeDescription).toContain('1500');
+    expect(change?.changeDescription).toContain('15000');
+  });
+
+  it('handles many simultaneous claim changes (rewrite pattern)', () => {
+    // If an LLM rewrites an entire section, most claims change
+    const before: ExtractedClaim[] = Array.from({ length: 10 }, (_, i) =>
+      makeClaim(`Claim ${i}: Organization was founded in ${2010 + i}`, 'temporal', `${2010 + i}`)
+    );
+    const after: ExtractedClaim[] = Array.from({ length: 10 }, (_, i) =>
+      makeClaim(`Claim ${i}: Organization was founded in ${2020 + i}`, 'temporal', `${2020 + i}`)
+    );
+
+    const diff = diffClaims(before, after);
+    // All claims should be detected as changed
+    expect(diff.summary.changed).toBe(10);
+    expect(diff.summary.added).toBe(0);
+    expect(diff.summary.removed).toBe(0);
+  });
+
+  it('handles the same claim appearing multiple times (dedup behavior)', () => {
+    const before: ExtractedClaim[] = [
+      makeClaim('OpenAI was founded in 2015', 'temporal', '2015'),
+    ];
+    const after: ExtractedClaim[] = [
+      // Same claim appears twice (e.g., in intro and summary)
+      makeClaim('OpenAI was founded in 2015', 'temporal', '2015'),
+      makeClaim('OpenAI was founded in 2015', 'temporal', '2015'),
+    ];
+
+    const diff = diffClaims(before, after);
+    // One should match, one should be "added"
+    const total = diff.summary.added + diff.summary.unchanged + diff.summary.changed;
+    expect(total).toBe(2); // 1 matched + 1 duplicate
+  });
+});
+
+describe('adversarial cases — scope checker', () => {
+  it('detects scope violation when agent modifies unrelated pages', () => {
+    // Scenario: Tier 2 agent should only touch conflict files
+    const allowedConflictFiles = ['content/docs/anthropic.mdx'];
+    const actuallyModified = [
+      'content/docs/anthropic.mdx',   // Allowed
+      'content/docs/openai.mdx',       // NOT allowed (scope violation)
+      'content/docs/deepmind.mdx',     // NOT allowed (scope violation)
+    ];
+
+    const result = checkScope(actuallyModified, allowedConflictFiles);
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(2);
+
+    const violatedFiles = result.violations.map(v => v.file);
+    expect(violatedFiles).toContain('content/docs/openai.mdx');
+    expect(violatedFiles).toContain('content/docs/deepmind.mdx');
+  });
+
+  it('reports violation reasons', () => {
+    const result = checkScope(
+      ['content/docs/secret.mdx'],
+      [],
+    );
+    expect(result.valid).toBe(false);
+    expect(result.violations[0].reason).toContain('not in the allowed scope');
+    expect(result.violations[0].file).toBe('content/docs/secret.mdx');
+  });
+});

--- a/crux/lib/semantic-diff/snapshot-store.ts
+++ b/crux/lib/semantic-diff/snapshot-store.ts
@@ -1,0 +1,241 @@
+/**
+ * Snapshot Store
+ *
+ * Stores before/after content snapshots for audit trail purposes.
+ * Snapshots are stored locally as JSON files in .claude/snapshots/.
+ *
+ * Design decisions:
+ * - Local filesystem storage initially (can migrate to wiki-server later)
+ * - JSON format for easy programmatic access
+ * - Files are gitignored (audit trail, not source code)
+ * - Retention: last 30 snapshots per page (older ones pruned automatically)
+ * - Snapshots are stored synchronously to avoid race conditions on apply
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { PROJECT_ROOT } from '../content-types.ts';
+import type { ContentSnapshot, SemanticDiff, ContradictionResult } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Storage configuration
+// ---------------------------------------------------------------------------
+
+const SNAPSHOTS_DIR = path.join(PROJECT_ROOT, '.claude', 'snapshots');
+const MAX_SNAPSHOTS_PER_PAGE = 30;
+
+// ---------------------------------------------------------------------------
+// Snapshot utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a short hash of content for change detection.
+ */
+function contentHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 12);
+}
+
+/**
+ * Get the snapshot directory for a page.
+ */
+function getPageSnapshotDir(pageId: string): string {
+  return path.join(SNAPSHOTS_DIR, pageId);
+}
+
+/**
+ * Get a timestamped filename for a snapshot.
+ */
+function getSnapshotFilename(timestamp: string): string {
+  // Replace colons and dots to make a valid filename
+  return `${timestamp.replace(/[:.]/g, '-')}.json`;
+}
+
+// ---------------------------------------------------------------------------
+// Pruning
+// ---------------------------------------------------------------------------
+
+/**
+ * Prune old snapshots if a page has more than MAX_SNAPSHOTS_PER_PAGE.
+ * Deletes the oldest files (by filename sort, which is chronological since we use ISO timestamps).
+ */
+function pruneOldSnapshots(pageDir: string): void {
+  try {
+    const files = fs.readdirSync(pageDir)
+      .filter(f => f.endsWith('.json'))
+      .sort(); // ISO timestamp sort = chronological
+
+    if (files.length > MAX_SNAPSHOTS_PER_PAGE) {
+      const toDelete = files.slice(0, files.length - MAX_SNAPSHOTS_PER_PAGE);
+      for (const file of toDelete) {
+        try {
+          fs.unlinkSync(path.join(pageDir, file));
+        } catch {
+          // Best effort — don't fail if we can't delete
+        }
+      }
+    }
+  } catch {
+    // Ignore pruning errors — this is a non-critical operation
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface StoreSnapshotOptions {
+  /** Agent or pipeline that made the change. Default: 'unknown'. */
+  agent?: string;
+  /** Tier used for the improvement. */
+  tier?: string;
+  /** Semantic diff result to include in snapshot. */
+  diff?: SemanticDiff;
+  /** Contradiction detection result to include in snapshot. */
+  contradictions?: ContradictionResult;
+}
+
+/**
+ * Store a before/after content snapshot for a page modification.
+ *
+ * Creates a JSON file in .claude/snapshots/<pageId>/<timestamp>.json.
+ * Returns the path to the stored snapshot file.
+ *
+ * This function is safe to call even if the snapshots directory doesn't exist —
+ * it creates it as needed. Errors are logged but never thrown.
+ */
+export function storeSnapshot(
+  pageId: string,
+  beforeContent: string,
+  afterContent: string,
+  options: StoreSnapshotOptions = {},
+): string | null {
+  try {
+    const timestamp = new Date().toISOString();
+    const pageDir = getPageSnapshotDir(pageId);
+
+    // Create directory structure
+    fs.mkdirSync(pageDir, { recursive: true });
+
+    const snapshot: ContentSnapshot = {
+      pageId,
+      timestamp,
+      agent: options.agent ?? 'unknown',
+      tier: options.tier,
+      beforeContent,
+      afterContent,
+      diff: options.diff,
+      contradictions: options.contradictions,
+    };
+
+    const filename = getSnapshotFilename(timestamp);
+    const snapshotPath = path.join(pageDir, filename);
+
+    fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2));
+
+    // Prune old snapshots (keep MAX_SNAPSHOTS_PER_PAGE)
+    pruneOldSnapshots(pageDir);
+
+    return snapshotPath;
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.warn(`[semantic-diff] Failed to store snapshot for ${pageId}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Load a specific snapshot by page ID and timestamp.
+ * Returns null if not found or unreadable.
+ */
+export function loadSnapshot(pageId: string, timestamp: string): ContentSnapshot | null {
+  try {
+    const pageDir = getPageSnapshotDir(pageId);
+    const filename = getSnapshotFilename(timestamp);
+    const snapshotPath = path.join(pageDir, filename);
+
+    if (!fs.existsSync(snapshotPath)) return null;
+
+    const raw = fs.readFileSync(snapshotPath, 'utf-8');
+    return JSON.parse(raw) as ContentSnapshot;
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.warn(`[semantic-diff] Failed to load snapshot for ${pageId}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * List all snapshots for a page, ordered chronologically (newest first).
+ * Returns an array of snapshot metadata (without content for efficiency).
+ */
+export function listSnapshots(pageId: string): Array<{
+  timestamp: string;
+  agent: string;
+  tier?: string;
+  path: string;
+  beforeHash: string;
+  afterHash: string;
+}> {
+  try {
+    const pageDir = getPageSnapshotDir(pageId);
+    if (!fs.existsSync(pageDir)) return [];
+
+    const files = fs.readdirSync(pageDir)
+      .filter(f => f.endsWith('.json'))
+      .sort()
+      .reverse(); // Newest first
+
+    return files
+      .map(filename => {
+        try {
+          const snapshotPath = path.join(pageDir, filename);
+          const raw = fs.readFileSync(snapshotPath, 'utf-8');
+          const snapshot = JSON.parse(raw) as ContentSnapshot;
+
+          return {
+            timestamp: snapshot.timestamp,
+            agent: snapshot.agent,
+            tier: snapshot.tier,
+            path: snapshotPath,
+            beforeHash: contentHash(snapshot.beforeContent),
+            afterHash: contentHash(snapshot.afterContent),
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get the most recent snapshot for a page, if any.
+ */
+export function getLatestSnapshot(pageId: string): ContentSnapshot | null {
+  try {
+    const pageDir = getPageSnapshotDir(pageId);
+    if (!fs.existsSync(pageDir)) return null;
+
+    const files = fs.readdirSync(pageDir)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    if (files.length === 0) return null;
+
+    const latest = files[files.length - 1];
+    const raw = fs.readFileSync(path.join(pageDir, latest), 'utf-8');
+    return JSON.parse(raw) as ContentSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the snapshots directory path (for informational purposes).
+ */
+export function getSnapshotsDir(): string {
+  return SNAPSHOTS_DIR;
+}

--- a/crux/lib/semantic-diff/types.ts
+++ b/crux/lib/semantic-diff/types.ts
@@ -1,0 +1,192 @@
+/**
+ * Types for the semantic diff system.
+ *
+ * Tracks factual claims in AI-modified wiki pages to detect contradictions,
+ * unauthorized scope changes, and provide audit trails.
+ */
+
+// ---------------------------------------------------------------------------
+// Core claim types
+// ---------------------------------------------------------------------------
+
+/** Types of factual claims that can be extracted from MDX content. */
+export type ClaimType =
+  | 'numeric'       // Numbers, statistics, counts
+  | 'temporal'      // Dates, years, time-related facts
+  | 'causal'        // Cause-effect relationships
+  | 'attribution'   // Attributions to people/organizations
+  | 'existence'     // Something exists or occurred
+  | 'comparison'    // Comparative statements
+  | 'definition'    // Definitional claims
+  | 'other';        // Uncategorized factual claims
+
+/** Confidence level for a claim extraction. */
+export type ExtractionConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * A single extracted factual claim from page content.
+ */
+export interface ExtractedClaim {
+  /** The claim text, as a concise assertable statement. */
+  text: string;
+  /** What type of claim this is. */
+  type: ClaimType;
+  /** Confidence in extraction quality. */
+  confidence: ExtractionConfidence;
+  /** Source sentence or paragraph this was extracted from (for verification). */
+  sourceContext: string;
+  /** Any specific value (number, date, name) that is the core of the claim. */
+  keyValue?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Diff types
+// ---------------------------------------------------------------------------
+
+/** Status of a claim in the diff. */
+export type ClaimDiffStatus =
+  | 'added'    // New claim not in before content
+  | 'removed'  // Claim present in before but not after
+  | 'changed'  // Similar claim but with different key value or meaning
+  | 'unchanged'; // Claim appears in both versions
+
+/**
+ * A single entry in a semantic diff.
+ */
+export interface ClaimDiffEntry {
+  status: ClaimDiffStatus;
+  /** The claim in the new (after) content. Undefined for 'removed'. */
+  newClaim?: ExtractedClaim;
+  /** The claim in the old (before) content. Undefined for 'added'. */
+  oldClaim?: ExtractedClaim;
+  /** If 'changed', a description of what changed. */
+  changeDescription?: string;
+}
+
+/**
+ * Result of diffing two versions of page content.
+ */
+export interface SemanticDiff {
+  /** Number of claims in the before content. */
+  claimsBefore: number;
+  /** Number of claims in the after content. */
+  claimsAfter: number;
+  /** Detailed list of changes. */
+  entries: ClaimDiffEntry[];
+  /** Summary counts. */
+  summary: {
+    added: number;
+    removed: number;
+    changed: number;
+    unchanged: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contradiction types
+// ---------------------------------------------------------------------------
+
+/** Severity of a contradiction. */
+export type ContradictionSeverity = 'high' | 'medium' | 'low';
+
+/**
+ * A detected contradiction between two claims.
+ */
+export interface Contradiction {
+  /** The new claim that contradicts something. */
+  newClaim: ExtractedClaim;
+  /** The existing claim being contradicted. */
+  existingClaim: ExtractedClaim;
+  /** Why this is a contradiction. */
+  reason: string;
+  /** How severe is this contradiction. */
+  severity: ContradictionSeverity;
+}
+
+/**
+ * Result of checking for contradictions.
+ */
+export interface ContradictionResult {
+  /** All detected contradictions. */
+  contradictions: Contradiction[];
+  /** Whether any high-severity contradictions were found. */
+  hasHighSeverity: boolean;
+  /** Summary of contradiction counts by severity. */
+  summary: {
+    high: number;
+    medium: number;
+    low: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scope checking types
+// ---------------------------------------------------------------------------
+
+/**
+ * A file that was changed outside the allowed scope.
+ */
+export interface ScopeViolation {
+  /** The file path that was changed. */
+  file: string;
+  /** Why this is a violation. */
+  reason: string;
+}
+
+/**
+ * Result of a scope check.
+ */
+export interface ScopeCheckResult {
+  /** Whether all changes are within allowed scope. */
+  valid: boolean;
+  /** Files changed that are within scope. */
+  allowedChanges: string[];
+  /** Files changed that are outside scope. */
+  violations: ScopeViolation[];
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot types
+// ---------------------------------------------------------------------------
+
+/**
+ * A before/after snapshot for audit trail purposes.
+ */
+export interface ContentSnapshot {
+  /** Page ID (entity ID like 'anthropic'). */
+  pageId: string;
+  /** Timestamp of this snapshot. */
+  timestamp: string;
+  /** The agent/pipeline that made the change. */
+  agent: string;
+  /** Tier used for this improvement. */
+  tier?: string;
+  /** Content before modification. */
+  beforeContent: string;
+  /** Content after modification. */
+  afterContent: string;
+  /** Semantic diff result. */
+  diff?: SemanticDiff;
+  /** Contradictions detected. */
+  contradictions?: ContradictionResult;
+}
+
+// ---------------------------------------------------------------------------
+// Combined result
+// ---------------------------------------------------------------------------
+
+/**
+ * Combined result of running the full semantic diff pipeline on a page change.
+ */
+export interface SemanticDiffResult {
+  pageId: string;
+  timestamp: string;
+  diff: SemanticDiff;
+  contradictions: ContradictionResult;
+  /** Path where the snapshot was stored. */
+  snapshotPath?: string;
+  /** Overall assessment: 'safe', 'warn', or 'block' */
+  assessment: 'safe' | 'warn' | 'block';
+  /** Human-readable summary of issues found. */
+  issues: string[];
+}


### PR DESCRIPTION
## Summary

- Adds `crux/lib/semantic-diff/` module that analyzes factual claim changes after AI modifications
- Extracts factual claims from MDX content using Haiku LLM (cheap, fast, ~20x cheaper than Sonnet)
- Diffs claims before and after modification to detect added/removed/changed facts
- Detects contradictions between new claims and existing page content (rule-based + LLM)
- Enforces file scope constraints to prevent AI agents from modifying unauthorized files
- Stores before/after snapshots in `.claude/snapshots/` for post-hoc audit trail
- Integrates into the page-improver pipeline as a non-blocking post-apply check

Closes #1416

## Architecture

New module: `crux/lib/semantic-diff/`

- `types.ts` — Shared types: ExtractedClaim, SemanticDiff, ContradictionResult, etc.
- `claim-extractor.ts` — MDX preprocessing + Haiku LLM claim extraction
- `diff-engine.ts` — Pure Jaccard-based claim matching and diff computation (no LLM)
- `contradiction-checker.ts` — Rule-based (numeric/temporal) + LLM contradiction detection
- `scope-checker.ts` — File scope enforcement (checks changed files against allowed list)
- `snapshot-store.ts` — Local filesystem snapshot storage with automatic pruning
- `index.ts` — Main runSemanticDiff() orchestrator + public re-exports

Integration in pipeline.ts:
- Captures originalContent before pipeline starts
- Calls runSemanticDiff() after fs.writeFileSync() in the apply step
- Non-blocking: warnings logged but apply never blocked (initial deployment mode)

## Safety design

- **Non-blocking initially**: Returns 'warn' assessment, never 'block', until confidence is established
- **Fail-open for analysis**: LLM failures are logged as warnings; page write is never prevented
- **Fail-closed for scope**: Scope violations are always reported (though currently non-blocking too)
- **Adversarially tested**: Tests include hallucination patterns (10x inflated numbers), mass rewrites, scope bypass attempts

## Test plan

- [x] 44 tests in `crux/lib/semantic-diff/semantic-diff.test.ts`
- [x] MDX preprocessing correctly strips frontmatter, JSX, imports, footnotes
- [x] Diff engine detects added/removed/changed claims correctly
- [x] Changed claims with different keyValues are flagged with change description
- [x] Scope checker catches violations and respects always-allowed paths
- [x] Snapshot store creates, retrieves, and lists snapshots
- [x] Adversarial: 10x inflated number detected as changed claim
- [x] Adversarial: mass rewrite (all claims changed) detected
- [x] Adversarial: scope violation when agent modifies unauthorized pages
- [x] Gate passes (all content checks pass)
- [x] Full crux test suite: 2503/2504 tests pass (1 pre-existing timeout unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)