### PR TITLE
fix(statements): address review feedback from #1564

### DIFF
--- a/apps/web/src/app/internal/statements/statements-table.tsx
+++ b/apps/web/src/app/internal/statements/statements-table.tsx
@@ -271,6 +271,7 @@ export function StatementsTable({ data, properties }: StatementsTableProps) {
         <select
           value={varietyFilter}
           onChange={(e) => setVarietyFilter(e.target.value)}
+          aria-label="Filter by statement variety"
           className="rounded-md border border-input bg-background px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <option value="all">All varieties</option>
@@ -280,6 +281,7 @@ export function StatementsTable({ data, properties }: StatementsTableProps) {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
+          aria-label="Filter by statement status"
           className="rounded-md border border-input bg-background px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <option value="all">All statuses</option>

--- a/apps/web/src/app/wiki/[id]/statements/citation-detail.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/citation-detail.tsx
@@ -43,6 +43,7 @@ export function CitationDetail({ citations }: { citations: Citation[] }) {
   return (
     <div className="inline-flex flex-col items-end">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300 text-[11px] font-medium hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors cursor-pointer"
         aria-expanded={open}
@@ -138,9 +139,11 @@ export function AttributedCitationDetail({
   return (
     <div className="relative">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300 text-[11px] font-medium hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors cursor-pointer"
         aria-expanded={open}
+        aria-label={`${citations.length} citation${citations.length !== 1 ? "s" : ""}`}
       >
         {citations.length} cite{citations.length !== 1 ? "s" : ""}
         {open ? (

--- a/apps/web/src/app/wiki/[id]/statements/page.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/page.tsx
@@ -231,7 +231,7 @@ function PropertyGroup({
   statements: StatementWithDetails[];
 }) {
   const active = statements.filter((s) => s.status === "active");
-  const superseded = statements.filter((s) => s.status !== "active");
+  const superseded = statements.filter((s) => s.status === "superseded");
 
   return (
     <div className="mb-4">
@@ -269,7 +269,7 @@ function PropertyGroup({
 function StructuredRow({ statement: s }: { statement: StatementWithDetails }) {
   const value = formatStatementValue(s, s.property);
   const statusBadge = getStatusBadge(s.status);
-  const isSuperseded = s.status !== "active";
+  const isSuperseded = s.status === "superseded";
 
   return (
     <tr className={`border-b border-border/30 last:border-0 ${isSuperseded ? "opacity-60" : ""}`}>
@@ -308,7 +308,7 @@ function StructuredRow({ statement: s }: { statement: StatementWithDetails }) {
 function AttributedRow({ statement: s }: { statement: StatementWithDetails }) {
   const varietyBadge = getVarietyBadge(s.variety);
   const statusBadge = getStatusBadge(s.status);
-  const isSuperseded = s.status !== "active";
+  const isSuperseded = s.status === "superseded";
 
   return (
     <div className={`rounded-lg border border-border/60 p-3 ${isSuperseded ? "opacity-60" : ""}`}>

--- a/apps/web/src/app/wiki/[id]/statements/statements-filter.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/statements-filter.tsx
@@ -34,10 +34,14 @@ export function StatementsFilter({
 
     if (!showSuperseded) {
       result = result.filter((s) => s.status === "active");
+    } else {
+      result = result.filter(
+        (s) => s.status === "active" || s.status === "superseded"
+      );
     }
 
     if (query.trim()) {
-      const q = query.toLowerCase();
+      const q = query.trim().toLowerCase();
       result = result.filter((s) => {
         const text = [
           s.property?.label,


### PR DESCRIPTION
## Summary
Implements review feedback from PR #1564 (CodeRabbit comments):

- **Accessibility**: Add `aria-label` to variety/status filter `<select>` elements in the statements dashboard so screen readers announce their purpose
- **Accessibility**: Add `type="button"` to citation toggle buttons to prevent accidental form submissions, and add missing `aria-label` to `AttributedCitationDetail` toggle
- **Bug fix**: Change `isSuperseded` logic from `s.status !== "active"` to `s.status === "superseded"` — the old logic incorrectly dimmed retracted statements as if they were superseded (3 occurrences in `page.tsx`)
- **Bug fix**: Fix "Show superseded" toggle in `StatementsFilter` to exclude retracted statements when checked — previously it showed all statuses including retracted, mismatching the label
- **Bug fix**: Add `.trim()` to search query normalization so whitespace-padded searches (e.g. `" ai "`) match correctly

## Skipped comments
- **Relative → alias import**: `./citation-detail` is a same-directory import; relative imports are fine here
- **Popover clipping in table overflow**: Needs careful UI investigation and portal-based solution; better as a separate PR

## Test plan
- [x] All 17 pre-push gate checks pass (tests, TypeScript, Next.js build, etc.)
- [ ] Verify filter dropdowns are announced correctly by screen readers
- [ ] Verify retracted statements are no longer incorrectly dimmed as superseded
- [ ] Verify "Show superseded" toggle no longer shows retracted statements
- [ ] Verify search with leading/trailing whitespace works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)