### PR TITLE
feat: add KB explorer pages (facts, properties, entity coverage)

### DIFF
--- a/apps/web/src/app/kb/kb-entities-content.tsx
+++ b/apps/web/src/app/kb/kb-entities-content.tsx
@@ -1,0 +1,90 @@
+import {
+  getKBEntities,
+  getKBProperties,
+  getKBFacts,
+  getKBItems,
+} from "@/data/kb";
+import { getEntityHref } from "@/data";
+import type { Fact, Entity } from "@longterm-wiki/kb";
+import { KBEntitiesTable } from "./kb-entities-table";
+
+export interface EntityRow {
+  entityId: string;
+  entityName: string;
+  entityHref: string;
+  entityType: string;
+  factCount: number;
+  propertyCount: number;
+  itemCount: number;
+  sourceCoverage: number;
+  properties: string[];
+}
+
+export function KBEntityCoverageContent() {
+  const entities = getKBEntities();
+  const properties = getKBProperties();
+  const propertiesById = new Map(properties.map((p) => [p.id, p]));
+
+  const rows: EntityRow[] = [];
+
+  for (const entity of entities) {
+    const facts: Fact[] = getKBFacts(entity.id);
+    const structuredFacts = facts.filter((f) => f.propertyId !== "description");
+
+    if (structuredFacts.length === 0) continue;
+
+    const propertyIds = new Set(structuredFacts.map((f) => f.propertyId));
+    const factsWithSource = structuredFacts.filter(
+      (f) => f.source || f.sourceResource
+    ).length;
+    const sourceCoverage =
+      structuredFacts.length > 0
+        ? Math.round((factsWithSource / structuredFacts.length) * 100)
+        : 0;
+
+    // Count items across all collections
+    let itemCount = 0;
+    // We can't enumerate collections without the schema, so check common ones
+    const commonCollections = [
+      "funding-rounds",
+      "key-people",
+      "products",
+      "model-releases",
+      "board-members",
+      "strategic-partnerships",
+      "safety-milestones",
+      "research-areas",
+    ];
+    for (const collection of commonCollections) {
+      itemCount += getKBItems(entity.id, collection).length;
+    }
+
+    const propertyNames = [...propertyIds]
+      .map((pid) => propertiesById.get(pid)?.name ?? pid)
+      .sort();
+
+    rows.push({
+      entityId: entity.id,
+      entityName: entity.name,
+      entityHref: getEntityHref(entity.id),
+      entityType: entity.type,
+      factCount: structuredFacts.length,
+      propertyCount: propertyIds.size,
+      itemCount,
+      sourceCoverage,
+      properties: propertyNames,
+    });
+  }
+
+  rows.sort((a, b) => b.factCount - a.factCount);
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+        {rows.length} entities with structured KB data (excluding
+        description-only entries). Sorted by fact count.
+      </p>
+      <KBEntitiesTable data={rows} />
+    </>
+  );
+}

--- a/apps/web/src/app/kb/kb-entities-table.tsx
+++ b/apps/web/src/app/kb/kb-entities-table.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type {
+  ColumnDef,
+  SortingState,
+} from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import type { EntityRow } from "./kb-entities-content";
+
+function SourceBar({ value }: { value: number }) {
+  const color =
+    value >= 80
+      ? "bg-emerald-500"
+      : value >= 50
+        ? "bg-amber-500"
+        : value > 0
+          ? "bg-red-400"
+          : "bg-muted";
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-12 h-2 bg-muted rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${Math.min(value, 100)}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">
+        {value}%
+      </span>
+    </div>
+  );
+}
+
+const columns: ColumnDef<EntityRow>[] = [
+  {
+    accessorKey: "entityName",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Entity</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={row.original.entityHref}
+        className="text-primary hover:underline text-xs font-medium"
+      >
+        {row.original.entityName}
+      </Link>
+    ),
+    size: 180,
+  },
+  {
+    accessorKey: "entityType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground capitalize">
+        {row.original.entityType}
+      </span>
+    ),
+    size: 110,
+  },
+  {
+    accessorKey: "factCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Facts</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums font-medium">
+        {row.original.factCount}
+      </span>
+    ),
+    size: 70,
+  },
+  {
+    accessorKey: "propertyCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Properties</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums font-medium">
+        {row.original.propertyCount}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    accessorKey: "itemCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Items</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums">
+        {row.original.itemCount > 0 ? row.original.itemCount : (
+          <span className="text-muted-foreground/30">&mdash;</span>
+        )}
+      </span>
+    ),
+    size: 70,
+  },
+  {
+    accessorKey: "sourceCoverage",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Source %</SortableHeader>
+    ),
+    cell: ({ row }) => <SourceBar value={row.original.sourceCoverage} />,
+    size: 110,
+  },
+  {
+    accessorKey: "properties",
+    header: "Properties",
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground truncate block max-w-[250px]" title={row.original.properties.join(", ")}>
+        {row.original.properties.join(", ")}
+      </span>
+    ),
+    size: 250,
+    enableSorting: false,
+  },
+];
+
+export function KBEntitiesTable({ data }: { data: EntityRow[] }) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "factCount", desc: true },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+
+  const entityTypes = useMemo(() => {
+    const types = new Set(data.map((r) => r.entityType));
+    return [...types].sort();
+  }, [data]);
+
+  const filteredData = useMemo(() => {
+    if (typeFilter === "all") return data;
+    return data.filter((r) => r.entityType === typeFilter);
+  }, [data, typeFilter]);
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const search = filterValue.toLowerCase();
+      const r = row.original;
+      return (
+        r.entityName.toLowerCase().includes(search) ||
+        r.entityType.toLowerCase().includes(search) ||
+        r.properties.some((p) => p.toLowerCase().includes(search))
+      );
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search entities..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-9 py-2 text-sm"
+          />
+        </div>
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All types</option>
+          {entityTypes.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        Showing {table.getFilteredRowModel().rows.length} of {data.length}{" "}
+        entities
+      </div>
+      <div className="overflow-x-auto">
+        <DataTable table={table} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/kb/kb-facts-content.tsx
+++ b/apps/web/src/app/kb/kb-facts-content.tsx
@@ -1,0 +1,100 @@
+import {
+  getKBEntities,
+  getKBProperties,
+  getKBFacts,
+} from "@/data/kb";
+import { getEntityHref } from "@/data";
+import type { Fact, Property, Entity } from "@longterm-wiki/kb";
+import { formatKBFactValue, formatKBDate } from "@/components/wiki/kb/format";
+import { KBFactsTable } from "./kb-facts-table";
+
+export interface FactRow {
+  factId: string;
+  entityId: string;
+  entityName: string;
+  entityHref: string;
+  entityType: string;
+  propertyId: string;
+  propertyName: string;
+  category: string;
+  displayValue: string;
+  rawRefValues: string[] | null;
+  asOf: string;
+  source: string;
+  sourceResource: string | undefined;
+  hasSource: boolean;
+}
+
+function resolveRefDisplayNames(
+  fact: Fact,
+  entitiesById: Map<string, Entity>,
+): string[] | null {
+  const v = fact.value;
+  if (v.type === "ref") {
+    const entity = entitiesById.get(v.value);
+    return [entity ? entity.name : v.value];
+  }
+  if (v.type === "refs") {
+    return v.value.map((refId: string) => {
+      const entity = entitiesById.get(refId);
+      return entity ? entity.name : refId;
+    });
+  }
+  return null;
+}
+
+export function KBFactsExplorerContent() {
+  const entities = getKBEntities();
+  const properties = getKBProperties();
+
+  const entitiesById = new Map(entities.map((e) => [e.id, e]));
+  const propertiesById = new Map(properties.map((p) => [p.id, p]));
+
+  const rows: FactRow[] = [];
+
+  for (const entity of entities) {
+    const facts = getKBFacts(entity.id);
+
+    for (const fact of facts) {
+      if (fact.propertyId === "description") continue;
+
+      const property = propertiesById.get(fact.propertyId);
+
+      const displayValue = formatKBFactValue(
+        fact,
+        property?.unit,
+        property?.display,
+      );
+
+      const refNames = resolveRefDisplayNames(fact, entitiesById);
+
+      rows.push({
+        factId: fact.id,
+        entityId: entity.id,
+        entityName: entity.name,
+        entityHref: getEntityHref(entity.id),
+        entityType: entity.type,
+        propertyId: fact.propertyId,
+        propertyName: property?.name ?? fact.propertyId,
+        category: property?.category ?? "other",
+        displayValue: refNames ? refNames.join(", ") : displayValue,
+        rawRefValues: refNames,
+        asOf: formatKBDate(fact.asOf),
+        source: fact.source ?? "",
+        sourceResource: fact.sourceResource,
+        hasSource: !!(fact.source || fact.sourceResource),
+      });
+    }
+  }
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+        All {rows.length} structured facts across {entities.length} entities,
+        excluding description-only entries. Use filters to narrow by entity type,
+        property category, or search text.
+      </p>
+      <KBFactsTable data={rows} />
+    </>
+  );
+}

--- a/apps/web/src/app/kb/kb-facts-table.tsx
+++ b/apps/web/src/app/kb/kb-facts-table.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type {
+  ColumnDef,
+  SortingState,
+} from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import type { FactRow } from "./kb-facts-content";
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "\u2026" : s;
+}
+
+const columns: ColumnDef<FactRow>[] = [
+  {
+    accessorKey: "entityName",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Entity</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <Link
+        href={row.original.entityHref}
+        className="text-primary hover:underline text-xs font-medium"
+      >
+        {row.original.entityName}
+      </Link>
+    ),
+    size: 160,
+  },
+  {
+    accessorKey: "propertyName",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Property</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs">{row.original.propertyName}</span>
+    ),
+    size: 140,
+  },
+  {
+    accessorKey: "category",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Category</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs capitalize text-muted-foreground">
+        {row.original.category}
+      </span>
+    ),
+    size: 100,
+  },
+  {
+    accessorKey: "displayValue",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Value</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs font-medium tabular-nums" title={row.original.displayValue}>
+        {truncate(row.original.displayValue, 60)}
+      </span>
+    ),
+    size: 200,
+  },
+  {
+    accessorKey: "asOf",
+    header: ({ column }) => (
+      <SortableHeader column={column}>As Of</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {row.original.asOf}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    accessorKey: "hasSource",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Source</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      if (row.original.source) {
+        return (
+          <a
+            href={row.original.source}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary hover:underline"
+            title={row.original.source}
+          >
+            Link
+          </a>
+        );
+      }
+      if (row.original.sourceResource) {
+        return <span className="text-xs text-muted-foreground">{row.original.sourceResource}</span>;
+      }
+      return <span className="text-xs text-muted-foreground/30">&mdash;</span>;
+    },
+    size: 70,
+  },
+];
+
+export function KBFactsTable({ data }: { data: FactRow[] }) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "entityName", desc: false },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
+
+  const entityTypes = useMemo(() => {
+    const types = new Set(data.map((r) => r.entityType));
+    return [...types].sort();
+  }, [data]);
+
+  const categories = useMemo(() => {
+    const cats = new Set(data.map((r) => r.category));
+    return [...cats].sort();
+  }, [data]);
+
+  const filteredData = useMemo(() => {
+    let filtered = data;
+    if (typeFilter !== "all") {
+      filtered = filtered.filter((r) => r.entityType === typeFilter);
+    }
+    if (categoryFilter !== "all") {
+      filtered = filtered.filter((r) => r.category === categoryFilter);
+    }
+    if (sourceFilter === "with-source") {
+      filtered = filtered.filter((r) => r.hasSource);
+    } else if (sourceFilter === "without-source") {
+      filtered = filtered.filter((r) => !r.hasSource);
+    }
+    return filtered;
+  }, [data, typeFilter, categoryFilter, sourceFilter]);
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const search = filterValue.toLowerCase();
+      const r = row.original;
+      return (
+        r.entityName.toLowerCase().includes(search) ||
+        r.propertyName.toLowerCase().includes(search) ||
+        r.displayValue.toLowerCase().includes(search) ||
+        r.category.toLowerCase().includes(search)
+      );
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search facts..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-9 py-2 text-sm"
+          />
+        </div>
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All types</option>
+          {entityTypes.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All categories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={sourceFilter}
+          onChange={(e) => setSourceFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All sources</option>
+          <option value="with-source">With source</option>
+          <option value="without-source">Without source</option>
+        </select>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        Showing {table.getFilteredRowModel().rows.length} of {data.length} facts
+      </div>
+      <div className="overflow-x-auto">
+        <DataTable table={table} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/kb/kb-overview-content.tsx
+++ b/apps/web/src/app/kb/kb-overview-content.tsx
@@ -1,0 +1,200 @@
+import Link from "next/link";
+import {
+  getKBEntities,
+  getKBProperties,
+  getKBFacts,
+} from "@/data/kb";
+import type { Fact } from "@longterm-wiki/kb";
+import { Database, BarChart3, Layers, BookOpen } from "lucide-react";
+
+/**
+ * Gather all KB facts across all entities.
+ * Excludes description-only facts for the "structured" count.
+ */
+function computeStats() {
+  const entities = getKBEntities();
+  const properties = getKBProperties();
+
+  let totalFacts = 0;
+  let structuredFacts = 0;
+  let factsWithSource = 0;
+  let entitiesWithStructuredData = 0;
+  const propertyUsage = new Map<string, number>();
+  const categoryCounts = new Map<string, number>();
+
+  for (const entity of entities) {
+    const facts: Fact[] = getKBFacts(entity.id);
+    totalFacts += facts.length;
+
+    const structured = facts.filter((f) => f.propertyId !== "description");
+    structuredFacts += structured.length;
+
+    if (structured.length > 0) {
+      entitiesWithStructuredData++;
+    }
+
+    for (const fact of structured) {
+      factsWithSource += fact.source || fact.sourceResource ? 1 : 0;
+      propertyUsage.set(
+        fact.propertyId,
+        (propertyUsage.get(fact.propertyId) ?? 0) + 1
+      );
+    }
+  }
+
+  for (const prop of properties) {
+    if (prop.category && propertyUsage.has(prop.id)) {
+      categoryCounts.set(
+        prop.category,
+        (categoryCounts.get(prop.category) ?? 0) +
+          (propertyUsage.get(prop.id) ?? 0)
+      );
+    }
+  }
+
+  const propertiesInUse = propertyUsage.size;
+  const sourceCoverage =
+    structuredFacts > 0
+      ? Math.round((factsWithSource / structuredFacts) * 100)
+      : 0;
+
+  return {
+    totalEntities: entities.length,
+    entitiesWithStructuredData,
+    totalFacts,
+    structuredFacts,
+    propertiesInUse,
+    totalProperties: properties.length,
+    sourceCoverage,
+    categoryCounts,
+  };
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sublabel,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string | number;
+  sublabel?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-2 text-muted-foreground mb-1">
+        <Icon className="w-4 h-4" />
+        <span className="text-xs font-medium uppercase tracking-wide">
+          {label}
+        </span>
+      </div>
+      <div className="text-2xl font-bold tabular-nums">{value}</div>
+      {sublabel && (
+        <div className="text-xs text-muted-foreground mt-1">{sublabel}</div>
+      )}
+    </div>
+  );
+}
+
+export function KBOverviewContent() {
+  const stats = computeStats();
+
+  const sortedCategories = [...stats.categoryCounts.entries()].sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-6">
+        The Knowledge Base (KB) stores structured, sourced facts about entities
+        tracked by this wiki. Each fact has a typed value, optional date stamp,
+        and source attribution. This section lets you explore the full dataset.
+      </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard
+          icon={Database}
+          label="Structured Facts"
+          value={stats.structuredFacts}
+          sublabel={`${stats.totalFacts} total including descriptions`}
+        />
+        <StatCard
+          icon={Layers}
+          label="Entities with Data"
+          value={stats.entitiesWithStructuredData}
+          sublabel={`of ${stats.totalEntities} total KB entities`}
+        />
+        <StatCard
+          icon={BarChart3}
+          label="Properties in Use"
+          value={stats.propertiesInUse}
+          sublabel={`of ${stats.totalProperties} defined`}
+        />
+        <StatCard
+          icon={BookOpen}
+          label="Source Coverage"
+          value={`${stats.sourceCoverage}%`}
+          sublabel="of structured facts have sources"
+        />
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-6 mb-8">
+        <Link
+          href="/wiki/E1020"
+          className="group block rounded-lg border border-border bg-card p-5 no-underline hover:border-primary/50 transition-colors"
+        >
+          <h3 className="text-base font-semibold mb-1 group-hover:text-primary transition-colors">
+            Facts Explorer
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Browse and filter all {stats.structuredFacts} structured facts.
+            Search by entity, property, or category.
+          </p>
+        </Link>
+        <Link
+          href="/wiki/E1021"
+          className="group block rounded-lg border border-border bg-card p-5 no-underline hover:border-primary/50 transition-colors"
+        >
+          <h3 className="text-base font-semibold mb-1 group-hover:text-primary transition-colors">
+            Properties Explorer
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            View all {stats.totalProperties} property definitions with usage
+            stats and coverage bars.
+          </p>
+        </Link>
+        <Link
+          href="/wiki/E1022"
+          className="group block rounded-lg border border-border bg-card p-5 no-underline hover:border-primary/50 transition-colors"
+        >
+          <h3 className="text-base font-semibold mb-1 group-hover:text-primary transition-colors">
+            Entity Coverage
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            See which entities have the most data and which need more coverage.
+          </p>
+        </Link>
+      </div>
+
+      {sortedCategories.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-3">Facts by Category</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {sortedCategories.map(([category, count]) => (
+              <div
+                key={category}
+                className="flex items-center justify-between rounded-md border border-border px-3 py-2"
+              >
+                <span className="text-sm capitalize">{category}</span>
+                <span className="text-sm font-medium tabular-nums text-muted-foreground">
+                  {count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/kb/kb-properties-content.tsx
+++ b/apps/web/src/app/kb/kb-properties-content.tsx
@@ -1,0 +1,104 @@
+import {
+  getKBEntities,
+  getKBProperties,
+  getKBFacts,
+} from "@/data/kb";
+import type { Fact } from "@longterm-wiki/kb";
+import { KBPropertiesTable } from "./kb-properties-table";
+
+export interface PropertyRow {
+  id: string;
+  name: string;
+  description: string;
+  dataType: string;
+  category: string;
+  unit: string;
+  temporal: boolean;
+  computed: boolean;
+  factCount: number;
+  entityCount: number;
+  appliesTo: string[];
+  /** Coverage: entityCount / totalApplicableEntities */
+  coverage: number;
+}
+
+export function KBPropertiesExplorerContent() {
+  const entities = getKBEntities();
+  const properties = getKBProperties();
+
+  // Build entity type counts for coverage calculation
+  const entityTypeCount = new Map<string, number>();
+  for (const entity of entities) {
+    entityTypeCount.set(
+      entity.type,
+      (entityTypeCount.get(entity.type) ?? 0) + 1
+    );
+  }
+
+  // Compute per-property usage stats (excluding description)
+  const propertyFacts = new Map<string, { factCount: number; entityIds: Set<string> }>();
+  for (const entity of entities) {
+    const facts: Fact[] = getKBFacts(entity.id);
+    for (const fact of facts) {
+      if (fact.propertyId === "description") continue;
+      let entry = propertyFacts.get(fact.propertyId);
+      if (!entry) {
+        entry = { factCount: 0, entityIds: new Set() };
+        propertyFacts.set(fact.propertyId, entry);
+      }
+      entry.factCount++;
+      entry.entityIds.add(entity.id);
+    }
+  }
+
+  const rows: PropertyRow[] = properties
+    .filter((p) => p.id !== "description")
+    .map((prop) => {
+      const usage = propertyFacts.get(prop.id);
+      const factCount = usage?.factCount ?? 0;
+      const entityCount = usage?.entityIds.size ?? 0;
+
+      // Calculate coverage based on appliesTo
+      let totalApplicable = 0;
+      if (prop.appliesTo && prop.appliesTo.length > 0) {
+        for (const type of prop.appliesTo) {
+          totalApplicable += entityTypeCount.get(type) ?? 0;
+        }
+      } else {
+        totalApplicable = entities.length;
+      }
+      const coverage =
+        totalApplicable > 0
+          ? Math.round((entityCount / totalApplicable) * 100)
+          : 0;
+
+      return {
+        id: prop.id,
+        name: prop.name,
+        description: prop.description ?? "",
+        dataType: prop.dataType,
+        category: prop.category ?? "other",
+        unit: prop.unit ?? "",
+        temporal: prop.temporal ?? false,
+        computed: prop.computed ?? false,
+        factCount,
+        entityCount,
+        appliesTo: prop.appliesTo ?? [],
+        coverage,
+      };
+    })
+    .sort((a, b) => b.factCount - a.factCount);
+
+  const inUse = rows.filter((r) => r.factCount > 0).length;
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+        {rows.length} properties defined ({inUse} in use). Coverage bars show
+        what percentage of applicable entities have at least one fact for each
+        property.
+      </p>
+      <KBPropertiesTable data={rows} />
+    </>
+  );
+}

--- a/apps/web/src/app/kb/kb-properties-table.tsx
+++ b/apps/web/src/app/kb/kb-properties-table.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type {
+  ColumnDef,
+  SortingState,
+} from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import type { PropertyRow } from "./kb-properties-content";
+
+function CoverageBar({ value }: { value: number }) {
+  const color =
+    value >= 50
+      ? "bg-emerald-500"
+      : value >= 20
+        ? "bg-amber-500"
+        : value > 0
+          ? "bg-red-400"
+          : "bg-muted";
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-16 h-2 bg-muted rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${Math.min(value, 100)}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">
+        {value}%
+      </span>
+    </div>
+  );
+}
+
+const columns: ColumnDef<PropertyRow>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Property</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <div>
+        <div className="text-xs font-medium">{row.original.name}</div>
+        <div className="text-xs text-muted-foreground truncate max-w-[250px]">
+          {row.original.description}
+        </div>
+      </div>
+    ),
+    size: 260,
+  },
+  {
+    accessorKey: "dataType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.dataType}
+        {row.original.unit ? ` (${row.original.unit})` : ""}
+      </span>
+    ),
+    size: 100,
+  },
+  {
+    accessorKey: "category",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Category</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs capitalize text-muted-foreground">
+        {row.original.category}
+      </span>
+    ),
+    size: 100,
+  },
+  {
+    accessorKey: "factCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Facts</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums font-medium">
+        {row.original.factCount}
+      </span>
+    ),
+    size: 70,
+  },
+  {
+    accessorKey: "entityCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Entities</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums font-medium">
+        {row.original.entityCount}
+      </span>
+    ),
+    size: 80,
+  },
+  {
+    accessorKey: "coverage",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Coverage</SortableHeader>
+    ),
+    cell: ({ row }) => <CoverageBar value={row.original.coverage} />,
+    size: 120,
+  },
+  {
+    accessorKey: "temporal",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Temporal</SortableHeader>
+    ),
+    cell: ({ row }) =>
+      row.original.temporal ? (
+        <span className="text-emerald-500 text-xs font-bold">Yes</span>
+      ) : (
+        <span className="text-muted-foreground/30 text-xs">No</span>
+      ),
+    size: 70,
+  },
+  {
+    accessorKey: "appliesTo",
+    header: "Applies To",
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.appliesTo.join(", ") || "all"}
+      </span>
+    ),
+    size: 140,
+  },
+];
+
+export function KBPropertiesTable({ data }: { data: PropertyRow[] }) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "factCount", desc: true },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [usageFilter, setUsageFilter] = useState<string>("all");
+
+  const categories = useMemo(() => {
+    const cats = new Set(data.map((r) => r.category));
+    return [...cats].sort();
+  }, [data]);
+
+  const filteredData = useMemo(() => {
+    let filtered = data;
+    if (categoryFilter !== "all") {
+      filtered = filtered.filter((r) => r.category === categoryFilter);
+    }
+    if (usageFilter === "in-use") {
+      filtered = filtered.filter((r) => r.factCount > 0);
+    } else if (usageFilter === "unused") {
+      filtered = filtered.filter((r) => r.factCount === 0);
+    }
+    return filtered;
+  }, [data, categoryFilter, usageFilter]);
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const search = filterValue.toLowerCase();
+      const r = row.original;
+      return (
+        r.name.toLowerCase().includes(search) ||
+        r.description.toLowerCase().includes(search) ||
+        r.id.toLowerCase().includes(search) ||
+        r.category.toLowerCase().includes(search)
+      );
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search properties..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-9 py-2 text-sm"
+          />
+        </div>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All categories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={usageFilter}
+          onChange={(e) => setUsageFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All usage</option>
+          <option value="in-use">In use</option>
+          <option value="unused">Unused</option>
+        </select>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        Showing {table.getFilteredRowModel().rows.length} of {data.length}{" "}
+        properties
+      </div>
+      <div className="overflow-x-auto">
+        <DataTable table={table} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/kb/page.tsx
+++ b/apps/web/src/app/kb/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function KBPage() {
+  redirect("/wiki/E1019");
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -63,6 +63,12 @@ export default function RootLayout({
                 Explore
               </Link>
               <Link
+                href="/kb"
+                className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+              >
+                Data
+              </Link>
+              <Link
                 href="/wiki/E755"
                 className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 
 const NAV_LINKS = [
   { href: "/wiki", label: "Explore" },
+  { href: "/kb", label: "Data" },
   { href: "/wiki/E755", label: "About" },
   { href: "/wiki/E779", label: "Internal" },
 ];

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -44,6 +44,12 @@ import { KeyTakeaways } from "@/components/wiki/KeyTakeaways";
 // Usage: <EpicTracker issues={[1043, 1065, 1074]} /> — renders live GitHub issue status table
 import { EpicTracker } from "@/components/wiki/EpicTracker";
 
+// KB Data section content components (public structured data at /kb/)
+import { KBOverviewContent } from "@/app/kb/kb-overview-content";
+import { KBFactsExplorerContent } from "@/app/kb/kb-facts-content";
+import { KBPropertiesExplorerContent } from "@/app/kb/kb-properties-content";
+import { KBEntityCoverageContent } from "@/app/kb/kb-entities-content";
+
 // Dashboard content components (rendered via MDX stubs at /wiki/E<id>)
 import { FactsPageContent } from "@/app/internal/facts/facts-content";
 import { PageCoverageContent } from "@/app/internal/page-coverage/page-coverage-content";
@@ -179,6 +185,12 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
 
   // Epic tracking
   EpicTracker,
+
+  // KB Data section components
+  KBOverviewContent,
+  KBFactsExplorerContent,
+  KBPropertiesExplorerContent,
+  KBEntityCoverageContent,
 
   // Dashboard content components
   FactsPageContent,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -334,10 +334,34 @@ export function getInternalNav(): NavSection[] {
 }
 
 // ============================================================================
+// KB DATA SECTION NAV (public structured data pages)
+// ============================================================================
+
+/**
+ * Build sidebar navigation for the /kb/ section (public structured data).
+ * Uses numeric entity IDs directly for stability (the slugs in the wiki-server
+ * ID registry differ from the page-level slugs assigned by build-data).
+ */
+export function getKBDataNav(): NavSection[] {
+  return [
+    {
+      title: "KB Data",
+      defaultOpen: true,
+      items: [
+        { label: "Overview", href: "/wiki/E1019" },
+        { label: "Facts Explorer", href: "/wiki/E1020" },
+        { label: "Properties", href: "/wiki/E1021" },
+        { label: "Entity Coverage", href: "/wiki/E1022" },
+      ],
+    },
+  ];
+}
+
+// ============================================================================
 // DETECT WHICH SIDEBAR TO SHOW
 // ============================================================================
 
-export type WikiSidebarType = "models" | "internal" | "about" | "kb" | "section" | null;
+export type WikiSidebarType = "models" | "internal" | "about" | "kb-data" | "kb" | "section" | null;
 
 /**
  * Determine which sidebar to show based on the entity path.
@@ -364,6 +388,11 @@ export function detectSidebarType(entityPath: string): WikiSidebarType {
 
   if (entityPath.startsWith("/internal/") || entityPath === "/internal") {
     return "internal";
+  }
+
+  // KB Data section — public structured data pages at /kb/
+  if (entityPath.startsWith("/kb/") || entityPath === "/kb") {
+    return "kb-data";
   }
 
   // Any knowledge-base subsection gets a sidebar (no hardcoded list needed)
@@ -431,6 +460,8 @@ export function getWikiNav(
       return getAboutNav();
     case "internal":
       return getInternalNav();
+    case "kb-data":
+      return getKBDataNav();
     case "kb": {
       const section = entityPath ? extractKbSection(entityPath) : null;
       return section ? getKbSectionNav(section) : [];

--- a/content/docs/kb/entities.mdx
+++ b/content/docs/kb/entities.mdx
@@ -1,0 +1,9 @@
+---
+numericId: E1022
+title: "Entity Coverage"
+description: "KB data coverage per entity - fact counts, properties, and source quality"
+contentFormat: dashboard
+lastEdited: "2026-03-09"
+---
+
+<KBEntityCoverageContent />

--- a/content/docs/kb/facts.mdx
+++ b/content/docs/kb/facts.mdx
@@ -1,0 +1,9 @@
+---
+numericId: E1020
+title: "Facts Explorer"
+description: "Browse and filter all structured KB facts across entities"
+contentFormat: dashboard
+lastEdited: "2026-03-09"
+---
+
+<KBFactsExplorerContent />

--- a/content/docs/kb/index.mdx
+++ b/content/docs/kb/index.mdx
@@ -1,0 +1,9 @@
+---
+numericId: E1019
+title: "KB Data Overview"
+description: "Structured data across wiki entities - facts, properties, and coverage statistics"
+contentFormat: dashboard
+lastEdited: "2026-03-09"
+---
+
+<KBOverviewContent />

--- a/content/docs/kb/properties.mdx
+++ b/content/docs/kb/properties.mdx
@@ -1,0 +1,9 @@
+---
+numericId: E1021
+title: "Properties Explorer"
+description: "All KB property definitions with usage statistics and coverage"
+contentFormat: dashboard
+lastEdited: "2026-03-09"
+---
+
+<KBPropertiesExplorerContent />


### PR DESCRIPTION
## Summary
- Cherry-pick from `claude/kb-section` branch (commit 1a62cb66)
- Add public `/kb` section with sidebar navigation and explorer pages
- Add Facts Explorer page for browsing all structured KB facts
- Add Properties Explorer page for viewing property definitions and usage
- Add Entity Coverage page for identifying data coverage gaps
- Add KB overview content component with statistics dashboard
- Register KB content components in MDX components
- Fix broken links from KB Data Overview page (E1019) to explorer pages

These pages were previously 404, causing dead links from the KB overview page.

## Test plan
- [x] `pnpm build` passes
- [x] Gate check passes
- [ ] /kb route loads correctly with overview
- [ ] Facts explorer loads and shows searchable facts table
- [ ] Properties explorer loads and shows property definitions
- [ ] Entity coverage page loads and shows coverage gaps
- [ ] Links from KB Data Overview page work

🤖 Generated with [Claude Code](https://claude.com/claude-code)