### PR TITLE
fix: remove dead claims queries from references route

### DIFF
--- a/apps/wiki-server/src/routes/references.ts
+++ b/apps/wiki-server/src/routes/references.ts
@@ -222,30 +222,20 @@ const app = new Hono()
     // Group by pageId (skip rows with no recoverable slug)
     const byPage: Record<
       string,
-      {
-        claimReferences: Array<{
-          claimId: number;
-          claimText: string;
-          verdict: string | null;
-          referenceId: string | null;
-        }>;
-        citations: Array<{
-          referenceId: string;
-          title: string | null;
-          url: string | null;
-          note: string | null;
-          resourceId: string | null;
-        }>;
-      }
+      Array<{
+        referenceId: string;
+        title: string | null;
+        url: string | null;
+        note: string | null;
+        resourceId: string | null;
+      }>
     > = {};
 
     for (const row of citationRows) {
       const pageId = row.pageSlug;
-      if (!pageId) continue; // skip rows with no recoverable page slug
-      if (!byPage[pageId]) {
-        byPage[pageId] = { claimReferences: [], citations: [] };
-      }
-      byPage[pageId].citations.push({
+      if (!pageId) continue;
+      if (!byPage[pageId]) byPage[pageId] = [];
+      byPage[pageId].push({
         referenceId: row.referenceId,
         title: row.title,
         url: row.url,
@@ -254,10 +244,15 @@ const app = new Hono()
       });
     }
 
-    const totalCitations = Object.values(byPage).reduce((n, p) => n + p.citations.length, 0);
+    const totalCitations = Object.values(byPage).reduce((n, p) => n + p.length, 0);
 
     return c.json({
-      pages: byPage,
+      pages: Object.fromEntries(
+        Object.entries(byPage).map(([id, citations]) => [
+          id,
+          { claimReferences: [], citations },
+        ])
+      ),
       totalPages: Object.keys(byPage).length,
       totalClaimRefs: 0,
       totalCitations,


### PR DESCRIPTION
## Summary

- `/api/references/all` and `/api/references/by-page/:pageId` return 500 errors because they query `claim_page_references` and `claims` tables that were archived (renamed with `_archived_` prefix) by migration `0065_archive_statements_claims_tables.sql`
- The Drizzle ORM schema still references the original table names, so queries fail at runtime since those tables no longer exist
- This removes all dead `claim_page_references`/`claims` queries from the GET endpoints and returns empty claim data to preserve the response shape
- The `POST /claim` endpoint now returns 410 Gone instead of crashing
- `POST /citation` and `POST /citations/batch` are unchanged — the `page_citations` table was not archived

## What was broken

Migration 0065 renamed:
- `claim_page_references` → `_archived_claim_page_references`
- `claims` → `_archived_claims`

But `apps/wiki-server/src/routes/references.ts` still queried both tables, causing every call to `/api/references/all` (used by `build-data.mjs` and `crux/commands/footnotes.ts`) and `/api/references/by-page/:pageId` to throw a 500.

## Test plan

- [ ] Verify `/api/references/all` returns `{ pages: {}, totalPages: 0, totalClaimRefs: 0, totalCitations: N }` without errors
- [ ] Verify `/api/references/by-page/<slug>` returns `{ references: [...], totalClaim: 0, totalCitation: N }` without errors
- [ ] Verify `POST /api/references/claim` returns 410 with an explanatory message
- [ ] Verify `POST /api/references/citation` still works as before
- [ ] Verify `build-data.mjs` completes without the "all attempts failed" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)