### PR TITLE
fix: use explicit collection names in record schemas instead of naive pluralization

### DIFF
--- a/packages/kb/data/schemas/records/board-seat.yaml
+++ b/packages/kb/data/schemas/records/board-seat.yaml
@@ -1,5 +1,6 @@
 name: Board Seat
 description: "Board of directors membership, current and former."
+collectionName: board-seats
 temporal: true
 
 endpoints:

--- a/packages/kb/data/schemas/records/career-history.yaml
+++ b/packages/kb/data/schemas/records/career-history.yaml
@@ -1,5 +1,6 @@
 name: Career History
 description: "Chronological career positions, including current and past roles."
+collectionName: career-history
 temporal: true
 
 endpoints:

--- a/packages/kb/data/schemas/records/charitable-pledge.yaml
+++ b/packages/kb/data/schemas/records/charitable-pledge.yaml
@@ -1,5 +1,6 @@
 name: Charitable Pledge
 description: "Charitable giving commitment by a person."
+collectionName: charitable-pledges
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/equity-position.yaml
+++ b/packages/kb/data/schemas/records/equity-position.yaml
@@ -1,5 +1,6 @@
 name: Equity Position
 description: "Current or historical equity ownership stake."
+collectionName: equity-positions
 temporal: true
 
 endpoints:

--- a/packages/kb/data/schemas/records/funding-round.yaml
+++ b/packages/kb/data/schemas/records/funding-round.yaml
@@ -1,5 +1,6 @@
 name: Funding Round
 description: "Equity and strategic investment rounds, in chronological order."
+collectionName: funding-rounds
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/grant.yaml
+++ b/packages/kb/data/schemas/records/grant.yaml
@@ -1,5 +1,6 @@
 name: Grant or Program
 description: "Major grants, programs, and spending initiatives."
+collectionName: grants
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/investment.yaml
+++ b/packages/kb/data/schemas/records/investment.yaml
@@ -1,5 +1,6 @@
 name: Investment Participation
 description: "An investor's participation in a company's funding round."
+collectionName: investments
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/key-person.yaml
+++ b/packages/kb/data/schemas/records/key-person.yaml
@@ -1,5 +1,6 @@
 name: Key Person
 description: "Current and former key personnel including founders, executives, and notable researchers."
+collectionName: key-persons
 temporal: true
 
 endpoints:

--- a/packages/kb/data/schemas/records/model-release.yaml
+++ b/packages/kb/data/schemas/records/model-release.yaml
@@ -1,5 +1,6 @@
 name: Model Release
 description: "AI model releases in chronological order."
+collectionName: model-releases
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/notable-publication.yaml
+++ b/packages/kb/data/schemas/records/notable-publication.yaml
@@ -1,5 +1,6 @@
 name: Notable Publication
 description: "Key publications, papers, and books authored or co-authored."
+collectionName: notable-publications
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/product.yaml
+++ b/packages/kb/data/schemas/records/product.yaml
@@ -1,5 +1,6 @@
 name: Product
 description: "Major products and services launched by an organization."
+collectionName: products
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/research-area.yaml
+++ b/packages/kb/data/schemas/records/research-area.yaml
@@ -1,5 +1,6 @@
 name: Research Area
 description: "Major research initiatives and focus areas."
+collectionName: research-areas
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/safety-milestone.yaml
+++ b/packages/kb/data/schemas/records/safety-milestone.yaml
@@ -1,5 +1,6 @@
 name: Safety Milestone
 description: "Significant safety research publications and policy milestones."
+collectionName: safety-milestones
 temporal: false
 
 endpoints:

--- a/packages/kb/data/schemas/records/strategic-partnership.yaml
+++ b/packages/kb/data/schemas/records/strategic-partnership.yaml
@@ -1,5 +1,6 @@
 name: Strategic Partnership
 description: "Major strategic partnerships and cloud/compute deals."
+collectionName: strategic-partnerships
 temporal: false
 
 endpoints:

--- a/packages/kb/src/graph.ts
+++ b/packages/kb/src/graph.ts
@@ -261,6 +261,19 @@ export class Graph {
   }
 
   /**
+   * Find a record schema by its collection name (e.g., "funding-rounds" → funding-round schema).
+   * Returns undefined if no schema has this collectionName.
+   */
+  getRecordSchemaByCollectionName(collectionName: string): RecordSchema | undefined {
+    for (const schema of this.recordSchemas.values()) {
+      if (schema.collectionName === collectionName) {
+        return schema;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Get record entries for a collection owned by an entity.
    */
   getRecords(entityId: string, collectionName: string): RecordEntry[] {

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -290,6 +290,7 @@ function parseRecordSchema(id: string, raw: unknown): RecordSchema {
     id,
     name: file.name,
     ...(file.description && { description: file.description }),
+    ...(file.collectionName && { collectionName: file.collectionName }),
     endpoints,
     fields: file.fields ?? {},
     ...(file.temporal && { temporal: true }),
@@ -439,7 +440,8 @@ async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unkno
 
 /**
  * Maps a collection name (e.g., "funding-rounds") to a record schema ID
- * (e.g., "funding-round"). Tries exact match, then depluralization.
+ * (e.g., "funding-round"). Uses explicit collectionName from schemas first,
+ * then falls back to naive depluralization.
  */
 function findRecordSchemaId(
   collectionName: string,
@@ -451,8 +453,15 @@ function findRecordSchemaId(
     return collectionName;
   }
 
-  // Depluralize and check: "funding-rounds" → "funding-round",
-  // "career-histories" → "career-history"
+  // Primary path: check if any allowed schema has this as its explicit collectionName
+  for (const id of allowedIds) {
+    const schema = graph.getRecordSchema(id);
+    if (schema?.collectionName === collectionName) {
+      return id;
+    }
+  }
+
+  // Fallback: naive depluralization for schemas without explicit collectionName
   const candidates: string[] = [];
   if (collectionName.endsWith("ies")) {
     candidates.push(collectionName.slice(0, -3) + "y"); // histories → history

--- a/packages/kb/src/types.ts
+++ b/packages/kb/src/types.ts
@@ -149,6 +149,8 @@ export interface RecordSchema {
   /** Display name */
   name: string;
   description?: string;
+  /** Plural collection name used in YAML files (e.g., "funding-rounds" for schema "funding-round") */
+  collectionName?: string;
   /** Entity reference fields that position this record in the graph */
   endpoints: Record<string, EndpointDef>;
   /** Data fields */
@@ -257,6 +259,8 @@ export interface SchemaFile {
 export interface RecordSchemaFile {
   name: string;
   description?: string;
+  /** Plural collection name used in YAML files (e.g., "funding-rounds" for schema "funding-round") */
+  collectionName?: string;
   temporal?: boolean;
   endpoints: Record<string, {
     types: string[];

--- a/packages/kb/tests/records.test.ts
+++ b/packages/kb/tests/records.test.ts
@@ -56,6 +56,48 @@ describe("records", () => {
     });
   });
 
+  describe("collectionName in record schemas", () => {
+    it("all record schemas have explicit collectionName", () => {
+      const schemas = graph.getAllRecordSchemas();
+      for (const schema of schemas) {
+        expect(schema.collectionName, `schema "${schema.id}" missing collectionName`).toBeDefined();
+      }
+    });
+
+    it("funding-round schema has collectionName 'funding-rounds'", () => {
+      const schema = graph.getRecordSchema("funding-round");
+      expect(schema!.collectionName).toBe("funding-rounds");
+    });
+
+    it("career-history schema has collectionName 'career-history'", () => {
+      const schema = graph.getRecordSchema("career-history");
+      expect(schema!.collectionName).toBe("career-history");
+    });
+
+    it("grant schema has collectionName 'grants'", () => {
+      const schema = graph.getRecordSchema("grant");
+      expect(schema!.collectionName).toBe("grants");
+    });
+
+    it("collectionName values are unique across schemas", () => {
+      const schemas = graph.getAllRecordSchemas();
+      const names = schemas.map((s) => s.collectionName).filter(Boolean);
+      const unique = new Set(names);
+      expect(unique.size).toBe(names.length);
+    });
+
+    it("getRecordSchemaByCollectionName resolves to correct schema", () => {
+      const schema = graph.getRecordSchemaByCollectionName("funding-rounds");
+      expect(schema).toBeDefined();
+      expect(schema!.id).toBe("funding-round");
+    });
+
+    it("getRecordSchemaByCollectionName returns undefined for unknown name", () => {
+      const schema = graph.getRecordSchemaByCollectionName("nonexistent");
+      expect(schema).toBeUndefined();
+    });
+  });
+
   describe("entity type schema records list", () => {
     it("organization schema lists record types", () => {
       const orgSchema = graph.getSchema("organization");


### PR DESCRIPTION
## Summary

- Adds `collectionName` field to `RecordSchema` and `RecordSchemaFile` types in `packages/kb/src/types.ts`
- Populates `collectionName` in all 14 record schema YAML files (`packages/kb/data/schemas/records/*.yaml`)
- Updates `findRecordSchemaId` in `packages/kb/src/loader.ts` to use schema-defined collection names as the primary lookup path, falling back to naive depluralization for backward compatibility
- Adds `getRecordSchemaByCollectionName` helper to `Graph` for reverse lookups
- Adds 7 new tests for collection name loading, uniqueness, and reverse lookup

## Motivation

The `findRecordSchemaId` function used naive English pluralization rules (`-s`, `-ies`) to map collection names to schema IDs. This breaks for words like "analysis" -> "analysiss", "process" -> "processs", etc. Making each schema explicitly declare its plural collection name eliminates this class of bugs.

Ref #2030

## Test plan

- [x] `npx vitest run packages/kb/tests/records.test.ts` -- 33 tests pass (7 new)
- [x] `npx vitest run packages/kb/tests/loader.test.ts` -- 31 tests pass
- [x] `npx vitest run crux/commands/kb.test.ts` -- 14 tests pass
- [x] All 279 tests pass across 12 test files

Generated with [Claude Code](https://claude.com/claude-code)