### PR TITLE
feat: add CSV/JSON export for entity statements

### DIFF
--- a/apps/web/src/app/wiki/[id]/statements/page.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/page.tsx
@@ -142,6 +142,7 @@ export default async function EntityStatementsPage({ params }: PageProps) {
             structured={resolvedStructured}
             attributed={resolvedAttributed}
             categories={categories}
+            entitySlug={slug}
           />
         </>
       )}

--- a/apps/web/src/app/wiki/[id]/statements/statements-client.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/statements-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
-import { Search } from "lucide-react";
+import { Search, Download } from "lucide-react";
 import {
   formatStatementValue,
   getStatusBadge,
@@ -15,20 +15,135 @@ interface StatementsClientProps {
   structured: ResolvedStatement[];
   attributed: ResolvedStatement[];
   categories: [string, ResolvedStatement[]][];
+  entitySlug: string;
 }
 
 type StatusFilter = "active" | "superseded" | "retracted";
+
+// ---- Export helpers ----
+
+function csvEscape(val: string | number | null | undefined): string {
+  if (val == null) return "";
+  const str = String(val);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function statementToFlatValue(s: ResolvedStatement): string {
+  if (s.valueEntityTitle) return s.valueEntityTitle;
+  if (s.valueText != null) return s.valueText;
+  if (s.valueDate != null) return s.valueDate;
+  if (s.valueEntityId != null) return s.valueEntityId;
+  return "";
+}
+
+function triggerDownload(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 export function StatementsClient({
   structured,
   attributed,
   categories,
+  entitySlug,
 }: StatementsClientProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [statusFilters, setStatusFilters] = useState<Set<StatusFilter>>(
     new Set(["active", "superseded"])
   );
+
+  const exportAsJson = useCallback(() => {
+    const allStatements = [...structured, ...attributed];
+    const data = {
+      entityId: entitySlug,
+      structured: structured.map((s) => ({
+        id: s.id,
+        variety: s.variety,
+        property: s.property?.label ?? s.propertyId,
+        propertyCategory: s.property?.category ?? null,
+        value: statementToFlatValue(s),
+        statementText: s.statementText,
+        validStart: s.validStart,
+        validEnd: s.validEnd,
+        status: s.status,
+        citationsCount: s.citations.length,
+        attributedTo: s.attributedTo,
+        verdict: s.verdict,
+        verdictScore: s.verdictScore,
+        claimCategory: s.claimCategory,
+      })),
+      attributed: attributed.map((s) => ({
+        id: s.id,
+        variety: s.variety,
+        property: s.property?.label ?? s.propertyId,
+        propertyCategory: s.property?.category ?? null,
+        value: statementToFlatValue(s),
+        statementText: s.statementText,
+        validStart: s.validStart,
+        validEnd: s.validEnd,
+        status: s.status,
+        citationsCount: s.citations.length,
+        attributedTo: s.attributedTo,
+        attributedToTitle: s.attributedToTitle,
+        verdict: s.verdict,
+        verdictScore: s.verdictScore,
+        claimCategory: s.claimCategory,
+      })),
+      total: allStatements.length,
+      exportedAt: new Date().toISOString(),
+    };
+    triggerDownload(
+      JSON.stringify(data, null, 2),
+      `${entitySlug}-statements.json`,
+      "application/json"
+    );
+  }, [structured, attributed, entitySlug]);
+
+  const exportAsCsv = useCallback(() => {
+    const allStatements = [...structured, ...attributed];
+    const headers = [
+      "id", "variety", "property", "propertyCategory", "value", "statementText",
+      "validStart", "validEnd", "status", "citationsCount",
+      "attributedTo", "verdict", "verdictScore", "claimCategory",
+    ];
+    const rows = allStatements.map((s) =>
+      headers.map((h) => {
+        switch (h) {
+          case "id": return csvEscape(s.id);
+          case "variety": return csvEscape(s.variety);
+          case "property": return csvEscape(s.property?.label ?? s.propertyId);
+          case "propertyCategory": return csvEscape(s.property?.category);
+          case "value": return csvEscape(statementToFlatValue(s));
+          case "statementText": return csvEscape(s.statementText);
+          case "validStart": return csvEscape(s.validStart);
+          case "validEnd": return csvEscape(s.validEnd);
+          case "status": return csvEscape(s.status);
+          case "citationsCount": return csvEscape(s.citations.length);
+          case "attributedTo": return csvEscape(s.attributedTo);
+          case "verdict": return csvEscape(s.verdict);
+          case "verdictScore": return csvEscape(s.verdictScore);
+          case "claimCategory": return csvEscape(s.claimCategory);
+          default: return "";
+        }
+      }).join(",")
+    );
+    triggerDownload(
+      [headers.join(","), ...rows].join("\n"),
+      `${entitySlug}-statements.csv`,
+      "text/csv"
+    );
+  }, [structured, attributed, entitySlug]);
 
   const allCategories = useMemo(
     () => categories.map(([name]) => name),
@@ -144,6 +259,25 @@ export function StatementsClient({
         <span className="text-xs text-muted-foreground">
           {totalVisible} of {totalAll}
         </span>
+
+        <div className="flex gap-1">
+          <button
+            onClick={exportAsJson}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded border border-border bg-background hover:bg-muted/50 text-muted-foreground"
+            title="Download as JSON"
+          >
+            <Download className="w-3 h-3" />
+            JSON
+          </button>
+          <button
+            onClick={exportAsCsv}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded border border-border bg-background hover:bg-muted/50 text-muted-foreground"
+            title="Download as CSV"
+          >
+            <Download className="w-3 h-3" />
+            CSV
+          </button>
+        </div>
       </div>
 
       {/* All-filters-off warning */}

--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -9,6 +9,7 @@
  * - POST /properties/upsert — batch upsert properties
  * - GET /stats             — basic statistics
  * - GET /quality-summary — aggregate quality distribution + per-entity coverage scores
+ * - GET /export    — export entity statements as JSON or CSV download
  * - PATCH /:id     — update statement status, verdict, or note
  * - POST /         — create statement + optional citations
  */
@@ -903,6 +904,122 @@ const statementsApp = new Hono()
       })),
       total: rows.length,
     });
+  })
+
+  // ---- GET /export — export statements for an entity as JSON or CSV ----
+  .get("/export", zv("query", z.object({
+    entityId: z.string().min(1).max(200),
+    format: z.enum(["json", "csv"]).default("json"),
+  })), async (c) => {
+    const { entityId, format } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    // Reuse by-entity query logic: fetch statements, citations, properties
+    const [rows, allCitations, propertyRows] = await Promise.all([
+      db
+        .select()
+        .from(statements)
+        .where(
+          and(
+            eq(statements.subjectEntityId, entityId),
+            sql`${statements.status} != 'retracted'`
+          )
+        )
+        .orderBy(desc(statements.validStart)),
+      db
+        .select()
+        .from(statementCitations)
+        .where(
+          sql`${statementCitations.statementId} IN (
+            SELECT ${statements.id} FROM ${statements}
+            WHERE ${statements.subjectEntityId} = ${entityId}
+            AND ${statements.status} != 'retracted'
+          )`
+        ),
+      db.select().from(properties),
+    ]);
+
+    // Build citation count map
+    const citationCountMap = new Map<number, number>();
+    for (const cit of allCitations) {
+      citationCountMap.set(cit.statementId, (citationCountMap.get(cit.statementId) ?? 0) + 1);
+    }
+
+    // Build property map
+    const propertyMap = new Map(propertyRows.map((p) => [p.id, p]));
+
+    // Format each statement with property info and citation count
+    const formatted = rows.map((s) => {
+      const prop = s.propertyId ? propertyMap.get(s.propertyId) : null;
+      return {
+        ...formatStatement(s),
+        property: prop
+          ? { id: prop.id, label: prop.label, category: prop.category, valueType: prop.valueType, unitFormatId: prop.unitFormatId }
+          : null,
+        citationsCount: citationCountMap.get(s.id) ?? 0,
+      };
+    });
+
+    const structured = formatted.filter((s) => s.variety === "structured");
+    const attributed = formatted.filter((s) => s.variety === "attributed");
+
+    if (format === "json") {
+      c.header("Content-Type", "application/json");
+      c.header("Content-Disposition", `attachment; filename="${entityId}-statements.json"`);
+      return c.json({ entityId, structured, attributed, total: rows.length });
+    }
+
+    // CSV format — flatten to rows
+    const csvHeaders = [
+      "id", "variety", "property", "propertyCategory", "value", "statementText",
+      "validStart", "validEnd", "status", "citationsCount",
+      "attributedTo", "verdict", "verdictScore", "claimCategory",
+    ];
+
+    function csvEscape(val: string | number | null | undefined): string {
+      if (val == null) return "";
+      const str = String(val);
+      if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    }
+
+    function formatValue(s: typeof formatted[number]): string {
+      if (s.valueNumeric != null) return String(s.valueNumeric) + (s.valueUnit ? ` ${s.valueUnit}` : "");
+      if (s.valueText != null) return s.valueText;
+      if (s.valueDate != null) return s.valueDate;
+      if (s.valueEntityId != null) return s.valueEntityId;
+      return "";
+    }
+
+    const csvRows = formatted.map((s) =>
+      csvHeaders.map((h) => {
+        switch (h) {
+          case "id": return csvEscape(s.id);
+          case "variety": return csvEscape(s.variety);
+          case "property": return csvEscape(s.property?.label ?? s.propertyId);
+          case "propertyCategory": return csvEscape(s.property?.category);
+          case "value": return csvEscape(formatValue(s));
+          case "statementText": return csvEscape(s.statementText);
+          case "validStart": return csvEscape(s.validStart);
+          case "validEnd": return csvEscape(s.validEnd);
+          case "status": return csvEscape(s.status);
+          case "citationsCount": return csvEscape(s.citationsCount);
+          case "attributedTo": return csvEscape(s.attributedTo);
+          case "verdict": return csvEscape(s.verdict);
+          case "verdictScore": return csvEscape(s.verdictScore);
+          case "claimCategory": return csvEscape(s.claimCategory);
+          default: return "";
+        }
+      }).join(",")
+    );
+
+    const csvContent = [csvHeaders.join(","), ...csvRows].join("\n");
+
+    c.header("Content-Type", "text/csv");
+    c.header("Content-Disposition", `attachment; filename="${entityId}-statements.csv"`);
+    return c.text(csvContent);
   })
 
   // ---- GET /:id — fetch a single statement with citations and property ----


### PR DESCRIPTION
## Summary
Adds CSV and JSON export capability for entity statements. Addresses issue 3.4 from [Discussion #1736](https://github.com/quantified-uncertainty/longterm-wiki/discussions/1736).

### Server-side:
- New `GET /api/statements/export` endpoint with `entityId` and `format` (json/csv) params
- JSON export: returns structured + attributed arrays with attachment header
- CSV export: flattens to rows with columns: id, variety, property, category, value, text, dates, status, citations count, etc.

### Client-side:
- JSON and CSV download buttons added to the wiki tab filter bar
- Client-side export from already-loaded data (no extra API call)
- Proper CSV escaping for commas, quotes, newlines

## Test plan
- [ ] JSON download produces valid JSON with all statement fields
- [ ] CSV download produces properly escaped CSV
- [ ] Download buttons visible in filter bar
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)