### PR TITLE
fix: KB dashboard error boundaries and accessibility

### DIFF
--- a/apps/web/src/app/kb/kb-publications-content.tsx
+++ b/apps/web/src/app/kb/kb-publications-content.tsx
@@ -7,7 +7,19 @@ import { KBPublicationsTable } from "./kb-publications-table";
 import type { PublicationDataRow } from "./kb-publications-table";
 
 export function KBPublicationsContent() {
-  const publications = getAllPublications();
+  let publications;
+  try {
+    publications = getAllPublications();
+  } catch (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-destructive font-medium">Failed to load publications data</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+      </div>
+    );
+  }
 
   const rows: PublicationDataRow[] = publications.map((pub) => {
     const resources = getResourcesForPublication(pub.id);

--- a/apps/web/src/app/kb/kb-resources-content.tsx
+++ b/apps/web/src/app/kb/kb-resources-content.tsx
@@ -15,7 +15,19 @@ function deriveFetchStatus(r: Resource): "full" | "metadata-only" | "unfetched" 
 }
 
 export function KBResourcesContent() {
-  const resources = getAllResources();
+  let resources;
+  try {
+    resources = getAllResources();
+  } catch (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-destructive font-medium">Failed to load resources data</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+      </div>
+    );
+  }
 
   const rows: ResourceDataRow[] = resources.map((r) => {
     const publication = getResourcePublication(r);

--- a/apps/web/src/components/wiki/kb/KBCellValue.tsx
+++ b/apps/web/src/components/wiki/kb/KBCellValue.tsx
@@ -74,7 +74,7 @@ export function KBCellValue({ value, fieldName, fieldDef }: KBCellValueProps) {
   // Booleans
   if (fieldType === "boolean" || typeof value === "boolean") {
     return (
-      <span className="text-muted-foreground">
+      <span className="text-muted-foreground" aria-label={value ? "Yes" : "No"}>
         {value ? "\u2713" : "\u2717"}
       </span>
     );

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -484,7 +484,7 @@ function parseRecordEntry(
  *
  * Uses a two-pass approach for entities:
  *   Pass 1: Load all entity headers (builds stableId → slug index)
- *   Pass 2: Load facts and items (resolves !ref tags using the index)
+ *   Pass 2: Load facts and records (resolves !ref tags using the index)
  */
 export async function loadKB(dataDir: string): Promise<Graph> {
   const graph = new Graph();


### PR DESCRIPTION
## Summary
- Add error boundaries (try-catch) to Resources and Publications dashboard content components so data-loading failures render a user-friendly error state instead of crashing the page
- Add `aria-label="Yes"/"No"` to boolean checkmark/X icons in `KBCellValue` for screen reader accessibility
- Fix stale "items" comment to "records" in KB loader

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (567/567 web app tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)