### PR TITLE
fix(ci): reduce auto-update page count to avoid timeout (#1467)

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -19,7 +19,7 @@ on:
       count:
         description: 'Max pages to update'
         required: false
-        default: '5'
+        default: '3'
         type: string
       dry_run:
         description: 'Dry run (no page improvements)'


### PR DESCRIPTION
## Summary
- Reduce auto-update default page count from 5→3 to fit within the 60-minute GitHub Actions timeout
- The improve pipeline (Sonnet-class models) was exceeding the time budget when processing 5 pages
- Added status comments to #1467 (auto-update failing) and #1525 (outage incident)

Closes #1467

## Test plan
- [x] Gate passes (all CI-blocking checks green)
- [x] Workflow change only — no logic to test
- [x] Next daily auto-update run (2026-03-03 06:00 UTC) will validate the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)