### PR TITLE
fix: correct numericIds for CAIS and SFF in KB

### DIFF
--- a/packages/kb/data/things/center-for-ai-safety.yaml
+++ b/packages/kb/data/things/center-for-ai-safety.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: oa9A0OV0RX
   type: organization
   name: "Center for AI Safety"
-  numericId: E1100
+  numericId: E47
   aliases:
     - CAIS
 

--- a/packages/kb/data/things/survival-and-flourishing-fund.yaml
+++ b/packages/kb/data/things/survival-and-flourishing-fund.yaml
@@ -3,7 +3,7 @@ thing:
   stableId: sIFjGbxVct
   type: organization
   name: "Survival and Flourishing Fund"
-  numericId: E1105
+  numericId: E567
   aliases:
     - SFF
 


### PR DESCRIPTION
## Summary

- Fix `center-for-ai-safety.yaml`: E1100 → **E47** (matches old entity slug `cais`)
- Fix `survival-and-flourishing-fund.yaml`: E1105 → **E567** (matches old entity slug `sff`)

PR #1920 incorrectly treated these as KB-only entities, but they exist in the old entity system under different slugs. The wrong IDs would cause broken wiki page URLs.

Found by review agent during post-merge audit.

## Test plan
- [x] KB validation passes (no duplicate numericIds) — data-only change, 2 lines
- [x] Build succeeds — no code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated organization record identifiers for the Center for AI Safety and Survival and Flourishing Fund to ensure accurate data integrity in the knowledge base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->