### PR TITLE
feat: add KBCompareTable cross-entity comparison component

### DIFF
--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -27,6 +27,7 @@ import { KBEntityFacts } from "@/components/wiki/kb/KBEntityFacts";
 import { KBItemCollection } from "@/components/wiki/kb/KBItemCollection";
 import { KBEntitySidebar } from "@/components/wiki/kb/KBEntitySidebar";
 import { KBRefLink } from "@/components/wiki/kb/KBRefLink";
+import { KBCompareTable } from "@/components/wiki/kb/KBCompareTable";
 
 // Table view components
 import SafetyApproachesTableView from "@/components/tables/views/SafetyApproachesTableView";
@@ -177,6 +178,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   KBItemCollection,
   KBEntitySidebar,
   KBRefLink,
+  KBCompareTable,
 
   // Epic tracking
   EpicTracker,

--- a/apps/web/src/components/wiki/kb/KBCompareTable.tsx
+++ b/apps/web/src/components/wiki/kb/KBCompareTable.tsx
@@ -1,0 +1,389 @@
+/**
+ * KBCompareTable — Cross-entity comparison table for KB data.
+ *
+ * Server component that renders a table comparing a single KB property across
+ * multiple entities side-by-side. Supports both latest-value and full time-series
+ * modes, determined automatically based on the property's temporal flag.
+ *
+ * For time-series properties (revenue, valuation, headcount), columns are years
+ * derived from the union of all asOf dates across the entities shown.
+ * For point-in-time properties (founded-date, headquarters), a single value
+ * column is rendered with an optional "as of" date.
+ *
+ * Usage in MDX:
+ *   <KBCompareTable property="revenue" />
+ *   <KBCompareTable property="headcount" entities={["anthropic", "openai", "deepmind"]} />
+ *   <KBCompareTable property="valuation" title="AI Lab Valuations" />
+ *   <KBCompareTable property="revenue" mode="latest" />
+ */
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  getKBAllFactsByProperty,
+  getKBFactsByProperty,
+  getKBEntities,
+  getKBProperty,
+  getKBEntity,
+} from "@data/kb";
+import type { Fact, Property } from "@longterm-wiki/kb";
+import { formatKBDate, formatKBFactValue, titleCase } from "./format";
+import { KBRefLink } from "./KBRefLink";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type CompareMode = "timeseries" | "latest" | "auto";
+
+interface KBCompareTableProps {
+  /** KB property ID to compare across entities (e.g., "revenue", "headcount") */
+  property: string;
+  /**
+   * KB entity IDs to include. If omitted, shows all entities that have at
+   * least one fact for the given property.
+   */
+  entities?: string[];
+  /** Optional heading override (defaults to property name) */
+  title?: string;
+  /**
+   * Display mode:
+   * - "auto"       — time-series if the property is temporal AND has multiple dated facts, else latest
+   * - "timeseries" — always show all dated values as columns by year
+   * - "latest"     — always show only the most recent value per entity
+   *
+   * Defaults to "auto".
+   */
+  mode?: CompareMode;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Extract a 4-digit year string from an asOf date like "2024-06" or "2024". */
+function extractYear(asOf: string): string {
+  return asOf.slice(0, 4);
+}
+
+/**
+ * Given a fact, render its value as a React node.
+ * Ref/refs values get KBRefLink; everything else gets the text formatter.
+ */
+function FactCellValue({
+  fact,
+  property,
+}: {
+  fact: Fact | undefined;
+  property: Property | undefined;
+}) {
+  if (!fact) {
+    return <span className="text-muted-foreground">{"\u2014"}</span>;
+  }
+
+  const v = fact.value;
+
+  if (v.type === "ref") {
+    return <KBRefLink id={v.value} />;
+  }
+
+  if (v.type === "refs") {
+    return (
+      <span className="inline-flex flex-wrap gap-1">
+        {v.value.map((refId, i) => (
+          <span key={`${refId}-${i}`}>
+            <KBRefLink id={refId} />
+            {i < v.value.length - 1 && (
+              <span className="text-muted-foreground">,</span>
+            )}
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  return (
+    <span className="tabular-nums">
+      {formatKBFactValue(fact, property?.unit, property?.display)}
+    </span>
+  );
+}
+
+// ── Time-series layout ────────────────────────────────────────────────────────
+
+/**
+ * Renders a table where rows = entities and columns = years.
+ * For each (entity, year) cell we pick the fact with the latest asOf within
+ * that year (handles multiple data points per year).
+ */
+function TimeSeriesTable({
+  entityRows,
+  years,
+  property,
+}: {
+  entityRows: Array<{ entityId: string; name: string; facts: Fact[] }>;
+  years: string[];
+  property: Property | undefined;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead scope="col" className="min-w-[120px]">
+            Entity
+          </TableHead>
+          {years.map((year) => (
+            <TableHead key={year} scope="col" className="text-right tabular-nums">
+              {year}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {entityRows.map(({ entityId, name, facts }) => {
+          // For each year column, pick the latest fact within that year
+          const factsByYear = new Map<string, Fact>();
+          for (const fact of facts) {
+            if (!fact.asOf) continue;
+            const year = extractYear(fact.asOf);
+            const existing = factsByYear.get(year);
+            if (!existing || fact.asOf > existing.asOf!) {
+              factsByYear.set(year, fact);
+            }
+          }
+
+          return (
+            <TableRow key={entityId}>
+              <TableCell className="font-medium">
+                <KBRefLink id={entityId} label={name} />
+              </TableCell>
+              {years.map((year) => {
+                const fact = factsByYear.get(year);
+                return (
+                  <TableCell key={year} className="text-right">
+                    <FactCellValue fact={fact} property={property} />
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+// ── Latest-value layout ───────────────────────────────────────────────────────
+
+/**
+ * Renders a simple two-column table: entity | value (with optional asOf date).
+ */
+function LatestValueTable({
+  entityRows,
+  property,
+}: {
+  entityRows: Array<{ entityId: string; name: string; fact: Fact }>;
+  property: Property | undefined;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead scope="col">Entity</TableHead>
+          <TableHead scope="col" className="text-right">
+            {property?.name ?? "Value"}
+          </TableHead>
+          <TableHead scope="col">As Of</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {entityRows.map(({ entityId, name, fact }) => (
+          <TableRow key={entityId}>
+            <TableCell className="font-medium">
+              <KBRefLink id={entityId} label={name} />
+            </TableCell>
+            <TableCell className="text-right font-medium">
+              <FactCellValue fact={fact} property={property} />
+            </TableCell>
+            <TableCell className="text-muted-foreground whitespace-nowrap">
+              {formatKBDate(fact.asOf)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function KBCompareTable({
+  property: propertyId,
+  entities: entityFilter,
+  title,
+  mode = "auto",
+}: KBCompareTableProps) {
+  const prop = getKBProperty(propertyId);
+  const heading = title ?? prop?.name ?? titleCase(propertyId);
+
+  // Resolve which entities to include
+  const allEntities = getKBEntities();
+
+  // Determine which entity IDs are in scope
+  const scopeIds: string[] | undefined = entityFilter;
+
+  // Get all facts for this property, scoped to the requested entities
+  const allFactsMap = getKBAllFactsByProperty(propertyId, scopeIds);
+
+  // If no entity filter was given, derive the list from entities that actually
+  // have facts for this property
+  const entityIds = scopeIds
+    ? scopeIds.filter((id) => allFactsMap.has(id))
+    : Array.from(allFactsMap.keys());
+
+  if (entityIds.length === 0) {
+    return (
+      <Card className="my-6">
+        <CardHeader className="flex-row items-center gap-2 space-y-0 pb-4">
+          <CardTitle className="text-base">{heading}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No data available.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Resolve entity display names (prefer KB name, fall back to entityId)
+  function getEntityName(entityId: string): string {
+    const kbEntity = getKBEntity(entityId);
+    if (kbEntity) return kbEntity.name;
+    const wikiEntity = allEntities.find((e) => e.id === entityId);
+    return wikiEntity?.name ?? entityId;
+  }
+
+  // Decide render mode
+  const totalFactCount = Array.from(allFactsMap.values()).reduce(
+    (sum, facts) => sum + facts.length,
+    0,
+  );
+  const hasDatedFacts = Array.from(allFactsMap.values()).some((facts) =>
+    facts.some((f) => f.asOf !== undefined),
+  );
+  const isTemporalProperty = prop?.temporal === true;
+
+  const resolvedMode: "timeseries" | "latest" =
+    mode === "timeseries"
+      ? "timeseries"
+      : mode === "latest"
+        ? "latest"
+        : isTemporalProperty && hasDatedFacts && totalFactCount > entityIds.length
+          ? "timeseries"
+          : "latest";
+
+  const totalEntityCount = entityIds.length;
+
+  // ── Time-series mode ────────────────────────────────────────────────────────
+  if (resolvedMode === "timeseries") {
+    // Collect all years present across all entities, sorted ascending
+    const yearSet = new Set<string>();
+    for (const facts of allFactsMap.values()) {
+      for (const fact of facts) {
+        if (fact.asOf) yearSet.add(extractYear(fact.asOf));
+      }
+    }
+    const years = Array.from(yearSet).sort();
+
+    // Sort entities by their most recent value descending (for numeric properties)
+    const entityRows = entityIds
+      .map((entityId) => ({
+        entityId,
+        name: getEntityName(entityId),
+        facts: allFactsMap.get(entityId) ?? [],
+      }))
+      .sort((a, b) => {
+        // Sort by entity name if no numeric sorting possible
+        const latestA = a.facts[0];
+        const latestB = b.facts[0];
+        if (
+          latestA?.value.type === "number" &&
+          latestB?.value.type === "number"
+        ) {
+          return latestB.value.value - latestA.value.value;
+        }
+        return a.name.localeCompare(b.name);
+      });
+
+    return (
+      <Card className="my-6">
+        <CardHeader className="flex-row items-center gap-2 space-y-0 pb-4">
+          <CardTitle className="text-base">{heading}</CardTitle>
+          <span className="text-xs text-muted-foreground">
+            {totalEntityCount}{" "}
+            {totalEntityCount === 1 ? "entity" : "entities"}
+            {" \u00b7 "}
+            {years.length} {years.length === 1 ? "year" : "years"}
+          </span>
+        </CardHeader>
+        <CardContent className="px-0 pt-0 overflow-x-auto">
+          <TimeSeriesTable
+            entityRows={entityRows}
+            years={years}
+            property={prop}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Latest-value mode ───────────────────────────────────────────────────────
+  const latestMap = getKBFactsByProperty(propertyId, entityIds);
+
+  const entityRows = entityIds
+    .filter((id) => latestMap.has(id))
+    .map((entityId) => ({
+      entityId,
+      name: getEntityName(entityId),
+      fact: latestMap.get(entityId)!,
+    }))
+    .sort((a, b) => {
+      if (
+        a.fact.value.type === "number" &&
+        b.fact.value.type === "number"
+      ) {
+        return b.fact.value.value - a.fact.value.value;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+  if (entityRows.length === 0) {
+    return (
+      <Card className="my-6">
+        <CardHeader className="flex-row items-center gap-2 space-y-0 pb-4">
+          <CardTitle className="text-base">{heading}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No data available.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="my-6">
+      <CardHeader className="flex-row items-center gap-2 space-y-0 pb-4">
+        <CardTitle className="text-base">{heading}</CardTitle>
+        <span className="text-xs text-muted-foreground">
+          {entityRows.length}{" "}
+          {entityRows.length === 1 ? "entity" : "entities"}
+        </span>
+      </CardHeader>
+      <CardContent className="px-0 pt-0">
+        <LatestValueTable entityRows={entityRows} property={prop} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/data/kb.ts
+++ b/apps/web/src/data/kb.ts
@@ -102,6 +102,73 @@ export function getKBProperties(): Property[] {
 export const getKBThing = getKBEntity;
 
 /**
+ * Get the latest fact for a given property across all entities.
+ * Returns a map of entityId → latest Fact for entities that have the property.
+ * Optionally filtered to a subset of entity IDs.
+ */
+export function getKBFactsByProperty(
+  propertyId: string,
+  entityIds?: string[],
+): Map<string, Fact> {
+  const kb = getKB();
+  if (!kb) return new Map();
+
+  const ids = entityIds ?? kb.entities.map((e) => e.id);
+  const result = new Map<string, Fact>();
+
+  for (const entityId of ids) {
+    const facts = (kb.facts[entityId] ?? []).filter(
+      (f) => f.propertyId === propertyId,
+    );
+    if (facts.length === 0) continue;
+
+    // Pick the latest by asOf
+    const sorted = facts.slice().sort((a, b) => {
+      if (a.asOf === undefined && b.asOf === undefined) return 0;
+      if (a.asOf === undefined) return 1;
+      if (b.asOf === undefined) return -1;
+      return b.asOf.localeCompare(a.asOf);
+    });
+    result.set(entityId, sorted[0]!);
+  }
+
+  return result;
+}
+
+/**
+ * Get all facts for a given property across all entities (full history).
+ * Returns a map of entityId → Fact[] (sorted most-recent-first).
+ * Optionally filtered to a subset of entity IDs.
+ */
+export function getKBAllFactsByProperty(
+  propertyId: string,
+  entityIds?: string[],
+): Map<string, Fact[]> {
+  const kb = getKB();
+  if (!kb) return new Map();
+
+  const ids = entityIds ?? kb.entities.map((e) => e.id);
+  const result = new Map<string, Fact[]>();
+
+  for (const entityId of ids) {
+    const facts = (kb.facts[entityId] ?? [])
+      .filter((f) => f.propertyId === propertyId)
+      .slice()
+      .sort((a, b) => {
+        if (a.asOf === undefined && b.asOf === undefined) return 0;
+        if (a.asOf === undefined) return 1;
+        if (b.asOf === undefined) return -1;
+        return b.asOf.localeCompare(a.asOf);
+      });
+    if (facts.length > 0) {
+      result.set(entityId, facts);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Get a type schema by type name.
  */
 export function getKBSchema(type: string): TypeSchema | undefined {

--- a/content/docs/knowledge-base/organizations/frontier-ai-comparison.mdx
+++ b/content/docs/knowledge-base/organizations/frontier-ai-comparison.mdx
@@ -59,6 +59,23 @@ The frontier AI landscape is consolidating around 5-6 major players, with the ra
 
 *Sources: [Sacra](https://sacra.com/c/anthropic/), [PitchBook](https://pitchbook.com/profiles/company/527294-17), [Bloomberg](https://www.bloomberg.com/news/articles/2026-01-21/anthropic-s-revenue-run-rate-tops-9-billion-as-vcs-pile-in)*
 
+#### Revenue Run-Rate (KB data)
+
+<KBCompareTable
+  property="revenue"
+  entities={["anthropic", "openai", "xai", "meta-ai", "deepmind"]}
+  title="Revenue ARR — Frontier AI Labs"
+/>
+
+#### Valuation (KB data)
+
+<KBCompareTable
+  property="valuation"
+  entities={["anthropic", "openai", "xai", "ssi"]}
+  mode="latest"
+  title="Latest Valuation — Frontier AI Labs"
+/>
+
 ### Talent Assessment
 
 | Company | Key Talent Strengths | Key Talent Weaknesses | Net Flow Direction |


### PR DESCRIPTION
## Summary

Adds \`KBCompareTable\`, a new React server component for comparing a single KB property across multiple entities side-by-side — the cross-entity comparison component requested in #1845.

### What it does

- **Time-series mode** (auto-selected for temporal properties like revenue, valuation, headcount): rows = entities, columns = years. Each cell shows the most recent data point within that year.
- **Latest-value mode** (auto-selected for point-in-time properties): simple table with entity | value | as-of-date columns.
- **Auto mode** (default): picks time-series if the property is marked \`temporal: true\` AND has multiple dated facts across entities; otherwise falls back to latest-value.
- Numeric rows sorted descending by most recent value; text rows sorted alphabetically.
- Missing cells render as an em-dash; ref values render as KBRefLink components.

### Files changed

| File | Change |
|------|--------|
| \`apps/web/src/components/wiki/kb/KBCompareTable.tsx\` | New component |
| \`apps/web/src/data/kb.ts\` | +\`getKBFactsByProperty()\` and \`getKBAllFactsByProperty()\` helpers |
| \`apps/web/src/components/mdx-components.tsx\` | Register \`KBCompareTable\` for MDX use |
| \`content/docs/knowledge-base/organizations/frontier-ai-comparison.mdx\` | Demo usage |

### Usage

\`\`\`mdx
<KBCompareTable property="revenue" />
<KBCompareTable property="headcount" entities={["anthropic", "openai", "deepmind"]} />
<KBCompareTable property="valuation" mode="latest" title="AI Lab Valuations" />
\`\`\`

## Test plan

- [x] TypeScript: tsc --noEmit passes cleanly (0 errors) in main repo
- [x] Gate check: all 4 CI-blocking checks pass
- [x] All 2797 tests pass
- [x] Demo visible on Frontier AI Comparison page
- [x] No data available fallback renders correctly
- [x] Time-series auto-detection works for temporal properties
- [x] Latest-value auto-detection works for non-temporal properties

Closes #1845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced KB comparison tables that display property data across multiple entities with intelligent mode selection between time-series and latest-value formats.
  * Added Revenue ARR and Latest Valuation comparison tables to frontier AI organizations documentation for side-by-side entity metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->