### PR TITLE
fix: disable groundskeeper issue-responder autofix

### DIFF
--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -4,7 +4,7 @@ import { registerTask, setGroundskeeperAgentId } from "./scheduler.js";
 import { sendDiscordNotification } from "./notify.js";
 import { healthCheck } from "./tasks/health-check.js";
 import { registerAsActiveAgent, sendHeartbeat } from "./wiki-server.js";
-import { issueResponder } from "./tasks/issue-responder.js";
+// import { issueResponder } from "./tasks/issue-responder.js"; // disabled
 import { githubShadowbanCheck } from "./tasks/github-shadowban-check.js";
 import { snapshotRetention } from "./tasks/snapshot-retention.js";
 import { logger } from "./logger.js";
@@ -20,7 +20,7 @@ logger.info({
       schedule: config.tasks.healthCheck.schedule,
     },
     issueResponder: {
-      enabled: config.tasks.issueResponder.enabled,
+      enabled: false, // hard-disabled in code
       schedule: config.tasks.issueResponder.schedule,
     },
     githubShadowbanCheck: {
@@ -45,13 +45,16 @@ registerTask(
   () => healthCheck(config)
 );
 
-registerTask(
-  config,
-  "issue-responder",
-  config.tasks.issueResponder.schedule,
-  config.tasks.issueResponder.enabled,
-  () => issueResponder(config)
-);
+// Issue responder disabled — was broken and repeatedly failing on issues.
+// See: https://github.com/quantified-uncertainty/longterm-wiki/issues/TBD
+// To re-enable, uncomment and fix the underlying issue-responder task.
+// registerTask(
+//   config,
+//   "issue-responder",
+//   config.tasks.issueResponder.schedule,
+//   config.tasks.issueResponder.enabled,
+//   () => issueResponder(config)
+// );
 
 registerTask(
   config,


### PR DESCRIPTION
## Summary
- Disables the groundskeeper issue-responder task that auto-picks up issues labeled `groundskeeper-autofix`
- The task was repeatedly picking up issues, failing, and re-attempting — creating noise without fixing anything
- Code is commented out (not deleted) so it can be re-enabled after the underlying issues are diagnosed

## Test plan
- [ ] Verify groundskeeper deploys without the issue-responder task running
- [ ] Confirm no more spurious "Groundskeeper is picking up this issue" comments on labeled issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)