### PR TITLE
feat: add pipeline quality gates for statements

### DIFF
--- a/apps/wiki-server/src/__tests__/statements-quality-gates.test.ts
+++ b/apps/wiki-server/src/__tests__/statements-quality-gates.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for pipeline quality gates on statement creation.
+ *
+ * These tests verify the `validateStatementQuality()` function which rejects
+ * semantically invalid statements that pass Zod schema validation but represent
+ * garbage data:
+ * 1. Empty structured statements (no value fields populated)
+ * 2. Benchmark scores with implausible magnitudes (e.g. 34,000,000%)
+ * 3. $0 values for financial properties (revenue, valuation, etc.)
+ * 4. Attributed statements with empty/whitespace-only statementText
+ *
+ * See discussion #1736, Section 5 for context.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateStatementQuality } from "../routes/statements.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A valid minimal structured statement with a value field. */
+function validStructured() {
+  return {
+    variety: "structured" as const,
+    statementText: "Anthropic was founded in 2021.",
+    subjectEntityId: "anthropic",
+    valueText: "2021",
+    citations: [],
+    pageReferences: [],
+  };
+}
+
+/** A valid attributed statement. */
+function validAttributed() {
+  return {
+    variety: "attributed" as const,
+    statementText: "Dario Amodei said AI safety is critical.",
+    subjectEntityId: "anthropic",
+    attributedTo: "dario-amodei",
+    citations: [],
+    pageReferences: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Block empty structured statements
+// ---------------------------------------------------------------------------
+
+describe("Quality gate: block empty structured statements", () => {
+  it("accepts structured statement with valueNumeric", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      valueText: undefined,
+      valueNumeric: 42,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts structured statement with valueText", () => {
+    const result = validateStatementQuality(validStructured());
+    expect(result).toBeNull();
+  });
+
+  it("accepts structured statement with valueDate", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      valueText: undefined,
+      valueDate: "2021-01-01",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts structured statement with valueEntityId", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      valueText: undefined,
+      valueEntityId: "google",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts structured statement with valueSeries", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      valueText: undefined,
+      valueSeries: { "2023": 100, "2024": 200 },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects structured statement with no value fields at all", () => {
+    const result = validateStatementQuality({
+      variety: "structured" as const,
+      statementText: "Some statement.",
+      subjectEntityId: "anthropic",
+      citations: [],
+      pageReferences: [],
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("Structured statements must have at least one value field");
+  });
+
+  it("rejects structured statement with all value fields explicitly null", () => {
+    const result = validateStatementQuality({
+      variety: "structured" as const,
+      statementText: "Some statement.",
+      subjectEntityId: "anthropic",
+      valueNumeric: null,
+      valueText: null,
+      valueDate: null,
+      valueEntityId: null,
+      valueSeries: null,
+      citations: [],
+      pageReferences: [],
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("Structured statements must have at least one value field");
+  });
+
+  it("does not apply empty-value check to attributed statements", () => {
+    // Attributed statements don't need value fields
+    const result = validateStatementQuality(validAttributed());
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Validate benchmark score magnitudes
+// ---------------------------------------------------------------------------
+
+describe("Quality gate: benchmark score magnitude", () => {
+  it("accepts benchmark score of 95 (percentage)", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: 95,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts benchmark score of 1800 (ELO)", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: 1800,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts benchmark score at the boundary (10000)", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: 10000,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects benchmark score of 34000000 (raw score stored as percentage)", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: 34000000,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("exceeds maximum plausible value");
+  });
+
+  it("rejects large negative benchmark score", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: -50000,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("exceeds maximum plausible value");
+  });
+
+  it("does not apply benchmark check to other properties", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "employee-count",
+      valueNumeric: 50000,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not apply benchmark check when valueNumeric is null", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "benchmark-score",
+      valueNumeric: null,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Block $0 for financial properties
+// ---------------------------------------------------------------------------
+
+describe("Quality gate: block $0 financial values", () => {
+  const financialProperties = [
+    "revenue",
+    "valuation",
+    "funding-round",
+    "operating-expenses",
+  ];
+
+  for (const propId of financialProperties) {
+    it(`rejects $0 for ${propId}`, () => {
+      const result = validateStatementQuality({
+        ...validStructured(),
+        propertyId: propId,
+        valueNumeric: 0,
+      });
+      expect(result).not.toBeNull();
+      expect(result).toContain("cannot have a value of $0");
+    });
+
+    it(`accepts non-zero value for ${propId}`, () => {
+      const result = validateStatementQuality({
+        ...validStructured(),
+        propertyId: propId,
+        valueNumeric: 1000000,
+      });
+      expect(result).toBeNull();
+    });
+  }
+
+  it("allows $0 for non-financial properties", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "employee-count",
+      valueNumeric: 0,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("allows null valueNumeric for financial properties", () => {
+    const result = validateStatementQuality({
+      ...validStructured(),
+      propertyId: "revenue",
+      valueNumeric: null,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Require statementText for attributed statements
+// ---------------------------------------------------------------------------
+
+describe("Quality gate: attributed statements need statementText", () => {
+  it("accepts attributed statement with non-empty statementText", () => {
+    const result = validateStatementQuality(validAttributed());
+    expect(result).toBeNull();
+  });
+
+  it("rejects attributed statement with whitespace-only statementText", () => {
+    const result = validateStatementQuality({
+      ...validAttributed(),
+      statementText: "   ",
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("non-empty statementText");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined: multiple rules don't interfere
+// ---------------------------------------------------------------------------
+
+describe("Quality gate: combined checks", () => {
+  it("a fully valid structured statement passes all checks", () => {
+    const result = validateStatementQuality({
+      variety: "structured" as const,
+      statementText: "Anthropic raised $7.3B in total funding.",
+      subjectEntityId: "anthropic",
+      propertyId: "funding-round",
+      valueNumeric: 7300000000,
+      valueUnit: "USD",
+      validStart: "2024-01-01",
+      citations: [],
+      pageReferences: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("a fully valid attributed statement passes all checks", () => {
+    const result = validateStatementQuality({
+      variety: "attributed" as const,
+      statementText: "We believe AI safety research is the most important work.",
+      subjectEntityId: "anthropic",
+      attributedTo: "dario-amodei",
+      citations: [],
+      pageReferences: [],
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -253,6 +253,69 @@ const ClearByEntityQuery = z.object({
   entityId: z.string().min(1).max(200),
 });
 
+// ---- Pipeline quality gate validation ----
+
+/** Property IDs that represent financial values where $0 is almost always a data error. */
+const FINANCIAL_PROPERTY_IDS = new Set([
+  "revenue",
+  "valuation",
+  "funding-round",
+  "operating-expenses",
+]);
+
+/** Maximum plausible benchmark score. ELO caps ~2000, percentages at 100, raw scores rarely exceed 10000. */
+const MAX_BENCHMARK_SCORE = 10000;
+
+/**
+ * Validate a parsed statement for semantic correctness beyond Zod schema checks.
+ * Returns null if valid, or a descriptive error message if invalid.
+ *
+ * Exported for unit testing.
+ */
+export function validateStatementQuality(
+  data: z.infer<typeof CreateStatementBody>
+): string | null {
+  // 1. Block empty structured statements: require at least one value field
+  if (data.variety === "structured") {
+    const hasValue =
+      data.valueNumeric != null ||
+      data.valueText != null ||
+      data.valueDate != null ||
+      data.valueEntityId != null ||
+      data.valueSeries != null;
+    if (!hasValue) {
+      return "Structured statements must have at least one value field (valueNumeric, valueText, valueDate, valueEntityId, or valueSeries)";
+    }
+  }
+
+  // 2. Validate benchmark score magnitudes
+  if (
+    data.propertyId === "benchmark-score" &&
+    data.valueNumeric != null &&
+    Math.abs(data.valueNumeric) > MAX_BENCHMARK_SCORE
+  ) {
+    return `Benchmark score ${data.valueNumeric} exceeds maximum plausible value of ${MAX_BENCHMARK_SCORE}. ELO scores cap around 2000, percentages at 100. Check if a raw score was stored with percentage format.`;
+  }
+
+  // 3. Block $0 for financial properties
+  if (
+    data.propertyId != null &&
+    FINANCIAL_PROPERTY_IDS.has(data.propertyId) &&
+    data.valueNumeric === 0
+  ) {
+    return `Financial property "${data.propertyId}" cannot have a value of $0. If the entity has no known value, omit the statement instead of recording zero.`;
+  }
+
+  // 4. Require statementText for attributed statements
+  if (data.variety === "attributed") {
+    if (!data.statementText || data.statementText.trim().length === 0) {
+      return "Attributed statements must have non-empty statementText";
+    }
+  }
+
+  return null;
+}
+
 // ---- Route definition (method-chained for Hono RPC type inference) ----
 
 const statementsApp = new Hono()
@@ -1034,6 +1097,13 @@ const statementsApp = new Hono()
     }
 
     const data = parsed.data;
+
+    // Pipeline quality gate — reject semantically invalid statements
+    const qualityError = validateStatementQuality(data);
+    if (qualityError) {
+      return c.json({ error: "validation_failed", message: qualityError }, 400);
+    }
+
     const db = getDrizzleDb();
 
     const statementId = await db.transaction(async (tx) => {
@@ -1112,6 +1182,21 @@ const statementsApp = new Hono()
     }
 
     const items = parsed.data.statements;
+
+    // Pipeline quality gate — validate all items before inserting any
+    for (let idx = 0; idx < items.length; idx++) {
+      const qualityError = validateStatementQuality(items[idx]);
+      if (qualityError) {
+        return c.json(
+          {
+            error: "validation_failed",
+            message: `Statement at index ${idx}: ${qualityError}`,
+          },
+          400
+        );
+      }
+    }
+
     const db = getDrizzleDb();
 
     const results: Array<{ id: number; sourceFactKey: string | null }> = [];


### PR DESCRIPTION
## Summary
Adds server-side validation to the statement creation API to prevent garbage data from entering the database. Addresses Section 5 of [Discussion #1736](https://github.com/quantified-uncertainty/longterm-wiki/discussions/1736).

### Quality gates added:
- **Block empty structured statements** — requires at least one value field (valueNumeric, valueText, valueDate, valueEntityId, or valueSeries)
- **Validate benchmark scores** — rejects scores > 10,000 (prevents "34,000,000%" nonsense)
- **Block $0 for financial properties** — rejects zero values for revenue, valuation, funding-round, operating-expenses
- **Require text for attributed statements** — statementText must be non-empty

### Implementation:
- `validateStatementQuality()` function runs after Zod parsing, before DB insert
- Applied to both single create (POST `/`) and batch create (POST `/batch`)
- Returns 400 with clear error messages
- 29 unit tests covering all validation rules

## Test plan
- [ ] All 29 new tests pass
- [ ] All existing tests pass (no regressions)
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)