### PR TITLE
docs: add no-new-bash-scripts convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ longterm-wiki/
 - **Content pages use local data**: Wiki pages read `database.json` — zero runtime API calls. Only internal dashboards make live wiki-server requests.
 - **API keys**: In environment variables, NOT `.env` files. Required: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`
 - **Wiki-server env switching**: Set `WIKI_SERVER_ENV=prod` to target the production wiki-server instead of localhost. This makes all `LONGTERMWIKI_*` env var lookups use the `PROD_` prefix (e.g., `PROD_LONGTERMWIKI_SERVER_URL`). Usage: `WIKI_SERVER_ENV=prod pnpm crux statements improve anthropic --dry-run`
+- **No new bash scripts**: Write new scripts/tools as TypeScript in `crux/`. Bash is only acceptable for git hooks (`.githooks/`), Claude Code hooks (`.claude/hooks/`), and CI glue where Node.js isn't available. Existing `scripts/pr-patrol.sh` is a known exception pending migration to TS.
 
 ## Detailed Guides (loaded automatically by Claude Code)
 


### PR DESCRIPTION
## Summary
- Adds a convention to CLAUDE.md: new scripts/tools must be TypeScript in `crux/`, not bash
- Bash is only acceptable for git hooks, Claude Code hooks, and CI glue where Node.js isn't available
- Documents `scripts/pr-patrol.sh` as a known exception pending migration

## Context
Audit found 8 shell scripts. Most are appropriately bash (git hooks, Claude Code hooks that need fast startup). The one strong migration candidate is `scripts/pr-patrol.sh` (741 lines of complex logic). This convention prevents new bash scripts from being added going forward.

## Test plan
- [x] Docs-only change — only `CLAUDE.md` modified
- [x] Single commit, clean branch from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)