### PR TITLE
refactor(crux): consolidate types, centralize config, fix README

### DIFF
--- a/crux/README.md
+++ b/crux/README.md
@@ -1,6 +1,6 @@
 # Crux — Longterm Wiki CLI Tooling
 
-Crux is the unified CLI for the Longterm Wiki project. It handles validation, content authoring, analysis, code generation, and automated fixes across ~625 MDX wiki pages and their YAML data layer.
+Crux is the unified CLI for the Longterm Wiki project. It handles validation, content authoring, analysis, code generation, and automated fixes across ~660 MDX wiki pages and their YAML data layer.
 
 ## Quick Start
 
@@ -36,7 +36,8 @@ crux.mjs                  CLI entry point — parses args, dispatches to domains
 │   ├── edit-log.ts       Per-page edit history
 │   ├── importance.ts     Ranking-based importance scoring
 │   ├── ci.ts             GitHub CI status and monitoring
-│   └── maintain.ts       Periodic maintenance and housekeeping
+│   ├── maintain.ts       Periodic maintenance and housekeeping
+│   └── ... (+26 more)    issues, pr, agents, context, facts, etc.
 │
 ├── authoring/            Page authoring scripts (invoked by content domain)
 │   ├── page-creator.ts   Create new pages with research pipeline
@@ -80,7 +81,6 @@ crux.mjs                  CLI entry point — parses args, dispatches to domains
 | **updates** | `content/docs/` frontmatter | invokes `content improve` |
 | **visual** | `content/docs/` | `content/docs/` (diagrams, charts) |
 | **check-links** | `data/resources/`, URLs | stdout (health reports) |
-| **edit-log** | PostgreSQL (wiki-server) | stdout (history) |
 | **edit-log** | wiki-server PostgreSQL DB | stdout (history) |
 | **importance** | `content/docs/`, `data/` | `content/docs/` frontmatter |
 | **ci** | GitHub API | stdout (check-run status) |
@@ -97,11 +97,37 @@ crux.mjs                  CLI entry point — parses args, dispatches to domains
 - **updates** — Schedule-aware update queue using `update_frequency` frontmatter
 - **visual** — Create, review, audit, and improve diagrams/charts/models
 - **check-links** — Check external URL health and find broken links
-- **edit-log** — View and query per-page edit history from the wiki-server PostgreSQL database
 - **edit-log** — View and query per-page edit history from PostgreSQL (via wiki-server API)
 - **importance** — Ranking-based importance scoring for pages
 - **ci** — GitHub CI check-run status monitoring with optional polling
 - **maintain** — Periodic maintenance: PR review, issue triage, cruft detection
+- **auto-update** — News-driven automatic wiki updates from RSS feeds and web searches
+- **issues** — GitHub issue tracking: create, search, start/done lifecycle, lint
+- **pr** — Pull request management: create, detect, fix-body, validate test plans
+- **pr-patrol** — Automated PR review and quality checks
+- **agents** — Agent session lifecycle management
+- **agent-checklist** — Session start/end checklists for Claude Code agents
+- **agent-session-events** — Query agent session event history
+- **sessions** — Session log management (DB-backed)
+- **context** — Assemble research context for pages, issues, entities, or topics
+- **query** — Full-text search across wiki content
+- **ids** — Entity ID allocation and registry management
+- **entity** — Entity YAML management and ontology tools
+- **facts** — Canonical fact extraction and management
+- **claims** — Claims ingestion and exploration
+- **statements** — Entity statement extraction, improvement, and scoring
+- **citations** — Citation accuracy checking and fix pipeline
+- **wiki-server** — Direct wiki-server API operations
+- **jobs** — Background job queue management
+- **health** — System health checks and monitoring
+- **audits** — Audit item tracking and verification
+- **evals** — Evaluation and benchmarking tools
+- **enrich** — Content enrichment pipeline
+- **research** — Research tools for source discovery
+- **epic** — GitHub Discussions for open-ended planning
+- **review** — Code review utilities
+- **grokipedia** — Cross-reference with Grokipedia content
+- **release** — Release management
 
 ## How to Add a Validation Rule
 

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -23,7 +23,7 @@ import {
   type SessionType,
   type ChecklistMetadata,
 } from '../lib/session/session-checklist.ts';
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { upsertAgentSession, updateAgentSession, getAgentSessionByBranch } from '../lib/wiki-server/agent-sessions.ts';
 import { registerAgent, listActiveAgents } from '../lib/wiki-server/active-agents.ts';
 
@@ -38,12 +38,11 @@ const VALID_TYPES: SessionType[] = ['content', 'infrastructure', 'bugfix', 'refa
 // Types
 // ---------------------------------------------------------------------------
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   ci?: boolean;
   type?: string;
   issue?: string;
   reason?: string;
-  [key: string]: unknown;
 }
 
 interface GitHubIssueResponse {

--- a/crux/commands/agent-session-events.ts
+++ b/crux/commands/agent-session-events.ts
@@ -6,7 +6,7 @@
  *   crux agent-session-events list [--agent=ID] [--limit=50]             Show event timeline
  */
 
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { createLogger } from '../lib/output.ts';
 import {
   appendEvent,
@@ -17,13 +17,12 @@ import { listActiveAgents } from '../lib/wiki-server/active-agents.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { execSync } from 'child_process';
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   type?: string;
   agent?: string;
   limit?: string;
   json?: boolean;
   ci?: boolean;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/agents.ts
+++ b/crux/commands/agents.ts
@@ -10,7 +10,7 @@
  *   crux agents sweep [--timeout=30]                             Mark stale agents
  */
 
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { createLogger } from '../lib/output.ts';
 import {
   registerAgent,
@@ -24,7 +24,7 @@ import {
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { sweepStaleSessions } from '../lib/wiki-server/agent-sessions.ts';
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   task?: string;
   branch?: string;
   issue?: string;
@@ -38,7 +38,6 @@ interface CommandOptions {
   limit?: string;
   json?: boolean;
   ci?: boolean;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/audits.ts
+++ b/crux/commands/audits.ts
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { parse as parseYaml } from 'yaml';
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 
 // ---------------------------------------------------------------------------
@@ -57,7 +57,7 @@ interface AuditsFile {
   post_merge: PostMergeItem[];
 }
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   pending?: boolean;
   category?: string;
   json?: boolean;
@@ -66,7 +66,6 @@ interface CommandOptions {
   fail?: boolean;
   notes?: string;
   status?: string;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/entity.ts
+++ b/crux/commands/entity.ts
@@ -8,15 +8,14 @@
  *   crux entity rename <old-id> <new-id> --apply   # Apply rename
  */
 
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { runRename } from '../entity/entity-rename.ts';
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   apply?: boolean;
   verbose?: boolean;
   dryRun?: boolean;
   ci?: boolean;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/epic.ts
+++ b/crux/commands/epic.ts
@@ -33,10 +33,8 @@ import { readFileSync } from 'fs';
 import { createLogger } from '../lib/output.ts';
 import { githubGraphQL, githubApi, REPO, getRepoNodeId } from '../lib/github.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 import { parseRequiredInt } from '../lib/cli.ts';
-
-type CommandOptions = Record<string, unknown>;
 
 const [OWNER, REPO_NAME] = REPO.split('/');
 

--- a/crux/commands/ids.ts
+++ b/crux/commands/ids.ts
@@ -9,7 +9,7 @@
  *   crux ids list [--limit=50] [--offset=0]          List all allocated IDs
  */
 
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
   allocateId,
   getIdBySlug,
@@ -18,12 +18,11 @@ import {
 } from '../lib/wiki-server/ids.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   description?: string;
   limit?: string;
   offset?: string;
   ci?: boolean;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/issues.ts
+++ b/crux/commands/issues.ts
@@ -20,7 +20,8 @@ import { join, dirname } from 'path';
 import { createLogger, type Colors } from '../lib/output.ts';
 import { githubApi, githubApiPaginated, REPO } from '../lib/github.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
-import { type CommandResult, parseIntOpt, parseRequiredInt } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { parseIntOpt, parseRequiredInt } from '../lib/cli.ts';
 import { listActiveAgents, registerAgent } from '../lib/wiki-server/active-agents.ts';
 import { getAgentSessionByBranch, updateAgentSession, PR_OUTCOMES, type PrOutcome } from '../lib/wiki-server/agent-sessions.ts';
 
@@ -84,7 +85,7 @@ interface RankedIssue {
   missingSections: string[]; // empty = well-formatted
 }
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   ci?: boolean;
   json?: boolean;
   pr?: string;
@@ -98,7 +99,6 @@ interface CommandOptions {
   depends?: string;
   criteria?: string;
   cost?: string;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -718,7 +718,7 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   }
 
   // Rate limit: max DAILY_CREATE_LIMIT issues per day (prevents tracker flood)
-  if (!options['no-limit']) {
+  if (!options['no-limit'] && !options.noLimit) {
     const todayCount = getCreatestoday();
     if (todayCount >= DAILY_CREATE_LIMIT) {
       return {

--- a/crux/commands/jobs.ts
+++ b/crux/commands/jobs.ts
@@ -27,13 +27,14 @@ import {
 } from '../lib/wiki-server/jobs.ts';
 import { apiRequest, type ApiResult } from '../lib/wiki-server/client.ts';
 import { getRegisteredTypes } from '../lib/job-handlers/index.ts';
-import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { parseIntOpt } from '../lib/cli.ts';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   ci?: boolean;
   json?: boolean;
   status?: string;
@@ -42,7 +43,6 @@ interface CommandOptions {
   priority?: string;
   maxRetries?: string;
   limit?: string;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/maintain.ts
+++ b/crux/commands/maintain.ts
@@ -18,7 +18,8 @@ import { execSync } from 'child_process';
 import { createLogger } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { githubApi, REPO } from '../lib/github.ts';
-import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { parseIntOpt } from '../lib/cli.ts';
 import { listSessions } from '../lib/wiki-server/sessions.ts';
 
 // ---------------------------------------------------------------------------
@@ -61,12 +62,11 @@ interface CruftItem {
 
 type TriageCategory = 'potentially-resolved' | 'stale' | 'actionable' | 'keep';
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   ci?: boolean;
   json?: boolean;
   since?: string;
   limit?: string;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/pr-patrol.ts
+++ b/crux/commands/pr-patrol.ts
@@ -11,10 +11,8 @@
  *   crux pr-patrol status           Show recent patrol activity
  */
 
-import type { CommandResult } from '../lib/cli.ts';
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 import { buildConfig, runDaemon, readRecentLogs } from '../pr-patrol/index.ts';
-
-type CommandOptions = Record<string, unknown>;
 
 async function run(
   args: string[],

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -18,9 +18,7 @@ import { githubApi, REPO } from '../lib/github.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
 import { rebaseAllPrs } from '../lib/pr-rebase.ts';
 import { resolveAllConflicts } from '../lib/conflict-resolution.ts';
-import type { CommandResult } from '../lib/cli.ts';
-
-type CommandOptions = Record<string, unknown>;
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 
 // ── Test plan validation ─────────────────────────────────────────────────────
 

--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -13,9 +13,7 @@
 import { execFileSync } from 'child_process';
 import { createLogger } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
-import type { CommandResult } from '../lib/cli.ts';
-
-type CommandOptions = Record<string, unknown>;
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/crux/commands/updates.ts
+++ b/crux/commands/updates.ts
@@ -16,7 +16,8 @@ import { createLogger } from '../lib/output.ts';
 import { parseFrontmatter } from '../lib/mdx-utils.ts';
 import { CONTENT_DIR_ABS, PROJECT_ROOT } from '../lib/content-types.ts';
 import { findMdxFiles } from '../lib/file-utils.ts';
-import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { parseIntOpt } from '../lib/cli.ts';
 import { triagePhase, loadPages as loadPagesFromImprover, findPage as findPageFromImprover } from '../authoring/page-improver.ts';
 import type { TriageResult } from '../authoring/page-improver.ts';
 
@@ -53,7 +54,7 @@ interface CategoryStats {
   avgPriority: number;
 }
 
-interface CommandOptions {
+interface CommandOptions extends BaseOptions {
   ci?: boolean;
   json?: boolean;
   limit?: string;
@@ -63,7 +64,6 @@ interface CommandOptions {
   dryRun?: boolean;
   triage?: boolean;
   noTriage?: boolean;
-  [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/command-types.ts
+++ b/crux/lib/command-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared type for CLI command option bags.
+ *
+ * All command handlers receive options as a string-keyed record.
+ * Command files can extend this with command-specific typed properties.
+ *
+ * @example
+ *   interface MyCommandOptions extends CommandOptions {
+ *     tier?: string;
+ *     dryRun?: boolean;
+ *   }
+ */
+export type CommandOptions = Record<string, unknown>;
+
+// Re-export CommandResult from cli.ts for co-location
+export type { CommandResult } from './cli.ts';

--- a/crux/lib/config.ts
+++ b/crux/lib/config.ts
@@ -1,0 +1,22 @@
+/**
+ * Centralized configuration constants for the crux CLI.
+ *
+ * Timeout values that are shared across multiple modules live here
+ * to prevent drift between duplicated constants.
+ */
+
+// ---------------------------------------------------------------------------
+// Wiki-server timeouts
+// ---------------------------------------------------------------------------
+
+/** Default timeout for individual wiki-server API requests (ms). */
+export const WIKI_SERVER_TIMEOUT_MS = 5_000;
+
+/** Timeout for batched wiki-server requests (ms). */
+export const WIKI_SERVER_BATCH_TIMEOUT_MS = 30_000;
+
+/** Health check timeout for wiki-server probes (ms). */
+export const WIKI_SERVER_HEALTH_CHECK_TIMEOUT_MS = 5_000;
+
+/** Delay between health check retries (ms). */
+export const WIKI_SERVER_HEALTH_CHECK_DELAY_MS = 10_000;

--- a/crux/lib/wiki-server/client.ts
+++ b/crux/lib/wiki-server/client.ts
@@ -13,8 +13,11 @@
 // Configuration
 // ---------------------------------------------------------------------------
 
-const TIMEOUT_MS = 5_000;
-export const BATCH_TIMEOUT_MS = 30_000;
+import {
+  WIKI_SERVER_TIMEOUT_MS as TIMEOUT_MS,
+  WIKI_SERVER_BATCH_TIMEOUT_MS as BATCH_TIMEOUT_MS,
+} from '../config.ts';
+export { BATCH_TIMEOUT_MS };
 
 /** API key scope — determines which env var to prefer for authentication. */
 export type ApiKeyScope = 'project' | 'content';

--- a/crux/wiki-server/sync-common.ts
+++ b/crux/wiki-server/sync-common.ts
@@ -11,14 +11,16 @@
  */
 
 import { buildHeaders, type ApiKeyScope } from "../lib/wiki-server/client.ts";
+import {
+  WIKI_SERVER_BATCH_TIMEOUT_MS as BATCH_TIMEOUT_MS,
+  WIKI_SERVER_HEALTH_CHECK_TIMEOUT_MS as HEALTH_CHECK_TIMEOUT_MS,
+  WIKI_SERVER_HEALTH_CHECK_DELAY_MS as HEALTH_CHECK_DELAY_MS,
+} from "../lib/config.ts";
 
 // --- Configuration ---
 const HEALTH_CHECK_RETRIES = 5;
-const HEALTH_CHECK_DELAY_MS = 10_000;
-const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 const BATCH_RETRY_ATTEMPTS = 3;
 const BATCH_RETRY_BASE_DELAY_MS = 2_000;
-const BATCH_TIMEOUT_MS = 30_000;
 export const MAX_CONSECUTIVE_FAILURES = 3;
 
 // --- Types ---


### PR DESCRIPTION
## Summary

Addresses code quality findings from a crux/ library audit:

- **Shared `CommandOptions` type** (`crux/lib/command-types.ts`): 14 command files now extend a single base type instead of independently declaring `type CommandOptions = Record<string, unknown>` or `interface CommandOptions { [key: string]: unknown; ... }`
- **Centralized timeout constants** (`crux/lib/config.ts`): Wiki-server timeout values (5s API, 30s batch, 5s health check, 10s health delay) are now defined once and imported by `client.ts` and `sync-common.ts`
- **README fixes**: Removed duplicate `edit-log` entry, added 27 missing domain references, updated page count from ~625 to ~660
- **Bug fix**: `--no-limit` flag in `crux issues create` was silently ignored because `crux.mjs` converts kebab-case to camelCase but the handler only checked `options['no-limit']`

## Related Issues

Closes #1754
Closes #1756
Closes #1757

Filed but not addressed in this PR:
- #1755 (extract shared help formatter)
- #1758 (add authoring pipeline tests)

## Test plan

- [x] `npx tsc --noEmit -p crux/tsconfig.json` passes (0 errors)
- [x] `pnpm test` passes (pre-existing failures in source-fetcher.test.ts and validate-review-marker.test.ts only)
- [x] `pnpm crux validate gate` passes
- [x] `pnpm crux issues create` with `--no-limit` now works correctly

https://claude.ai/code/session_01RK5QvhtkMzMqoxFNEHLE1j
