### PR TITLE
fix: resolve Dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   },
   "pnpm": {
     "overrides": {
-      "rollup": ">=4.59.0"
+      "rollup": ">=4.59.0",
+      "dompurify": ">=3.3.2",
+      "immutable": ">=4.3.8"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   rollup: '>=4.59.0'
+  dompurify: '>=3.3.2'
+  immutable: '>=4.3.8'
 
 importers:
 
@@ -2945,8 +2947,9 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3377,8 +3380,8 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5969,7 +5972,7 @@ snapshots:
       commander: 12.1.0
       d3-format: 3.1.2
       d3-time-format: 4.1.0
-      immutable: 4.3.7
+      immutable: 5.1.5
       ink: 5.2.1(@types/react@19.2.13)(react@18.3.1)
       jstat: 1.9.6
       lodash: 4.17.23
@@ -7390,7 +7393,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
-  dompurify@3.3.1:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7871,7 +7874,7 @@ snapshots:
   ieee754@1.2.1:
     optional: true
 
-  immutable@4.3.7: {}
+  immutable@5.1.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -8315,7 +8318,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.19
-      dompurify: 3.3.1
+      dompurify: 3.3.2
       katex: 0.16.32
       khroma: 2.1.0
       lodash-es: 4.17.23


### PR DESCRIPTION
## Summary

- Add pnpm overrides for `dompurify` (>=3.3.2) and `immutable` (>=4.3.8) to resolve transitive dependency security vulnerabilities
- Fixes 3 of the 5 Dependabot alerts; the remaining 2 (`next-mdx-remote`) are stale alerts already resolved by the existing v6.0.0 dependency

## Vulnerability details

| Alert | Package | Severity | Status |
|-------|---------|----------|--------|
| #6 | `immutable` (via `@quri/squiggle-lang`) | High | **Fixed** via override >=4.3.8 |
| #4 | `dompurify` (via `mermaid`) | Moderate | **Fixed** via override >=3.3.2 |
| #3 | `rollup` (via `vite`) | High | Already fixed by existing override >=4.59.0 |
| #1, #2 | `next-mdx-remote` | High | Stale — already at v6.0.0 (patched version) |

Both `dompurify` and `immutable` are transitive dependencies where the direct parent packages (`mermaid` and `@quri/squiggle-lang`) have not yet released versions pulling in patched transitive deps. Using pnpm overrides is the standard approach for this situation.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2639 tests)
- [x] `pnpm crux validate gate` passes (all 18 checks)
- [x] Verified patched versions installed via `pnpm why dompurify` and `pnpm why immutable`

Closes #1966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
