### PR TITLE
fix: update pr-patrol prompt tests to match rewritten prompt

### DIFF
--- a/crux/pr-patrol/prompts.test.ts
+++ b/crux/pr-patrol/prompts.test.ts
@@ -36,7 +36,7 @@ describe('buildPrompt', () => {
     const pr = makeDetectedPr({ issues: ['ci-failure'] });
     const prompt = buildPrompt(pr, REPO);
     expect(prompt).toContain('### CI Failure');
-    expect(prompt).toContain('STOP IMMEDIATELY');
+    expect(prompt).toContain('pre-existing failure on main');
   });
 
   it('includes missing-testplan section', () => {
@@ -136,7 +136,7 @@ describe('buildPrompt', () => {
     const pr = makeDetectedPr({ issues: ['conflict'] });
     const prompt = buildPrompt(pr, REPO);
     expect(prompt).toContain('## Guardrails');
-    expect(prompt).toContain('## When to stop early');
+    expect(prompt).toContain('## When to stop (escalate to human)');
   });
 
   it('truncates long bot comment bodies', () => {


### PR DESCRIPTION
## Summary
- PR #1945 rewrote the pr-patrol prompt (removing `STOP IMMEDIATELY`, renaming `## When to stop early` → `## When to stop (escalate to human)`) but didn't update the tests
- Fixes 2 failing assertions in `pr-patrol/prompts.test.ts`

## Test plan
- [x] `pnpm test:crux` passes (2502/2502 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for prompt validation checks in CI failure and guardrails scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->