### PR TITLE
fix: sanitize footnote text to prevent MDX compilation failures

### DIFF
--- a/apps/web/src/lib/__tests__/reference-preprocessor.test.ts
+++ b/apps/web/src/lib/__tests__/reference-preprocessor.test.ts
@@ -470,6 +470,25 @@ describe("preprocessReferences", () => {
     expect(matches.length).toBe(1);
   });
 
+  it("deduplicates case-insensitively with leading whitespace", () => {
+    const content = "Fact[^rc-dup2].";
+    const refData = makeReferenceData(
+      {},
+      {
+        "rc-dup2": {
+          title: "AI Safety Report",
+          url: "https://example.com/safety",
+          note: "  ai safety report — detailed findings on alignment risks",
+        },
+      }
+    );
+
+    const { content: result } = preprocessReferences(content, refData);
+    // Should deduplicate despite case and whitespace differences
+    const matches = result.match(/[Aa][Ii] [Ss]afety [Rr]eport/g) || [];
+    expect(matches.length).toBe(1);
+  });
+
   it("does not deduplicate when note does not start with title", () => {
     const content = "Fact[^rc-nodup1].";
     const refData = makeReferenceData(

--- a/apps/web/src/lib/reference-preprocessor.ts
+++ b/apps/web/src/lib/reference-preprocessor.ts
@@ -98,9 +98,15 @@ function buildClaimFootnote(data: ClaimRefData): string {
  * issue where the LLM-generated note repeats the source title).
  */
 function buildCitationFootnote(data: CitationData): string {
-  // Deduplicate: if note already starts with the title text, use note alone
-  const noteOverlapsTitle =
-    data.title && data.note && data.note.startsWith(data.title);
+  // Deduplicate: if note already starts with the title text, use note alone.
+  // Normalize whitespace and compare case-insensitively to catch DB variations.
+  const normalizedTitle = data.title?.trim();
+  const normalizedNote = data.note?.trimStart();
+  const noteOverlapsTitle = Boolean(
+    normalizedTitle &&
+      normalizedNote &&
+      normalizedNote.toLowerCase().startsWith(normalizedTitle.toLowerCase())
+  );
 
   if (data.title && data.url && !noteOverlapsTitle) {
     const link = `[${data.title}](${data.url})`;
@@ -108,12 +114,14 @@ function buildCitationFootnote(data: CitationData): string {
   }
   if (data.url) {
     // When note overlaps title, use note as the link text instead
-    const linkText = noteOverlapsTitle ? data.note! : (data.title || data.url);
+    const linkText = noteOverlapsTitle ? normalizedNote! : (data.title || data.url);
     const link = `[${linkText}](${data.url})`;
     return sanitizeFootnoteText(link);
   }
   if (data.title) {
-    const text = noteOverlapsTitle ? data.note! : (data.note ? `${data.title} — ${data.note}` : data.title);
+    const text = noteOverlapsTitle
+      ? normalizedNote!
+      : (data.note ? `${data.title} — ${data.note}` : data.title);
     return sanitizeFootnoteText(text);
   }
   return sanitizeFootnoteText(data.note || "Citation");


### PR DESCRIPTION
## Summary

- Add `sanitizeFootnoteText()` to `reference-preprocessor.ts` that escapes `<` characters in database-sourced citation text before injecting into MDX footnote definitions
- Fix title/note deduplication in `buildCitationFootnote()` when the note field already starts with the title text
- Add 6 new tests covering sanitization and deduplication behavior

## Problem

Two pages fail MDX compilation on Vercel builds:
- `government-authority-commercial-ai-infrastructure` — citation notes contain raw `<U.S.C.` that MDX misinterprets as a broken JSX member expression
- `financial-stability-risks-ai-capex` — citation title/note fields overlap, causing duplicated footnote content with `<EntityLink>` components in footnote definitions

## Test plan

- [x] All 28 reference-preprocessor tests pass (6 new)
- [x] Gate validation passes (all CI-blocking checks green)
- [ ] Verify both failing pages compile on Vercel after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed citation footnotes to properly handle special characters, improving compatibility with complex citation formats.
  * Enhanced citation deduplication to reduce redundant information when note text mirrors the citation title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->