### PR TITLE
feat: add DEFAULT_PROPERTIES for all 14 KB entity types

### DIFF
--- a/apps/web/src/components/wiki/kb/KBEntitySidebar.tsx
+++ b/apps/web/src/components/wiki/kb/KBEntitySidebar.tsx
@@ -31,7 +31,12 @@ interface KBEntitySidebarProps {
   className?: string;
 }
 
-/** Default properties to show for each entity type, in display order. */
+/** Default properties to show for each entity type, in display order.
+ *
+ * Each list is derived from the schema's `required` + `recommended` properties
+ * (in `packages/kb/data/schemas/<type>.yaml`), with `description` excluded
+ * (it belongs in the page content, not the sidebar).
+ */
 const DEFAULT_PROPERTIES: Record<string, string[]> = {
   organization: [
     "founded-date",
@@ -54,6 +59,79 @@ const DEFAULT_PROPERTIES: Record<string, string[]> = {
     "employed-by",
     "role",
     "founder-of",
+    "education",
+    "notable-for",
+  ],
+  "ai-model": [
+    "developed-by",
+    "model-release-date",
+    "model-family",
+    "parameter-count",
+    "context-window",
+    "modality",
+    "license-type",
+    "training-compute",
+  ],
+  analysis: [
+    "evidence-strength",
+    "publication-date",
+  ],
+  approach: [
+    "intervention-type",
+    "maturity-level",
+    "time-horizon",
+    "tractability",
+    "evidence-strength",
+    "expert-consensus-level",
+  ],
+  argument: [
+    "evidence-strength",
+    "expert-consensus-level",
+  ],
+  capability: [
+    "maturity-level",
+    "evidence-strength",
+    "expert-consensus-level",
+    "time-horizon",
+  ],
+  concept: [
+    "expert-consensus-level",
+    "evidence-strength",
+    "time-horizon",
+    "research-consensus",
+  ],
+  debate: [
+    "core-question",
+    "expert-consensus-level",
+    "evidence-strength",
+    "time-horizon",
+  ],
+  event: [
+    "publication-date",
+  ],
+  incident: [
+    "incident-date",
+    "organizations-involved",
+    "incident-status",
+    "financial-impact",
+    "casualties",
+  ],
+  policy: [
+    "time-horizon",
+    "evidence-strength",
+  ],
+  project: [
+    "developed-by",
+    "launched-date",
+    "maturity-level",
+  ],
+  risk: [
+    "severity-level",
+    "likelihood-estimate",
+    "time-horizon",
+    "reversibility",
+    "evidence-strength",
+    "expert-consensus-level",
   ],
 };
 


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_PROPERTIES` entries for all 12 missing entity types in `KBEntitySidebar`: `ai-model`, `analysis`, `approach`, `argument`, `capability`, `concept`, `debate`, `event`, `incident`, `policy`, `project`, and `risk`
- Adds `education` and `notable-for` to the existing `person` defaults (these were in the schema's recommended list but missing from the sidebar)
- Properties for each type are derived from the corresponding `packages/kb/data/schemas/<type>.yaml` `required` + `recommended` lists, excluding `description` (shown in page content, not sidebar)

## KBFactValue / KBF duplication finding
`KBFactValue` (`apps/web/src/components/wiki/kb/KBFactValue.tsx`) has **zero MDX usage** across 700+ pages. `KBF` (`apps/web/src/components/wiki/KBF.tsx`) is used in 17 MDX files and serves the same purpose (inline KB fact with hover tooltip). `KBFactValue` is registered in `mdx-components.tsx` and exported from `kb/index.ts`, but never referenced in any MDX content. It is functionally redundant with `KBF` -- the main differences are that `KBF` supports `showDate` and `children` override props while `KBFactValue` has currency display. A future cleanup could consolidate them, but since `KBFactValue` is registered as a valid MDX component, removing it requires care to avoid breaking any content that might use it in the future.

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify sidebar renders correctly for non-org/person entity types that have KB facts

🤖 Generated with [Claude Code](https://claude.com/claude-code)