### PR TITLE
fix(ci): add container logs on smoke test failure, increase timeout

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -89,9 +89,9 @@ jobs:
             -e WIKI_SERVER_API_KEY="${LONGTERMWIKI_SERVER_API_KEY}" \
             "$IMAGE"
 
-          # Wait for the server to be ready (up to 30s: 10 attempts × 3s delay).
+          # Wait for the server to be ready (up to 60s: 20 attempts × 3s delay).
           # The server runs migrations on startup, so allow time for that.
-          MAX_ATTEMPTS=10
+          MAX_ATTEMPTS=20
           DELAY=3
           STATUS=""
           for i in $(seq 1 $MAX_ATTEMPTS); do
@@ -108,6 +108,12 @@ jobs:
           done
 
           if [ "$STATUS" != "healthy" ]; then
+            echo "::group::Container logs (last 200 lines)"
+            docker logs --tail 200 "$CONTAINER_NAME" 2>&1 || echo "(no logs available)"
+            echo "::endgroup::"
+            echo "::group::Container inspect"
+            docker inspect "$CONTAINER_NAME" --format '{{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' 2>/dev/null || true
+            echo "::endgroup::"
             echo "::error::Pre-deploy smoke test failed — container did not become healthy within $((MAX_ATTEMPTS * DELAY))s. Aborting deploy to prevent serving broken traffic."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Add `docker logs` and `docker inspect` output when the pre-deploy smoke test fails, so we can see why the container didn't become healthy
- Increase timeout from 30s (10×3s) to 60s (20×3s) to handle slower migrations

## Context
The Phase 4a migration deploy (#1505, #1509) failed the smoke test with "no response" on all health check attempts, but we had no container logs to diagnose the issue. This makes future failures debuggable.

## Test plan
- [x] Workflow YAML is valid
- [x] All gate checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended pre-deployment health check timeout from 30 seconds to 60 seconds for improved deployment reliability.
  * Enhanced diagnostic logging on deployment health check failures to facilitate troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->