### PR TITLE
fix(ci): add --allowedTools to claude-code-action workflows

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -84,7 +84,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 10"
+          claude_args: '--max-turns 10 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 20"
+          claude_args: '--max-turns 20 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
         env:

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -115,7 +115,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 15"
+          claude_args: '--max-turns 15 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

- Add explicit `--allowedTools` parameter to all three `claude-code-action@v1` workflow invocations
- Affects: `scheduled-maintenance.yml`, `ci-autofix.yml`, `claude-assistant.yml`
- Without this, the action runs without tool permissions, causing the workflows to fail

## Context

The Scheduled Maintenance workflow was failing because `claude-code-action@v1` needs explicit tool allowlisting via `--allowedTools` in `claude_args`. The same issue affected the CI Auto-Fix and Claude Assistant workflows.

## Test plan

- [ ] Verify Scheduled Maintenance workflow runs successfully on next trigger
- [ ] Verify CI Auto-Fix workflow runs successfully on next CI failure
- [ ] Verify Claude Assistant workflow runs successfully on next @claude mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)