### PR TITLE
refactor: reorganize GitHub labels for better usability

### DIFF
--- a/.github/ISSUE_TEMPLATE/ui-bug.yml
+++ b/.github/ISSUE_TEMPLATE/ui-bug.yml
@@ -1,7 +1,7 @@
 name: "UI / frontend bug"
 description: "Report a rendering issue, broken layout, or other UI problem"
 type: "Bug"
-labels: ["ui-bug"]
+labels: ["bug", "ui"]
 body:
   - type: input
     id: page

--- a/.github/workflows/protected-paths-check.yml
+++ b/.github/workflows/protected-paths-check.yml
@@ -1,7 +1,7 @@
 name: Protected Paths Check
 
 # Flags PRs that modify agent behavioral rules, CI workflows, or validation
-# code for mandatory human review. Without the `rules-change-reviewed` label,
+# code for mandatory human review. Without the `0-rules-reviewed` label,
 # the check fails so these changes cannot merge unnoticed.
 
 on:
@@ -11,11 +11,11 @@ on:
 
 jobs:
   check-protected-paths:
-    # Only run on label events if the label is rules-change-reviewed.
+    # Only run on label events if the label is 0-rules-reviewed.
     # Other label changes (e.g. claude-working heartbeat) are irrelevant.
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
-      github.event.label.name == 'rules-change-reviewed'
+      github.event.label.name == '0-rules-reviewed'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -41,7 +41,7 @@ jobs:
               /^\.squawk\.toml$/,
             ];
 
-            const REVIEW_LABEL = 'rules-change-reviewed';
+            const REVIEW_LABEL = '0-rules-reviewed';
             const COMMENT_MARKER = '<!-- protected-paths-check -->';
 
             // Get list of files changed in this PR

--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -177,7 +177,7 @@ export async function determineTitle(date: string): Promise<string> {
 
 // ── Label management ─────────────────────────────────────────────────────────
 
-const RELEASE_LABEL = 'release';
+const RELEASE_LABEL = '0-release';
 
 async function ensureLabel(): Promise<void> {
   try {


### PR DESCRIPTION
## Summary

Reorganize GitHub labels from 74 → 51 for better usability:

- **Prefix human-action labels with `0-`** so they sort to the top of the label picker: `0-not-ready`, `0-release`, `0-reviewed`, `0-rules-reviewed`
- **Delete 5 duplicates** (`tech-debt` → `technical-debt`, `bugfix` → `bug`, `ui-bug` → `bug`+`ui`, `content-error`, `content-suggestion`)
- **Delete 8 redundant dimensions** (all `urgency:*`, `ease:*`, `size:XS/XL` — consolidated into `priority:*` and `size:S/M/L`)
- **Delete 10 vague/unused labels** (`risk`, `safety`, `process`, `consistency`, `content-quality`, `data`, `exploration`, `cleanup`, `ux`, `dx`)
- All issues transferred to canonical labels before deletion

### Code changes

- `protected-paths-check.yml`: Updated `rules-change-reviewed` → `0-rules-reviewed`
- `crux/commands/release.ts`: Updated `RELEASE_LABEL` constant
- `.github/ISSUE_TEMPLATE/ui-bug.yml`: Updated labels from `ui-bug` → `bug, ui`

## Test plan

- [x] Labels verified via `gh label list` — 51 labels, `0-*` at top
- [x] All issues with deleted labels transferred to canonical labels
- [x] TypeScript check passes (pre-existing errors only, no new ones)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue template labeling system.
  * Updated internal workflow configurations and label references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->