### PR TITLE
test(e2e): post-deploy Playwright smoke tests against production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,18 +209,6 @@ jobs:
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
 
-      # --- E2E smoke tests (production gate only — not run on normal PRs) ---
-
-      - name: E2E smoke tests
-        if: github.ref == 'refs/heads/production' || (github.event_name == 'pull_request' && github.base_ref == 'production')
-        env:
-          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
-          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
-        run: |
-          cd apps/web
-          npx playwright install chromium --with-deps
-          npx playwright test
-
   migrate-test:
     name: Test DB migrations
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-post-deploy.yml
+++ b/.github/workflows/e2e-post-deploy.yml
@@ -1,0 +1,54 @@
+name: E2E Post-Deploy Smoke Tests
+
+# Runs Playwright E2E tests against the live production site after deploy.
+# Triggers automatically when CI completes on the production branch,
+# or manually via workflow_dispatch.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [production]
+  workflow_dispatch: {}
+
+jobs:
+  e2e:
+    # Only run if CI succeeded (or on manual trigger)
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: cd apps/web && npx playwright install chromium --with-deps
+
+      # Vercel deploy takes a few minutes after CI triggers the hook.
+      # Wait for the site to be reachable before running tests.
+      - name: Wait for production site
+        run: |
+          echo "Waiting for https://www.longtermwiki.com to be reachable..."
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null https://www.longtermwiki.com; then
+              echo "Site is up (attempt $i)"
+              break
+            fi
+            echo "Attempt $i/30 — waiting 30s..."
+            sleep 30
+          done
+
+      - name: Run E2E smoke tests against production
+        env:
+          PLAYWRIGHT_BASE_URL: https://www.longtermwiki.com
+        run: cd apps/web && npx playwright test

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,17 +1,21 @@
 import { defineConfig } from "@playwright/test";
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3001";
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
   use: {
-    baseURL: "http://localhost:3001",
+    baseURL,
     headless: true,
   },
-  webServer: {
-    command: "PORT=3001 pnpm start",
-    port: 3001,
-    timeout: 30_000,
-    // If you already have `pnpm dev` running locally, reuse it
-    reuseExistingServer: true,
-  },
+  // Auto-start local server only when testing against localhost
+  ...(!process.env.PLAYWRIGHT_BASE_URL && {
+    webServer: {
+      command: "PORT=3001 pnpm start",
+      port: 3001,
+      timeout: 30_000,
+      reuseExistingServer: true,
+    },
+  }),
 });


### PR DESCRIPTION
## Summary
- Adds Playwright E2E test that visits `/wiki?tag=Anthropic` on the live production site and asserts the first result is exactly "Anthropic"
- New `e2e-post-deploy.yml` workflow triggers automatically after CI succeeds on the production branch, or manually via `workflow_dispatch`
- Playwright config supports `PLAYWRIGHT_BASE_URL` env var; auto-starts local server only when testing locally
- Removes the pre-deploy E2E step that was added in #1877 (post-deploy is more useful — tests the real deployed site)

## Test plan
- [ ] After next production deploy, verify `e2e-post-deploy` workflow triggers and passes
- [ ] Manual test: `PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test` from `apps/web/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)