### PR TITLE
refactor: centralize grant funder IDs into constants.ts

### DIFF
--- a/crux/lib/grant-import/constants.ts
+++ b/crux/lib/grant-import/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Entity stableIds for grant-making organizations.
+ * These are looked up from data/entities/ YAML files.
+ * To find or allocate new IDs: pnpm crux ids allocate <slug>
+ */
+export const FUNDER_IDS = {
+  OPEN_PHILANTHROPY: "ULjDXpSLCI",
+  SFF: "sIFjGbxVct",
+  FTX_FUTURE_FUND: "JhIGCaI3Ng",
+  MANIFUND: "fFVOuFZCRf",
+  LTFF: "yA12C1KcjQ",
+  CEA: "gNsqAes7Dw",
+} as const;

--- a/crux/lib/grant-import/sources/coefficient-giving.ts
+++ b/crux/lib/grant-import/sources/coefficient-giving.ts
@@ -3,11 +3,11 @@ import { parseCSVLine, reassembleCSVRows } from "../csv.ts";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
+import { FUNDER_IDS } from "../constants.ts";
 
 const CG_CSV_URL =
   "https://coefficientgiving.org/wp-content/uploads/Coefficient-Giving-Grants-Archive.csv";
 const CG_CSV_PATH = "/tmp/coefficient-giving-grants.csv";
-const FUNDER_ID = "ULjDXpSLCI";
 
 export const source: GrantSource = {
   id: "coefficient-giving",
@@ -58,7 +58,7 @@ export const source: GrantSource = {
 
       grants.push({
         source: "coefficient-giving",
-        funderId: FUNDER_ID,
+        funderId: FUNDER_IDS.OPEN_PHILANTHROPY,
         granteeName: orgName,
         granteeId,
         name: grantName.substring(0, 500),

--- a/crux/lib/grant-import/sources/ea-funds.ts
+++ b/crux/lib/grant-import/sources/ea-funds.ts
@@ -3,6 +3,7 @@ import { parseCSVLine } from "../csv.ts";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
+import { FUNDER_IDS } from "../constants.ts";
 
 const EA_FUNDS_CSV_URL = "https://funds.effectivealtruism.org/api/grants";
 const EA_FUNDS_CSV_PATH = "/tmp/ea-funds-grants.csv";
@@ -14,11 +15,11 @@ export function resolveEAFundEntityIds(
   const cea = matcher.match("cea");
 
   return {
-    "Long-Term Future Fund": ltff?.stableId || "yA12C1KcjQ",
-    "Animal Welfare Fund": cea?.stableId || "gNsqAes7Dw",
-    "EA Infrastructure Fund": cea?.stableId || "gNsqAes7Dw",
-    "Effective Altruism Infrastructure Fund": cea?.stableId || "gNsqAes7Dw",
-    "Global Health and Development Fund": cea?.stableId || "gNsqAes7Dw",
+    "Long-Term Future Fund": ltff?.stableId || FUNDER_IDS.LTFF,
+    "Animal Welfare Fund": cea?.stableId || FUNDER_IDS.CEA,
+    "EA Infrastructure Fund": cea?.stableId || FUNDER_IDS.CEA,
+    "Effective Altruism Infrastructure Fund": cea?.stableId || FUNDER_IDS.CEA,
+    "Global Health and Development Fund": cea?.stableId || FUNDER_IDS.CEA,
   };
 }
 

--- a/crux/lib/grant-import/sources/ftx-future-fund.ts
+++ b/crux/lib/grant-import/sources/ftx-future-fund.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from "fs";
 import { execSync } from "child_process";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
+import { FUNDER_IDS } from "../constants.ts";
 
 const FTX_SQL_BASE_URL =
   "https://raw.githubusercontent.com/vipulnaik/donations/master/sql/donations/private-foundations/ftx-future-fund/";
@@ -19,7 +20,6 @@ const FTX_SQL_FILES = [
   "ftx-future-fund-staff-led-grants.sql",
 ];
 const FTX_SQL_DIR = "/tmp/ftx-future-fund-sql";
-const FUNDER_ID = "JhIGCaI3Ng";
 
 interface FTXSQLGrant {
   donee: string;
@@ -158,7 +158,7 @@ export const source: GrantSource = {
 
         grants.push({
           source: "ftx-future-fund",
-          funderId: FUNDER_ID,
+          funderId: FUNDER_IDS.FTX_FUTURE_FUND,
           granteeName: g.donee,
           granteeId,
           name,

--- a/crux/lib/grant-import/sources/manifund.ts
+++ b/crux/lib/grant-import/sources/manifund.ts
@@ -2,8 +2,8 @@ import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
 import { execSync } from "child_process";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
+import { FUNDER_IDS } from "../constants.ts";
 
-const MANIFUND_FUNDER_ID = "fFVOuFZCRf";
 const MANIFUND_API_URL = "https://manifund.org/api/v0/projects";
 const MANIFUND_CACHE_PATH = "/tmp/manifund-projects.json";
 
@@ -173,7 +173,7 @@ export function parseManifundProjects(
 
     grants.push({
       source: "manifund",
-      funderId: MANIFUND_FUNDER_ID,
+      funderId: FUNDER_IDS.MANIFUND,
       granteeName: creatorName,
       granteeId,
       name: project.title.substring(0, 500),

--- a/crux/lib/grant-import/sources/sff.ts
+++ b/crux/lib/grant-import/sources/sff.ts
@@ -2,10 +2,10 @@ import { readFileSync } from "fs";
 import { downloadIfMissing } from "../download.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
+import { FUNDER_IDS } from "../constants.ts";
 
 const SFF_URL = "https://survivalandflourishing.fund/recommendations";
 const SFF_HTML_PATH = "/tmp/sff-recommendations.html";
-const FUNDER_ID = "sIFjGbxVct";
 
 /**
  * Parse the SFF amount field which can have several formats:
@@ -133,7 +133,7 @@ export const source: GrantSource = {
 
       grants.push({
         source: "sff",
-        funderId: FUNDER_ID,
+        funderId: FUNDER_IDS.SFF,
         granteeName: organization,
         granteeId,
         name,


### PR DESCRIPTION
## Summary
- Extract hardcoded funder entity IDs from 5 source files into `crux/lib/grant-import/constants.ts`
- Single place to audit and update funder IDs
- No behavioral changes

Stacks on #2133

## Test plan
- [x] Existing grant-import tests pass (61/61)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)