### PR TITLE
fix(ci): fix seed-statements workflow boolean condition and force re-index

### DIFF
--- a/.github/workflows/seed-statements.yml
+++ b/.github/workflows/seed-statements.yml
@@ -46,7 +46,7 @@ jobs:
           cd apps/wiki-server && npx tsx scripts/seed-properties.ts
 
       - name: Migrate YAML facts to statements
-        if: inputs.dry_run != true
+        if: ${{ inputs.dry_run != true }}
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
@@ -54,7 +54,7 @@ jobs:
           cd apps/wiki-server && npx tsx scripts/migrate-facts-to-statements.ts
 
       - name: Migrate claims to statements
-        if: inputs.dry_run != true
+        if: ${{ inputs.dry_run != true }}
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |


### PR DESCRIPTION
## Summary

- Fixes `if: inputs.dry_run != true` → `if: ${{ inputs.dry_run != true }}` for the two migration steps in `seed-statements.yml`
- Without the `${{ }}` expression wrapper, GitHub Actions may not correctly evaluate `workflow_dispatch` boolean inputs
- Also forces GitHub to re-index the workflow file — after PR #1570 landed as an empty merge commit at HEAD, the "Seed Statements System" workflow never appeared in the GitHub Actions UI

## Why this matters

The statements tables in production are empty. We need to trigger the seed workflow to populate them, but it can't be triggered until GitHub has indexed the file.

## Next steps after merge

1. Verify "Seed Statements System" appears in GitHub Actions UI
2. Trigger with `dry_run: true` first (seed properties only) to sanity-check
3. Trigger with `dry_run: false` (full migration) to populate production data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow syntax to use proper expression format for conditional statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->