### PR TITLE
fix: auto-update CI reads wrong report field, causing skipped citation/risk checks

### DIFF
--- a/crux/authoring/grading/steps.ts
+++ b/crux/authoring/grading/steps.ts
@@ -10,6 +10,7 @@
 
 import { callLlm } from '../../lib/llm.ts';
 import { parseJsonResponse } from '../../lib/anthropic.ts';
+import { parseJsonFromLlm } from '../../lib/json-parsing.ts';
 import { readFileSync } from 'fs';
 import { stripFrontmatter } from '../../lib/patterns.ts';
 import { ValidationEngine, ContentFile } from '../../lib/validation/validation-engine.ts';
@@ -144,7 +145,14 @@ export async function runChecklistReview(client: Anthropic, page: PageInfo): Pro
       maxTokens: 1500,
     });
 
-    const parsed = parseJsonResponse(result.text) as { warnings?: ChecklistWarning[] };
+    // Use parseJsonFromLlm for resilient handling of truncated LLM output.
+    // The raw JSON.parse was failing with "Unterminated string in JSON" when
+    // responses hit the maxTokens limit, producing noisy error logs in CI.
+    const parsed = parseJsonFromLlm<{ warnings?: ChecklistWarning[] }>(
+      result.text,
+      `checklist-review:${page.id}`,
+      () => ({ warnings: [] }),
+    );
     return parsed.warnings || [];
   } catch (err: unknown) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/crux/auto-update/ci-verify-citations.test.ts
+++ b/crux/auto-update/ci-verify-citations.test.ts
@@ -96,14 +96,14 @@ describe('extractPageIdsFromReport', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('extracts successful page IDs from run report', () => {
+  it('extracts successful page IDs from run report (execution.results)', () => {
     const reportPath = join(tmpDir, 'report.yaml');
     writeFileSync(reportPath, `
 date: '2026-02-20'
 execution:
   pagesUpdated: 2
   pagesFailed: 1
-  pages:
+  results:
     - pageId: existential-risk
       status: success
     - pageId: miri
@@ -114,6 +114,22 @@ execution:
 
     const ids = extractPageIdsFromReport(reportPath);
     expect(ids).toEqual(['existential-risk', 'miri']);
+  });
+
+  it('also supports legacy execution.pages field name', () => {
+    const reportPath = join(tmpDir, 'report-legacy.yaml');
+    writeFileSync(reportPath, `
+date: '2026-02-20'
+execution:
+  pagesUpdated: 1
+  pagesFailed: 0
+  pages:
+    - pageId: legacy-page
+      status: success
+`);
+
+    const ids = extractPageIdsFromReport(reportPath);
+    expect(ids).toEqual(['legacy-page']);
   });
 
   it('returns empty array for missing file', () => {

--- a/crux/auto-update/ci-verify-citations.ts
+++ b/crux/auto-update/ci-verify-citations.ts
@@ -54,11 +54,14 @@ export function extractPageIdsFromReport(reportPath: string): string[] {
     const content = readFileSync(reportPath, 'utf-8');
     const report = parseYaml(content);
 
-    if (!report?.execution?.pages || !Array.isArray(report.execution.pages)) {
+    // The run report stores page results under execution.results (see types.ts RunReport).
+    // Support both field names for backwards compatibility with older report files.
+    const pages = report?.execution?.results ?? report?.execution?.pages;
+    if (!Array.isArray(pages)) {
       return [];
     }
 
-    return report.execution.pages
+    return pages
       .filter((p: { status?: string }) => p.status === 'success')
       .map((p: { pageId?: string }) => p.pageId)
       .filter((id: unknown): id is string => typeof id === 'string');


### PR DESCRIPTION
## Summary

- **Root cause fix**: `extractPageIdsFromReport()` was reading `report.execution.pages` but the orchestrator writes results under `report.execution.results` (per the `RunReport` type in `types.ts`). This caused every auto-update run to report "No successful pages in report", skipping citation verification and hallucination risk scoring -- even when 3-4 pages were successfully updated.
- **JSON parse resilience**: Switched the checklist review step from raw `JSON.parse` to `parseJsonFromLlm`, which handles truncated LLM responses gracefully instead of producing noisy "Unterminated string in JSON" errors in CI logs.
- **Note on git push**: The git push failure (issue's second failure mode) was already fixed in commit `f00a0111` which changed `--force-with-lease` to `--force` for shallow CI clones. That fix was not yet on `main` when the March 8-10 runs failed, but it is now deployed.

## Changes

| File | Change |
|------|--------|
| `crux/auto-update/ci-verify-citations.ts` | Read `execution.results` with `execution.pages` fallback |
| `crux/auto-update/ci-verify-citations.test.ts` | Updated test to use correct field name + added legacy compatibility test |
| `crux/authoring/grading/steps.ts` | Use `parseJsonFromLlm` instead of raw `parseJsonResponse` for checklist review |

## Test plan

- [x] All 9 auto-update citation tests pass (including new legacy compatibility test)
- [x] All 98 auto-update tests pass
- [x] Full crux test suite passes (2639 tests, 1 pre-existing timeout unrelated to changes)
- [x] TypeScript compilation clean (crux tsconfig)
- [x] Gate check passes (all 11 checks)

Closes #1960

Generated with [Claude Code](https://claude.com/claude-code)