### PR TITLE
fix: unify KB numericId format to E-prefix

### DIFF
--- a/packages/kb/data/things/center-for-ai-safety.yaml
+++ b/packages/kb/data/things/center-for-ai-safety.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: oa9A0OV0RX
   type: organization
   name: "Center for AI Safety"
-  numericId: 1100
+  numericId: E1100
   aliases:
     - CAIS
 

--- a/packages/kb/data/things/chan-zuckerberg-initiative.yaml
+++ b/packages/kb/data/things/chan-zuckerberg-initiative.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: rYERluiUwH
   type: organization
   name: "Chan Zuckerberg Initiative"
-  numericId: 1101
+  numericId: E519
   aliases:
     - CZI
 

--- a/packages/kb/data/things/coefficient-giving.yaml
+++ b/packages/kb/data/things/coefficient-giving.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: ULjDXpSLCI
   type: organization
   name: "Coefficient Giving"
-  numericId: 1102
+  numericId: E521
   aliases:
     - Open Philanthropy
     - OP

--- a/packages/kb/data/things/jaan-tallinn.yaml
+++ b/packages/kb/data/things/jaan-tallinn.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: 6gjF5d3geg
   type: person
   name: "Jaan Tallinn"
-  numericId: 1103
+  numericId: E577
   aliases:
     - Tallinn
 

--- a/packages/kb/data/things/manifund.yaml
+++ b/packages/kb/data/things/manifund.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: fFVOuFZCRf
   type: organization
   name: "Manifund"
-  numericId: 1104
+  numericId: E547
 
 facts:
   - id: f_manifund_ai_safety_2025

--- a/packages/kb/data/things/survival-and-flourishing-fund.yaml
+++ b/packages/kb/data/things/survival-and-flourishing-fund.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: sIFjGbxVct
   type: organization
   name: "Survival and Flourishing Fund"
-  numericId: 1105
+  numericId: E1105
   aliases:
     - SFF
 


### PR DESCRIPTION
## Summary

- Fixed 6 KB entity YAML files that had bare-integer `numericId` values instead of E-prefixed strings
- 4 entities that exist in both the old entity system and KB had different numericIds (e.g., `jaan-tallinn` was `1103` in KB but `E577` in old entities) -- these now match the old entity IDs to prevent collision during migration
- 2 KB-only entities (`center-for-ai-safety`, `survival-and-flourishing-fund`) had E-prefix added to their existing integers
- All 362 KB entities now consistently use E-prefix format

## Changes

| Entity | Before | After | Reason |
|--------|--------|-------|--------|
| chan-zuckerberg-initiative | 1101 | E519 | Match old entity |
| coefficient-giving | 1102 | E521 | Match old entity |
| jaan-tallinn | 1103 | E577 | Match old entity |
| manifund | 1104 | E547 | Match old entity |
| center-for-ai-safety | 1100 | E1100 | KB-only, prefix added |
| survival-and-flourishing-fund | 1105 | E1105 | KB-only, prefix added |

## Context

The KB loader already had `normalizeNumericId()` to handle bare integers at runtime by prepending "E", but the YAML source files were inconsistent. More critically, the 4 entities with old-entity equivalents had **different** numeric IDs, which would cause ID collisions when migrating entities from old -> KB.

## Test plan

- [x] KB loader test `all numericIds use E-prefix format and are unique` passes
- [x] id-registry tests pass
- [x] `pnpm build-data:quick` runs without ID collision errors
- [x] TypeScript compilation passes for KB package

Generated with [Claude Code](https://claude.com/claude-code)