### PR TITLE
feat: add Current Deployment section to System Health dashboard

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,17 @@ import { resolve } from "path";
 loadEnv({ path: resolve(import.meta.dirname, "../../.env") });
 
 const nextConfig: NextConfig = {
+  env: {
+    // Vercel provides these at build time — expose to the client so the
+    // System Health dashboard can show which commit is currently deployed.
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA:
+      process.env.VERCEL_GIT_COMMIT_SHA ?? "",
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF:
+      process.env.VERCEL_GIT_COMMIT_REF ?? "",
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE:
+      process.env.VERCEL_GIT_COMMIT_MESSAGE ?? "",
+    NEXT_PUBLIC_BUILD_TIMESTAMP: new Date().toISOString(),
+  },
   transpilePackages: [
     "@quri/squiggle-components",
     "@quri/squiggle-lang",

--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -661,6 +661,105 @@ function RecentSessionsSection({
   );
 }
 
+const GITHUB_REPO = "quantified-uncertainty/longterm-wiki";
+
+function CurrentDeploymentSection() {
+  const commitSha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "";
+  const commitRef = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ?? "";
+  const commitMessage =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE ?? "";
+  const buildTimestamp = process.env.NEXT_PUBLIC_BUILD_TIMESTAMP ?? "";
+
+  if (!commitSha && !buildTimestamp) {
+    return (
+      <>
+        <SectionHeader>Current Deployment</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          Build metadata unavailable (not deployed via Vercel)
+        </div>
+      </>
+    );
+  }
+
+  const shortSha = commitSha.slice(0, 8);
+  const commitUrl = commitSha
+    ? `https://github.com/${GITHUB_REPO}/commit/${commitSha}`
+    : null;
+
+  // If the branch looks like a PR branch (e.g. "claude/foo"), link to the
+  // repo's PR list filtered by head ref. For "main", link to the commit.
+  const isPrBranch = commitRef && commitRef !== "main";
+  const prSearchUrl = isPrBranch
+    ? `https://github.com/${GITHUB_REPO}/pulls?q=is%3Apr+head%3A${encodeURIComponent(commitRef)}`
+    : null;
+
+  const buildAge = buildTimestamp ? formatRelativeTime(buildTimestamp) : null;
+
+  return (
+    <>
+      <SectionHeader>Current Deployment</SectionHeader>
+      <div className="rounded-lg border border-border/60 p-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+          {/* Commit */}
+          <div>
+            <span className="text-muted-foreground text-xs">Commit</span>
+            <div className="font-mono text-xs mt-0.5">
+              {commitUrl ? (
+                <a
+                  href={commitUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  {shortSha}
+                </a>
+              ) : (
+                shortSha || "—"
+              )}
+              {commitMessage && (
+                <span className="ml-2 text-muted-foreground truncate inline-block max-w-[300px] align-bottom">
+                  {commitMessage}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Branch / PR */}
+          <div>
+            <span className="text-muted-foreground text-xs">Branch</span>
+            <div className="text-xs mt-0.5">
+              <span className="font-mono">{commitRef || "—"}</span>
+              {prSearchUrl && (
+                <a
+                  href={prSearchUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-2 text-blue-600 hover:underline"
+                >
+                  View PR
+                </a>
+              )}
+            </div>
+          </div>
+
+          {/* Build time */}
+          <div>
+            <span className="text-muted-foreground text-xs">Built</span>
+            <div className="text-xs mt-0.5">
+              {buildAge && <span>{buildAge}</span>}
+              {buildTimestamp && (
+                <span className="ml-2 text-muted-foreground">
+                  {new Date(buildTimestamp).toLocaleString()}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function formatRelativeTime(isoString: string): string {
   const now = Date.now();
   const then = new Date(isoString).getTime();
@@ -744,6 +843,9 @@ export async function SystemHealthContent() {
           ))}
         </div>
       )}
+
+      {/* Current deployment */}
+      <CurrentDeploymentSection />
 
       {/* Quick stats */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">


### PR DESCRIPTION
## Summary

- Exposes Vercel build-time env vars (`VERCEL_GIT_COMMIT_SHA`, `VERCEL_GIT_COMMIT_REF`, `VERCEL_GIT_COMMIT_MESSAGE`, build timestamp) via `next.config.ts` `env` field
- Adds a "Current Deployment" card to the System Health dashboard (E927) showing:
  - Commit hash linked to the GitHub commit page
  - Branch name with a "View PR" link (for non-main branches, links to GitHub PR search filtered by head ref)
  - Relative build age ("3h ago") plus absolute timestamp

This makes it easy to see at a glance which commit is live and how old the current build is.

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 373 tests pass (`pnpm test`)
- [x] Full production build succeeds (`pnpm build`)
- [x] All 19 gate checks pass (`pnpm crux validate gate --fix`)
- [ ] Verify on Vercel deployment that env vars are populated and links work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System Health dashboard now displays deployment status information, including commit SHA, branch/PR references, and build timestamp for better visibility into deployed versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->