### PR TITLE
feat(statements): add --target-coverage iterative optimization loop

### DIFF
--- a/crux/commands/statements.ts
+++ b/crux/commands/statements.ts
@@ -47,7 +47,7 @@ const SCRIPTS = {
   improve: {
     script: 'statements/improve.ts',
     description: 'Generate new statements to fill coverage gaps',
-    passthrough: ['json', 'dry-run', 'org-type', 'category', 'no-research', 'min-score', 'budget'],
+    passthrough: ['json', 'dry-run', 'org-type', 'category', 'no-research', 'min-score', 'budget', 'target-coverage', 'max-iterations'],
     positional: true,
   },
 };
@@ -77,6 +77,8 @@ Options:
   --no-research         Skip web research (improve only)
   --min-score=N         Quality gate threshold (default: 0.5, improve only)
   --budget=N            Cost cap in USD (default: 5, improve only)
+  --target-coverage=N   Target coverage score for iterative loop (improve only)
+  --max-iterations=N    Max iterations for iterative loop (default: 5, improve only)
 
 Examples:
   crux statements extract anthropic                Extract statements (dry run)
@@ -93,6 +95,7 @@ Examples:
   crux statements improve anthropic --dry-run      Preview generated statements
   crux statements improve anthropic --category=safety  Target one category
   crux statements improve anthropic --no-research  Skip web search
+  crux statements improve anthropic --target-coverage=0.8 --max-iterations=3  Iterate until 80%
 
 Workflow:
   1. crux statements extract <page-id> --apply     Extract statements from page

--- a/crux/statements/improve.test.ts
+++ b/crux/statements/improve.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { qualityGate } from './improve.ts';
+import { describe, it, expect, vi } from 'vitest';
+import { qualityGate, runIterativeLoop } from './improve.ts';
+import type { PassResult, IterativeOptions, PassFn } from './improve.ts';
 import type { ScoringStatement } from './scoring.ts';
+import { CostTracker } from '../lib/cost-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -141,5 +143,203 @@ describe('qualityGate', () => {
     expect(result.accepted.length).toBe(1);
     expect(result.accepted[0].citations).toHaveLength(1);
     expect(result.accepted[0].citations![0].url).toBe('https://example.com/rsp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Iterative loop helpers
+// ---------------------------------------------------------------------------
+
+function makePassResult(overrides: Partial<PassResult> = {}): PassResult {
+  return {
+    entityId: 'test-entity',
+    entityType: 'organization',
+    categoriesProcessed: ['safety'],
+    coverageBefore: 0.3,
+    coverageAfter: 0.5,
+    created: 3,
+    rejected: 1,
+    totalCost: 0.1,
+    rejections: [],
+    ...overrides,
+  };
+}
+
+function makeIterativeOptions(overrides: Partial<IterativeOptions> = {}): IterativeOptions {
+  return {
+    entityId: 'test-entity',
+    orgType: null,
+    categoryFilter: null,
+    minScore: 0.5,
+    budget: 10,
+    noResearch: true,
+    dryRun: false,
+    client: {} as any,
+    tracker: new CostTracker(),
+    targetCoverage: 0.8,
+    maxIterations: 5,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a mock pass function that returns the given results in sequence.
+ */
+function mockPassFn(results: PassResult[]): PassFn {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    if (callIndex >= results.length) {
+      throw new Error(`mockPassFn: unexpected call ${callIndex + 1}, only ${results.length} results provided`);
+    }
+    return results[callIndex++];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Iterative loop tests
+// ---------------------------------------------------------------------------
+
+describe('runIterativeLoop', () => {
+  it('stops when target coverage is reached', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.5, created: 3 }),
+      makePassResult({ coverageBefore: 0.5, coverageAfter: 0.7, created: 2 }),
+      makePassResult({ coverageBefore: 0.7, coverageAfter: 0.85, created: 2 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.8 }),
+      passFn,
+    );
+
+    expect(result.converged).toBe(true);
+    expect(result.stalled).toBe(false);
+    expect(result.passes).toHaveLength(3);
+    expect(result.finalCoverage).toBe(0.85);
+    expect(result.totalCreated).toBe(7);
+    expect(passFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops when max iterations hit', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.1, coverageAfter: 0.2, created: 2 }),
+      makePassResult({ coverageBefore: 0.2, coverageAfter: 0.3, created: 2 }),
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.4, created: 2 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.95, maxIterations: 3 }),
+      passFn,
+    );
+
+    expect(result.converged).toBe(false);
+    expect(result.stalled).toBe(false);
+    expect(result.passes).toHaveLength(3);
+    expect(result.finalCoverage).toBe(0.4);
+    expect(result.totalCreated).toBe(6);
+  });
+
+  it('detects convergence when no statements are created', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.5, created: 3 }),
+      makePassResult({ coverageBefore: 0.5, coverageAfter: 0.5, created: 0, rejected: 0 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.9 }),
+      passFn,
+    );
+
+    expect(result.converged).toBe(false);
+    expect(result.stalled).toBe(true);
+    expect(result.passes).toHaveLength(2);
+    expect(result.finalCoverage).toBe(0.5);
+    expect(result.totalCreated).toBe(3);
+    expect(result.totalRejected).toBe(1); // from first pass default
+  });
+
+  it('detects stall when coverage does not improve between passes', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.5, created: 3 }),
+      makePassResult({ coverageBefore: 0.5, coverageAfter: 0.5, created: 1 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.9 }),
+      passFn,
+    );
+
+    expect(result.converged).toBe(false);
+    expect(result.stalled).toBe(true);
+    expect(result.passes).toHaveLength(2);
+  });
+
+  it('stops when budget is exhausted', async () => {
+    const tracker = new CostTracker();
+
+    const passFn = vi.fn(async () => {
+      // Simulate cost accumulation in the tracker
+      tracker.recordExternalCost('test-model', 6, 'test');
+      return makePassResult({ coverageBefore: 0.3, coverageAfter: 0.5, created: 3 });
+    });
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.95, budget: 10, tracker }),
+      passFn,
+    );
+
+    // First pass spends $6, then budget check: $6 < $10, so second pass runs and
+    // spends another $6 ($12 total). Third pass: $12 >= $10, so loop stops.
+    expect(result.passes).toHaveLength(2);
+    expect(result.converged).toBe(false);
+  });
+
+  it('aggregates totals across all passes', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.5, created: 3, rejected: 2 }),
+      makePassResult({ coverageBefore: 0.5, coverageAfter: 0.85, created: 4, rejected: 1 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.8 }),
+      passFn,
+    );
+
+    expect(result.totalCreated).toBe(7);
+    expect(result.totalRejected).toBe(3);
+    expect(result.passes).toHaveLength(2);
+  });
+
+  it('handles single pass convergence (target met on first try)', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: 0.9, created: 5 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.8 }),
+      passFn,
+    );
+
+    expect(result.converged).toBe(true);
+    expect(result.stalled).toBe(false);
+    expect(result.passes).toHaveLength(1);
+    expect(result.finalCoverage).toBe(0.9);
+    expect(passFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses coverageBefore when coverageAfter is null (dry-run)', async () => {
+    const passFn = mockPassFn([
+      makePassResult({ coverageBefore: 0.3, coverageAfter: null, created: 0 }),
+    ]);
+
+    const result = await runIterativeLoop(
+      makeIterativeOptions({ targetCoverage: 0.8 }),
+      passFn,
+    );
+
+    // coverageAfter is null, so finalCoverage = coverageBefore = 0.3
+    // created is 0, so stalled = true
+    expect(result.stalled).toBe(true);
+    expect(result.finalCoverage).toBe(0.3);
   });
 });

--- a/crux/statements/improve.ts
+++ b/crux/statements/improve.ts
@@ -94,6 +94,23 @@ export interface PassResult {
   rejections: Array<{ text: string; reason: string; score: number }>;
 }
 
+/** Options for an iterative improvement loop. */
+export interface IterativeOptions extends ImproveOptions {
+  targetCoverage: number;
+  maxIterations: number;
+}
+
+/** Result of an iterative improvement loop. */
+export interface IterativeResult {
+  passes: PassResult[];
+  finalCoverage: number;
+  converged: boolean;  // true if target reached
+  stalled: boolean;    // true if no improvement in last pass
+  totalCreated: number;
+  totalRejected: number;
+  totalCost: number;
+}
+
 // ---------------------------------------------------------------------------
 // Statement generation
 // ---------------------------------------------------------------------------
@@ -523,6 +540,77 @@ export async function runSinglePass(opts: ImproveOptions): Promise<PassResult> {
 }
 
 // ---------------------------------------------------------------------------
+// Iterative improvement loop
+// ---------------------------------------------------------------------------
+
+/** Function signature for a single improvement pass (injectable for testing). */
+export type PassFn = (opts: ImproveOptions) => Promise<PassResult>;
+
+/**
+ * Run multiple improvement passes until coverage target is reached, budget is
+ * exhausted, max iterations hit, or no progress is made (convergence).
+ *
+ * Calls `passFn()` (defaults to `runSinglePass`) in a loop, checking
+ * `passResult.coverageAfter` against the target after each pass.
+ * Reports per-iteration progression.
+ */
+export async function runIterativeLoop(
+  opts: IterativeOptions,
+  passFn: PassFn = runSinglePass,
+): Promise<IterativeResult> {
+  const { targetCoverage, maxIterations, budget, tracker } = opts;
+  const passes: PassResult[] = [];
+  let finalCoverage = 0;
+  let converged = false;
+  let stalled = false;
+
+  for (let i = 0; i < maxIterations; i++) {
+    // Check budget before starting a new pass
+    if (tracker.totalCost >= budget) break;
+
+    const passResult = await passFn(opts);
+    passes.push(passResult);
+
+    // Determine the latest coverage value
+    const currentCoverage = passResult.coverageAfter ?? passResult.coverageBefore;
+    finalCoverage = currentCoverage;
+
+    // Check if target reached
+    if (currentCoverage >= targetCoverage) {
+      converged = true;
+      break;
+    }
+
+    // Convergence detection: stop if no statements were created and coverage
+    // didn't improve (all gaps filled or all candidates rejected)
+    if (passResult.created === 0) {
+      stalled = true;
+      break;
+    }
+
+    // Also stall if coverage didn't improve compared to prior pass
+    if (passes.length >= 2) {
+      const prevCoverage = passes[passes.length - 2].coverageAfter
+        ?? passes[passes.length - 2].coverageBefore;
+      if (currentCoverage <= prevCoverage) {
+        stalled = true;
+        break;
+      }
+    }
+  }
+
+  return {
+    passes,
+    finalCoverage,
+    converged,
+    stalled,
+    totalCreated: passes.reduce((sum, p) => sum + p.created, 0),
+    totalRejected: passes.reduce((sum, p) => sum + p.rejected, 0),
+    totalCost: tracker.totalCost,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // CLI: main (thin wrapper)
 // ---------------------------------------------------------------------------
 
@@ -537,47 +625,119 @@ async function main() {
     console.error(`${c.red}Error: provide an entity ID${c.reset}`);
     console.error(`  Usage: pnpm crux statements improve <entity-id> [options]`);
     console.error(`  Options: --org-type=TYPE --dry-run --category=CAT --no-research --min-score=N --budget=N --json`);
+    console.error(`           --target-coverage=N --max-iterations=N`);
     process.exit(1);
   }
 
   const tracker = new CostTracker();
   const client = createLlmClient();
 
+  const budgetVal = typeof args.budget === 'number'
+    ? args.budget
+    : typeof args.budget === 'string' ? parseFloat(args.budget) : 5;
+  const minScoreVal = typeof args['min-score'] === 'number'
+    ? args['min-score']
+    : typeof args['min-score'] === 'string' ? parseFloat(args['min-score']) : 0.5;
+
   const opts: ImproveOptions = {
     entityId,
     orgType: (args['org-type'] as string) ?? null,
     categoryFilter: (args.category as string) ?? null,
-    minScore: typeof args['min-score'] === 'number' ? args['min-score'] : 0.5,
-    budget: typeof args.budget === 'number' ? args.budget : 5,
+    minScore: minScoreVal,
+    budget: budgetVal,
     noResearch: args['no-research'] === true,
     dryRun: args['dry-run'] === true,
     client,
     tracker,
   };
 
+  // Parse iterative loop flags
+  const targetCoverageRaw = args['target-coverage'];
+  const targetCoverage = typeof targetCoverageRaw === 'number'
+    ? targetCoverageRaw
+    : typeof targetCoverageRaw === 'string' ? parseFloat(targetCoverageRaw) : null;
+
+  const maxIterationsRaw = args['max-iterations'];
+  const maxIterations = typeof maxIterationsRaw === 'number'
+    ? maxIterationsRaw
+    : typeof maxIterationsRaw === 'string' ? parseInt(maxIterationsRaw, 10) : 5;
+
   if (!jsonOutput) console.log(`${c.dim}Analyzing coverage gaps for ${entityId}...${c.reset}`);
 
-  let result: PassResult;
-  try {
-    result = await runSinglePass(opts);
-  } catch (err) {
-    console.error(`${c.red}${err instanceof Error ? err.message : String(err)}${c.reset}`);
-    process.exit(1);
-  }
+  // Dispatch: iterative loop or single pass
+  if (targetCoverage != null && !isNaN(targetCoverage)) {
+    const iterOpts: IterativeOptions = {
+      ...opts,
+      targetCoverage,
+      maxIterations,
+    };
 
-  if (jsonOutput) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(`\n${c.bold}${c.blue}Improvement Summary: ${entityId}${c.reset}`);
-    console.log(`  Categories:  ${result.categoriesProcessed.join(', ') || '(none — no gaps)'}`);
-    console.log(`  Created:     ${c.green}${result.created}${c.reset}`);
-    console.log(`  Rejected:    ${c.red}${result.rejected}${c.reset}`);
-    console.log(`  Coverage:    ${result.coverageBefore.toFixed(3)}${result.coverageAfter != null ? ` → ${result.coverageAfter.toFixed(3)}` : ''}`);
-    console.log(`  Cost:        $${result.totalCost.toFixed(4)}`);
-    if (opts.dryRun) {
-      console.log(`  ${c.dim}(dry run — no statements were inserted)${c.reset}`);
+    let iterResult: IterativeResult;
+    try {
+      if (!jsonOutput) {
+        console.log(`${c.dim}Target coverage: ${targetCoverage.toFixed(3)}, max iterations: ${maxIterations}${c.reset}`);
+      }
+
+      iterResult = await runIterativeLoop({
+        ...iterOpts,
+        // Wrap runSinglePass progress reporting for non-JSON mode
+      });
+    } catch (err) {
+      console.error(`${c.red}${err instanceof Error ? err.message : String(err)}${c.reset}`);
+      process.exit(1);
     }
-    console.log('');
+
+    if (jsonOutput) {
+      console.log(JSON.stringify(iterResult, null, 2));
+    } else {
+      console.log(`\n${c.bold}${c.blue}Iterative Improvement Summary: ${entityId}${c.reset}`);
+      console.log(`  Iterations:  ${iterResult.passes.length}`);
+      for (let i = 0; i < iterResult.passes.length; i++) {
+        const pass = iterResult.passes[i];
+        const coverageAfterStr = pass.coverageAfter != null ? pass.coverageAfter.toFixed(3) : 'N/A';
+        const delta = pass.coverageAfter != null
+          ? (pass.coverageAfter - pass.coverageBefore)
+          : 0;
+        const deltaStr = delta > 0 ? `${c.green}+${delta.toFixed(3)}${c.reset}` : delta.toFixed(3);
+        console.log(`    Pass ${i + 1}:  coverage ${pass.coverageBefore.toFixed(3)} → ${coverageAfterStr} (${deltaStr}), created ${pass.created}`);
+      }
+      console.log(`  Created:     ${c.green}${iterResult.totalCreated}${c.reset}`);
+      console.log(`  Rejected:    ${c.red}${iterResult.totalRejected}${c.reset}`);
+      console.log(`  Coverage:    ${iterResult.passes.length > 0 ? iterResult.passes[0].coverageBefore.toFixed(3) : 'N/A'} → ${iterResult.finalCoverage.toFixed(3)}`);
+      console.log(`  Converged:   ${iterResult.converged ? `${c.green}yes${c.reset}` : 'no'}`);
+      if (iterResult.stalled) {
+        console.log(`  ${c.dim}(stalled — no improvement in last pass)${c.reset}`);
+      }
+      console.log(`  Cost:        $${iterResult.totalCost.toFixed(4)}`);
+      if (opts.dryRun) {
+        console.log(`  ${c.dim}(dry run — no statements were inserted)${c.reset}`);
+      }
+      console.log('');
+    }
+  } else {
+    // Single-pass mode (original behavior)
+    let result: PassResult;
+    try {
+      result = await runSinglePass(opts);
+    } catch (err) {
+      console.error(`${c.red}${err instanceof Error ? err.message : String(err)}${c.reset}`);
+      process.exit(1);
+    }
+
+    if (jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`\n${c.bold}${c.blue}Improvement Summary: ${entityId}${c.reset}`);
+      console.log(`  Categories:  ${result.categoriesProcessed.join(', ') || '(none — no gaps)'}`);
+      console.log(`  Created:     ${c.green}${result.created}${c.reset}`);
+      console.log(`  Rejected:    ${c.red}${result.rejected}${c.reset}`);
+      console.log(`  Coverage:    ${result.coverageBefore.toFixed(3)}${result.coverageAfter != null ? ` → ${result.coverageAfter.toFixed(3)}` : ''}`);
+      console.log(`  Cost:        $${result.totalCost.toFixed(4)}`);
+      if (opts.dryRun) {
+        console.log(`  ${c.dim}(dry run — no statements were inserted)${c.reset}`);
+      }
+      console.log('');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `runIterativeLoop()` function that calls `runSinglePass()` in a loop until coverage target is reached, budget exhausted, max iterations hit, or no improvement detected (convergence)
- Add `--target-coverage=N` and `--max-iterations=N` CLI flags to `crux statements improve`
- When `--target-coverage` is set, CLI dispatches to iterative mode; without it, single-pass behavior is preserved
- Add 8 new tests covering all stop conditions (target reached, max iterations, convergence/stall, budget exhaustion)

## Architecture

- New types: `IterativeOptions`, `IterativeResult`, `PassFn`
- `PassFn` parameter in `runIterativeLoop()` enables dependency injection for testing without mocking module internals
- Per-iteration progress reporting in CLI output (coverage delta, statements created per pass)

## Test plan

- [x] All 14 tests pass in `improve.test.ts` (6 existing + 8 new)
- [x] No TypeScript errors in modified files
- [x] Single-pass mode (no `--target-coverage`) behavior unchanged

Closes #1656
