### PR TITLE
security: fix two red-team findings

### DIFF
--- a/.github/workflows/protected-paths-check.yml
+++ b/.github/workflows/protected-paths-check.yml
@@ -33,6 +33,7 @@ jobs:
               /^crux\/lib\/session-checklist\.ts$/,
               /^crux\/lib\/page-templates\.ts$/,
               /^crux\/auto-update\//,
+              /^\.squawk\.toml$/,
             ];
 
             const REVIEW_LABEL = 'rules-change-reviewed';
@@ -74,6 +75,7 @@ jobs:
               'Session checklist (crux/lib/session-checklist.ts)': [],
               'Page templates (crux/lib/page-templates.ts)': [],
               'Auto-update system (crux/auto-update/)': [],
+              'Linter config (.squawk.toml)': [],
             };
 
             for (const file of protectedFiles) {
@@ -90,6 +92,7 @@ jobs:
               else if (/^crux\/lib\/session-checklist\.ts$/.test(file)) categories['Session checklist (crux/lib/session-checklist.ts)'].push(file);
               else if (/^crux\/lib\/page-templates\.ts$/.test(file)) categories['Page templates (crux/lib/page-templates.ts)'].push(file);
               else if (/^crux\/auto-update\//.test(file)) categories['Auto-update system (crux/auto-update/)'].push(file);
+              else if (/^\.squawk\.toml$/.test(file)) categories['Linter config (.squawk.toml)'].push(file);
             }
 
             // Check if the review label is present AND was added by a human

--- a/apps/web/src/app/wiki/[id]/page.tsx
+++ b/apps/web/src/app/wiki/[id]/page.tsx
@@ -37,6 +37,7 @@ import { getCitationQuotes, computeCitationHealth } from "@/lib/citation-data";
 import type { CitationQuote } from "@/lib/citation-data";
 
 import { GITHUB_REPO_URL } from "@lib/site-config";
+import { isAdmin } from "@/lib/auth";
 
 /**
  * Build a reference map from citation quotes and footnote index data.
@@ -451,6 +452,26 @@ function WithSidebar({
   );
 }
 
+/**
+ * Auth gate for internal dashboard pages accessed via /wiki/E{id}.
+ *
+ * The middleware protects /internal/* but internal dashboards redirect to
+ * /wiki/E{id} which bypasses that check. This function enforces the same
+ * auth requirement at render time by checking the entity's canonical path.
+ */
+async function requireAuthForInternal(entityPath: string): Promise<void> {
+  if (!entityPath.startsWith("/internal")) return;
+
+  const oauthConfigured =
+    !!process.env.GITHUB_CLIENT_ID && !!process.env.GITHUB_CLIENT_SECRET;
+  if (!oauthConfigured) return; // Dev mode — no auth enforcement
+
+  const admin = await isAdmin();
+  if (!admin) {
+    redirect(`/login?callbackUrl=${encodeURIComponent(`/wiki/`)}`);
+  }
+}
+
 export default async function WikiPage({ params }: PageProps) {
   const { id } = await params;
 
@@ -459,6 +480,9 @@ export default async function WikiPage({ params }: PageProps) {
     const slug = numericIdToSlug(id.toUpperCase());
     if (!slug) notFound();
 
+    const entityPath = getEntityPath(slug) || "";
+    await requireAuthForInternal(entityPath);
+
     const [result, citationQuotes] = await Promise.all([
       renderMdxPage(slug),
       getCitationQuotes(slug),
@@ -466,7 +490,6 @@ export default async function WikiPage({ params }: PageProps) {
     if (!result) notFound();
     if (isMdxError(result)) return <MdxErrorView error={result} />;
 
-    const entityPath = getEntityPath(slug) || "";
     const pageData = getPageById(slug);
     const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;
     const fullWidth = isFullWidth(contentFormat, result.frontmatter);
@@ -493,6 +516,9 @@ export default async function WikiPage({ params }: PageProps) {
     }
 
     // No numeric ID — render directly by slug (page-only content without entity)
+    const entityPath = getEntityPath(id) || "";
+    await requireAuthForInternal(entityPath);
+
     const [result, citationQuotes] = await Promise.all([
       renderMdxPage(id),
       getCitationQuotes(id),
@@ -500,7 +526,6 @@ export default async function WikiPage({ params }: PageProps) {
     if (!result) notFound();
     if (isMdxError(result)) return <MdxErrorView error={result} />;
 
-    const entityPath = getEntityPath(id) || "";
     const pageData = getPageById(id);
     const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;
     const fullWidth = isFullWidth(contentFormat, result.frontmatter);


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity findings from security red-team review of recently merged code:

- **Add `.squawk.toml` to protected-paths-check**: Without this, an attacker could modify `.squawk.toml` to disable migration safety rules in the same PR as a dangerous migration, bypassing review. The CI workflow now flags `.squawk.toml` changes for mandatory human review.

- **Add auth gate for internal wiki pages accessed via `/wiki/E{id}`**: The middleware protects `/internal/*` routes, but all internal dashboards redirect to `/wiki/E{id}` which was unprotected. Added a `requireAuthForInternal()` check in the wiki page component that verifies the entity's canonical path and redirects unauthenticated users to `/login` when the page belongs to `/internal/`.

## Test plan

- [x] All 367 tests pass (pre-existing `auth.test.ts` failure with missing `next-auth` package is resolved after `pnpm install`)
- [x] TypeScript type check passes cleanly
- [x] Gate check passes (all CI-blocking checks green)
- [ ] Manual: verify that accessing `/wiki/E899` (Pages dashboard) redirects to login when not authenticated
- [ ] Manual: verify that modifying `.squawk.toml` in a PR triggers the protected-paths-check


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>