### PR TITLE
fix: remove stale <F> references and add deprecation gate rule

### DIFF
--- a/crux/authoring/creator/synthesis.ts
+++ b/crux/authoring/creator/synthesis.ts
@@ -248,14 +248,14 @@ ratings:
   actionability: 5
   completeness: 6
 ---
-import {EntityLink, R, F, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
 
 ## Inline Data Components
 
 Use these to keep numbers in sync with the canonical facts database:
 
-- **\\\`<F e="entity-id" f="hashId">display text</F>\\\`** — Inline canonical fact with hover tooltip. Fact IDs are 8-char hex hashes — use only IDs from the Fact Lookup Table.
-  Example: \\\`<F e="anthropic" f="6796e194">\\\\$380B</F>\\\`
+- **\\\`<KBF entity="entity-slug" property="property-id" />\\\`** — Inline canonical KB fact value with hover tooltip showing source and date. Use the entity slug and property ID from the KB Fact Lookup Table.
+  Example: \\\`<KBF entity="anthropic" property="valuation" />\\\`
 - **\\\`<Calc expr="..." format="..." precision={N} suffix="x" />\\\`** — Computed value from fact expressions.
   The \\\`expr\\\` uses \\\`{entity.hashId}\\\` references and supports +, -, *, /, ^, ().
   Example: \\\`<Calc expr="{anthropic.6796e194} / {anthropic.0ed4db9e}" precision={0} suffix="x" />\\\` → "27x"

--- a/crux/authoring/page-improver/phases/enrich.test.ts
+++ b/crux/authoring/page-improver/phases/enrich.test.ts
@@ -84,14 +84,14 @@ describe('enrichPhase', () => {
     const { enrichFactRefs } = await import('../../../enrich/enrich-fact-refs.ts');
     (enrichEntityLinks as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('LLM timeout'));
     (enrichFactRefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      content: '## Test\n\nContent with <F entity="x" fact="y" />.',
+      content: '## Test\n\nContent with <KBF entity="x" property="y" />.',
       insertedCount: 1,
     });
 
     const { content, result } = await enrichPhase(makePage(), '## Test\n\nContent.', makeOptions());
 
     // Fact-ref should still have run successfully
-    expect(content).toContain('<F entity=');
+    expect(content).toContain('<KBF entity=');
     expect(result.entityLinks.insertedCount).toBe(0); // failed
     expect(result.factRefs.insertedCount).toBe(1); // succeeded
   });

--- a/crux/authoring/page-improver/phases/prompts.ts
+++ b/crux/authoring/page-improver/phases/prompts.ts
@@ -131,7 +131,7 @@ ${kbContext ? `
 The following facts are stored in the Knowledge Base for this entity. They are the canonical source of truth for structured data. When writing prose:
 - **DO NOT contradict these values** — they are sourced and verified
 - **Prefer \`<KBF>\`** over hardcoded values for KB properties — values stay in sync as facts update
-- **Prefer \`<F>\`** for inline citations with hover tooltips (copy the fact ID from the table below)
+- Use \`<KBF entity="entity-slug" property="property-id" />\` for inline facts with hover tooltips (use the entity slug and property ID from the table below)
 
 \`\`\`
 ${kbContext}

--- a/crux/lib/kb-context.ts
+++ b/crux/lib/kb-context.ts
@@ -104,8 +104,7 @@ export async function buildKbContextForPage(
 
   const lines: string[] = [];
   lines.push(`KB Facts for ${entity.name} (entity: "${entity.id}"${entity.stableId != null ? `, stableId: ${entity.stableId}` : ''})`);
-  lines.push(`Use <KBF entity="${entity.id}" property="PROPERTY_ID" /> to reference these inline.`);
-  lines.push(`The fact ID (8-char hex) can be used in <F e="${entity.id}" f="FACT_ID">display</F> for hover tooltips.`);
+  lines.push(`Use <KBF entity="${entity.id}" property="PROPERTY_ID" /> to reference these inline (auto-renders with hover tooltip showing source/date).`);
   lines.push('');
   lines.push(`${'Fact ID'.padEnd(14)} ${'Property'.padEnd(28)} Value (source)`);
   lines.push('-'.repeat(90));

--- a/crux/lib/rules/index.ts
+++ b/crux/lib/rules/index.ts
@@ -93,6 +93,9 @@ import { noExecSyncRule } from './no-exec-sync.ts';
 
 // Data integrity checks
 import { resourceRefIntegrityRule } from './resource-ref-integrity.ts';
+
+// Deprecated component detection
+import { noDeprecatedComponentsRule } from './no-deprecated-components.ts';
 // Pipeline artifact detection
 import { pipelineArtifactsRule } from './pipeline-artifacts.ts';
 
@@ -177,6 +180,7 @@ export {
   urlSafetyRule,
   noExecSyncRule,
   resourceRefIntegrityRule,
+  noDeprecatedComponentsRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,
   blockSectionQualityRule,
@@ -242,6 +246,7 @@ export const allRules: Rule[] = [
   urlSafetyRule,
   noExecSyncRule,
   resourceRefIntegrityRule,
+  noDeprecatedComponentsRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,
   blockSectionQualityRule,

--- a/crux/lib/rules/no-deprecated-components.test.ts
+++ b/crux/lib/rules/no-deprecated-components.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the no-deprecated-components rule.
+ *
+ * Verifies that the old `<F e="..." f="...">` fact component syntax is caught
+ * while legitimate uses (code blocks, internal pages, KBF) are not flagged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { noDeprecatedComponentsRule } from './no-deprecated-components.ts';
+import { Severity } from '../validation/validation-engine.ts';
+
+function mockContent(
+  body: string,
+  opts: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    path: (opts.path as string) ?? 'content/docs/test-page.mdx',
+    relativePath: (opts.relativePath as string) ?? 'test-page.mdx',
+    body,
+    raw: `---\ntitle: Test\n---\n${body}`,
+    frontmatter: { title: 'Test Page' },
+    isIndex: false,
+  };
+}
+
+describe('no-deprecated-components rule', () => {
+  it('passes on clean MDX with no deprecated components', async () => {
+    const content = mockContent('## Overview\n\nThis is a clean page with no deprecated components.');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('reports ERROR for <F e="..." f="..."> usage', async () => {
+    const content = mockContent('Revenue is <F e="anthropic" f="6796e194">\\$380B</F>.');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(1);
+    expect(issues[0].rule).toBe('no-deprecated-components');
+    expect(issues[0].severity).toBe(Severity.ERROR);
+    expect(issues[0].message).toContain('Deprecated <F>');
+    expect(issues[0].message).toContain('KBF');
+  });
+
+  it('reports ERROR for <F f="..." e="..."> (reversed attribute order)', async () => {
+    const content = mockContent('Revenue is <F f="6796e194" e="anthropic">\\$380B</F>.');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(1);
+    expect(issues[0].rule).toBe('no-deprecated-components');
+    expect(issues[0].severity).toBe(Severity.ERROR);
+  });
+
+  it('reports ERROR for self-closing <F e="..." /> syntax', async () => {
+    const content = mockContent('The valuation is <F e="anthropic" f="6796e194" />.');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(1);
+  });
+
+  it('skips <F> usage inside fenced code blocks', async () => {
+    const body = '```\n<F e="anthropic" f="6796e194">\\$380B</F>\n```';
+    const content = mockContent(body);
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('skips <F> usage inside inline code spans', async () => {
+    const body = 'Use `<F e="entity" f="fact">display</F>` syntax for old facts.';
+    const content = mockContent(body);
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('skips internal/ pages', async () => {
+    const content = mockContent('<F e="anthropic" f="6796e194">\\$380B</F>', {
+      relativePath: 'internal/data-system-authority.mdx',
+    });
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('skips pages with /internal/ anywhere in relativePath', async () => {
+    const content = mockContent('<F e="anthropic" f="6796e194">\\$380B</F>', {
+      relativePath: 'docs/internal/migration-guide.mdx',
+    });
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('does NOT flag <KBF entity="..." property="..." /> (the replacement)', async () => {
+    const content = mockContent('<KBF entity="anthropic" property="valuation" />');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('does NOT flag generic <F> without e= or f= attributes', async () => {
+    const content = mockContent('The formula is F = ma.');
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(0);
+  });
+
+  it('reports correct line number', async () => {
+    const body = 'First line\nSecond line\n<F e="anthropic" f="revenue">\\$1B</F>\nFourth line';
+    const content = mockContent(body);
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(1);
+    expect(issues[0].line).toBe(3);
+  });
+
+  it('reports multiple errors for multiple deprecated usages', async () => {
+    const body = [
+      '<F e="anthropic" f="revenue">\\$1B</F>',
+      'Some text',
+      '<F e="openai" f="valuation">\\$100B</F>',
+    ].join('\n');
+    const content = mockContent(body);
+    const issues = await noDeprecatedComponentsRule.check(content as any, {} as any);
+    expect(issues.length).toBe(2);
+  });
+});

--- a/crux/lib/rules/no-deprecated-components.ts
+++ b/crux/lib/rules/no-deprecated-components.ts
@@ -1,0 +1,71 @@
+/**
+ * Rule: No Deprecated Components
+ *
+ * Catches usage of deprecated MDX components that have been replaced.
+ * Currently detects:
+ * - `<F e="..." f="...">` — the old inline fact component, replaced by `<KBF entity="..." property="..." />`
+ *
+ * Only matches the specific old fact syntax (`<F e=` or `<F f=`) to avoid
+ * false positives on legitimate `<F>` HTML elements or abbreviations.
+ * Skips fenced code blocks and internal/ pages (which may document the old system).
+ */
+
+import { createRule, Issue, Severity, type ContentFile, type ValidationEngine } from '../validation/validation-engine.ts';
+
+/**
+ * Matches `<F e="` or `<F f="` (the old fact component attribute patterns).
+ * Does NOT match generic `<F>` which could be a legitimate HTML element.
+ */
+const DEPRECATED_F_RE = /<F\s+(?:e=|f=)/g;
+
+export const noDeprecatedComponentsRule = createRule({
+  id: 'no-deprecated-components',
+  name: 'No Deprecated Components',
+  description: 'Catch usage of deprecated MDX components (e.g. old <F e="..." f="..."> fact syntax)',
+
+  check(content: ContentFile, _engine: ValidationEngine): Issue[] {
+    const issues: Issue[] = [];
+
+    // Skip internal documentation pages (may reference old syntax for documentation purposes)
+    if (
+      content.relativePath.startsWith('internal/') ||
+      content.relativePath.includes('/internal/')
+    ) {
+      return issues;
+    }
+
+    const lines = content.body.split('\n');
+    let inFencedBlock = false;
+
+    for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+      const line = lines[lineIdx];
+
+      // Track fenced code blocks (``` or ~~~)
+      if (/^[ \t]*(`{3,}|~{3,})/.test(line)) {
+        inFencedBlock = !inFencedBlock;
+        continue;
+      }
+      if (inFencedBlock) continue;
+
+      // Strip inline code spans before checking
+      const strippedLine = line.replace(/`[^`]*`/g, '');
+
+      DEPRECATED_F_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = DEPRECATED_F_RE.exec(strippedLine)) !== null) {
+        issues.push(new Issue({
+          rule: 'no-deprecated-components',
+          file: content.path,
+          line: lineIdx + 1,
+          message: `Deprecated <F> fact component detected. Use <KBF entity="..." property="..." /> instead.`,
+          severity: Severity.ERROR,
+        }));
+      }
+    }
+
+    return issues;
+  },
+});
+
+export default noDeprecatedComponentsRule;

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -212,6 +212,7 @@ const UNIFIED_BLOCKING_RULES = [
   'entitylink-ids',
   'footnote-integrity',
   'frontmatter-schema',
+  'no-deprecated-components',
   'no-quoted-subcategory',
   'numeric-id-integrity',
   'pipeline-artifacts',


### PR DESCRIPTION
## Summary
- Updates prompt templates (`synthesis.ts`, `prompts.ts`, `kb-context.ts`) to use `<KBF entity="..." property="..." />` instead of the deprecated `<F e="..." f="...">` fact component syntax
- Adds `no-deprecated-components` unified validation rule that catches `<F e=` / `<F f=` patterns in MDX content (skips code blocks and internal/ pages)
- Registers the rule as CI-blocking in `UNIFIED_BLOCKING_RULES` to prevent regression
- Updates enrich test mock data to use `<KBF>` instead of `<F>`

## Details

The old `<F>` inline fact component was replaced by `<KBF>` but several prompt templates and code still referenced the old syntax. CodeRabbit flagged this in PR #1899.

Changes:
1. **`crux/authoring/creator/synthesis.ts`** -- Import instruction changed from `F` to `KBF`, usage examples updated to `<KBF entity="..." property="..." />`
2. **`crux/authoring/page-improver/phases/prompts.ts`** -- Removed stale "Prefer `<F>`" instruction, replaced with `<KBF>` guidance
3. **`crux/lib/kb-context.ts`** -- Removed line instructing LLMs about `<F>` syntax, consolidated into single `<KBF>` instruction
4. **`crux/lib/rules/no-deprecated-components.ts`** -- New validation rule matching `<F e=` and `<F f=` patterns
5. **`crux/lib/rules/no-deprecated-components.test.ts`** -- 12 unit tests covering: clean content, deprecated usage, reversed attributes, self-closing, fenced code blocks, inline code spans, internal pages, KBF not flagged, generic F not flagged, line numbers, multiple errors

## Test plan
- [x] `pnpm crux validate unified --rules=no-deprecated-components` passes on all 664 content files
- [x] No `<F e=` or `<F f=` patterns remain in production MDX (only in internal/ page inside code span)
- [x] 12 unit tests cover: clean content, deprecated usage (both attribute orders), fenced blocks, inline code, internal pages, KBF replacement, generic F
- [x] All 118 crux test files pass (2514 tests)
- [x] TypeScript clean (0 errors in crux/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation rule to detect deprecated inline fact component syntax.

* **Documentation**
  * Updated guidance to use KBF syntax for inline facts, referencing entity slug and property ID.
  * Added documentation for Calc component format support (currency, percent, number, auto).

* **Tests**
  * Added comprehensive test coverage for deprecated component detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->