### PR TITLE
fix: resolve failing groundskeeper tasks snapshot-retention and github-shadowban-check

### DIFF
--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -80,7 +80,15 @@ export function loadConfig(): Config {
         enabled: envBool("TASK_GITHUB_SHADOWBAN_CHECK_ENABLED", true),
         schedule:
           process.env["TASK_GITHUB_SHADOWBAN_CHECK_SCHEDULE"] ?? "0 9 * * *",
-        usernames: ["quri-bot"],
+        // Default to empty — no dedicated bot account exists for this project.
+        // Populate TASK_GITHUB_SHADOWBAN_CHECK_USERNAMES (comma-separated) if
+        // a custom GitHub automation account is created and needs monitoring.
+        // Previously hardcoded "quri-bot" which does not exist on GitHub,
+        // causing every run to return 404 -> "banned" -> success: false.
+        usernames: (process.env["TASK_GITHUB_SHADOWBAN_CHECK_USERNAMES"] ?? "")
+          .split(",")
+          .map((u) => u.trim())
+          .filter(Boolean),
       },
       snapshotRetention: {
         enabled: envBool("TASK_SNAPSHOT_RETENTION_ENABLED", true),

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -38,12 +38,16 @@ describe("snapshotRetention", () => {
 
   beforeEach(() => {
     config = makeConfig();
-    process.env["WIKI_SERVER_API_KEY"] = "test-key";
+    // Use LONGTERMWIKI_CONTENT_KEY — the content-scoped key required for
+    // cleanup endpoints (DELETE /api/hallucination-risk/cleanup and
+    // DELETE /api/citations/accuracy-snapshots/cleanup).
+    process.env["LONGTERMWIKI_CONTENT_KEY"] = "test-content-key";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete process.env["WIKI_SERVER_API_KEY"];
+    delete process.env["LONGTERMWIKI_CONTENT_KEY"];
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
   });
 
   it("returns success when both cleanups succeed", async () => {
@@ -102,13 +106,37 @@ describe("snapshotRetention", () => {
     expect(result.summary).toContain("citation_accuracy: FAILED");
   });
 
-  it("returns failure when API key is not set", async () => {
-    delete process.env["WIKI_SERVER_API_KEY"];
+  it("returns failure when no API key is set", async () => {
+    // Clear both content key and legacy superkey — neither is available
+    delete process.env["LONGTERMWIKI_CONTENT_KEY"];
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
 
     const result = await snapshotRetention(config);
 
     expect(result.success).toBe(false);
     expect(result.summary).toContain("FAILED");
+  });
+
+  it("uses LONGTERMWIKI_SERVER_API_KEY as fallback when content key is absent", async () => {
+    delete process.env["LONGTERMWIKI_CONTENT_KEY"];
+    process.env["LONGTERMWIKI_SERVER_API_KEY"] = "legacy-superkey";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ deleted: 5, keep: 100 }),
+      })
+    );
+
+    const result = await snapshotRetention(config);
+
+    expect(result.success).toBe(true);
+    // Verify the legacy Bearer token was sent
+    const calls = vi.mocked(fetch).mock.calls;
+    expect((calls[0][1] as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer legacy-superkey",
+    });
   });
 
   it("still runs second cleanup when first throws", async () => {

--- a/apps/groundskeeper/src/tasks/snapshot-retention.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.ts
@@ -11,6 +11,14 @@ interface CleanupResult {
 /**
  * Call the wiki-server cleanup endpoint for a snapshot table.
  * Returns the number of rows deleted, or null on failure.
+ *
+ * The cleanup endpoints (/api/hallucination-risk/cleanup and
+ * /api/citations/accuracy-snapshots/cleanup) require `content` scope.
+ * Use LONGTERMWIKI_CONTENT_KEY for the content-scoped key, or fall back
+ * to LONGTERMWIKI_SERVER_API_KEY (legacy superkey that grants all scopes).
+ *
+ * Do NOT use WIKI_SERVER_API_KEY here — that key has `project` scope only
+ * and will be rejected with 403 on content-scope DELETE endpoints.
  */
 async function callCleanupEndpoint(
   config: Config,
@@ -18,10 +26,18 @@ async function callCleanupEndpoint(
   keep: number,
 ): Promise<CleanupResult | null> {
   const url = `${config.wikiServerUrl}${path}?keep=${keep}`;
-  const apiKey = process.env["WIKI_SERVER_API_KEY"];
+  // Use content-scoped key for cleanup endpoints (require `content` scope).
+  // Fall back to legacy superkey which grants all scopes.
+  const apiKey =
+    process.env["LONGTERMWIKI_CONTENT_KEY"] ??
+    process.env["LONGTERMWIKI_SERVER_API_KEY"];
 
   if (!apiKey) {
-    logger.warn("WIKI_SERVER_API_KEY not set, skipping cleanup");
+    logger.warn(
+      "Neither LONGTERMWIKI_CONTENT_KEY nor LONGTERMWIKI_SERVER_API_KEY is set — skipping cleanup. " +
+        "Set LONGTERMWIKI_CONTENT_KEY (content-scoped) or LONGTERMWIKI_SERVER_API_KEY (legacy superkey) " +
+        "in the groundskeeper environment.",
+    );
     return null;
   }
 


### PR DESCRIPTION
## Summary

- **`snapshot-retention` root cause**: The task called `DELETE /api/hallucination-risk/cleanup` and `DELETE /api/citations/accuracy-snapshots/cleanup`, both of which require `content` scope. However, the task was reading `WIKI_SERVER_API_KEY` — the project-scoped key used for run recording — which only grants `project` scope. Every request got a 403, causing 30s of auth failures. Fixed by using `LONGTERMWIKI_CONTENT_KEY` (content-scoped key) with fallback to `LONGTERMWIKI_SERVER_API_KEY` (legacy superkey that grants all scopes).

- **`github-shadowban-check` root cause**: The task was hardcoded to monitor `quri-bot`, a GitHub account that does not exist. Every check returned HTTP 404, which the task correctly interprets as "account banned" → `success: false`. Fixed by defaulting to an empty username list and reading from the `TASK_GITHUB_SHADOWBAN_CHECK_USERNAMES` environment variable (comma-separated). The task now returns `success: true` with "No usernames configured to monitor" when the list is empty.

- **Error surfacing**: Both tasks were already logging errors (snapshot-retention at `error` level with HTTP status, github-shadowban at `warn` level for API errors). The fixes make the errors actionable rather than silencing them.

## Files changed

- `apps/groundskeeper/src/tasks/snapshot-retention.ts` — use `LONGTERMWIKI_CONTENT_KEY` (content-scoped) instead of `WIKI_SERVER_API_KEY` (project-scoped)
- `apps/groundskeeper/src/config.ts` — read `TASK_GITHUB_SHADOWBAN_CHECK_USERNAMES` env var instead of hardcoding `quri-bot`
- `apps/groundskeeper/src/tasks/snapshot-retention.test.ts` — update tests to use new env var names; add fallback test

## Production action required

After merging, two environment variables need to be set in the groundskeeper's Kubernetes deployment:

1. **`LONGTERMWIKI_CONTENT_KEY`** — the content-scoped API key for the wiki-server. This is the same key used by the build pipeline for syncing pages/entities/facts. Set this to allow `snapshot-retention` to run successfully.

2. **`TASK_GITHUB_SHADOWBAN_CHECK_USERNAMES`** — optional. Leave empty (or omit) unless a custom GitHub automation account is created and needs shadow-ban monitoring.

Closes #1616