### PR TITLE
Replace hardcoded funding table on E815 with KBItemTable

### DIFF
--- a/content/docs/knowledge-base/organizations/anthropic-stakeholders.mdx
+++ b/content/docs/knowledge-base/organizations/anthropic-stakeholders.mdx
@@ -34,7 +34,7 @@ The table below shows each stakeholder's estimated equity stake, the fraction pl
 
 <AnthropicStakeholdersTable />
 
-**Total funding raised**: <KBF entity="anthropic" property="total-funding" /> across 16 rounds. **Current valuation**: <KBF entity="anthropic" property="valuation" showDate /> (Series G).
+**Total funding raised**: <KBF entity="anthropic" property="total-funding" /> across 17 rounds. **Current valuation**: <KBF entity="anthropic" property="valuation" showDate /> (Series G).
 
 ## Founder Donation Pledges
 
@@ -69,26 +69,9 @@ Employee capital in donor-advised funds (\$27–76B risk-adjusted) is the **most
 
 ## Funding Timeline
 
-| Round | Date | Amount | Valuation | Lead Investors |
-|---|---|---|---|---|
-| Seed | Early 2021 | Undisclosed | — | Tallinn, Moskovitz, Eric Schmidt |
-| Series A | May 2021 | \$124M | \$550M | Jaan Tallinn |
-| Series B | Apr 2022 | \$580M | ≈\$4B | Spark Capital |
-| FTX Investment | 2022 | \$500M | — | FTX/Alameda |
-| Google (initial) | Late 2022 | \$300M | — | Google (10% stake) |
-| Series C | May 2023 | \$450M | — | Spark, Google, Salesforce |
-| Amazon (initial) | Sept 2023 | \$4B | — | Amazon |
-| Google (follow-on) | Oct 2023 | \$2B | — | Google |
-| Series D | Dec 2023 | \$2B | \$18B | Various |
-| Amazon (follow-on) | Mar 2024 | \$2.75B | — | Amazon |
-| Amazon (third) | Nov 2024 | \$4B | — | Amazon |
-| Google (third) | Early 2025 | \$1B | — | Google |
-| Series E | Mar 2025 | \$3.5B | \$61.5B | Lightspeed |
-| Series F | Sept 2025 | \$13B | \$183B | Altimeter, Baillie Gifford, BlackRock |
-| Microsoft/Nvidia | Nov 2025 | Up to \$15B | \$350B | Microsoft, Nvidia |
-| Series G | Feb 2026 | \$30B | <KBF entity="anthropic" property="valuation" /> | GIC, Coatue (co-leads) |
+<KBItemTable entity="anthropic" collection="funding-rounds" title="Funding History" columns={["date", "amount", "valuation", "lead_investor", "notes"]} />
 
-**Total raised**: <KBF entity="anthropic" property="total-funding" /> across 16 rounds. [Anthropic](https://www.anthropic.com/news/anthropic-raises-30-billion-series-g-funding-380-billion-post-money-valuation)
+**Total raised**: <KBF entity="anthropic" property="total-funding" /> across 17 rounds. [Anthropic](https://www.anthropic.com/news/anthropic-raises-30-billion-series-g-funding-380-billion-post-money-valuation)
 
 **Google** has invested \$3.3B across 3 rounds for approximately ~14% of equity. **Amazon** has invested \$10.75B and serves as Anthropic's primary cloud partner; its exact stake is undisclosed.
 

--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -393,21 +393,39 @@ items:
   funding-rounds:
     type: funding-round
     entries:
+      i_k7RmTe4nPQ:
+        date: 2021-01
+        amount: null
+        lead_investor: "Tallinn, Moskovitz, Eric Schmidt"
+        notes: "Seed round; amount undisclosed"
+
       i_VImpFJfKiQ:
-        date: 2021-04
+        date: 2021-05
         amount: 124e6
         valuation: 550e6
         lead_investor: jaan-tallinn
         source: https://techcrunch.com/2021/05/05/anthropic-raises-124m-to-build-safer-ai/
-        notes: "Seed/Series A combined round; Jaan Tallinn led, Dustin Moskovitz participated"
+        notes: "Series A; Jaan Tallinn led, Dustin Moskovitz participated"
 
       i_Xdb6KUs2og:
         date: 2022-04
         amount: 580e6
         valuation: 4e9
-        lead_investor: ftx
+        lead_investor: spark-capital
         source: https://fortune.com/2022/04/29/ai-startup-anthropic-raises-580-million/
-        notes: "FTX reportedly invested ~$500M; estate later sold stake for ~$1.4B"
+        notes: "Series B led by Spark Capital"
+
+      i_wQ8pNx3vJA:
+        date: 2022-06
+        amount: 500e6
+        lead_investor: ftx
+        notes: "FTX/Alameda investment; stake later sold for ~$1.4B to pay creditors"
+
+      i_hR5cYm9tKQ:
+        date: 2022-11
+        amount: 300e6
+        lead_investor: google
+        notes: "Initial Google investment for ~10% stake"
 
       i_aJCVQbfceQ:
         date: 2023-05
@@ -428,7 +446,13 @@ items:
         amount: 2e9
         lead_investor: google
         source: https://blog.google/technology/ai/google-anthropic-investment/
-        notes: "Part of Google's up-to-$2B commitment; ~10% equity stake and board observer seat"
+        notes: "Google follow-on; part of up-to-$2B commitment; board observer seat"
+
+      i_dN6bLx2wRA:
+        date: 2023-12
+        amount: 2e9
+        valuation: 18e9
+        notes: "Series D; various investors"
 
       i_05J6ESa7gA:
         date: 2024-03


### PR DESCRIPTION
## Summary
- Added 4 missing funding-round entries to `packages/kb/data/things/anthropic.yaml`: Seed (Jan 2021), FTX Investment ($500M, Jun 2022), Google initial ($300M, Nov 2022), Series D ($2B, Dec 2023)
- Fixed Series B `lead_investor` from `ftx` to `spark-capital` (FTX was an investor, not the lead)
- Replaced the 16-row hardcoded markdown table on E815 (Anthropic Stakeholders) with `<KBItemTable entity="anthropic" collection="funding-rounds" ... />`
- Updated round count from 16 to 17 in two places

## Test plan
- [x] `pnpm crux fix escaping` — no issues
- [x] `pnpm crux fix markdown` — no issues
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks passed
- [ ] Visual check: verify the KBItemTable renders correctly on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)