### PR TITLE
feat: expand KB schema to cover more entity types

### DIFF
--- a/packages/kb/data/properties.yaml
+++ b/packages/kb/data/properties.yaml
@@ -185,7 +185,7 @@ properties:
     description: "Date the organization was incorporated or officially founded"
     dataType: date
     category: organization
-    appliesTo: [organization]
+    appliesTo: [organization, funder]
 
   born-year:
     name: Birth Year
@@ -210,7 +210,7 @@ properties:
     description: "Primary office location (city, state/country)"
     dataType: text
     category: organization
-    appliesTo: [organization]
+    appliesTo: [organization, funder]
 
   legal-structure:
     name: Legal Structure
@@ -548,21 +548,21 @@ properties:
     description: "Degree of expert agreement: high / medium / low / contested / unknown"
     dataType: text
     category: epistemic
-    appliesTo: [risk, approach, debate, concept, capability]
+    appliesTo: [risk, risk-factor, approach, debate, concept, capability, safety-agenda]
 
   evidence-strength:
     name: Evidence Strength
     description: "Quality of supporting evidence: strong / moderate / weak / mixed / theoretical"
     dataType: text
     category: epistemic
-    appliesTo: [risk, approach, debate, concept, capability, analysis]
+    appliesTo: [risk, risk-factor, approach, debate, concept, capability, analysis, safety-agenda, case-study]
 
   severity-level:
     name: Severity Level
     description: "Potential impact severity: catastrophic / severe / moderate / minor"
     dataType: text
     category: risk
-    appliesTo: [risk]
+    appliesTo: [risk, risk-factor]
 
   likelihood-estimate:
     name: Likelihood Estimate
@@ -571,7 +571,7 @@ properties:
     unit: percent
     category: risk
     temporal: true
-    appliesTo: [risk]
+    appliesTo: [risk, risk-factor]
     display:
       suffix: "%"
 
@@ -580,14 +580,14 @@ properties:
     description: "Whether the impact is reversible: reversible / partially-reversible / irreversible"
     dataType: text
     category: risk
-    appliesTo: [risk]
+    appliesTo: [risk, risk-factor]
 
   time-horizon:
     name: Time Horizon
     description: "Timeframe for risk materialization or approach relevance: near-term / medium-term / long-term / ongoing"
     dataType: text
     category: concept
-    appliesTo: [risk, approach, debate, concept, capability]
+    appliesTo: [risk, risk-factor, approach, debate, concept, capability, safety-agenda]
 
   # ── Approach & Response Properties ────────────────────────────────────
 
@@ -596,35 +596,35 @@ properties:
     description: "Category of approach: technical / policy / governance / research / community"
     dataType: text
     category: approach
-    appliesTo: [approach]
+    appliesTo: [approach, safety-agenda]
 
   maturity-level:
     name: Maturity Level
     description: "Development stage: theoretical / early-research / active-research / deployed / mature"
     dataType: text
     category: approach
-    appliesTo: [approach, capability]
+    appliesTo: [approach, capability, safety-agenda]
 
   key-proponents:
     name: Key Proponents
     description: "People or organizations most associated with advocating this approach"
     dataType: refs
     category: approach
-    appliesTo: [approach, debate]
+    appliesTo: [approach, debate, safety-agenda]
 
   addresses-risk:
     name: Addresses Risk
     description: "Risk(s) this approach is designed to mitigate (refs to risk entities)"
     dataType: refs
     category: approach
-    appliesTo: [approach]
+    appliesTo: [approach, safety-agenda]
 
   tractability:
     name: Tractability
     description: "How tractable the approach is: high / medium / low / unknown"
     dataType: text
     category: approach
-    appliesTo: [approach]
+    appliesTo: [approach, safety-agenda]
 
   # ── Debate Properties ─────────────────────────────────────────────────
 
@@ -656,14 +656,14 @@ properties:
     description: "Date a research paper, report, or document was published"
     dataType: date
     category: research
-    appliesTo: [concept, approach, risk, debate]
+    appliesTo: [concept, approach, risk, risk-factor, debate, analysis, safety-agenda]
 
   research-consensus:
     name: Research Consensus
     description: "What the research literature broadly agrees on regarding this topic"
     dataType: text
     category: epistemic
-    appliesTo: [risk, approach, debate, concept, capability]
+    appliesTo: [risk, risk-factor, approach, debate, concept, capability, safety-agenda]
 
   survey-result:
     name: Survey Result
@@ -672,7 +672,7 @@ properties:
     unit: percent
     category: epistemic
     temporal: true
-    appliesTo: [risk, approach, debate, concept]
+    appliesTo: [risk, risk-factor, approach, debate, concept]
     display:
       suffix: "%"
 
@@ -681,7 +681,7 @@ properties:
     description: "Key unresolved questions in this area"
     dataType: text
     category: epistemic
-    appliesTo: [risk, approach, debate, concept, capability]
+    appliesTo: [risk, risk-factor, approach, debate, concept, capability, safety-agenda]
 
   # ── General Properties ───────────────────────────────────────────────
 
@@ -690,14 +690,14 @@ properties:
     description: "Brief description of this entity"
     dataType: text
     category: general
-    appliesTo: [organization, person, ai-model, risk, approach, capability, concept, debate, policy, project, event, analysis, argument]
+    appliesTo: [organization, person, ai-model, risk, risk-factor, approach, capability, concept, debate, policy, project, event, analysis, argument, safety-agenda, case-study, funder, historical, incident]
 
   website:
     name: Website
     description: "Primary website URL"
     dataType: text
     category: general
-    appliesTo: [organization, person, project]
+    appliesTo: [organization, person, project, funder, safety-agenda]
 
   org-type:
     name: Organization Type
@@ -705,6 +705,143 @@ properties:
     dataType: text
     category: organization
     appliesTo: [organization]
+
+  # ── Event Properties ───────────────────────────────────────────────
+
+  event-date:
+    name: Event Date
+    description: "Date the event occurred or began"
+    dataType: date
+    category: event
+    appliesTo: [event]
+
+  event-type:
+    name: Event Type
+    description: "Category of event: summit, announcement, legislative, milestone, conference, publication, launch"
+    dataType: text
+    category: event
+    appliesTo: [event]
+
+  event-organizers:
+    name: Organizers
+    description: "Organizations or people who organized this event"
+    dataType: refs
+    category: event
+    appliesTo: [event]
+
+  event-location:
+    name: Location
+    description: "Where the event took place (city, country)"
+    dataType: text
+    category: event
+    appliesTo: [event]
+
+  # ── Policy Properties ──────────────────────────────────────────────
+
+  policy-status:
+    name: Policy Status
+    description: "Current status: proposed, enacted, enforced, rescinded, expired, superseded"
+    dataType: text
+    category: policy
+    appliesTo: [policy]
+
+  policy-type:
+    name: Policy Type
+    description: "Type of policy: executive-order, legislation, regulation, voluntary-commitment, treaty, standard, guideline"
+    dataType: text
+    category: policy
+    appliesTo: [policy]
+
+  jurisdiction:
+    name: Jurisdiction
+    description: "Geographic or political jurisdiction: US, EU, UK, China, international, state-level"
+    dataType: text
+    category: policy
+    appliesTo: [policy]
+
+  enacted-date:
+    name: Enacted Date
+    description: "Date the policy was enacted, signed, or took effect"
+    dataType: date
+    category: policy
+    appliesTo: [policy]
+
+  sponsoring-body:
+    name: Sponsoring Body
+    description: "Government body, agency, or organization that introduced the policy"
+    dataType: ref
+    category: policy
+    appliesTo: [policy]
+
+  # ── Project Properties ─────────────────────────────────────────────
+
+  project-status:
+    name: Project Status
+    description: "Current status: active, completed, abandoned, paused, archived"
+    dataType: text
+    category: project
+    appliesTo: [project]
+
+  project-type:
+    name: Project Type
+    description: "Type of project: research, software, benchmark, dataset, framework, tool, evaluation"
+    dataType: text
+    category: project
+    appliesTo: [project]
+
+  # ── Cross-Entity Relationship Properties ────────────────────────────
+
+  related-risks:
+    name: Related Risks
+    description: "Risk entities that this entity is relevant to or addresses"
+    dataType: refs
+    category: relationship
+    appliesTo: [approach, concept, capability, event, policy, project, safety-agenda, case-study]
+
+  related-entities:
+    name: Related Entities
+    description: "Other entities closely related to this one (general cross-reference)"
+    dataType: refs
+    category: relationship
+    appliesTo: [event, policy, project, concept, analysis, argument, case-study, funder, historical, risk-factor, safety-agenda]
+
+  # ── Funder Properties ──────────────────────────────────────────────
+
+  total-granted:
+    name: Total Granted
+    description: "Total amount of grants or donations made"
+    dataType: number
+    unit: USD
+    category: financial
+    temporal: true
+    appliesTo: [funder, organization]
+    display:
+      divisor: 1e6
+      prefix: "$"
+      suffix: "M"
+
+  focus-areas:
+    name: Focus Areas
+    description: "Primary areas of funding or philanthropic focus"
+    dataType: text
+    category: funder
+    appliesTo: [funder, organization]
+
+  # ── Historical Properties ──────────────────────────────────────────
+
+  start-date:
+    name: Start Date
+    description: "When this era, period, or historical entity began"
+    dataType: date
+    category: historical
+    appliesTo: [historical, event]
+
+  end-date:
+    name: End Date
+    description: "When this era, period, or historical entity ended (omit if ongoing)"
+    dataType: date
+    category: historical
+    appliesTo: [historical, event]
 
   # ── Incident Properties ──────────────────────────────────────────────
 

--- a/packages/kb/data/schemas/case-study.yaml
+++ b/packages/kb/data/schemas/case-study.yaml
@@ -1,0 +1,36 @@
+type: case-study
+name: Case Study
+
+required: []
+# Case studies analyze specific real-world examples; no properties are universally required.
+
+recommended:
+  - description
+  - evidence-strength
+  - related-risks
+  - related-entities
+
+items:
+  key-events:
+    description: "Chronological events that define this case study"
+    fields:
+      date: { type: date, required: true, description: "Date of the event (YYYY-MM-DD or YYYY-MM)" }
+      event: { type: text, required: true, description: "Brief description of what happened" }
+      source: { type: text, description: "URL to primary source or news article" }
+      notes: { type: text, description: "Significance or context" }
+
+  lessons-learned:
+    description: "Key lessons or takeaways from this case study"
+    fields:
+      lesson: { type: text, required: true, description: "Lesson or takeaway" }
+      applicability: { type: text, description: "Where this lesson applies: AI-safety / governance / technical / organizational" }
+      source: { type: text, description: "URL to analysis drawing this lesson" }
+      notes: { type: text, description: "Context, limitations, or counterexamples" }
+
+  actors:
+    description: "Key actors in this case study and their roles"
+    fields:
+      entity: { type: ref, required: true, description: "Thing ID of the actor" }
+      role: { type: text, required: true, description: "Their role in the case study" }
+      source: { type: text, description: "URL confirming involvement" }
+      notes: { type: text, description: "Context about their actions or motivations" }

--- a/packages/kb/data/schemas/event.yaml
+++ b/packages/kb/data/schemas/event.yaml
@@ -6,6 +6,11 @@ required: []
 
 recommended:
   - description
+  - event-date
+  - event-type
+  - event-location
+  - event-organizers
+  - related-entities
 
 items:
   key-outcomes:
@@ -23,3 +28,11 @@ items:
       role: { type: text, description: "Their role in the event" }
       source: { type: text, description: "URL confirming participation" }
       notes: { type: text, description: "Context about their involvement" }
+
+  timeline:
+    description: "Chronological sequence of key moments within this event"
+    fields:
+      date: { type: date, required: true, description: "Date of the moment (YYYY-MM-DD or YYYY-MM)" }
+      event: { type: text, required: true, description: "Brief description of what happened" }
+      source: { type: text, description: "URL to news article or primary source" }
+      notes: { type: text, description: "Additional context or significance" }

--- a/packages/kb/data/schemas/funder.yaml
+++ b/packages/kb/data/schemas/funder.yaml
@@ -1,0 +1,34 @@
+type: funder
+name: Funder
+
+required: []
+# Funders vary from foundations to individuals; no properties are universally required.
+
+recommended:
+  - description
+  - total-granted
+  - focus-areas
+  - website
+  - founded-date
+  - headquarters
+
+items:
+  major-grants:
+    description: "Significant grants or donations made by this funder"
+    fields:
+      recipient: { type: text, required: true, description: "Recipient organization name or Thing ID" }
+      amount: { type: number, unit: USD, description: "Grant amount in USD" }
+      year: { type: number, required: true, description: "Year the grant was made" }
+      purpose: { type: text, description: "What the funding was for" }
+      source: { type: text, description: "URL to grant announcement or tax filing" }
+      notes: { type: text, description: "Context, conditions, or impact" }
+
+  funding-programs:
+    description: "Recurring funding programs or initiatives"
+    fields:
+      name: { type: text, required: true, description: "Program name" }
+      annual-budget: { type: number, unit: USD, description: "Annual budget in USD" }
+      started: { type: date, description: "When the program began" }
+      status: { type: text, description: "Current status: active, completed, paused" }
+      source: { type: text, description: "URL to program description" }
+      notes: { type: text, description: "Scope, impact, or notable recipients" }

--- a/packages/kb/data/schemas/historical.yaml
+++ b/packages/kb/data/schemas/historical.yaml
@@ -1,0 +1,38 @@
+type: historical
+name: Historical Period
+
+required: []
+# Historical periods and eras; no properties are universally required.
+
+recommended:
+  - description
+  - start-date
+  - end-date
+  - related-entities
+
+items:
+  key-events:
+    description: "Defining events of this historical period"
+    fields:
+      date: { type: date, required: true, description: "Date of the event (YYYY or YYYY-MM)" }
+      event: { type: text, required: true, description: "Brief description of what happened" }
+      significance: { type: text, description: "Why this event mattered for the period" }
+      source: { type: text, description: "URL to primary source or historical analysis" }
+      notes: { type: text, description: "Context or historiographic perspective" }
+
+  defining-figures:
+    description: "Key people who shaped this historical period"
+    fields:
+      person: { type: ref, required: true, description: "Thing ID of the person" }
+      role: { type: text, required: true, description: "Their role in this period" }
+      contribution: { type: text, description: "Their primary contribution or influence" }
+      source: { type: text, description: "URL to biographical or historical source" }
+      notes: { type: text, description: "Context about their influence" }
+
+  defining-institutions:
+    description: "Key organizations that shaped this historical period"
+    fields:
+      organization: { type: ref, required: true, description: "Thing ID of the organization" }
+      role: { type: text, required: true, description: "Their role in this period" }
+      source: { type: text, description: "URL to historical analysis" }
+      notes: { type: text, description: "Context about their influence" }

--- a/packages/kb/data/schemas/policy.yaml
+++ b/packages/kb/data/schemas/policy.yaml
@@ -6,6 +6,12 @@ required: []
 
 recommended:
   - description
+  - policy-status
+  - policy-type
+  - jurisdiction
+  - enacted-date
+  - sponsoring-body
+  - related-risks
 
 items:
   key-provisions:
@@ -23,3 +29,11 @@ items:
       impact: { type: text, description: "How this entity is affected" }
       source: { type: text, description: "URL to impact analysis" }
       notes: { type: text, description: "Context or compliance status" }
+
+  legislative-history:
+    description: "Key dates and milestones in the policy's legislative or regulatory process"
+    fields:
+      date: { type: date, required: true, description: "Date of the milestone (YYYY-MM-DD or YYYY-MM)" }
+      event: { type: text, required: true, description: "What happened (introduced, amended, passed, signed, enforced)" }
+      source: { type: text, description: "URL to official record or news coverage" }
+      notes: { type: text, description: "Context, vote counts, or amendments" }

--- a/packages/kb/data/schemas/project.yaml
+++ b/packages/kb/data/schemas/project.yaml
@@ -7,6 +7,11 @@ required: []
 recommended:
   - description
   - developed-by
+  - project-status
+  - project-type
+  - launched-date
+  - website
+  - related-risks
 
 items:
   milestones:
@@ -24,3 +29,12 @@ items:
       role: { type: text, description: "Their role or contribution" }
       source: { type: text, description: "URL confirming the contribution" }
       notes: { type: text, description: "Context about their involvement" }
+
+  releases:
+    description: "Major releases or versions of this project"
+    fields:
+      version: { type: text, required: true, description: "Version number or release name" }
+      date: { type: date, required: true, description: "Release date (YYYY-MM or YYYY-MM-DD)" }
+      description: { type: text, description: "What was new in this release" }
+      source: { type: text, description: "URL to release notes or announcement" }
+      notes: { type: text, description: "Significance or adoption impact" }

--- a/packages/kb/data/schemas/risk-factor.yaml
+++ b/packages/kb/data/schemas/risk-factor.yaml
@@ -1,0 +1,31 @@
+type: risk-factor
+name: Risk Factor
+
+required: []
+# Risk factors contribute to broader risks; no properties are universally required.
+
+recommended:
+  - description
+  - severity-level
+  - time-horizon
+  - evidence-strength
+  - expert-consensus-level
+  - related-risks
+
+items:
+  mechanisms:
+    description: "Ways this factor contributes to or amplifies risks"
+    fields:
+      risk: { type: text, required: true, description: "Risk or outcome this factor contributes to" }
+      mechanism: { type: text, required: true, description: "How this factor increases risk" }
+      strength: { type: text, description: "Strength of contribution: strong / moderate / weak / speculative" }
+      source: { type: text, description: "URL to supporting analysis" }
+      notes: { type: text, description: "Context, caveats, or counterarguments" }
+
+  indicators:
+    description: "Observable indicators that this risk factor is increasing or decreasing"
+    fields:
+      indicator: { type: text, required: true, description: "What to observe or measure" }
+      current-trend: { type: text, description: "Current direction: increasing / stable / decreasing / unknown" }
+      source: { type: text, description: "URL to data or analysis" }
+      notes: { type: text, description: "Measurement challenges or caveats" }

--- a/packages/kb/data/schemas/safety-agenda.yaml
+++ b/packages/kb/data/schemas/safety-agenda.yaml
@@ -1,0 +1,43 @@
+type: safety-agenda
+name: Safety Agenda
+
+required: []
+# Safety agendas are comprehensive research programs; no properties are universally required.
+
+recommended:
+  - description
+  - intervention-type
+  - maturity-level
+  - time-horizon
+  - evidence-strength
+  - expert-consensus-level
+  - website
+
+items:
+  research-threads:
+    description: "Major research threads or workstreams within this agenda"
+    fields:
+      name: { type: text, required: true, description: "Research thread name" }
+      description: { type: text, required: true, description: "What this thread aims to achieve" }
+      status: { type: text, description: "Current status: active / completed / planned / abandoned" }
+      lead-org: { type: text, description: "Primary organization pursuing this thread" }
+      source: { type: text, description: "URL to research program description" }
+      notes: { type: text, description: "Progress, key results, or open challenges" }
+
+  key-publications:
+    description: "Foundational publications defining or advancing this agenda"
+    fields:
+      title: { type: text, required: true, description: "Publication title" }
+      authors: { type: text, description: "Author(s)" }
+      year: { type: number, required: true, description: "Publication year" }
+      url: { type: text, description: "URL to paper" }
+      notes: { type: text, description: "Significance or key arguments" }
+
+  proponent-orgs:
+    description: "Organizations actively pursuing this safety agenda"
+    fields:
+      organization: { type: ref, required: true, description: "Thing ID of the organization" }
+      role: { type: text, description: "Their role: pioneer, major-contributor, implementer, funder" }
+      commitment-level: { type: text, description: "Commitment: primary-focus / significant / partial / exploratory" }
+      source: { type: text, description: "URL to evidence of their involvement" }
+      notes: { type: text, description: "Context about their approach or contributions" }


### PR DESCRIPTION
## Summary
- Add 5 new schemas: `risk-factor`, `safety-agenda`, `case-study`, `funder`, `historical`
- Add 18 new properties for event, policy, project, funder, historical, and cross-entity relationships
- Extend `appliesTo` on 15+ existing properties to include the new entity types
- Enrich existing `event`, `policy`, and `project` schemas with additional recommended properties and item collections (timeline, legislative-history, releases)

Total coverage: **19 schemas** (was 14), **~80 properties** (was 60).

### New schemas
| Schema | Purpose | Recommended properties | Item collections |
|--------|---------|----------------------|-----------------|
| `risk-factor` | Contributing factors to risks | severity-level, time-horizon, evidence-strength, related-risks | mechanisms, indicators |
| `safety-agenda` | Comprehensive safety programs | intervention-type, maturity-level, time-horizon, website | research-threads, key-publications, proponent-orgs |
| `case-study` | Real-world examples | evidence-strength, related-risks, related-entities | key-events, lessons-learned, actors |
| `funder` | Funding organizations | total-granted, focus-areas, website, founded-date | major-grants, funding-programs |
| `historical` | Historical periods/eras | start-date, end-date, related-entities | key-events, defining-figures, defining-institutions |

### New properties (18)
Event: `event-date`, `event-type`, `event-location`, `event-organizers`
Policy: `policy-status`, `policy-type`, `jurisdiction`, `enacted-date`, `sponsoring-body`
Project: `project-status`, `project-type`
Funder: `total-granted`, `focus-areas`
Historical: `start-date`, `end-date`
Cross-entity: `related-risks`, `related-entities`

## Test plan
- [x] KB schema validation passes (362 entities, 0 blocking errors)
- [x] All 20 gate checks pass
- [x] Pre-existing KB loader test failures unchanged (property count mismatch, documented in MEMORY.md)
- [x] KB command tests pass (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)