### PR TITLE
fix(pr-patrol): reduce compute waste with issue-type budgets and timeout abandonment

### DIFF
--- a/crux/pr-patrol/index.test.ts
+++ b/crux/pr-patrol/index.test.ts
@@ -4,6 +4,7 @@ import {
   findMergeCandidates,
   detectIssues,
   computeBudget,
+  looksLikeNoOp,
   type GqlPrNode,
 } from './index.ts';
 
@@ -470,5 +471,45 @@ describe('detectIssues', () => {
     // Set stale threshold to far in the past so this PR is not stale
     const result = detectIssues(pr, 0);
     expect(result.issues).toEqual([]);
+  });
+});
+
+// ── looksLikeNoOp ───────────────────────────────────────────────────────────
+
+describe('looksLikeNoOp', () => {
+  it('detects "no action needed" in output tail', () => {
+    expect(looksLikeNoOp('Analyzed the issue. No action needed for this PR.')).toBe(true);
+  });
+
+  it('detects "requires human intervention"', () => {
+    expect(looksLikeNoOp('The check-protected-paths check requires human intervention to add the label.')).toBe(true);
+  });
+
+  it('detects "pre-existing failure"', () => {
+    expect(looksLikeNoOp('This is a pre-existing failure also present on main.')).toBe(true);
+  });
+
+  it('detects "also failing on main"', () => {
+    expect(looksLikeNoOp('The CI check is also failing on main, so this is not introduced by this PR.')).toBe(true);
+  });
+
+  it('detects "stopping early"', () => {
+    expect(looksLikeNoOp('Stopping early because the issue cannot be resolved automatically.')).toBe(true);
+  });
+
+  it('does NOT flag normal fix output', () => {
+    expect(looksLikeNoOp('Fixed the TypeScript error in src/index.ts. All tests passing now.')).toBe(false);
+  });
+
+  it('does NOT flag output with "no" in unrelated context', () => {
+    expect(looksLikeNoOp('Added the missing test. No regressions found after running the suite.')).toBe(false);
+  });
+
+  it('only checks last 1000 chars of output', () => {
+    const longOutput = 'x'.repeat(2000) + 'No action needed.';
+    expect(looksLikeNoOp(longOutput)).toBe(true);
+    // Pattern in the first 1000 chars but not the last 1000
+    const earlyMatch = 'No action needed.' + 'x'.repeat(2000);
+    expect(looksLikeNoOp(earlyMatch)).toBe(false);
   });
 });

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -48,7 +48,7 @@ interface ScoredPr extends DetectedPr {
   score: number;
 }
 
-export type FixOutcome = 'fixed' | 'max-turns' | 'timeout' | 'error' | 'dry-run';
+export type FixOutcome = 'fixed' | 'no-op' | 'max-turns' | 'timeout' | 'error' | 'dry-run';
 
 export type MergeOutcome = 'merged' | 'dry-run' | 'error';
 
@@ -204,6 +204,33 @@ function recordFailure(key: number | string): number {
   return count;
 }
 
+function resetFailCount(key: number | string): void {
+  const file = join(STATE_DIR, `failures-${key}`);
+  if (existsSync(file)) writeFileSync(file, '0');
+}
+
+/**
+ * Detect when Claude exited cleanly but didn't actually fix anything
+ * (e.g., followed "stop early" guidance for human-required issues).
+ */
+const NO_OP_PATTERNS = [
+  /no action needed/i,
+  /no code changes? needed/i,
+  /requires? human intervention/i,
+  /needs? human/i,
+  /cannot be fixed automatically/i,
+  /pre-existing.*(failure|issue|problem)/i,
+  /also failing on main/i,
+  /stopping early/i,
+  /nothing to fix/i,
+];
+
+export function looksLikeNoOp(output: string): boolean {
+  // Only check the last portion of output (where the conclusion lives)
+  const tail = output.slice(-1000);
+  return NO_OP_PATTERNS.some((p) => p.test(tail));
+}
+
 function isAbandoned(key: number | string): boolean {
   return getFailCount(key) >= 2;
 }
@@ -351,8 +378,16 @@ async function fixMainBranch(status: MainBranchStatus, config: PatrolConfig): Pr
         log(`${cl.red}✗ Main branch fix abandoned after ${failCount} failures${cl.reset}`);
       }
     } else if (result.exitCode === 0 && !result.hitMaxTurns) {
-      outcome = 'fixed';
-      log(`${cl.green}✓ Main branch CI fix processed${cl.reset} (${elapsedS}s)`);
+      const isNoOp = looksLikeNoOp(result.output);
+      outcome = isNoOp ? 'no-op' : 'fixed';
+      if (isNoOp) {
+        recordFailure(MAIN_BRANCH_KEY);
+        reason = 'No-op: agent determined issue needs human intervention';
+        log(`${cl.yellow}⚠ Main branch fix no-op — agent stopped early${cl.reset} (${elapsedS}s)`);
+      } else {
+        resetFailCount(MAIN_BRANCH_KEY);
+        log(`${cl.green}✓ Main branch CI fix processed${cl.reset} (${elapsedS}s)`);
+      }
     } else if (result.hitMaxTurns) {
       const failCount = recordFailure(MAIN_BRANCH_KEY);
       outcome = 'max-turns';
@@ -1323,8 +1358,20 @@ async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<void> {
         ).catch(() => log('  Warning: could not post abandonment comment'));
       }
     } else if (result.exitCode === 0 && !result.hitMaxTurns) {
-      log(`${cl.green}✓ PR #${pr.number} processed successfully${cl.reset} (${elapsedS}s)`);
-      outcome = 'fixed';
+      const isNoOp = looksLikeNoOp(result.output);
+      outcome = isNoOp ? 'no-op' : 'fixed';
+
+      if (isNoOp) {
+        // No-op: Claude determined the issue can't be fixed automatically.
+        // Don't reset fail count — treat like a soft failure so the PR
+        // gets skipped on future cycles instead of being retried forever.
+        const failCount = recordFailure(pr.number);
+        reason = `No-op: agent determined issue needs human intervention (attempt ${failCount})`;
+        log(`${cl.yellow}⚠ PR #${pr.number} no-op — agent stopped early${cl.reset} (${elapsedS}s)`);
+      } else {
+        resetFailCount(pr.number);
+        log(`${cl.green}✓ PR #${pr.number} processed successfully${cl.reset} (${elapsedS}s)`);
+      }
 
       // Post summary comment
       const summary = result.output.slice(-500);
@@ -1450,19 +1497,35 @@ ${recentEntries}
       timeoutMinutes: 5, // Should complete quickly
     });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
-    const filedIssue = /Created issue #|created.*#\d/.test(result.output);
 
-    appendJsonl(REFLECTION_FILE, {
-      cycle_number: cycleCount,
-      elapsed_s: elapsedS,
-      filed_issue: filedIssue,
-      exit_code: result.exitCode,
-      summary: result.output.slice(-500),
-    });
-
-    log(
-      `${cl.green}✓ Reflection complete${cl.reset} (${elapsedS}s, filed_issue=${filedIssue})`,
-    );
+    if (result.timedOut || result.hitMaxTurns) {
+      const reason = result.timedOut ? 'timeout' : 'max-turns';
+      appendJsonl(REFLECTION_FILE, {
+        cycle_number: cycleCount,
+        elapsed_s: elapsedS,
+        filed_issue: false,
+        exit_code: result.exitCode,
+        outcome: 'incomplete',
+        reason,
+        summary: result.output.slice(-500),
+      });
+      log(
+        `${cl.yellow}⚠ Reflection incomplete${cl.reset} (${elapsedS}s, ${reason})`,
+      );
+    } else {
+      const filedIssue = /Created issue #|created.*#\d/.test(result.output);
+      appendJsonl(REFLECTION_FILE, {
+        cycle_number: cycleCount,
+        elapsed_s: elapsedS,
+        filed_issue: filedIssue,
+        exit_code: result.exitCode,
+        outcome: 'complete',
+        summary: result.output.slice(-500),
+      });
+      log(
+        `${cl.green}✓ Reflection complete${cl.reset} (${elapsedS}s, filed_issue=${filedIssue})`,
+      );
+    }
   } catch (e) {
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
     log(


### PR DESCRIPTION
## Summary

PR Patrol was spending **90%+ of compute time on failed attempts** — only 35 minutes out of 6.2 hours produced successful fixes. The rest was timeouts and max-turns failures, often on the same unfixable PRs repeatedly.

Root causes and fixes:

- **Timeouts didn't count toward abandonment** — a PR could timeout at 30 minutes indefinitely without being abandoned. Now both timeouts and max-turns increment the same failure counter (abandoned at 2).
- **All issue types got 40 turns / 30 min** — `missing-issue-ref` (a 10-second `gh pr edit`) got the same budget as resolving merge conflicts. Now each issue type has a scaled budget:
  - `conflict`: 40 turns / 30 min
  - `ci-failure`, `bot-review-major`: 25 turns / 15 min  
  - `stale`: 10 turns / 5 min
  - `missing-testplan`, `bot-review-nitpick`: 8 turns / 5 min
  - `missing-issue-ref`: 5 turns / 3 min
- **No early-exit guidance** — Claude would burn all turns trying to fix unfixable CI checks (like `check-protected-paths` needing a human label). Prompt now has explicit "when to stop early" section listing unfixable scenarios.
- **Reflection used Sonnet** for simple JSONL log analysis — switched to Haiku with 5-min timeout.

## Test plan

- [x] All 34 PR Patrol tests pass (including 6 new `computeBudget` tests)
- [x] TypeScript compiles clean
- [x] Added `pr-patrol/**/*.test.ts` to vitest config (was missing)

Related to #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
