### PR TITLE
Change GitHub shadowban check schedule from every 30 minutes to daily

### DIFF
--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -73,7 +73,7 @@ export function loadConfig(): Config {
       githubShadowbanCheck: {
         enabled: envBool("TASK_GITHUB_SHADOWBAN_CHECK_ENABLED", true),
         schedule:
-          process.env["TASK_GITHUB_SHADOWBAN_CHECK_SCHEDULE"] ?? "*/30 * * * *",
+          process.env["TASK_GITHUB_SHADOWBAN_CHECK_SCHEDULE"] ?? "0 9 * * *",
         usernames: ["quri-bot"],
       },
     },


### PR DESCRIPTION
## Summary
Updated the default schedule for the GitHub shadowban check task from running every 30 minutes to running once daily at 9 AM UTC.

## Changes
- Modified the default cron schedule for `TASK_GITHUB_SHADOWBAN_CHECK_SCHEDULE` from `*/30 * * * *` (every 30 minutes) to `0 9 * * *` (daily at 9 AM)
- This reduces the frequency of shadowban checks, which should decrease API usage and system load while still maintaining regular monitoring

## Details
The schedule can still be overridden via the `TASK_GITHUB_SHADOWBAN_CHECK_SCHEDULE` environment variable if needed. This change only affects the default behavior when the environment variable is not explicitly set.

https://claude.ai/code/session_01DAa75Njxq5ajMWSx8RtsbF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default schedule for GitHub shadowban checks from running every 30 minutes to running daily at 9 AM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->