### PR TITLE
feat: use pr-patrol:working label instead of agent:working for PR Patrol

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -5,7 +5,7 @@ run-name: "Auto-Rebase PRs${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' ||
 # Logic lives in crux/lib/pr-rebase.ts; this workflow is a thin orchestrator.
 #
 # Safeguards (implemented in TypeScript):
-#   1. Skip PRs with the `agent:working` label (agent actively working)
+#   1. Skip PRs with any working label (`agent:working`, `pr-patrol:working`)
 #   2. Skip PRs updated within 30 minutes (active work)
 #   3. Skip branches with commits pushed within 30 minutes (active work)
 #   4. Skip branches where last commit contains [ci-autofix] (feedback loop)

--- a/.github/workflows/ci-pr-health.yml
+++ b/.github/workflows/ci-pr-health.yml
@@ -2,7 +2,7 @@ name: CI & PR Health
 run-name: "CI & PR Health${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
 
 # Checks GitHub Actions workflow health, job queue status, and PR/issue quality.
-# Also cleans up stale agent:working labels.
+# Also cleans up stale working labels (agent:working, pr-patrol:working).
 # Runs twice daily — same schedule as the unified wellness check it replaced.
 #
 # Checks performed:

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -110,7 +110,7 @@ jobs:
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           LONGTERMWIKI_PROJECT_KEY: ${{ secrets.LONGTERMWIKI_PROJECT_KEY }}
 
-      - name: Cleanup stale agent:working labels
+      - name: Cleanup stale working labels
         run: pnpm crux issues cleanup --fix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/groundskeeper/src/tasks/session-sweep.ts
+++ b/apps/groundskeeper/src/tasks/session-sweep.ts
@@ -67,6 +67,9 @@ async function callSweepEndpoint(
   }
 }
 
+/** The label used by Claude Code agent sessions (not PR Patrol). */
+const AGENT_WORKING_LABEL = "agent:working";
+
 /**
  * Remove the agent:working label from a GitHub issue if it has that label.
  * Returns true if the label was removed (or wasn't present), false on error.
@@ -92,7 +95,7 @@ async function removeClaudeWorkingLabel(
     }
 
     const hasLabel = issue.labels.some(
-      (label) => (typeof label === "string" ? label : label.name) === "agent:working",
+      (label) => (typeof label === "string" ? label : label.name) === AGENT_WORKING_LABEL,
     );
 
     if (!hasLabel) {
@@ -104,7 +107,7 @@ async function removeClaudeWorkingLabel(
       owner,
       repo,
       issue_number: issueNumber,
-      name: "agent:working",
+      name: AGENT_WORKING_LABEL,
     });
 
     logger.info({ issueNumber }, "Removed agent:working label from closed issue");

--- a/crux/commands/health.ts
+++ b/crux/commands/health.ts
@@ -42,7 +42,7 @@ Options:
   --json          JSON output (all results as structured data)
   --report        Aggregate markdown report to stdout
   --auto-issue    Manage GitHub wellness issue (create/update/close)
-  --cleanup-labels Auto-remove stale agent:working labels (>8 hours)
+  --cleanup-labels Auto-remove stale working labels (>8 hours)
 
 Environment:
   LONGTERMWIKI_SERVER_URL        Wiki-server URL (required for most checks)

--- a/crux/health/checks/pr-quality.ts
+++ b/crux/health/checks/pr-quality.ts
@@ -4,15 +4,15 @@
  * Checks:
  *   - Recent PRs with empty/missing body (<20 chars)
  *   - Stale open PRs (>7 days since last update)
- *   - Issues stuck with agent:working label (>8 hours)
+ *   - Issues/PRs stuck with working labels (agent:working, pr-patrol:working) >8 hours
  *   - Open bug count (informational)
  *
- * Optionally auto-removes stale agent:working labels (self-healing).
+ * Optionally auto-removes stale working labels (self-healing).
  */
 
 import type { CheckResult } from '../health-check.ts';
 import { githubApi, REPO } from '../../lib/github.ts';
-import { LABELS } from '../../lib/labels.ts';
+import { LABELS, ANY_WORKING_LABELS } from '../../lib/labels.ts';
 
 interface PullRequest {
   number: number;
@@ -110,49 +110,52 @@ export async function checkPrQuality(options?: {
 
   // ── Issue quality checks ─────────────────────────────────────────────
 
-  // Check for agent:working label issues stuck >8 hours
-  let stuckIssues: Issue[] = [];
-  try {
-    stuckIssues = await githubApi<Issue[]>(
-      `/repos/${REPO}/issues?labels=${encodeURIComponent(LABELS.AGENT_WORKING)}&state=open&per_page=20`,
-    );
-  } catch (err) {
-    detail.push(`SKIP  ${LABELS.AGENT_WORKING} issues: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  // Check for working labels (agent:working, pr-patrol:working) stuck >8 hours
+  for (const workingLabel of ANY_WORKING_LABELS) {
+    let stuckIssues: Issue[] = [];
+    try {
+      stuckIssues = await githubApi<Issue[]>(
+        `/repos/${REPO}/issues?labels=${encodeURIComponent(workingLabel)}&state=open&per_page=20`,
+      );
+    } catch (err) {
+      detail.push(`SKIP  ${workingLabel} issues: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
 
-  const stuckOnes = stuckIssues.filter((issue) => {
-    const lastActivity = issue.updated_at || issue.created_at;
-    return hoursAgoFromNow(lastActivity, now) > STUCK_LABEL_THRESHOLD_H;
-  });
+    const stuckOnes = stuckIssues.filter((issue) => {
+      const lastActivity = issue.updated_at || issue.created_at;
+      return hoursAgoFromNow(lastActivity, now) > STUCK_LABEL_THRESHOLD_H;
+    });
 
-  if (stuckOnes.length > 0) {
-    failures.push(`${stuckOnes.length} issue(s) stuck with ${LABELS.AGENT_WORKING} label for 8+ hours`);
+    if (stuckOnes.length > 0) {
+      failures.push(`${stuckOnes.length} issue(s) stuck with ${workingLabel} label for 8+ hours`);
 
-    if (cleanupStaleLabels) {
-      for (const issue of stuckOnes) {
-        try {
-          await githubApi(
-            `/repos/${REPO}/issues/${issue.number}/labels/${encodeURIComponent(LABELS.AGENT_WORKING)}`,
-            { method: 'DELETE' },
-          );
-          detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — auto-removed stale ${LABELS.AGENT_WORKING} label`);
-        } catch (err) {
-          // 404 means label was already removed — that's fine
-          const msg = err instanceof Error ? err.message : String(err);
-          if (!msg.includes('404')) {
-            detail.push(`WARN  #${issue.number} — failed to remove label: ${msg}`);
-          } else {
-            detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — label already removed`);
+      if (cleanupStaleLabels) {
+        for (const issue of stuckOnes) {
+          try {
+            await githubApi(
+              `/repos/${REPO}/issues/${issue.number}/labels/${encodeURIComponent(workingLabel)}`,
+              { method: 'DELETE' },
+            );
+            detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — auto-removed stale ${workingLabel} label`);
+          } catch (err) {
+            // 404 means label was already removed — that's fine
+            const msg = err instanceof Error ? err.message : String(err);
+            if (!msg.includes('404')) {
+              detail.push(`WARN  #${issue.number} — failed to remove label: ${msg}`);
+            } else {
+              detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — label already removed`);
+            }
           }
+        }
+      } else {
+        for (const issue of stuckOnes) {
+          detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — stuck with ${workingLabel}`);
         }
       }
     } else {
-      for (const issue of stuckOnes) {
-        detail.push(`WARN  #${issue.number} ${issue.title.slice(0, 50)} — stuck with ${LABELS.AGENT_WORKING}`);
-      }
+      detail.push(`PASS  No stuck ${workingLabel} sessions`);
     }
-  } else {
-    detail.push(`PASS  No stuck ${LABELS.AGENT_WORKING} sessions`);
   }
 
   // Count open bugs (informational)

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -22,7 +22,7 @@
  *   crux health --json               JSON output
  *   crux health --report             Aggregate markdown report to stdout
  *   crux health --auto-issue         Manage GitHub wellness issue
- *   crux health --cleanup-labels     Auto-remove stale agent:working labels
+ *   crux health --cleanup-labels     Auto-remove stale working labels
  */
 
 import { getColors } from '../lib/output.ts';

--- a/crux/lib/labels.ts
+++ b/crux/lib/labels.ts
@@ -34,6 +34,7 @@ export const LABELS = {
   // Agent activity
   AGENT_WORKING: 'agent:working',
   AGENT_FILED: 'agent:filed',
+  PR_PATROL_WORKING: 'pr-patrol:working',
 } as const;
 
 export type LabelName = (typeof LABELS)[keyof typeof LABELS];
@@ -44,6 +45,12 @@ export const STAGE_LABELS = Object.values(LABELS).filter((l) =>
 export const BLOCK_LABELS = Object.values(LABELS).filter((l) =>
   l.startsWith('block:'),
 );
+
+/** All labels that indicate something is actively working on an issue/PR. */
+export const ANY_WORKING_LABELS: readonly string[] = [
+  LABELS.AGENT_WORKING,
+  LABELS.PR_PATROL_WORKING,
+];
 
 type LabelMeta = { color: string; description: string };
 
@@ -56,6 +63,10 @@ export const LABEL_META = {
   [LABELS.AGENT_FILED]: {
     color: 'ededed',
     description: 'Issue filed by an agent',
+  },
+  [LABELS.PR_PATROL_WORKING]: {
+    color: '6f42c1',
+    description: 'PR Patrol actively working on this',
   },
   [LABELS.STAGE_APPROVED]: {
     color: '0e8a16',

--- a/crux/lib/pr-analysis/merge-check.ts
+++ b/crux/lib/pr-analysis/merge-check.ts
@@ -37,6 +37,10 @@ export function checkMergeEligibility(pr: GqlPrNode): MergeCandidate {
     blockReasons.push('agent-working');
   }
 
+  if (labels.includes(LABELS.PR_PATROL_WORKING)) {
+    blockReasons.push('pr-patrol-working');
+  }
+
   if (labels.includes(LABELS.STAGE_MERGING)) {
     blockReasons.push('in-merge-queue');
   }

--- a/crux/lib/pr-analysis/pr-analysis.test.ts
+++ b/crux/lib/pr-analysis/pr-analysis.test.ts
@@ -191,6 +191,14 @@ describe('checkMergeEligibility (lib)', () => {
     expect(result.blockReasons).toContain('agent-working');
   });
 
+  it('blocks PRs with pr-patrol:working label', () => {
+    const pr = makePrNode({
+      labels: { nodes: [{ name: 'stage:approved' }, { name: 'pr-patrol:working' }] },
+    });
+    const result = checkMergeEligibility(pr);
+    expect(result.blockReasons).toContain('pr-patrol-working');
+  });
+
   it('blocks PRs with CI failures', () => {
     const pr = makePrNode({
       commits: {

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -50,6 +50,7 @@ export type MergeBlockReason =
   | 'unresolved-threads'
   | 'unchecked-items'
   | 'agent-working'
+  | 'pr-patrol-working'
   | 'is-draft'
   | 'in-merge-queue';
 

--- a/crux/lib/pr-rebase.test.ts
+++ b/crux/lib/pr-rebase.test.ts
@@ -29,6 +29,13 @@ describe('shouldSkipPr', () => {
     expect(result.reason).toContain(LABELS.AGENT_WORKING);
   });
 
+  it('skips PR with pr-patrol:working label', () => {
+    const pr = makeCandidate({ labels: [LABELS.PR_PATROL_WORKING] });
+    const result = shouldSkipPr(pr, NOW, OLD_BRANCH_TIP, 'fix: some change', RECENT_WINDOW);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain(LABELS.PR_PATROL_WORKING);
+  });
+
   it('skips recently updated PR', () => {
     // PR was updated 10 minutes ago
     const recentUpdate = new Date((NOW - 600) * 1000).toISOString();

--- a/crux/lib/pr-rebase.ts
+++ b/crux/lib/pr-rebase.ts
@@ -5,7 +5,7 @@
  * to avoid disrupting active agent work.
  *
  * Safeguards:
- *   1. Skip PRs with the `agent:working` label (agent actively working)
+ *   1. Skip PRs with any working label (`agent:working`, `pr-patrol:working`)
  *   2. Skip PRs updated within 30 minutes (active work)
  *   3. Skip branches with commits pushed within 30 minutes (active work)
  *   4. Skip branches where the last commit message contains `[ci-autofix]` (feedback loop)
@@ -16,7 +16,7 @@
 
 import { git, gitSafe, isValidBranchName, commitEpoch, commitSubject, pushWithRetry, revParse, configBotUser } from './git.ts';
 import { githubApi, REPO } from './github.ts';
-import { LABELS } from './labels.ts';
+import { LABELS, ANY_WORKING_LABELS } from './labels.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -55,7 +55,7 @@ const DEFAULT_RECENT_WINDOW = 1800; // 30 minutes in seconds
  * Determine whether a PR should be skipped for rebase.
  *
  * Encapsulates all 5 safeguards:
- *   1. `agent:working` label
+ *   1. Any working label (`agent:working`, `pr-patrol:working`)
  *   2. PR updated within recentWindow
  *   3. Branch tip pushed within recentWindow
  *   4. Last commit message contains `[ci-autofix]`
@@ -75,9 +75,10 @@ export function shouldSkipPr(
   lastCommitMessage: string,
   recentWindow: number,
 ): { skip: boolean; reason?: string } {
-  // Safeguard 1: agent:working label
-  if (pr.labels.includes(LABELS.AGENT_WORKING)) {
-    return { skip: true, reason: `has '${LABELS.AGENT_WORKING}' label (agent actively working)` };
+  // Safeguard 1: any working label (agent:working, pr-patrol:working)
+  const workingLabel = ANY_WORKING_LABELS.find((wl) => pr.labels.includes(wl));
+  if (workingLabel) {
+    return { skip: true, reason: `has '${workingLabel}' label (actively being worked on)` };
   }
 
   // Safeguard 5: stage:merging label (in merge queue — rebase would invalidate entry)

--- a/crux/pr-patrol/comments.test.ts
+++ b/crux/pr-patrol/comments.test.ts
@@ -165,7 +165,12 @@ describe('buildStatusCommentBody', () => {
 
   it('shows stage for agent-working', () => {
     const body = buildStatusCommentBody(makePrNode(), ['agent-working']);
-    expect(body).toContain('Claude is working on this PR');
+    expect(body).toContain('An agent is actively working on this PR');
+  });
+
+  it('shows stage for pr-patrol-working', () => {
+    const body = buildStatusCommentBody(makePrNode(), ['pr-patrol-working']);
+    expect(body).toContain('PR Patrol is actively working on this PR');
   });
 
   it('shows draft stage', () => {
@@ -202,7 +207,7 @@ describe('buildStatusCommentBody', () => {
       'ci-failing',
       'agent-working',
     ]);
-    expect(body).toContain('Claude is working on this PR');
+    expect(body).toContain('An agent is actively working on this PR');
     // Both block reasons should still appear in the Blocks line
     expect(body).toContain('`ci-failing`');
     expect(body).toContain('`agent-working`');

--- a/crux/pr-patrol/comments.ts
+++ b/crux/pr-patrol/comments.ts
@@ -153,7 +153,10 @@ function computeStage(blockReasons: MergeBlockReason[]): string {
     return 'In merge queue';
   }
   if (blockReasons.includes('agent-working')) {
-    return 'Claude is working on this PR';
+    return 'An agent is actively working on this PR';
+  }
+  if (blockReasons.includes('pr-patrol-working')) {
+    return 'PR Patrol is actively working on this PR';
   }
   if (blockReasons.includes('ci-pending')) {
     return 'Waiting for CI to complete';

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -23,6 +23,7 @@ import type {
   PatrolConfig,
 } from './types.ts';
 import { LABELS } from './types.ts';
+import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import {
   appendJsonl,
   cl,
@@ -64,7 +65,7 @@ export function detectAllPrIssuesFromNodes(
   return prs
     .filter((pr) => {
       const labels = pr.labels.nodes.map((l) => l.name);
-      if (labels.includes(LABELS.AGENT_WORKING)) return false;
+      if (ANY_WORKING_LABELS.some((wl) => labels.includes(wl))) return false;
       // Skip draft PRs — they're not ready for automated fixes
       if (pr.isDraft) return false;
       return true;

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -349,27 +349,27 @@ async function claimPr(prNum: number, repo: string): Promise<void> {
   try {
     await githubApi(`/repos/${repo}/issues/${prNum}/labels`, {
       method: 'POST',
-      body: { labels: [LABELS.AGENT_WORKING] },
+      body: { labels: [LABELS.PR_PATROL_WORKING] },
     });
     claimedPr = prNum;
     setPersistedClaimedPr(prNum);
   } catch {
-    log(`  ${cl.yellow}Warning: could not add ${LABELS.AGENT_WORKING} label to PR #${prNum}${cl.reset}`);
+    log(`  ${cl.yellow}Warning: could not add ${LABELS.PR_PATROL_WORKING} label to PR #${prNum}${cl.reset}`);
   }
 }
 
 async function releasePr(prNum: number, repo: string): Promise<void> {
   try {
-    await githubApi(`/repos/${repo}/issues/${prNum}/labels/${encodeURIComponent(LABELS.AGENT_WORKING)}`, {
+    await githubApi(`/repos/${repo}/issues/${prNum}/labels/${encodeURIComponent(LABELS.PR_PATROL_WORKING)}`, {
       method: 'DELETE',
     });
   } catch (e) {
     // 404 is expected (label already absent) — swallow silently.
     // Any other error (network, 500, auth) needs visibility since a stale
-    // claude-working label makes detectAllPrIssuesFromNodes skip the PR.
+    // pr-patrol:working label makes detectAllPrIssuesFromNodes skip the PR.
     const msg = e instanceof Error ? e.message : String(e);
     if (!msg.includes('404') && !msg.includes('Not Found')) {
-      log(`  Warning: could not remove claude-working label from PR #${prNum}: ${msg}`);
+      log(`  Warning: could not remove pr-patrol:working label from PR #${prNum}: ${msg}`);
     }
   }
   if (claimedPr === prNum) {

--- a/crux/pr-patrol/format.ts
+++ b/crux/pr-patrol/format.ts
@@ -387,7 +387,7 @@ ${c.bold}Auto-Merge (via Merge Queue)${c.reset}
   ${c.green}\u2713${c.reset} No merge conflicts
   ${c.green}\u2713${c.reset} No unresolved review threads
   ${c.green}\u2713${c.reset} No unchecked checkboxes in PR body
-  ${c.green}\u2713${c.reset} No \`${LABELS.AGENT_WORKING}\` label
+  ${c.green}\u2713${c.reset} No working labels (\`${LABELS.AGENT_WORKING}\` or \`${LABELS.PR_PATROL_WORKING}\`)
   ${c.green}\u2713${c.reset} No \`${LABELS.STAGE_MERGING}\` label (not already in queue)
   ${c.green}\u2713${c.reset} Not a draft (drafts are auto-undrafted first if eligible)
 

--- a/crux/pr-patrol/index.test.ts
+++ b/crux/pr-patrol/index.test.ts
@@ -380,6 +380,18 @@ describe('checkMergeEligibility', () => {
     expect(result.blockReasons).toContain('agent-working');
   });
 
+  it('blocks when pr-patrol:working label is present', () => {
+    const result = checkMergeEligibility(
+      makePrNode({
+        labels: {
+          nodes: [{ name: LABELS.STAGE_APPROVED }, { name: LABELS.PR_PATROL_WORKING }],
+        },
+      }),
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.blockReasons).toContain('pr-patrol-working');
+  });
+
   it('blocks when PR is a draft', () => {
     const result = checkMergeEligibility(
       makePrNode({ isDraft: true }),


### PR DESCRIPTION
## Summary

- PR Patrol now uses `pr-patrol:working` (purple) instead of sharing the generic `agent:working` (blue) label with Claude Code sessions
- Adds `ANY_WORKING_LABELS` array so skip/block checks still honor both labels
- All merge-check, auto-rebase, health check, and detection code updated to check both labels
- Tests added for the new label in merge-check, rebase, and comments

This resolves the confusion where `agent:working` appeared on PRs but didn't indicate which agent was responsible.

**Label semantics after this change:**
| Label | Color | Used by |
|-------|-------|---------|
| `agent:working` | Blue | Claude Code sessions (`crux issues start/done`) |
| `pr-patrol:working` | Purple | PR Patrol claim/release cycle |

## Test plan

- [x] All crux tests pass (2839/2839, 1 pre-existing timeout)
- [x] New tests for `pr-patrol:working` in merge-check, rebase, and comments
- [ ] After merge: verify PR Patrol applies `pr-patrol:working` instead of `agent:working`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `pr-patrol:working` label to indicate when PR Patrol is actively working on a PR.
  * System now recognizes multiple working labels and blocks PR merges when active work is detected.
  * Health checks now handle multiple working labels during stale label cleanup.

* **Chores**
  * Updated messaging to more accurately describe active work status on PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->