### PR TITLE
fix: align schema with archived claims/statements tables

### DIFF
--- a/apps/wiki-server/src/__tests__/integration.test.ts
+++ b/apps/wiki-server/src/__tests__/integration.test.ts
@@ -72,7 +72,7 @@ const ALL_EXPECTED_TABLES = [
   "resources",
   "resource_citations",
   "summaries",
-  "claims",
+  "_archived_claims",
   "page_links",
 ];
 

--- a/apps/wiki-server/src/routes/citations.ts
+++ b/apps/wiki-server/src/routes/citations.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, count, avg, sql, asc, desc, isNotNull, lt } from "drizzle-orm";
 import { getDrizzleDb, getDb } from "../db.js";
-import { citationQuotes, citationContent, citationAccuracySnapshots, wikiPages, resources, claims } from "../schema.js";
+import { citationQuotes, citationContent, citationAccuracySnapshots, wikiPages, resources } from "../schema.js";
 import { checkRefsExist } from "./ref-check.js";
 import {
   parseJsonBody,
@@ -20,8 +20,6 @@ import {
   MarkAccuracyBatchSchema as SharedMarkAccuracyBatchSchema,
   UpsertCitationContentSchema,
   CITATION_CONTENT_PREVIEW_MAX,
-  LinkCitationClaimSchema,
-  LinkCitationsClaimsBatchSchema,
 } from "../api-types.js";
 import { logger } from "../logger.js";
 import { resolvePageIntId, resolvePageIntIds } from "./page-id-helpers.js";
@@ -1135,81 +1133,20 @@ const citationsApp = new Hono()
     });
   })
 
-  // ---- PATCH /quotes/:id/link-claim ---- [DEPRECATED: claims are now the source of truth]
-  // Links a citation_quote to a claim via the claim_id FK.
+  // ---- PATCH /quotes/:id/link-claim ---- [REMOVED: claims tables archived by migration 0065]
   .patch("/quotes/:id/link-claim", async (c) => {
-    deprecationWarning("PATCH /quotes/:id/link-claim");
-    const idStr = c.req.param("id");
-    const id = Number(idStr);
-    if (!Number.isInteger(id) || id <= 0) {
-      return validationError(c, "Quote ID must be a positive integer");
-    }
-
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = LinkCitationClaimSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const db = getDrizzleDb();
-
-    // Verify claim exists
-    const claimRows = await db.select({ id: claims.id }).from(claims).where(eq(claims.id, parsed.data.claimId)).limit(1);
-    if (claimRows.length === 0) return notFoundError(c, `Claim not found: ${parsed.data.claimId}`);
-
-    const rows = await db
-      .update(citationQuotes)
-      .set({ claimId: parsed.data.claimId, updatedAt: sql`now()` })
-      .where(eq(citationQuotes.id, id))
-      .returning({ id: citationQuotes.id, pageId: citationQuotes.pageId, footnote: citationQuotes.footnote });
-
-    if (rows.length === 0) return notFoundError(c, `Citation quote not found: ${id}`);
-
-    return c.json({ linked: true, quoteId: Number(rows[0].id), claimId: parsed.data.claimId });
+    return c.json(
+      { error: "Claim linking is no longer supported. The claims tables were archived by migration 0065." },
+      410,
+    );
   })
 
-  // ---- POST /quotes/link-claims-batch ---- [DEPRECATED: claims are now the source of truth]
+  // ---- POST /quotes/link-claims-batch ---- [REMOVED: claims tables archived by migration 0065]
   .post("/quotes/link-claims-batch", async (c) => {
-    deprecationWarning("POST /quotes/link-claims-batch");
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = LinkCitationsClaimsBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Pre-validate that all referenced claim IDs exist (mirrors the single-item endpoint)
-    const uniqueClaimIds = [...new Set(items.map((i) => i.claimId))];
-    const existingClaims = await db
-      .select({ id: claims.id })
-      .from(claims)
-      .where(sql`${claims.id} = ANY(${uniqueClaimIds})`);
-    const existingClaimIdSet = new Set(existingClaims.map((r) => r.id));
-    const missingClaimIds = uniqueClaimIds.filter((id) => !existingClaimIdSet.has(id));
-    if (missingClaimIds.length > 0) {
-      return validationError(c, `Referenced claims not found: ${missingClaimIds.join(", ")}`);
-    }
-
-    let linkedCount = 0;
-
-    try {
-      await db.transaction(async (tx) => {
-        for (const item of items) {
-          const rows = await tx
-            .update(citationQuotes)
-            .set({ claimId: item.claimId, updatedAt: sql`now()` })
-            .where(eq(citationQuotes.id, item.quoteId))
-            .returning({ id: citationQuotes.id });
-          if (rows.length > 0) linkedCount++;
-        }
-      });
-    } catch (err) {
-      return dbError(c, "citation quotes link-claims-batch", err, { itemCount: items.length });
-    }
-
-    return c.json({ linked: linkedCount });
+    return c.json(
+      { error: "Claim linking is no longer supported. The claims tables were archived by migration 0065." },
+      410,
+    );
   })
 
   // NOTE: POST /quotes/propagate-from-claims was removed in #1310.

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -54,9 +54,8 @@ export const citationQuotes = pgTable(
     sourceTitle: text("source_title"),
     sourceType: text("source_type"),
     extractionModel: text("extraction_model"),
-    claimId: bigint("claim_id", { mode: "number" }).references(() => claims.id, {
-      onDelete: "set null",
-    }),
+    /** @deprecated FK to claims was dropped by migration 0065 (claims table archived). Column kept for data. */
+    claimId: bigint("claim_id", { mode: "number" }),
     accuracyVerdict: text("accuracy_verdict"),
     accuracyIssues: text("accuracy_issues"),
     accuracyScore: real("accuracy_score"),
@@ -389,8 +388,9 @@ export const summaries = pgTable(
  * new code should use section instead.
  * footnoteRefs is also legacy — new code should use claim_page_references table.
  */
+/** @archived Migration 0065 renamed this table to _archived_claims. Schema kept for citationQuotes.claimId FK reference. */
 export const claims = pgTable(
-  "claims",
+  "_archived_claims",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     entityId: text("entity_id") // primary entity (extraction source)
@@ -481,8 +481,9 @@ asOf: text("as_of"),                // temporal index: YYYY-MM or YYYY-MM-DD
  * claim_mode on the parent claim tells you whether the wiki endorses the claim
  * or is attributing it to another entity (e.g., "Anthropic claims that...").
  */
+/** @archived Migration 0065 renamed this table to _archived_claim_sources. */
 export const claimSources = pgTable(
-  "claim_sources",
+  "_archived_claim_sources",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     claimId: bigint("claim_id", { mode: "number" })
@@ -516,8 +517,9 @@ export const claimSources = pgTable(
 );
 
 /** Claim-to-page references — links a claim to every wiki page it appears on. */
+/** @archived Migration 0065 renamed this table to _archived_claim_page_references. */
 export const claimPageReferences = pgTable(
-  "claim_page_references",
+  "_archived_claim_page_references",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     claimId: bigint("claim_id", { mode: "number" })
@@ -1162,8 +1164,9 @@ export const properties = pgTable(
  * `valid_start` / `valid_end` are text (not date) to support partial dates
  * like "2025", "2025-07", "2026-02" from YAML facts.
  */
+/** @archived Migration 0065 renamed this table to _archived_statements. */
 export const statements = pgTable(
-  "statements",
+  "_archived_statements",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     variety: text("variety").notNull(), // "structured" | "attributed"
@@ -1236,8 +1239,9 @@ export const statements = pgTable(
  * Each row represents one resource backing a statement. Supports both
  * resource_id (linked to data/resources/) and raw URL fallback.
  */
+/** @archived Migration 0065 renamed this table to _archived_statement_citations. */
 export const statementCitations = pgTable(
-  "statement_citations",
+  "_archived_statement_citations",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     statementId: bigint("statement_id", { mode: "number" })
@@ -1262,8 +1266,9 @@ export const statementCitations = pgTable(
 );
 
 /** Statement-to-page references — links a statement to every wiki page it appears on. */
+/** @archived Migration 0065 renamed this table to _archived_statement_page_references. */
 export const statementPageReferences = pgTable(
-  "statement_page_references",
+  "_archived_statement_page_references",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     statementId: bigint("statement_id", { mode: "number" }).notNull().references(
@@ -1290,8 +1295,9 @@ export const statementPageReferences = pgTable(
  *
  * Each row is a snapshot of an entity's overall statement quality at a point in time.
  */
+/** @archived Migration 0065 renamed this table to _archived_entity_coverage_scores. */
 export const entityCoverageScores = pgTable(
-  "entity_coverage_scores",
+  "_archived_entity_coverage_scores",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     entityId: text("entity_id").notNull(),


### PR DESCRIPTION
## Summary
- Migration 0065 renamed claims/statements tables to `_archived_*` but the Drizzle schema and citations route still referenced old names, causing 500 errors
- Updated all 7 archived table definitions in `schema.ts` to use `_archived_*` names
- Replaced broken `link-claim` and `link-claims-batch` citations endpoints with 410 Gone
- Removed stale FK reference from `citationQuotes.claimId` → `claims.id`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2642 tests)
- [x] Gate checks pass
- [x] Updated integration test expected table name

🤖 Generated with [Claude Code](https://claude.com/claude-code)