### PR TITLE
fix(kb): use range value for Anthropic headcount with 3x uncertainty

### DIFF
--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -137,11 +137,13 @@ facts:
 
   - id: f_hc_2024_09
     property: headcount
-    value: 1097
+    value:
+      - 870
+      - 2847
     asOf: 2024-09
     source: https://seo.ai/blog/how-many-people-work-at-anthropic
     sourceResource: 423364c2f6bc5f49
-    notes: "Various sources report 870-2847 depending on method; 1097 is one consistent estimate"
+    notes: "Point estimate 1097 from LinkedIn/consistent sources; full range 870-2847 depending on methodology"
 
   - id: f_hc_2026_01
     property: headcount


### PR DESCRIPTION
## Summary
- Converted Anthropic headcount fact `f_hc_2024_09` from a point estimate (1097) to a range value [870, 2847] to accurately represent the 3x uncertainty across different measurement methodologies
- Updated notes to clarify that 1097 is the LinkedIn/consistent-source point estimate while the full range spans 870-2847

## Details
The KB type system already supports `range` values (`{ type: "range"; low: number; high: number }`), and the YAML loader parses two-element numeric arrays as ranges. This fact was storing a single number despite its own notes acknowledging a wide range.

This is the first use of a `range` value in the KB YAML files. Other entities (xAI, Meta AI) have similar headcount uncertainty but are not addressed in this PR.

Closes #1931

## Test plan
- [x] KB schema validation passes (0 blocking errors)
- [x] All 418 tests pass
- [x] All 16 gate checks pass
