### PR TITLE
fix: client components import SortHeader directly to avoid fs dependency

### DIFF
--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import { SortHeader } from "@/components/directory";
+import { SortHeader } from "@/components/directory/SortHeader";
 import { formatCompactCurrency } from "@/lib/format-compact";
 
 export interface GrantRow {

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import { SortHeader } from "@/components/directory";
+import { SortHeader } from "@/components/directory/SortHeader";
 
 export interface RiskRow {
   id: string;


### PR DESCRIPTION
## Summary
- `risks-table.tsx` and `grants-table.tsx` (both `"use client"`) were importing `SortHeader` from `@/components/directory` barrel
- The barrel now re-exports `FactsSection` which pulls in `kb.ts` → `database.ts` → `fs`
- Next.js build fails because `fs` is not available in client bundles
- Fix: import `SortHeader` directly from `@/components/directory/SortHeader`

Fixes the build failure on main after #2134.

## Test plan
- [ ] `pnpm build` passes (CI will verify)