### PR TITLE
test: expand grant import test coverage for edge cases

### DIFF
--- a/crux/lib/grant-import/__tests__/csv.test.ts
+++ b/crux/lib/grant-import/__tests__/csv.test.ts
@@ -29,6 +29,21 @@ describe("parseCSVLine", () => {
   it("handles empty string", () => {
     expect(parseCSVLine("")).toEqual([""]);
   });
+
+  it("handles line with only commas", () => {
+    expect(parseCSVLine(",,,")).toEqual(["", "", "", ""]);
+  });
+
+  it("handles very long field (>10K chars)", () => {
+    const longField = "x".repeat(15000);
+    const result = parseCSVLine(`a,${longField},c`);
+    expect(result).toEqual(["a", longField, "c"]);
+    expect(result[1]).toHaveLength(15000);
+  });
+
+  it("handles field with only whitespace", () => {
+    expect(parseCSVLine("  ,\t,  \t  ")).toEqual(["  ", "\t", "  \t  "]);
+  });
 });
 
 describe("reassembleCSVRows", () => {
@@ -48,5 +63,11 @@ describe("reassembleCSVRows", () => {
     const text = "Header\nRow 1\n\nRow 2";
     const rows = reassembleCSVRows(text);
     expect(rows).toEqual(["Row 1", "Row 2"]);
+  });
+
+  it("returns empty array for header-only input", () => {
+    const text = "Name,Amount";
+    const rows = reassembleCSVRows(text);
+    expect(rows).toEqual([]);
   });
 });

--- a/crux/lib/grant-import/__tests__/ftx.test.ts
+++ b/crux/lib/grant-import/__tests__/ftx.test.ts
@@ -40,4 +40,29 @@ describe("parseFTXSQLFile", () => {
     const grants = parseFTXSQLFile(sql, "open-call");
     expect(grants).toEqual([]);
   });
+
+  it("handles escaped single quotes like O'Brien", () => {
+    const sql = `insert into donations(donor,donee,amount,donation_date) values
+('FTX Future Fund','O''Brien Foundation',750000,'2022-07-15','month','donation log',NULL);`;
+
+    const grants = parseFTXSQLFile(sql, "open-call");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].donee).toBe("O'Brien Foundation");
+    expect(grants[0].amount).toBe(750000);
+  });
+
+  it("parses zero amount", () => {
+    const sql = `insert into donations(donor,donee,amount,donation_date) values
+('FTX Future Fund','Zero Grant Org',0,'2022-08-01','month','donation log',NULL);`;
+
+    const grants = parseFTXSQLFile(sql, "staff-led");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].amount).toBe(0);
+    expect(grants[0].donee).toBe("Zero Grant Org");
+  });
+
+  it("returns empty array for empty SQL file", () => {
+    const grants = parseFTXSQLFile("", "open-call");
+    expect(grants).toEqual([]);
+  });
 });

--- a/crux/lib/grant-import/__tests__/manifund.test.ts
+++ b/crux/lib/grant-import/__tests__/manifund.test.ts
@@ -133,4 +133,40 @@ describe("parseManifundProjects", () => {
     const total = grants.reduce((s, g) => s + (g.amount || 0), 0);
     expect(total).toBe(30000);
   });
+
+  it("uses 'Unknown' when profiles is null", () => {
+    const project = makeProject({
+      profiles: null,
+    });
+    const grants = parseManifundProjects([project], matcher);
+    expect(grants[0].granteeName).toBe("Unknown");
+  });
+
+  it("falls back to username when full_name is missing (null-like)", () => {
+    const project = makeProject({
+      profiles: { username: "jdoe", full_name: "" },
+    });
+    const grants = parseManifundProjects([project], matcher);
+    expect(grants[0].granteeName).toBe("jdoe");
+  });
+
+  it("sets focusArea to null when no causes", () => {
+    const project = makeProject({
+      causes: [],
+    });
+    const grants = parseManifundProjects([project], matcher);
+    expect(grants[0].focusArea).toBeNull();
+  });
+
+  it("joins multiple causes with comma separator", () => {
+    const project = makeProject({
+      causes: [
+        { title: "AI Safety", slug: "ai-safety" },
+        { title: "Biosecurity", slug: "biosecurity" },
+        { title: "Nuclear Risk", slug: "nuclear-risk" },
+      ],
+    });
+    const grants = parseManifundProjects([project], matcher);
+    expect(grants[0].focusArea).toBe("AI Safety, Biosecurity, Nuclear Risk");
+  });
 });

--- a/crux/lib/grant-import/__tests__/sff.test.ts
+++ b/crux/lib/grant-import/__tests__/sff.test.ts
@@ -25,6 +25,15 @@ describe("parseSFFAmount", () => {
   it("returns null for empty string", () => {
     expect(parseSFFAmount("")).toBeNull();
   });
+
+  it("sums matching pledge amount", () => {
+    // $1,535,000 + $500,000 with dagger
+    expect(parseSFFAmount("$1,535,000 +$500,000\u2021")).toBe(2035000);
+  });
+
+  it("handles amount string with only dagger (no plus)", () => {
+    expect(parseSFFAmount("$500,000\u2021")).toBe(500000);
+  });
 });
 
 describe("sffRoundToDate", () => {
@@ -58,5 +67,13 @@ describe("sffRoundToDate", () => {
 
   it("returns null for unrecognized format", () => {
     expect(sffRoundToDate("Something Else")).toBeNull();
+  });
+
+  it("parses SFF-YYYY-Q1", () => {
+    expect(sffRoundToDate("SFF-2020-Q1")).toBe("2020-01");
+  });
+
+  it("parses SFF-YYYY-Q2", () => {
+    expect(sffRoundToDate("SFF-2020-Q2")).toBe("2020-04");
   });
 });

--- a/crux/lib/grant-import/__tests__/sync.test.ts
+++ b/crux/lib/grant-import/__tests__/sync.test.ts
@@ -104,6 +104,114 @@ describe("toSyncGrant", () => {
     expect(sync.notes).toBe("Global Health");
   });
 
+  it("uses description alone when no focusArea", () => {
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Test",
+      granteeId: null,
+      name: "Test",
+      amount: 1000,
+      date: null,
+      focusArea: null,
+      description: "Research on alignment techniques",
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.notes).toBe("Research on alignment techniques");
+  });
+
+  it("sets notes to null when neither focusArea nor description", () => {
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Test",
+      granteeId: null,
+      name: "Test",
+      amount: 1000,
+      date: null,
+      focusArea: null,
+      description: null,
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.notes).toBeNull();
+  });
+
+  it("passes through null amount", () => {
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Test Org",
+      granteeId: null,
+      name: "Undisclosed grant",
+      amount: null,
+      date: "2024-01",
+      focusArea: null,
+      description: null,
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.amount).toBeNull();
+  });
+
+  it("generates ID correctly with null date", () => {
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Test Org",
+      granteeId: null,
+      name: "Grant with no date",
+      amount: 5000,
+      date: null,
+      focusArea: null,
+      description: null,
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.id).toHaveLength(10);
+    // Null date becomes empty string in ID input
+    expect(sync.date).toBeNull();
+  });
+
+  it("truncates very long granteeName in granteeId to 200 chars", () => {
+    const longName = "A".repeat(500);
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: longName,
+      granteeId: null,
+      name: "Test",
+      amount: 1000,
+      date: null,
+      focusArea: null,
+      description: null,
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.granteeId).toHaveLength(200);
+  });
+
+  it("truncates name in ID input to 100 chars", () => {
+    const longName = "B".repeat(200);
+    const raw1: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Test",
+      granteeId: null,
+      name: longName,
+      amount: 1000,
+      date: null,
+      focusArea: null,
+      description: null,
+    };
+    // Same raw but with name extended beyond 100 chars in a different way
+    const raw2: RawGrant = {
+      ...raw1,
+      name: longName + "EXTRA",
+    };
+    const sync1 = toSyncGrant(raw1, defaultSourceUrl);
+    const sync2 = toSyncGrant(raw2, defaultSourceUrl);
+    // Both should produce the same ID since name is truncated to 100 chars
+    // and both share the same first 100 chars
+    expect(sync1.id).toBe(sync2.id);
+  });
+
   // ID stability tests — these pin the exact ID for existing CG/EA Funds grants
   it("produces stable ID for CG grant (ID must not change)", () => {
     const raw: RawGrant = {


### PR DESCRIPTION
## Summary
- Added error path and edge case tests across the grant import test suite
- CSV: only-commas line, very long fields (>10K chars), whitespace-only fields, header-only input
- Sync: null amount passthrough, null date ID generation, granteeName truncation to 200 chars, name truncation in ID input to 100 chars, description-only notes, neither-notes null
- FTX: O'Brien-style escaped quotes, zero amount parsing, empty SQL file
- Manifund: null profiles -> "Unknown", username fallback, empty causes -> null focusArea, multiple causes joined
- SFF: Q1/Q2 quarter parsing, dagger-only amounts, matching pledge sums

Stacks on #2133

## Test plan
- [x] All 82 tests pass (`npx vitest run --config crux/vitest.config.ts crux/lib/grant-import/`)
- [x] All existing tests still pass
- [x] No new source code changes, only test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)