### PR TITLE
fix: extract shared escapeIlike utility and fix missing backslash escaping

### DIFF
--- a/apps/wiki-server/src/__tests__/escape-ilike.test.ts
+++ b/apps/wiki-server/src/__tests__/escape-ilike.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { escapeIlike } from "../routes/utils.js";
+
+describe("escapeIlike", () => {
+  it("passes normal string through unchanged", () => {
+    expect(escapeIlike("hello")).toBe("hello");
+  });
+
+  it("escapes % wildcard", () => {
+    expect(escapeIlike("50%")).toBe("50\\%");
+  });
+
+  it("escapes _ wildcard", () => {
+    expect(escapeIlike("a_b")).toBe("a\\_b");
+  });
+
+  it("escapes backslash", () => {
+    expect(escapeIlike("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes all three metacharacters together", () => {
+    expect(escapeIlike("%_\\")).toBe("\\%\\_\\\\");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeIlike("")).toBe("");
+  });
+
+  it("leaves branch-like strings unchanged", () => {
+    expect(escapeIlike("claude/fix-bug")).toBe("claude/fix-bug");
+  });
+});

--- a/apps/wiki-server/src/routes/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/agent-sessions.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   firstOrThrow,
+  escapeIlike,
 } from "./utils.js";
 import {
   CreateAgentSessionSchema,
@@ -288,7 +289,7 @@ const agentSessionsApp = new Hono()
     const { branch_prefix: branchPrefix } = parsed.data;
     const db = getDrizzleDb();
     const whereClause = branchPrefix
-      ? like(agentSessions.branch, `${branchPrefix.replace(/%/g, "\\%").replace(/_/g, "\\_")}%`)
+      ? like(agentSessions.branch, `${escapeIlike(branchPrefix)}%`)
       : undefined;
     const INSIGHTS_LIMIT = 5000;
     const rows = await db.select({

--- a/apps/wiki-server/src/routes/entities.ts
+++ b/apps/wiki-server/src/routes/entities.ts
@@ -10,6 +10,7 @@ import {
   invalidJsonError,
   notFoundError,
   paginationQuery,
+  escapeIlike,
 } from "./utils.js";
 import {
   SyncEntitySchema as SharedSyncEntitySchema,
@@ -35,10 +36,6 @@ const SearchQuery = z.object({
 });
 
 // ---- Helpers ----
-
-function escapeIlike(s: string): string {
-  return s.replace(/[%_\\]/g, "\\$&");
-}
 
 function formatEntity(e: typeof entities.$inferSelect) {
   return {

--- a/apps/wiki-server/src/routes/utils.ts
+++ b/apps/wiki-server/src/routes/utils.ts
@@ -68,3 +68,8 @@ export function firstOrThrow<T>(rows: T[], context: string): T {
   }
   return rows[0];
 }
+
+/** Escape SQL ILIKE/LIKE wildcard metacharacters: %, _, and \ */
+export function escapeIlike(s: string): string {
+  return s.replace(/[%_\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- Extracts `escapeIlike()` from `entities.ts` into shared `utils.ts`
- Fixes bug in `agent-sessions.ts` where LIKE pattern escaping missed backslash characters
- The inline `.replace(/%/g, "\\%").replace(/_/g, "\\_")` only escaped `%` and `_` but not `\`
- Adds unit tests for the shared utility

## Test plan
- [ ] New escape-ilike tests pass (7 tests)
- [ ] Existing entities tests still pass (21 tests)
- [ ] Existing agent-sessions tests still pass (43 tests)
- [ ] `pnpm --filter wiki-server test` passes (550 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)