### PR TITLE
Add 13 toggleable columns to Facts Explorer

### DIFF
--- a/apps/web/src/app/kb/kb-facts-content.tsx
+++ b/apps/web/src/app/kb/kb-facts-content.tsx
@@ -21,6 +21,22 @@ export interface FactRow {
   source: string;
   sourceResource: string | undefined;
   hasSource: boolean;
+  valueType: string;
+  notes: string;
+  sourceQuote: string;
+  validEnd: string;
+  isCurrent: boolean;
+  derivedFrom: string;
+  currency: string;
+  usdEquivalent: number | null;
+  unit: string;
+  temporal: boolean;
+  /** Months since asOf date (for sorting). -1 = unknown, negative = future. */
+  freshnessMonths: number;
+  /** Human-readable freshness label */
+  freshnessLabel: string;
+  /** Filled optional metadata fields out of 4 (source, asOf, notes, sourceQuote) */
+  completenessScore: number;
 }
 
 function resolveRefDisplayNames(
@@ -39,6 +55,28 @@ function resolveRefDisplayNames(
     });
   }
   return null;
+}
+
+/** Returns { months, label } — months is raw count for sorting, label is display string.
+ *  Computed at build time so freshness reflects the build date, not viewer's clock. */
+function computeFreshness(asOf: string | undefined): {
+  months: number;
+  label: string;
+} {
+  if (!asOf) return { months: -1, label: "Unknown" };
+  const now = new Date();
+  const parts = asOf.split("-").map(Number);
+  const date = new Date(parts[0], (parts[1] ?? 1) - 1, parts[2] ?? 1);
+  const months = Math.floor(
+    (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24 * 30.44),
+  );
+  if (months < 0) return { months, label: "Future" };
+  if (months < 1) return { months: 0, label: "< 1 month" };
+  if (months < 12) return { months, label: `${months}mo` };
+  const years = Math.floor(months / 12);
+  const rem = months % 12;
+  const label = rem > 0 ? `${years}y ${rem}mo` : `${years}y`;
+  return { months, label };
 }
 
 export function KBFactsExplorerContent() {
@@ -66,6 +104,15 @@ export function KBFactsExplorerContent() {
 
       const refNames = resolveRefDisplayNames(fact, entitiesById);
 
+      const completeness = [
+        fact.source || fact.sourceResource,
+        fact.asOf,
+        fact.notes,
+        fact.sourceQuote,
+      ].filter(Boolean).length;
+
+      const freshness = computeFreshness(fact.asOf);
+
       rows.push({
         factId: fact.id,
         entityId: entity.id,
@@ -80,6 +127,19 @@ export function KBFactsExplorerContent() {
         source: fact.source ?? "",
         sourceResource: fact.sourceResource,
         hasSource: !!(fact.source || fact.sourceResource),
+        valueType: fact.value.type,
+        notes: fact.notes ?? "",
+        sourceQuote: fact.sourceQuote ?? "",
+        validEnd: formatKBDate(fact.validEnd),
+        isCurrent: !fact.validEnd,
+        derivedFrom: fact.derivedFrom ?? "",
+        currency: fact.currency ?? "",
+        usdEquivalent: fact.usdEquivalent ?? null,
+        unit: property?.unit ?? "",
+        temporal: property?.temporal ?? false,
+        freshnessMonths: freshness.months,
+        freshnessLabel: freshness.label,
+        completenessScore: completeness,
       });
     }
   }

--- a/apps/web/src/app/kb/kb-facts-table.tsx
+++ b/apps/web/src/app/kb/kb-facts-table.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import Link from "next/link";
 import type {
   ColumnDef,
   SortingState,
+  VisibilityState,
 } from "@tanstack/react-table";
 import {
   getCoreRowModel,
@@ -12,7 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { Search } from "lucide-react";
+import { Search, Columns3 } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
 import type { FactRow } from "./kb-facts-content";
@@ -21,7 +22,15 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "\u2026" : s;
 }
 
-const columns: ColumnDef<FactRow>[] = [
+const COMPLETENESS_COLORS = [
+  "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300",
+  "bg-lime-100 text-lime-700 dark:bg-lime-900/40 dark:text-lime-300",
+  "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+];
+
+const allColumns: ColumnDef<FactRow>[] = [
   {
     accessorKey: "entityName",
     header: ({ column }) => (
@@ -70,11 +79,26 @@ const columns: ColumnDef<FactRow>[] = [
       <SortableHeader column={column}>Value</SortableHeader>
     ),
     cell: ({ row }) => (
-      <span className="text-xs font-medium tabular-nums" title={row.original.displayValue}>
+      <span
+        className="text-xs font-medium tabular-nums"
+        title={row.original.displayValue}
+      >
         {truncate(row.original.displayValue, 60)}
       </span>
     ),
     size: 200,
+  },
+  {
+    accessorKey: "valueType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Value Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground font-mono">
+        {row.original.valueType}
+      </span>
+    ),
+    size: 80,
   },
   {
     accessorKey: "asOf",
@@ -86,6 +110,45 @@ const columns: ColumnDef<FactRow>[] = [
         {row.original.asOf}
       </span>
     ),
+    size: 90,
+  },
+  {
+    accessorKey: "validEnd",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Valid End</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {row.original.validEnd}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    accessorKey: "isCurrent",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Current</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span
+        className={`text-xs font-medium ${row.original.isCurrent ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}
+      >
+        {row.original.isCurrent ? "Yes" : "No"}
+      </span>
+    ),
+    size: 70,
+  },
+  {
+    accessorKey: "freshnessMonths",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Freshness</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {row.original.freshnessLabel}
+      </span>
+    ),
+    sortingFn: "basic",
     size: 90,
   },
   {
@@ -108,11 +171,156 @@ const columns: ColumnDef<FactRow>[] = [
         );
       }
       if (row.original.sourceResource) {
-        return <span className="text-xs text-muted-foreground">{row.original.sourceResource}</span>;
+        return (
+          <span className="text-xs text-muted-foreground">
+            {row.original.sourceResource}
+          </span>
+        );
       }
-      return <span className="text-xs text-muted-foreground/30">&mdash;</span>;
+      return <span className="text-muted-foreground/40 text-xs">-</span>;
     },
     size: 70,
+  },
+  {
+    accessorKey: "sourceQuote",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Source Quote</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.sourceQuote ? (
+        <span
+          className="text-xs text-muted-foreground italic"
+          title={row.original.sourceQuote}
+        >
+          {truncate(row.original.sourceQuote, 60)}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 200,
+  },
+  {
+    accessorKey: "notes",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Notes</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.notes ? (
+        <span
+          className="text-xs text-muted-foreground"
+          title={row.original.notes}
+        >
+          {truncate(row.original.notes, 60)}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 200,
+  },
+  {
+    accessorKey: "entityType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Entity Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs capitalize text-muted-foreground">
+        {row.original.entityType}
+      </span>
+    ),
+    size: 110,
+  },
+  {
+    accessorKey: "unit",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Unit</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.unit ? (
+        <span className="text-xs text-muted-foreground font-mono">
+          {row.original.unit}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 80,
+  },
+  {
+    accessorKey: "temporal",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Temporal</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.temporal ? (
+        <span className="text-xs text-blue-600 dark:text-blue-400">Yes</span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 70,
+  },
+  {
+    accessorKey: "currency",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Currency</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.currency ? (
+        <span className="text-xs text-muted-foreground font-mono">
+          {row.original.currency}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 70,
+  },
+  {
+    accessorKey: "usdEquivalent",
+    header: ({ column }) => (
+      <SortableHeader column={column}>USD Equiv</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const v = row.original.usdEquivalent;
+      return v != null ? (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          ${v.toLocaleString()}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      );
+    },
+    sortUndefined: "last",
+    size: 100,
+  },
+  {
+    accessorKey: "derivedFrom",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Derived From</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.derivedFrom ? (
+        <span className="text-xs text-muted-foreground font-mono">
+          {truncate(row.original.derivedFrom, 30)}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/40 text-xs">-</span>
+      ),
+    size: 120,
+  },
+  {
+    accessorKey: "completenessScore",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Completeness</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const score = row.original.completenessScore;
+      return (
+        <span
+          className={`inline-flex items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${COMPLETENESS_COLORS[score] ?? COMPLETENESS_COLORS[0]}`}
+        >
+          {score}/4
+        </span>
+      );
+    },
+    size: 90,
   },
   {
     accessorKey: "factId",
@@ -133,6 +341,23 @@ const columns: ColumnDef<FactRow>[] = [
   },
 ];
 
+// Columns hidden by default — everything not listed here is visible
+const DEFAULT_HIDDEN: VisibilityState = {
+  valueType: false,
+  validEnd: false,
+  isCurrent: false,
+  freshnessMonths: false,
+  sourceQuote: false,
+  notes: false,
+  entityType: false,
+  unit: false,
+  temporal: false,
+  currency: false,
+  usdEquivalent: false,
+  derivedFrom: false,
+  completenessScore: false,
+};
+
 export function KBFactsTable({ data }: { data: FactRow[] }) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "entityName", desc: false },
@@ -141,6 +366,32 @@ export function KBFactsTable({ data }: { data: FactRow[] }) {
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [sourceFilter, setSourceFilter] = useState<string>("all");
+  const [columnVisibility, setColumnVisibility] =
+    useState<VisibilityState>(DEFAULT_HIDDEN);
+  const [showColumnPicker, setShowColumnPicker] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Close column picker on click outside
+  useEffect(() => {
+    if (!showColumnPicker) return;
+    function handler(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setShowColumnPicker(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showColumnPicker]);
+
+  // Close column picker on Escape
+  useEffect(() => {
+    if (!showColumnPicker) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key === "Escape") setShowColumnPicker(false);
+    }
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [showColumnPicker]);
 
   const entityTypes = useMemo(() => {
     const types = new Set(data.map((r) => r.entityType));
@@ -170,10 +421,11 @@ export function KBFactsTable({ data }: { data: FactRow[] }) {
 
   const table = useReactTable({
     data: filteredData,
-    columns,
-    state: { sorting, globalFilter },
+    columns: allColumns,
+    state: { sorting, globalFilter, columnVisibility },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
+    onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -185,6 +437,7 @@ export function KBFactsTable({ data }: { data: FactRow[] }) {
         r.propertyName.toLowerCase().includes(search) ||
         r.displayValue.toLowerCase().includes(search) ||
         r.category.toLowerCase().includes(search) ||
+        r.notes.toLowerCase().includes(search) ||
         r.factId.toLowerCase().includes(search)
       );
     },
@@ -192,7 +445,7 @@ export function KBFactsTable({ data }: { data: FactRow[] }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
         <div className="relative flex-1 min-w-[200px]">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <input
@@ -236,6 +489,38 @@ export function KBFactsTable({ data }: { data: FactRow[] }) {
           <option value="with-source">With source</option>
           <option value="without-source">Without source</option>
         </select>
+
+        {/* Column picker — same pattern as resources-data-table */}
+        <div className="relative" ref={pickerRef}>
+          <button
+            onClick={() => setShowColumnPicker((v) => !v)}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium border border-border rounded-md bg-background text-muted-foreground hover:bg-muted transition-colors"
+          >
+            <Columns3 className="h-3.5 w-3.5" />
+            Columns
+          </button>
+          {showColumnPicker && (
+            <div className="absolute right-0 top-full mt-1 z-50 bg-background border border-border rounded-lg shadow-lg p-2 min-w-[180px] max-h-80 overflow-y-auto">
+              {table.getAllLeafColumns().map((col) => (
+                <label
+                  key={col.id}
+                  className="flex items-center gap-2 px-2 py-1 text-xs hover:bg-muted rounded cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={col.getIsVisible()}
+                    onChange={col.getToggleVisibilityHandler()}
+                    className="rounded"
+                  />
+                  {typeof col.columnDef.header === "string"
+                    ? col.columnDef.header
+                    : col.id.charAt(0).toUpperCase() +
+                      col.id.slice(1).replace(/([A-Z])/g, " $1")}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
       <div className="text-xs text-muted-foreground">
         Showing {table.getFilteredRowModel().rows.length} of {data.length} facts


### PR DESCRIPTION
## Summary
- Adds 13 new columns to the KB Facts Explorer table (E1020): value type, valid end, current, freshness, source quote, notes, entity type, unit, temporal, currency, USD equivalent, derived from, and completeness score
- All new columns hidden by default — toggled via a "Columns" dropdown picker (reuses the `resources-data-table` inline picker pattern with TanStack's built-in `getToggleVisibilityHandler`)
- Freshness sorts numerically by month count, USD equivalent sorts as raw number, completeness uses a 0–4 color-coded badge with dark mode support

## Details
**Data layer** (`kb-facts-content.tsx`): Extended `FactRow` with 13 new fields pulled from `Fact` and `Property` types. Completeness counts 4 optional metadata fields (source, asOf, notes, sourceQuote). Freshness returns both a numeric month count (for sorting) and a human-readable label (for display), with "Future" handling for forward-dated facts.

**Table** (`kb-facts-table.tsx`): Added column definitions for all new fields. Column picker uses click-outside + Escape to close. Empty cells use consistent `-` pattern (matching resources table). All colors include `dark:` variants.

## Test plan
- [x] TypeScript type-check passes (no new errors beyond pre-existing Hono mismatch)
- [x] All 2561 tests pass (`pnpm test`)
- [x] `computeFreshness` edge cases verified: undefined, empty, future dates, year-only, recent, old
- [x] Column label derivation verified for all 20 column IDs
- [x] Build failure confirmed as pre-existing on main (wiki-server.ts Hono version mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)