### PR TITLE
fix(wiki-server): use dedicated migration client without statement_timeout

### DIFF
--- a/apps/wiki-server/src/db.ts
+++ b/apps/wiki-server/src/db.ts
@@ -55,17 +55,30 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export async function initDb() {
-  const db = getDrizzleDb();
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error("DATABASE_URL environment variable is required");
+  }
+
   logger.info("Running migrations...");
   const startMs = Date.now();
+
+  // Use a dedicated single-connection client for migrations — no statement_timeout.
+  // DDL (ALTER TABLE, CREATE INDEX) can be blocked by concurrent transactions and
+  // needs more than the 30s timeout configured on the main pool.
+  const migrationSql = postgres(url, { max: 1, connect_timeout: 10 });
+  const migrationDb = drizzle(migrationSql, { schema });
+
   try {
-    await migrate(db, {
+    await migrate(migrationDb, {
       migrationsFolder: path.resolve(__dirname, "../drizzle"),
     });
     logger.info({ durationMs: Date.now() - startMs }, "Migrations completed");
   } catch (err) {
     logger.error({ err }, "Migration failed");
     throw err;
+  } finally {
+    await migrationSql.end();
   }
 }
 


### PR DESCRIPTION
## Summary
- Root cause found via container logs (#1512): `ALTER TABLE wiki_pages ADD COLUMN slug text` was killed by `statement_timeout=30s`
- The main DB pool sets `statement_timeout: 30000` on every connection to prevent pool exhaustion
- During migrations, DDL (ALTER TABLE) needs an ACCESS EXCLUSIVE lock, which can be blocked by the running production server's concurrent transactions on the same table
- The 30s timeout kills the ALTER before it can acquire the lock

## Fix
- Create a dedicated single-connection postgres client for migrations **without** `statement_timeout`
- Close the migration client immediately after migrations complete
- The main pool retains its 30s timeout for normal API operations

## Container logs (root cause)
```
PostgresError: canceling statement due to statement timeout
```
On the very first migration statement: `ALTER TABLE wiki_pages ADD COLUMN slug text`

## Test plan
- [x] All 603 wiki-server tests pass
- [x] All gate checks pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database migration reliability by optimizing connection handling and timeout management to prevent connection pool exhaustion during database updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->