### PR TITLE
fix(auto-update): scope orphaned-footnotes fix to pipeline pages only (#1857)

### DIFF
--- a/crux/auto-update/ci-orchestrate.ts
+++ b/crux/auto-update/ci-orchestrate.ts
@@ -7,7 +7,7 @@
  * Steps:
  *   1. Create date-stamped branch (auto-update/YYYY-MM-DD)
  *   2. Run auto-update pipeline (fetch -> digest -> route -> improve)
- *   3. Auto-fix: fix escaping, fix markdown, validate gate --fix
+ *   3. Auto-fix: fix escaping, fix markdown, fix orphaned-footnotes (scoped), validate gate --fix
  *   4. NEEDS CITATION cleanup (find markers, run improve, verify gone)
  *   5. Paranoid content review on each changed page
  *   6. Content quality checks (truncation + footnotes)
@@ -214,16 +214,22 @@ interface ReviewAlert {
   reason: string;
 }
 
-async function runParanoidReview(verbose: boolean): Promise<{ alerts: ReviewAlert[]; blocked: string[] }> {
-  // Find MDX files modified (not yet committed)
+async function runParanoidReview(verbose: boolean, scopedFiles?: string[]): Promise<{ alerts: ReviewAlert[]; blocked: string[] }> {
+  // Use the explicitly scoped file list when provided (files modified by the pipeline).
+  // Falling back to git diff would include any files touched by fix steps (e.g.,
+  // gate --fix or orphaned-footnotes sweeps), which can bloat the review to 100+ pages.
   let changedMdx: string[];
-  try {
-    const diff = git(['diff', '--name-only', 'HEAD', '--', 'content/docs/']);
-    changedMdx = diff
-      ? diff.split('\n').filter(f => f.endsWith('.mdx'))
-      : [];
-  } catch {
-    changedMdx = [];
+  if (scopedFiles !== undefined) {
+    changedMdx = scopedFiles.filter(f => f.endsWith('.mdx'));
+  } else {
+    try {
+      const diff = git(['diff', '--name-only', 'HEAD', '--', 'content/docs/']);
+      changedMdx = diff
+        ? diff.split('\n').filter(f => f.endsWith('.mdx'))
+        : [];
+    } catch {
+      changedMdx = [];
+    }
   }
 
   if (changedMdx.length === 0) {
@@ -350,6 +356,22 @@ export async function orchestrateCiAutoUpdate(
     return { branch, hasChanges: false, pagesUpdated: 0, prUrl: null, exitCode: 1 };
   }
 
+  // Capture the set of MDX files actually modified by the pipeline (Step 2),
+  // BEFORE any broad fix commands run. This prevents fix orphaned-footnotes from
+  // sweeping the entire codebase and inflating the paranoid review to 100+ pages.
+  let pipelineModifiedMdx: string[] = [];
+  try {
+    const diffOutput = execFileSync('git', ['diff', '--name-only', 'HEAD', '--', 'content/docs/'], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    pipelineModifiedMdx = diffOutput ? diffOutput.split('\n').filter(f => f.endsWith('.mdx')) : [];
+  } catch {
+    // If git diff fails, fall back to empty list (review will run on git diff at that time)
+  }
+  console.log(`Pipeline modified ${pipelineModifiedMdx.length} MDX file(s) in content/docs/`);
+
   // ── Step 3: Auto-fix (escaping, markdown, gate) ──
   console.log('\n--- Step 3: Run validation fixes ---');
   try {
@@ -370,13 +392,23 @@ export async function orchestrateCiAutoUpdate(
     console.warn(`::warning::fix markdown failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  try {
-    execFileSync('pnpm', ['crux', 'fix', 'orphaned-footnotes', '--apply'], {
-      cwd: PROJECT_ROOT,
-      stdio: 'inherit',
-    });
-  } catch (err) {
-    console.warn(`::warning::fix orphaned-footnotes failed: ${err instanceof Error ? err.message : String(err)}`);
+  // Fix orphaned footnotes only in files modified by this pipeline run.
+  // Running `fix orphaned-footnotes --apply` without --file sweeps the entire
+  // codebase (600+ pages), which inflates git diff and causes paranoid review
+  // to process 100+ pages, blowing the 2-hour timeout.
+  if (pipelineModifiedMdx.length > 0) {
+    for (const file of pipelineModifiedMdx) {
+      try {
+        execFileSync('pnpm', ['crux', 'fix', 'orphaned-footnotes', '--apply', `--file=${join(PROJECT_ROOT, file)}`], {
+          cwd: PROJECT_ROOT,
+          stdio: 'inherit',
+        });
+      } catch (err) {
+        console.warn(`::warning::fix orphaned-footnotes failed for ${file}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  } else {
+    console.log('No MDX files modified — skipping orphaned-footnotes fix');
   }
 
   try {
@@ -392,17 +424,7 @@ export async function orchestrateCiAutoUpdate(
   console.log('\n--- Step 4: NEEDS CITATION cleanup ---');
   // Only check files modified by this auto-update run, not pre-existing markers
   // in unrelated pages throughout the codebase.
-  let modifiedMdxFiles: string[] = [];
-  try {
-    const diffOutput = execFileSync('git', ['diff', '--name-only', 'HEAD', '--', 'content/docs/'], {
-      cwd: PROJECT_ROOT,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    modifiedMdxFiles = diffOutput ? diffOutput.split('\n').filter(f => f.endsWith('.mdx')) : [];
-  } catch {
-    // If git diff fails, fall back to full scan
-  }
+  const modifiedMdxFiles = pipelineModifiedMdx;
   const citationCleanup = await cleanupNeedsCitation(modifiedMdxFiles, options.verbose);
   if (citationCleanup.remaining.length > 0) {
     console.error('NEEDS CITATION markers remain -- manual review required before merging.');
@@ -411,7 +433,9 @@ export async function orchestrateCiAutoUpdate(
 
   // ── Step 5: Paranoid content review ──
   console.log('\n--- Step 5: Paranoid content review ---');
-  const review = await runParanoidReview(options.verbose);
+  // Pass the original pipeline files so review is scoped to them, not any
+  // additional files changed by the fix steps (e.g., gate --fix touching other pages).
+  const review = await runParanoidReview(options.verbose, pipelineModifiedMdx);
   if (review.blocked.length > 0) {
     console.error('Paranoid review blocked commit. Re-run the improve pipeline on blocked pages.');
     return { branch, hasChanges: false, pagesUpdated, prUrl: null, exitCode: 1 };


### PR DESCRIPTION
## Summary

The auto-update workflow was consistently timing out at 2 hours and failing, tripping the system wellness check.

### Root Cause

`fix orphaned-footnotes --apply` in Step 3 was scanning the **entire** `content/docs/` directory (~600+ MDX files) rather than only the pages modified by the auto-update pipeline. This caused:

1. The git diff to balloon from ~4 pages to 165+ pages (pre-existing orphaned footnotes across the wiki got fixed too)
2. The paranoid content review (Step 5) ran on all 165 changed pages at 45–90s each, totalling 2+ hours of LLM calls
3. The job hit the 120-minute timeout and was cancelled before finishing

Evidence from the March 7 run log:
- Step 2 finished at 07:47 — pipeline updated 4 pages
- `fix orphaned-footnotes --apply` at 07:48 modified 161 additional pre-existing pages
- Step 5 at 07:55: `Running paranoid review on 165 changed page(s)...`
- Cancelled at 08:30 — still reviewing page ~5 of 165

### Fix

- Capture the list of MDX files modified by the pipeline (Step 2) **before** any fix commands run
- Run `fix orphaned-footnotes --file=<path>` for each pipeline-modified file only, instead of the global `--apply` sweep
- Pass the same scoped file list to `runParanoidReview` so it only reviews the actual pipeline pages, not any extra files touched by fix steps

### Expected Outcome

- Paranoid review runs on 3–4 pages instead of 165
- Total workflow time drops from 2h+ to ~90 minutes
- No more timeout cancellations

## Test plan

- [x] TypeScript type-check passes (`npx tsc --noEmit --project crux/tsconfig.json`)
- [x] Module loads without errors
- [x] Existing unit tests unaffected (only `isAutoUpdateAllowedFile` is tested; logic changes are in non-tested integration code)
- [ ] Next scheduled auto-update run (2026-03-08 06:00 UTC) should complete within 2 hours without timeout

Closes #1857
