### PR TITLE
fix(ci): add --allowedTools to claude-code-action workflows

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -84,7 +84,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 10"
+          claude_args: '--max-turns 10 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -115,7 +115,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 15"
+          claude_args: '--max-turns 15 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

- Add `--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"` to the `scheduled-maintenance.yml` workflow
- Add the same `--allowedTools` to `ci-autofix.yml`

Both workflows were running `claude-code-action` without pre-approved tools, causing 11 permission denials out of 15 max turns and failing with `error_max_turns`. The maintenance agent couldn't execute any tools and burned through its turn budget doing nothing.

## Test plan

- [x] All gate checks pass locally (14/14)
- [x] Verified diff is minimal — 2 files, 2 insertions, 2 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tool permissions for automated code fix and scheduled maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->