### PR TITLE
fix: resolve KB component rendering bugs

### DIFF
--- a/apps/web/src/components/wiki/EntityLink.tsx
+++ b/apps/web/src/components/wiki/EntityLink.tsx
@@ -80,6 +80,7 @@ export function EntityLink({
             "absolute left-0 top-full mt-1 z-50 w-[280px] p-3 bg-popover text-popover-foreground border rounded-md shadow-md pointer-events-none opacity-0 invisible"
           )}
           role="tooltip"
+          aria-hidden="true"
         >
           {entityType && (
             <span className="flex items-center gap-1.5 mb-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/wiki/kb/KBAutoFacts.tsx
+++ b/apps/web/src/components/wiki/kb/KBAutoFacts.tsx
@@ -442,7 +442,7 @@ export function KBAutoFacts({ entityId }: KBAutoFactsProps) {
           <span className="text-sm font-semibold text-foreground">
             Structured Data
           </span>
-          <span className="text-xs text-muted-foreground flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground flex items-center gap-1.5 ml-1">
             {substantiveFacts.length > 0 && (
               <span>
                 {substantiveFacts.length}{" "}

--- a/apps/web/src/components/wiki/kb/KBCellValue.tsx
+++ b/apps/web/src/components/wiki/kb/KBCellValue.tsx
@@ -75,7 +75,7 @@ export function KBCellValue({ value, fieldName, fieldDef }: KBCellValueProps) {
   if (fieldType === "boolean" || typeof value === "boolean") {
     return (
       <span className="text-muted-foreground">
-        {value ? "\u2713" : "\u2014"}
+        {value ? "\u2713" : "\u2717"}
       </span>
     );
   }

--- a/apps/web/src/components/wiki/kb/KBFactTable.tsx
+++ b/apps/web/src/components/wiki/kb/KBFactTable.tsx
@@ -37,7 +37,6 @@ interface KBFactTableProps {
 export function KBFactTable({ entity, property, title, includeExpired }: KBFactTableProps) {
   const allFacts = getKBFacts(entity, property);
   const facts = includeExpired ? allFacts : allFacts.filter((f) => !isFactExpired(f));
-  const expiredCount = allFacts.length - facts.length;
   const prop = getKBProperty(property);
   const heading = title ?? prop?.name ?? property;
 

--- a/apps/web/src/components/wiki/kb/format.ts
+++ b/apps/web/src/components/wiki/kb/format.ts
@@ -67,7 +67,7 @@ export function formatKBNumber(
     }
     const formatted = Number.isInteger(num)
       ? num.toLocaleString()
-      : num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+      : num.toLocaleString("en-US", { maximumFractionDigits: 2 });
     // If currency override provided and display has a currency-like prefix, use currency symbol
     let prefix = display.prefix ?? "";
     if (currency && Object.hasOwn(CURRENCIES, currency)) {

--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -87,14 +87,14 @@ facts:
     property: valuation
     value: 61.5e9
     asOf: 2025-03
-    source: https://www.anthropic.com/news/series-e
+    source: https://www.anthropic.com/news/anthropic-raises-series-e-at-usd61-5b-post-money-valuation
     notes: "Series E post-money valuation"
 
   - id: f_val_2025_09
     property: valuation
     value: 183e9
     asOf: 2025-09
-    source: https://www.anthropic.com/news/series-f
+    source: https://www.anthropic.com/news/anthropic-raises-series-f-at-usd183b-post-money-valuation
     notes: "Series F post-money valuation"
 
   - id: f_mN3pQ7kX2r
@@ -839,7 +839,7 @@ items:
         valuation: 61.5e9
         instrument: equity
         lead_investor: lightspeed
-        source: https://www.anthropic.com/news/series-e
+        source: https://www.anthropic.com/news/anthropic-raises-series-e-at-usd61-5b-post-money-valuation
         notes: "Led by Lightspeed Venture Partners. ~5.7% dilution."
 
       i_R6dd3cZH8A:
@@ -849,7 +849,7 @@ items:
         valuation: 183e9
         instrument: equity
         lead_investor: iconiq
-        source: https://www.anthropic.com/news/series-f
+        source: https://www.anthropic.com/news/anthropic-raises-series-f-at-usd183b-post-money-valuation
         notes: "Led by ICONIQ, Fidelity, Lightspeed. ARR had reached $4B. ~7.1% dilution."
 
       i_Qci9UDdgkw:


### PR DESCRIPTION
## Summary
- Fix missing spacing between "Structured Data" heading and fact count badges in KBAutoFacts
- Add `aria-hidden` to EntityLink tooltip spans to prevent tooltip text from leaking into table cell text content (affects KBAutoFacts item tables)
- Update 4 broken Anthropic source URLs (Series E and F announcements moved to longer slugs)
- Distinguish boolean `false` (✗) from missing data (—) in KB cell values
- Fix locale inconsistency in KB number formatting (use `en-US` instead of system locale)
- Remove unused `expiredCount` variable in KBFactTable

## Test plan
- [ ] `pnpm build` passes
- [ ] Verify Anthropic page Structured Data section renders with proper spacing
- [ ] Verify EntityLink tooltips don't pollute table cell text in KBAutoFacts
- [ ] Verify source links for Anthropic Series E/F resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)