### PR TITLE
feat: KB verdict & verification improvements (P2)

### DIFF
--- a/apps/wiki-server/drizzle/0069_add_source_url_to_kb_verifications.sql
+++ b/apps/wiki-server/drizzle/0069_add_source_url_to_kb_verifications.sql
@@ -1,0 +1,4 @@
+-- Add source_url column to kb_fact_resource_verifications.
+-- Tracks which URL was actually verified, since the fact's source URL can change over time.
+
+ALTER TABLE kb_fact_resource_verifications ADD COLUMN IF NOT EXISTS source_url TEXT;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1774512000000,
       "tag": "0068_add_kb_fact_verifications",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1774598400000,
+      "tag": "0069_add_source_url_to_kb_verifications",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/kb-verifications.test.ts
+++ b/apps/wiki-server/src/__tests__/kb-verifications.test.ts
@@ -19,7 +19,7 @@ interface VerdictRecord {
 interface VerificationRecord {
   id: number;
   fact_id: string;
-  resource_id: string;
+  resource_id: string | null;
   verdict: string;
   confidence: number | null;
   extracted_value: string | null;
@@ -27,6 +27,7 @@ interface VerificationRecord {
   is_primary_source: boolean;
   checked_at: string;
   notes: string | null;
+  source_url: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -90,6 +91,7 @@ function resetStores() {
       is_primary_source: true,
       checked_at: now,
       notes: "Direct match",
+      source_url: "https://example.com/funding",
       created_at: now,
       updated_at: now,
     },
@@ -177,6 +179,49 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       }
     }
     return verdicts;
+  }
+
+  // INSERT into kb_fact_resource_verifications (POST /verifications)
+  if (q.includes("insert") && q.includes("kb_fact_resource_verifications")) {
+    const nextId = verifications.length > 0 ? Math.max(...verifications.map((v) => v.id)) + 1 : 1;
+    const now = new Date().toISOString();
+    // Extract fact_id from params (first string starting with f_)
+    const factId = params.find(
+      (p) => typeof p === "string" && (p as string).startsWith("f_")
+    ) as string ?? "unknown";
+    const record: VerificationRecord = {
+      id: nextId,
+      fact_id: factId,
+      resource_id: null,
+      verdict: "confirmed",
+      confidence: null,
+      extracted_value: null,
+      checker_model: null,
+      is_primary_source: false,
+      checked_at: now,
+      notes: null,
+      source_url: null,
+      created_at: now,
+      updated_at: now,
+    };
+    verifications.push(record);
+    return [{ id: nextId }];
+  }
+
+  // UPDATE kb_fact_verdicts SET needs_recheck (auto-flag on new verification)
+  if (q.includes("update") && q.includes("kb_fact_verdicts")) {
+    const factId = params.find(
+      (p) => typeof p === "string" && (p as string).startsWith("f_")
+    ) as string | undefined;
+    if (factId) {
+      const verdict = verdicts.find((v) => v.fact_id === factId);
+      if (verdict) {
+        verdict.needs_recheck = true;
+        verdict.updated_at = new Date().toISOString();
+        return [{ fact_id: verdict.fact_id }];
+      }
+    }
+    return [];
   }
 
   // SELECT from kb_fact_resource_verifications
@@ -292,5 +337,85 @@ describe("GET /api/kb-verifications/verdicts/:factId", () => {
       `/api/kb-verifications/verdicts/${longId}`
     );
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/kb-verifications/verifications", () => {
+  it("inserts a resource verification and returns 201", async () => {
+    const res = await app.request("/api/kb-verifications/verifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        factId: "f_abc123",
+        verdict: "confirmed",
+        confidence: 0.9,
+        extractedValue: "14 billion",
+        checkerModel: "claude-3-haiku",
+        isPrimarySource: true,
+        notes: "Direct match from source",
+        sourceUrl: "https://example.com/funding-report",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBeGreaterThan(0);
+    expect(body.verdictFlagged).toBe(true);
+  });
+
+  it("sets needs_recheck on existing verdict when new verification is inserted", async () => {
+    // f_abc123 starts with needs_recheck: false
+    const preVerdict = verdicts.find((v) => v.fact_id === "f_abc123");
+    expect(preVerdict?.needs_recheck).toBe(false);
+
+    await app.request("/api/kb-verifications/verifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        factId: "f_abc123",
+        verdict: "contradicted",
+        confidence: 0.8,
+      }),
+    });
+
+    // After insertion, the verdict should be flagged for recheck
+    const postVerdict = verdicts.find((v) => v.fact_id === "f_abc123");
+    expect(postVerdict?.needs_recheck).toBe(true);
+  });
+
+  it("returns verdictFlagged: false when no existing verdict exists", async () => {
+    const res = await app.request("/api/kb-verifications/verifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        factId: "f_newFact999",
+        verdict: "confirmed",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.verdictFlagged).toBe(false);
+  });
+
+  it("rejects invalid verdict values", async () => {
+    const res = await app.request("/api/kb-verifications/verifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        factId: "f_abc123",
+        verdict: "invalid_verdict",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing factId", async () => {
+    const res = await app.request("/api/kb-verifications/verifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        verdict: "confirmed",
+      }),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/wiki-server/src/routes/kb-verifications.ts
+++ b/apps/wiki-server/src/routes/kb-verifications.ts
@@ -7,14 +7,43 @@ import {
   kbFactResourceVerifications,
   facts,
 } from "../schema.js";
-import { zv, notFoundError } from "./utils.js";
+import {
+  zv,
+  notFoundError,
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+} from "./utils.js";
 
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
 const MAX_FACT_ID_LENGTH = 100;
+const MAX_URL_LENGTH = 2048;
+
+// ---- Valid verdict values ----
+
+const VALID_RESOURCE_VERDICTS = [
+  "confirmed",
+  "contradicted",
+  "unverifiable",
+  "outdated",
+  "partial",
+] as const;
 
 // ---- Query schemas ----
+
+const ResourceVerificationBody = z.object({
+  factId: z.string().min(1).max(MAX_FACT_ID_LENGTH),
+  resourceId: z.string().max(200).optional(),
+  verdict: z.enum(VALID_RESOURCE_VERDICTS),
+  confidence: z.number().min(0).max(1).optional(),
+  extractedValue: z.string().max(2000).optional(),
+  checkerModel: z.string().max(100).optional(),
+  isPrimarySource: z.boolean().default(false),
+  notes: z.string().max(5000).optional(),
+  sourceUrl: z.string().url().max(MAX_URL_LENGTH).optional(),
+});
 
 const VerdictsQuery = z.object({
   verdict: z.string().max(50).optional(),
@@ -198,10 +227,57 @@ const kbVerificationsApp = new Hono()
         isPrimarySource: v.isPrimarySource,
         checkedAt: v.checkedAt,
         notes: v.notes,
+        sourceUrl: v.sourceUrl,
         createdAt: v.createdAt,
         updatedAt: v.updatedAt,
       })),
     });
+  })
+
+  // ---- POST /verifications ----
+  .post("/verifications", async (c) => {
+    const raw = await parseJsonBody(c);
+    if (!raw) return invalidJsonError(c);
+
+    const parsed = ResourceVerificationBody.safeParse(raw);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const body = parsed.data;
+    const db = getDrizzleDb();
+
+    const now = new Date();
+
+    // Insert the resource verification
+    const [inserted] = await db
+      .insert(kbFactResourceVerifications)
+      .values({
+        factId: body.factId,
+        resourceId: body.resourceId ?? null,
+        verdict: body.verdict,
+        confidence: body.confidence ?? null,
+        extractedValue: body.extractedValue ?? null,
+        checkerModel: body.checkerModel ?? null,
+        isPrimarySource: body.isPrimarySource,
+        notes: body.notes ?? null,
+        sourceUrl: body.sourceUrl ?? null,
+        checkedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning({ id: kbFactResourceVerifications.id });
+
+    // Auto-set needs_recheck on the corresponding verdict if one exists.
+    // When new evidence is inserted, the aggregate verdict may be stale.
+    const updated = await db
+      .update(kbFactVerdicts)
+      .set({ needsRecheck: true, updatedAt: now })
+      .where(eq(kbFactVerdicts.factId, body.factId))
+      .returning({ factId: kbFactVerdicts.factId });
+
+    return c.json({
+      id: inserted.id,
+      verdictFlagged: updated.length > 0,
+    }, 201);
   });
 
 // ---- Exports ----

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1350,6 +1350,7 @@ export const kbFactResourceVerifications = pgTable(
       .notNull()
       .defaultNow(),
     notes: text("notes"),
+    sourceUrl: text("source_url"), // URL that was actually verified (fact source can change over time)
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/crux/commands/kb-verify.ts
+++ b/crux/commands/kb-verify.ts
@@ -24,6 +24,7 @@ import type { Entity, Fact, Property } from '../../packages/kb/src/types.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { parseJsonResponse } from '../lib/anthropic.ts';
 import { getCitationContentByUrl } from '../lib/wiki-server/citations.ts';
+import { apiRequest } from '../lib/wiki-server/client.ts';
 import {
   detectPaywall,
   isUnverifiableDomain,
@@ -366,6 +367,33 @@ async function verifySingleFact(
 }
 
 /**
+ * Store a verification result in the wiki-server database.
+ * Best-effort: logs a warning on failure but does not block the pipeline.
+ */
+async function storeVerificationResult(result: VerificationResult): Promise<void> {
+  const body = {
+    factId: result.factId,
+    verdict: result.verdict,
+    confidence: result.confidence,
+    extractedValue: result.extractedValue,
+    checkerModel: 'claude-3-haiku', // matches MODELS.haiku used in verifySingleFact
+    isPrimarySource: true,
+    notes: result.reasoning,
+    sourceUrl: result.sourceUrl,
+  };
+
+  const response = await apiRequest<{ id: number; verdictFlagged: boolean }>(
+    'POST',
+    '/api/kb-verifications/verifications',
+    body,
+  );
+
+  if (!response.ok) {
+    console.warn(`[kb-verify] Failed to store verification for ${result.factId}: ${response.error}`);
+  }
+}
+
+/**
  * Collect facts to verify based on the command options.
  */
 function collectFacts(
@@ -520,6 +548,11 @@ export async function verifyCommand(
       if (result.verdict === 'contradicted' || result.verdict === 'outdated') {
         console.log(`    Source says: ${result.extractedValue.slice(0, 100)}`);
       }
+
+      // Store result in wiki-server (best-effort, does not block pipeline)
+      storeVerificationResult(result).catch((e: unknown) => {
+        console.warn(`[kb-verify] Failed to store result for ${result.factId}: ${e instanceof Error ? e.message : String(e)}`);
+      });
     }
   }
 

--- a/crux/lib/search/paywall-detection.test.ts
+++ b/crux/lib/search/paywall-detection.test.ts
@@ -11,6 +11,7 @@ import {
   isUnverifiableDomain,
   classifyFetchError,
   PAYWALL_SIGNALS,
+  NEGATIVE_PAYWALL_SIGNALS,
   UNVERIFIABLE_DOMAINS,
 } from './paywall-detection.ts';
 
@@ -44,7 +45,7 @@ describe('detectPaywall', () => {
     expect(detectPaywall(longContent)).toBe(false);
   });
 
-  it('detects paywall when two signals appear early in longer content', () => {
+  it('detects paywall when two signals appear early and close together', () => {
     const longContent = 'Subscribe to read this content is for subscribers ' + 'A'.repeat(2000);
     expect(detectPaywall(longContent)).toBe(true);
   });
@@ -64,6 +65,46 @@ describe('detectPaywall', () => {
     for (const signal of PAYWALL_SIGNALS) {
       expect(detectPaywall(signal)).toBe(true);
     }
+  });
+
+  // ---- Proximity-based detection ----
+
+  it('rejects two signals that are far apart in long content (>500 chars gap)', () => {
+    // Two signals exist but are >500 chars apart — should NOT trigger
+    const longContent = 'subscribe to read ' + 'A'.repeat(600) + ' login required ' + 'B'.repeat(800);
+    expect(detectPaywall(longContent)).toBe(false);
+  });
+
+  it('detects paywall when two signals are within 500 chars of each other', () => {
+    // Two signals within proximity window
+    const longContent = 'subscribe to read ' + 'A'.repeat(200) + ' login required ' + 'B'.repeat(1500);
+    expect(detectPaywall(longContent)).toBe(true);
+  });
+
+  it('detects paywall when signals are adjacent', () => {
+    const longContent = 'subscribe to read. please sign in to continue. ' + 'A'.repeat(1500);
+    expect(detectPaywall(longContent)).toBe(true);
+  });
+
+  // ---- Negative signal suppression ----
+
+  it('suppresses paywall detection when multiple negative signals are present', () => {
+    // Real article (>= 500 chars) with paywall-like words but clear article body indicators.
+    // The two paywall signals are within proximity range, but the negative signals override.
+    const articleContent =
+      'subscribe to read more about this topic. login required for premium features. ' +
+      'A'.repeat(500) +
+      ' comments section at the bottom. share this article with friends. ' +
+      'about the author: John Doe. references listed below. related articles follow.';
+    expect(detectPaywall(articleContent)).toBe(false);
+  });
+
+  it('does not suppress with fewer than 3 negative signals', () => {
+    // Only 2 negative signals — not enough to suppress
+    const content = 'subscribe to read. login required. ' +
+      'A'.repeat(500) +
+      ' comments section at the bottom. about the author.';
+    expect(detectPaywall(content)).toBe(true);
   });
 });
 

--- a/crux/lib/search/paywall-detection.ts
+++ b/crux/lib/search/paywall-detection.ts
@@ -24,6 +24,15 @@ export const PAYWALL_SIGNALS = [
   'please sign in', 'register to read',
 ];
 
+/**
+ * Negative signals — patterns that indicate the page is NOT paywalled,
+ * even if paywall-like phrases appear (e.g., a blog post about newsletters).
+ */
+export const NEGATIVE_PAYWALL_SIGNALS = [
+  'comments section', 'share this article', 'related articles',
+  'about the author', 'table of contents', 'references',
+];
+
 // ---------------------------------------------------------------------------
 // Structured error types for source fetch failures
 // ---------------------------------------------------------------------------
@@ -56,8 +65,13 @@ export function isUnverifiableDomain(url: string): boolean {
  * Detect paywall signals in page content.
  *
  * For short content (< 500 chars), a single paywall signal is enough.
- * For longer content, at least 2 signals must appear in the first 2000 chars
- * to avoid false positives from pages that merely mention paywalls.
+ * For longer content (>= 500 chars):
+ *   1. At least 2 paywall signals must appear in the first 2000 chars
+ *   2. Those 2 signals must appear within a 500-character window of each other
+ *      (proximity check) to reduce false positives from articles that merely
+ *      mention paywalls in different contexts
+ *   3. If enough negative signals are present (indicating real article content),
+ *      the detection is suppressed
  */
 export function detectPaywall(content: string): boolean {
   if (!content) return false;
@@ -66,10 +80,47 @@ export function detectPaywall(content: string): boolean {
   if (content.length < 500) {
     return PAYWALL_SIGNALS.some(s => lower.includes(s));
   }
-  // Longer content: paywall signal must appear early (first 2000 chars)
+  // Longer content: paywall signals must appear early (first 2000 chars)
   const early = lower.slice(0, 2000);
-  const signalCount = PAYWALL_SIGNALS.filter(s => early.includes(s)).length;
-  return signalCount >= 2;
+
+  // Find positions of all matching paywall signals in the early content
+  const signalPositions: number[] = [];
+  for (const signal of PAYWALL_SIGNALS) {
+    const idx = early.indexOf(signal);
+    if (idx !== -1) {
+      signalPositions.push(idx);
+    }
+  }
+
+  // Need at least 2 distinct signals
+  if (signalPositions.length < 2) {
+    return false;
+  }
+
+  // Proximity check: at least 2 signals must appear within a 500-char window
+  signalPositions.sort((a, b) => a - b);
+  let hasProximity = false;
+  for (let i = 0; i < signalPositions.length - 1; i++) {
+    if (signalPositions[i + 1] - signalPositions[i] <= 500) {
+      hasProximity = true;
+      break;
+    }
+  }
+
+  if (!hasProximity) {
+    return false;
+  }
+
+  // Negative signal check: if the content has multiple indicators of a real
+  // article body, suppress the paywall detection. Count negative signals
+  // across the full content (not just early), since article markers like
+  // "about the author" and "references" tend to appear at the end.
+  const negativeCount = NEGATIVE_PAYWALL_SIGNALS.filter(s => lower.includes(s)).length;
+  if (negativeCount >= 3) {
+    return false;
+  }
+
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Auto-set `needs_recheck` flag when new resource verifications are inserted for existing verdicts
- Add `source_url` column to track which URL was verified at the time of verification
- Improve paywall detection with proximity-based signal matching to reduce false positives

## Changes

### Fix 1: Auto-set needs_recheck on new resource verifications
Added a `POST /verifications` endpoint to `kb-verifications` route. When a new resource verification is inserted for a fact that already has an aggregate verdict, the endpoint automatically sets `needs_recheck = true` on the verdict row. Also integrated the CLI `kb-verify` command to store results via this endpoint after each verification run.

### Fix 2: Track source_url in resource verifications
Added `source_url TEXT` column to `kb_fact_resource_verifications` table (migration 0069). This tracks the URL that was actually verified, since a fact's source URL can change over time. The POST endpoint and CLI command both populate this field.

### Fix 3: Proximity-based paywall signal matching
For long content (>=500 chars), paywall detection now requires:
1. At least 2 paywall signals in the first 2000 chars (unchanged)
2. Those signals must appear within a 500-character window of each other (new proximity check)
3. If 3+ negative signals are present (e.g., "about the author", "references", "comments section"), detection is suppressed

## Test plan
- [x] Wiki-server TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 14 kb-verifications tests pass (including 5 new POST tests)
- [x] All 34 paywall-detection tests pass (including 4 new proximity/negative signal tests)
- [x] New POST endpoint validates input (rejects invalid verdicts, missing factId)
- [x] needs_recheck flag correctly set when verdict exists, not set when it doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)