### PR TITLE
feat(dashboards): add UI pagination to DataTable, fix agent-sessions truncation

### DIFF
--- a/apps/web/src/app/internal/agent-sessions/agent-sessions-content.tsx
+++ b/apps/web/src/app/internal/agent-sessions/agent-sessions-content.tsx
@@ -1,4 +1,5 @@
 import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
+import { fetchAllPaginated } from "@lib/fetch-paginated";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { AgentSessionsTable } from "./sessions-table";
 import type {
@@ -40,16 +41,18 @@ async function loadFromApi(): Promise<FetchResult<AgentSessionRow[]>> {
   );
   if (!agentResult.ok) return agentResult;
 
-  // Fetch session logs (completed sessions with PR/cost info)
-  const logsResult = await fetchDetailed<{ sessions: SessionRow[] }>(
-    "/api/sessions?limit=500",
-    { revalidate: 60 }
-  );
+  // Fetch all session logs (completed sessions with PR/cost info), paginating through all pages
+  const logsResult = await fetchAllPaginated<SessionRow>({
+    path: "/api/sessions",
+    itemsKey: "sessions",
+    pageSize: 500,
+    revalidate: 60,
+  });
 
   // Build a branch → session log map for enrichment
   const logsByBranch = new Map<string, SessionRow>();
   if (logsResult.ok) {
-    for (const log of logsResult.data.sessions) {
+    for (const log of logsResult.data.items) {
       if (log.branch) {
         logsByBranch.set(log.branch, log);
       }

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -12,10 +12,11 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table"
-import { Search } from "lucide-react"
+import { Search, ChevronLeft, ChevronRight } from "lucide-react"
 import {
   Table,
   TableBody,
@@ -43,6 +44,8 @@ interface DataTableWithDataProps<TData, TValue> {
   defaultSorting?: SortingState
   renderExpandedRow?: (row: Row<TData>) => React.ReactNode
   getRowClassName?: (row: Row<TData>) => string
+  /** Number of rows per page. Defaults to 100. Set to 0 to disable pagination. */
+  pageSize?: number
 }
 
 type DataTableProps<TData, TValue = unknown> =
@@ -170,11 +173,23 @@ function DataTableWithData<TData, TValue>({
   defaultSorting = [],
   renderExpandedRow,
   getRowClassName,
+  pageSize = 100,
 }: DataTableWithDataProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>(defaultSorting)
   const [columnFilters, setColumnFilters] =
     React.useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = React.useState("")
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: pageSize > 0 ? pageSize : data.length,
+  })
+
+  // Reset to page 1 when filter changes
+  React.useEffect(() => {
+    setPagination((p) => ({ ...p, pageIndex: 0 }))
+  }, [globalFilter])
+
+  const paginationEnabled = pageSize > 0
 
   const table = useReactTable({
     data,
@@ -184,18 +199,36 @@ function DataTableWithData<TData, TValue>({
     getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    ...(paginationEnabled
+      ? {
+          getPaginationRowModel: getPaginationRowModel(),
+          onPaginationChange: setPagination,
+        }
+      : {}),
     onGlobalFilterChange: setGlobalFilter,
     globalFilterFn: "includesString",
     state: {
       sorting,
       columnFilters,
       globalFilter,
+      ...(paginationEnabled ? { pagination } : {}),
     },
   })
 
+  const filteredCount = table.getFilteredRowModel().rows.length
+  const pageCount = table.getPageCount()
+  const currentPage = table.getState().pagination.pageIndex + 1
+  const canPrev = table.getCanPreviousPage()
+  const canNext = table.getCanNextPage()
+
+  // Page range info: "Showing 1-100 of 500"
+  const { pageIndex, pageSize: ps } = table.getState().pagination
+  const rangeStart = pageIndex * ps + 1
+  const rangeEnd = Math.min((pageIndex + 1) * ps, filteredCount)
+
   return (
     <div className="space-y-4">
-      {/* Search */}
+      {/* Search + row count */}
       <div className="flex items-center gap-4 pb-4">
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -207,7 +240,9 @@ function DataTableWithData<TData, TValue>({
           />
         </div>
         <span className="text-sm text-muted-foreground whitespace-nowrap">
-          {table.getFilteredRowModel().rows.length} of {data.length} results
+          {filteredCount === data.length
+            ? `${data.length} results`
+            : `${filteredCount} of ${data.length} results`}
         </span>
       </div>
 
@@ -217,6 +252,38 @@ function DataTableWithData<TData, TValue>({
         renderExpandedRow={renderExpandedRow}
         getRowClassName={getRowClassName}
       />
+
+      {/* Pagination controls (only shown when pagination is enabled and there are multiple pages) */}
+      {paginationEnabled && pageCount > 1 && (
+        <div className="flex items-center justify-between px-1">
+          <span className="text-sm text-muted-foreground">
+            Showing {rangeStart}–{rangeEnd} of {filteredCount}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => table.previousPage()}
+              disabled={!canPrev}
+              className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+              Prev
+            </button>
+            <span className="px-2 text-xs text-muted-foreground tabular-nums">
+              {currentPage} / {pageCount}
+            </span>
+            <button
+              onClick={() => table.nextPage()}
+              disabled={!canNext}
+              className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="Next page"
+            >
+              Next
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **DataTable pagination**: Added reusable Prev/Next pagination controls to the `DataTable` legacy API (`DataTableWithDataProps`). Defaults to 100 rows/page; controls only appear when there are 2+ pages. Set `pageSize=0` to disable pagination (backwards-compatible for callers that have already paginated server-side).
- **Agent sessions truncation fix**: `agent-sessions-content.tsx` was fetching `/api/sessions?limit=500` with a hardcoded ceiling. Replaced with `fetchAllPaginated` to exhaust all pages, preventing silent truncation when session logs exceed 500 rows.
- **Statements/property-explorer verification**: Confirmed both `/internal/statements` and `/internal/property-explorer` already correctly paginate through all API results. No truncation.
- **`/api/sessions/insights` verification**: Endpoint uses `INSIGHTS_LIMIT = 5000` with an explicit truncation warning in logs. Safe for current data volumes.

## Test plan

- [x] TypeScript: `tsc --noEmit` — clean, no errors
- [x] Unit tests: `pnpm test` — 2675 tests pass
- [x] Gate: `pnpm crux validate gate --fix` — passed

Closes #1717


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data tables now support pagination with Previous/Next navigation buttons and configurable page sizes (default 100 items per page).
  * Result count displays updated to show current page position (e.g., "10 of 50 results").
  * Pagination automatically resets to page 1 when applying search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->