### PR TITLE
feat: KB improvements — fact links, items explorer, CLI commands, context integration

### DIFF
--- a/apps/web/src/app/kb/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/kb/entity/[entityId]/page.tsx
@@ -297,7 +297,7 @@ export default async function KBEntityPage({
                   const latestFact = facts[0];
 
                   return (
-                    <details key={propertyId} className="group">
+                    <details key={propertyId} id={propertyId} className="group scroll-mt-16">
                       <summary className="flex items-center gap-4 px-4 py-2.5 cursor-pointer hover:bg-muted/50 text-sm select-none">
                         <span className="font-medium min-w-[10rem]">
                           {property?.name ?? propertyId}
@@ -344,7 +344,7 @@ export default async function KBEntityPage({
                           </thead>
                           <tbody className="divide-y divide-border/50">
                             {facts.map((fact) => (
-                              <tr key={fact.id}>
+                              <tr key={fact.id} id={fact.id} className="scroll-mt-16">
                                 <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
                                   {formatKBDate(fact.asOf)}
                                 </td>
@@ -409,7 +409,7 @@ export default async function KBEntityPage({
                       : [...allFieldNames];
 
                     return (
-                      <details key={collectionName} className="group">
+                      <details key={collectionName} id={`items-${collectionName}`} className="group scroll-mt-16">
                         <summary className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-muted/50 text-sm select-none border border-border rounded-lg">
                           <span className="font-medium">
                             {titleCase(collectionName)}

--- a/apps/web/src/app/kb/kb-items-content.tsx
+++ b/apps/web/src/app/kb/kb-items-content.tsx
@@ -1,0 +1,50 @@
+import { getAllKBItems, getKBEntity } from "@/data/kb";
+import { titleCase } from "@/components/wiki/kb/format";
+import { KBItemsTable } from "./kb-items-table";
+
+export interface ItemRow {
+  itemKey: string;
+  entityId: string;
+  entityName: string;
+  collection: string;
+  fieldCount: number;
+  /** First 3 field names for preview */
+  previewFields: string[];
+}
+
+export function KBItemsExplorerContent() {
+  const allItems = getAllKBItems();
+
+  const rows: ItemRow[] = allItems.map(({ entityId, collection, entry }) => {
+    const entity = getKBEntity(entityId);
+    const fieldNames = Object.keys(entry.fields);
+    return {
+      itemKey: entry.key,
+      entityId,
+      entityName: entity?.name ?? entityId,
+      collection: titleCase(collection),
+      fieldCount: fieldNames.length,
+      previewFields: fieldNames.slice(0, 3),
+    };
+  });
+
+  // Sort by entity name then collection
+  rows.sort((a, b) => {
+    const cmp = a.entityName.localeCompare(b.entityName);
+    return cmp !== 0 ? cmp : a.collection.localeCompare(b.collection);
+  });
+
+  // Summary stats
+  const entityCount = new Set(rows.map((r) => r.entityId)).size;
+  const collectionCount = new Set(rows.map((r) => `${r.entityId}/${r.collection}`)).size;
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+        {rows.length} items across {collectionCount} collections from{" "}
+        {entityCount} entities.
+      </p>
+      <KBItemsTable data={rows} />
+    </>
+  );
+}

--- a/apps/web/src/app/kb/kb-items-table.tsx
+++ b/apps/web/src/app/kb/kb-items-table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import type { ItemRow } from "./kb-items-content";
+
+const columns: ColumnDef<ItemRow>[] = [
+  {
+    accessorKey: "itemKey",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Item Key</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={`/kb/item/${row.original.itemKey}`}
+        className="text-primary hover:underline font-mono text-xs"
+      >
+        {row.original.itemKey}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "entityName",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Entity</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={`/kb/entity/${row.original.entityId}`}
+        className="text-primary hover:underline text-sm"
+      >
+        {row.original.entityName}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "collection",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Collection</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm">{row.original.collection}</span>
+    ),
+  },
+  {
+    accessorKey: "fieldCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Fields</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm tabular-nums">{row.original.fieldCount}</span>
+    ),
+  },
+  {
+    id: "preview",
+    header: "Preview Fields",
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.previewFields.join(", ")}
+      </span>
+    ),
+    enableSorting: false,
+  },
+];
+
+export function KBItemsTable({ data }: { data: ItemRow[] }) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = useState("");
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const search = filterValue.toLowerCase();
+      const r = row.original;
+      return (
+        r.itemKey.toLowerCase().includes(search) ||
+        r.entityName.toLowerCase().includes(search) ||
+        r.collection.toLowerCase().includes(search) ||
+        r.previewFields.some((f) => f.toLowerCase().includes(search))
+      );
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  return (
+    <div>
+      <div className="relative mb-4">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="Filter items..."
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      <DataTable table={table} />
+    </div>
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -49,6 +49,7 @@ import { KBOverviewContent } from "@/app/kb/kb-overview-content";
 import { KBFactsExplorerContent } from "@/app/kb/kb-facts-content";
 import { KBPropertiesExplorerContent } from "@/app/kb/kb-properties-content";
 import { KBEntityCoverageContent } from "@/app/kb/kb-entities-content";
+import { KBItemsExplorerContent } from "@/app/kb/kb-items-content";
 
 // Dashboard content components (rendered via MDX stubs at /wiki/E<id>)
 import { FactsPageContent } from "@/app/internal/facts/facts-content";
@@ -191,6 +192,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   KBFactsExplorerContent,
   KBPropertiesExplorerContent,
   KBEntityCoverageContent,
+  KBItemsExplorerContent,
 
   // Dashboard content components
   FactsPageContent,

--- a/apps/web/src/components/wiki/KBF.tsx
+++ b/apps/web/src/components/wiki/KBF.tsx
@@ -13,7 +13,6 @@
 
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { getEntityById, getEntityHref } from "@data";
 import { getKBFacts, getKBLatest, getKBProperty } from "@data/kb";
 import type { Fact } from "@longterm-wiki/kb";
 import {
@@ -175,16 +174,14 @@ export function KBF({
           </span>
         )}
 
-        {/* entity.property key — link entity to its page if it exists */}
-        <span className="block text-muted-foreground/60 mt-1.5 font-mono text-[10px]">
-          {getEntityById(entity) ? (
-            <Link href={getEntityHref(entity)} className="text-primary hover:underline">
-              {entity}
-            </Link>
-          ) : (
-            entity
-          )}
-          .{property}
+        {/* Fact detail link */}
+        <span className="block mt-1.5">
+          <Link
+            href={`/kb/fact/${fact.id}`}
+            className="text-primary/70 hover:text-primary hover:underline font-mono text-[10px]"
+          >
+            {entity}.{property} →
+          </Link>
         </span>
       </span>
     </span>

--- a/apps/web/src/components/wiki/kb/KBAutoFacts.tsx
+++ b/apps/web/src/components/wiki/kb/KBAutoFacts.tsx
@@ -21,6 +21,7 @@ import type { Fact, Property, ItemEntry, FieldDef } from "@longterm-wiki/kb";
 import { formatKBDate, isUrl, shortDomain, titleCase } from "@components/wiki/kb/format";
 import { KBFactValueDisplay } from "@components/wiki/kb/KBFactValueDisplay";
 import { KBCellValue } from "@components/wiki/kb/KBCellValue";
+import Link from "next/link";
 import {
   ChevronRight,
   ExternalLink,
@@ -460,12 +461,15 @@ export function KBAutoFacts({ entityId }: KBAutoFactsProps) {
         </summary>
 
         <div className="px-4 pb-4 pt-2 border-t border-border/50">
-          {/* Attribution */}
+          {/* Attribution + KB detail link */}
           <p className="text-xs text-muted-foreground/60 mb-3">
             Structured data for {entityName}.{" "}
-            <span className="text-muted-foreground/40">
-              Source: KB
-            </span>
+            <Link
+              href={`/kb/entity/${entityId}`}
+              className="text-primary/60 hover:text-primary hover:underline"
+            >
+              View full KB profile →
+            </Link>
           </p>
 
           {/* Facts table grouped by category */}

--- a/apps/web/src/components/wiki/kb/KBFactValue.tsx
+++ b/apps/web/src/components/wiki/kb/KBFactValue.tsx
@@ -12,7 +12,6 @@
 
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { getEntityById, getEntityHref } from "@data";
 import { getKBFacts, getKBLatest, getKBProperty, getKBFactVerification } from "@data/kb";
 import type { Fact } from "@longterm-wiki/kb";
 import { CURRENCIES, resolveCurrency } from "@longterm-wiki/kb/currencies";
@@ -150,15 +149,14 @@ export function KBFactValue({
             <VerificationDot verdict={verification} showLabel />
           </span>
         )}
-        <span className="block text-muted-foreground/60 mt-1.5 font-mono text-xs">
-          {getEntityById(entity) ? (
-            <Link href={getEntityHref(entity)} className="text-primary hover:underline">
-              {entity}
-            </Link>
-          ) : (
-            entity
-          )}
-          .{property}
+        {/* Fact detail link */}
+        <span className="block mt-1.5">
+          <Link
+            href={`/kb/fact/${fact.id}`}
+            className="text-primary/70 hover:text-primary hover:underline font-mono text-[10px]"
+          >
+            {entity}.{property} →
+          </Link>
         </span>
       </span>
     </span>

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -369,6 +369,7 @@ export function getKBDataNav(): NavSection[] {
         { label: "Facts Explorer", href: "/wiki/E1020" },
         { label: "Properties", href: "/wiki/E1021" },
         { label: "Entity Coverage", href: "/wiki/E1022" },
+        { label: "Items Explorer", href: "/wiki/E1026" },
       ],
     },
     {

--- a/content/docs/kb/items.mdx
+++ b/content/docs/kb/items.mdx
@@ -1,0 +1,9 @@
+---
+numericId: E1026
+title: "Items Explorer"
+description: "Browse all KB item entries across entities and collections"
+contentFormat: dashboard
+lastEdited: "2026-03-09"
+---
+
+<KBItemsExplorerContent />

--- a/crux/commands/context.ts
+++ b/crux/commands/context.ts
@@ -43,6 +43,7 @@ import type {
 import { githubApi, REPO } from '../lib/github.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
+import { buildKbContextForPage } from '../lib/kb-context.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -487,6 +488,20 @@ async function forEntity(
     bundle += factsBlock(factsResult.data.facts);
   }
 
+  // KB structured facts (from packages/kb/data/things/*.yaml)
+  const kbContext = await buildKbContextForPage(
+    e.numericId ?? '',
+    `${entityId}.mdx`,
+  ).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`KB context load failed: ${msg}`);
+    return null;
+  });
+  if (kbContext) {
+    bundle += `## KB Structured Facts\n\n\`\`\`\n${kbContext}\n\`\`\`\n\n`;
+    bundle += `> View full KB profile: /kb/entity/${entityId}\n\n`;
+  }
+
   if (e.relatedEntries?.length) {
     bundle += `## Related Entities\n\n`;
     for (const r of e.relatedEntries.slice(0, 10)) {
@@ -526,6 +541,7 @@ async function forEntity(
     `${c.green}✓${c.reset} Context bundle written to ${c.cyan}${outputPath}${c.reset}`,
     `  Entity: ${e.title} (${entityId}) [${e.entityType}]`,
     factsResult.ok ? `  Facts: ${factsResult.data.facts.length}` : '',
+    kbContext ? `  KB structured facts: included` : '',
     pageSearchResult.ok ? `  Pages mentioning entity: ${pageSearchResult.data.results.length}` : '',
   ]
     .filter(Boolean)

--- a/crux/commands/kb.ts
+++ b/crux/commands/kb.ts
@@ -616,6 +616,239 @@ async function coverageCommand(
   return { exitCode: 0, output: lines.join('\n') };
 }
 
+// ── fact command ─────────────────────────────────────────────────────────
+
+async function factCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const factId = args.find((a) => !a.startsWith('--'));
+
+  if (!factId) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux kb fact <fact-id>
+
+  Show a single fact with full metadata.
+
+Examples:
+  crux kb fact f_dW5cR9mJ8q`,
+    };
+  }
+
+  const graph = await loadGraph();
+
+  // Search all entities for this fact
+  for (const entity of graph.getAllEntities()) {
+    const facts = graph.getFacts(entity.id);
+    const match = facts.find((f: Fact) => f.id === factId);
+    if (match) {
+      const property = graph.getProperty(match.propertyId);
+      const val = formatFactValue(match, property, graph);
+
+      if (options.ci) {
+        return { exitCode: 0, output: JSON.stringify({ entity: entity.id, entityName: entity.name, fact: match, formattedValue: val }) };
+      }
+
+      const lines: string[] = [];
+      lines.push(`\x1b[1m${match.id}\x1b[0m`);
+      lines.push(`Entity:   ${entity.name} (${entity.id})`);
+      lines.push(`Property: ${property?.name ?? match.propertyId} (${match.propertyId})`);
+      lines.push(`Value:    ${val}`);
+      if (match.asOf) lines.push(`As of:    ${match.asOf}`);
+      if (match.validEnd) lines.push(`Valid until: ${match.validEnd}`);
+      if (match.source) lines.push(`Source:   ${match.source}`);
+      if (match.sourceResource) lines.push(`Source Resource: ${match.sourceResource}`);
+      if (match.notes) lines.push(`Notes:    ${match.notes}`);
+      if (match.currency) lines.push(`Currency: ${match.currency}`);
+      lines.push(`\nWeb: /kb/fact/${match.id}`);
+      lines.push(`Entity page: /kb/entity/${entity.id}#${match.propertyId}`);
+      return { exitCode: 0, output: lines.join('\n') };
+    }
+  }
+
+  return { exitCode: 1, output: `Fact not found: ${factId}` };
+}
+
+// ── stale command ────────────────────────────────────────────────────────
+
+async function staleCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const daysStr = args.find((a) => !a.startsWith('--')) ?? '180';
+  const days = parseInt(daysStr, 10);
+  if (isNaN(days) || days <= 0) {
+    return { exitCode: 1, output: `Invalid days: ${daysStr}` };
+  }
+
+  const graph = await loadGraph();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+  interface StaleEntry { entityId: string; entityName: string; propertyId: string; propertyName: string; asOf: string; factId: string; }
+  const stale: StaleEntry[] = [];
+
+  for (const entity of graph.getAllEntities()) {
+    const facts = graph.getFacts(entity.id);
+    // Group by property, take latest per property
+    const latestByProp = new Map<string, Fact>();
+    for (const f of facts) {
+      if (f.propertyId === 'description') continue;
+      if (f.id.startsWith('inv_')) continue;
+      const existing = latestByProp.get(f.propertyId);
+      if (!existing || (f.asOf && (!existing.asOf || f.asOf > existing.asOf))) {
+        latestByProp.set(f.propertyId, f);
+      }
+    }
+
+    for (const [propertyId, fact] of latestByProp) {
+      if (fact.asOf && fact.asOf < cutoffStr) {
+        const property = graph.getProperty(propertyId);
+        stale.push({
+          entityId: entity.id,
+          entityName: entity.name,
+          propertyId,
+          propertyName: property?.name ?? propertyId,
+          asOf: fact.asOf,
+          factId: fact.id,
+        });
+      }
+    }
+  }
+
+  stale.sort((a, b) => a.asOf.localeCompare(b.asOf));
+
+  const limit = options.limit ? parseInt(String(options.limit), 10) : 30;
+  const shown = stale.slice(0, limit);
+
+  if (options.ci) {
+    return { exitCode: 0, output: JSON.stringify(stale) };
+  }
+
+  if (stale.length === 0) {
+    return { exitCode: 0, output: `No facts older than ${days} days found.` };
+  }
+
+  const lines: string[] = [];
+  lines.push(`\x1b[1mStale facts (older than ${days} days, cutoff: ${cutoffStr}):\x1b[0m`);
+  lines.push('');
+  const header = `${'Entity'.padEnd(24)} ${'Property'.padEnd(24)} ${'As Of'.padEnd(12)} Fact ID`;
+  lines.push(header);
+  lines.push('-'.repeat(header.length + 16));
+  for (const s of shown) {
+    lines.push(`${s.entityName.slice(0, 23).padEnd(24)} ${s.propertyName.slice(0, 23).padEnd(24)} ${s.asOf.padEnd(12)} ${s.factId}`);
+  }
+  if (stale.length > limit) {
+    lines.push(`\n... and ${stale.length - limit} more (use --limit=${stale.length} to see all)`);
+  }
+  lines.push(`\nTotal: ${stale.length} stale facts`);
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+// ── needs-update command ─────────────────────────────────────────────────
+
+async function needsUpdateCommand(
+  args: string[],
+  options: KBCommandOptions,
+): Promise<CommandResult> {
+  const entityId = args.find((a) => !a.startsWith('--'));
+
+  if (!entityId) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux kb needs-update <entity-id>
+
+  Show what data is missing or stale for an entity.
+
+Examples:
+  crux kb needs-update anthropic
+  crux kb needs-update openai`,
+    };
+  }
+
+  const graph = await loadGraph();
+  const entity = graph.getEntity(entityId);
+
+  if (!entity) {
+    return { exitCode: 1, output: `Entity not found: ${entityId}` };
+  }
+
+  // Get applicable properties for this entity type
+  const allProperties = graph.getAllProperties().filter((p) => !p.computed);
+  const applicable = allProperties.filter((p) =>
+    !p.appliesTo || p.appliesTo.length === 0 || p.appliesTo.includes(entity.type),
+  );
+
+  const facts = graph.getFacts(entity.id).filter((f: Fact) => !f.id.startsWith('inv_'));
+  const usedProps = new Set(facts.map((f: Fact) => f.propertyId));
+
+  // Missing properties
+  const missing = applicable.filter((p) => !usedProps.has(p.id));
+
+  // Stale properties (latest fact > 180 days old)
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 180);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+  interface StaleProperty { property: typeof applicable[0]; latestAsOf: string; }
+  const staleProps: StaleProperty[] = [];
+
+  for (const prop of applicable) {
+    if (!usedProps.has(prop.id)) continue;
+    const propFacts = facts.filter((f: Fact) => f.propertyId === prop.id);
+    const latest = propFacts.reduce((best: Fact | null, f: Fact) =>
+      !best || (f.asOf && (!best.asOf || f.asOf > best.asOf)) ? f : best, null);
+    if (latest?.asOf && latest.asOf < cutoffStr) {
+      staleProps.push({ property: prop, latestAsOf: latest.asOf });
+    }
+  }
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        entityId: entity.id,
+        entityName: entity.name,
+        entityType: entity.type,
+        totalApplicable: applicable.length,
+        totalUsed: usedProps.size,
+        missing: missing.map((p) => ({ id: p.id, name: p.name, category: p.category })),
+        stale: staleProps.map((s) => ({ id: s.property.id, name: s.property.name, latestAsOf: s.latestAsOf })),
+      }),
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`\x1b[1m${entity.name}\x1b[0m (${entity.id}) — ${entity.type}`);
+  lines.push(`Properties: ${usedProps.size}/${applicable.length} used (${Math.round((usedProps.size / applicable.length) * 100)}%)`);
+  lines.push('');
+
+  if (missing.length > 0) {
+    lines.push(`\x1b[33mMissing properties (${missing.length}):\x1b[0m`);
+    for (const p of missing.slice(0, 20)) {
+      lines.push(`  ${p.id.padEnd(28)} ${p.name} ${p.category ? `[${p.category}]` : ''}`);
+    }
+    if (missing.length > 20) lines.push(`  ... and ${missing.length - 20} more`);
+    lines.push('');
+  }
+
+  if (staleProps.length > 0) {
+    lines.push(`\x1b[31mStale properties (>${cutoffStr}):\x1b[0m`);
+    for (const s of staleProps) {
+      lines.push(`  ${s.property.id.padEnd(28)} ${s.property.name.padEnd(20)} last: ${s.latestAsOf}`);
+    }
+    lines.push('');
+  }
+
+  if (missing.length === 0 && staleProps.length === 0) {
+    lines.push('\x1b[32mAll applicable properties are present and up-to-date.\x1b[0m');
+  }
+
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
 // ── Exports ─────────────────────────────────────────────────────────────
 
 export const commands = {
@@ -626,6 +859,9 @@ export const commands = {
   properties: propertiesCommand,
   search: searchCommand,
   coverage: coverageCommand,
+  fact: factCommand,
+  stale: staleCommand,
+  'needs-update': needsUpdateCommand,
   migrate: kbMigrateCommands.default,
 };
 
@@ -641,30 +877,25 @@ Commands:
   properties [--type=X] List all property definitions with usage counts
   search <query>        Search entities by name, ID, or alias
   coverage [--type=X]   Show entity coverage against required/recommended properties
+  fact <fact-id>        Show a single fact with full metadata
+  stale [days]          List facts older than N days (default: 180)
+  needs-update <id>     Show missing and stale data for an entity
   migrate <slug>        Migrate entity from old system to KB [--dry-run] [--stub-old]
 
 Options:
   --type=X              Filter list/search/coverage by entity type (e.g. organization, person)
-  --limit=N             Limit number of results (list only)
+  --limit=N             Limit number of results
   --ci                  JSON output
   --errors-only         Show only errors (validate)
   --rule=X              Filter by rule name (validate)
-  --dry-run             Preview migration without writing files (migrate only)
-  --stub-old            Strip old entity to stub after migration (migrate only)
-  --force               Overwrite existing KB thing file (migrate only)
 
 Examples:
   crux kb show anthropic              Show Anthropic with all facts and items
-  crux kb show dario-amodei           Show a person entity
-  crux kb list                        List all entities
   crux kb list --type=person          List only person entities
-  crux kb lookup mK9pX3rQ7n           Look up entity by stableId
-  crux kb properties                  List all properties with usage stats
   crux kb search anthropic            Find entities matching "anthropic"
-  crux kb search amodei --type=person Search only person entities
-  crux kb coverage                    Show all entities scored by property coverage
-  crux kb coverage --type=organization Organizations only
-  crux kb migrate ajeya-cotra --dry-run   Preview entity migration
-  crux kb migrate ajeya-cotra --stub-old  Migrate + strip old entity
+  crux kb fact f_dW5cR9mJ8q           Show fact details
+  crux kb stale 90                    Facts older than 90 days
+  crux kb needs-update anthropic      What's missing for Anthropic
+  crux kb coverage --type=organization Organizations property coverage
 `;
 }


### PR DESCRIPTION
## Summary
Six KB improvements from the [improvement plan](https://github.com/quantified-uncertainty/longterm-wiki/discussions/1981#discussioncomment-16058196):

- **Link KBF tooltips to /kb detail pages**: `<KBF>` and `<KBFactValue>` tooltips now link to `/kb/fact/{id}` instead of wiki entity pages, connecting wiki prose to the KB debug views
- **"View full KB profile" link**: KBAutoFacts structured data cards on wiki pages now link to `/kb/entity/{id}`
- **Anchor IDs on entity pages**: Facts and item collections have anchor IDs (`/kb/entity/anthropic#revenue`, `#items-funding-rounds`) for direct linking
- **Items Explorer** (`/wiki/E1026`): New searchable table of all KB items across entities and collections, added to sidebar
- **CLI commands**: `crux kb fact`, `crux kb stale`, `crux kb needs-update` for agent access to KB data
- **Context assembly integration**: `crux context for-entity` now includes KB structured facts from YAML

## Test plan
- [x] `pnpm build` — all pages generate (708 wiki + all KB pages)
- [x] `pnpm test` — 2527 pass (10 pre-existing failures on main)
- [x] `crux kb fact f_qR5tY9wE1a` returns correct Anthropic revenue fact
- [x] `crux kb stale 90` lists 97 stale facts
- [x] `crux kb needs-update anthropic` shows 10 missing + 6 stale properties

Closes discussion items 1, 5, 7, 9 from #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced KB Items Explorer dashboard to browse all KB item entries across entities and collections with search, sorting, and filtering capabilities.
  * Added in-page anchor linking and smooth scrolling on KB entity detail pages.
  * Direct fact detail pages accessible from KB references throughout the application.
  * New CLI commands for KB management: `fact` (search facts), `stale` (identify outdated facts), and `needs-update` (review missing/stale properties).

* **Documentation**
  * Added documentation for the KB Items Explorer dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->