### PR TITLE
feat: @longterm-wiki/kb — greenfield Knowledge Base library

### DIFF
--- a/packages/kb/EXPERIMENTAL.md
+++ b/packages/kb/EXPERIMENTAL.md
@@ -1,0 +1,10 @@
+# EXPERIMENTAL: Knowledge Base Library
+
+This package is an **experiment**. It may be promoted to production or killed after evaluation.
+
+- **Different code quality standards** — iteration speed over polish
+- **Not depended on by production code** — no imports from apps/web or apps/wiki-server yet
+- **Scoped to Anthropic** — one test entity, not the full wiki
+- **Kill/promote deadline**: 2 weeks from first code (target: 2026-03-20)
+
+See `.claude/design/kb-library.md` for the full design doc.

--- a/packages/kb/data/properties.yaml
+++ b/packages/kb/data/properties.yaml
@@ -1,0 +1,149 @@
+properties:
+
+  # ── Financial ────────────────────────────────────────────────
+
+  revenue:
+    name: Revenue
+    description: "Annualized run-rate revenue (ARR) or trailing twelve-month revenue"
+    dataType: number
+    unit: USD
+    category: financial
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  valuation:
+    name: Valuation
+    description: "Post-money valuation at most recent funding round or mark-to-market"
+    dataType: number
+    unit: USD
+    category: financial
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  headcount:
+    name: Headcount
+    description: "Total full-time employee count"
+    dataType: number
+    unit: employees
+    category: financial
+    appliesTo: [organization]
+    display:
+      suffix: " employees"
+
+  total-funding:
+    name: Total Funding Raised
+    description: "Cumulative capital raised across all funding rounds"
+    dataType: number
+    unit: USD
+    category: financial
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  funding-round-amount:
+    name: Funding Round Amount
+    description: "Capital raised in a specific funding round"
+    dataType: number
+    unit: USD
+    category: financial
+    appliesTo: [organization]
+    display:
+      divisor: 1e6
+      prefix: "$"
+      suffix: "M"
+
+  # ── People & Relationships ────────────────────────────────────
+
+  employed-by:
+    name: Employed By
+    description: "Organization this person currently or historically works for"
+    dataType: ref
+    category: people
+    appliesTo: [person]
+    inverseId: employer-of
+    inverseName: Employs
+
+  employer-of:
+    name: Employs
+    description: "People employed by this organization (computed from employed-by facts)"
+    dataType: refs
+    category: people
+    appliesTo: [organization]
+    inverseId: employed-by
+    inverseName: Employed By
+    computed: true
+
+  role:
+    name: Role / Title
+    description: "Job title or role at primary employer"
+    dataType: text
+    category: people
+    appliesTo: [person]
+
+  founded-by:
+    name: Founded By
+    description: "Person(s) who founded this organization"
+    dataType: refs
+    category: people
+    appliesTo: [organization]
+    inverseId: founder-of
+    inverseName: Founded
+
+  founder-of:
+    name: Founder Of
+    description: "Organization(s) this person founded (computed from founded-by facts)"
+    dataType: refs
+    category: people
+    appliesTo: [person]
+    inverseId: founded-by
+    inverseName: Founded By
+    computed: true
+
+  # ── Dates ─────────────────────────────────────────────────────
+
+  founded-date:
+    name: Founded Date
+    description: "Date the organization was incorporated or officially founded"
+    dataType: date
+    category: organization
+    appliesTo: [organization]
+
+  born-year:
+    name: Birth Year
+    description: "Year the person was born"
+    dataType: number
+    category: biographical
+    appliesTo: [person]
+    display:
+      suffix: ""
+
+  launched-date:
+    name: Launch Date
+    description: "Date a product or project was publicly launched"
+    dataType: date
+    category: product
+    appliesTo: [product, project]
+
+  # ── Structure ─────────────────────────────────────────────────
+
+  headquarters:
+    name: Headquarters
+    description: "Primary office location (city, state/country)"
+    dataType: text
+    category: organization
+    appliesTo: [organization]
+
+  legal-structure:
+    name: Legal Structure
+    description: "Corporate form (e.g. Public benefit corporation, LLC, 501(c)(3))"
+    dataType: text
+    category: organization
+    appliesTo: [organization]

--- a/packages/kb/data/schemas/organization.yaml
+++ b/packages/kb/data/schemas/organization.yaml
@@ -1,0 +1,35 @@
+type: organization
+name: Organization
+
+required:
+  - founded-date
+  - headquarters
+
+recommended:
+  - revenue
+  - valuation
+  - headcount
+  - legal-structure
+  - total-funding
+
+items:
+  funding-rounds:
+    description: "Equity and strategic investment rounds, in chronological order"
+    fields:
+      date: { type: date, required: true, description: "Close date (YYYY-MM)" }
+      amount: { type: number, unit: USD, description: "Capital raised in this round" }
+      valuation: { type: number, unit: USD, description: "Post-money valuation" }
+      lead_investor: { type: ref, description: "Lead investor (Thing ID slug)" }
+      source: { type: text, description: "URL to announcement or news article" }
+      notes: { type: text, description: "Context, caveats, or important details" }
+
+  key-people:
+    description: "Current and former key personnel including founders, executives, and notable researchers"
+    fields:
+      person: { type: ref, required: true, description: "Thing ID of the person" }
+      title: { type: text, required: true, description: "Job title or role description" }
+      start: { type: date, description: "Start date at this organization (YYYY-MM)" }
+      end: { type: date, description: "End date if no longer in role (YYYY-MM); omit if current" }
+      is_founder: { type: boolean, description: "True if this person co-founded the organization" }
+      source: { type: text, description: "URL confirming the role" }
+      notes: { type: text, description: "Context about the role or transition" }

--- a/packages/kb/data/schemas/person.yaml
+++ b/packages/kb/data/schemas/person.yaml
@@ -1,0 +1,10 @@
+type: person
+name: Person
+
+required: []
+# People often lack publicly available birth years; no hard requirements.
+
+recommended:
+  - employed-by
+  - role
+  - born-year

--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -1,0 +1,203 @@
+thing:
+  id: anthropic
+  stableId: mK9pX3rQ7n
+  type: organization
+  name: Anthropic
+  numericId: 3
+  aliases:
+    - Anthropic PBC
+    - Anthropic AI
+
+facts:
+  - id: f_8kX2pQ7mNr
+    property: founded-date
+    value: 2021-01
+    source: https://anthropic.com/company
+    notes: "Founded by seven former OpenAI researchers in January 2021"
+
+  - id: f_mN3pQ7kX2r
+    property: valuation
+    value: 380e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Series G post-money valuation"
+
+  - id: f_qR5tY9wE1a
+    property: revenue
+    value: 100e6
+    asOf: 2023-12
+    notes: "Approximate ARR at end of 2023, pre-growth acceleration"
+
+  - id: f_xZ7bD2nM4c
+    property: revenue
+    value: 900e6
+    asOf: 2024-06
+    notes: "ARR mid-2024 estimate"
+
+  - id: f_pL4wK8vF2j
+    property: revenue
+    value: 2e9
+    asOf: 2025-03
+    source: https://www.reuters.com/technology/anthropic-on-track-raise-money-2-billion-run-rate-revenue-sources-2025-03-15/
+    notes: "Run-rate revenue March 2025"
+
+  - id: f_tG6nH1yS3b
+    property: revenue
+    value: 8.5e9
+    asOf: 2025-12
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Annualized run rate at end of 2025, per Series G announcement context"
+
+  - id: f_dW5cR9mJ8q
+    property: revenue
+    value: 19e9
+    asOf: 2026-03
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Projected 2026 guidance midpoint (company guidance $20-26B annualized, run-rate ~$14B as of Feb 2026)"
+
+  - id: f_vB2hE7oA5k
+    property: headquarters
+    value: "San Francisco, CA"
+    source: https://anthropic.com/company
+
+  - id: f_cN4fT3rM6p
+    property: headcount
+    value: 1035
+    asOf: 2024-09
+    notes: "Approximate headcount mid-late 2024; various sources report 870-2847 depending on method"
+    source: https://www.anthropic.com/news
+
+  - id: f_jY8uL5xV1w
+    property: legal-structure
+    value: "Public benefit corporation"
+    source: https://corpgov.law.harvard.edu/2023/10/28/anthropic-long-term-benefit-trust/
+    notes: "Incorporated as Delaware PBC with Long-Term Benefit Trust holding Class T stock"
+
+  - id: f_sQ2kP9nZ4r
+    property: total-funding
+    value: 67e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Total funding raised including $30B Series G"
+
+items:
+  funding-rounds:
+    type: funding-round
+    entries:
+      seed:
+        date: 2021-04
+        amount: 124e6
+        valuation: 550e6
+        lead_investor: jaan-tallinn
+        source: https://techcrunch.com/2021/05/05/anthropic-raises-124m-to-build-safer-ai/
+        notes: "Seed/Series A combined round; Jaan Tallinn led, Dustin Moskovitz participated"
+
+      series-a:
+        date: 2022-04
+        amount: 580e6
+        valuation: 4e9
+        lead_investor: ftx
+        source: https://fortune.com/2022/04/29/ai-startup-anthropic-raises-580-million/
+        notes: "FTX reportedly invested ~$500M; estate later sold stake for ~$1.4B"
+
+      series-b:
+        date: 2023-05
+        amount: 450e6
+        valuation: 4.1e9
+        source: https://fortune.com/2023/05/25/anthropic-raises-450-million/
+        notes: "Bridge round as company sought larger strategic investment"
+
+      series-c-amazon:
+        date: 2023-09
+        amount: 1.25e9
+        lead_investor: amazon
+        source: https://press.aboutamazon.com/2023/9/amazon-and-anthropic-announce-strategic-collaboration
+        notes: "First tranche of Amazon's up-to-$4B commitment; AWS becomes primary cloud partner"
+
+      series-c-google:
+        date: 2023-10
+        amount: 2e9
+        lead_investor: google
+        source: https://blog.google/technology/ai/google-anthropic-investment/
+        notes: "Part of Google's up-to-$2B commitment; Google Cloud partnership"
+
+      series-d:
+        date: 2024-05
+        amount: 2.75e9
+        lead_investor: amazon
+        source: https://www.anthropic.com/news/anthropic-2024-funding
+        notes: "Amazon second tranche; brings Amazon total to ~$6.75B"
+
+      series-e:
+        date: 2024-11
+        amount: 4e9
+        valuation: 18e9
+        source: https://www.anthropic.com/news/series-e
+        notes: "Led by multiple investors; valuation reached $18B post-money"
+
+      series-f:
+        date: 2025-07
+        amount: 3.5e9
+        valuation: 61.5e9
+        source: https://www.anthropic.com/news/series-f
+        notes: "Series F; ARR had reached $4B by announcement time"
+
+      series-g:
+        date: 2026-02
+        amount: 30e9
+        valuation: 380e9
+        lead_investor: gic
+        source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+        notes: "Led by GIC and Coatue; co-leads D.E. Shaw Ventures, Dragoneer, Founders Fund, ICONIQ, MGX"
+
+  key-people:
+    type: key-person
+    entries:
+      dario-ceo:
+        person: dario-amodei
+        title: CEO
+        start: 2021-01
+        is_founder: true
+        source: https://anthropic.com/company
+
+      daniela-president:
+        person: daniela-amodei
+        title: President
+        start: 2021-01
+        is_founder: true
+        source: https://anthropic.com/company
+
+      chris-olah:
+        person: chris-olah
+        title: "Research Lead, Mechanistic Interpretability"
+        start: 2021-01
+        is_founder: true
+        source: https://transformer-circuits.pub/
+
+      tom-brown:
+        person: tom-brown
+        title: "Co-founder"
+        start: 2021-01
+        is_founder: true
+        notes: "GPT-3 lead author; founder, transitioned to other roles over time"
+
+      jan-leike:
+        person: jan-leike
+        title: "Head of Alignment Science"
+        start: 2024-05
+        source: https://anthropic.com/news/jan-leike-joins-anthropic
+        notes: "Joined after resigning from OpenAI where he co-led Superalignment team"
+
+      mike-krieger-cpo:
+        person: mike-krieger
+        title: "Chief Product Officer"
+        start: 2024-05
+        end: 2025-08
+        source: https://www.theverge.com/2024/5/14/24157180/anthropic-mike-krieger-chief-product-officer
+        notes: "Co-founder of Instagram; departed CPO role in 2025-08 to lead Anthropic Labs"
+
+      holden-karnofsky:
+        person: holden-karnofsky
+        title: "Member of Technical Staff"
+        start: 2025-01
+        notes: "Works on responsible scaling policy; co-founder of GiveWell / Coefficient Giving"

--- a/packages/kb/data/things/dario-amodei.yaml
+++ b/packages/kb/data/things/dario-amodei.yaml
@@ -1,0 +1,27 @@
+thing:
+  id: dario-amodei
+  stableId: zR4nW8xB2f
+  type: person
+  name: "Dario Amodei"
+  numericId: 15
+  aliases:
+    - "Dario"
+
+facts:
+  - id: f_aE3mK7pQ9x
+    property: employed-by
+    value: anthropic
+    asOf: 2021-01
+    source: https://anthropic.com/company
+    notes: "Co-founded Anthropic in January 2021; serves as CEO"
+
+  - id: f_bT6wL2nH5v
+    property: role
+    value: "CEO"
+    asOf: 2021-01
+    source: https://anthropic.com/company
+
+  - id: f_cY9rP4jS1d
+    property: born-year
+    value: 1983
+    notes: "Born 1983; approximate from public reporting"

--- a/packages/kb/data/things/jan-leike.yaml
+++ b/packages/kb/data/things/jan-leike.yaml
@@ -1,0 +1,31 @@
+thing:
+  id: jan-leike
+  stableId: hQ7mR2kN5p
+  type: person
+  name: "Jan Leike"
+  numericId: 67
+  aliases:
+    - "Jan Leike"
+
+facts:
+  - id: f_dF5bX8wC3g
+    property: employed-by
+    value: openai
+    asOf: 2021-01
+    validEnd: 2024-05
+    source: https://openai.com/blog/introducing-superalignment
+    notes: "Joined OpenAI circa 2021; co-led the Superalignment team from its founding in July 2023"
+
+  - id: f_eH9jV6nK4t
+    property: employed-by
+    value: anthropic
+    asOf: 2024-05
+    source: https://anthropic.com/news/jan-leike-joins-anthropic
+    notes: "Resigned from OpenAI in May 2024, citing safety concerns; joined Anthropic same month to lead Alignment Science team"
+
+  - id: f_gW2pL8rA7m
+    property: role
+    value: "Head of Alignment Science"
+    asOf: 2024-05
+    source: https://anthropic.com/news/jan-leike-joins-anthropic
+    notes: "Leads alignment science at Anthropic; focuses on scalable oversight, weak-to-strong generalization, and robustness to jailbreaks"

--- a/packages/kb/package.json
+++ b/packages/kb/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@longterm-wiki/kb",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "yaml": "^2.7.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/kb/src/graph.ts
+++ b/packages/kb/src/graph.ts
@@ -1,0 +1,188 @@
+/**
+ * In-memory knowledge base graph.
+ * The main class users interact with after loading YAML via loadKB().
+ */
+
+import type {
+  Thing,
+  Fact,
+  Property,
+  TypeSchema,
+  ItemCollection,
+  ItemEntry,
+  FactQuery,
+  PropertyQuery,
+} from "./types.ts";
+
+export class Graph {
+  private things: Map<string, Thing> = new Map();
+  private facts: Map<string, Fact[]> = new Map(); // keyed by subjectId
+  private properties: Map<string, Property> = new Map();
+  private schemas: Map<string, TypeSchema> = new Map();
+  // thingId → collectionName → collection
+  private items: Map<string, Map<string, ItemCollection>> = new Map();
+
+  // ── Mutation (used by loader and inverse computation) ──────────────
+
+  addThing(thing: Thing): void {
+    this.things.set(thing.id, thing);
+  }
+
+  addFact(fact: Fact): void {
+    const existing = this.facts.get(fact.subjectId);
+    if (existing) {
+      existing.push(fact);
+    } else {
+      this.facts.set(fact.subjectId, [fact]);
+    }
+  }
+
+  addProperty(property: Property): void {
+    this.properties.set(property.id, property);
+  }
+
+  addSchema(schema: TypeSchema): void {
+    this.schemas.set(schema.type, schema);
+  }
+
+  addItemCollection(
+    thingId: string,
+    collectionName: string,
+    collection: ItemCollection
+  ): void {
+    let thingCollections = this.items.get(thingId);
+    if (!thingCollections) {
+      thingCollections = new Map();
+      this.items.set(thingId, thingCollections);
+    }
+    thingCollections.set(collectionName, collection);
+  }
+
+  // ── Thing queries ──────────────────────────────────────────────────
+
+  getThing(id: string): Thing | undefined {
+    return this.things.get(id);
+  }
+
+  getAllThings(): Thing[] {
+    return Array.from(this.things.values());
+  }
+
+  getByType(type: string): Thing[] {
+    return Array.from(this.things.values()).filter((t) => t.type === type);
+  }
+
+  // ── Fact queries ───────────────────────────────────────────────────
+
+  getFacts(thingId: string, query?: FactQuery): Fact[] {
+    const all = this.facts.get(thingId) ?? [];
+    let result = all;
+
+    if (query?.property !== undefined) {
+      result = result.filter((f) => f.propertyId === query.property);
+    }
+
+    if (query?.current) {
+      result = result.filter((f) => f.validEnd === undefined);
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the most recent fact for a given (thingId, propertyId) pair,
+   * ordering by asOf descending. Facts without asOf come last.
+   */
+  getLatest(thingId: string, propertyId: string): Fact | undefined {
+    const facts = this.getFacts(thingId, { property: propertyId });
+    if (facts.length === 0) return undefined;
+
+    return facts.slice().sort((a, b) => {
+      if (a.asOf === undefined && b.asOf === undefined) return 0;
+      if (a.asOf === undefined) return 1;
+      if (b.asOf === undefined) return -1;
+      return b.asOf.localeCompare(a.asOf);
+    })[0];
+  }
+
+  /**
+   * Returns a map of thingId → Fact for all things that have a fact with
+   * the given propertyId. When `latest: true` is passed, only the most
+   * recent fact per thing is returned.
+   */
+  getByProperty(
+    propertyId: string,
+    query?: PropertyQuery
+  ): Map<string, Fact> {
+    const result = new Map<string, Fact>();
+
+    for (const thingId of this.things.keys()) {
+      if (query?.latest) {
+        const latest = this.getLatest(thingId, propertyId);
+        if (latest !== undefined) {
+          result.set(thingId, latest);
+        }
+      } else {
+        // Without latest, return the most recent fact if multiple exist,
+        // to keep the return type consistent (Map<string, Fact>).
+        const latest = this.getLatest(thingId, propertyId);
+        if (latest !== undefined) {
+          result.set(thingId, latest);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the IDs of things referenced by ref/refs facts on this thing.
+   */
+  getRelated(thingId: string, propertyId: string): string[] {
+    const facts = this.getFacts(thingId, { property: propertyId });
+    const ids: string[] = [];
+
+    for (const fact of facts) {
+      if (fact.value.type === "ref") {
+        ids.push(fact.value.value);
+      } else if (fact.value.type === "refs") {
+        ids.push(...fact.value.value);
+      }
+    }
+
+    return ids;
+  }
+
+  // ── Item queries ───────────────────────────────────────────────────
+
+  getItems(thingId: string, collectionName: string): ItemEntry[] {
+    const thingCollections = this.items.get(thingId);
+    if (!thingCollections) return [];
+
+    const collection = thingCollections.get(collectionName);
+    if (!collection) return [];
+
+    return Object.entries(collection.entries).map(([key, fields]) => ({
+      key,
+      fields,
+    }));
+  }
+
+  // ── Property & schema queries ──────────────────────────────────────
+
+  getProperty(id: string): Property | undefined {
+    return this.properties.get(id);
+  }
+
+  getAllProperties(): Property[] {
+    return Array.from(this.properties.values());
+  }
+
+  getSchema(type: string): TypeSchema | undefined {
+    return this.schemas.get(type);
+  }
+
+  getAllSchemas(): TypeSchema[] {
+    return Array.from(this.schemas.values());
+  }
+}

--- a/packages/kb/src/ids.ts
+++ b/packages/kb/src/ids.ts
@@ -1,0 +1,109 @@
+/**
+ * Stable ID generation for the Knowledge Base library.
+ *
+ * - generateStableId()         — random 10-char alphanumeric (for Thing.stableId)
+ * - generateFactId()           — "f_" + 10-char alphanumeric (random)
+ * - contentHash(parts)         — deterministic SHA-256-based 10-char token
+ * - generateContentFactId(...) — "f_" + contentHash (idempotent sync helper)
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+/** Characters used to replace `-` and `_` from base64url output. */
+const REPLACEMENT_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Returns a clean 10-character alphanumeric string derived from
+ * `crypto.randomBytes(7).toString("base64url")`, with any `-` or `_`
+ * replaced by alphanumeric characters so the result is URL-safe and visually
+ * consistent.
+ */
+function randomAlphanumeric10(): string {
+  const raw = randomBytes(7).toString("base64url").slice(0, 10);
+  return raw
+    .split("")
+    .map((ch) => {
+      if (ch === "-" || ch === "_") {
+        // Replace with a deterministic-looking but effectively random char by
+        // drawing a fresh byte mod the replacement alphabet length.
+        const byte = randomBytes(1)[0];
+        return REPLACEMENT_CHARS[byte % REPLACEMENT_CHARS.length];
+      }
+      return ch;
+    })
+    .join("");
+}
+
+/**
+ * Returns a random 10-character alphanumeric string suitable for use as a
+ * Thing's `stableId`.  Survives renames because it is purely random.
+ *
+ * @example
+ * generateStableId() // "a3Kf2rZ9mQ"
+ */
+export function generateStableId(): string {
+  return randomAlphanumeric10();
+}
+
+/**
+ * Returns a random fact ID: `"f_"` followed by 10 random alphanumeric chars.
+ * Use this when you do not need determinism (i.e., you are creating a brand-new
+ * fact that has no natural content key).
+ *
+ * @example
+ * generateFactId() // "f_x7Nm2pA0qR"
+ */
+export function generateFactId(): string {
+  return `f_${randomAlphanumeric10()}`;
+}
+
+/**
+ * Produces a deterministic 10-character base64url token by SHA-256 hashing
+ * the concatenation of `parts` (joined with a null-byte separator to prevent
+ * accidental collisions between adjacent inputs).
+ *
+ * Same inputs always produce the same output — suitable for content-addressed
+ * keys and idempotent sync operations.
+ *
+ * @example
+ * contentHash(["anthropic", "revenue", "1000000000", "2024"])
+ * // always the same 10-char string
+ */
+export function contentHash(parts: string[]): string {
+  const combined = parts.join("\x00");
+  return createHash("sha256")
+    .update(combined, "utf8")
+    .digest("base64url")
+    .slice(0, 10);
+}
+
+/**
+ * Generates a deterministic fact ID from its logical key components.
+ * The ID is `"f_"` followed by a {@link contentHash} of
+ * `[subjectId, propertyId, JSON.stringify(value), asOf ?? ""]`.
+ *
+ * Use this when syncing facts from an external source so that re-running the
+ * sync does not create duplicates.
+ *
+ * @param subjectId  - Thing slug the fact is about
+ * @param propertyId - Property ID from the registry
+ * @param value      - The fact value (any JSON-serialisable type)
+ * @param asOf       - Optional temporal anchor (ISO date or YYYY-MM string)
+ *
+ * @example
+ * generateContentFactId("anthropic", "revenue", 1_000_000_000, "2024")
+ * // "f_<10 deterministic chars>"
+ */
+export function generateContentFactId(
+  subjectId: string,
+  propertyId: string,
+  value: unknown,
+  asOf?: string
+): string {
+  return `f_${contentHash([
+    subjectId,
+    propertyId,
+    JSON.stringify(value),
+    asOf ?? "",
+  ])}`;
+}

--- a/packages/kb/src/index.ts
+++ b/packages/kb/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Public API for the @longterm-wiki/kb package.
+ */
+
+export { loadKB } from "./loader.ts";
+export { Graph } from "./graph.ts";
+export { computeInverses } from "./inverse.ts";
+export { validate, validateThing } from "./validate.ts";
+export * from "./types.ts";
+export * from "./ids.ts";
+export { serialize } from "./serialize.ts";
+export type { SerializedKB } from "./serialize.ts";

--- a/packages/kb/src/inverse.ts
+++ b/packages/kb/src/inverse.ts
@@ -1,0 +1,142 @@
+/**
+ * Computes inverse relationships from property definitions and adds derived
+ * facts to the graph.
+ *
+ * For every property that declares an `inverseId`, this module scans all
+ * existing facts that use that property and — for each ref/refs value —
+ * synthesises a mirror fact on the referenced thing using the inverse
+ * property ID.  The derived fact carries the same temporal bounds (asOf,
+ * validEnd) as its source and records the source fact's ID in `derivedFrom`.
+ *
+ * Derived fact IDs are content-addressed: `inv_` + first-8 chars of a
+ * SHA-256 hash of (subjectId + propertyId + value).  This makes the
+ * operation idempotent — running it twice on the same graph produces the
+ * same IDs and `addFact` will just push a duplicate; callers should only
+ * run this once per graph lifecycle.
+ */
+
+import { createHash } from "node:crypto";
+import type { Fact } from "./types.ts";
+import type { Graph } from "./graph.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a deterministic 8-character hex token for use in derived fact IDs.
+ * Inputs are null-byte separated to prevent accidental collisions.
+ */
+function inverseHash(parts: string[]): string {
+  return createHash("sha256")
+    .update(parts.join("\x00"), "utf8")
+    .digest("hex")
+    .slice(0, 8);
+}
+
+/**
+ * Builds the ID for a single derived inverse fact.
+ * Format: `inv_` + 8-char content hash.
+ */
+function derivedId(
+  subjectId: string,
+  propertyId: string,
+  refValue: string
+): string {
+  return `inv_${inverseHash([subjectId, propertyId, refValue])}`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Scans the graph for facts that belong to properties with an `inverseId`,
+ * then synthesises and adds the corresponding mirror facts on the referenced
+ * things.
+ *
+ * Only `ref` and `refs` value types participate in inverse computation.
+ * All other value types are silently skipped.
+ *
+ * Edge cases:
+ * - If the referenced thing does not exist in the graph, a console warning is
+ *   emitted and the inverse is skipped (no crash).
+ * - Temporal bounds (`asOf`, `validEnd`) are preserved from the source fact.
+ * - Running this function more than once on the same graph will result in
+ *   duplicate facts (same `derivedFrom` ID).  Call it exactly once per graph.
+ */
+export function computeInverses(graph: Graph): void {
+  const allProperties = graph.getAllProperties();
+
+  for (const property of allProperties) {
+    const { inverseId } = property;
+    if (!inverseId) continue;
+
+    // Collect all facts across every thing that use this property.
+    const allThings = graph.getAllThings();
+
+    for (const thing of allThings) {
+      const facts = graph.getFacts(thing.id, { property: property.id });
+
+      for (const fact of facts) {
+        _processFactInverse(graph, fact, inverseId);
+      }
+    }
+  }
+}
+
+/**
+ * Creates and adds a single derived inverse fact, given a source fact that
+ * has a `ref` or `refs` value.  For `refs`, one inverse fact is created per
+ * referenced ID.
+ */
+function _processFactInverse(
+  graph: Graph,
+  sourceFact: Fact,
+  inversePropertyId: string
+): void {
+  const { value } = sourceFact;
+
+  if (value.type === "ref") {
+    _addSingleInverse(graph, sourceFact, inversePropertyId, value.value);
+  } else if (value.type === "refs") {
+    for (const refId of value.value) {
+      _addSingleInverse(graph, sourceFact, inversePropertyId, refId);
+    }
+  }
+  // All other value types (number, text, date, boolean, json) are skipped.
+}
+
+/**
+ * Constructs and adds one derived inverse fact.
+ * Skips silently (with a warning) if the referenced thing is not in the graph.
+ */
+function _addSingleInverse(
+  graph: Graph,
+  sourceFact: Fact,
+  inversePropertyId: string,
+  referencedThingId: string
+): void {
+  // Guard: the referenced thing must exist.
+  if (!graph.getThing(referencedThingId)) {
+    console.warn(
+      `[kb/inverse] Skipping inverse for fact "${sourceFact.id}": ` +
+        `referenced thing "${referencedThingId}" not found in graph.`
+    );
+    return;
+  }
+
+  const id = derivedId(
+    referencedThingId,
+    inversePropertyId,
+    sourceFact.subjectId
+  );
+
+  const derived: Fact = {
+    id,
+    subjectId: referencedThingId,
+    propertyId: inversePropertyId,
+    value: { type: "ref", value: sourceFact.subjectId },
+    asOf: sourceFact.asOf,
+    validEnd: sourceFact.validEnd,
+    derivedFrom: sourceFact.id,
+  };
+
+  graph.addFact(derived);
+}

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -1,0 +1,233 @@
+/**
+ * YAML → Graph loader.
+ * Reads properties.yaml, schemas/*.yaml, and things/*.yaml from a data directory.
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { Graph } from "./graph.ts";
+import type {
+  PropertiesFile,
+  SchemaFile,
+  ThingFile,
+  RawFact,
+  Property,
+  TypeSchema,
+  Thing,
+  Fact,
+  FactValue,
+  ItemCollection,
+} from "./types.ts";
+
+// ── Value normalization ────────────────────────────────────────────────
+
+/**
+ * ISO date pattern: full date (2021-01-01) or year-month (2021-01).
+ * Does NOT match bare years like "2021" to avoid false positives with numbers.
+ */
+const DATE_RE = /^\d{4}-\d{2}(-\d{2})?$/;
+
+/**
+ * Normalizes a raw YAML value into a typed FactValue.
+ * The property's dataType is used as a hint — if the property says "ref",
+ * a string value is wrapped as {type: "ref"} rather than {type: "text"}.
+ */
+function normalizeValue(raw: unknown, dataType?: string): FactValue {
+  // Explicit dataType hint takes priority for ref/refs disambiguation.
+  if (dataType === "ref" && typeof raw === "string") {
+    return { type: "ref", value: raw };
+  }
+  if (dataType === "refs" && Array.isArray(raw)) {
+    return { type: "refs", value: raw.map(String) };
+  }
+
+  if (typeof raw === "boolean") {
+    return { type: "boolean", value: raw };
+  }
+
+  if (typeof raw === "number") {
+    return { type: "number", value: raw };
+  }
+
+  if (typeof raw === "string") {
+    if (DATE_RE.test(raw)) {
+      return { type: "date", value: raw };
+    }
+    return { type: "text", value: raw };
+  }
+
+  if (Array.isArray(raw)) {
+    // Treat as refs if all elements are strings
+    if (raw.every((v) => typeof v === "string")) {
+      return { type: "refs", value: raw as string[] };
+    }
+    return { type: "json", value: raw };
+  }
+
+  // Fall back to json for objects and anything else
+  return { type: "json", value: raw };
+}
+
+// ── Individual parsers ─────────────────────────────────────────────────
+
+function parseProperties(raw: unknown): Map<string, Property> {
+  const file = raw as PropertiesFile;
+  const result = new Map<string, Property>();
+
+  for (const [id, def] of Object.entries(file.properties ?? {})) {
+    result.set(id, { id, ...def });
+  }
+
+  return result;
+}
+
+function parseSchema(raw: unknown): TypeSchema {
+  const file = raw as SchemaFile;
+  return {
+    type: file.type,
+    name: file.name,
+    required: file.required ?? [],
+    recommended: file.recommended ?? [],
+    items: file.items,
+  };
+}
+
+function parseThing(raw: ThingFile["thing"]): Thing {
+  return {
+    id: raw.id,
+    stableId: raw.stableId,
+    type: raw.type,
+    name: raw.name,
+    ...(raw.parent !== undefined && { parent: raw.parent }),
+    ...(raw.aliases !== undefined && { aliases: raw.aliases }),
+    ...(raw.previousIds !== undefined && { previousIds: raw.previousIds }),
+    ...(raw.numericId !== undefined && { numericId: raw.numericId }),
+  };
+}
+
+function parseFact(
+  rawFact: RawFact,
+  thingId: string,
+  properties: Map<string, Property>
+): Fact {
+  const prop = properties.get(rawFact.property);
+  const value = normalizeValue(rawFact.value, prop?.dataType);
+
+  return {
+    id: rawFact.id,
+    subjectId: thingId,
+    propertyId: rawFact.property,
+    value,
+    ...(rawFact.asOf !== undefined && { asOf: rawFact.asOf }),
+    ...(rawFact.validEnd !== undefined && { validEnd: rawFact.validEnd }),
+    ...(rawFact.source !== undefined && { source: rawFact.source }),
+    ...(rawFact.sourceQuote !== undefined && {
+      sourceQuote: rawFact.sourceQuote,
+    }),
+    ...(rawFact.notes !== undefined && { notes: rawFact.notes }),
+  };
+}
+
+function parseItemCollection(
+  raw: ThingFile["items"],
+  collectionName: string
+): ItemCollection | undefined {
+  if (!raw) return undefined;
+  const col = raw[collectionName];
+  if (!col) return undefined;
+  return {
+    type: col.type,
+    entries: col.entries ?? {},
+  };
+}
+
+// ── Helper: read all .yaml files from a directory ─────────────────────
+
+async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unknown }[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // Directory doesn't exist — return empty array
+    return [];
+  }
+
+  const yamlFiles = entries.filter(
+    (e) => extname(e) === ".yaml" || extname(e) === ".yml"
+  );
+
+  const results = await Promise.all(
+    yamlFiles.map(async (filename) => {
+      const content = await readFile(join(dir, filename), "utf-8");
+      return { name: filename, parsed: parseYaml(content) };
+    })
+  );
+
+  return results;
+}
+
+// ── Main loader ────────────────────────────────────────────────────────
+
+/**
+ * Loads a knowledge base from a data directory into an in-memory Graph.
+ *
+ * Expected directory layout:
+ *   <dataDir>/properties.yaml
+ *   <dataDir>/schemas/*.yaml
+ *   <dataDir>/things/*.yaml
+ */
+export async function loadKB(dataDir: string): Promise<Graph> {
+  const graph = new Graph();
+
+  // 1. Load properties
+  let properties = new Map<string, Property>();
+  try {
+    const propertiesContent = await readFile(
+      join(dataDir, "properties.yaml"),
+      "utf-8"
+    );
+    properties = parseProperties(parseYaml(propertiesContent));
+  } catch {
+    // properties.yaml is optional for minimal setups
+  }
+
+  for (const property of properties.values()) {
+    graph.addProperty(property);
+  }
+
+  // 2. Load schemas
+  const schemaFiles = await readYamlFiles(join(dataDir, "schemas"));
+  for (const { parsed } of schemaFiles) {
+    const schema = parseSchema(parsed);
+    graph.addSchema(schema);
+  }
+
+  // 3. Load things
+  const thingFiles = await readYamlFiles(join(dataDir, "things"));
+  for (const { parsed } of thingFiles) {
+    const file = parsed as ThingFile;
+
+    // 3a. Parse thing
+    const thing = parseThing(file.thing);
+    graph.addThing(thing);
+
+    // 3b. Parse facts
+    for (const rawFact of file.facts ?? []) {
+      const fact = parseFact(rawFact, thing.id, properties);
+      graph.addFact(fact);
+    }
+
+    // 3c. Parse items
+    if (file.items) {
+      for (const collectionName of Object.keys(file.items)) {
+        const collection = parseItemCollection(file.items, collectionName);
+        if (collection) {
+          graph.addItemCollection(thing.id, collectionName, collection);
+        }
+      }
+    }
+  }
+
+  return graph;
+}

--- a/packages/kb/src/serialize.ts
+++ b/packages/kb/src/serialize.ts
@@ -1,0 +1,32 @@
+/**
+ * Serialization: Graph → JSON (for downstream consumers like build-data).
+ */
+
+import type { Graph } from "./graph.ts";
+
+export interface SerializedKB {
+  things: ReturnType<Graph["getAllThings"]>;
+  facts: Record<string, ReturnType<Graph["getFacts"]>>;
+  properties: ReturnType<Graph["getAllProperties"]>;
+  schemas: ReturnType<Graph["getAllSchemas"]>;
+}
+
+/**
+ * Serialize a Graph to a plain JSON-friendly object.
+ * Useful for writing to database.json or sending over the wire.
+ */
+export function serialize(graph: Graph): SerializedKB {
+  const things = graph.getAllThings();
+  const properties = graph.getAllProperties();
+  const schemas = graph.getAllSchemas();
+
+  const facts: SerializedKB["facts"] = {};
+  for (const thing of things) {
+    const thingFacts = graph.getFacts(thing.id);
+    if (thingFacts.length > 0) {
+      facts[thing.id] = thingFacts;
+    }
+  }
+
+  return { things, facts, properties, schemas };
+}

--- a/packages/kb/src/types.ts
+++ b/packages/kb/src/types.ts
@@ -1,0 +1,215 @@
+/**
+ * Core data model for the Knowledge Base library.
+ * Inspired by Ken Standard, extended with temporal data and stable IDs.
+ */
+
+// ── Values ──────────────────────────────────────────────────────────
+
+export type FactValue =
+  | { type: "number"; value: number; unit?: string }
+  | { type: "text"; value: string }
+  | { type: "date"; value: string }
+  | { type: "boolean"; value: boolean }
+  | { type: "ref"; value: string }
+  | { type: "refs"; value: string[] }
+  | { type: "json"; value: unknown };
+
+// ── Thing ───────────────────────────────────────────────────────────
+
+export interface Thing {
+  /** Human-readable slug: "anthropic", "claude-3-5-sonnet" */
+  id: string;
+  /** Random 10-char ID that survives renames */
+  stableId: string;
+  /** References a TypeSchema: "organization", "person" */
+  type: string;
+  /** Display name */
+  name: string;
+  /** Parent thing ID (e.g., funding round → org) */
+  parent?: string;
+  /** Alternative names for search */
+  aliases?: string[];
+  /** Former slugs for redirects */
+  previousIds?: string[];
+  /** Legacy wiki URL ID (E42) */
+  numericId?: number;
+}
+
+// ── Fact ────────────────────────────────────────────────────────────
+
+export interface Fact {
+  /** Random 10-char "f_xxxxxxxx" or content-hash */
+  id: string;
+  /** Thing ID (slug) this fact is about */
+  subjectId: string;
+  /** Property ID from the registry */
+  propertyId: string;
+  /** Typed value */
+  value: FactValue;
+  /** When this was true (ISO date or YYYY-MM) */
+  asOf?: string;
+  /** When this stopped being true (null/undefined = still true) */
+  validEnd?: string;
+  /** Source URL */
+  source?: string;
+  /** Relevant excerpt from source */
+  sourceQuote?: string;
+  /** Free-text annotation */
+  notes?: string;
+  /** If this fact was computed (e.g., inverse relationship) */
+  derivedFrom?: string;
+}
+
+// ── Property ────────────────────────────────────────────────────────
+
+export interface PropertyDisplay {
+  divisor?: number;
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface Property {
+  /** Property ID: "revenue", "employed-by" */
+  id: string;
+  /** Display name: "Revenue", "Employed By" */
+  name: string;
+  description?: string;
+  /** Value type: "number", "text", "date", "ref", "refs", "boolean" */
+  dataType: string;
+  /** Unit: "USD", "percent", "tokens" */
+  unit?: string;
+  /** Grouping: "financial", "people", "safety" */
+  category?: string;
+  /** Inverse property ID: "employed-by" → "employer-of" */
+  inverseId?: string;
+  /** Inverse display name: "Employed By" → "Employs" */
+  inverseName?: string;
+  /** Thing types this property is valid for */
+  appliesTo?: string[];
+  /** Display formatting */
+  display?: PropertyDisplay;
+  /** If true, this property is computed (never stored directly) */
+  computed?: boolean;
+}
+
+// ── Type Schemas ────────────────────────────────────────────────────
+
+export interface FieldDef {
+  type: string;
+  required?: boolean;
+  unit?: string;
+  description?: string;
+}
+
+export interface ItemCollectionSchema {
+  description: string;
+  fields: Record<string, FieldDef>;
+}
+
+export interface TypeSchema {
+  /** Thing type this schema applies to: "organization", "person" */
+  type: string;
+  /** Display name: "Organization" */
+  name: string;
+  /** Property IDs that must have facts */
+  required: string[];
+  /** Property IDs that should have facts */
+  recommended: string[];
+  /** Named item collections (e.g., funding-rounds, key-people) */
+  items?: Record<string, ItemCollectionSchema>;
+}
+
+// ── Items (lightweight sub-collections) ─────────────────────────────
+
+export interface ItemEntry {
+  /** Local key within the collection: "series-a", "dario-ceo" */
+  key: string;
+  /** Typed fields (schema defined in ItemCollectionSchema) */
+  fields: Record<string, unknown>;
+}
+
+export interface ItemCollection {
+  /** References an item type (used for schema lookup) */
+  type: string;
+  /** Keyed entries */
+  entries: Record<string, Record<string, unknown>>;
+}
+
+// ── YAML file shapes ────────────────────────────────────────────────
+
+/** Shape of a thing's YAML file (data/things/anthropic.yaml) */
+export interface ThingFile {
+  thing: {
+    id: string;
+    stableId: string;
+    type: string;
+    name: string;
+    parent?: string;
+    aliases?: string[];
+    previousIds?: string[];
+    numericId?: number;
+  };
+  facts?: RawFact[];
+  items?: Record<string, RawItemCollection>;
+}
+
+/** Fact as stored in YAML (before normalization) */
+export interface RawFact {
+  id: string;
+  property: string;
+  value: unknown;
+  asOf?: string;
+  validEnd?: string;
+  source?: string;
+  sourceQuote?: string;
+  notes?: string;
+}
+
+/** Item collection as stored in YAML */
+export interface RawItemCollection {
+  type: string;
+  entries: Record<string, Record<string, unknown>>;
+}
+
+/** Shape of properties.yaml */
+export interface PropertiesFile {
+  properties: Record<string, Omit<Property, "id">>;
+}
+
+/** Shape of a schema YAML file */
+export interface SchemaFile {
+  type: string;
+  name: string;
+  required: string[];
+  recommended: string[];
+  items?: Record<string, {
+    description: string;
+    fields: Record<string, FieldDef>;
+  }>;
+}
+
+// ── Validation ──────────────────────────────────────────────────────
+
+export type ValidationSeverity = "error" | "warning" | "info";
+
+export interface ValidationResult {
+  severity: ValidationSeverity;
+  thingId?: string;
+  propertyId?: string;
+  message: string;
+  /** Which check produced this */
+  rule: string;
+}
+
+// ── Query options ───────────────────────────────────────────────────
+
+export interface FactQuery {
+  property?: string;
+  /** Only return facts that are currently valid (no validEnd) */
+  current?: boolean;
+}
+
+export interface PropertyQuery {
+  /** Only return the latest fact per entity (by asOf) */
+  latest?: boolean;
+}

--- a/packages/kb/src/validate.ts
+++ b/packages/kb/src/validate.ts
@@ -1,0 +1,382 @@
+/**
+ * Schema validation for the Knowledge Base graph.
+ *
+ * Checks performed:
+ *  1. required-properties  (error)   — each thing must have a fact for every
+ *                                      property listed in its TypeSchema.required
+ *  2. recommended-properties (warning) — same check for TypeSchema.recommended
+ *  3. property-applies-to  (warning)  — if a property lists appliesTo, ensure
+ *                                       the thing's type is in that list
+ *  4. ref-integrity        (error)    — ref/refs values must point to existing
+ *                                       things in the graph
+ *  5. item-collection-schema (error/warning) — validate item entries against
+ *                                       the ItemCollectionSchema defined in the
+ *                                       thing's TypeSchema (if one exists)
+ *  6. completeness         (info)     — percentage of required+recommended
+ *                                       properties that have at least one fact
+ */
+
+import type { Graph } from "./graph.ts";
+import type {
+  Fact,
+  FactValue,
+  FieldDef,
+  ItemCollectionSchema,
+  TypeSchema,
+  ValidationResult,
+} from "./types.ts";
+
+// ── Utility helpers ───────────────────────────────────────────────────────────
+
+/** Returns true if the thing has at least one fact for the given propertyId. */
+function hasFact(graph: Graph, thingId: string, propertyId: string): boolean {
+  return graph.getFacts(thingId, { property: propertyId }).length > 0;
+}
+
+/**
+ * Very lightweight date-format check.
+ * Accepts: YYYY, YYYY-MM, YYYY-MM-DD.
+ */
+function looksLikeDate(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return /^\d{4}(-\d{2}(-\d{2})?)?$/.test(value);
+}
+
+// ── Per-thing check implementations ───────────────────────────────────────────
+
+/** Check 1: required properties. */
+function checkRequired(
+  graph: Graph,
+  thingId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const propertyId of schema.required) {
+    if (!hasFact(graph, thingId, propertyId)) {
+      results.push({
+        severity: "error",
+        thingId,
+        propertyId,
+        message: `Missing required property "${propertyId}" on thing "${thingId}" (type: ${schema.type}).`,
+        rule: "required-properties",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 2: recommended properties. */
+function checkRecommended(
+  graph: Graph,
+  thingId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const propertyId of schema.recommended) {
+    if (!hasFact(graph, thingId, propertyId)) {
+      results.push({
+        severity: "warning",
+        thingId,
+        propertyId,
+        message: `Missing recommended property "${propertyId}" on thing "${thingId}" (type: ${schema.type}).`,
+        rule: "recommended-properties",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 3: property appliesTo type constraint. */
+function checkPropertyAppliesTo(
+  graph: Graph,
+  thingId: string,
+  thingType: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(thingId);
+
+  for (const fact of facts) {
+    const property = graph.getProperty(fact.propertyId);
+    if (!property) continue; // Unknown properties are caught by other checks if needed.
+    if (!property.appliesTo || property.appliesTo.length === 0) continue;
+
+    if (!property.appliesTo.includes(thingType)) {
+      results.push({
+        severity: "warning",
+        thingId,
+        propertyId: fact.propertyId,
+        message:
+          `Property "${fact.propertyId}" applies to [${property.appliesTo.join(", ")}] ` +
+          `but thing "${thingId}" is of type "${thingType}".`,
+        rule: "property-applies-to",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 4: ref/refs integrity — referenced things must exist. */
+function checkRefIntegrity(graph: Graph, thingId: string): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(thingId);
+
+  for (const fact of facts) {
+    const missingRefs = _findMissingRefs(graph, fact.value);
+
+    for (const missingId of missingRefs) {
+      results.push({
+        severity: "error",
+        thingId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${thingId}" references unknown thing "${missingId}" ` +
+          `(property: "${fact.propertyId}").`,
+        rule: "ref-integrity",
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Returns the list of referenced thing IDs that do not exist in the graph.
+ * Only inspects ref/refs value types.
+ */
+function _findMissingRefs(graph: Graph, value: FactValue): string[] {
+  if (value.type === "ref") {
+    return graph.getThing(value.value) ? [] : [value.value];
+  }
+
+  if (value.type === "refs") {
+    return value.value.filter((id) => !graph.getThing(id));
+  }
+
+  return [];
+}
+
+/** Check 5: item collection schema validation. */
+function checkItemCollections(
+  graph: Graph,
+  thingId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  if (!schema.items) return results;
+
+  for (const [collectionName, collectionSchema] of Object.entries(
+    schema.items
+  )) {
+    const entries = graph.getItems(thingId, collectionName);
+
+    for (const entry of entries) {
+      const entryResults = _validateItemEntry(
+        graph,
+        thingId,
+        collectionName,
+        entry.key,
+        entry.fields,
+        collectionSchema
+      );
+      results.push(...entryResults);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Validates a single item entry against an ItemCollectionSchema.
+ * Produces errors for missing required fields and warnings for type mismatches.
+ */
+function _validateItemEntry(
+  graph: Graph,
+  thingId: string,
+  collectionName: string,
+  entryKey: string,
+  fields: Record<string, unknown>,
+  schema: ItemCollectionSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const prefix = `Item "${collectionName}/${entryKey}" on thing "${thingId}"`;
+
+  for (const [fieldName, fieldDef] of Object.entries(schema.fields)) {
+    const value = fields[fieldName];
+
+    // Required field presence check (error).
+    if (fieldDef.required && (value === undefined || value === null)) {
+      results.push({
+        severity: "error",
+        thingId,
+        message: `${prefix}: missing required field "${fieldName}".`,
+        rule: "item-collection-schema",
+      });
+      continue; // Skip type check for absent field.
+    }
+
+    // Type validity check (warning) — only when value is present.
+    if (value !== undefined && value !== null) {
+      const typeError = _checkFieldType(graph, fieldDef, value, fieldName, prefix);
+      if (typeError) {
+        results.push({
+          severity: "warning",
+          thingId,
+          message: typeError,
+          rule: "item-collection-schema",
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Returns an error message string if `value` does not match the expected type
+ * from `fieldDef`, or null if the value is acceptable.
+ */
+function _checkFieldType(
+  graph: Graph,
+  fieldDef: FieldDef,
+  value: unknown,
+  fieldName: string,
+  prefix: string
+): string | null {
+  switch (fieldDef.type) {
+    case "number":
+      if (typeof value !== "number") {
+        return `${prefix}: field "${fieldName}" expected number, got ${typeof value}.`;
+      }
+      break;
+
+    case "boolean":
+      if (typeof value !== "boolean") {
+        return `${prefix}: field "${fieldName}" expected boolean, got ${typeof value}.`;
+      }
+      break;
+
+    case "date":
+      if (!looksLikeDate(value)) {
+        return (
+          `${prefix}: field "${fieldName}" expected a date string (YYYY, YYYY-MM, ` +
+          `or YYYY-MM-DD), got ${JSON.stringify(value)}.`
+        );
+      }
+      break;
+
+    case "ref":
+      if (typeof value !== "string") {
+        return `${prefix}: field "${fieldName}" expected a thing ID string (ref), got ${typeof value}.`;
+      }
+      // Verify the referenced thing exists.
+      if (!graph.getThing(value)) {
+        return (
+          `${prefix}: field "${fieldName}" references unknown thing "${value}".`
+        );
+      }
+      break;
+
+    case "text":
+      if (typeof value !== "string") {
+        return `${prefix}: field "${fieldName}" expected string (text), got ${typeof value}.`;
+      }
+      break;
+
+    // "json" and unknown types: no type check.
+    default:
+      break;
+  }
+
+  return null;
+}
+
+/** Check 6: completeness report. */
+function checkCompleteness(
+  graph: Graph,
+  thingId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const tracked = [...schema.required, ...schema.recommended];
+  if (tracked.length === 0) return [];
+
+  const present = tracked.filter((p) => hasFact(graph, thingId, p)).length;
+  const pct = Math.round((present / tracked.length) * 100);
+
+  return [
+    {
+      severity: "info",
+      thingId,
+      message:
+        `Completeness for "${thingId}" (type: ${schema.type}): ` +
+        `${present}/${tracked.length} required+recommended properties present (${pct}%).`,
+      rule: "completeness",
+    },
+  ];
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Validates a single thing against its TypeSchema.
+ * Returns an array of ValidationResult objects.
+ *
+ * If no TypeSchema is registered for the thing's type, a warning is returned
+ * and no further checks are run for that thing.
+ */
+export function validateThing(
+  graph: Graph,
+  thingId: string
+): ValidationResult[] {
+  const thing = graph.getThing(thingId);
+  if (!thing) {
+    return [
+      {
+        severity: "error",
+        thingId,
+        message: `Thing "${thingId}" not found in graph.`,
+        rule: "thing-exists",
+      },
+    ];
+  }
+
+  const schema = graph.getSchema(thing.type);
+  if (!schema) {
+    return [
+      {
+        severity: "warning",
+        thingId,
+        message: `No TypeSchema registered for type "${thing.type}" (thing: "${thingId}"). Skipping schema checks.`,
+        rule: "schema-exists",
+      },
+    ];
+  }
+
+  return [
+    ...checkRequired(graph, thingId, schema),
+    ...checkRecommended(graph, thingId, schema),
+    ...checkPropertyAppliesTo(graph, thingId, thing.type),
+    ...checkRefIntegrity(graph, thingId),
+    ...checkItemCollections(graph, thingId, schema),
+    ...checkCompleteness(graph, thingId, schema),
+  ];
+}
+
+/**
+ * Validates the entire graph — runs validateThing() on every thing.
+ * Returns an array of all ValidationResult objects across all things.
+ */
+export function validate(graph: Graph): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const thing of graph.getAllThings()) {
+    results.push(...validateThing(graph, thing.id));
+  }
+
+  return results;
+}

--- a/packages/kb/tests/graph.test.ts
+++ b/packages/kb/tests/graph.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader.ts";
+import type { Graph } from "../src/graph.ts";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("graph", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("getThing", () => {
+    it("returns the correct thing for a valid ID", () => {
+      const thing = graph.getThing("anthropic");
+      expect(thing).toBeDefined();
+      expect(thing!.id).toBe("anthropic");
+      expect(thing!.name).toBe("Anthropic");
+      expect(thing!.type).toBe("organization");
+    });
+
+    it("returns undefined for a missing thing", () => {
+      const thing = graph.getThing("nonexistent-org");
+      expect(thing).toBeUndefined();
+    });
+  });
+
+  describe("getAllThings", () => {
+    it("returns all things in the graph", () => {
+      const things = graph.getAllThings();
+      expect(things).toHaveLength(3);
+    });
+  });
+
+  describe("getFacts", () => {
+    it("returns all facts for a thing", () => {
+      const facts = graph.getFacts("anthropic");
+      // 5 revenue + 1 valuation + 1 founded-date + 1 headquarters + 1 headcount
+      // + 1 legal-structure + 1 total-funding = 11
+      expect(facts).toHaveLength(11);
+    });
+
+    it("returns empty array for a thing with no facts", () => {
+      const facts = graph.getFacts("nonexistent");
+      expect(facts).toEqual([]);
+    });
+
+    it("filters by property", () => {
+      const revenueFacts = graph.getFacts("anthropic", {
+        property: "revenue",
+      });
+      expect(revenueFacts).toHaveLength(5);
+      for (const fact of revenueFacts) {
+        expect(fact.propertyId).toBe("revenue");
+      }
+    });
+
+    it("filters by current (no validEnd)", () => {
+      // Jan Leike has 2 employed-by facts: one with validEnd (OpenAI), one without (Anthropic)
+      const currentFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+        current: true,
+      });
+      expect(currentFacts).toHaveLength(1);
+      expect(currentFacts[0].value).toEqual({
+        type: "ref",
+        value: "anthropic",
+      });
+    });
+
+    it("returns both current and ended facts without current filter", () => {
+      const allFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      expect(allFacts).toHaveLength(2);
+    });
+
+    it("can combine property and current filters", () => {
+      // All Jan Leike's employed-by facts that are current
+      const facts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+        current: true,
+      });
+      expect(facts).toHaveLength(1);
+      expect(facts[0].validEnd).toBeUndefined();
+    });
+  });
+
+  describe("getLatest", () => {
+    it("returns the most recent fact by asOf for a time series", () => {
+      const latest = graph.getLatest("anthropic", "revenue");
+      expect(latest).toBeDefined();
+      // The most recent revenue fact is asOf: 2026-03 with value 19e9
+      expect(latest!.asOf).toBe("2026-03");
+      expect(latest!.value).toEqual({ type: "number", value: 19e9 });
+    });
+
+    it("returns undefined for a missing property", () => {
+      const latest = graph.getLatest("anthropic", "nonexistent-property");
+      expect(latest).toBeUndefined();
+    });
+
+    it("returns undefined for a missing thing", () => {
+      const latest = graph.getLatest("nonexistent", "revenue");
+      expect(latest).toBeUndefined();
+    });
+
+    it("returns the only fact when there is just one", () => {
+      const latest = graph.getLatest("anthropic", "headquarters");
+      expect(latest).toBeDefined();
+      expect(latest!.value).toEqual({
+        type: "text",
+        value: "San Francisco, CA",
+      });
+    });
+  });
+
+  describe("getByProperty", () => {
+    it("returns facts across entities for a given property", () => {
+      const revMap = graph.getByProperty("revenue");
+      // Only Anthropic has revenue facts
+      expect(revMap.size).toBe(1);
+      expect(revMap.has("anthropic")).toBe(true);
+    });
+
+    it("returns facts from multiple entities", () => {
+      const roleMap = graph.getByProperty("role");
+      // Both Dario and Jan have role facts
+      expect(roleMap.size).toBe(2);
+      expect(roleMap.has("dario-amodei")).toBe(true);
+      expect(roleMap.has("jan-leike")).toBe(true);
+    });
+
+    it("returns latest fact per entity with latest:true", () => {
+      const revMap = graph.getByProperty("revenue", { latest: true });
+      expect(revMap.size).toBe(1);
+      const anthropicRev = revMap.get("anthropic");
+      expect(anthropicRev).toBeDefined();
+      expect(anthropicRev!.asOf).toBe("2026-03");
+    });
+
+    it("returns empty map for unused property", () => {
+      const map = graph.getByProperty("launched-date");
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe("getByType", () => {
+    it("returns things of a given type", () => {
+      const orgs = graph.getByType("organization");
+      expect(orgs).toHaveLength(1);
+      expect(orgs[0].id).toBe("anthropic");
+    });
+
+    it("returns multiple things of the same type", () => {
+      const people = graph.getByType("person");
+      expect(people).toHaveLength(2);
+      const ids = people.map((p) => p.id).sort();
+      expect(ids).toEqual(["dario-amodei", "jan-leike"]);
+    });
+
+    it("returns empty array for unknown type", () => {
+      const things = graph.getByType("product");
+      expect(things).toHaveLength(0);
+    });
+  });
+
+  describe("getRelated", () => {
+    it("returns referenced thing IDs from ref facts", () => {
+      const related = graph.getRelated("jan-leike", "employed-by");
+      expect(related).toContain("openai");
+      expect(related).toContain("anthropic");
+      expect(related).toHaveLength(2);
+    });
+
+    it("returns referenced thing IDs from a single ref fact", () => {
+      const related = graph.getRelated("dario-amodei", "employed-by");
+      expect(related).toEqual(["anthropic"]);
+    });
+
+    it("returns empty array when no facts match", () => {
+      const related = graph.getRelated("anthropic", "employed-by");
+      expect(related).toEqual([]);
+    });
+
+    it("returns empty array for nonexistent thing", () => {
+      const related = graph.getRelated("nonexistent", "employed-by");
+      expect(related).toEqual([]);
+    });
+  });
+
+  describe("getItems", () => {
+    it("returns item entries with keys and fields", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      expect(rounds.length).toBeGreaterThan(0);
+
+      // Each entry has a key and fields
+      for (const entry of rounds) {
+        expect(typeof entry.key).toBe("string");
+        expect(typeof entry.fields).toBe("object");
+      }
+    });
+
+    it("returns correct data for a specific entry", () => {
+      const people = graph.getItems("anthropic", "key-people");
+      const darioCeo = people.find((p) => p.key === "dario-ceo");
+      expect(darioCeo).toBeDefined();
+      expect(darioCeo!.fields.person).toBe("dario-amodei");
+      expect(darioCeo!.fields.title).toBe("CEO");
+      expect(darioCeo!.fields.start).toBe("2021-01");
+      expect(darioCeo!.fields.is_founder).toBe(true);
+    });
+
+    it("returns empty array for missing collection", () => {
+      const items = graph.getItems("anthropic", "nonexistent");
+      expect(items).toEqual([]);
+    });
+
+    it("returns empty array for thing without items", () => {
+      const items = graph.getItems("jan-leike", "key-people");
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("property and schema queries", () => {
+    it("getProperty returns correct property", () => {
+      const prop = graph.getProperty("headquarters");
+      expect(prop).toBeDefined();
+      expect(prop!.name).toBe("Headquarters");
+      expect(prop!.dataType).toBe("text");
+    });
+
+    it("getProperty returns undefined for missing property", () => {
+      expect(graph.getProperty("nonexistent")).toBeUndefined();
+    });
+
+    it("getSchema returns correct schema", () => {
+      const schema = graph.getSchema("organization");
+      expect(schema).toBeDefined();
+      expect(schema!.name).toBe("Organization");
+    });
+
+    it("getSchema returns undefined for missing schema", () => {
+      expect(graph.getSchema("nonexistent")).toBeUndefined();
+    });
+  });
+});

--- a/packages/kb/tests/ids.test.ts
+++ b/packages/kb/tests/ids.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateStableId,
+  generateFactId,
+  contentHash,
+  generateContentFactId,
+} from "../src/ids.ts";
+
+describe("ids", () => {
+  describe("generateStableId", () => {
+    it("returns a 10-character string", () => {
+      const id = generateStableId();
+      expect(id).toHaveLength(10);
+    });
+
+    it("returns only alphanumeric characters (no - or _)", () => {
+      // Run multiple times to increase confidence since replacement is probabilistic
+      for (let i = 0; i < 50; i++) {
+        const id = generateStableId();
+        expect(id).toMatch(/^[A-Za-z0-9]{10}$/);
+      }
+    });
+
+    it("generates unique IDs on successive calls", () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateStableId());
+      }
+      // With 10 alphanumeric chars, collisions in 100 tries are astronomically unlikely
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe("generateFactId", () => {
+    it('returns a string starting with "f_"', () => {
+      const id = generateFactId();
+      expect(id.startsWith("f_")).toBe(true);
+    });
+
+    it('returns "f_" followed by 10 alphanumeric characters', () => {
+      const id = generateFactId();
+      expect(id).toHaveLength(12); // "f_" + 10 chars
+      expect(id).toMatch(/^f_[A-Za-z0-9]{10}$/);
+    });
+
+    it("does not contain - or _ after the f_ prefix", () => {
+      for (let i = 0; i < 50; i++) {
+        const id = generateFactId();
+        const suffix = id.slice(2);
+        expect(suffix).toMatch(/^[A-Za-z0-9]{10}$/);
+      }
+    });
+  });
+
+  describe("contentHash", () => {
+    it("is deterministic: same inputs produce same output", () => {
+      const parts = ["anthropic", "revenue", "1000000000", "2024"];
+      const hash1 = contentHash(parts);
+      const hash2 = contentHash(parts);
+      expect(hash1).toBe(hash2);
+    });
+
+    it("returns a 10-character string", () => {
+      const hash = contentHash(["hello", "world"]);
+      expect(hash).toHaveLength(10);
+    });
+
+    it("produces different output for different inputs", () => {
+      const hash1 = contentHash(["anthropic", "revenue"]);
+      const hash2 = contentHash(["openai", "revenue"]);
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("distinguishes between different argument boundaries", () => {
+      // "ab" + "cd" should differ from "a" + "bcd" because of null-byte separator
+      const hash1 = contentHash(["ab", "cd"]);
+      const hash2 = contentHash(["a", "bcd"]);
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("handles empty parts array", () => {
+      const hash = contentHash([]);
+      expect(hash).toHaveLength(10);
+    });
+  });
+
+  describe("generateContentFactId", () => {
+    it('returns a string starting with "f_"', () => {
+      const id = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id.startsWith("f_")).toBe(true);
+    });
+
+    it("is deterministic: same inputs produce same output", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id1).toBe(id2);
+    });
+
+    it("produces different output for different values", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("anthropic", "revenue", 2e9, "2024");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("produces different output for different subjects", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("openai", "revenue", 1e9, "2024");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("handles missing asOf parameter", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9);
+      const id2 = generateContentFactId("anthropic", "revenue", 1e9);
+      expect(id1).toBe(id2);
+    });
+
+    it("returns f_ + 10 characters (12 total)", () => {
+      const id = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id).toHaveLength(12);
+    });
+  });
+});

--- a/packages/kb/tests/inverse.test.ts
+++ b/packages/kb/tests/inverse.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader.ts";
+import { computeInverses } from "../src/inverse.ts";
+import type { Graph } from "../src/graph.ts";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("inverse", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+    // Suppress console.warn for expected warnings about missing things
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    computeInverses(graph);
+    vi.restoreAllMocks();
+  });
+
+  describe("computeInverses", () => {
+    it("creates employer-of facts on anthropic from employed-by on persons", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      // Both dario-amodei and jan-leike have employed-by: anthropic
+      expect(employerOfFacts.length).toBeGreaterThanOrEqual(2);
+
+      const refValues = employerOfFacts.map((f) => {
+        expect(f.value.type).toBe("ref");
+        return (f.value as { type: "ref"; value: string }).value;
+      });
+      expect(refValues).toContain("dario-amodei");
+      expect(refValues).toContain("jan-leike");
+    });
+
+    it("inverse facts have derivedFrom set", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      for (const fact of employerOfFacts) {
+        expect(fact.derivedFrom).toBeDefined();
+        expect(typeof fact.derivedFrom).toBe("string");
+      }
+    });
+
+    it("inverse fact IDs start with inv_", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      for (const fact of employerOfFacts) {
+        expect(fact.id.startsWith("inv_")).toBe(true);
+      }
+    });
+
+    it("inverse facts preserve asOf temporal bound", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      // Dario's employed-by has asOf: 2021-01, so the inverse should too
+      const darioInverse = employerOfFacts.find(
+        (f) =>
+          f.value.type === "ref" &&
+          (f.value as { type: "ref"; value: string }).value === "dario-amodei"
+      );
+      expect(darioInverse).toBeDefined();
+      expect(darioInverse!.asOf).toBe("2021-01");
+    });
+
+    it("inverse facts preserve validEnd temporal bound", () => {
+      // Jan Leike's OpenAI employment has validEnd: 2024-05
+      // But openai is not in the graph, so that inverse is skipped.
+      // Jan Leike's Anthropic employment has no validEnd.
+      const janInverse = graph
+        .getFacts("anthropic", { property: "employer-of" })
+        .find(
+          (f) =>
+            f.value.type === "ref" &&
+            (f.value as { type: "ref"; value: string }).value === "jan-leike"
+        );
+      expect(janInverse).toBeDefined();
+      expect(janInverse!.validEnd).toBeUndefined();
+    });
+
+    it("getRelated returns person IDs via employer-of after computing inverses", () => {
+      const related = graph.getRelated("anthropic", "employer-of");
+      expect(related).toContain("dario-amodei");
+      expect(related).toContain("jan-leike");
+    });
+
+    it("skips inverse when referenced thing does not exist in graph", () => {
+      // Jan Leike has employed-by: openai, but openai is not in the graph.
+      // The inverse should NOT have been created on a nonexistent "openai" thing.
+      const openaiThing = graph.getThing("openai");
+      expect(openaiThing).toBeUndefined();
+
+      // Even if somehow facts were added, there should be no openai employer-of facts
+      const openaiFacts = graph.getFacts("openai", {
+        property: "employer-of",
+      });
+      expect(openaiFacts).toEqual([]);
+    });
+
+    it("logs a warning when referenced thing does not exist", async () => {
+      // Load a fresh graph and capture warnings
+      const freshGraph = await loadKB(DATA_DIR);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      computeInverses(freshGraph);
+
+      // Should have warned about openai not being in the graph
+      const warnings = warnSpy.mock.calls.map((call) => call[0]);
+      const openaiWarning = warnings.find(
+        (w) => typeof w === "string" && w.includes("openai")
+      );
+      expect(openaiWarning).toBeDefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it("inverse fact IDs are deterministic (content-addressed)", async () => {
+      // Load two separate graphs, compute inverses on both, compare IDs
+      const graph1 = await loadKB(DATA_DIR);
+      const graph2 = await loadKB(DATA_DIR);
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      computeInverses(graph1);
+      computeInverses(graph2);
+      warnSpy.mockRestore();
+
+      const facts1 = graph1
+        .getFacts("anthropic", { property: "employer-of" })
+        .map((f) => f.id)
+        .sort();
+      const facts2 = graph2
+        .getFacts("anthropic", { property: "employer-of" })
+        .map((f) => f.id)
+        .sort();
+
+      expect(facts1).toEqual(facts2);
+    });
+  });
+});

--- a/packages/kb/tests/loader.test.ts
+++ b/packages/kb/tests/loader.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader.ts";
+import type { Graph } from "../src/graph.ts";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("loader", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("things", () => {
+    it("loads Anthropic from disk", () => {
+      const anthropic = graph.getThing("anthropic");
+      expect(anthropic).toBeDefined();
+      expect(anthropic!.name).toBe("Anthropic");
+      expect(anthropic!.stableId).toBe("mK9pX3rQ7n");
+      expect(anthropic!.type).toBe("organization");
+      expect(anthropic!.numericId).toBe(3);
+    });
+
+    it("loads all 3 things (anthropic, dario-amodei, jan-leike)", () => {
+      const things = graph.getAllThings();
+      expect(things).toHaveLength(3);
+
+      const ids = things.map((t) => t.id).sort();
+      expect(ids).toEqual(["anthropic", "dario-amodei", "jan-leike"]);
+    });
+
+    it("loads thing aliases", () => {
+      const anthropic = graph.getThing("anthropic");
+      expect(anthropic!.aliases).toEqual(["Anthropic PBC", "Anthropic AI"]);
+    });
+  });
+
+  describe("properties", () => {
+    it("loads 15 properties", () => {
+      const properties = graph.getAllProperties();
+      expect(properties).toHaveLength(15);
+    });
+
+    it("loads property details correctly", () => {
+      const revenue = graph.getProperty("revenue");
+      expect(revenue).toBeDefined();
+      expect(revenue!.name).toBe("Revenue");
+      expect(revenue!.dataType).toBe("number");
+      expect(revenue!.unit).toBe("USD");
+      expect(revenue!.category).toBe("financial");
+      expect(revenue!.appliesTo).toEqual(["organization"]);
+    });
+
+    it("loads property display formatting", () => {
+      const revenue = graph.getProperty("revenue");
+      expect(revenue!.display).toEqual({
+        divisor: 1e9,
+        prefix: "$",
+        suffix: "B",
+      });
+    });
+
+    it("loads inverse property relationships", () => {
+      const employedBy = graph.getProperty("employed-by");
+      expect(employedBy!.inverseId).toBe("employer-of");
+      expect(employedBy!.inverseName).toBe("Employs");
+    });
+
+    it("marks computed properties", () => {
+      const employerOf = graph.getProperty("employer-of");
+      expect(employerOf!.computed).toBe(true);
+    });
+  });
+
+  describe("schemas", () => {
+    it("loads 2 schemas (organization, person)", () => {
+      const schemas = graph.getAllSchemas();
+      expect(schemas).toHaveLength(2);
+    });
+
+    it("loads organization schema with required and recommended properties", () => {
+      const orgSchema = graph.getSchema("organization");
+      expect(orgSchema).toBeDefined();
+      expect(orgSchema!.name).toBe("Organization");
+      expect(orgSchema!.required).toEqual(["founded-date", "headquarters"]);
+      expect(orgSchema!.recommended).toContain("revenue");
+      expect(orgSchema!.recommended).toContain("valuation");
+    });
+
+    it("loads person schema with empty required array", () => {
+      const personSchema = graph.getSchema("person");
+      expect(personSchema).toBeDefined();
+      expect(personSchema!.required).toEqual([]);
+      expect(personSchema!.recommended).toContain("employed-by");
+      expect(personSchema!.recommended).toContain("role");
+      expect(personSchema!.recommended).toContain("born-year");
+    });
+
+    it("loads item collection schemas on organization", () => {
+      const orgSchema = graph.getSchema("organization");
+      expect(orgSchema!.items).toBeDefined();
+      expect(orgSchema!.items!["funding-rounds"]).toBeDefined();
+      expect(orgSchema!.items!["key-people"]).toBeDefined();
+
+      const frFields = orgSchema!.items!["funding-rounds"].fields;
+      expect(frFields["date"].required).toBe(true);
+      expect(frFields["date"].type).toBe("date");
+      expect(frFields["amount"].type).toBe("number");
+      expect(frFields["lead_investor"].type).toBe("ref");
+    });
+  });
+
+  describe("facts", () => {
+    it("loads correct number of facts for Anthropic (11)", () => {
+      const facts = graph.getFacts("anthropic");
+      // 5 revenue + 1 valuation + 1 founded-date + 1 headquarters + 1 headcount
+      // + 1 legal-structure + 1 total-funding = 11
+      expect(facts).toHaveLength(11);
+    });
+
+    it("loads correct number of facts for Dario Amodei (3)", () => {
+      const facts = graph.getFacts("dario-amodei");
+      expect(facts).toHaveLength(3);
+    });
+
+    it("loads correct number of facts for Jan Leike (3)", () => {
+      const facts = graph.getFacts("jan-leike");
+      expect(facts).toHaveLength(3);
+    });
+
+    it("normalizes number values as {type: 'number'}", () => {
+      const revenueFacts = graph.getFacts("anthropic", {
+        property: "revenue",
+      });
+      expect(revenueFacts.length).toBeGreaterThan(0);
+      for (const fact of revenueFacts) {
+        expect(fact.value.type).toBe("number");
+        expect(typeof (fact.value as { type: "number"; value: number }).value).toBe("number");
+      }
+    });
+
+    it("normalizes ref values as {type: 'ref'}", () => {
+      const employedByFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      expect(employedByFacts).toHaveLength(2);
+      for (const fact of employedByFacts) {
+        expect(fact.value.type).toBe("ref");
+      }
+    });
+
+    it("normalizes date values as {type: 'date'}", () => {
+      const foundedFacts = graph.getFacts("anthropic", {
+        property: "founded-date",
+      });
+      expect(foundedFacts).toHaveLength(1);
+      expect(foundedFacts[0].value).toEqual({
+        type: "date",
+        value: "2021-01",
+      });
+    });
+
+    it("normalizes text values as {type: 'text'}", () => {
+      const hqFacts = graph.getFacts("anthropic", {
+        property: "headquarters",
+      });
+      expect(hqFacts).toHaveLength(1);
+      expect(hqFacts[0].value).toEqual({
+        type: "text",
+        value: "San Francisco, CA",
+      });
+    });
+
+    it("preserves temporal metadata (asOf and validEnd)", () => {
+      const janFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      // One fact has validEnd (the OpenAI one)
+      const openAiFact = janFacts.find(
+        (f) => f.value.type === "ref" && f.value.value === "openai"
+      );
+      expect(openAiFact).toBeDefined();
+      expect(openAiFact!.asOf).toBe("2021-01");
+      expect(openAiFact!.validEnd).toBe("2024-05");
+
+      // One fact has no validEnd (the Anthropic one)
+      const anthropicFact = janFacts.find(
+        (f) => f.value.type === "ref" && f.value.value === "anthropic"
+      );
+      expect(anthropicFact).toBeDefined();
+      expect(anthropicFact!.asOf).toBe("2024-05");
+      expect(anthropicFact!.validEnd).toBeUndefined();
+    });
+
+    it("preserves source and notes metadata", () => {
+      const foundedFacts = graph.getFacts("anthropic", {
+        property: "founded-date",
+      });
+      expect(foundedFacts[0].source).toBe("https://anthropic.com/company");
+      expect(foundedFacts[0].notes).toBe(
+        "Founded by seven former OpenAI researchers in January 2021"
+      );
+    });
+  });
+
+  describe("item collections", () => {
+    it("loads funding-rounds collection for Anthropic", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      expect(rounds).toHaveLength(9);
+    });
+
+    it("loads key-people collection for Anthropic", () => {
+      const people = graph.getItems("anthropic", "key-people");
+      expect(people).toHaveLength(7);
+    });
+
+    it("item entries have correct keys and field values", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      const seed = rounds.find((r) => r.key === "seed");
+      expect(seed).toBeDefined();
+      expect(seed!.fields.date).toBe("2021-04");
+      expect(seed!.fields.amount).toBe(124e6);
+      expect(seed!.fields.valuation).toBe(550e6);
+      expect(seed!.fields.lead_investor).toBe("jaan-tallinn");
+    });
+
+    it("returns empty array for non-existent collection", () => {
+      const items = graph.getItems("anthropic", "nonexistent");
+      expect(items).toEqual([]);
+    });
+
+    it("returns empty array for non-existent thing", () => {
+      const items = graph.getItems("nonexistent", "funding-rounds");
+      expect(items).toEqual([]);
+    });
+  });
+});

--- a/packages/kb/tests/validate.test.ts
+++ b/packages/kb/tests/validate.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader.ts";
+import { validate, validateThing } from "../src/validate.ts";
+import { Graph } from "../src/graph.ts";
+import type { ValidationResult } from "../src/types.ts";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("validate", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("validateThing — anthropic (organization)", () => {
+    let results: ValidationResult[];
+
+    beforeAll(() => {
+      results = validateThing(graph, "anthropic");
+    });
+
+    it("has no required-property errors (founded-date and headquarters present)", () => {
+      const requiredErrors = results.filter(
+        (r) => r.rule === "required-properties" && r.severity === "error"
+      );
+      expect(requiredErrors).toHaveLength(0);
+    });
+
+    it("has a completeness info message showing percentage", () => {
+      const completeness = results.filter((r) => r.rule === "completeness");
+      expect(completeness).toHaveLength(1);
+      expect(completeness[0].severity).toBe("info");
+      expect(completeness[0].message).toContain("Completeness");
+      expect(completeness[0].message).toMatch(/\d+%/);
+    });
+
+    it("completeness shows high percentage for well-populated entity", () => {
+      const completeness = results.find((r) => r.rule === "completeness");
+      // Anthropic has all 7 required+recommended properties:
+      // required: founded-date, headquarters (2)
+      // recommended: revenue, valuation, headcount, legal-structure, total-funding (5)
+      // Total: 7/7 = 100%
+      expect(completeness!.message).toContain("100%");
+    });
+
+    it("has no recommended-property warnings (all recommended are present)", () => {
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties" && r.severity === "warning"
+      );
+      expect(recommendedWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("validateThing — person schemas", () => {
+    it("person with all recommended properties has no warnings", () => {
+      // Dario has employed-by, role, and born-year
+      const results = validateThing(graph, "dario-amodei");
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties"
+      );
+      expect(recommendedWarnings).toHaveLength(0);
+    });
+
+    it("person missing recommended properties gets warnings", () => {
+      // Jan Leike has employed-by and role but NO born-year
+      const results = validateThing(graph, "jan-leike");
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties"
+      );
+      expect(recommendedWarnings).toHaveLength(1);
+      expect(recommendedWarnings[0].message).toContain("born-year");
+    });
+  });
+
+  describe("ref-integrity", () => {
+    it("catches refs to non-existent things", () => {
+      // Jan Leike references "openai" which is not in our test data
+      const results = validateThing(graph, "jan-leike");
+      const refErrors = results.filter((r) => r.rule === "ref-integrity");
+      expect(refErrors.length).toBeGreaterThan(0);
+
+      const openaiRef = refErrors.find((r) => r.message.includes("openai"));
+      expect(openaiRef).toBeDefined();
+      expect(openaiRef!.severity).toBe("error");
+    });
+
+    it("does not flag refs to existing things", () => {
+      // Dario references "anthropic" which exists
+      const results = validateThing(graph, "dario-amodei");
+      const refErrors = results.filter((r) => r.rule === "ref-integrity");
+      expect(refErrors).toHaveLength(0);
+    });
+  });
+
+  describe("item-collection-schema validation", () => {
+    it("validates item entries against schema", () => {
+      const results = validateThing(graph, "anthropic");
+      const itemResults = results.filter(
+        (r) => r.rule === "item-collection-schema"
+      );
+      // The anthropic data has funding-round entries with lead_investor referencing
+      // things not in our test graph (ftx, amazon, google, gic, jaan-tallinn).
+      // These should produce type warnings since they reference non-existent things.
+      const refWarnings = itemResults.filter(
+        (r) =>
+          r.severity === "warning" && r.message.includes("unknown thing")
+      );
+      expect(refWarnings.length).toBeGreaterThan(0);
+    });
+
+    it("does not report errors for required fields that are present", () => {
+      // funding-rounds schema requires 'date', key-people requires 'person' and 'title'
+      // All entries in our test data provide these fields
+      const results = validateThing(graph, "anthropic");
+      const requiredFieldErrors = results.filter(
+        (r) =>
+          r.rule === "item-collection-schema" &&
+          r.severity === "error" &&
+          r.message.includes("missing required field")
+      );
+      expect(requiredFieldErrors).toHaveLength(0);
+    });
+
+    it("validates key-people person refs against the graph", () => {
+      const results = validateThing(graph, "anthropic");
+      const itemResults = results.filter(
+        (r) =>
+          r.rule === "item-collection-schema" &&
+          r.message.includes("key-people")
+      );
+      // Some key-people reference persons not in the graph
+      // (daniela-amodei, chris-olah, tom-brown, mike-krieger, holden-karnofsky)
+      const unknownPeople = itemResults.filter(
+        (r) => r.message.includes("unknown thing")
+      );
+      expect(unknownPeople.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("validate (full graph)", () => {
+    it("returns results for all things", () => {
+      const results = validate(graph);
+
+      // Should have results for anthropic, dario-amodei, and jan-leike
+      const thingIds = new Set(results.map((r) => r.thingId).filter(Boolean));
+      expect(thingIds.has("anthropic")).toBe(true);
+      expect(thingIds.has("dario-amodei")).toBe(true);
+      expect(thingIds.has("jan-leike")).toBe(true);
+    });
+
+    it("includes completeness info for every thing", () => {
+      const results = validate(graph);
+      const completeness = results.filter((r) => r.rule === "completeness");
+      expect(completeness).toHaveLength(3); // one per thing
+    });
+
+    it("properly categorizes severity levels", () => {
+      const results = validate(graph);
+
+      const errors = results.filter((r) => r.severity === "error");
+      const warnings = results.filter((r) => r.severity === "warning");
+      const infos = results.filter((r) => r.severity === "info");
+
+      // There should be at least some errors (ref-integrity for openai)
+      expect(errors.length).toBeGreaterThan(0);
+      // There should be at least some warnings (recommended properties, or item ref warnings)
+      expect(warnings.length).toBeGreaterThan(0);
+      // There should be info messages (completeness for all 3 things)
+      expect(infos.length).toBe(3);
+    });
+  });
+
+  describe("validateThing — edge cases", () => {
+    it("returns error for non-existent thing", () => {
+      const results = validateThing(graph, "nonexistent");
+      expect(results).toHaveLength(1);
+      expect(results[0].severity).toBe("error");
+      expect(results[0].rule).toBe("thing-exists");
+    });
+
+    it("returns warning for thing with no registered schema", () => {
+      // Create a minimal graph with a thing of unknown type
+      const minGraph = new Graph();
+      minGraph.addThing({
+        id: "test-product",
+        stableId: "abc123def0",
+        type: "product",
+        name: "Test Product",
+      });
+
+      const results = validateThing(minGraph, "test-product");
+      expect(results).toHaveLength(1);
+      expect(results[0].severity).toBe("warning");
+      expect(results[0].rule).toBe("schema-exists");
+      expect(results[0].message).toContain("product");
+    });
+
+    it("validates required fields are missing in a minimal graph", () => {
+      // Create a minimal org with no facts
+      const minGraph = new Graph();
+      minGraph.addSchema({
+        type: "organization",
+        name: "Organization",
+        required: ["founded-date", "headquarters"],
+        recommended: ["revenue"],
+      });
+      minGraph.addThing({
+        id: "empty-org",
+        stableId: "xyz456abc0",
+        type: "organization",
+        name: "Empty Org",
+      });
+
+      const results = validateThing(minGraph, "empty-org");
+      const requiredErrors = results.filter(
+        (r) => r.rule === "required-properties"
+      );
+      expect(requiredErrors).toHaveLength(2);
+      expect(requiredErrors.map((r) => r.propertyId).sort()).toEqual([
+        "founded-date",
+        "headquarters",
+      ]);
+    });
+  });
+
+  describe("property-applies-to check", () => {
+    it("warns when property is used on wrong thing type", () => {
+      // Create a scenario where a "revenue" fact is on a person (wrong type)
+      const testGraph = new Graph();
+      testGraph.addSchema({
+        type: "person",
+        name: "Person",
+        required: [],
+        recommended: [],
+      });
+      testGraph.addProperty({
+        id: "revenue",
+        name: "Revenue",
+        dataType: "number",
+        appliesTo: ["organization"],
+      });
+      testGraph.addThing({
+        id: "wrong-type",
+        stableId: "abc123def0",
+        type: "person",
+        name: "Wrong Type",
+      });
+      testGraph.addFact({
+        id: "f_test123456",
+        subjectId: "wrong-type",
+        propertyId: "revenue",
+        value: { type: "number", value: 1000 },
+      });
+
+      const results = validateThing(testGraph, "wrong-type");
+      const appliesToWarnings = results.filter(
+        (r) => r.rule === "property-applies-to"
+      );
+      expect(appliesToWarnings).toHaveLength(1);
+      expect(appliesToWarnings[0].severity).toBe("warning");
+      expect(appliesToWarnings[0].message).toContain("organization");
+      expect(appliesToWarnings[0].message).toContain("person");
+    });
+  });
+});

--- a/packages/kb/tsconfig.json
+++ b/packages/kb/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/kb/vitest.config.ts
+++ b/packages/kb/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,19 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/kb:
+    dependencies:
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
 packages:
 
   '@alcalzone/ansi-tokenize@0.1.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "apps/discord-bot"
   - "apps/wiki-server"
   - "apps/groundskeeper"
+  - "packages/kb"


### PR DESCRIPTION
## Summary

Implements a self-contained TypeScript Knowledge Base library (`packages/kb/`) as a greenfield experiment, inspired by the Ken Standard data model. This is the foundational package for structured entity data with temporal tracking and computed relationships.

### What's included

- **Core data model** (`types.ts`): Thing, Fact, Property, TypeSchema, ItemCollection — discriminated union FactValues with 7 types (number, text, date, boolean, ref, refs, json)
- **YAML loader** (`loader.ts`): Reads thing files, properties, and schemas from disk with automatic value type inference based on property dataType
- **In-memory Graph** (`graph.ts`): Query engine with `getFacts()`, `getLatest()`, `getByProperty()`, `getRelated()`, `getItems()`, `getByType()`
- **Computed inverses** (`inverse.ts`): Define `employed-by` on a person, auto-generates `employer-of` on the org — eliminates manual duplication
- **Schema validation** (`validate.ts`): 6 check types — required/recommended properties, appliesTo constraints, ref integrity, item collection schemas, completeness scoring
- **Stable IDs** (`ids.ts`): Random 10-char alphanumeric IDs that survive renames + content-hash deterministic fact IDs for idempotent sync
- **Serialization** (`serialize.ts`): Graph → JSON for downstream consumers
- **Test data**: Anthropic entity with 11 facts, 9 funding rounds, 7 key people; Dario Amodei and Jan Leike with temporal employment history
- **102 tests** across 5 test files, all passing

### Design decisions

- **Greenfield, not refactor**: Clean-room implementation decoupled from wiki rendering, wiki-server, and crux CLI
- **YAML as source of truth**: Version-controlled, PR-reviewable, human-editable files
- **Experimental**: Different quality standards, 2-week kill/promote deadline (see `EXPERIMENTAL.md`)
- **No production dependencies**: Not imported by any production code yet

### Architecture

```
packages/kb/
├── src/           # Library source (8 modules)
├── data/          # Test YAML data (Anthropic, 2 people, 15 properties, 2 schemas)
├── tests/         # 102 tests across 5 files
├── package.json   # @longterm-wiki/kb workspace package
└── EXPERIMENTAL.md
```

See `.claude/design/kb-library.md` for the full design doc.

Closes #1798

## Test plan

- [x] `npx vitest run` — 102 tests pass (ids, loader, graph, inverse, validate)
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] Gate checks pass (build-data, tests, unified rules, schema, typecheck)
- [x] Package added to pnpm-workspace.yaml and installs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced experimental Knowledge Base Library supporting organizations and people entities with financial metrics, relationships, and biographical data.
  * Added functionality to load, query, validate, and serialize knowledge base data.
  * Included property definitions for financial attributes, employment relationships, dates, and organizational structure.
  * Added example data for sample organizations and individuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->