### PR TITLE
fix: remove duplicate normalizeValueDate and update coverage-targets test

### DIFF
--- a/crux/statements/coverage-targets.test.ts
+++ b/crux/statements/coverage-targets.test.ts
@@ -51,11 +51,11 @@ describe('resolveCoverageTargets', () => {
   });
 
   it('returns null for unknown entity type', () => {
-    expect(resolveCoverageTargets('concept')).toBeNull();
+    expect(resolveCoverageTargets('widget')).toBeNull();
   });
 
   it('returns null for unknown entity type even with orgType', () => {
-    expect(resolveCoverageTargets('concept', 'frontier-lab')).toBeNull();
+    expect(resolveCoverageTargets('widget', 'frontier-lab')).toBeNull();
   });
 });
 

--- a/crux/statements/improve.ts
+++ b/crux/statements/improve.ts
@@ -69,28 +69,6 @@ function normalizeValueDate(d: string | null | undefined): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Normalize a date string from LLM output to a valid ISO date (YYYY-MM-DD) or null.
- * LLMs often produce partial dates like "2024" or "2024-06" which fail PostgreSQL date columns.
- */
-function normalizeValueDate(d: string | null | undefined): string | null {
-  if (!d) return null;
-  // Full ISO date: YYYY-MM-DD → keep as-is
-  if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
-  // Year-month: YYYY-MM → append -01
-  if (/^\d{4}-\d{2}$/.test(d)) return `${d}-01`;
-  // Year only: YYYY → append -01-01
-  if (/^\d{4}$/.test(d)) return `${d}-01-01`;
-  // Anything else (ISO datetime, etc.) — try to parse
-  const parsed = new Date(d);
-  if (!isNaN(parsed.getTime())) return parsed.toISOString().slice(0, 10);
-  return null; // Unparseable — drop it
-}
-
-// ---------------------------------------------------------------------------
 // Types (exported for use by future pass functions)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes two test failures introduced in #1723:

- **`crux/statements/improve.ts`**: commit #1723 accidentally added a second identical declaration of `normalizeValueDate` (lines 79–91), causing esbuild to fail with `The symbol "normalizeValueDate" has already been declared`. Remove the duplicate.
- **`crux/statements/coverage-targets.test.ts`**: commit #1723 added `concept` to the `TARGETS` map, but the test still expected `resolveCoverageTargets('concept')` to return `null`. Update the tests to use `'widget'` which has no coverage targets.

## Test plan

- [x] `pnpm test:crux` — 2665 tests, 115 files, all pass
- [x] Gate checks — all 9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)