### PR TITLE
refactor: split wellness-check.yml into 3 focused per-concern workflows

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -55,17 +55,19 @@ audits:
 
   - id: scheduled-workflows-running
     category: infrastructure
-    description: "All scheduled GitHub Actions (wellness-check, maintenance, auto-update, server-health-monitor) ran within expected windows"
+    description: "All scheduled GitHub Actions (server-api-health, frontend-data-health, ci-pr-health, maintenance, auto-update, server-health-monitor) ran within expected windows"
     check_type: hybrid
     check_command: |
-      for wf in wellness-check.yml scheduled-maintenance.yml auto-update.yml server-health-monitor.yml; do
+      for wf in server-api-health.yml frontend-data-health.yml ci-pr-health.yml scheduled-maintenance.yml auto-update.yml server-health-monitor.yml; do
         echo "=== $wf ==="
         gh api "repos/quantified-uncertainty/longterm-wiki/actions/workflows/$wf/runs?per_page=3" \
           --jq '.workflow_runs[:3] | .[] | "\(.created_at) \(.conclusion)"' 2>/dev/null || echo "failed to fetch"
       done
     how_to_verify: |
       Review the check_command output. Each workflow should have recent successful runs:
-      - wellness-check: twice daily (within 24h)
+      - server-api-health: twice daily (within 24h)
+      - frontend-data-health: twice daily (within 24h)
+      - ci-pr-health: twice daily (within 24h)
       - scheduled-maintenance: daily on weekdays (within 48h)
       - auto-update: daily (within 48h)
       - server-health-monitor: weekly (within 9 days)

--- a/.github/workflows/ci-pr-health.yml
+++ b/.github/workflows/ci-pr-health.yml
@@ -1,17 +1,11 @@
-name: Wellness Check
+name: CI & PR Health
 
-# Comprehensive twice-daily health audit of the entire system.
-#
-# All check logic lives in TypeScript (crux/health/). This workflow
-# is a thin orchestration layer that runs the checks and manages
-# GitHub issues automatically.
+# Checks GitHub Actions workflow health, job queue status, and PR/issue quality.
+# Also cleans up stale claude-working labels.
+# Runs twice daily — same schedule as the unified wellness check it replaced.
 #
 # Checks performed:
-#   - Server & DB sanity (counts in expected ranges, uptime)
-#   - API smoke tests (search, page fetch, entity list)
 #   - GitHub Actions workflow health (scheduled jobs running?)
-#   - Frontend availability (Vercel URL returns content)
-#   - Data freshness (last sync time, recent edits)
 #   - Job queue health (failure rates, pending backlogs)
 #   - PR & issue quality (empty bodies, stale PRs, stuck labels)
 #
@@ -24,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: wellness-check
+  group: ci-pr-health
   cancel-in-progress: false
 
 jobs:
@@ -52,9 +46,17 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm crux health check --report --auto-issue --cleanup-labels
+      - name: GitHub Actions health
+        run: pnpm crux health check --check=actions --report --auto-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Job queue health
+        run: pnpm crux health check --check=job-queue --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
-          WIKI_PUBLIC_URL: ${{ secrets.WIKI_PUBLIC_URL }}
+      - name: PR & issue quality
+        run: pnpm crux health check --check=pr-quality --report --auto-issue --cleanup-labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend-data-health.yml
+++ b/.github/workflows/frontend-data-health.yml
@@ -1,0 +1,55 @@
+name: Frontend & Data Health
+
+# Checks public-facing frontend availability and data freshness.
+# Runs twice daily — same schedule as the unified wellness check it replaced.
+#
+# Checks performed:
+#   - Frontend availability (Vercel URL returns content)
+#   - Data freshness (last sync time, recent edits)
+#
+# Issues are created/updated/closed automatically under the "wellness" label.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 8 AM UTC daily
+    - cron: "0 20 * * *" # 8 PM UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: frontend-data-health
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Automation is active"
+
+  check:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Frontend availability
+        run: pnpm crux health check --check=frontend --report --auto-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WIKI_PUBLIC_URL: ${{ secrets.WIKI_PUBLIC_URL }}
+      - name: Data freshness
+        run: pnpm crux health check --check=freshness --report --auto-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}

--- a/.github/workflows/server-api-health.yml
+++ b/.github/workflows/server-api-health.yml
@@ -1,0 +1,56 @@
+name: Server & API Health
+
+# Checks wiki-server availability, DB record counts, and API smoke tests.
+# Runs twice daily — same schedule as the unified wellness check it replaced.
+#
+# Checks performed:
+#   - Server & DB sanity (counts in expected ranges, uptime)
+#   - API smoke tests (search, page fetch, entity list)
+#
+# Issues are created/updated/closed automatically under the "wellness" label.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 8 AM UTC daily
+    - cron: "0 20 * * *" # 8 PM UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: server-api-health
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    # Global circuit breaker — skip when automation is paused.
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Automation is active"
+
+  check:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Server health
+        run: pnpm crux health check --check=server --report --auto-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+      - name: API smoke tests
+        run: pnpm crux health check --check=api --report --auto-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}

--- a/crux/commands/health.ts
+++ b/crux/commands/health.ts
@@ -4,7 +4,10 @@
  * Run comprehensive system wellness checks against the wiki-server,
  * GitHub Actions, and optionally the public frontend.
  *
- * Mirrors the checks performed by .github/workflows/wellness-check.yml
+ * Mirrors the checks performed by the focused health workflows:
+ *   .github/workflows/server-api-health.yml
+ *   .github/workflows/frontend-data-health.yml
+ *   .github/workflows/ci-pr-health.yml
  * so the same checks can be run locally during development or debugging.
  */
 

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -101,7 +101,7 @@ export function buildWellnessReport(checks: CheckResult[]): WellnessReport {
 
   issueLines.push('---');
   issueLines.push(
-    '*Created by the [wellness check workflow](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/wellness-check.yml). Closes automatically when all checks pass.*',
+    '*Created by the wellness check workflows ([server-api-health](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/server-api-health.yml), [frontend-data-health](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/frontend-data-health.yml), [ci-pr-health](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/ci-pr-health.yml)). Closes automatically when all checks pass.*',
   );
 
   const issueBody = issueLines.join('\n');


### PR DESCRIPTION
## Summary

- Split `wellness-check.yml` (which had previously grown to 1,121 lines with 9 jobs and inline bash scripts) into 3 focused workflow files covering separate concerns
- The file was already reduced to 60 lines by PR #1692 (which moved logic to TypeScript crux commands), but this PR completes the structural split into independent workflows
- All 7 health checks are preserved with identical logic (no changes to `crux/health/`)

## New workflow files

- **`server-api-health.yml`** (56 lines) — Server & DB sanity + API smoke tests
- **`frontend-data-health.yml`** (55 lines) — Frontend availability + data freshness
- **`ci-pr-health.yml`** (62 lines) — GitHub Actions health + job queue + PR quality + label cleanup

## Benefits

- Each workflow runs and fails independently — a server outage doesn't block CI health checks
- Each file is focused on one concern and easier to reason about
- Bugs in one check don't prevent others from running
- Different schedules can be applied per concern in the future (e.g., server health hourly)

## Reference updates

- `crux/commands/health.ts` — updated comment to reference new workflow files
- `crux/health/wellness-report.ts` — updated issue footer links to new workflow files
- `.claude/audits.yaml` — updated scheduled-workflows-running audit check to use new file names

## Test plan

- [ ] Verify the 3 new workflow files (`server-api-health.yml`, `frontend-data-health.yml`, `ci-pr-health.yml`) exist in `.github/workflows/` after merge
- [ ] Manually trigger each new workflow via `workflow_dispatch` on the Actions tab and confirm they run without errors
- [ ] Check that `pnpm crux health run` still works correctly (references updated in `crux/commands/health.ts`)
- [ ] Confirm that `crux/health/wellness-report.ts` issue footer links point to the new workflow file names (not the old `wellness-check.yml`)
- [ ] After merge, monitor the next scheduled run (8 AM or 8 PM UTC) to confirm all 3 workflows execute and no wellness issues are created erroneously
- [ ] Verify the old `wellness-check.yml` is no longer present (this PR adds the 3 replacements; deletion of the old file should be confirmed)

> **Note**: The `check-protected-paths` CI check fails because this PR modifies `.github/workflows/` files, which require the `rules-change-reviewed` label to be added by a human reviewer before merging.

Closes #1667