### PR TITLE
fix: eliminate silent data truncation from hard-coded fetch limits

### DIFF
--- a/apps/wiki-server/src/routes/sessions.ts
+++ b/apps/wiki-server/src/routes/sessions.ts
@@ -454,6 +454,9 @@ const sessionsApp = new Hono()
         )
       : undefined;
 
+    // Use a high limit and warn on truncation; insights are internal-only and grow slowly.
+    // If the session count ever approaches this limit, switch to pagination.
+    const INSIGHTS_LIMIT = 5000;
     const rows = await db
       .select({
         date: sessions.date,
@@ -465,7 +468,13 @@ const sessionsApp = new Hono()
       .from(sessions)
       .where(whereClause)
       .orderBy(desc(sessions.date), desc(sessions.id))
-      .limit(500);
+      .limit(INSIGHTS_LIMIT);
+
+    if (rows.length === INSIGHTS_LIMIT) {
+      console.warn(
+        `[sessions/insights] Result count hit limit (${INSIGHTS_LIMIT}); insights may be truncated. Consider adding pagination.`
+      );
+    }
 
     type Insight = {
       date: string;

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -3,8 +3,11 @@
 /**
  * System Wellness Check
  *
- * Mirrors the checks in .github/workflows/wellness-check.yml so the same
+ * Mirrors the checks in the focused health workflows so the same
  * health signals can be monitored locally or in ad-hoc debugging sessions.
+ *   .github/workflows/server-api-health.yml
+ *   .github/workflows/frontend-data-health.yml
+ *   .github/workflows/ci-pr-health.yml
  *
  * Usage:
  *   crux health                      Run all checks


### PR DESCRIPTION
## Summary

- Replace hard-coded `?limit=500` single-fetch in `statements-content.tsx` (internal Statements dashboard) with a `fetchAllStatementsPaginated()` helper that pages through all results — prevents silent truncation of the dashboard table and wrong entity-count stats when total exceeds 500
- Replace hard-coded `?limit=200` single-fetch in `property-explorer-content.tsx` (internal Property Explorer dashboard) with the same paginating approach — prevents wrong entity-to-property coverage counts when total exceeds 200
- Raise the hard-coded `.limit(500)` in the `/insights` endpoint of `sessions.ts` to `INSIGHTS_LIMIT = 5000` with a `console.warn` when the limit is hit — converts a silent cap to a visible warning; documents when pagination is needed

Both web fixes also log a `console.warn` when multi-page fetching triggers, so operators can see when data volumes are growing.

**Why these were the real problems (not the `fetchAllStatements` in statements-data.ts):**
The functions that were already paginating correctly:
- `statements-data.ts` `fetchAllStatements()` — already paginates
- `statements/page.tsx` `fetchAllStatementsDetailed()` — already paginates
- `statements/properties/page.tsx` `fetchAllStatementsForProperties()` — already paginates
- `claims-data.ts` `fetchAllClaims()` — already paginates

The actual silent-truncation bugs were in the two internal dashboards that used a raw hard-coded limit without checking `total`.

## Test plan

- [ ] Open `/internal/statements` dashboard and confirm the table loads all statements (not capped at 500); if statement count < 500, check network tab to verify `?limit=500&offset=0` is used
- [ ] Open `/internal/property-explorer` dashboard and confirm entity-to-property coverage counts are not truncated (previously capped at 200); if statement count < 200, check network tab to verify `?limit=500&offset=0` is used
- [ ] When statement count exceeds 500 (or 200 for property-explorer), verify `console.warn` appears in server logs indicating multi-page fetch was triggered
- [ ] Call `/api/sessions/insights` with a wiki-server that has >500 sessions and confirm all rows are returned (up to 5000), and that hitting exactly 5000 emits a `console.warn` in wiki-server logs
- [ ] `pnpm build` exits 0 with no TypeScript errors
- [ ] `pnpm test` passes — the new `statements-boundary-validation.test.ts` suite covers paginator logic

Closes #1650