### PR TITLE
fix(wiki-server): override server-level statement_timeout for migrations

### DIFF
--- a/apps/wiki-server/src/db.ts
+++ b/apps/wiki-server/src/db.ts
@@ -37,7 +37,10 @@ export function getDb() {
       idle_timeout: 20,
       connect_timeout: 10,
       connection: {
-        statement_timeout: 30000, // Kill queries after 30s to prevent pool exhaustion
+        // Kill queries after 30s to prevent pool exhaustion.
+        // Note: use a non-zero number here. postgres.js filters out falsy values
+        // (including 0), so `statement_timeout: 0` would silently not be sent.
+        statement_timeout: 30000,
       },
     });
   }
@@ -63,10 +66,32 @@ export async function initDb() {
   logger.info("Running migrations...");
   const startMs = Date.now();
 
-  // Use a dedicated single-connection client for migrations — no statement_timeout.
-  // DDL (ALTER TABLE, CREATE INDEX) can be blocked by concurrent transactions and
-  // needs more than the 30s timeout configured on the main pool.
-  const migrationSql = postgres(url, { max: 1, connect_timeout: 10 });
+  // Dedicated single-connection client for migrations with relaxed timeouts.
+  //
+  // Why: DDL (ALTER TABLE) requires ACCESS EXCLUSIVE locks. During deploys, old
+  // pods hold connections with active queries, so lock acquisition can take 30s+.
+  // The PostgreSQL *role* also has statement_timeout=30s server-side, which applies
+  // regardless of JS client config — we must explicitly override it here.
+  //
+  // Gotcha: postgres.js filters falsy values (`.filter(([, v]) => v)` in
+  // connection.js:1004), so `statement_timeout: 0` (number) is silently dropped.
+  // We use string values and a Record<string, string> type to work around both
+  // the falsy-filtering and the TS types (which declare these as `number`).
+  //
+  // Settings:
+  //   statement_timeout: '0'       — No per-statement limit; DDL must complete once locked
+  //   lock_timeout: '120000'       — 2min cap on lock wait; fail fast, let pod retry
+  //   idle_in_transaction_session_timeout: '600000' — 10min bound on total migration txn
+  const migrationConnection: Record<string, string> = {
+    statement_timeout: '0',
+    lock_timeout: '120000',
+    idle_in_transaction_session_timeout: '600000',
+  };
+  const migrationSql = postgres(url, {
+    max: 1,
+    connect_timeout: 10,
+    connection: migrationConnection,
+  });
   const migrationDb = drizzle(migrationSql, { schema });
 
   try {


### PR DESCRIPTION
## Summary

The Phase 4a migration (#1498) has been failing in the pre-deploy smoke test because `ALTER TABLE wiki_pages ADD COLUMN slug text` times out after ~31 seconds. PR #1513 created a dedicated migration client but didn't override the **server-level** `statement_timeout=30s` set on the PostgreSQL role.

### Root cause chain

1. The PostgreSQL role has `statement_timeout=30s` configured at the server/role level
2. This applies to **all** connections regardless of JS client config — unless explicitly overridden via connection parameters
3. PR #1513's migration client omitted the `connection` parameter, so the server default still applied
4. During deploys, old pods hold connections with active queries on `wiki_pages`, blocking the ACCESS EXCLUSIVE lock needed by `ALTER TABLE`
5. The lock wait + statement together exceed 30s → PostgreSQL kills the statement

### Fix

Explicitly set connection parameters on the migration client that override the server-level defaults:

- `statement_timeout: '0'` — No per-statement limit (DDL must complete once lock acquired)
- `lock_timeout: '120000'` — 2-minute cap on lock acquisition (fail fast, let pod retry)  
- `idle_in_transaction_session_timeout: '600000'` — 10-minute bound on total migration transaction

### postgres.js gotcha (the subtle part)

postgres.js filters connection params with `.filter(([, v]) => v)` (connection.js line 1004), which drops **falsy** values. Since `0` is falsy in JavaScript, `statement_timeout: 0` would be **silently dropped** — the server-level 30s default would still apply. We use the string `'0'` instead, which is truthy and gets sent to PostgreSQL correctly.

The TypeScript types declare these as `number`, so we use `Record<string, string>` to sidestep the type mismatch without `as unknown as T` double-casts.

## Test plan

- [x] `tsc --noEmit` passes
- [x] 603 wiki-server tests pass
- [x] All 9 gate checks pass
- [ ] Pre-deploy smoke test succeeds (migration completes without timeout)
- [ ] Phase 4a schema changes visible in production DB

Closes #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)