### PR TITLE
fix: E1011 build crash — guard against undefined labels

### DIFF
--- a/apps/web/src/app/internal/pr-dashboard/pr-dashboard-board.tsx
+++ b/apps/web/src/app/internal/pr-dashboard/pr-dashboard-board.tsx
@@ -115,7 +115,7 @@ function relativeTime(date: string): string {
 
 function PRCard({ pr }: { pr: PullData }) {
   // Filter labels that are purely workflow/stage markers from display
-  const displayLabels = pr.labels.filter(
+  const displayLabels = (pr.labels ?? []).filter(
     (l) =>
       l !== "stage:approved" &&
       l !== "agent:working" &&

--- a/apps/web/src/app/internal/pr-dashboard/pr-dashboard-shared.ts
+++ b/apps/web/src/app/internal/pr-dashboard/pr-dashboard-shared.ts
@@ -45,7 +45,8 @@ export type KanbanColumn = "draft" | "ci-issues" | "needs-review" | "approved";
 export function classifyPR(pr: PullData): KanbanColumn {
   if (pr.isDraft) return "draft";
 
-  const hasApproved = pr.labels.some(
+  const labels = pr.labels ?? [];
+  const hasApproved = labels.some(
     (l) => l === "stage:approved"
   );
   if (hasApproved) return "approved";


### PR DESCRIPTION
## Summary
- `classifyPR()` and `PRCard` call `.some()` / `.filter()` on `pr.labels` which crashes when undefined
- In CI, the wiki-server returns PR data where `labels` can be undefined, causing `TypeError: Cannot read properties of undefined (reading 'some')` during static generation of `/wiki/E1011`
- This was masked by earlier test failures preventing the build step from running

Introduced by PR #1839, exposed after PR #1875 fixed the blocking test.

## Test plan
- [x] `pnpm build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors in the PR dashboard that occurred when pull request labels were unavailable or missing. Enhanced error handling ensures the dashboard properly processes and displays all pull requests regardless of label availability, while maintaining all existing label filtering behavior and improving overall application stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->