### PR TITLE
security: fix red-team findings in semantic diff module

### DIFF
--- a/crux/lib/semantic-diff/claim-extractor.ts
+++ b/crux/lib/semantic-diff/claim-extractor.ts
@@ -156,9 +156,11 @@ async function extractClaimsFromChunk(
 ): Promise<ExtractedClaim[]> {
   const client = createLlmClient();
 
-  const prompt = `Extract all verifiable factual claims from this wiki page content:
+  const prompt = `Extract all verifiable factual claims from this wiki page content.
 
+<content>
 ${chunk}
+</content>
 
 Return the claims as a JSON object with a "claims" array.`;
 

--- a/crux/lib/semantic-diff/contradiction-checker.ts
+++ b/crux/lib/semantic-diff/contradiction-checker.ts
@@ -46,7 +46,7 @@ function parseNumericFromClaim(claim: ExtractedClaim): number | undefined {
  * Higher threshold means we only flag contradictions when claims are clearly
  * talking about the same thing.
  */
-function areClainsAboutSameSubject(a: ExtractedClaim, b: ExtractedClaim): boolean {
+function areClaimsAboutSameSubject(a: ExtractedClaim, b: ExtractedClaim): boolean {
   return jaccardWordSimilarity(a.text, b.text) >= 0.4;
 }
 
@@ -65,7 +65,7 @@ function detectNumericContradictions(
 
   for (const newClaim of numericNew) {
     for (const existing of numericExisting) {
-      if (!areClainsAboutSameSubject(newClaim, existing)) continue;
+      if (!areClaimsAboutSameSubject(newClaim, existing)) continue;
 
       const newVal = parseNumericFromClaim(newClaim);
       const existVal = parseNumericFromClaim(existing);
@@ -103,7 +103,7 @@ function detectTemporalContradictions(
 
   for (const newClaim of temporalNew) {
     for (const existing of temporalExisting) {
-      if (!areClainsAboutSameSubject(newClaim, existing)) continue;
+      if (!areClaimsAboutSameSubject(newClaim, existing)) continue;
       if (newClaim.keyValue === existing.keyValue) continue;
 
       // Year-based comparison for temporal claims

--- a/crux/lib/semantic-diff/index.ts
+++ b/crux/lib/semantic-diff/index.ts
@@ -8,8 +8,8 @@
  * 4. Store before/after snapshots for audit trail
  *
  * Design principles:
- * - Non-blocking by default: returns 'warn' assessment rather than 'block'
- *   until confidence in the system is established
+ * - Non-blocking by default: returns 'warn' assessment, never blocks
+ *   (blocking may be added later when confidence in the system is established)
  * - Fail-open for analysis (if LLM fails, still write the page with a warning)
  * - Fail-closed for scope checks (scope violations always block)
  * - Cost-conscious: uses Haiku for all LLM calls
@@ -70,17 +70,15 @@ export interface SemanticDiffOptions {
  * Currently:
  * - 'safe': No high-severity contradictions, reasonable claim changes
  * - 'warn': Medium-severity contradictions or unusual claim change ratio
- * - 'block': High-severity contradictions (reserved for future use when
- *            confidence in the system is established)
  *
- * The system starts in non-blocking mode: 'block' is not returned in the
- * initial implementation to avoid false positives. Callers should treat
- * 'warn' as informational for now.
+ * A 'block' level may be added in the future when confidence in the
+ * system is established. For now, callers should treat 'warn' as
+ * informational.
  */
 function computeAssessment(
   diff: SemanticDiffResult['diff'],
   contradictions: SemanticDiffResult['contradictions'],
-): { assessment: 'safe' | 'warn' | 'block'; issues: string[] } {
+): { assessment: 'safe' | 'warn'; issues: string[] } {
   const issues: string[] = [];
 
   // High-severity contradictions = warn (not block yet, non-blocking mode)

--- a/crux/lib/semantic-diff/scope-checker.ts
+++ b/crux/lib/semantic-diff/scope-checker.ts
@@ -53,7 +53,9 @@ const ALWAYS_ALLOWED_PATTERNS = [
  */
 function isAlwaysAllowed(filePath: string): boolean {
   const normalized = filePath.replace(/\\/g, '/');
-  return ALWAYS_ALLOWED_PATTERNS.some(pattern => normalized.includes(pattern));
+  return ALWAYS_ALLOWED_PATTERNS.some(pattern =>
+    normalized === pattern || normalized.startsWith(pattern)
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/semantic-diff/types.ts
+++ b/crux/lib/semantic-diff/types.ts
@@ -185,8 +185,8 @@ export interface SemanticDiffResult {
   contradictions: ContradictionResult;
   /** Path where the snapshot was stored. */
   snapshotPath?: string;
-  /** Overall assessment: 'safe', 'warn', or 'block' */
-  assessment: 'safe' | 'warn' | 'block';
+  /** Overall assessment: 'safe' or 'warn' */
+  assessment: 'safe' | 'warn';
   /** Human-readable summary of issues found. */
   issues: string[];
 }


### PR DESCRIPTION
## Summary

Addresses 4 red-team findings from the review of PR #1453 (semantic diff, merged before fixes could land):

- **Remove dead `block` assessment type**: The `'block'` value was defined in types but unreachable in code — removed to prevent confusion
- **Add XML content delimiters for prompt injection mitigation**: Wrap interpolated page content in `<content>` tags in LLM prompts to reduce injection surface
- **Fix scope checker path traversal**: Changed `includes()` to `===` / `startsWith()` prefix matching so a file like `data/evil-data/entities/` can't bypass the always-allowed list by containing a valid prefix as substring
- **Fix typo**: `areClainsAboutSameSubject` → `areClaimsAboutSameSubject`

## Test plan

- [ ] CI passes
- [ ] Verify semantic diff types compile cleanly
- [ ] Verify scope checker correctly rejects paths that contain but don't start with allowed prefixes

Closes #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)