### PR TITLE
fix: deploy job conditions check wrong branch

### DIFF
--- a/.github/workflows/discord-bot-docker.yml
+++ b/.github/workflows/discord-bot-docker.yml
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,scope=discord-bot,mode=max
 
       - name: Update ArgoCD image tag
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/production'
         env:
           ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/groundskeeper-docker.yml
+++ b/.github/workflows/groundskeeper-docker.yml
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,scope=groundskeeper,mode=max
 
       - name: Update ArgoCD image tag
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/production'
         env:
           ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -68,7 +68,7 @@ jobs:
     name: Pre-deploy smoke test
     needs: build-and-push
     if: >-
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/production'
       && inputs.skip_smoke_test != true
     runs-on: ubuntu-latest
 
@@ -156,7 +156,7 @@ jobs:
   pre-deploy-backup:
     name: Pre-deploy database backup
     needs: build-and-push
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/production'
     uses: ./.github/workflows/database-backup.yml
     with:
       backup_prefix: pre-deploy
@@ -166,7 +166,7 @@ jobs:
     name: Deploy to ArgoCD
     needs: [build-and-push, pre-deploy-smoke-test, pre-deploy-backup]
     if: >-
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/production'
       && !cancelled()
       && (needs.pre-deploy-smoke-test.result == 'success' || needs.pre-deploy-smoke-test.result == 'skipped')
     # Deploy proceeds if smoke test passed OR was skipped (DDL migration deploys).


### PR DESCRIPTION
## Summary

- All three Docker workflow files (`wiki-server-docker.yml`, `discord-bot-docker.yml`, `groundskeeper-docker.yml`) trigger on pushes to the `production` branch, but the deploy/smoke-test/backup job conditions still checked `github.ref == 'refs/heads/main'`
- This mismatch meant deploy steps have been **silently skipped** on every push to `production` since March 4, when the trigger branches were changed
- This PR changes all `if:` conditions from `refs/heads/main` to `refs/heads/production` so deploys actually run

## Changes

| File | Conditions fixed |
|------|-----------------|
| `wiki-server-docker.yml` | `pre-deploy-smoke-test`, `pre-deploy-backup`, `deploy` jobs |
| `discord-bot-docker.yml` | `Update ArgoCD image tag` step |
| `groundskeeper-docker.yml` | `Update ArgoCD image tag` step |

## Test plan

- [ ] Merge to `main`, then merge `main` into `production`
- [ ] Verify the wiki-server workflow runs the deploy job (not just build)
- [ ] Verify the discord-bot workflow runs the ArgoCD update step
- [ ] Verify the groundskeeper workflow runs the ArgoCD update step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation workflow configurations across multiple services to modify branch-based execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->