### PR TITLE
fix: add missing frontmatter to design doc (CI blocker)

### DIFF
--- a/content/docs/internal/design-pg-resources-unified-ids.md
+++ b/content/docs/internal/design-pg-resources-unified-ids.md
@@ -1,3 +1,10 @@
+---
+title: "Design: PG-Native Resources & Unified ID System"
+description: "Draft proposal for migrating resources to PG-native storage with a unified ID resolver."
+subcategory: architecture
+lastEdited: "2026-03-10"
+---
+
 # Design: PG-Native Resources & Unified ID System
 
 **Status**: Draft proposal


### PR DESCRIPTION
## Summary
- `content/docs/internal/design-pg-resources-unified-ids.md` was committed without frontmatter, causing the `frontmatter-schema` validation to fail on main
- Adds required frontmatter fields (title, description, subcategory, lastEdited)

## Test plan
- [x] `pnpm crux validate unified --rules=frontmatter-schema --errors-only` passes

Closes #2067