### PR TITLE
fix: allow merge commits to not invalidate review-done marker

### DIFF
--- a/crux/validate/validate-review-marker.test.ts
+++ b/crux/validate/validate-review-marker.test.ts
@@ -9,6 +9,7 @@ import { execSync } from 'child_process';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { onlyMergeCommitsSince } from './validate-review-marker.ts';
 
 const REPO_ROOT = `${__dirname}/../..`;
 
@@ -65,9 +66,6 @@ function createTempRepo(): string {
 // ---------------------------------------------------------------------------
 
 describe('onlyMergeCommitsSince', () => {
-  // We test the logic indirectly by verifying that the git commands used
-  // by the function produce the expected results in controlled scenarios.
-
   let tmpDir: string;
 
   beforeAll(() => {
@@ -78,15 +76,15 @@ describe('onlyMergeCommitsSince', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('returns true when markerSha equals headSha', () => {
-    // The logic `if (markerSha === headSha) return true` is early-exit.
-    // Verify we get the same SHA back from the single commit.
+  it('returns true when markerSha equals headSha (same-SHA early-exit)', () => {
+    // Verify the early-exit path: when marker and HEAD are the same commit,
+    // no new commits exist, so the review is still valid.
     const sha = makeCommit(tmpDir, 'a.txt', 'hello');
-    expect(sha).toBe(sha); // trivially true — guards the early-exit path
+    expect(onlyMergeCommitsSince(sha, sha, tmpDir)).toBe(true);
   });
 
   it('returns true when all intervening commits are merge commits', () => {
-    // Set up: main → feature branch with one commit → merge back to feature
+    // Set up: main → feature branch with one commit → merge main back into feature
     // Simulates: developer reviews at SHA A, then merges main into branch
     // (producing a merge commit M). Only M is between A and HEAD.
     makeCommit(tmpDir, 'base.txt', 'base');
@@ -104,22 +102,8 @@ describe('onlyMergeCommitsSince', () => {
     gitExec(tmpDir, 'merge main --no-edit -m "Merge main into feature"');
     const headAfterMerge = gitExec(tmpDir, 'rev-parse HEAD');
 
-    // Verify using --first-parent (the same flag used by onlyMergeCommitsSince):
-    // only the merge commit itself appears on the feature branch lineage, not
-    // the upstream commit that was merged in.
-    const allFirstParent = execSync(
-      `git log --first-parent --format=%H ${reviewedSha}..${headAfterMerge}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    const mergeFirstParent = execSync(
-      `git log --first-parent --merges --format=%H ${reviewedSha}..${headAfterMerge}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    expect(allFirstParent.length).toBeGreaterThan(0);
-    // All first-parent commits should be merge commits
-    expect(allFirstParent.length).toBe(mergeFirstParent.length);
+    // The function should return true: only a merge commit was added since review
+    expect(onlyMergeCommitsSince(reviewedSha, headAfterMerge, tmpDir)).toBe(true);
 
     // Clean up branch for next test
     gitExec(tmpDir, 'checkout main');
@@ -132,20 +116,7 @@ describe('onlyMergeCommitsSince', () => {
     const reviewedSha = makeCommit(tmpDir, 'reviewed-base.txt', 'reviewed state');
     const newCodeSha = makeCommit(tmpDir, 'new-code.txt', 'new code after review');
 
-    const allFirstParent = execSync(
-      `git log --first-parent --format=%H ${reviewedSha}..${newCodeSha}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    const mergeFirstParent = execSync(
-      `git log --first-parent --merges --format=%H ${reviewedSha}..${newCodeSha}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    // There should be 1 non-merge first-parent commit (newCodeSha itself)
-    expect(allFirstParent.length).toBe(1);
-    expect(mergeFirstParent.length).toBe(0);
-    expect(allFirstParent.length).not.toBe(mergeFirstParent.length);
+    expect(onlyMergeCommitsSince(reviewedSha, newCodeSha, tmpDir)).toBe(false);
   });
 
   it('returns false when merge commit follows a non-merge commit after review', () => {
@@ -165,22 +136,29 @@ describe('onlyMergeCommitsSince', () => {
     gitExec(tmpDir, 'merge main --no-edit -m "Merge main into feature2"');
     const headAfterMerge = gitExec(tmpDir, 'rev-parse HEAD');
 
-    const allFirstParent = execSync(
-      `git log --first-parent --format=%H ${reviewedSha}..${headAfterMerge}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    const mergeFirstParent = execSync(
-      `git log --first-parent --merges --format=%H ${reviewedSha}..${headAfterMerge}`,
-      { cwd: tmpDir, encoding: 'utf-8' }
-    ).trim().split('\n').filter(Boolean);
-
-    // Should have at least 1 non-merge first-parent commit (the code change)
-    expect(allFirstParent.length).toBeGreaterThan(mergeFirstParent.length);
+    // Should return false: a non-merge commit (unreviewed code) was added
+    expect(onlyMergeCommitsSince(reviewedSha, headAfterMerge, tmpDir)).toBe(false);
 
     // Cleanup
     gitExec(tmpDir, 'checkout main');
     gitExec(tmpDir, 'branch -D feature2');
+  });
+
+  it('returns false when markerSha is not an ancestor of headSha', () => {
+    // Simulates a rebase/force-push where the marker SHA no longer exists
+    // in the history of HEAD — should be treated as invalid.
+    const sha1 = makeCommit(tmpDir, 'orphan1.txt', 'first commit');
+    // Create a divergent branch to get a non-ancestor SHA
+    gitExec(tmpDir, 'checkout -b orphan-branch');
+    const orphanSha = makeCommit(tmpDir, 'orphan2.txt', 'divergent commit');
+    gitExec(tmpDir, 'checkout main');
+    const mainHeadSha = makeCommit(tmpDir, 'mainonly.txt', 'main commit');
+    gitExec(tmpDir, 'branch -D orphan-branch');
+
+    // orphanSha is not an ancestor of mainHeadSha → should return false
+    expect(onlyMergeCommitsSince(orphanSha, mainHeadSha, tmpDir)).toBe(false);
+
+    void sha1; // used to set up repo state
   });
 });
 

--- a/crux/validate/validate-review-marker.ts
+++ b/crux/validate/validate-review-marker.ts
@@ -91,14 +91,16 @@ function getHeadSha(): string {
  *   - markerSha is not an ancestor of headSha (rebase / force-push situation)
  *   - Any first-parent commit in the range is a non-merge commit (new code)
  *   - git commands fail for any reason (fail-closed)
+ *
+ * @param cwd - directory to run git commands in; defaults to PROJECT_ROOT
  */
-export function onlyMergeCommitsSince(markerSha: string, headSha: string): boolean {
+export function onlyMergeCommitsSince(markerSha: string, headSha: string, cwd: string = PROJECT_ROOT): boolean {
   if (markerSha === headSha) return true;
   try {
     // Verify that markerSha is an ancestor of headSha — if not, something
     // unusual happened (rebase, force-push) and we should require re-review.
     execSync(`git merge-base --is-ancestor ${markerSha} ${headSha}`, {
-      cwd: PROJECT_ROOT,
+      cwd,
       encoding: 'utf-8',
     });
   } catch {
@@ -111,7 +113,7 @@ export function onlyMergeCommitsSince(markerSha: string, headSha: string): boole
     // commits that were brought in transitively from the merged branch.
     const allFirstParent = execSync(
       `git log --first-parent --format=%H ${markerSha}..${headSha}`,
-      { cwd: PROJECT_ROOT, encoding: 'utf-8' }
+      { cwd, encoding: 'utf-8' }
     )
       .trim()
       .split('\n')
@@ -122,7 +124,7 @@ export function onlyMergeCommitsSince(markerSha: string, headSha: string): boole
     // Among those first-parent commits, count the merge commits.
     const mergeFirstParent = execSync(
       `git log --first-parent --merges --format=%H ${markerSha}..${headSha}`,
-      { cwd: PROJECT_ROOT, encoding: 'utf-8' }
+      { cwd, encoding: 'utf-8' }
     )
       .trim()
       .split('\n')


### PR DESCRIPTION
## Summary

- Review marker validation now treats merge commits as transparent: if the only commits between the marker SHA and HEAD are merge commits (e.g., "Merge branch 'main' into feature"), the marker is still considered valid
- Fixes the workflow where merging `main` into a PR branch to resolve conflicts required manually re-running `/review-pr` or overwriting `.claude/review-done`
- Non-merge commits (new code authored on the branch) still invalidate the marker as before
- Fail-closed: if the marker SHA is not an ancestor of HEAD (rebase/force-push), the check fails and requires re-review

## Implementation

Added `onlyMergeCommitsSince(markerSha, headSha)` to `validate-review-marker.ts`:

1. Verifies `markerSha` is an ancestor of `headSha` via `git merge-base --is-ancestor`
2. Uses `git log --first-parent` to walk only the branch's own commit lineage (excludes commits brought in transitively from the merged branch)
3. Compares count of all first-parent commits vs. merge-only first-parent commits — equal counts means only merge commits were added

## Tests

Added 4 new tests covering:
- Merge commit after review → passes (marker still valid)
- New code commit after review → fails (marker invalidated)
- New code commit + merge commit after review → fails (marker still invalidated)
- markerSha equals headSha → passes (trivial early-exit case)

Closes #1695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review markers now remain valid if only merge commits have been added since the last review; CLI will note this condition.

* **Tests**
  * Added comprehensive tests covering merge vs non-merge commit sequences and ancestry cases for review-marker validation.
  * Expanded CLI smoke tests to ensure validation runs without crashing and reports diff/threshold information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->