### PR TITLE
feat: extend Calc component to resolve KB fact references

### DIFF
--- a/apps/web/src/components/wiki/Calc.tsx
+++ b/apps/web/src/components/wiki/Calc.tsx
@@ -1,6 +1,38 @@
-import { getFact } from "@/data";
+import { getFact, type Fact } from "@/data";
+import { getKBLatest, getKBProperty } from "@data/kb";
+import { formatKBFactValue } from "@/components/wiki/kb/format";
 import { calc, formatValue, type CalcFormat } from "@/lib/calc-engine";
 import { cn } from "@/lib/utils";
+
+/**
+ * Combined fact lookup: tries old-system facts first, falls back to KB facts.
+ * Converts KB facts into the old Fact format so the calc engine can consume them.
+ */
+function combinedFactLookup(entity: string, factId: string): Fact | undefined {
+  // Try old-system fact lookup first
+  const oldFact = getFact(entity, factId);
+  if (oldFact) return oldFact;
+
+  // Fall back to KB lookup (entity = KB entity ID, factId = KB property ID)
+  const kbFact = getKBLatest(entity, factId);
+  if (!kbFact) return undefined;
+
+  // Extract numeric value from the KB FactValue — Calc only works with numbers
+  const v = kbFact.value;
+  if (v.type !== "number") return undefined;
+
+  const prop = getKBProperty(factId);
+  const displayValue = formatKBFactValue(kbFact, prop?.unit, prop?.display);
+
+  return {
+    value: displayValue,
+    numeric: v.value,
+    asOf: kbFact.asOf,
+    entity,
+    factId,
+    source: kbFact.source,
+  };
+}
 
 interface CalcProps {
   /** Expression with {entity.factId} references, e.g. "{anthropic.valuation} / {anthropic.revenue-arr-2025}" */
@@ -24,8 +56,12 @@ interface CalcProps {
  * Evaluates a math expression referencing canonical facts, renders the result
  * inline with a hover tooltip showing the formula and inputs.
  *
+ * Supports both old-system fact references (8-char hex IDs) and KB property
+ * references. Old-system facts are tried first; KB facts are used as fallback.
+ *
  * Usage in MDX:
- *   <Calc expr="{anthropic.valuation} / {anthropic.revenue-arr-2025}" precision={1} suffix="x" />
+ *   <Calc expr="{anthropic.6796e194} / {anthropic.0ed4db9e}" precision={1} suffix="x" />
+ *   <Calc expr="{anthropic.valuation} / {anthropic.revenue}" precision={0} suffix="x" />
  *   <Calc expr="{anthropic.revenue-run-rate} * 2.5" format="currency" />
  *   <Calc expr="{anthropic.gross-margin}" format="percent" />
  */
@@ -39,7 +75,7 @@ export function Calc({
   className,
 }: CalcProps) {
   try {
-    const result = calc(expr, getFact, { format, precision, prefix, suffix });
+    const result = calc(expr, combinedFactLookup, { format, precision, prefix, suffix });
     const displayValue = children || result.display;
 
     // Build human-readable formula for tooltip: replace refs with their values

--- a/apps/web/src/lib/__tests__/calc-engine.test.ts
+++ b/apps/web/src/lib/__tests__/calc-engine.test.ts
@@ -202,6 +202,97 @@ describe("formatValue", () => {
 // Integration: calc with formatting
 // ────────────────────────────────────────────────────────────
 
+// ────────────────────────────────────────────────────────────
+// KB-style property references (human-readable keys)
+// ────────────────────────────────────────────────────────────
+
+describe("calc — KB-style property references", () => {
+  // Simulates what combinedFactLookup produces when resolving KB facts
+  const kbFacts: Record<string, Fact> = {
+    "anthropic.valuation": {
+      value: "$380 billion",
+      numeric: 380_000_000_000,
+      asOf: "2026-02",
+      entity: "anthropic",
+      factId: "valuation",
+    },
+    "anthropic.revenue": {
+      value: "$9 billion",
+      numeric: 9_000_000_000,
+      asOf: "2025-12",
+      entity: "anthropic",
+      factId: "revenue",
+    },
+    "anthropic.gross-margin": {
+      value: "40%",
+      numeric: 0.4,
+      asOf: "2025",
+      entity: "anthropic",
+      factId: "gross-margin",
+    },
+  };
+
+  function kbLookup(entity: string, factId: string): Fact | undefined {
+    return kbFacts[`${entity}.${factId}`];
+  }
+
+  it("resolves human-readable property names", () => {
+    const result = calc("{anthropic.valuation}", kbLookup);
+    expect(result.value).toBe(380_000_000_000);
+  });
+
+  it("computes ratios using KB property names", () => {
+    const result = calc(
+      "{anthropic.valuation} / {anthropic.revenue}",
+      kbLookup,
+      { precision: 0, suffix: "x" }
+    );
+    expect(result.display).toBe("42x");
+  });
+
+  it("tracks inputs with KB property names", () => {
+    const result = calc(
+      "{anthropic.valuation} / {anthropic.revenue}",
+      kbLookup
+    );
+    expect(result.inputs).toHaveLength(2);
+    expect(result.inputs[0].ref).toBe("anthropic.valuation");
+    expect(result.inputs[0].factId).toBe("valuation");
+    expect(result.inputs[1].ref).toBe("anthropic.revenue");
+    expect(result.inputs[1].factId).toBe("revenue");
+  });
+
+  it("handles hyphenated property names", () => {
+    const result = calc("{anthropic.gross-margin}", kbLookup, {
+      format: "percent",
+    });
+    expect(result.display).toBe("40%");
+  });
+
+  it("works with combined old and KB lookups (fallback pattern)", () => {
+    // Simulate the combinedFactLookup: old system first, KB fallback
+    function combinedLookup(entity: string, factId: string): Fact | undefined {
+      return mockLookup(entity, factId) ?? kbLookup(entity, factId);
+    }
+
+    // Old-system ref should still work
+    const oldResult = calc("{anthropic.6796e194}", combinedLookup);
+    expect(oldResult.value).toBe(380_000_000_000);
+
+    // KB-style ref should also work
+    const kbResult = calc("{anthropic.valuation}", combinedLookup);
+    expect(kbResult.value).toBe(380_000_000_000);
+
+    // Mixed expression with both styles
+    const mixedResult = calc(
+      "{anthropic.6796e194} / {anthropic.revenue}",
+      combinedLookup,
+      { precision: 0, suffix: "x" }
+    );
+    expect(mixedResult.display).toBe("42x");
+  });
+});
+
 describe("calc — formatted output", () => {
   it("formats P/S ratio with suffix", () => {
     const result = calc(


### PR DESCRIPTION
## Summary
- Extends the `<Calc>` MDX component to resolve KB entity.property references (e.g., `{anthropic.valuation}`) alongside existing old-system hex-hash fact IDs (e.g., `{anthropic.6796e194}`)
- Old-system fact lookup is tried first for backward compatibility; KB lookup is used as fallback
- KB facts with non-number values are gracefully skipped (Calc only works with numeric values)
- Adds 5 new tests covering KB-style property names, hyphenated keys, and combined old+KB lookup patterns

## How it works
A new `combinedFactLookup()` function in `Calc.tsx` wraps both `getFact()` (old system) and `getKBLatest()` (KB system). When the KB fallback is used, the KB `Fact` is converted to the old `Fact` format with proper numeric extraction and display formatting via `formatKBFactValue()`.

## Test plan
- [x] All 30 calc-engine tests pass (including 5 new KB-style tests)
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Old expressions like `{anthropic.6796e194}` continue to resolve (backward compatible)
- [x] New expressions like `{anthropic.valuation}` resolve via KB fallback
- [x] Mixed expressions with both old and KB refs work correctly


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calculator expressions can now resolve properties from Knowledge Base sources alongside existing fact lookups, enabling calculations with a wider range of available data.

* **Tests**
  * Added comprehensive test coverage for Knowledge Base property resolution in calculator expressions, including mixed lookup scenarios and formatted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->