### PR TITLE
fix(wiki-server): unblock facts sync by tolerating sentinel subjects

### DIFF
--- a/apps/wiki-server/src/routes/facts.ts
+++ b/apps/wiki-server/src/routes/facts.ts
@@ -233,17 +233,26 @@ const factsApp = new Hono()
       );
     }
 
-    // Validate subject references (optional field, also points to entities)
+    // Validate subject references (optional field, also points to entities).
+    // Missing subjects are nulled out rather than rejecting the entire batch,
+    // since sentinel values like "industry-average" are used in YAML but
+    // aren't real entities in the DB.
     const subjectIds = [
       ...new Set(items.map((f) => f.subject).filter((s): s is string => s != null)),
     ];
+    let missingSubjects: string[] = [];
     if (subjectIds.length > 0) {
-      const missingSubjects = await checkRefsExist(db, entities, entities.id, subjectIds);
+      missingSubjects = await checkRefsExist(db, entities, entities.id, subjectIds);
       if (missingSubjects.length > 0) {
-        return validationError(
-          c,
-          `Referenced subject entities not found: ${missingSubjects.join(", ")}`
+        console.warn(
+          `Facts sync: nulling out ${missingSubjects.length} unresolved subject(s): ${missingSubjects.join(", ")}`
         );
+        const missingSet = new Set(missingSubjects);
+        for (const item of items) {
+          if (item.subject && missingSet.has(item.subject)) {
+            item.subject = null;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Facts sync endpoint now warns and nulls out unresolved `subject` references instead of rejecting the entire batch
- Unblocks the **Sync Entities & Facts** workflow which has been failing since the subject validation was added in `b40dbf9` (PR #1641)
- The sentinel value `industry-average` in `data/facts/anthropic.yaml` is used as a benchmark indicator, not a real entity — the FK constraint in the DB requires nulling it during sync

## Context

The Sync Entities & Facts workflow has been failing continuously. The most recent failure rejected all 144 facts because one fact had `subject: industry-average` which isn't a real entity.

See #1759 for the full investigation (the workflow has additional pre-existing failures dating back to Feb 25 that need separate investigation).

Closes #1759

## Test plan

- [ ] Verify wiki-server builds (`pnpm build`)
- [ ] After deploy, re-run the Sync Entities & Facts workflow and confirm it passes
- [ ] Check server logs for the warning message about nulled subjects

https://claude.ai/code/session_01GxwyPf2Q2xcCFuka8rGpR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch processing now tolerates missing subject references: instead of rejecting the entire batch, unresolved subjects are set to null and processing continues. The system logs warnings indicating how many references were unresolved, allowing partial completion and improved visibility into data issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->