### PR TITLE
refactor: rename Thing → Entity in KB package

### DIFF
--- a/packages/kb/scripts/upsert-resources.ts
+++ b/packages/kb/scripts/upsert-resources.ts
@@ -1,5 +1,5 @@
 /**
- * Upsert all source URLs from KB thing files to the wiki-server resources DB.
+ * Upsert all source URLs from KB entity files to the wiki-server resources DB.
  * Run: WIKI_SERVER_ENV=prod npx tsx packages/kb/scripts/upsert-resources.ts
  */
 import "dotenv/config";

--- a/packages/kb/src/graph.ts
+++ b/packages/kb/src/graph.ts
@@ -4,7 +4,7 @@
  */
 
 import type {
-  Thing,
+  Entity,
   Fact,
   Property,
   TypeSchema,
@@ -15,21 +15,21 @@ import type {
 } from "./types";
 
 export class Graph {
-  private things: Map<string, Thing> = new Map();
+  private entities: Map<string, Entity> = new Map();
   private facts: Map<string, Fact[]> = new Map(); // keyed by subjectId
   private factIds: Set<string> = new Set(); // dedup guard
   private properties: Map<string, Property> = new Map();
   private schemas: Map<string, TypeSchema> = new Map();
-  // thingId → collectionName → collection
+  // entityId → collectionName → collection
   private items: Map<string, Map<string, ItemCollection>> = new Map();
   // stableId → slug reverse index
   private stableIdIndex: Map<string, string> = new Map();
 
   // ── Mutation (used by loader and inverse computation) ──────────────
 
-  addThing(thing: Thing): void {
-    this.things.set(thing.id, thing);
-    this.stableIdIndex.set(thing.stableId, thing.id);
+  addEntity(entity: Entity): void {
+    this.entities.set(entity.id, entity);
+    this.stableIdIndex.set(entity.stableId, entity.id);
   }
 
   /**
@@ -57,28 +57,28 @@ export class Graph {
   }
 
   addItemCollection(
-    thingId: string,
+    entityId: string,
     collectionName: string,
     collection: ItemCollection
   ): void {
-    let thingCollections = this.items.get(thingId);
-    if (!thingCollections) {
-      thingCollections = new Map();
-      this.items.set(thingId, thingCollections);
+    let entityCollections = this.items.get(entityId);
+    if (!entityCollections) {
+      entityCollections = new Map();
+      this.items.set(entityId, entityCollections);
     }
-    thingCollections.set(collectionName, collection);
+    entityCollections.set(collectionName, collection);
   }
 
-  // ── Thing queries ──────────────────────────────────────────────────
+  // ── Entity queries ─────────────────────────────────────────────────
 
-  getThing(id: string): Thing | undefined {
-    return this.things.get(id);
+  getEntity(id: string): Entity | undefined {
+    return this.entities.get(id);
   }
 
-  /** Resolve a stableId to its Thing. */
-  getThingByStableId(stableId: string): Thing | undefined {
+  /** Resolve a stableId to its Entity. */
+  getEntityByStableId(stableId: string): Entity | undefined {
     const slug = this.stableIdIndex.get(stableId);
-    return slug ? this.things.get(slug) : undefined;
+    return slug ? this.entities.get(slug) : undefined;
   }
 
   /** Resolve a stableId to a slug. Returns undefined if not found. */
@@ -86,18 +86,18 @@ export class Graph {
     return this.stableIdIndex.get(stableId);
   }
 
-  getAllThings(): Thing[] {
-    return Array.from(this.things.values());
+  getAllEntities(): Entity[] {
+    return Array.from(this.entities.values());
   }
 
-  getByType(type: string): Thing[] {
-    return Array.from(this.things.values()).filter((t) => t.type === type);
+  getByType(type: string): Entity[] {
+    return Array.from(this.entities.values()).filter((t) => t.type === type);
   }
 
   // ── Fact queries ───────────────────────────────────────────────────
 
-  getFacts(thingId: string, query?: FactQuery): Fact[] {
-    const all = this.facts.get(thingId) ?? [];
+  getFacts(entityId: string, query?: FactQuery): Fact[] {
+    const all = this.facts.get(entityId) ?? [];
     let result = all;
 
     if (query?.property !== undefined) {
@@ -112,11 +112,11 @@ export class Graph {
   }
 
   /**
-   * Returns the most recent fact for a given (thingId, propertyId) pair,
+   * Returns the most recent fact for a given (entityId, propertyId) pair,
    * ordering by asOf descending. Facts without asOf come last.
    */
-  getLatest(thingId: string, propertyId: string): Fact | undefined {
-    const facts = this.getFacts(thingId, { property: propertyId });
+  getLatest(entityId: string, propertyId: string): Fact | undefined {
+    const facts = this.getFacts(entityId, { property: propertyId });
     if (facts.length === 0) return undefined;
 
     return facts.slice().sort((a, b) => {
@@ -137,10 +137,10 @@ export class Graph {
   ): Map<string, Fact> {
     const result = new Map<string, Fact>();
 
-    for (const thingId of this.things.keys()) {
-      const latest = this.getLatest(thingId, propertyId);
+    for (const entityId of this.entities.keys()) {
+      const latest = this.getLatest(entityId, propertyId);
       if (latest !== undefined) {
-        result.set(thingId, latest);
+        result.set(entityId, latest);
       }
     }
 
@@ -154,10 +154,10 @@ export class Graph {
   getAllByProperty(propertyId: string): Map<string, Fact[]> {
     const result = new Map<string, Fact[]>();
 
-    for (const thingId of this.things.keys()) {
-      const facts = this.getFacts(thingId, { property: propertyId });
+    for (const entityId of this.entities.keys()) {
+      const facts = this.getFacts(entityId, { property: propertyId });
       if (facts.length > 0) {
-        result.set(thingId, facts);
+        result.set(entityId, facts);
       }
     }
 
@@ -165,10 +165,10 @@ export class Graph {
   }
 
   /**
-   * Returns the IDs of things referenced by ref/refs facts on this thing.
+   * Returns the IDs of entities referenced by ref/refs facts on this entity.
    */
-  getRelated(thingId: string, propertyId: string): string[] {
-    const facts = this.getFacts(thingId, { property: propertyId });
+  getRelated(entityId: string, propertyId: string): string[] {
+    const facts = this.getFacts(entityId, { property: propertyId });
     const ids: string[] = [];
 
     for (const fact of facts) {
@@ -184,11 +184,11 @@ export class Graph {
 
   // ── Item queries ───────────────────────────────────────────────────
 
-  getItems(thingId: string, collectionName: string): ItemEntry[] {
-    const thingCollections = this.items.get(thingId);
-    if (!thingCollections) return [];
+  getItems(entityId: string, collectionName: string): ItemEntry[] {
+    const entityCollections = this.items.get(entityId);
+    if (!entityCollections) return [];
 
-    const collection = thingCollections.get(collectionName);
+    const collection = entityCollections.get(collectionName);
     if (!collection) return [];
 
     return Object.entries(collection.entries).map(([key, fields]) => ({
@@ -199,36 +199,36 @@ export class Graph {
 
   /**
    * Scans all items across all entities for fields that reference the
-   * given thingId. Returns matches with context about where they appear.
+   * given entityId. Returns matches with context about where they appear.
    *
    * Uses schema field definitions to identify `ref` type fields. Falls
    * back to string-matching if no schema is available.
    */
   getItemsMentioning(
-    thingId: string
+    entityId: string
   ): Array<{
-    ownerThingId: string;
+    ownerEntityId: string;
     collection: string;
     entry: ItemEntry;
     /** Which field(s) contain the reference */
     matchingFields: string[];
   }> {
     const results: Array<{
-      ownerThingId: string;
+      ownerEntityId: string;
       collection: string;
       entry: ItemEntry;
       matchingFields: string[];
     }> = [];
 
-    for (const [ownerThingId, thingCollections] of this.items.entries()) {
-      if (ownerThingId === thingId) continue; // Skip self-references
+    for (const [ownerEntityId, entityCollections] of this.items.entries()) {
+      if (ownerEntityId === entityId) continue; // Skip self-references
 
-      const ownerThing = this.things.get(ownerThingId);
-      const schema = ownerThing
-        ? this.schemas.get(ownerThing.type)
+      const ownerEntity = this.entities.get(ownerEntityId);
+      const schema = ownerEntity
+        ? this.schemas.get(ownerEntity.type)
         : undefined;
 
-      for (const [collectionName, collection] of thingCollections.entries()) {
+      for (const [collectionName, collection] of entityCollections.entries()) {
         const collectionSchema = schema?.items?.[collectionName];
         const fieldDefs = collectionSchema?.fields;
 
@@ -239,14 +239,14 @@ export class Graph {
             const fieldDef = fieldDefs?.[fieldName];
 
             // Check ref fields explicitly
-            if (fieldDef?.type === "ref" && fieldValue === thingId) {
+            if (fieldDef?.type === "ref" && fieldValue === entityId) {
               matchingFields.push(fieldName);
             }
             // Also check string values that match (covers untyped fields)
             else if (
               !fieldDef &&
               typeof fieldValue === "string" &&
-              fieldValue === thingId
+              fieldValue === entityId
             ) {
               matchingFields.push(fieldName);
             }
@@ -254,7 +254,7 @@ export class Graph {
 
           if (matchingFields.length > 0) {
             results.push({
-              ownerThingId,
+              ownerEntityId,
               collection: collectionName,
               entry: { key: entryKey, fields },
               matchingFields,

--- a/packages/kb/src/ids.ts
+++ b/packages/kb/src/ids.ts
@@ -1,7 +1,7 @@
 /**
  * Stable ID generation for the Knowledge Base library.
  *
- * - generateStableId()         — random 10-char alphanumeric (for Thing.stableId)
+ * - generateStableId()         — random 10-char alphanumeric (for Entity.stableId)
  * - generateFactId()           — "f_" + 10-char alphanumeric (random)
  * - contentHash(parts)         — deterministic SHA-256-based 10-char token
  * - generateContentFactId(...) — "f_" + contentHash (idempotent sync helper)
@@ -36,7 +36,7 @@ function randomAlphanumeric10(): string {
 
 /**
  * Returns a random 10-character alphanumeric string suitable for use as a
- * Thing's `stableId`.  Survives renames because it is purely random.
+ * Entity's `stableId`.  Survives renames because it is purely random.
  *
  * @example
  * generateStableId() // "a3Kf2rZ9mQ"
@@ -91,7 +91,7 @@ export function contentHash(parts: string[]): string {
  * Use this when syncing facts from an external source so that re-running the
  * sync does not create duplicates.
  *
- * @param subjectId  - Thing slug the fact is about
+ * @param subjectId  - Entity slug the fact is about
  * @param propertyId - Property ID from the registry
  * @param value      - The fact value (any JSON-serialisable type)
  * @param asOf       - Optional temporal anchor (ISO date or YYYY-MM string)

--- a/packages/kb/src/index.ts
+++ b/packages/kb/src/index.ts
@@ -5,7 +5,7 @@
 export { loadKB } from "./loader";
 export { Graph } from "./graph";
 export { computeInverses } from "./inverse";
-export { validate, validateThing } from "./validate";
+export { validate, validateEntity } from "./validate";
 export * from "./types";
 export * from "./ids";
 export { serialize } from "./serialize";

--- a/packages/kb/src/inverse.ts
+++ b/packages/kb/src/inverse.ts
@@ -4,7 +4,7 @@
  *
  * For every property that declares an `inverseId`, this module scans all
  * existing facts that use that property and — for each ref/refs value —
- * synthesises a mirror fact on the referenced thing using the inverse
+ * synthesises a mirror fact on the referenced entity using the inverse
  * property ID.  The derived fact carries the same temporal bounds (asOf,
  * validEnd) as its source and records the source fact's ID in `derivedFrom`.
  *
@@ -54,13 +54,13 @@ function derivedId(
 /**
  * Scans the graph for facts that belong to properties with an `inverseId`,
  * then synthesises and adds the corresponding mirror facts on the referenced
- * things.
+ * entities.
  *
  * Only `ref` and `refs` value types participate in inverse computation.
  * All other value types are silently skipped.
  *
  * Edge cases:
- * - If the referenced thing does not exist in the graph, a console warning is
+ * - If the referenced entity does not exist in the graph, a console warning is
  *   emitted and the inverse is skipped (no crash).
  * - Temporal bounds (`asOf`, `validEnd`) are preserved from the source fact.
  * - Running this function more than once on the same graph will result in
@@ -77,11 +77,11 @@ export function computeInverses(graph: Graph): void {
     // counterpart.  Processing them would create duplicates.
     if (property.computed) continue;
 
-    // Collect all facts across every thing that use this property.
-    const allThings = graph.getAllThings();
+    // Collect all facts across every entity that use this property.
+    const allEntities = graph.getAllEntities();
 
-    for (const thing of allThings) {
-      const facts = graph.getFacts(thing.id, { property: property.id });
+    for (const entity of allEntities) {
+      const facts = graph.getFacts(entity.id, { property: property.id });
 
       for (const fact of facts) {
         // Skip facts that are already derived (from a previous inverse pass).
@@ -116,25 +116,25 @@ function _processFactInverse(
 
 /**
  * Constructs and adds one derived inverse fact.
- * Skips silently (with a warning) if the referenced thing is not in the graph.
+ * Skips silently (with a warning) if the referenced entity is not in the graph.
  */
 function _addSingleInverse(
   graph: Graph,
   sourceFact: Fact,
   inversePropertyId: string,
-  referencedThingId: string
+  referencedEntityId: string
 ): void {
-  // Guard: the referenced thing must exist.
-  if (!graph.getThing(referencedThingId)) {
+  // Guard: the referenced entity must exist.
+  if (!graph.getEntity(referencedEntityId)) {
     console.warn(
       `[kb/inverse] Skipping inverse for fact "${sourceFact.id}": ` +
-        `referenced thing "${referencedThingId}" not found in graph.`
+        `referenced entity "${referencedEntityId}" not found in graph.`
     );
     return;
   }
 
   const id = derivedId(
-    referencedThingId,
+    referencedEntityId,
     inversePropertyId,
     sourceFact.subjectId,
     sourceFact.asOf,
@@ -143,7 +143,7 @@ function _addSingleInverse(
 
   const derived: Fact = {
     id,
-    subjectId: referencedThingId,
+    subjectId: referencedEntityId,
     propertyId: inversePropertyId,
     value: { type: "ref", value: sourceFact.subjectId },
     asOf: sourceFact.asOf,

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -13,11 +13,11 @@ import { Graph } from "./graph";
 import type {
   PropertiesFile,
   SchemaFile,
-  ThingFile,
+  EntityFile,
   RawFact,
   Property,
   TypeSchema,
-  Thing,
+  Entity,
   Fact,
   FactValue,
   ItemCollection,
@@ -175,7 +175,7 @@ function parseSchema(raw: unknown): TypeSchema {
   };
 }
 
-function parseThing(raw: ThingFile["thing"]): Thing {
+function parseEntity(raw: EntityFile["thing"]): Entity {
   return {
     id: raw.id,
     stableId: raw.stableId,
@@ -190,7 +190,7 @@ function parseThing(raw: ThingFile["thing"]): Thing {
 
 function parseFact(
   rawFact: RawFact,
-  thingId: string,
+  entityId: string,
   properties: Map<string, Property>
 ): Fact | null {
   const prop = properties.get(rawFact.property);
@@ -198,7 +198,7 @@ function parseFact(
   // Computed properties are populated by inverse computation, not stored directly.
   if (prop?.computed) {
     console.warn(
-      `[kb/loader] Skipping fact "${rawFact.id}" on "${thingId}": ` +
+      `[kb/loader] Skipping fact "${rawFact.id}" on "${entityId}": ` +
         `property "${rawFact.property}" is computed (populated by inverse computation).`
     );
     return null;
@@ -208,7 +208,7 @@ function parseFact(
 
   return {
     id: rawFact.id,
-    subjectId: thingId,
+    subjectId: entityId,
     propertyId: rawFact.property,
     value,
     ...(rawFact.asOf !== undefined && { asOf: String(rawFact.asOf) }),
@@ -222,7 +222,7 @@ function parseFact(
 }
 
 function parseItemCollection(
-  raw: ThingFile["items"],
+  raw: EntityFile["items"],
   collectionName: string
 ): ItemCollection | undefined {
   if (!raw) return undefined;
@@ -271,8 +271,8 @@ async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unkno
  *   <dataDir>/schemas/*.yaml
  *   <dataDir>/things/*.yaml
  *
- * Uses a two-pass approach for things:
- *   Pass 1: Load all thing headers (builds stableId → slug index)
+ * Uses a two-pass approach for entities:
+ *   Pass 1: Load all entity headers (builds stableId → slug index)
  *   Pass 2: Load facts and items (resolves !ref tags using the index)
  */
 export async function loadKB(dataDir: string): Promise<Graph> {
@@ -304,25 +304,25 @@ export async function loadKB(dataDir: string): Promise<Graph> {
     graph.addSchema(schema);
   }
 
-  // 3. Load things (two passes)
-  const thingFiles = await readYamlFiles(join(dataDir, "things"));
+  // 3. Load entities (two passes)
+  const entityFiles = await readYamlFiles(join(dataDir, "things"));
 
-  // Pass 1: Load all thing headers to build stableId index
-  const parsedFiles: { thing: Thing; file: ThingFile }[] = [];
-  for (const { parsed } of thingFiles) {
-    const file = parsed as ThingFile;
-    const thing = parseThing(file.thing);
-    graph.addThing(thing);
-    parsedFiles.push({ thing, file });
+  // Pass 1: Load all entity headers to build stableId index
+  const parsedEntityFiles: { entity: Entity; file: EntityFile }[] = [];
+  for (const { parsed } of entityFiles) {
+    const file = parsed as EntityFile;
+    const entity = parseEntity(file.thing);
+    graph.addEntity(entity);
+    parsedEntityFiles.push({ entity, file });
   }
 
   // Pass 2: Load facts and items with !ref resolution
-  for (const { thing, file } of parsedFiles) {
+  for (const { entity, file } of parsedEntityFiles) {
     // Resolve !ref markers in facts
     for (const rawFact of file.facts ?? []) {
-      const resolvedValue = resolveRefs(rawFact.value, graph, `${thing.id}/facts`);
+      const resolvedValue = resolveRefs(rawFact.value, graph, `${entity.id}/facts`);
       const resolvedFact = { ...rawFact, value: resolvedValue };
-      const fact = parseFact(resolvedFact as RawFact, thing.id, properties);
+      const fact = parseFact(resolvedFact as RawFact, entity.id, properties);
       if (fact) graph.addFact(fact);
     }
 
@@ -331,13 +331,13 @@ export async function loadKB(dataDir: string): Promise<Graph> {
       const resolvedItems = resolveRefs(
         file.items,
         graph,
-        `${thing.id}/items`
-      ) as ThingFile["items"];
+        `${entity.id}/items`
+      ) as EntityFile["items"];
 
       for (const collectionName of Object.keys(resolvedItems!)) {
         const collection = parseItemCollection(resolvedItems, collectionName);
         if (collection) {
-          graph.addItemCollection(thing.id, collectionName, collection);
+          graph.addItemCollection(entity.id, collectionName, collection);
         }
       }
     }

--- a/packages/kb/src/serialize.ts
+++ b/packages/kb/src/serialize.ts
@@ -6,7 +6,7 @@ import type { Graph } from "./graph";
 import type { ItemEntry } from "./types";
 
 export interface SerializedKB {
-  things: ReturnType<Graph["getAllThings"]>;
+  entities: ReturnType<Graph["getAllEntities"]>;
   facts: Record<string, ReturnType<Graph["getFacts"]>>;
   properties: ReturnType<Graph["getAllProperties"]>;
   schemas: ReturnType<Graph["getAllSchemas"]>;
@@ -18,34 +18,34 @@ export interface SerializedKB {
  * Useful for writing to database.json or sending over the wire.
  */
 export function serialize(graph: Graph): SerializedKB {
-  const things = graph.getAllThings();
+  const entities = graph.getAllEntities();
   const properties = graph.getAllProperties();
   const schemas = graph.getAllSchemas();
 
   const facts: SerializedKB["facts"] = {};
   const items: SerializedKB["items"] = {};
 
-  for (const thing of things) {
-    const thingFacts = graph.getFacts(thing.id);
-    if (thingFacts.length > 0) {
-      facts[thing.id] = thingFacts;
+  for (const entity of entities) {
+    const entityFacts = graph.getFacts(entity.id);
+    if (entityFacts.length > 0) {
+      facts[entity.id] = entityFacts;
     }
 
-    // Serialize item collections for this thing
-    const schema = graph.getSchema(thing.type);
+    // Serialize item collections for this entity
+    const schema = graph.getSchema(entity.type);
     if (schema?.items) {
-      const thingItems: Record<string, ItemEntry[]> = {};
+      const entityItems: Record<string, ItemEntry[]> = {};
       for (const collectionName of Object.keys(schema.items)) {
-        const entries = graph.getItems(thing.id, collectionName);
+        const entries = graph.getItems(entity.id, collectionName);
         if (entries.length > 0) {
-          thingItems[collectionName] = entries;
+          entityItems[collectionName] = entries;
         }
       }
-      if (Object.keys(thingItems).length > 0) {
-        items[thing.id] = thingItems;
+      if (Object.keys(entityItems).length > 0) {
+        items[entity.id] = entityItems;
       }
     }
   }
 
-  return { things, facts, properties, schemas, items };
+  return { entities, facts, properties, schemas, items };
 }

--- a/packages/kb/src/types.ts
+++ b/packages/kb/src/types.ts
@@ -14,9 +14,9 @@ export type FactValue =
   | { type: "refs"; value: string[] }
   | { type: "json"; value: unknown };
 
-// ── Thing ───────────────────────────────────────────────────────────
+// ── Entity ──────────────────────────────────────────────────────────
 
-export interface Thing {
+export interface Entity {
   /** Human-readable slug: "anthropic", "claude-3-5-sonnet" */
   id: string;
   /** Random 10-char ID that survives renames */
@@ -25,7 +25,7 @@ export interface Thing {
   type: string;
   /** Display name */
   name: string;
-  /** Parent thing ID (e.g., funding round → org) */
+  /** Parent entity ID (e.g., funding round → org) */
   parent?: string;
   /** Alternative names for search */
   aliases?: string[];
@@ -40,7 +40,7 @@ export interface Thing {
 export interface Fact {
   /** Random 10-char "f_xxxxxxxx" or content-hash */
   id: string;
-  /** Thing ID (slug) this fact is about */
+  /** Entity ID (slug) this fact is about */
   subjectId: string;
   /** Property ID from the registry */
   propertyId: string;
@@ -84,7 +84,7 @@ export interface Property {
   inverseId?: string;
   /** Inverse display name: "Employed By" → "Employs" */
   inverseName?: string;
-  /** Thing types this property is valid for */
+  /** Entity types this property is valid for */
   appliesTo?: string[];
   /** Display formatting */
   display?: PropertyDisplay;
@@ -107,7 +107,7 @@ export interface ItemCollectionSchema {
 }
 
 export interface TypeSchema {
-  /** Thing type this schema applies to: "organization", "person" */
+  /** Entity type this schema applies to: "organization", "person" */
   type: string;
   /** Display name: "Organization" */
   name: string;
@@ -137,8 +137,8 @@ export interface ItemCollection {
 
 // ── YAML file shapes ────────────────────────────────────────────────
 
-/** Shape of a thing's YAML file (data/things/anthropic.yaml) */
-export interface ThingFile {
+/** Shape of an entity's YAML file (data/things/anthropic.yaml) */
+export interface EntityFile {
   thing: {
     id: string;
     stableId: string;
@@ -194,7 +194,7 @@ export type ValidationSeverity = "error" | "warning" | "info";
 
 export interface ValidationResult {
   severity: ValidationSeverity;
-  thingId?: string;
+  entityId?: string;
   propertyId?: string;
   message: string;
   /** Which check produced this */

--- a/packages/kb/src/validate.ts
+++ b/packages/kb/src/validate.ts
@@ -2,16 +2,16 @@
  * Schema validation for the Knowledge Base graph.
  *
  * Checks performed:
- *  1. required-properties  (error)   — each thing must have a fact for every
+ *  1. required-properties  (error)   — each entity must have a fact for every
  *                                      property listed in its TypeSchema.required
  *  2. recommended-properties (warning) — same check for TypeSchema.recommended
  *  3. property-applies-to  (warning)  — if a property lists appliesTo, ensure
- *                                       the thing's type is in that list
+ *                                       the entity's type is in that list
  *  4. ref-integrity        (error)    — ref/refs values must point to existing
- *                                       things in the graph
+ *                                       entities in the graph
  *  5. item-collection-schema (error/warning) — validate item entries against
  *                                       the ItemCollectionSchema defined in the
- *                                       thing's TypeSchema (if one exists)
+ *                                       entity's TypeSchema (if one exists)
  *  6. completeness         (info)     — percentage of required+recommended
  *                                       properties that have at least one fact
  */
@@ -28,9 +28,9 @@ import type {
 
 // ── Utility helpers ───────────────────────────────────────────────────────────
 
-/** Returns true if the thing has at least one fact for the given propertyId. */
-function hasFact(graph: Graph, thingId: string, propertyId: string): boolean {
-  return graph.getFacts(thingId, { property: propertyId }).length > 0;
+/** Returns true if the entity has at least one fact for the given propertyId. */
+function hasFact(graph: Graph, entityId: string, propertyId: string): boolean {
+  return graph.getFacts(entityId, { property: propertyId }).length > 0;
 }
 
 /**
@@ -42,23 +42,23 @@ function looksLikeDate(value: unknown): boolean {
   return /^\d{4}(-\d{2}(-\d{2})?)?$/.test(value);
 }
 
-// ── Per-thing check implementations ───────────────────────────────────────────
+// ── Per-entity check implementations ──────────────────────────────────────────
 
 /** Check 1: required properties. */
 function checkRequired(
   graph: Graph,
-  thingId: string,
+  entityId: string,
   schema: TypeSchema
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
 
   for (const propertyId of schema.required) {
-    if (!hasFact(graph, thingId, propertyId)) {
+    if (!hasFact(graph, entityId, propertyId)) {
       results.push({
         severity: "error",
-        thingId,
+        entityId,
         propertyId,
-        message: `Missing required property "${propertyId}" on thing "${thingId}" (type: ${schema.type}).`,
+        message: `Missing required property "${propertyId}" on entity "${entityId}" (type: ${schema.type}).`,
         rule: "required-properties",
       });
     }
@@ -70,18 +70,18 @@ function checkRequired(
 /** Check 2: recommended properties. */
 function checkRecommended(
   graph: Graph,
-  thingId: string,
+  entityId: string,
   schema: TypeSchema
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
 
   for (const propertyId of schema.recommended) {
-    if (!hasFact(graph, thingId, propertyId)) {
+    if (!hasFact(graph, entityId, propertyId)) {
       results.push({
         severity: "warning",
-        thingId,
+        entityId,
         propertyId,
-        message: `Missing recommended property "${propertyId}" on thing "${thingId}" (type: ${schema.type}).`,
+        message: `Missing recommended property "${propertyId}" on entity "${entityId}" (type: ${schema.type}).`,
         rule: "recommended-properties",
       });
     }
@@ -93,25 +93,25 @@ function checkRecommended(
 /** Check 3: property appliesTo type constraint. */
 function checkPropertyAppliesTo(
   graph: Graph,
-  thingId: string,
-  thingType: string
+  entityId: string,
+  entityType: string
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
-  const facts = graph.getFacts(thingId);
+  const facts = graph.getFacts(entityId);
 
   for (const fact of facts) {
     const property = graph.getProperty(fact.propertyId);
     if (!property) continue; // Unknown properties are caught by other checks if needed.
     if (!property.appliesTo || property.appliesTo.length === 0) continue;
 
-    if (!property.appliesTo.includes(thingType)) {
+    if (!property.appliesTo.includes(entityType)) {
       results.push({
         severity: "warning",
-        thingId,
+        entityId,
         propertyId: fact.propertyId,
         message:
           `Property "${fact.propertyId}" applies to [${property.appliesTo.join(", ")}] ` +
-          `but thing "${thingId}" is of type "${thingType}".`,
+          `but entity "${entityId}" is of type "${entityType}".`,
         rule: "property-applies-to",
       });
     }
@@ -120,10 +120,10 @@ function checkPropertyAppliesTo(
   return results;
 }
 
-/** Check 4: ref/refs integrity — referenced things must exist. */
-function checkRefIntegrity(graph: Graph, thingId: string): ValidationResult[] {
+/** Check 4: ref/refs integrity — referenced entities must exist. */
+function checkRefIntegrity(graph: Graph, entityId: string): ValidationResult[] {
   const results: ValidationResult[] = [];
-  const facts = graph.getFacts(thingId);
+  const facts = graph.getFacts(entityId);
 
   for (const fact of facts) {
     const missingRefs = _findMissingRefs(graph, fact.value);
@@ -131,10 +131,10 @@ function checkRefIntegrity(graph: Graph, thingId: string): ValidationResult[] {
     for (const missingId of missingRefs) {
       results.push({
         severity: "error",
-        thingId,
+        entityId,
         propertyId: fact.propertyId,
         message:
-          `Fact "${fact.id}" on "${thingId}" references unknown thing "${missingId}" ` +
+          `Fact "${fact.id}" on "${entityId}" references unknown entity "${missingId}" ` +
           `(property: "${fact.propertyId}").`,
         rule: "ref-integrity",
       });
@@ -145,16 +145,16 @@ function checkRefIntegrity(graph: Graph, thingId: string): ValidationResult[] {
 }
 
 /**
- * Returns the list of referenced thing IDs that do not exist in the graph.
+ * Returns the list of referenced entity IDs that do not exist in the graph.
  * Only inspects ref/refs value types.
  */
 function _findMissingRefs(graph: Graph, value: FactValue): string[] {
   if (value.type === "ref") {
-    return graph.getThing(value.value) ? [] : [value.value];
+    return graph.getEntity(value.value) ? [] : [value.value];
   }
 
   if (value.type === "refs") {
-    return value.value.filter((id) => !graph.getThing(id));
+    return value.value.filter((id) => !graph.getEntity(id));
   }
 
   return [];
@@ -163,7 +163,7 @@ function _findMissingRefs(graph: Graph, value: FactValue): string[] {
 /** Check 5: item collection schema validation. */
 function checkItemCollections(
   graph: Graph,
-  thingId: string,
+  entityId: string,
   schema: TypeSchema
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
@@ -173,12 +173,12 @@ function checkItemCollections(
   for (const [collectionName, collectionSchema] of Object.entries(
     schema.items
   )) {
-    const entries = graph.getItems(thingId, collectionName);
+    const entries = graph.getItems(entityId, collectionName);
 
     for (const entry of entries) {
       const entryResults = _validateItemEntry(
         graph,
-        thingId,
+        entityId,
         collectionName,
         entry.key,
         entry.fields,
@@ -197,14 +197,14 @@ function checkItemCollections(
  */
 function _validateItemEntry(
   graph: Graph,
-  thingId: string,
+  entityId: string,
   collectionName: string,
   entryKey: string,
   fields: Record<string, unknown>,
   schema: ItemCollectionSchema
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
-  const prefix = `Item "${collectionName}/${entryKey}" on thing "${thingId}"`;
+  const prefix = `Item "${collectionName}/${entryKey}" on entity "${entityId}"`;
 
   for (const [fieldName, fieldDef] of Object.entries(schema.fields)) {
     const value = fields[fieldName];
@@ -213,7 +213,7 @@ function _validateItemEntry(
     if (fieldDef.required && (value === undefined || value === null)) {
       results.push({
         severity: "error",
-        thingId,
+        entityId,
         message: `${prefix}: missing required field "${fieldName}".`,
         rule: "item-collection-schema",
       });
@@ -226,7 +226,7 @@ function _validateItemEntry(
       if (typeError) {
         results.push({
           severity: "warning",
-          thingId,
+          entityId,
           message: typeError,
           rule: "item-collection-schema",
         });
@@ -272,12 +272,12 @@ function _checkFieldType(
 
     case "ref":
       if (typeof value !== "string") {
-        return `${prefix}: field "${fieldName}" expected a thing ID string (ref), got ${typeof value}.`;
+        return `${prefix}: field "${fieldName}" expected an entity ID string (ref), got ${typeof value}.`;
       }
-      // Verify the referenced thing exists.
-      if (!graph.getThing(value)) {
+      // Verify the referenced entity exists.
+      if (!graph.getEntity(value)) {
         return (
-          `${prefix}: field "${fieldName}" references unknown thing "${value}".`
+          `${prefix}: field "${fieldName}" references unknown entity "${value}".`
         );
       }
       break;
@@ -299,21 +299,21 @@ function _checkFieldType(
 /** Check 6: completeness report. */
 function checkCompleteness(
   graph: Graph,
-  thingId: string,
+  entityId: string,
   schema: TypeSchema
 ): ValidationResult[] {
   const tracked = [...schema.required, ...schema.recommended];
   if (tracked.length === 0) return [];
 
-  const present = tracked.filter((p) => hasFact(graph, thingId, p)).length;
+  const present = tracked.filter((p) => hasFact(graph, entityId, p)).length;
   const pct = Math.round((present / tracked.length) * 100);
 
   return [
     {
       severity: "info",
-      thingId,
+      entityId,
       message:
-        `Completeness for "${thingId}" (type: ${schema.type}): ` +
+        `Completeness for "${entityId}" (type: ${schema.type}): ` +
         `${present}/${tracked.length} required+recommended properties present (${pct}%).`,
       rule: "completeness",
     },
@@ -323,59 +323,59 @@ function checkCompleteness(
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
- * Validates a single thing against its TypeSchema.
+ * Validates a single entity against its TypeSchema.
  * Returns an array of ValidationResult objects.
  *
- * If no TypeSchema is registered for the thing's type, a warning is returned
- * and no further checks are run for that thing.
+ * If no TypeSchema is registered for the entity's type, a warning is returned
+ * and no further checks are run for that entity.
  */
-export function validateThing(
+export function validateEntity(
   graph: Graph,
-  thingId: string
+  entityId: string
 ): ValidationResult[] {
-  const thing = graph.getThing(thingId);
-  if (!thing) {
+  const entity = graph.getEntity(entityId);
+  if (!entity) {
     return [
       {
         severity: "error",
-        thingId,
-        message: `Thing "${thingId}" not found in graph.`,
-        rule: "thing-exists",
+        entityId,
+        message: `Entity "${entityId}" not found in graph.`,
+        rule: "entity-exists",
       },
     ];
   }
 
-  const schema = graph.getSchema(thing.type);
+  const schema = graph.getSchema(entity.type);
   if (!schema) {
     return [
       {
         severity: "warning",
-        thingId,
-        message: `No TypeSchema registered for type "${thing.type}" (thing: "${thingId}"). Skipping schema checks.`,
+        entityId,
+        message: `No TypeSchema registered for type "${entity.type}" (entity: "${entityId}"). Skipping schema checks.`,
         rule: "schema-exists",
       },
     ];
   }
 
   return [
-    ...checkRequired(graph, thingId, schema),
-    ...checkRecommended(graph, thingId, schema),
-    ...checkPropertyAppliesTo(graph, thingId, thing.type),
-    ...checkRefIntegrity(graph, thingId),
-    ...checkItemCollections(graph, thingId, schema),
-    ...checkCompleteness(graph, thingId, schema),
+    ...checkRequired(graph, entityId, schema),
+    ...checkRecommended(graph, entityId, schema),
+    ...checkPropertyAppliesTo(graph, entityId, entity.type),
+    ...checkRefIntegrity(graph, entityId),
+    ...checkItemCollections(graph, entityId, schema),
+    ...checkCompleteness(graph, entityId, schema),
   ];
 }
 
 /**
- * Validates the entire graph — runs validateThing() on every thing.
- * Returns an array of all ValidationResult objects across all things.
+ * Validates the entire graph — runs validateEntity() on every entity.
+ * Returns an array of all ValidationResult objects across all entities.
  */
 export function validate(graph: Graph): ValidationResult[] {
   const results: ValidationResult[] = [];
 
-  for (const thing of graph.getAllThings()) {
-    results.push(...validateThing(graph, thing.id));
+  for (const entity of graph.getAllEntities()) {
+    results.push(...validateEntity(graph, entity.id));
   }
 
   return results;

--- a/packages/kb/tests/graph.test.ts
+++ b/packages/kb/tests/graph.test.ts
@@ -12,30 +12,30 @@ describe("graph", () => {
     graph = await loadKB(DATA_DIR);
   });
 
-  describe("getThing", () => {
-    it("returns the correct thing for a valid ID", () => {
-      const thing = graph.getThing("anthropic");
-      expect(thing).toBeDefined();
-      expect(thing!.id).toBe("anthropic");
-      expect(thing!.name).toBe("Anthropic");
-      expect(thing!.type).toBe("organization");
+  describe("getEntity", () => {
+    it("returns the correct entity for a valid ID", () => {
+      const entity = graph.getEntity("anthropic");
+      expect(entity).toBeDefined();
+      expect(entity!.id).toBe("anthropic");
+      expect(entity!.name).toBe("Anthropic");
+      expect(entity!.type).toBe("organization");
     });
 
-    it("returns undefined for a missing thing", () => {
-      const thing = graph.getThing("nonexistent-org");
-      expect(thing).toBeUndefined();
+    it("returns undefined for a missing entity", () => {
+      const entity = graph.getEntity("nonexistent-org");
+      expect(entity).toBeUndefined();
     });
   });
 
-  describe("getAllThings", () => {
-    it("returns all things in the graph", () => {
-      const things = graph.getAllThings();
-      expect(things).toHaveLength(16);
+  describe("getAllEntities", () => {
+    it("returns all entities in the graph", () => {
+      const entities = graph.getAllEntities();
+      expect(entities).toHaveLength(16);
     });
   });
 
   describe("getFacts", () => {
-    it("returns all facts for a thing", () => {
+    it("returns all facts for an entity", () => {
       const facts = graph.getFacts("anthropic");
       // 9 revenue + 4 valuation + 3 total-funding + 3 headcount + 1 founded-date
       // + 1 headquarters + 1 legal-structure + 2 gross-margin + 2 cash-burn
@@ -45,7 +45,7 @@ describe("graph", () => {
       expect(facts).toHaveLength(36);
     });
 
-    it("returns empty array for a thing with no facts", () => {
+    it("returns empty array for an entity with no facts", () => {
       const facts = graph.getFacts("nonexistent");
       expect(facts).toEqual([]);
     });
@@ -105,7 +105,7 @@ describe("graph", () => {
       expect(latest).toBeUndefined();
     });
 
-    it("returns undefined for a missing thing", () => {
+    it("returns undefined for a missing entity", () => {
       const latest = graph.getLatest("nonexistent", "revenue");
       expect(latest).toBeUndefined();
     });
@@ -153,14 +153,14 @@ describe("graph", () => {
   });
 
   describe("getByType", () => {
-    it("returns things of a given type", () => {
+    it("returns entities of a given type", () => {
       const orgs = graph.getByType("organization");
       expect(orgs).toHaveLength(5);
       const orgIds = orgs.map((o) => o.id).sort();
       expect(orgIds).toEqual(["anthropic", "deepmind", "meta-ai", "openai", "xai"]);
     });
 
-    it("returns multiple things of the same type", () => {
+    it("returns multiple entities of the same type", () => {
       const people = graph.getByType("person");
       expect(people).toHaveLength(11);
       const ids = people.map((p) => p.id).sort();
@@ -172,20 +172,20 @@ describe("graph", () => {
     });
 
     it("returns empty array for unknown type", () => {
-      const things = graph.getByType("product");
-      expect(things).toHaveLength(0);
+      const entities = graph.getByType("product");
+      expect(entities).toHaveLength(0);
     });
   });
 
   describe("getRelated", () => {
-    it("returns referenced thing IDs from ref facts", () => {
+    it("returns referenced entity IDs from ref facts", () => {
       const related = graph.getRelated("jan-leike", "employed-by");
       expect(related).toContain("openai");
       expect(related).toContain("anthropic");
       expect(related).toHaveLength(2);
     });
 
-    it("returns referenced thing IDs from a single ref fact", () => {
+    it("returns referenced entity IDs from a single ref fact", () => {
       const related = graph.getRelated("dario-amodei", "employed-by");
       expect(related).toEqual(["anthropic"]);
     });
@@ -195,7 +195,7 @@ describe("graph", () => {
       expect(related).toEqual([]);
     });
 
-    it("returns empty array for nonexistent thing", () => {
+    it("returns empty array for nonexistent entity", () => {
       const related = graph.getRelated("nonexistent", "employed-by");
       expect(related).toEqual([]);
     });
@@ -228,14 +228,14 @@ describe("graph", () => {
       expect(items).toEqual([]);
     });
 
-    it("returns empty array for thing without items", () => {
+    it("returns empty array for entity without items", () => {
       const items = graph.getItems("jan-leike", "key-people");
       expect(items).toEqual([]);
     });
   });
 
   describe("getItemsMentioning", () => {
-    it("finds items referencing a thing via ref fields", () => {
+    it("finds items referencing an entity via ref fields", () => {
       // Anthropic's key-people collection has person fields referencing
       // dario-amodei, jan-leike, etc. (typed as ref in schema)
       const mentions = graph.getItemsMentioning("dario-amodei");
@@ -243,7 +243,7 @@ describe("graph", () => {
 
       // Should find the key-people entry on Anthropic
       const anthropicMention = mentions.find(
-        (m) => m.ownerThingId === "anthropic" && m.collection === "key-people"
+        (m) => m.ownerEntityId === "anthropic" && m.collection === "key-people"
       );
       expect(anthropicMention).toBeDefined();
       expect(anthropicMention!.matchingFields).toContain("person");
@@ -253,12 +253,12 @@ describe("graph", () => {
     it("does not include self-references", () => {
       const mentions = graph.getItemsMentioning("anthropic");
       // Should not find items from Anthropic's own collections
-      const selfRefs = mentions.filter((m) => m.ownerThingId === "anthropic");
+      const selfRefs = mentions.filter((m) => m.ownerEntityId === "anthropic");
       expect(selfRefs).toHaveLength(0);
     });
 
-    it("returns empty array for thing with no mentions", () => {
-      const mentions = graph.getItemsMentioning("nonexistent-thing");
+    it("returns empty array for entity with no mentions", () => {
+      const mentions = graph.getItemsMentioning("nonexistent-entity");
       expect(mentions).toHaveLength(0);
     });
   });

--- a/packages/kb/tests/inverse.test.ts
+++ b/packages/kb/tests/inverse.test.ts
@@ -87,11 +87,11 @@ describe("inverse", () => {
       expect(related).toContain("jan-leike");
     });
 
-    it("skips inverse when referenced thing does not exist in graph", () => {
+    it("skips inverse when referenced entity does not exist in graph", () => {
       // Anthropic has founded-by refs including persons not in the graph
       // (e.g., "daniela-amodei" is referenced in key-people but not as a
-      // founded-by fact). Verify that nonexistent things don't get created.
-      const nonexistent = graph.getThing("nonexistent-entity");
+      // founded-by fact). Verify that nonexistent entities don't get created.
+      const nonexistent = graph.getEntity("nonexistent-entity");
       expect(nonexistent).toBeUndefined();
 
       const facts = graph.getFacts("nonexistent-entity", {
@@ -100,7 +100,7 @@ describe("inverse", () => {
       expect(facts).toEqual([]);
     });
 
-    it("logs a warning when referenced thing does not exist", async () => {
+    it("logs a warning when referenced entity does not exist", async () => {
       // Create a minimal graph with a dangling ref to test the warning
       const { Graph } = await import("../src/graph.ts");
       const freshGraph = new Graph();
@@ -119,7 +119,7 @@ describe("inverse", () => {
         inverseName: "Employed By",
         computed: true,
       });
-      freshGraph.addThing({
+      freshGraph.addEntity({
         id: "test-person",
         stableId: "test123456",
         type: "person",

--- a/packages/kb/tests/loader.test.ts
+++ b/packages/kb/tests/loader.test.ts
@@ -12,9 +12,9 @@ describe("loader", () => {
     graph = await loadKB(DATA_DIR);
   });
 
-  describe("things", () => {
+  describe("entities", () => {
     it("loads Anthropic from disk", () => {
-      const anthropic = graph.getThing("anthropic");
+      const anthropic = graph.getEntity("anthropic");
       expect(anthropic).toBeDefined();
       expect(anthropic!.name).toBe("Anthropic");
       expect(anthropic!.stableId).toBe("mK9pX3rQ7n");
@@ -22,11 +22,11 @@ describe("loader", () => {
       expect(anthropic!.numericId).toBe(3);
     });
 
-    it("loads all 16 things", () => {
-      const things = graph.getAllThings();
-      expect(things).toHaveLength(16);
+    it("loads all 16 entities", () => {
+      const entities = graph.getAllEntities();
+      expect(entities).toHaveLength(16);
 
-      const ids = things.map((t) => t.id).sort();
+      const ids = entities.map((t) => t.id).sort();
       expect(ids).toEqual([
         "anthropic", "chris-olah", "daniela-amodei", "dario-amodei",
         "deepmind", "demis-hassabis", "elon-musk", "geoffrey-hinton",
@@ -35,8 +35,8 @@ describe("loader", () => {
       ].sort());
     });
 
-    it("loads thing aliases", () => {
-      const anthropic = graph.getThing("anthropic");
+    it("loads entity aliases", () => {
+      const anthropic = graph.getEntity("anthropic");
       expect(anthropic!.aliases).toEqual(["Anthropic PBC", "Anthropic AI"]);
     });
   });
@@ -238,7 +238,7 @@ describe("loader", () => {
       expect(items).toEqual([]);
     });
 
-    it("returns empty array for non-existent thing", () => {
+    it("returns empty array for non-existent entity", () => {
       const items = graph.getItems("nonexistent", "funding-rounds");
       expect(items).toEqual([]);
     });

--- a/packages/kb/tests/stress-test.test.ts
+++ b/packages/kb/tests/stress-test.test.ts
@@ -201,13 +201,13 @@ describe("Q8: OpenAI current valuation (was IMPOSSIBLE)", () => {
     // The API call is clean regardless of whether OpenAI data exists
     const fact = graph.getLatest("openai", "valuation");
 
-    const openaiThing = graph.getThing("openai");
-    if (openaiThing) {
+    const openaiEntity = graph.getEntity("openai");
+    if (openaiEntity) {
       // If OpenAI data has been added, we should get a valuation
       expect(fact).toBeDefined();
       expect(fact!.value.type).toBe("number");
     } else {
-      // OpenAI thing not yet in KB -- the query pattern works, just no data
+      // OpenAI entity not yet in KB -- the query pattern works, just no data
       expect(fact).toBeUndefined();
     }
   });
@@ -544,8 +544,8 @@ describe("Q20: Bidirectional person-org lookup", () => {
     expect(role).toBeDefined();
     expect((role!.value as { type: "text"; value: string }).value).toBe("CEO");
 
-    // Verify the thing exists and is a person
-    const dario = graph.getThing("dario-amodei");
+    // Verify the entity exists and is a person
+    const dario = graph.getEntity("dario-amodei");
     expect(dario).toBeDefined();
     expect(dario!.type).toBe("person");
   });
@@ -558,7 +558,7 @@ describe("Q20: Bidirectional person-org lookup", () => {
     expect(ceo!.fields.person).toBe("dario-amodei");
 
     // Verify the referenced person exists
-    const person = graph.getThing(ceo!.fields.person as string);
+    const person = graph.getEntity(ceo!.fields.person as string);
     expect(person).toBeDefined();
     expect(person!.name).toBe("Dario Amodei");
   });

--- a/packages/kb/tests/validate.test.ts
+++ b/packages/kb/tests/validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import path from "node:path";
 import { loadKB } from "../src/loader";
-import { validate, validateThing } from "../src/validate";
+import { validate, validateEntity } from "../src/validate";
 import { Graph } from "../src/graph";
 import type { ValidationResult } from "../src/types";
 
@@ -14,11 +14,11 @@ describe("validate", () => {
     graph = await loadKB(DATA_DIR);
   });
 
-  describe("validateThing — anthropic (organization)", () => {
+  describe("validateEntity — anthropic (organization)", () => {
     let results: ValidationResult[];
 
     beforeAll(() => {
-      results = validateThing(graph, "anthropic");
+      results = validateEntity(graph, "anthropic");
     });
 
     it("has no required-property errors (founded-date and headquarters present)", () => {
@@ -53,10 +53,10 @@ describe("validate", () => {
     });
   });
 
-  describe("validateThing — person schemas", () => {
+  describe("validateEntity — person schemas", () => {
     it("person with all recommended properties has no warnings", () => {
       // Dario has employed-by, role, and born-year
-      const results = validateThing(graph, "dario-amodei");
+      const results = validateEntity(graph, "dario-amodei");
       const recommendedWarnings = results.filter(
         (r) => r.rule === "recommended-properties"
       );
@@ -65,7 +65,7 @@ describe("validate", () => {
 
     it("person missing recommended properties gets warnings", () => {
       // Jan Leike has employed-by and role but NO born-year
-      const results = validateThing(graph, "jan-leike");
+      const results = validateEntity(graph, "jan-leike");
       const recommendedWarnings = results.filter(
         (r) => r.rule === "recommended-properties"
       );
@@ -75,17 +75,17 @@ describe("validate", () => {
   });
 
   describe("ref-integrity", () => {
-    it("catches refs to non-existent things", () => {
+    it("catches refs to non-existent entities", () => {
       // OpenAI key-people reference persons not in our test data (e.g., ilya-sutskever)
-      const results = validateThing(graph, "openai");
+      const results = validateEntity(graph, "openai");
       const refErrors = results.filter((r) => r.rule === "ref-integrity" || r.rule === "item-collection-schema");
       // There should be warnings for referenced persons not in the graph
       expect(refErrors.length).toBeGreaterThan(0);
     });
 
-    it("does not flag refs to existing things", () => {
+    it("does not flag refs to existing entities", () => {
       // Dario references "anthropic" which exists
-      const results = validateThing(graph, "dario-amodei");
+      const results = validateEntity(graph, "dario-amodei");
       const refErrors = results.filter((r) => r.rule === "ref-integrity");
       expect(refErrors).toHaveLength(0);
     });
@@ -93,16 +93,16 @@ describe("validate", () => {
 
   describe("item-collection-schema validation", () => {
     it("validates item entries against schema", () => {
-      const results = validateThing(graph, "anthropic");
+      const results = validateEntity(graph, "anthropic");
       const itemResults = results.filter(
         (r) => r.rule === "item-collection-schema"
       );
       // The anthropic data has funding-round entries with lead_investor referencing
-      // things not in our test graph (ftx, amazon, google, gic, jaan-tallinn).
-      // These should produce type warnings since they reference non-existent things.
+      // entities not in our test graph (ftx, amazon, google, gic, jaan-tallinn).
+      // These should produce type warnings since they reference non-existent entities.
       const refWarnings = itemResults.filter(
         (r) =>
-          r.severity === "warning" && r.message.includes("unknown thing")
+          r.severity === "warning" && r.message.includes("unknown entity")
       );
       expect(refWarnings.length).toBeGreaterThan(0);
     });
@@ -110,7 +110,7 @@ describe("validate", () => {
     it("does not report errors for required fields that are present", () => {
       // funding-rounds schema requires 'date', key-people requires 'person' and 'title'
       // All entries in our test data provide these fields
-      const results = validateThing(graph, "anthropic");
+      const results = validateEntity(graph, "anthropic");
       const requiredFieldErrors = results.filter(
         (r) =>
           r.rule === "item-collection-schema" &&
@@ -121,7 +121,7 @@ describe("validate", () => {
     });
 
     it("validates key-people person refs against the graph", () => {
-      const results = validateThing(graph, "anthropic");
+      const results = validateEntity(graph, "anthropic");
       const itemResults = results.filter(
         (r) =>
           r.rule === "item-collection-schema" &&
@@ -130,27 +130,27 @@ describe("validate", () => {
       // Some key-people reference persons not in the graph
       // (daniela-amodei, chris-olah, tom-brown, mike-krieger, holden-karnofsky)
       const unknownPeople = itemResults.filter(
-        (r) => r.message.includes("unknown thing")
+        (r) => r.message.includes("unknown entity")
       );
       expect(unknownPeople.length).toBeGreaterThan(0);
     });
   });
 
   describe("validate (full graph)", () => {
-    it("returns results for all things", () => {
+    it("returns results for all entities", () => {
       const results = validate(graph);
 
       // Should have results for all 16 entities
-      const thingIds = new Set(results.map((r) => r.thingId).filter(Boolean));
-      expect(thingIds.has("anthropic")).toBe(true);
-      expect(thingIds.has("dario-amodei")).toBe(true);
-      expect(thingIds.has("jan-leike")).toBe(true);
+      const entityIds = new Set(results.map((r) => r.entityId).filter(Boolean));
+      expect(entityIds.has("anthropic")).toBe(true);
+      expect(entityIds.has("dario-amodei")).toBe(true);
+      expect(entityIds.has("jan-leike")).toBe(true);
     });
 
-    it("includes completeness info for every thing", () => {
+    it("includes completeness info for every entity", () => {
       const results = validate(graph);
       const completeness = results.filter((r) => r.rule === "completeness");
-      expect(completeness).toHaveLength(16); // one per thing
+      expect(completeness).toHaveLength(16); // one per entity
     });
 
     it("properly categorizes severity levels", () => {
@@ -161,30 +161,30 @@ describe("validate", () => {
 
       // There should be at least some warnings (recommended properties, or item ref warnings)
       expect(warnings.length).toBeGreaterThan(0);
-      // There should be info messages (completeness for all 16 things)
+      // There should be info messages (completeness for all 16 entities)
       expect(infos.length).toBe(16);
     });
   });
 
-  describe("validateThing — edge cases", () => {
-    it("returns error for non-existent thing", () => {
-      const results = validateThing(graph, "nonexistent");
+  describe("validateEntity — edge cases", () => {
+    it("returns error for non-existent entity", () => {
+      const results = validateEntity(graph, "nonexistent");
       expect(results).toHaveLength(1);
       expect(results[0].severity).toBe("error");
-      expect(results[0].rule).toBe("thing-exists");
+      expect(results[0].rule).toBe("entity-exists");
     });
 
-    it("returns warning for thing with no registered schema", () => {
-      // Create a minimal graph with a thing of unknown type
+    it("returns warning for entity with no registered schema", () => {
+      // Create a minimal graph with an entity of unknown type
       const minGraph = new Graph();
-      minGraph.addThing({
+      minGraph.addEntity({
         id: "test-product",
         stableId: "abc123def0",
         type: "product",
         name: "Test Product",
       });
 
-      const results = validateThing(minGraph, "test-product");
+      const results = validateEntity(minGraph, "test-product");
       expect(results).toHaveLength(1);
       expect(results[0].severity).toBe("warning");
       expect(results[0].rule).toBe("schema-exists");
@@ -200,14 +200,14 @@ describe("validate", () => {
         required: ["founded-date", "headquarters"],
         recommended: ["revenue"],
       });
-      minGraph.addThing({
+      minGraph.addEntity({
         id: "empty-org",
         stableId: "xyz456abc0",
         type: "organization",
         name: "Empty Org",
       });
 
-      const results = validateThing(minGraph, "empty-org");
+      const results = validateEntity(minGraph, "empty-org");
       const requiredErrors = results.filter(
         (r) => r.rule === "required-properties"
       );
@@ -220,7 +220,7 @@ describe("validate", () => {
   });
 
   describe("property-applies-to check", () => {
-    it("warns when property is used on wrong thing type", () => {
+    it("warns when property is used on wrong entity type", () => {
       // Create a scenario where a "revenue" fact is on a person (wrong type)
       const testGraph = new Graph();
       testGraph.addSchema({
@@ -235,7 +235,7 @@ describe("validate", () => {
         dataType: "number",
         appliesTo: ["organization"],
       });
-      testGraph.addThing({
+      testGraph.addEntity({
         id: "wrong-type",
         stableId: "abc123def0",
         type: "person",
@@ -248,7 +248,7 @@ describe("validate", () => {
         value: { type: "number", value: 1000 },
       });
 
-      const results = validateThing(testGraph, "wrong-type");
+      const results = validateEntity(testGraph, "wrong-type");
       const appliesToWarnings = results.filter(
         (r) => r.rule === "property-applies-to"
       );


### PR DESCRIPTION
## Summary

Aligns KB terminology with the wiki's existing "entity" vocabulary. Systematic rename across all 14 source/test files.

- `Thing` → `Entity`, `ThingFile` → `EntityFile`
- `addThing` → `addEntity`, `getThing` → `getEntity`, `getAllThings` → `getAllEntities`
- `getThingByStableId` → `getEntityByStableId`, `validateThing` → `validateEntity`
- All `thingId` params → `entityId`

Preserved: `data/things/` directory name, `EntityFile.thing` YAML key, `subjectId` in Fact type.

Also filed GitHub issues for next steps:
- #1805: CLI readability tooling (`crux kb show`)
- #1806: Frontend components for KB entity data
- #1807: Property vocabulary expansion for concept entities
- #1808: `!date` YAML tag

## Test plan

- [x] All 133 KB tests pass after rename
- [x] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)