### PR TITLE
fix: disable Vercel GitHub integration to stop PR failure statuses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,4 +246,5 @@ jobs:
   # Deploy job removed — production deploys are now handled by the scheduled
   # deploy hook (scheduled-deploy.yml, every hour) instead of per-push.
   # This caps Vercel build minutes at 24/day max vs 50-80/day previously.
-  # See vercel.json ignoreCommand which also blocks Git-triggered main builds.
+  # vercel.json sets github.enabled=false to prevent Vercel from posting
+  # PR failure statuses (deploy hooks bypass the GitHub integration).

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,5 +4,8 @@
   "installCommand": "cd .. && npx pnpm@9 install",
   "buildCommand": "node scripts/build-data.mjs && next build",
   "_ignoreCommandNote": "Vercel ignoreCommand uses INVERTED exit codes: exit 1 = BUILD (do not skip), exit 0 = SKIP. This is the opposite of Unix convention. The command below builds only the 'production' branch.",
-  "ignoreCommand": "bash -c '# Vercel exit code convention: exit 1=BUILD (do not skip), exit 0=SKIP (ignore). Opposite of normal Unix convention.\n[[ $VERCEL_GIT_COMMIT_REF == production ]] && exit 1; exit 0'"
+  "ignoreCommand": "bash -c '# Vercel exit code convention: exit 1=BUILD (do not skip), exit 0=SKIP (ignore). Opposite of normal Unix convention.\n[[ $VERCEL_GIT_COMMIT_REF == production ]] && exit 1; exit 0'",
+  "github": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Problem

Every PR was showing a red Vercel failure status. Root cause: commit #1630 restricted the `ignoreCommand` to only build `production`, but Vercel's GitHub integration still fires on every PR push and posts **two** failure statuses per commit:

1. `"Deployment failed."` (links to Vercel docs) — the ignoreCommand skip result
2. `"Deployment has failed"` (links to real deployment) — an actual failed preview build

Confirmed via `gh api repos/.../commits/<sha>/statuses` on PR #1735.

## Fix

Set `"github": {"enabled": false}` in `apps/web/vercel.json`.

This disables Vercel's GitHub integration (no more PR status checks). The hourly production deploy continues to work — deploy hooks **bypass** the GitHub integration and are unaffected by this setting.

## Why this is safe

- Production deploys: ✅ Still work via `scheduled-deploy.yml` cron (deploy hook)
- PR preview builds: Cleanly disabled (were already broken)
- Vercel PR status checks: Removed (the red failures disappear)
- Vercel project settings / env vars: Unaffected

## Test plan

- [ ] After merge, open a new PR and confirm no Vercel status checks appear (no red or green Vercel badges)
- [ ] Verify the scheduled production deploy still runs successfully via `scheduled-deploy.yml` (check Actions run after next hourly trigger)
- [ ] Confirm `apps/web/vercel.json` is valid JSON (no conflict markers)