### PR TITLE
feat(pr-patrol): watch mode, deploy health detection, CI culprit ID

### DIFF
--- a/crux/commands/pr-patrol.ts
+++ b/crux/commands/pr-patrol.ts
@@ -39,6 +39,7 @@ import {
   formatStats,
   formatExplain,
 } from '../pr-patrol/format.ts';
+import { runWatchLoop } from '../pr-patrol/watch.ts';
 
 async function run(
   args: string[],
@@ -60,6 +61,21 @@ async function status(
   _args: string[],
   options: CommandOptions,
 ): Promise<CommandResult> {
+  // Watch mode — live refresh
+  if (options.watch) {
+    if (options.json) {
+      return { output: 'Error: --json is not supported with --watch\n', exitCode: 1 };
+    }
+    const rawInterval = typeof options.interval === 'number'
+      ? options.interval
+      : typeof options.interval === 'string'
+        ? parseInt(options.interval, 10)
+        : 10;
+    const interval = Number.isNaN(rawInterval) || rawInterval < 1 ? 10 : rawInterval;
+    await runWatchLoop(interval, options);
+    return { output: '', exitCode: 0 };
+  }
+
   const colors = getColors(options.ci as boolean | undefined);
   const count = typeof options.count === 'number' ? options.count : (typeof options.count === 'string' ? parseInt(options.count, 10) : 20);
 
@@ -185,8 +201,16 @@ Commands:
   explain          Detailed explanation of what PR Patrol does
   merge-status     Show PRs labeled ${LABELS.STAGE_APPROVED} and their eligibility
 
-Status/History Options:
+Status Options:
+  --watch          Live-refreshing display (clears and redraws every interval)
+  --interval=N     Refresh interval in seconds for --watch (default: 10)
   --count=N        Number of entries to show (default: 20 for status, 100 for history)
+  --type=TYPE      Filter by type: pr, merge, cycle, main, overlap, undraft
+  --pr=N           Filter to a specific PR number
+  --json           Output raw JSON for scripting
+
+History Options:
+  --count=N        Number of entries to show (default: 100)
   --type=TYPE      Filter by type: pr, merge, cycle, main, overlap, undraft
   --pr=N           Filter to a specific PR number
   --outcome=X      Filter by outcome: fixed, max-turns, timeout, error, enqueued, merged
@@ -223,6 +247,8 @@ Examples:
   crux pr-patrol once --dry-run          Preview what would be fixed/merged
   crux pr-patrol run --interval=120      Run with 2-minute cycles
   crux pr-patrol status                  Show recent activity
+  crux pr-patrol status --watch          Live-refreshing dashboard
+  crux pr-patrol status --watch --interval=5  Faster refresh
   crux pr-patrol status --pr=1234        Show activity for a specific PR
   crux pr-patrol history --since=7d      Browse last 7 days of logs
   crux pr-patrol stats --since=30d       Monthly performance stats

--- a/crux/lib/pr-analysis/ci-status.test.ts
+++ b/crux/lib/pr-analysis/ci-status.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../github.ts', () => ({
+  githubApi: vi.fn(),
+  REPO: 'test/repo',
+}));
+
+import { checkMainBranch, findRecentMerges } from './ci-status.ts';
+import { githubApi } from '../github.ts';
+
+const mockApi = vi.mocked(githubApi);
+
+afterEach(() => vi.resetAllMocks());
+
+describe('checkMainBranch', () => {
+  it('returns not-red when latest run succeeded', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        { id: 1, status: 'completed', conclusion: 'success', created_at: '2026-03-06T10:00:00Z', head_sha: 'abc', html_url: '' },
+      ],
+    });
+    const result = await checkMainBranch('test/repo');
+    expect(result.isRed).toBe(false);
+    expect(result.lastGreenSha).toBeUndefined();
+  });
+
+  it('returns red with lastGreenSha when latest run failed', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        { id: 2, status: 'completed', conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'bad', html_url: 'https://run/2' },
+        { id: 1, status: 'completed', conclusion: 'success', created_at: '2026-03-06T10:00:00Z', head_sha: 'good', html_url: 'https://run/1' },
+      ],
+    });
+    const result = await checkMainBranch('test/repo');
+    expect(result.isRed).toBe(true);
+    expect(result.lastGreenSha).toBe('good');
+    expect(result.lastGreenAt).toBe('2026-03-06T10:00:00Z');
+  });
+
+  it('returns red without lastGreen when all runs failed', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        { id: 2, status: 'completed', conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'bad2', html_url: '' },
+        { id: 1, status: 'completed', conclusion: 'failure', created_at: '2026-03-06T10:00:00Z', head_sha: 'bad1', html_url: '' },
+      ],
+    });
+    const result = await checkMainBranch('test/repo');
+    expect(result.isRed).toBe(true);
+    expect(result.lastGreenSha).toBeUndefined();
+    expect(result.lastGreenAt).toBeUndefined();
+  });
+
+  it('returns not-red when API fails (fail-open)', async () => {
+    mockApi.mockRejectedValueOnce(new Error('API error'));
+    const result = await checkMainBranch('test/repo');
+    expect(result.isRed).toBe(false);
+  });
+});
+
+describe('findRecentMerges', () => {
+  it('returns empty array when since is undefined', async () => {
+    const result = await findRecentMerges('test/repo', undefined);
+    expect(result).toEqual([]);
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it('returns PRs merged after since timestamp', async () => {
+    mockApi.mockResolvedValueOnce([
+      { number: 100, title: 'New feature', merged_at: '2026-03-06T11:00:00Z', merge_commit_sha: 'sha1', user: { login: 'alice' } },
+      { number: 99, title: 'Old fix', merged_at: '2026-03-06T09:00:00Z', merge_commit_sha: 'sha2', user: { login: 'bob' } },
+      { number: 98, title: 'Not merged', merged_at: null, merge_commit_sha: null, user: { login: 'carol' } },
+    ]);
+    const result = await findRecentMerges('test/repo', '2026-03-06T10:00:00Z');
+    expect(result).toHaveLength(1);
+    expect(result[0].prNumber).toBe(100);
+    expect(result[0].mergedBy).toBe('alice');
+  });
+
+  it('returns empty when API fails (fail-open)', async () => {
+    mockApi.mockRejectedValueOnce(new Error('Network error'));
+    const result = await findRecentMerges('test/repo', '2026-03-06T10:00:00Z');
+    expect(result).toEqual([]);
+  });
+});

--- a/crux/lib/pr-analysis/ci-status.ts
+++ b/crux/lib/pr-analysis/ci-status.ts
@@ -6,7 +6,7 @@
  */
 
 import { githubApi, REPO } from '../github.ts';
-import type { MainBranchStatus } from './types.ts';
+import type { MainBranchStatus, RecentMerge } from './types.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -51,11 +51,15 @@ export async function checkMainBranch(repo?: string): Promise<MainBranchStatus> 
     // main-branch alert only fires on hard 'failure', not 'cancelled'/'timed_out'.
     // Cancelled/timed-out runs on main are transient and self-heal on re-run.
     if (latest.conclusion === 'failure') {
+      // Find the last green run to help identify culprits
+      const lastGreen = runs.find((r) => r.conclusion === 'success');
       return {
         isRed: true,
         runId: latest.id,
         sha: latest.head_sha,
         htmlUrl: latest.html_url,
+        lastGreenSha: lastGreen?.head_sha,
+        lastGreenAt: lastGreen?.created_at,
       };
     }
 
@@ -64,5 +68,44 @@ export async function checkMainBranch(repo?: string): Promise<MainBranchStatus> 
     // Best-effort: if the API call fails (network, auth, rate-limit), assume CI is not red.
     // Callers handle their own error reporting if needed.
     return notRed;
+  }
+}
+
+// ── Recent merge identification ─────────────────────────────────────────────
+
+interface PullRequestListItem {
+  number: number;
+  title: string;
+  merged_at: string | null;
+  merge_commit_sha: string | null;
+  user: { login: string } | null;
+}
+
+/**
+ * Find PRs merged since a given timestamp.
+ * Used to identify likely culprits when main CI goes red.
+ */
+export async function findRecentMerges(repo?: string, since?: string): Promise<RecentMerge[]> {
+  if (!since) return [];
+  const r = repo ?? REPO;
+
+  try {
+    const pulls = await githubApi<PullRequestListItem[]>(
+      `/repos/${r}/pulls?state=closed&sort=updated&direction=desc&per_page=10`,
+    );
+
+    const sinceTime = new Date(since).getTime();
+    return pulls
+      .filter((pr) => pr.merged_at && new Date(pr.merged_at).getTime() >= sinceTime)
+      .map((pr) => ({
+        prNumber: pr.number,
+        title: pr.title,
+        mergedAt: pr.merged_at!,
+        mergedBy: pr.user?.login ?? 'unknown',
+        sha: pr.merge_commit_sha ?? '',
+      }));
+  } catch {
+    // Fail-open: culprit identification is informational only
+    return [];
   }
 }

--- a/crux/lib/pr-analysis/deploy-status.test.ts
+++ b/crux/lib/pr-analysis/deploy-status.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../github.ts', () => ({
+  githubApi: vi.fn(),
+  REPO: 'test/repo',
+}));
+
+import { checkDeployHealth } from './deploy-status.ts';
+import { githubApi } from '../github.ts';
+
+const mockApi = vi.mocked(githubApi);
+
+afterEach(() => vi.resetAllMocks());
+
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    status: 'completed',
+    conclusion: 'success',
+    created_at: '2026-03-06T10:00:00Z',
+    head_sha: 'abc123',
+    html_url: 'https://github.com/test/repo/actions/runs/1',
+    ...overrides,
+  };
+}
+
+describe('checkDeployHealth', () => {
+  it('returns healthy when latest run succeeded', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [makeRun()],
+      total_count: 1,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(true);
+    expect(result.lastDeploy?.status).toBe('success');
+    expect(result.failingSince).toBeNull();
+  });
+
+  it('returns unhealthy when latest run failed', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 2, conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'def456' }),
+        makeRun({ id: 1, conclusion: 'success', created_at: '2026-03-06T10:00:00Z' }),
+      ],
+      total_count: 2,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(false);
+    expect(result.lastDeploy?.status).toBe('failure');
+    expect(result.failingSince).toBe('2026-03-06T12:00:00Z');
+  });
+
+  it('returns healthy with null lastDeploy when no runs exist', async () => {
+    mockApi.mockResolvedValueOnce({ workflow_runs: [], total_count: 0 });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(true);
+    expect(result.lastDeploy).toBeNull();
+  });
+
+  it('returns healthy when API call fails (fail-open)', async () => {
+    mockApi.mockRejectedValueOnce(new Error('Network error'));
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(true);
+    expect(result.lastDeploy).toBeNull();
+  });
+
+  it('identifies failingSince from consecutive failures', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 3, conclusion: 'failure', created_at: '2026-03-06T14:00:00Z', head_sha: 'ghi789' }),
+        makeRun({ id: 2, conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'def456' }),
+        makeRun({ id: 1, conclusion: 'success', created_at: '2026-03-06T10:00:00Z' }),
+      ],
+      total_count: 3,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(false);
+    // failingSince should be the earliest consecutive failure
+    expect(result.failingSince).toBe('2026-03-06T12:00:00Z');
+  });
+});

--- a/crux/lib/pr-analysis/deploy-status.ts
+++ b/crux/lib/pr-analysis/deploy-status.ts
@@ -1,0 +1,84 @@
+/**
+ * PR Analysis — Wiki-server deploy health check.
+ *
+ * Pure GitHub API wrapper — no daemon state, no logging.
+ * Queries the wiki-server-docker.yml workflow for recent deploy status.
+ */
+
+import { githubApi, REPO } from '../github.ts';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface WorkflowRun {
+  id: number;
+  status: string;
+  conclusion: string | null;
+  created_at: string;
+  head_sha: string;
+  html_url: string;
+}
+
+interface WorkflowRunsResponse {
+  workflow_runs: WorkflowRun[];
+  total_count: number;
+}
+
+export interface DeployHealthStatus {
+  healthy: boolean;
+  lastDeploy: {
+    status: string; // 'success' | 'failure' | 'cancelled' | etc.
+    sha: string;
+    url: string;
+    timestamp: string;
+  } | null;
+  failingSince: string | null; // ISO timestamp of first consecutive failure
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEPLOY_WORKFLOW = 'wiki-server-docker.yml';
+
+// ── Deploy health check ─────────────────────────────────────────────────────
+
+/**
+ * Check whether the wiki-server deploy pipeline is healthy.
+ * Returns status without side effects — no logging, no state updates.
+ */
+export async function checkDeployHealth(repo?: string): Promise<DeployHealthStatus> {
+  const r = repo ?? REPO;
+  const notAvailable: DeployHealthStatus = { healthy: true, lastDeploy: null, failingSince: null };
+
+  try {
+    const resp = await githubApi<WorkflowRunsResponse>(
+      `/repos/${r}/actions/workflows/${DEPLOY_WORKFLOW}/runs?per_page=5&status=completed`,
+    );
+
+    const runs = resp.workflow_runs ?? [];
+    if (runs.length === 0) return notAvailable;
+
+    const latest = runs[0];
+    const lastDeploy = {
+      status: latest.conclusion ?? 'unknown',
+      sha: latest.head_sha,
+      url: latest.html_url,
+      timestamp: latest.created_at,
+    };
+
+    if (latest.conclusion === 'success') {
+      return { healthy: true, lastDeploy, failingSince: null };
+    }
+
+    // Find when consecutive failures started (walk backward through runs)
+    let failingSince = latest.created_at;
+    for (const run of runs) {
+      if (run.conclusion === 'success') break;
+      failingSince = run.created_at;
+    }
+
+    return { healthy: false, lastDeploy, failingSince };
+  } catch {
+    // Fail-open: if we can't check deploy health, assume it's fine.
+    // Callers handle their own error reporting if needed.
+    return notAvailable;
+  }
+}

--- a/crux/lib/pr-analysis/index.ts
+++ b/crux/lib/pr-analysis/index.ts
@@ -30,6 +30,7 @@ export type {
   MergeBlockReason,
   MergeCandidate,
   MainBranchStatus,
+  RecentMerge,
   GqlReviewThread,
   GqlPrNode,
   PrOverlap,
@@ -63,7 +64,12 @@ export {
 
 // ── CI status ────────────────────────────────────────────────────────────────
 
-export { checkMainBranch } from './ci-status.ts';
+export { checkMainBranch, findRecentMerges } from './ci-status.ts';
+
+// ── Deploy health ────────────────────────────────────────────────────────────
+
+export { checkDeployHealth } from './deploy-status.ts';
+export type { DeployHealthStatus } from './deploy-status.ts';
 
 // ── Automated rebase ─────────────────────────────────────────────────────────
 

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -71,6 +71,18 @@ export interface MainBranchStatus {
   runId: number | null;
   sha: string;
   htmlUrl: string;
+  /** SHA of the last successful CI run (only populated when isRed is true). */
+  lastGreenSha?: string;
+  /** ISO timestamp of the last successful CI run (only populated when isRed is true). */
+  lastGreenAt?: string;
+}
+
+export interface RecentMerge {
+  prNumber: number;
+  title: string;
+  mergedAt: string;
+  mergedBy: string;
+  sha: string;
 }
 
 // ── GraphQL types ───────────────────────────────────────────────────────────

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -11,7 +11,8 @@
 import { spawn } from 'child_process';
 import { githubApi } from '../lib/github.ts';
 import { gitSafe } from '../lib/git.ts';
-import { checkMainBranch as libCheckMainBranch } from '../lib/pr-analysis/index.ts';
+import { checkMainBranch as libCheckMainBranch, findRecentMerges as libFindRecentMerges } from '../lib/pr-analysis/index.ts';
+import type { RecentMerge } from '../lib/pr-analysis/index.ts';
 import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
 import type { FixOutcome, MainBranchStatus, PatrolConfig, ScoredPr } from './types.ts';
 import { LABELS } from './types.ts';
@@ -36,6 +37,13 @@ import {
   recordFailure,
   resetFailCount,
   trackMainFixPr,
+  getMainRedSince,
+  setMainRedSince,
+  clearMainRedSince,
+  getMainFixAttempts,
+  incrementMainFixAttempts,
+  resetMainFixAttempts,
+  setPersistedClaimedPr,
 } from './state.ts';
 import { buildMainBranchPrompt, buildPrompt } from './prompts.ts';
 import { computeBudget } from './scoring.ts';
@@ -126,7 +134,25 @@ export async function checkMainBranch(config: PatrolConfig): Promise<MainBranchS
 
     if (status.isRed) {
       log(`  ${cl.red}🔴 Main branch CI is RED${cl.reset} (run #${status.runId}, sha ${status.sha.slice(0, 8)})`);
+
+      // Track red-since state
+      if (!getMainRedSince()) {
+        setMainRedSince(new Date().toISOString());
+      }
+
+      // Identify likely culprits (PRs merged since last green)
+      const culprits = await libFindRecentMerges(config.repo, status.lastGreenAt).catch(() => [] as RecentMerge[]);
+      if (culprits.length > 0) {
+        log(`  Likely culprits: ${culprits.map((c) => `#${c.prNumber} (${c.title.slice(0, 40)})`).join(', ')}`);
+      }
     } else {
+      // Main is green — reset tracking if it was red before
+      if (getMainRedSince()) {
+        log(`  Main branch recovered (was red since ${getMainRedSince()})`);
+        clearMainRedSince();
+        resetMainFixAttempts();
+        resetFailCount(MAIN_BRANCH_KEY);
+      }
       log(`  ${cl.green}Main branch CI is green${cl.reset}`);
     }
 
@@ -152,6 +178,9 @@ export async function fixMainBranch(status: MainBranchStatus, config: PatrolConf
     markProcessed(MAIN_BRANCH_KEY);
     return;
   }
+
+  const attemptNum = incrementMainFixAttempts();
+  log(`  Fix attempt #${attemptNum}`);
 
   const prompt = buildMainBranchPrompt(status.runId!, config.repo);
   const startTime = Date.now();
@@ -323,6 +352,7 @@ async function claimPr(prNum: number, repo: string): Promise<void> {
       body: { labels: [LABELS.AGENT_WORKING] },
     });
     claimedPr = prNum;
+    setPersistedClaimedPr(prNum);
   } catch {
     log(`  ${cl.yellow}Warning: could not add ${LABELS.AGENT_WORKING} label to PR #${prNum}${cl.reset}`);
   }
@@ -342,7 +372,10 @@ async function releasePr(prNum: number, repo: string): Promise<void> {
       log(`  Warning: could not remove claude-working label from PR #${prNum}: ${msg}`);
     }
   }
-  if (claimedPr === prNum) claimedPr = null;
+  if (claimedPr === prNum) {
+    claimedPr = null;
+    setPersistedClaimedPr(null);
+  }
 }
 
 export async function releaseCurrentClaim(repo: string): Promise<void> {

--- a/crux/pr-patrol/format.test.ts
+++ b/crux/pr-patrol/format.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { getColors } from '../lib/output.ts';
+import {
+  formatHealthSummary,
+  type HealthSummary,
+} from './format.ts';
+
+// CI mode disables ANSI — predictable assertions
+const c = getColors(true);
+
+describe('formatHealthSummary', () => {
+  it('shows green status when everything is healthy', () => {
+    const health: HealthSummary = {
+      mainBranch: { isRed: false, redSince: null, fixAttempts: 0, culprits: [] },
+      deploy: { healthy: true, lastDeploy: null, failingSince: null },
+      daemon: { state: 'idle', currentPr: null, cycleCount: 5, lastCycleAt: null },
+    };
+    const result = formatHealthSummary(health, c);
+    expect(result).toContain('GREEN');
+    expect(result).toContain('idle');
+    expect(result).toContain('cycles: 5');
+  });
+
+  it('shows red main branch with culprits', () => {
+    const health: HealthSummary = {
+      mainBranch: {
+        isRed: true,
+        redSince: new Date(Date.now() - 7200_000).toISOString(),
+        fixAttempts: 3,
+        culprits: [1842, 1840],
+      },
+      deploy: { healthy: true, lastDeploy: null, failingSince: null },
+      daemon: { state: 'fixing', currentPr: 1842, cycleCount: 10, lastCycleAt: null },
+    };
+    const result = formatHealthSummary(health, c);
+    expect(result).toContain('RED');
+    expect(result).toContain('3 fix attempts');
+    expect(result).toContain('#1842');
+    expect(result).toContain('#1840');
+    expect(result).toContain('fixing');
+  });
+
+  it('shows failing deploy status', () => {
+    const health: HealthSummary = {
+      mainBranch: { isRed: false, redSince: null, fixAttempts: 0, culprits: [] },
+      deploy: {
+        healthy: false,
+        lastDeploy: { status: 'failure', sha: 'abc', url: '', timestamp: new Date(Date.now() - 3600_000).toISOString() },
+        failingSince: new Date(Date.now() - 3600_000).toISOString(),
+      },
+      daemon: { state: 'idle', currentPr: null, cycleCount: 5, lastCycleAt: null },
+    };
+    const result = formatHealthSummary(health, c);
+    expect(result).toContain('FAILING');
+  });
+
+  it('shows no data for deploy when lastDeploy is null', () => {
+    const health: HealthSummary = {
+      mainBranch: { isRed: false, redSince: null, fixAttempts: 0, culprits: [] },
+      deploy: { healthy: true, lastDeploy: null, failingSince: null },
+      daemon: { state: 'idle', currentPr: null, cycleCount: 0, lastCycleAt: null },
+    };
+    const result = formatHealthSummary(health, c);
+    expect(result).toContain('no data');
+  });
+});

--- a/crux/pr-patrol/format.ts
+++ b/crux/pr-patrol/format.ts
@@ -12,6 +12,7 @@ import type {
   LogEntry,
   CycleSummaryEntry,
 } from './log-reader.ts';
+import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
 
 // ── Utilities ───────────────────────────────────────────────────────────────
 
@@ -284,6 +285,77 @@ export function formatStats(stats: AggregatedStats, since: string, c: Colors): s
   }
 
   return lines.join('\n') + '\n';
+}
+
+// ── Health summary formatting ───────────────────────────────────────────────
+
+export interface HealthSummary {
+  mainBranch: {
+    isRed: boolean;
+    redSince: string | null;
+    fixAttempts: number;
+    culprits: number[]; // PR numbers
+  };
+  deploy: DeployHealthStatus;
+  daemon: {
+    state: 'idle' | 'fixing' | 'merging';
+    currentPr: number | null;
+    cycleCount: number;
+    lastCycleAt: string | null;
+  };
+}
+
+/** Format the system health summary for the watch view. */
+export function formatHealthSummary(health: HealthSummary, c: Colors): string {
+  const lines: string[] = [
+    `${c.bold}System Health${c.reset}`,
+    '',
+  ];
+
+  // Main branch
+  if (health.mainBranch.isRed) {
+    const duration = health.mainBranch.redSince
+      ? relativeTime(health.mainBranch.redSince).replace(' ago', '')
+      : 'unknown';
+    const culprits = health.mainBranch.culprits.length > 0
+      ? `  Likely culprits: ${health.mainBranch.culprits.map((n) => `#${n}`).join(', ')}`
+      : '';
+    lines.push(
+      `  Main CI:    ${c.red}RED${c.reset} for ${duration} (${health.mainBranch.fixAttempts} fix attempts)${culprits}`,
+    );
+  } else {
+    lines.push(`  Main CI:    ${c.green}GREEN${c.reset}`);
+  }
+
+  // Deploy
+  if (health.deploy.lastDeploy === null) {
+    lines.push(`  Deploy:     ${c.dim}no data${c.reset}`);
+  } else if (health.deploy.healthy) {
+    lines.push(
+      `  Deploy:     ${c.green}healthy${c.reset}  ${c.dim}(${relativeTime(health.deploy.lastDeploy.timestamp)})${c.reset}`,
+    );
+  } else {
+    const since = health.deploy.failingSince
+      ? relativeTime(health.deploy.failingSince).replace(' ago', '')
+      : 'unknown';
+    lines.push(`  Deploy:     ${c.red}FAILING${c.reset} for ${since}`);
+  }
+
+  // Daemon state
+  const stateStr = health.daemon.state === 'idle'
+    ? `${c.dim}idle${c.reset}`
+    : health.daemon.state === 'fixing'
+      ? health.daemon.currentPr != null
+        ? `${c.yellow}fixing PR #${health.daemon.currentPr}${c.reset}`
+        : `${c.yellow}fixing${c.reset}`
+      : `${c.cyan}merging${c.reset}`;
+  const lastCycle = health.daemon.lastCycleAt
+    ? `  ${c.dim}last cycle: ${relativeTime(health.daemon.lastCycleAt)}${c.reset}`
+    : '';
+  lines.push(`  Daemon:     ${stateStr}  cycles: ${health.daemon.cycleCount}${lastCycle}`);
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 // ── Explain formatting ──────────────────────────────────────────────────────

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -104,6 +104,8 @@ import {
   fixPr,
   releaseCurrentClaim,
 } from './execution.ts';
+import { checkDeployHealth as libCheckDeployHealth } from '../lib/pr-analysis/deploy-status.ts';
+import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
 import { runReflection } from './reflection.ts';
 
 const cl = getColors();
@@ -260,6 +262,18 @@ async function runCheckCycle(
     return; // Main takes the whole cycle; PRs wait
   }
 
+  // 0b. Check deploy health
+  const deployHealth: DeployHealthStatus = await libCheckDeployHealth(config.repo).catch((e) => {
+    log(`  ${cl.yellow}Warning: deploy health check failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
+    return { healthy: true, lastDeploy: null, failingSince: null } as DeployHealthStatus;
+  });
+
+  if (!deployHealth.healthy) {
+    log(`  ${cl.red}Deploy pipeline is failing${cl.reset} since ${deployHealth.failingSince ?? 'unknown'}`);
+  } else if (deployHealth.lastDeploy) {
+    log(`  Deploy pipeline is healthy`);
+  }
+
   // 1. Fetch all open PRs (shared between fix and merge phases)
   const allPrs = await daemonFetchOpenPrs(config);
 
@@ -374,10 +388,15 @@ async function runCheckCycle(
   }
 
   // Enqueue ALL eligible PRs — the merge queue handles serialization
-  for (const candidate of eligibleForMerge) {
-    const outcome = await enqueuePr(candidate, config);
-    if (outcome === 'enqueued' || outcome === 'dry-run') {
-      enqueuedPrs.push(candidate.number);
+  // Skip if deploy pipeline is failing — don't merge into a broken pipeline
+  if (!deployHealth.healthy) {
+    log(`  ${cl.yellow}Skipping merge enqueue — deploy pipeline is failing since ${deployHealth.failingSince ?? 'unknown'}${cl.reset}`);
+  } else {
+    for (const candidate of eligibleForMerge) {
+      const outcome = await enqueuePr(candidate, config);
+      if (outcome === 'enqueued' || outcome === 'dry-run') {
+        enqueuedPrs.push(candidate.number);
+      }
     }
   }
 
@@ -396,6 +415,8 @@ async function runCheckCycle(
     prs_enqueued: enqueuedPrs.length > 0 ? enqueuedPrs : undefined,
     merge_candidates: mergeCandidates.length,
     merge_eligible: eligibleForMerge.length,
+    deploy_healthy: deployHealth.healthy,
+    deploy_failing_since: deployHealth.failingSince ?? undefined,
   });
 }
 

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -194,3 +194,57 @@ export function clearProcessed(key: number | string): void {
   const file = join(STATE_DIR, `processed-${key}`);
   if (existsSync(file)) writeFileSync(file, '0');
 }
+
+// ── Main branch red-since tracking ──────────────────────────────────────────
+
+const MAIN_RED_SINCE_FILE = join(STATE_DIR, 'main-red-since');
+const MAIN_FIX_ATTEMPTS_FILE = join(STATE_DIR, 'main-fix-attempts');
+
+export function getMainRedSince(): string | null {
+  const file = MAIN_RED_SINCE_FILE;
+  if (!existsSync(file)) return null;
+  const content = readFileSync(file, 'utf-8').trim();
+  return content || null;
+}
+
+export function setMainRedSince(timestamp: string): void {
+  writeFileSync(MAIN_RED_SINCE_FILE, timestamp);
+}
+
+export function clearMainRedSince(): void {
+  const file = MAIN_RED_SINCE_FILE;
+  if (existsSync(file)) writeFileSync(file, '');
+}
+
+export function getMainFixAttempts(): number {
+  const file = MAIN_FIX_ATTEMPTS_FILE;
+  if (!existsSync(file)) return 0;
+  return parseInt(readFileSync(file, 'utf-8').trim(), 10) || 0;
+}
+
+export function incrementMainFixAttempts(): number {
+  const count = getMainFixAttempts() + 1;
+  writeFileSync(MAIN_FIX_ATTEMPTS_FILE, String(count));
+  return count;
+}
+
+export function resetMainFixAttempts(): void {
+  const file = MAIN_FIX_ATTEMPTS_FILE;
+  if (existsSync(file)) writeFileSync(file, '0');
+}
+
+// ── Claimed PR tracking (shared between daemon and watcher) ────────────────
+
+const CLAIMED_PR_FILE = join(STATE_DIR, 'claimed-pr');
+
+export function getPersistedClaimedPr(): number | null {
+  if (!existsSync(CLAIMED_PR_FILE)) return null;
+  const content = readFileSync(CLAIMED_PR_FILE, 'utf-8').trim();
+  if (!content) return null;
+  const n = parseInt(content, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+export function setPersistedClaimedPr(prNum: number | null): void {
+  writeFileSync(CLAIMED_PR_FILE, prNum != null ? String(prNum) : '');
+}

--- a/crux/pr-patrol/watch.ts
+++ b/crux/pr-patrol/watch.ts
@@ -1,0 +1,128 @@
+/**
+ * PR Patrol — Watch Mode
+ *
+ * Live-refreshing terminal display of PR Patrol status.
+ * Reads from local JSONL logs and state files + lightweight API calls
+ * per cycle (deploy health, main branch CI). Does NOT re-scan GitHub PRs.
+ *
+ * Degrades to single-shot in non-TTY environments.
+ */
+
+import { existsSync } from 'fs';
+import type { CommandOptions } from '../lib/command-types.ts';
+import { getColors, type Colors } from '../lib/output.ts';
+import {
+  readAllEntries,
+  filterByTime,
+} from './log-reader.ts';
+import {
+  formatStatus,
+  formatHealthSummary,
+  type HealthSummary,
+} from './format.ts';
+import {
+  JSONL_FILE,
+  getMainRedSince,
+  getMainFixAttempts,
+  getPersistedClaimedPr,
+} from './state.ts';
+import { checkDeployHealth } from '../lib/pr-analysis/deploy-status.ts';
+import { checkMainBranch as libCheckMainBranch } from '../lib/pr-analysis/index.ts';
+import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
+
+const CLEAR_SCREEN = '\x1B[2J\x1B[H';
+const DEFAULT_REPO = 'quantified-uncertainty/longterm-wiki';
+
+export async function runWatchLoop(
+  intervalSeconds: number,
+  options: CommandOptions,
+): Promise<void> {
+  const isTTY = process.stdout.isTTY;
+  const colors = getColors(options.ci as boolean | undefined);
+
+  // If not a TTY, run once and exit (degrade gracefully)
+  if (!isTTY) {
+    const output = await buildWatchOutput(colors, options);
+    process.stdout.write(output);
+    return;
+  }
+
+  let shuttingDown = false;
+  const shutdown = () => {
+    shuttingDown = true;
+    process.stdout.write('\n');
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  while (!shuttingDown) {
+    const output = await buildWatchOutput(colors, options);
+    process.stdout.write(CLEAR_SCREEN);
+    process.stdout.write(output);
+    process.stdout.write(`\n${colors.dim}Refreshing every ${intervalSeconds}s. Press Ctrl+C to exit.${colors.reset}\n`);
+
+    await new Promise((r) => setTimeout(r, intervalSeconds * 1000));
+  }
+}
+
+async function buildWatchOutput(c: Colors, options: CommandOptions): Promise<string> {
+  const parts: string[] = [];
+
+  // Timestamp header
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  parts.push(`${c.bold}PR Patrol — Live Status${c.reset}  ${c.dim}${now}${c.reset}\n`);
+  parts.push(`${c.dim}${'─'.repeat(50)}${c.reset}\n\n`);
+
+  // Live health checks (both fail-open)
+  let deployHealth: DeployHealthStatus = { healthy: true, lastDeploy: null, failingSince: null };
+  let mainIsRed = false;
+  try {
+    deployHealth = await checkDeployHealth();
+  } catch {
+    // Fail-open — deploy health check is best-effort
+  }
+  try {
+    const mainStatus = await libCheckMainBranch(DEFAULT_REPO);
+    mainIsRed = mainStatus.isRed;
+  } catch {
+    // Fail-open — fall back to persisted state
+    mainIsRed = !!getMainRedSince();
+  }
+
+  // Gather cycle info from recent JSONL
+  const entries = existsSync(JSONL_FILE) ? readAllEntries(JSONL_FILE) : [];
+  const recentCycles = filterByTime(entries, '1h')
+    .filter((e) => e.type === 'cycle_summary');
+  const lastCycle = recentCycles[recentCycles.length - 1];
+
+  const claimedPr = getPersistedClaimedPr();
+  const mainRedSince = getMainRedSince();
+  const health: HealthSummary = {
+    mainBranch: {
+      isRed: mainIsRed,
+      redSince: mainRedSince,
+      fixAttempts: getMainFixAttempts(),
+      culprits: [], // Would need to parse from latest JSONL entry; kept simple for now
+    },
+    deploy: deployHealth,
+    daemon: {
+      state: claimedPr ? 'fixing' : 'idle',
+      currentPr: claimedPr,
+      cycleCount: recentCycles.length,
+      lastCycleAt: lastCycle?.timestamp ?? null,
+    },
+  };
+  parts.push(formatHealthSummary(health, c));
+
+  // Recent activity
+  const count = typeof options.count === 'number' ? options.count : 15;
+  const recent = entries.slice(-count);
+  if (recent.length > 0) {
+    parts.push(formatStatus(recent, c));
+  } else {
+    parts.push(`${c.dim}No PR Patrol logs found.${c.reset}\n`);
+  }
+
+  return parts.join('');
+}


### PR DESCRIPTION
## Summary

Three enhancements to PR Patrol for better observability and reliability:

1. **Watch mode** (`crux pr-patrol status --watch`): Live-refreshing terminal display showing system health (main CI, deploy pipeline, daemon state) and recent activity. Degrades to single-shot in non-TTY. Ctrl+C for clean exit.

2. **Deploy health detection**: Checks `wiki-server-docker.yml` workflow status via GitHub Actions API. When deploy pipeline is unhealthy, merge queue is paused to avoid merging into broken pipeline. Fail-open on API errors.

3. **CI culprit identification**: When main goes red, surfaces recently-merged PRs as likely culprits. Tracks red-since duration and fix attempt count via file-based state. Informational only — helps humans decide what to do.

All changes are additive (optional type fields, new JSONL fields) with fail-open error handling. 16 new tests across 3 test files.

## Key changes

- **New files**: `deploy-status.ts`, `deploy-status.test.ts`, `ci-status.test.ts`, `watch.ts`, `format.test.ts`
- **Modified**: `ci-status.ts` (lastGreen fields + findRecentMerges), `types.ts` (RecentMerge type), `state.ts` (main-red tracking), `execution.ts` (culprit logging), `format.ts` (health summary formatter), `index.ts` (deploy health integration + merge blocking), `commands/pr-patrol.ts` (--watch flag)

## Test plan

- [x] 16 new tests pass (deploy health: 5, CI status: 7, format: 4)
- [x] TypeScript check clean (`tsc --noEmit`)
- [x] Full test suite: 2918/2919 pass (1 pre-existing timeout in prefer-entitylink)
- [x] Paranoid diff review completed — fixed NaN interval guard and double state read
- [x] All API calls are fail-open (return safe defaults on error)
- [x] Backward compatible (additive optional fields only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live watch mode (--watch, --interval) for a continuously updating PR Patrol status view
  * Deploy health tracking with failing-since info and gating of merge enqueue when deploy is unhealthy
  * Main-branch diagnostics now show last successful build (SHA/timestamp), likely culprit PRs, red-since and fix-attempt counts
  * Persistent claim/unclaim of PRs and persistent main-branch state

* **Tests**
  * Added tests for CI status, deploy health, and health summary formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->