### PR TITLE
test: fix known-gap backslash escaping test in agent-sessions

### DIFF
--- a/apps/wiki-server/src/__tests__/agent-sessions.test.ts
+++ b/apps/wiki-server/src/__tests__/agent-sessions.test.ts
@@ -769,11 +769,7 @@ describe("Agent Sessions API", () => {
       expect(likeCall!.params[0]).toBe("claude/my\\_%");
     });
 
-    // NOTE: The current agent-sessions.ts code does NOT escape backslashes in
-    // branch_prefix. It only escapes % and _. A backslash in the prefix could
-    // act as a LIKE escape character rather than a literal. This is a known gap;
-    // the fix is tracked separately. This test documents current behavior.
-    it("does not currently escape \\\\ in branch_prefix (known gap)", async () => {
+    it("escapes \\\\ in branch_prefix so it is treated as a literal character", async () => {
       await postJson(app, "/api/agent-sessions", {
         ...sampleSession,
         branch: "claude/path\\to\\branch",
@@ -785,14 +781,12 @@ describe("Agent Sessions API", () => {
       );
       expect(res.status).toBe(200);
 
-      // Current behavior: backslash is NOT escaped — it passes through as-is
       const likeCall = dispatchCalls.find((c) =>
         c.query.toLowerCase().includes("like")
       );
       expect(likeCall).toBeDefined();
-      // Current (buggy) behavior: claude/path\% — backslash not escaped
-      // Correct behavior would be: claude/path\\%
-      expect(likeCall!.params[0]).toBe("claude/path\\%");
+      // Backslash is escaped to \\ so it is treated as a literal in the LIKE pattern
+      expect(likeCall!.params[0]).toBe("claude/path\\\\%");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the CI failure from run #22862051450.

**Root cause:** Commit `83d8f3c8` (fix: extract shared escapeIlike utility and fix missing backslash escaping) updated `agent-sessions.ts` to use the new `escapeIlike()` function, which now correctly escapes backslashes in LIKE patterns (`\` → `\\`). However, the existing test in `agent-sessions.test.ts` was written *before* this fix to document the old "known gap" behavior (backslashes passing through unescaped) and was not updated.

**Fix:** Updated the test to:
1. Expect the correct (post-fix) behavior: `claude/path\\%` instead of `claude/path\%`
2. Rename it from "does not currently escape \\\\ in branch_prefix (known gap)" to "escapes \\\\ in branch_prefix so it is treated as a literal character"
3. Remove the stale "known gap" comments

## Test verification

All 557 tests pass locally (`pnpm test` in `apps/wiki-server`).