### PR TITLE
fix: add error isolation to monitoring/extended endpoint

### DIFF
--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -511,24 +511,27 @@ function IntegritySection({
   integrity: ExtendedHealthData["integrity"];
 }) {
   const isClean = integrity.status === "clean";
+  const isError = integrity.status === "error";
 
   return (
     <>
       <SectionHeader>Data Integrity</SectionHeader>
       <div
         className={`rounded-lg border border-border/60 p-4 mb-6 ${
-          isClean ? "bg-green-500/10" : "bg-yellow-500/10"
+          isError ? "bg-muted/50" : isClean ? "bg-green-500/10" : "bg-yellow-500/10"
         }`}
       >
         <div className="flex items-center justify-between mb-2">
           <span
             className={`text-sm font-semibold ${
-              isClean ? "text-green-600" : "text-yellow-600"
+              isError ? "text-muted-foreground" : isClean ? "text-green-600" : "text-yellow-600"
             }`}
           >
-            {isClean
-              ? "No dangling references"
-              : `${integrity.totalDanglingRefs} dangling reference${integrity.totalDanglingRefs !== 1 ? "s" : ""}`}
+            {isError
+              ? "Could not check integrity (database query failed)"
+              : isClean
+                ? "No dangling references"
+                : `${integrity.totalDanglingRefs} dangling reference${integrity.totalDanglingRefs !== 1 ? "s" : ""}`}
           </span>
         </div>
         {!isClean && (

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -360,7 +360,8 @@ const monitoringApp = new Hono()
     const db = getDrizzleDb();
     const rawDb = getDb();
 
-    // Run all queries in parallel
+    // Run all queries in parallel — each with .catch() so a single failure
+    // doesn't take down the entire /extended endpoint (see #1909).
     const [
       ciResult,
       gkStatsResult,
@@ -375,16 +376,28 @@ const monitoringApp = new Hono()
       }),
 
       // 2. Groundskeeper task stats (last 24h)
-      fetchGroundskeeperStats(db),
+      fetchGroundskeeperStats(db).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch groundskeeper stats");
+        return [];
+      }),
 
       // 3. Data integrity summary (dangling refs)
-      fetchIntegritySummary(rawDb),
+      fetchIntegritySummary(rawDb).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch integrity summary");
+        return { totalDanglingRefs: 0, status: "error" as const, breakdown: { facts: 0, claims: 0, summaries: 0, citations: 0, editLogs: 0 } };
+      }),
 
       // 4. Auto-update system stats
-      fetchAutoUpdateStats(db),
+      fetchAutoUpdateStats(db).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch auto-update stats");
+        return { totalRuns: 0, recentRuns: [] as { id: number; date: string; trigger: string; pagesUpdated: number; pagesFailed: number; budgetSpent: number; completed: boolean }[] };
+      }),
 
       // 5. Recent agent sessions
-      fetchRecentSessions(rawDb),
+      fetchRecentSessions(rawDb).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch recent sessions");
+        return [];
+      }),
     ]);
 
     return c.json({


### PR DESCRIPTION
## Summary
- Add `.catch()` handlers to all 5 `Promise.all()` entries in the `/api/monitoring/extended` endpoint so individual query failures don't crash the entire endpoint with HTTP 500
- Handle `"error"` integrity status in the frontend `IntegritySection` to show a descriptive message instead of misleading "0 dangling references"

## Investigation notes (issue #1909)

The wellness check flagged `auto-update.yml` — all 5 recent runs failed. Root cause analysis:

| Run | Conclusion | Root Cause |
|-----|-----------|------------|
| Mar 8 | failure | `git push` failed — ran before `cc2c9c13` (push resilience fix) landed on main |
| Mar 7 | cancelled | Wiki-server unreachable at preflight |
| Mar 6 | failure | Content quality checks failed (validation errors, JSON parse) |
| Mar 5 | cancelled | Wiki-server unreachable at preflight |
| Mar 4 | skipped | Automation paused |

The push resilience fix (`cc2c9c13`) is already on main. The next scheduled run (Mar 9 06:00 UTC) will use the fixed code. No further action needed for auto-update.

The System Health dashboard 500 errors are fixed by this PR — the monitoring endpoint now isolates failures per-query.

## Test plan
- [x] TypeScript compiles cleanly (wiki-server + web)
- [x] Existing tests pass (2 pre-existing failures from missing database.json in worktree)
- [ ] After deploy: verify /wiki/E927 loads CI Pipeline and Data Integrity sections
- [ ] After Mar 9 06:00 UTC: verify auto-update run succeeds with push resilience fix

Closes #1909
