### PR TITLE
fix: risk detail pages read from entity data instead of empty KB properties

### DIFF
--- a/apps/web/src/app/risks/[slug]/page.tsx
+++ b/apps/web/src/app/risks/[slug]/page.tsx
@@ -2,19 +2,15 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { resolveRiskBySlug, getRiskSlugs } from "@/app/risks/risk-utils";
-import { getKBFacts, getKBLatest, getKBProperty } from "@/data/kb";
-import { getTypedEntityById, isRisk, getEntityById } from "@/data";
+import { getKBEntity, getKBEntitySlug } from "@/data/kb";
+import { getTypedEntityById, isRisk } from "@/data";
 import { getEntityWikiHref } from "@/lib/directory-utils";
 import {
   ProfileStatCard,
   Breadcrumbs,
 } from "@/components/directory";
-import {
-  formatKBFactValue,
-  formatKBDate,
-  titleCase,
-} from "@/components/wiki/kb/format";
-import type { Fact, Property } from "@longterm-wiki/kb";
+import { titleCase } from "@/components/wiki/kb/format";
+import type { RiskEntity } from "@/data/entity-schemas";
 
 export function generateStaticParams() {
   return getRiskSlugs().map((slug) => ({ slug }));
@@ -50,67 +46,45 @@ const RISK_CATEGORY_LABELS: Record<string, string> = {
   epistemic: "Epistemic",
 };
 
-// ── Fact sidebar helpers ──────────────────────────────────────────────
+// ── Severity badge colors ─────────────────────────────────────────────
+const SEVERITY_COLORS: Record<string, string> = {
+  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+  "medium-high": "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  high: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  catastrophic: "bg-red-200 text-red-900 dark:bg-red-900/40 dark:text-red-200",
+};
 
-const FACT_CATEGORIES: { id: string; label: string; order: number }[] = [
-  { id: "assessment", label: "Assessment", order: 0 },
-  { id: "risk", label: "Risk", order: 1 },
-  { id: "other", label: "Other", order: 99 },
-];
+// ── Helpers to extract display values from entity data ─────────────────
 
-/** Group facts by property, taking only the latest per property. */
-function getLatestFactsByProperty(facts: Fact[]): Map<string, Fact> {
-  const latest = new Map<string, Fact>();
-  for (const fact of facts) {
-    if (fact.propertyId === "description") continue;
-    if (!latest.has(fact.propertyId)) {
-      latest.set(fact.propertyId, fact);
+function getLikelihoodDisplay(risk: RiskEntity): string | null {
+  if (!risk.likelihood) return null;
+  if (typeof risk.likelihood === "string") return titleCase(risk.likelihood);
+  const parts: string[] = [];
+  if (risk.likelihood.level) parts.push(titleCase(risk.likelihood.level));
+  if (risk.likelihood.status) parts.push(`(${risk.likelihood.status})`);
+  if (risk.likelihood.display) return risk.likelihood.display;
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+function getTimeframeDisplay(risk: RiskEntity): string | null {
+  if (!risk.timeframe) return null;
+  if (typeof risk.timeframe === "string") return risk.timeframe;
+  if (risk.timeframe.display) return risk.timeframe.display;
+  const parts: string[] = [];
+  if (risk.timeframe.earliest && risk.timeframe.latest) {
+    parts.push(`${risk.timeframe.earliest}--${risk.timeframe.latest}`);
+  }
+  if (risk.timeframe.median) {
+    if (parts.length > 0) {
+      parts.push(`(median ${risk.timeframe.median})`);
+    } else {
+      parts.push(`~${risk.timeframe.median}`);
     }
   }
-  return latest;
+  return parts.length > 0 ? parts.join(" ") : null;
 }
-
-/** Group property IDs by category, returning sorted categories. */
-function groupByCategory(
-  propertyIds: string[],
-): Array<{ category: string; label: string; props: string[] }> {
-  const groups = new Map<string, string[]>();
-  for (const propId of propertyIds) {
-    const prop = getKBProperty(propId);
-    const category = prop?.category ?? "other";
-    const list = groups.get(category) ?? [];
-    list.push(propId);
-    groups.set(category, list);
-  }
-
-  const catMap = new Map(FACT_CATEGORIES.map((c) => [c.id, c]));
-  return [...groups.entries()]
-    .map(([catId, props]) => ({
-      category: catId,
-      label: catMap.get(catId)?.label ?? titleCase(catId),
-      order: catMap.get(catId)?.order ?? 99,
-      props,
-    }))
-    .sort((a, b) => a.order - b.order);
-}
-
-/** Format a fact value for display, returning null if no fact. */
-function formatFact(
-  fact: Fact | undefined,
-  property?: Partial<Property>,
-): string | null {
-  if (!fact) return null;
-  return formatKBFactValue(fact, property?.unit, property?.display);
-}
-
-// ── Hero stat properties for risk pages ────────────────────────────────
-const HERO_STATS = [
-  "severity-level",
-  "likelihood-estimate",
-  "time-horizon",
-  "evidence-strength",
-  "expert-consensus-level",
-];
 
 // ── Main page ─────────────────────────────────────────────────────────
 
@@ -124,45 +98,65 @@ export default async function RiskProfilePage({
   if (!entity) return notFound();
 
   const typedEntity = getTypedEntityById(entity.id);
-  const riskCategory =
-    typedEntity && isRisk(typedEntity) ? (typedEntity.riskCategory ?? null) : null;
+  const risk = typedEntity && isRisk(typedEntity) ? typedEntity : null;
 
-  // Description from the database entity
-  const dbEntity = getEntityById(entity.id);
-  const descriptionText =
-    (dbEntity as { description?: string } | undefined)?.description ?? null;
-
-  // All facts for the sidebar
-  const allFacts = getKBFacts(entity.id).filter(
-    (f) => f.propertyId !== "description",
-  );
+  const riskCategory = risk?.riskCategory ?? null;
+  const descriptionText = risk?.description ?? null;
 
   const wikiHref = getEntityWikiHref(entity);
 
-  // Fact sidebar data
-  const latestByProp = getLatestFactsByProperty(allFacts);
-  const categoryGroups = groupByCategory([...latestByProp.keys()]);
-
-  // Build stat cards from hero facts
+  // Build stat cards from entity data
   const stats: Array<{
     label: string;
     value: string;
     sub?: string;
   }> = [];
 
-  for (const propId of HERO_STATS) {
-    const fact = getKBLatest(entity.id, propId);
-    if (!fact) continue;
-    const prop = getKBProperty(propId);
-    const value = formatFact(fact, prop ?? undefined);
-    if (value) {
-      stats.push({
-        label: prop?.name ?? titleCase(propId),
-        value,
-        sub: fact.asOf ? `as of ${formatKBDate(fact.asOf)}` : undefined,
-      });
-    }
+  if (risk?.severity) {
+    stats.push({ label: "Severity", value: titleCase(risk.severity) });
   }
+  const likelihoodStr = risk ? getLikelihoodDisplay(risk) : null;
+  if (likelihoodStr) {
+    stats.push({ label: "Likelihood", value: likelihoodStr });
+  }
+  const timeframeStr = risk ? getTimeframeDisplay(risk) : null;
+  if (timeframeStr) {
+    stats.push({ label: "Time Horizon", value: timeframeStr });
+  }
+  if (risk?.maturity) {
+    stats.push({ label: "Maturity", value: risk.maturity });
+  }
+
+  // Related entities from YAML data
+  const relatedEntries = risk?.relatedEntries ?? [];
+  const resolvedRelated = relatedEntries.map((entry) => {
+    const kbEntity = getKBEntity(entry.id);
+    const entrySlug = kbEntity ? getKBEntitySlug(entry.id) : undefined;
+    return {
+      id: entry.id,
+      type: entry.type,
+      relationship: entry.relationship,
+      name: kbEntity?.name ?? titleCase(entry.id.replace(/-/g, " ")),
+      href: entrySlug && entry.type === "risk"
+        ? `/risks/${entrySlug}`
+        : entrySlug && entry.type === "organization"
+          ? `/organizations/${entrySlug}`
+          : entrySlug && entry.type === "person"
+            ? `/people/${entrySlug}`
+            : kbEntity?.numericId
+              ? `/wiki/${kbEntity.numericId}`
+              : `/kb/entity/${entry.id}`,
+    };
+  });
+
+  // Sources from YAML data
+  const sources = risk?.sources ?? [];
+
+  // Custom fields from YAML data
+  const customFields = risk?.customFields ?? [];
+
+  // Tags
+  const tags = risk?.tags ?? [];
 
   return (
     <div className="max-w-[70rem] mx-auto px-6 py-8">
@@ -186,6 +180,15 @@ export default async function RiskProfilePage({
               }`}
             >
               {RISK_CATEGORY_LABELS[riskCategory] ?? riskCategory}
+            </span>
+          )}
+          {risk?.severity && (
+            <span
+              className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
+                SEVERITY_COLORS[risk.severity] ?? "bg-gray-100 text-gray-600"
+              }`}
+            >
+              {titleCase(risk.severity)}
             </span>
           )}
         </div>
@@ -223,7 +226,7 @@ export default async function RiskProfilePage({
 
       {/* Stat cards */}
       {stats.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
           {stats.map((s) => (
             <ProfileStatCard key={s.label} {...s} />
           ))}
@@ -233,61 +236,224 @@ export default async function RiskProfilePage({
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main content */}
         <div className="lg:col-span-2 space-y-8">
-          {/* Placeholder for future risk-specific content sections */}
+          {/* Wiki page call-to-action */}
+          {wikiHref && (
+            <section className="border border-primary/20 rounded-xl bg-primary/5 p-5">
+              <h2 className="text-base font-bold tracking-tight mb-2">
+                Full Wiki Article
+              </h2>
+              <p className="text-sm text-muted-foreground mb-3">
+                Read the full wiki article for detailed analysis, background, and references.
+              </p>
+              <Link
+                href={wikiHref}
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                Read wiki article &rarr;
+              </Link>
+            </section>
+          )}
+
+          {/* Related Entities */}
+          {resolvedRelated.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Related Entities
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {resolvedRelated.length}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+                {resolvedRelated.map((rel) => (
+                  <div
+                    key={rel.id}
+                    className="flex items-center justify-between gap-3 px-4 py-3"
+                  >
+                    <div className="min-w-0">
+                      <Link
+                        href={rel.href}
+                        className="text-sm font-medium text-primary hover:underline"
+                      >
+                        {rel.name}
+                      </Link>
+                      {rel.relationship && (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          ({rel.relationship})
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 shrink-0">
+                      {rel.type}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Sources */}
+          {sources.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Sources
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {sources.length}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+                {sources.map((src, i) => (
+                  <div key={i} className="px-4 py-3">
+                    <div className="text-sm font-medium">
+                      {src.url ? (
+                        <a
+                          href={src.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {src.title} &#8599;
+                        </a>
+                      ) : (
+                        <span>{src.title}</span>
+                      )}
+                    </div>
+                    {(src.author || src.date) && (
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {[src.author, src.date].filter(Boolean).join(", ")}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
         </div>
 
         {/* Sidebar */}
         <div className="space-y-8">
-          {/* Facts sidebar */}
-          {allFacts.length > 0 && (
+          {/* Assessment details from entity data */}
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Assessment
+            </h2>
+            <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+              {risk?.severity && (
+                <div className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm">
+                  <span className="text-muted-foreground text-xs">Severity</span>
+                  <span className="font-medium text-xs">{titleCase(risk.severity)}</span>
+                </div>
+              )}
+              {likelihoodStr && (
+                <div className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm">
+                  <span className="text-muted-foreground text-xs">Likelihood</span>
+                  <span className="font-medium text-xs">{likelihoodStr}</span>
+                </div>
+              )}
+              {timeframeStr && (
+                <div className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm">
+                  <span className="text-muted-foreground text-xs">Time Horizon</span>
+                  <span className="font-medium text-xs">{timeframeStr}</span>
+                </div>
+              )}
+              {risk?.maturity && (
+                <div className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm">
+                  <span className="text-muted-foreground text-xs">Maturity</span>
+                  <span className="font-medium text-xs">{risk.maturity}</span>
+                </div>
+              )}
+              {riskCategory && (
+                <div className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm">
+                  <span className="text-muted-foreground text-xs">Category</span>
+                  <span className="font-medium text-xs">
+                    {RISK_CATEGORY_LABELS[riskCategory] ?? riskCategory}
+                  </span>
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* Custom fields */}
+          {customFields.length > 0 && (
             <section>
               <h2 className="text-lg font-bold tracking-tight mb-4">
-                Facts
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {latestByProp.size}
-                </span>
+                Details
               </h2>
               <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
-                {categoryGroups.map(({ category, label, props }) => (
-                  <div key={category} className="px-4 py-3">
-                    <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 mb-2">
-                      {label}
-                    </div>
-                    <div className="space-y-1.5">
-                      {props.map((propId) => {
-                        const fact = latestByProp.get(propId);
-                        if (!fact) return null;
-                        const property = getKBProperty(propId);
-                        return (
-                          <div
-                            key={propId}
-                            className="flex items-baseline justify-between gap-2 text-sm"
-                          >
-                            <span className="text-muted-foreground text-xs truncate">
-                              {property?.name ?? titleCase(propId)}
-                            </span>
-                            <span className="font-medium text-xs tabular-nums text-right shrink-0 max-w-[55%] truncate">
-                              {formatKBFactValue(
-                                fact,
-                                property?.unit,
-                                property?.display,
-                              )}
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </div>
+                {customFields.map((cf, i) => (
+                  <div
+                    key={i}
+                    className="flex items-baseline justify-between gap-2 px-4 py-2.5 text-sm"
+                  >
+                    <span className="text-muted-foreground text-xs truncate">
+                      {cf.label}
+                    </span>
+                    <span className="font-medium text-xs text-right shrink-0 max-w-[60%]">
+                      {cf.link ? (
+                        <a
+                          href={cf.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {cf.value}
+                        </a>
+                      ) : (
+                        cf.value
+                      )}
+                    </span>
                   </div>
                 ))}
               </div>
-              <Link
-                href={`/kb/entity/${entity.id}`}
-                className="block mt-2 text-xs text-primary hover:underline text-center"
-              >
-                View all facts in KB explorer &rarr;
-              </Link>
             </section>
           )}
+
+          {/* Tags */}
+          {tags.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Tags
+              </h2>
+              <div className="flex flex-wrap gap-1.5">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-muted text-muted-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Quick links */}
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Quick Links
+            </h2>
+            <div className="flex flex-col gap-2">
+              {wikiHref && (
+                <Link
+                  href={wikiHref}
+                  className="text-xs text-primary hover:underline"
+                >
+                  Wiki page &rarr;
+                </Link>
+              )}
+              <Link
+                href={`/kb/entity/${entity.id}`}
+                className="text-xs text-primary hover:underline"
+              >
+                View in KB explorer &rarr;
+              </Link>
+              <Link
+                href="/risks"
+                className="text-xs text-primary hover:underline"
+              >
+                All risks &rarr;
+              </Link>
+            </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Risk detail pages (`/risks/[slug]`) were completely empty because they looked up KB facts with properties like `severity-level`, `likelihood-estimate`, `time-horizon`, `evidence-strength`, and `expert-consensus-level` -- none of which exist in KB data
- The actual risk data lives in `data/entities/risks.yaml` as typed entity fields (`severity`, `likelihood`, `timeframe`, `maturity`) and was already modeled in `RiskEntity` via `entity-schemas.ts`
- Rewired the page to read from `getTypedEntityById()` + `isRisk()` typed entity data instead of nonexistent KB facts

## What changed
- **Hero stat cards**: Now populated from `RiskEntity` fields (severity, likelihood, timeframe, maturity) instead of empty KB lookups
- **Header**: Added severity badge alongside the existing risk category badge
- **Main content area**: Replaced empty placeholder with wiki page CTA, related entities list, and sources list
- **Sidebar**: Replaced empty KB facts panel with assessment details, custom fields, tags, and quick links -- all sourced from entity YAML data
- **Cleanup**: Removed unused KB imports (`getKBFacts`, `getKBLatest`, `getKBProperty`, `formatKBFactValue`, `formatKBDate`) and dead helper functions (`getLatestFactsByProperty`, `groupByCategory`, `formatFact`)

## Test plan
- [x] `pnpm build` passes (all 62+ risk paths compiled)
- [x] `pnpm test` -- no new failures (pre-existing source-fetcher failures only)
- [x] TypeScript type-check passes
- [ ] Verify a risk detail page (e.g. `/risks/authentication-collapse`) shows severity, likelihood, timeframe, maturity, description, related entities, and sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)