### PR TITLE
feat: add /risks/ directory section

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -75,6 +75,12 @@ export default function RootLayout({
                 People
               </Link>
               <Link
+                href="/risks"
+                className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+              >
+                Risks
+              </Link>
+              <Link
                 href="/grants"
                 className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
               >

--- a/apps/web/src/app/risks/[slug]/page.tsx
+++ b/apps/web/src/app/risks/[slug]/page.tsx
@@ -1,0 +1,295 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { resolveRiskBySlug, getRiskSlugs } from "@/app/risks/risk-utils";
+import { getKBFacts, getKBLatest, getKBProperty } from "@/data/kb";
+import { getTypedEntityById, isRisk, getEntityById } from "@/data";
+import { getEntityWikiHref } from "@/lib/directory-utils";
+import {
+  ProfileStatCard,
+  Breadcrumbs,
+} from "@/components/directory";
+import {
+  formatKBFactValue,
+  formatKBDate,
+  titleCase,
+} from "@/components/wiki/kb/format";
+import type { Fact, Property } from "@longterm-wiki/kb";
+
+export function generateStaticParams() {
+  return getRiskSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const entity = resolveRiskBySlug(slug);
+  return {
+    title: entity ? `${entity.name} | Risks` : "Risk Not Found",
+    description: entity
+      ? `Profile and assessment data for ${entity.name}.`
+      : undefined,
+  };
+}
+
+// ── Risk category colors ──────────────────────────────────────────────
+const RISK_CATEGORY_COLORS: Record<string, string> = {
+  accident: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  misuse: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  structural: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  epistemic: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+};
+
+const RISK_CATEGORY_LABELS: Record<string, string> = {
+  accident: "Accident",
+  misuse: "Misuse",
+  structural: "Structural",
+  epistemic: "Epistemic",
+};
+
+// ── Fact sidebar helpers ──────────────────────────────────────────────
+
+const FACT_CATEGORIES: { id: string; label: string; order: number }[] = [
+  { id: "assessment", label: "Assessment", order: 0 },
+  { id: "risk", label: "Risk", order: 1 },
+  { id: "other", label: "Other", order: 99 },
+];
+
+/** Group facts by property, taking only the latest per property. */
+function getLatestFactsByProperty(facts: Fact[]): Map<string, Fact> {
+  const latest = new Map<string, Fact>();
+  for (const fact of facts) {
+    if (fact.propertyId === "description") continue;
+    if (!latest.has(fact.propertyId)) {
+      latest.set(fact.propertyId, fact);
+    }
+  }
+  return latest;
+}
+
+/** Group property IDs by category, returning sorted categories. */
+function groupByCategory(
+  propertyIds: string[],
+): Array<{ category: string; label: string; props: string[] }> {
+  const groups = new Map<string, string[]>();
+  for (const propId of propertyIds) {
+    const prop = getKBProperty(propId);
+    const category = prop?.category ?? "other";
+    const list = groups.get(category) ?? [];
+    list.push(propId);
+    groups.set(category, list);
+  }
+
+  const catMap = new Map(FACT_CATEGORIES.map((c) => [c.id, c]));
+  return [...groups.entries()]
+    .map(([catId, props]) => ({
+      category: catId,
+      label: catMap.get(catId)?.label ?? titleCase(catId),
+      order: catMap.get(catId)?.order ?? 99,
+      props,
+    }))
+    .sort((a, b) => a.order - b.order);
+}
+
+/** Format a fact value for display, returning null if no fact. */
+function formatFact(
+  fact: Fact | undefined,
+  property?: Partial<Property>,
+): string | null {
+  if (!fact) return null;
+  return formatKBFactValue(fact, property?.unit, property?.display);
+}
+
+// ── Hero stat properties for risk pages ────────────────────────────────
+const HERO_STATS = [
+  "severity-level",
+  "likelihood-estimate",
+  "time-horizon",
+  "evidence-strength",
+  "expert-consensus-level",
+];
+
+// ── Main page ─────────────────────────────────────────────────────────
+
+export default async function RiskProfilePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const entity = resolveRiskBySlug(slug);
+  if (!entity) return notFound();
+
+  const typedEntity = getTypedEntityById(entity.id);
+  const riskCategory =
+    typedEntity && isRisk(typedEntity) ? (typedEntity.riskCategory ?? null) : null;
+
+  // Description from the database entity
+  const dbEntity = getEntityById(entity.id);
+  const descriptionText =
+    (dbEntity as { description?: string } | undefined)?.description ?? null;
+
+  // All facts for the sidebar
+  const allFacts = getKBFacts(entity.id).filter(
+    (f) => f.propertyId !== "description",
+  );
+
+  const wikiHref = getEntityWikiHref(entity);
+
+  // Fact sidebar data
+  const latestByProp = getLatestFactsByProperty(allFacts);
+  const categoryGroups = groupByCategory([...latestByProp.keys()]);
+
+  // Build stat cards from hero facts
+  const stats: Array<{
+    label: string;
+    value: string;
+    sub?: string;
+  }> = [];
+
+  for (const propId of HERO_STATS) {
+    const fact = getKBLatest(entity.id, propId);
+    if (!fact) continue;
+    const prop = getKBProperty(propId);
+    const value = formatFact(fact, prop ?? undefined);
+    if (value) {
+      stats.push({
+        label: prop?.name ?? titleCase(propId),
+        value,
+        sub: fact.asOf ? `as of ${formatKBDate(fact.asOf)}` : undefined,
+      });
+    }
+  }
+
+  return (
+    <div className="max-w-[70rem] mx-auto px-6 py-8">
+      <Breadcrumbs
+        items={[
+          { label: "Risks", href: "/risks" },
+          { label: entity.name },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            {entity.name}
+          </h1>
+          {riskCategory && (
+            <span
+              className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
+                RISK_CATEGORY_COLORS[riskCategory] ?? "bg-gray-100 text-gray-600"
+              }`}
+            >
+              {RISK_CATEGORY_LABELS[riskCategory] ?? riskCategory}
+            </span>
+          )}
+        </div>
+        {entity.aliases && entity.aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground/70 mb-2">
+            Also known as: {entity.aliases.join(", ")}
+          </p>
+        )}
+
+        {/* Description */}
+        {descriptionText && (
+          <p className="text-sm text-muted-foreground leading-relaxed mb-3 max-w-prose">
+            {descriptionText}
+          </p>
+        )}
+
+        {/* Links row */}
+        <div className="flex items-center gap-4 mt-2 text-sm">
+          {wikiHref && (
+            <Link
+              href={wikiHref}
+              className="text-primary hover:text-primary/80 font-medium transition-colors"
+            >
+              Wiki page &rarr;
+            </Link>
+          )}
+          <Link
+            href={`/kb/entity/${entity.id}`}
+            className="text-primary hover:text-primary/80 font-medium transition-colors"
+          >
+            KB data &rarr;
+          </Link>
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      {stats.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
+          {stats.map((s) => (
+            <ProfileStatCard key={s.label} {...s} />
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Main content */}
+        <div className="lg:col-span-2 space-y-8">
+          {/* Placeholder for future risk-specific content sections */}
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-8">
+          {/* Facts sidebar */}
+          {allFacts.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Facts
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {latestByProp.size}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+                {categoryGroups.map(({ category, label, props }) => (
+                  <div key={category} className="px-4 py-3">
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 mb-2">
+                      {label}
+                    </div>
+                    <div className="space-y-1.5">
+                      {props.map((propId) => {
+                        const fact = latestByProp.get(propId);
+                        if (!fact) return null;
+                        const property = getKBProperty(propId);
+                        return (
+                          <div
+                            key={propId}
+                            className="flex items-baseline justify-between gap-2 text-sm"
+                          >
+                            <span className="text-muted-foreground text-xs truncate">
+                              {property?.name ?? titleCase(propId)}
+                            </span>
+                            <span className="font-medium text-xs tabular-nums text-right shrink-0 max-w-[55%] truncate">
+                              {formatKBFactValue(
+                                fact,
+                                property?.unit,
+                                property?.display,
+                              )}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <Link
+                href={`/kb/entity/${entity.id}`}
+                className="block mt-2 text-xs text-primary hover:underline text-center"
+              >
+                View all facts in KB explorer &rarr;
+              </Link>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/risks/page.tsx
+++ b/apps/web/src/app/risks/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import { getKBEntities, getKBLatest, getKBEntitySlug } from "@/data/kb";
+import { getTypedEntityById, isRisk } from "@/data";
+import { ProfileStatCard } from "@/components/directory";
+import { RisksTable, type RiskRow } from "./risks-table";
+
+export const metadata: Metadata = {
+  title: "Risks",
+  description:
+    "Directory of AI-related risks tracked in the knowledge base, including accident risks, misuse risks, structural risks, and epistemic risks.",
+};
+
+/** Extract a text value from a KB fact for display. */
+function textValue(
+  fact: { value: { type: string; value: unknown } } | undefined,
+): string | null {
+  if (!fact) return null;
+  if (fact.value.type === "text") return fact.value.value as string;
+  if (fact.value.type === "number") return String(fact.value.value);
+  return null;
+}
+
+export default function RisksPage() {
+  const allEntities = getKBEntities();
+  const risks = allEntities.filter((e) => e.type === "risk");
+
+  const rows: RiskRow[] = risks.map((entity) => {
+    const typedEntity = getTypedEntityById(entity.id);
+    const riskCategory =
+      typedEntity && isRisk(typedEntity) ? (typedEntity.riskCategory ?? null) : null;
+
+    const severityFact = getKBLatest(entity.id, "severity-level");
+    const likelihoodFact = getKBLatest(entity.id, "likelihood-estimate");
+    const timeHorizonFact = getKBLatest(entity.id, "time-horizon");
+    const evidenceFact = getKBLatest(entity.id, "evidence-strength");
+    const consensusFact = getKBLatest(entity.id, "expert-consensus-level");
+
+    return {
+      id: entity.id,
+      slug: getKBEntitySlug(entity.id) ?? null,
+      name: entity.name,
+      numericId: entity.numericId ?? null,
+      wikiPageId: entity.wikiPageId ?? entity.numericId ?? null,
+      riskCategory,
+      severity: textValue(severityFact),
+      likelihood: textValue(likelihoodFact),
+      timeHorizon: textValue(timeHorizonFact),
+      evidenceStrength: textValue(evidenceFact),
+      expertConsensus: textValue(consensusFact),
+    };
+  });
+
+  // Compute summary stats
+  const byCategory = {
+    accident: rows.filter((r) => r.riskCategory === "accident").length,
+    misuse: rows.filter((r) => r.riskCategory === "misuse").length,
+    structural: rows.filter((r) => r.riskCategory === "structural").length,
+    epistemic: rows.filter((r) => r.riskCategory === "epistemic").length,
+  };
+  const withSeverity = rows.filter((r) => r.severity != null).length;
+  const withLikelihood = rows.filter((r) => r.likelihood != null).length;
+
+  const stats = [
+    { label: "Total Risks", value: String(rows.length) },
+    { label: "Accident", value: String(byCategory.accident) },
+    { label: "Misuse", value: String(byCategory.misuse) },
+    { label: "Structural", value: String(byCategory.structural) },
+    { label: "Epistemic", value: String(byCategory.epistemic) },
+    { label: "With Severity Data", value: String(withSeverity) },
+    { label: "With Likelihood Data", value: String(withLikelihood) },
+  ];
+
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
+          Risks
+        </h1>
+        <p className="text-muted-foreground text-sm max-w-2xl">
+          Directory of AI-related risks tracked in the knowledge base,
+          including accident risks, misuse risks, structural risks, and
+          epistemic risks.
+        </p>
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-8">
+        {stats.map((stat) => (
+          <ProfileStatCard key={stat.label} label={stat.label} value={stat.value} />
+        ))}
+      </div>
+
+      <RisksTable rows={rows} />
+    </div>
+  );
+}

--- a/apps/web/src/app/risks/risk-utils.ts
+++ b/apps/web/src/app/risks/risk-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared utilities for /risks routes.
+ */
+import {
+  getKBEntities,
+  getKBEntity,
+  resolveKBSlug,
+  getKBSlugMap,
+} from "@/data/kb";
+import type { Entity } from "@longterm-wiki/kb";
+
+/**
+ * Resolve a URL slug (e.g., "power-seeking") to a KB risk entity.
+ * Returns undefined if not found or not a risk.
+ */
+export function resolveRiskBySlug(slug: string): Entity | undefined {
+  const entityId = resolveKBSlug(slug);
+  if (!entityId) return undefined;
+  const entity = getKBEntity(entityId);
+  if (!entity || entity.type !== "risk") return undefined;
+  return entity;
+}
+
+/**
+ * Get all risk slugs for generateStaticParams.
+ */
+export function getRiskSlugs(): string[] {
+  const slugMap = getKBSlugMap();
+  const entities = getKBEntities();
+  const riskIds = new Set(
+    entities.filter((e) => e.type === "risk").map((e) => e.id),
+  );
+
+  return Object.entries(slugMap)
+    .filter(([, id]) => riskIds.has(id))
+    .map(([slug]) => slug);
+}

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { SortHeader } from "@/components/directory";
+
+export interface RiskRow {
+  id: string;
+  slug: string | null;
+  name: string;
+  numericId: string | null;
+  wikiPageId: string | null;
+  riskCategory: string | null;
+  severity: string | null;
+  likelihood: string | null;
+  timeHorizon: string | null;
+  evidenceStrength: string | null;
+  expertConsensus: string | null;
+}
+
+const RISK_CATEGORY_LABELS: Record<string, string> = {
+  accident: "Accident",
+  misuse: "Misuse",
+  structural: "Structural",
+  epistemic: "Epistemic",
+};
+
+const RISK_CATEGORY_COLORS: Record<string, string> = {
+  accident: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  misuse: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  structural: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  epistemic: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+};
+
+type SortKey = "name" | "category" | "severity" | "likelihood" | "timeHorizon";
+type SortDir = "asc" | "desc";
+
+const SEVERITY_ORDER: Record<string, number> = {
+  low: 1,
+  medium: 2,
+  "medium-high": 3,
+  high: 4,
+  critical: 5,
+  catastrophic: 6,
+};
+
+export function RisksTable({ rows }: { rows: RiskRow[] }) {
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  // Collect unique categories for filter
+  const categories = useMemo(() => {
+    const cats = new Set<string>();
+    for (const r of rows) {
+      if (r.riskCategory) cats.add(r.riskCategory);
+    }
+    return [...cats].sort();
+  }, [rows]);
+
+  // Count by category for badges
+  const categoryCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: rows.length };
+    for (const r of rows) {
+      const c = r.riskCategory ?? "unknown";
+      counts[c] = (counts[c] ?? 0) + 1;
+    }
+    return counts;
+  }, [rows]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+  };
+
+  const filtered = useMemo(() => {
+    let result = rows;
+
+    if (categoryFilter !== "all") {
+      result = result.filter((r) => r.riskCategory === categoryFilter);
+    }
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((r) => r.name.toLowerCase().includes(q));
+    }
+
+    const dir = sortDir === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      const getValue = (row: RiskRow): string | number | null => {
+        switch (sortKey) {
+          case "name":
+            return row.name.toLowerCase();
+          case "category":
+            return row.riskCategory ?? "";
+          case "severity":
+            return row.severity ? (SEVERITY_ORDER[row.severity] ?? 0) : null;
+          case "likelihood":
+            return row.likelihood ?? null;
+          case "timeHorizon":
+            return row.timeHorizon ?? null;
+        }
+      };
+
+      const va = getValue(a);
+      const vb = getValue(b);
+
+      // Nulls sort last regardless of direction
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1;
+      if (vb == null) return -1;
+
+      if (typeof va === "string" && typeof vb === "string") {
+        return va.localeCompare(vb) * dir;
+      }
+      return ((va as number) - (vb as number)) * dir;
+    });
+
+    return result;
+  }, [rows, search, categoryFilter, sortKey, sortDir]);
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-5">
+        <input
+          type="text"
+          placeholder="Search risks..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
+        />
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            onClick={() => setCategoryFilter("all")}
+            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+              categoryFilter === "all"
+                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+            }`}
+          >
+            All
+            <span className="ml-1 text-[10px] opacity-60">{categoryCounts.all}</span>
+          </button>
+          {categories.map((c) => (
+            <button
+              key={c}
+              onClick={() => setCategoryFilter(categoryFilter === c ? "all" : c)}
+              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                categoryFilter === c
+                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+              }`}
+            >
+              {RISK_CATEGORY_LABELS[c] ?? c}
+              <span className="ml-1 text-[10px] opacity-60">
+                {categoryCounts[c] ?? 0}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Results count */}
+      <div className="text-xs text-muted-foreground mb-3">
+        Showing {filtered.length} of {rows.length} risks
+      </div>
+
+      {/* Table */}
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <SortHeader label="Risk" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
+              <SortHeader label="Category" sortKey="category" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
+              <SortHeader label="Severity" sortKey="severity" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
+              <SortHeader label="Likelihood" sortKey="likelihood" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
+              <SortHeader label="Time Horizon" sortKey="timeHorizon" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
+              <th className="py-2.5 px-3 font-medium text-left">Evidence</th>
+              <th className="py-2.5 px-3 font-medium text-left">Consensus</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {filtered.map((row) => (
+              <tr
+                key={row.id}
+                className="hover:bg-muted/20 transition-colors"
+              >
+                {/* Name */}
+                <td className="py-2.5 px-3">
+                  {row.slug ? (
+                    <Link
+                      href={`/risks/${row.slug}`}
+                      className="font-medium text-foreground hover:text-primary transition-colors"
+                    >
+                      {row.name}
+                    </Link>
+                  ) : (
+                    <span className="font-medium text-foreground">{row.name}</span>
+                  )}
+                  {row.wikiPageId && (
+                    <Link
+                      href={`/wiki/${row.wikiPageId}`}
+                      className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                      title="Wiki page"
+                    >
+                      wiki
+                    </Link>
+                  )}
+                </td>
+
+                {/* Category */}
+                <td className="py-2.5 px-3">
+                  {row.riskCategory && (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        RISK_CATEGORY_COLORS[row.riskCategory] ?? "bg-gray-100 text-gray-600"
+                      }`}
+                    >
+                      {RISK_CATEGORY_LABELS[row.riskCategory] ?? row.riskCategory}
+                    </span>
+                  )}
+                </td>
+
+                {/* Severity */}
+                <td className="py-2.5 px-3 text-sm capitalize">
+                  {row.severity ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                </td>
+
+                {/* Likelihood */}
+                <td className="py-2.5 px-3 text-sm capitalize">
+                  {row.likelihood ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                </td>
+
+                {/* Time Horizon */}
+                <td className="py-2.5 px-3 text-sm">
+                  {row.timeHorizon ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                </td>
+
+                {/* Evidence Strength */}
+                <td className="py-2.5 px-3 text-sm capitalize">
+                  {row.evidenceStrength ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                </td>
+
+                {/* Expert Consensus */}
+                <td className="py-2.5 px-3 text-sm capitalize">
+                  {row.expertConsensus ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No risks match your search.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -8,6 +8,7 @@ const NAV_LINKS = [
   { href: "/wiki", label: "Explore" },
   { href: "/organizations", label: "Organizations" },
   { href: "/people", label: "People" },
+  { href: "/risks", label: "Risks" },
   { href: "/grants", label: "Grants" },
   { href: "/kb", label: "Data" },
   { href: "/wiki/E755", label: "About" },


### PR DESCRIPTION
## Summary
- Add a new `/risks/` directory section following the exact same patterns as `/people/` and `/organizations/`
- Includes listing page with summary stats (total risks, category breakdown, severity/likelihood coverage)
- Client-side sortable/filterable table with category filter pills (Accident, Misuse, Structural, Epistemic)
- Individual risk profile pages at `/risks/[slug]` with stat cards, category badge, and KB facts sidebar
- Added "Risks" link to desktop nav and mobile nav between "People" and "Grants"

## Files created
- `apps/web/src/app/risks/risk-utils.ts` -- slug resolution and static params (mirrors org-utils.ts)
- `apps/web/src/app/risks/page.tsx` -- listing page with stats grid
- `apps/web/src/app/risks/risks-table.tsx` -- "use client" sortable table component
- `apps/web/src/app/risks/[slug]/page.tsx` -- risk profile page with breadcrumbs, category badge, facts sidebar

## Files modified
- `apps/web/src/app/layout.tsx` -- added "Risks" nav link
- `apps/web/src/components/MobileNav.tsx` -- added "Risks" to mobile nav

## Test plan
- [ ] Verify `/risks` page renders with risk entities from KB data
- [ ] Verify category filter pills work correctly
- [ ] Verify table sorting by name, category, severity, likelihood, time horizon
- [ ] Verify `/risks/[slug]` profile pages render for individual risks
- [ ] Verify "Risks" link appears in desktop and mobile navigation
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify build succeeds (`pnpm build`)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Risks" section to the navigation menu (desktop and mobile)
  * Introduced a Risks directory page with filtering, sorting, and search capabilities
  * Added individual risk profile pages with detailed information, metadata, and external references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->