### PR TITLE
fix(wiki-server): pre-fix JOINs on wp.id → wp.slug for Phase D PK swap

### DIFF
--- a/apps/wiki-server/src/routes/explore.ts
+++ b/apps/wiki-server/src/routes/explore.ts
@@ -288,7 +288,7 @@ const exploreApp = new Hono()
         e.tags AS entity_tags, e.clusters AS entity_clusters
         ${searchRankSelect}
       FROM wiki_pages wp
-      LEFT JOIN entities e ON wp.id = e.id
+      LEFT JOIN entities e ON wp.slug = e.id
       ${mainWhere}
       ORDER BY ${orderBy}
       LIMIT $${limitParamIdx} OFFSET $${offsetParamIdx}
@@ -386,7 +386,7 @@ const exploreApp = new Hono()
           e.tags AS entity_tags, e.clusters AS entity_clusters,
           similarity(wp.title, $${trigramParamIdx}) AS search_rank
         FROM wiki_pages wp
-        LEFT JOIN entities e ON wp.id = e.id
+        LEFT JOIN entities e ON wp.slug = e.id
         ${trigramWhere}
         ORDER BY similarity(wp.title, $${trigramParamIdx}) DESC
         LIMIT $${trigramParamIdx + 1} OFFSET $${trigramParamIdx + 2}

--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -427,7 +427,7 @@ const integrityApp = new Hono()
             SELECT
               wp.id,
               EXISTS (SELECT 1 FROM citation_quotes cq WHERE cq.page_id = wp.id) AS has_cq,
-              EXISTS (SELECT 1 FROM claims c WHERE c.entity_id = wp.id) AS has_claims
+              EXISTS (SELECT 1 FROM claims c WHERE c.entity_id = wp.slug) AS has_claims
             FROM wiki_pages wp
           ) sub`
     )) as Array<Record<string, string>>;


### PR DESCRIPTION
## Summary

Three raw SQL JOINs compared columns that stay `text` forever (`entities.id`, `claims.entity_id`) against `wiki_pages.id`, which becomes an `integer` after the Phase D PK swap. This would silently return wrong results.

Fix: switch to `wp.slug` — already `NOT NULL UNIQUE` from Phase A, same value as `wp.id` today, works before and after Phase D.

Changes:
- `explore.ts`: `LEFT JOIN entities e ON wp.id = e.id` → `ON wp.slug = e.id` (2 occurrences)
- `integrity.ts`: `EXISTS ... WHERE c.entity_id = wp.id` → `wp.slug` (1 occurrence)

RT-5 and RT-6 from discussion #1497. Part of the risk reduction plan in discussion #1531.

## Test plan
- [x] All 606 wiki-server tests pass
- [x] Gate passes (11/11 checks)
- [x] TypeScript clean

## Risk
Zero — `slug` and `id` contain identical values today. JOIN results are identical before and after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of data associations for wiki pages in explore and integrity features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->