### PR TITLE
feat: wire resourceId into statement and citation pipelines

### DIFF
--- a/apps/wiki-server/drizzle/0064_page_citations_resource_fk_on_delete.sql
+++ b/apps/wiki-server/drizzle/0064_page_citations_resource_fk_on_delete.sql
@@ -1,0 +1,8 @@
+-- Fix page_citations.resource_id FK to use ON DELETE SET NULL
+-- (consistent with statement_citations.resource_id and claim_citations.resource_id)
+ALTER TABLE page_citations
+  DROP CONSTRAINT IF EXISTS page_citations_resource_id_resources_id_fk;
+
+ALTER TABLE page_citations
+  ADD CONSTRAINT page_citations_resource_id_resources_id_fk
+  FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE SET NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1774080000000,
       "tag": "0063_add_session_id_to_agent_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1774166400000,
+      "tag": "0064_page_citations_resource_fk_on_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1285,7 +1285,9 @@ export const pageCitations = pgTable(
     title: varchar("title"),
     url: varchar("url"),
     note: text("note"),
-    resourceId: text("resource_id").references(() => resources.id),
+    resourceId: text("resource_id").references(() => resources.id, {
+      onDelete: "set null",
+    }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   },
   (table) => [

--- a/crux/claims/convert-new-footnotes.ts
+++ b/crux/claims/convert-new-footnotes.ts
@@ -17,6 +17,7 @@ import { parseFootnotes } from '../lib/footnote-parser.ts';
 import { createCitationsBatch } from '../lib/wiki-server/references.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import type { PageCitationInsert } from '../../apps/wiki-server/src/api-types.ts';
+import { getResourceByUrl } from '../lib/search/resource-lookup.ts';
 
 // ---------------------------------------------------------------------------
 // Reference ID generation (shared with migrate-footnotes.ts)
@@ -118,6 +119,7 @@ export async function convertNewFootnotes(
         title: fn.title ?? undefined,
         url: fn.url ?? undefined,
         note: fn.rawText,
+        resourceId: fn.url ? (getResourceByUrl(fn.url)?.id ?? undefined) : undefined,
       }));
 
       if (citationInserts.length > 0) {
@@ -177,12 +179,14 @@ export async function createDbEntriesForRcFootnotes(
     const mdLink = entry.rawText.match(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/);
     const bareUrl = entry.rawText.match(/(https?:\/\/[^\s,)"']+)/);
 
+    const resolvedUrl = mdLink?.[2] ?? bareUrl?.[1];
     return {
       referenceId: entry.referenceId,
       pageId,
       title: mdLink?.[1] ?? undefined,
-      url: mdLink?.[2] ?? bareUrl?.[1] ?? undefined,
+      url: resolvedUrl ?? undefined,
       note: entry.rawText,
+      resourceId: resolvedUrl ? (getResourceByUrl(resolvedUrl)?.id ?? undefined) : undefined,
     };
   });
 

--- a/crux/statements/extract.ts
+++ b/crux/statements/extract.ts
@@ -614,7 +614,7 @@ async function main() {
           // Look up URL from wiki-server page_citations table (rc-XXXX → URL)
           const pageCit = citationUrlMap.get(ref);
           return {
-            resourceId: null,
+            resourceId: pageCit?.resourceId ?? null,
             url: pageCit?.url ?? null,
             sourceQuote: null,
             locationNote: `footnote: ${ref}`,

--- a/crux/statements/improve.ts
+++ b/crux/statements/improve.ts
@@ -46,6 +46,7 @@ import {
 } from './scoring.ts';
 import { resolveCoverageTargets } from './coverage-targets.ts';
 import { validateCreateStatementBatch, checkAgainstExisting } from './validate-quality.ts';
+import { getResourceByUrl } from '../lib/search/resource-lookup.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -259,7 +260,7 @@ export function qualityGate(
       status: 'active',
       claimCategory: null,
       citations: gen.citations?.map((c) => ({
-        resourceId: null,
+        resourceId: c.url ? (getResourceByUrl(c.url)?.id ?? null) : null,
         url: c.url ?? null,
         sourceQuote: c.sourceQuote ?? null,
       })),
@@ -316,6 +317,7 @@ export function qualityGate(
       valueDate: normalizeValueDate(gen.valueDate),
       validStart: gen.validStart,
       citations: gen.citations?.map((c) => ({
+        resourceId: c.url ? (getResourceByUrl(c.url)?.id ?? undefined) : undefined,
         url: c.url,
         sourceQuote: c.sourceQuote,
       })),


### PR DESCRIPTION
## Summary

- **Extract pipeline**: Use `pageCit.resourceId` from wiki-server page_citations table instead of hardcoded `null` in `extract.ts`
- **Improve pipeline**: Look up resources by URL via `getResourceByUrl()` for both quality-gate scoring and accepted statement creation in `improve.ts`
- **Footnote conversion**: Look up resources by URL when creating page_citation DB entries in `convert-new-footnotes.ts` (both new footnote conversion and existing rc-footnote registration)
- **Schema fix**: Add `ON DELETE SET NULL` to `page_citations.resource_id` FK constraint (consistent with `statement_citations` and `claim_citations`)

This bridges the previously-disconnected `resourceId` FK columns so that citations in the statements pipeline link to curated resources when a matching URL exists in the resource registry.

## Test plan

- [x] TypeScript type-checks pass (`tsc --noEmit` for crux and wiki-server)
- [x] All 2914 tests pass (`pnpm test`)
- [x] All 20 gate checks pass (`pnpm crux validate gate --fix`)
- [ ] Verify `resourceId` populated on new statement extraction (requires wiki-server)

