### PR TITLE
fix: address CodeRabbit review comments from PR #1764

### DIFF
--- a/.claude/commands/entity-deep-dive.md
+++ b/.claude/commands/entity-deep-dive.md
@@ -72,7 +72,7 @@ Based on your assessment, take action in priority order:
 
 Summarize what you found and what you changed:
 
-```
+```md
 ## Entity Deep Dive: [Entity Name]
 
 ### Quality Assessment

--- a/.claude/commands/knowledge-gap.md
+++ b/.claude/commands/knowledge-gap.md
@@ -100,7 +100,7 @@ Check for important recent developments (last 6 months) that aren't reflected:
 
 ## Phase 3: Write the Report
 
-```
+```md
 ## Knowledge Gap Analysis — [DATE]
 
 ### Coverage Summary

--- a/.claude/commands/ontology-review.md
+++ b/.claude/commands/ontology-review.md
@@ -84,7 +84,7 @@ Produce a structured report. Be specific — reference statement IDs, entity slu
 
 ### Report Format
 
-```
+```md
 ## Ontology Review: [Entity Name] ([entity-type])
 
 ### Summary

--- a/apps/web/src/app/wiki/[id]/statements/current-snapshot.tsx
+++ b/apps/web/src/app/wiki/[id]/statements/current-snapshot.tsx
@@ -105,8 +105,11 @@ function SnapshotRow({
 
   // Show qualifier context if present — format "category:value" as just "value"
   const qualifierLabel = s.qualifierKey
-    ? (s.qualifierKey.includes(":") ? s.qualifierKey.split(":")[1] : s.qualifierKey)
-        ?.replace(/-/g, " ")
+    ? (
+        s.qualifierKey.includes(":")
+          ? s.qualifierKey.split(":").slice(1).join(":")
+          : s.qualifierKey
+      ).replace(/-/g, " ")
     : null;
 
   // First citation URL for inline source

--- a/apps/wiki-server/src/routes/statements.ts
+++ b/apps/wiki-server/src/routes/statements.ts
@@ -437,9 +437,11 @@ const statementsApp = new Hono()
         .limit(1);
       if (entityRow.length > 0 && entityRow[0].relatedEntries) {
         const childIds = (
-          entityRow[0].relatedEntries as Array<{ id: string }>
-        ).map((re) => re.id);
-        entityIds = [entityId, ...childIds];
+          entityRow[0].relatedEntries as Array<{ id: string; relationship?: string }>
+        )
+          .filter((re) => re.relationship === "composed-of")
+          .map((re) => re.id);
+        entityIds = [...new Set([entityId, ...childIds])];
       }
     }
 

--- a/crux/statements/ideate.ts
+++ b/crux/statements/ideate.ts
@@ -533,20 +533,32 @@ async function main() {
     console.log(`\n${c.bold}Ontology Analysis: ${entityId}${c.reset}\n`);
   }
 
-  // Check budget
-  if (tracker.totalCost > budget) {
-    console.error(`Budget exceeded: $${tracker.totalCost.toFixed(4)} > $${budget}`);
-    process.exit(1);
-  }
-
   const result = await analyzeEntityClusters(entityId, {
     client,
     tracker,
     minCluster,
   });
 
+  // Check budget after analysis
+  if (tracker.totalCost > budget) {
+    console.error(`Budget exceeded: $${tracker.totalCost.toFixed(4)} > $${budget}`);
+    process.exit(1);
+  }
+
+  // Apply if requested
+  let applyResult: Awaited<ReturnType<typeof applyIdeation>> | undefined;
+  if (apply && result.clusters.length > 0) {
+    if (!jsonOutput) {
+      console.log(`\n${c.bold}Applying ideation results...${c.reset}\n`);
+    }
+    applyResult = await applyIdeation(result, { dryRun: false });
+  }
+
   if (jsonOutput) {
-    console.log(JSON.stringify(result, null, 2));
+    const output = applyResult
+      ? { ...result, applied: applyResult, cost: tracker.totalCost }
+      : { ...result, cost: tracker.totalCost };
+    console.log(JSON.stringify(output, null, 2));
   } else {
     // Pretty-print results
     console.log(`  Entity type: ${result.parentEntityType}`);
@@ -577,26 +589,9 @@ async function main() {
     console.log(`  ${c.dim}Analysis: ${result.analysis}${c.reset}`);
     console.log(`  Cost: $${tracker.totalCost.toFixed(4)}`);
 
-    if (result.clusters.length > 0 && !apply) {
-      console.log(
-        `\n  Run with ${c.bold}--apply${c.reset} to create these entities and reassign statements.`,
-      );
-    }
-  }
-
-  // Apply if requested
-  if (apply && result.clusters.length > 0) {
-    if (!jsonOutput) {
-      console.log(`\n${c.bold}Applying ideation results...${c.reset}\n`);
-    }
-
-    const applyResult = await applyIdeation(result, { dryRun: false });
-
-    if (jsonOutput) {
-      console.log(JSON.stringify(applyResult, null, 2));
-    } else {
+    if (applyResult) {
       if (applyResult.created.length > 0) {
-        console.log(`  Created ${applyResult.created.length} entities:`);
+        console.log(`\n  Created ${applyResult.created.length} entities:`);
         for (const e of applyResult.created) {
           console.log(`    - ${e.numericId} ${e.slug} ("${e.title}")`);
         }
@@ -608,6 +603,10 @@ async function main() {
           console.log(`    - ${err}`);
         }
       }
+    } else if (result.clusters.length > 0) {
+      console.log(
+        `\n  Run with ${c.bold}--apply${c.reset} to create these entities and reassign statements.`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
Addresses the review comments left by CodeRabbit on PR #1764 that were not resolved before it was closed.

**Fixes applied:**
- Add `md` language identifiers to 3 unlabeled code fences in `.claude/commands/` docs (markdownlint MD040)
- Fix qualifier label parsing in `current-snapshot.tsx` — `split(":")[1]` dropped segments after first colon; now uses `.slice(1).join(":")`
- Filter `includeChildren` in statements route to only `composed-of` relationships — was previously pulling ALL related entities (people, risks, partner orgs)
- Move budget check in `ideate.ts` to after LLM analysis — was checking `tracker.totalCost` immediately after creating a fresh `CostTracker` (always 0)
- Combine JSON output in `ideate.ts` `--json --apply` mode into a single object instead of two separate `console.log(JSON.stringify(...))` calls

## Test plan
- [x] TypeScript clean (app + crux)
- [x] All 2670 tests pass
- [x] No behavioral regressions — all changes are bug fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved display of complex multi-segment data labels for better readability.
  * Refined filtering of related entities to more accurately reflect composition relationships.

* **Features**
  * Enhanced ideation workflow with better progress messaging and output formatting.

* **Documentation**
  * Updated Markdown syntax highlighting in command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->