### PR TITLE
fix: validate record field names against schema in add-record

### DIFF
--- a/crux/commands/kb.test.ts
+++ b/crux/commands/kb.test.ts
@@ -448,5 +448,8 @@ describe('crux kb add-record', () => {
     expect(result.output).toContain('Valid fields');
     expect(result.output).toContain('raised');
     expect(result.output).toContain('name');
+    // Should also mention convention fields
+    expect(result.output).toContain('Also allowed');
+    expect(result.output).toContain('asOf');
   }, 30_000);
 });

--- a/crux/commands/kb.ts
+++ b/crux/commands/kb.ts
@@ -1185,20 +1185,20 @@ Examples:
     entry[key] = !isNaN(num) && val.trim() !== '' ? num : val;
   }
 
-
   // Validate field names against the record schema
+  const conventionFields = ['asOf', 'validEnd', 'display_name'];
   const validFields = new Set([
     ...Object.keys(recordSchema.fields),
     ...Object.keys(recordSchema.endpoints),
     // Convention fields not defined in schema but allowed on any record
-    'asOf', 'validEnd', 'display_name',
+    ...conventionFields,
   ]);
   const unknownFields = Object.keys(entry).filter((k) => !validFields.has(k));
   if (unknownFields.length > 0) {
     const schemaFields = [...Object.keys(recordSchema.fields), ...Object.keys(recordSchema.endpoints)].sort();
     return {
       exitCode: 1,
-      output: `Unknown field${unknownFields.length > 1 ? 's' : ''}: ${unknownFields.map((f) => `"${f}"`).join(', ')}\n  Valid fields for "${recordTypeArg}": ${schemaFields.join(', ')}`,
+      output: `Unknown field${unknownFields.length > 1 ? 's' : ''}: ${unknownFields.map((f) => `"${f}"`).join(', ')}\n  Valid fields for "${recordTypeArg}": ${schemaFields.join(', ')}\n  Also allowed on any record: ${conventionFields.join(', ')}`,
     };
   }
   // Add asOf if provided


### PR DESCRIPTION
## Summary

- Adds field name validation to `crux kb add-record` — after parsing `key=value` pairs, each field name is checked against the record schema's `fields` and `endpoints` maps
- Unknown fields produce a blocking error listing the valid field names, preventing silent data corruption from typos like `amunt=2e9` or `roole=CEO`
- Convention fields (`asOf`, `validEnd`, `display_name`) are always allowed since they are used across all record types but not schema-defined

## Test plan

- [x] Added test: unknown field names produce error with field name and valid fields list
- [x] All 39 tests in `crux/commands/kb.test.ts` pass
- [x] Existing tests for valid usage, missing args, bad schema, and invalid k=v format still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)