### PR TITLE
refactor(kb): triage validation warnings to reduce noise

### DIFF
--- a/crux/validate/validate-kb-schema.ts
+++ b/crux/validate/validate-kb-schema.ts
@@ -8,7 +8,7 @@
  *
  * Usage:
  *   npx tsx crux/validate/validate-kb-schema.ts            # errors only (gate mode)
- *   npx tsx crux/validate/validate-kb-schema.ts --verbose   # include warnings
+ *   npx tsx crux/validate/validate-kb-schema.ts --verbose   # include warnings + info
  */
 
 import { join } from "path";
@@ -23,6 +23,58 @@ const verbose = process.argv.includes("--verbose");
 // (e.g., "University of Toronto", "Google Brain"). These are data quality items,
 // not integrity violations.
 const DEMOTED_RULES = new Set(["ref-integrity"]);
+
+/** Print a summary table of validation results grouped by rule and severity. */
+function printSummaryTable(results: ValidationResult[]): void {
+  // Count by rule × severity
+  const counts = new Map<string, { error: number; warning: number; info: number }>();
+
+  for (const r of results) {
+    if (!counts.has(r.rule)) {
+      counts.set(r.rule, { error: 0, warning: 0, info: 0 });
+    }
+    const entry = counts.get(r.rule)!;
+    if (r.severity === "error") entry.error++;
+    else if (r.severity === "warning") entry.warning++;
+    else entry.info++;
+  }
+
+  // Sort by total count descending
+  const sorted = [...counts.entries()].sort((a, b) => {
+    const totalA = a[1].error + a[1].warning + a[1].info;
+    const totalB = b[1].error + b[1].warning + b[1].info;
+    return totalB - totalA;
+  });
+
+  console.log("\n┌─────────────────────────────────┬───────┬─────────┬──────┬───────┐");
+  console.log("│ Rule                            │ Error │ Warning │ Info │ Total │");
+  console.log("├─────────────────────────────────┼───────┼─────────┼──────┼───────┤");
+
+  let totalErrors = 0;
+  let totalWarnings = 0;
+  let totalInfo = 0;
+
+  for (const [rule, c] of sorted) {
+    const total = c.error + c.warning + c.info;
+    totalErrors += c.error;
+    totalWarnings += c.warning;
+    totalInfo += c.info;
+
+    const ruleCol = rule.padEnd(31);
+    const errCol = (c.error || "").toString().padStart(5);
+    const warnCol = (c.warning || "").toString().padStart(7);
+    const infoCol = (c.info || "").toString().padStart(4);
+    const totalCol = total.toString().padStart(5);
+    console.log(`│ ${ruleCol} │ ${errCol} │ ${warnCol} │ ${infoCol} │ ${totalCol} │`);
+  }
+
+  const grandTotal = totalErrors + totalWarnings + totalInfo;
+  console.log("├─────────────────────────────────┼───────┼─────────┼──────┼───────┤");
+  console.log(
+    `│ ${"TOTAL".padEnd(31)} │ ${totalErrors.toString().padStart(5)} │ ${totalWarnings.toString().padStart(7)} │ ${totalInfo.toString().padStart(4)} │ ${grandTotal.toString().padStart(5)} │`
+  );
+  console.log("└─────────────────────────────────┴───────┴─────────┴──────┴───────┘");
+}
 
 async function main(): Promise<void> {
   // Dynamic import to avoid loading KB code when this validator is skipped
@@ -45,24 +97,28 @@ async function main(): Promise<void> {
     (r: { severity: string; rule: string }) => r.severity === "error" && DEMOTED_RULES.has(r.rule)
   );
   const warnings = results.filter((r: { severity: string }) => r.severity === "warning");
+  const infos = results.filter((r: { severity: string }) => r.severity === "info");
 
   if (verbose) {
     for (const w of warnings) {
-      console.log(`⚠ [${w.rule}] ${w.message}`);
+      console.log(`\u26A0 [${w.rule}] ${w.message}`);
     }
     for (const d of demotedErrors) {
-      console.log(`⚠ [${d.rule}] ${d.message} (demoted to warning)`);
+      console.log(`\u26A0 [${d.rule}] ${d.message} (demoted to warning)`);
     }
   }
 
   for (const e of blockingErrors) {
-    console.error(`✗ [${e.rule}] ${e.message}`);
+    console.error(`\u2717 [${e.rule}] ${e.message}`);
   }
+
+  // Always print the summary table for visibility
+  printSummaryTable(results);
 
   if (blockingErrors.length > 0) {
     console.error(
       `\nKB schema validation failed: ${blockingErrors.length} blocking error(s), ` +
-        `${demotedErrors.length} demoted, ${warnings.length} warning(s)`
+        `${demotedErrors.length} demoted, ${warnings.length} warning(s), ${infos.length} info`
     );
     process.exit(1);
   }
@@ -73,7 +129,7 @@ async function main(): Promise<void> {
       ? `, ${demotedErrors.length} ref-integrity warning(s)`
       : "";
   console.log(
-    `KB schema validation passed: ${entityCount} entities, 0 blocking errors${demotedNote}, ${warnings.length} warning(s)`
+    `\nKB schema validation passed: ${entityCount} entities, 0 blocking errors${demotedNote}, ${warnings.length} warning(s), ${infos.length} info`
   );
 }
 

--- a/packages/kb/src/validate.ts
+++ b/packages/kb/src/validate.ts
@@ -124,7 +124,7 @@ function checkRecommended(
   for (const propertyId of schema.recommended) {
     if (!hasFact(graph, entityId, propertyId)) {
       results.push({
-        severity: "warning",
+        severity: "info",
         entityId,
         propertyId,
         message: `Missing recommended property "${propertyId}" on entity "${entityId}" (type: ${schema.type}).`,
@@ -528,6 +528,10 @@ function checkNonTemporalMultiple(
   return results;
 }
 
+// Property categories where stale temporal data is actionable (changes frequently).
+// Other categories (people, biographical, etc.) have data that stays stable for years.
+const STALE_WARNING_CATEGORIES = new Set(["financial", "product"]);
+
 /** Check 14: stale temporal data — most recent asOf is >2 years old. */
 function checkStaleTemporal(
   graph: Graph,
@@ -556,8 +560,15 @@ function checkStaleTemporal(
 
   for (const [propertyId, latest] of latestAsOf) {
     if (latest < twoYearsAgo) {
+      const property = graph.getProperty(propertyId);
+      const category = property?.category;
+      // Financial/product properties change frequently — staleness is actionable.
+      // Other categories (people, biographical) are stable and demoted to info.
+      const severity: "warning" | "info" =
+        category && STALE_WARNING_CATEGORIES.has(category) ? "warning" : "info";
+
       results.push({
-        severity: "warning",
+        severity,
         entityId,
         propertyId,
         message:


### PR DESCRIPTION
## Summary

Reduces KB validation warnings from ~2,500 to ~500 (an 80% reduction) by demoting noisy, non-actionable rules to info level while preserving actionable warnings.

### Changes

**`packages/kb/src/validate.ts`**
- Demoted `recommended-properties` (1,966 items) from `warning` to `info` severity -- these are informational completeness hints, not issues requiring action
- Demoted `stale-temporal` for non-financial/non-product categories (e.g., `employed-by`, `role`) to `info` -- employment history doesn't need frequent updating. Financial/product properties (revenue, headcount, user-count) remain as warnings

**`crux/validate/validate-kb-schema.ts`**
- Added a summary table at the end of validation output that groups counts by rule and severity
- Added info-level count to the final summary line

### Validation output after changes

```
Rule                            | Error | Warning | Info | Total
recommended-properties          |       |         | 1966 |  1966
missing-source                  |       |     419 |      |   419
completeness                    |       |         |  362 |   362
stale-temporal                  |       |       8 |   35 |    43
item-collection-schema          |       |      40 |      |    40
duplicate-facts                 |       |      28 |      |    28
ref-integrity                   |    22 |         |      |    22
non-temporal-multiple           |       |      10 |      |    10
TOTAL                           |    22 |     507 | 2363 |  2892
```

Warnings that remain actionable: `missing-source`, `duplicate-facts`, `unknown-property`, `item-collection-schema`, `non-temporal-multiple`, `future-date`, `property-applies-to`, and `stale-temporal` for financial/product properties.

Closes #1930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational (info) severity level to validation messages, complementing warnings and errors
  * Introduced a summary table showing validation results grouped by rule and severity

* **Improvements**
  * Updated validation output formatting with unicode symbols for better clarity
  * Refined categorization of missing recommended properties and stale temporal data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->