### PR TITLE
docs: comprehensive statements page review (E1009)

### DIFF
--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -316,6 +316,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Consistency Audit (Feb 2026)", href: internalHref("website-consistency-audit-2026-02") },
         { label: "Importance Ranking", href: internalHref("importance-ranking") },
         { label: "Page Length Research", href: internalHref("page-length-research") },
+        { label: "Statements Review", href: internalHref("statements-review") },
       ],
     },
     {

--- a/content/docs/internal/statements-review.mdx
+++ b/content/docs/internal/statements-review.mdx
@@ -1,0 +1,285 @@
+---
+numericId: E1009
+title: "Statements Page Review — Anthropic & Systemic Issues"
+description: "Comprehensive review of the Anthropic statements pages identifying 32 issues across data quality, UX, missing features, and architecture, with design mockups and a prioritized fix roadmap."
+subcategory: research
+lastEdited: "2026-03-05"
+---
+
+## Overview
+
+Review of [`/wiki/E22/statements`](/wiki/E22/statements) and [`/statements/entity/anthropic`](/statements/entity/anthropic) (plus systemic issues visible on OpenAI, DeepMind, etc.). The statements system has solid architecture but currently displays bad data, has confusing UX, and is missing key features.
+
+**Stats**: 335 total statements for Anthropic. 126 active (69 structured, 57 attributed). 209 inactive/retracted (62% garbage rate). 10 conflicting properties detected. 125 of 126 verdicts are "Unverified."
+
+---
+
+## Section 1: Critical Data Quality Issues
+
+### 1.1 Massive "Uncategorized" section of empty/garbage statements
+
+The first section visible on `/statements/entity/anthropic` is **"Uncategorized (0 Active, 114 Inactive)"** — 114 rows of retracted statements that are almost entirely empty dashes. A few have orphaned fragments like "insulate safety mission from short-term commercial pressures" or raw entity IDs like "dario-amodei" with no property or context.
+
+On OpenAI's page, it's worse: **161 Active** uncategorized statements that are empty dashes and not even retracted.
+
+**Impact**: The page looks broken and untrustworthy. Any user seeing this will immediately lose confidence in the data.
+
+**Code location**: `apps/web/src/app/statements/entity/[entityId]/page.tsx` lines 236-244 — iterates all categories including empty ones. `statement-processing.ts` lines 114-130 — `groupByCategory()` falls back to "uncategorized" when `property.category` is null.
+
+**Fix**: Filter out categories where all statements are inactive. Hide "Uncategorized" by default. Purge empty statements from the database.
+
+### 1.2 Absurd benchmark scores: "34,000,000%" and "300,000%"
+
+The Performance category shows values like **"Benchmark Score: 34,000,000%"** and **"Benchmark Score: 55,000%"**. Raw scores (likely ELO or absolute metrics) were stored with a percentage `unitFormatId`.
+
+**Code location**: `apps/web/src/lib/unit-formats.ts` — `formatWithUnitFormat()` applies the "percent" format (suffix: "%") blindly. No sanity check on value magnitude. `data/fact-measures.yaml` — the "benchmark-score" property uses percent format but some benchmarks aren't percentages.
+
+**Fix**: Benchmark scores need sub-properties indicating which benchmark. Value formatting needs magnitude validation. Consider separate unitFormats for different score types.
+
+### 1.3 "Revenue: \$0B" listed as Active
+
+Three active statements show "Revenue: \$0B" for different 2025 periods, directly contradicting "Revenue: \$19B" and "\$1B" in other active rows.
+
+**Fix**: Quality gate should reject \$0 revenue for entities with known revenue. Existing \$0 entries should be retracted.
+
+### 1.4 "Equity Value: per-share-tender \$0B" — qualifier leaked into display
+
+The qualifier "per-share-tender" appears as part of the value text instead of being suppressed or formatted separately.
+
+**Code location**: `statement-display.ts` line 84 — `formatQualifier()` only suppresses "exactly" and context-style qualifiers (containing ":"). "per-share-tender" doesn't match either pattern so it's printed as-is.
+
+### 1.5 "Founder: Test delete me" in production data
+
+A test record is visible (though retracted). Test data should never exist in production.
+
+### 1.6 "Acquired By: Jan Leike" and "Acquired By: John Schulman"
+
+Categorically wrong — these researchers *left* Anthropic, they didn't acquire it. Property assignment is completely incorrect.
+
+### 1.7 Multiple contradictory "active" statements
+
+Current Snapshot shows **10 conflicting properties** with amber warnings. Many aren't real conflicts — just different time periods. Revenue \$19B (2026-03) and \$14B (2026-02) are sequential data points, not contradictions. Funding Round \$30B and \$4B are different rounds.
+
+**Code location**: `statement-processing.ts` lines 76-106 — `detectConflicts()` groups by `propertyId::qualifierKey` but ignores temporal ordering. Two statements with different `validStart` but same property are flagged as conflicting even when one supersedes the other.
+
+**Fix**: Conflict detection should exclude statements where temporal ranges don't overlap. Old values should be auto-superseded when new ones with later dates arrive.
+
+### 1.8 "Total Funding: \$67B" marked "Unsupported 95%"
+
+The most prominent value in the Current Snapshot is flagged in red as unsupported. If it's unsupported, why is it the active value?
+
+---
+
+## Section 2: UX / Layout Problems
+
+### 2.1 Two completely different pages for the same data
+
+`/wiki/E22/statements` and `/statements/entity/anthropic` show the same data with completely different layouts:
+- **Wiki tab**: Current Snapshot table, collapsible categories, filter bar
+- **Standalone**: Summary strip, stats cards, category tables, sidebar
+
+Neither links clearly to the other. Neither is clearly canonical.
+
+**Code**: Wiki tab at `apps/web/src/app/wiki/[id]/statements/` (server component + StatementsClient). Standalone at `apps/web/src/app/statements/entity/[entityId]/page.tsx`. Different code paths, different features (wiki has conflict detection; standalone has sidebar).
+
+**Fix**: Consolidate to one canonical URL.
+
+### 2.2 Every verdict is "Unverified" — the column is pure noise
+
+125 of 126 active statements show "Unverified". The Verdict column takes 15% of horizontal space for zero information.
+
+**Code**: `VerdictBadge.tsx` lines 110-155 — always renders, falls back to gray "Unverified" style when `verdict === null`. No conditional hiding.
+
+**Fix**: Hide Verdict column when \>90% of values are "Unverified". Or show a banner: "Verdicts pending."
+
+### 2.3 Source column shows bare domain names
+
+"en.wikipedia.org" or "1 cite" — no article title, no date, no quote. Useless for verification.
+
+### 2.4 Sidebar category counts are system-wide, not entity-specific
+
+On `/statements/entity/anthropic`, the sidebar shows Financial: 341, Organizational: 179, etc. These are **global totals** across ALL entities, not Anthropic-specific.
+
+**Code**: `statements-nav.ts` lines 42-77 — `getStatementCategories()` fetches `/api/statements/properties` without any entity filter.
+
+### 2.5 No sorting within categories
+
+The Financial section (40 statements) is sorted by date. Can't sort by property name, value, or citation count.
+
+### 2.6 Period display is inconsistent and ambiguous
+
+Mixed formats: "since 2026-02", "2025-11 → 2026-02", "2023 → 2024", "—". "since X" is ambiguous — start date vs. as-of date.
+
+**Code**: `formatPeriod()` is duplicated in `statements-client.tsx:273-278` and `entity/[entityId]/page.tsx:275-280`. Neither is in the shared `statement-display.ts`.
+
+### 2.7 No narrative context or explanation
+
+No introductory text. New users don't know what "Structured" vs "Attributed" means, what "Retracted" implies, or how to interpret conflicts.
+
+### 2.8 Attributed claims lack date/source context
+
+Quotes show "Attributed to: Anthropic" + "1 citation" but no date, no source title, no way to assess recency or credibility.
+
+### 2.9 Broken text in attributed claims
+
+"Dario Amodei has stated an estimated 10– probability" — em-dash truncated the actual probability value.
+
+### 2.10 Stats cards are confusing across pages
+
+Wiki tab: "Active: 126 | Active Structured: 69 | Active Attributed: 57 | Active Cited: 126"
+Standalone: "Total: 335 | Active Structured: 69 | Active Attributed: 57 | With Citations: 251"
+
+"Total: 335" includes 209 garbage/retracted records. "With Citations: 251" counts retracted-with-citations.
+
+---
+
+## Section 3: Missing Features
+
+### 3.1 No timeline / historical visualization
+
+Anthropic's valuation: \$0.6B → \$4B → \$18.1B → \$61.5B → \$183B → \$350B → \$380B over 4 years. Fascinating data trapped in a flat table. A line chart per property would be transformative.
+
+### 3.2 No cross-entity comparison
+
+Can't compare Anthropic's revenue to OpenAI's. Each entity page is isolated.
+
+### 3.3 No working "current values" summary
+
+The Current Snapshot attempts this but has 10 conflicts, no categories, and no confidence indicators.
+
+### 3.4 No export/download
+
+No CSV/JSON download for analysis.
+
+### 3.5 No quality scores visible to users
+
+The 10-dimension scoring system exists internally but is invisible to users.
+
+### 3.6 No report/flag mechanism
+
+Users can't flag incorrect statements. No feedback loop.
+
+---
+
+## Section 4: Data Architecture Issues
+
+### 4.1 Structured vs. Attributed split is confusing
+
+Some attributed claims contain factual data that could be structured. Some structured statements are really claims (Revenue Guidance is forward-looking). The two sections have completely different formatting.
+
+### 4.2 Property taxonomy too flat for financial data
+
+"Funding Round" appears 10+ times with qualifiers (series-b, amazon, etc.) shown as gray parenthetical text. Qualifiers aren't searchable or filterable.
+
+### 4.3 Citation quality uniformly low
+
+Most citations are bare domain names. No article title, publication date, or source quote.
+
+### 4.4 No quality gate prevents garbage
+
+Empty statements, "\$0B" revenue, "34,000,000%" scores all made it into the Active database. The pipeline has no effective filter.
+
+---
+
+## Section 5: Design Mockups
+
+### 5.1 Proposed: Consolidated Entity Statements Page
+
+Key changes from current design:
+- Top summary cards show 4-6 key metrics with date context and source links
+- Inline mini-timeline sparklines for properties with 3+ historical values
+- Quality indicators (dot rating) replace useless "Unverified" verdicts
+- "Hide superseded" checkbox ON by default
+- Sort/group controls per category section
+- Source shows article name not just domain
+- Attributed claims reformatted with date and source name inline
+- No "Uncategorized" section visible
+
+### 5.2 Proposed: Current Snapshot Redesign
+
+Key changes:
+- Grouped by category instead of flat list
+- Only most-recent value per property shown
+- Conflicts shown as a footnote count, not inline "(also: X, Y, Z)"
+- "Disputed" flag replaces inline alternate values
+- Period formatted as human-readable "Mar 2026" not "2026-03"
+
+---
+
+## Section 6: Prioritized Fix Roadmap
+
+### Phase 1: Data Cleanup (highest impact, no code changes needed)
+- **Purge empty statements** — DELETE rows where propertyId IS NULL AND valueNumeric IS NULL AND valueText IS NULL AND statementText IS NULL
+- **Retract \$0 revenue entries** — PATCH status → "retracted" with archiveReason
+- **Retract absurd benchmark scores** — 34,000,000%, 300,000%, 55,000%
+- **Delete test data** — "Test delete me" founder entry
+- **Fix wrong properties** — "Acquired By: Jan Leike" → retract
+- **Auto-supersede old values** — For properties like Valuation, Revenue where newer entries exist, mark older active entries as "superseded"
+
+### Phase 2: Quick UX Wins (small code changes, big impact)
+
+| Fix | File | Effort |
+|-----|------|--------|
+| Hide retracted by default | `statements-client.tsx:29-31` — change default to `new Set(["active"])` | 1 line |
+| Hide empty categories | `entity/[entityId]/page.tsx:236-244` — filter before rendering | 5 lines |
+| Hide Verdict column when all "Unverified" | `statements-client.tsx:316-318` — conditional render | 10 lines |
+| Extract `formatPeriod` to shared utils | Move to `statement-display.ts`, import in both pages | 15 min |
+| Format periods as human-readable | "Mar 2026" instead of "2026-03" | 20 lines |
+| Collapse "Uncategorized" by default | entity page — set `defaultOpen=false` for uncategorized | 1 line |
+
+### Phase 3: Structural Improvements (medium effort)
+
+| Fix | Effort |
+|-----|--------|
+| Consolidate two pages → one canonical URL | 2-4 hours |
+| Fix sidebar counts to be entity-specific (requires API change) | 2 hours |
+| Improve conflict detection to respect temporal ranges | 2 hours |
+| Redesign Current Snapshot (grouped by category, single value per property) | 3 hours |
+| Add introductory help text explaining structured vs attributed | 30 min |
+| Fix citation display (show article title, not just domain) | 2 hours |
+
+### Phase 4: Feature Additions (larger effort)
+
+| Feature | Effort |
+|---------|--------|
+| Timeline/sparkline charts per property | 1-2 days |
+| Quality score indicators visible to users | 1 day |
+| Cross-entity comparison view | 2-3 days |
+| Export CSV/JSON | 4 hours |
+| Report/flag mechanism | 1 day |
+| Sort/group controls per category | 4 hours |
+
+### Phase 5: Pipeline Quality Gates
+
+| Fix | Effort |
+|-----|--------|
+| Block empty statements from being created | 2 hours |
+| Validate benchmark score magnitudes before applying % format | 2 hours |
+| Auto-supersede conflicting temporal values on insert | 4 hours |
+| Reject \$0 values for known-revenue entities | 1 hour |
+| Validate property applicability (no "Acquired By" for researchers) | 4 hours |
+
+---
+
+## Priority Summary
+
+| Priority | Issue | Impact |
+|----------|-------|--------|
+| P0 | Empty/garbage statements shown as Active (1.1) | Page looks broken |
+| P0 | Absurd values like "34,000,000%" (1.2) | Destroys credibility |
+| P0 | "\$0B Revenue" contradictions (1.3) | Factually wrong |
+| P1 | Two different pages for same data (2.1) | Confusing navigation |
+| P1 | All verdicts "Unverified" — wasted space (2.2) | Visual noise |
+| P1 | Sidebar counts are system-wide (2.4) | Misleading |
+| P1 | No timeline visualization (3.1) | Missing key feature |
+| P1 | Retracted statements too visible | Cluttered UX |
+| P2 | "10 conflicting properties" not actually conflicts (1.7) | Temporal model broken |
+| P2 | Period display ambiguous (2.6) | Hard to interpret |
+| P2 | No narrative context (2.7) | Unfriendly to new users |
+| P2 | Test data in production (1.5) | Unprofessional |
+| P2 | Wrong property assignments (1.6) | Data errors |
+| P2 | Citation quality uniformly low (4.3) | Can't verify claims |
+| P3 | No cross-entity comparison (3.2) | Missing feature |
+| P3 | No export capability (3.4) | Missing feature |
+| P3 | No quality scores visible (3.5) | Missing feature |
+| P3 | No report/flag mechanism (3.6) | Missing feature |


### PR DESCRIPTION
## Summary

- Comprehensive review of Anthropic statements pages (`/wiki/E22/statements` and `/statements/entity/anthropic`) identifying 32 specific issues
- Issues organized into 6 sections: Critical Data Quality, UX/Layout, Missing Features, Data Architecture, Design Mockups, and Prioritized Fix Roadmap
- Includes code-level analysis with exact file paths and line numbers for each fixable issue
- Design mockups for improved Current Snapshot and consolidated entity page
- 5-phase fix roadmap from data cleanup (no code) through pipeline quality gates
- Created as internal wiki page at E1009 with sidebar registration

Key findings:
- 62% of Anthropic's statements are inactive/retracted garbage
- 114 empty "Uncategorized" retracted statements shown first
- Absurd values like "Benchmark Score: 34,000,000%"
- "$0B Revenue" listed as Active alongside "$19B Revenue"
- Two completely different pages showing the same data
- 125 of 126 verdicts are "Unverified" (wasted column space)
- Sidebar counts are system-wide, not entity-specific

## Test plan

- [x] Gate check passes (`pnpm crux validate gate --scope=content --fix`)
- [x] All 380 tests pass
- [x] MDX compiles without errors
- [x] New page registered in sidebar under Research section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
