### PR TITLE
fix: demote missing-issue-ref to advisory-only in PR Patrol

### DIFF
--- a/crux/lib/pr-analysis/index.ts
+++ b/crux/lib/pr-analysis/index.ts
@@ -37,6 +37,8 @@ export type {
   AutoRebaseResult,
 } from './types.ts';
 
+export { ADVISORY_ISSUES } from './types.ts';
+
 // ── Detection ────────────────────────────────────────────────────────────────
 
 export {

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -18,6 +18,14 @@ export type PrIssueType =
   | 'bot-review-major'
   | 'bot-review-nitpick';
 
+/** Issues that are logged but not fixed — advisory only.
+ *  These are still detected by the shared library but filtered out by the
+ *  PR Patrol daemon before scoring/fixing. They waste budget (e.g.,
+ *  missing-issue-ref consistently hits max-turns with no useful outcome). */
+export const ADVISORY_ISSUES: ReadonlySet<PrIssueType> = new Set([
+  'missing-issue-ref',
+]);
+
 export interface BotComment {
   threadId: string;
   path: string;

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -23,6 +23,7 @@ import type {
   PatrolConfig,
 } from './types.ts';
 import { LABELS } from './types.ts';
+import { ADVISORY_ISSUES } from '../lib/pr-analysis/types.ts';
 import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import {
   appendJsonl,
@@ -71,13 +72,18 @@ export function detectAllPrIssuesFromNodes(
       return true;
     })
     .map((pr) => {
-      const { issues, botComments } = libDetectIssues(pr, staleThresholdMs);
+      const { issues: allIssues, botComments } = libDetectIssues(pr, staleThresholdMs);
+      const advisoryIssues = allIssues.filter((i) => ADVISORY_ISSUES.has(i));
+      const fixableIssues = allIssues.filter((i) => !ADVISORY_ISSUES.has(i));
+      if (advisoryIssues.length > 0) {
+        log(`  PR #${pr.number}: advisory issues (skipped): ${advisoryIssues.join(', ')}`);
+      }
       return {
         number: pr.number,
         title: pr.title,
         branch: pr.headRefName,
         createdAt: pr.createdAt,
-        issues,
+        issues: fixableIssues,
         botComments,
         labels: pr.labels.nodes.map((l) => l.name),
       };

--- a/crux/pr-patrol/format.ts
+++ b/crux/pr-patrol/format.ts
@@ -372,7 +372,7 @@ ${c.bold}Issue Types${c.reset} ${c.dim}(by priority score)${c.reset}
   ${c.red}conflict${c.reset}            ${c.dim}(100)${c.reset}  PR has merge conflicts with main
   ${c.red}ci-failure${c.reset}           ${c.dim}(80)${c.reset}   CI checks are failing
   ${c.yellow}bot-review-major${c.reset}    ${c.dim}(55)${c.reset}   Bot reviewers flagged critical/major issues
-  ${c.yellow}missing-issue-ref${c.reset}   ${c.dim}(40)${c.reset}   PR body lacks "Closes #N" reference
+  ${c.dim}missing-issue-ref${c.reset}   ${c.dim}(40)${c.reset}   PR body lacks "Closes #N" reference ${c.dim}(advisory only)${c.reset}
   ${c.yellow}stale${c.reset}               ${c.dim}(30)${c.reset}   PR not updated in 48+ hours
   ${c.dim}missing-testplan${c.reset}    ${c.dim}(20)${c.reset}   PR body lacks "## Test plan" section
   ${c.dim}bot-review-nitpick${c.reset}  ${c.dim}(15)${c.reset}   Bot reviewers left minor nitpick comments

--- a/crux/pr-patrol/index.test.ts
+++ b/crux/pr-patrol/index.test.ts
@@ -494,7 +494,9 @@ describe('findMergeCandidates', () => {
 // ── computeBudget ────────────────────────────────────────────────────────────
 
 describe('computeBudget', () => {
-  it('gives small budget for missing-issue-ref only', () => {
+  it('returns default budget for advisory-only issue (missing-issue-ref)', () => {
+    // missing-issue-ref is advisory-only and has no budget entry;
+    // computeBudget returns the default minimum budget
     const budget = computeBudget(['missing-issue-ref']);
     expect(budget.maxTurns).toBe(5);
     expect(budget.timeoutMinutes).toBe(3);

--- a/crux/pr-patrol/scoring.test.ts
+++ b/crux/pr-patrol/scoring.test.ts
@@ -69,7 +69,9 @@ describe('computeScore', () => {
 // ── computeBudget ────────────────────────────────────────────────────────────
 
 describe('computeBudget', () => {
-  it('gives small budget for missing-issue-ref only', () => {
+  it('returns default budget for advisory-only issue (missing-issue-ref)', () => {
+    // missing-issue-ref is advisory-only and has no budget entry;
+    // computeBudget returns the default minimum budget
     const budget = computeBudget(['missing-issue-ref']);
     expect(budget.maxTurns).toBe(5);
     expect(budget.timeoutMinutes).toBe(3);

--- a/crux/pr-patrol/scoring.ts
+++ b/crux/pr-patrol/scoring.ts
@@ -26,11 +26,12 @@ export interface IssueBudget {
   timeoutMinutes: number;
 }
 
-const ISSUE_BUDGETS: Record<PrIssueType, IssueBudget> = {
+// Note: missing-issue-ref is an advisory-only issue (see ADVISORY_ISSUES in types.ts)
+// and is filtered out before reaching the budget system, so it's not listed here.
+const ISSUE_BUDGETS: Partial<Record<PrIssueType, IssueBudget>> = {
   conflict:            { maxTurns: 60, timeoutMinutes: 60 },
   'ci-failure':        { maxTurns: 50, timeoutMinutes: 45 },
   'bot-review-major':  { maxTurns: 50, timeoutMinutes: 45 },
-  'missing-issue-ref': { maxTurns: 5,  timeoutMinutes: 3 },
   stale:               { maxTurns: 10, timeoutMinutes: 5 },
   'missing-testplan':  { maxTurns: 8,  timeoutMinutes: 5 },
   'bot-review-nitpick':{ maxTurns: 8,  timeoutMinutes: 5 },
@@ -42,6 +43,7 @@ export function computeBudget(issues: PrIssueType[]): IssueBudget {
   let timeoutMinutes = 3;
   for (const issue of issues) {
     const budget = ISSUE_BUDGETS[issue];
+    if (!budget) continue; // advisory-only issues have no budget entry
     if (budget.maxTurns > maxTurns) maxTurns = budget.maxTurns;
     if (budget.timeoutMinutes > timeoutMinutes) timeoutMinutes = budget.timeoutMinutes;
   }


### PR DESCRIPTION
## Summary
- `missing-issue-ref` is now advisory-only: detected and logged but not sent to Claude for fixing
- This issue type consistently hit max-turns (5) and got abandoned — very low ROI
- The daemon detection layer filters advisory issues out before scoring/fixing
- Budget entry removed from `ISSUE_BUDGETS`; `explain` command shows it as "(advisory only)"

## Changes
- `crux/lib/pr-analysis/types.ts`: Added `ADVISORY_ISSUES` set
- `crux/pr-patrol/detection.ts`: Filters advisory issues from fixable issues
- `crux/pr-patrol/scoring.ts`: Removed budget entry, made type `Partial<Record>`
- `crux/pr-patrol/format.ts`: Shows advisory label in explain output

## Test plan
- [x] All 136 pr-patrol tests pass
- [x] TypeScript compilation clean
- [x] Advisory issues logged but excluded from fix queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced advisory issues classification for issues detected but not automatically fixed
  * "missing-issue-ref" now classified as advisory only and excluded from scoring
  * Advisory issues filtered from automated fixing processes
  * Display updated to mark advisory issues in reporting

* **Tests**
  * Updated test descriptions to reflect advisory issue behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->