### PR TITLE
feat(statements): add quality mode to rewrite low-scoring statements

### DIFF
--- a/crux/commands/statements.ts
+++ b/crux/commands/statements.ts
@@ -47,7 +47,7 @@ const SCRIPTS = {
   improve: {
     script: 'statements/improve.ts',
     description: 'Generate new statements to fill coverage gaps',
-    passthrough: ['json', 'dry-run', 'org-type', 'category', 'no-research', 'min-score', 'budget', 'target-coverage', 'max-iterations'],
+    passthrough: ['json', 'dry-run', 'org-type', 'category', 'no-research', 'min-score', 'budget', 'target-coverage', 'max-iterations', 'mode'],
     positional: true,
   },
 };
@@ -79,6 +79,7 @@ Options:
   --budget=N            Cost cap in USD (default: 5, improve only)
   --target-coverage=N   Target coverage score for iterative loop (improve only)
   --max-iterations=N    Max iterations for iterative loop (default: 5, improve only)
+  --mode=quality        Rewrite low-scoring statements instead of generating new ones
 
 Examples:
   crux statements extract anthropic                Extract statements (dry run)
@@ -96,6 +97,7 @@ Examples:
   crux statements improve anthropic --category=safety  Target one category
   crux statements improve anthropic --no-research  Skip web search
   crux statements improve anthropic --target-coverage=0.8 --max-iterations=3  Iterate until 80%
+  crux statements improve anthropic --mode=quality          Rewrite low-scoring statements
 
 Workflow:
   1. crux statements extract <page-id> --apply     Extract statements from page

--- a/crux/statements/improve.test.ts
+++ b/crux/statements/improve.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { qualityGate, runIterativeLoop } from './improve.ts';
-import type { PassResult, IterativeOptions, PassFn } from './improve.ts';
+import { qualityGate, runIterativeLoop, toScoringStatement, qualityGateRewrite } from './improve.ts';
+import type { PassResult, IterativeOptions, PassFn, GeneratedStatement } from './improve.ts';
 import type { ScoringStatement } from './scoring.ts';
 import { CostTracker } from '../lib/cost-tracker.ts';
 
@@ -341,5 +341,150 @@ describe('runIterativeLoop', () => {
     // created is 0, so stalled = true
     expect(result.stalled).toBe(true);
     expect(result.finalCoverage).toBe(0.3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toScoringStatement
+// ---------------------------------------------------------------------------
+
+describe('toScoringStatement', () => {
+  it('converts a raw statement row to ScoringStatement', () => {
+    const raw = {
+      id: 42,
+      variety: 'structured',
+      statementText: 'Anthropic was founded in 2021.',
+      subjectEntityId: 'anthropic',
+      propertyId: 'founded_date',
+      valueNumeric: null,
+      valueUnit: null,
+      valueText: null,
+      valueEntityId: null,
+      valueDate: '2021-01-01',
+      validStart: '2021',
+      validEnd: null,
+      status: 'active',
+      claimCategory: 'factual',
+      citations: [{ url: 'https://example.com', sourceQuote: 'Founded in 2021' }],
+      property: { id: 'founded_date', label: 'Founded Date', category: 'milestone', stalenessCadence: null },
+    };
+
+    const result = toScoringStatement(raw);
+    expect(result.id).toBe(42);
+    expect(result.statementText).toBe('Anthropic was founded in 2021.');
+    expect(result.propertyId).toBe('founded_date');
+    expect(result.valueDate).toBe('2021-01-01');
+    expect(result.property?.category).toBe('milestone');
+    expect(result.citations).toHaveLength(1);
+  });
+
+  it('handles missing optional fields', () => {
+    const raw = {
+      id: 1,
+      variety: 'structured',
+      statementText: 'Test statement.',
+      subjectEntityId: 'test',
+      propertyId: null,
+    };
+
+    const result = toScoringStatement(raw);
+    expect(result.id).toBe(1);
+    expect(result.valueNumeric).toBeNull();
+    expect(result.property).toBeNull();
+    expect(result.citations).toBeUndefined();
+  });
+
+  it('converts string valueNumeric to number', () => {
+    const raw = {
+      id: 1,
+      variety: 'structured',
+      statementText: 'Revenue is $1B.',
+      subjectEntityId: 'test',
+      propertyId: 'revenue',
+      valueNumeric: '1000000000',
+    };
+
+    const result = toScoringStatement(raw);
+    expect(result.valueNumeric).toBe(1000000000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qualityGateRewrite
+// ---------------------------------------------------------------------------
+
+describe('qualityGateRewrite', () => {
+  const entityId = 'anthropic';
+  const entityName = 'Anthropic';
+  const propertyMap = new Map([
+    ['founded_date', { id: 'founded_date', label: 'Founded Date', category: 'milestone' }],
+    ['employee_count', { id: 'employee_count', label: 'Employee Count', category: 'organizational' }],
+  ]);
+
+  it('accepts a rewrite that scores higher than original', () => {
+    const rewrite: GeneratedStatement = {
+      statementText: 'Anthropic was founded in 2021 by Dario Amodei and Daniela Amodei in San Francisco.',
+      propertyId: 'founded_date',
+      variety: 'structured',
+      validStart: '2021',
+    };
+
+    const siblings = [
+      makeStmt({ id: 2, statementText: 'Anthropic has over 1000 employees.', propertyId: 'employee_count' }),
+    ];
+
+    const result = qualityGateRewrite(rewrite, 0.1, entityId, entityName, siblings, propertyMap);
+    expect(result.accepted).toBe(true);
+    expect(result.newScore).toBeGreaterThan(0.1);
+    expect(result.reason).toBe('Improved');
+  });
+
+  it('rejects a rewrite that is a near-duplicate of a sibling', () => {
+    const rewrite: GeneratedStatement = {
+      statementText: 'Anthropic raised $7.3 billion in a Series E funding round in 2024.',
+      propertyId: 'funding-round-amount',
+      variety: 'structured',
+    };
+
+    const siblings = [
+      makeStmt({
+        id: 2,
+        statementText: 'Anthropic raised $7.3 billion in a Series E funding round in 2024.',
+      }),
+    ];
+
+    const result = qualityGateRewrite(rewrite, 0.3, entityId, entityName, siblings, propertyMap);
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain('Near-duplicate');
+  });
+
+  it('rejects a rewrite that does not improve score', () => {
+    const rewrite: GeneratedStatement = {
+      statementText: 'Bad.',
+      propertyId: 'founded_date',
+      variety: 'structured',
+    };
+
+    const siblings: ScoringStatement[] = [];
+
+    // originalScore is high, rewrite is terrible
+    const result = qualityGateRewrite(rewrite, 0.9, entityId, entityName, siblings, propertyMap);
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain('not better');
+  });
+
+  it('handles unknown propertyId gracefully', () => {
+    const rewrite: GeneratedStatement = {
+      statementText: 'Anthropic focuses on AI safety research and develops the Claude AI assistant.',
+      propertyId: 'nonexistent-prop',
+      variety: 'structured',
+    };
+
+    const siblings: ScoringStatement[] = [];
+
+    // Should still work, just without property metadata
+    const result = qualityGateRewrite(rewrite, 0.1, entityId, entityName, siblings, propertyMap);
+    expect(typeof result.accepted).toBe('boolean');
+    expect(typeof result.newScore).toBe('number');
   });
 });

--- a/crux/statements/improve.ts
+++ b/crux/statements/improve.ts
@@ -29,14 +29,19 @@ import {
   createStatementBatch,
   storeCoverageScore,
   getProperties,
+  getStatementsByEntity,
+  patchStatement,
   type CreateStatementInput,
 } from '../lib/wiki-server/statements.ts';
+import { getEntity } from '../lib/wiki-server/entities.ts';
 import { analyzeGaps, type GapAnalysis } from './gaps.ts';
 import {
   scoreStatement,
   scoreUniqueness,
+  scoreAllStatements,
   type ScoringStatement,
   type ScoringContext,
+  type ScoringResult,
 } from './scoring.ts';
 import { resolveCoverageTargets } from './coverage-targets.ts';
 
@@ -384,6 +389,361 @@ export function buildPropertyMap(
 }
 
 // ---------------------------------------------------------------------------
+// Quality mode: rewrite low-scoring statements
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a rewritten version of a low-scoring statement via LLM.
+ */
+export async function generateRewrite(
+  original: ScoringStatement,
+  entityName: string,
+  entityType: string,
+  properties: Array<{ id: string; label: string; description: string | null }>,
+  client: Anthropic,
+  tracker: CostTracker,
+): Promise<GeneratedStatement | null> {
+  const propertyList = properties
+    .map((p) => `  - ${p.id}: ${p.label}${p.description ? ` — ${p.description}` : ''}`)
+    .join('\n');
+
+  const prompt = {
+    system: `You are a structured data expert improving low-quality factual statements for a knowledge base. Your rewrite must:
+- Be atomic: exactly one fact per statement
+- Be self-contained: mention the entity by name
+- Be precise: use specific numbers, dates, or named entities when possible
+- Be verifiable: could be checked against public sources
+- Preserve the core factual claim while improving clarity and structure
+
+Respond ONLY with a JSON object (not an array).`,
+    user: `Rewrite this statement about ${entityName} (${entityType}) to improve its quality:
+
+Original: "${original.statementText}"
+Property: ${original.propertyId ?? 'none'}
+Variety: ${original.variety}
+
+Available properties:
+${propertyList}
+
+Return a JSON object with:
+- "statementText": string — improved, self-contained sentence mentioning "${entityName}"
+- "propertyId": string — best-matching property ID from the list above
+- "variety": "structured" or "attributed"
+- "valueText": string | null
+- "valueNumeric": number | null
+- "valueUnit": string | null
+- "valueDate": string | null
+- "validStart": string | null — when this fact became true (YYYY or YYYY-MM-DD)
+- "citations": [{"url": string | null, "sourceQuote": string | null}]
+
+Preserve the original fact. Improve structure, clarity, and completeness.`,
+  };
+
+  const result = await callLlm(client, prompt, {
+    model: MODELS.sonnet,
+    maxTokens: 2000,
+    temperature: 0.2,
+    retryLabel: 'improve-rewrite',
+    tracker,
+    label: `rewrite-${original.id}`,
+  });
+
+  const parsed = parseJsonFromLlm<GeneratedStatement>(
+    result.text,
+    'improve-rewrite',
+    () => null,
+  );
+
+  if (!parsed || typeof parsed.statementText !== 'string' || parsed.statementText.length < 10) {
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * Convert a raw statement row from the API to a ScoringStatement.
+ */
+export function toScoringStatement(stmt: {
+  id: number;
+  variety: string;
+  statementText: string | null;
+  subjectEntityId: string | null;
+  propertyId: string | null;
+  valueNumeric?: number | string | null;
+  valueUnit?: string | null;
+  valueText?: string | null;
+  valueEntityId?: string | null;
+  valueDate?: string | null;
+  validStart?: string | null;
+  validEnd?: string | null;
+  status?: string | null;
+  claimCategory?: string | null;
+  citations?: Array<{
+    resourceId?: string | null;
+    url?: string | null;
+    sourceQuote?: string | null;
+  }>;
+  property?: {
+    id: string;
+    label: string;
+    category: string;
+    stalenessCadence?: string | null;
+  } | null;
+}): ScoringStatement {
+  return {
+    id: stmt.id,
+    variety: stmt.variety ?? 'structured',
+    statementText: stmt.statementText ?? '',
+    subjectEntityId: stmt.subjectEntityId ?? '',
+    propertyId: stmt.propertyId ?? null,
+    valueNumeric: typeof stmt.valueNumeric === 'string'
+      ? parseFloat(stmt.valueNumeric) || null
+      : (stmt.valueNumeric ?? null),
+    valueUnit: stmt.valueUnit ?? null,
+    valueText: stmt.valueText ?? null,
+    valueEntityId: stmt.valueEntityId ?? null,
+    valueDate: stmt.valueDate ?? null,
+    validStart: stmt.validStart ?? null,
+    validEnd: stmt.validEnd ?? null,
+    status: (stmt.status as string) ?? 'active',
+    claimCategory: stmt.claimCategory ?? null,
+    citations: stmt.citations?.map((c) => ({
+      resourceId: c.resourceId ?? null,
+      url: c.url ?? null,
+      sourceQuote: c.sourceQuote ?? null,
+    })),
+    property: stmt.property ?? null,
+  };
+}
+
+/**
+ * Quality gate for a rewritten statement: must score higher than the original.
+ */
+export function qualityGateRewrite(
+  rewrite: GeneratedStatement,
+  originalScore: number,
+  entityId: string,
+  entityName: string,
+  siblings: ScoringStatement[],
+  propertyMap: Map<string, { id: string; label: string; category: string; stalenessCadence?: string | null }>,
+): { accepted: boolean; newScore: number; reason: string } {
+  const propMeta = rewrite.propertyId ? propertyMap.get(rewrite.propertyId) : null;
+
+  const tempStmt: ScoringStatement = {
+    id: -1,
+    variety: rewrite.variety ?? 'structured',
+    statementText: rewrite.statementText,
+    subjectEntityId: entityId,
+    propertyId: rewrite.propertyId ?? null,
+    valueNumeric: rewrite.valueNumeric ?? null,
+    valueUnit: rewrite.valueUnit ?? null,
+    valueText: rewrite.valueText ?? null,
+    valueEntityId: null,
+    valueDate: rewrite.valueDate ?? null,
+    validStart: rewrite.validStart ?? null,
+    validEnd: null,
+    status: 'active',
+    claimCategory: null,
+    citations: rewrite.citations?.map((c) => ({
+      resourceId: null,
+      url: c.url ?? null,
+      sourceQuote: c.sourceQuote ?? null,
+    })),
+    property: propMeta ? {
+      id: propMeta.id,
+      label: propMeta.label,
+      category: propMeta.category,
+      stalenessCadence: propMeta.stalenessCadence,
+    } : null,
+  };
+
+  // Check uniqueness against siblings (excluding the original)
+  const uniqueness = scoreUniqueness(tempStmt, siblings);
+  if (uniqueness < 0.2) {
+    return { accepted: false, newScore: 0, reason: `Near-duplicate of another statement (uniqueness=${uniqueness.toFixed(3)})` };
+  }
+
+  const ctx: ScoringContext = { siblings, entityId, entityName };
+  const result = scoreStatement(tempStmt, ctx);
+
+  if (result.qualityScore <= originalScore) {
+    return {
+      accepted: false,
+      newScore: result.qualityScore,
+      reason: `Rewrite not better (${result.qualityScore.toFixed(3)} <= original ${originalScore.toFixed(3)})`,
+    };
+  }
+
+  return { accepted: true, newScore: result.qualityScore, reason: 'Improved' };
+}
+
+/**
+ * Quality mode: find low-scoring statements and rewrite them.
+ *
+ * Scores all statements for an entity, picks the bottom N by quality,
+ * generates rewrites via LLM, quality-gates them (must score higher),
+ * then supersedes originals and inserts new versions.
+ */
+export async function runQualityPass(opts: ImproveOptions): Promise<PassResult> {
+  const { entityId, minScore, budget, dryRun, client, tracker } = opts;
+
+  // Fetch entity info and statements in parallel
+  const [entityResult, stmtsResult, propResult] = await Promise.all([
+    getEntity(entityId),
+    getStatementsByEntity(entityId),
+    getProperties(),
+  ]);
+
+  const entityName = entityResult.ok
+    ? (entityResult.data as { name?: string }).name ?? slugToDisplayName(entityId)
+    : slugToDisplayName(entityId);
+  const entityType = entityResult.ok
+    ? (entityResult.data as { entityType?: string }).entityType ?? 'organization'
+    : 'organization';
+
+  if (!stmtsResult.ok) {
+    throw new Error(`Failed to fetch statements for ${entityId}: ${stmtsResult.error}`);
+  }
+
+  const rawStatements = stmtsResult.data.statements;
+  const allProperties = propResult.ok ? propResult.data.properties : [];
+  const fullPropertyMap = buildPropertyMap(allProperties);
+
+  // Convert to scoring format and score all
+  const scoringStmts = rawStatements
+    .filter((s) => s.status === 'active')
+    .map(toScoringStatement);
+
+  const scores = scoreAllStatements(scoringStmts, entityId, entityName);
+
+  // Find low-scoring statements (below minScore or bottom 20%, whichever is more)
+  const scoredPairs = scoringStmts.map((stmt, i) => ({
+    stmt,
+    score: scores[i].qualityScore,
+  }));
+  scoredPairs.sort((a, b) => a.score - b.score);
+
+  const threshold = Math.max(minScore, 0.4);
+  const candidates = scoredPairs
+    .filter((p) => p.score < threshold)
+    .slice(0, 10); // cap at 10 per pass
+
+  if (candidates.length === 0) {
+    return {
+      entityId,
+      entityType,
+      categoriesProcessed: ['quality-rewrite'],
+      coverageBefore: scores.length > 0
+        ? scores.reduce((s, r) => s + r.qualityScore, 0) / scores.length
+        : 0,
+      coverageAfter: null,
+      created: 0,
+      rejected: 0,
+      totalCost: tracker.totalCost,
+      rejections: [],
+    };
+  }
+
+  let created = 0;
+  let rejected = 0;
+  const rejections: PassResult['rejections'] = [];
+  const avgScoreBefore = scores.reduce((s, r) => s + r.qualityScore, 0) / scores.length;
+
+  for (const { stmt, score: originalScore } of candidates) {
+    if (tracker.totalCost >= budget) break;
+
+    // Find properties for this statement's category
+    const category = stmt.property?.category;
+    const categoryProps = category
+      ? allProperties.filter((p) => p.category === category)
+      : allProperties.slice(0, 20);
+
+    const rewrite = await generateRewrite(
+      stmt, entityName, entityType, categoryProps, client, tracker,
+    );
+
+    if (!rewrite) {
+      rejected++;
+      rejections.push({
+        text: (stmt.statementText ?? '').slice(0, 80),
+        reason: 'LLM returned no valid rewrite',
+        score: originalScore,
+      });
+      continue;
+    }
+
+    // Quality gate: must score higher than original
+    // Exclude the original from siblings for uniqueness check
+    const siblingsWithoutOriginal = scoringStmts.filter((s) => s.id !== stmt.id);
+    const gate = qualityGateRewrite(
+      rewrite, originalScore, entityId, entityName,
+      siblingsWithoutOriginal, fullPropertyMap,
+    );
+
+    if (!gate.accepted) {
+      rejected++;
+      rejections.push({
+        text: rewrite.statementText.slice(0, 80),
+        reason: gate.reason,
+        score: gate.newScore,
+      });
+      continue;
+    }
+
+    // Insert new statement, then supersede original (safe ordering)
+    if (!dryRun) {
+      const newStmt: CreateStatementInput = {
+        variety: rewrite.variety ?? 'structured',
+        statementText: rewrite.statementText,
+        subjectEntityId: entityId,
+        propertyId: rewrite.propertyId ?? undefined,
+        valueText: rewrite.valueText,
+        valueNumeric: rewrite.valueNumeric,
+        valueUnit: rewrite.valueUnit,
+        valueDate: rewrite.valueDate,
+        validStart: rewrite.validStart,
+        citations: rewrite.citations?.map((c) => ({
+          url: c.url,
+          sourceQuote: c.sourceQuote,
+        })),
+      };
+
+      const insertResult = await createStatementBatch([newStmt]);
+      if (insertResult.ok) {
+        // Only supersede original after successful insert
+        await patchStatement(stmt.id, {
+          status: 'superseded',
+          archiveReason: `Rewritten by quality mode (${originalScore.toFixed(3)} → ${gate.newScore.toFixed(3)})`,
+        });
+      } else {
+        rejected++;
+        rejections.push({
+          text: rewrite.statementText.slice(0, 80),
+          reason: 'Failed to insert rewritten statement',
+          score: gate.newScore,
+        });
+        continue;
+      }
+    }
+
+    created++;
+  }
+
+  return {
+    entityId,
+    entityType,
+    categoriesProcessed: ['quality-rewrite'],
+    coverageBefore: avgScoreBefore,
+    coverageAfter: null, // quality mode doesn't re-analyze coverage
+    created,
+    rejected,
+    totalCost: tracker.totalCost,
+    rejections,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Core: single improvement pass (composable)
 // ---------------------------------------------------------------------------
 
@@ -625,7 +985,7 @@ async function main() {
     console.error(`${c.red}Error: provide an entity ID${c.reset}`);
     console.error(`  Usage: pnpm crux statements improve <entity-id> [options]`);
     console.error(`  Options: --org-type=TYPE --dry-run --category=CAT --no-research --min-score=N --budget=N --json`);
-    console.error(`           --target-coverage=N --max-iterations=N`);
+    console.error(`           --target-coverage=N --max-iterations=N --mode=quality`);
     process.exit(1);
   }
 
@@ -662,10 +1022,42 @@ async function main() {
     ? maxIterationsRaw
     : typeof maxIterationsRaw === 'string' ? parseInt(maxIterationsRaw, 10) : 5;
 
+  // Parse mode flag
+  const mode = (args.mode as string) ?? null;
+
   if (!jsonOutput) console.log(`${c.dim}Analyzing coverage gaps for ${entityId}...${c.reset}`);
 
-  // Dispatch: iterative loop or single pass
-  if (targetCoverage != null && !isNaN(targetCoverage)) {
+  // Dispatch: quality mode → iterative loop → single pass
+  if (mode === 'quality') {
+    let result: PassResult;
+    try {
+      if (!jsonOutput) console.log(`${c.dim}Quality mode: rewriting low-scoring statements...${c.reset}`);
+      result = await runQualityPass(opts);
+    } catch (err) {
+      console.error(`${c.red}${err instanceof Error ? err.message : String(err)}${c.reset}`);
+      process.exit(1);
+    }
+
+    if (jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`\n${c.bold}${c.blue}Quality Rewrite Summary: ${entityId}${c.reset}`);
+      console.log(`  Rewritten:   ${c.green}${result.created}${c.reset}`);
+      console.log(`  Rejected:    ${c.red}${result.rejected}${c.reset}`);
+      console.log(`  Avg score:   ${result.coverageBefore.toFixed(3)}${result.coverageAfter != null ? ` → ${result.coverageAfter.toFixed(3)}` : ''}`);
+      console.log(`  Cost:        $${result.totalCost.toFixed(4)}`);
+      if (opts.dryRun) {
+        console.log(`  ${c.dim}(dry run — no statements were modified)${c.reset}`);
+      }
+      if (result.rejections.length > 0) {
+        console.log(`\n  ${c.dim}Rejections:${c.reset}`);
+        for (const r of result.rejections) {
+          console.log(`    ${c.red}✗${c.reset} ${r.text}… — ${r.reason}`);
+        }
+      }
+      console.log('');
+    }
+  } else if (targetCoverage != null && !isNaN(targetCoverage)) {
     const iterOpts: IterativeOptions = {
       ...opts,
       targetCoverage,


### PR DESCRIPTION
## Summary

Adds `--mode=quality` to `crux statements improve` which finds low-scoring active statements for an entity, generates improved rewrites via LLM, quality-gates them (must score higher than original), and replaces originals with safe write ordering (create new → supersede old).

- `generateRewrite()`: LLM prompt for improving a single statement
- `toScoringStatement()`: converts raw API rows to scoring format
- `qualityGateRewrite()`: ensures rewrite scores higher than original
- `runQualityPass()`: orchestrates the full quality improvement pass
- 3-way CLI dispatch: `--mode=quality` | `--target-coverage` | default single-pass
- 7 new tests for quality mode functions

Supersedes #1674 (rebased cleanly onto main after #1673 merge).

Closes #1655

## Test plan
- [x] 21 tests pass (6 original + 8 iterative + 7 quality mode)
- [x] TypeScript clean (crux)
- [x] Gate check passes
- [x] Full test suite passes (2560 tests)
