### PR TITLE
feat(ci): add PR size warning (non-test additions) and Drizzle schema drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # The default checkout is shallow (depth=1). The drift check uses
+          # `git diff BASE...HEAD` (3-dot), which requires the merge-base of both
+          # SHAs. Fetch enough history so the merge-base is available; without
+          # this, getChangedFiles() silently returns [] → false-negative.
+          git fetch --unshallow 2>/dev/null || git fetch --depth=100 origin 2>/dev/null || true
           npx tsx crux/validate/validate-schema-drift.ts \
             || echo "::warning::Schema drift check failed unexpectedly — review validator output above"
 

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -80,13 +80,6 @@ jobs:
               return;
             }
 
-            // Get PR metadata for the comment
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
             // Check if we already posted a size warning (avoid duplicates on re-push)
             const MARKER = '<!-- pr-size-check -->';
             const { data: comments } = await github.rest.issues.listComments({

--- a/crux/validate/validate-schema-drift.ts
+++ b/crux/validate/validate-schema-drift.ts
@@ -59,15 +59,17 @@ interface CheckResult {
   details: string[];
 }
 
-function getChangedFiles(baseSha: string, headSha: string): string[] {
+function getChangedFiles(baseSha: string, headSha: string): string[] | null {
   try {
     const output = execSync(`git diff --name-only ${baseSha}...${headSha}`, {
       cwd: PROJECT_ROOT,
       encoding: 'utf-8',
     });
     return output.trim().split('\n').filter(Boolean);
-  } catch {
-    return [];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`git diff failed (shallow clone or missing commits?): ${msg}`);
+    return null; // null = git failure, distinguish from [] = no files changed
   }
 }
 
@@ -91,6 +93,14 @@ function runPrDriftCheck(baseSha: string, headSha: string, c: ReturnType<typeof 
   console.log(`${c.blue}Checking Drizzle schema drift (PR mode: ${baseSha.slice(0, 8)}...${headSha.slice(0, 8)})...${c.reset}\n`);
 
   const changedFiles = getChangedFiles(baseSha, headSha);
+  if (changedFiles === null) {
+    const msg = `Could not determine changed files via git diff (shallow clone without sufficient history?). ` +
+      `Skipping schema drift check — check CI logs and ensure the checkout has enough history.`;
+    console.log(`${c.yellow}Warning: ${msg}${c.reset}`);
+    console.log(`::warning::${msg}`);
+    return { passed: true, warnings: 1, errors: 0, details: [msg] };
+  }
+
   const addedFiles = getAddedFiles(baseSha, headSha);
 
   const schemaChanged = changedFiles.includes(SCHEMA_PATH);


### PR DESCRIPTION
## Summary

Two new CI advisory checks (warnings, not failures) addressing the pattern of post-merge fix chains caused by large PRs and schema drift.

### PR size warning (#1685)

The existing `pr-size-check.yml` was checking `additions + deletions` (total lines touched) rather than additions-only excluding low-risk file types. This PR updates it to:

- Filter out test files (`*.test.ts`, `*.spec.ts`), wiki content (`content/docs/**`), snapshots, static assets, and lockfiles before counting
- Threshold is now **500 non-test infrastructure additions** (previously total additions+deletions)
- Comment shows both non-test additions and total additions for full context
- Adds `actions/checkout` with `fetch-depth: 0` to enable per-file diff via `git diff --numstat`

This matches the issue's intent: "large infra PRs correlate with post-merge bugs; test and content PRs are low-risk."

### Drizzle schema drift detection (#1686)

New `crux/validate/validate-schema-drift.ts` with two detection modes:

1. **PR mode** (when `BASE_SHA`/`HEAD_SHA` env vars are set): Checks if `apps/wiki-server/src/schema.ts` was modified without a corresponding new/modified migration file in `apps/wiki-server/drizzle/`. Emits `::warning::` if drift is detected.

2. **Local/structural mode** (no PR context): Runs `drizzle-kit check` which compares `schema.ts` against the migration journal snapshots (`meta/*.json`) — no live database required.

Added "Drizzle schema drift detection (advisory)" step to `ci.yml`, running on `pull_request` events with `continue-on-error: true`. This catches the class of bug from PR #1570 where migration 0052 was recorded in the journal as complete but its SQL never executed.

Both checks are **advisory only** — they emit yellow `::warning::` annotations without blocking merge.

## Test plan

- [x] `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/pr-size-check.yml` — no errors
- [x] `npx tsx crux/validate/validate-schema-drift.ts` — runs cleanly, reports "Schema and migration journal are in sync"
- [x] `BASE_SHA=<base> HEAD_SHA=<head> npx tsx crux/validate/validate-schema-drift.ts` — PR mode works, reports "schema.ts not modified" for commits that don't touch schema
- [x] `pnpm crux validate gate --fix` — all checks pass
- [x] `npx tsx crux/validate/validate-actions-yaml.ts` — all 30 workflow files valid

Closes #1685
Closes #1686
