### PR TITLE
fix: replace duplicated schema.ts with re-export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ apps/web/tsconfig.tsbuildinfo
 # Generated data (all rebuilt by prebuild script / build-data.mjs)
 src/data/
 apps/web/src/data/*.json
-apps/web/src/data/schema.ts
 public/search-docs.json
 public/search-index.json
 data/id-registry.json

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -6,7 +6,6 @@ tsconfig.tsbuildinfo
 
 # Generated data (all rebuilt by prebuild script / build-data.mjs)
 src/data/*.json
-src/data/schema.ts
 src/data/pages.json
 src/data/stats.json
 src/data/link-health.json

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -1756,12 +1756,8 @@ async function main() {
   console.log(`Unique tags: ${stats.totalTags}`);
   console.log(`Top types: ${Object.entries(stats.byType).slice(0, 5).map(([t, c]) => `${t}(${c})`).join(', ')}`);
 
-  // ==========================================================================
-  // Copy canonical schema.ts to apps/web output directory
-  // ==========================================================================
-  const SCHEMA_SRC = join(DATA_DIR, 'schema.ts');
-  copyFileSync(SCHEMA_SRC, join(OUTPUT_DIR, 'schema.ts'));
-  console.log('✓ Copied data/schema.ts → apps/web/src/data/schema.ts');
+  // schema.ts: apps/web/src/data/schema.ts re-exports from data/schema.ts
+  // (no build-time copy needed — see #1526)
 
   // ==========================================================================
   // LLM Accessibility Files

--- a/apps/web/src/data/schema.ts
+++ b/apps/web/src/data/schema.ts
@@ -1,0 +1,3 @@
+// Re-export from canonical source to avoid duplication.
+// See https://github.com/quantified-uncertainty/longterm-wiki/issues/1526
+export * from "../../../../data/schema";


### PR DESCRIPTION
## Summary
- Replace the build-time copy of `data/schema.ts` → `apps/web/src/data/schema.ts` with a one-line re-export (`export * from "../../../../data/schema"`)
- Remove the `copyFileSync` call from `build-data.mjs` that performed the duplication
- Un-gitignore `apps/web/src/data/schema.ts` so the re-export file is tracked in git

The two files were byte-for-byte identical (951 lines). The web copy had zero direct importers -- Next.js uses `entity-schemas.ts` instead. This change eliminates the risk of silent drift between the canonical `data/schema.ts` and its web copy.

Verified: `tsc --noEmit` passes cleanly.

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)