### PR TITLE
fix: wrap MDX tables with overflow-x-auto

### DIFF
--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -229,6 +229,16 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   Tabs: MdxTabs,
   TabItem: MdxTabItem,
 
+  // Wrap markdown tables with overflow-x-auto to prevent horizontal page overflow
+  table: (props: React.ComponentProps<"table">) => (
+    <div className="overflow-x-auto">
+      <table {...props} />
+    </div>
+  ),
+
+  // Add scope="col" to th elements for accessibility
+  th: (props: React.ComponentProps<"th">) => <th scope="col" {...props} />,
+
   // Override sup to add rich tooltips on footnote superscripts
   sup: FootnoteSup,
 


### PR DESCRIPTION
## Summary
- MDX-authored markdown tables lacked overflow wrappers, causing horizontal page overflow on content-heavy pages like Anthropic (E22)
- KB auto-generated tables already had `overflow-x-auto` but MDX tables from `| ... |` syntax did not
- Added `table` component override in mdx-components.tsx to wrap all MDX tables with `overflow-x-auto`
- Added `scope="col"` to `th` elements for accessibility

## Test plan
- [ ] `pnpm build` passes
- [ ] Anthropic page (E22) no longer has horizontal overflow
- [ ] Tables on mobile viewports scroll horizontally within their container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown tables now handle overflow with horizontal scrolling when exceeding viewport width

* **Accessibility**
  * Table headers enhanced with proper semantic scope attributes for improved screen reader support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->