### PR TITLE
fix: remove main from Vercel ignoreCommand to restore production deploys

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,5 @@
   "framework": "nextjs",
   "installCommand": "cd .. && npx pnpm@9 install",
   "buildCommand": "node scripts/build-data.mjs && next build",
-  "ignoreCommand": "bash -c '[[ $VERCEL_GIT_COMMIT_REF == main || $VERCEL_GIT_COMMIT_REF == claude/* ]] && exit 0; exit 1'"
+  "ignoreCommand": "bash -c '[[ $VERCEL_GIT_COMMIT_REF == claude/* ]] && exit 0; exit 1'"
 }


### PR DESCRIPTION
## Summary
- The `ignoreCommand` was blocking all `main` branch builds (exit 0 = skip), including deploy hook builds triggered by the scheduled GitHub Action
- This meant no production deployments could succeed — every main build was cancelled in ~5 seconds
- Remove `main` from the pattern so only `claude/*` preview builds are skipped

## Test plan
- [x] Merge to main and verify Vercel production build starts and completes instead of being cancelled
