### PR TITLE
fix(system-health): 7 dashboard bugs — stale agents, CI dedup, status labels

### DIFF
--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -280,6 +280,7 @@ function SectionUnavailable({ title, error }: { title: string; error?: ApiErrorR
   );
 }
 
+
 /** Deduplicate CI check runs by name, keeping the most informative conclusion. */
 function deduplicateChecks(checks: CiCheckRun[]): CiCheckRun[] {
   const byName = new Map<string, CiCheckRun>();

--- a/apps/web/src/app/internal/system-health/system-health-table.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-table.tsx
@@ -48,8 +48,8 @@ const SERVICE_LABELS: Record<string, string> = {
   "wiki-server": "Wiki Server",
   groundskeeper: "Groundskeeper",
   "discord-bot": "Discord Bot",
-  "vercel-frontend": "Vercel",
-  "github-actions": "GH Actions",
+  "vercel-frontend": "Vercel Frontend",
+  "github-actions": "GitHub Actions",
 };
 
 // ── Columns ─────────────────────────────────────────────────────────────

--- a/apps/wiki-server/src/routes/github-pulls.ts
+++ b/apps/wiki-server/src/routes/github-pulls.ts
@@ -151,6 +151,7 @@ const githubPullsApp = new Hono().get("/", async (c) => {
         query: OPEN_PRS_QUERY,
         variables: { owner: REPO_OWNER, name: REPO_NAME },
       }),
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!resp.ok) {


### PR DESCRIPTION
## Summary

Fixes 7 bugs found during an intensive review of the System Health dashboard (E927):

- **Active agents count inflated** — was counting all rows with `status='active'` including orphaned sessions. Now filters by `heartbeatAt` within last 15 minutes, matching the staleness logic used elsewhere
- **CI checks section showed ~15 duplicate entries** — multiple `claude` check runs all showing "skipped" cluttered the UI. Added deduplication by name, keeping the most informative conclusion
- **`allPassed` misclassified skipped checks** — `allPassed = allCompleted && !anyFailed` treated skipped checks as passing, showing "All checks passed" when many were skipped. Now requires at least one non-skipped check to succeed
- **"Unknown" service status was misleading** — Discord Bot, Vercel Frontend, and GitHub Actions could never show "healthy" (only "unknown" when no incidents). Relabeled to "Not monitored" for clarity
- **SERVICE_LABELS inconsistent** — table component used "Vercel" / "GH Actions" while content component used "Vercel Frontend" / "GitHub Actions". Aligned to the longer, clearer names
- **Redundant IncidentDisplayRow type** — was a field-by-field copy of IncidentEntry. Replaced with type alias, removed identity mapping
- **GitHub PR GraphQL fetch had no timeout** — unlike `fetchCiStatus()` which used `AbortSignal.timeout(8000)`, the PR fetch could hang indefinitely. Added 10s timeout

## Related issues filed

- #1615 — Dangling editLog references are false positives (investigation needed)
- #1616 — Groundskeeper tasks snapshot-retention and github-shadowban-check failing silently
- #1617 — Open PRs error state hidden behind "0 open PRs"

## Test plan

- [x] `pnpm exec tsc --noEmit` — zero type errors (both web and wiki-server)
- [x] `pnpm test` — 372/373 pass (1 pre-existing failure: missing internal MDX in database.json)
- [x] Wiki-server tests — 608/608 pass
- [x] `pnpm crux validate gate` — all 12 checks pass
- [x] Full Next.js build succeeds (889 static pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deduplication of CI checks to display clearer, more informative results.

* **Bug Fixes**
  * Updated status label from "Unknown" to "Not monitored."
  * Improved active agent count calculation by excluding stale agents (15+ minutes inactive).
  * Enhanced CI status accuracy to require all non-skipped checks to pass.
  * Added timeout protection to GitHub GraphQL requests.

* **UI Updates**
  * Updated service labels: "Vercel" → "Vercel Frontend," "GH Actions" → "GitHub Actions."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->