### PR TITLE
feat: fix citation dots pipeline to read from Statements V2 tables

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -872,6 +872,41 @@ async function buildCitationQuotesBundle() {
 }
 
 /**
+ * Fetch all statement-backed citation dot data from the new statements pipeline.
+ * Returns { [pageSlug]: DotEntry[] } keyed by page slug (not numeric ID).
+ * This replaces the legacy citationQuotes bundle for pages that have Statements V2 data.
+ * Returns an empty object if the server is unavailable.
+ */
+async function buildStatementCitationDots() {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl) {
+    console.log('  statementCitationDots: skipped (LONGTERMWIKI_SERVER_URL not set)');
+    return {};
+  }
+
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+    const res = await fetch(
+      `${serverUrl}/api/statements/citation-dots/all`,
+      { headers, signal: AbortSignal.timeout(30_000) }
+    );
+    if (!res.ok) {
+      console.log(`  statementCitationDots: skipped (server returned ${res.status})`);
+      return {};
+    }
+    const data = await res.json();
+    console.log(`  statementCitationDots: ${data.totalEntries ?? 0} entries across ${data.totalPages ?? 0} pages`);
+    return data.pages || {};
+  } catch (err) {
+    console.log(`  statementCitationDots: skipped (${err.message || 'server unavailable'})`);
+    return {};
+  }
+}
+
+/**
  * Fetch all page references (claim refs + citations) from the wiki-server.
  * Returns a map of pageId → { claimReferences, citations } for the reference preprocessor.
  * Falls back to an empty object if the server is unavailable.
@@ -1269,15 +1304,17 @@ async function main() {
   // Fetch edit log dates, earliest edit log dates, and citation stats from
   // wiki-server (parallel). Also build git-based date maps (synchronous, fast).
   const gitDateMaps = CONTENT_ONLY ? { gitCreatedMap: new Map(), gitModifiedMap: new Map() } : buildGitDateMaps();
-  const [editLogDates, earliestEditLogDates, citationStats, citationQuotesBundle] = CONTENT_ONLY
-    ? [new Map(), new Map(), new Map(), {}]
+  const [editLogDates, earliestEditLogDates, citationStats, citationQuotesBundle, statementCitationDots] = CONTENT_ONLY
+    ? [new Map(), new Map(), new Map(), {}, {}]
     : await Promise.all([
         buildEditLogDateMap(),
         buildEarliestEditLogDateMap(),
         buildCitationStatsMap(),
         buildCitationQuotesBundle(),
+        buildStatementCitationDots(),
       ]);
   database.citationQuotes = citationQuotesBundle;
+  database.statementCitationDots = statementCitationDots;
 
   // Build pages registry with frontmatter data (quality, etc.)
   const pages = buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEditLogDates);

--- a/apps/web/src/app/wiki/[id]/page.tsx
+++ b/apps/web/src/app/wiki/[id]/page.tsx
@@ -33,7 +33,7 @@ import { ReferenceProvider } from "@/components/wiki/ReferenceContext";
 import type { RefMapEntry } from "@/components/wiki/ReferenceContext";
 import type { RefMapEntry as PreprocessorRefMapEntry } from "@/lib/reference-preprocessor";
 import { References } from "@/components/wiki/References";
-import { getCitationQuotes, computeCitationHealth } from "@/lib/citation-data";
+import { getCitationQuotes, getStatementCitationQuotes, computeCitationHealth } from "@/lib/citation-data";
 import type { CitationQuote } from "@/lib/citation-data";
 import { EntityStatementsCard } from "@/components/wiki/EntityStatementsCard";
 import { PageStatementsSection } from "@/components/wiki/PageStatementsSection";
@@ -472,12 +472,23 @@ export default async function WikiPage({ params }: PageProps) {
 
     const entityPath = getEntityPath(slug) || "";
 
-    const [result, citationQuotes] = await Promise.all([
+    const [result, legacyCitationQuotes] = await Promise.all([
       renderMdxPage(slug),
       getCitationQuotes(slug),
     ]);
     if (!result) notFound();
     if (isMdxError(result)) return <MdxErrorView error={result} />;
+
+    // Merge statement-pipeline quotes (Statements V2) with legacy quotes.
+    // Statement quotes take precedence for any footnote they cover.
+    const stmtCitationQuotes = result.referenceMap
+      ? getStatementCitationQuotes(slug, result.referenceMap)
+      : [];
+    const stmtFootnotes = new Set(stmtCitationQuotes.map((q) => q.footnote));
+    const citationQuotes: CitationQuote[] = [
+      ...stmtCitationQuotes,
+      ...legacyCitationQuotes.filter((q) => !stmtFootnotes.has(q.footnote)),
+    ];
 
     const pageData = getPageById(slug);
     const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;
@@ -507,12 +518,23 @@ export default async function WikiPage({ params }: PageProps) {
     // No numeric ID — render directly by slug (page-only content without entity)
     const entityPath = getEntityPath(id) || "";
 
-    const [result, citationQuotes] = await Promise.all([
+    const [result, legacyCitationQuotes] = await Promise.all([
       renderMdxPage(id),
       getCitationQuotes(id),
     ]);
     if (!result) notFound();
     if (isMdxError(result)) return <MdxErrorView error={result} />;
+
+    // Merge statement-pipeline quotes (Statements V2) with legacy quotes.
+    // Statement quotes take precedence for any footnote they cover.
+    const stmtCitationQuotes = result.referenceMap
+      ? getStatementCitationQuotes(id, result.referenceMap)
+      : [];
+    const stmtFootnotes = new Set(stmtCitationQuotes.map((q) => q.footnote));
+    const citationQuotes: CitationQuote[] = [
+      ...stmtCitationQuotes,
+      ...legacyCitationQuotes.filter((q) => !stmtFootnotes.has(q.footnote)),
+    ];
 
     const pageData = getPageById(id);
     const contentFormat = (pageData?.contentFormat || "article") as ContentFormat;

--- a/apps/web/src/data/index.ts
+++ b/apps/web/src/data/index.ts
@@ -228,6 +228,26 @@ interface DatabaseShape {
     verificationDifficulty: string | null;
     accuracyCheckedAt: string | null;
   }>>;
+  /**
+   * Statement-backed citation dot data bundled at build time, keyed by page slug.
+   * Populated by buildStatementCitationDots() from /api/statements/citation-dots/all.
+   * Each entry is keyed by footnoteResourceId (e.g. "cr-abc123") and must be mapped
+   * to a numeric footnote number via the referenceMap from renderMdxPage().
+   */
+  statementCitationDots?: Record<string, Array<{
+    footnoteResourceId: string;
+    claimText: string;
+    url: string | null;
+    resourceId: string | null;
+    sourceQuote: string | null;
+    sourceTitle: string | null;
+    sourceType: string | null;
+    quoteVerified: boolean;
+    accuracyVerdict: string | null;
+    accuracyScore: number | null;
+    accuracyIssues: string | null;
+    accuracyCheckedAt: string | null;
+  }>>;
 }
 
 // ============================================================================
@@ -1071,6 +1091,16 @@ export async function getRiskStats(): Promise<RiskStats | null> {
  */
 export function getLocalCitationQuotes(pageId: string) {
   return getDatabase().citationQuotes?.[pageId];
+}
+
+/**
+ * Get build-time statement citation dot data for a page from database.json.
+ * Keyed by page slug (not numeric ID). Returns undefined if no data was bundled.
+ * Each entry uses footnoteResourceId (e.g. "cr-abc123") instead of numeric footnote numbers;
+ * callers must resolve to numeric footnotes via the referenceMap from renderMdxPage().
+ */
+export function getStatementCitationDots(pageId: string) {
+  return getDatabase().statementCitationDots?.[pageId];
 }
 
 export function getResourceCredibility(

--- a/apps/web/src/lib/citation-data.ts
+++ b/apps/web/src/lib/citation-data.ts
@@ -1,11 +1,12 @@
 import { fetchFromWikiServer } from "./wiki-server";
-import { getLocalCitationQuotes } from "@/data";
+import { getLocalCitationQuotes, getStatementCitationDots } from "@/data";
 import type {
   ClaimsBySourceUrlResult,
 } from "@wiki-server/api-response-types";
 import type {
   AccuracyVerdict,
 } from "@wiki-server/api-types";
+import type { RefMapEntry } from "@/lib/reference-preprocessor";
 
 /**
  * Valid accuracy verdict values — mirrors ACCURACY_VERDICTS from api-types.
@@ -135,6 +136,58 @@ export async function getCitationQuotesByUrl(
     `/api/claims/by-source-url?url=${encodeURIComponent(url)}`,
     { revalidate: 600 }
   );
+}
+
+/**
+ * Get citation quotes for a page from the Statements V2 pipeline.
+ *
+ * Reads the build-time statementCitationDots bundle and resolves
+ * footnoteResourceId strings (e.g. "cr-abc123") to numeric footnote
+ * numbers using the referenceMap produced by renderMdxPage().
+ *
+ * Returns an empty array if no statement data exists for this page,
+ * or if no entries map to footnote numbers in the referenceMap.
+ */
+export function getStatementCitationQuotes(
+  pageId: string,
+  referenceMap: Map<number, RefMapEntry>
+): CitationQuote[] {
+  const dots = getStatementCitationDots(pageId);
+  if (!dots || dots.length === 0) return [];
+
+  // Build reverse map: originalId (e.g. "cr-abc123") → numeric footnote number
+  const idToFootnote = new Map<string, number>();
+  for (const [footnoteNum, entry] of referenceMap) {
+    if (entry.originalId) {
+      idToFootnote.set(entry.originalId, footnoteNum);
+    }
+  }
+
+  const result: CitationQuote[] = [];
+  for (const dot of dots) {
+    const footnoteNum = idToFootnote.get(dot.footnoteResourceId);
+    if (footnoteNum === undefined) continue;
+
+    result.push({
+      footnote: footnoteNum,
+      url: dot.url,
+      resourceId: dot.resourceId,
+      claimText: dot.claimText,
+      sourceQuote: dot.sourceQuote,
+      sourceTitle: dot.sourceTitle,
+      sourceType: dot.sourceType,
+      quoteVerified: dot.quoteVerified,
+      verificationScore: null,
+      verifiedAt: null,
+      accuracyVerdict: toAccuracyVerdict(dot.accuracyVerdict),
+      accuracyScore: dot.accuracyScore,
+      accuracyIssues: dot.accuracyIssues,
+      accuracySupportingQuotes: null,
+      verificationDifficulty: null,
+      accuracyCheckedAt: dot.accuracyCheckedAt,
+    });
+  }
+  return result;
 }
 
 /**

--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -21,6 +21,7 @@ import {
   count,
   desc,
   isNull,
+  isNotNull,
   sql,
 } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
@@ -30,6 +31,8 @@ import {
   statementPageReferences,
   properties,
   entityCoverageScores,
+  wikiPages,
+  resources,
 } from "../schema.js";
 import {
   parseJsonBody,
@@ -1355,6 +1358,113 @@ const statementsApp = new Hono()
     });
 
     return c.json({ deleted: deleted.length, ok: true });
+  })
+
+  // ---- GET /citation-dots/all — build-time bundle for citation dot overlays ----
+  /**
+   * Returns all statement-backed citation dot data grouped by page slug.
+   * Called once at build time by buildStatementCitationDots() in build-data.mjs.
+   * Joins statementPageReferences → statements → statementCitations (primary) →
+   * wikiPages → resources to produce the minimal data the CitationOverlay needs.
+   *
+   * Only includes rows where:
+   *  - footnoteResourceId IS NOT NULL (statement appears as a footnote on the page)
+   *  - statement.status = 'active'
+   */
+  .get("/citation-dots/all", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        pageSlug: wikiPages.slug,
+        footnoteResourceId: statementPageReferences.footnoteResourceId,
+        statementText: statements.statementText,
+        verdict: statements.verdict,
+        verdictScore: statements.verdictScore,
+        verdictQuotes: statements.verdictQuotes,
+        verifiedAt: statements.verifiedAt,
+        citUrl: statementCitations.url,
+        citResourceId: statementCitations.resourceId,
+        citSourceQuote: statementCitations.sourceQuote,
+        resourceTitle: resources.title,
+        resourceUrl: resources.url,
+        resourceType: resources.type,
+      })
+      .from(statementPageReferences)
+      .innerJoin(statements, eq(statementPageReferences.statementId, statements.id))
+      .innerJoin(wikiPages, eq(statementPageReferences.pageIdInt, wikiPages.integerIdCol))
+      .leftJoin(
+        statementCitations,
+        and(
+          eq(statementCitations.statementId, statements.id),
+          eq(statementCitations.isPrimary, true)
+        )
+      )
+      .leftJoin(resources, eq(statementCitations.resourceId, resources.id))
+      .where(
+        and(
+          isNotNull(statementPageReferences.footnoteResourceId),
+          eq(statements.status, "active")
+        )
+      );
+
+    // Map statement verdicts to legacy AccuracyVerdict values expected by CitationOverlay
+    function verdictToAccuracy(verdict: string | null): string | null {
+      if (!verdict) return null;
+      switch (verdict) {
+        case "verified": return "accurate";
+        case "disputed": return "inaccurate";
+        case "unsupported": return "unsupported";
+        case "unverified": return "not_verifiable";
+        default: return null;
+      }
+    }
+
+    // Group by page slug
+    const pages: Record<string, Array<{
+      footnoteResourceId: string;
+      claimText: string;
+      url: string | null;
+      resourceId: string | null;
+      sourceQuote: string | null;
+      sourceTitle: string | null;
+      sourceType: string | null;
+      quoteVerified: boolean;
+      accuracyVerdict: string | null;
+      accuracyScore: number | null;
+      accuracyIssues: string | null;
+      accuracyCheckedAt: string | null;
+    }>> = {};
+
+    for (const row of rows) {
+      if (!row.pageSlug || !row.footnoteResourceId) continue;
+
+      const accuracyVerdict = verdictToAccuracy(row.verdict);
+      // Only include rows that have something to show (verified or has verdict)
+      const quoteVerified = row.verdict === "verified";
+      if (!quoteVerified && !accuracyVerdict) continue;
+
+      if (!pages[row.pageSlug]) pages[row.pageSlug] = [];
+      pages[row.pageSlug].push({
+        footnoteResourceId: row.footnoteResourceId,
+        claimText: row.statementText ?? "",
+        url: row.citUrl ?? row.resourceUrl ?? null,
+        resourceId: row.citResourceId ?? null,
+        sourceQuote: row.citSourceQuote ?? null,
+        sourceTitle: row.resourceTitle ?? null,
+        sourceType: row.resourceType ?? null,
+        quoteVerified,
+        accuracyVerdict,
+        accuracyScore: row.verdictScore ?? null,
+        accuracyIssues: null,
+        accuracyCheckedAt: row.verifiedAt ? row.verifiedAt.toISOString() : null,
+      });
+    }
+
+    const totalPages = Object.keys(pages).length;
+    const totalEntries = Object.values(pages).reduce((sum, arr) => sum + arr.length, 0);
+
+    return c.json({ pages, totalPages, totalEntries });
   });
 
 export const statementsRoute = statementsApp;


### PR DESCRIPTION
## Summary

- Add `GET /api/statements/citation-dots/all` endpoint in `statements.ts` that joins `statementPageReferences` → `statements` → `statementCitations (primary)` → `wikiPages` → `resources` and returns citation dot data grouped by page slug, mapping statement verdicts to `AccuracyVerdict` values (`verified→accurate`, `disputed→inaccurate`, `unsupported→unsupported`, `unverified→not_verifiable`)
- Add `buildStatementCitationDots()` in `build-data.mjs` that fetches from the new endpoint and stores results as `database.statementCitationDots` (keyed by page slug, each entry uses `footnoteResourceId` string instead of numeric footnote)
- Add `statementCitationDots` field to `DatabaseShape` and `getStatementCitationDots()` getter in `data/index.ts`
- Add `getStatementCitationQuotes(pageId, referenceMap)` in `citation-data.ts` that bridges `footnoteResourceId` strings (e.g. `cr-abc123`) to numeric footnote numbers via the `referenceMap` produced by `renderMdxPage()`
- Merge statement quotes with legacy quotes in `page.tsx`; statement data takes precedence for any footnote it covers, legacy fills the rest (no regression for pages without statements)

## Why

The citation verification dot overlays were completely dark in production. The `CitationOverlay` component and `ReferenceContext` tooltips receive `CitationQuote[]` data from `database.json`, but `buildCitationQuotesBundle()` still read from the old `citationQuotes` table which is empty — all new data from the Statements V2 pipeline is written to `statement_citations` and `statementPageReferences`.

This PR adds a parallel data path that reads from the new tables and bridges to the numeric footnote system the overlay components expect, while preserving full backward compatibility with any legacy data.

## Test plan

- [x] TypeScript type checks pass (`npx tsc --noEmit` in both `apps/web` and `apps/wiki-server`)
- [x] All 2616 tests pass (`pnpm test`)
- [x] All gate checks pass (`pnpm crux validate gate --fix`)
- [x] Full Next.js production build succeeds
- [ ] In production: verify citation dots appear on pages with `statement_citations` rows
- [ ] Verify legacy pages (with `citationQuotes` data) still show dots correctly

Closes #1598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated statement-backed citation verification data providing accuracy verdicts and verification scores across all wiki pages.
  * Enhanced citation coverage by merging verified statement citations with existing citation sources for comprehensive footnote documentation and source quality assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->