### PR TITLE
docs: update CLAUDE.md for recent PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,12 @@ pnpm crux maintain health-snapshot       # Quantified code health metrics
 pnpm crux maintain health-snapshot --json  # JSON for trend tracking
 pnpm crux maintain detect-cruft          # Find TODOs, large files, dead code
 
+# Agent session tracking
+pnpm crux agents register        # Register active agent with wiki-server
+pnpm crux agents status          # Show current agent status
+pnpm crux agent-session-events log "message"  # Log an event to the session timeline
+pnpm crux agent-session-events list           # List events for current agent
+
 # Epic management (multi-issue tracking)
 pnpm crux epic                   # List open epics
 pnpm crux epic create "Title"    # Create a new epic
@@ -134,6 +140,8 @@ pnpm crux content improve <page-id> --tier=standard --apply  # polish | standard
 
 Session logs are written automatically after `--apply` runs. Do not also run `/agent-session-ready-PR` for improve-only sessions.
 
+The improve pipeline includes a **semantic diff safety check** (`crux/lib/semantic-diff/`) that automatically runs after `--apply`. It extracts factual claims before and after modification, diffs them, and checks for contradictions. Warnings are logged but writes are never blocked. Snapshots are stored in `.claude/snapshots/` (gitignored) for post-hoc auditing.
+
 ### After any page edit
 
 Run `pnpm crux fix escaping` and `pnpm crux fix markdown`, then verify with `pnpm crux validate gate --fix`.
@@ -176,6 +184,8 @@ For non-trivial changes (>5 files or >300 lines), run `/review-pr` before shippi
 - **Proactive issue filing**: When you encounter bugs, tech debt, or improvements you can't fix in the current session, file a GitHub issue. Always search first (`crux issues search "topic"`) to avoid duplicates. If a match exists, add a comment instead. See `.claude/rules/proactive-github-filing.md`.
 - **Epics**: Use `crux epic` for tracking multi-issue work. For epics needing detailed coordination (decision logs, sprint plans, status tracking), create an epic wiki page using the convention in `content/docs/internal/epic-page-conventions.mdx` and add an `<EpicTracker issues={[...]} />` component. See E897 (claims roadmap) for a working example. Individual tasks stay as Issues.
 - **API keys**: In environment variables, NOT `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`
+- **Local data mode**: Set `WIKI_DATA_MODE=local` in the Next.js environment to eliminate all runtime wiki-server API calls from content pages. Data comes from `database.json` built at deploy time. Dashboards still call the wiki-server for live data.
+- **Wiki-server rate limits**: Authenticated requests (with `LONGTERMWIKI_SERVER_API_KEY` bearer token) get 1000 read/200 write per minute. Unauthenticated get 100 read/20 write per minute. Health endpoint (`/healthz`) is exempt.
 - **Hono RPC**: Mandatory for all new wiki-server routes; convert existing routes when modifying them. See `.claude/rules/wiki-server-rpc-migration.md`.
 - **Entity IDs**: **Never manually invent numericIds** (E42, E886, etc.). Always allocate from the wiki-server: `pnpm crux ids allocate <slug>`. The gate runs `assign-ids.mjs` automatically as a safety net, but allocating early prevents conflicts between concurrent agents. Use `pnpm crux ids check <slug>` to look up existing IDs.
 
@@ -196,3 +206,4 @@ Rules enforced by gate checks and PR review. See [#1246](https://github.com/quan
 - `.claude/rules/proactive-github-filing.md` — When/how to file issues, comments, and discussions
 - `.claude/rules/pr-review-guidelines.md` — PR review and ship process
 - `.claude/rules/session-logging.md` — Session log format and storage
+- `.claude/rules/error-handling.md` — Error handling strategy and `.catch()` patterns


### PR DESCRIPTION
## Summary

- Add missing documentation for features from 15 PRs merged 2026-03-01
- Agent session tracking CLI commands (`agents register/status`, `agent-session-events log/list`)
- Semantic diff safety check description in Page Authoring section
- `WIKI_DATA_MODE=local` environment variable documentation
- Wiki-server rate limit tiers (authenticated vs unauthenticated)
- Error handling rules file reference

Closes #1464

## Context

Production verification testing revealed that several recently merged features lacked documentation in CLAUDE.md, meaning agents and developers wouldn't discover them. This PR closes those gaps.

Other issues found during testing (#1458, #1459, #1460, #1462, #1463) were either already fixed by PR #1468 or require manual action (Vercel env vars, DB investigation).

## Test plan

- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify no CI failures from the doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)