### PR TITLE
fix: extend statement_timeout for materialized view refresh

### DIFF
--- a/apps/wiki-server/src/routes/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/hallucination-risk.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq, desc, sql } from "drizzle-orm";
-import { getDrizzleDb, getDb } from "../db.js";
+import { getDrizzleDb, getDb, type SqlQuery } from "../db.js";
 import { hallucinationRiskSnapshots } from "../schema.js";
 import {
   parseJsonBody,
@@ -105,14 +105,16 @@ export function clearMatViewCache(): void {
 async function refreshMaterializedView(): Promise<void> {
   const rawDb = getDb();
   try {
-    await rawDb.begin(async (tx) => {
+    await rawDb.begin(async (txRaw) => {
+      const tx = txRaw as unknown as SqlQuery;
       await tx`SET LOCAL statement_timeout = '300000'`; // 5 minutes
       await tx`REFRESH MATERIALIZED VIEW CONCURRENTLY hallucination_risk_latest`;
     });
   } catch (err) {
     // CONCURRENTLY requires a unique index; fall back if not available
     logger.warn({ err }, "Concurrent refresh failed, trying non-concurrent");
-    await rawDb.begin(async (tx) => {
+    await rawDb.begin(async (txRaw) => {
+      const tx = txRaw as unknown as SqlQuery;
       await tx`SET LOCAL statement_timeout = '300000'`; // 5 minutes
       await tx`REFRESH MATERIALIZED VIEW hallucination_risk_latest`;
     });


### PR DESCRIPTION
## Summary
- Materialized view refreshes (`REFRESH MATERIALIZED VIEW [CONCURRENTLY]`) are background operations that can legitimately take 30-60s+, but the connection pool has a 30s `statement_timeout` configured in `db.ts`
- This caused `PostgresError: canceling statement due to statement timeout` errors in production during both concurrent and non-concurrent refresh attempts
- Fix: wrap each `REFRESH MATERIALIZED VIEW` call in a transaction with `SET LOCAL statement_timeout = '300000'` (5 minutes), scoping the override to just that operation without affecting the global connection pool timeout

## Details
The `SET LOCAL` command only applies within the current transaction, so the 30s default timeout remains in effect for all normal application queries. The concurrent-then-non-concurrent fallback pattern is preserved.

The 5-minute timeout was chosen to provide ample headroom as the dataset grows, while still providing a safety net against truly stuck queries.

## Test plan
- [ ] Deploy to staging and trigger a manual refresh via `POST /hallucination-risk/refresh`
- [ ] Verify the refresh completes without timeout errors in logs
- [ ] Confirm normal queries still respect the 30s timeout (e.g., slow query simulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of the hallucination risk assessment feature by improving the reliability of background data refresh operations, reducing potential timeout issues and ensuring more consistent system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->