### PR TITLE
Fix main branch CI failure: update backslash escape test

### DIFF
--- a/apps/wiki-server/src/__tests__/agent-sessions.test.ts
+++ b/apps/wiki-server/src/__tests__/agent-sessions.test.ts
@@ -769,11 +769,7 @@ describe("Agent Sessions API", () => {
       expect(likeCall!.params[0]).toBe("claude/my\\_%");
     });
 
-    // NOTE: The current agent-sessions.ts code does NOT escape backslashes in
-    // branch_prefix. It only escapes % and _. A backslash in the prefix could
-    // act as a LIKE escape character rather than a literal. This is a known gap;
-    // the fix is tracked separately. This test documents current behavior.
-    it("does not currently escape \\\\ in branch_prefix (known gap)", async () => {
+    it("escapes \\\\ in branch_prefix so it is treated as a literal character", async () => {
       await postJson(app, "/api/agent-sessions", {
         ...sampleSession,
         branch: "claude/path\\to\\branch",
@@ -785,14 +781,12 @@ describe("Agent Sessions API", () => {
       );
       expect(res.status).toBe(200);
 
-      // Current behavior: backslash is NOT escaped — it passes through as-is
       const likeCall = dispatchCalls.find((c) =>
         c.query.toLowerCase().includes("like")
       );
       expect(likeCall).toBeDefined();
-      // Current (buggy) behavior: claude/path\% — backslash not escaped
-      // Correct behavior would be: claude/path\\%
-      expect(likeCall!.params[0]).toBe("claude/path\\%");
+      // The pattern should be claude/path\\% — escaped literal \ followed by trailing wildcard
+      expect(likeCall!.params[0]).toBe("claude/path\\\\%");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes CI failure from run #22862051450.

The `escapeIlike` function in `utils.ts` was updated to also escape backslashes (`/[%_\\]/g`), but a test in `agent-sessions.test.ts` still asserted the old (buggy) behavior — that backslashes were **not** escaped. This test was intentionally written as a "known gap" documentation, with a comment already saying the correct output would be `claude/path\\%`.

The fix updates the test to:
- Assert the correct escaped value `claude/path\\\\%`
- Remove the "known gap" framing now that it's fixed
- Rename the test to positively describe correct behavior

All 557 wiki-server tests pass locally.

Fixes CI failure from run #22862051450.