### PR TITLE
fix: increase auto-update timeout and align scheduled count default

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -60,7 +60,7 @@ jobs:
   auto-update:
     needs: [preflight]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARGS="--budget=${{ inputs.budget || '30' }} --count=${{ inputs.count || '5' }} --verbose"
+          ARGS="--budget=${{ inputs.budget || '30' }} --count=${{ inputs.count || '3' }} --verbose"
 
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"


### PR DESCRIPTION
## Summary

- Root cause identified: `timeout-minutes: 60` was too low for the auto-update job. Each page improvement takes ~10-12 min; with ~18 min of setup/install/build-data overhead and 5 pages, the job needs ~78 minutes — well over the 60-minute limit.
- Evidence: Run [22705771773](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/22705771773) (2026-03-05) shows the job ran for exactly 1h0m15s and was cut off mid-improvement on page 5/6. Annotation: "The job has exceeded the maximum execution time of 1h0m0s". Same pattern for runs 22660285330 and 22618059745 on prior days.
- Fix 1: Increased `timeout-minutes` from 60 to 120.
- Fix 2: Aligned the scheduled-run count default (`|| '5'`) with the `workflow_dispatch` UI default (which was already `'3'`). This was a latent inconsistency — the scheduled run was processing 5 pages/day while the manual trigger UI showed 3 as the default.

With 3 pages and 120 minutes: ~54 min expected runtime (3 × 12 min + 18 min overhead), well within the new limit.

Closes #1725