### PR TITLE
feat: extract auto-update CI orchestration from YAML shell to TypeScript

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,10 +1,8 @@
 name: Auto-Update Wiki
 
 # News-driven automatic wiki update system.
-# Fetches news from configured sources, routes relevant items to pages,
-# and creates PRs with improvements.
-#
-# Budget and page limits are configurable per-run.
+# All pipeline logic lives in `crux/auto-update/ci-orchestrate.ts`.
+# This workflow handles only: trigger, permissions, setup, and the single crux call.
 
 on:
   schedule:
@@ -44,7 +42,6 @@ concurrency:
 jobs:
   preflight:
     # Global circuit breaker — skip when automation is paused or wiki-server is down.
-    # Set the AUTOMATION_PAUSED repository variable to 'true' to pause all automated workflows.
     if: vars.AUTOMATION_PAUSED != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +62,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          # Use a token that can create PRs
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v4
@@ -87,37 +83,24 @@ jobs:
           LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
           LONGTERMWIKI_CONTENT_KEY: ${{ secrets.LONGTERMWIKI_CONTENT_KEY }}
 
-      - name: Create auto-update branch
-        run: |
-          DATE=$(date +%Y-%m-%d)
-          BRANCH="auto-update/${DATE}"
-          git checkout -b "$BRANCH"
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-          echo "DATE=$DATE" >> $GITHUB_ENV
-
       - name: Restore auto-update state
         uses: actions/cache/restore@v4
         with:
           path: data/auto-update/state.yaml
-          # Unique key per run so we always save; restore-keys picks up latest
           key: auto-update-state-${{ github.run_id }}
           restore-keys: |
             auto-update-state-
 
-      - name: Run auto-update pipeline
+      - name: Run auto-update CI pipeline
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           SCRY_API_KEY: ${{ secrets.SCRY_API_KEY }}
           FIRECRAWL_KEY: ${{ secrets.FIRECRAWL_KEY }}
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARGS="--trigger=scheduled --verbose"
-
-          # Use workflow_dispatch inputs or defaults
-          BUDGET="${{ inputs.budget || '30' }}"
-          COUNT="${{ inputs.count || '5' }}"
-          ARGS="$ARGS --budget=$BUDGET --count=$COUNT"
+          ARGS="--budget=${{ inputs.budget || '30' }} --count=${{ inputs.count || '5' }} --verbose"
 
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
@@ -127,8 +110,8 @@ jobs:
             ARGS="$ARGS --sources=${{ inputs.sources }}"
           fi
 
-          echo "Running: pnpm crux auto-update run $ARGS"
-          pnpm crux auto-update run $ARGS
+          echo "Running: pnpm crux auto-update run-ci $ARGS"
+          pnpm crux auto-update run-ci $ARGS
 
       - name: Save auto-update state
         if: always()
@@ -136,264 +119,3 @@ jobs:
         with:
           path: data/auto-update/state.yaml
           key: auto-update-state-${{ github.run_id }}
-
-      - name: Run validation
-        if: success()
-        run: |
-          pnpm crux fix escaping
-          pnpm crux fix markdown
-          pnpm crux validate gate --fix || echo "::warning::Validation issues found"
-
-      - name: Review AI-generated content
-        if: success()
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: |
-          # Find changed MDX files that contain NEEDS CITATION markers
-          FLAGGED=$(grep -rl "NEEDS CITATION" content/docs/ 2>/dev/null || true)
-          if [ -z "$FLAGGED" ]; then
-            echo "No NEEDS CITATION markers found — content review passed."
-            exit 0
-          fi
-
-          echo "::warning::Found NEEDS CITATION markers in: $FLAGGED"
-          echo "Running targeted improvement pass to remove uncited claims..."
-
-          for FILE in $FLAGGED; do
-            # Extract page ID from filename (strip path and .mdx extension)
-            PAGE_ID=$(basename "$FILE" .mdx)
-            echo "Fixing: $PAGE_ID ($FILE)"
-            pnpm crux content improve "$PAGE_ID" --tier=polish --apply \
-              --directions "Remove all {/* NEEDS CITATION */} markers and the content they flag. If a claim cannot be verified from your knowledge, remove it entirely rather than leaving uncited speculation. Do not add speculative content as a replacement." \
-              || echo "::warning::Could not auto-fix $PAGE_ID — marker left in place"
-          done
-
-          # Final check: fail if markers still present after fix attempt
-          STILL_FLAGGED=$(grep -rl "NEEDS CITATION" content/docs/ 2>/dev/null || true)
-          if [ -n "$STILL_FLAGGED" ]; then
-            echo "::error::NEEDS CITATION markers remain after fix attempt: $STILL_FLAGGED"
-            echo "Manual review required before merging."
-            exit 1
-          fi
-          echo "All NEEDS CITATION markers resolved."
-
-      - name: Paranoid review of changed pages
-        if: success()
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: |
-          # Find MDX files modified by the auto-update pipeline (not yet committed)
-          CHANGED_MDX=$(git diff --name-only HEAD -- content/docs/ | grep '\.mdx$' || true)
-
-          if [ -z "$CHANGED_MDX" ]; then
-            echo "No MDX files changed — skipping paranoid review"
-            exit 0
-          fi
-
-          COUNT=$(echo "$CHANGED_MDX" | wc -l | tr -d ' ')
-          echo "Running paranoid review on $COUNT changed page(s)..."
-
-          BLOCKED=""
-          for FILE in $CHANGED_MDX; do
-            PAGE_ID=$(basename "$FILE" .mdx)
-            echo "Reviewing: $PAGE_ID ($FILE)"
-
-            RESULT_RAW=$(pnpm --silent crux content review "$PAGE_ID" \
-              --model=claude-haiku-4-5-20251001 --json 2>/dev/null \
-              || true)
-
-            # Extract just the JSON object line (guards against any pnpm/dotenv preamble)
-            JSON_LINE=$(echo "$RESULT_RAW" | grep -E '^\{' | tail -1)
-            RESULT="${JSON_LINE:-{\"error\":\"review failed\",\"gapCount\":0,\"needsReResearch\":false}}"
-
-            NEEDS_RESEARCH=$(echo "$RESULT" | jq -r '.needsReResearch // false' 2>/dev/null || echo "false")
-            GAP_COUNT=$(echo "$RESULT" | jq -r '.gapCount // 0' 2>/dev/null || echo "0")
-            ASSESSMENT=$(echo "$RESULT" | jq -r '.overallAssessment // "No assessment"' 2>/dev/null || echo "No assessment")
-            ERROR=$(echo "$RESULT" | jq -r '.error // ""' 2>/dev/null || echo "parse-error")
-
-            if [ -n "$ERROR" ] && [ "$ERROR" != "null" ]; then
-              echo "::warning::$PAGE_ID — review failed: $ERROR"
-            elif [ "$NEEDS_RESEARCH" = "true" ]; then
-              echo "::error::$PAGE_ID — needs re-research ($GAP_COUNT gap(s)): $ASSESSMENT"
-              BLOCKED="$BLOCKED $PAGE_ID"
-            elif [ "$GAP_COUNT" -gt 0 ]; then
-              echo "::warning::$PAGE_ID — $GAP_COUNT gap(s) (editorial): $ASSESSMENT"
-            else
-              echo "  $PAGE_ID: clean"
-            fi
-          done
-
-          if [ -n "$BLOCKED" ]; then
-            echo "::error::Paranoid review blocked commit for:$BLOCKED"
-            echo "Re-run the improve pipeline on these pages or fix the issues manually."
-            exit 1
-          fi
-
-          echo "All changed pages passed paranoid review"
-
-      - name: Content quality checks (truncation + footnotes)
-        if: success()
-        run: pnpm crux auto-update content-checks --diff
-
-      - name: Find run report
-        id: report
-        if: always()
-        run: |
-          # Run reports use timestamp filenames (e.g., 2026-02-17T06-00-00.yaml)
-          REPORT=$(ls -t data/auto-update/runs/${DATE}*.yaml 2>/dev/null | grep -v '\-details\.yaml$' | head -1)
-          if [ -n "$REPORT" ]; then
-            echo "path=$REPORT" >> $GITHUB_OUTPUT
-            echo "Found report: $REPORT"
-          else
-            echo "path=" >> $GITHUB_OUTPUT
-            echo "No report found"
-          fi
-
-      - name: Verify citations on updated pages
-        id: citations
-        if: success() && steps.report.outputs.path != ''
-        run: |
-          # dotenv stdout is suppressed via DOTENV_CONFIG_QUIET in the crux script.
-          # Progress messages go to stderr; only JSON goes to stdout.
-          RESULT=$(pnpm --silent crux auto-update verify-citations --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
-
-          # Validate JSON before parsing (defensive against any remaining stdout noise)
-          if ! echo "$RESULT" | jq empty 2>/dev/null; then
-            echo "::warning::verify-citations produced invalid JSON, falling back to empty result"
-            RESULT='{}'
-          fi
-
-          SUMMARY=$(echo "$RESULT" | jq -r '.markdownSummary // ""')
-          HAS_BROKEN=$(echo "$RESULT" | jq -r '.hasBroken // false')
-
-          {
-            echo "CITATION_SUMMARY<<CITATION_EOF"
-            echo "$SUMMARY"
-            echo "CITATION_EOF"
-          } >> "$GITHUB_ENV"
-
-          if [ "$HAS_BROKEN" = "true" ]; then
-            echo "::warning::Broken citations detected"
-          fi
-
-      - name: Compute hallucination risk scores
-        id: risk
-        if: success() && steps.report.outputs.path != ''
-        run: |
-          # Rebuild data layer so risk scoring sees the updated content
-          cd apps/web && node --import tsx/esm scripts/build-data.mjs 2>/dev/null
-          cd "$GITHUB_WORKSPACE"
-
-          # dotenv stdout is suppressed via DOTENV_CONFIG_QUIET in the crux script.
-          # Progress messages go to stderr; only JSON goes to stdout.
-          RESULT=$(pnpm --silent crux auto-update risk-scores --from-report="${{ steps.report.outputs.path }}" --json 2>/dev/null || echo '{}')
-
-          # Validate JSON before parsing
-          if ! echo "$RESULT" | jq empty 2>/dev/null; then
-            echo "::warning::risk-scores produced invalid JSON, falling back to empty result"
-            RESULT='{}'
-          fi
-
-          SUMMARY=$(echo "$RESULT" | jq -r '.markdownSummary // ""')
-          HAS_HIGH=$(echo "$RESULT" | jq -r '.hasHighRisk // false')
-
-          {
-            echo "RISK_SUMMARY<<RISK_EOF"
-            echo "$SUMMARY"
-            echo "RISK_EOF"
-          } >> "$GITHUB_ENV"
-
-          if [ "$HAS_HIGH" = "true" ]; then
-            echo "::warning::High-risk pages detected"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for changes
-        id: changes
-        run: |
-          if git diff --quiet && git diff --staged --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No changes to commit"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected"
-          fi
-
-      - name: Commit and push
-        if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Security: stage only files the auto-update pipeline is expected to
-          # modify, not everything in the working tree.
-          git diff --name-only | while IFS= read -r file; do
-            if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
-              git add -- "$file"
-            else
-              echo "::warning::Skipping unexpected modified file from auto-update: $file"
-            fi
-          done
-
-          # Also stage any new (untracked) files in expected directories
-          git ls-files --others --exclude-standard -- 'content/docs/' 'data/' | while IFS= read -r file; do
-            if echo "$file" | grep -qE '^(content/docs/.*\.mdx|data/.*\.(yaml|yml))$'; then
-              git add -- "$file"
-            fi
-          done
-
-          if ! git diff --cached --quiet; then
-            git commit -m "auto-update: ${DATE} daily wiki refresh
-
-          Automated news-driven wiki update.
-          Run report: ${{ steps.report.outputs.path }}"
-            git push -u origin "$BRANCH"
-          else
-            echo "No expected auto-update changes to commit."
-          fi
-
-      - name: Create or update PR
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if PR already exists for this branch
-          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists, changes pushed to branch"
-          else
-            # Build PR body via TS script, with citation/risk summaries
-            BODY=$(pnpm crux auto-update pr-body \
-              --report="${{ steps.report.outputs.path }}" \
-              --date="$DATE" \
-              --citations="$CITATION_SUMMARY" \
-              --risk="$RISK_SUMMARY" 2>/dev/null || echo "## Auto-Update Run — ${DATE}")
-
-            BODY_FILE=$(mktemp)
-            echo "$BODY" > "$BODY_FILE"
-
-            gh pr create \
-              --title "Auto-update: ${DATE} daily wiki refresh" \
-              --body-file "$BODY_FILE" \
-              --label "auto-update" || echo "PR creation failed (label may not exist)"
-
-            rm -f "$BODY_FILE"
-          fi
-
-      - name: Summary
-        if: always()
-        run: |
-          REPORT="${{ steps.report.outputs.path }}"
-          if [ -n "$REPORT" ] && [ -f "$REPORT" ]; then
-            echo "## Auto-Update Summary" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```yaml' >> $GITHUB_STEP_SUMMARY
-            head -30 "$REPORT" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          else
-            echo "No run report generated" >> $GITHUB_STEP_SUMMARY
-          fi

--- a/crux/auto-update/ci-orchestrate.test.ts
+++ b/crux/auto-update/ci-orchestrate.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for CI orchestration utilities.
+ *
+ * Tests the pure helper functions (file allow-list) that are used by the
+ * CI orchestrator. The orchestrator itself is integration-heavy (git, GitHub API,
+ * subprocesses) and is covered by the workflow's own CI run.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isAutoUpdateAllowedFile } from './ci-orchestrate.ts';
+
+// ── isAutoUpdateAllowedFile ──────────────────────────────────────────────────
+
+describe('isAutoUpdateAllowedFile', () => {
+  it('allows content MDX files', () => {
+    expect(isAutoUpdateAllowedFile('content/docs/ai-safety.mdx')).toBe(true);
+    expect(isAutoUpdateAllowedFile('content/docs/internal/dashboard.mdx')).toBe(true);
+    expect(isAutoUpdateAllowedFile('content/docs/people/john-doe.mdx')).toBe(true);
+  });
+
+  it('allows data YAML files', () => {
+    expect(isAutoUpdateAllowedFile('data/entities/orgs.yaml')).toBe(true);
+    expect(isAutoUpdateAllowedFile('data/auto-update/state.yml')).toBe(true);
+    expect(isAutoUpdateAllowedFile('data/auto-update/runs/2026-03-04.yaml')).toBe(true);
+    expect(isAutoUpdateAllowedFile('data/facts/ai-safety.yaml')).toBe(true);
+  });
+
+  it('rejects TypeScript files', () => {
+    expect(isAutoUpdateAllowedFile('crux/commands/auto-update.ts')).toBe(false);
+    expect(isAutoUpdateAllowedFile('apps/web/src/app/page.tsx')).toBe(false);
+  });
+
+  it('rejects config and env files', () => {
+    expect(isAutoUpdateAllowedFile('.env')).toBe(false);
+    expect(isAutoUpdateAllowedFile('package.json')).toBe(false);
+    expect(isAutoUpdateAllowedFile('pnpm-lock.yaml')).toBe(false);
+    expect(isAutoUpdateAllowedFile('tsconfig.json')).toBe(false);
+  });
+
+  it('rejects workflow files', () => {
+    expect(isAutoUpdateAllowedFile('.github/workflows/auto-update.yml')).toBe(false);
+    expect(isAutoUpdateAllowedFile('.github/workflows/ci.yml')).toBe(false);
+  });
+
+  it('rejects non-MDX content files', () => {
+    expect(isAutoUpdateAllowedFile('content/docs/ai-safety.md')).toBe(false);
+    expect(isAutoUpdateAllowedFile('content/docs/ai-safety.txt')).toBe(false);
+  });
+
+  it('rejects files outside content/docs and data directories', () => {
+    expect(isAutoUpdateAllowedFile('apps/web/src/data/pages.json')).toBe(false);
+    expect(isAutoUpdateAllowedFile('docs/README.md')).toBe(false);
+  });
+
+  it('rejects paths with directory traversal', () => {
+    expect(isAutoUpdateAllowedFile('../content/docs/evil.mdx')).toBe(false);
+    expect(isAutoUpdateAllowedFile('content/../.env')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isAutoUpdateAllowedFile('')).toBe(false);
+  });
+});

--- a/crux/auto-update/ci-orchestrate.ts
+++ b/crux/auto-update/ci-orchestrate.ts
@@ -1,0 +1,577 @@
+/**
+ * CI Orchestration for Auto-Update
+ *
+ * Full CI pipeline that replaces the shell logic in .github/workflows/auto-update.yml.
+ * Runs as a single TypeScript entry point: `pnpm crux auto-update run-ci`.
+ *
+ * Steps:
+ *   1. Create date-stamped branch (auto-update/YYYY-MM-DD)
+ *   2. Run auto-update pipeline (fetch -> digest -> route -> improve)
+ *   3. Auto-fix: fix escaping, fix markdown, validate gate --fix
+ *   4. NEEDS CITATION cleanup (find markers, run improve, verify gone)
+ *   5. Paranoid content review on each changed page
+ *   6. Content quality checks (truncation + footnotes)
+ *   7. Find run report
+ *   8. Verify citations
+ *   9. Compute hallucination risk scores
+ *  10. Selective staging (only content/docs/*.mdx and data/*.yaml)
+ *  11. Commit and push
+ *  12. Create or update PR
+ */
+
+import { execFileSync } from 'child_process';
+import { basename, join } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { githubApi, REPO } from '../lib/github.ts';
+import { runPipeline } from './orchestrator.ts';
+import {
+  verifyCitationsForPages,
+  extractPageIdsFromReport,
+  findRunReport,
+} from './ci-verify-citations.ts';
+import { computeRiskScores } from './ci-risk-scores.ts';
+import { runContentChecks } from './ci-content-checks.ts';
+import { buildPrBody } from './ci-pr-body.ts';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface CiOrchestrateOptions {
+  budget: number;
+  count: number;
+  dryRun: boolean;
+  sources?: string;
+  verbose: boolean;
+}
+
+export interface CiOrchestrateResult {
+  branch: string;
+  hasChanges: boolean;
+  pagesUpdated: number;
+  prUrl: string | null;
+  exitCode: number;
+}
+
+// ── File allow-list ──────────────────────────────────────────────────────────
+
+/**
+ * Match only allowed file patterns for auto-update staging.
+ * Security-critical: prevents staging unexpected files (code, config, secrets).
+ */
+export function isAutoUpdateAllowedFile(path: string): boolean {
+  return /^(content\/docs\/.*\.mdx|data\/.*\.(yaml|yml))$/.test(path);
+}
+
+// ── Git helpers ──────────────────────────────────────────────────────────────
+
+function git(args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function configBotUser(): void {
+  git(['config', 'user.name', 'github-actions[bot]']);
+  git(['config', 'user.email', 'github-actions[bot]@users.noreply.github.com']);
+}
+
+function hasUnstagedOrUntracked(): boolean {
+  try {
+    const diffOutput = git(['diff', '--name-only']);
+    const untrackedOutput = git(['ls-files', '--others', '--exclude-standard']);
+    return diffOutput.length > 0 || untrackedOutput.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function hasStagedChanges(): boolean {
+  try {
+    git(['diff', '--cached', '--quiet']);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// ── Selective staging ────────────────────────────────────────────────────────
+
+interface StagingResult {
+  staged: string[];
+  skipped: string[];
+}
+
+function stageAllowedFiles(): StagingResult {
+  const staged: string[] = [];
+  const skipped: string[] = [];
+
+  // Stage modified tracked files
+  const modified = git(['diff', '--name-only']);
+  if (modified) {
+    for (const file of modified.split('\n').filter(Boolean)) {
+      if (isAutoUpdateAllowedFile(file)) {
+        git(['add', '--', file]);
+        staged.push(file);
+      } else {
+        skipped.push(file);
+      }
+    }
+  }
+
+  // Stage new untracked files in expected directories
+  const untracked = git(['ls-files', '--others', '--exclude-standard', '--', 'content/docs/', 'data/']);
+  if (untracked) {
+    for (const file of untracked.split('\n').filter(Boolean)) {
+      if (isAutoUpdateAllowedFile(file)) {
+        git(['add', '--', file]);
+        staged.push(file);
+      } else {
+        skipped.push(file);
+      }
+    }
+  }
+
+  return { staged, skipped };
+}
+
+// ── NEEDS CITATION cleanup ───────────────────────────────────────────────────
+
+function findNeedsCitationFiles(): string[] {
+  try {
+    const output = execFileSync('grep', ['-rl', 'NEEDS CITATION', 'content/docs/'], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return output ? output.split('\n').filter(Boolean) : [];
+  } catch {
+    // grep returns exit code 1 when no matches found
+    return [];
+  }
+}
+
+async function cleanupNeedsCitation(verbose: boolean): Promise<{ fixed: string[]; remaining: string[] }> {
+  const flagged = findNeedsCitationFiles();
+  if (flagged.length === 0) {
+    console.log('No NEEDS CITATION markers found -- content review passed.');
+    return { fixed: [], remaining: [] };
+  }
+
+  console.warn(`::warning::Found NEEDS CITATION markers in: ${flagged.join(', ')}`);
+  console.log('Running targeted improvement pass to remove uncited claims...');
+
+  const fixed: string[] = [];
+  for (const file of flagged) {
+    const pageId = basename(file, '.mdx');
+    console.log(`Fixing: ${pageId} (${file})`);
+
+    try {
+      execFileSync('pnpm', [
+        'crux', 'content', 'improve', pageId,
+        '--tier=polish', '--apply',
+        '--directions', 'Remove all {/* NEEDS CITATION */} markers and the content they flag. If a claim cannot be verified from your knowledge, remove it entirely rather than leaving uncited speculation. Do not add speculative content as a replacement.',
+      ], {
+        cwd: PROJECT_ROOT,
+        stdio: verbose ? 'inherit' : ['pipe', 'pipe', 'pipe'],
+        timeout: 300_000, // 5 minutes per page
+      });
+      fixed.push(pageId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`::warning::Could not auto-fix ${pageId} -- marker left in place: ${msg}`);
+    }
+  }
+
+  // Final check
+  const remaining = findNeedsCitationFiles();
+  if (remaining.length > 0) {
+    console.error(`::error::NEEDS CITATION markers remain after fix attempt: ${remaining.join(', ')}`);
+  } else {
+    console.log('All NEEDS CITATION markers resolved.');
+  }
+
+  return { fixed, remaining };
+}
+
+// ── Paranoid content review ──────────────────────────────────────────────────
+
+interface ReviewAlert {
+  pageId: string;
+  reason: string;
+}
+
+async function runParanoidReview(verbose: boolean): Promise<{ alerts: ReviewAlert[]; blocked: string[] }> {
+  // Find MDX files modified (not yet committed)
+  let changedMdx: string[];
+  try {
+    const diff = git(['diff', '--name-only', 'HEAD', '--', 'content/docs/']);
+    changedMdx = diff
+      ? diff.split('\n').filter(f => f.endsWith('.mdx'))
+      : [];
+  } catch {
+    changedMdx = [];
+  }
+
+  if (changedMdx.length === 0) {
+    console.log('No MDX files changed -- skipping paranoid review');
+    return { alerts: [], blocked: [] };
+  }
+
+  console.log(`Running paranoid review on ${changedMdx.length} changed page(s)...`);
+
+  const alerts: ReviewAlert[] = [];
+  const blocked: string[] = [];
+
+  for (const file of changedMdx) {
+    const pageId = basename(file, '.mdx');
+    console.log(`Reviewing: ${pageId} (${file})`);
+
+    let resultRaw: string;
+    try {
+      resultRaw = execFileSync('pnpm', [
+        '--silent', 'crux', 'content', 'review', pageId,
+        '--model=claude-haiku-4-5-20251001', '--json',
+      ], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 120_000, // 2 minutes per page
+      });
+    } catch {
+      console.warn(`::warning::${pageId} -- review failed`);
+      continue;
+    }
+
+    // Extract JSON line (guards against pnpm/dotenv preamble)
+    const jsonLine = resultRaw
+      .split('\n')
+      .filter(line => line.trim().startsWith('{'))
+      .pop();
+
+    if (!jsonLine) {
+      console.warn(`::warning::${pageId} -- review produced no JSON output`);
+      continue;
+    }
+
+    let result: {
+      needsReResearch?: boolean;
+      gapCount?: number;
+      overallAssessment?: string;
+      error?: string;
+    };
+    try {
+      result = JSON.parse(jsonLine);
+    } catch {
+      console.warn(`::warning::${pageId} -- review JSON parse failed`);
+      continue;
+    }
+
+    if (result.error) {
+      console.warn(`::warning::${pageId} -- review error: ${result.error}`);
+    } else if (result.needsReResearch) {
+      const reason = `needs re-research (${result.gapCount ?? 0} gap(s)): ${result.overallAssessment ?? 'unknown'}`;
+      console.error(`::error::${pageId} -- ${reason}`);
+      blocked.push(pageId);
+      alerts.push({ pageId, reason });
+    } else if ((result.gapCount ?? 0) > 0) {
+      const reason = `${result.gapCount} gap(s) (editorial): ${result.overallAssessment ?? 'unknown'}`;
+      console.warn(`::warning::${pageId} -- ${reason}`);
+      alerts.push({ pageId, reason });
+    } else {
+      console.log(`  ${pageId}: clean`);
+    }
+  }
+
+  if (blocked.length > 0) {
+    console.error(`::error::Paranoid review blocked commit for: ${blocked.join(', ')}`);
+  } else {
+    console.log('All changed pages passed paranoid review');
+  }
+
+  return { alerts, blocked };
+}
+
+// ── Main orchestrator ────────────────────────────────────────────────────────
+
+export async function orchestrateCiAutoUpdate(
+  options: CiOrchestrateOptions,
+): Promise<CiOrchestrateResult> {
+  const date = new Date().toISOString().slice(0, 10);
+  const branch = `auto-update/${date}`;
+  let reportPath: string | null = null;
+
+  console.log(`=== Auto-Update CI Orchestration (${date}) ===`);
+  console.log(`Budget: $${options.budget}, Count: ${options.count}, Dry run: ${options.dryRun}`);
+
+  // ── Step 1: Create date-stamped branch ──
+  console.log('\n--- Step 1: Create branch ---');
+  try {
+    git(['checkout', '-b', branch]);
+    console.log(`Created branch: ${branch}`);
+  } catch {
+    // Branch may already exist if re-running on the same day
+    try {
+      git(['checkout', branch]);
+      console.log(`Switched to existing branch: ${branch}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to create or switch to branch ${branch}: ${msg}`);
+      return { branch, hasChanges: false, pagesUpdated: 0, prUrl: null, exitCode: 1 };
+    }
+  }
+
+  // ── Step 2: Run auto-update pipeline ──
+  console.log('\n--- Step 2: Run auto-update pipeline ---');
+  let pagesUpdated = 0;
+  try {
+    const { report, reportPath: rp } = await runPipeline({
+      budget: String(options.budget),
+      count: String(options.count),
+      dryRun: options.dryRun,
+      sources: options.sources,
+      verbose: options.verbose,
+      trigger: 'scheduled',
+    });
+    reportPath = rp;
+    pagesUpdated = report.execution.pagesUpdated;
+    console.log(`Pipeline complete: ${pagesUpdated} page(s) updated, report at ${reportPath}`);
+
+    if (report.execution.pagesFailed > 0) {
+      console.warn(`::warning::${report.execution.pagesFailed} page(s) failed during pipeline`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Pipeline failed: ${msg}`);
+    return { branch, hasChanges: false, pagesUpdated: 0, prUrl: null, exitCode: 1 };
+  }
+
+  // ── Step 3: Auto-fix (escaping, markdown, gate) ──
+  console.log('\n--- Step 3: Run validation fixes ---');
+  try {
+    execFileSync('pnpm', ['crux', 'fix', 'escaping'], {
+      cwd: PROJECT_ROOT,
+      stdio: 'inherit',
+    });
+  } catch (err) {
+    console.warn(`::warning::fix escaping failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    execFileSync('pnpm', ['crux', 'fix', 'markdown'], {
+      cwd: PROJECT_ROOT,
+      stdio: 'inherit',
+    });
+  } catch (err) {
+    console.warn(`::warning::fix markdown failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    execFileSync('pnpm', ['crux', 'validate', 'gate', '--fix'], {
+      cwd: PROJECT_ROOT,
+      stdio: 'inherit',
+    });
+  } catch {
+    console.warn('::warning::Validation issues found (gate --fix)');
+  }
+
+  // ── Step 4: NEEDS CITATION cleanup ──
+  console.log('\n--- Step 4: NEEDS CITATION cleanup ---');
+  const citationCleanup = await cleanupNeedsCitation(options.verbose);
+  if (citationCleanup.remaining.length > 0) {
+    console.error('NEEDS CITATION markers remain -- manual review required before merging.');
+    return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 1 };
+  }
+
+  // ── Step 5: Paranoid content review ──
+  console.log('\n--- Step 5: Paranoid content review ---');
+  const review = await runParanoidReview(options.verbose);
+  if (review.blocked.length > 0) {
+    console.error('Paranoid review blocked commit. Re-run the improve pipeline on blocked pages.');
+    return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 1 };
+  }
+
+  // ── Step 6: Content quality checks ──
+  console.log('\n--- Step 6: Content quality checks ---');
+  const contentChecks = runContentChecks({ baseBranch: 'HEAD' });
+  if (!contentChecks.passed) {
+    console.error(`Content quality checks failed: ${contentChecks.markdownSummary}`);
+    return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 1 };
+  }
+  console.log('Content quality checks passed.');
+
+  // ── Step 7: Find run report ──
+  console.log('\n--- Step 7: Find run report ---');
+  if (!reportPath) {
+    reportPath = findRunReport(date);
+  }
+  if (reportPath) {
+    console.log(`Found report: ${reportPath}`);
+  } else {
+    console.log('No report found');
+  }
+
+  // ── Step 8: Verify citations ──
+  let citationSummary: string | undefined;
+  if (reportPath) {
+    console.log('\n--- Step 8: Verify citations ---');
+    const pageIds = extractPageIdsFromReport(reportPath);
+    if (pageIds.length > 0) {
+      try {
+        const citationResult = await verifyCitationsForPages(pageIds);
+        citationSummary = citationResult.markdownSummary;
+        if (citationResult.hasBroken) {
+          console.warn('::warning::Broken citations detected');
+        }
+        console.log(`Citation verification complete: ${citationResult.totalVerified} verified, ${citationResult.totalBroken} broken`);
+      } catch (err) {
+        console.warn(`::warning::Citation verification failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      console.log('No successful pages in report -- skipping citation verification');
+    }
+  }
+
+  // ── Step 9: Compute hallucination risk scores ──
+  let riskSummary: string | undefined;
+  if (reportPath) {
+    console.log('\n--- Step 9: Compute hallucination risk scores ---');
+
+    // Rebuild data layer so risk scoring sees updated content
+    try {
+      execFileSync('node', ['--import', 'tsx/esm', 'scripts/build-data.mjs'], {
+        cwd: join(PROJECT_ROOT, 'apps/web'),
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+    } catch (err) {
+      console.warn(`::warning::Data rebuild for risk scoring failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const pageIds = extractPageIdsFromReport(reportPath);
+    if (pageIds.length > 0) {
+      try {
+        const riskResult = await computeRiskScores(pageIds);
+        riskSummary = riskResult.markdownSummary;
+        if (riskResult.hasHighRisk) {
+          console.warn('::warning::High-risk pages detected');
+        }
+        console.log(`Risk scoring complete: ${riskResult.pages.length} page(s) assessed`);
+      } catch (err) {
+        console.warn(`::warning::Risk scoring failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      console.log('No successful pages in report -- skipping risk scoring');
+    }
+  }
+
+  // ── Step 10: Check for changes ──
+  console.log('\n--- Step 10: Check for changes ---');
+  if (!hasUnstagedOrUntracked()) {
+    console.log('No changes to commit');
+    return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 0 };
+  }
+
+  // ── Step 11: Selective staging, commit, and push ──
+  console.log('\n--- Step 11: Commit and push ---');
+  configBotUser();
+
+  const { staged, skipped } = stageAllowedFiles();
+  if (skipped.length > 0) {
+    for (const file of skipped) {
+      console.warn(`::warning::Skipping unexpected modified file from auto-update: ${file}`);
+    }
+  }
+
+  if (!hasStagedChanges()) {
+    console.log('No expected auto-update changes to commit.');
+    return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 0 };
+  }
+
+  console.log(`Staged ${staged.length} file(s)`);
+
+  const commitMsg = `auto-update: ${date} daily wiki refresh\n\nAutomated news-driven wiki update.\nRun report: ${reportPath || 'N/A'}`;
+  git(['commit', '-m', commitMsg]);
+  git(['push', '-u', 'origin', branch]);
+  console.log(`Pushed to origin/${branch}`);
+
+  // ── Step 12: Create or update PR ──
+  console.log('\n--- Step 12: Create or update PR ---');
+  let prUrl: string | null = null;
+
+  try {
+    // Check for existing PR
+    interface PrListItem {
+      number: number;
+      html_url: string;
+    }
+    const existingPrs = await githubApi<PrListItem[]>(
+      `/repos/${REPO}/pulls?head=quantified-uncertainty:${branch}&state=open`,
+    );
+
+    if (existingPrs && existingPrs.length > 0) {
+      prUrl = existingPrs[0].html_url;
+      console.log(`PR #${existingPrs[0].number} already exists, changes pushed to branch`);
+      console.log(`  URL: ${prUrl}`);
+    } else {
+      // Build PR body
+      const body = buildPrBody({
+        reportPath,
+        date,
+        citationSummary,
+        riskSummary,
+      });
+
+      interface PrCreateResult {
+        number: number;
+        html_url: string;
+      }
+      const pr = await githubApi<PrCreateResult>(
+        `/repos/${REPO}/pulls`,
+        {
+          method: 'POST',
+          body: {
+            title: `Auto-update: ${date} daily wiki refresh`,
+            body,
+            head: branch,
+            base: 'main',
+          },
+        },
+      );
+      prUrl = pr.html_url;
+      console.log(`Created PR #${pr.number}: ${prUrl}`);
+
+      // Try to add auto-update label (non-fatal if label doesn't exist)
+      try {
+        await githubApi(
+          `/repos/${REPO}/issues/${pr.number}/labels`,
+          {
+            method: 'POST',
+            body: { labels: ['auto-update'] },
+          },
+        );
+      } catch (err) {
+        console.warn(`::warning::Could not add label: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`PR creation failed: ${msg}`);
+    // Non-fatal -- the branch is pushed, PR can be created manually
+  }
+
+  // ── Summary ──
+  console.log('\n=== Auto-Update CI Complete ===');
+  console.log(`Branch: ${branch}`);
+  console.log(`Pages updated: ${pagesUpdated}`);
+  console.log(`Staged files: ${staged.length}`);
+  if (prUrl) console.log(`PR: ${prUrl}`);
+
+  return {
+    branch,
+    hasChanges: true,
+    pagesUpdated,
+    prUrl,
+    exitCode: 0,
+  };
+}

--- a/crux/commands/auto-update.ts
+++ b/crux/commands/auto-update.ts
@@ -36,6 +36,7 @@ import {
 import { computeRiskScores } from '../auto-update/ci-risk-scores.ts';
 import { runContentChecks } from '../auto-update/ci-content-checks.ts';
 import { buildPrBody } from '../auto-update/ci-pr-body.ts';
+import { orchestrateCiAutoUpdate } from '../auto-update/ci-orchestrate.ts';
 import { createJob } from '../lib/wiki-server/jobs.ts';
 import type { AutoUpdateOptions, RunReport } from '../auto-update/types.ts';
 import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
@@ -628,11 +629,28 @@ async function contentChecks(args: string[], options: AutoUpdateOptions): Promis
   return { output, exitCode: result.passed ? 0 : 1 };
 }
 
+/**
+ * Full CI orchestration: branch, pipeline, validation, review, commit, PR.
+ * Replaces the shell logic in .github/workflows/auto-update.yml.
+ */
+async function runCi(args: string[], options: AutoUpdateOptions): Promise<CommandResult> {
+  const result = await orchestrateCiAutoUpdate({
+    budget: parseFloat(options.budget || '30'),
+    count: parseIntOpt(options.count, 5),
+    dryRun: Boolean(options.dryRun || options['dry-run']),
+    sources: options.sources || undefined,
+    verbose: Boolean(options.verbose),
+  });
+
+  return { output: '', exitCode: result.exitCode };
+}
+
 // ── Command Registry ────────────────────────────────────────────────────────
 
 export const commands = {
   default: plan,
   run,
+  'run-ci': runCi,
   digest,
   plan,
   sources,
@@ -657,6 +675,7 @@ Pipeline: fetch sources → build digest → route to pages → execute updates
 Commands:
   plan                 Show what would be updated (default)
   run                  Execute the full auto-update pipeline
+  run-ci               Full CI orchestration: branch, pipeline, validate, review, commit, PR
   submit               Submit as background jobs (parallel via job queue)
   digest               Fetch sources and show news digest only
   sources              List configured news sources
@@ -716,6 +735,7 @@ Examples:
   crux auto-update audit-gate existential-risk   Audit a specific page
   crux auto-update submit --budget=30            Submit as parallel background jobs
   crux auto-update submit --dry-run              Preview job plan without creating jobs
+  crux auto-update run-ci --budget=30 --count=5  Full CI pipeline (used by GitHub Actions)
 `;
 
 }


### PR DESCRIPTION
## Summary

Extracts ~280 lines of shell logic from `.github/workflows/auto-update.yml` into a structured TypeScript module (`crux/auto-update/ci-orchestrate.ts`), invoked via `pnpm crux auto-update run-ci`.

- **New file**: `crux/auto-update/ci-orchestrate.ts` -- full CI orchestration (branch creation, pipeline execution, validation fixes, NEEDS CITATION cleanup, paranoid review, content quality checks, citation verification, risk scoring, selective staging, commit/push, PR creation)
- **New file**: `crux/auto-update/ci-orchestrate.test.ts` -- 9 tests for `isAutoUpdateAllowedFile()` security allow-list
- **Modified**: `crux/commands/auto-update.ts` -- added `run-ci` subcommand and help text
- **Slimmed**: `.github/workflows/auto-update.yml` -- from 400 lines to 121 lines (kept triggers, permissions, concurrency, preflight, setup, cache, single `run-ci` call)

### Benefits over shell approach
- **Testable**: Pure functions like `isAutoUpdateAllowedFile()` have unit tests
- **Type-safe**: Programmatic imports from existing CI helpers instead of subprocess JSON parsing with jq
- **Debuggable**: Can run locally via `pnpm crux auto-update run-ci --dry-run --verbose`
- **Maintainable**: Structured TypeScript with clear step numbering vs fragile shell with heredocs and env variable passing

### What stayed in YAML
GitHub Actions primitives that cannot move to TypeScript: trigger config, permissions, concurrency, checkout, pnpm/node setup, `actions/cache` for state.yaml, and the build-data step.
