### PR TITLE
fix: address CodeRabbit review feedback on release command

### DIFF
--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -251,8 +251,9 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
   await ensureLabel();
 
   // Check for existing open release PR
+  const [repoOwner] = REPO.split('/');
   const existingPRs = await githubApi<GitHubPR[]>(
-    `/repos/${REPO}/pulls?base=production&head=quantified-uncertainty:main&state=open`
+    `/repos/${REPO}/pulls?base=production&head=${repoOwner}:main&state=open`
   );
 
   if (existingPRs.length > 0) {

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -41,6 +41,7 @@
  *   health      System wellness checks (server, DB, GitHub Actions, frontend, data freshness)
  *   ids         Entity ID allocation and lookup (allocate, check, list)
  *   audits      System-level behavioral verification (ongoing + post-merge)
+ *   release     Production release management (create release PRs from main → production)
  *
  * Global Options:
  *   --ci        JSON output for CI pipelines
@@ -219,6 +220,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   ids         Entity ID allocation and lookup (allocate, check, list)
   statements  Extract and verify structured statements from wiki pages
   audits      System-level behavioral verification (ongoing + post-merge)
+  release     Production release management (main → production)
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines


### PR DESCRIPTION
## Summary

- Derive repo owner from `REPO` constant instead of hardcoding `quantified-uncertainty` in the open-PR lookup query (fixes portability)
- Add `release` domain to CLI help output (`showHelp()`) and top JSDoc comment

Addresses CodeRabbit review comments from #1680:
- https://github.com/quantified-uncertainty/longterm-wiki/pull/1680#discussion_r2887074944
- https://github.com/quantified-uncertainty/longterm-wiki/pull/1680#discussion_r2887074950

## Test plan
- [x] `vitest run crux/commands/release.test.ts` — all 15 tests pass
- [x] `pnpm crux release --help` shows release domain help
- [x] `pnpm crux --help` lists `release` in domain list

🤖 Generated with [Claude Code](https://claude.com/claude-code)