### PR TITLE
fix: re-download empty/corrupt grant data files

### DIFF
--- a/crux/lib/grant-import/__tests__/download.test.ts
+++ b/crux/lib/grant-import/__tests__/download.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { downloadIfMissing } from "../download";
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { existsSync, statSync, unlinkSync, readFileSync } from "fs";
+import { execSync } from "child_process";
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockStatSync = vi.mocked(statSync);
+const mockUnlinkSync = vi.mocked(unlinkSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: after download, readFileSync returns a non-empty buffer
+  mockReadFileSync.mockReturnValue(Buffer.alloc(1024));
+});
+
+describe("downloadIfMissing", () => {
+  it("downloads when file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    downloadIfMissing("https://example.com/data.csv", "/tmp/data.csv", "test data");
+
+    expect(mockExecSync).toHaveBeenCalledOnce();
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("curl"),
+      expect.any(Object),
+    );
+  });
+
+  it("skips download when file exists and is non-empty", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ size: 5000 } as ReturnType<typeof statSync>);
+
+    downloadIfMissing("https://example.com/data.csv", "/tmp/data.csv", "test data");
+
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("re-downloads when file exists but is empty", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ size: 0 } as ReturnType<typeof statSync>);
+
+    downloadIfMissing("https://example.com/data.csv", "/tmp/data.csv", "test data");
+
+    expect(mockUnlinkSync).toHaveBeenCalledWith("/tmp/data.csv");
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("includes --max-time 120 in curl command", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    downloadIfMissing("https://example.com/data.csv", "/tmp/data.csv", "test data");
+
+    const curlCmd = mockExecSync.mock.calls[0][0] as string;
+    expect(curlCmd).toContain("--max-time 120");
+  });
+});

--- a/crux/lib/grant-import/download.ts
+++ b/crux/lib/grant-import/download.ts
@@ -1,11 +1,17 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, statSync, unlinkSync } from "fs";
 import { execSync } from "child_process";
 
 /** Download a file via curl if it doesn't already exist locally. */
 export function downloadIfMissing(url: string, path: string, label: string): void {
-  if (existsSync(path)) return;
+  if (existsSync(path)) {
+    const fileSize = statSync(path).size;
+    if (fileSize > 0) return;
+    // Empty file from interrupted download — remove and re-download
+    console.warn(`Found empty file at ${path}, re-downloading...`);
+    unlinkSync(path);
+  }
   console.log(`Downloading ${label}...`);
-  execSync(`curl -fsSL --retry 3 --connect-timeout 10 -o "${path}" "${url}"`, {
+  execSync(`curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 -o "${path}" "${url}"`, {
     stdio: "inherit",
   });
   const size = readFileSync(path).length;


### PR DESCRIPTION
## Summary
- `downloadIfMissing()` now checks file size — empty files (from interrupted downloads) trigger re-download
- Added `--max-time 120` to curl to prevent hanging
- Added tests for download logic

Stacks on #2133

## Test plan
- [x] New download tests pass (4 tests)
- [x] Existing grant-import tests pass (65 total)
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)