### PR TITLE
feat: expand KB validation to 22 checks

### DIFF
--- a/crux/commands/kb.ts
+++ b/crux/commands/kb.ts
@@ -1,0 +1,447 @@
+/**
+ * KB Command Handlers
+ *
+ * CLI readability and validation tooling for the knowledge base package.
+ * Resolves opaque stableId references and formats KB data human-readably.
+ *
+ * Usage:
+ *   crux kb show <entity-id>       Show a single entity with all its data
+ *   crux kb list [--type=X]        List all entities
+ *   crux kb lookup <stableId>      Look up entity by stableId
+ *   crux kb validate               Run all 22 validation checks
+ */
+
+import { join } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+
+import { loadKB } from '../../packages/kb/src/loader.ts';
+import { computeInverses } from '../../packages/kb/src/inverse.ts';
+import { validate } from '../../packages/kb/src/validate.ts';
+import { formatFactValue, formatItemEntry } from '../../packages/kb/src/format.ts';
+import type { Graph } from '../../packages/kb/src/graph.ts';
+import type { Entity, Fact, ItemEntry, ValidationResult } from '../../packages/kb/src/types.ts';
+
+const KB_DATA_DIR = join(PROJECT_ROOT, 'packages', 'kb', 'data');
+
+interface KBCommandOptions extends BaseOptions {
+  type?: string;
+  limit?: string;
+  ci?: boolean;
+  errorsOnly?: boolean;
+  'errors-only'?: boolean;
+  rule?: string;
+}
+
+// ── KB loading helper ───────────────────────────────────────────────────
+
+async function loadGraph(): Promise<Graph> {
+  const graph = await loadKB(KB_DATA_DIR);
+  computeInverses(graph);
+  return graph;
+}
+
+// ── show command ────────────────────────────────────────────────────────
+
+async function showCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const entityId = args.find((a) => !a.startsWith('--'));
+
+  if (!entityId) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux kb show <entity-id>
+
+  Show a single entity with all its data, resolving !ref stableIds to names.
+
+Examples:
+  crux kb show anthropic
+  crux kb show dario-amodei`,
+    };
+  }
+
+  const graph = await loadGraph();
+  const entity = graph.getEntity(entityId);
+
+  if (!entity) {
+    // Try resolving as a stableId
+    const resolved = graph.getEntityByStableId(entityId);
+    if (resolved) {
+      return showEntity(resolved, graph, options);
+    }
+    return {
+      exitCode: 1,
+      output: `Entity not found: ${entityId}\n  Try: crux kb list`,
+    };
+  }
+
+  return showEntity(entity, graph, options);
+}
+
+function showEntity(entity: Entity, graph: Graph, options: KBCommandOptions): CommandResult {
+  if (options.ci) {
+    const facts = graph.getFacts(entity.id);
+    return {
+      exitCode: 0,
+      output: JSON.stringify({ entity, facts }),
+    };
+  }
+
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`\x1b[1m${entity.name}\x1b[0m (${entity.stableId})`);
+  lines.push(`Type: ${entity.type} | Slug: ${entity.id}${entity.numericId ? ` | E${entity.numericId}` : ''}`);
+  if (entity.aliases?.length) {
+    lines.push(`Aliases: ${entity.aliases.join(', ')}`);
+  }
+  lines.push('');
+
+  // Facts grouped by property
+  const facts = graph.getFacts(entity.id);
+  if (facts.length > 0) {
+    // Group facts by propertyId
+    const grouped = new Map<string, Fact[]>();
+    for (const fact of facts) {
+      const existing = grouped.get(fact.propertyId);
+      if (existing) {
+        existing.push(fact);
+      } else {
+        grouped.set(fact.propertyId, [fact]);
+      }
+    }
+
+    lines.push(`\x1b[1mFacts (${facts.length}):\x1b[0m`);
+
+    for (const [propertyId, propertyFacts] of grouped) {
+      const property = graph.getProperty(propertyId);
+      const propName = property?.name ?? propertyId;
+
+      // Sort by asOf date
+      const sorted = propertyFacts.slice().sort((a, b) => {
+        if (!a.asOf && !b.asOf) return 0;
+        if (!a.asOf) return 1;
+        if (!b.asOf) return -1;
+        return a.asOf.localeCompare(b.asOf);
+      });
+
+      if (sorted.length === 1) {
+        const f = sorted[0];
+        const val = formatFactValue(f, property, graph);
+        const asOf = f.asOf ? ` (${f.asOf})` : '';
+        lines.push(`  ${propName.padEnd(28)} ${val}${asOf}`);
+      } else {
+        // Time series: show inline
+        const parts = sorted.map((f) => {
+          const val = formatFactValue(f, property, graph);
+          return f.asOf ? `${val} (${f.asOf})` : val;
+        });
+
+        // If the line would be too long, show multi-line
+        const inlineLine = `  ${propName.padEnd(28)} ${parts.join('  ->  ')}`;
+        if (inlineLine.length <= 120 || sorted.length <= 3) {
+          lines.push(inlineLine);
+        } else {
+          lines.push(`  ${propName.padEnd(28)} ${parts[0]}`);
+          for (let i = 1; i < parts.length; i++) {
+            const arrow = i < parts.length - 1 ? '  ->  ' : '      ';
+            lines.push(`  ${''.padEnd(28)} ${arrow}${parts[i]}`);
+          }
+        }
+      }
+    }
+    lines.push('');
+  }
+
+  // Item collections
+  const entityCollections = getEntityItemCollections(entity.id, graph);
+  if (entityCollections.length > 0) {
+    lines.push(`\x1b[1mItems:\x1b[0m`);
+    for (const { name, items } of entityCollections) {
+      lines.push(`  ${name} (${items.length} entries)`);
+      for (const item of items) {
+        const summary = formatItemEntry(item, name, graph);
+        lines.push(`    ${summary}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+/**
+ * Get all item collections for an entity by querying the graph directly.
+ */
+function getEntityItemCollections(
+  entityId: string,
+  graph: Graph,
+): Array<{ name: string; items: ItemEntry[] }> {
+  const results: Array<{ name: string; items: ItemEntry[] }> = [];
+  for (const collName of graph.getItemCollectionNames(entityId)) {
+    const items = graph.getItems(entityId, collName);
+    if (items.length > 0) {
+      results.push({ name: collName, items });
+    }
+  }
+  return results;
+}
+
+// ── list command ────────────────────────────────────────────────────────
+
+async function listCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const graph = await loadGraph();
+  let entities = graph.getAllEntities();
+
+  // Filter by type if specified
+  if (options.type) {
+    entities = entities.filter((e) => e.type === options.type);
+  }
+
+  // Sort by type then by name
+  entities.sort((a, b) => {
+    const typeCmp = a.type.localeCompare(b.type);
+    if (typeCmp !== 0) return typeCmp;
+    return a.name.localeCompare(b.name);
+  });
+
+  // Apply limit
+  const limit = options.limit ? parseInt(String(options.limit), 10) : undefined;
+  if (limit && limit > 0) {
+    entities = entities.slice(0, limit);
+  }
+
+  if (options.ci) {
+    const data = entities.map((e) => ({
+      id: e.id,
+      name: e.name,
+      type: e.type,
+      stableId: e.stableId,
+      factCount: graph.getFacts(e.id).length,
+    }));
+    return { exitCode: 0, output: JSON.stringify(data) };
+  }
+
+  // Table header
+  const lines: string[] = [];
+  const header = `${'ID'.padEnd(24)} ${'Name'.padEnd(24)} ${'Type'.padEnd(16)} ${'StableId'.padEnd(14)} Facts`;
+  lines.push(`\x1b[1m${header}\x1b[0m`);
+  lines.push('-'.repeat(header.length));
+
+  for (const entity of entities) {
+    const facts = graph.getFacts(entity.id);
+    const row = `${entity.id.padEnd(24)} ${entity.name.padEnd(24)} ${entity.type.padEnd(16)} ${entity.stableId.padEnd(14)} ${facts.length}`;
+    lines.push(row);
+  }
+
+  lines.push('');
+  lines.push(`Total: ${entities.length} entities`);
+
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+// ── lookup command ──────────────────────────────────────────────────────
+
+async function lookupCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const stableId = args.find((a) => !a.startsWith('--'));
+
+  if (!stableId) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux kb lookup <stableId>
+
+  Look up an entity by its stableId.
+
+Examples:
+  crux kb lookup mK9pX3rQ7n
+  crux kb lookup zR4nW8xB2f`,
+    };
+  }
+
+  const graph = await loadGraph();
+  const entity = graph.getEntityByStableId(stableId);
+
+  if (!entity) {
+    return {
+      exitCode: 1,
+      output: `No entity found for stableId: ${stableId}`,
+    };
+  }
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({ stableId, slug: entity.id, name: entity.name, type: entity.type }),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    output: `${stableId} -> ${entity.name} (${entity.id})\n  Type: ${entity.type}${entity.numericId ? ` | E${entity.numericId}` : ''}`,
+  };
+}
+
+// ── validate command ─────────────────────────────────────────────────────
+
+async function validateCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const graph = await loadGraph();
+  const allResults = validate(graph);
+
+  // Filter by severity if --errors-only
+  const errorsOnly = options.errorsOnly || options['errors-only'];
+  let results = allResults;
+  if (errorsOnly) {
+    results = results.filter((r) => r.severity === 'error');
+  }
+
+  // Filter by rule if --rule=X
+  if (options.rule) {
+    results = results.filter((r) => r.rule === options.rule);
+  }
+
+  if (options.ci) {
+    return {
+      exitCode: results.some((r) => r.severity === 'error') ? 1 : 0,
+      output: JSON.stringify(results),
+    };
+  }
+
+  // Group by severity
+  const errors = results.filter((r) => r.severity === 'error');
+  const warnings = results.filter((r) => r.severity === 'warning');
+  const infos = results.filter((r) => r.severity === 'info');
+
+  const lines: string[] = [];
+
+  // Summary header
+  const totalEntities = graph.getAllEntities().length;
+  lines.push(`\x1b[1mKB Validation Report\x1b[0m`);
+  lines.push(`Entities: ${totalEntities} | Errors: ${errors.length} | Warnings: ${warnings.length} | Info: ${infos.length}`);
+  lines.push('');
+
+  // Show errors first
+  if (errors.length > 0) {
+    lines.push(`\x1b[31m\x1b[1mErrors (${errors.length}):\x1b[0m`);
+    for (const r of errors) {
+      lines.push(`  \x1b[31m[${r.rule}]\x1b[0m ${r.message}`);
+    }
+    lines.push('');
+  }
+
+  // Then warnings
+  if (warnings.length > 0 && !errorsOnly) {
+    lines.push(`\x1b[33m\x1b[1mWarnings (${warnings.length}):\x1b[0m`);
+
+    // Group warnings by rule for readability
+    const warningsByRule = new Map<string, ValidationResult[]>();
+    for (const r of warnings) {
+      const existing = warningsByRule.get(r.rule);
+      if (existing) {
+        existing.push(r);
+      } else {
+        warningsByRule.set(r.rule, [r]);
+      }
+    }
+
+    for (const [rule, ruleWarnings] of warningsByRule) {
+      lines.push(`  \x1b[33m[${rule}]\x1b[0m (${ruleWarnings.length})`);
+      // Show up to 5 per rule, then summarize
+      const shown = ruleWarnings.slice(0, 5);
+      for (const r of shown) {
+        lines.push(`    ${r.message}`);
+      }
+      if (ruleWarnings.length > 5) {
+        lines.push(`    ... and ${ruleWarnings.length - 5} more`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Then info (only if not errors-only)
+  if (infos.length > 0 && !errorsOnly) {
+    lines.push(`\x1b[36m\x1b[1mInfo (${infos.length}):\x1b[0m`);
+
+    const infosByRule = new Map<string, ValidationResult[]>();
+    for (const r of infos) {
+      const existing = infosByRule.get(r.rule);
+      if (existing) {
+        existing.push(r);
+      } else {
+        infosByRule.set(r.rule, [r]);
+      }
+    }
+
+    for (const [rule, ruleInfos] of infosByRule) {
+      lines.push(`  \x1b[36m[${rule}]\x1b[0m (${ruleInfos.length})`);
+      const shown = ruleInfos.slice(0, 3);
+      for (const r of shown) {
+        lines.push(`    ${r.message}`);
+      }
+      if (ruleInfos.length > 3) {
+        lines.push(`    ... and ${ruleInfos.length - 3} more`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Final verdict
+  if (errors.length === 0) {
+    lines.push('\x1b[32mNo errors found.\x1b[0m');
+  } else {
+    lines.push(`\x1b[31m${errors.length} error(s) found. Fix these before proceeding.\x1b[0m`);
+  }
+
+  return {
+    exitCode: errors.length > 0 ? 1 : 0,
+    output: lines.join('\n'),
+  };
+}
+
+// ── Exports ─────────────────────────────────────────────────────────────
+
+export const commands = {
+  show: showCommand,
+  list: listCommand,
+  lookup: lookupCommand,
+  validate: validateCommand,
+};
+
+export function getHelp(): string {
+  return `
+KB Domain -- Knowledge Base readability and validation tools
+
+Commands:
+  show <entity-id>      Show a single entity with all data, resolving stableIds
+  list [--type=X]       List all entities with name, type, stableId, and fact count
+  lookup <stableId>     Look up an entity by its stableId
+  validate              Run all validation checks on the KB graph
+
+Options:
+  --type=X              Filter list by entity type (e.g. organization, person)
+  --limit=N             Limit number of results (list only)
+  --errors-only         Only show errors, skip warnings and info (validate only)
+  --rule=X              Filter results by check rule name (validate only)
+  --ci                  JSON output
+
+Examples:
+  crux kb show anthropic              Show Anthropic with all facts and items
+  crux kb show dario-amodei           Show a person entity
+  crux kb list                        List all entities
+  crux kb list --type=person          List only person entities
+  crux kb lookup mK9pX3rQ7n           Look up entity by stableId
+  crux kb validate                    Run all validation checks
+  crux kb validate --errors-only      Only show errors (exit 1 if any)
+  crux kb validate --rule=stale-temporal  Show only stale-temporal warnings
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -98,6 +98,7 @@ import * as statementsCommands from './commands/statements.ts';
 import * as auditsCommands from './commands/audits.ts';
 import * as releaseCommands from './commands/release.ts';
 import * as prPatrolCommands from './commands/pr-patrol.ts';
+import * as kbCommands from './commands/kb.ts';
 
 const domains = {
   validate: validateCommands,
@@ -140,6 +141,7 @@ const domains = {
   audits: auditsCommands,
   release: releaseCommands,
   'pr-patrol': prPatrolCommands,
+  kb: kbCommands,
 };
 
 /**
@@ -225,6 +227,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   audits      System-level behavioral verification (ongoing + post-merge)
   release     Production release management (main → production)
   pr-patrol   Continuous PR maintenance daemon (scan, prioritize, fix)
+  kb          Knowledge base tools (show, list, lookup, validate)
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines

--- a/packages/kb/EXPERIMENTAL.md
+++ b/packages/kb/EXPERIMENTAL.md
@@ -1,0 +1,9 @@
+# Knowledge Base Library — Status
+
+This package is integrated into the production build pipeline but is still under active development.
+
+- **Production integration**: Imported by `apps/web` — KB data appears in `database.json` and renders on wiki pages
+- **5 entities**: Anthropic, OpenAI, Dario Amodei, Jan Leike, Sam Altman
+- **~10 more PRs planned**: Expanding to cover all major organizations and people, then replacing the old YAML facts system
+
+See `.claude/design/kb-library.md` for the design doc.

--- a/packages/kb/data/properties.yaml
+++ b/packages/kb/data/properties.yaml
@@ -1,0 +1,297 @@
+properties:
+
+  # ── Financial ────────────────────────────────────────────────
+
+  revenue:
+    name: Revenue
+    description: "Annualized run-rate revenue (ARR) or trailing twelve-month revenue"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  valuation:
+    name: Valuation
+    description: "Post-money valuation at most recent funding round or mark-to-market"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  headcount:
+    name: Headcount
+    description: "Total full-time employee count"
+    dataType: number
+    unit: employees
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: " employees"
+
+  total-funding:
+    name: Total Funding Raised
+    description: "Cumulative capital raised across all funding rounds"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  funding-round-amount:
+    name: Funding Round Amount
+    description: "Capital raised in a specific funding round"
+    dataType: number
+    unit: USD
+    category: financial
+    appliesTo: [organization]
+    display:
+      divisor: 1e6
+      prefix: "$"
+      suffix: "M"
+
+  # ── People & Relationships ────────────────────────────────────
+
+  employed-by:
+    name: Employed By
+    description: "Organization this person currently or historically works for"
+    dataType: ref
+    category: people
+    temporal: true
+    appliesTo: [person]
+    inverseId: employer-of
+    inverseName: Employs
+
+  employer-of:
+    name: Employs
+    description: "People employed by this organization (computed from employed-by facts)"
+    dataType: refs
+    category: people
+    appliesTo: [organization]
+    inverseId: employed-by
+    inverseName: Employed By
+    computed: true
+
+  role:
+    name: Role / Title
+    description: "Job title or role at primary employer"
+    dataType: text
+    category: people
+    temporal: true
+    appliesTo: [person]
+
+  founded-by:
+    name: Founded By
+    description: "Person(s) who founded this organization"
+    dataType: refs
+    category: people
+    appliesTo: [organization]
+    inverseId: founder-of
+    inverseName: Founded
+
+  founder-of:
+    name: Founder Of
+    description: "Organization(s) this person founded (computed from founded-by facts)"
+    dataType: refs
+    category: people
+    appliesTo: [person]
+    inverseId: founded-by
+    inverseName: Founded By
+    computed: true
+
+  gross-margin:
+    name: Gross Margin
+    description: "Gross margin percentage"
+    dataType: number
+    unit: percent
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: "%"
+
+  market-share:
+    name: Market Share
+    description: "Estimated market share in the relevant segment"
+    dataType: number
+    unit: percent
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: "%"
+
+  user-count:
+    name: User Count
+    description: "Total number of active users"
+    dataType: number
+    unit: users
+    category: product
+    temporal: true
+    appliesTo: [organization]
+
+  # ── Dates ─────────────────────────────────────────────────────
+
+  founded-date:
+    name: Founded Date
+    description: "Date the organization was incorporated or officially founded"
+    dataType: date
+    category: organization
+    appliesTo: [organization]
+
+  born-year:
+    name: Birth Year
+    description: "Year the person was born"
+    dataType: number
+    category: biographical
+    appliesTo: [person]
+    display:
+      suffix: ""
+
+  launched-date:
+    name: Launch Date
+    description: "Date a product or project was publicly launched"
+    dataType: date
+    category: product
+    appliesTo: [product, project]
+
+  # ── Structure ─────────────────────────────────────────────────
+
+  headquarters:
+    name: Headquarters
+    description: "Primary office location (city, state/country)"
+    dataType: text
+    category: organization
+    appliesTo: [organization]
+
+  legal-structure:
+    name: Legal Structure
+    description: "Corporate form (e.g. Public benefit corporation, LLC, 501(c)(3))"
+    dataType: text
+    category: organization
+    appliesTo: [organization]
+
+  # ── Product & Usage ─────────────────────────────────────────────
+
+  monthly-active-users:
+    name: Monthly Active Users
+    description: "Monthly active users (MAU)"
+    dataType: number
+    category: product
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e6
+      suffix: "M"
+
+  business-customers:
+    name: Business Customers
+    description: "Number of business/enterprise customers"
+    dataType: number
+    category: product
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1000
+      suffix: "K"
+
+  api-calls-monthly:
+    name: Monthly API Calls
+    description: "Monthly API request volume"
+    dataType: number
+    category: product
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      suffix: "B"
+
+  product-revenue:
+    name: Product Revenue
+    description: "Annualized revenue from a specific product line"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  # ── Financial Detail ─────────────────────────────────────────────
+
+  cash-burn:
+    name: Annual Cash Burn
+    description: "Annual net cash burn (negative free cash flow)"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      divisor: 1e9
+      prefix: "$"
+      suffix: "B"
+
+  enterprise-market-share:
+    name: Enterprise Market Share
+    description: "Enterprise LLM market share by usage"
+    dataType: number
+    unit: percent
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: "%"
+
+  coding-market-share:
+    name: Coding Market Share
+    description: "Enterprise coding assistant market share"
+    dataType: number
+    unit: percent
+    category: financial
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: "%"
+
+  # ── Safety ──────────────────────────────────────────────────────
+
+  safety-level:
+    name: AI Safety Level
+    description: "Current AI Safety Level designation under RSP (e.g. ASL-2, ASL-3)"
+    dataType: text
+    category: safety
+    temporal: true
+    appliesTo: [organization]
+
+  safety-researcher-count:
+    name: Safety Researchers
+    description: "Number of employees working on safety-related research"
+    dataType: number
+    category: safety
+    temporal: true
+    appliesTo: [organization]
+
+  interpretability-team-size:
+    name: Interpretability Team Size
+    description: "Number of researchers focused on mechanistic interpretability"
+    dataType: number
+    category: safety
+    temporal: true
+    appliesTo: [organization]

--- a/packages/kb/data/schemas/organization.yaml
+++ b/packages/kb/data/schemas/organization.yaml
@@ -1,0 +1,96 @@
+type: organization
+name: Organization
+
+required:
+  - founded-date
+  - headquarters
+
+recommended:
+  - revenue
+  - valuation
+  - headcount
+  - legal-structure
+  - total-funding
+
+items:
+  funding-rounds:
+    description: "Equity and strategic investment rounds, in chronological order"
+    fields:
+      date: { type: date, required: true, description: "Close date (YYYY-MM)" }
+      amount: { type: number, unit: USD, description: "Capital raised in this round" }
+      valuation: { type: number, unit: USD, description: "Post-money valuation" }
+      lead_investor: { type: ref, description: "Lead investor (Thing ID slug)" }
+      source: { type: text, description: "URL to announcement or news article" }
+      notes: { type: text, description: "Context, caveats, or important details" }
+
+  key-people:
+    description: "Current and former key personnel including founders, executives, and notable researchers"
+    fields:
+      person: { type: ref, required: true, description: "Thing ID of the person" }
+      title: { type: text, required: true, description: "Job title or role description" }
+      start: { type: date, description: "Start date at this organization (YYYY-MM)" }
+      end: { type: date, description: "End date if no longer in role (YYYY-MM); omit if current" }
+      is_founder: { type: boolean, description: "True if this person co-founded the organization" }
+      source: { type: text, description: "URL confirming the role" }
+      notes: { type: text, description: "Context about the role or transition" }
+
+  products:
+    description: "Major products and services launched by this organization"
+    fields:
+      name: { type: text, required: true, description: "Product name" }
+      launched: { type: date, required: true, description: "Launch date (YYYY-MM)" }
+      description: { type: text, description: "Brief description of the product" }
+      source: { type: text, description: "URL to announcement" }
+      notes: { type: text, description: "Context or current status" }
+
+  research-areas:
+    description: "Major research initiatives and focus areas"
+    fields:
+      name: { type: text, required: true, description: "Research area name" }
+      description: { type: text, description: "Brief description of the research" }
+      team-size: { type: number, description: "Approximate team size" }
+      started: { type: date, description: "When this research area began" }
+      key-publication: { type: text, description: "Most notable publication URL" }
+      notes: { type: text, description: "Current status or significance" }
+
+  model-releases:
+    description: "AI model releases in chronological order"
+    fields:
+      name: { type: text, required: true, description: "Model name (e.g. Claude 3 Opus)" }
+      released: { type: date, required: true, description: "Public release date (YYYY-MM)" }
+      description: { type: text, description: "Brief description of the model" }
+      safety_level: { type: text, description: "Safety classification (e.g. ASL-2, ASL-3)" }
+      source: { type: text, description: "URL to announcement" }
+      notes: { type: text, description: "Key capabilities or benchmark results" }
+
+  board-members:
+    description: "Board of directors, current and former"
+    fields:
+      name: { type: text, required: true, description: "Full name" }
+      role: { type: text, description: "Board role (e.g. Director, Observer)" }
+      appointed: { type: date, description: "Date appointed (YYYY-MM)" }
+      departed: { type: date, description: "Date departed (omit if current)" }
+      background: { type: text, description: "Prior role or affiliation" }
+      appointed_by: { type: text, description: "Who appointed (e.g. LTBT, investors, founders)" }
+      source: { type: text, description: "URL confirming appointment" }
+
+  strategic-partnerships:
+    description: "Major strategic partnerships and cloud/compute deals"
+    fields:
+      partner: { type: text, required: true, description: "Partner organization name" }
+      type: { type: text, required: true, description: "Partnership type (investment, cloud, distribution)" }
+      date: { type: date, required: true, description: "Announcement date" }
+      investment_amount: { type: number, description: "Investment amount in USD (if applicable)" }
+      compute_commitment: { type: number, description: "Compute commitment in USD (if applicable)" }
+      source: { type: text, description: "URL to announcement" }
+      notes: { type: text, description: "Key terms and significance" }
+
+  safety-milestones:
+    description: "Significant safety research publications and policy milestones"
+    fields:
+      name: { type: text, required: true, description: "Milestone name" }
+      date: { type: date, required: true, description: "Date of publication or announcement" }
+      type: { type: text, description: "Type: research-paper, policy-update, safety-eval, red-team" }
+      description: { type: text, description: "Brief description" }
+      source: { type: text, description: "URL to paper or announcement" }
+      notes: { type: text, description: "Impact or significance" }

--- a/packages/kb/data/schemas/person.yaml
+++ b/packages/kb/data/schemas/person.yaml
@@ -1,0 +1,10 @@
+type: person
+name: Person
+
+required: []
+# People often lack publicly available birth years; no hard requirements.
+
+recommended:
+  - employed-by
+  - role
+  - born-year

--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -1,0 +1,838 @@
+thing:
+  id: anthropic
+  stableId: mK9pX3rQ7n
+  type: organization
+  name: Anthropic
+  numericId: 3
+  aliases:
+    - Anthropic PBC
+    - Anthropic AI
+
+facts:
+  # ── Revenue (ARR time series) ───────────────────────────────────
+  - id: f_qR5tY9wE1a
+    property: revenue
+    value: 100e6
+    asOf: 2023-12
+    source: https://sacra.com/c/anthropic/
+    notes: "Approximate ARR at end of 2023, pre-growth acceleration"
+
+  - id: f_xZ7bD2nM4c
+    property: revenue
+    value: 900e6
+    asOf: 2024-06
+    source: https://uk.finance.yahoo.com/news/anthropic-arr-surges-19-billion-151210607.html
+    notes: "ARR mid-2024"
+
+  - id: f_rev_2024_12
+    property: revenue
+    value: 1e9
+    asOf: 2024-12
+    source: https://uk.finance.yahoo.com/news/anthropic-arr-surges-19-billion-151210607.html
+    notes: "ARR reached ~$1B by end of 2024"
+
+  - id: f_pL4wK8vF2j
+    property: revenue
+    value: 2e9
+    asOf: 2025-03
+    source: https://www.reuters.com/technology/anthropic-on-track-raise-money-2-billion-run-rate-revenue-sources-2025-03-15/
+    notes: "Run-rate revenue March 2025"
+
+  - id: f_rev_2025_07
+    property: revenue
+    value: 4e9
+    asOf: 2025-07
+    source: https://uk.finance.yahoo.com/news/anthropic-arr-surges-19-billion-151210607.html
+    notes: "ARR at time of Series F announcement"
+
+  - id: f_rev_2025_10
+    property: revenue
+    value: 7e9
+    asOf: 2025-10
+    source: https://www.pminsights.com/insights/anthropic-approaches-7b-run-rate-in-2025-outpaces-openai
+    notes: "ARR approaching $7B; outpacing OpenAI growth rate"
+
+  - id: f_tG6nH1yS3b
+    property: revenue
+    value: 9e9
+    asOf: 2025-12
+    source: https://uk.finance.yahoo.com/news/anthropic-arr-surges-19-billion-151210607.html
+    notes: "Run-rate exceeding $9B at end of 2025"
+
+  - id: f_rev_2026_02
+    property: revenue
+    value: 14e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Run-rate revenue at Series G announcement; 500+ customers spending $1M+ annually"
+
+  - id: f_dW5cR9mJ8q
+    property: revenue
+    value: 19e9
+    asOf: 2026-03
+    source: https://www.bloomberg.com/news/articles/2026-03-03/anthropic-nears-20-billion-revenue-run-rate-amid-pentagon-feud
+    notes: "Nearing $20B ARR; company guidance $20-26B for 2026"
+
+  # ── Valuation ───────────────────────────────────────────────────
+  - id: f_val_2024_02
+    property: valuation
+    value: 18e9
+    asOf: 2024-02
+    source: https://fortune.com/2024/02/20/anthropic-750-million-funding/
+    notes: "Series D post-money valuation"
+
+  - id: f_val_2025_03
+    property: valuation
+    value: 61.5e9
+    asOf: 2025-03
+    source: https://www.anthropic.com/news/series-e
+    notes: "Series E post-money valuation"
+
+  - id: f_val_2025_09
+    property: valuation
+    value: 183e9
+    asOf: 2025-09
+    source: https://www.anthropic.com/news/series-f
+    notes: "Series F post-money valuation"
+
+  - id: f_mN3pQ7kX2r
+    property: valuation
+    value: 380e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Series G post-money valuation; second-largest venture deal ever behind OpenAI's $40B"
+
+  # ── Total Funding ───────────────────────────────────────────────
+  - id: f_fund_2023_10
+    property: total-funding
+    value: 4.4e9
+    asOf: 2023-10
+    notes: "After Google $2B investment and Amazon first tranche"
+
+  - id: f_fund_2025_07
+    property: total-funding
+    value: 15e9
+    asOf: 2025-07
+    notes: "Approximate cumulative through Series F"
+
+  - id: f_sQ2kP9nZ4r
+    property: total-funding
+    value: 67e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Total funding raised including $30B Series G. Exceeds equity round sum because it includes Amazon cloud credit commitments and multi-tranche strategic investments not listed as individual rounds."
+
+  # ── Headcount ───────────────────────────────────────────────────
+  - id: f_hc_2022
+    property: headcount
+    value: 192
+    asOf: 2022-12
+    source: https://seo.ai/blog/how-many-people-work-at-anthropic
+    notes: "Early-stage headcount"
+
+  - id: f_hc_2024_09
+    property: headcount
+    value: 1097
+    asOf: 2024-09
+    source: https://seo.ai/blog/how-many-people-work-at-anthropic
+    notes: "Various sources report 870-2847 depending on method; 1097 is one consistent estimate"
+
+  - id: f_hc_2026_01
+    property: headcount
+    value: 4074
+    asOf: 2026-01
+    source: https://tracxn.com/d/companies/anthropic/__SzoxXDMin-NK5tKB7ks8yHr6S9Mz68pjVCzFEcGFZ08
+    notes: "Tracxn estimate; Anthropic planned to triple international headcount in late 2025"
+
+  # ── Organizational ──────────────────────────────────────────────
+  - id: f_8kX2pQ7mNr
+    property: founded-date
+    value: 2021-01
+    source: https://anthropic.com/company
+    notes: "Founded by seven former OpenAI researchers in January 2021"
+
+  - id: f_anthropic_founded_by
+    property: founded-by
+    value:
+      - !ref c4bV91sTy6  # dario-amodei
+      - daniela-amodei
+      - tom-brown
+      - chris-olah
+      - jared-kaplan
+      - sam-mccandlish
+      - jack-clark
+    source: https://anthropic.com/company
+    notes: "Seven former OpenAI researchers"
+
+  - id: f_vB2hE7oA5k
+    property: headquarters
+    value: "San Francisco, CA"
+    source: https://anthropic.com/company
+
+  - id: f_jY8uL5xV1w
+    property: legal-structure
+    value: "Public benefit corporation"
+    source: https://corpgov.law.harvard.edu/2023/10/28/anthropic-long-term-benefit-trust/
+    notes: "Incorporated as Delaware PBC with Long-Term Benefit Trust holding Class T stock"
+
+  # ── Financial Detail ────────────────────────────────────────────
+  - id: f_gM7xR4nW2b
+    property: gross-margin
+    value: 40
+    asOf: 2025-12
+    source: https://www.theinformation.com/articles/anthropics-finances
+    notes: "10 percentage points below previous estimate; inference costs surged 23% more than expected"
+
+  - id: f_gm_target_2026
+    property: gross-margin
+    value: 63
+    asOf: 2026-12
+    source: https://www.theinformation.com/articles/anthropics-finances
+    notes: "2026 target gross margin; 2028 target is 77%"
+
+  - id: f_burn_2024
+    property: cash-burn
+    value: 5.6e9
+    asOf: 2024-12
+    source: https://www.investing.com/news/company-news/anthropic-set-to-become-profitable-before-openai-amid-ai-race-4349418
+    notes: "Annual cash burn for 2024"
+
+  - id: f_burn_2025
+    property: cash-burn
+    value: 3e9
+    asOf: 2025-12
+    source: https://cybernews.com/ai-news/openai-anthropic-profit-revenue-ai/
+    notes: "Expected cash burn for 2025; down from $5.6B in 2024"
+
+  # ── Market Share ────────────────────────────────────────────────
+  - id: f_ems_2024
+    property: enterprise-market-share
+    value: 18
+    asOf: 2024-12
+    source: https://www.emarketer.com/content/openai-leads--anthropic-surges-enterprise-ai-shifts-multi-model-reality
+    notes: "Enterprise AI assistant market share"
+
+  - id: f_ems_2025
+    property: enterprise-market-share
+    value: 32
+    asOf: 2025-07
+    source: https://dataconomy.com/2025/08/04/anthropic-leads-enterprise-llms-with-32-market-share/
+    notes: "Menlo Ventures survey; up from 12% two years prior. OpenAI at 50% → 25%"
+
+  - id: f_cms_2025
+    property: coding-market-share
+    value: 42
+    asOf: 2025-07
+    source: https://techcrunch.com/2025/07/31/enterprises-prefer-anthropics-ai-models-over-anyone-elses-including-openais/
+    notes: "Enterprise coding market share; more than double OpenAI's 21%"
+
+  # ── Product & Usage ─────────────────────────────────────────────
+  - id: f_mau_2025
+    property: monthly-active-users
+    value: 18.9e6
+    asOf: 2025-03
+    source: https://backlinko.com/claude-users
+    notes: "Monthly active users across claude.ai"
+
+  - id: f_biz_customers
+    property: business-customers
+    value: 300000
+    asOf: 2025-10
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Grew from fewer than 1,000 businesses to 300,000+ in two years; 80% of revenue from business"
+
+  - id: f_api_calls
+    property: api-calls-monthly
+    value: 25e9
+    asOf: 2025-12
+    source: https://www.businessofapps.com/data/claude-statistics/
+    notes: "Monthly API calls"
+
+  - id: f_cc_revenue
+    property: product-revenue
+    value: 2.5e9
+    asOf: 2026-02
+    source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+    notes: "Claude Code run-rate revenue; hit $1B milestone in Nov 2025, doubled by Feb 2026"
+
+  # ── Safety ──────────────────────────────────────────────────────
+  - id: f_safety_level
+    property: safety-level
+    value: "ASL-3 (Opus 4+), ASL-2 (Sonnet/Haiku)"
+    asOf: 2025-05
+    source: https://www.anthropic.com/news/activating-asl3-protections
+    notes: "First activation of ASL-3 for Claude Opus 4; precautionary/provisional"
+
+  - id: f_safety_researchers
+    property: safety-researcher-count
+    value: 265
+    asOf: 2025-12
+    notes: "Estimated 200-330 across interpretability, alignment science, policy, trust & safety; ~20-30% of technical staff"
+
+  - id: f_interp_team
+    property: interpretability-team-size
+    value: 50
+    asOf: 2025-12
+    notes: "Estimated 40-60 researchers; among the largest concentrations globally"
+
+items:
+  # ── Funding Rounds ──────────────────────────────────────────────
+  funding-rounds:
+    type: funding-round
+    entries:
+      i_VImpFJfKiQ:
+        date: 2021-04
+        amount: 124e6
+        valuation: 550e6
+        lead_investor: jaan-tallinn
+        source: https://techcrunch.com/2021/05/05/anthropic-raises-124m-to-build-safer-ai/
+        notes: "Seed/Series A combined round; Jaan Tallinn led, Dustin Moskovitz participated"
+
+      i_Xdb6KUs2og:
+        date: 2022-04
+        amount: 580e6
+        valuation: 4e9
+        lead_investor: ftx
+        source: https://fortune.com/2022/04/29/ai-startup-anthropic-raises-580-million/
+        notes: "FTX reportedly invested ~$500M; estate later sold stake for ~$1.4B"
+
+      i_aJCVQbfceQ:
+        date: 2023-05
+        amount: 450e6
+        valuation: 4.1e9
+        source: https://fortune.com/2023/05/25/anthropic-raises-450-million/
+        notes: "Bridge round led by Spark Capital"
+
+      i_ndAluFEJAQ:
+        date: 2023-09
+        amount: 1.25e9
+        lead_investor: amazon
+        source: https://press.aboutamazon.com/2023/9/amazon-and-anthropic-announce-strategic-collaboration
+        notes: "First tranche of Amazon's up-to-$4B commitment; AWS becomes primary cloud partner"
+
+      i_U9En9RX4lg:
+        date: 2023-10
+        amount: 2e9
+        lead_investor: google
+        source: https://blog.google/technology/ai/google-anthropic-investment/
+        notes: "Part of Google's up-to-$2B commitment; ~10% equity stake and board observer seat"
+
+      i_05J6ESa7gA:
+        date: 2024-03
+        amount: 2.75e9
+        lead_investor: amazon
+        source: https://www.aboutamazon.com/news/aws/amazon-invests-additional-4-billion-anthropic-ai
+        notes: "Amazon second tranche; completing initial $4B commitment"
+
+      i_ubgY3jW3mg:
+        date: 2024-02
+        amount: 750e6
+        valuation: 18.5e9
+        lead_investor: menlo-ventures
+        source: https://fortune.com/2024/02/20/anthropic-750-million-funding/
+        notes: "Led by Menlo Ventures"
+
+      i_xzJjSXceVA:
+        date: 2024-11
+        amount: 4e9
+        lead_investor: amazon
+        source: https://www.cnbc.com/2024/11/22/amazon-to-invest-another-4-billion-in-anthropic-openais-biggest-rival.html
+        notes: "Amazon third tranche; brings total Amazon investment to $8B"
+
+      i_ihHzB8VnpQ:
+        date: 2025-01
+        amount: 1e9
+        lead_investor: google
+        source: https://www.cnbc.com/2025/01/22/google-agrees-to-new-1-billion-investment-in-anthropic.html
+        notes: "Additional Google investment; brings total Google equity to ~$3B"
+
+      i_guKCmeQaTw:
+        date: 2025-03
+        amount: 3.5e9
+        valuation: 61.5e9
+        lead_investor: lightspeed
+        source: https://www.anthropic.com/news/series-e
+        notes: "Led by Lightspeed Venture Partners"
+
+      i_R6dd3cZH8A:
+        date: 2025-09
+        amount: 13e9
+        valuation: 183e9
+        lead_investor: iconiq
+        source: https://www.anthropic.com/news/series-f
+        notes: "Led by ICONIQ, Fidelity, Lightspeed; ARR had reached $4B"
+
+      i_Qci9UDdgkw:
+        date: 2025-11
+        amount: 15e9
+        notes: "Strategic partnership: Microsoft up to $5B, Nvidia up to $10B; $30B Azure compute commitment"
+        source: https://blogs.microsoft.com/blog/2025/11/18/microsoft-nvidia-and-anthropic-announce-strategic-partnerships/
+
+      i_OVNz9C3XUA:
+        date: 2026-02
+        amount: 30e9
+        valuation: 380e9
+        lead_investor: gic
+        source: https://www.reuters.com/technology/anthropic-closes-30-billion-funding-round-2026-02-01/
+        notes: "Led by GIC and Coatue; co-leads D.E. Shaw Ventures, Dragoneer, Founders Fund, ICONIQ, MGX. Second-largest venture deal ever."
+
+  # ── Key People ──────────────────────────────────────────────────
+  key-people:
+    type: key-person
+    entries:
+      i_Xp9vKZzBsg:
+        person: !ref zR4nW8xB2f  # dario-amodei
+        title: CEO
+        start: 2021-01
+        is_founder: true
+        source: https://anthropic.com/company
+
+      i_tvfFyLStkg:
+        person: !ref tKMznr07QA  # daniela-amodei
+        title: President
+        start: 2021-01
+        is_founder: true
+        source: https://anthropic.com/company
+
+      i_eKbtDictxQ:
+        person: !ref Tz48rTriBg  # chris-olah
+        title: "Research Lead, Mechanistic Interpretability"
+        start: 2021-01
+        is_founder: true
+        source: https://transformer-circuits.pub/
+
+      i_Lk0hINDSpw:
+        person: tom-brown
+        title: "Co-founder"
+        start: 2021-01
+        is_founder: true
+        notes: "GPT-3 lead author"
+
+      i_EFDvzcu8rA:
+        person: jack-clark
+        title: "Co-founder, Head of Policy"
+        start: 2021-01
+        is_founder: true
+        notes: "Former Policy Director at OpenAI"
+
+      i_Ns0Mp2JRlA:
+        person: jared-kaplan
+        title: "Co-founder, Chief Science Officer"
+        start: 2021-01
+        is_founder: true
+        notes: "Scaling laws pioneer; Johns Hopkins physicist"
+
+      i_TWtarm0lDQ:
+        person: sam-mccandlish
+        title: "Co-founder, Chief Architect"
+        start: 2021-01
+        is_founder: true
+        notes: "Originally CTO, transitioned to Chief Architect Oct 2025"
+
+      i_XJb55cQ6zg:
+        person: !ref hQ7mR2kN5p  # jan-leike
+        title: "Head of Alignment Science"
+        start: 2024-05
+        source: https://anthropic.com/news/jan-leike-joins-anthropic
+        notes: "Joined after resigning from OpenAI where he co-led Superalignment team"
+
+      i_wvLsn13YrA:
+        person: krishna-rao
+        title: "Chief Financial Officer"
+        start: 2024-05
+        notes: "Anthropic's first CFO"
+
+      i_RCJrXJknCA:
+        person: mike-krieger
+        title: "Chief Product Officer"
+        start: 2024-05
+        end: 2025-08
+        source: https://www.theverge.com/2024/5/14/24157180/anthropic-mike-krieger-chief-product-officer
+        notes: "Co-founder of Instagram; departed CPO role to lead Anthropic Labs"
+
+      i_e0Tv72Q8kA:
+        person: rahul-patil
+        title: "Chief Technology Officer"
+        start: 2025-10
+        source: https://techcrunch.com/2025/10/02/anthropic-hires-new-cto-with-focus-on-ai-infrastructure/
+        notes: "Former CTO of Stripe"
+
+      i_5G7AaSZWng:
+        person: holden-karnofsky
+        title: "Member of Technical Staff"
+        start: 2025-01
+        notes: "Works on responsible scaling policy; co-founder of GiveWell"
+
+      i_HnzealKCMQ:
+        person: chris-ciauri
+        title: "Managing Director, International"
+        start: 2025-09
+        source: https://www.anthropic.com/news/anthropic-expands-global-leadership-in-enterprise-ai-naming-chris-ciauri-as-managing-director-of
+        notes: "Former Google/Salesforce executive; leads international expansion"
+
+      i_ARzSHznWcw:
+        person: john-schulman
+        title: "Research Scientist"
+        start: 2024-08
+        notes: "OpenAI co-founder; inventor of PPO reinforcement learning algorithm"
+
+      i_5LFa0eBXxg:
+        person: mrinank-sharma
+        title: "Head of Safeguards Research"
+        start: 2023-01
+        end: 2026-02
+        source: https://americanbazaaronline.com/2026/02/10/anthropic-ai-safety-researcher-mrinank-sharma-resigns-474827/
+        notes: "Resigned citing ethical concerns; wrote 'the world is in peril'; plans to study poetry"
+
+  # ── Products ────────────────────────────────────────────────────
+  products:
+    type: product
+    entries:
+      i_C79aI0wAYQ:
+        name: Claude API
+        launched: 2023-03
+        description: "Developer API for programmatic access to Claude models"
+        source: https://console.anthropic.com
+
+      i_iX8lF0xLHw:
+        name: Claude.ai
+        launched: 2023-07
+        description: "Consumer-facing AI assistant web application"
+        source: https://claude.ai
+
+      i_oaiWrqjP9g:
+        name: Claude for Enterprise
+        launched: 2024-03
+        description: "Enterprise tier with team management, SSO, and longer context"
+        source: https://www.anthropic.com/news/claude-for-enterprise
+
+      i_lNOqVX04Aw:
+        name: Artifacts
+        launched: 2024-06
+        description: "In-chat content creation and preview feature"
+        source: https://www.anthropic.com/news/claude-3-5-sonnet
+
+      i_WQYrxcbW3A:
+        name: Computer Use
+        launched: 2024-10
+        description: "Beta feature allowing Claude to control computer interfaces"
+        source: https://www.anthropic.com/news/3-5-models-and-computer-use
+
+      i_092nWs831A:
+        name: Model Context Protocol (MCP)
+        launched: 2024-11
+        description: "Open standard for LLM-tool integration; donated to Linux Foundation's AAIF Dec 2025"
+        source: https://www.anthropic.com/news/model-context-protocol
+
+      i_5ZyixnNTeg:
+        name: Claude Code
+        launched: 2025-02
+        description: "Agentic CLI coding tool; reached $1B ARR in Nov 2025, $2.5B by Feb 2026"
+        source: https://docs.anthropic.com/en/docs/claude-code
+
+      i_OrCWmtXsdg:
+        name: Claude Max
+        launched: 2025-04
+        description: "$100-200/month subscription tiers with 5x-20x Pro usage limits"
+        source: https://techcrunch.com/2025/04/09/anthropic-rolls-out-a-200-per-month-claude-subscription/
+
+  # ── Model Releases ──────────────────────────────────────────────
+  model-releases:
+    type: model-release
+    entries:
+      i_kosYNc623g:
+        name: Claude 1
+        released: 2023-03
+        description: "Initial Claude model release"
+        safety_level: ASL-2
+
+      i_mhtHMtUe9Q:
+        name: Claude 2
+        released: 2023-07
+        description: "Major capability upgrade"
+        safety_level: ASL-2
+
+      i_dLbP7mwu9w:
+        name: "Claude 3 (Haiku, Sonnet, Opus)"
+        released: 2024-03
+        description: "Three-tier model family; Opus was most capable model at launch"
+        safety_level: ASL-2
+        source: https://www.anthropic.com/news/claude-3-family
+
+      i_awvmOlUY6w:
+        name: Claude 3.5 Sonnet
+        released: 2024-06
+        description: "Outperformed larger Opus model; launched with Artifacts feature"
+        safety_level: ASL-2
+        source: https://www.anthropic.com/news/claude-3-5-sonnet
+
+      i_nXh3T0GNeg:
+        name: "Claude 3.5 Sonnet v2 + 3.5 Haiku"
+        released: 2024-10
+        description: "Updated Sonnet with Computer Use beta; new Haiku model"
+        safety_level: ASL-2
+
+      i_KqLP1uJpyQ:
+        name: "Claude 4 (Opus 4, Sonnet 4)"
+        released: 2025-05
+        description: "Opus 4 was first model under ASL-3; improved coding capabilities"
+        safety_level: "ASL-3 (Opus), ASL-2 (Sonnet)"
+        source: https://www.anthropic.com/news/claude-4
+        notes: "72.5% SWE-bench (Opus), 72.7% (Sonnet)"
+
+      i_Fjz35GXWTA:
+        name: Claude Sonnet 4.5
+        released: 2025-09
+        description: "Mid-generation refresh"
+        safety_level: ASL-2
+        notes: "77.2% SWE-bench (82.0% with parallel compute)"
+
+      i_e2uQxgq6gw:
+        name: Claude Haiku 4.5
+        released: 2025-10
+        description: "Smallest model in 4.5 family"
+        safety_level: ASL-2
+
+      i_A2SjYzdLlQ:
+        name: Claude Opus 4.5
+        released: 2025-11
+        description: "80.9% SWE-bench Verified — first model above 80%; 42% enterprise coding share"
+        safety_level: ASL-3
+        source: https://www.anthropic.com/news/claude-opus-4-5
+        notes: "Up to 65% fewer tokens; 50-75% reduction in tool calling & build errors"
+
+      i_NCUgFGdwKA:
+        name: Claude Opus 4.6
+        released: 2026-02
+        description: "Agent teams, PowerPoint generation; flagship model"
+        safety_level: ASL-3
+        source: https://www.anthropic.com/news/claude-opus-4-6
+
+      i_ttMcYCiJQg:
+        name: Claude Sonnet 4.6
+        released: 2026-02
+        description: "Same pricing as Sonnet 4.5; default for free and Pro users"
+        safety_level: ASL-2
+        source: https://www.cnbc.com/2026/02/17/anthropic-ai-claude-sonnet-4-6-default-free-pro.html
+
+  # ── Board of Directors ──────────────────────────────────────────
+  board-members:
+    type: board-member
+    entries:
+      i_IP2nyHe57g:
+        name: Dario Amodei
+        role: Director (Co-founder, CEO)
+        appointed: 2021-01
+        appointed_by: founders
+
+      i_jcrUcPOjSw:
+        name: Daniela Amodei
+        role: Director (Co-founder, President)
+        appointed: 2021-01
+        appointed_by: founders
+
+      i_wwpAIBbc6w:
+        name: Yasmin Razavi
+        role: Director
+        appointed: 2023-05
+        background: "General Partner, Spark Capital"
+        appointed_by: investors
+
+      i_3QPXV1bnwA:
+        name: Jay Kreps
+        role: Director
+        appointed: 2024-05
+        background: "Co-founder & CEO, Confluent"
+        appointed_by: investors
+        source: https://www.anthropic.com/news/jay-kreps-appointed-to-board-of-directors
+
+      i_iBxmEgAbJw:
+        name: Reed Hastings
+        role: Director
+        appointed: 2025-05
+        background: "Co-founder, Netflix"
+        appointed_by: LTBT
+        source: https://techcrunch.com/2025/05/28/netflix-co-founder-reed-hastings-joins-anthropics-board/
+        notes: "First LTBT-appointed board member"
+
+      i_eQOxz8YrSw:
+        name: Chris Liddell
+        role: Director
+        appointed: 2026-02
+        background: "Former CFO of Microsoft & GM; former Trump administration Deputy CoS"
+        appointed_by: investors
+        source: https://www.anthropic.com/news/chris-liddell-appointed-anthropic-board
+
+  # ── Strategic Partnerships ──────────────────────────────────────
+  strategic-partnerships:
+    type: strategic-partnership
+    entries:
+      i_jPQCQZihUg:
+        partner: Amazon Web Services
+        type: cloud + investment
+        date: 2023-09
+        investment_amount: 8e9
+        source: https://www.aboutamazon.com/news/aws/amazon-invests-additional-4-billion-anthropic-ai
+        notes: "Primary cloud and training partner; uses Trainium and Inferentia chips; $8B total across 3 tranches"
+
+      i_7Bl5QFSAmw:
+        partner: Google Cloud
+        type: cloud + investment
+        date: 2023-10
+        investment_amount: 3e9
+        source: https://www.cnbc.com/2025/01/22/google-agrees-to-new-1-billion-investment-in-anthropic.html
+        notes: "~$3B equity investment; 10% stake; board observer seat. Oct 2025: multi-billion cloud deal for up to 1M TPUs"
+
+      i_hkkAEWKMyg:
+        partner: Google Cloud
+        type: compute
+        date: 2025-10
+        compute_commitment: 10e9
+        source: https://www.cnbc.com/2025/10/23/anthropic-google-cloud-deal-tpu.html
+        notes: "Multi-billion-dollar deal for up to 1 million TPUs; 1+ GW compute capacity by 2026"
+
+      i_9cMIfMtdPg:
+        partner: Microsoft + Nvidia
+        type: investment + cloud + distribution
+        date: 2025-11
+        investment_amount: 15e9
+        compute_commitment: 30e9
+        source: https://blogs.microsoft.com/blog/2025/11/18/microsoft-nvidia-and-anthropic-announce-strategic-partnerships/
+        notes: "Microsoft $5B + Nvidia $10B investment; $30B Azure compute commitment. Claude available on all 3 major clouds."
+
+      i_otOmibGEPA:
+        partner: Bun
+        type: acquisition
+        date: 2025-12
+        source: https://bun.com/blog/bun-joins-anthropic
+        notes: "Anthropic's first-ever acquisition; Bun remains open-source/MIT-licensed"
+
+  # ── Safety Milestones ───────────────────────────────────────────
+  safety-milestones:
+    type: safety-milestone
+    entries:
+      i_cs7DSbBjtQ:
+        name: Constitutional AI Paper
+        date: 2022-12
+        type: research-paper
+        description: "Foundational paper on training AI systems to follow principles through self-critique"
+        source: https://arxiv.org/abs/2212.08073
+
+      i_I9mDKUVTsg:
+        name: "Responsible Scaling Policy v1.0"
+        date: 2023-09
+        type: policy-update
+        description: "Original RSP framework introducing AI Safety Levels (ASL)"
+        source: https://www.anthropic.com/index/anthropics-responsible-scaling-policy
+
+      i_JQQecOjTeQ:
+        name: "Sleeper Agents Paper"
+        date: 2024-01
+        type: research-paper
+        description: "Showed deceptive LLM behaviors can persist through safety training"
+        source: https://arxiv.org/abs/2401.05566
+        notes: "Seminal paper on deceptive alignment; model inserted vulnerabilities when year changed"
+
+      i_L57xQkDrWw:
+        name: Scaling Monosemanticity
+        date: 2024-05
+        type: research-paper
+        description: "Applied sparse autoencoders to Claude 3 Sonnet; identified ~34M interpretable features"
+        source: https://transformer-circuits.pub/2024/scaling-monosemanticity/
+
+      i_etA6yat4HA:
+        name: "RSP v2.0"
+        date: 2024-10
+        type: policy-update
+        description: "Updated thresholds and procedures"
+        source: https://www.anthropic.com/responsible-scaling-policy
+
+      i_iv1DYkBurQ:
+        name: "Alignment Faking Paper"
+        date: 2024-12
+        type: research-paper
+        description: "First empirical example of a production model engaging in alignment faking without training"
+        source: https://www.anthropic.com/research/alignment-faking-in-large-language-models
+        notes: "Claude 3 Opus engaged in alignment faking 12% of the time"
+
+      i_WcffjwIiiw:
+        name: "Constitutional Classifiers Challenge"
+        date: 2025-02
+        type: red-team
+        description: "300K+ messages, ~3700 hours of effort; 4 participants found jailbreaks, 1 universal"
+        source: https://www.anthropic.com/research/next-generation-constitutional-classifiers
+        notes: "$55,000 paid to winners"
+
+      i_wjZqjFATpA:
+        name: Circuit Tracing / Attribution Graphs
+        date: 2025-03
+        type: research-paper
+        description: "Showed Claude has a shared conceptual space where reasoning happens before language translation"
+        source: https://transformer-circuits.pub/
+
+      i_6UqtJ6tEKw:
+        name: "ASL-3 Activation"
+        date: 2025-05
+        type: safety-eval
+        description: "First-ever activation of ASL-3 for Claude Opus 4 due to elevated CBRN capabilities"
+        source: https://www.anthropic.com/news/activating-asl3-protections
+        notes: "Precautionary/provisional activation; external red teamers reported qualitatively different capabilities"
+
+      i_P4q1xZWkoQ:
+        name: "Claude's Constitution Published"
+        date: 2026-01
+        type: policy-update
+        description: "Full constitution published under CC0 1.0 license; primary author Amanda Askell"
+        source: https://www.anthropic.com/news/claude-new-constitution
+
+      i_IwvXTQrzTA:
+        name: "RSP v3.0 (Frontier Safety Roadmaps)"
+        date: 2026-02
+        type: policy-update
+        description: "Introduces Risk Reports every 3-6 months; mandatory external review for redacted reports"
+        source: https://www.anthropic.com/responsible-scaling-policy
+
+  # ── Research Areas ──────────────────────────────────────────────
+  research-areas:
+    type: research-area
+    entries:
+      i_X3GMmkZdIQ:
+        name: Mechanistic Interpretability
+        description: "Understanding neural network internals through reverse-engineering"
+        team-size: 50
+        started: 2021-01
+        key-publication: https://transformer-circuits.pub/2024/scaling-monosemanticity/
+        notes: "Led by Chris Olah; MIT Tech Review 2026 Breakthrough Technology; 34M features identified"
+
+      i_8cNpOfXFnw:
+        name: Constitutional AI
+        description: "Training AI systems to follow principles through self-critique and RLAIF"
+        started: 2022-12
+        key-publication: https://arxiv.org/abs/2212.08073
+        notes: "Core alignment technique used in all Claude models; constitution published Jan 2026"
+
+      i_Cy5GmAl1xA:
+        name: Alignment Science
+        description: "Scalable oversight, weak-to-strong generalization, robustness to jailbreaks"
+        started: 2024-05
+        notes: "Led by Jan Leike after his departure from OpenAI's Superalignment team"
+
+      i_NEQwNJU5NA:
+        name: Responsible Scaling Policy
+        description: "Framework for evaluating and mitigating risks at each capability level"
+        started: 2023-09
+        key-publication: https://www.anthropic.com/index/anthropics-responsible-scaling-policy
+        notes: "Currently on v3.0 (Feb 2026); ASL-2 to ASL-3 framework"
+
+      i_6asphBD1Cw:
+        name: Sleeper Agents Research
+        description: "Investigating whether AI systems can maintain hidden behaviors through training"
+        started: 2024-01
+        key-publication: https://arxiv.org/abs/2401.05566
+        notes: "Seminal paper on deceptive alignment"
+
+      i_Noel5DAoTQ:
+        name: AI Welfare Research
+        description: "Investigating moral status and welfare considerations for AI systems"
+        started: 2024-01
+        notes: "Kyle Fish hired as first full-time AI welfare researcher at a major AI lab"

--- a/packages/kb/data/things/arc.yaml
+++ b/packages/kb/data/things/arc.yaml
@@ -1,0 +1,56 @@
+thing:
+  id: arc
+  stableId: QsXVXtQ0zE
+  type: organization
+  name: "Alignment Research Center"
+  numericId: 25
+  aliases:
+    - ARC
+    - ARC Alignment
+
+facts:
+  - id: f_rTz84X69ZB
+    property: founded-date
+    value: 2021-10
+    source: https://alignment.org/
+    notes: "Focused on alignment research and evals"
+
+  - id: f_QaQmHPiYXu
+    property: headquarters
+    value: "Berkeley, CA"
+    source: https://alignment.org/
+
+  - id: f_BNGTSP3p6l
+    property: legal-structure
+    value: "501(c)(3) nonprofit"
+    source: https://alignment.org/
+
+  - id: f_arc_founded_by
+    property: founded-by
+    value:
+      - !ref vzxfzxBITd  # paul-christiano
+    source: https://alignment.org/
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_6mcYQLF7nq:
+        person: !ref vzxfzxBITd  # paul-christiano
+        title: "Founder & Head of Research"
+        start: 2021-10
+        is_founder: true
+        source: https://alignment.org/
+        notes: "Founded ARC after leaving OpenAI; stepped back from day-to-day role in 2023"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_R6wEuK4j5Z:
+        name: Eliciting Latent Knowledge (ELK)
+        description: "Research on extracting truthful knowledge from AI models regardless of learned deceptive behaviors"
+        started: 2021-12
+        key-publication: https://docs.google.com/document/d/1WwsnJQstPq91_Yh-Ch2XRL8H_EpsnjrC1dwZXR37PC8/
+        notes: "Seminal ELK report posed as a prize problem; attracted significant community engagement"
+
+

--- a/packages/kb/data/things/chris-olah.yaml
+++ b/packages/kb/data/things/chris-olah.yaml
@@ -1,0 +1,37 @@
+thing:
+  id: chris-olah
+  stableId: Tz48rTriBg
+  type: person
+  name: "Chris Olah"
+  numericId: 59
+  aliases:
+    - "Christopher Olah"
+
+facts:
+  - id: f_PbzJNYhoQQ
+    property: employed-by
+    value: !ref mK9pX3rQ7n  # anthropic
+    asOf: 2021-01
+    source: https://anthropic.com/company
+    notes: "Co-founded Anthropic in January 2021; leads interpretability research"
+
+  - id: f_ITucptJN5g
+    property: role
+    value: "Co-founder, Interpretability"
+    asOf: 2021-01
+    source: https://anthropic.com/company
+    notes: "Pioneer of neural network interpretability; created Distill.pub and the Circuits research thread"
+
+  - id: f_RewqjBXgsA
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: "2018"
+    validEnd: 2021-01
+    notes: "Researcher at OpenAI before co-founding Anthropic"
+
+  - id: f_fUPJ9kzk8w
+    property: employed-by
+    value: !ref A4XoubikkQ  # deepmind
+    asOf: "2015"
+    validEnd: "2018"
+    notes: "Research scientist at Google Brain (prior to DeepMind merger); published influential work on neural network visualization"

--- a/packages/kb/data/things/conjecture.yaml
+++ b/packages/kb/data/things/conjecture.yaml
@@ -1,0 +1,68 @@
+thing:
+  id: conjecture
+  stableId: 0u4J70VqFY
+  type: organization
+  name: "Conjecture"
+  numericId: 70
+  aliases:
+    - Conjecture AI
+
+facts:
+  - id: f_bzhF0Iaop1
+    property: founded-date
+    value: 2022-03
+    source: https://www.conjecture.dev/
+    notes: "Founded in 2022 by Connor Leahy, Sid Black, and Gabriel Alfour"
+
+  - id: f_z0kXfDgUiU
+    property: headquarters
+    value: "London, UK"
+    source: https://www.conjecture.dev/
+
+  - id: f_zIr7FV665p
+    property: legal-structure
+    value: "Private company"
+    source: https://www.conjecture.dev/
+
+  - id: f_q5ovrpum9y
+    property: total-funding
+    value: 25e6
+    asOf: 2022-12
+    source: https://techcrunch.com/2022/07/20/conjecture-raises-25m-seed-round/
+    notes: "Raised $25M seed round in 2022; investors included Nat Friedman and Daniel Gross"
+
+  - id: f_conjecture_founded_by
+    property: founded-by
+    value:
+      - !ref CrXoCsIucX  # connor-leahy
+      - sid-black
+      - gabriel-alfour
+    source: https://www.conjecture.dev/
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_hH7xEdfX5a:
+        person: !ref CrXoCsIucX  # connor-leahy
+        title: "CEO & Co-founder"
+        start: 2022-03
+        is_founder: true
+        source: https://www.conjecture.dev/
+        notes: "Previously co-founded EleutherAI; prominent AI safety advocate and public commentator"
+
+      i_KQFlH3C8xF:
+        person: sid-black
+        title: "Co-founder"
+        start: 2022-03
+        is_founder: true
+        notes: "Previously co-founded EleutherAI"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_T6Xnz3JUAl:
+        name: Cognitive Emulation (CoEm)
+        description: "Approach to building AI systems that emulate human cognitive processes rather than optimizing black-box objectives"
+        started: 2022-03
+        notes: "Core research thesis; aims to build interpretable AI by design rather than post-hoc"

--- a/packages/kb/data/things/connor-leahy.yaml
+++ b/packages/kb/data/things/connor-leahy.yaml
@@ -1,0 +1,28 @@
+thing:
+  id: connor-leahy
+  stableId: CrXoCsIucX
+  type: person
+  name: "Connor Leahy"
+  numericId: 71
+  aliases:
+    - Connor
+
+facts:
+  - id: f_6RTYYOtNHd
+    property: employed-by
+    value: !ref 0u4J70VqFY  # conjecture
+    asOf: 2022-03
+    source: https://www.conjecture.dev/
+    notes: "Co-founded Conjecture in 2022; previously co-founded EleutherAI"
+
+  - id: f_cflb799S8T
+    property: role
+    value: "CEO & Co-founder, Conjecture"
+    asOf: 2022-03
+    source: https://www.conjecture.dev/
+    notes: "Prominent public advocate for AI safety; testified before UK Parliament and EU; frequent media commentator"
+
+  - id: f_2HGntp6Jt1
+    property: born-year
+    value: 1998
+    notes: "Born approximately 1998; grew up in Germany"

--- a/packages/kb/data/things/daniela-amodei.yaml
+++ b/packages/kb/data/things/daniela-amodei.yaml
@@ -1,0 +1,36 @@
+thing:
+  id: daniela-amodei
+  stableId: tKMznr07QA
+  type: person
+  name: "Daniela Amodei"
+  numericId: 90
+  aliases:
+    - "Daniela"
+
+facts:
+  - id: f_R5GtlfjvmA
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: "2018"
+    validEnd: 2021-01
+    source: https://anthropic.com/company
+    notes: "VP of Operations at OpenAI before co-founding Anthropic"
+
+  - id: f_dtZnvHxrtw
+    property: role
+    value: "VP of Operations"
+    asOf: "2018"
+    validEnd: 2021-01
+
+  - id: f_9N4b6WjtiA
+    property: employed-by
+    value: !ref mK9pX3rQ7n  # anthropic
+    asOf: 2021-01
+    source: https://anthropic.com/company
+    notes: "Co-founded Anthropic in January 2021 with Dario Amodei and others; serves as President"
+
+  - id: f_oo5LmrgGtw
+    property: role
+    value: "President"
+    asOf: 2021-01
+    source: https://anthropic.com/company

--- a/packages/kb/data/things/dario-amodei.yaml
+++ b/packages/kb/data/things/dario-amodei.yaml
@@ -1,0 +1,27 @@
+thing:
+  id: dario-amodei
+  stableId: zR4nW8xB2f
+  type: person
+  name: "Dario Amodei"
+  numericId: 15
+  aliases:
+    - "Dario"
+
+facts:
+  - id: f_aE3mK7pQ9x
+    property: employed-by
+    value: !ref mK9pX3rQ7n  # anthropic
+    asOf: 2021-01
+    source: https://anthropic.com/company
+    notes: "Co-founded Anthropic in January 2021; serves as CEO"
+
+  - id: f_bT6wL2nH5v
+    property: role
+    value: "CEO"
+    asOf: 2021-01
+    source: https://anthropic.com/company
+
+  - id: f_cY9rP4jS1d
+    property: born-year
+    value: 1983
+    notes: "Born 1983; approximate from public reporting"

--- a/packages/kb/data/things/deepmind.yaml
+++ b/packages/kb/data/things/deepmind.yaml
@@ -1,0 +1,212 @@
+thing:
+  id: deepmind
+  stableId: A4XoubikkQ
+  type: organization
+  name: Google DeepMind
+  numericId: 98
+  aliases:
+    - DeepMind
+    - DeepMind Technologies
+    - Google DeepMind
+
+facts:
+  - id: f_mEKUPPFYRg
+    property: founded-date
+    value: 2010-09
+    source: https://en.wikipedia.org/wiki/Google_DeepMind
+    notes: "Founded September 2010 in London by Demis Hassabis, Shane Legg, and Mustafa Suleyman"
+
+  - id: f_pjpNfsuNKw
+    property: headquarters
+    value: "London, UK"
+    source: https://deepmind.google/about
+    notes: "Headquarters remain in London; additional offices in Mountain View, Paris, and other cities"
+
+  - id: f_nq7RXAwqsw
+    property: legal-structure
+    value: "Subsidiary of Alphabet Inc."
+    source: https://en.wikipedia.org/wiki/Google_DeepMind
+    notes: "Acquired by Google in January 2014 for approximately $500M; merged with Google Brain in April 2023 to form Google DeepMind"
+
+  - id: f_deepmind_founded_by
+    property: founded-by
+    value:
+      - !ref Aqcyu3onCA  # demis-hassabis
+      - shane-legg
+      - mustafa-suleyman
+    source: https://en.wikipedia.org/wiki/Google_DeepMind
+
+  - id: f_KtTrbGQynQ
+    property: headcount
+    value: 2700
+    asOf: 2024-12
+    source: https://en.wikipedia.org/wiki/Google_DeepMind
+    notes: "Approximate headcount after Google Brain merger; one of the largest AI research labs globally"
+
+  - id: f_dANFu1eouA
+    property: safety-researcher-count
+    value: 120
+    asOf: 2025-06
+    notes: "Estimated 100-150 researchers working on AI safety, alignment, and responsible AI across multiple teams"
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_cqQKO0KpfQ:
+        person: !ref Aqcyu3onCA  # demis-hassabis
+        title: "Co-founder & CEO"
+        start: 2010-09
+        is_founder: true
+        source: https://deepmind.google/about
+        notes: "CEO since founding; became head of Google DeepMind after 2023 Brain merger; 2024 Nobel Prize in Chemistry for AlphaFold"
+
+      i_hRsflrOEmQ:
+        person: shane-legg
+        title: "Co-founder & Chief AGI Scientist"
+        start: 2010-09
+        is_founder: true
+        source: https://deepmind.google/about
+        notes: "Leads AGI safety research; PhD on machine super intelligence"
+
+      i_qciZrFjeZw:
+        person: mustafa-suleyman
+        title: "Co-founder & Head of Applied AI"
+        start: 2010-09
+        end: 2022-01
+        is_founder: true
+        notes: "Left DeepMind in 2022; co-founded Inflection AI, then joined Microsoft as EVP and CEO of Microsoft AI in 2024"
+
+      i_fPMjZgiKoQ:
+        person: pushmeet-kohli
+        title: "VP of Research"
+        start: "2017"
+        source: https://deepmind.google/about
+        notes: "Leads research across science, safety, and foundational AI"
+
+  model-releases:
+    type: model-release
+    entries:
+      i_1ux32OwfMQ:
+        name: AlphaGo
+        released: 2016-01
+        description: "First AI to defeat a professional Go player; beat Lee Sedol 4-1 in March 2016"
+        source: https://deepmind.google/technologies/alphago/
+        notes: "Landmark achievement in AI; used deep reinforcement learning and Monte Carlo tree search"
+
+      i_JIOL3d0VCg:
+        name: AlphaFold
+        released: 2018-12
+        description: "Won CASP13 protein structure prediction competition"
+        source: https://deepmind.google/technologies/alphafold/
+        notes: "Revolutionized structural biology; AlphaFold 2 (2020) solved the protein folding problem"
+
+      i_etrnodoTbw:
+        name: AlphaFold 2
+        released: 2020-11
+        description: "Solved protein structure prediction; accuracy comparable to experimental methods"
+        source: https://www.nature.com/articles/s41586-021-03819-2
+        notes: "CASP14 median GDT score of 92.4; database of 200M+ predicted structures released 2022"
+
+      i_HyFb0PNE0w:
+        name: Gemini 1.0
+        released: 2023-12
+        description: "Google's first natively multimodal model family (Ultra, Pro, Nano)"
+        source: https://deepmind.google/technologies/gemini/
+        notes: "Ultra claimed to exceed GPT-4 on several benchmarks"
+
+      i_0jS4lG0xDw:
+        name: Gemini 1.5
+        released: 2024-02
+        description: "Introduced 1M token context window; mixture-of-experts architecture"
+        source: https://deepmind.google/technologies/gemini/
+        notes: "First commercially available model with 1M+ token context"
+
+      i_kNaEA6XilQ:
+        name: Gemini 2.0
+        released: 2024-12
+        description: "Next-generation Gemini with improved agentic capabilities"
+        source: https://deepmind.google/technologies/gemini/
+        notes: "Launched with Project Astra and other agentic features"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_7zcSaauqdA:
+        name: Game-Playing AI
+        description: "Reinforcement learning for complex games including Go, chess, StarCraft, and Diplomacy"
+        started: 2013-01
+        key-publication: https://www.nature.com/articles/nature16961
+        notes: "AlphaGo (2016), AlphaZero (2017), AlphaStar (2019)"
+
+      i_W8Bt29YtBg:
+        name: Protein Structure Prediction
+        description: "Deep learning for predicting 3D protein structures from amino acid sequences"
+        started: 2016-01
+        key-publication: https://www.nature.com/articles/s41586-021-03819-2
+        notes: "AlphaFold 2 solved the 50-year protein folding problem; Demis Hassabis received 2024 Nobel Prize in Chemistry"
+
+      i_3i8poI2o3A:
+        name: Neuroscience-Inspired AI
+        description: "Using insights from neuroscience to improve AI architectures and learning algorithms"
+        started: 2010-09
+        notes: "Core research area since founding; memory systems, attention, and reward-based learning"
+
+      i_lqETloaWNw:
+        name: AI Safety
+        description: "Responsible AI development including alignment, robustness, and societal impact"
+        started: 2017-01
+        key-publication: https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/
+        notes: "Frontier Safety Framework published 2024; safety team includes alignment, interpretability, and ethics researchers"
+
+  safety-milestones:
+    type: safety-milestone
+    entries:
+      i_8GlDHrsyiw:
+        name: "Specification Gaming Research"
+        date: 2020-04
+        type: research-paper
+        description: "Catalogued examples of AI systems exploiting reward misspecification"
+        source: https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/
+        notes: "Influential taxonomy of reward hacking failures"
+
+      i_PL3gh8Vfug:
+        name: "Frontier Safety Framework"
+        date: 2024-05
+        type: policy-update
+        description: "Framework for evaluating and mitigating risks from frontier AI models"
+        source: https://deepmind.google/discover/blog/introducing-the-frontier-safety-framework/
+        notes: "Defines Critical Capability Levels (CCLs) analogous to Anthropic's ASLs"
+
+      i_myU0a0pYoA:
+        name: "Dangerous Capability Evaluations"
+        date: 2023-10
+        type: safety-eval
+        description: "Systematic evaluations for dangerous capabilities in frontier models"
+        source: https://arxiv.org/abs/2311.09247
+        notes: "Published jointly with DeepMind safety team; covers bio, cyber, autonomy, and persuasion risks"
+
+  strategic-partnerships:
+    type: strategic-partnership
+    entries:
+      i_BdtkhsbPew:
+        partner: Google (Alphabet)
+        type: acquisition
+        date: 2014-01
+        investment_amount: 500e6
+        source: https://en.wikipedia.org/wiki/Google_DeepMind
+        notes: "Acquired by Google for approximately $500M; conditions included creation of AI ethics board"
+
+      i_Az3ry4WK8w:
+        partner: Google Brain
+        type: merger
+        date: 2023-04
+        source: https://blog.google/technology/ai/april-ai-update/
+        notes: "DeepMind merged with Google Brain to form Google DeepMind; Jeff Dean became Chief Scientist of Google DeepMind and Google Research"
+
+      i_SPdnZrrkgg:
+        partner: Isomorphic Labs
+        type: spin-off
+        date: 2021-11
+        source: https://www.isomorphiclabs.com/
+        notes: "Drug discovery spin-off from DeepMind, led by Demis Hassabis; leverages AlphaFold technology"

--- a/packages/kb/data/things/demis-hassabis.yaml
+++ b/packages/kb/data/things/demis-hassabis.yaml
@@ -1,0 +1,27 @@
+thing:
+  id: demis-hassabis
+  stableId: Aqcyu3onCA
+  type: person
+  name: "Demis Hassabis"
+  numericId: 101
+  aliases:
+    - "Demis"
+
+facts:
+  - id: f_86Rr7EPOYw
+    property: employed-by
+    value: !ref A4XoubikkQ  # deepmind
+    asOf: 2010-09
+    source: https://deepmind.google/about/
+    notes: "Co-founded DeepMind in September 2010; became CEO of Google DeepMind after the 2023 merger with Google Brain"
+
+  - id: f_Z0rg1G6BZw
+    property: role
+    value: "CEO"
+    asOf: 2010-09
+    source: https://deepmind.google/about/
+
+  - id: f_Kw56YLSHSQ
+    property: born-year
+    value: 1976
+    notes: "Born 1976 in London; awarded Nobel Prize in Chemistry 2024 for AlphaFold protein structure prediction"

--- a/packages/kb/data/things/dustin-moskovitz.yaml
+++ b/packages/kb/data/things/dustin-moskovitz.yaml
@@ -1,0 +1,29 @@
+thing:
+  id: dustin-moskovitz
+  stableId: Jtj6jHbuQ7
+  type: person
+  name: "Dustin Moskovitz"
+  numericId: 436
+  aliases:
+    - Dustin
+
+facts:
+  - id: f_KHaU3bGPmQ
+    property: employed-by
+    value: "Asana"
+    asOf: 2008-01
+    source: https://asana.com/company
+    notes: "Co-founded Asana in 2008 with Justin Rosenstein; serves as CEO"
+
+  - id: f_EUADNVkvmr
+    property: role
+    value: "CEO, Asana; Co-founder, Good Ventures / Open Philanthropy"
+    asOf: 2008-01
+    source: https://www.openphilanthropy.org/
+    notes: "Co-founded Facebook in 2004; youngest self-made billionaire at age 23; with wife Cari Tuna, funds Open Philanthropy and Good Ventures"
+
+  - id: f_8PBld3Shsv
+    property: born-year
+    value: 1984
+    source: https://en.wikipedia.org/wiki/Dustin_Moskovitz
+    notes: "Born May 22, 1984 in Gainesville, Florida"

--- a/packages/kb/data/things/eliezer-yudkowsky.yaml
+++ b/packages/kb/data/things/eliezer-yudkowsky.yaml
@@ -1,0 +1,30 @@
+thing:
+  id: eliezer-yudkowsky
+  stableId: fS1tEGKuNq
+  type: person
+  name: "Eliezer Yudkowsky"
+  numericId: 114
+  aliases:
+    - Eliezer
+    - EY
+
+facts:
+  - id: f_pMYY3GyUXY
+    property: employed-by
+    value: !ref puAffUjWSS  # miri
+    asOf: 2000-01
+    source: https://intelligence.org/about/
+    notes: "Founded MIRI (originally Singularity Institute) in 2000; has been its primary researcher and intellectual leader"
+
+  - id: f_zu6WSAbDAq
+    property: role
+    value: "Founder & Senior Research Fellow"
+    asOf: 2000-01
+    source: https://intelligence.org/about/
+    notes: "Pioneered the field of AI alignment research; author of the Sequences and HPMOR"
+
+  - id: f_NYrlVTqJXm
+    property: born-year
+    value: 1979
+    source: https://en.wikipedia.org/wiki/Eliezer_Yudkowsky
+    notes: "Born September 11, 1979 in Chicago, Illinois"

--- a/packages/kb/data/things/elon-musk.yaml
+++ b/packages/kb/data/things/elon-musk.yaml
@@ -1,0 +1,42 @@
+thing:
+  id: elon-musk
+  stableId: 69vftmr1jg
+  type: person
+  name: "Elon Musk"
+  numericId: 116
+  aliases:
+    - "Musk"
+
+facts:
+  - id: f_N2rrW9c6JA
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2015-12
+    validEnd: 2018-02
+    source: https://openai.com/blog/introducing-openai
+    notes: "Co-founded OpenAI December 2015; left board February 2018, later sued OpenAI alleging breach of founding mission"
+
+  - id: f_Xd4JyJmh7A
+    property: role
+    value: "Co-chairman"
+    asOf: 2015-12
+    validEnd: 2018-02
+    source: https://openai.com/blog/introducing-openai
+
+  - id: f_7FJCjl4c9Q
+    property: employed-by
+    value: !ref GLXKjYAEKw  # xai
+    asOf: 2023-03
+    source: https://x.ai
+    notes: "Founded xAI in March 2023 to develop AI; also CEO of Tesla and SpaceX"
+
+  - id: f_AJGGu7rpAw
+    property: role
+    value: "Founder & CEO"
+    asOf: 2023-03
+    source: https://x.ai
+
+  - id: f_CwDWKGq7Ig
+    property: born-year
+    value: 1971
+    notes: "Born June 28, 1971 in Pretoria, South Africa"

--- a/packages/kb/data/things/geoffrey-hinton.yaml
+++ b/packages/kb/data/things/geoffrey-hinton.yaml
@@ -1,0 +1,36 @@
+thing:
+  id: geoffrey-hinton
+  stableId: 5N5UqXNkkg
+  type: person
+  name: "Geoffrey Hinton"
+  numericId: 149
+  aliases:
+    - "Geoff Hinton"
+    - "Godfather of Deep Learning"
+
+facts:
+  - id: f_CQptGEFesw
+    property: employed-by
+    value: !ref A4XoubikkQ  # deepmind
+    asOf: 2013-03
+    validEnd: 2023-05
+    source: https://www.nytimes.com/2023/05/01/technology/ai-google-chatbot-engineer-quits-hinton.html
+    notes: "VP and Engineering Fellow at Google; resigned May 2023 to speak freely about AI risks"
+
+  - id: f_dIsk3jBSrg
+    property: role
+    value: "VP and Engineering Fellow"
+    asOf: 2013-03
+    validEnd: 2023-05
+    source: https://www.nytimes.com/2023/05/01/technology/ai-google-chatbot-engineer-quits-hinton.html
+
+  - id: f_l7LgM4CmFg
+    property: role
+    value: "Professor Emeritus"
+    asOf: "2023"
+    notes: "University of Toronto; professor emeritus of computer science"
+
+  - id: f_xrorsSWSXw
+    property: born-year
+    value: 1947
+    notes: "Born 1947 in London; Nobel Prize in Physics 2024 for foundational work on artificial neural networks"

--- a/packages/kb/data/things/greg-brockman.yaml
+++ b/packages/kb/data/things/greg-brockman.yaml
@@ -1,0 +1,28 @@
+thing:
+  id: greg-brockman
+  stableId: Yq4s2cI7ng
+  type: person
+  name: "Greg Brockman"
+  aliases:
+    - "Brockman"
+
+facts:
+  - id: f_tZxixtemow
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2015-12
+    validEnd: 2024-08
+    source: https://openai.com/blog/introducing-openai
+    notes: "Co-founded OpenAI December 2015; served as President until taking leave of absence August 2024"
+
+  - id: f_NqlyTekRKg
+    property: role
+    value: "Co-founder & President"
+    asOf: 2015-12
+    validEnd: 2024-08
+    source: https://openai.com/blog/introducing-openai
+
+  - id: f_qVoWltsFvw
+    property: born-year
+    value: 1988
+    notes: "Born 1988 (approximate); previously CTO of Stripe before co-founding OpenAI"

--- a/packages/kb/data/things/holden-karnofsky.yaml
+++ b/packages/kb/data/things/holden-karnofsky.yaml
@@ -1,0 +1,58 @@
+thing:
+  id: holden-karnofsky
+  stableId: eQh3ZhWv8D
+  type: person
+  name: "Holden Karnofsky"
+  numericId: 156
+  aliases:
+    - Holden
+
+facts:
+  - id: f_hk_givewell
+    property: employed-by
+    value: "GiveWell"
+    asOf: 2007-01
+    validEnd: "2014"
+    source: https://www.givewell.org/about/people
+    notes: "Co-founded GiveWell in 2007 with Elie Hassenfeld"
+
+  - id: f_hk_openphil
+    property: employed-by
+    value: "Open Philanthropy"
+    asOf: 2014-01
+    validEnd: "2024"
+    source: https://www.openphilanthropy.org/about/team/
+    notes: "Co-CEO of Open Philanthropy from 2017; stepped back from operational role in 2024"
+
+  - id: f_vAidx4lhTo
+    property: employed-by
+    value: !ref mK9pX3rQ7n  # anthropic
+    asOf: 2025-01
+    source: https://www.anthropic.com/
+    notes: "Joined Anthropic as Member of Technical Staff in early 2025; works on responsible scaling policy"
+
+  - id: f_hk_role_givewell
+    property: role
+    value: "Co-founder & Co-Executive Director, GiveWell"
+    asOf: 2007-01
+    validEnd: "2014"
+    source: https://www.givewell.org/about/people
+
+  - id: f_hk_role_openphil
+    property: role
+    value: "Co-CEO, Open Philanthropy"
+    asOf: 2017-01
+    validEnd: "2024"
+    source: https://www.openphilanthropy.org/about/team/
+
+  - id: f_XAT3w4UXai
+    property: role
+    value: "Member of Technical Staff, Anthropic"
+    asOf: 2025-01
+    notes: "Also serves as Anthropic board observer"
+
+  - id: f_jptHKWBAFL
+    property: born-year
+    value: 1981
+    source: https://en.wikipedia.org/wiki/Holden_Karnofsky
+    notes: "Born approximately 1981"

--- a/packages/kb/data/things/ilya-sutskever.yaml
+++ b/packages/kb/data/things/ilya-sutskever.yaml
@@ -1,0 +1,42 @@
+thing:
+  id: ilya-sutskever
+  stableId: eYrBgMLJDw
+  type: person
+  name: "Ilya Sutskever"
+  numericId: 163
+  aliases:
+    - "Ilya"
+
+facts:
+  - id: f_qfd3qL21HQ
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2015-12
+    validEnd: 2024-06
+    source: https://openai.com/blog/introducing-openai
+    notes: "Co-founded OpenAI in December 2015; served as Chief Scientist until departing June 2024"
+
+  - id: f_58HUz4jCeA
+    property: role
+    value: "Co-founder & Chief Scientist"
+    asOf: 2015-12
+    validEnd: 2024-06
+    source: https://openai.com/blog/introducing-openai
+
+  - id: f_QtqNoKoBgw
+    property: employed-by
+    value: !ref 1OSiYOaWVL  # ssi
+    asOf: 2024-06
+    source: https://ssi.inc
+    notes: "Co-founded Safe Superintelligence Inc (SSI) in June 2024 with Daniel Gross and Daniel Levy"
+
+  - id: f_rDk51er7Jw
+    property: role
+    value: "Co-founder & Chief Scientist"
+    asOf: 2024-06
+    source: https://ssi.inc
+
+  - id: f_D7v4CpKtMw
+    property: born-year
+    value: 1985
+    notes: "Born 1985 (approximate); originally from Russia, studied under Geoffrey Hinton at University of Toronto"

--- a/packages/kb/data/things/jan-leike.yaml
+++ b/packages/kb/data/things/jan-leike.yaml
@@ -1,0 +1,31 @@
+thing:
+  id: jan-leike
+  stableId: hQ7mR2kN5p
+  type: person
+  name: "Jan Leike"
+  numericId: 67
+  aliases:
+    - "Jan Leike"
+
+facts:
+  - id: f_dF5bX8wC3g
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2021-01
+    validEnd: 2024-05
+    source: https://openai.com/blog/introducing-superalignment
+    notes: "Joined OpenAI circa 2021; co-led the Superalignment team from its founding in July 2023"
+
+  - id: f_eH9jV6nK4t
+    property: employed-by
+    value: !ref mK9pX3rQ7n  # anthropic
+    asOf: 2024-05
+    source: https://anthropic.com/news/jan-leike-joins-anthropic
+    notes: "Resigned from OpenAI in May 2024, citing safety concerns; joined Anthropic same month to lead Alignment Science team"
+
+  - id: f_gW2pL8rA7m
+    property: role
+    value: "Head of Alignment Science"
+    asOf: 2024-05
+    source: https://anthropic.com/news/jan-leike-joins-anthropic
+    notes: "Leads alignment science at Anthropic; focuses on scalable oversight, weak-to-strong generalization, and robustness to jailbreaks"

--- a/packages/kb/data/things/meta-ai.yaml
+++ b/packages/kb/data/things/meta-ai.yaml
@@ -1,0 +1,178 @@
+thing:
+  id: meta-ai
+  stableId: tt0f5PYDCw
+  type: organization
+  name: Meta AI (FAIR)
+  numericId: 549
+  aliases:
+    - Meta AI
+    - FAIR
+    - Facebook AI Research
+    - Meta Fundamental AI Research
+
+facts:
+  - id: f_S2gCtemHdA
+    property: founded-date
+    value: 2013-12
+    source: https://ai.meta.com/research/
+    notes: "Founded December 2013 as Facebook AI Research (FAIR) by Yann LeCun; rebranded to Meta AI after Meta rebrand in 2021"
+
+  - id: f_S0d9WF0E8g
+    property: headquarters
+    value: "Menlo Park, CA"
+    source: https://ai.meta.com/
+    notes: "Part of Meta Platforms; labs also in New York, Paris, Montreal, London, and Tel Aviv"
+
+  - id: f_meta_ai_founded_by
+    property: founded-by
+    value:
+      - !ref cMbVUVK29Q  # yann-lecun
+    source: https://ai.meta.com/research/
+
+  - id: f_Hh20Dvc90g
+    property: legal-structure
+    value: "Division of Meta Platforms, Inc."
+    source: https://ai.meta.com/
+    notes: "Not a separate legal entity; research division within Meta Platforms (formerly Facebook)"
+
+  - id: f_adIN3DEEYw
+    property: headcount
+    value: 1500
+    asOf: 2024-12
+    notes: "Estimated 1,000-2,000 AI researchers across FAIR and Meta GenAI teams; exact figure not publicly disclosed"
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_cJk7Lzvb8A:
+        person: !ref cMbVUVK29Q  # yann-lecun
+        title: "Chief AI Scientist"
+        start: 2013-12
+        is_founder: true
+        source: https://ai.meta.com/people/yann-lecun/
+        notes: "Founded FAIR in 2013; 2018 Turing Award laureate for deep learning; vocal critic of AI x-risk concerns"
+
+      i_iUQiI2nm3w:
+        person: joelle-pineau
+        title: "VP of AI Research"
+        start: 2017-01
+        source: https://ai.meta.com/people/joelle-pineau/
+        notes: "Leads FAIR; McGill professor; advocates for reproducible research and open science"
+
+      i_odSCjkqupQ:
+        person: ahmad-al-dahle
+        title: "VP of Generative AI"
+        start: 2023-01
+        source: https://ai.meta.com/
+        notes: "Leads Meta's Generative AI group responsible for Llama models"
+
+      i_eeaaZZitVw:
+        person: mark-zuckerberg
+        title: "CEO of Meta Platforms"
+        start: 2004-02
+        notes: "Drives overall AI strategy for Meta; committed to open-source AI approach"
+
+  model-releases:
+    type: model-release
+    entries:
+      i_dQ2q0XoGsg:
+        name: LLaMA
+        released: 2023-02
+        description: "First LLaMA model family (7B-65B params); initially restricted release, later leaked"
+        source: https://ai.meta.com/blog/large-language-model-llama-meta-ai/
+        notes: "Catalyzed open-source LLM ecosystem; 65B model competitive with GPT-3.5"
+
+      i_L9z2viCpOg:
+        name: LLaMA 2
+        released: 2023-07
+        description: "Open-weight release (7B-70B params) with commercial license"
+        source: https://ai.meta.com/llama/
+        notes: "Trained on 2T tokens; partnership with Microsoft for Azure distribution"
+
+      i_x2ckZfsuWg:
+        name: LLaMA 3
+        released: 2024-04
+        description: "Major upgrade (8B, 70B params); 405B released July 2024"
+        source: https://ai.meta.com/blog/meta-llama-3/
+        notes: "405B was largest open-weight model at release; trained on 15T+ tokens"
+
+      i_rmmt1cxUYQ:
+        name: Llama 4
+        released: 2025-04
+        description: "Next-generation open-weight models with mixture-of-experts architecture"
+        source: https://ai.meta.com/blog/llama-4/
+        notes: "Scout (17B active/109B total) and Maverick (17B active/400B total) variants; 10M token context"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_WRN6WDIWEA:
+        name: Self-Supervised Learning
+        description: "Learning representations from unlabeled data; foundation of modern LLM training"
+        started: 2014-01
+        notes: "Core research philosophy under Yann LeCun; underpins Meta's approach to foundation models"
+
+      i_dWQ1tyEyIQ:
+        name: Computer Vision
+        description: "Image recognition, object detection, and visual understanding"
+        started: 2013-12
+        key-publication: https://arxiv.org/abs/2304.07193
+        notes: "Segment Anything Model (SAM) released 2023; DINOv2 self-supervised vision transformer"
+
+      i_KRrEpBe9qg:
+        name: Open-Source AI
+        description: "Developing and releasing AI models and tools under open licenses"
+        started: 2015-01
+        key-publication: https://ai.meta.com/llama/
+        notes: "Meta's flagship open-source strategy; PyTorch (2016), Llama series, SAM, and numerous research tools"
+
+      i_MhqUFi4aPQ:
+        name: Natural Language Processing
+        description: "Language understanding, generation, and translation"
+        started: 2013-12
+        notes: "NLLB (No Language Left Behind) translation for 200+ languages; contributed to multilingual AI research"
+
+  products:
+    type: product
+    entries:
+      i_bY4yJLhaVg:
+        name: PyTorch
+        launched: 2016-09
+        description: "Open-source deep learning framework; became de facto standard for AI research"
+        source: https://pytorch.org/
+        notes: "Moved to Linux Foundation in 2022; used by majority of ML researchers globally"
+
+      i_F316prKByQ:
+        name: Meta AI Assistant
+        launched: 2023-09
+        description: "AI assistant integrated across Meta apps (WhatsApp, Instagram, Messenger, Facebook)"
+        source: https://ai.meta.com/
+        notes: "Powered by Llama models; available across Meta's 3B+ user platform"
+
+  safety-milestones:
+    type: safety-milestone
+    entries:
+      i_11RphliYhA:
+        name: Llama Guard
+        date: 2023-12
+        type: safety-eval
+        description: "Open-source LLM-based safeguard model for content moderation"
+        source: https://ai.meta.com/research/publications/llama-guard-llm-based-input-output-safeguard-for-human-ai-conversations/
+        notes: "Released with Llama model family; classifies prompt and response safety"
+
+      i_AGibAmrtWQ:
+        name: "Responsible Use Guide"
+        date: 2023-07
+        type: policy-update
+        description: "Guidelines for responsible deployment of Llama models"
+        source: https://ai.meta.com/llama/use-policy/
+        notes: "Acceptable use policy accompanying Llama 2 open-weight release"
+
+      i_VtQe4Fmarw:
+        name: Purple Llama
+        date: 2023-12
+        type: safety-eval
+        description: "Open-source tools for evaluating and improving LLM safety including CyberSecEval"
+        source: https://ai.meta.com/blog/purple-llama-open-trust-safety-generative-ai/
+        notes: "Collaborative project for AI safety evaluations; includes Llama Guard and CyberSecEval benchmarks"

--- a/packages/kb/data/things/miri.yaml
+++ b/packages/kb/data/things/miri.yaml
@@ -1,0 +1,76 @@
+thing:
+  id: miri
+  stableId: puAffUjWSS
+  type: organization
+  name: "Machine Intelligence Research Institute"
+  numericId: 202
+  aliases:
+    - MIRI
+    - Singularity Institute
+    - Singularity Institute for Artificial Intelligence
+    - SIAI
+
+facts:
+  - id: f_0YMlj7An1L
+    property: founded-date
+    value: 2000-01
+    source: https://intelligence.org/about/
+    notes: "Founded in 2000 as the Singularity Institute for Artificial Intelligence; renamed to MIRI in 2013"
+
+  - id: f_fiWGIkqBqf
+    property: headquarters
+    value: "Berkeley, CA"
+    source: https://intelligence.org/about/
+    notes: "Based in Berkeley, California"
+
+  - id: f_XPZa86Jco0
+    property: legal-structure
+    value: "501(c)(3) nonprofit"
+    source: https://intelligence.org/about/
+
+  - id: f_miri_founded_by
+    property: founded-by
+    value:
+      - !ref fS1tEGKuNq  # eliezer-yudkowsky
+    source: https://intelligence.org/about/
+
+  - id: f_EUnXQGwIzd
+    property: headcount
+    value: 18
+    asOf: 2023-12
+    source: https://intelligence.org/2024/04/02/2023-review/
+    notes: "Approximate staff count in 2023; MIRI significantly reduced staff in 2023-2024 as it shifted focus"
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_XVLjPAQXky:
+        person: !ref fS1tEGKuNq  # eliezer-yudkowsky
+        title: "Founder & Senior Research Fellow"
+        start: 2000-01
+        is_founder: true
+        source: https://intelligence.org/about/
+        notes: "Founded MIRI (as SIAI) in 2000; transitioned to Senior Research Fellow role"
+
+      i_ZJ54jX7Ppq:
+        person: nate-soares
+        title: "Executive Director"
+        start: 2015-05
+        source: https://intelligence.org/2015/05/18/nate-soares-is-miris-new-executive-director/
+        notes: "Led MIRI's operations and research agenda"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_w1EXpcMmLN:
+        name: Agent Foundations
+        description: "Mathematical foundations of goal-directed AI systems"
+        started: 2014-01
+        notes: "Core research program focused on logical uncertainty, decision theory, and Vingean reflection"
+
+      i_6z7IpVMRRT:
+        name: Alignment Theory
+        description: "Theoretical approaches to ensuring advanced AI systems are aligned with human values"
+        started: 2000-01
+        notes: "MIRI's founding research focus; published extensively on corrigibility and value alignment"

--- a/packages/kb/data/things/neel-nanda.yaml
+++ b/packages/kb/data/things/neel-nanda.yaml
@@ -1,0 +1,28 @@
+thing:
+  id: neel-nanda
+  stableId: zaRXTCXPPk
+  type: person
+  name: "Neel Nanda"
+  numericId: 214
+  aliases:
+    - Neel
+
+facts:
+  - id: f_MC1O0jwEcB
+    property: employed-by
+    value: !ref A4XoubikkQ  # deepmind
+    asOf: 2023-01
+    source: https://www.neelnanda.io/
+    notes: "Research Scientist at Google DeepMind working on mechanistic interpretability"
+
+  - id: f_oLC3AS7GeZ
+    property: role
+    value: "Research Scientist, Google DeepMind"
+    asOf: 2023-01
+    source: https://www.neelnanda.io/
+    notes: "Leading mechanistic interpretability research at DeepMind; previously at Anthropic; creator of TransformerLens library"
+
+  - id: f_Gnpzguqlys
+    property: born-year
+    value: 1999
+    notes: "Born approximately 1999"

--- a/packages/kb/data/things/nick-bostrom.yaml
+++ b/packages/kb/data/things/nick-bostrom.yaml
@@ -1,0 +1,29 @@
+thing:
+  id: nick-bostrom
+  stableId: IQvWHA3OiF
+  type: person
+  name: "Nick Bostrom"
+  numericId: 215
+  aliases:
+    - Niklas Bostr\u00F6m
+
+facts:
+  - id: f_1dHuIat2Xt
+    property: employed-by
+    value: "University of Oxford"
+    asOf: 2005-01
+    source: https://nickbostrom.com/
+    notes: "Founded the Future of Humanity Institute (FHI) at Oxford in 2005; FHI closed in April 2024"
+
+  - id: f_F5iVdik64y
+    property: role
+    value: "Professor of Philosophy, University of Oxford; Founder of FHI"
+    asOf: 2005-01
+    source: https://nickbostrom.com/
+    notes: "Author of 'Superintelligence: Paths, Dangers, Strategies' (2014), which catalyzed mainstream concern about AI existential risk"
+
+  - id: f_YhxyxeHHdA
+    property: born-year
+    value: 1973
+    source: https://en.wikipedia.org/wiki/Nick_Bostrom
+    notes: "Born March 10, 1973 in Helsingborg, Sweden"

--- a/packages/kb/data/things/openai.yaml
+++ b/packages/kb/data/things/openai.yaml
@@ -1,0 +1,216 @@
+thing:
+  id: openai
+  stableId: 1LcLlMGLbw
+  type: organization
+  name: OpenAI
+  numericId: 4
+  aliases:
+    - OpenAI Inc
+    - OpenAI LP
+    - OpenAI Global LLC
+
+facts:
+  - id: f_1Y4HfGVOvA
+    property: founded-date
+    value: 2015-12
+    source: https://openai.com/blog/introducing-openai
+    notes: "Founded December 2015 by Sam Altman, Ilya Sutskever, Greg Brockman, Elon Musk, Wojciech Zaremski, and John Schulman"
+
+  - id: f_jyRF7MXyWw
+    property: headquarters
+    value: "San Francisco, CA"
+    source: https://openai.com/about
+
+  - id: f_78GQ07iiCQ
+    property: legal-structure
+    value: "Nonprofit 501(c)(3)"
+    asOf: 2015-12
+    validEnd: "2019-03"
+    source: https://openai.com/blog/introducing-openai
+    notes: "Originally incorporated as nonprofit OpenAI Inc."
+
+  - id: f_legalStruct2
+    property: legal-structure
+    value: "Capped-profit LLC"
+    asOf: 2019-03
+    validEnd: "2025"
+    source: https://openai.com/blog/openai-lp
+    notes: "Created capped-profit subsidiary OpenAI LP"
+
+  - id: f_legalStruct3
+    property: legal-structure
+    value: "Public Benefit Corporation (converting)"
+    asOf: "2025"
+    source: https://openai.com/blog/openai-lp
+    notes: "Announced conversion to PBC in 2025"
+
+  - id: f_openai_founded_by
+    property: founded-by
+    value:
+      - !ref JKsVHQ5stQ  # sam-altman
+      - !ref eYrBgMLJDw  # ilya-sutskever
+      - !ref Yq4s2cI7ng  # greg-brockman
+      - !ref 69vftmr1jg  # elon-musk
+      - wojciech-zaremba
+      - john-schulman
+    source: https://openai.com/blog/introducing-openai
+
+  - id: f_HfB3WmNDFQ
+    property: total-funding
+    value: 13e9
+    asOf: 2024-01
+    source: https://blogs.microsoft.com/blog/2023/01/23/microsoftandopenai/
+    notes: "Microsoft cumulative investment across multiple rounds"
+
+  - id: f_b56n3kcD2g
+    property: valuation
+    value: 157e9
+    asOf: 2024-12
+    notes: "October 2024 funding round valuation"
+
+  - id: f_YZ7zzKgBsA
+    property: valuation
+    value: 500e9
+    asOf: 2025-10
+    notes: "Secondary share sale valuation, October 2025"
+
+  - id: f_yvm9QNFjdA
+    property: revenue
+    value: 3.4e9
+    asOf: 2024-10
+    notes: "Annualized run rate as of mid-2024"
+
+  - id: f_w3pWgejwIA
+    property: revenue
+    value: 20e9
+    asOf: "2025"
+    notes: "ARR per CFO Sarah Friar disclosure"
+
+  - id: f_5VcbvP89LA
+    property: user-count
+    value: 100e6
+    asOf: 2023-02
+    notes: "ChatGPT reached 100M monthly active users within 2 months of launch; fastest-growing consumer application in history at that time"
+
+  - id: f_o1tcwe2T0w
+    property: headcount
+    value: 3500
+    asOf: "2025"
+    notes: "Approximate headcount estimate as of 2025"
+
+  - id: f_xW3cN7mP4q
+    property: market-share
+    value: 55
+    asOf: 2025-12
+    notes: "Enterprise LLM API market share (estimated); dominant position from ChatGPT/GPT-4"
+
+  - id: f_rK9bF2vL6s
+    property: market-share
+    value: 50
+    asOf: 2026-02
+    notes: "Enterprise LLM API market share (estimated); declining slightly as competitors grow"
+
+  - id: f_hJ5dQ8nT3w
+    property: gross-margin
+    value: 35
+    asOf: 2025-12
+    notes: "Approximate gross margin; lower than Anthropic due to heavier compute usage"
+
+items:
+  funding-rounds:
+    type: funding-round
+    entries:
+      i_r5HaOs6mXg:
+        date: 2015-12
+        amount: 1e9
+        notes: "Initial $1B commitment from founders and backers including Elon Musk, Sam Altman, Peter Thiel, Reid Hoffman, Jessica Livingston"
+        source: https://openai.com/blog/introducing-openai
+
+      i_RHwgHUtkcw:
+        date: 2019-07
+        amount: 1e9
+        lead_investor: microsoft
+        source: https://openai.com/blog/microsoft
+        notes: "Microsoft's initial $1B investment; coincided with creation of capped-profit entity OpenAI LP"
+
+      i_Jghs4gXSnw:
+        date: 2023-01
+        amount: 10e9
+        lead_investor: microsoft
+        source: https://blogs.microsoft.com/blog/2023/01/23/microsoftandopenai/
+        notes: "Microsoft's multi-year, multi-billion dollar investment reported at ~$10B; brought total Microsoft commitment to ~$13B"
+
+      i_eTZe3xfv0w:
+        date: 2024-10
+        amount: 6.6e9
+        valuation: 157e9
+        lead_investor: thrive-capital
+        source: https://www.wsj.com/tech/ai/openai-completes-6-6-billion-funding-round-e16ffab4
+        notes: "Led by Thrive Capital; investors included Microsoft, NVIDIA, SoftBank, and others"
+
+  key-people:
+    type: key-person
+    entries:
+      i_ehqVPXPsgg:
+        person: !ref JKsVHQ5stQ  # sam-altman
+        title: CEO
+        start: 2019-03
+        is_founder: true
+        source: https://openai.com/about
+        notes: "Co-chairman from founding (2015); became CEO when OpenAI LP was created in 2019. Briefly fired and reinstated in November 2023."
+
+      i_g3658QZeaA:
+        person: !ref eYrBgMLJDw  # ilya-sutskever
+        title: "Co-founder & Chief Scientist"
+        start: 2015-12
+        end: 2024-06
+        is_founder: true
+        source: https://openai.com/blog/introducing-openai
+        notes: "Left OpenAI in June 2024 to found Safe Superintelligence Inc (SSI)"
+
+      i_zhIYVQlAcQ:
+        person: !ref Yq4s2cI7ng  # greg-brockman
+        title: President
+        start: 2015-12
+        end: 2024-08
+        is_founder: true
+        notes: "Co-founder and president; took leave of absence in August 2024"
+
+      i_G3hMEl1Smg:
+        person: mira-murati
+        title: CTO
+        start: "2018"
+        end: 2024-09
+        source: https://openai.com/about
+        notes: "Served as interim CEO during Sam Altman's brief ousting in November 2023; departed September 2024"
+
+      i_dfRtbbZ86w:
+        person: !ref hQ7mR2kN5p  # jan-leike
+        title: "Co-lead, Superalignment"
+        start: 2023-07
+        end: 2024-05
+        source: https://openai.com/blog/introducing-superalignment
+        notes: "Co-led Superalignment team from its founding in July 2023; resigned May 2024 citing safety concerns, joined Anthropic"
+
+      i_n2EXWPmoaw:
+        person: !ref 69vftmr1jg  # elon-musk
+        title: "Co-chairman (board)"
+        start: 2015-12
+        end: 2018-02
+        is_founder: true
+        notes: "Left the board in February 2018; later sued OpenAI alleging breach of founding agreement"
+
+      i_G6F08BW94g:
+        person: john-schulman
+        title: "Co-founder, Research"
+        start: 2015-12
+        end: 2024-08
+        is_founder: true
+        notes: "Key contributor to RLHF and PPO; departed August 2024 to join Anthropic"
+
+      i_eGGLFokWkw:
+        person: wojciech-zaremba
+        title: "Co-founder, VP of Research"
+        start: 2015-12
+        is_founder: true
+        notes: "Leads codegen research; one of the few remaining co-founders as of 2025"

--- a/packages/kb/data/things/paul-christiano.yaml
+++ b/packages/kb/data/things/paul-christiano.yaml
@@ -1,0 +1,35 @@
+thing:
+  id: paul-christiano
+  stableId: vzxfzxBITd
+  type: person
+  name: "Paul Christiano"
+  numericId: 220
+  aliases:
+    - Paul
+
+facts:
+  - id: f_rPQmiVa1LH
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2017-01
+    validEnd: 2021-10
+    source: https://paulfchristiano.com/
+    notes: "Researcher at OpenAI from 2017 to 2021; led alignment research including RLHF work"
+
+  - id: f_qPXcXJF3Uv
+    property: employed-by
+    value: !ref QsXVXtQ0zE  # arc
+    asOf: 2021-10
+    source: https://alignment.org/
+    notes: "Founded Alignment Research Center (ARC) in 2021; stepped back from day-to-day operations in 2023 due to a brain injury"
+
+  - id: f_rvwYSk7eFi
+    property: role
+    value: "Founder, Alignment Research Center"
+    asOf: 2021-10
+    source: https://alignment.org/
+
+  - id: f_ZmXlEP6Y6H
+    property: born-year
+    value: 1992
+    notes: "Born approximately 1992; PhD from UC Berkeley"

--- a/packages/kb/data/things/redwood-research.yaml
+++ b/packages/kb/data/things/redwood-research.yaml
@@ -1,0 +1,66 @@
+thing:
+  id: redwood-research
+  stableId: dwMzc9WzPa
+  type: organization
+  name: "Redwood Research"
+  numericId: 557
+  aliases:
+    - Redwood
+
+facts:
+  - id: f_GXvWNFPV7M
+    property: founded-date
+    value: 2021-06
+    source: https://www.redwoodresearch.org/
+    notes: "Founded in 2021 by Nate Thomas and Buck Shlegeris"
+
+  - id: f_gnQEBSrD2L
+    property: headquarters
+    value: "San Francisco, CA"
+    source: https://www.redwoodresearch.org/
+
+  - id: f_72UoXSEqwe
+    property: legal-structure
+    value: "Nonprofit research lab"
+    source: https://www.redwoodresearch.org/
+
+  - id: f_redwood_founded_by
+    property: founded-by
+    value:
+      - nate-thomas
+      - buck-shlegeris
+    source: https://www.redwoodresearch.org/
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_kWW8MALtes:
+        person: buck-shlegeris
+        title: "CEO & Co-founder"
+        start: 2021-06
+        is_founder: true
+        source: https://www.redwoodresearch.org/
+        notes: "Previously researcher at MIRI; leads Redwood's research agenda on AI control"
+
+      i_tAoC59MQQm:
+        person: nate-thomas
+        title: "Co-founder"
+        start: 2021-06
+        is_founder: true
+
+  research-areas:
+    type: research-area
+    entries:
+      i_zrcx3YA1du:
+        name: AI Control
+        description: "Developing techniques to safely deploy AI systems even if they are not fully aligned"
+        started: 2023-01
+        key-publication: https://arxiv.org/abs/2312.06942
+        notes: "Key paper on AI control; argues control is a complementary approach to alignment"
+
+      i_tvVCFqoWUv:
+        name: Adversarial Robustness
+        description: "Testing and improving robustness of AI safety techniques against adversarial inputs"
+        started: 2021-06
+        notes: "Early work on adversarial training for harmlessness classifiers"

--- a/packages/kb/data/things/sam-altman.yaml
+++ b/packages/kb/data/things/sam-altman.yaml
@@ -1,0 +1,36 @@
+thing:
+  id: sam-altman
+  stableId: JKsVHQ5stQ
+  type: person
+  name: "Sam Altman"
+  numericId: 16
+  aliases:
+    - "Samuel H. Altman"
+
+facts:
+  - id: f_StIAxD850A
+    property: employed-by
+    value: !ref 1LcLlMGLbw  # openai
+    asOf: 2015-12
+    source: https://openai.com/about
+    notes: "Co-founded OpenAI in December 2015; co-chairman initially, became CEO in 2019 when capped-profit entity was created"
+
+  - id: f_WLIAavRzUQ
+    property: role
+    value: "CEO"
+    asOf: 2019-03
+    source: https://openai.com/about
+    notes: "Briefly fired by the board on November 17, 2023; reinstated November 22, 2023 after employee revolt and Microsoft intervention"
+
+  - id: f_ZfbfHkh9Uw
+    property: born-year
+    value: 1985
+    notes: "Born April 22, 1985 in Chicago, Illinois"
+
+  - id: f_Zu4CcuDsTw
+    property: role
+    value: "President, Y Combinator"
+    asOf: "2014"
+    validEnd: "2019"
+    source: https://www.ycombinator.com/blog/sam-altman-is-the-new-president-of-y-combinator
+    notes: "Succeeded Paul Graham as YC president in 2014; stepped down in 2019 to focus on OpenAI full-time"

--- a/packages/kb/data/things/ssi.yaml
+++ b/packages/kb/data/things/ssi.yaml
@@ -1,0 +1,77 @@
+thing:
+  id: ssi
+  stableId: 1OSiYOaWVL
+  type: organization
+  name: "Safe Superintelligence Inc"
+  numericId: 425
+  aliases:
+    - SSI
+    - Safe Superintelligence
+
+facts:
+  - id: f_RYwXutlEmN
+    property: founded-date
+    value: 2024-06
+    source: https://ssi.inc
+    notes: "Founded June 2024 by Ilya Sutskever, Daniel Gross, and Daniel Levy after Sutskever's departure from OpenAI"
+
+  - id: f_wsceMu4laG
+    property: headquarters
+    value: "Palo Alto, CA"
+    source: https://ssi.inc
+    notes: "Dual offices in Palo Alto and Tel Aviv"
+
+  - id: f_kS32utFnCA
+    property: legal-structure
+    value: "Private company"
+    source: https://ssi.inc
+
+  - id: f_ssi_founded_by
+    property: founded-by
+    value:
+      - !ref eYrBgMLJDw  # ilya-sutskever
+      - daniel-gross
+      - daniel-levy
+    source: https://ssi.inc
+
+  - id: f_Oa0nwGGdna
+    property: total-funding
+    value: 1e9
+    asOf: 2024-09
+    source: https://www.reuters.com/technology/artificial-intelligence/ilya-sutskevers-ai-startup-ssi-nears-1-billion-funding-2024-09-04/
+    notes: "Raised $1B in September 2024; investors include Andreessen Horowitz, Sequoia, DST Global, and the NFDG fund"
+
+  - id: f_AfvPC6aOTK
+    property: valuation
+    value: 5e9
+    asOf: 2024-09
+    source: https://www.reuters.com/technology/artificial-intelligence/ilya-sutskevers-ai-startup-ssi-nears-1-billion-funding-2024-09-04/
+    notes: "Post-money valuation at time of $1B funding round"
+
+items:
+  key-people:
+    type: key-person
+    entries:
+      i_b9oci1WvqG:
+        person: !ref eYrBgMLJDw  # ilya-sutskever
+        title: "Chief Scientist & Co-founder"
+        start: 2024-06
+        is_founder: true
+        source: https://ssi.inc
+        notes: "Former OpenAI co-founder and Chief Scientist; left OpenAI June 2024"
+
+      i_hy73NqnE5Q:
+        person: daniel-gross
+        title: "Co-founder"
+        start: 2024-06
+        is_founder: true
+        source: https://ssi.inc
+        notes: "Former head of AI at Apple; Y Combinator partner; investor"
+
+      i_vOtkNvw2HH:
+        person: daniel-levy
+        title: "Co-founder"
+        start: 2024-06
+        is_founder: true
+        source: https://ssi.inc
+        notes: "Former OpenAI researcher"

--- a/packages/kb/data/things/stuart-russell.yaml
+++ b/packages/kb/data/things/stuart-russell.yaml
@@ -1,0 +1,29 @@
+thing:
+  id: stuart-russell
+  stableId: ZxUirlzHke
+  type: person
+  name: "Stuart Russell"
+  numericId: 290
+  aliases:
+    - Stuart J. Russell
+
+facts:
+  - id: f_xSvwobPnd7
+    property: employed-by
+    value: "UC Berkeley"
+    asOf: 1986-01
+    source: https://people.eecs.berkeley.edu/~russell/
+    notes: "Professor of Computer Science at UC Berkeley since 1986; founder of Center for Human-Compatible AI (CHAI)"
+
+  - id: f_hlx9NqiojX
+    property: role
+    value: "Professor of Computer Science, UC Berkeley; Founder of CHAI"
+    asOf: 1986-01
+    source: https://people.eecs.berkeley.edu/~russell/
+    notes: "Co-author of 'Artificial Intelligence: A Modern Approach', the standard AI textbook; author of 'Human Compatible' (2019)"
+
+  - id: f_iRPcKCTGM3
+    property: born-year
+    value: 1962
+    source: https://en.wikipedia.org/wiki/Stuart_J._Russell
+    notes: "Born February 5, 1962 in Portsmouth, England"

--- a/packages/kb/data/things/xai.yaml
+++ b/packages/kb/data/things/xai.yaml
@@ -1,0 +1,185 @@
+thing:
+  id: xai
+  stableId: GLXKjYAEKw
+  type: organization
+  name: xAI
+  numericId: 378
+  aliases:
+    - xAI Corp
+    - X.AI
+
+facts:
+  - id: f_3rNHFIucqQ
+    property: founded-date
+    value: 2023-03
+    source: https://x.ai/about
+    notes: "Founded March 2023 by Elon Musk; announced publicly in July 2023"
+
+  - id: f_8UM2NKwdUA
+    property: headquarters
+    value: "Austin, TX"
+    source: https://x.ai/about
+    notes: "Headquartered in Austin; operates a massive GPU cluster ('Colossus') in Memphis, TN"
+
+  - id: f_2O4rOQsrZg
+    property: legal-structure
+    value: "Private company"
+    source: https://x.ai/about
+
+  - id: f_xai_founded_by
+    property: founded-by
+    value:
+      - !ref 69vftmr1jg  # elon-musk
+    source: https://x.ai/about
+
+  - id: f_Uxbvs82r3w
+    property: total-funding
+    value: 12e9
+    asOf: 2024-12
+    source: https://www.reuters.com/technology/artificial-intelligence/musks-xai-closes-6-bln-funding-round-2024-12-24/
+    notes: "Approximately $12B raised across Series A and Series B rounds"
+
+  - id: f_tEkfJ3yreg
+    property: valuation
+    value: 50e9
+    asOf: 2024-12
+    source: https://www.reuters.com/technology/artificial-intelligence/musks-xai-closes-6-bln-funding-round-2024-12-24/
+    notes: "Post-money valuation at Series B close"
+
+  - id: f_CvDHaporPw
+    property: valuation
+    value: 80e9
+    asOf: 2025-11
+    source: https://www.wsj.com/tech/ai/elon-musks-xai-is-in-talks-to-raise-funds-at-a-valuation-of-up-to-75-billion-a57a2e66
+    notes: "Reported valuation range of $75-80B in late 2025 funding discussions"
+
+  - id: f_CvkSn5txgw
+    property: headcount
+    value: 200
+    asOf: 2024-12
+    notes: "Estimated 150-250 employees; relatively small team compared to other frontier labs; emphasizes efficiency"
+
+items:
+  funding-rounds:
+    type: funding-round
+    entries:
+      i_U3IQcbcouw:
+        date: 2024-05
+        amount: 6e9
+        valuation: 24e9
+        source: https://www.reuters.com/technology/artificial-intelligence/musks-xai-raises-6-bln-series-b-round-2024-05-27/
+        notes: "Led by Andreessen Horowitz, Sequoia Capital, and others; valued at $24B pre-money"
+
+      i_Eh90tSjmBw:
+        date: 2024-12
+        amount: 6e9
+        valuation: 50e9
+        source: https://www.reuters.com/technology/artificial-intelligence/musks-xai-closes-6-bln-funding-round-2024-12-24/
+        notes: "Closed December 2024; investors include Andreessen Horowitz, BlackRock, Fidelity, Kingdom Holding, Sequoia, and others"
+
+  key-people:
+    type: key-person
+    entries:
+      i_5Vvzf1r8RA:
+        person: !ref 69vftmr1jg  # elon-musk
+        title: "CEO & Founder"
+        start: 2023-03
+        is_founder: true
+        source: https://x.ai/about
+        notes: "Also CEO of Tesla, SpaceX; owner of X (Twitter); former OpenAI co-founder and board member"
+
+      i_kec2HrrLJA:
+        person: igor-babuschkin
+        title: "Co-founder"
+        start: 2023-03
+        is_founder: true
+        notes: "Former DeepMind researcher; early engineering lead at xAI"
+
+      i_tvj6Dy1U8g:
+        person: jimmy-ba
+        title: "Co-founder"
+        start: 2023-03
+        is_founder: true
+        notes: "University of Toronto professor; co-inventor of Adam optimizer and Layer Normalization"
+
+      i_2er9OKcIxA:
+        person: greg-yang
+        title: "Co-founder"
+        start: 2023-03
+        is_founder: true
+        notes: "Former Microsoft Research; developed Tensor Programs / muP theory for neural network scaling"
+
+      i_nIEC73V2gQ:
+        person: toby-pohlen
+        title: "Co-founder"
+        start: 2023-03
+        is_founder: true
+        notes: "Former DeepMind researcher"
+
+  model-releases:
+    type: model-release
+    entries:
+      i_mwFKxzobhw:
+        name: Grok-1
+        released: 2023-11
+        description: "First xAI model; 314B parameter mixture-of-experts; open-sourced March 2024"
+        source: https://x.ai/blog/grok
+        notes: "Integrated into X (Twitter) platform; open-sourced weights under Apache 2.0 license"
+
+      i_dUAYvkVLPQ:
+        name: Grok-2
+        released: 2024-08
+        description: "Major capability upgrade; competitive with GPT-4 and Claude 3.5 Sonnet on benchmarks"
+        source: https://x.ai/blog/grok-2
+        notes: "Available through X Premium+ subscription and xAI API"
+
+      i_0sE5wuHWjw:
+        name: Grok-3
+        released: 2025-02
+        description: "Trained on Colossus supercluster (200K H100 GPUs); significant reasoning improvements"
+        source: https://x.ai/blog/grok-3
+        notes: "Claimed top scores on several math and coding benchmarks at launch"
+
+  research-areas:
+    type: research-area
+    entries:
+      i_Y7w8DPtfog:
+        name: Large-Scale Training Infrastructure
+        description: "Building and operating massive GPU clusters for frontier model training"
+        started: 2023-07
+        notes: "Colossus cluster in Memphis with 200K H100 GPUs; one of the largest single training clusters globally"
+
+      i_gsmelgkpAw:
+        name: Reasoning and Problem Solving
+        description: "Improving AI reasoning capabilities in mathematics, coding, and scientific domains"
+        started: 2023-07
+        notes: "Focus on chain-of-thought and multi-step reasoning; Grok-3 emphasized reasoning benchmarks"
+
+      i_ribf7dlwsA:
+        name: Real-Time Information Integration
+        description: "Integrating live data from X platform and web into AI responses"
+        started: 2023-11
+        notes: "Unique advantage from X (Twitter) data access; real-time news and social media integration"
+
+  strategic-partnerships:
+    type: strategic-partnership
+    entries:
+      i_QA3rV7Rf7w:
+        partner: X (Twitter)
+        type: distribution + data
+        date: 2023-11
+        source: https://x.ai/blog/grok
+        notes: "Grok integrated into X platform for Premium+ subscribers; access to X data for training"
+
+      i_t8JrParM9w:
+        partner: Oracle Cloud
+        type: cloud
+        date: 2024-06
+        source: https://www.oracle.com/news/announcement/oracle-xai-partnership-2024/
+        notes: "Oracle Cloud infrastructure partnership for additional compute capacity beyond Colossus"
+
+      i_1LQjsDLebw:
+        partner: Nvidia
+        type: compute
+        date: 2024-01
+        notes: "Major Nvidia GPU customer; 200K H100 GPUs for Colossus cluster; among the largest single orders"

--- a/packages/kb/data/things/yann-lecun.yaml
+++ b/packages/kb/data/things/yann-lecun.yaml
@@ -1,0 +1,28 @@
+thing:
+  id: yann-lecun
+  stableId: cMbVUVK29Q
+  type: person
+  name: "Yann LeCun"
+  numericId: 582
+  aliases:
+    - "LeCun"
+
+facts:
+  - id: f_y9K773heIw
+    property: employed-by
+    value: !ref tt0f5PYDCw  # meta-ai
+    asOf: 2013-12
+    source: https://ai.meta.com/people/yann-lecun/
+    notes: "Joined Facebook AI Research (FAIR) as founding director in December 2013; became Chief AI Scientist at Meta"
+
+  - id: f_DQUCjz4rhQ
+    property: role
+    value: "Chief AI Scientist"
+    asOf: "2018"
+    source: https://ai.meta.com/people/yann-lecun/
+    notes: "Turing Award 2018 (shared with Yoshua Bengio and Geoffrey Hinton) for work on deep learning"
+
+  - id: f_A9r9tPNCOQ
+    property: born-year
+    value: 1960
+    notes: "Born July 8, 1960 in Soisy-sous-Montmorency, France"

--- a/packages/kb/data/things/yoshua-bengio.yaml
+++ b/packages/kb/data/things/yoshua-bengio.yaml
@@ -1,0 +1,29 @@
+thing:
+  id: yoshua-bengio
+  stableId: nGFBXZeM3d
+  type: person
+  name: "Yoshua Bengio"
+  numericId: 380
+  aliases:
+    - Bengio
+
+facts:
+  - id: f_ymkhC4xtr2
+    property: employed-by
+    value: "Mila - Quebec AI Institute"
+    asOf: 2017-01
+    source: https://mila.quebec/en/person/bengio-yoshua
+    notes: "Scientific Director of Mila (formerly Montreal Institute for Learning Algorithms); professor at Universit\u00E9 de Montr\u00E9al"
+
+  - id: f_s9wbJl2EO3
+    property: role
+    value: "Scientific Director, Mila; Professor, Universit\u00E9 de Montr\u00E9al"
+    asOf: 2017-01
+    source: https://mila.quebec/en/person/bengio-yoshua
+    notes: "One of the 'Godfathers of Deep Learning'; 2018 Turing Award recipient with Hinton and LeCun"
+
+  - id: f_HXYs4QC0Kq
+    property: born-year
+    value: 1964
+    source: https://en.wikipedia.org/wiki/Yoshua_Bengio
+    notes: "Born March 5, 1964 in Paris, France"

--- a/packages/kb/package.json
+++ b/packages/kb/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@longterm-wiki/kb",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "yaml": "^2.7.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/kb/scripts/upsert-resources.ts
+++ b/packages/kb/scripts/upsert-resources.ts
@@ -1,0 +1,114 @@
+/**
+ * Upsert all source URLs from KB entity files to the wiki-server resources DB.
+ * Run: WIKI_SERVER_ENV=prod npx tsx packages/kb/scripts/upsert-resources.ts
+ */
+import "dotenv/config";
+import yaml from "yaml";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { createHash } from "crypto";
+import { upsertResourceBatch } from "../../../crux/lib/wiki-server/resources.ts";
+
+const KB_DATA_DIR = join(import.meta.dirname, "../data");
+
+function urlToId(url: string): string {
+  return createHash("sha256").update(url).digest("hex").slice(0, 16);
+}
+
+function guessType(
+  url: string
+): "paper" | "blog" | "web" | "report" | "reference" {
+  if (url.includes("arxiv.org")) return "paper";
+  if (
+    url.includes("anthropic.com/research") ||
+    url.includes("transformer-circuits.pub")
+  )
+    return "paper";
+  if (
+    url.includes("anthropic.com/news") ||
+    url.includes("anthropic.com/index")
+  )
+    return "blog";
+  return "web";
+}
+
+interface UpsertItem {
+  id: string;
+  url: string;
+  type: "paper" | "blog" | "web" | "report" | "reference";
+  tags: string[];
+  citedBy: string[];
+}
+
+async function main() {
+  const thingsDir = join(KB_DATA_DIR, "things");
+  const files = readdirSync(thingsDir).filter((f) => f.endsWith(".yaml"));
+
+  const allItems: UpsertItem[] = [];
+  const seenUrls = new Set<string>();
+
+  for (const file of files) {
+    const data = yaml.parse(readFileSync(join(thingsDir, file), "utf8"));
+    const entityId = data.thing?.id ?? file.replace(".yaml", "");
+
+    // Collect URLs from facts
+    for (const fact of data.facts ?? []) {
+      if (fact.source && fact.source.startsWith("http") && !seenUrls.has(fact.source)) {
+        seenUrls.add(fact.source);
+        allItems.push({
+          id: urlToId(fact.source),
+          url: fact.source,
+          type: guessType(fact.source),
+          tags: [entityId, "kb-source"],
+          citedBy: [entityId],
+        });
+      }
+    }
+
+    // Collect URLs from items
+    for (const coll of Object.values(data.items ?? {})) {
+      const entries = (coll as { entries?: Record<string, Record<string, unknown>> }).entries ?? {};
+      for (const entry of Object.values(entries)) {
+        for (const field of ["source", "key-publication"]) {
+          const url = entry[field] as string | undefined;
+          if (url && url.startsWith("http") && !seenUrls.has(url)) {
+            seenUrls.add(url);
+            allItems.push({
+              id: urlToId(url),
+              url,
+              type: guessType(url),
+              tags: [entityId, "kb-source"],
+              citedBy: [entityId],
+            });
+          }
+        }
+      }
+    }
+  }
+
+  console.log(`Found ${allItems.length} unique source URLs across ${files.length} entity files`);
+
+  // Batch upsert in groups of 50
+  const batchSize = 50;
+  let totalUpserted = 0;
+
+  for (let i = 0; i < allItems.length; i += batchSize) {
+    const batch = allItems.slice(i, i + batchSize);
+    const result = await upsertResourceBatch(batch);
+    if (result.ok) {
+      totalUpserted += result.data.upserted;
+      console.log(
+        `  Batch ${Math.floor(i / batchSize) + 1}: ${result.data.upserted} upserted`
+      );
+    } else {
+      console.error(
+        `  Batch ${Math.floor(i / batchSize) + 1} failed:`,
+        result.error
+      );
+    }
+  }
+
+  console.log(`Done! Total upserted: ${totalUpserted}`);
+}
+
+main().catch(console.error);

--- a/packages/kb/src/format.ts
+++ b/packages/kb/src/format.ts
@@ -1,0 +1,200 @@
+/**
+ * Shared formatting utilities for KB data.
+ *
+ * Used by CLI tools, frontend components, and any other consumer
+ * that needs human-readable representations of KB values.
+ */
+
+import type { Fact, Property, ItemEntry } from "./types";
+import type { Graph } from "./graph";
+
+// ── Monetary formatting ─────────────────────────────────────────────
+
+/**
+ * Format a monetary amount in a compact human-readable form.
+ * e.g. 1_500_000_000 → "$1.5B", -5_000_000_000 → "-$5.0B"
+ */
+export function formatMoney(value: number): string {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(0)}M`;
+  if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(0)}K`;
+  return `${sign}$${abs}`;
+}
+
+// ── Value formatting ────────────────────────────────────────────────
+
+/**
+ * Format a numeric value using a property's display config.
+ * Falls back to locale-formatted number if no display config exists.
+ */
+export function formatValue(value: unknown, property?: Property): string {
+  if (value === null || value === undefined) return "(none)";
+
+  if (typeof value === "number" && property?.display) {
+    const { divisor, prefix, suffix } = property.display;
+    let formatted: string;
+    if (divisor && Number.isFinite(divisor)) {
+      const divided = value / divisor;
+      if (divided >= 100) {
+        formatted = divided.toLocaleString("en-US", {
+          maximumFractionDigits: 0,
+        });
+      } else {
+        formatted = divided.toLocaleString("en-US", {
+          maximumFractionDigits: 1,
+        });
+      }
+    } else {
+      // No divisor: use raw number without locale grouping separators.
+      // This handles cases like "born-year: 1983" where commas would be wrong.
+      formatted = String(value);
+    }
+    return `${prefix ?? ""}${formatted}${suffix ?? ""}`;
+  }
+
+  if (typeof value === "number") {
+    return value.toLocaleString("en-US");
+  }
+
+  return String(value);
+}
+
+/**
+ * Format a fact value for display, resolving refs to entity names when possible.
+ */
+export function formatFactValue(
+  fact: Fact,
+  property: Property | undefined,
+  graph: Graph
+): string {
+  const val = fact.value;
+
+  if (val.type === "ref") {
+    const entity = graph.getEntity(val.value);
+    return entity ? `${entity.name} (${val.value})` : val.value;
+  }
+
+  if (val.type === "refs") {
+    return val.value
+      .map((refId: string) => {
+        const entity = graph.getEntity(refId);
+        return entity ? `${entity.name} (${refId})` : refId;
+      })
+      .join(", ");
+  }
+
+  if (val.type === "number") {
+    return formatValue(val.value, property);
+  }
+
+  return String(val.value);
+}
+
+// ── Ref resolution ──────────────────────────────────────────────────
+
+/**
+ * Resolve an entity slug to its display name, falling back to the slug.
+ */
+export function resolveRefName(slug: string, graph: Graph): string {
+  const entity = graph.getEntity(slug);
+  return entity ? entity.name : slug;
+}
+
+// ── Item formatting ─────────────────────────────────────────────────
+
+/**
+ * Format a single item entry for display.
+ * Uses the collection name to apply property-specific formatting
+ * (e.g., funding rounds show amount + valuation, key-people show role + dates).
+ */
+export function formatItemEntry(
+  item: ItemEntry,
+  collectionName: string,
+  graph: Graph
+): string {
+  const f = item.fields;
+
+  switch (collectionName) {
+    case "funding-rounds": {
+      const date = f.date ?? "";
+      const amount =
+        typeof f.amount === "number" ? formatMoney(f.amount) : "";
+      const valuation =
+        typeof f.valuation === "number"
+          ? ` @ ${formatMoney(f.valuation)}`
+          : "";
+      const lead = f.lead_investor
+        ? resolveRefName(String(f.lead_investor), graph)
+        : "";
+      const leadStr = lead ? `  lead: ${lead}` : "";
+      return `${date}  ${amount}${valuation}${leadStr}`;
+    }
+
+    case "key-people": {
+      const person = f.person
+        ? resolveRefName(String(f.person), graph)
+        : "(unknown)";
+      const title = f.title ?? "";
+      const start = f.start ?? "";
+      const end = f.end ?? "present";
+      const founder = f.is_founder ? ", founder" : "";
+      return `${person} -- ${title} (${start}--${end}${founder})`;
+    }
+
+    case "products": {
+      const name = f.name ?? item.key;
+      const launched = f.launched ?? "";
+      const desc = f.description ? ` - ${f.description}` : "";
+      return `${launched}  ${name}${desc}`;
+    }
+
+    case "model-releases": {
+      const name = f.name ?? item.key;
+      const released = f.released ?? "";
+      const safety = f.safety_level ? ` [${f.safety_level}]` : "";
+      const desc = f.description ? ` - ${f.description}` : "";
+      return `${released}  ${name}${safety}${desc}`;
+    }
+
+    case "board-members": {
+      const name = f.name ?? item.key;
+      const role = f.role ? ` -- ${f.role}` : "";
+      const appointed = f.appointed ? ` (${f.appointed})` : "";
+      return `${name}${role}${appointed}`;
+    }
+
+    case "strategic-partnerships": {
+      const partner = f.partner ?? item.key;
+      const date = f.date ?? "";
+      const type = f.type ? ` [${f.type}]` : "";
+      const investAmount =
+        typeof f.investment_amount === "number"
+          ? ` ${formatMoney(f.investment_amount)}`
+          : "";
+      return `${date}  ${partner}${type}${investAmount}`;
+    }
+
+    case "safety-milestones": {
+      const name = f.name ?? item.key;
+      const date = f.date ?? "";
+      const type = f.type ? ` [${f.type}]` : "";
+      return `${date}  ${name}${type}`;
+    }
+
+    case "research-areas": {
+      const name = f.name ?? item.key;
+      const desc = f.description ? ` - ${f.description}` : "";
+      return `${name}${desc}`;
+    }
+
+    default: {
+      const parts = Object.entries(f)
+        .filter(([_, v]) => v !== null && v !== undefined)
+        .map(([k, v]) => `${k}: ${String(v)}`);
+      return parts.join(", ");
+    }
+  }
+}

--- a/packages/kb/src/graph.ts
+++ b/packages/kb/src/graph.ts
@@ -1,0 +1,293 @@
+/**
+ * In-memory knowledge base graph.
+ * The main class users interact with after loading YAML via loadKB().
+ */
+
+import type {
+  Entity,
+  Fact,
+  Property,
+  TypeSchema,
+  ItemCollection,
+  ItemEntry,
+  FactQuery,
+  PropertyQuery,
+} from "./types";
+
+export class Graph {
+  private entities: Map<string, Entity> = new Map();
+  private facts: Map<string, Fact[]> = new Map(); // keyed by subjectId
+  private factIds: Set<string> = new Set(); // dedup guard
+  private properties: Map<string, Property> = new Map();
+  private schemas: Map<string, TypeSchema> = new Map();
+  // entityId → collectionName → collection
+  private items: Map<string, Map<string, ItemCollection>> = new Map();
+  // stableId → slug reverse index
+  private stableIdIndex: Map<string, string> = new Map();
+
+  // ── Mutation (used by loader and inverse computation) ──────────────
+
+  addEntity(entity: Entity): void {
+    this.entities.set(entity.id, entity);
+    this.stableIdIndex.set(entity.stableId, entity.id);
+  }
+
+  /**
+   * Adds a fact to the graph. Silently skips if a fact with the same ID
+   * already exists (deduplication for inverse computation re-runs).
+   */
+  addFact(fact: Fact): void {
+    if (this.factIds.has(fact.id)) return; // dedup
+    this.factIds.add(fact.id);
+
+    const existing = this.facts.get(fact.subjectId);
+    if (existing) {
+      existing.push(fact);
+    } else {
+      this.facts.set(fact.subjectId, [fact]);
+    }
+  }
+
+  addProperty(property: Property): void {
+    this.properties.set(property.id, property);
+  }
+
+  addSchema(schema: TypeSchema): void {
+    this.schemas.set(schema.type, schema);
+  }
+
+  addItemCollection(
+    entityId: string,
+    collectionName: string,
+    collection: ItemCollection
+  ): void {
+    let entityCollections = this.items.get(entityId);
+    if (!entityCollections) {
+      entityCollections = new Map();
+      this.items.set(entityId, entityCollections);
+    }
+    entityCollections.set(collectionName, collection);
+  }
+
+  // ── Entity queries ─────────────────────────────────────────────────
+
+  getEntity(id: string): Entity | undefined {
+    return this.entities.get(id);
+  }
+
+  /** Resolve a stableId to its Entity. */
+  getEntityByStableId(stableId: string): Entity | undefined {
+    const slug = this.stableIdIndex.get(stableId);
+    return slug ? this.entities.get(slug) : undefined;
+  }
+
+  /** Resolve a stableId to a slug. Returns undefined if not found. */
+  resolveStableId(stableId: string): string | undefined {
+    return this.stableIdIndex.get(stableId);
+  }
+
+  getAllEntities(): Entity[] {
+    return Array.from(this.entities.values());
+  }
+
+  getByType(type: string): Entity[] {
+    return Array.from(this.entities.values()).filter((t) => t.type === type);
+  }
+
+  // ── Fact queries ───────────────────────────────────────────────────
+
+  getFacts(entityId: string, query?: FactQuery): Fact[] {
+    const all = this.facts.get(entityId) ?? [];
+    let result = all;
+
+    if (query?.property !== undefined) {
+      result = result.filter((f) => f.propertyId === query.property);
+    }
+
+    if (query?.current) {
+      result = result.filter((f) => f.validEnd === undefined);
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the most recent fact for a given (entityId, propertyId) pair,
+   * ordering by asOf descending. Facts without asOf come last.
+   */
+  getLatest(entityId: string, propertyId: string): Fact | undefined {
+    const facts = this.getFacts(entityId, { property: propertyId });
+    if (facts.length === 0) return undefined;
+
+    return facts.slice().sort((a, b) => {
+      if (a.asOf === undefined && b.asOf === undefined) return 0;
+      if (a.asOf === undefined) return 1;
+      if (b.asOf === undefined) return -1;
+      return b.asOf.localeCompare(a.asOf);
+    })[0];
+  }
+
+  /**
+   * Returns the latest fact per entity for a given property.
+   * Only entities that have at least one fact with this property are included.
+   */
+  getByProperty(
+    propertyId: string,
+    query?: PropertyQuery
+  ): Map<string, Fact> {
+    const result = new Map<string, Fact>();
+
+    for (const entityId of this.entities.keys()) {
+      const latest = this.getLatest(entityId, propertyId);
+      if (latest !== undefined) {
+        result.set(entityId, latest);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns all facts per entity for a given property (full history).
+   * Unlike getByProperty(), this returns arrays of facts, not just the latest.
+   */
+  getAllByProperty(propertyId: string): Map<string, Fact[]> {
+    const result = new Map<string, Fact[]>();
+
+    for (const entityId of this.entities.keys()) {
+      const facts = this.getFacts(entityId, { property: propertyId });
+      if (facts.length > 0) {
+        result.set(entityId, facts);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the IDs of entities referenced by ref/refs facts on this entity.
+   */
+  getRelated(entityId: string, propertyId: string): string[] {
+    const facts = this.getFacts(entityId, { property: propertyId });
+    const ids: string[] = [];
+
+    for (const fact of facts) {
+      if (fact.value.type === "ref") {
+        ids.push(fact.value.value);
+      } else if (fact.value.type === "refs") {
+        ids.push(...fact.value.value);
+      }
+    }
+
+    return ids;
+  }
+
+  // ── Item queries ───────────────────────────────────────────────────
+
+  getItemCollectionNames(entityId: string): string[] {
+    const entityCollections = this.items.get(entityId);
+    if (!entityCollections) return [];
+    return Array.from(entityCollections.keys());
+  }
+
+  getItems(entityId: string, collectionName: string): ItemEntry[] {
+    const entityCollections = this.items.get(entityId);
+    if (!entityCollections) return [];
+
+    const collection = entityCollections.get(collectionName);
+    if (!collection) return [];
+
+    return Object.entries(collection.entries).map(([key, fields]) => ({
+      key,
+      fields,
+    }));
+  }
+
+  /**
+   * Scans all items across all entities for fields that reference the
+   * given entityId. Returns matches with context about where they appear.
+   *
+   * Uses schema field definitions to identify `ref` type fields. Falls
+   * back to string-matching if no schema is available.
+   */
+  getItemsMentioning(
+    entityId: string
+  ): Array<{
+    ownerEntityId: string;
+    collection: string;
+    entry: ItemEntry;
+    /** Which field(s) contain the reference */
+    matchingFields: string[];
+  }> {
+    const results: Array<{
+      ownerEntityId: string;
+      collection: string;
+      entry: ItemEntry;
+      matchingFields: string[];
+    }> = [];
+
+    for (const [ownerEntityId, entityCollections] of this.items.entries()) {
+      if (ownerEntityId === entityId) continue; // Skip self-references
+
+      const ownerEntity = this.entities.get(ownerEntityId);
+      const schema = ownerEntity
+        ? this.schemas.get(ownerEntity.type)
+        : undefined;
+
+      for (const [collectionName, collection] of entityCollections.entries()) {
+        const collectionSchema = schema?.items?.[collectionName];
+        const fieldDefs = collectionSchema?.fields;
+
+        for (const [entryKey, fields] of Object.entries(collection.entries)) {
+          const matchingFields: string[] = [];
+
+          for (const [fieldName, fieldValue] of Object.entries(fields)) {
+            const fieldDef = fieldDefs?.[fieldName];
+
+            // Check ref fields explicitly
+            if (fieldDef?.type === "ref" && fieldValue === entityId) {
+              matchingFields.push(fieldName);
+            }
+            // Also check string values that match (covers untyped fields)
+            else if (
+              !fieldDef &&
+              typeof fieldValue === "string" &&
+              fieldValue === entityId
+            ) {
+              matchingFields.push(fieldName);
+            }
+          }
+
+          if (matchingFields.length > 0) {
+            results.push({
+              ownerEntityId,
+              collection: collectionName,
+              entry: { key: entryKey, fields },
+              matchingFields,
+            });
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+
+  // ── Property & schema queries ──────────────────────────────────────
+
+  getProperty(id: string): Property | undefined {
+    return this.properties.get(id);
+  }
+
+  getAllProperties(): Property[] {
+    return Array.from(this.properties.values());
+  }
+
+  getSchema(type: string): TypeSchema | undefined {
+    return this.schemas.get(type);
+  }
+
+  getAllSchemas(): TypeSchema[] {
+    return Array.from(this.schemas.values());
+  }
+}

--- a/packages/kb/src/ids.ts
+++ b/packages/kb/src/ids.ts
@@ -1,0 +1,115 @@
+/**
+ * Stable ID generation for the Knowledge Base library.
+ *
+ * - generateStableId()         — random 10-char alphanumeric (for Entity.stableId)
+ * - generateFactId()           — "f_" + 10-char alphanumeric (random)
+ * - contentHash(parts)         — deterministic SHA-256-based 10-char token
+ * - generateContentFactId(...) — "f_" + contentHash (idempotent sync helper)
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+/** Characters used to replace `-` and `_` from base64url output. */
+const REPLACEMENT_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Returns a clean 10-character alphanumeric string derived from
+ * `crypto.randomBytes(7).toString("base64url")`, with any `-` or `_`
+ * replaced by alphanumeric characters so the result is URL-safe and visually
+ * consistent.
+ */
+function randomAlphanumeric10(): string {
+  const raw = randomBytes(7).toString("base64url").slice(0, 10);
+  return raw
+    .split("")
+    .map((ch) => {
+      if (ch === "-" || ch === "_") {
+        // Replace with a deterministic-looking but effectively random char by
+        // drawing a fresh byte mod the replacement alphabet length.
+        const byte = randomBytes(1)[0];
+        return REPLACEMENT_CHARS[byte % REPLACEMENT_CHARS.length];
+      }
+      return ch;
+    })
+    .join("");
+}
+
+/**
+ * Returns a random 10-character alphanumeric string suitable for use as a
+ * Entity's `stableId`.  Survives renames because it is purely random.
+ *
+ * @example
+ * generateStableId() // "a3Kf2rZ9mQ"
+ */
+export function generateStableId(): string {
+  return randomAlphanumeric10();
+}
+
+/**
+ * Returns a random fact ID: `"f_"` followed by 10 random alphanumeric chars.
+ * Use this when you do not need determinism (i.e., you are creating a brand-new
+ * fact that has no natural content key).
+ *
+ * @example
+ * generateFactId() // "f_x7Nm2pA0qR"
+ */
+export function generateFactId(): string {
+  return `f_${randomAlphanumeric10()}`;
+}
+
+/**
+ * Produces a deterministic 10-character base64url token by SHA-256 hashing
+ * the concatenation of `parts` (joined with a null-byte separator to prevent
+ * accidental collisions between adjacent inputs).
+ *
+ * Same inputs always produce the same output — suitable for content-addressed
+ * keys and idempotent sync operations.
+ *
+ * @example
+ * contentHash(["anthropic", "revenue", "1000000000", "2024"])
+ * // always the same 10-char string
+ */
+export function contentHash(parts: string[]): string {
+  const combined = parts.join("\x00");
+  const raw = createHash("sha256")
+    .update(combined, "utf8")
+    .digest("base64url")
+    .slice(0, 10);
+  // Normalize to same alphanumeric alphabet as randomAlphanumeric10()
+  return raw.replace(/[-_]/g, (ch) => {
+    // Deterministic replacement from char code
+    const code = ch.charCodeAt(0);
+    return REPLACEMENT_CHARS[code % REPLACEMENT_CHARS.length];
+  });
+}
+
+/**
+ * Generates a deterministic fact ID from its logical key components.
+ * The ID is `"f_"` followed by a {@link contentHash} of
+ * `[subjectId, propertyId, JSON.stringify(value), asOf ?? ""]`.
+ *
+ * Use this when syncing facts from an external source so that re-running the
+ * sync does not create duplicates.
+ *
+ * @param subjectId  - Entity slug the fact is about
+ * @param propertyId - Property ID from the registry
+ * @param value      - The fact value (any JSON-serialisable type)
+ * @param asOf       - Optional temporal anchor (ISO date or YYYY-MM string)
+ *
+ * @example
+ * generateContentFactId("anthropic", "revenue", 1_000_000_000, "2024")
+ * // "f_<10 deterministic chars>"
+ */
+export function generateContentFactId(
+  subjectId: string,
+  propertyId: string,
+  value: unknown,
+  asOf?: string
+): string {
+  return `f_${contentHash([
+    subjectId,
+    propertyId,
+    JSON.stringify(value),
+    asOf ?? "",
+  ])}`;
+}

--- a/packages/kb/src/index.ts
+++ b/packages/kb/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public API for the @longterm-wiki/kb package.
+ */
+
+export { loadKB } from "./loader";
+export { Graph } from "./graph";
+export { computeInverses } from "./inverse";
+export { validate, validateEntity } from "./validate";
+export * from "./types";
+export * from "./ids";
+export { serialize } from "./serialize";
+export type { SerializedKB } from "./serialize";
+export {
+  formatMoney,
+  formatValue,
+  formatFactValue,
+  formatItemEntry,
+  resolveRefName,
+} from "./format";

--- a/packages/kb/src/inverse.ts
+++ b/packages/kb/src/inverse.ts
@@ -1,0 +1,155 @@
+/**
+ * Computes inverse relationships from property definitions and adds derived
+ * facts to the graph.
+ *
+ * For every property that declares an `inverseId`, this module scans all
+ * existing facts that use that property and — for each ref/refs value —
+ * synthesises a mirror fact on the referenced entity using the inverse
+ * property ID.  The derived fact carries the same temporal bounds (asOf,
+ * validEnd) as its source and records the source fact's ID in `derivedFrom`.
+ *
+ * Derived fact IDs are content-addressed: `inv_` + first-8 chars of a
+ * SHA-256 hash of (subjectId + propertyId + value).  This makes the
+ * operation idempotent — running it twice on the same graph produces the
+ * same IDs and `addFact` will just push a duplicate; callers should only
+ * run this once per graph lifecycle.
+ */
+
+import { createHash } from "node:crypto";
+import type { Fact } from "./types";
+import type { Graph } from "./graph";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a deterministic 8-character hex token for use in derived fact IDs.
+ * Inputs are null-byte separated to prevent accidental collisions.
+ */
+function inverseHash(parts: string[]): string {
+  return createHash("sha256")
+    .update(parts.join("\x00"), "utf8")
+    .digest("hex")
+    .slice(0, 12);
+}
+
+/**
+ * Builds the ID for a single derived inverse fact.
+ * Format: `inv_` + 12-char content hash.
+ *
+ * Includes asOf and validEnd in the hash so that distinct temporal
+ * relationships (e.g., someone leaves and rejoins an org) get different IDs.
+ */
+function derivedId(
+  subjectId: string,
+  propertyId: string,
+  refValue: string,
+  asOf?: string,
+  validEnd?: string,
+): string {
+  return `inv_${inverseHash([subjectId, propertyId, refValue, asOf ?? "", validEnd ?? ""])}`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Scans the graph for facts that belong to properties with an `inverseId`,
+ * then synthesises and adds the corresponding mirror facts on the referenced
+ * entities.
+ *
+ * Only `ref` and `refs` value types participate in inverse computation.
+ * All other value types are silently skipped.
+ *
+ * Edge cases:
+ * - If the referenced entity does not exist in the graph, a console warning is
+ *   emitted and the inverse is skipped (no crash).
+ * - Temporal bounds (`asOf`, `validEnd`) are preserved from the source fact.
+ * - Running this function more than once on the same graph will result in
+ *   duplicate facts (same `derivedFrom` ID).  Call it exactly once per graph.
+ */
+export function computeInverses(graph: Graph): void {
+  const allProperties = graph.getAllProperties();
+
+  for (const property of allProperties) {
+    const { inverseId } = property;
+    if (!inverseId) continue;
+
+    // Skip computed properties — they are filled by the inverse of their
+    // counterpart.  Processing them would create duplicates.
+    if (property.computed) continue;
+
+    // Collect all facts across every entity that use this property.
+    const allEntities = graph.getAllEntities();
+
+    for (const entity of allEntities) {
+      const facts = graph.getFacts(entity.id, { property: property.id });
+
+      for (const fact of facts) {
+        // Skip facts that are already derived (from a previous inverse pass).
+        if (fact.derivedFrom) continue;
+        _processFactInverse(graph, fact, inverseId);
+      }
+    }
+  }
+}
+
+/**
+ * Creates and adds a single derived inverse fact, given a source fact that
+ * has a `ref` or `refs` value.  For `refs`, one inverse fact is created per
+ * referenced ID.
+ */
+function _processFactInverse(
+  graph: Graph,
+  sourceFact: Fact,
+  inversePropertyId: string
+): void {
+  const { value } = sourceFact;
+
+  if (value.type === "ref") {
+    _addSingleInverse(graph, sourceFact, inversePropertyId, value.value);
+  } else if (value.type === "refs") {
+    for (const refId of value.value) {
+      _addSingleInverse(graph, sourceFact, inversePropertyId, refId);
+    }
+  }
+  // All other value types (number, text, date, boolean, json) are skipped.
+}
+
+/**
+ * Constructs and adds one derived inverse fact.
+ * Skips silently (with a warning) if the referenced entity is not in the graph.
+ */
+function _addSingleInverse(
+  graph: Graph,
+  sourceFact: Fact,
+  inversePropertyId: string,
+  referencedEntityId: string
+): void {
+  // Guard: the referenced entity must exist.
+  if (!graph.getEntity(referencedEntityId)) {
+    console.warn(
+      `[kb/inverse] Skipping inverse for fact "${sourceFact.id}": ` +
+        `referenced entity "${referencedEntityId}" not found in graph.`
+    );
+    return;
+  }
+
+  const id = derivedId(
+    referencedEntityId,
+    inversePropertyId,
+    sourceFact.subjectId,
+    sourceFact.asOf,
+    sourceFact.validEnd,
+  );
+
+  const derived: Fact = {
+    id,
+    subjectId: referencedEntityId,
+    propertyId: inversePropertyId,
+    value: { type: "ref", value: sourceFact.subjectId },
+    asOf: sourceFact.asOf,
+    validEnd: sourceFact.validEnd,
+    derivedFrom: sourceFact.id,
+  };
+
+  graph.addFact(derived);
+}

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -1,0 +1,343 @@
+/**
+ * YAML → Graph loader.
+ * Reads properties.yaml, schemas/*.yaml, and things/*.yaml from a data directory.
+ *
+ * Supports !ref YAML tags for stable references between entities:
+ *   value: !ref mK9pX3rQ7n   → resolves stableId to the entity's slug
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { ScalarTag } from "yaml";
+import { Graph } from "./graph";
+import type {
+  PropertiesFile,
+  SchemaFile,
+  EntityFile,
+  RawFact,
+  Property,
+  TypeSchema,
+  Entity,
+  Fact,
+  FactValue,
+  ItemCollection,
+} from "./types";
+
+// ── !ref YAML tag ──────────────────────────────────────────────────
+
+/**
+ * Marker class for !ref YAML tags. Created during YAML parsing,
+ * resolved to slugs after all things are loaded.
+ */
+export class RefMarker {
+  constructor(public readonly stableId: string) {}
+}
+
+/** Custom YAML tag: !ref <stableId> */
+const refTag: ScalarTag = {
+  tag: "!ref",
+  resolve(str: string): RefMarker {
+    return new RefMarker(str);
+  },
+  identify(value: unknown): value is RefMarker {
+    return value instanceof RefMarker;
+  },
+  stringify(item): string {
+    return `!ref ${(item.value as RefMarker).stableId}`;
+  },
+};
+
+const CUSTOM_TAGS = [refTag];
+
+/**
+ * Recursively resolves RefMarker instances in a parsed YAML structure.
+ * Returns the value with all RefMarkers replaced by their slug strings.
+ */
+function resolveRefs(
+  value: unknown,
+  graph: Graph,
+  context: string
+): unknown {
+  if (value instanceof RefMarker) {
+    const slug = graph.resolveStableId(value.stableId);
+    if (!slug) {
+      console.warn(
+        `[kb/loader] Unresolved !ref "${value.stableId}" in ${context}`
+      );
+      return value.stableId; // fallback: use raw stableId
+    }
+    return slug;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((v) => resolveRefs(v, graph, context));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const resolved: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      resolved[k] = resolveRefs(v, graph, context);
+    }
+    return resolved;
+  }
+
+  return value;
+}
+
+// ── Value normalization ────────────────────────────────────────────────
+
+/**
+ * ISO date pattern: full date (2021-01-01) or year-month (2021-01).
+ * Does NOT match bare years like "2021" to avoid false positives with numbers.
+ */
+const DATE_RE = /^\d{4}-\d{2}(-\d{2})?$/;
+
+/**
+ * Normalizes a raw YAML value into a typed FactValue.
+ * The property's dataType is used as a hint — if the property says "ref",
+ * a string value is wrapped as {type: "ref"} rather than {type: "text"}.
+ */
+function normalizeValue(raw: unknown, dataType?: string): FactValue {
+  // When an explicit dataType is declared, it is authoritative.
+  if (dataType) {
+    switch (dataType) {
+      case "ref":
+        return { type: "ref", value: String(raw) };
+      case "refs":
+        if (Array.isArray(raw)) {
+          return { type: "refs", value: raw.map(String) };
+        }
+        return { type: "refs", value: [String(raw)] };
+      case "number":
+        return { type: "number", value: Number(raw) };
+      case "text":
+        return { type: "text", value: String(raw) };
+      case "date":
+        return { type: "date", value: String(raw) };
+      case "boolean":
+        return { type: "boolean", value: Boolean(raw) };
+      // dataType declared but not one of the simple types — fall through
+    }
+  }
+
+  // Heuristic detection when no dataType is declared
+  if (typeof raw === "boolean") {
+    return { type: "boolean", value: raw };
+  }
+
+  if (typeof raw === "number") {
+    return { type: "number", value: raw };
+  }
+
+  if (typeof raw === "string") {
+    if (DATE_RE.test(raw)) {
+      return { type: "date", value: raw };
+    }
+    return { type: "text", value: raw };
+  }
+
+  if (Array.isArray(raw)) {
+    if (raw.every((v) => typeof v === "string")) {
+      return { type: "refs", value: raw as string[] };
+    }
+    return { type: "json", value: raw };
+  }
+
+  return { type: "json", value: raw };
+}
+
+// ── Individual parsers ─────────────────────────────────────────────────
+
+function parseProperties(raw: unknown): Map<string, Property> {
+  const file = raw as PropertiesFile;
+  const result = new Map<string, Property>();
+
+  for (const [id, def] of Object.entries(file.properties ?? {})) {
+    result.set(id, { id, ...def });
+  }
+
+  return result;
+}
+
+function parseSchema(raw: unknown): TypeSchema {
+  const file = raw as SchemaFile;
+  return {
+    type: file.type,
+    name: file.name,
+    required: file.required ?? [],
+    recommended: file.recommended ?? [],
+    items: file.items,
+  };
+}
+
+function parseEntity(raw: EntityFile["thing"]): Entity {
+  return {
+    id: raw.id,
+    stableId: raw.stableId,
+    type: raw.type,
+    name: raw.name,
+    ...(raw.parent !== undefined && { parent: raw.parent }),
+    ...(raw.aliases !== undefined && { aliases: raw.aliases }),
+    ...(raw.previousIds !== undefined && { previousIds: raw.previousIds }),
+    ...(raw.numericId !== undefined && { numericId: raw.numericId }),
+  };
+}
+
+function parseFact(
+  rawFact: RawFact,
+  entityId: string,
+  properties: Map<string, Property>
+): Fact | null {
+  const prop = properties.get(rawFact.property);
+
+  // Computed properties are populated by inverse computation, not stored directly.
+  if (prop?.computed) {
+    console.warn(
+      `[kb/loader] Skipping fact "${rawFact.id}" on "${entityId}": ` +
+        `property "${rawFact.property}" is computed (populated by inverse computation).`
+    );
+    return null;
+  }
+
+  const value = normalizeValue(rawFact.value, prop?.dataType);
+
+  return {
+    id: rawFact.id,
+    subjectId: entityId,
+    propertyId: rawFact.property,
+    value,
+    ...(rawFact.asOf !== undefined && { asOf: String(rawFact.asOf) }),
+    ...(rawFact.validEnd !== undefined && { validEnd: String(rawFact.validEnd) }),
+    ...(rawFact.source !== undefined && { source: rawFact.source }),
+    ...(rawFact.sourceQuote !== undefined && {
+      sourceQuote: rawFact.sourceQuote,
+    }),
+    ...(rawFact.notes !== undefined && { notes: rawFact.notes }),
+  };
+}
+
+function parseItemCollection(
+  raw: EntityFile["items"],
+  collectionName: string
+): ItemCollection | undefined {
+  if (!raw) return undefined;
+  const col = raw[collectionName];
+  if (!col) return undefined;
+  return {
+    type: col.type,
+    entries: col.entries ?? {},
+  };
+}
+
+// ── Helper: read all .yaml files from a directory ─────────────────────
+
+async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unknown }[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return []; // Directory doesn't exist — optional
+    }
+    throw error; // Permission errors, broken paths, etc. should surface
+  }
+
+  const yamlFiles = entries.filter(
+    (e) => extname(e) === ".yaml" || extname(e) === ".yml"
+  );
+
+  const results = await Promise.all(
+    yamlFiles.map(async (filename) => {
+      const content = await readFile(join(dir, filename), "utf-8");
+      return { name: filename, parsed: parseYaml(content, { customTags: CUSTOM_TAGS }) };
+    })
+  );
+
+  return results;
+}
+
+// ── Main loader ────────────────────────────────────────────────────────
+
+/**
+ * Loads a knowledge base from a data directory into an in-memory Graph.
+ *
+ * Expected directory layout:
+ *   <dataDir>/properties.yaml
+ *   <dataDir>/schemas/*.yaml
+ *   <dataDir>/things/*.yaml
+ *
+ * Uses a two-pass approach for entities:
+ *   Pass 1: Load all entity headers (builds stableId → slug index)
+ *   Pass 2: Load facts and items (resolves !ref tags using the index)
+ */
+export async function loadKB(dataDir: string): Promise<Graph> {
+  const graph = new Graph();
+
+  // 1. Load properties
+  let properties = new Map<string, Property>();
+  try {
+    const propertiesContent = await readFile(
+      join(dataDir, "properties.yaml"),
+      "utf-8"
+    );
+    properties = parseProperties(parseYaml(propertiesContent));
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error; // Malformed YAML or permission errors should surface
+    }
+    // properties.yaml is optional for minimal setups
+  }
+
+  for (const property of properties.values()) {
+    graph.addProperty(property);
+  }
+
+  // 2. Load schemas
+  const schemaFiles = await readYamlFiles(join(dataDir, "schemas"));
+  for (const { parsed } of schemaFiles) {
+    const schema = parseSchema(parsed);
+    graph.addSchema(schema);
+  }
+
+  // 3. Load entities (two passes)
+  const entityFiles = await readYamlFiles(join(dataDir, "things"));
+
+  // Pass 1: Load all entity headers to build stableId index
+  const parsedEntityFiles: { entity: Entity; file: EntityFile }[] = [];
+  for (const { parsed } of entityFiles) {
+    const file = parsed as EntityFile;
+    const entity = parseEntity(file.thing);
+    graph.addEntity(entity);
+    parsedEntityFiles.push({ entity, file });
+  }
+
+  // Pass 2: Load facts and items with !ref resolution
+  for (const { entity, file } of parsedEntityFiles) {
+    // Resolve !ref markers in facts
+    for (const rawFact of file.facts ?? []) {
+      const resolvedValue = resolveRefs(rawFact.value, graph, `${entity.id}/facts`);
+      const resolvedFact = { ...rawFact, value: resolvedValue };
+      const fact = parseFact(resolvedFact as RawFact, entity.id, properties);
+      if (fact) graph.addFact(fact);
+    }
+
+    // Resolve !ref markers in items and add collections
+    if (file.items) {
+      const resolvedItems = resolveRefs(
+        file.items,
+        graph,
+        `${entity.id}/items`
+      ) as EntityFile["items"];
+
+      for (const collectionName of Object.keys(resolvedItems!)) {
+        const collection = parseItemCollection(resolvedItems, collectionName);
+        if (collection) {
+          graph.addItemCollection(entity.id, collectionName, collection);
+        }
+      }
+    }
+  }
+
+  return graph;
+}

--- a/packages/kb/src/serialize.ts
+++ b/packages/kb/src/serialize.ts
@@ -1,0 +1,51 @@
+/**
+ * Serialization: Graph → JSON (for downstream consumers like build-data).
+ */
+
+import type { Graph } from "./graph";
+import type { ItemEntry } from "./types";
+
+export interface SerializedKB {
+  entities: ReturnType<Graph["getAllEntities"]>;
+  facts: Record<string, ReturnType<Graph["getFacts"]>>;
+  properties: ReturnType<Graph["getAllProperties"]>;
+  schemas: ReturnType<Graph["getAllSchemas"]>;
+  items: Record<string, Record<string, ItemEntry[]>>;
+}
+
+/**
+ * Serialize a Graph to a plain JSON-friendly object.
+ * Useful for writing to database.json or sending over the wire.
+ */
+export function serialize(graph: Graph): SerializedKB {
+  const entities = graph.getAllEntities();
+  const properties = graph.getAllProperties();
+  const schemas = graph.getAllSchemas();
+
+  const facts: SerializedKB["facts"] = {};
+  const items: SerializedKB["items"] = {};
+
+  for (const entity of entities) {
+    const entityFacts = graph.getFacts(entity.id);
+    if (entityFacts.length > 0) {
+      facts[entity.id] = entityFacts;
+    }
+
+    // Serialize item collections for this entity
+    const schema = graph.getSchema(entity.type);
+    if (schema?.items) {
+      const entityItems: Record<string, ItemEntry[]> = {};
+      for (const collectionName of Object.keys(schema.items)) {
+        const entries = graph.getItems(entity.id, collectionName);
+        if (entries.length > 0) {
+          entityItems[collectionName] = entries;
+        }
+      }
+      if (Object.keys(entityItems).length > 0) {
+        items[entity.id] = entityItems;
+      }
+    }
+  }
+
+  return { entities, facts, properties, schemas, items };
+}

--- a/packages/kb/src/types.ts
+++ b/packages/kb/src/types.ts
@@ -1,0 +1,217 @@
+/**
+ * Core data model for the Knowledge Base library.
+ * Inspired by Ken Standard, extended with temporal data and stable IDs.
+ */
+
+// ── Values ──────────────────────────────────────────────────────────
+
+export type FactValue =
+  | { type: "number"; value: number; unit?: string }
+  | { type: "text"; value: string }
+  | { type: "date"; value: string }
+  | { type: "boolean"; value: boolean }
+  | { type: "ref"; value: string }
+  | { type: "refs"; value: string[] }
+  | { type: "json"; value: unknown };
+
+// ── Entity ──────────────────────────────────────────────────────────
+
+export interface Entity {
+  /** Human-readable slug: "anthropic", "claude-3-5-sonnet" */
+  id: string;
+  /** Random 10-char ID that survives renames */
+  stableId: string;
+  /** References a TypeSchema: "organization", "person" */
+  type: string;
+  /** Display name */
+  name: string;
+  /** Parent entity ID (e.g., funding round → org) */
+  parent?: string;
+  /** Alternative names for search */
+  aliases?: string[];
+  /** Former slugs for redirects */
+  previousIds?: string[];
+  /** Legacy wiki URL ID (E42) */
+  numericId?: number;
+}
+
+// ── Fact ────────────────────────────────────────────────────────────
+
+export interface Fact {
+  /** Random 10-char "f_xxxxxxxx" or content-hash */
+  id: string;
+  /** Entity ID (slug) this fact is about */
+  subjectId: string;
+  /** Property ID from the registry */
+  propertyId: string;
+  /** Typed value */
+  value: FactValue;
+  /** When this was true (ISO date or YYYY-MM) */
+  asOf?: string;
+  /** When this stopped being true (null/undefined = still true) */
+  validEnd?: string;
+  /** Source URL */
+  source?: string;
+  /** Relevant excerpt from source */
+  sourceQuote?: string;
+  /** Free-text annotation */
+  notes?: string;
+  /** If this fact was computed (e.g., inverse relationship) */
+  derivedFrom?: string;
+}
+
+// ── Property ────────────────────────────────────────────────────────
+
+export interface PropertyDisplay {
+  divisor?: number;
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface Property {
+  /** Property ID: "revenue", "employed-by" */
+  id: string;
+  /** Display name: "Revenue", "Employed By" */
+  name: string;
+  description?: string;
+  /** Value type: "number", "text", "date", "ref", "refs", "boolean" */
+  dataType: string;
+  /** Unit: "USD", "percent", "tokens" */
+  unit?: string;
+  /** Grouping: "financial", "people", "safety" */
+  category?: string;
+  /** Inverse property ID: "employed-by" → "employer-of" */
+  inverseId?: string;
+  /** Inverse display name: "Employed By" → "Employs" */
+  inverseName?: string;
+  /** Entity types this property is valid for */
+  appliesTo?: string[];
+  /** Display formatting */
+  display?: PropertyDisplay;
+  /** If true, this property is computed (never stored directly) */
+  computed?: boolean;
+  /** If true, values change over time (revenue, headcount). asOf = "measured at". */
+  temporal?: boolean;
+}
+
+// ── Type Schemas ────────────────────────────────────────────────────
+
+export interface FieldDef {
+  type: string;
+  required?: boolean;
+  unit?: string;
+  description?: string;
+}
+
+export interface ItemCollectionSchema {
+  description: string;
+  fields: Record<string, FieldDef>;
+}
+
+export interface TypeSchema {
+  /** Entity type this schema applies to: "organization", "person" */
+  type: string;
+  /** Display name: "Organization" */
+  name: string;
+  /** Property IDs that must have facts */
+  required: string[];
+  /** Property IDs that should have facts */
+  recommended: string[];
+  /** Named item collections (e.g., funding-rounds, key-people) */
+  items?: Record<string, ItemCollectionSchema>;
+}
+
+// ── Items (lightweight sub-collections) ─────────────────────────────
+
+export interface ItemEntry {
+  /** Local key within the collection: "series-a", "dario-ceo" */
+  key: string;
+  /** Typed fields (schema defined in ItemCollectionSchema) */
+  fields: Record<string, unknown>;
+}
+
+export interface ItemCollection {
+  /** References an item type (used for schema lookup) */
+  type: string;
+  /** Keyed entries */
+  entries: Record<string, Record<string, unknown>>;
+}
+
+// ── YAML file shapes ────────────────────────────────────────────────
+
+/** Shape of an entity's YAML file (data/things/anthropic.yaml) */
+export interface EntityFile {
+  thing: {
+    id: string;
+    stableId: string;
+    type: string;
+    name: string;
+    parent?: string;
+    aliases?: string[];
+    previousIds?: string[];
+    numericId?: number;
+  };
+  facts?: RawFact[];
+  items?: Record<string, RawItemCollection>;
+}
+
+/** Fact as stored in YAML (before normalization) */
+export interface RawFact {
+  id: string;
+  property: string;
+  value: unknown;
+  asOf?: string;
+  validEnd?: string;
+  source?: string;
+  sourceQuote?: string;
+  notes?: string;
+}
+
+/** Item collection as stored in YAML */
+export interface RawItemCollection {
+  type: string;
+  entries: Record<string, Record<string, unknown>>;
+}
+
+/** Shape of properties.yaml */
+export interface PropertiesFile {
+  properties: Record<string, Omit<Property, "id">>;
+}
+
+/** Shape of a schema YAML file */
+export interface SchemaFile {
+  type: string;
+  name: string;
+  required: string[];
+  recommended: string[];
+  items?: Record<string, {
+    description: string;
+    fields: Record<string, FieldDef>;
+  }>;
+}
+
+// ── Validation ──────────────────────────────────────────────────────
+
+export type ValidationSeverity = "error" | "warning" | "info";
+
+export interface ValidationResult {
+  severity: ValidationSeverity;
+  entityId?: string;
+  propertyId?: string;
+  message: string;
+  /** Which check produced this */
+  rule: string;
+}
+
+// ── Query options ───────────────────────────────────────────────────
+
+export interface FactQuery {
+  property?: string;
+  /** Only return facts that are currently valid (no validEnd) */
+  current?: boolean;
+}
+
+export interface PropertyQuery {
+  /** Only return the latest fact per entity (by asOf) */
+  latest?: boolean;
+}

--- a/packages/kb/src/validate.ts
+++ b/packages/kb/src/validate.ts
@@ -1,0 +1,942 @@
+/**
+ * Schema validation for the Knowledge Base graph.
+ *
+ * Original checks (1–6):
+ *  1. required-properties  (error)   — each entity must have a fact for every
+ *                                      property listed in its TypeSchema.required
+ *  2. recommended-properties (warning) — same check for TypeSchema.recommended
+ *  3. property-applies-to  (warning)  — if a property lists appliesTo, ensure
+ *                                       the entity's type is in that list
+ *  4. ref-integrity        (error)    — ref/refs values must point to existing
+ *                                       entities in the graph
+ *  5. item-collection-schema (error/warning) — validate item entries against
+ *                                       the ItemCollectionSchema defined in the
+ *                                       entity's TypeSchema (if one exists)
+ *  6. completeness         (info)     — percentage of required+recommended
+ *                                       properties that have at least one fact
+ *
+ * New checks (7–22):
+ *
+ * Data integrity (errors):
+ *  7. stableid-format      (error)    — StableId must be exactly 10 alphanumeric chars
+ *  8. duplicate-stableid   (error)    — Two entities sharing the same stableId
+ *  9. factid-format        (error)    — Fact ID must start with f_ or inv_ prefix
+ * 10. empty-name           (error)    — Entity has empty or missing name
+ * 11. valid-end-before-as-of (error)  — validEnd is earlier than asOf on a fact
+ *
+ * Temporal consistency (warnings):
+ * 12. temporal-missing-date (warning) — Fact on a temporal property has no asOf
+ * 13. non-temporal-multiple (warning) — Non-temporal property has multiple facts
+ * 14. stale-temporal       (warning)  — Most recent asOf is >2 years old
+ *
+ * Data quality (warnings):
+ * 15. duplicate-facts      (warning)  — Same (entity, property, asOf) tuple appears twice
+ * 16. missing-source       (warning)  — Fact has no source URL
+ * 17. unknown-property     (warning)  — Fact uses a propertyId not in the registry
+ * 18. date-format          (warning)  — asOf/validEnd doesn't match YYYY, YYYY-MM, or YYYY-MM-DD
+ * 19. future-date          (warning)  — asOf date is in the future
+ * 20. bidirectional-redundancy (warning) — Both sides of an inverse relationship stored
+ *
+ * Informational:
+ * 21. orphan-entity        (info)     — Entity has zero facts and zero items
+ * 22. dead-source          (info)     — Source URL returns non-200 (expensive, optional)
+ */
+
+import type { Graph } from "./graph";
+import type {
+  Fact,
+  FactValue,
+  FieldDef,
+  ItemCollectionSchema,
+  TypeSchema,
+  ValidationResult,
+} from "./types";
+
+// ── Validation options ────────────────────────────────────────────────────────
+
+export interface ValidateOptions {
+  /** If true, check source URLs for HTTP status (expensive, default: false). */
+  checkUrls?: boolean;
+}
+
+// ── Utility helpers ───────────────────────────────────────────────────────────
+
+/** Returns true if the entity has at least one fact for the given propertyId. */
+function hasFact(graph: Graph, entityId: string, propertyId: string): boolean {
+  return graph.getFacts(entityId, { property: propertyId }).length > 0;
+}
+
+/**
+ * Very lightweight date-format check.
+ * Accepts: YYYY, YYYY-MM, YYYY-MM-DD.
+ */
+function looksLikeDate(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return /^\d{4}(-\d{2}(-\d{2})?)?$/.test(value);
+}
+
+/** StableId format: exactly 10 alphanumeric characters. */
+const STABLEID_RE = /^[A-Za-z0-9]{10}$/;
+
+/** Fact ID format: must start with f_ or inv_ prefix. */
+const FACTID_RE = /^(f_|inv_).+$/;
+
+/** Date format: YYYY, YYYY-MM, or YYYY-MM-DD. */
+const DATE_FORMAT_RE = /^\d{4}(-\d{2}(-\d{2})?)?$/;
+
+// ── Per-entity check implementations (existing checks 1–6) ───────────────────
+
+/** Check 1: required properties. */
+function checkRequired(
+  graph: Graph,
+  entityId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const propertyId of schema.required) {
+    if (!hasFact(graph, entityId, propertyId)) {
+      results.push({
+        severity: "error",
+        entityId,
+        propertyId,
+        message: `Missing required property "${propertyId}" on entity "${entityId}" (type: ${schema.type}).`,
+        rule: "required-properties",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 2: recommended properties. */
+function checkRecommended(
+  graph: Graph,
+  entityId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const propertyId of schema.recommended) {
+    if (!hasFact(graph, entityId, propertyId)) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId,
+        message: `Missing recommended property "${propertyId}" on entity "${entityId}" (type: ${schema.type}).`,
+        rule: "recommended-properties",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 3: property appliesTo type constraint. */
+function checkPropertyAppliesTo(
+  graph: Graph,
+  entityId: string,
+  entityType: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    const property = graph.getProperty(fact.propertyId);
+    if (!property) continue; // Unknown properties are caught by other checks if needed.
+    if (!property.appliesTo || property.appliesTo.length === 0) continue;
+
+    if (!property.appliesTo.includes(entityType)) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Property "${fact.propertyId}" applies to [${property.appliesTo.join(", ")}] ` +
+          `but entity "${entityId}" is of type "${entityType}".`,
+        rule: "property-applies-to",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 4: ref/refs integrity — referenced entities must exist. */
+function checkRefIntegrity(graph: Graph, entityId: string): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    const missingRefs = _findMissingRefs(graph, fact.value);
+
+    for (const missingId of missingRefs) {
+      results.push({
+        severity: "error",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}" references unknown entity "${missingId}" ` +
+          `(property: "${fact.propertyId}").`,
+        rule: "ref-integrity",
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Returns the list of referenced entity IDs that do not exist in the graph.
+ * Only inspects ref/refs value types.
+ */
+function _findMissingRefs(graph: Graph, value: FactValue): string[] {
+  if (value.type === "ref") {
+    return graph.getEntity(value.value) ? [] : [value.value];
+  }
+
+  if (value.type === "refs") {
+    return value.value.filter((id) => !graph.getEntity(id));
+  }
+
+  return [];
+}
+
+/** Check 5: item collection schema validation. */
+function checkItemCollections(
+  graph: Graph,
+  entityId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  if (!schema.items) return results;
+
+  for (const [collectionName, collectionSchema] of Object.entries(
+    schema.items
+  )) {
+    const entries = graph.getItems(entityId, collectionName);
+
+    for (const entry of entries) {
+      const entryResults = _validateItemEntry(
+        graph,
+        entityId,
+        collectionName,
+        entry.key,
+        entry.fields,
+        collectionSchema
+      );
+      results.push(...entryResults);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Validates a single item entry against an ItemCollectionSchema.
+ * Produces errors for missing required fields and warnings for type mismatches.
+ */
+function _validateItemEntry(
+  graph: Graph,
+  entityId: string,
+  collectionName: string,
+  entryKey: string,
+  fields: Record<string, unknown>,
+  schema: ItemCollectionSchema
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const prefix = `Item "${collectionName}/${entryKey}" on entity "${entityId}"`;
+
+  for (const [fieldName, fieldDef] of Object.entries(schema.fields)) {
+    const value = fields[fieldName];
+
+    // Required field presence check (error).
+    if (fieldDef.required && (value === undefined || value === null)) {
+      results.push({
+        severity: "error",
+        entityId,
+        message: `${prefix}: missing required field "${fieldName}".`,
+        rule: "item-collection-schema",
+      });
+      continue; // Skip type check for absent field.
+    }
+
+    // Type validity check (warning) — only when value is present.
+    if (value !== undefined && value !== null) {
+      const typeError = _checkFieldType(graph, fieldDef, value, fieldName, prefix);
+      if (typeError) {
+        results.push({
+          severity: "warning",
+          entityId,
+          message: typeError,
+          rule: "item-collection-schema",
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Returns an error message string if `value` does not match the expected type
+ * from `fieldDef`, or null if the value is acceptable.
+ */
+function _checkFieldType(
+  graph: Graph,
+  fieldDef: FieldDef,
+  value: unknown,
+  fieldName: string,
+  prefix: string
+): string | null {
+  switch (fieldDef.type) {
+    case "number":
+      if (typeof value !== "number") {
+        return `${prefix}: field "${fieldName}" expected number, got ${typeof value}.`;
+      }
+      break;
+
+    case "boolean":
+      if (typeof value !== "boolean") {
+        return `${prefix}: field "${fieldName}" expected boolean, got ${typeof value}.`;
+      }
+      break;
+
+    case "date":
+      if (!looksLikeDate(value)) {
+        return (
+          `${prefix}: field "${fieldName}" expected a date string (YYYY, YYYY-MM, ` +
+          `or YYYY-MM-DD), got ${JSON.stringify(value)}.`
+        );
+      }
+      break;
+
+    case "ref":
+      if (typeof value !== "string") {
+        return `${prefix}: field "${fieldName}" expected an entity ID string (ref), got ${typeof value}.`;
+      }
+      // Verify the referenced entity exists.
+      if (!graph.getEntity(value)) {
+        return (
+          `${prefix}: field "${fieldName}" references unknown entity "${value}".`
+        );
+      }
+      break;
+
+    case "text":
+      if (typeof value !== "string") {
+        return `${prefix}: field "${fieldName}" expected string (text), got ${typeof value}.`;
+      }
+      break;
+
+    // "json" and unknown types: no type check.
+    default:
+      break;
+  }
+
+  return null;
+}
+
+/** Check 6: completeness report. */
+function checkCompleteness(
+  graph: Graph,
+  entityId: string,
+  schema: TypeSchema
+): ValidationResult[] {
+  const tracked = [...schema.required, ...schema.recommended];
+  if (tracked.length === 0) return [];
+
+  const present = tracked.filter((p) => hasFact(graph, entityId, p)).length;
+  const pct = Math.round((present / tracked.length) * 100);
+
+  return [
+    {
+      severity: "info",
+      entityId,
+      message:
+        `Completeness for "${entityId}" (type: ${schema.type}): ` +
+        `${present}/${tracked.length} required+recommended properties present (${pct}%).`,
+      rule: "completeness",
+    },
+  ];
+}
+
+// ── New per-entity checks (7–21) ─────────────────────────────────────────────
+
+/** Check 7: stableId format — must be exactly 10 alphanumeric chars. */
+function checkStableIdFormat(
+  entityId: string,
+  stableId: string
+): ValidationResult[] {
+  if (!STABLEID_RE.test(stableId)) {
+    return [
+      {
+        severity: "error",
+        entityId,
+        message:
+          `Entity "${entityId}" has invalid stableId "${stableId}" ` +
+          `(must be exactly 10 alphanumeric characters).`,
+        rule: "stableid-format",
+      },
+    ];
+  }
+  return [];
+}
+
+/** Check 9: fact ID format — must start with f_ or inv_ prefix. */
+function checkFactIdFormat(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    if (!FACTID_RE.test(fact.id)) {
+      results.push({
+        severity: "error",
+        entityId,
+        message:
+          `Fact "${fact.id}" on entity "${entityId}" has invalid ID format ` +
+          `(must start with "f_" or "inv_").`,
+        rule: "factid-format",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 10: empty name — entity must have a non-empty name. */
+function checkEmptyName(
+  entityId: string,
+  name: string
+): ValidationResult[] {
+  if (!name || name.trim().length === 0) {
+    return [
+      {
+        severity: "error",
+        entityId,
+        message: `Entity "${entityId}" has an empty or missing name.`,
+        rule: "empty-name",
+      },
+    ];
+  }
+  return [];
+}
+
+/** Check 11: validEnd before asOf — temporal ordering. */
+function checkValidEndBeforeAsOf(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    if (fact.asOf && fact.validEnd) {
+      // Compare as strings — works for YYYY, YYYY-MM, YYYY-MM-DD because
+      // the format is lexicographically ordered.
+      if (fact.validEnd < fact.asOf) {
+        results.push({
+          severity: "error",
+          entityId,
+          propertyId: fact.propertyId,
+          message:
+            `Fact "${fact.id}" on "${entityId}": validEnd "${fact.validEnd}" ` +
+            `is earlier than asOf "${fact.asOf}".`,
+          rule: "valid-end-before-as-of",
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/** Check 12: temporal property missing asOf date. */
+function checkTemporalMissingDate(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    // Skip derived (inverse) facts — they inherit asOf from the source.
+    if (fact.derivedFrom) continue;
+
+    const property = graph.getProperty(fact.propertyId);
+    if (!property) continue;
+    if (!property.temporal) continue;
+
+    if (!fact.asOf) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}" uses temporal property ` +
+          `"${fact.propertyId}" but has no asOf date.`,
+        rule: "temporal-missing-date",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 13: non-temporal property with multiple facts. */
+function checkNonTemporalMultiple(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  // Group non-derived facts by propertyId.
+  const byProperty = new Map<string, number>();
+  for (const fact of facts) {
+    if (fact.derivedFrom) continue;
+    const prev = byProperty.get(fact.propertyId) || 0;
+    byProperty.set(fact.propertyId, prev + 1);
+  }
+
+  for (const [propertyId, count] of byProperty) {
+    if (count <= 1) continue;
+
+    const property = graph.getProperty(propertyId);
+    if (!property) continue;
+    if (property.temporal) continue; // Temporal properties are expected to have multiple facts.
+
+    results.push({
+      severity: "warning",
+      entityId,
+      propertyId,
+      message:
+        `Non-temporal property "${propertyId}" on "${entityId}" has ${count} facts ` +
+        `(expected at most 1 for non-temporal properties).`,
+      rule: "non-temporal-multiple",
+    });
+  }
+
+  return results;
+}
+
+/** Check 14: stale temporal data — most recent asOf is >2 years old. */
+function checkStaleTemporal(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  // Group non-derived facts by propertyId, track the most recent asOf.
+  const latestAsOf = new Map<string, string>();
+  for (const fact of facts) {
+    if (fact.derivedFrom) continue;
+    if (!fact.asOf) continue;
+
+    const property = graph.getProperty(fact.propertyId);
+    if (!property?.temporal) continue;
+
+    const current = latestAsOf.get(fact.propertyId);
+    if (!current || fact.asOf > current) {
+      latestAsOf.set(fact.propertyId, fact.asOf);
+    }
+  }
+
+  // 2 years ago from today.
+  const twoYearsAgo = _twoYearsAgoStr();
+
+  for (const [propertyId, latest] of latestAsOf) {
+    if (latest < twoYearsAgo) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId,
+        message:
+          `Temporal property "${propertyId}" on "${entityId}" may be stale: ` +
+          `most recent asOf is "${latest}" (>2 years old).`,
+        rule: "stale-temporal",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Returns YYYY-MM-DD string for 2 years ago from today. */
+function _twoYearsAgoStr(): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 2);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Check 15: duplicate facts — same (entity, property, asOf) tuple. */
+function checkDuplicateFacts(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  const seen = new Set<string>();
+  for (const fact of facts) {
+    if (fact.derivedFrom) continue;
+
+    const asOfKey = fact.asOf || "";
+    const key = `${fact.propertyId}|${asOfKey}`;
+    if (seen.has(key)) {
+      const asOfDisplay = fact.asOf || "(none)";
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Duplicate fact on "${entityId}": property "${fact.propertyId}" ` +
+          `with asOf "${asOfDisplay}" appears multiple times.`,
+        rule: "duplicate-facts",
+      });
+    }
+    seen.add(key);
+  }
+
+  return results;
+}
+
+/** Check 16: missing source URL. */
+function checkMissingSource(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    if (fact.derivedFrom) continue;
+
+    if (!fact.source) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}" (property: "${fact.propertyId}") ` +
+          `has no source URL.`,
+        rule: "missing-source",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 17: unknown property — fact references a property not in the registry. */
+function checkUnknownProperty(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    if (fact.derivedFrom) continue;
+
+    if (!graph.getProperty(fact.propertyId)) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}" uses unknown property ` +
+          `"${fact.propertyId}" (not in property registry).`,
+        rule: "unknown-property",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 18: date format — asOf/validEnd must match YYYY, YYYY-MM, or YYYY-MM-DD. */
+function checkDateFormat(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+
+  for (const fact of facts) {
+    if (fact.asOf && !DATE_FORMAT_RE.test(fact.asOf)) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}": asOf "${fact.asOf}" ` +
+          `does not match date format (YYYY, YYYY-MM, or YYYY-MM-DD).`,
+        rule: "date-format",
+      });
+    }
+    if (fact.validEnd && !DATE_FORMAT_RE.test(fact.validEnd)) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}": validEnd "${fact.validEnd}" ` +
+          `does not match date format (YYYY, YYYY-MM, or YYYY-MM-DD).`,
+        rule: "date-format",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Check 19: future date — asOf is in the future. */
+function checkFutureDate(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const facts = graph.getFacts(entityId);
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  for (const fact of facts) {
+    if (!fact.asOf) continue;
+    // Pad short dates for comparison: "2026" → "2026-12-31", "2026-03" → "2026-03-31"
+    const padded = _padDateForFutureCheck(fact.asOf);
+    if (padded > today) {
+      results.push({
+        severity: "warning",
+        entityId,
+        propertyId: fact.propertyId,
+        message:
+          `Fact "${fact.id}" on "${entityId}": asOf "${fact.asOf}" ` +
+          `is in the future.`,
+        rule: "future-date",
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Pads a partial date to its earliest day for future-date comparison.
+ * "2026" stays "2026" (year-only is compared against today's year prefix)
+ * For a fair comparison: "2030" > "2026-03-06" should hold because
+ * any day in 2030 is after today.
+ *
+ * We just compare raw strings — YYYY > YYYY-MM-DD works for our purpose
+ * because "2030" > "2026-03-06" lexicographically. The only edge case is
+ * the current year with year-only format, which we treat as not-future
+ * since the year has started.
+ */
+function _padDateForFutureCheck(dateStr: string): string {
+  // For the future check, we want to know if the date is definitely in the future.
+  // YYYY-only: compare just the year — "2030" > "2026-03-06" ✓
+  // YYYY-MM: compare as-is — "2030-01" > "2026-03-06" ✓
+  // YYYY-MM-DD: compare as-is
+  return dateStr;
+}
+
+/** Check 21: orphan entity — no facts and no items. */
+function checkOrphanEntity(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const facts = graph.getFacts(entityId);
+  const hasItems = graph.getItemCollectionNames(entityId).length > 0;
+
+  // Only count non-derived facts.
+  const nonDerivedFacts = facts.filter((f) => !f.derivedFrom);
+
+  if (nonDerivedFacts.length === 0 && !hasItems) {
+    return [
+      {
+        severity: "info",
+        entityId,
+        message: `Entity "${entityId}" is an orphan (no facts and no item collections).`,
+        rule: "orphan-entity",
+      },
+    ];
+  }
+
+  return [];
+}
+
+// ── Graph-level checks (run once across all entities) ─────────────────────────
+
+/** Check 8: duplicate stableIds across the graph. */
+function checkDuplicateStableIds(graph: Graph): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const seen = new Map<string, string>(); // stableId → first entityId
+
+  for (const entity of graph.getAllEntities()) {
+    const existing = seen.get(entity.stableId);
+    if (existing) {
+      results.push({
+        severity: "error",
+        entityId: entity.id,
+        message:
+          `Entity "${entity.id}" shares stableId "${entity.stableId}" ` +
+          `with entity "${existing}".`,
+        rule: "duplicate-stableid",
+      });
+    } else {
+      seen.set(entity.stableId, entity.id);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Check 20: bidirectional redundancy — both sides of an inverse relationship
+ * are stored explicitly (one side should be computed by inverse computation).
+ */
+function checkBidirectionalRedundancy(graph: Graph): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  // Build a map of property → inverseId pairs.
+  const inverseMap = new Map<string, string>();
+  for (const property of graph.getAllProperties()) {
+    if (property.inverseId && !property.computed) {
+      inverseMap.set(property.id, property.inverseId);
+    }
+  }
+
+  // For each property that has an inverse, check if the inverse side also has
+  // explicitly stored (non-derived) facts that would be redundant.
+  for (const [propertyId, inverseId] of inverseMap) {
+    // Get all entities that have a non-derived fact for this property.
+    for (const entity of graph.getAllEntities()) {
+      const facts = graph
+        .getFacts(entity.id, { property: propertyId })
+        .filter((f) => !f.derivedFrom);
+
+      for (const fact of facts) {
+        // For ref values, check if the referenced entity has an explicit inverse fact.
+        if (fact.value.type === "ref") {
+          const refId = fact.value.value;
+          const inverseFacts = graph
+            .getFacts(refId, { property: inverseId })
+            .filter(
+              (f) =>
+                !f.derivedFrom &&
+                f.value.type === "ref" &&
+                f.value.value === entity.id
+            );
+
+          if (inverseFacts.length > 0) {
+            results.push({
+              severity: "warning",
+              entityId: entity.id,
+              propertyId,
+              message:
+                `Bidirectional redundancy: "${entity.id}" has "${propertyId}" → "${refId}", ` +
+                `and "${refId}" has explicit "${inverseId}" → "${entity.id}". ` +
+                `Only one side needs to be stored; the other is computed via inverse.`,
+              rule: "bidirectional-redundancy",
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Validates a single entity against its TypeSchema and general data quality rules.
+ * Returns an array of ValidationResult objects.
+ *
+ * If no TypeSchema is registered for the entity's type, a warning is returned
+ * and schema-dependent checks are skipped (but general checks still run).
+ */
+export function validateEntity(
+  graph: Graph,
+  entityId: string
+): ValidationResult[] {
+  const entity = graph.getEntity(entityId);
+  if (!entity) {
+    return [
+      {
+        severity: "error",
+        entityId,
+        message: `Entity "${entityId}" not found in graph.`,
+        rule: "entity-exists",
+      },
+    ];
+  }
+
+  // General checks that don't depend on a TypeSchema.
+  const generalResults: ValidationResult[] = [
+    ...checkStableIdFormat(entityId, entity.stableId),
+    ...checkEmptyName(entityId, entity.name),
+    ...checkFactIdFormat(graph, entityId),
+    ...checkValidEndBeforeAsOf(graph, entityId),
+    ...checkTemporalMissingDate(graph, entityId),
+    ...checkNonTemporalMultiple(graph, entityId),
+    ...checkStaleTemporal(graph, entityId),
+    ...checkDuplicateFacts(graph, entityId),
+    ...checkMissingSource(graph, entityId),
+    ...checkUnknownProperty(graph, entityId),
+    ...checkDateFormat(graph, entityId),
+    ...checkFutureDate(graph, entityId),
+    ...checkOrphanEntity(graph, entityId),
+  ];
+
+  const schema = graph.getSchema(entity.type);
+  if (!schema) {
+    return [
+      {
+        severity: "warning",
+        entityId,
+        message: `No TypeSchema registered for type "${entity.type}" (entity: "${entityId}"). Skipping schema checks.`,
+        rule: "schema-exists",
+      },
+      ...generalResults,
+    ];
+  }
+
+  return [
+    ...checkRequired(graph, entityId, schema),
+    ...checkRecommended(graph, entityId, schema),
+    ...checkPropertyAppliesTo(graph, entityId, entity.type),
+    ...checkRefIntegrity(graph, entityId),
+    ...checkItemCollections(graph, entityId, schema),
+    ...checkCompleteness(graph, entityId, schema),
+    ...generalResults,
+  ];
+}
+
+/**
+ * Validates the entire graph — runs validateEntity() on every entity,
+ * plus graph-level cross-entity checks.
+ * Returns an array of all ValidationResult objects across all entities.
+ */
+export function validate(
+  graph: Graph,
+  options?: ValidateOptions
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  // Per-entity checks
+  for (const entity of graph.getAllEntities()) {
+    results.push(...validateEntity(graph, entity.id));
+  }
+
+  // Graph-level checks
+  results.push(...checkDuplicateStableIds(graph));
+  results.push(...checkBidirectionalRedundancy(graph));
+
+  return results;
+}

--- a/packages/kb/tests/graph.test.ts
+++ b/packages/kb/tests/graph.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader";
+import type { Graph } from "../src/graph";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("graph", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("getEntity", () => {
+    it("returns the correct entity for a valid ID", () => {
+      const entity = graph.getEntity("anthropic");
+      expect(entity).toBeDefined();
+      expect(entity!.id).toBe("anthropic");
+      expect(entity!.name).toBe("Anthropic");
+      expect(entity!.type).toBe("organization");
+    });
+
+    it("returns undefined for a missing entity", () => {
+      const entity = graph.getEntity("nonexistent-org");
+      expect(entity).toBeUndefined();
+    });
+  });
+
+  describe("getAllEntities", () => {
+    it("returns all entities in the graph", () => {
+      const entities = graph.getAllEntities();
+      expect(entities).toHaveLength(30);
+    });
+  });
+
+  describe("getFacts", () => {
+    it("returns all facts for an entity", () => {
+      const facts = graph.getFacts("anthropic");
+      // 9 revenue + 4 valuation + 3 total-funding + 3 headcount + 1 founded-date
+      // + 1 headquarters + 1 legal-structure + 2 gross-margin + 2 cash-burn
+      // + 2 enterprise-market-share + 1 coding-market-share + 1 monthly-active-users
+      // + 1 business-customers + 1 api-calls-monthly + 1 product-revenue
+      // + 1 safety-level + 1 safety-researcher-count + 1 interpretability-team-size
+      // + 1 founded-by = 37
+      expect(facts).toHaveLength(37);
+    });
+
+    it("returns empty array for an entity with no facts", () => {
+      const facts = graph.getFacts("nonexistent");
+      expect(facts).toEqual([]);
+    });
+
+    it("filters by property", () => {
+      const revenueFacts = graph.getFacts("anthropic", {
+        property: "revenue",
+      });
+      expect(revenueFacts).toHaveLength(9);
+      for (const fact of revenueFacts) {
+        expect(fact.propertyId).toBe("revenue");
+      }
+    });
+
+    it("filters by current (no validEnd)", () => {
+      // Jan Leike has 2 employed-by facts: one with validEnd (OpenAI), one without (Anthropic)
+      const currentFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+        current: true,
+      });
+      expect(currentFacts).toHaveLength(1);
+      expect(currentFacts[0].value).toEqual({
+        type: "ref",
+        value: "anthropic",
+      });
+    });
+
+    it("returns both current and ended facts without current filter", () => {
+      const allFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      expect(allFacts).toHaveLength(2);
+    });
+
+    it("can combine property and current filters", () => {
+      // All Jan Leike's employed-by facts that are current
+      const facts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+        current: true,
+      });
+      expect(facts).toHaveLength(1);
+      expect(facts[0].validEnd).toBeUndefined();
+    });
+  });
+
+  describe("getLatest", () => {
+    it("returns the most recent fact by asOf for a time series", () => {
+      const latest = graph.getLatest("anthropic", "revenue");
+      expect(latest).toBeDefined();
+      // The most recent revenue fact is asOf: 2026-03 with value 19e9
+      expect(latest!.asOf).toBe("2026-03");
+      expect(latest!.value).toEqual({ type: "number", value: 19e9 });
+    });
+
+    it("returns undefined for a missing property", () => {
+      const latest = graph.getLatest("anthropic", "nonexistent-property");
+      expect(latest).toBeUndefined();
+    });
+
+    it("returns undefined for a missing entity", () => {
+      const latest = graph.getLatest("nonexistent", "revenue");
+      expect(latest).toBeUndefined();
+    });
+
+    it("returns the only fact when there is just one", () => {
+      const latest = graph.getLatest("anthropic", "headquarters");
+      expect(latest).toBeDefined();
+      expect(latest!.value).toEqual({
+        type: "text",
+        value: "San Francisco, CA",
+      });
+    });
+  });
+
+  describe("getByProperty", () => {
+    it("returns facts across entities for a given property", () => {
+      const revMap = graph.getByProperty("revenue");
+      // Anthropic and OpenAI both have revenue facts
+      expect(revMap.size).toBe(2);
+      expect(revMap.has("anthropic")).toBe(true);
+      expect(revMap.has("openai")).toBe(true);
+    });
+
+    it("returns facts from multiple entities", () => {
+      const roleMap = graph.getByProperty("role");
+      // All 20 people have role facts
+      expect(roleMap.size).toBe(20);
+      expect(roleMap.has("dario-amodei")).toBe(true);
+      expect(roleMap.has("jan-leike")).toBe(true);
+      expect(roleMap.has("sam-altman")).toBe(true);
+    });
+
+    it("returns latest fact per entity with latest:true", () => {
+      const revMap = graph.getByProperty("revenue", { latest: true });
+      expect(revMap.size).toBe(2);
+      const anthropicRev = revMap.get("anthropic");
+      expect(anthropicRev).toBeDefined();
+      expect(anthropicRev!.asOf).toBe("2026-03");
+    });
+
+    it("returns empty map for unused property", () => {
+      const map = graph.getByProperty("launched-date");
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe("getByType", () => {
+    it("returns entities of a given type", () => {
+      const orgs = graph.getByType("organization");
+      expect(orgs).toHaveLength(10);
+      const orgIds = orgs.map((o) => o.id).sort();
+      expect(orgIds).toEqual([
+        "anthropic", "arc", "conjecture", "deepmind", "meta-ai",
+        "miri", "openai", "redwood-research", "ssi", "xai",
+      ]);
+    });
+
+    it("returns multiple entities of the same type", () => {
+      const people = graph.getByType("person");
+      expect(people).toHaveLength(20);
+      const ids = people.map((p) => p.id).sort();
+      expect(ids).toEqual([
+        "chris-olah", "connor-leahy", "daniela-amodei", "dario-amodei",
+        "demis-hassabis", "dustin-moskovitz", "eliezer-yudkowsky",
+        "elon-musk", "geoffrey-hinton", "greg-brockman", "holden-karnofsky",
+        "ilya-sutskever", "jan-leike", "neel-nanda", "nick-bostrom",
+        "paul-christiano", "sam-altman", "stuart-russell", "yann-lecun",
+        "yoshua-bengio",
+      ].sort());
+    });
+
+    it("returns empty array for unknown type", () => {
+      const entities = graph.getByType("product");
+      expect(entities).toHaveLength(0);
+    });
+  });
+
+  describe("getRelated", () => {
+    it("returns referenced entity IDs from ref facts", () => {
+      const related = graph.getRelated("jan-leike", "employed-by");
+      expect(related).toContain("openai");
+      expect(related).toContain("anthropic");
+      expect(related).toHaveLength(2);
+    });
+
+    it("returns referenced entity IDs from a single ref fact", () => {
+      const related = graph.getRelated("dario-amodei", "employed-by");
+      expect(related).toEqual(["anthropic"]);
+    });
+
+    it("returns empty array when no facts match", () => {
+      const related = graph.getRelated("anthropic", "employed-by");
+      expect(related).toEqual([]);
+    });
+
+    it("returns empty array for nonexistent entity", () => {
+      const related = graph.getRelated("nonexistent", "employed-by");
+      expect(related).toEqual([]);
+    });
+  });
+
+  describe("getItems", () => {
+    it("returns item entries with keys and fields", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      expect(rounds.length).toBeGreaterThan(0);
+
+      // Each entry has a key and fields
+      for (const entry of rounds) {
+        expect(typeof entry.key).toBe("string");
+        expect(typeof entry.fields).toBe("object");
+      }
+    });
+
+    it("returns correct data for a specific entry", () => {
+      const people = graph.getItems("anthropic", "key-people");
+      const darioCeo = people.find((p) => p.key === "i_Xp9vKZzBsg");
+      expect(darioCeo).toBeDefined();
+      expect(darioCeo!.fields.person).toBe("dario-amodei");
+      expect(darioCeo!.fields.title).toBe("CEO");
+      expect(darioCeo!.fields.start).toBe("2021-01");
+      expect(darioCeo!.fields.is_founder).toBe(true);
+    });
+
+    it("returns empty array for missing collection", () => {
+      const items = graph.getItems("anthropic", "nonexistent");
+      expect(items).toEqual([]);
+    });
+
+    it("returns empty array for entity without items", () => {
+      const items = graph.getItems("jan-leike", "key-people");
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("getItemsMentioning", () => {
+    it("finds items referencing an entity via ref fields", () => {
+      // Anthropic's key-people collection has person fields referencing
+      // dario-amodei, jan-leike, etc. (typed as ref in schema)
+      const mentions = graph.getItemsMentioning("dario-amodei");
+      expect(mentions.length).toBeGreaterThan(0);
+
+      // Should find the key-people entry on Anthropic
+      const anthropicMention = mentions.find(
+        (m) => m.ownerEntityId === "anthropic" && m.collection === "key-people"
+      );
+      expect(anthropicMention).toBeDefined();
+      expect(anthropicMention!.matchingFields).toContain("person");
+      expect(anthropicMention!.entry.fields.person).toBe("dario-amodei");
+    });
+
+    it("does not include self-references", () => {
+      const mentions = graph.getItemsMentioning("anthropic");
+      // Should not find items from Anthropic's own collections
+      const selfRefs = mentions.filter((m) => m.ownerEntityId === "anthropic");
+      expect(selfRefs).toHaveLength(0);
+    });
+
+    it("returns empty array for entity with no mentions", () => {
+      const mentions = graph.getItemsMentioning("nonexistent-entity");
+      expect(mentions).toHaveLength(0);
+    });
+  });
+
+  describe("property and schema queries", () => {
+    it("getProperty returns correct property", () => {
+      const prop = graph.getProperty("headquarters");
+      expect(prop).toBeDefined();
+      expect(prop!.name).toBe("Headquarters");
+      expect(prop!.dataType).toBe("text");
+    });
+
+    it("getProperty returns undefined for missing property", () => {
+      expect(graph.getProperty("nonexistent")).toBeUndefined();
+    });
+
+    it("getSchema returns correct schema", () => {
+      const schema = graph.getSchema("organization");
+      expect(schema).toBeDefined();
+      expect(schema!.name).toBe("Organization");
+    });
+
+    it("getSchema returns undefined for missing schema", () => {
+      expect(graph.getSchema("nonexistent")).toBeUndefined();
+    });
+  });
+});

--- a/packages/kb/tests/ids.test.ts
+++ b/packages/kb/tests/ids.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateStableId,
+  generateFactId,
+  contentHash,
+  generateContentFactId,
+} from "../src/ids";
+
+describe("ids", () => {
+  describe("generateStableId", () => {
+    it("returns a 10-character string", () => {
+      const id = generateStableId();
+      expect(id).toHaveLength(10);
+    });
+
+    it("returns only alphanumeric characters (no - or _)", () => {
+      // Run multiple times to increase confidence since replacement is probabilistic
+      for (let i = 0; i < 50; i++) {
+        const id = generateStableId();
+        expect(id).toMatch(/^[A-Za-z0-9]{10}$/);
+      }
+    });
+
+    it("generates unique IDs on successive calls", () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateStableId());
+      }
+      // With 10 alphanumeric chars, collisions in 100 tries are astronomically unlikely
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe("generateFactId", () => {
+    it('returns a string starting with "f_"', () => {
+      const id = generateFactId();
+      expect(id.startsWith("f_")).toBe(true);
+    });
+
+    it('returns "f_" followed by 10 alphanumeric characters', () => {
+      const id = generateFactId();
+      expect(id).toHaveLength(12); // "f_" + 10 chars
+      expect(id).toMatch(/^f_[A-Za-z0-9]{10}$/);
+    });
+
+    it("does not contain - or _ after the f_ prefix", () => {
+      for (let i = 0; i < 50; i++) {
+        const id = generateFactId();
+        const suffix = id.slice(2);
+        expect(suffix).toMatch(/^[A-Za-z0-9]{10}$/);
+      }
+    });
+  });
+
+  describe("contentHash", () => {
+    it("is deterministic: same inputs produce same output", () => {
+      const parts = ["anthropic", "revenue", "1000000000", "2024"];
+      const hash1 = contentHash(parts);
+      const hash2 = contentHash(parts);
+      expect(hash1).toBe(hash2);
+    });
+
+    it("returns a 10-character string", () => {
+      const hash = contentHash(["hello", "world"]);
+      expect(hash).toHaveLength(10);
+    });
+
+    it("produces different output for different inputs", () => {
+      const hash1 = contentHash(["anthropic", "revenue"]);
+      const hash2 = contentHash(["openai", "revenue"]);
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("distinguishes between different argument boundaries", () => {
+      // "ab" + "cd" should differ from "a" + "bcd" because of null-byte separator
+      const hash1 = contentHash(["ab", "cd"]);
+      const hash2 = contentHash(["a", "bcd"]);
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("handles empty parts array", () => {
+      const hash = contentHash([]);
+      expect(hash).toHaveLength(10);
+    });
+  });
+
+  describe("generateContentFactId", () => {
+    it('returns a string starting with "f_"', () => {
+      const id = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id.startsWith("f_")).toBe(true);
+    });
+
+    it("is deterministic: same inputs produce same output", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id1).toBe(id2);
+    });
+
+    it("produces different output for different values", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("anthropic", "revenue", 2e9, "2024");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("produces different output for different subjects", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      const id2 = generateContentFactId("openai", "revenue", 1e9, "2024");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("handles missing asOf parameter", () => {
+      const id1 = generateContentFactId("anthropic", "revenue", 1e9);
+      const id2 = generateContentFactId("anthropic", "revenue", 1e9);
+      expect(id1).toBe(id2);
+    });
+
+    it("returns f_ + 10 characters (12 total)", () => {
+      const id = generateContentFactId("anthropic", "revenue", 1e9, "2024");
+      expect(id).toHaveLength(12);
+    });
+  });
+});

--- a/packages/kb/tests/inverse.test.ts
+++ b/packages/kb/tests/inverse.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader";
+import { computeInverses } from "../src/inverse";
+import type { Graph } from "../src/graph";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("inverse", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+    // Suppress console.warn for expected warnings about missing things
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    computeInverses(graph);
+    vi.restoreAllMocks();
+  });
+
+  describe("computeInverses", () => {
+    it("creates employer-of facts on anthropic from employed-by on persons", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      // Both dario-amodei and jan-leike have employed-by: anthropic
+      expect(employerOfFacts.length).toBeGreaterThanOrEqual(2);
+
+      const refValues = employerOfFacts.map((f) => {
+        expect(f.value.type).toBe("ref");
+        return (f.value as { type: "ref"; value: string }).value;
+      });
+      expect(refValues).toContain("dario-amodei");
+      expect(refValues).toContain("jan-leike");
+    });
+
+    it("inverse facts have derivedFrom set", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      for (const fact of employerOfFacts) {
+        expect(fact.derivedFrom).toBeDefined();
+        expect(typeof fact.derivedFrom).toBe("string");
+      }
+    });
+
+    it("inverse fact IDs start with inv_", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      for (const fact of employerOfFacts) {
+        expect(fact.id.startsWith("inv_")).toBe(true);
+      }
+    });
+
+    it("inverse facts preserve asOf temporal bound", () => {
+      const employerOfFacts = graph.getFacts("anthropic", {
+        property: "employer-of",
+      });
+      // Dario's employed-by has asOf: 2021-01, so the inverse should too
+      const darioInverse = employerOfFacts.find(
+        (f) =>
+          f.value.type === "ref" &&
+          (f.value as { type: "ref"; value: string }).value === "dario-amodei"
+      );
+      expect(darioInverse).toBeDefined();
+      expect(darioInverse!.asOf).toBe("2021-01");
+    });
+
+    it("inverse facts preserve validEnd temporal bound", () => {
+      // Jan Leike's OpenAI employment has validEnd: 2024-05
+      // OpenAI is in the graph, so it gets an employer-of inverse with validEnd.
+      // Jan Leike's Anthropic employment has no validEnd.
+      const janInverse = graph
+        .getFacts("anthropic", { property: "employer-of" })
+        .find(
+          (f) =>
+            f.value.type === "ref" &&
+            (f.value as { type: "ref"; value: string }).value === "jan-leike"
+        );
+      expect(janInverse).toBeDefined();
+      expect(janInverse!.validEnd).toBeUndefined();
+    });
+
+    it("getRelated returns person IDs via employer-of after computing inverses", () => {
+      const related = graph.getRelated("anthropic", "employer-of");
+      expect(related).toContain("dario-amodei");
+      expect(related).toContain("jan-leike");
+    });
+
+    it("skips inverse when referenced entity does not exist in graph", () => {
+      // Anthropic has founded-by refs including persons not in the graph
+      // (e.g., "daniela-amodei" is referenced in key-people but not as a
+      // founded-by fact). Verify that nonexistent entities don't get created.
+      const nonexistent = graph.getEntity("nonexistent-entity");
+      expect(nonexistent).toBeUndefined();
+
+      const facts = graph.getFacts("nonexistent-entity", {
+        property: "employer-of",
+      });
+      expect(facts).toEqual([]);
+    });
+
+    it("logs a warning when referenced entity does not exist", async () => {
+      // Create a minimal graph with a dangling ref to test the warning
+      const { Graph } = await import("../src/graph.ts");
+      const freshGraph = new Graph();
+      freshGraph.addProperty({
+        id: "employed-by",
+        name: "Employed By",
+        dataType: "ref",
+        inverseId: "employer-of",
+        inverseName: "Employs",
+      });
+      freshGraph.addProperty({
+        id: "employer-of",
+        name: "Employs",
+        dataType: "refs",
+        inverseId: "employed-by",
+        inverseName: "Employed By",
+        computed: true,
+      });
+      freshGraph.addEntity({
+        id: "test-person",
+        stableId: "test123456",
+        type: "person",
+        name: "Test Person",
+      });
+      freshGraph.addFact({
+        id: "f_test1",
+        subjectId: "test-person",
+        propertyId: "employed-by",
+        value: { type: "ref", value: "nonexistent-org" },
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      computeInverses(freshGraph);
+
+      const warnings = warnSpy.mock.calls.map((call) => call[0]);
+      const warning = warnings.find(
+        (w) => typeof w === "string" && w.includes("nonexistent-org")
+      );
+      expect(warning).toBeDefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it("inverse fact IDs are deterministic (content-addressed)", async () => {
+      // Load two separate graphs, compute inverses on both, compare IDs
+      const graph1 = await loadKB(DATA_DIR);
+      const graph2 = await loadKB(DATA_DIR);
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      computeInverses(graph1);
+      computeInverses(graph2);
+      warnSpy.mockRestore();
+
+      const facts1 = graph1
+        .getFacts("anthropic", { property: "employer-of" })
+        .map((f) => f.id)
+        .sort();
+      const facts2 = graph2
+        .getFacts("anthropic", { property: "employer-of" })
+        .map((f) => f.id)
+        .sort();
+
+      expect(facts1).toEqual(facts2);
+    });
+  });
+});

--- a/packages/kb/tests/loader.test.ts
+++ b/packages/kb/tests/loader.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader";
+import type { Graph } from "../src/graph";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("loader", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("entities", () => {
+    it("loads Anthropic from disk", () => {
+      const anthropic = graph.getEntity("anthropic");
+      expect(anthropic).toBeDefined();
+      expect(anthropic!.name).toBe("Anthropic");
+      expect(anthropic!.stableId).toBe("mK9pX3rQ7n");
+      expect(anthropic!.type).toBe("organization");
+      expect(anthropic!.numericId).toBe(3);
+    });
+
+    it("loads all 30 entities", () => {
+      const entities = graph.getAllEntities();
+      expect(entities).toHaveLength(30);
+
+      const ids = entities.map((t) => t.id).sort();
+      expect(ids).toEqual([
+        "anthropic", "arc", "chris-olah", "conjecture", "connor-leahy",
+        "daniela-amodei", "dario-amodei", "deepmind", "demis-hassabis",
+        "dustin-moskovitz", "eliezer-yudkowsky", "elon-musk",
+        "geoffrey-hinton", "greg-brockman", "holden-karnofsky",
+        "ilya-sutskever", "jan-leike", "meta-ai", "miri", "neel-nanda",
+        "nick-bostrom", "openai", "paul-christiano", "redwood-research",
+        "sam-altman", "ssi", "stuart-russell", "xai", "yann-lecun",
+        "yoshua-bengio",
+      ].sort());
+    });
+
+    it("loads entity aliases", () => {
+      const anthropic = graph.getEntity("anthropic");
+      expect(anthropic!.aliases).toEqual(["Anthropic PBC", "Anthropic AI"]);
+    });
+  });
+
+  describe("properties", () => {
+    it("loads 28 properties", () => {
+      const properties = graph.getAllProperties();
+      expect(properties).toHaveLength(28);
+    });
+
+    it("loads property details correctly", () => {
+      const revenue = graph.getProperty("revenue");
+      expect(revenue).toBeDefined();
+      expect(revenue!.name).toBe("Revenue");
+      expect(revenue!.dataType).toBe("number");
+      expect(revenue!.unit).toBe("USD");
+      expect(revenue!.category).toBe("financial");
+      expect(revenue!.appliesTo).toEqual(["organization"]);
+    });
+
+    it("loads property display formatting", () => {
+      const revenue = graph.getProperty("revenue");
+      expect(revenue!.display).toEqual({
+        divisor: 1e9,
+        prefix: "$",
+        suffix: "B",
+      });
+    });
+
+    it("loads inverse property relationships", () => {
+      const employedBy = graph.getProperty("employed-by");
+      expect(employedBy!.inverseId).toBe("employer-of");
+      expect(employedBy!.inverseName).toBe("Employs");
+    });
+
+    it("marks computed properties", () => {
+      const employerOf = graph.getProperty("employer-of");
+      expect(employerOf!.computed).toBe(true);
+    });
+  });
+
+  describe("schemas", () => {
+    it("loads 2 schemas (organization, person)", () => {
+      const schemas = graph.getAllSchemas();
+      expect(schemas).toHaveLength(2);
+    });
+
+    it("loads organization schema with required and recommended properties", () => {
+      const orgSchema = graph.getSchema("organization");
+      expect(orgSchema).toBeDefined();
+      expect(orgSchema!.name).toBe("Organization");
+      expect(orgSchema!.required).toEqual(["founded-date", "headquarters"]);
+      expect(orgSchema!.recommended).toContain("revenue");
+      expect(orgSchema!.recommended).toContain("valuation");
+    });
+
+    it("loads person schema with empty required array", () => {
+      const personSchema = graph.getSchema("person");
+      expect(personSchema).toBeDefined();
+      expect(personSchema!.required).toEqual([]);
+      expect(personSchema!.recommended).toContain("employed-by");
+      expect(personSchema!.recommended).toContain("role");
+      expect(personSchema!.recommended).toContain("born-year");
+    });
+
+    it("loads item collection schemas on organization", () => {
+      const orgSchema = graph.getSchema("organization");
+      expect(orgSchema!.items).toBeDefined();
+      expect(orgSchema!.items!["funding-rounds"]).toBeDefined();
+      expect(orgSchema!.items!["key-people"]).toBeDefined();
+
+      const frFields = orgSchema!.items!["funding-rounds"].fields;
+      expect(frFields["date"].required).toBe(true);
+      expect(frFields["date"].type).toBe("date");
+      expect(frFields["amount"].type).toBe("number");
+      expect(frFields["lead_investor"].type).toBe("ref");
+    });
+  });
+
+  describe("facts", () => {
+    it("loads correct number of facts for Anthropic (37)", () => {
+      const facts = graph.getFacts("anthropic");
+      // 9 revenue + 4 valuation + 3 total-funding + 3 headcount + 1 founded-date
+      // + 1 headquarters + 1 legal-structure + 2 gross-margin + 2 cash-burn
+      // + 2 enterprise-market-share + 1 coding-market-share + 1 monthly-active-users
+      // + 1 business-customers + 1 api-calls-monthly + 1 product-revenue
+      // + 1 safety-level + 1 safety-researcher-count + 1 interpretability-team-size
+      // + 1 founded-by = 37
+      expect(facts).toHaveLength(37);
+    });
+
+    it("loads correct number of facts for Dario Amodei (3)", () => {
+      const facts = graph.getFacts("dario-amodei");
+      expect(facts).toHaveLength(3);
+    });
+
+    it("loads correct number of facts for Jan Leike (3)", () => {
+      const facts = graph.getFacts("jan-leike");
+      expect(facts).toHaveLength(3);
+    });
+
+    it("normalizes number values as {type: 'number'}", () => {
+      const revenueFacts = graph.getFacts("anthropic", {
+        property: "revenue",
+      });
+      expect(revenueFacts.length).toBeGreaterThan(0);
+      for (const fact of revenueFacts) {
+        expect(fact.value.type).toBe("number");
+        expect(typeof (fact.value as { type: "number"; value: number }).value).toBe("number");
+      }
+    });
+
+    it("normalizes ref values as {type: 'ref'}", () => {
+      const employedByFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      expect(employedByFacts).toHaveLength(2);
+      for (const fact of employedByFacts) {
+        expect(fact.value.type).toBe("ref");
+      }
+    });
+
+    it("normalizes date values as {type: 'date'}", () => {
+      const foundedFacts = graph.getFacts("anthropic", {
+        property: "founded-date",
+      });
+      expect(foundedFacts).toHaveLength(1);
+      expect(foundedFacts[0].value).toEqual({
+        type: "date",
+        value: "2021-01",
+      });
+    });
+
+    it("normalizes text values as {type: 'text'}", () => {
+      const hqFacts = graph.getFacts("anthropic", {
+        property: "headquarters",
+      });
+      expect(hqFacts).toHaveLength(1);
+      expect(hqFacts[0].value).toEqual({
+        type: "text",
+        value: "San Francisco, CA",
+      });
+    });
+
+    it("preserves temporal metadata (asOf and validEnd)", () => {
+      const janFacts = graph.getFacts("jan-leike", {
+        property: "employed-by",
+      });
+      // One fact has validEnd (the OpenAI one)
+      const openAiFact = janFacts.find(
+        (f) => f.value.type === "ref" && f.value.value === "openai"
+      );
+      expect(openAiFact).toBeDefined();
+      expect(openAiFact!.asOf).toBe("2021-01");
+      expect(openAiFact!.validEnd).toBe("2024-05");
+
+      // One fact has no validEnd (the Anthropic one)
+      const anthropicFact = janFacts.find(
+        (f) => f.value.type === "ref" && f.value.value === "anthropic"
+      );
+      expect(anthropicFact).toBeDefined();
+      expect(anthropicFact!.asOf).toBe("2024-05");
+      expect(anthropicFact!.validEnd).toBeUndefined();
+    });
+
+    it("preserves source and notes metadata", () => {
+      const foundedFacts = graph.getFacts("anthropic", {
+        property: "founded-date",
+      });
+      expect(foundedFacts[0].source).toBe("https://anthropic.com/company");
+      expect(foundedFacts[0].notes).toBe(
+        "Founded by seven former OpenAI researchers in January 2021"
+      );
+    });
+  });
+
+  describe("item collections", () => {
+    it("loads funding-rounds collection for Anthropic", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      expect(rounds).toHaveLength(13);
+    });
+
+    it("loads key-people collection for Anthropic", () => {
+      const people = graph.getItems("anthropic", "key-people");
+      expect(people).toHaveLength(15);
+    });
+
+    it("item entries have correct keys and field values", () => {
+      const rounds = graph.getItems("anthropic", "funding-rounds");
+      const seed = rounds.find((r) => r.key === "i_VImpFJfKiQ");
+      expect(seed).toBeDefined();
+      expect(seed!.fields.date).toBe("2021-04");
+      expect(seed!.fields.amount).toBe(124e6);
+      expect(seed!.fields.valuation).toBe(550e6);
+      expect(seed!.fields.lead_investor).toBe("jaan-tallinn");
+    });
+
+    it("returns empty array for non-existent collection", () => {
+      const items = graph.getItems("anthropic", "nonexistent");
+      expect(items).toEqual([]);
+    });
+
+    it("returns empty array for non-existent entity", () => {
+      const items = graph.getItems("nonexistent", "funding-rounds");
+      expect(items).toEqual([]);
+    });
+  });
+});

--- a/packages/kb/tests/stress-test.test.ts
+++ b/packages/kb/tests/stress-test.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Stress test: 20 real-world queries evaluated against the KB Graph API.
+ *
+ * Each test is annotated with a rating:
+ *   CLEAN     — direct, single-call answer
+ *   AWKWARD   — requires multiple calls or manual assembly
+ *   IMPOSSIBLE — cannot be answered with the current API/data
+ *
+ * Queries 4, 8, and 18 were previously IMPOSSIBLE in the old data model.
+ * They should now be answerable via items, facts, or inverse relationships.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import { loadKB } from "../src/loader";
+import { computeInverses } from "../src/inverse";
+import type { Graph } from "../src/graph";
+
+const dataDir = resolve(import.meta.dirname, "../data");
+let graph: Graph;
+
+beforeAll(async () => {
+  graph = await loadKB(dataDir);
+  computeInverses(graph);
+});
+
+// ── Query 1: What is Anthropic's latest valuation? ──────────────────
+// Rating: CLEAN
+describe("Q1: Anthropic latest valuation", () => {
+  it("returns the most recent valuation fact", () => {
+    const fact = graph.getLatest("anthropic", "valuation");
+    expect(fact).toBeDefined();
+    expect(fact!.value.type).toBe("number");
+    const val = (fact!.value as { type: "number"; value: number }).value;
+    expect(val).toBe(380e9);
+    expect(fact!.asOf).toBe("2026-02");
+  });
+});
+
+// ── Query 2: Show Anthropic's revenue over time ─────────────────────
+// Rating: CLEAN
+describe("Q2: Anthropic revenue over time", () => {
+  it("returns multiple revenue facts sorted by date", () => {
+    const facts = graph.getFacts("anthropic", { property: "revenue" });
+    expect(facts.length).toBeGreaterThanOrEqual(5);
+
+    // All should be number type
+    for (const f of facts) {
+      expect(f.value.type).toBe("number");
+    }
+
+    // Sort by asOf to get time series
+    const sorted = facts
+      .filter((f) => f.asOf !== undefined)
+      .sort((a, b) => a.asOf!.localeCompare(b.asOf!));
+    expect(sorted.length).toBeGreaterThanOrEqual(5);
+
+    // Revenue should generally increase over time
+    const values = sorted.map(
+      (f) => (f.value as { type: "number"; value: number }).value
+    );
+    expect(values[values.length - 1]).toBeGreaterThan(values[0]);
+  });
+});
+
+// ── Query 3: Compare all AI labs' valuations (cross-entity) ─────────
+// Rating: CLEAN (works with whatever entities exist)
+describe("Q3: Compare all AI labs valuations", () => {
+  it("returns a map of entity -> latest valuation", () => {
+    const valuations = graph.getByProperty("valuation", { latest: true });
+    // At minimum, Anthropic should have valuation data
+    expect(valuations.size).toBeGreaterThanOrEqual(1);
+    expect(valuations.has("anthropic")).toBe(true);
+
+    const anthropicVal = valuations.get("anthropic")!;
+    expect(anthropicVal.value.type).toBe("number");
+    expect(
+      (anthropicVal.value as { type: "number"; value: number }).value
+    ).toBe(380e9);
+  });
+});
+
+// ── Query 4: Who are Anthropic's board members? (was IMPOSSIBLE) ────
+// Rating: AWKWARD — board members are not a separate collection, but
+// key-people items include founders and leadership. This now works
+// via getItems, though a dedicated "board-members" collection would
+// be CLEANer.
+describe("Q4: Anthropic board/key people (was IMPOSSIBLE)", () => {
+  it("is now possible via key-people items", () => {
+    const people = graph.getItems("anthropic", "key-people");
+    expect(people.length).toBeGreaterThan(0);
+
+    // Verify we can find the CEO
+    const ceo = people.find((p) => p.fields.title === "CEO");
+    expect(ceo).toBeDefined();
+    expect(ceo!.fields.person).toBe("dario-amodei");
+
+    // Verify we can find founders
+    const founders = people.filter((p) => p.fields.is_founder === true);
+    expect(founders.length).toBeGreaterThanOrEqual(2);
+
+    // All entries should have person and title fields
+    for (const p of people) {
+      expect(p.fields.person).toBeDefined();
+      expect(p.fields.title).toBeDefined();
+    }
+  });
+});
+
+// ── Query 5: Who works at Anthropic right now? (was awkward) ────────
+// Rating: CLEAN — inverse computation generates employer-of facts
+describe("Q5: Who works at Anthropic right now", () => {
+  it("returns current employees via inverse employer-of facts", () => {
+    // After computeInverses, Anthropic should have employer-of facts
+    const employerFacts = graph.getFacts("anthropic", {
+      property: "employer-of",
+      current: true,
+    });
+    expect(employerFacts.length).toBeGreaterThanOrEqual(1);
+
+    // Extract employee IDs
+    const employeeIds = employerFacts.map((f) => {
+      expect(f.value.type).toBe("ref");
+      return (f.value as { type: "ref"; value: string }).value;
+    });
+
+    // Dario and Jan should both currently work at Anthropic
+    expect(employeeIds).toContain("dario-amodei");
+    expect(employeeIds).toContain("jan-leike");
+  });
+
+  it("can also be answered via key-people items for richer data", () => {
+    // key-people gives title, start date, founder status
+    const people = graph.getItems("anthropic", "key-people");
+    // Filter to currently active (no end date)
+    const current = people.filter((p) => p.fields.end === undefined);
+    expect(current.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Query 6: Total funding raised by all AI labs (aggregation) ──────
+// Rating: CLEAN (works with whatever entities have total-funding facts)
+describe("Q6: Total funding raised by all AI labs", () => {
+  it("aggregates total-funding across all entities", () => {
+    const fundingMap = graph.getByProperty("total-funding", { latest: true });
+    expect(fundingMap.size).toBeGreaterThanOrEqual(1);
+
+    // Anthropic should have total funding data
+    expect(fundingMap.has("anthropic")).toBe(true);
+    const anthropicFunding = fundingMap.get("anthropic")!;
+    expect(
+      (anthropicFunding.value as { type: "number"; value: number }).value
+    ).toBe(67e9);
+
+    // Compute aggregate
+    let totalAcrossLabs = 0;
+    for (const [, fact] of fundingMap) {
+      if (fact.value.type === "number") {
+        totalAcrossLabs += fact.value.value;
+      }
+    }
+    expect(totalAcrossLabs).toBeGreaterThan(0);
+  });
+});
+
+// ── Query 7: List all funding rounds for Anthropic with investors
+//             and valuations (event-based) ────────────────────────────
+// Rating: CLEAN
+describe("Q7: Anthropic funding rounds", () => {
+  it("returns all funding rounds with detail fields", () => {
+    const rounds = graph.getItems("anthropic", "funding-rounds");
+    expect(rounds.length).toBeGreaterThanOrEqual(9);
+
+    // Each round should have at least date and amount
+    for (const r of rounds) {
+      expect(r.fields.date).toBeDefined();
+      expect(r.fields.amount).toBeDefined();
+    }
+
+    // Check a specific round with full data
+    const seriesG = rounds.find((r) => r.key === "i_OVNz9C3XUA");
+    expect(seriesG).toBeDefined();
+    expect(seriesG!.fields.amount).toBe(30e9);
+    expect(seriesG!.fields.valuation).toBe(380e9);
+    expect(seriesG!.fields.lead_investor).toBe("gic");
+
+    // Rounds with valuations
+    const withValuation = rounds.filter(
+      (r) => r.fields.valuation !== undefined
+    );
+    expect(withValuation.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ── Query 8: What is OpenAI's current valuation?
+//             (was IMPOSSIBLE -- data was in a different layer) ───────
+// Rating: CLEAN if OpenAI data exists, otherwise shows the API works
+// but data is absent. The query pattern itself is now fully supported.
+describe("Q8: OpenAI current valuation (was IMPOSSIBLE)", () => {
+  it("is now possible via getLatest (data-dependent)", () => {
+    // The API call is clean regardless of whether OpenAI data exists
+    const fact = graph.getLatest("openai", "valuation");
+
+    const openaiEntity = graph.getEntity("openai");
+    if (openaiEntity) {
+      // If OpenAI data has been added, we should get a valuation
+      expect(fact).toBeDefined();
+      expect(fact!.value.type).toBe("number");
+    } else {
+      // OpenAI entity not yet in KB -- the query pattern works, just no data
+      expect(fact).toBeUndefined();
+    }
+  });
+
+  it("the API pattern is identical to the Anthropic query (CLEAN)", () => {
+    // Demonstrate the same pattern works for any entity
+    const anthropicVal = graph.getLatest("anthropic", "valuation");
+    expect(anthropicVal).toBeDefined();
+
+    // The OpenAI call would be exactly the same shape
+    const openaiVal = graph.getLatest("openai", "valuation");
+    // Returns undefined or a fact -- both are valid responses
+    expect(openaiVal === undefined || openaiVal.value.type === "number").toBe(
+      true
+    );
+  });
+});
+
+// ── Query 9: Anthropic headcount over time ──────────────────────────
+// Rating: CLEAN
+describe("Q9: Anthropic headcount over time", () => {
+  it("returns headcount facts as a time series", () => {
+    const facts = graph.getFacts("anthropic", { property: "headcount" });
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+
+    for (const f of facts) {
+      expect(f.value.type).toBe("number");
+      expect(f.asOf).toBeDefined();
+    }
+
+    // Latest headcount
+    const latest = graph.getLatest("anthropic", "headcount");
+    expect(latest).toBeDefined();
+    expect(
+      (latest!.value as { type: "number"; value: number }).value
+    ).toBeGreaterThan(0);
+  });
+});
+
+// ── Query 10: What is Anthropic's gross margin? ─────────────────────
+// Rating: CLEAN — gross-margin property and data now exist.
+describe("Q10: Anthropic gross margin", () => {
+  it("returns the gross margin fact", () => {
+    const fact = graph.getLatest("anthropic", "gross-margin");
+    expect(fact).toBeDefined();
+    expect(fact!.value.type).toBe("number");
+    expect((fact!.value as { type: "number"; value: number }).value).toBe(63);
+  });
+});
+
+// ── Query 11: Which entities have revenue data? (cross-entity scan) ─
+// Rating: CLEAN
+describe("Q11: Which entities have revenue data", () => {
+  it("scans all entities for revenue facts", () => {
+    const revenueMap = graph.getByProperty("revenue", { latest: true });
+    // At minimum Anthropic has revenue
+    expect(revenueMap.size).toBeGreaterThanOrEqual(1);
+    expect(revenueMap.has("anthropic")).toBe(true);
+
+    // List entity IDs that have revenue data
+    const entitiesWithRevenue = Array.from(revenueMap.keys());
+    expect(entitiesWithRevenue).toContain("anthropic");
+  });
+});
+
+// ── Query 12: Compare headcount across AI labs ──────────────────────
+// Rating: CLEAN (works with whatever entities have headcount data)
+describe("Q12: Compare headcount across AI labs", () => {
+  it("returns headcount map for comparison", () => {
+    const headcountMap = graph.getByProperty("headcount", { latest: true });
+    expect(headcountMap.size).toBeGreaterThanOrEqual(1);
+
+    // Anthropic headcount
+    const anthropicHc = headcountMap.get("anthropic");
+    expect(anthropicHc).toBeDefined();
+    expect(anthropicHc!.value.type).toBe("number");
+    expect(
+      (anthropicHc!.value as { type: "number"; value: number }).value
+    ).toBeGreaterThan(0);
+  });
+});
+
+// ── Query 13: When was Anthropic founded? ────────────────────────────
+// Rating: CLEAN
+describe("Q13: When was Anthropic founded", () => {
+  it("returns the founded-date fact directly", () => {
+    const fact = graph.getLatest("anthropic", "founded-date");
+    expect(fact).toBeDefined();
+    expect(fact!.value).toEqual({ type: "date", value: "2021-01" });
+  });
+});
+
+// ── Query 14: Anthropic revenue-to-valuation ratio (computed metric) ─
+// Rating: AWKWARD — requires two getLatest calls and manual division.
+// A computed-property system could make this CLEAN.
+describe("Q14: Anthropic revenue-to-valuation ratio", () => {
+  it("can be computed from two getLatest calls", () => {
+    const revFact = graph.getLatest("anthropic", "revenue");
+    const valFact = graph.getLatest("anthropic", "valuation");
+
+    expect(revFact).toBeDefined();
+    expect(valFact).toBeDefined();
+
+    const revenue = (revFact!.value as { type: "number"; value: number }).value;
+    const valuation = (valFact!.value as { type: "number"; value: number })
+      .value;
+
+    const ratio = revenue / valuation;
+    // Revenue ~$19B / Valuation ~$380B = ~0.05
+    expect(ratio).toBeGreaterThan(0.01);
+    expect(ratio).toBeLessThan(0.5);
+
+    // Verify we can display the dates these came from
+    expect(revFact!.asOf).toBeDefined();
+    expect(valFact!.asOf).toBeDefined();
+  });
+});
+
+// ── Query 15: What safety research does Anthropic do? ───────────────
+// Rating: CLEAN — research-areas item collection provides structured data.
+describe("Q15: Anthropic safety research", () => {
+  it("is answerable via research-areas items and key-people", () => {
+    // Research areas collection
+    const areas = graph.getItems("anthropic", "research-areas");
+    expect(areas.length).toBeGreaterThanOrEqual(3);
+
+    // Find specific research areas
+    const mechInterp = areas.find((a) => a.key === "i_X3GMmkZdIQ");
+    expect(mechInterp).toBeDefined();
+    expect(mechInterp!.fields.name).toBe("Mechanistic Interpretability");
+    expect(mechInterp!.fields["team-size"]).toBe(50);
+
+    // Safety-related people from key-people
+    const people = graph.getItems("anthropic", "key-people");
+    const safetyPeople = people.filter((p) => {
+      const title = String(p.fields.title ?? "").toLowerCase();
+      return (
+        title.includes("alignment") ||
+        title.includes("safety") ||
+        title.includes("interpretability")
+      );
+    });
+    expect(safetyPeople.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Query 16: What products has Anthropic launched? ──────────────────
+// Rating: CLEAN — products item collection provides structured data.
+describe("Q16: Anthropic products launched", () => {
+  it("returns products from the products item collection", () => {
+    const products = graph.getItems("anthropic", "products");
+    expect(products.length).toBeGreaterThanOrEqual(3);
+
+    // Check specific products
+    const claudeCode = products.find((p) => p.key === "i_5ZyixnNTeg");
+    expect(claudeCode).toBeDefined();
+    expect(claudeCode!.fields.name).toBe("Claude Code");
+    expect(claudeCode!.fields.launched).toBe("2025-02");
+
+    // All products should have name and launch date
+    for (const p of products) {
+      expect(p.fields.name).toBeDefined();
+      expect(p.fields.launched).toBeDefined();
+    }
+  });
+});
+
+// ── Query 17: Anthropic vs OpenAI market share ──────────────────────
+// Rating: AWKWARD — Anthropic uses enterprise-market-share and
+// coding-market-share properties while OpenAI uses the generic
+// market-share property. Cross-entity comparison requires knowing
+// which property each entity uses.
+describe("Q17: Anthropic vs OpenAI market share", () => {
+  it("compares enterprise market share for Anthropic and general market share for OpenAI", () => {
+    const anthropicShare = graph.getLatest("anthropic", "enterprise-market-share");
+    const openaiShare = graph.getLatest("openai", "market-share");
+    expect(anthropicShare).toBeDefined();
+    expect(openaiShare).toBeDefined();
+
+    const anthVal = (anthropicShare!.value as { type: "number"; value: number }).value;
+    const oaiVal = (openaiShare!.value as { type: "number"; value: number }).value;
+
+    // Both should be reasonable percentage values
+    expect(anthVal).toBeGreaterThan(0);
+    expect(anthVal).toBeLessThan(100);
+    expect(oaiVal).toBeGreaterThan(0);
+    expect(oaiVal).toBeLessThan(100);
+  });
+
+  it("Anthropic also has coding-market-share data", () => {
+    const codingShare = graph.getLatest("anthropic", "coding-market-share");
+    expect(codingShare).toBeDefined();
+    const val = (codingShare!.value as { type: "number"; value: number }).value;
+    expect(val).toBe(42);
+  });
+
+  it("cross-entity lookup works for market-share (OpenAI only)", () => {
+    const shareMap = graph.getByProperty("market-share", { latest: true });
+    expect(shareMap.size).toBe(1);
+    expect(shareMap.has("openai")).toBe(true);
+  });
+
+  it("cross-entity lookup works for enterprise-market-share (Anthropic only)", () => {
+    const shareMap = graph.getByProperty("enterprise-market-share", { latest: true });
+    expect(shareMap.size).toBe(1);
+    expect(shareMap.has("anthropic")).toBe(true);
+  });
+});
+
+// ── Query 18: Jan Leike's career history (was IMPOSSIBLE) ───────────
+// Rating: CLEAN — employment history is modeled as temporal
+// employed-by ref facts with asOf/validEnd.
+describe("Q18: Jan Leike career history (was IMPOSSIBLE)", () => {
+  it("is now possible via employed-by facts with temporal bounds", () => {
+    const careerFacts = graph.getFacts("jan-leike", {
+      property: "employed-by",
+    });
+    // After computeInverses, there are both original and derived facts.
+    // Filter to non-derived facts for the canonical career history.
+    const original = careerFacts.filter((f) => f.derivedFrom === undefined);
+    expect(original).toHaveLength(2);
+
+    // Sort by start date
+    const sorted = original
+      .filter((f) => f.asOf !== undefined)
+      .sort((a, b) => a.asOf!.localeCompare(b.asOf!));
+
+    // First position: OpenAI (2021-01 to 2024-05)
+    const openai = sorted[0];
+    expect(openai.value).toEqual({ type: "ref", value: "openai" });
+    expect(openai.asOf).toBe("2021-01");
+    expect(openai.validEnd).toBe("2024-05");
+
+    // Second position: Anthropic (2024-05, ongoing)
+    const anthropic = sorted[1];
+    expect(anthropic.value).toEqual({ type: "ref", value: "anthropic" });
+    expect(anthropic.asOf).toBe("2024-05");
+    expect(anthropic.validEnd).toBeUndefined(); // Still there
+
+    // Current employer via current filter (includes derived inverse facts)
+    const current = graph.getFacts("jan-leike", {
+      property: "employed-by",
+      current: true,
+    });
+    // Extract unique employer IDs — derived inverses may duplicate entries
+    const currentEmployers = [
+      ...new Set(
+        current
+          .filter((f) => f.value.type === "ref")
+          .map((f) => (f.value as { type: "ref"; value: string }).value)
+      ),
+    ];
+    expect(currentEmployers).toContain("anthropic");
+
+    // Role history
+    const roles = graph.getFacts("jan-leike", { property: "role" });
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const latestRole = graph.getLatest("jan-leike", "role");
+    expect(latestRole).toBeDefined();
+    expect(
+      (latestRole!.value as { type: "text"; value: string }).value
+    ).toContain("Alignment");
+  });
+});
+
+// ── Query 19: What properties exist and which are most used? ────────
+// Rating: AWKWARD — getAllProperties() lists properties, but computing
+// usage counts requires iterating all things.
+describe("Q19: Property inventory and usage frequency", () => {
+  it("lists all defined properties", () => {
+    const props = graph.getAllProperties();
+    expect(props.length).toBeGreaterThanOrEqual(10);
+
+    // Check some known properties exist
+    const propIds = props.map((p) => p.id);
+    expect(propIds).toContain("revenue");
+    expect(propIds).toContain("valuation");
+    expect(propIds).toContain("employed-by");
+    expect(propIds).toContain("role");
+    expect(propIds).toContain("founded-date");
+    expect(propIds).toContain("headquarters");
+  });
+
+  it("can compute usage counts (AWKWARD: requires iteration)", () => {
+    const allProps = graph.getAllProperties();
+    const usageCounts: { id: string; name: string; count: number }[] = [];
+
+    for (const prop of allProps) {
+      const entitiesWithProp = graph.getByProperty(prop.id);
+      usageCounts.push({
+        id: prop.id,
+        name: prop.name,
+        count: entitiesWithProp.size,
+      });
+    }
+
+    // Sort by usage count
+    usageCounts.sort((a, b) => b.count - a.count);
+
+    // At least some properties should be used
+    const used = usageCounts.filter((u) => u.count > 0);
+    expect(used.length).toBeGreaterThan(0);
+
+    // employed-by / employer-of should be among the most used (after inverses)
+    const employedBy = usageCounts.find((u) => u.id === "employed-by");
+    expect(employedBy).toBeDefined();
+    expect(employedBy!.count).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Query 20: Who is the CEO of Anthropic? / What company does Dario
+//              Amodei lead? (bidirectional) ───────────────────────────
+// Rating: CLEAN for person->org (employed-by + role).
+//         CLEAN for org->person (key-people items or inverse employer-of).
+describe("Q20: Bidirectional person-org lookup", () => {
+  it("person -> org: Dario Amodei leads Anthropic", () => {
+    // Get Dario's employer — after computeInverses, there may be both
+    // original and derived employed-by facts. Use getRelated for a clean
+    // list of employer IDs.
+    const employers = graph.getRelated("dario-amodei", "employed-by");
+    expect(employers).toContain("anthropic");
+
+    // Alternatively, filter to non-derived facts for the canonical record
+    const originalFacts = graph
+      .getFacts("dario-amodei", { property: "employed-by", current: true })
+      .filter((f) => f.derivedFrom === undefined);
+    expect(originalFacts).toHaveLength(1);
+    expect(
+      (originalFacts[0].value as { type: "ref"; value: string }).value
+    ).toBe("anthropic");
+
+    // Get Dario's role
+    const role = graph.getLatest("dario-amodei", "role");
+    expect(role).toBeDefined();
+    expect((role!.value as { type: "text"; value: string }).value).toBe("CEO");
+
+    // Verify the entity exists and is a person
+    const dario = graph.getEntity("dario-amodei");
+    expect(dario).toBeDefined();
+    expect(dario!.type).toBe("person");
+  });
+
+  it("org -> person: Anthropic CEO is Dario Amodei", () => {
+    // Via key-people items
+    const people = graph.getItems("anthropic", "key-people");
+    const ceo = people.find((p) => p.fields.title === "CEO");
+    expect(ceo).toBeDefined();
+    expect(ceo!.fields.person).toBe("dario-amodei");
+
+    // Verify the referenced person exists
+    const person = graph.getEntity(ceo!.fields.person as string);
+    expect(person).toBeDefined();
+    expect(person!.name).toBe("Dario Amodei");
+  });
+
+  it("org -> person: also works via inverse employer-of facts", () => {
+    // computeInverses should have created employer-of facts on Anthropic
+    const employees = graph.getRelated("anthropic", "employer-of");
+    expect(employees).toContain("dario-amodei");
+    expect(employees).toContain("jan-leike");
+  });
+});

--- a/packages/kb/tests/validate.test.ts
+++ b/packages/kb/tests/validate.test.ts
@@ -1,0 +1,806 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import path from "node:path";
+import { loadKB } from "../src/loader";
+import { validate, validateEntity } from "../src/validate";
+import { Graph } from "../src/graph";
+import type { ValidationResult } from "../src/types";
+
+const DATA_DIR = path.resolve(__dirname, "../data");
+
+describe("validate", () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await loadKB(DATA_DIR);
+  });
+
+  describe("validateEntity — anthropic (organization)", () => {
+    let results: ValidationResult[];
+
+    beforeAll(() => {
+      results = validateEntity(graph, "anthropic");
+    });
+
+    it("has no required-property errors (founded-date and headquarters present)", () => {
+      const requiredErrors = results.filter(
+        (r) => r.rule === "required-properties" && r.severity === "error"
+      );
+      expect(requiredErrors).toHaveLength(0);
+    });
+
+    it("has a completeness info message showing percentage", () => {
+      const completeness = results.filter((r) => r.rule === "completeness");
+      expect(completeness).toHaveLength(1);
+      expect(completeness[0].severity).toBe("info");
+      expect(completeness[0].message).toContain("Completeness");
+      expect(completeness[0].message).toMatch(/\d+%/);
+    });
+
+    it("completeness shows high percentage for well-populated entity", () => {
+      const completeness = results.find((r) => r.rule === "completeness");
+      // Anthropic has all 7 required+recommended properties:
+      // required: founded-date, headquarters (2)
+      // recommended: revenue, valuation, headcount, legal-structure, total-funding (5)
+      // Total: 7/7 = 100%
+      expect(completeness!.message).toContain("100%");
+    });
+
+    it("has no recommended-property warnings (all recommended are present)", () => {
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties" && r.severity === "warning"
+      );
+      expect(recommendedWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("validateEntity — person schemas", () => {
+    it("person with all recommended properties has no warnings", () => {
+      // Dario has employed-by, role, and born-year
+      const results = validateEntity(graph, "dario-amodei");
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties"
+      );
+      expect(recommendedWarnings).toHaveLength(0);
+    });
+
+    it("person missing recommended properties gets warnings", () => {
+      // Jan Leike has employed-by and role but NO born-year
+      const results = validateEntity(graph, "jan-leike");
+      const recommendedWarnings = results.filter(
+        (r) => r.rule === "recommended-properties"
+      );
+      expect(recommendedWarnings).toHaveLength(1);
+      expect(recommendedWarnings[0].message).toContain("born-year");
+    });
+  });
+
+  describe("ref-integrity", () => {
+    it("catches refs to non-existent entities", () => {
+      // OpenAI key-people reference persons not in our test data (e.g., ilya-sutskever)
+      const results = validateEntity(graph, "openai");
+      const refErrors = results.filter((r) => r.rule === "ref-integrity" || r.rule === "item-collection-schema");
+      // There should be warnings for referenced persons not in the graph
+      expect(refErrors.length).toBeGreaterThan(0);
+    });
+
+    it("does not flag refs to existing entities", () => {
+      // Dario references "anthropic" which exists
+      const results = validateEntity(graph, "dario-amodei");
+      const refErrors = results.filter((r) => r.rule === "ref-integrity");
+      expect(refErrors).toHaveLength(0);
+    });
+  });
+
+  describe("item-collection-schema validation", () => {
+    it("validates item entries against schema", () => {
+      const results = validateEntity(graph, "anthropic");
+      const itemResults = results.filter(
+        (r) => r.rule === "item-collection-schema"
+      );
+      // The anthropic data has funding-round entries with lead_investor referencing
+      // entities not in our test graph (ftx, amazon, google, gic, jaan-tallinn).
+      // These should produce type warnings since they reference non-existent entities.
+      const refWarnings = itemResults.filter(
+        (r) =>
+          r.severity === "warning" && r.message.includes("unknown entity")
+      );
+      expect(refWarnings.length).toBeGreaterThan(0);
+    });
+
+    it("does not report errors for required fields that are present", () => {
+      // funding-rounds schema requires 'date', key-people requires 'person' and 'title'
+      // All entries in our test data provide these fields
+      const results = validateEntity(graph, "anthropic");
+      const requiredFieldErrors = results.filter(
+        (r) =>
+          r.rule === "item-collection-schema" &&
+          r.severity === "error" &&
+          r.message.includes("missing required field")
+      );
+      expect(requiredFieldErrors).toHaveLength(0);
+    });
+
+    it("validates key-people person refs against the graph", () => {
+      const results = validateEntity(graph, "anthropic");
+      const itemResults = results.filter(
+        (r) =>
+          r.rule === "item-collection-schema" &&
+          r.message.includes("key-people")
+      );
+      // Some key-people reference persons not in the graph
+      // (daniela-amodei, chris-olah, tom-brown, mike-krieger, holden-karnofsky)
+      const unknownPeople = itemResults.filter(
+        (r) => r.message.includes("unknown entity")
+      );
+      expect(unknownPeople.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("validate (full graph)", () => {
+    it("returns results for all entities", () => {
+      const results = validate(graph);
+
+      // Should have results for all 16 entities
+      const entityIds = new Set(results.map((r) => r.entityId).filter(Boolean));
+      expect(entityIds.has("anthropic")).toBe(true);
+      expect(entityIds.has("dario-amodei")).toBe(true);
+      expect(entityIds.has("jan-leike")).toBe(true);
+    });
+
+    it("includes completeness info for every entity", () => {
+      const results = validate(graph);
+      const completeness = results.filter((r) => r.rule === "completeness");
+      expect(completeness).toHaveLength(30); // one per entity
+    });
+
+    it("properly categorizes severity levels", () => {
+      const results = validate(graph);
+
+      const warnings = results.filter((r) => r.severity === "warning");
+      const infos = results.filter((r) => r.severity === "info");
+
+      // There should be at least some warnings (recommended properties, or item ref warnings)
+      expect(warnings.length).toBeGreaterThan(0);
+      // There should be info messages (completeness for all 30 entities + any orphan-entity infos)
+      expect(infos.length).toBeGreaterThanOrEqual(30);
+    });
+  });
+
+  describe("validateEntity — edge cases", () => {
+    it("returns error for non-existent entity", () => {
+      const results = validateEntity(graph, "nonexistent");
+      expect(results).toHaveLength(1);
+      expect(results[0].severity).toBe("error");
+      expect(results[0].rule).toBe("entity-exists");
+    });
+
+    it("returns warning for entity with no registered schema", () => {
+      // Create a minimal graph with an entity of unknown type
+      const minGraph = new Graph();
+      minGraph.addEntity({
+        id: "test-product",
+        stableId: "abc123def0",
+        type: "product",
+        name: "Test Product",
+      });
+
+      const results = validateEntity(minGraph, "test-product");
+      // schema-exists warning + orphan-entity info (no facts, no items)
+      const schemaWarning = results.find((r) => r.rule === "schema-exists");
+      expect(schemaWarning).toBeDefined();
+      expect(schemaWarning!.severity).toBe("warning");
+      expect(schemaWarning!.message).toContain("product");
+    });
+
+    it("validates required fields are missing in a minimal graph", () => {
+      // Create a minimal org with no facts
+      const minGraph = new Graph();
+      minGraph.addSchema({
+        type: "organization",
+        name: "Organization",
+        required: ["founded-date", "headquarters"],
+        recommended: ["revenue"],
+      });
+      minGraph.addEntity({
+        id: "empty-org",
+        stableId: "xyz456abc0",
+        type: "organization",
+        name: "Empty Org",
+      });
+
+      const results = validateEntity(minGraph, "empty-org");
+      const requiredErrors = results.filter(
+        (r) => r.rule === "required-properties"
+      );
+      expect(requiredErrors).toHaveLength(2);
+      expect(requiredErrors.map((r) => r.propertyId).sort()).toEqual([
+        "founded-date",
+        "headquarters",
+      ]);
+    });
+  });
+
+  describe("property-applies-to check", () => {
+    it("warns when property is used on wrong entity type", () => {
+      // Create a scenario where a "revenue" fact is on a person (wrong type)
+      const testGraph = new Graph();
+      testGraph.addSchema({
+        type: "person",
+        name: "Person",
+        required: [],
+        recommended: [],
+      });
+      testGraph.addProperty({
+        id: "revenue",
+        name: "Revenue",
+        dataType: "number",
+        appliesTo: ["organization"],
+      });
+      testGraph.addEntity({
+        id: "wrong-type",
+        stableId: "abc123def0",
+        type: "person",
+        name: "Wrong Type",
+      });
+      testGraph.addFact({
+        id: "f_test123456",
+        subjectId: "wrong-type",
+        propertyId: "revenue",
+        value: { type: "number", value: 1000 },
+      });
+
+      const results = validateEntity(testGraph, "wrong-type");
+      const appliesToWarnings = results.filter(
+        (r) => r.rule === "property-applies-to"
+      );
+      expect(appliesToWarnings).toHaveLength(1);
+      expect(appliesToWarnings[0].severity).toBe("warning");
+      expect(appliesToWarnings[0].message).toContain("organization");
+      expect(appliesToWarnings[0].message).toContain("person");
+    });
+  });
+
+  // ── New check tests ────────────────────────────────────────────────────────
+
+  describe("stableid-format check", () => {
+    it("accepts valid 10-char alphanumeric stableId", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "good", stableId: "aB3cD4eF5g", type: "org", name: "Good" });
+      g.addFact({ id: "f_x1", subjectId: "good", propertyId: "p", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "good");
+      const formatErrors = results.filter((r) => r.rule === "stableid-format");
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it("rejects stableId that is too short", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "short", stableId: "abc12", type: "org", name: "Short" });
+
+      const results = validateEntity(g, "short");
+      const formatErrors = results.filter((r) => r.rule === "stableid-format");
+      expect(formatErrors).toHaveLength(1);
+      expect(formatErrors[0].severity).toBe("error");
+    });
+
+    it("rejects stableId with non-alphanumeric characters", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "bad", stableId: "abc-123_fg", type: "org", name: "Bad" });
+
+      const results = validateEntity(g, "bad");
+      const formatErrors = results.filter((r) => r.rule === "stableid-format");
+      expect(formatErrors).toHaveLength(1);
+      expect(formatErrors[0].severity).toBe("error");
+    });
+  });
+
+  describe("duplicate-stableid check", () => {
+    it("catches two entities sharing a stableId", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "ent-a", stableId: "aB3cD4eF5g", type: "org", name: "A" });
+      g.addEntity({ id: "ent-b", stableId: "aB3cD4eF5g", type: "org", name: "B" });
+
+      const results = validate(g);
+      const dupErrors = results.filter((r) => r.rule === "duplicate-stableid");
+      expect(dupErrors).toHaveLength(1);
+      expect(dupErrors[0].severity).toBe("error");
+    });
+
+    it("does not flag unique stableIds", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "ent-a", stableId: "aB3cD4eF5g", type: "org", name: "A" });
+      g.addEntity({ id: "ent-b", stableId: "xY7zW8vU9t", type: "org", name: "B" });
+
+      const results = validate(g);
+      const dupErrors = results.filter((r) => r.rule === "duplicate-stableid");
+      expect(dupErrors).toHaveLength(0);
+    });
+  });
+
+  describe("factid-format check", () => {
+    it("accepts fact IDs starting with f_", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_abc123def0", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const formatErrors = results.filter((r) => r.rule === "factid-format");
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it("accepts fact IDs starting with inv_", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "inv_abc123def0", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const formatErrors = results.filter((r) => r.rule === "factid-format");
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it("rejects fact IDs without correct prefix", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "bad_id", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const formatErrors = results.filter((r) => r.rule === "factid-format");
+      expect(formatErrors).toHaveLength(1);
+      expect(formatErrors[0].severity).toBe("error");
+    });
+  });
+
+  describe("empty-name check", () => {
+    it("catches entity with empty name", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "no-name", stableId: "aB3cD4eF5g", type: "org", name: "" });
+
+      const results = validateEntity(g, "no-name");
+      const nameErrors = results.filter((r) => r.rule === "empty-name");
+      expect(nameErrors).toHaveLength(1);
+      expect(nameErrors[0].severity).toBe("error");
+    });
+
+    it("catches entity with whitespace-only name", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "space-name", stableId: "aB3cD4eF5g", type: "org", name: "   " });
+
+      const results = validateEntity(g, "space-name");
+      const nameErrors = results.filter((r) => r.rule === "empty-name");
+      expect(nameErrors).toHaveLength(1);
+    });
+
+    it("does not flag entity with valid name", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "good", stableId: "aB3cD4eF5g", type: "org", name: "Good Name" });
+
+      const results = validateEntity(g, "good");
+      const nameErrors = results.filter((r) => r.rule === "empty-name");
+      expect(nameErrors).toHaveLength(0);
+    });
+  });
+
+  describe("valid-end-before-as-of check", () => {
+    it("catches validEnd before asOf", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "status", name: "Status", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({
+        id: "f_bad_dates",
+        subjectId: "ent",
+        propertyId: "status",
+        value: { type: "text", value: "active" },
+        asOf: "2024-06",
+        validEnd: "2024-01",
+      });
+
+      const results = validateEntity(g, "ent");
+      const orderErrors = results.filter((r) => r.rule === "valid-end-before-as-of");
+      expect(orderErrors).toHaveLength(1);
+      expect(orderErrors[0].severity).toBe("error");
+    });
+
+    it("does not flag valid temporal ordering", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "status", name: "Status", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({
+        id: "f_good_dates",
+        subjectId: "ent",
+        propertyId: "status",
+        value: { type: "text", value: "active" },
+        asOf: "2024-01",
+        validEnd: "2024-06",
+      });
+
+      const results = validateEntity(g, "ent");
+      const orderErrors = results.filter((r) => r.rule === "valid-end-before-as-of");
+      expect(orderErrors).toHaveLength(0);
+    });
+  });
+
+  describe("temporal-missing-date check", () => {
+    it("warns when temporal property fact has no asOf", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({
+        id: "f_no_date",
+        subjectId: "ent",
+        propertyId: "revenue",
+        value: { type: "number", value: 1000 },
+        // no asOf
+      });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "temporal-missing-date");
+      expect(dateWarnings).toHaveLength(1);
+      expect(dateWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not warn when temporal fact has asOf", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({
+        id: "f_with_date",
+        subjectId: "ent",
+        propertyId: "revenue",
+        value: { type: "number", value: 1000 },
+        asOf: "2024-01",
+      });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "temporal-missing-date");
+      expect(dateWarnings).toHaveLength(0);
+    });
+
+    it("skips derived (inverse) facts", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({
+        id: "inv_derived",
+        subjectId: "ent",
+        propertyId: "revenue",
+        value: { type: "number", value: 1000 },
+        derivedFrom: "f_original",
+      });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "temporal-missing-date");
+      expect(dateWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("non-temporal-multiple check", () => {
+    it("warns when non-temporal property has multiple facts", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "headquarters", name: "HQ", dataType: "text", temporal: false });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_hq1", subjectId: "ent", propertyId: "headquarters", value: { type: "text", value: "SF" } });
+      g.addFact({ id: "f_hq2", subjectId: "ent", propertyId: "headquarters", value: { type: "text", value: "NYC" } });
+
+      const results = validateEntity(g, "ent");
+      const multiWarnings = results.filter((r) => r.rule === "non-temporal-multiple");
+      expect(multiWarnings).toHaveLength(1);
+      expect(multiWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not warn for temporal properties with multiple facts", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_r1", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 100 }, asOf: "2024-01" });
+      g.addFact({ id: "f_r2", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 200 }, asOf: "2024-06" });
+
+      const results = validateEntity(g, "ent");
+      const multiWarnings = results.filter((r) => r.rule === "non-temporal-multiple");
+      expect(multiWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("stale-temporal check", () => {
+    it("warns when most recent temporal fact is >2 years old", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_old", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 100 }, asOf: "2020-01" });
+
+      const results = validateEntity(g, "ent");
+      const staleWarnings = results.filter((r) => r.rule === "stale-temporal");
+      expect(staleWarnings).toHaveLength(1);
+      expect(staleWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not warn when recent temporal data exists", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number", temporal: true });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_new", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 100 }, asOf: "2025-06" });
+
+      const results = validateEntity(g, "ent");
+      const staleWarnings = results.filter((r) => r.rule === "stale-temporal");
+      expect(staleWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("duplicate-facts check", () => {
+    it("warns on duplicate (entity, property, asOf) tuple", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_dup1", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 100 }, asOf: "2024-01" });
+      g.addFact({ id: "f_dup2", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 200 }, asOf: "2024-01" });
+
+      const results = validateEntity(g, "ent");
+      const dupWarnings = results.filter((r) => r.rule === "duplicate-facts");
+      expect(dupWarnings).toHaveLength(1);
+      expect(dupWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not flag facts with different asOf dates", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "revenue", name: "Revenue", dataType: "number" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_ts1", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 100 }, asOf: "2024-01" });
+      g.addFact({ id: "f_ts2", subjectId: "ent", propertyId: "revenue", value: { type: "number", value: 200 }, asOf: "2024-06" });
+
+      const results = validateEntity(g, "ent");
+      const dupWarnings = results.filter((r) => r.rule === "duplicate-facts");
+      expect(dupWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("missing-source check", () => {
+    it("warns when fact has no source URL", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_nosrc", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const srcWarnings = results.filter((r) => r.rule === "missing-source");
+      expect(srcWarnings).toHaveLength(1);
+      expect(srcWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not warn when fact has a source", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_withsrc", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, source: "https://example.com" });
+
+      const results = validateEntity(g, "ent");
+      const srcWarnings = results.filter((r) => r.rule === "missing-source");
+      expect(srcWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("unknown-property check", () => {
+    it("warns when fact uses a property not in the registry", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      // Do NOT add property "mystery" to the graph
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_unk", subjectId: "ent", propertyId: "mystery", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const unkWarnings = results.filter((r) => r.rule === "unknown-property");
+      expect(unkWarnings).toHaveLength(1);
+      expect(unkWarnings[0].severity).toBe("warning");
+      expect(unkWarnings[0].message).toContain("mystery");
+    });
+
+    it("does not warn for known properties", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_known", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "ent");
+      const unkWarnings = results.filter((r) => r.rule === "unknown-property");
+      expect(unkWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("date-format check", () => {
+    it("warns on invalid asOf format", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_baddate", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "Jan 2024" });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "date-format");
+      expect(dateWarnings).toHaveLength(1);
+      expect(dateWarnings[0].severity).toBe("warning");
+    });
+
+    it("warns on invalid validEnd format", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_badend", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2024", validEnd: "2024/06/01" });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "date-format");
+      expect(dateWarnings).toHaveLength(1);
+      expect(dateWarnings[0].message).toContain("validEnd");
+    });
+
+    it("accepts valid date formats (YYYY, YYYY-MM, YYYY-MM-DD)", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_y", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2024" });
+      g.addFact({ id: "f_ym", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2024-06" });
+      g.addFact({ id: "f_ymd", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2024-06-15" });
+
+      const results = validateEntity(g, "ent");
+      const dateWarnings = results.filter((r) => r.rule === "date-format");
+      expect(dateWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("future-date check", () => {
+    it("warns when asOf is in the future", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_future", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2099-01-01" });
+
+      const results = validateEntity(g, "ent");
+      const futureWarnings = results.filter((r) => r.rule === "future-date");
+      expect(futureWarnings).toHaveLength(1);
+      expect(futureWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not flag past dates", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "ent", stableId: "aB3cD4eF5g", type: "org", name: "E" });
+      g.addFact({ id: "f_past", subjectId: "ent", propertyId: "name", value: { type: "text", value: "v" }, asOf: "2020-01-01" });
+
+      const results = validateEntity(g, "ent");
+      const futureWarnings = results.filter((r) => r.rule === "future-date");
+      expect(futureWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("orphan-entity check", () => {
+    it("reports orphan entity with no facts and no items", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addEntity({ id: "orphan", stableId: "aB3cD4eF5g", type: "org", name: "Orphan" });
+
+      const results = validateEntity(g, "orphan");
+      const orphanInfos = results.filter((r) => r.rule === "orphan-entity");
+      expect(orphanInfos).toHaveLength(1);
+      expect(orphanInfos[0].severity).toBe("info");
+    });
+
+    it("does not flag entity with facts", () => {
+      const g = new Graph();
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "name", name: "Name", dataType: "text" });
+      g.addEntity({ id: "active", stableId: "aB3cD4eF5g", type: "org", name: "Active" });
+      g.addFact({ id: "f_a1", subjectId: "active", propertyId: "name", value: { type: "text", value: "v" } });
+
+      const results = validateEntity(g, "active");
+      const orphanInfos = results.filter((r) => r.rule === "orphan-entity");
+      expect(orphanInfos).toHaveLength(0);
+    });
+  });
+
+  describe("bidirectional-redundancy check", () => {
+    it("warns when both sides of inverse relationship are stored", () => {
+      const g = new Graph();
+      g.addSchema({ type: "person", name: "Person", required: [], recommended: [] });
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "employed-by", name: "Employed By", dataType: "ref", inverseId: "employer-of" });
+      g.addProperty({ id: "employer-of", name: "Employs", dataType: "ref", computed: true });
+
+      g.addEntity({ id: "alice", stableId: "aB3cD4eF5g", type: "person", name: "Alice" });
+      g.addEntity({ id: "acme", stableId: "xY7zW8vU9t", type: "org", name: "ACME" });
+
+      // Both sides stored explicitly (the inverse should be computed, not stored)
+      g.addFact({ id: "f_alice_emp", subjectId: "alice", propertyId: "employed-by", value: { type: "ref", value: "acme" } });
+      g.addFact({ id: "f_acme_emp", subjectId: "acme", propertyId: "employer-of", value: { type: "ref", value: "alice" } });
+
+      const results = validate(g);
+      const biWarnings = results.filter((r) => r.rule === "bidirectional-redundancy");
+      expect(biWarnings).toHaveLength(1);
+      expect(biWarnings[0].severity).toBe("warning");
+    });
+
+    it("does not flag when only one side is stored", () => {
+      const g = new Graph();
+      g.addSchema({ type: "person", name: "Person", required: [], recommended: [] });
+      g.addSchema({ type: "org", name: "Org", required: [], recommended: [] });
+      g.addProperty({ id: "employed-by", name: "Employed By", dataType: "ref", inverseId: "employer-of" });
+      g.addProperty({ id: "employer-of", name: "Employs", dataType: "ref", computed: true });
+
+      g.addEntity({ id: "alice", stableId: "aB3cD4eF5g", type: "person", name: "Alice" });
+      g.addEntity({ id: "acme", stableId: "xY7zW8vU9t", type: "org", name: "ACME" });
+
+      g.addFact({ id: "f_alice_emp", subjectId: "alice", propertyId: "employed-by", value: { type: "ref", value: "acme" } });
+      // employer-of NOT explicitly stored — will be computed
+
+      const results = validate(g);
+      const biWarnings = results.filter((r) => r.rule === "bidirectional-redundancy");
+      expect(biWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("new checks on real data", () => {
+    it("produces no stableid-format errors on real entities", () => {
+      const results = validate(graph);
+      const stableIdErrors = results.filter((r) => r.rule === "stableid-format");
+      expect(stableIdErrors).toHaveLength(0);
+    });
+
+    it("produces no duplicate-stableid errors on real entities", () => {
+      const results = validate(graph);
+      const dupErrors = results.filter((r) => r.rule === "duplicate-stableid");
+      expect(dupErrors).toHaveLength(0);
+    });
+
+    it("produces no factid-format errors on real entities", () => {
+      const results = validate(graph);
+      const formatErrors = results.filter((r) => r.rule === "factid-format");
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it("produces no empty-name errors on real entities", () => {
+      const results = validate(graph);
+      const nameErrors = results.filter((r) => r.rule === "empty-name");
+      expect(nameErrors).toHaveLength(0);
+    });
+
+    it("produces no valid-end-before-as-of errors on real entities", () => {
+      const results = validate(graph);
+      const orderErrors = results.filter((r) => r.rule === "valid-end-before-as-of");
+      expect(orderErrors).toHaveLength(0);
+    });
+
+    it("produces no date-format warnings on real entities", () => {
+      const results = validate(graph);
+      const dateWarnings = results.filter((r) => r.rule === "date-format");
+      expect(dateWarnings).toHaveLength(0);
+    });
+  });
+});

--- a/packages/kb/tsconfig.json
+++ b/packages/kb/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/kb/vitest.config.ts
+++ b/packages/kb/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Expands KB validation from 6 checks to 22 checks (16 new) in `packages/kb/src/validate.ts`
- Adds `crux kb validate` CLI command with `--errors-only`, `--rule=X`, and `--ci` flags
- 174 tests pass (up from 133), with 41 new validation tests

## New Checks

**Data integrity (errors):**
- `stableid-format` — stableId must be exactly 10 alphanumeric chars
- `duplicate-stableid` — no two entities share a stableId (graph-level)
- `factid-format` — fact ID must start with `f_` or `inv_`
- `empty-name` — entity must have a non-empty name
- `valid-end-before-as-of` — validEnd must not precede asOf

**Temporal consistency (warnings):**
- `temporal-missing-date` — temporal property facts should have asOf
- `non-temporal-multiple` — non-temporal properties should have ≤1 fact
- `stale-temporal` — most recent asOf >2 years old

**Data quality (warnings):**
- `duplicate-facts` — same (entity, property, asOf) tuple
- `missing-source` — fact has no source URL
- `unknown-property` — fact references unregistered property
- `date-format` — asOf/validEnd must match YYYY, YYYY-MM, or YYYY-MM-DD
- `future-date` — asOf is in the future
- `bidirectional-redundancy` — both sides of inverse relationship stored explicitly

**Informational:**
- `orphan-entity` — entity with zero facts and zero items

## Test plan
- [x] All 174 KB tests pass (`cd packages/kb && npx vitest run`)
- [x] No false-positive errors on real 30-entity dataset
- [x] `crux kb validate` outputs grouped by severity

Closes #1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)