### PR TITLE
feat(wiki-server): Phase D1 — switch all read queries from _old to _int columns

### DIFF
--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -1336,7 +1336,8 @@ const citationsApp = new Hono()
         WHERE id NOT IN (
           SELECT id FROM (
             SELECT id, ROW_NUMBER() OVER (
-              PARTITION BY page_id_int ORDER BY snapshot_at DESC
+              -- COALESCE to -1 so NULL page_id_int rows don't all collapse into one partition
+              PARTITION BY COALESCE(page_id_int, -1) ORDER BY snapshot_at DESC
             ) AS rn
             FROM citation_accuracy_snapshots
           ) ranked
@@ -1365,7 +1366,8 @@ const citationsApp = new Hono()
       WHERE id NOT IN (
         SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
-            PARTITION BY page_id_int ORDER BY snapshot_at DESC
+            -- COALESCE to -1 so NULL page_id_int rows don't all collapse into one partition
+            PARTITION BY COALESCE(page_id_int, -1) ORDER BY snapshot_at DESC
           ) AS rn
           FROM citation_accuracy_snapshots
         ) ranked

--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -302,9 +302,10 @@ const hallucinationRiskApp = new Hono()
     // Fallback: use DISTINCT ON on the base table (slow but correct)
     const db = getDrizzleDb();
 
+    // Use pageIdInt (integer column) for consistency with the DISTINCT ON below
     const pagesResult = await db
       .select({
-        count: sql<number>`count(distinct ${hallucinationRiskSnapshots.pageId})`,
+        count: sql<number>`count(distinct ${hallucinationRiskSnapshots.pageIdInt})`,
       })
       .from(hallucinationRiskSnapshots);
     const uniquePages = Number(pagesResult[0].count);
@@ -312,8 +313,10 @@ const hallucinationRiskApp = new Hono()
     const levelDist = await rawDb<LevelDistRow[]>`
       SELECT level, count(*)::int AS count
       FROM (
+        -- Exclude NULL page_id_int rows; DISTINCT ON NULLs would collapse all into one group
         SELECT DISTINCT ON (page_id_int) level
         FROM hallucination_risk_snapshots
+        WHERE page_id_int IS NOT NULL
         ORDER BY page_id_int, computed_at DESC
       ) latest
       GROUP BY level
@@ -413,7 +416,8 @@ const hallucinationRiskApp = new Hono()
         WHERE id NOT IN (
           SELECT id FROM (
             SELECT id, ROW_NUMBER() OVER (
-              PARTITION BY page_id_int ORDER BY computed_at DESC
+              -- COALESCE to -1 so NULL page_id_int rows don't all collapse into one partition
+              PARTITION BY COALESCE(page_id_int, -1) ORDER BY computed_at DESC
             ) AS rn
             FROM hallucination_risk_snapshots
           ) ranked
@@ -444,7 +448,8 @@ const hallucinationRiskApp = new Hono()
       WHERE id NOT IN (
         SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
-            PARTITION BY page_id_int ORDER BY computed_at DESC
+            -- COALESCE to -1 so NULL page_id_int rows don't all collapse into one partition
+            PARTITION BY COALESCE(page_id_int, -1) ORDER BY computed_at DESC
           ) AS rn
           FROM hallucination_risk_snapshots
         ) ranked

--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -321,9 +321,10 @@ const integrityApp = new Hono()
         "entities"
       ),
       // 5. citation_quotes.page_id_int → wiki_pages
+      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id_int::text AS ref FROM citation_quotes WHERE page_id_int NOT IN (SELECT integer_id FROM wiki_pages)`,
+        sql`SELECT DISTINCT page_id_int::text AS ref FROM citation_quotes WHERE (page_id_int IS NULL OR page_id_int NOT IN (SELECT integer_id FROM wiki_pages))`,
         "citation_quotes",
         "page_id_int",
         "wiki_pages"
@@ -337,9 +338,10 @@ const integrityApp = new Hono()
         "resources"
       ),
       // 7. edit_logs.page_id_int → wiki_pages
+      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id_int::text AS ref FROM edit_logs WHERE page_id_int NOT IN (SELECT integer_id FROM wiki_pages)`,
+        sql`SELECT DISTINCT page_id_int::text AS ref FROM edit_logs WHERE (page_id_int IS NULL OR page_id_int NOT IN (SELECT integer_id FROM wiki_pages))`,
         "edit_logs",
         "page_id_int",
         "wiki_pages"
@@ -353,9 +355,10 @@ const integrityApp = new Hono()
         "entities"
       ),
       // 9. resource_citations.page_id_int → wiki_pages
+      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id_int::text AS ref FROM resource_citations WHERE page_id_int NOT IN (SELECT integer_id FROM wiki_pages)`,
+        sql`SELECT DISTINCT page_id_int::text AS ref FROM resource_citations WHERE (page_id_int IS NULL OR page_id_int NOT IN (SELECT integer_id FROM wiki_pages))`,
         "resource_citations",
         "page_id_int",
         "wiki_pages"

--- a/apps/wiki-server/src/routes/links.ts
+++ b/apps/wiki-server/src/routes/links.ts
@@ -204,7 +204,8 @@ const linksApp = new Hono()
         wp.entity_type AS source_type
       FROM page_links pl
       LEFT JOIN wiki_pages wp ON wp.integer_id = pl.source_id_int
-      WHERE pl.target_id_int = ${targetIntId}
+      -- Filter NULL source_id_int: DISTINCT ON NULLs would collapse into one group with a NULL id
+      WHERE pl.target_id_int = ${targetIntId} AND pl.source_id_int IS NOT NULL
       ORDER BY pl.source_id_int, pl.weight DESC
     ) sub
     ORDER BY sub.weight DESC
@@ -357,7 +358,9 @@ const linksApp = new Hono()
     FROM page_links pl
     LEFT JOIN wiki_pages ws ON ws.integer_id = pl.source_id_int
     LEFT JOIN wiki_pages wt ON wt.integer_id = pl.target_id_int
-    WHERE pl.source_id_int = ${graphEntityIntId} OR pl.target_id_int = ${graphEntityIntId}
+    -- Exclude rows where either endpoint lacks an integer ID (would produce NULL node ids)
+    WHERE pl.source_id_int IS NOT NULL AND pl.target_id_int IS NOT NULL
+      AND (pl.source_id_int = ${graphEntityIntId} OR pl.target_id_int = ${graphEntityIntId})
     ORDER BY pl.weight DESC
     LIMIT ${MAX_GRAPH_EDGES}
   `;

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -478,8 +478,9 @@ async function fetchIntegritySummary(rawDb: ReturnType<typeof getDb>) {
       (SELECT count(*) FROM facts WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_facts,
       (SELECT count(*) FROM claims WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_claims,
       (SELECT count(*) FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_summaries,
-      (SELECT count(*) FROM citation_quotes WHERE page_id_int NOT IN (SELECT integer_id FROM wiki_pages))::int AS dangling_citations,
-      (SELECT count(*) FROM edit_logs WHERE page_id_int NOT IN (SELECT integer_id FROM wiki_pages))::int AS dangling_edit_logs
+      -- NULL-safe: NULL NOT IN (...) = NULL in SQL, so treat NULL page_id_int as dangling
+      (SELECT count(*) FROM citation_quotes WHERE (page_id_int IS NULL OR page_id_int NOT IN (SELECT integer_id FROM wiki_pages)))::int AS dangling_citations,
+      (SELECT count(*) FROM edit_logs WHERE (page_id_int IS NULL OR page_id_int NOT IN (SELECT integer_id FROM wiki_pages)))::int AS dangling_edit_logs
   `;
 
   const row = result[0] as {


### PR DESCRIPTION
## Summary

Part of the wiki_pages integer PK migration epic (#1497). This is **Phase D1** (code-only, no DDL, fully reversible).

- Switch all READ queries in 5 wiki-server route files from `_old` text columns to `_int` integer columns
- Write paths (INSERT/ON CONFLICT) are **unchanged** — still write to `_old` columns (that changes in D2)
- All API response shapes are preserved — text slugs returned via `JOIN wiki_pages wp ON wp.integer_id = table.page_id_int` then `wp.id AS slug`

### Files changed

| File | Changes |
|------|---------|
| `citations.ts` | `PARTITION BY page_id_old` → `page_id_int` |
| `hallucination-risk.ts` | `DISTINCT ON`/`ORDER BY`/`PARTITION BY` on base table; fallback queries add `wiki_pages` JOIN to recover text slug |
| `integrity.ts` | Dangling ref checks use `page_id_int NOT IN (SELECT integer_id FROM wiki_pages)`; `::text` cast preserves `{ ref: string }` interface |
| `links.ts` | Backlinks, related CTE, graph, stats — all switched to `source_id_int`/`target_id_int`; slugs recovered via wiki_pages JOINs |
| `monitoring.ts` | Health dangling counts use `page_id_int NOT IN (SELECT integer_id FROM wiki_pages)` |

### Why this is safe

- Both `_old` (text) and `_int` (integer) columns are **100% populated** — dual-write has been running since Phase B
- Reads on `_int` with the existing indexes are at least as fast as `_old`
- Rollback: revert this PR and redeploy — no DDL to undo

### Migration sequence

- [x] Phase A–C: Add integer columns, dual-write, resolve slugs
- [x] Phase C′: Rename `page_id` → `page_id_old` (PR #1539, merged)
- [x] **Phase D1: Switch reads to _int** ← this PR
- [ ] Phase D2: Stop writing _old + drop columns (code + psql)
- [ ] Phase D3/E: Swap wiki_pages PK (point of no return)
- [ ] Phase F: Cleanup

## Test plan

- [x] All 2451 unit/integration tests pass (`pnpm test`)
- [x] Gate passes — 11/11 checks green (`pnpm crux validate gate`)
- [x] Fresh-context subagent diff review — no CRITICAL/HIGH findings
- [x] Reads verified against dual-write baseline: integer join returns same slugs as text lookup
- [x] matview queries unchanged (hallucination_risk_latest exposes `page_id` column at matview level — unaffected by base table changes)

Closes #1497 (partial — phase D1 complete)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized backend identifier usage across integrity, citation, linking, stats, and monitoring logic to improve consistency without changing public APIs.

* **Bug Fixes**
  * Fixed NULL/duplicate handling that could mis-rank snapshots or mis-count per-page results, improving accuracy of cleanup, stats, links, and monitoring outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->