### PR TITLE
fix(kb): use gpu-count property for CZI GPU facts

### DIFF
--- a/packages/kb/data/properties.yaml
+++ b/packages/kb/data/properties.yaml
@@ -431,6 +431,17 @@ properties:
       divisor: 1e9
       suffix: "B"
 
+  gpu-count:
+    name: GPU Count
+    description: "Number of GPUs in a compute cluster or available for training/inference"
+    dataType: number
+    unit: GPUs
+    category: product
+    temporal: true
+    appliesTo: [organization]
+    display:
+      suffix: " GPUs"
+
   benchmark-score:
     name: Benchmark Score
     description: "Performance score on a specific benchmark"

--- a/packages/kb/data/things/chan-zuckerberg-initiative.yaml
+++ b/packages/kb/data/things/chan-zuckerberg-initiative.yaml
@@ -71,7 +71,7 @@ facts:
     notes: "Grant to establish Biohub New York focused on infectious disease"
 
   - id: f_czi_gpu_cluster_2024
-    property: infrastructure-investment
+    property: gpu-count
     value: 1024
     asOf: "2024"
     source: https://chanzuckerberg.com/rfa/ai-computing-gpu/
@@ -79,7 +79,7 @@ facts:
     notes: "NVIDIA H100 DGX SuperPOD cluster (1,024 GPUs) for life sciences AI"
 
   - id: f_czi_gpu_planned_2028
-    property: infrastructure-investment
+    property: gpu-count
     value: 10000
     asOf: "2025"
     source: https://www.science.org/content/article/ai-drives-dramatic-expansion-chan-zuckerberg-initiative-s-funding-end-all-diseases


### PR DESCRIPTION
## Summary

- Created new `gpu-count` property in `packages/kb/data/properties.yaml` with `unit: GPUs`, `dataType: number`, `temporal: true`, `appliesTo: [organization]`, and display suffix `" GPUs"`
- Changed CZI facts `f_czi_gpu_cluster_2024` (1,024 GPUs) and `f_czi_gpu_planned_2028` (10,000 GPUs) from `property: infrastructure-investment` to `property: gpu-count`
- KB validation passes: 362 entities, 0 blocking errors

The `infrastructure-investment` property has `unit: USD` and `display: { divisor: 1e9, prefix: "$" }`, so storing GPU counts there caused nonsensical display values (e.g., "$0.000001B" for 1,024 GPUs).

Closes #1910

## Test plan

- [x] `npx tsx crux/validate/validate-kb-schema.ts` passes (0 blocking errors)
- [x] `pnpm test` — all 421 tests pass (2 pre-existing failures from missing build artifacts in worktree)
- [x] Other `infrastructure-investment` users (Anthropic, Meta AI) unaffected