### PR TITLE
refactor: DRY up last inline header construction in build-data.mjs

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -942,9 +942,7 @@ async function mergePGRecordsIntoKB(kb) {
     return { personnel: 0, grants: 0 };
   }
 
-  const headers = { 'Content-Type': 'application/json' };
-  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
-  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+  const headers = buildHeaders();
 
   let personnelCount = 0;
   let grantsCount = 0;


### PR DESCRIPTION
## Summary

- Replaced the last remaining inline header construction (`Content-Type` + `Authorization`) in `mergePGRecordsIntoKB()` with the existing shared `buildHeaders()` helper
- The `buildHeaders()` function was already defined at the top of `build-data.mjs` and used by 7 other call sites — this catches the one that was missed

## Test plan

- [x] `node --check` passes (no syntax errors)
- [x] `pnpm build` succeeds (including `build-data.mjs` execution as prebuild step)
- [x] All 18 gate checks pass
- [x] Verified no other inline header construction patterns remain

Closes #1985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->