### PR TITLE
docs: add production URL to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 AI safety wiki with ~700 MDX pages, Next.js frontend, YAML data layer, and CLI tooling.
 
+**Production URL**: `https://www.longtermwiki.com` — do NOT use `longterm.wiki`, `longtermwiki.org`, or any other domain.
+
 **This is a routing document.** Detailed guides live in `content/docs/internal/` and `.claude/rules/`. Use `pnpm crux <domain> --help` for full CLI reference.
 
 **Agent memory**: Read `.claude/memory/MEMORY.md` at session start for cross-session facts and corrections. Update it when you learn stable new facts (confirmed URLs, naming conventions, recurring gotchas). This file is checked into git so all agents and worktrees share it.


### PR DESCRIPTION
## Summary
- Adds the production URL (`https://www.longtermwiki.com`) to the top of CLAUDE.md so it's always in agent context
- Agents were guessing `longterm.wiki` from the project name instead of using the correct domain
- Previously only documented in `.claude/memory/MEMORY.md` which agents sometimes skip reading

## Test plan
- [x] Verified CLAUDE.md renders correctly with the new line
- [x] Change is documentation-only, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)