### PR TITLE
fix(ci): increase scheduled-maintenance max-turns and timeout

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -58,7 +58,7 @@ jobs:
   maintain:
     needs: [preflight]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Determine cadence
         id: cadence
@@ -119,7 +119,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 30 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
+          claude_args: '--max-turns 60 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

- `scheduled-maintenance.yml` was failing with `error_max_turns` — the 2026-03-05 run needed 31 turns but was limited to 30.
- Also increases `timeout-minutes` from 30 to 60 to give enough wall-clock headroom for weekly/monthly sweeps.

## Root cause

Run [22708103847](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/22708103847) (2026-03-05T07:59:11Z) ended with `error_max_turns` after 31 turns. The daily maintenance workflow easily exceeds 30 turns; weekly sweeps need even more.

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `timeout-minutes` | 30 | 60 |
| `--max-turns` | 30 | 60 |

## Context: Other failing workflows

This PR fixes the `scheduled-maintenance` failure. The other two flagged workflows:
- **auto-update**: already fixed by PR #1729 (timeout 60→120 min)
- **server-health-monitor**: historical push-triggered failures — push triggers have been removed; next Monday schedule run should pass

## Test plan

- [x] `timeout-minutes` increased from 30 to 60 in workflow YAML
- [x] `--max-turns` increased from 30 to 60 in Claude args
- [x] Gate check passes (no TypeScript or content changes)
- [ ] Next scheduled run of `scheduled-maintenance.yml` completes without `error_max_turns`

Closes #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled maintenance workflow parameters to enhance system maintenance processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->