### PR TITLE
fix(kb): extract sourceResource UUIDs from notes to dedicated YAML keys

### DIFF
--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -291,13 +291,15 @@ facts:
     property: valuation
     value: 350e9
     asOf: 2025-11
-    notes: "Valuation at Microsoft/Nvidia commitment. sourceResource: 787a2639f9e64ca5"
+    sourceResource: 787a2639f9e64ca5
+    notes: "Valuation at Microsoft/Nvidia commitment."
 
   - id: f_revenue_guidance_2026
     property: revenue-guidance
     value: 20e9
     asOf: 2026-01
-    notes: "Base case $20B, best case $26B per Reuters. sourceResource: cb3e2358bd128df5"
+    sourceResource: cb3e2358bd128df5
+    notes: "Base case $20B, best case $26B per Reuters."
 
   - id: f_retention_rate_2025
     property: retention-rate
@@ -321,41 +323,48 @@ facts:
     property: infrastructure-investment
     value: 50e9
     asOf: "2026"
-    notes: "AI infrastructure expansion plan announced November 2025. sourceResource: 52c1c2def0184008"
+    sourceResource: 52c1c2def0184008
+    notes: "AI infrastructure expansion plan announced November 2025."
 
   - id: f_breakeven_target
     property: description
     value: "Projected breakeven year: 2028"
-    notes: "Per internal financial projections. sourceResource: eb642ee7de582ff5"
+    sourceResource: eb642ee7de582ff5
+    notes: "Per internal financial projections."
 
   - id: f_google_stake_pct
     property: equity-stake-percent
     value: 14
     asOf: 2026-02
-    notes: "Approximate Google post-Series G equity stake; computed from $3.3B invested across 3 rounds. sourceResource: 233fe5e95bfcf8bc"
+    sourceResource: 233fe5e95bfcf8bc
+    notes: "Approximate Google post-Series G equity stake; computed from $3.3B invested across 3 rounds."
 
   - id: f_founder_equity_value
     property: equity-value
     value: 66.5e9
     asOf: 2026-02
-    notes: "All seven co-founders combined equity value estimated $53-80B (midpoint used); 2-3% each x $380B valuation. sourceResource: fd8351a24e375eba"
+    sourceResource: fd8351a24e375eba
+    notes: "All seven co-founders combined equity value estimated $53-80B (midpoint used); 2-3% each x $380B valuation."
 
   - id: f_founder_pledge_total
     property: description
     value: "Founder pledge total (80% of equity): $43-64B estimated"
-    notes: "All seven co-founders pledged to donate 80% of their wealth. sourceResource: fd8351a24e375eba"
+    sourceResource: fd8351a24e375eba
+    notes: "All seven co-founders pledged to donate 80% of their wealth."
 
   - id: f_employee_equity_value
     property: equity-value
     value: 57e9
     asOf: 2026-02
-    notes: "Employee equity pool value estimated $46-68B (midpoint used); 12-18% of $380B valuation. sourceResource: 8e3ff50b9ef2a1a8"
+    sourceResource: 8e3ff50b9ef2a1a8
+    notes: "Employee equity pool value estimated $46-68B (midpoint used); 12-18% of $380B valuation."
 
   - id: f_per_founder_stake_pct
     property: equity-stake-percent
     value: 2.5
     asOf: 2026-02
-    notes: "Per-founder equity stake; each of 7 co-founders holds approximately 2-3% (midpoint used). sourceResource: fd8351a24e375eba"
+    sourceResource: fd8351a24e375eba
+    notes: "Per-founder equity stake; each of 7 co-founders holds approximately 2-3% (midpoint used)."
 
   - id: f_tallinn_stake_pct
     property: equity-stake-percent

--- a/packages/kb/data/things/jaan-tallinn.yaml
+++ b/packages/kb/data/things/jaan-tallinn.yaml
@@ -11,7 +11,7 @@ facts:
   - id: f_jt_skype_cofound
     property: description
     value: "Co-founded Skype in 2003, sold to eBay for $2.6B in 2005"
-    notes: "sourceResource: 3f21a01b3b4948e1"
+    sourceResource: 3f21a01b3b4948e1
 
   - id: f_jt_net_worth
     property: net-worth

--- a/packages/kb/data/things/openai.yaml
+++ b/packages/kb/data/things/openai.yaml
@@ -124,29 +124,32 @@ facts:
     asOf: 2020-06
     source: https://arxiv.org/abs/2005.14165
     sourceResource: 2cab3ea10b8b7ae2
-    notes: "GPT-3 parameter count. sourceResource: 2cab3ea10b8b7ae2"
+    notes: "GPT-3 parameter count."
 
   - id: f_o1_aime_score
     property: benchmark-score
     value: 83
     asOf: 2024-09
-    notes: "o1 model performance on AIME math competition. sourceResource: 9edf2bd5938d8386"
+    sourceResource: 9edf2bd5938d8386
+    notes: "o1 model performance on AIME math competition."
 
   - id: f_o1_swe_bench
     property: benchmark-score
     value: 71.7
     asOf: 2024-09
-    notes: "o1 model on SWE-bench Verified. sourceResource: 9edf2bd5938d8386"
+    sourceResource: 9edf2bd5938d8386
+    notes: "o1 model on SWE-bench Verified."
 
   - id: f_revenue_growth_2024
     property: description
     value: "Monthly revenue growth from early 2023 to September 2024: 1,700%"
-    notes: "Not single-year YoY; reflects rapid growth from near-zero base. sourceResource: 9437e7cf32e629df"
+    sourceResource: 9437e7cf32e629df
+    notes: "Not single-year YoY; reflects rapid growth from near-zero base."
 
   - id: f_cofounder_departure
     property: description
     value: "75% of co-founders departed within 9 years of founding (by 2024)"
-    notes: "sourceResource: 85ba042a002437a0"
+    sourceResource: 85ba042a002437a0
 
 items:
   funding-rounds:

--- a/packages/kb/data/things/sam-altman.yaml
+++ b/packages/kb/data/things/sam-altman.yaml
@@ -64,37 +64,40 @@ facts:
     property: net-worth
     value: 2.8e9
     asOf: "2024"
-    notes: "Investment portfolio value per WSJ investigation. sourceResource: 69a7aca55efbfa51"
+    sourceResource: 69a7aca55efbfa51
+    notes: "Investment portfolio value per WSJ investigation."
 
   - id: f_sa_openai_salary
     property: description
     value: "OpenAI annual salary (2024): $76,001"
-    notes: "Per OpenAI tax filing. sourceResource: 29e5d58fe306259d"
+    sourceResource: 29e5d58fe306259d
+    notes: "Per OpenAI tax filing."
 
   - id: f_sa_loopt_sale
     property: description
     value: "Loopt sold to Green Dot Corporation for $43.4M"
-    notes: "sourceResource: 9eb603bcd6ee754a"
+    sourceResource: 9eb603bcd6ee754a
 
   - id: f_sa_stripe_investment
     property: description
     value: "Early Stripe investment (2009): $15,000 for 2%"
-    notes: "Per WSJ investigation. sourceResource: 792c07f18a99af7c"
+    sourceResource: 792c07f18a99af7c
+    notes: "Per WSJ investigation."
 
   - id: f_sa_yc_companies
     property: description
     value: "Y Combinator companies funded during tenure: 1,900 (through 2019)"
-    notes: "sourceResource: b795385697c55df2"
+    sourceResource: b795385697c55df2
 
   - id: f_sa_board_crisis
     property: description
     value: "Board crisis (Nov 2023): 738 of 770 employees (95%) signed letter threatening to quit"
-    notes: "sourceResource: ddced8916d043aa2"
+    sourceResource: ddced8916d043aa2
 
   - id: f_sa_helion_investment
     property: description
     value: "Personal investment in Helion Energy: $375M"
-    notes: "sourceResource: 003e2cbd0f507952"
+    sourceResource: 003e2cbd0f507952
 
 items:
   career-history:


### PR DESCRIPTION
## Summary

- Extracted `sourceResource` UUIDs embedded in `notes` fields to proper `sourceResource:` YAML keys across 22 KB facts in 4 files
- When notes contained only the sourceResource reference, removed the notes field entirely
- When notes contained real text plus sourceResource, kept the notes text and extracted the UUID

**Files changed:** `anthropic.yaml` (9 facts), `openai.yaml` (5 facts), `sam-altman.yaml` (7 facts), `jaan-tallinn.yaml` (1 fact)

KB schema validation passes with 0 blocking errors.

Closes #1911

## Test plan

- [x] Searched all KB YAML files — no remaining `notes:.*sourceResource:` patterns
- [x] `npx tsx crux/validate/validate-kb-schema.ts` passes (362 entities, 0 blocking errors)
- [x] Spot-checked edited facts to verify correct YAML structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)