### PR TITLE
fix: clarify statement stats cards and add intro text

### DIFF
--- a/apps/web/src/app/wiki/[id]/statements/page.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/page.tsx
@@ -86,9 +86,10 @@ export default async function EntityStatementsPage({ params }: PageProps) {
   // Stats
   const activeStructured = resolvedStructured.filter((s) => s.status === "active");
   const activeAttributed = resolvedAttributed.filter((s) => s.status === "active");
-  const activeCited =
-    activeStructured.filter((s) => s.citations.length > 0).length +
-    activeAttributed.filter((s) => s.citations.length > 0).length;
+  const activeTotal = activeStructured.length + activeAttributed.length;
+  const retractedCount =
+    resolvedStructured.filter((s) => s.status === "retracted").length +
+    resolvedAttributed.filter((s) => s.status === "retracted").length;
 
   return (
     <div className="max-w-5xl mx-auto px-6 py-8">
@@ -119,11 +120,18 @@ export default async function EntityStatementsPage({ params }: PageProps) {
 
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-        <StatCard label="Active" value={activeStructured.length + activeAttributed.length} />
-        <StatCard label="Active Structured" value={activeStructured.length} color="blue" />
-        <StatCard label="Active Attributed" value={activeAttributed.length} color="amber" />
-        <StatCard label="Active Cited" value={activeCited} color="emerald" />
+        <StatCard label="Active" value={activeTotal} />
+        <StatCard label="Structured" value={activeStructured.length} color="blue" />
+        <StatCard label="Attributed" value={activeAttributed.length} color="amber" />
+        <StatCard label="Retracted" value={retractedCount} color={retractedCount > 0 ? "rose" : undefined} />
       </div>
+
+      {/* Brief intro */}
+      <p className="text-xs text-muted-foreground mb-6">
+        Structured statements are specific data points (revenue, headcount,
+        dates) with typed values. Attributed statements are notable claims
+        attributed to people or organizations.
+      </p>
 
       {total === 0 ? (
         <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">

--- a/apps/web/src/components/internal/StatCard.tsx
+++ b/apps/web/src/components/internal/StatCard.tsx
@@ -9,7 +9,7 @@ export function StatCard({
 }: {
   label: string;
   value: number;
-  color?: "emerald" | "blue" | "amber";
+  color?: "emerald" | "blue" | "amber" | "rose";
 }) {
   const colorClass =
     color === "emerald"
@@ -18,7 +18,9 @@ export function StatCard({
         ? "text-blue-600"
         : color === "amber"
           ? "text-amber-600"
-          : "text-foreground";
+          : color === "rose"
+            ? "text-rose-600"
+            : "text-foreground";
 
   return (
     <div className="rounded-lg border border-border/60 px-3 py-2">


### PR DESCRIPTION
## Summary
Fixes misleading stats cards and adds narrative context to statements pages. Addresses issues 2.7 and 2.10 from [Discussion #1736](https://github.com/quantified-uncertainty/longterm-wiki/discussions/1736).

### Stats card fixes:
- **Standalone page**: "Total: 335" (including 209 retracted) → "Active" (only active count). "With Citations: 251" (including retracted) → only counts active with citations
- **Wiki tab**: Replaced redundant "Active Cited" (always = Active count) with "Retracted" count for data quality visibility
- Renamed "Active Structured"/"Active Attributed" → "Structured"/"Attributed" (active context is implicit)

### Narrative context:
- Added brief intro paragraph on both pages explaining structured vs attributed statements
- Added "rose" color to StatCard component for retracted count display

## Test plan
- [ ] TypeScript compiles clean
- [ ] Stats cards show correct active-only counts
- [ ] Intro text visible on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)