### PR TITLE
fix(security): consolidate isSafeUrl and guard all URL rendering against XSS

### DIFF
--- a/apps/web/src/components/wiki/CitationOverlay.tsx
+++ b/apps/web/src/components/wiki/CitationOverlay.tsx
@@ -12,6 +12,9 @@ import {
   ExternalLink,
 } from "lucide-react";
 import type { CitationQuote } from "@/lib/citation-data";
+import { isSafeUrl } from "./resource-utils";
+// Re-export for backwards compatibility — tests import isSafeUrl from this module.
+export { isSafeUrl } from "./resource-utils";
 
 interface VerdictConfig {
   icon: typeof CheckCircle2;
@@ -90,16 +93,6 @@ function getVerdictConfig(quote: CitationQuote): VerdictConfig | null {
     return VERIFIED_ONLY_CONFIG;
   }
   return null;
-}
-
-/** Only allow safe URL schemes in citation links */
-export function isSafeUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 function formatDate(iso: string): string {

--- a/apps/web/src/components/wiki/Crux.tsx
+++ b/apps/web/src/components/wiki/Crux.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { cn } from "@lib/utils";
 import { getCruxById } from "@data";
 import type { CruxPosition } from "@data";
+import { isSafeUrl } from "./resource-utils";
 
 interface CruxProps {
   id?: string;
@@ -147,7 +148,7 @@ export function Crux(props: CruxProps) {
       {relevantResearch && relevantResearch.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {relevantResearch.map((research, i) => (
-            research.url ? (
+            research.url && isSafeUrl(research.url) ? (
               <a
                 key={i}
                 href={research.url}

--- a/apps/web/src/components/wiki/FootnoteTooltip.tsx
+++ b/apps/web/src/components/wiki/FootnoteTooltip.tsx
@@ -7,6 +7,7 @@ import { cn } from "@lib/utils";
 import { useReferenceData } from "./ReferenceContext";
 import { VerdictBadge } from "./VerdictBadge";
 import type { RefMapEntry } from "./ReferenceContext";
+import { getDomain, isSafeUrl } from "./resource-utils";
 
 /**
  * Format an ISO date string for compact display.
@@ -20,25 +21,6 @@ function formatDate(iso: string): string {
     });
   } catch {
     return iso;
-  }
-}
-
-/** Only allow safe URL schemes in links */
-function isSafeUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-/** Extract domain from URL for display */
-function getDomain(url: string): string | null {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return null;
   }
 }
 

--- a/apps/web/src/components/wiki/InfoBox.tsx
+++ b/apps/web/src/components/wiki/InfoBox.tsx
@@ -10,6 +10,7 @@ import { getEntityTypeHeader, getEntityTypeLabel, getOrgTypeLabel } from "@/data
 import type { AnyEntityTypeName } from "@/data/entity-type-names";
 import type { ExternalLinksData } from "@/data";
 import { InfoBoxDescription } from "./InfoBoxDescription";
+import { isSafeUrl } from "./resource-utils";
 
 type LucideIcon = React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & { size?: number | string }>;
 
@@ -349,9 +350,13 @@ export function InfoBox({
                 </span>
                 <span className="flex-1 text-foreground break-words" style={!href ? getValueStyle(field.label) : undefined}>
                   {field.label === "Website" ? (
-                    <a href={field.value} target="_blank" rel="noopener noreferrer" className="text-accent-foreground no-underline hover:underline">
-                      {(() => { try { return new URL(field.value).hostname.replace("www.", ""); } catch { return field.value; } })()}
-                    </a>
+                    isSafeUrl(field.value) ? (
+                      <a href={field.value} target="_blank" rel="noopener noreferrer" className="text-accent-foreground no-underline hover:underline">
+                        {(() => { try { return new URL(field.value).hostname.replace("www.", ""); } catch { return field.value; } })()}
+                      </a>
+                    ) : (
+                      <span>{field.value}</span>
+                    )
                   ) : href ? (
                     <Link href={href} className="no-underline hover:underline" style={getValueStyle(field.label)}>{field.value}</Link>
                   ) : (

--- a/apps/web/src/components/wiki/InlineCitationCards.tsx
+++ b/apps/web/src/components/wiki/InlineCitationCards.tsx
@@ -12,7 +12,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import type { CitationQuote } from "@/lib/citation-data";
-import { getDomain } from "./resource-utils";
+import { getDomain, isSafeUrl } from "./resource-utils";
 
 interface VerdictConfig {
   icon: typeof CheckCircle2;
@@ -83,15 +83,6 @@ function getVerdictConfig(quote: CitationQuote): VerdictConfig | null {
     return VERIFIED_ONLY_CONFIG;
   }
   return null;
-}
-
-function isSafeUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 function formatDate(iso: string): string {

--- a/apps/web/src/components/wiki/References.tsx
+++ b/apps/web/src/components/wiki/References.tsx
@@ -11,7 +11,7 @@ import type { Resource } from "@data";
 import { CredibilityBadge } from "./CredibilityBadge";
 import { ReferenceCitationDetails } from "./ReferenceCitationDetails";
 import { ReferenceCitationDot } from "./ReferenceCitationDot";
-import { formatAuthors, getDomain } from "./resource-utils";
+import { formatAuthors, getDomain, isSafeUrl } from "./resource-utils";
 import { cn } from "@lib/utils";
 import { ExternalLink } from "lucide-react";
 
@@ -129,7 +129,7 @@ function ReferenceEntry({ entry, pageId }: { entry: ResolvedRef; pageId?: string
           >
             {resource.title}
           </a>
-        ) : (
+        ) : resource.url && isSafeUrl(resource.url) ? (
           <a
             href={resource.url}
             target="_blank"
@@ -138,6 +138,10 @@ function ReferenceEntry({ entry, pageId }: { entry: ResolvedRef; pageId?: string
           >
             {resource.title}
           </a>
+        ) : (
+          <span className="text-[13px] text-foreground/80 font-medium leading-relaxed">
+            {resource.title}
+          </span>
         )}
         {resource.url && <ReferenceCitationDot url={resource.url} />}
         {metaParts.length > 0 && (
@@ -193,7 +197,7 @@ function ReferenceEntry({ entry, pageId }: { entry: ResolvedRef; pageId?: string
               <CredibilityBadge level={credibility} size="sm" />
             </div>
           )}
-          {resource.url && (
+          {resource.url && isSafeUrl(resource.url) && (
             <div className="mt-1.5 flex items-center gap-2">
               <a
                 href={resource.url}

--- a/apps/web/src/components/wiki/ResourceLink.tsx
+++ b/apps/web/src/components/wiki/ResourceLink.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { getResourceById, getResourceCredibility, getResourcePublication } from "@data";
 import { CredibilityBadge } from "./CredibilityBadge";
 import { ResourceTags } from "./ResourceTags";
-import { getResourceTypeIcon } from "./resource-utils";
+import { getResourceTypeIcon, isSafeUrl } from "./resource-utils";
 import { cn } from "@lib/utils";
 import styles from "./tooltip.module.css";
 
@@ -44,24 +44,37 @@ export function ResourceLink({
   const icon = showType ? getResourceTypeIcon(resource.type) : null;
   const credibility = getResourceCredibility(resource);
   const publication = getResourcePublication(resource);
+  const safeUrl = resource.url && isSafeUrl(resource.url) ? resource.url : null;
 
   return (
     <span className={styles.wrapper}>
-      <a
-        href={resource.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cn("text-accent-foreground no-underline font-medium hover:underline", className)}
-      >
-        {icon && <span className="mr-1">{icon}</span>}
-        <span>{displayLabel}</span>
-        {showCredibility && credibility && (
-          <span className="ml-1">
-            <CredibilityBadge level={credibility} size="sm" />
-          </span>
-        )}
-        <span className="text-xs ml-0.5 opacity-70">{"\u2197"}</span>
-      </a>
+      {safeUrl ? (
+        <a
+          href={safeUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn("text-accent-foreground no-underline font-medium hover:underline", className)}
+        >
+          {icon && <span className="mr-1">{icon}</span>}
+          <span>{displayLabel}</span>
+          {showCredibility && credibility && (
+            <span className="ml-1">
+              <CredibilityBadge level={credibility} size="sm" />
+            </span>
+          )}
+          <span className="text-xs ml-0.5 opacity-70">{"\u2197"}</span>
+        </a>
+      ) : (
+        <span className={cn("text-accent-foreground font-medium", className)}>
+          {icon && <span className="mr-1">{icon}</span>}
+          <span>{displayLabel}</span>
+          {showCredibility && credibility && (
+            <span className="ml-1">
+              <CredibilityBadge level={credibility} size="sm" />
+            </span>
+          )}
+        </span>
+      )}
       {n != null && n >= 1 && (
         <a
           id={`cite-${n}`}
@@ -126,16 +139,18 @@ export function ResourceLink({
           </span>
         )}
 
-        <span className="flex gap-2 mt-2 pointer-events-auto">
-          <a
-            href={resource.url}
-            className="flex-1 px-2.5 py-1.5 text-xs font-medium text-center no-underline rounded transition-colors bg-muted text-foreground hover:bg-muted/80 border border-border"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Source {"\u2197"}
-          </a>
-        </span>
+        {safeUrl && (
+          <span className="flex gap-2 mt-2 pointer-events-auto">
+            <a
+              href={safeUrl}
+              className="flex-1 px-2.5 py-1.5 text-xs font-medium text-center no-underline rounded transition-colors bg-muted text-foreground hover:bg-muted/80 border border-border"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Source {"\u2197"}
+            </a>
+          </span>
+        )}
       </span>
     </span>
   );

--- a/apps/web/src/lib/__tests__/citation-data.test.ts
+++ b/apps/web/src/lib/__tests__/citation-data.test.ts
@@ -3,7 +3,7 @@ import {
   computeCitationHealth,
   type CitationQuote,
 } from "../citation-data";
-import { isSafeUrl } from "../../components/wiki/CitationOverlay";
+import { isSafeUrl } from "../../components/wiki/resource-utils";
 
 function makeQuote(overrides: Partial<CitationQuote> = {}): CitationQuote {
   return {


### PR DESCRIPTION
## Summary

- Consolidate `isSafeUrl()` to a single canonical implementation in `resource-utils.ts`; remove 3 duplicate local implementations from `InlineCitationCards.tsx`, `FootnoteTooltip.tsx`, and `CitationOverlay.tsx`
- Guard all `<a href={url}>` with `isSafeUrl()` in `References.tsx`, `ResourceLink.tsx`, `InfoBox.tsx`, and `Crux.tsx` — unsafe URLs now render as plain text instead of clickable links
- Update `citation-data.test.ts` to import `isSafeUrl` from the canonical source (`resource-utils`) rather than `CitationOverlay`

## Security

This PR closes an XSS vector where external URLs from YAML/database data were rendered as `<a href>` without scheme validation. A malicious entity with a `javascript:` URL in their website field, external links, or research references could inject executable JavaScript.

The fix is conservative: if a URL fails `isSafeUrl()`, the component renders plain text instead of a link. No errors are thrown.

## Test Plan

- [x] All 2545 tests pass (`pnpm test`)
- [x] TypeScript type check clean (`tsc --noEmit`)
- [x] Gate check passes (`pnpm crux validate gate`)
- [x] Edge cases verified: `javascript:`, `data:`, `vbscript:`, `file:`, `ftp:`, uppercase `JAVASCRIPT:`, empty string, protocol-relative URLs all blocked
- [x] Normal `https://` and `http://` URLs pass correctly

Closes #1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsafe URLs are now validated and displayed as plain text instead of clickable links across citations, research references, website fields, and resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->