### PR TITLE
feat(statements): add verdict columns, PATCH endpoint, migration improvements

### DIFF
--- a/apps/wiki-server/drizzle/0052_add_statement_verdicts.sql
+++ b/apps/wiki-server/drizzle/0052_add_statement_verdicts.sql
@@ -1,0 +1,10 @@
+-- Add verdict/verification columns to statements table.
+-- These carry forward claim_verdict, claim_verdict_score, etc. from the claims table
+-- during claims→statements migration. ~557 claims have verdict data, ~136 have quotes.
+
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "verdict" text;
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "verdict_score" real;
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "verdict_quotes" text;
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "verdict_model" text;
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "verified_at" timestamp with time zone;
+ALTER TABLE "statements" ADD COLUMN IF NOT EXISTS "claim_category" text;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1772956800000,
       "tag": "0051_create_statements_system",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1773043200000,
+      "tag": "0052_add_statement_verdicts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/scripts/migrate-claims-to-statements.ts
+++ b/apps/wiki-server/scripts/migrate-claims-to-statements.ts
@@ -17,6 +17,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { sql, eq, or, inArray } from "drizzle-orm";
 import * as schema from "../src/schema.js";
+import { seedProperties } from "./seed-properties.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,6 +45,12 @@ interface ClaimRow {
   attributedTo: string | null;
   section: string | null;
   factId: string | null;
+  claimVerdict: string | null;
+  claimVerdictScore: number | null;
+  claimVerdictQuotes: string | null;
+  claimVerdictModel: string | null;
+  claimVerifiedAt: Date | null;
+  claimCategory: string | null;
 }
 
 interface ClaimSourceRow {
@@ -269,6 +276,12 @@ export async function migrateClaims(
       attributedTo: schema.claims.attributedTo,
       section: schema.claims.section,
       factId: schema.claims.factId,
+      claimVerdict: schema.claims.claimVerdict,
+      claimVerdictScore: schema.claims.claimVerdictScore,
+      claimVerdictQuotes: schema.claims.claimVerdictQuotes,
+      claimVerdictModel: schema.claims.claimVerdictModel,
+      claimVerifiedAt: schema.claims.claimVerifiedAt,
+      claimCategory: schema.claims.claimCategory,
     })
     .from(schema.claims)
     .where(
@@ -403,6 +416,12 @@ export async function migrateClaims(
         validStart: claim.asOf ?? null,
         validEnd: null as string | null,
         attributedTo,
+        verdict: claim.claimVerdict ?? null,
+        verdictScore: claim.claimVerdictScore ?? null,
+        verdictQuotes: claim.claimVerdictQuotes ?? null,
+        verdictModel: claim.claimVerdictModel ?? null,
+        verifiedAt: claim.claimVerifiedAt ?? null,
+        claimCategory: claim.claimCategory ?? null,
         status: "active" as const,
         sourceFactKey,
         note,
@@ -488,7 +507,11 @@ if (isMain) {
   const db = drizzle(sqlConn, { schema });
 
   try {
-    console.log(`Migrating claims for entity: ${entityFilter}`);
+    console.log("Seeding properties from fact-measures.yaml...");
+    const seedResult = await seedProperties(db);
+    console.log(`  Properties seeded: ${seedResult.inserted} inserted, ${seedResult.updated} updated`);
+
+    console.log(`\nMigrating claims for entity: ${entityFilter}`);
     const result = await migrateClaims(db, entityFilter);
 
     console.log(`\n--- Migration Summary ---`);

--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -1,10 +1,11 @@
 /**
  * Statements route — Hono RPC method-chained route for the Statements system.
  *
- * Phase 1c: Minimal CRUD for statements + citations.
  * - GET /          — list with filters (by entity, property, variety, status)
  * - GET /current   — current value for entity+property (valid_end IS NULL)
- * - POST /         — create statement + citations
+ * - GET /stats     — basic statistics
+ * - PATCH /:id     — update statement status, verdict, or note
+ * - POST /         — create statement + optional citations
  */
 
 import { Hono } from "hono";
@@ -88,6 +89,12 @@ function formatStatement(s: typeof statements.$inferSelect) {
     validEnd: s.validEnd,
     temporalGranularity: s.temporalGranularity,
     attributedTo: s.attributedTo,
+    verdict: s.verdict,
+    verdictScore: s.verdictScore,
+    verdictQuotes: s.verdictQuotes,
+    verdictModel: s.verdictModel,
+    verifiedAt: s.verifiedAt,
+    claimCategory: s.claimCategory,
     sourceFactKey: s.sourceFactKey,
     note: s.note,
     createdAt: s.createdAt,
@@ -95,7 +102,17 @@ function formatStatement(s: typeof statements.$inferSelect) {
   };
 }
 
-// ---- Create body schema ----
+// ---- Body schemas ----
+
+const PatchStatementBody = z.object({
+  status: z.enum(["active", "superseded", "retracted"]).optional(),
+  archiveReason: z.string().max(2000).nullish(),
+  verdict: z.string().max(50).nullish(),
+  verdictScore: z.number().min(0).max(1).nullish(),
+  verdictQuotes: z.string().max(10000).nullish(),
+  verdictModel: z.string().max(200).nullish(),
+  note: z.string().max(2000).nullish(),
+});
 
 const CreateStatementBody = z.object({
   variety: z.enum(["structured", "attributed"]),
@@ -237,6 +254,48 @@ const statementsApp = new Hono()
       byStatus: Object.fromEntries(byStatus.map((r) => [r.status, r.count])),
       propertiesCount: propertiesCount[0].count,
     });
+  })
+
+  // ---- PATCH /:id — update statement status, verdict, or note ----
+  .patch("/:id", async (c) => {
+    const idParam = c.req.param("id");
+    const id = parseInt(idParam, 10);
+    if (isNaN(id)) {
+      return c.json({ error: VALIDATION_ERROR, message: "Invalid statement ID" }, 400);
+    }
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = PatchStatementBody.safeParse(body);
+    if (!parsed.success) {
+      return validationError(c, parsed.error.message);
+    }
+
+    const data = parsed.data;
+    const db = getDrizzleDb();
+
+    // Build update set — inline to match codebase pattern (sql`now()` accepted at runtime)
+    const rows = await db
+      .update(statements)
+      .set({
+        ...(data.status !== undefined && { status: data.status }),
+        ...(data.archiveReason !== undefined && { archiveReason: data.archiveReason ?? null }),
+        ...(data.verdict !== undefined && { verdict: data.verdict ?? null }),
+        ...(data.verdictScore !== undefined && { verdictScore: data.verdictScore ?? null }),
+        ...(data.verdictQuotes !== undefined && { verdictQuotes: data.verdictQuotes ?? null }),
+        ...(data.verdictModel !== undefined && { verdictModel: data.verdictModel ?? null }),
+        ...(data.note !== undefined && { note: data.note ?? null }),
+        updatedAt: sql`now()`,
+      })
+      .where(eq(statements.id, id))
+      .returning();
+
+    if (rows.length === 0) {
+      return c.json({ error: "not_found", message: "Statement not found" }, 404);
+    }
+
+    return c.json({ statement: formatStatement(rows[0]), ok: true });
   })
 
   // ---- POST / — create statement + optional citations ----

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1150,6 +1150,13 @@ export const statements = pgTable(
     attributedTo: text("attributed_to").references(() => entities.id, {
       onDelete: "set null",
     }),
+    // --- Verdict / verification ---
+    verdict: text("verdict"), // "verified", "unsupported", "disputed", "unverified"
+    verdictScore: real("verdict_score"), // 0–1 confidence
+    verdictQuotes: text("verdict_quotes"), // external source quotes supporting verdict
+    verdictModel: text("verdict_model"), // LLM model used for verification
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    claimCategory: text("claim_category"), // factual, opinion, analytical, speculative, relational
     // --- Metadata ---
     status: text("status").notNull().default("active"), // "active", "superseded", "retracted"
     archiveReason: text("archive_reason"), // why this statement was superseded/retracted


### PR DESCRIPTION
## Summary

- **Migration 0052**: Adds 6 verdict/verification columns to `statements` table (`verdict`, `verdict_score`, `verdict_quotes`, `verdict_model`, `verified_at`, `claim_category`) — preserves data from 557 verified claims
- **Schema**: Matching Drizzle column definitions in `schema.ts`
- **Migration script**: `migrate-claims-to-statements.ts` now carries verdict data and auto-seeds properties before running
- **PATCH endpoint**: `PATCH /api/statements/:id` for updating status, verdict, archive reason, and notes

## Test plan

- [x] `tsc --noEmit` — no type errors in wiki-server
- [x] `pnpm build` — production build succeeds
- [x] Migration SQL uses `IF NOT EXISTS` for idempotency
- [x] Schema columns match migration SQL
- [x] `formatStatement()` includes all new verdict fields
- [x] PATCH endpoint validates input via Zod schema
- [ ] Integration tests pass with DATABASE_URL (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)