### PR TITLE
fix: filter expired KB facts by validEnd + fix Calc percent bug

### DIFF
--- a/apps/web/src/components/wiki/Calc.tsx
+++ b/apps/web/src/components/wiki/Calc.tsx
@@ -40,7 +40,12 @@ function kbFactLookup(entity: string, propertyId: string): CalcFact | undefined 
       else if (abs >= 1e6) value = `$${(numeric / 1e6).toFixed(1)} million`;
       else value = `$${numeric.toLocaleString("en-US")}`;
     } else if (unit === "percent") {
-      value = `${(numeric * 100).toFixed(1)}%`;
+      // KB stores percent as whole numbers (e.g., 40 = 40%), not decimals.
+      // Display the whole-number form for the tooltip value string.
+      value = `${numeric.toFixed(1)}%`;
+      // Normalize to decimal for calc-engine arithmetic so that
+      // format="percent" (which multiplies by 100) produces the right result.
+      numeric = numeric / 100;
     } else {
       value = numeric.toLocaleString("en-US");
     }

--- a/apps/web/src/components/wiki/kb/KBEntityFacts.tsx
+++ b/apps/web/src/components/wiki/kb/KBEntityFacts.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getKBFacts, getKBEntity, getKBProperties } from "@data/kb";
+import { getKBFacts, getKBEntity, getKBProperties, isFactExpired } from "@data/kb";
 import type { Fact, Property } from "@longterm-wiki/kb";
 import { formatKBDate, isUrl, shortDomain, titleCase } from "./format";
 import { KBFactValueDisplay } from "./KBFactValueDisplay";
@@ -123,9 +123,9 @@ function SingleValueProperty({
   propertyId: string;
   items: FactWithProperty[];
 }) {
-  // Prefer currently-active facts (validEnd == null), then sort by asOf descending
-  const candidates = items.some((item) => !item.fact.validEnd)
-    ? items.filter((item) => !item.fact.validEnd)
+  // Prefer non-expired facts (validEnd absent or in the future), then sort by asOf descending
+  const candidates = items.some((item) => !isFactExpired(item.fact))
+    ? items.filter((item) => !isFactExpired(item.fact))
     : items;
   const sorted = [...candidates].sort((a, b) => {
     if (!a.fact.asOf && !b.fact.asOf) return 0;

--- a/apps/web/src/components/wiki/kb/KBFactTable.tsx
+++ b/apps/web/src/components/wiki/kb/KBFactTable.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getKBFacts, getKBProperty } from "@data/kb";
+import { getKBFacts, getKBProperty, isFactExpired } from "@data/kb";
 import { formatKBDate, isUrl, shortDomain } from "./format";
 import { KBFactValueDisplay } from "./KBFactValueDisplay";
 
@@ -30,10 +30,14 @@ interface KBFactTableProps {
   property: string;
   /** Optional heading (defaults to property name) */
   title?: string;
+  /** Show expired facts (those with validEnd in the past). Defaults to false. */
+  includeExpired?: boolean;
 }
 
-export function KBFactTable({ entity, property, title }: KBFactTableProps) {
-  const facts = getKBFacts(entity, property);
+export function KBFactTable({ entity, property, title, includeExpired }: KBFactTableProps) {
+  const allFacts = getKBFacts(entity, property);
+  const facts = includeExpired ? allFacts : allFacts.filter((f) => !isFactExpired(f));
+  const expiredCount = allFacts.length - facts.length;
   const prop = getKBProperty(property);
   const heading = title ?? prop?.name ?? property;
 

--- a/apps/web/src/data/__tests__/kb-expired.test.ts
+++ b/apps/web/src/data/__tests__/kb-expired.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { isFactExpired } from "../kb";
+import type { Fact } from "@longterm-wiki/kb";
+
+/** Create a minimal fact stub for testing isFactExpired. */
+function makeFact(validEnd?: string): Fact {
+  return {
+    id: "f_test",
+    subjectId: "test-entity",
+    propertyId: "test-property",
+    value: { type: "text", value: "test" },
+    validEnd,
+  };
+}
+
+describe("isFactExpired", () => {
+  it("returns false for facts without validEnd", () => {
+    expect(isFactExpired(makeFact(undefined))).toBe(false);
+  });
+
+  it("returns true for a YYYY date in the past", () => {
+    expect(isFactExpired(makeFact("2020"))).toBe(true);
+  });
+
+  it("returns true for a YYYY-MM date in the past", () => {
+    expect(isFactExpired(makeFact("2020-06"))).toBe(true);
+  });
+
+  it("returns true for a YYYY-MM-DD date in the past", () => {
+    expect(isFactExpired(makeFact("2020-01-15"))).toBe(true);
+  });
+
+  it("returns false for a YYYY date far in the future", () => {
+    expect(isFactExpired(makeFact("2099"))).toBe(false);
+  });
+
+  it("returns false for a YYYY-MM date in the future", () => {
+    expect(isFactExpired(makeFact("2099-12"))).toBe(false);
+  });
+
+  it("returns false for a YYYY-MM-DD date in the future", () => {
+    expect(isFactExpired(makeFact("2099-12-31"))).toBe(false);
+  });
+});

--- a/apps/web/src/data/kb.ts
+++ b/apps/web/src/data/kb.ts
@@ -46,11 +46,40 @@ export function getKBFacts(entity: string, property?: string): Fact[] {
 }
 
 /**
- * Get the latest (most recent by asOf) fact for an entity + property.
+ * Check whether a fact has expired based on its validEnd field.
+ * A fact is expired if validEnd is set AND validEnd < today's date.
+ * Supports YYYY, YYYY-MM, and YYYY-MM-DD formats.
+ * Facts without validEnd are never expired.
  */
-export function getKBLatest(entity: string, property: string): Fact | undefined {
+export function isFactExpired(fact: Fact): boolean {
+  if (!fact.validEnd) return false;
+  // Pad partial dates so comparison works: "2024" → "2024-01-01", "2024-06" → "2024-06-01"
+  const parts = fact.validEnd.split("-");
+  const padded =
+    parts.length === 1
+      ? `${parts[0]}-01-01`
+      : parts.length === 2
+        ? `${parts[0]}-${parts[1]}-01`
+        : fact.validEnd;
+  const today = new Date().toISOString().slice(0, 10);
+  return padded < today;
+}
+
+/**
+ * Get the latest (most recent by asOf) fact for an entity + property.
+ * By default, excludes expired facts (those with a validEnd in the past).
+ * Set includeExpired=true to return expired facts as well.
+ */
+export function getKBLatest(
+  entity: string,
+  property: string,
+  options?: { includeExpired?: boolean },
+): Fact | undefined {
   const facts = getKBFacts(entity, property);
-  return facts[0]; // Already sorted most-recent-first
+  if (options?.includeExpired) {
+    return facts[0]; // Already sorted most-recent-first
+  }
+  return facts.find((f) => !isFactExpired(f));
 }
 
 /**
@@ -110,10 +139,12 @@ export const getKBThing = getKBEntity;
  * Get the latest fact for a given property across all entities.
  * Returns a map of entityId → latest Fact for entities that have the property.
  * Optionally filtered to a subset of entity IDs.
+ * By default, excludes expired facts (those with a validEnd in the past).
  */
 export function getKBFactsByProperty(
   propertyId: string,
   entityIds?: string[],
+  options?: { includeExpired?: boolean },
 ): Map<string, Fact> {
   const kb = getKB();
   if (!kb) return new Map();
@@ -122,8 +153,8 @@ export function getKBFactsByProperty(
   const result = new Map<string, Fact>();
 
   for (const entityId of ids) {
-    const facts = getKBFacts(entityId, propertyId);
-    if (facts.length > 0) result.set(entityId, facts[0]!);
+    const fact = getKBLatest(entityId, propertyId, options);
+    if (fact) result.set(entityId, fact);
   }
 
   return result;
@@ -133,10 +164,12 @@ export function getKBFactsByProperty(
  * Get all facts for a given property across all entities (full history).
  * Returns a map of entityId → Fact[] (sorted most-recent-first).
  * Optionally filtered to a subset of entity IDs.
+ * By default, excludes expired facts (those with a validEnd in the past).
  */
 export function getKBAllFactsByProperty(
   propertyId: string,
   entityIds?: string[],
+  options?: { includeExpired?: boolean },
 ): Map<string, Fact[]> {
   const kb = getKB();
   if (!kb) return new Map();
@@ -145,7 +178,10 @@ export function getKBAllFactsByProperty(
   const result = new Map<string, Fact[]>();
 
   for (const entityId of ids) {
-    const facts = getKBFacts(entityId, propertyId);
+    let facts = getKBFacts(entityId, propertyId);
+    if (!options?.includeExpired) {
+      facts = facts.filter((f) => !isFactExpired(f));
+    }
     if (facts.length > 0) result.set(entityId, facts);
   }
 


### PR DESCRIPTION
## Summary
- Add `isFactExpired()` utility to check if a KB fact's `validEnd` date is in the past (supports YYYY, YYYY-MM, YYYY-MM-DD formats)
- `getKBLatest()`, `getKBFactsByProperty()`, and `getKBAllFactsByProperty()` now exclude expired facts by default (opt-in `includeExpired` parameter available)
- `KBFactTable` and `KBEntityFacts.SingleValueProperty` updated to use the new date-aware filtering instead of checking `validEnd === undefined`
- Fix Calc percent double-multiplication: KB stores 40 for 40%, but `kbFactLookup` was multiplying by 100 producing "4000.0%". Now displays correctly and normalizes to decimal for calc-engine arithmetic

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 403 existing tests pass (2 pre-existing failures from missing generated data files in worktree)
- [x] New `kb-expired.test.ts` test file with 7 test cases for `isFactExpired()` covering all date formats and edge cases
- [x] Verified KB YAML data stores percent values as whole numbers (e.g., `gross-margin: 40`)
- [x] Confirmed `format-value.ts` `formatValue(40, "percent")` correctly produces `"40%"` (no multiplication)

Generated with [Claude Code](https://claude.com/claude-code)