### PR TITLE
Add quality monitoring to maintenance workflow and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # --- Security: dependency audit (advisory, non-blocking) ---
+
+      - name: Dependency security audit
+        continue-on-error: true
+        run: pnpm audit --audit-level=high 2>/dev/null || echo "::warning::Dependency audit found high-severity vulnerabilities — run 'pnpm audit' locally for details"
+
       # --- Build data (once, shared by all subsequent steps) ---
 
       - name: Build data

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -134,6 +134,8 @@ jobs:
             2. Read the report. Focus on recurring issues (marked with `!!`).
             3. If recurring issues exist, add them to `.claude/common-issues.md`.
             4. Check for issues flagged as "potentially-resolved" — but DO NOT auto-close them (see rules below).
+            5. Run `pnpm crux audits run-auto` — check automated audit items (e.g., agent session logging, scheduled workflow health). If any check fails, file or comment on a GitHub issue.
+            6. Run `pnpm crux maintain fix-chains` — check for recent fix chains (feature PRs followed by 2+ fix PRs). If the fix-to-feature ratio exceeds 40%, note it in the report summary.
 
             ### If cadence = weekly
             1. Run `pnpm crux maintain` (full sweep).
@@ -144,6 +146,12 @@ jobs:
                - P2: Propagate recurring learnings to `.claude/common-issues.md` or `.claude/rules/`.
             4. For P3+ items that are too large to fix now, file GitHub issues so they're tracked.
             5. Run `pnpm crux validate` and fix any blocking errors.
+            6. Run `pnpm crux audits run-auto` and `pnpm crux audits list --pending` — check all audit items and flag any that are overdue.
+            7. Run a **retrospective analysis** (as described in `.claude/commands/retrospective.md`):
+               a. Run `pnpm crux maintain fix-chains` to identify fix chains from the past 7 days.
+               b. Calculate the fix-to-feature ratio from merged PRs. If >35%, flag it prominently.
+               c. Check for PRs over 500 lines — were they split? Did they generate fix chains?
+               d. Summarize findings in the PR body. If process improvements are needed, update `.claude/rules/` files or file issues.
 
             ### If cadence = monthly
             1. Do everything from the weekly cadence.


### PR DESCRIPTION
## Summary

Schedules three existing-but-unused quality tools to run automatically:

- **Daily maintenance**: Now runs `crux audits run-auto` (checks audit items like session logging, workflow health) and `crux maintain fix-chains` (detects fix-PR chains, flags when fix ratio >40%)
- **Weekly maintenance**: Now includes a retrospective analysis — fix chains, fix-to-feature ratio, PR size distribution — alongside the existing full sweep. Also runs `crux audits list --pending` to flag overdue audit items.
- **CI**: Adds `pnpm audit --audit-level=high` as an advisory (non-blocking) step. GitHub already reports 4 vulnerabilities on the default branch.

## Context

These changes come from a systematic investigation of the last 200 merged PRs. Key findings:

- Fix-PR ratio trending from 25% to 48% over 6 days — invisible without monitoring
- 2-day CI outage went undetected
- 7 audit items existed but had never been checked (last_checked: null)
- /retrospective command existed but was never scheduled

All three tools already existed and work correctly. This PR just wires them into the scheduled workflows.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/scheduled-maintenance.yml` | Add steps 5-6 to daily, steps 6-7 to weekly |
| `.github/workflows/ci.yml` | Add advisory pnpm audit step before build |

## Test plan

- [x] `pnpm crux audits run-auto` — works (tested locally)
- [x] `pnpm crux maintain fix-chains` — works (tested locally)
- [x] YAML syntax validated (no tabs, prompt block at 12+ indent)
- [x] Gate check passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)