### PR TITLE
refactor: extract shared date parsing for grant sources

### DIFF
--- a/crux/lib/grant-import/__tests__/dates.test.ts
+++ b/crux/lib/grant-import/__tests__/dates.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  QUARTER_TO_MONTH,
+  parseMonthYear,
+  parseQuarterYear,
+  extractISODate,
+  truncateToMonth,
+} from "../dates.ts";
+
+describe("QUARTER_TO_MONTH", () => {
+  it("maps all four quarters", () => {
+    expect(QUARTER_TO_MONTH["1"]).toBe("01");
+    expect(QUARTER_TO_MONTH["2"]).toBe("04");
+    expect(QUARTER_TO_MONTH["3"]).toBe("07");
+    expect(QUARTER_TO_MONTH["4"]).toBe("10");
+  });
+});
+
+describe("parseMonthYear", () => {
+  it("parses 'February 2016'", () => {
+    expect(parseMonthYear("February 2016")).toBe("2016-02");
+  });
+
+  it("parses 'December 2023'", () => {
+    expect(parseMonthYear("December 2023")).toBe("2023-12");
+  });
+
+  it("parses 'January 2020'", () => {
+    expect(parseMonthYear("January 2020")).toBe("2020-01");
+  });
+
+  it("handles leading/trailing whitespace", () => {
+    expect(parseMonthYear("  March 2021  ")).toBe("2021-03");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseMonthYear("")).toBeNull();
+  });
+
+  it("returns null for unrecognized month name", () => {
+    expect(parseMonthYear("Foo 2020")).toBeNull();
+  });
+
+  it("returns null for single word", () => {
+    expect(parseMonthYear("2020")).toBeNull();
+  });
+
+  it("returns null for three-word input", () => {
+    expect(parseMonthYear("January 1 2020")).toBeNull();
+  });
+});
+
+describe("parseQuarterYear", () => {
+  it("parses '2025 Q3'", () => {
+    expect(parseQuarterYear("2025 Q3")).toBe("2025-07");
+  });
+
+  it("parses '2024 Q1'", () => {
+    expect(parseQuarterYear("2024 Q1")).toBe("2024-01");
+  });
+
+  it("parses '2023 Q2'", () => {
+    expect(parseQuarterYear("2023 Q2")).toBe("2023-04");
+  });
+
+  it("parses '2022 Q4'", () => {
+    expect(parseQuarterYear("2022 Q4")).toBe("2022-10");
+  });
+
+  it("handles leading/trailing whitespace", () => {
+    expect(parseQuarterYear("  2025 Q3  ")).toBe("2025-07");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseQuarterYear("")).toBeNull();
+  });
+
+  it("returns null for non-quarter format", () => {
+    expect(parseQuarterYear("2025 H1")).toBeNull();
+  });
+
+  it("returns null for invalid quarter number", () => {
+    expect(parseQuarterYear("2025 Q5")).toBeNull();
+  });
+
+  it("returns null for year-only", () => {
+    expect(parseQuarterYear("2025")).toBeNull();
+  });
+});
+
+describe("extractISODate", () => {
+  it("extracts date from ISO timestamp", () => {
+    expect(extractISODate("2023-05-15T12:00:00Z")).toBe("2023-05-15");
+  });
+
+  it("extracts date from plain YYYY-MM-DD", () => {
+    expect(extractISODate("2022-03-15")).toBe("2022-03-15");
+  });
+
+  it("extracts date from string with trailing content", () => {
+    expect(extractISODate("2024-01-01 some extra text")).toBe("2024-01-01");
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractISODate("")).toBeNull();
+  });
+
+  it("returns null for non-date string", () => {
+    expect(extractISODate("not a date")).toBeNull();
+  });
+
+  it("returns null for year-month only", () => {
+    expect(extractISODate("2023-05")).toBeNull();
+  });
+});
+
+describe("truncateToMonth", () => {
+  it("truncates YYYY-MM-DD to YYYY-MM", () => {
+    expect(truncateToMonth("2022-03-15")).toBe("2022-03");
+  });
+
+  it("keeps YYYY-MM unchanged", () => {
+    expect(truncateToMonth("2022-03")).toBe("2022-03");
+  });
+
+  it("truncates full ISO timestamp", () => {
+    expect(truncateToMonth("2024-12-25T00:00:00Z")).toBe("2024-12");
+  });
+
+  it("returns null for empty string", () => {
+    expect(truncateToMonth("")).toBeNull();
+  });
+
+  it("returns null for year-only", () => {
+    expect(truncateToMonth("2022")).toBeNull();
+  });
+
+  it("returns null for non-date string", () => {
+    expect(truncateToMonth("not a date")).toBeNull();
+  });
+});

--- a/crux/lib/grant-import/dates.ts
+++ b/crux/lib/grant-import/dates.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared date parsing utilities for grant import sources.
+ *
+ * Each grant source encodes dates differently. These helpers normalize
+ * the most common formats into ISO-style strings (YYYY, YYYY-MM, or YYYY-MM-DD).
+ */
+
+/** Quarter number (1-4) to the month string for the quarter's start. */
+export const QUARTER_TO_MONTH: Record<string, string> = {
+  "1": "01",
+  "2": "04",
+  "3": "07",
+  "4": "10",
+};
+
+const MONTH_NAMES: Record<string, string> = {
+  January: "01",
+  February: "02",
+  March: "03",
+  April: "04",
+  May: "05",
+  June: "06",
+  July: "07",
+  August: "08",
+  September: "09",
+  October: "10",
+  November: "11",
+  December: "12",
+};
+
+/**
+ * Parse "Month Year" format.
+ * @example parseMonthYear("February 2016") // "2016-02"
+ * @example parseMonthYear("December 2023") // "2023-12"
+ */
+export function parseMonthYear(input: string): string | null {
+  const parts = input.trim().split(" ");
+  if (parts.length !== 2) return null;
+
+  const monthNum = MONTH_NAMES[parts[0]];
+  if (!monthNum || !parts[1]) return null;
+
+  return `${parts[1]}-${monthNum}`;
+}
+
+/**
+ * Parse "YYYY QN" format (year followed by quarter).
+ * @example parseQuarterYear("2025 Q3") // "2025-07"
+ * @example parseQuarterYear("2024 Q1") // "2024-01"
+ */
+export function parseQuarterYear(input: string): string | null {
+  const m = input.trim().match(/^(\d{4})\s+Q(\d)$/);
+  if (!m) return null;
+
+  const month = QUARTER_TO_MONTH[m[2]];
+  if (!month) return null;
+
+  return `${m[1]}-${month}`;
+}
+
+/**
+ * Extract an ISO date prefix (YYYY-MM-DD) from a longer string.
+ * Useful for ISO 8601 timestamps like "2023-05-15T12:00:00Z".
+ * @example extractISODate("2023-05-15T12:00:00Z") // "2023-05-15"
+ * @example extractISODate("2022-03-15") // "2022-03-15"
+ */
+export function extractISODate(input: string): string | null {
+  const m = input.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Truncate a date string to month precision (YYYY-MM).
+ * Accepts YYYY-MM-DD or YYYY-MM input.
+ * @example truncateToMonth("2022-03-15") // "2022-03"
+ * @example truncateToMonth("2022-03") // "2022-03"
+ */
+export function truncateToMonth(isoDate: string): string | null {
+  const m = isoDate.match(/^(\d{4}-\d{2})/);
+  return m ? m[1] : null;
+}

--- a/crux/lib/grant-import/sources/coefficient-giving.ts
+++ b/crux/lib/grant-import/sources/coefficient-giving.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { parseCSVLine, reassembleCSVRows } from "../csv.ts";
+import { parseMonthYear } from "../dates.ts";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
@@ -40,21 +41,7 @@ export const source: GrantSource = {
       const granteeId = matchGrantee(orgName, matcher);
 
       // Parse date: "February 2016" → "2016-02"
-      let isoDate: string | null = null;
-      if (date) {
-        const parts = date.split(" ");
-        if (parts.length === 2) {
-          const monthNames: Record<string, string> = {
-            January: "01", February: "02", March: "03", April: "04",
-            May: "05", June: "06", July: "07", August: "08",
-            September: "09", October: "10", November: "11", December: "12",
-          };
-          const monthNum = monthNames[parts[0]];
-          if (monthNum && parts[1]) {
-            isoDate = `${parts[1]}-${monthNum}`;
-          }
-        }
-      }
+      const isoDate = date ? parseMonthYear(date) : null;
 
       grants.push({
         source: "coefficient-giving",

--- a/crux/lib/grant-import/sources/ea-funds.ts
+++ b/crux/lib/grant-import/sources/ea-funds.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { parseCSVLine } from "../csv.ts";
+import { parseQuarterYear } from "../dates.ts";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
@@ -59,16 +60,7 @@ export const source: GrantSource = {
       const granteeId = matchGrantee(grantee, matcher);
 
       // Date from round: "2025 Q3" → "2025-07", "2024 Q1" → "2024-01"
-      let isoDate: string | null = null;
-      if (round) {
-        const m = round.match(/^(\d{4})\s+Q(\d)$/);
-        if (m) {
-          const qMonth: Record<string, string> = {
-            "1": "01", "2": "04", "3": "07", "4": "10",
-          };
-          isoDate = `${m[1]}-${qMonth[m[2]] || "01"}`;
-        }
-      }
+      let isoDate: string | null = round ? parseQuarterYear(round) : null;
       if (!isoDate && year) {
         isoDate = year;
       }

--- a/crux/lib/grant-import/sources/ftx-future-fund.ts
+++ b/crux/lib/grant-import/sources/ftx-future-fund.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "fs";
 import { execSync } from "child_process";
+import { truncateToMonth } from "../dates.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
 
@@ -149,7 +150,7 @@ export const source: GrantSource = {
           name = `Grant to ${g.donee}`;
         }
 
-        const isoDate = g.date ? g.date.substring(0, 7) : null;
+        const isoDate = g.date ? truncateToMonth(g.date) : null;
 
         const focusParts: string[] = [];
         if (g.causeArea) focusParts.push(g.causeArea);

--- a/crux/lib/grant-import/sources/manifund.ts
+++ b/crux/lib/grant-import/sources/manifund.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
 import { execSync } from "child_process";
+import { extractISODate } from "../dates.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
 
@@ -157,13 +158,9 @@ export function parseManifundProjects(
 
     const granteeId = matchGrantee(creatorName, matcher);
 
-    let isoDate: string | null = null;
-    if (project.created_at) {
-      const dateMatch = project.created_at.match(/^(\d{4}-\d{2}-\d{2})/);
-      if (dateMatch) {
-        isoDate = dateMatch[1];
-      }
-    }
+    const isoDate = project.created_at
+      ? extractISODate(project.created_at)
+      : null;
 
     const focusArea = project.causes.length > 0
       ? project.causes.map(c => c.title).join(", ")

--- a/crux/lib/grant-import/sources/sff.ts
+++ b/crux/lib/grant-import/sources/sff.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { QUARTER_TO_MONTH } from "../dates.ts";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
@@ -48,10 +49,7 @@ export function sffRoundToDate(round: string): string | null {
   const qMatch = round.match(/SFF-(\d{4})-Q(\d)/);
   if (qMatch) {
     const year = qMatch[1];
-    const qMonth: Record<string, string> = {
-      "1": "01", "2": "04", "3": "07", "4": "10",
-    };
-    return `${year}-${qMonth[qMatch[2]] || "01"}`;
+    return `${year}-${QUARTER_TO_MONTH[qMatch[2]] || "01"}`;
   }
 
   const yearMatch = round.match(/SFF-(\d{4})/);


### PR DESCRIPTION
## Summary
- New `crux/lib/grant-import/dates.ts` with shared date parsing helpers (`parseMonthYear`, `parseQuarterYear`, `extractISODate`, `truncateToMonth`, `QUARTER_TO_MONTH`)
- Replaces ad-hoc date parsing in 5 source files (coefficient-giving, ea-funds, sff, ftx-future-fund, manifund)
- Shared `QUARTER_TO_MONTH` constant eliminates duplication between EA Funds and SFF
- 30 new tests covering all date formats and edge cases

Stacks on #2133

## Test plan
- [x] New dates tests pass (30 tests)
- [x] Existing grant-import tests still pass (91 total)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)