### PR TITLE
fix: add KB type alias for model -> ai-model

### DIFF
--- a/crux/commands/kb-migrate.ts
+++ b/crux/commands/kb-migrate.ts
@@ -68,13 +68,12 @@ const TYPE_MAP: Record<string, string> = {
   executive: 'person',
   // Renamed types
   crux: 'debate',
-  model: 'analysis',
   // Plural aliases
   'safety-approaches': 'safety-agenda',
   policies: 'policy',
   concepts: 'concept',
   events: 'event',
-  models: 'analysis',
+  models: 'model',
 };
 
 /**
@@ -93,6 +92,7 @@ const VALID_KB_TYPES = new Set([
   'funder',
   'historical',
   'incident',
+  'model', // alias for ai-model schema; resolveKBType() handles the mapping
   'organization',
   'person',
   'policy',

--- a/packages/kb/src/graph.ts
+++ b/packages/kb/src/graph.ts
@@ -14,6 +14,34 @@ import type {
   PropertyQuery,
 } from "./types";
 
+// ── KB type aliases ─────────────────────────────────────────────────────────
+//
+// Maps entity type names (from data/entities/) to KB schema type names
+// (from packages/kb/data/schemas/). The canonical entity type system uses
+// "model" but the KB schema is named "ai-model" to be more descriptive.
+// This alias ensures model entities are validated against the ai-model schema.
+
+export const KB_TYPE_ALIASES: Record<string, string> = {
+  model: "ai-model",
+};
+
+/** Reverse map: schema type → entity type alias(es) that map to it. */
+const KB_TYPE_REVERSE: Map<string, string[]> = new Map();
+for (const [alias, canonical] of Object.entries(KB_TYPE_ALIASES)) {
+  const existing = KB_TYPE_REVERSE.get(canonical) ?? [];
+  existing.push(alias);
+  KB_TYPE_REVERSE.set(canonical, existing);
+}
+
+/**
+ * Resolves an entity type to its KB schema type.
+ * If the type has an alias (e.g., "model" → "ai-model"), returns the alias target.
+ * Otherwise returns the type unchanged.
+ */
+export function resolveKBType(type: string): string {
+  return KB_TYPE_ALIASES[type] ?? type;
+}
+
 export class Graph {
   private entities: Map<string, Entity> = new Map();
   private facts: Map<string, Fact[]> = new Map(); // keyed by subjectId
@@ -91,7 +119,12 @@ export class Graph {
   }
 
   getByType(type: string): Entity[] {
-    return Array.from(this.entities.values()).filter((t) => t.type === type);
+    // Match entities whose type is either the given type or any alias that
+    // maps to it (e.g., getByType("ai-model") also returns type:"model" entities).
+    const aliases = KB_TYPE_REVERSE.get(type) ?? [];
+    return Array.from(this.entities.values()).filter(
+      (t) => t.type === type || aliases.includes(t.type)
+    );
   }
 
   // ── Fact queries ───────────────────────────────────────────────────
@@ -231,7 +264,7 @@ export class Graph {
 
       const ownerEntity = this.entities.get(ownerEntityId);
       const schema = ownerEntity
-        ? this.schemas.get(ownerEntity.type)
+        ? this.getSchema(ownerEntity.type)
         : undefined;
 
       for (const [collectionName, collection] of entityCollections.entries()) {
@@ -284,7 +317,7 @@ export class Graph {
   }
 
   getSchema(type: string): TypeSchema | undefined {
-    return this.schemas.get(type);
+    return this.schemas.get(type) ?? this.schemas.get(resolveKBType(type));
   }
 
   getAllSchemas(): TypeSchema[] {

--- a/packages/kb/src/index.ts
+++ b/packages/kb/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { loadKB } from "./loader";
-export { Graph } from "./graph";
+export { Graph, resolveKBType, KB_TYPE_ALIASES } from "./graph";
 export { computeInverses } from "./inverse";
 export { validate, validateEntity } from "./validate";
 export * from "./types";

--- a/packages/kb/src/validate.ts
+++ b/packages/kb/src/validate.ts
@@ -46,6 +46,7 @@
  */
 
 import type { Graph } from "./graph";
+import { resolveKBType } from "./graph";
 import type {
   Fact,
   FactValue,
@@ -144,13 +145,16 @@ function checkPropertyAppliesTo(
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
   const facts = graph.getFacts(entityId);
+  // Resolve the entity type through KB aliases (e.g., "model" → "ai-model")
+  // so that appliesTo: [ai-model] matches entities with type: model.
+  const resolvedType = resolveKBType(entityType);
 
   for (const fact of facts) {
     const property = graph.getProperty(fact.propertyId);
     if (!property) continue; // Unknown properties are caught by other checks if needed.
     if (!property.appliesTo || property.appliesTo.length === 0) continue;
 
-    if (!property.appliesTo.includes(entityType)) {
+    if (!property.appliesTo.includes(entityType) && !property.appliesTo.includes(resolvedType)) {
       results.push({
         severity: "warning",
         entityId,

--- a/packages/kb/tests/type-aliases.test.ts
+++ b/packages/kb/tests/type-aliases.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Graph, resolveKBType, KB_TYPE_ALIASES } from "../src/graph";
+
+describe("KB type aliases", () => {
+  describe("resolveKBType", () => {
+    it("resolves 'model' to 'ai-model'", () => {
+      expect(resolveKBType("model")).toBe("ai-model");
+    });
+
+    it("passes through types without aliases", () => {
+      expect(resolveKBType("organization")).toBe("organization");
+      expect(resolveKBType("person")).toBe("person");
+      expect(resolveKBType("ai-model")).toBe("ai-model");
+    });
+  });
+
+  describe("KB_TYPE_ALIASES", () => {
+    it("contains model -> ai-model mapping", () => {
+      expect(KB_TYPE_ALIASES).toHaveProperty("model", "ai-model");
+    });
+  });
+
+  describe("Graph.getSchema with aliases", () => {
+    it("resolves schema for aliased types", () => {
+      const graph = new Graph();
+      graph.addSchema({
+        type: "ai-model",
+        name: "AI Model",
+        required: ["developed-by"],
+        recommended: ["parameter-count"],
+      });
+
+      // Direct lookup works
+      expect(graph.getSchema("ai-model")).toBeDefined();
+      expect(graph.getSchema("ai-model")!.type).toBe("ai-model");
+
+      // Alias lookup works: "model" resolves to "ai-model" schema
+      expect(graph.getSchema("model")).toBeDefined();
+      expect(graph.getSchema("model")!.type).toBe("ai-model");
+
+      // Non-existent type still returns undefined
+      expect(graph.getSchema("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("Graph.getByType with aliases", () => {
+    it("getByType('ai-model') includes entities with type 'model'", () => {
+      const graph = new Graph();
+      graph.addEntity({
+        id: "gpt-4",
+        stableId: "abc1234567",
+        type: "model",
+        name: "GPT-4",
+      });
+      graph.addEntity({
+        id: "anthropic",
+        stableId: "def1234567",
+        type: "organization",
+        name: "Anthropic",
+      });
+
+      const aiModels = graph.getByType("ai-model");
+      expect(aiModels).toHaveLength(1);
+      expect(aiModels[0].id).toBe("gpt-4");
+
+      // Direct type query still works
+      const models = graph.getByType("model");
+      expect(models).toHaveLength(1);
+      expect(models[0].id).toBe("gpt-4");
+
+      // Organization query is unaffected
+      const orgs = graph.getByType("organization");
+      expect(orgs).toHaveLength(1);
+      expect(orgs[0].id).toBe("anthropic");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `KB_TYPE_ALIASES` map in `packages/kb/src/graph.ts` that maps `model` -> `ai-model`, bridging the naming mismatch between the canonical entity type system (`model`) and the KB schema system (`ai-model`)
- Update `getSchema()`, `getByType()`, and `getItemsMentioning()` to resolve types through aliases
- Update `checkPropertyAppliesTo()` in validation to accept aliased types (so `appliesTo: [ai-model]` matches entities with `type: model`)
- Fix `kb-migrate.ts`: remove incorrect `model -> analysis` mapping, add `model` to `VALID_KB_TYPES`

## Test plan
- [x] New unit tests pass (`packages/kb/tests/type-aliases.test.ts` -- 5 tests)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] `pnpm crux kb validate` runs without new errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)