### PR TITLE
docs: add !date YAML tag documentation for KB

### DIFF
--- a/content/docs/internal/canonical-facts.mdx
+++ b/content/docs/internal/canonical-facts.mdx
@@ -173,6 +173,45 @@ facts:
 - `notes` — shown in tooltip
 - `source` — attribution link
 
+### Custom YAML Tags
+
+KB YAML files support two custom tags for type-safe data entry:
+
+#### `!ref` — Entity References
+
+Cross-references between entities. Ensures referential integrity at load time.
+
+```yaml
+# Preferred format (stableId:slug — enables cross-validation)
+value: !ref mK9pX3rQ7n:dario-amodei
+
+# Bare stableId (deprecated, still works)
+value: !ref mK9pX3rQ7n
+```
+
+#### `!date` — Explicit Date Typing
+
+Forces a value to be treated as a date, even when YAML would otherwise parse it as a number or string. This is especially important for **bare years** like `2019`, which YAML auto-parses as the integer 1919 (or similar numeric coercion).
+
+```yaml
+# Without !date — YAML parses 2019 as an integer, not a date
+founded: 2019          # ⚠️ Parsed as number 2019, not a date
+
+# With !date — explicitly typed as a date
+founded: !date 2019        # ✓ { type: "date", value: "2019" }
+started: !date 2023-06     # ✓ { type: "date", value: "2023-06" }
+born:    !date 2023-06-15  # ✓ { type: "date", value: "2023-06-15" }
+```
+
+**When to use `!date`:**
+- **Bare years** (e.g. `2019`, `2023`) — always use `!date` to prevent numeric parsing
+- **Year-month** (e.g. `2023-06`) — use `!date` for clarity, though the loader's date heuristic (`DATE_RE`) can usually detect these
+- **Full ISO dates** (e.g. `2023-06-15`) — optional; the heuristic detects these reliably, but `!date` makes intent explicit
+
+**When `!date` is not needed:**
+- Date strings in `asOf` and `validEnd` fields — these are always treated as dates by the loader regardless of format
+- Quoted date strings that match the `YYYY-MM-DD` or `YYYY-MM` pattern — the loader's regex heuristic handles these
+
 ## Adding New Facts
 
 1. Add the entry to the appropriate `packages/kb/data/things/<entity>.yaml` file

--- a/content/docs/internal/data-system-authority.mdx
+++ b/content/docs/internal/data-system-authority.mdx
@@ -95,6 +95,7 @@ Do not delete old facts files outright if there are still active `<F>` tags refe
 | Authority | Properties for KB entities | Properties for non-KB entities |
 | Data model | Typed facts with `property`, `value`, `asOf`, `source`, `validEnd` | Hash-keyed facts with `measure`, `value`, `asOf`, `source` |
 | Cross-entity refs | Yes — `!ref` format for entity references | No |
+| Custom YAML tags | `!ref` (entity references), `!date` (explicit date typing) | None |
 | Time series | Yes — multiple facts per property with `asOf` | Yes — multiple entries with `asOf` |
 | Display components | `<KBFactTable>`, `<KBEntitySidebar>`, `<KBEntityFacts>` | `<F>`, `<Calc>` inline components |
 | Update workflow | Edit KB YAML file | Edit facts YAML file |


### PR DESCRIPTION
## Summary
- Add documentation for the `!date` and `!ref` YAML custom tags in the KB data authoring guides
- Updated `content/docs/internal/canonical-facts.mdx` with a new "Custom YAML Tags" section covering both tags, with usage examples and guidance on when each is needed
- Updated `content/docs/internal/data-system-authority.mdx` system comparison table to list KB custom YAML tags
- The `!date` tag implementation was completed previously (DateMarker class, loader integration, 10 passing tests in `packages/kb/tests/date-tag.test.ts`)
- This PR closes the documentation gap from the acceptance criteria

Closes #1808

## Test plan
- [x] Existing date-tag tests pass (10/10): `pnpm test -- packages/kb/tests/date-tag.test.ts`
- [x] Gate check passes: `pnpm crux validate gate --scope=content --fix`
- [x] No escaping or markdown issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)