### PR TITLE
fix: grant import safety fixes (shell injection, error handling)

### DIFF
--- a/crux/commands/import-grants.ts
+++ b/crux/commands/import-grants.ts
@@ -30,16 +30,22 @@ import type { GrantSource, RawGrant, SyncGrant } from "../lib/grant-import/types
 const SOURCE_URL_MAP = new Map(ALL_SOURCES.map(s => [s.id, s.sourceUrl]));
 
 function sourceUrlFor(sourceId: string): string {
-  return SOURCE_URL_MAP.get(sourceId) ?? ALL_SOURCES[0].sourceUrl;
+  const url = SOURCE_URL_MAP.get(sourceId);
+  if (!url) {
+    throw new Error(
+      `No sourceUrl found for source ID "${sourceId}". Known sources: ${[...SOURCE_URL_MAP.keys()].join(", ")}`
+    );
+  }
+  return url;
 }
 
 function filterSources(sourceFilter?: string): GrantSource[] {
   if (!sourceFilter) return ALL_SOURCES;
   const src = ALL_SOURCES.find(s => s.id === sourceFilter);
   if (!src) {
-    console.error(`Unknown source: ${sourceFilter}`);
-    console.error(`Available: ${ALL_SOURCES.map(s => s.id).join(", ")}`);
-    process.exit(1);
+    throw new Error(
+      `Unknown source: ${sourceFilter}. Available: ${ALL_SOURCES.map(s => s.id).join(", ")}`
+    );
   }
   return [src];
 }

--- a/crux/lib/grant-import/types.ts
+++ b/crux/lib/grant-import/types.ts
@@ -25,6 +25,12 @@ export interface RawGrant {
 export interface SyncGrant {
   id: string;
   organizationId: string;
+  /**
+   * Despite the name, this stores the human-readable display name (not an entity
+   * stableId). The wiki-server grants schema expects this field name, so it cannot
+   * be renamed without a coordinated server migration. Compare with RawGrant.granteeId,
+   * which IS an entity stableId (or null if unmatched).
+   */
   granteeId: string | null;
   name: string;
   amount: number | null;


### PR DESCRIPTION
## Summary
- Fix shell injection vulnerability in `download.ts` — use `execFileSync` array form instead of string interpolation into a shell command
- Add clarifying JSDoc comment on `SyncGrant.granteeId` explaining it stores display names (not entity IDs); renaming is unsafe because the wiki-server `SyncGrantItemSchema` expects `granteeId`
- Replace `process.exit(1)` with `throw new Error()` in `filterSources()` for proper error propagation
- Replace silent fallback in `sourceUrlFor()` (which would silently use the wrong source URL) with an explicit error

## Test plan
- [x] All 61 grant-import tests pass (`npx vitest run --config crux/vitest.config.ts crux/lib/grant-import/`)
- [x] No functional behavior change for valid inputs — only error paths are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)