### PR TITLE
refactor: make grant analysis functions return data

### DIFF
--- a/crux/lib/grant-import/__tests__/analysis.test.ts
+++ b/crux/lib/grant-import/__tests__/analysis.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMatchStats,
+  getTopUnmatched,
+  getIdCollisions,
+  getByFunder,
+} from "../analysis.ts";
+import type { RawGrant, SyncGrant } from "../types.ts";
+
+function makeRawGrant(overrides: Partial<RawGrant> = {}): RawGrant {
+  return {
+    source: "test",
+    funderId: "funder-1",
+    granteeName: "Test Org",
+    granteeId: null,
+    name: "Test Grant",
+    amount: 100_000,
+    date: "2024-01-01",
+    focusArea: null,
+    description: null,
+    ...overrides,
+  };
+}
+
+function makeSyncGrant(overrides: Partial<SyncGrant> = {}): SyncGrant {
+  return {
+    id: "grant-1",
+    organizationId: "org-1",
+    granteeId: null,
+    name: "Test Grant",
+    amount: 100_000,
+    currency: "USD",
+    date: "2024-01-01",
+    status: null,
+    source: "test",
+    notes: null,
+    ...overrides,
+  };
+}
+
+describe("getMatchStats", () => {
+  it("returns zeros for empty input", () => {
+    const stats = getMatchStats([]);
+    expect(stats).toEqual({
+      total: 0,
+      matched: 0,
+      unmatched: 0,
+      matchRate: 0,
+      uniqueGranteeNames: 0,
+      matchedGranteeNames: 0,
+    });
+  });
+
+  it("computes correct stats for a mix of matched and unmatched grants", () => {
+    const grants = [
+      makeRawGrant({ granteeName: "Org A", granteeId: "entity-1" }),
+      makeRawGrant({ granteeName: "Org A", granteeId: "entity-1" }),
+      makeRawGrant({ granteeName: "Org B", granteeId: null }),
+      makeRawGrant({ granteeName: "Org C", granteeId: "entity-3" }),
+    ];
+
+    const stats = getMatchStats(grants);
+    expect(stats.total).toBe(4);
+    expect(stats.matched).toBe(3);
+    expect(stats.unmatched).toBe(1);
+    expect(stats.matchRate).toBe(0.75);
+    expect(stats.uniqueGranteeNames).toBe(3);
+    expect(stats.matchedGranteeNames).toBe(2);
+  });
+
+  it("returns matchRate of 1 when all grants are matched", () => {
+    const grants = [
+      makeRawGrant({ granteeId: "entity-1" }),
+      makeRawGrant({ granteeId: "entity-2" }),
+    ];
+    const stats = getMatchStats(grants);
+    expect(stats.matchRate).toBe(1);
+    expect(stats.unmatched).toBe(0);
+  });
+
+  it("returns matchRate of 0 when no grants are matched", () => {
+    const grants = [
+      makeRawGrant({ granteeId: null }),
+      makeRawGrant({ granteeId: null }),
+    ];
+    const stats = getMatchStats(grants);
+    expect(stats.matchRate).toBe(0);
+    expect(stats.matched).toBe(0);
+  });
+});
+
+describe("getTopUnmatched", () => {
+  it("returns empty array when all grants are matched", () => {
+    const grants = [
+      makeRawGrant({ granteeId: "entity-1" }),
+    ];
+    expect(getTopUnmatched(grants)).toEqual([]);
+  });
+
+  it("aggregates unmatched grants by grantee name, sorted by total amount", () => {
+    const grants = [
+      makeRawGrant({ granteeName: "Small Org", granteeId: null, amount: 10_000 }),
+      makeRawGrant({ granteeName: "Big Org", granteeId: null, amount: 500_000 }),
+      makeRawGrant({ granteeName: "Big Org", granteeId: null, amount: 300_000 }),
+      makeRawGrant({ granteeName: "Medium Org", granteeId: null, amount: 200_000 }),
+      // This one is matched, so should be excluded
+      makeRawGrant({ granteeName: "Matched Org", granteeId: "entity-1", amount: 1_000_000 }),
+    ];
+
+    const result = getTopUnmatched(grants);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ name: "Big Org", totalAmount: 800_000, count: 2 });
+    expect(result[1]).toEqual({ name: "Medium Org", totalAmount: 200_000, count: 1 });
+    expect(result[2]).toEqual({ name: "Small Org", totalAmount: 10_000, count: 1 });
+  });
+
+  it("respects the limit parameter", () => {
+    const grants = [
+      makeRawGrant({ granteeName: "A", granteeId: null, amount: 300 }),
+      makeRawGrant({ granteeName: "B", granteeId: null, amount: 200 }),
+      makeRawGrant({ granteeName: "C", granteeId: null, amount: 100 }),
+    ];
+
+    const result = getTopUnmatched(grants, 2);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("A");
+    expect(result[1].name).toBe("B");
+  });
+
+  it("treats null amounts as 0", () => {
+    const grants = [
+      makeRawGrant({ granteeName: "No Amount", granteeId: null, amount: null }),
+    ];
+    const result = getTopUnmatched(grants);
+    expect(result[0].totalAmount).toBe(0);
+    expect(result[0].count).toBe(1);
+  });
+});
+
+describe("getIdCollisions", () => {
+  it("returns zero collisions for unique IDs", () => {
+    const grants = [
+      makeSyncGrant({ id: "a" }),
+      makeSyncGrant({ id: "b" }),
+      makeSyncGrant({ id: "c" }),
+    ];
+    const result = getIdCollisions(grants);
+    expect(result).toEqual({ uniqueIds: 3, collisions: 0 });
+  });
+
+  it("detects collisions for duplicate IDs", () => {
+    const grants = [
+      makeSyncGrant({ id: "a" }),
+      makeSyncGrant({ id: "b" }),
+      makeSyncGrant({ id: "a" }),
+      makeSyncGrant({ id: "a" }),
+    ];
+    const result = getIdCollisions(grants);
+    expect(result).toEqual({ uniqueIds: 2, collisions: 2 });
+  });
+
+  it("returns zeros for empty input", () => {
+    expect(getIdCollisions([])).toEqual({ uniqueIds: 0, collisions: 0 });
+  });
+});
+
+describe("getByFunder", () => {
+  it("returns empty array for no grants", () => {
+    expect(getByFunder([])).toEqual([]);
+  });
+
+  it("groups and counts grants by organizationId, sorted descending", () => {
+    const grants = [
+      makeSyncGrant({ organizationId: "org-a" }),
+      makeSyncGrant({ organizationId: "org-b" }),
+      makeSyncGrant({ organizationId: "org-a" }),
+      makeSyncGrant({ organizationId: "org-a" }),
+      makeSyncGrant({ organizationId: "org-b" }),
+      makeSyncGrant({ organizationId: "org-c" }),
+    ];
+
+    const result = getByFunder(grants);
+    expect(result).toEqual([
+      { organizationId: "org-a", count: 3 },
+      { organizationId: "org-b", count: 2 },
+      { organizationId: "org-c", count: 1 },
+    ]);
+  });
+});

--- a/crux/lib/grant-import/analysis.ts
+++ b/crux/lib/grant-import/analysis.ts
@@ -1,20 +1,51 @@
 import type { RawGrant, SyncGrant } from "./types.ts";
 
-export function printMatchStats(grants: RawGrant[]): void {
-  const matched = grants.filter((g) => g.granteeId !== null);
-  const unmatched = grants.filter((g) => g.granteeId === null);
+// --- Data types ---
 
-  console.log(`Entity matching:`);
-  console.log(`  Matched: ${matched.length} (${grants.length > 0 ? ((matched.length / grants.length) * 100).toFixed(1) : 0}%)`);
-  console.log(`  Unmatched: ${unmatched.length} (stored as display names)\n`);
-
-  const granteeNames = new Set(grants.map((g) => g.granteeName));
-  const matchedNames = new Set(matched.map((g) => g.granteeName));
-  console.log(`Unique grantee names: ${granteeNames.size}`);
-  console.log(`Matched to entities: ${matchedNames.size}`);
+export interface MatchStats {
+  total: number;
+  matched: number;
+  unmatched: number;
+  matchRate: number; // 0-1
+  uniqueGranteeNames: number;
+  matchedGranteeNames: number;
 }
 
-export function printTopUnmatched(grants: RawGrant[], limit = 30): void {
+export interface UnmatchedGrantee {
+  name: string;
+  totalAmount: number;
+  count: number;
+}
+
+export interface IdCollisions {
+  uniqueIds: number;
+  collisions: number;
+}
+
+export interface FunderBreakdown {
+  organizationId: string;
+  count: number;
+}
+
+// --- Data functions ---
+
+export function getMatchStats(grants: RawGrant[]): MatchStats {
+  const matched = grants.filter((g) => g.granteeId !== null);
+  const unmatched = grants.filter((g) => g.granteeId === null);
+  const granteeNames = new Set(grants.map((g) => g.granteeName));
+  const matchedNames = new Set(matched.map((g) => g.granteeName));
+
+  return {
+    total: grants.length,
+    matched: matched.length,
+    unmatched: unmatched.length,
+    matchRate: grants.length > 0 ? matched.length / grants.length : 0,
+    uniqueGranteeNames: granteeNames.size,
+    matchedGranteeNames: matchedNames.size,
+  };
+}
+
+export function getTopUnmatched(grants: RawGrant[], limit = 30): UnmatchedGrantee[] {
   const unmatched = grants.filter((g) => g.granteeId === null);
   const unmatchedByOrg = new Map<string, { total: number; count: number }>();
   for (const g of unmatched) {
@@ -24,35 +55,69 @@ export function printTopUnmatched(grants: RawGrant[], limit = 30): void {
     unmatchedByOrg.set(g.granteeName, entry);
   }
 
-  const sorted = [...unmatchedByOrg.entries()]
+  return [...unmatchedByOrg.entries()]
     .sort((a, b) => b[1].total - a[1].total)
-    .slice(0, limit);
-
-  console.log(`\nTop ${limit} unmatched grantees by amount:`);
-  for (const [name, data] of sorted) {
-    console.log(
-      `  $${(data.total / 1e6).toFixed(1)}M (${data.count} grants) — ${name}`
-    );
-  }
+    .slice(0, limit)
+    .map(([name, data]) => ({
+      name,
+      totalAmount: data.total,
+      count: data.count,
+    }));
 }
 
-export function checkIdCollisions(syncGrants: SyncGrant[]): void {
+export function getIdCollisions(syncGrants: SyncGrant[]): IdCollisions {
   const idSet = new Set<string>();
   let collisions = 0;
   for (const g of syncGrants) {
     if (idSet.has(g.id)) collisions++;
     idSet.add(g.id);
   }
-  console.log(`\nGenerated ${idSet.size} unique IDs (${collisions} collisions → would be deduped)`);
+  return { uniqueIds: idSet.size, collisions };
 }
 
-export function printByFunder(syncGrants: SyncGrant[]): void {
+export function getByFunder(syncGrants: SyncGrant[]): FunderBreakdown[] {
   const byFunder = new Map<string, number>();
   for (const g of syncGrants) {
     byFunder.set(g.organizationId, (byFunder.get(g.organizationId) || 0) + 1);
   }
+  return [...byFunder.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([organizationId, count]) => ({ organizationId, count }));
+}
+
+// --- Print functions (thin wrappers) ---
+
+export function printMatchStats(grants: RawGrant[]): void {
+  const stats = getMatchStats(grants);
+
+  console.log(`Entity matching:`);
+  console.log(`  Matched: ${stats.matched} (${(stats.matchRate * 100).toFixed(1)}%)`);
+  console.log(`  Unmatched: ${stats.unmatched} (stored as display names)\n`);
+  console.log(`Unique grantee names: ${stats.uniqueGranteeNames}`);
+  console.log(`Matched to entities: ${stats.matchedGranteeNames}`);
+}
+
+export function printTopUnmatched(grants: RawGrant[], limit = 30): void {
+  const topUnmatched = getTopUnmatched(grants, limit);
+
+  console.log(`\nTop ${limit} unmatched grantees by amount:`);
+  for (const entry of topUnmatched) {
+    console.log(
+      `  $${(entry.totalAmount / 1e6).toFixed(1)}M (${entry.count} grants) — ${entry.name}`
+    );
+  }
+}
+
+export function checkIdCollisions(syncGrants: SyncGrant[]): void {
+  const { uniqueIds, collisions } = getIdCollisions(syncGrants);
+  console.log(`\nGenerated ${uniqueIds} unique IDs (${collisions} collisions → would be deduped)`);
+}
+
+export function printByFunder(syncGrants: SyncGrant[]): void {
+  const breakdown = getByFunder(syncGrants);
+
   console.log(`\nGrants by funder entity:`);
-  for (const [id, count] of [...byFunder.entries()].sort((a, b) => b[1] - a[1])) {
-    console.log(`  ${id}: ${count} grants`);
+  for (const entry of breakdown) {
+    console.log(`  ${entry.organizationId}: ${entry.count} grants`);
   }
 }


### PR DESCRIPTION
## Summary
- Extract data computation from `print*` functions into testable `get*` functions
- `getMatchStats()`, `getTopUnmatched()`, `getIdCollisions()`, `getByFunder()` return structured data
- Existing `print*` functions preserved as thin wrappers
- Added tests for all analysis functions

Stacks on #2133

## Test plan
- [ ] New analysis tests pass (13 tests)
- [ ] Existing grant-import tests pass (74 total)
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)