### PR TITLE
fix(tests): update wiki-server test mocks for Phase D2a migration

### DIFF
--- a/apps/wiki-server/src/__tests__/auto-update-news.test.ts
+++ b/apps/wiki-server/src/__tests__/auto-update-news.test.ts
@@ -236,8 +236,8 @@ const dispatch: SqlDispatcher = (query, params) => {
         relevance_score: params[o + 6] as number | null,
         topics_json: params[o + 7] as string[] | null,
         entities_json: params[o + 8] as string[] | null,
-        routed_to_page_id: routedSlug,
-        routed_to_page_id_old: routedSlug,
+        routed_to_page_id: routedSlug, // synthetic convenience field for tests
+        routed_to_page_id_old: null, // D2a: not written on insert
         routed_to_page_id_int: routedIntId,
         routed_to_page_title: params[o + 10] as string | null,
         routed_tier: params[o + 11] as string | null,
@@ -309,9 +309,9 @@ const dispatch: SqlDispatcher = (query, params) => {
 
   // ---- SELECT FROM auto_update_news_items WHERE run_id = $1  (GET /by-run) ----
   // Phase D2a: query now uses LEFT JOIN wiki_pages + COALESCE for routedToPageSlug.
-  // extractColumns finds "id" for the COALESCE expr (last quoted ident in
-  // coalesce("auto_update_news_items"."routed_to_page_id", "wiki_pages"."id")).
-  // We override "id" in the returned row to be the page slug so positional mapping works.
+  // The SELECT expands all 15 schema columns + 1 COALESCE at position 15.
+  // extractColumns returns null for the COALESCE (identifiers inside parens),
+  // so .values() uses Object.values(row)[15] for that position.
   if (
     q.includes("auto_update_news_items") &&
     !q.includes("inner join") &&
@@ -325,15 +325,16 @@ const dispatch: SqlDispatcher = (query, params) => {
       .filter((r) => r.run_id === runId)
       .sort((a, b) => (b.relevance_score ?? -1) - (a.relevance_score ?? -1))
       .map((r) => {
-        // The SELECT expands all 15 schema columns + 1 COALESCE at position 15.
-        // extractColumns returns null for the COALESCE (identifiers inside parens),
-        // so .values() uses Object.values(row)[15] for that position.
         // Strip routed_to_page_id (not a real SQL column — schema uses routed_to_page_id_old)
         // then append the COALESCE result so it lands at position 15.
+        // D2a COALESCE: routed_to_page_id_old ?? wiki_pages.id (via int lookup)
         const { routed_to_page_id: _slug, ...rest } = r;
         return {
           ...rest,
-          _coalesce_result: r.routed_to_page_id ?? null,
+          _coalesce_result:
+            r.routed_to_page_id_old ??
+            slugFromIntId(r.routed_to_page_id_int) ??
+            null,
         };
       });
   }

--- a/apps/wiki-server/src/__tests__/auto-update-runs.test.ts
+++ b/apps/wiki-server/src/__tests__/auto-update-runs.test.ts
@@ -52,8 +52,8 @@ let runStore: Array<{
 let resultStore: Array<{
   id: number;
   run_id: number;
-  page_id: string;
-  page_id_old: string;
+  page_id: string | null;
+  page_id_old: string | null;
   page_id_int: number | null;
   status: string;
   tier: string | null;
@@ -139,12 +139,12 @@ const dispatch: SqlDispatcher = (query, params) => {
     for (let i = 0; i < numRows; i++) {
       const o = i * COLS;
       const pageIdInt = params[o + 1] as number | null;
-      const pageSlug = slugFromIntId(pageIdInt) ?? `unknown-${pageIdInt}`;
+      const pageSlug = slugFromIntId(pageIdInt);
       const row = {
         id: nextResultId++,
         run_id: params[o] as number,
         page_id: pageSlug,
-        page_id_old: pageSlug,
+        page_id_old: null, // D2a: not written on insert
         page_id_int: pageIdInt,
         status: params[o + 2] as string,
         tier: params[o + 3] as string | null,
@@ -171,7 +171,8 @@ const dispatch: SqlDispatcher = (query, params) => {
       .map((r) => ({
         run_id: r.run_id,
         // "id" is what extractColumns finds for coalesce(..., "wiki_pages"."id")
-        id: r.page_id,
+        // D2a COALESCE: page_id_old ?? wiki_pages.id (via int lookup)
+        id: r.page_id_old ?? slugFromIntId(r.page_id_int) ?? null,
         status: r.status,
         tier: r.tier,
         duration_ms: r.duration_ms,

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -292,7 +292,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       const pageIdInt = params[o] as number | null;
       const row = {
         id: nextSnapshotId++,
-        page_id: slugFromIntId(pageIdInt) ?? `unknown-${pageIdInt}`,
+        page_id: slugFromIntId(pageIdInt),
         page_id_int: pageIdInt,
         total_citations: params[o + 1] as number,
         checked_citations: params[o + 2] as number,

--- a/apps/wiki-server/src/__tests__/edit-logs.test.ts
+++ b/apps/wiki-server/src/__tests__/edit-logs.test.ts
@@ -8,8 +8,8 @@ let nextSlugIntId = 1000;
 const slugIntIdMap = new Map<string, number>();
 let editStore: Array<{
   id: number;
-  page_id: string;
-  page_id_old: string;
+  page_id: string | null;
+  page_id_old: string | null;
   page_id_int: number | null;
   date: string;
   tool: string;
@@ -148,11 +148,11 @@ function createMockSql() {
       for (let i = 0; i < numRows; i++) {
         const o = i * COLS;
         const pageIdInt = params[o] as number | null;
-        const pageSlug = slugFromIntId(pageIdInt) ?? `unknown-${pageIdInt}`;
+        const pageSlug = slugFromIntId(pageIdInt);
         const row = {
           id: nextId++,
           page_id: pageSlug,
-          page_id_old: pageSlug,
+          page_id_old: null, // D2a: not written on insert
           page_id_int: pageIdInt,
           date: String(params[o + 1]),
           tool: params[o + 2] as string,

--- a/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
+++ b/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
@@ -9,8 +9,8 @@ let nextSlugIntId = 1000;
 const slugIntIdMap = new Map<string, number>();
 let riskStore: Array<{
   id: number;
-  page_id: string;
-  page_id_old: string;
+  page_id: string | null;
+  page_id_old: string | null;
   page_id_int: number | null;
   score: number;
   level: string;
@@ -116,11 +116,11 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     for (let i = 0; i < rowCount; i++) {
       const off = i * PARAMS_PER_ROW;
       const pageIdInt = params[off] as number | null;
-      const pageSlug = slugFromIntId(pageIdInt) ?? `unknown-${pageIdInt}`;
+      const pageSlug = slugFromIntId(pageIdInt);
       const row = {
         id: nextId++,
         page_id: pageSlug,
-        page_id_old: pageSlug,
+        page_id_old: null, // D2a: not written on insert
         page_id_int: pageIdInt,
         score: params[off + 1] as number,
         level: params[off + 2] as string,


### PR DESCRIPTION
## Summary

**Fixes 30+ consecutive CI failures on main since March 2nd.** All wiki-server test runs have been failing because test mocks were not updated to match the Phase D2a schema migration.

### Root Cause

The Phase D2a migration renamed `page_id` columns to `page_id_old` and stopped writing them on INSERT. Routes now JOIN `wiki_pages` to recover slugs from `page_id_int`. However, the test mock SQL dispatchers in 5 test files were not updated to simulate this new JOIN-based behavior, causing:

- **edit-logs**: Filtering by `page_id_int`, stats aggregation, latest/earliest dates all returning wrong results
- **auto-update-news**: COALESCE for `routed_to_page_id` returning wrong column values
- **auto-update-runs**: Results not properly JOINed with wiki_pages for page slugs
- **citations**: Accuracy trends filtering returning empty results
- **hallucination-risk**: Similar page_id_int filtering issues

### Changes

- Updated mock SQL dispatchers in all 5 affected test files to properly simulate wiki_pages JOINs
- Removed legacy `page_id_old` writes from test mock INSERT handlers
- Fixed `extractColumns` usage for COALESCE and GROUP BY queries

## Test plan

- [x] All 608 wiki-server tests pass (28 test files, 0 failures)
- [x] Production build succeeds (`pnpm build` exits 0)
- [x] Rebased on latest main (includes Statements V2 Wave 1)
- [x] No new code introduced — only test mock dispatchers updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure across multiple test suites to align mock data structures with updated database schema patterns, including revised column layouts and helper utilities for ID mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->