### PR TITLE
feat: enhance crux kb migrate with full type mapping and --force flag

### DIFF
--- a/crux/commands/kb-migrate.ts
+++ b/crux/commands/kb-migrate.ts
@@ -42,19 +42,44 @@ interface KBCommandOptions extends BaseOptions {
   'dry-run'?: boolean;
   stubOld?: boolean;
   'stub-old'?: boolean;
+  force?: boolean;
 }
 
 // ── Entity type mapping ───────────────────────────────────────────────
 
 /**
  * Maps old entity types to KB thing types.
- * Only types that need remapping are listed; others pass through.
+ * Types not listed here pass through unchanged (e.g., organization, person, concept).
+ * See apps/web/src/data/entity-type-names.ts for the full canonical type list.
  */
 const TYPE_MAP: Record<string, string> = {
+  // Organization subtypes (old lab-* types and synonyms → organization)
+  lab: 'organization',
+  'lab-frontier': 'organization',
+  'lab-research': 'organization',
+  'lab-startup': 'organization',
+  'lab-academic': 'organization',
+  nonprofit: 'organization',
+  government: 'organization',
+  company: 'organization',
+  funder: 'organization',
+  // People subtypes → person
+  researcher: 'person',
+  policymaker: 'person',
+  executive: 'person',
+  // Renamed types
   crux: 'debate',
   'safety-agenda': 'approach',
   historical: 'event',
-  model: 'analysis',
+  model: 'ai-model',
+  'risk-factor': 'risk',
+  'case-study': 'incident',
+  // Plural aliases
+  'safety-approaches': 'approach',
+  policies: 'policy',
+  concepts: 'concept',
+  events: 'event',
+  models: 'ai-model',
 };
 
 /**
@@ -69,6 +94,7 @@ const VALID_KB_TYPES = new Set([
   'concept',
   'debate',
   'event',
+  'incident',
   'organization',
   'person',
   'policy',
@@ -243,17 +269,19 @@ async function migrateCommand(
   const slug = args.find((a) => !a.startsWith('--'));
   const dryRun = options.dryRun || options['dry-run'] || false;
   const stubOld = options.stubOld || options['stub-old'] || false;
+  const force = options.force || false;
 
   if (!slug) {
     return {
       exitCode: 1,
-      output: `Usage: crux kb migrate <entity-slug> [--dry-run] [--stub-old]
+      output: `Usage: crux kb migrate <entity-slug> [--dry-run] [--stub-old] [--force]
 
   Migrate an entity from data/entities/*.yaml to packages/kb/data/things/*.yaml.
 
 Options:
   --dry-run    Print the generated YAML without writing any files
   --stub-old   After migration, strip the old entity to a minimal stub
+  --force      Overwrite existing KB thing file if it already exists
 
 Examples:
   crux kb migrate deepmind --dry-run
@@ -264,10 +292,10 @@ Examples:
 
   // 1. Check if KB thing already exists
   const kbPath = join(KB_THINGS_DIR, `${slug}.yaml`);
-  if (existsSync(kbPath)) {
+  if (existsSync(kbPath) && !force) {
     return {
       exitCode: 1,
-      output: `KB thing already exists at ${kbPath}\nUse 'crux kb show ${slug}' to inspect it.`,
+      output: `KB thing already exists at ${kbPath}\nUse 'crux kb show ${slug}' to inspect it, or pass --force to overwrite.`,
     };
   }
 
@@ -362,7 +390,7 @@ export function getHelp(): string {
 KB Migrate — Migrate entities from old system to KB
 
 Usage:
-  crux kb migrate <entity-slug> [--dry-run] [--stub-old]
+  crux kb migrate <entity-slug> [--dry-run] [--stub-old] [--force]
 
   Reads an entity from data/entities/*.yaml and creates a new KB thing file
   at packages/kb/data/things/<slug>.yaml with the mapped structure.
@@ -371,11 +399,17 @@ Options:
   --dry-run    Print the generated YAML without writing any files
   --stub-old   After migration, strip the old entity down to a minimal stub
                (keeps id, numericId, type, title, relatedEntries)
+  --force      Overwrite existing KB thing file if it already exists
 
 Type Mapping:
-  crux         -> debate
-  safety-agenda -> approach
-  historical   -> event
+  lab, lab-*, nonprofit, government, company, funder -> organization
+  researcher, policymaker, executive                 -> person
+  crux                                               -> debate
+  safety-agenda, safety-approaches                   -> approach
+  historical                                         -> event
+  model, models                                      -> ai-model
+  risk-factor                                        -> risk
+  case-study                                         -> incident
   (all others pass through unchanged)
 
 What gets migrated:
@@ -394,5 +428,6 @@ Examples:
   crux kb migrate deepmind --dry-run        Preview migration
   crux kb migrate ajeya-cotra               Create KB thing file
   crux kb migrate ajeya-cotra --stub-old    Create KB thing + strip old entity
+  crux kb migrate deepmind --force          Overwrite existing KB thing
 `;
 }

--- a/crux/commands/kb.ts
+++ b/crux/commands/kb.ts
@@ -494,6 +494,7 @@ Options:
   --rule=X              Filter by rule name (validate)
   --dry-run             Preview migration without writing files (migrate only)
   --stub-old            Strip old entity to stub after migration (migrate only)
+  --force               Overwrite existing KB thing file (migrate only)
 
 Examples:
   crux kb show anthropic              Show Anthropic with all facts and items


### PR DESCRIPTION
## Summary
- Expands the `crux kb migrate` type mapping from 4 entries to full coverage of all old entity types (lab-*, nonprofit, researcher, policymaker, executive, risk-factor, case-study, model, plural aliases, etc.)
- Fixes incorrect `model -> analysis` mapping to `model -> ai-model` (matching the actual KB schema)
- Adds `--force` flag to allow overwriting existing KB thing files
- Adds `incident` to valid KB types (was missing despite having a schema file)
- Updates help text with complete type mapping reference

## Test plan
- [x] `pnpm crux kb migrate anthropic-core-views --dry-run` works with correct type mapping
- [x] `pnpm crux kb migrate deepmind --dry-run --force` works for existing KB entities
- [x] `pnpm crux kb migrate nonexistent-entity --dry-run` shows proper error
- [x] No-args usage shows updated help text with --force
- [x] TypeScript compiles without errors (`npx tsc --noEmit` shows no kb-migrate errors)
- [x] All 2499 crux tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)