### PR TITLE
feat: add structured JSONL logging and periodic reflection to PR Patrol

### DIFF
--- a/scripts/pr-patrol.sh
+++ b/scripts/pr-patrol.sh
@@ -36,6 +36,13 @@ JSONL_FILE="${CACHE_DIR}/runs.jsonl"
 REFLECTION_FILE="${CACHE_DIR}/reflections.jsonl"
 CYCLE_COUNT=0
 REFLECTION_INTERVAL="${PR_PATROL_REFLECTION_INTERVAL:-10}"
+
+# Must be a positive integer (prevents modulo arithmetic errors in the reflection loop)
+if ! [[ "$REFLECTION_INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: PR_PATROL_REFLECTION_INTERVAL must be a positive integer (got: $REFLECTION_INTERVAL)" >&2
+  exit 1
+fi
+
 ONCE=false
 DRY_RUN=false
 
@@ -99,7 +106,7 @@ log_pr_result() {
   local reason=${7:-}
 
   local issues_json
-  issues_json=$(echo "$issues_csv" | jq -R 'split(",")')
+  issues_json=$(echo "$issues_csv" | jq -R 'split(",") | map(select(length > 0))')
 
   jq -nc \
     --arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \


### PR DESCRIPTION
## Summary

- Adds persistent structured logging to PR Patrol: every PR fix result and check cycle is recorded as a JSON line in `~/.cache/pr-patrol/runs.jsonl`
- Every 10 cycles (~50 min), spawns a Claude reflection session that analyzes the last 100 log entries for recurring patterns and optionally files a single GitHub issue
- Fixes a summary truncation bug (`tail -c 1500 | head -c 500` took a random middle slice instead of the last 500 chars)

## Details

**JSONL logging** — two record types appended to `~/.cache/pr-patrol/runs.jsonl`:
- `pr_result`: pr_num, title, branch, issues_detected, result (fixed/max-turns/error/dry-run), elapsed_s, reason, cycle_number
- `cycle_summary`: prs_scanned, queue_size, pr_processed, cycle_number

**Periodic reflection** — configurable via `PR_PATROL_REFLECTION_INTERVAL` (default: 10 cycles). The reflection prompt:
- Reads the last 100 JSONL entries
- Looks for patterns: repeated max-turns failures, unfixable issue types, wasted re-processing
- Searches for duplicate issues before filing
- Files at most 1 GitHub issue with the `pr-patrol` label
- Results logged to `~/.cache/pr-patrol/reflections.jsonl`

## Test plan

- [x] `bash -n scripts/pr-patrol.sh` passes (syntax check)
- [x] `jq` commands tested in isolation — all produce valid JSON with correct fields
- [x] Edge cases tested: null pr_processed, special chars in titles, empty reason strings
- [ ] Manual: `./scripts/pr-patrol.sh --once --dry-run` creates JSONL entries
- [ ] Manual: After 10+ cycles, reflection triggers and analyzes logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging with structured metrics tracking for PR scanning cycles.
  * Added periodic analysis workflow to review PR processing patterns and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->