### PR TITLE
test: strengthen tag-sync assertions with value verification

### DIFF
--- a/packages/kb/tests/tag-sync.test.ts
+++ b/packages/kb/tests/tag-sync.test.ts
@@ -1,28 +1,29 @@
 /**
  * Tests that CUSTOM_TAGS exported by the KB loader stay synchronized with
- * the KB writer's usage. Catches regressions like adding a new tag to the
- * loader that the writer doesn't handle, or changing tag behavior.
+ * the KB writer's usage. Catches regressions like changing tag behavior
+ * or adding a new tag without updating round-trip serialization.
  */
 
 import { describe, it, expect } from "vitest";
-import { parse as parseYaml, parseDocument, stringify as stringifyYaml } from "yaml";
-import { CUSTOM_TAGS } from "../src/loader";
+import {
+  parse as parseYaml,
+  parseDocument,
+  stringify as stringifyYaml,
+} from "yaml";
+import { CUSTOM_TAGS, RefMarker, DateMarker, SrcMarker } from "../src/loader";
 
 describe("CUSTOM_TAGS synchronization", () => {
-  it("exports at least the three core tags (!ref, !date, !src)", () => {
-    expect(CUSTOM_TAGS.length).toBeGreaterThanOrEqual(3);
+  it("exports exactly the three core tags (!ref, !date, !src)", () => {
+    // Exact match — forces test update when tags are added/removed
+    expect(CUSTOM_TAGS.length).toBe(3);
     const tagNames = CUSTOM_TAGS.map((t) => t.tag);
     expect(tagNames).toContain("!ref");
     expect(tagNames).toContain("!date");
     expect(tagNames).toContain("!src");
   });
 
-  it("every tag has tag, resolve, identify, and stringify properties", () => {
+  it("every tag has required ScalarTag properties", () => {
     for (const tag of CUSTOM_TAGS) {
-      expect(tag).toHaveProperty("tag");
-      expect(tag).toHaveProperty("resolve");
-      expect(tag).toHaveProperty("identify");
-      expect(tag).toHaveProperty("stringify");
       expect(typeof tag.tag).toBe("string");
       expect(typeof tag.resolve).toBe("function");
       expect(typeof tag.identify).toBe("function");
@@ -30,28 +31,52 @@ describe("CUSTOM_TAGS synchronization", () => {
     }
   });
 
-  it("each tag survives a YAML stringify -> parse round-trip", () => {
-    const samples: Record<string, string> = {
-      "!ref": "abc1234567:some-slug",
-      "!date": "2024-06",
-      "!src": "my-alias",
-    };
+  it("!ref survives stringify → parse round-trip with correct value", () => {
+    const original = { ref: new RefMarker("abc1234567", "some-slug") };
+    const yaml = stringifyYaml(original, { customTags: CUSTOM_TAGS });
 
-    for (const tag of CUSTOM_TAGS) {
-      const yamlInput = `value: ${tag.tag} ${samples[tag.tag]}`;
-      const parsed = parseYaml(yamlInput, { customTags: CUSTOM_TAGS });
-      const serialized = stringifyYaml(parsed, { customTags: CUSTOM_TAGS });
-      expect(serialized).toContain(tag.tag);
+    // Tag and value appear together
+    expect(yaml).toContain("!ref abc1234567:some-slug");
 
-      const reparsed = parseYaml(serialized, { customTags: CUSTOM_TAGS });
-      const reserializedAgain = stringifyYaml(reparsed, {
-        customTags: CUSTOM_TAGS,
-      });
-      expect(reserializedAgain).toContain(tag.tag);
-    }
+    const parsed = parseYaml(yaml, { customTags: CUSTOM_TAGS }) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.ref).toBeInstanceOf(RefMarker);
+    const ref = parsed.ref as RefMarker;
+    expect(ref.stableId).toBe("abc1234567");
+    expect(ref.expectedSlug).toBe("some-slug");
   });
 
-  it("parseDocument (used by kb-writer) preserves all tags via toString()", () => {
+  it("!date survives stringify → parse round-trip with correct value", () => {
+    const original = { date: new DateMarker("2024-06") };
+    const yaml = stringifyYaml(original, { customTags: CUSTOM_TAGS });
+
+    expect(yaml).toContain("!date 2024-06");
+
+    const parsed = parseYaml(yaml, { customTags: CUSTOM_TAGS }) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.date).toBeInstanceOf(DateMarker);
+    expect((parsed.date as DateMarker).value).toBe("2024-06");
+  });
+
+  it("!src survives stringify → parse round-trip with correct value", () => {
+    const original = { src: new SrcMarker("my-alias") };
+    const yaml = stringifyYaml(original, { customTags: CUSTOM_TAGS });
+
+    expect(yaml).toContain("!src my-alias");
+
+    const parsed = parseYaml(yaml, { customTags: CUSTOM_TAGS }) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.src).toBeInstanceOf(SrcMarker);
+    expect((parsed.src as SrcMarker).alias).toBe("my-alias");
+  });
+
+  it("parseDocument (used by kb-writer) preserves all tags through toString()", () => {
     const yaml = [
       "ref_field: !ref abc1234567:some-slug",
       "date_field: !date 2025-01",
@@ -61,11 +86,28 @@ describe("CUSTOM_TAGS synchronization", () => {
     const doc = parseDocument(yaml, { customTags: CUSTOM_TAGS });
     const output = doc.toString();
 
-    expect(output).toContain("!ref");
-    expect(output).toContain("abc1234567:some-slug");
-    expect(output).toContain("!date");
-    expect(output).toContain("2025-01");
-    expect(output).toContain("!src");
-    expect(output).toContain("my-source");
+    // Check tag + value appear together on the correct field
+    expect(output).toContain("!ref abc1234567:some-slug");
+    expect(output).toContain("!date 2025-01");
+    expect(output).toContain("!src my-source");
+  });
+
+  it("parseDocument does NOT add tags to new plain values", () => {
+    // Simulates what kb-writer does: parse a doc, add new nodes, serialize
+    const yaml = "existing: !date 2024-06\n";
+    const doc = parseDocument(yaml, { customTags: CUSTOM_TAGS });
+
+    // Add a new plain string value that looks like a date
+    const contents = doc.contents as import("yaml").YAMLMap;
+    const newNode = doc.createNode("2025-01");
+    contents.set("new_field", newNode);
+
+    const output = doc.toString();
+
+    // Existing tagged value should keep its tag
+    expect(output).toContain("!date 2024-06");
+    // New plain string should NOT get a tag
+    expect(output).toMatch(/new_field: ['"]?2025-01/);
+    expect(output).not.toMatch(/new_field: !date/);
   });
 });


### PR DESCRIPTION
## Summary
- Round-trip tests now verify parsed marker class properties (`stableId`, `expectedSlug`, `value`, `alias`) — not just tag name presence
- Adds test that `parseDocument` + `createNode()` does not accidentally tag plain values
- All 7 tests pass

Follow-up to #2047 (already merged with weaker assertions).

## Test plan
- [x] `npx vitest run packages/kb/tests/tag-sync.test.ts` — 7/7 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>