### PR TITLE
fix: CI red on main — scoring test expectations + E1011 build crash

### DIFF
--- a/crux/pr-patrol/index.test.ts
+++ b/crux/pr-patrol/index.test.ts
@@ -495,8 +495,8 @@ describe('computeBudget', () => {
 
   it('gives medium budget for ci-failure', () => {
     const budget = computeBudget(['ci-failure']);
-    expect(budget.maxTurns).toBe(25);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(35);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
   it('gives full budget for conflict', () => {
@@ -507,8 +507,8 @@ describe('computeBudget', () => {
 
   it('uses highest budget when multiple issues present', () => {
     const budget = computeBudget(['missing-issue-ref', 'ci-failure']);
-    expect(budget.maxTurns).toBe(25);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(35);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
   it('conflict dominates when mixed with smaller issues', () => {

--- a/crux/pr-patrol/scoring.test.ts
+++ b/crux/pr-patrol/scoring.test.ts
@@ -76,8 +76,8 @@ describe('computeBudget', () => {
 
   it('gives medium budget for ci-failure', () => {
     const budget = computeBudget(['ci-failure']);
-    expect(budget.maxTurns).toBe(25);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(35);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
   it('gives full budget for conflict', () => {
@@ -88,8 +88,8 @@ describe('computeBudget', () => {
 
   it('uses highest budget when multiple issues present', () => {
     const budget = computeBudget(['missing-issue-ref', 'ci-failure']);
-    expect(budget.maxTurns).toBe(25);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(35);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
   it('conflict dominates when mixed with smaller issues', () => {
@@ -100,8 +100,8 @@ describe('computeBudget', () => {
 
   it('gives medium budget for bot-review-major', () => {
     const budget = computeBudget(['bot-review-major']);
-    expect(budget.maxTurns).toBe(25);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(35);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
   it('gives small budget for bot-review-nitpick', () => {


### PR DESCRIPTION
## Summary
Two fixes for CI being red on main:

1. **Scoring test expectations** — PR #1859 bumped `ci-failure` and `bot-review-major` budgets from `{maxTurns: 25, timeoutMinutes: 15}` to `{maxTurns: 35, timeoutMinutes: 20}` but forgot to update 5 test assertions across `scoring.test.ts` and `index.test.ts`

2. **E1011 build crash** — `classifyPR()` and `PRCard` call `.some()` / `.filter()` on `pr.labels` which is undefined when the wiki-server returns PR data without labels in CI. Added defensive `?? []` fallback.

## Test plan
- [x] `cd crux && npx vitest run pr-patrol/scoring.test.ts pr-patrol/index.test.ts` — 63/63 pass
- [x] `pnpm build` passes locally (E1011 renders without crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)