### PR TITLE
docs: add comments to Vercel ignoreCommand explaining exit code convention

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,6 @@
   "framework": "nextjs",
   "installCommand": "cd .. && npx pnpm@9 install",
   "buildCommand": "node scripts/build-data.mjs && next build",
-  "ignoreCommand": "bash -c '[[ $VERCEL_GIT_COMMIT_REF == production ]] && exit 1; exit 0'"
+  "_ignoreCommandNote": "Vercel ignoreCommand uses INVERTED exit codes: exit 1 = BUILD (do not skip), exit 0 = SKIP. This is the opposite of Unix convention. The command below builds only the 'production' branch.",
+  "ignoreCommand": "bash -c '# Vercel exit code convention: exit 1=BUILD (do not skip), exit 0=SKIP (ignore). Opposite of normal Unix convention.\n[[ $VERCEL_GIT_COMMIT_REF == production ]] && exit 1; exit 0'"
 }


### PR DESCRIPTION
## Summary
- Added a `_ignoreCommandNote` JSON key adjacent to `ignoreCommand` in `apps/web/vercel.json` explaining that Vercel uses inverted exit codes
- Added an inline bash comment inside the command itself explaining the convention: exit 1 = BUILD, exit 0 = SKIP
- This convention was gotten wrong 4 times across PRs #1586, #1611, #1630

## Why
Vercel's `ignoreCommand` uses exit codes opposite to Unix convention: `exit 1` means "do build" and `exit 0` means "skip build". This has caused repeated confusion. The comment makes the intent explicit so future maintainers won't accidentally swap the codes.

## Test plan
- [x] No logic change — exit codes are unchanged, only comments added
- [x] Tests pass: `pnpm test` (2616 tests, all pass)
- [x] Gate passes

Closes #1659