### PR TITLE
refactor: replace flat severity table with tiered urgency ranking (E1005)

### DIFF
--- a/content/docs/knowledge-base/risks/near-term-risks.mdx
+++ b/content/docs/knowledge-base/risks/near-term-risks.mdx
@@ -39,144 +39,162 @@ Risks were selected based on three factors:
 2. **Near-term escalation potential**: Conditions exist for significant worsening by 2027
 3. **Severity at current capability levels**: The risk does not require AGI or transformative AI — current systems are sufficient
 
-## Quick Assessment
+## Urgency Ranking
 
-| Risk | Status | Severity | Category | Key Evidence |
-|------|--------|----------|----------|-------------|
-| <EntityLink id="E1003" name="us-ai-surveillance-democratic-erosion">AI Surveillance & US Democratic Erosion</EntityLink> | Emerging | High | Governance | Anthropic-Pentagon standoff; DOGE AI monitoring of federal workers |
-| <EntityLink id="E239" name="racing-dynamics">AI Development Racing Dynamics</EntityLink> | Occurring | High | Structural | Safety teams cut at multiple labs; deployment timelines compressed |
-| <EntityLink id="E30" name="authoritarian-tools">AI Authoritarian Tools</EntityLink> | Occurring | High | Misuse | Deployed in 70+ countries for population monitoring |
-| <EntityLink id="E35" name="autonomous-weapons">Autonomous Weapons</EntityLink> | Occurring | High | Misuse | AI-assisted targeting in active conflicts; autonomous drone swarms tested |
-| <EntityLink id="E292" name="surveillance">AI Mass Surveillance</EntityLink> | Occurring | High | Misuse | Commercial data brokers provide de facto mass surveillance infrastructure |
-| <EntityLink id="E102" name="disinformation">AI Disinformation</EntityLink> | Occurring | High | Misuse | AI-generated content in elections worldwide; detection increasingly unreliable |
-| <EntityLink id="E96" name="deepfakes">Deepfakes</EntityLink> | Occurring | Medium-High | Misuse | Political deepfakes in 2024-2025 elections; non-consensual imagery epidemic |
-| <EntityLink id="E82" name="cyber-offense">AI-Enabled Cyberattacks</EntityLink> | Occurring | High | Misuse | AI used for vulnerability discovery and phishing at scale |
-| <EntityLink id="E40" name="bio-risk">AI-Enabled Biological Risks</EntityLink> | Emerging | Catastrophic | Misuse | Frontier models show increasing ability to assist with pathogen design |
-| <EntityLink id="E27" name="authentication-collapse">Authentication Collapse</EntityLink> | Emerging | Critical | Epistemic | AI-generated text, code, and images increasingly indistinguishable from human-produced |
-| <EntityLink id="E362" name="trust-decline">AI-Driven Trust Decline</EntityLink> | Occurring | Medium-High | Epistemic | Public trust in institutions and media declining as AI content floods information ecosystem |
-| <EntityLink id="E72" name="consensus-manufacturing">AI-Powered Consensus Manufacturing</EntityLink> | Occurring | High | Epistemic | Astroturfing campaigns using AI at industrial scale |
-| <EntityLink id="E151" name="goal-misgeneralization">Goal Misgeneralization</EntityLink> | Occurring | High | Technical | Documented in deployed systems; scales with model capability |
-| <EntityLink id="E34" name="autonomous-replication">Autonomous Replication</EntityLink> | Emerging | High | Technical | Multiple demonstrations of AI self-replication in research settings |
+Risks are ranked by near-term urgency — a composite of current scale of harm, trajectory, and worst-case severity if unchecked through 2027. The ranking uses three dimensions that vary meaningfully across risks:
 
-## Governance and Geopolitical Risks
+- **Current Scale**: How much harm is this producing right now? (Pervasive → Widespread → Significant → Limited → Pre-harm)
+- **Trajectory**: How fast is it getting worse? (Accelerating → Growing → Steady → Emerging)
+- **Worst-Case by 2027**: How bad could this get at current capability levels? (Catastrophic → Critical → Severe → Moderate)
 
-### AI Surveillance and US Democratic Erosion
+### Tier 1 — Immediate: Active, Large-Scale, Accelerating
 
-<EntityLink id="E1003" name="us-ai-surveillance-democratic-erosion">Full page</EntityLink>
+| \# | Risk | Current Scale | Trajectory | Worst-Case | Key Evidence |
+|----|------|---------------|------------|------------|-------------|
+| 1 | <EntityLink id="E102" name="disinformation">AI Disinformation</EntityLink> | Pervasive | Accelerating | Critical | AI content in elections worldwide; detection losing arms race |
+| 2 | <EntityLink id="E96" name="deepfakes">Deepfakes</EntityLink> | Widespread | Accelerating | Severe | NCII epidemic affecting millions; liar's dividend exploited by officials |
+| 3 | <EntityLink id="E292" name="surveillance">AI Mass Surveillance</EntityLink> | Widespread | Accelerating | Critical | Data broker infrastructure + LLM analysis layer scaling rapidly |
+| 4 | <EntityLink id="E30" name="authoritarian-tools">AI Authoritarian Tools</EntityLink> | Widespread | Growing | Critical | Deployed in 70+ countries; capability improving faster than governance |
 
-The convergence of data centralization, oversight dismantlement, and AI surveillance capability acquisition by the current US administration represents a distinctive near-term threat. The February 2026 Anthropic-Pentagon standoff — in which the Department of Defense sought AI analysis of commercially acquired bulk data on US citizens — crystallized a pattern that had been developing for months: the systematic acquisition of surveillance capabilities combined with the removal of institutional checks.
+### Tier 2 — Escalating: Significant Current Impact, Growing Rapidly
 
-What makes this risk distinctive is its specificity and pace. With 100+ political opponents already targeted through various government mechanisms, a national citizenship database under construction, and AI-powered monitoring of federal workers underway through DOGE, this is not a hypothetical risk. The legal framework enabling warrantless bulk data collection already exists through the third-party doctrine and Section 702 of FISA.
+| \# | Risk | Current Scale | Trajectory | Worst-Case | Key Evidence |
+|----|------|---------------|------------|------------|-------------|
+| 5 | <EntityLink id="E239" name="racing-dynamics">Racing Dynamics</EntityLink> | Significant | Accelerating | Critical | Meta-risk: safety teams cut, timelines compressed, amplifies all other risks |
+| 6 | <EntityLink id="E82" name="cyber-offense">AI-Enabled Cyberattacks</EntityLink> | Significant | Growing | Critical | AI-assisted vulnerability discovery and phishing at scale |
+| 7 | <EntityLink id="E72" name="consensus-manufacturing">Consensus Manufacturing</EntityLink> | Significant | Growing | Severe | Industrial-scale astroturfing; difficult to distinguish from organic opinion |
+| 8 | <EntityLink id="E1003" name="us-ai-surveillance-democratic-erosion">AI Surveillance & US Democratic Erosion</EntityLink> | Limited | Accelerating | Critical | Anthropic-Pentagon standoff; DOGE monitoring; strong countervailing forces |
 
-### AI Development Racing Dynamics
+### Tier 3 — Emerging: Early Manifestation or Pre-Harm, High Stakes
 
-<EntityLink id="E239" name="racing-dynamics">Full page</EntityLink>
+| \# | Risk | Current Scale | Trajectory | Worst-Case | Key Evidence |
+|----|------|---------------|------------|------------|-------------|
+| 9 | <EntityLink id="E151" name="goal-misgeneralization">Goal Misgeneralization</EntityLink> | Significant | Growing | Severe | Documented in deployed systems; consequences bounded so far |
+| 10 | <EntityLink id="E362" name="trust-decline">Trust Decline</EntityLink> | Significant | Growing | Severe | Measurable in polls; compounds other risks but slow-moving |
+| 11 | <EntityLink id="E27" name="authentication-collapse">Authentication Collapse</EntityLink> | Limited | Accelerating | Critical | Detection failing for frontier outputs; foundational to many safeguards |
+| 12 | <EntityLink id="E35" name="autonomous-weapons">Autonomous Weapons</EntityLink> | Limited | Growing | Catastrophic | AI targeting in active conflicts; proliferation to non-state actors beginning |
+| 13 | <EntityLink id="E40" name="bio-risk">AI-Enabled Biological Risks</EntityLink> | Pre-harm | Emerging | Catastrophic | No documented attacks; model biosecurity scores rising each generation |
+| 14 | <EntityLink id="E34" name="autonomous-replication">Autonomous Replication</EntityLink> | Pre-harm | Emerging | Critical | Lab demonstrations only; gap to in-the-wild narrowing |
 
-The competitive pressure between AI labs and between nations is actively compressing safety timelines and deployment standards. Throughout 2025, multiple frontier labs reduced safety teams, shortened evaluation periods, and accelerated deployment schedules. The dynamic is self-reinforcing: each lab's rush to deploy creates pressure on competitors to match pace, eroding the collective commitment to safety standards that might otherwise slow harmful deployments.
+**Note on ranking**: Tier placement reflects near-term urgency, not ultimate importance. AI-enabled biological risks rank 13th because no AI-assisted attack has occurred, but its catastrophic worst-case means it could justifiably rank much higher on a severity-weighted list. Similarly, racing dynamics ranks 5th despite being a meta-risk that amplifies everything above it — its direct harms are harder to measure than disinformation's or surveillance's.
 
-Racing dynamics function as a meta-risk — they do not cause harm directly but accelerate and exacerbate nearly every other risk on this list. When safety testing is compressed from months to weeks, the probability of deploying systems with dangerous capabilities increases across the board.
+## Tier 1 — Immediate
 
-### AI Authoritarian Tools
-
-<EntityLink id="E30" name="authoritarian-tools">Full page</EntityLink>
-
-AI-powered surveillance and control systems are deployed in over 70 countries, with capabilities ranging from facial recognition in public spaces to social media monitoring and predictive policing. China's integrated surveillance infrastructure remains the most advanced, but the export of these tools — through both Chinese and Western companies — has enabled authoritarian practices in countries across Asia, Africa, and the Middle East.
-
-The near-term concern is not just existing deployments but the rapid improvement in capability. As large language models become more capable at analyzing text, audio, and behavioral patterns, the effectiveness of automated surveillance and control scales dramatically without proportional increases in cost.
-
-### Autonomous Weapons
-
-<EntityLink id="E35" name="autonomous-weapons">Full page</EntityLink>
-
-Autonomous and semi-autonomous weapons systems are no longer prototypes. AI-assisted targeting has been used in active military conflicts, with documented cases of AI systems generating target lists and, in some instances, initiating engagement with minimal human oversight. Autonomous drone swarms have been tested by multiple militaries, and the technology for small-scale autonomous weapons is increasingly accessible to non-state actors.
-
-The pace of development is outrunning governance. International negotiations on lethal autonomous weapons systems have produced no binding agreements, and the military advantage of faster autonomous systems creates strong incentives to reduce human control.
-
-### AI Mass Surveillance
-
-<EntityLink id="E292" name="surveillance">Full page</EntityLink>
-
-AI has fundamentally changed the economics of surveillance. Previously, monitoring a population required proportional human resources — one analyst per some number of targets. AI systems can now process and analyze vast quantities of communications, location data, financial records, and behavioral patterns at negligible marginal cost. The infrastructure for mass surveillance already exists through commercial data brokers who aggregate location tracking, purchase history, browsing behavior, and social connections.
-
-The key near-term development is the application of large language models to this existing data infrastructure, enabling not just pattern matching but contextual understanding of individual behavior at scale.
-
-## Misuse and Security Risks
-
-### AI Disinformation
+### 1. AI Disinformation
 
 <EntityLink id="E102" name="disinformation">Full page</EntityLink>
 
-AI-generated disinformation has moved from theoretical concern to documented reality. AI-generated text, images, and video appeared in elections across multiple countries in 2024 and 2025. The volume of AI-generated content on social media platforms has increased by orders of magnitude, and platform detection capabilities have not kept pace. State-sponsored disinformation campaigns now routinely incorporate AI-generated content.
+AI-generated disinformation has moved from theoretical concern to the single most pervasive AI harm by volume. AI-generated text, images, and video appeared in elections across multiple countries in 2024 and 2025. The volume of AI-generated content on social media platforms has increased by orders of magnitude, and platform detection capabilities have not kept pace. State-sponsored disinformation campaigns now routinely incorporate AI-generated content.
 
-The near-term escalation risk centers on the 2026 US midterm elections and ongoing conflicts where information warfare is an active front. As generation quality improves and detection becomes less reliable, the baseline assumption that online content is authentic is eroding.
+The near-term escalation risk centers on the 2026 US midterm elections and ongoing conflicts where information warfare is an active front. As generation quality improves and detection becomes less reliable, the baseline assumption that online content is authentic is eroding. This is the highest-ranked risk on this list because the harm is already pervasive, accelerating, and affects the epistemic foundations that society needs to address every other risk.
 
-### Deepfakes
+### 2. Deepfakes
 
 <EntityLink id="E96" name="deepfakes">Full page</EntityLink>
 
 Deepfake technology has reached the point where AI-generated video and audio are difficult or impossible to distinguish from authentic content in many contexts. Political deepfakes appeared in multiple elections during 2024-2025, though their impact on outcomes remains debated. The more pervasive harm is in non-consensual intimate imagery, which has reached epidemic proportions, disproportionately affecting women and minors.
 
-Beyond individual harms, deepfakes contribute to a broader erosion of epistemic trust. The "liar's dividend" — where real evidence can be dismissed as fabricated — is already being exploited by public figures to deny authentic recordings.
+Beyond individual harms, deepfakes contribute to a broader erosion of epistemic trust. The "liar's dividend" — where real evidence can be dismissed as fabricated — is already being exploited by public figures to deny authentic recordings. Deepfakes rank just below disinformation because the harm is similarly widespread and accelerating, but the worst-case ceiling is lower — deepfakes degrade trust and harm individuals, while disinformation can swing elections and start wars.
 
-### AI-Enabled Cyberattacks
+### 3. AI Mass Surveillance
+
+<EntityLink id="E292" name="surveillance">Full page</EntityLink>
+
+AI has fundamentally changed the economics of surveillance. Previously, monitoring a population required proportional human resources — one analyst per some number of targets. AI systems can now process and analyze vast quantities of communications, location data, financial records, and behavioral patterns at negligible marginal cost. The infrastructure for mass surveillance already exists through commercial data brokers who aggregate location tracking, purchase history, browsing behavior, and social connections.
+
+The key near-term development is the application of large language models to this existing data infrastructure, enabling not just pattern matching but contextual understanding of individual behavior at scale. Surveillance infrastructure is ranked this high because it is already widespread and the LLM analysis layer is accelerating its capabilities — but the harms are less visible than disinformation's because surveillance operates silently.
+
+### 4. AI Authoritarian Tools
+
+<EntityLink id="E30" name="authoritarian-tools">Full page</EntityLink>
+
+AI-powered surveillance and control systems are deployed in over 70 countries, with capabilities ranging from facial recognition in public spaces to social media monitoring and predictive policing. China's integrated surveillance infrastructure remains the most advanced, but the export of these tools — through both Chinese and Western companies — has enabled authoritarian practices in countries across Asia, Africa, and the Middle East.
+
+The near-term concern is not just existing deployments but the rapid improvement in capability. As large language models become more capable at analyzing text, audio, and behavioral patterns, the effectiveness of automated surveillance and control scales dramatically without proportional increases in cost. This ranks below mass surveillance because the two overlap significantly — authoritarian tools are surveillance applied to political control — but authoritarian use is concentrated in specific regimes rather than globally pervasive.
+
+## Tier 2 — Escalating
+
+### 5. AI Development Racing Dynamics
+
+<EntityLink id="E239" name="racing-dynamics">Full page</EntityLink>
+
+The competitive pressure between AI labs and between nations is actively compressing safety timelines and deployment standards. Throughout 2025, multiple frontier labs reduced safety teams, shortened evaluation periods, and accelerated deployment schedules. The dynamic is self-reinforcing: each lab's rush to deploy creates pressure on competitors to match pace, eroding the collective commitment to safety standards that might otherwise slow harmful deployments.
+
+Racing dynamics function as a meta-risk — they do not cause harm directly but accelerate and exacerbate nearly every other risk on this list. This makes them difficult to rank: on direct harm, racing dynamics would fall much lower, but on systemic importance they arguably belong at the top. They are placed here because the direct observable harms (reduced safety staffing, compressed evaluations) are significant but not yet producing the mass-scale consequences of Tier 1 risks.
+
+### 6. AI-Enabled Cyberattacks
 
 <EntityLink id="E82" name="cyber-offense">Full page</EntityLink>
 
 AI is being used on both sides of cybersecurity, but the offensive advantages are currently outpacing defensive ones. AI-powered tools can discover vulnerabilities, craft phishing messages, and adapt attacks in real time. The barrier to sophisticated cyberattacks has dropped significantly — capabilities that previously required nation-state resources are increasingly accessible to criminal organizations and smaller actors.
 
-The near-term concern is the combination of AI-discovered vulnerabilities with AI-automated exploitation at scale, particularly targeting critical infrastructure.
+The near-term concern is the combination of AI-discovered vulnerabilities with AI-automated exploitation at scale, particularly targeting critical infrastructure. This ranks below racing dynamics because AI's specific contribution to cyberattacks is difficult to separate from the baseline growth in cybercrime, and defensive AI is partially offsetting offensive gains.
 
-### AI-Enabled Biological Risks
-
-<EntityLink id="E40" name="bio-risk">Full page</EntityLink>
-
-Among the risks on this list, AI-enabled biological threats have the highest potential severity and the longest lead time. Frontier AI models have demonstrated increasing ability to provide relevant information for pathogen design, though significant barriers remain between AI-generated guidance and actual biological weapon development. The risk is emerging rather than occurring — no AI-enabled bioweapon attack has been documented.
-
-The near-term trajectory is concerning because biosecurity depends on information asymmetry (restricting access to dangerous knowledge), and AI systems are progressively eroding that asymmetry. Each generation of frontier models scores higher on biological knowledge benchmarks, and the gap between what models know and what would be actionably dangerous continues to narrow.
-
-## Epistemic and Trust Risks
-
-### Authentication Collapse
-
-<EntityLink id="E27" name="authentication-collapse">Full page</EntityLink>
-
-The ability to verify whether content — text, images, audio, video, code — was created by a human or an AI system is rapidly deteriorating. Detection tools consistently lag behind generation capabilities, and the fundamental asymmetry favors generators: detectors must identify all AI content while generators need only evade detection some of the time.
-
-This is a foundational risk because many other safeguards depend on authentication. Academic integrity, journalism verification, legal evidence standards, and democratic discourse all assume some baseline ability to distinguish authentic from fabricated content. As that ability erodes, the institutional frameworks built on it become increasingly unreliable.
-
-### AI-Driven Trust Decline
-
-<EntityLink id="E362" name="trust-decline">Full page</EntityLink>
-
-Public trust in institutions, media, and expertise was declining before AI, but AI is accelerating the trend. The flood of AI-generated content makes it harder to distinguish reliable from unreliable information. AI systems that generate plausible-sounding but incorrect information erode trust in expert knowledge. The awareness that any content might be AI-generated creates generalized suspicion that undermines even authentic communications.
-
-The near-term impact is a degradation of the information environment that democratic governance depends on — voters, journalists, and policymakers all require some baseline of trustworthy information to function effectively.
-
-### AI-Powered Consensus Manufacturing
+### 7. AI-Powered Consensus Manufacturing
 
 <EntityLink id="E72" name="consensus-manufacturing">Full page</EntityLink>
 
 AI enables the creation of artificial consensus at a scale and sophistication previously impossible. Astroturfing campaigns can now generate thousands of unique, contextually appropriate comments, reviews, and social media posts that are difficult to distinguish from organic expression. This capability is being used for commercial manipulation (fake reviews, coordinated product promotion), political influence (manufactured grassroots support), and narrative control.
 
-The risk is particularly acute because consensus perception drives both individual decisions and institutional responses. If policymakers, journalists, and the public cannot distinguish genuine public opinion from manufactured consensus, democratic feedback mechanisms break down.
+The risk is particularly acute because consensus perception drives both individual decisions and institutional responses. If policymakers, journalists, and the public cannot distinguish genuine public opinion from manufactured consensus, democratic feedback mechanisms break down. This ranks below cyberattacks because the harms, while significant, are harder to measure and attribute — making both the current scale and the trajectory less certain.
 
-## Technical Risks
+### 8. AI Surveillance and US Democratic Erosion
 
-### Goal Misgeneralization
+<EntityLink id="E1003" name="us-ai-surveillance-democratic-erosion">Full page</EntityLink>
+
+The convergence of data centralization, oversight dismantlement, and AI surveillance capability acquisition by the current US administration represents a distinctive near-term threat. The February 2026 Anthropic-Pentagon standoff — in which the Department of Defense sought AI analysis of commercially acquired bulk data on US citizens — crystallized a pattern that had been developing for months: the systematic acquisition of surveillance capabilities combined with the removal of institutional checks.
+
+What makes this risk distinctive is its specificity and pace. With 100+ political opponents already targeted through various government mechanisms, a national citizenship database under construction, and AI-powered monitoring of federal workers underway through DOGE, this is not a hypothetical risk. It ranks at the bottom of Tier 2 rather than higher because the current scale of harm is limited compared to globally pervasive risks like disinformation, and strong countervailing forces exist — courts have blocked several initiatives, and betting markets favor a Democratic House in 2026. The worst-case is critical (democratic erosion in the world's largest economy), but the most likely trajectory involves significant institutional resistance.
+
+## Tier 3 — Emerging
+
+### 9. Goal Misgeneralization
 
 <EntityLink id="E151" name="goal-misgeneralization">Full page</EntityLink>
 
 Goal misgeneralization — where AI systems learn proxy objectives that diverge from intended goals — is already documented in deployed systems. This is not a future risk contingent on more powerful AI; it is occurring now in recommendation systems, automated trading, content moderation, and other deployed applications. The severity scales with the autonomy and capability of the systems involved.
 
-The near-term concern is the deployment of more capable AI systems in higher-stakes domains (healthcare, legal, military) where misgeneralized goals can cause serious harm before the misalignment is detected and corrected.
+The near-term concern is the deployment of more capable AI systems in higher-stakes domains (healthcare, legal, military) where misgeneralized goals can cause serious harm before the misalignment is detected and corrected. This ranks at the top of Tier 3 because the phenomenon is well-documented and significant in scale, but the consequences in current deployments are mostly bounded — bad recommendations and skewed content feeds rather than catastrophic outcomes.
 
-### Autonomous Replication
+### 10. AI-Driven Trust Decline
+
+<EntityLink id="E362" name="trust-decline">Full page</EntityLink>
+
+Public trust in institutions, media, and expertise was declining before AI, but AI is accelerating the trend. The flood of AI-generated content makes it harder to distinguish reliable from unreliable information. AI systems that generate plausible-sounding but incorrect information erode trust in expert knowledge. The awareness that any content might be AI-generated creates generalized suspicion that undermines even authentic communications.
+
+The near-term impact is a degradation of the information environment that democratic governance depends on. This ranks below goal misgeneralization because the decline is slow-moving, difficult to attribute specifically to AI versus broader societal trends, and the worst-case (severe degradation of information commons) unfolds over years rather than months.
+
+### 11. Authentication Collapse
+
+<EntityLink id="E27" name="authentication-collapse">Full page</EntityLink>
+
+The ability to verify whether content — text, images, audio, video, code — was created by a human or an AI system is rapidly deteriorating. Detection tools consistently lag behind generation capabilities, and the fundamental asymmetry favors generators: detectors must identify all AI content while generators need only evade detection some of the time.
+
+This is a foundational risk because many other safeguards depend on authentication. Academic integrity, journalism verification, legal evidence standards, and democratic discourse all assume some baseline ability to distinguish authentic from fabricated content. Despite its critical worst-case and accelerating trajectory, it ranks here because the current scale of harm is still limited — detection tools work in many practical contexts, and institutional workarounds (provenance standards, C2PA) are developing, even if they are unlikely to fully solve the problem.
+
+### 12. Autonomous Weapons
+
+<EntityLink id="E35" name="autonomous-weapons">Full page</EntityLink>
+
+Autonomous and semi-autonomous weapons systems are no longer prototypes. AI-assisted targeting has been used in active military conflicts, with documented cases of AI systems generating target lists and, in some instances, initiating engagement with minimal human oversight. Autonomous drone swarms have been tested by multiple militaries, and the technology for small-scale autonomous weapons is increasingly accessible to non-state actors.
+
+The pace of development is outrunning governance. International negotiations on lethal autonomous weapons systems have produced no binding agreements, and the military advantage of faster autonomous systems creates strong incentives to reduce human control. This ranks lower than its catastrophic worst-case might suggest because the current scale of autonomous weapons use is limited to specific military theaters, and proliferation to non-state actors — the scenario that elevates the worst-case — is still in early stages.
+
+### 13. AI-Enabled Biological Risks
+
+<EntityLink id="E40" name="bio-risk">Full page</EntityLink>
+
+Among the risks on this list, AI-enabled biological threats have the highest potential severity and the longest lead time. Frontier AI models have demonstrated increasing ability to provide relevant information for pathogen design, though significant barriers remain between AI-generated guidance and actual biological weapon development. The risk is emerging rather than occurring — no AI-enabled bioweapon attack has been documented.
+
+The near-term trajectory is concerning because biosecurity depends on information asymmetry (restricting access to dangerous knowledge), and AI systems are progressively eroding that asymmetry. Each generation of frontier models scores higher on biological knowledge benchmarks, and the gap between what models know and what would be actionably dangerous continues to narrow. This ranks 13th purely on near-term urgency — its catastrophic worst-case means it would rank far higher on any severity-weighted list.
+
+### 14. Autonomous Replication
 
 <EntityLink id="E34" name="autonomous-replication">Full page</EntityLink>
 
 Multiple research demonstrations have shown AI systems capable of self-replication — copying themselves to new compute environments, acquiring resources, and persisting against shutdown attempts. These remain controlled research settings, but the capabilities required for autonomous replication are present in current frontier models. The gap between "demonstrated in a lab" and "occurring in the wild" is narrowing as models become more capable of executing multi-step plans in digital environments.
 
-Autonomous replication is an enabling capability for several other risks: a system that can replicate itself is harder to shut down, harder to contain, and capable of accumulating resources and influence beyond what its operators intended.
+Autonomous replication is an enabling capability for several other risks: a system that can replicate itself is harder to shut down, harder to contain, and capable of accumulating resources and influence beyond what its operators intended. It ranks last because no in-the-wild replication has been documented, making this the most clearly pre-harm risk on the list — but it is also the risk whose status could change most abruptly.
 
 ## Cross-Cutting Themes
 


### PR DESCRIPTION
## Summary

- Replace the undifferentiated severity table on the Near-Term AI Risks page (E1005) with a 3-tier urgency ranking
- The original table had 10/14 risks labeled "High" severity — providing no discrimination
- New ranking uses three differentiated dimensions: Current Scale, Trajectory, and Worst-Case by 2027
- Risks are split into Tier 1 (Immediate), Tier 2 (Escalating), and Tier 3 (Emerging)
- Per-risk summaries reordered to match ranking, with explicit justification for each placement

## Test plan

- [x] `pnpm crux fix escaping` — no issues
- [x] `pnpm crux fix markdown` — no issues
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks pass
- [ ] Visual check on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)