### PR TITLE
Split KB data out of database.json into kb-data.json

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -2287,10 +2287,19 @@ async function main() {
     mkdirSync(OUTPUT_DIR, { recursive: true });
   }
 
-  // Write combined JSON (strip raw entities — only typedEntities needed at runtime)
-  const { entities: _rawEntities, ...databaseForOutput } = database;
+  // Write combined JSON (strip raw entities and KB data — only typedEntities needed at runtime)
+  const { entities: _rawEntities, kb: _kbData, ...databaseForOutput } = database;
   writeFileSync(OUTPUT_FILE, JSON.stringify(databaseForOutput, null, 2));
-  console.log(`\n✓ Written: ${OUTPUT_FILE} (raw entities stripped, typedEntities only)`);
+  console.log(`\n✓ Written: ${OUTPUT_FILE} (raw entities stripped, KB split out, typedEntities only)`);
+
+  // Write KB data to a separate file (loaded independently by kb.ts)
+  const KB_OUTPUT_FILE = join(OUTPUT_DIR, 'kb-data.json');
+  if (_kbData) {
+    writeFileSync(KB_OUTPUT_FILE, JSON.stringify(_kbData, null, 2));
+    console.log(`✓ Written: ${KB_OUTPUT_FILE} (KB entities, facts, records, schemas)`);
+  } else {
+    console.warn('⚠ KB data not available — kb-data.json not written');
+  }
 
   // Also write individual JSON files for selective imports
   for (const { key, file, dir } of DATA_FILES) {

--- a/apps/web/src/data/database.ts
+++ b/apps/web/src/data/database.ts
@@ -416,8 +416,6 @@ interface DatabaseShape {
     accuracyIssues: string | null;
     accuracyCheckedAt: string | null;
   }>>;
-  /** KB (Knowledge Base) structured entity data from packages/kb */
-  kb?: import("@longterm-wiki/kb").SerializedKB;
   /** KB fact verification status: factId → verdict (from citation quotes cross-reference) */
   kbFactVerification?: Record<string, string>;
 }

--- a/apps/web/src/data/explore.ts
+++ b/apps/web/src/data/explore.ts
@@ -5,6 +5,7 @@
 import { getDatabase, getTypedEntities, isRisk } from "./database";
 import type { ContentFormat, RawEntity, AnyEntity } from "./database";
 import { getEntityHref } from "./entity-nav";
+import { getKB } from "./kb";
 import type { SerializedKB } from "@longterm-wiki/kb";
 
 export interface ExploreItem {
@@ -101,7 +102,7 @@ export function getExploreItems(): ExploreItem[] {
   const db = getDatabase();
   const typedEntities = getTypedEntities();
   const pageMap = new Map((db.pages || []).map((p) => [p.id, p]));
-  const kb = db.kb;
+  const kb = getKB();
 
   // Build a set of page IDs claimed by entities (including aliased ones)
   const entityClaimedPageIds = new Set<string>();

--- a/apps/web/src/data/kb.ts
+++ b/apps/web/src/data/kb.ts
@@ -1,22 +1,36 @@
 /**
  * KB data access layer.
  *
- * Reads the `kb` field from database.json (populated by build-data.mjs).
+ * Reads kb-data.json (populated by build-data.mjs) — a dedicated file
+ * split out from database.json for faster incremental builds and smaller
+ * main database bundle.
+ *
  * The KB data may not exist if build-data hasn't been wired up yet,
  * so all accessors return undefined/empty gracefully.
  */
 
+import fs from "fs";
+import path from "path";
 import { getDatabase } from "@data";
 import type { Fact, Property, Entity, RecordEntry, RecordSchema } from "@longterm-wiki/kb";
 import type { SerializedKB } from "@longterm-wiki/kb";
 
-function getKB(): SerializedKB | undefined {
+const LOCAL_DATA_DIR = path.resolve(process.cwd(), "src/data");
+
+let _kbData: SerializedKB | undefined | null = null; // null = not yet loaded
+
+/** Get the full serialized KB data (or undefined if not available). */
+export function getKB(): SerializedKB | undefined {
+  if (_kbData !== null) return _kbData;
+
+  const kbPath = path.join(LOCAL_DATA_DIR, "kb-data.json");
   try {
-    const db = getDatabase();
-    return db.kb;
+    const raw = fs.readFileSync(kbPath, "utf-8");
+    _kbData = JSON.parse(raw) as SerializedKB;
   } catch {
-    return undefined;
+    _kbData = undefined;
   }
+  return _kbData;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Split KB (knowledge base) data into a dedicated `kb-data.json` file, separate from `database.json`
- Reduces `database.json` by ~680KB (from ~6.6MB to ~5.9MB)
- Enables faster incremental builds when only KB YAML changes (future optimization)
- All public KB accessors (`getKBFacts`, `getKBLatest`, `getKBRecords`, etc.) work exactly as before

## Changes

- **`build-data.mjs`**: Write KB data to `kb-data.json` and exclude `kb` field from `database.json`
- **`kb.ts`**: Load from `kb-data.json` directly (with lazy caching) instead of `database.json`'s `kb` field
- **`explore.ts`**: Use exported `getKB()` from `kb.ts` instead of `db.kb`
- **`database.ts`**: Remove `kb` field from `DatabaseShape` interface

`kbFactVerification` remains in `database.json` since it's used alongside page data (not KB-specific).

Closes #2033

## Test plan

- [x] `pnpm build-data:content` produces both `database.json` (without `kb`) and `kb-data.json` (with KB data)
- [x] `kb-data.json` contains expected keys: entities, facts, properties, schemas, recordSchemas, records, slugToEntityId
- [x] TypeScript check (`tsc --noEmit`) passes with zero errors
- [x] All 2642 tests pass (`pnpm test`)

Generated with [Claude Code](https://claude.com/claude-code)