### PR TITLE
Fix main branch CI failure: update stale citation-data test

### DIFF
--- a/apps/web/src/lib/__tests__/citation-data.test.ts
+++ b/apps/web/src/lib/__tests__/citation-data.test.ts
@@ -148,19 +148,20 @@ describe("getCitationQuotes", () => {
     expect(result).toEqual([]);
   });
 
-  it("filters out quotes without verification data", async () => {
+  it("returns all quotes including those without verification data", async () => {
     vi.resetModules();
     const localQuotes = [
       makeQuote({ footnote: 1, quoteVerified: true }), // has verification
-      makeQuote({ footnote: 2 }), // no verification data — should be filtered
+      makeQuote({ footnote: 2 }), // no verification data — still included (NULL-verdict dots)
       makeQuote({ footnote: 3, accuracyVerdict: "accurate" }), // has accuracy
     ];
     mockCitationDeps({ getLocalCitationQuotes: () => localQuotes });
     const mod = await import("../citation-data");
     const result = mod.getCitationQuotes("test-page");
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
     expect(result[0].footnote).toBe(1);
-    expect(result[1].footnote).toBe(3);
+    expect(result[1].footnote).toBe(2);
+    expect(result[2].footnote).toBe(3);
   });
 
   it("always uses local data (no API calls)", async () => {


### PR DESCRIPTION
## Summary

- Commit `f8a4872` intentionally removed a filter from `getCitationQuotes` to allow NULL-verdict dots from the Statements V2 pipeline to pass through
- The test `"filters out quotes without verification data"` still expected the old filtering behavior (length 2), but the function now returns all quotes (length 3)
- Updated the test description and assertions to match the current behavior

## Root cause

The filter `.filter((q) => q.quoteVerified || q.accuracyVerdict !== null)` was removed intentionally, but the test was not updated in the same commit.

## Test plan
- [x] `pnpm test` passes locally (417/417 tests green)
- [x] `pnpm crux validate gate` passes

Fixes CI failure from run #22813958205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated citation quote test cases to verify proper handling of quotes without verification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->