### PR TITLE
fix(statements): clean up Anthropic data quality + allow variety PATCH

### DIFF
--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -119,6 +119,7 @@ function formatStatement(s: typeof statements.$inferSelect) {
 
 const PatchStatementBody = z.object({
   status: z.enum(["active", "superseded", "retracted"]).optional(),
+  variety: z.enum(["structured", "attributed"]).optional(),
   archiveReason: z.string().max(2000).nullish(),
   verdict: z.string().max(50).nullish(),
   verdictScore: z.number().min(0).max(1).nullish(),
@@ -668,6 +669,7 @@ const statementsApp = new Hono()
       .update(statements)
       .set({
         ...(data.status !== undefined && { status: data.status }),
+        ...(data.variety !== undefined && { variety: data.variety }),
         ...(data.archiveReason !== undefined && { archiveReason: data.archiveReason ?? null }),
         ...(data.verdict !== undefined && { verdict: data.verdict ?? null }),
         ...(data.verdictScore !== undefined && { verdictScore: data.verdictScore ?? null }),


### PR DESCRIPTION
## Summary

- Retracted 152 low-quality Anthropic statements via the PATCH API (production DB changes, no migration needed)
- Created 10 high-quality structured statements from YAML facts data with proper citations
- Added `variety` field to `PatchStatementBody` so future sessions can reclassify statements between structured/attributed via the API

### Data cleanup breakdown
| Category | Count | Action |
|----------|-------|--------|
| Text claims (structured, no propertyId) | 114 | Retracted |
| Revenue $0 extraction errors | 4 | Retracted |
| Revenue-guidance $0 | 1 | Retracted |
| Dateless equity-value rows | 6 | Retracted |
| Empty/valueless structured rows | 7 | Retracted |
| Wrong property (acquired-by for hires) | 2 | Retracted |
| Questionable data (no-context benchmarks, duplicates) | 13 | Retracted |
| Bad attributed (duplicates, garbled) | 5 | Retracted |
| Duplicate total-funding | 1 | Superseded |

### New statements created
- Valuation: $380B (2026-02), $350B (2025-11) with Reuters citations
- Revenue ARR: $14B, $9B, $4B, $1B time series with citations
- Revenue guidance: $20-26B (2026)
- Series G: $30B (2026-02)
- Gross margin: 40% (2025)
- Claude Code product revenue: $2.5B (2026-02)

**Result:** 37 active structured + 48 active attributed (was 175 + 53 = 228)

## Code change
2-line addition to `apps/wiki-server/src/routes/statements.ts`:
- Added `variety` to `PatchStatementBody` Zod schema
- Added `variety` to the PATCH handler's `.set()` call

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2451/2451)
- [x] TypeScript errors in wiki-server are pre-existing (test files only)
- [x] Verified production API reflects cleanup (37 active structured)

Closes #1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)