### PR TITLE
fix(statements): exclude retracted/empty statements from display

### DIFF
--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -59,7 +59,10 @@ const CurrentQuery = z.object({
 
 const ByEntityQuery = z.object({
   entityId: z.string().min(1).max(200),
-  includeRetracted: z.coerce.boolean().default(false),
+  includeRetracted: z.preprocess(
+    (v) => typeof v === "string" ? v.toLowerCase() === "true" : v,
+    z.coerce.boolean()
+  ).default(false),
 });
 
 const ByPageQuery = z.object({
@@ -884,7 +887,7 @@ const statementsApp = new Hono()
     const body = await parseJsonBody(c);
     const parsed = z
       .object({
-        entityId: z.string().max(200).optional(),
+        entityId: z.string().min(1).max(200).optional(),
         dryRun: z.boolean().default(true),
       })
       .safeParse(body ?? {});
@@ -923,7 +926,7 @@ const statementsApp = new Hono()
 
     if (dryRun || allIds.length === 0) {
       return c.json({
-        dryRun: true,
+        dryRun,
         retracted: retractedRows.length,
         empty: emptyRows.length,
         totalToDelete: allIds.length,
@@ -931,36 +934,38 @@ const statementsApp = new Hono()
       });
     }
 
-    // Delete citations first (FK constraint), then statements
+    // Delete citations first (FK constraint), then statements — all in one transaction
     console.warn(`[statements/cleanup] Deleting ${allIds.length} statements (${retractedRows.length} retracted, ${emptyRows.length} empty)`);
 
-    await db
-      .delete(statementCitations)
-      .where(
-        sql`${statementCitations.statementId} IN (${sql.join(
-          allIds.map((id) => sql`${id}`),
-          sql`, `
-        )})`
-      );
+    const deleted = await db.transaction(async (tx) => {
+      await tx
+        .delete(statementCitations)
+        .where(
+          sql`${statementCitations.statementId} IN (${sql.join(
+            allIds.map((id) => sql`${id}`),
+            sql`, `
+          )})`
+        );
 
-    await db
-      .delete(statementPageReferences)
-      .where(
-        sql`${statementPageReferences.statementId} IN (${sql.join(
-          allIds.map((id) => sql`${id}`),
-          sql`, `
-        )})`
-      );
+      await tx
+        .delete(statementPageReferences)
+        .where(
+          sql`${statementPageReferences.statementId} IN (${sql.join(
+            allIds.map((id) => sql`${id}`),
+            sql`, `
+          )})`
+        );
 
-    const deleted = await db
-      .delete(statements)
-      .where(
-        sql`${statements.id} IN (${sql.join(
-          allIds.map((id) => sql`${id}`),
-          sql`, `
-        )})`
-      )
-      .returning({ id: statements.id });
+      return tx
+        .delete(statements)
+        .where(
+          sql`${statements.id} IN (${sql.join(
+            allIds.map((id) => sql`${id}`),
+            sql`, `
+          )})`
+        )
+        .returning({ id: statements.id });
+    });
 
     return c.json({
       dryRun: false,

--- a/crux/statements/extract.ts
+++ b/crux/statements/extract.ts
@@ -633,7 +633,7 @@ async function main() {
     if (result.ok) {
       inserted += result.data.inserted;
     } else {
-      failed += batch.length;
+      failed += items.length;
       console.error(`  ${c.red}Batch insert failed: ${result.message}${c.reset}`);
       // Log first item for debugging
       if (items.length > 0) {


### PR DESCRIPTION
## Summary
- Filter retracted statements from the `by-entity` API endpoint by default (pass `?includeRetracted=true` to see them)
- Add `POST /api/statements/cleanup` endpoint to bulk-delete retracted and empty structured statements (with `dryRun` preview mode)
- Fix extraction pipeline to drop structured statements with no property and no values before inserting (prevents blank "—" rows)

## Context
Entity statement pages (e.g. `/statements/entity/anthropic`) show retracted statements with dimmed opacity, cluttering the view with 100+ useless rows. Additionally, some entities (e.g. CZI) have dozens of "active" structured statements that show "—" for Property, Value, and Period because the extraction pipeline nulls out invalid property IDs but still inserts the statement.

## After deploying
Run the cleanup endpoint to remove existing bad data:
```bash
# Preview
curl -X POST $SERVER/api/statements/cleanup -H 'Content-Type: application/json' -d '{"dryRun": true}'
# Execute
curl -X POST $SERVER/api/statements/cleanup -H 'Content-Type: application/json' -d '{"dryRun": false}'
```

## Test plan
- [x] TypeScript type-check passes (wiki-server + web)
- [x] Full Next.js build succeeds
- [x] Gate checks pass
- [x] No console.log violations
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional includeRetracted parameter (defaults to false) to include retracted statements when retrieving.
  * Added a /cleanup endpoint to find and remove retracted and empty statements; supports dry-run mode and returns counts.

* **Bug Fixes**
  * Extraction now skips empty structured statements to prevent invalid data insertion; improved failure logging for batch inserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->