### PR TITLE
fix: entity matcher handles missing data files gracefully

### DIFF
--- a/crux/lib/grant-import/__tests__/entity-matcher.test.ts
+++ b/crux/lib/grant-import/__tests__/entity-matcher.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { matchGrantee, MANUAL_GRANTEE_OVERRIDES } from "../entity-matcher.ts";
+import { describe, it, expect, vi } from "vitest";
+import { matchGrantee, MANUAL_GRANTEE_OVERRIDES, buildEntityMatcher } from "../entity-matcher.ts";
 import type { EntityMatcher } from "../types.ts";
+import * as fs from "fs";
 
 function makeMockMatcher(map: Record<string, string>): EntityMatcher {
   const nameMap = new Map(
@@ -60,5 +61,98 @@ describe("matchGrantee", () => {
   it("includes FTX-specific overrides", () => {
     expect(MANUAL_GRANTEE_OVERRIDES["Ought"]).toBe("elicit");
     expect(MANUAL_GRANTEE_OVERRIDES["Quantified Uncertainty Research Institute"]).toBe("quri");
+  });
+});
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof fs>("fs");
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+describe("buildEntityMatcher — missing files", () => {
+  it("handles missing kb-data.json gracefully", () => {
+    const readMock = vi.mocked(fs.readFileSync);
+    readMock.mockImplementation((path: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const pathStr = String(path);
+      if (pathStr.includes("kb-data.json")) {
+        const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      if (pathStr.includes("database.json")) {
+        return JSON.stringify({ typedEntities: [] });
+      }
+      throw new Error(`Unexpected read: ${pathStr}`);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const matcher = buildEntityMatcher();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("kb-data.json not found")
+    );
+    // Matcher still works, just empty
+    expect(matcher.match("Nonexistent Org")).toBeNull();
+    expect(matcher.allNames.size).toBe(0);
+
+    warnSpy.mockRestore();
+    readMock.mockRestore();
+  });
+
+  it("handles missing database.json gracefully", () => {
+    const readMock = vi.mocked(fs.readFileSync);
+    readMock.mockImplementation((path: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const pathStr = String(path);
+      if (pathStr.includes("kb-data.json")) {
+        return JSON.stringify({ slugToEntityId: {}, entities: {} });
+      }
+      if (pathStr.includes("database.json")) {
+        const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      throw new Error(`Unexpected read: ${pathStr}`);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const matcher = buildEntityMatcher();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("database.json not found")
+    );
+    expect(matcher.match("Nonexistent Org")).toBeNull();
+
+    warnSpy.mockRestore();
+    readMock.mockRestore();
+  });
+
+  it("handles both files missing gracefully", () => {
+    const readMock = vi.mocked(fs.readFileSync);
+    readMock.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const matcher = buildEntityMatcher();
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(matcher.allNames.size).toBe(0);
+    expect(matcher.match("anything")).toBeNull();
+
+    warnSpy.mockRestore();
+    readMock.mockRestore();
+  });
+
+  it("re-throws non-ENOENT errors", () => {
+    const readMock = vi.mocked(fs.readFileSync);
+    readMock.mockImplementation(() => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    expect(() => buildEntityMatcher()).toThrow("EACCES: permission denied");
+
+    readMock.mockRestore();
   });
 });

--- a/crux/lib/grant-import/entity-matcher.ts
+++ b/crux/lib/grant-import/entity-matcher.ts
@@ -67,8 +67,20 @@ export function buildEntityMatcher(): EntityMatcher {
   const nameMap = new Map<string, EntityMatch>();
 
   // Load KB data from kb-data.json (database.json strips the kb field)
+  let kbData: { slugToEntityId?: Record<string, string>; entities?: Record<string, { name?: string; aliases?: string[] }> } = {};
   const kbDataPath = resolve("apps/web/src/data/kb-data.json");
-  const kbData = JSON.parse(readFileSync(kbDataPath, "utf8"));
+  try {
+    kbData = JSON.parse(readFileSync(kbDataPath, "utf8"));
+  } catch (e: unknown) {
+    if (e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT") {
+      console.warn(
+        `kb-data.json not found — run 'pnpm build-data:content' first. Entity matching will be limited to manual overrides.`
+      );
+    } else {
+      throw e;
+    }
+  }
+
   const slugToId: Record<string, string> = kbData.slugToEntityId || {};
   const idToSlug = new Map<string, string>();
   for (const [slug, id] of Object.entries(slugToId)) {
@@ -76,9 +88,7 @@ export function buildEntityMatcher(): EntityMatcher {
   }
 
   if (kbData.entities) {
-    for (const [eid, entity] of Object.entries(
-      kbData.entities as Record<string, { name?: string; aliases?: string[] }>
-    )) {
+    for (const [eid, entity] of Object.entries(kbData.entities)) {
       const slug = idToSlug.get(eid) || "";
       const match: EntityMatch = {
         stableId: eid,
@@ -97,8 +107,20 @@ export function buildEntityMatcher(): EntityMatcher {
   }
 
   // Also load typedEntities from database.json for non-KB entities
+  let db: { typedEntities?: Array<{ id: string; title?: string }> } = {};
   const dbPath = resolve("apps/web/src/data/database.json");
-  const db = JSON.parse(readFileSync(dbPath, "utf8"));
+  try {
+    db = JSON.parse(readFileSync(dbPath, "utf8"));
+  } catch (e: unknown) {
+    if (e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT") {
+      console.warn(
+        `database.json not found — run 'pnpm build-data:content' first. Entity matching will be limited to manual overrides.`
+      );
+    } else {
+      throw e;
+    }
+  }
+
   for (const e of db.typedEntities || []) {
     const slug = e.id;
     const stableId = slugToId[slug] || slug;


### PR DESCRIPTION
## Summary
- `buildEntityMatcher()` now catches ENOENT when loading kb-data.json or database.json
- Logs a clear warning pointing to `pnpm build-data:content`
- Falls back to manual overrides only — import still works on fresh clones
- Added tests for missing file handling

Stacks on #2133

## Test plan
- [x] New entity-matcher tests pass (missing file scenarios)
- [x] Existing grant-import tests pass (65/65)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)