### PR TITLE
fix: KB security & data integrity fixes (P1)

### DIFF
--- a/apps/web/src/app/kb/kb-publications-content.tsx
+++ b/apps/web/src/app/kb/kb-publications-content.tsx
@@ -22,7 +22,7 @@ export function KBPublicationsContent() {
       id: pub.id,
       name: pub.name,
       type: pub.type,
-      credibility: pub.credibility,
+      credibility: pub.credibility ?? null,
       peerReviewed: pub.peer_reviewed ?? false,
       resourceCount: resources.length,
       pageCount: pageSet.size,
@@ -31,10 +31,11 @@ export function KBPublicationsContent() {
 
   const totalResources = rows.reduce((s, r) => s + r.resourceCount, 0);
   const peerReviewedCount = rows.filter((r) => r.peerReviewed).length;
+  const withCredibility = rows.filter((r) => r.credibility != null);
   const avgCredibility =
-    rows.length > 0
-      ? (rows.reduce((s, r) => s + r.credibility, 0) / rows.length).toFixed(1)
-      : "0";
+    withCredibility.length > 0
+      ? (withCredibility.reduce((s, r) => s + r.credibility!, 0) / withCredibility.length).toFixed(1)
+      : "-";
 
   return (
     <>

--- a/apps/web/src/app/kb/kb-publications-table.tsx
+++ b/apps/web/src/app/kb/kb-publications-table.tsx
@@ -29,7 +29,7 @@ export interface PublicationDataRow {
   id: string;
   name: string;
   type: string;
-  credibility: number;
+  credibility: number | null;
   peerReviewed: boolean;
   resourceCount: number;
   pageCount: number;
@@ -112,9 +112,12 @@ function makeColumns(): ColumnDef<PublicationDataRow>[] {
       header: ({ column }) => (
         <SortableHeader column={column}>Credibility</SortableHeader>
       ),
-      cell: ({ row }) => (
-        <CredibilityBadge level={row.original.credibility} size="sm" showLabel />
-      ),
+      cell: ({ row }) => {
+        const c = row.original.credibility;
+        if (c == null) return <span className="text-muted-foreground/40 text-xs">-</span>;
+        return <CredibilityBadge level={c} size="sm" showLabel />;
+      },
+      sortUndefined: "last",
     },
     {
       accessorKey: "peerReviewed",

--- a/apps/web/src/lib/__tests__/fact-footnote-preprocessor.test.ts
+++ b/apps/web/src/lib/__tests__/fact-footnote-preprocessor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   preprocessFactFootnotes,
   buildFactFootnoteDefinition,
+  escapeMarkdownInQuote,
   type FactLookupFn,
 } from "../fact-footnote-preprocessor";
 import type { Fact } from "@longterm-wiki/kb";
@@ -383,5 +384,74 @@ describe("buildFactFootnoteDefinition", () => {
 
     const def = buildFactFootnoteDefinition(fact);
     expect(def).toBe("Source: SEC filing Q4 2024");
+  });
+
+  it("escapes Markdown special characters in sourceQuote", () => {
+    const fact = makeFact({
+      id: "f_mdchars",
+      source: "https://example.com",
+      sourceQuote: "Revenue was *very* high with `code` and _emphasis_ [link]",
+    });
+
+    const def = buildFactFootnoteDefinition(fact);
+
+    // Special chars should be escaped
+    expect(def).toContain("\\*very\\*");
+    expect(def).toContain("\\`code\\`");
+    expect(def).toContain("\\_emphasis\\_");
+    expect(def).toContain("\\[link\\]");
+    // The outer italic markers should still be present
+    expect(def).toContain('*"Revenue');
+    expect(def).toContain('\\]"*');
+  });
+
+  it("escapes backslashes in sourceQuote", () => {
+    const fact = makeFact({
+      id: "f_backslash",
+      sourceQuote: "path\\to\\file",
+    });
+
+    const def = buildFactFootnoteDefinition(fact);
+    expect(def).toContain("path\\\\to\\\\file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: escapeMarkdownInQuote
+// ---------------------------------------------------------------------------
+
+describe("escapeMarkdownInQuote", () => {
+  it("escapes asterisks", () => {
+    expect(escapeMarkdownInQuote("*bold*")).toBe("\\*bold\\*");
+  });
+
+  it("escapes backticks", () => {
+    expect(escapeMarkdownInQuote("`code`")).toBe("\\`code\\`");
+  });
+
+  it("escapes underscores", () => {
+    expect(escapeMarkdownInQuote("_italic_")).toBe("\\_italic\\_");
+  });
+
+  it("escapes square brackets", () => {
+    expect(escapeMarkdownInQuote("[link](url)")).toBe("\\[link\\](url)");
+  });
+
+  it("escapes backslashes", () => {
+    expect(escapeMarkdownInQuote("a\\b")).toBe("a\\\\b");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(escapeMarkdownInQuote("Revenue reached $1B")).toBe(
+      "Revenue reached $1B"
+    );
+  });
+
+  it("handles multiple special characters together", () => {
+    expect(escapeMarkdownInQuote("*_`[\\")).toBe("\\*\\_\\`\\[\\\\");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeMarkdownInQuote("")).toBe("");
   });
 });

--- a/apps/web/src/lib/fact-footnote-preprocessor.ts
+++ b/apps/web/src/lib/fact-footnote-preprocessor.ts
@@ -28,6 +28,14 @@ const FACT_FOOTNOTE_RE = /\[\^fact:([a-zA-Z0-9_]+)\](?!:)/g;
 export type FactLookupFn = (factId: string) => Fact | undefined;
 
 /**
+ * Escape Markdown special characters in source quotes to prevent them from
+ * being interpreted as formatting. Characters escaped: \ * ` _ [ ]
+ */
+export function escapeMarkdownInQuote(text: string): string {
+  return text.replace(/([\\*`_\[\]])/g, "\\$1");
+}
+
+/**
  * Escape `<` characters that could trigger JSX/HTML parsing in MDX footnote
  * definitions. Reuses the same logic as the reference preprocessor.
  */
@@ -56,7 +64,7 @@ export function buildFactFootnoteDefinition(fact: Fact): string {
   }
 
   if (fact.sourceQuote) {
-    parts.push(`*"${fact.sourceQuote}"*`);
+    parts.push(`*"${escapeMarkdownInQuote(fact.sourceQuote)}"*`);
   }
 
   if (fact.asOf) {

--- a/crux/commands/kb-verify.ts
+++ b/crux/commands/kb-verify.ts
@@ -146,7 +146,7 @@ async function fetchSourceContent(url: string): Promise<FetchSourceResult> {
       /^169\.254\./.test(host) ||
       // IPv6 private/reserved ranges
       /^fe80:/i.test(host) ||          // link-local
-      /^f[cd]/i.test(host) ||          // unique local (fc00::/7)
+      /^f[cd][0-9a-f]{2}:/i.test(host) || // unique local (fc00::/7)
       /^::ffff:127\./i.test(host) ||   // IPv4-mapped loopback
       /^::ffff:10\./i.test(host) ||    // IPv4-mapped private
       /^::ffff:192\.168\./i.test(host) || // IPv4-mapped private


### PR DESCRIPTION
## Summary
- Fix IPv6 SSRF gap in KB verification source fetcher: the regex `/^f[cd]/i` was overbroad and would match legitimate hostnames like `facebook.com` or `fdic.gov`; tightened to `/^f[cd][0-9a-f]{2}:/i` to only match actual `fc00::/7` unique local IPv6 addresses
- Add Markdown escaping for `sourceQuote` in fact footnotes: characters `\`, `*`, `` ` ``, `_`, `[`, `]` in source quotes are now escaped before insertion into footnote definitions, preventing broken rendering when quotes contain Markdown formatting characters
- Fix null-safety in publications credibility averaging: null credibility values are now filtered out before computing the mean instead of being treated as 0, which was deflating the displayed average

## Test plan
- [x] `tsc --noEmit` passes (no type errors)
- [x] All 31 fact-footnote-preprocessor tests pass (including 10 new tests)
- [x] New `escapeMarkdownInQuote` unit tests cover all special characters
- [x] New `buildFactFootnoteDefinition` tests verify escaping in context
- [x] Pre-existing test suite unaffected (562 tests pass)

Generated with [Claude Code](https://claude.com/claude-code)