### PR TITLE
fix: increase maintenance workflow max-turns from 15 to 30

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -115,7 +115,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 15 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
+          claude_args: '--max-turns 30 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary
- The weekly scheduled maintenance sweep was failing with `error_max_turns` because `--max-turns 15` was too low
- Increased to 30 to give the sweep enough room for: running maintain command, reading report, acting on items, running validation, committing, pushing, and creating a PR
- Failed run: https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/22646950845

## Test plan
- [ ] Re-run the scheduled maintenance workflow and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve system reliability and processing capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->