### PR TITLE
Disable automatic triggers and add filters to reduce API spending

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip draft PRs and bot-created PRs (claude/ branches from automation)
+    # to reduce unnecessary Anthropic API spending.
+    if: |
+      github.event.pull_request.draft == false &&
+      !startsWith(github.event.pull_request.head.ref, 'claude/') &&
+      github.event.pull_request.user.type != 'Bot'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -18,14 +18,18 @@ name: Resolve Merge Conflicts
 # Requires: ANTHROPIC_API_KEY secret in the repository.
 
 on:
+  # Automatic triggers (schedule + workflow_run) are disabled to control
+  # Anthropic API spending. Re-enable them only if you want automated
+  # conflict resolution to run. Use workflow_dispatch for on-demand runs.
+
   # Run after auto-rebase finishes (proper sequencing, no sleep hack)
-  workflow_run:
-    workflows: ["Auto-Rebase PRs"]
-    types: [completed]
+  # workflow_run:
+  #   workflows: ["Auto-Rebase PRs"]
+  #   types: [completed]
 
   # Catch any stragglers (e.g. PRs made conflicting by force-pushes)
-  schedule:
-    - cron: "0 */6 * * *" # every 6 hours
+  # schedule:
+  #   - cron: "0 */6 * * *" # every 6 hours
 
   # Allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
## Summary
This PR reduces Anthropic API spending by disabling automatic workflow triggers and adding filters to prevent unnecessary code review runs on draft and bot-created PRs.

## Key Changes
- **resolve-conflicts.yml**: Disabled automatic triggers (`workflow_run` and `schedule`) while keeping `workflow_dispatch` enabled for manual on-demand runs
  - Added explanatory comments about why automatic triggers are disabled
  - Automatic conflict resolution can still be triggered manually when needed

- **claude-code-review.yml**: Added conditional filters to skip code reviews on:
  - Draft pull requests (`github.event.pull_request.draft == false`)
  - Bot-created PRs from automation (`!startsWith(github.event.pull_request.head.ref, 'claude/')`)
  - Bot user accounts (`github.event.pull_request.user.type != 'Bot'`)
  - Replaced the commented-out author filter with the new cost-reduction filters

## Implementation Details
These changes maintain the ability to run workflows on-demand while preventing unnecessary API calls that would occur from automated triggers and bot-generated PRs. The filters are applied at the job level to prevent workflow execution before any API calls are made.

https://claude.ai/code/session_01C56ZpFSWWki7AkbTGVZCBX