### PR TITLE
feat: add /ai-models index page with sortable comparison table

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -29,6 +29,12 @@ const TIER_LABELS: Record<string, string> = {
   opus: "Opus",
 };
 
+const TIER_ORDER: Record<string, number> = {
+  haiku: 0,
+  sonnet: 1,
+  opus: 2,
+};
+
 const TIER_COLORS: Record<string, string> = {
   haiku: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
   sonnet: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
@@ -100,18 +106,24 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
     for (const r of rows) {
       if (r.modelTier) set.add(r.modelTier);
     }
-    return [...set].sort();
+    return [...set].sort(
+      (a, b) =>
+        (TIER_ORDER[a] ?? Number.MAX_SAFE_INTEGER) -
+        (TIER_ORDER[b] ?? Number.MAX_SAFE_INTEGER),
+    );
   }, [rows]);
 
   const tierCounts = useMemo(() => {
-    const counts: Record<string, number> = { all: rows.filter((r) => !r.isFamily).length };
+    const counts: Record<string, number> = { all: 0 };
     for (const r of rows) {
+      if (!showFamilies && r.isFamily) continue;
+      counts.all += 1;
       if (r.isFamily) continue;
       const t = r.modelTier ?? "other";
       counts[t] = (counts[t] ?? 0) + 1;
     }
     return counts;
-  }, [rows]);
+  }, [rows, showFamilies]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -149,7 +161,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
           case "name":
             return row.title.toLowerCase();
           case "tier":
-            return row.modelTier ?? "";
+            return TIER_ORDER[row.modelTier ?? ""] ?? Number.MAX_SAFE_INTEGER;
           case "releaseDate":
             return row.releaseDate;
           case "inputPrice":

--- a/apps/web/src/app/ai-models/page.tsx
+++ b/apps/web/src/app/ai-models/page.tsx
@@ -18,14 +18,14 @@ export default function AiModelsPage() {
       ? getTypedEntityById(entity.developer)
       : null;
 
-    // Find SWE-bench score
-    const sweBench = entity.benchmarks?.find(
-      (b) => b.name === "SWE-bench Verified",
-    );
+    // Find SWE-bench score (accept both "SWE-bench" and "SWE-bench Verified")
+    const isSweBench = (name: string) =>
+      name === "SWE-bench" || name === "SWE-bench Verified";
+    const sweBench = entity.benchmarks?.find((b) => isSweBench(b.name));
 
     // Find top non-SWE benchmark for display
     const topBenchmark =
-      entity.benchmarks?.find((b) => b.name !== "SWE-bench Verified") ?? null;
+      entity.benchmarks?.find((b) => !isSweBench(b.name)) ?? null;
 
     // Is this a family entry (no tier, no release date)?
     const isFamily = !entity.modelTier && !entity.releaseDate;


### PR DESCRIPTION
## Summary

- Adds `/ai-models` route with a sortable, filterable comparison table of all AI models
- Columns: Model name, Tier (Haiku/Sonnet/Opus), Release date, Input/Output pricing, Context window, Safety level, SWE-bench score
- Filter by tier with count badges, search by name/developer, toggle to show/hide family parent entries
- Follows the same pattern as `/organizations` and `/people` index pages

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Gate check passes (`pnpm crux validate gate --fix`)
- [x] TypeScript check passes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched AI Models catalog page with an interactive table for browsing and comparing AI models. Users can search by model name or developer, filter by tier or model family, and sort columns to compare key metrics including pricing, context window sizes, safety levels, release dates, and performance benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->