### PR TITLE
feat: add PR Kanban Dashboard (E1011)

### DIFF
--- a/apps/web/src/app/internal/pr-dashboard/page.tsx
+++ b/apps/web/src/app/internal/pr-dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function PRDashboardPage() {
+  redirect("/wiki/E1011");
+}

--- a/apps/web/src/app/internal/pr-dashboard/pr-dashboard-board.tsx
+++ b/apps/web/src/app/internal/pr-dashboard/pr-dashboard-board.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { GITHUB_REPO_URL } from "@lib/site-config";
+import { classifyPR, type PullData, type PRStats, type KanbanColumn } from "./pr-dashboard-shared";
+
+// ── Column Config ───────────────────────────────────────────────────────
+
+const COLUMN_CONFIG: Array<{
+  key: KanbanColumn;
+  title: string;
+  emptyText: string;
+  headerColor: string;
+}> = [
+  {
+    key: "draft",
+    title: "Draft",
+    emptyText: "No draft PRs",
+    headerColor: "text-muted-foreground",
+  },
+  {
+    key: "ci-issues",
+    title: "CI Running / Failing",
+    emptyText: "All CI checks passing",
+    headerColor: "text-yellow-600",
+  },
+  {
+    key: "needs-review",
+    title: "Needs Review",
+    emptyText: "No PRs awaiting review",
+    headerColor: "text-blue-600",
+  },
+  {
+    key: "approved",
+    title: "Approved",
+    emptyText: "No approved PRs",
+    headerColor: "text-green-600",
+  },
+];
+
+// ── CI Status Badge ────────────────────────────────────────────────────
+// TODO: extract CiStatusBadge, MergeStatusBadge, and their style objects
+// to shared pr-badges.tsx (also used by system-health/open-prs-table.tsx)
+
+const CI_STYLES: Record<string, { cls: string; label: string }> = {
+  success: { cls: "bg-green-500/15 text-green-600", label: "passing" },
+  failure: { cls: "bg-red-500/15 text-red-500", label: "failing" },
+  pending: { cls: "bg-yellow-500/15 text-yellow-600", label: "building" },
+  error: { cls: "bg-red-500/15 text-red-500", label: "error" },
+  unknown: { cls: "bg-muted text-muted-foreground", label: "unknown" },
+};
+
+function CiStatusBadge({ status }: { status: string }) {
+  const style = CI_STYLES[status] ?? CI_STYLES.unknown;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${style.cls}`}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+// ── Merge Status Badge ─────────────────────────────────────────────────
+
+const MERGE_STYLES: Record<string, { cls: string; label: string }> = {
+  mergeable: { cls: "bg-green-500/15 text-green-600", label: "clean" },
+  conflicting: { cls: "bg-red-500/15 text-red-500", label: "conflicts" },
+  unknown: { cls: "bg-muted text-muted-foreground", label: "pending" },
+};
+
+function MergeStatusBadge({ status }: { status: string }) {
+  const style = MERGE_STYLES[status] ?? MERGE_STYLES.unknown;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${style.cls}`}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+// ── Label Pill ─────────────────────────────────────────────────────────
+
+function LabelPill({ name }: { name: string }) {
+  const isBlock = name.startsWith("block:");
+  const isWarning =
+    name.startsWith("needs:") || name.startsWith("waiting:");
+  const cls = isBlock
+    ? "bg-red-500/15 text-red-600"
+    : isWarning
+      ? "bg-orange-500/15 text-orange-600"
+      : "bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+    >
+      {name}
+    </span>
+  );
+}
+
+// ── Relative Time ──────────────────────────────────────────────────────
+
+function relativeTime(date: string): string {
+  const now = Date.now();
+  const then = new Date(date).getTime();
+  const hoursAgo = Math.round((now - then) / 3600000);
+
+  if (hoursAgo < 1) return "<1h ago";
+  if (hoursAgo < 24) return `${hoursAgo}h ago`;
+  return `${Math.round(hoursAgo / 24)}d ago`;
+}
+
+// ── PR Card ────────────────────────────────────────────────────────────
+
+function PRCard({ pr }: { pr: PullData }) {
+  // Filter labels that are purely workflow/stage markers from display
+  const displayLabels = pr.labels.filter(
+    (l) =>
+      l !== "stage:approved" &&
+      l !== "ready-to-merge" &&
+      l !== "claude-working" &&
+      l !== "filed-by-agent"
+  );
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-background p-3 shadow-sm">
+      {/* Header: PR number + author */}
+      <div className="flex items-center justify-between mb-1">
+        <a
+          href={`${GITHUB_REPO_URL}/pull/${pr.number}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-blue-600 hover:underline tabular-nums font-medium"
+        >
+          #{pr.number}
+        </a>
+        <span className="text-[11px] text-muted-foreground">{pr.author}</span>
+      </div>
+
+      {/* Title */}
+      <a
+        href={`${GITHUB_REPO_URL}/pull/${pr.number}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block text-sm leading-snug mb-2 truncate hover:underline"
+        title={pr.title}
+      >
+        {pr.title}
+      </a>
+
+      {/* Badges row */}
+      <div className="flex flex-wrap items-center gap-1.5 mb-2">
+        <CiStatusBadge status={pr.ciStatus} />
+        <MergeStatusBadge status={pr.mergeable} />
+        {pr.unresolvedThreads > 0 && (
+          <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-purple-500/15 text-purple-600">
+            {pr.unresolvedThreads} thread{pr.unresolvedThreads !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Labels */}
+      {displayLabels.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {displayLabels.map((label) => (
+            <LabelPill key={label} name={label} />
+          ))}
+        </div>
+      )}
+
+      {/* Footer: size + age */}
+      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+        <span className="tabular-nums">
+          <span className="text-green-600">+{pr.additions}</span>
+          {" / "}
+          <span className="text-red-500">-{pr.deletions}</span>
+        </span>
+        <span className="tabular-nums" suppressHydrationWarning>
+          {relativeTime(pr.createdAt)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Column ─────────────────────────────────────────────────────────────
+
+function KanbanColumnComponent({
+  title,
+  headerColor,
+  emptyText,
+  pulls,
+}: {
+  title: string;
+  headerColor: string;
+  emptyText: string;
+  pulls: PullData[];
+}) {
+  return (
+    <div className="flex flex-col min-w-[260px]">
+      {/* Column header */}
+      <div className="flex items-center gap-2 mb-3">
+        <h3 className={`text-sm font-semibold ${headerColor}`}>{title}</h3>
+        <span className="inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground min-w-[20px]">
+          {pulls.length}
+        </span>
+      </div>
+
+      {/* Cards */}
+      <div className="flex flex-col gap-2">
+        {pulls.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/60 p-4 text-center text-xs text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          pulls.map((pr) => <PRCard key={pr.number} pr={pr} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Stats Bar ──────────────────────────────────────────────────────────
+
+function StatsBar({ stats }: { stats: PRStats }) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground mb-6">
+      <span>
+        Open PRs:{" "}
+        <span className="font-semibold text-foreground">{stats.total}</span>
+      </span>
+      <span>
+        Draft:{" "}
+        <span className="font-semibold text-foreground">{stats.draft}</span>
+      </span>
+      <span>
+        CI Failing:{" "}
+        <span
+          className={`font-semibold ${stats.ciFailing > 0 ? "text-red-500" : "text-foreground"}`}
+        >
+          {stats.ciFailing}
+        </span>
+      </span>
+      <span>
+        Needs Review:{" "}
+        <span
+          className={`font-semibold ${stats.needsReview > 0 ? "text-blue-600" : "text-foreground"}`}
+        >
+          {stats.needsReview}
+        </span>
+      </span>
+      <span>
+        Conflicting:{" "}
+        <span
+          className={`font-semibold ${stats.conflicting > 0 ? "text-red-500" : "text-foreground"}`}
+        >
+          {stats.conflicting}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+// ── Board ──────────────────────────────────────────────────────────────
+
+export function PRDashboardBoard({
+  pulls,
+  stats,
+}: {
+  pulls: PullData[];
+  stats: PRStats;
+}) {
+  // Classify PRs into columns
+  const columns: Record<KanbanColumn, PullData[]> = {
+    draft: [],
+    "ci-issues": [],
+    "needs-review": [],
+    approved: [],
+  };
+
+  for (const pr of pulls) {
+    const col = classifyPR(pr);
+    columns[col].push(pr);
+  }
+
+  // Sort each column: most recently updated first
+  for (const col of Object.values(columns)) {
+    col.sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+  }
+
+  if (pulls.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+        <p className="text-lg font-medium mb-2">No open pull requests</p>
+        <p className="text-sm">
+          Open PRs will appear here when agents or contributors create them.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <StatsBar stats={stats} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+        {COLUMN_CONFIG.map((cfg) => (
+          <KanbanColumnComponent
+            key={cfg.key}
+            title={cfg.title}
+            headerColor={cfg.headerColor}
+            emptyText={cfg.emptyText}
+            pulls={columns[cfg.key]}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/internal/pr-dashboard/pr-dashboard-content.tsx
+++ b/apps/web/src/app/internal/pr-dashboard/pr-dashboard-content.tsx
@@ -1,0 +1,50 @@
+import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { PRDashboardBoard } from "./pr-dashboard-board";
+import { computeStats, type PullData } from "./pr-dashboard-shared";
+
+// Re-export shared types so existing consumers (mdx-components) keep working
+export type { PullData, PRStats, KanbanColumn } from "./pr-dashboard-shared";
+export { classifyPR } from "./pr-dashboard-shared";
+
+// ── Data Loading ────────────────────────────────────────────────────────
+
+interface PullsResponse {
+  pulls: PullData[];
+  error?: string;
+}
+
+async function loadFromApi(): Promise<FetchResult<PullsResponse>> {
+  return fetchDetailed<PullsResponse>("/api/github/pulls", { revalidate: 15 });
+}
+
+function noLocalFallback(): PullsResponse {
+  return { pulls: [], error: "Wiki-server unavailable" };
+}
+
+// ── Content Component (server) ───────────────────────────────────────────
+
+export async function PRDashboardContent() {
+  const { data, source, apiError } = await withApiFallback(
+    loadFromApi,
+    noLocalFallback
+  );
+
+  const pulls = data.pulls ?? [];
+  const error = data.error ?? undefined;
+  const stats = computeStats(pulls);
+
+  return (
+    <>
+      <DataSourceBanner source={source} apiError={apiError} />
+      {error && (
+        <div className="border-l-4 border-amber-400 bg-amber-50 dark:bg-amber-950/30 px-4 py-3 mb-4 not-prose">
+          <p className="text-sm text-amber-800 dark:text-amber-200">
+            {error}
+          </p>
+        </div>
+      )}
+      <PRDashboardBoard pulls={pulls} stats={stats} />
+    </>
+  );
+}

--- a/apps/web/src/app/internal/pr-dashboard/pr-dashboard-shared.ts
+++ b/apps/web/src/app/internal/pr-dashboard/pr-dashboard-shared.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared types and pure functions for the PR Dashboard.
+ *
+ * This module is intentionally free of server-only imports so it can be
+ * safely imported by both the server content component and the "use client"
+ * board component.
+ */
+
+// ── Types (matches OpenPR from wiki-server github-pulls route) ──────────
+
+export interface PullData {
+  number: number;
+  title: string;
+  branch: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  isDraft: boolean;
+  additions: number;
+  deletions: number;
+  ciStatus: "success" | "failure" | "pending" | "error" | "unknown";
+  mergeable: "mergeable" | "conflicting" | "unknown";
+  labels: string[];
+  unresolvedThreads: number;
+}
+
+// ── Stats ────────────────────────────────────────────────────────────────
+
+export interface PRStats {
+  total: number;
+  draft: number;
+  ciFailing: number;
+  needsReview: number;
+  conflicting: number;
+}
+
+// ── Kanban Column Classification ────────────────────────────────────────
+
+export type KanbanColumn = "draft" | "ci-issues" | "needs-review" | "approved";
+
+/**
+ * Classify a PR into one of the Kanban columns.
+ * Single source of truth: used by both stats computation and board grouping.
+ */
+export function classifyPR(pr: PullData): KanbanColumn {
+  if (pr.isDraft) return "draft";
+
+  const hasApproved = pr.labels.some(
+    (l) => l === "stage:approved" || l === "ready-to-merge"
+  );
+  if (hasApproved) return "approved";
+
+  if (
+    pr.ciStatus === "pending" ||
+    pr.ciStatus === "failure" ||
+    pr.ciStatus === "error"
+  ) {
+    return "ci-issues";
+  }
+
+  return "needs-review";
+}
+
+/**
+ * Compute aggregate stats from a list of PRs using the shared classifyPR logic.
+ */
+export function computeStats(pulls: PullData[]): PRStats {
+  const counts: Record<KanbanColumn, number> = {
+    draft: 0,
+    "ci-issues": 0,
+    "needs-review": 0,
+    approved: 0,
+  };
+
+  for (const pr of pulls) {
+    counts[classifyPR(pr)]++;
+  }
+
+  return {
+    total: pulls.length,
+    draft: counts.draft,
+    ciFailing: pulls.filter((p) => p.ciStatus === "failure").length,
+    needsReview: counts["needs-review"],
+    conflicting: pulls.filter((p) => p.mergeable === "conflicting").length,
+  };
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -56,6 +56,7 @@ import { GroundskeeperRunsContent } from "@/app/internal/groundskeeper-runs/grou
 import { SystemHealthContent } from "@/app/internal/system-health/system-health-content";
 import { StatementQualityContent } from "@/app/internal/statement-quality/statement-quality-content";
 import { StatementScoresContent } from "@/app/internal/statement-scores/statement-scores-content";
+import { PRDashboardContent } from "@/app/internal/pr-dashboard/pr-dashboard-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -184,6 +185,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   SystemHealthContent,
   StatementQualityContent,
   StatementScoresContent,
+  PRDashboardContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -249,6 +249,7 @@ export function getInternalNav(): NavSection[] {
       defaultOpen: true,
       items: [
         { label: "System Health", href: internalHref("system-health-dashboard") },
+        { label: "PR Dashboard", href: internalHref("pr-dashboard") },
         { label: "Pages", href: internalHref("page-coverage-dashboard") },
         { label: "Entities & Pages", href: internalHref("entities-dashboard") },
         { label: "Page Changes", href: internalHref("page-changes-dashboard") },

--- a/apps/wiki-server/src/routes/github-pulls.ts
+++ b/apps/wiki-server/src/routes/github-pulls.ts
@@ -18,6 +18,8 @@ export interface OpenPR {
   deletions: number;
   ciStatus: "success" | "failure" | "pending" | "error" | "unknown";
   mergeable: "mergeable" | "conflicting" | "unknown";
+  labels: string[];
+  unresolvedThreads: number;
 }
 
 // ── GraphQL query ──────────────────────────────────────────────────────────
@@ -37,6 +39,12 @@ query($owner: String!, $name: String!) {
         isDraft
         additions
         deletions
+        labels(first: 20) {
+          nodes { name }
+        }
+        reviewThreads(first: 50) {
+          nodes { isResolved isOutdated }
+        }
         commits(last: 1) {
           nodes {
             commit {
@@ -63,6 +71,12 @@ interface GQLPRNode {
   isDraft: boolean;
   additions: number;
   deletions: number;
+  labels: {
+    nodes: Array<{ name: string }>;
+  };
+  reviewThreads: {
+    nodes: Array<{ isResolved: boolean; isOutdated: boolean }>;
+  };
   commits: {
     nodes: Array<{
       commit: {
@@ -113,6 +127,9 @@ function mapMergeable(m: GQLPRNode["mergeable"]): OpenPR["mergeable"] {
 
 function mapNode(node: GQLPRNode): OpenPR {
   const lastCommit = node.commits.nodes[0]?.commit;
+  const unresolvedThreads = node.reviewThreads.nodes.filter(
+    (t) => !t.isResolved && !t.isOutdated
+  ).length;
   return {
     number: node.number,
     title: node.title,
@@ -125,6 +142,8 @@ function mapNode(node: GQLPRNode): OpenPR {
     deletions: node.deletions,
     ciStatus: mapCiStatus(lastCommit?.statusCheckRollup?.state),
     mergeable: mapMergeable(node.mergeable),
+    labels: node.labels.nodes.map((l) => l.name),
+    unresolvedThreads,
   };
 }
 

--- a/content/docs/internal/pr-dashboard.mdx
+++ b/content/docs/internal/pr-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+numericId: E1011
+title: "PR Dashboard"
+description: "Kanban view of all open pull requests grouped by stage"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-03-06"
+---
+
+<PRDashboardContent />

--- a/data/entities/pr-dashboard.yaml
+++ b/data/entities/pr-dashboard.yaml
@@ -1,0 +1,8 @@
+- id: pr-dashboard
+  numericId: E1011
+  type: internal
+  title: PR Dashboard
+  description: >-
+    Kanban view of all open pull requests grouped by stage (Draft, CI Issues,
+    Needs Review, Approved). Used for monitoring PR pipeline health.
+  lastUpdated: 2026-03


### PR DESCRIPTION
## Summary

New internal dashboard at `/internal/pr-dashboard/` showing all open PRs grouped by stage in a Kanban-style board.

### New files
- `apps/web/src/app/internal/pr-dashboard/pr-dashboard-shared.ts` — shared types (`PullData`, `PRStats`, `KanbanColumn`) and pure functions (`classifyPR`, `computeStats`), safely importable by both server and client components
- `apps/web/src/app/internal/pr-dashboard/pr-dashboard-content.tsx` — server component fetching from wiki-server with `fetchDetailed` + `withApiFallback`, renders `DataSourceBanner` + board
- `apps/web/src/app/internal/pr-dashboard/pr-dashboard-board.tsx` — client component with Kanban columns (Draft, CI Issues, Needs Review, Approved), PR cards with badges
- `apps/web/src/app/internal/pr-dashboard/page.tsx` — redirect to `/wiki/E1011`
- `content/docs/internal/pr-dashboard.mdx` — MDX stub (E1011)
- `data/entities/pr-dashboard.yaml` — entity definition

### Modified files
- `apps/wiki-server/src/routes/github-pulls.ts` — extended GraphQL query with `labels` and `reviewThreads`, added `labels: string[]` and `unresolvedThreads: number` to `OpenPR` interface
- `apps/web/src/components/mdx-components.tsx` — registered `PRDashboardContent`
- `apps/web/src/lib/wiki-nav.ts` — added sidebar entry

### Architecture decisions
- Used Pattern A (MDX stub + content component) per internal dashboard rules
- Created `pr-dashboard-shared.ts` to avoid server/client boundary issues (client component can't import from server module with `fetchDetailed`)
- `classifyPR` is single source of truth for column assignment, used by both stats and board

## Test plan
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Entity ID E1011 allocated via wiki-server
- [ ] Preview dashboard at `/internal/pr-dashboard/` with dev server
- [ ] Verify PR cards show correct labels, CI status, merge status

Related: GitHub Discussion #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)