### PR TITLE
fix(wiki-server): increase smoke test timeout, lower lock_timeout

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -89,9 +89,12 @@ jobs:
             -e WIKI_SERVER_API_KEY="${LONGTERMWIKI_SERVER_API_KEY}" \
             "$IMAGE"
 
-          # Wait for the server to be ready (up to 60s: 20 attempts × 3s delay).
-          # The server runs migrations on startup, so allow time for that.
-          MAX_ATTEMPTS=20
+          # Wait for the server to be ready (up to 150s: 50 attempts × 3s delay).
+          # The server runs migrations on startup, which may need to wait for
+          # ACCESS EXCLUSIVE locks on wiki_pages while the production server's
+          # connections drain (lock_timeout=60s in db.ts). Allow enough headroom
+          # for lock wait + DDL execution + server startup.
+          MAX_ATTEMPTS=50
           DELAY=3
           STATUS=""
           for i in $(seq 1 $MAX_ATTEMPTS); do

--- a/apps/wiki-server/src/db.ts
+++ b/apps/wiki-server/src/db.ts
@@ -80,11 +80,12 @@ export async function initDb() {
   //
   // Settings:
   //   statement_timeout: '0'       — No per-statement limit; DDL must complete once locked
-  //   lock_timeout: '120000'       — 2min cap on lock wait; fail fast, let pod retry
+  //   lock_timeout: '60000'        — 60s cap on lock wait; must be < smoke test timeout
+  //                                  so we get a clear error rather than silent hang
   //   idle_in_transaction_session_timeout: '600000' — 10min bound on total migration txn
   const migrationConnection: Record<string, string> = {
     statement_timeout: '0',
-    lock_timeout: '120000',
+    lock_timeout: '60000',
     idle_in_transaction_session_timeout: '600000',
   };
   const migrationSql = postgres(url, {


### PR DESCRIPTION
## Summary

Follow-up to #1514 (statement_timeout override). The `statement_timeout` fix worked — no more timeout errors in the logs. However, the migration is now **hanging** waiting for the ACCESS EXCLUSIVE lock on `wiki_pages` because the production server still holds connections that query that table.

The smoke test gives up at 60s, but `lock_timeout` was 120s — so the migration never gets a chance to either succeed or produce a clear error within the smoke test window.

### Changes

1. **Lower `lock_timeout` from 120s to 60s** — If the lock can't be acquired in 60s, fail fast with a clear error rather than hanging silently past the smoke test window
2. **Increase smoke test timeout from 60s to 150s** (50 attempts × 3s) — Give the migration enough headroom for: lock wait (up to 60s) + DDL execution (~10-20s) + server startup (~5s)

### Why this should work now

PostgreSQL's lock queue is FIFO with starvation prevention. Once the ALTER TABLE requests an ACCESS EXCLUSIVE lock:
1. Existing transactions on `wiki_pages` finish (production server's `statement_timeout=30s` bounds each one)
2. New queries queue behind the ALTER TABLE (can't skip ahead of an exclusive lock request)
3. Once existing transactions drain, the ALTER TABLE acquires the lock

With 150s of smoke test headroom, there's plenty of time for this sequence to complete.

## Test plan

- [x] `tsc --noEmit` passes
- [x] 603 wiki-server tests pass, 359 app tests pass  
- [x] All 14 gate checks pass
- [ ] Pre-deploy smoke test succeeds
- [ ] Phase 4a migration runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)