### PR TITLE
feat: add /audit and /retrospective skill files

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,137 @@
+# Codebase Audit
+
+Strategic review of codebase health, complexity trends, and simplification opportunities. Produces a written report with concrete recommendations.
+
+**Recommended cadence:** Biweekly, or after a burst of infrastructure PRs.
+
+**Relationship to `/maintain`:** `/maintain` handles day-to-day cleanup (close issues, fix cruft, propagate learnings). `/audit` is the strategic counterpart — it asks whether systems are earning their complexity and whether the overall trajectory is healthy.
+
+## Phase 1: Measure
+
+Gather quantitative signals. Run all of these — the report needs hard numbers, not impressions.
+
+```bash
+# Health metrics snapshot
+pnpm crux maintain health-snapshot --json
+
+# Cruft detection
+pnpm crux maintain detect-cruft
+
+# Code size by top-level directory (quick proxy for complexity distribution)
+find . -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' | grep -v node_modules | grep -v .next | xargs wc -l | sort -rn | head -40
+
+# Unused exports and dead code (if knip is available)
+npx knip --reporter compact 2>/dev/null || echo "knip not configured — skip"
+
+# Recent growth: lines added/removed in last 14 days
+git log --since="14 days ago" --pretty=tformat: --numstat | awk '{ add += $1; del += $2 } END { printf "Added: %d  Removed: %d  Net: %d\n", add, del, add-del }'
+
+# File count trend
+echo "Total TS/TSX/MJS files:"; find . -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' | grep -v node_modules | grep -v .next | wc -l
+
+# GitHub Actions workflow count
+ls -1 .github/workflows/*.yml 2>/dev/null | wc -l
+
+# Internal dashboard count
+ls -1 apps/web/src/app/internal/ 2>/dev/null | wc -l
+```
+
+Read the output of each command. Note the numbers — you will reference them in the report.
+
+## Phase 2: Analyze
+
+With the numbers in hand, investigate these questions. Use Grep, Glob, and Read tools to gather evidence. Do NOT guess — find the actual code.
+
+### 2a. Complexity hotspots
+
+Identify the 5 largest directories/files by line count. For each, ask:
+- Is this size justified by what it does?
+- Could it be split, simplified, or partially removed?
+- How often is it modified? (Use `git log --oneline --since="30 days ago" -- <path> | wc -l`)
+
+### 2b. Systems earning their keep
+
+For each major infrastructure system (groundskeeper, active-agents, agent-checklist, semantic-diff, rate-limiter, etc.), evaluate:
+- **Size**: How many lines of production code + test code?
+- **Usage**: Is it actually called/checked by other systems? Grep for imports.
+- **Recent churn**: How many PRs touched it in the last 30 days? High churn on infrastructure = red flag.
+- **Value delivered**: What concrete problem does it solve? Is there a simpler alternative?
+
+Flag any system where test code exceeds production code by more than 2:1 — this often indicates over-engineering.
+
+### 2c. Overlap and duplication
+
+Look for systems that partially overlap:
+- Multiple solutions to the same problem (e.g., two ways to track agent status)
+- Features that could be consolidated into one
+- Defensive checks that duplicate what another check already catches
+
+### 2d. Documentation staleness
+
+Quickly scan these files for accuracy:
+- `CLAUDE.md` — do the commands still work? Are the conventions current?
+- `.claude/rules/*.md` — any rules that reference removed systems?
+- `README.md` files in key directories — still accurate?
+- `content/docs/internal/*.mdx` — any internal docs referencing old patterns?
+
+Don't fix documentation here — just note what's stale for the report.
+
+### 2e. Dead code signals
+
+Look for:
+- Exported functions/types with zero importers (knip output, or manual grep)
+- Feature flags or config options that are always set to the same value
+- Commented-out code blocks (detect-cruft output)
+- Files that haven't been modified in 90+ days in fast-moving directories
+
+## Phase 3: Write the Report
+
+Produce a structured report. Be specific and evidence-based — include line counts, file paths, and PR numbers. The report should be actionable by someone who hasn't read the codebase recently.
+
+### Report structure
+
+```
+## Codebase Audit — [DATE]
+
+### Key Metrics
+- Total lines (TS/TSX/MJS): X
+- Net growth last 14 days: +/- X
+- GitHub Actions workflows: X
+- Internal dashboards: X
+- Health snapshot score: [paste key metrics]
+
+### Top Complexity Hotspots
+[Top 5 largest directories/files with size, churn, and assessment]
+
+### Systems Review
+[For each major system: size, usage, churn, verdict (keep/simplify/remove)]
+
+### Overlap & Consolidation Opportunities
+[Specific pairs/groups of systems that overlap]
+
+### Documentation Issues
+[List of stale docs with what's wrong]
+
+### Dead Code Candidates
+[Specific exports, files, or features that appear unused]
+
+### Recommended Actions
+[Prioritized list: what to do, estimated effort, expected impact]
+- Tier 1 (safe, do now): ...
+- Tier 2 (needs discussion): ...
+- Tier 3 (architectural decision): ...
+```
+
+## Phase 4: Act or File
+
+For each recommendation:
+- **Quick wins** (< 30 min, safe): Do them in this session if time allows
+- **Medium items**: File a GitHub issue with the evidence from the report (`pnpm crux issues create`)
+- **Architectural decisions**: Note them for the user to discuss — don't file issues for things that need human judgment
+
+## Guardrails
+
+- **Do not remove code during the audit.** The audit produces a report and files issues. Removal happens in separate, focused PRs.
+- **Evidence over impressions.** Every claim in the report should reference a file path, line count, or command output.
+- **Compare to value, not to zero.** A 1,000-line system that prevents real bugs is fine. A 200-line system that solves a hypothetical problem is not.
+- **Content pages are the product.** Infrastructure exists to serve wiki content. If infrastructure is growing faster than content, flag it prominently.

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,0 +1,128 @@
+# Retrospective
+
+Analyze recent PR patterns, session logs, and development process to identify what's working, what's not, and what to change. Produces a written report focused on process improvements.
+
+**Recommended cadence:** Weekly, or after a particularly intense development period.
+
+**Relationship to other commands:**
+- `/maintain` handles tactical cleanup (close issues, fix cruft)
+- `/audit` reviews codebase health and complexity
+- `/retrospective` reviews the development *process* — how work is getting done, not what the code looks like
+
+## Phase 1: Gather Data
+
+Collect recent development activity. Default lookback is 7 days; adjust with the date range in the commands below.
+
+```bash
+# Merged PRs in the last 7 days
+gh pr list --state merged --limit 50 --json number,title,additions,deletions,mergedAt,author,labels --jq '.[] | select(.mergedAt > (now - 7*86400 | strftime("%Y-%m-%dT%H:%M:%SZ")))' 2>/dev/null || echo "gh CLI unavailable — check GITHUB_TOKEN"
+
+# PR size distribution
+gh pr list --state merged --limit 50 --json number,title,additions,deletions,mergedAt --jq '.[] | select(.mergedAt > (now - 7*86400 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | "\(.number)\t+\(.additions)/-\(.deletions)\t\(.title)"' 2>/dev/null
+
+# Session logs from the period
+pnpm crux maintain review-prs --since=$(date -v-7d +%Y-%m-%d) 2>/dev/null || echo "review-prs unavailable"
+
+# Recent commit classification (feature vs fix vs refactor)
+git log --since="7 days ago" --oneline | head -50
+
+# Open issues snapshot
+gh issue list --limit 30 --json number,title,labels,createdAt --jq '.[] | "\(.number)\t\(.labels | map(.name) | join(","))\t\(.title)"' 2>/dev/null
+```
+
+Also read the session log review from `crux maintain` output if available — it extracts issues and learnings from session logs and flags recurring problems.
+
+## Phase 2: Analyze Patterns
+
+Work through each of these lenses. Use the data from Phase 1 as evidence.
+
+### 2a. PR Patterns
+
+**Fix chains:** Look for sequences where a feature PR was followed by 2+ fix PRs. These indicate the original PR shipped incomplete or without sufficient testing. List specific chains by PR number.
+
+**Size distribution:** Flag any PRs over 500 lines added. Were they reviewable? Could they have been split?
+
+**Feature vs. fix ratio:** Count how many PRs were new features vs. bug fixes vs. infrastructure. A healthy ratio depends on project phase, but if fixes outnumber features 3:1, something is wrong upstream.
+
+**Revert/close rate:** Were any PRs closed without merging or reverted? Why?
+
+### 2b. Session Log Analysis
+
+Read the session log issues and learnings from the `crux maintain review-prs` output. Look for:
+
+**Recurring friction:** Problems that appear in 2+ session logs. These are systemic issues worth fixing at the root.
+
+**Time sinks:** Sessions that spent most of their time on setup, debugging infrastructure, or fighting tooling rather than delivering value.
+
+**Learnings that weren't propagated:** Session log learnings that should have been added to CLAUDE.md, rules files, or common-issues.md but weren't.
+
+### 2c. Agent-Filed Issues Quality
+
+If agents filed issues during the period, review them:
+- Are they specific and actionable, or speculative?
+- Do they correspond to real bugs or concrete tech debt?
+- Were any duplicates of existing issues?
+
+### 2d. CI and Tooling
+
+- Did CI break during the period? How long was it broken?
+- Were there any gate check false positives or false negatives?
+- Did any tooling changes cause downstream problems?
+
+### 2e. Content vs. Infrastructure Balance
+
+Count:
+- Wiki content pages created or substantively updated
+- Lines of infrastructure code added (net)
+- Number of internal dashboards or monitoring systems added
+
+Is the ratio reasonable for the project's current goals?
+
+## Phase 3: Write the Report
+
+### Report structure
+
+```
+## Retrospective — [DATE RANGE]
+
+### Summary Stats
+- PRs merged: X
+- Net lines: +X/-Y
+- Content pages updated: X
+- Fix-to-feature ratio: X:Y
+- Largest PR: #N (+X lines)
+
+### What Went Well
+[2-4 specific things that worked, with evidence]
+
+### What Didn't Go Well
+[2-4 specific problems, with PR numbers and details]
+
+### Fix Chains
+[List each chain: Feature PR → Fix 1 → Fix 2 → ...]
+
+### Recurring Friction
+[Problems that appeared in multiple sessions]
+
+### Process Recommendations
+[Specific, actionable changes — not vague "we should do better"]
+Each recommendation should state:
+- What to change
+- Why (with evidence from this retrospective)
+- Expected impact
+```
+
+## Phase 4: Act
+
+For each recommendation:
+- **Process changes** (updating rules, CLAUDE.md, or conventions): Make the change now if it's clear-cut, or note it for user discussion if it involves tradeoffs.
+- **Tooling fixes**: File a GitHub issue if you can't fix it in this session.
+- **Propagate learnings**: Update `.claude/rules/` or `CLAUDE.md` with any recurring patterns identified.
+
+## Guardrails
+
+- **Be specific.** "PRs are too big" is not useful. "#1453 was 2,246 lines because the semantic diff module was added as a single PR instead of being split into core + tests + integration" is useful.
+- **Praise what works.** The report should include positive observations, not just problems. Reinforcing good patterns is as important as flagging bad ones.
+- **Recommendations must be actionable.** "Improve code quality" is not a recommendation. "Add a 500-line soft cap to the PR template with a checklist item asking whether the PR can be split" is.
+- **Don't relitigate closed decisions.** If something was decided and shipped, evaluate the outcome rather than arguing it should have been done differently.
+- **Keep it short.** The report should be readable in 5 minutes. If it's longer, the most important findings will get lost.


### PR DESCRIPTION
## Summary
- Add `/audit` skill: strategic codebase review — complexity trends, dead code, simplification opportunities, documentation staleness. Biweekly cadence.
- Add `/retrospective` skill: PR pattern analysis — fix chains, session log review, process improvement recommendations. Weekly cadence.
- Both are markdown-only (zero code, zero maintenance), complementing the existing `/maintain` command for day-to-day cleanup.

## Relationship to existing commands
| Command | Purpose | Cadence |
|---------|---------|---------|
| `/maintain` | Day-to-day: close issues, fix cruft, propagate learnings | Daily/weekly |
| `/audit` | Strategic: complexity trends, dead code, simplification | Biweekly |
| `/retrospective` | Process: PR patterns, fix chains, what's working | Weekly |

## Test plan
- [x] Both files are picked up by Claude Code skill discovery
- [x] No code changes — markdown only

🤖 Generated with [Claude Code](https://claude.com/claude-code)