### PR TITLE
feat: improve grant entity match rate with expanded overrides

### DIFF
--- a/crux/lib/grant-import/__tests__/entity-matcher.test.ts
+++ b/crux/lib/grant-import/__tests__/entity-matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { matchGrantee, MANUAL_GRANTEE_OVERRIDES, buildEntityMatcher } from "../entity-matcher.ts";
+import { matchGrantee, MANUAL_GRANTEE_OVERRIDES, normalizeGranteeName, buildEntityMatcher } from "../entity-matcher.ts";
 import type { EntityMatcher } from "../types.ts";
 import * as fs from "fs";
 
@@ -68,6 +68,166 @@ describe("matchGrantee", () => {
   it("includes FTX-specific overrides", () => {
     expect(MANUAL_GRANTEE_OVERRIDES["Ought"]).toBe("elicit");
     expect(MANUAL_GRANTEE_OVERRIDES["Quantified Uncertainty Research Institute"]).toBe("quri");
+  });
+
+  it("matches after stripping Inc. suffix", () => {
+    // "Anthropic, Inc." normalizes to "Anthropic" which has an override
+    expect(matchGrantee("Anthropic, Inc.", matcher)).toBe("def456");
+  });
+
+  it("matches after stripping LLC suffix", () => {
+    const matcherWithOpenAI = makeMockMatcher({
+      ...Object.fromEntries(
+        Object.entries({ miri: "abc123", anthropic: "def456", arc: "ghi789", "center-for-ai-safety": "jkl012", cset: "mno345", elicit: "pqr678", openai: "oai999" })
+      ),
+    });
+    expect(matchGrantee("OpenAI, LLC", matcherWithOpenAI)).toBe("oai999");
+  });
+
+  it("matches after stripping Foundation suffix", () => {
+    const matcherWithGoodVentures = makeMockMatcher({
+      "good-ventures": "gv001",
+    });
+    expect(matchGrantee("Good Ventures Foundation", matcherWithGoodVentures)).toBe("gv001");
+  });
+
+  it("does not strip suffix from middle of name", () => {
+    // "Foundation for Something" should not become "for Something"
+    const result = matchGrantee("Foundation for Something", matcher);
+    expect(result).toBeNull();
+  });
+});
+
+describe("normalizeGranteeName", () => {
+  it("strips ', Inc.' suffix", () => {
+    expect(normalizeGranteeName("Anthropic, Inc.")).toBe("Anthropic");
+  });
+
+  it("strips ', Inc' suffix (no period)", () => {
+    expect(normalizeGranteeName("OpenAI, Inc")).toBe("OpenAI");
+  });
+
+  it("strips ' LLC' suffix", () => {
+    expect(normalizeGranteeName("OpenAI Global LLC")).toBe("OpenAI Global");
+  });
+
+  it("strips ', LLC' suffix", () => {
+    expect(normalizeGranteeName("SomeOrg, LLC")).toBe("SomeOrg");
+  });
+
+  it("strips ' Ltd.' suffix", () => {
+    expect(normalizeGranteeName("DeepMind Ltd.")).toBe("DeepMind");
+  });
+
+  it("strips ' Foundation' suffix", () => {
+    expect(normalizeGranteeName("Good Ventures Foundation")).toBe("Good Ventures");
+  });
+
+  it("strips ' Corporation' suffix", () => {
+    expect(normalizeGranteeName("Microsoft Corporation")).toBe("Microsoft");
+  });
+
+  it("strips ' Corp.' suffix", () => {
+    expect(normalizeGranteeName("RAND Corp.")).toBe("RAND");
+  });
+
+  it("strips ' Incorporated' suffix", () => {
+    expect(normalizeGranteeName("Something Incorporated")).toBe("Something");
+  });
+
+  it("is case-insensitive for suffix matching", () => {
+    expect(normalizeGranteeName("SomeOrg, INC.")).toBe("SomeOrg");
+    expect(normalizeGranteeName("SomeOrg, llc")).toBe("SomeOrg");
+  });
+
+  it("returns name unchanged when no suffix", () => {
+    expect(normalizeGranteeName("Anthropic")).toBe("Anthropic");
+  });
+
+  it("handles whitespace-only names", () => {
+    expect(normalizeGranteeName("  ")).toBe("");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeGranteeName("  Anthropic, Inc.  ")).toBe("Anthropic");
+  });
+
+  it("only strips one suffix", () => {
+    // "Org Inc. Foundation" — strips Foundation (matched first due to suffix ordering)
+    expect(normalizeGranteeName("Org Inc Foundation")).toBe("Org Inc");
+  });
+
+  it("does not strip partial word matches", () => {
+    // "Incubator" should not match "Inc"
+    expect(normalizeGranteeName("AI Incubator")).toBe("AI Incubator");
+  });
+});
+
+describe("MANUAL_GRANTEE_OVERRIDES coverage", () => {
+  it("maps major AI safety orgs", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["MIRI"]).toBe("miri");
+    expect(MANUAL_GRANTEE_OVERRIDES["ARC"]).toBe("arc");
+    expect(MANUAL_GRANTEE_OVERRIDES["METR"]).toBe("metr");
+    expect(MANUAL_GRANTEE_OVERRIDES["CAIS"]).toBe("center-for-ai-safety");
+    expect(MANUAL_GRANTEE_OVERRIDES["Apollo Research"]).toBe("apollo-research");
+    expect(MANUAL_GRANTEE_OVERRIDES["Conjecture"]).toBe("conjecture");
+    expect(MANUAL_GRANTEE_OVERRIDES["Goodfire"]).toBe("goodfire");
+  });
+
+  it("maps policy/governance orgs", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["FHI"]).toBe("fhi");
+    expect(MANUAL_GRANTEE_OVERRIDES["CSER"]).toBe("cser");
+    expect(MANUAL_GRANTEE_OVERRIDES["FLI"]).toBe("fli");
+    expect(MANUAL_GRANTEE_OVERRIDES["CLTR"]).toBe("centre-for-long-term-resilience");
+    expect(MANUAL_GRANTEE_OVERRIDES["GPAI"]).toBe("gpai");
+    expect(MANUAL_GRANTEE_OVERRIDES["Pause AI"]).toBe("pause-ai");
+  });
+
+  it("maps EA orgs", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["CEA"]).toBe("cea");
+    expect(MANUAL_GRANTEE_OVERRIDES["GWWC"]).toBe("giving-what-we-can");
+    expect(MANUAL_GRANTEE_OVERRIDES["Effective Ventures"]).toBe("cea");
+    expect(MANUAL_GRANTEE_OVERRIDES["EA Global"]).toBe("ea-global");
+  });
+
+  it("maps funders", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["Open Phil"]).toBe("coefficient-giving");
+    expect(MANUAL_GRANTEE_OVERRIDES["SFF"]).toBe("survival-and-flourishing-fund");
+    expect(MANUAL_GRANTEE_OVERRIDES["LTFF"]).toBe("ltff");
+    expect(MANUAL_GRANTEE_OVERRIDES["CZI"]).toBe("chan-zuckerberg-initiative");
+    expect(MANUAL_GRANTEE_OVERRIDES["Schmidt Futures"]).toBe("schmidt-futures");
+  });
+
+  it("maps forecasting orgs", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["QURI"]).toBe("quri");
+    expect(MANUAL_GRANTEE_OVERRIDES["Forecasting Research Institute"]).toBe("fri");
+    expect(MANUAL_GRANTEE_OVERRIDES["Samotsvety"]).toBe("samotsvety");
+  });
+
+  it("maps biosecurity orgs", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["NTI"]).toBe("nti-bio");
+    expect(MANUAL_GRANTEE_OVERRIDES["SecureDNA"]).toBe("securedna");
+    expect(MANUAL_GRANTEE_OVERRIDES["IBBIS"]).toBe("ibbis");
+    expect(MANUAL_GRANTEE_OVERRIDES["CEPI"]).toBe("coalition-for-epidemic-preparedness-innovations");
+    expect(MANUAL_GRANTEE_OVERRIDES["CFAR"]).toBe("center-for-applied-rationality");
+  });
+
+  it("maps tech companies", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["Google DeepMind"]).toBe("deepmind");
+    expect(MANUAL_GRANTEE_OVERRIDES["Microsoft"]).toBe("microsoft");
+    expect(MANUAL_GRANTEE_OVERRIDES["NVIDIA"]).toBe("nvidia");
+    expect(MANUAL_GRANTEE_OVERRIDES["Meta AI"]).toBe("meta-ai");
+  });
+
+  it("maps name variants for OpenAI", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["OpenAI"]).toBe("openai");
+    expect(MANUAL_GRANTEE_OVERRIDES["OpenAI LP"]).toBe("openai");
+    expect(MANUAL_GRANTEE_OVERRIDES["OpenAI Global, LLC"]).toBe("openai");
+  });
+
+  it("maps name variants for Anthropic", () => {
+    expect(MANUAL_GRANTEE_OVERRIDES["Anthropic"]).toBe("anthropic");
+    expect(MANUAL_GRANTEE_OVERRIDES["Anthropic PBC"]).toBe("anthropic");
   });
 });
 

--- a/crux/lib/grant-import/entity-matcher.ts
+++ b/crux/lib/grant-import/entity-matcher.ts
@@ -2,65 +2,250 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import type { EntityMatch, EntityMatcher } from "./types.ts";
 
+/**
+ * Suffixes to strip from grantee names during normalization.
+ * Order matters: longer suffixes should come first to avoid partial matches.
+ * Patterns are matched case-insensitively at the end of the name, optionally
+ * preceded by a comma or space.
+ */
+const STRIP_SUFFIXES = [
+  "incorporated",
+  "corporation",
+  "foundation",
+  "limited",
+  "inc.",
+  "inc",
+  "llc",
+  "ltd.",
+  "ltd",
+  "l.l.c.",
+  "corp.",
+  "corp",
+  "co.",
+  "gmbh",
+  "plc",
+  "ngo",
+  "a.s.",
+  "b.v.",
+  "pty",
+];
+
+/**
+ * Normalize a grantee name by stripping common corporate/legal suffixes
+ * and extra whitespace. This helps match "OpenAI, Inc." to "OpenAI".
+ */
+export function normalizeGranteeName(name: string): string {
+  let normalized = name.trim();
+
+  for (const suffix of STRIP_SUFFIXES) {
+    // Match suffix at end of string, optionally preceded by comma/space
+    const pattern = new RegExp(`[,\\s]+${suffix.replace(/\./g, "\\.")}\\s*$`, "i");
+    if (pattern.test(normalized)) {
+      normalized = normalized.replace(pattern, "").trim();
+      break; // Only strip one suffix
+    }
+  }
+
+  // Collapse multiple spaces
+  normalized = normalized.replace(/\s+/g, " ").trim();
+
+  return normalized;
+}
+
 /** Manual name -> slug overrides for known orgs that don't match automatically */
 export const MANUAL_GRANTEE_OVERRIDES: Record<string, string> = {
-  "Center for Security and Emerging Technology": "cset",
-  CSET: "cset",
+  // --- AI Safety Labs ---
+  Anthropic: "anthropic",
+  "Anthropic PBC": "anthropic",
+  OpenAI: "openai",
+  "OpenAI LP": "openai",
+  "OpenAI Global, LLC": "openai",
+  DeepMind: "deepmind",
+  "Google DeepMind": "deepmind",
+  "xAI": "xai",
+  "xAI Corp": "xai",
+
+  // --- AI Safety Research Orgs ---
   "Machine Intelligence Research Institute": "miri",
   MIRI: "miri",
-  "Future of Humanity Institute": "fhi",
-  "Centre for the Study of Existential Risk": "cser",
-  GiveWell: "givewell",
   "Alignment Research Center": "arc",
   ARC: "arc",
+  "ARC Evals": "arc-evals",
+  "Model Evaluation and Threat Research": "metr",
+  METR: "metr",
   "Center for AI Safety": "center-for-ai-safety",
+  CAIS: "center-for-ai-safety",
   "Center for Human-Compatible AI": "chai",
+  "Center for Human-Compatible Artificial Intelligence": "chai",
   CHAI: "chai",
-  "Centre for Effective Altruism": "cea",
-  "80,000 Hours": "80000-hours",
-  "80000 Hours": "80000-hours",
   "Redwood Research": "redwood-research",
-  Anthropic: "anthropic",
-  OpenAI: "openai",
-  "Survival and Flourishing Fund": "survival-and-flourishing-fund",
+  "Apollo Research": "apollo-research",
+  Conjecture: "conjecture",
+  "FAR AI": "far-ai",
+  "FAR.AI": "far-ai",
+  "Palisade Research": "palisade-research",
+  ControlAI: "controlai",
+  "Control AI": "controlai",
+  Goodfire: "goodfire",
+  "Seldon Lab": "seldon-lab",
+  SSI: "ssi",
+  "Safe Superintelligence": "ssi",
+  "Safe Superintelligence Inc.": "ssi",
+
+  // --- AI Safety Training/Community ---
+  "MATS Research": "mats",
+  MATS: "mats",
+  "ML Alignment Theory Scholars": "mats",
   BlueDot: "bluedot-impact",
   "BlueDot Impact": "bluedot-impact",
   Constellation: "constellation",
-  "MATS Research": "mats",
-  MATS: "mats",
-  "Johns Hopkins Center for Health Security": "johns-hopkins-center-for-health-security",
-  "Nuclear Threat Initiative": "nti-bio",
-  "NTI | Bio": "nti-bio",
-  Metaculus: "metaculus",
-  "Center for Applied Rationality": "center-for-applied-rationality",
-  "Longview Philanthropy": "longview-philanthropy",
-  SecureBio: "securebio",
-  Elicit: "elicit",
   "AI Safety Support": "ai-safety-support",
-  "FAR AI": "far-ai",
-  "Institute for AI Policy and Strategy": "iaps",
-  RAND: "rand",
-  "RAND Corporation": "rand",
-  Manifund: "manifund",
+  LessWrong: "lesswrong",
+  Lighthaven: "lighthaven",
+
+  // --- Policy/Governance Orgs ---
+  "Center for Security and Emerging Technology": "cset",
+  CSET: "cset",
+  "Future of Humanity Institute": "fhi",
+  FHI: "fhi",
+  "Centre for the Study of Existential Risk": "cser",
+  CSER: "cser",
   GovAI: "govai",
   "Centre for Governance of AI (GovAI)": "govai",
   "Centre for Governance of AI": "govai",
-  "Founders Pledge": "founders-pledge",
-  "Good Ventures": "good-ventures",
-  "Open Philanthropy": "coefficient-giving",
-  GiveDirectly: "givedirectly",
+  "Center for Governance of AI": "govai",
+  "Institute for AI Policy and Strategy": "iaps",
+  IAPS: "iaps",
+  "Future of Life Institute": "fli",
+  FLI: "fli",
+  "Centre for Long-Term Resilience": "centre-for-long-term-resilience",
+  CLTR: "centre-for-long-term-resilience",
+  "Centre for Long Term Resilience": "centre-for-long-term-resilience",
+  "UK AI Safety Institute": "uk-aisi",
+  "UK AISI": "uk-aisi",
+  "US AI Safety Institute": "us-aisi",
+  "US AISI": "us-aisi",
+  RAND: "rand",
+  "RAND Corporation": "rand",
+  "Global Partnership on AI": "gpai",
+  GPAI: "gpai",
+  "NIST AI": "nist-ai",
+  "Frontier Model Forum": "frontier-model-forum",
+  "Pause AI": "pause-ai",
+  PauseAI: "pause-ai",
+  "Council on Strategic Risks": "council-on-strategic-risks",
+  "Secure AI Project": "secure-ai-project",
+  "Swift Centre": "swift-centre",
+
+  // --- EA Orgs ---
+  "Centre for Effective Altruism": "cea",
+  CEA: "cea",
   "Effective Ventures Foundation": "cea",
+  "Effective Ventures": "cea",
+  "80,000 Hours": "80000-hours",
+  "80000 Hours": "80000-hours",
+  "80 000 Hours": "80000-hours",
+  "Eighty Thousand Hours": "80000-hours",
+  "Giving What We Can": "giving-what-we-can",
+  GWWC: "giving-what-we-can",
+  "Founders Pledge": "founders-pledge",
+  "Longview Philanthropy": "longview-philanthropy",
+  "Rethink Priorities": "rethink-priorities",
+  "1Day Sooner": "1day-sooner",
+  "1DaySooner": "1day-sooner",
+  "EA Global": "ea-global",
+
+  // --- Funders/Philanthropies ---
+  "Open Philanthropy": "coefficient-giving",
+  "Open Philanthropy Project": "coefficient-giving",
+  "Open Phil": "coefficient-giving",
+  "Survival and Flourishing Fund": "survival-and-flourishing-fund",
+  SFF: "survival-and-flourishing-fund",
+  "Survival and Flourishing .Fund": "survival-and-flourishing-fund",
+  "Good Ventures": "good-ventures",
+  "Good Ventures Foundation": "good-ventures",
+  GiveWell: "givewell",
+  GiveDirectly: "givedirectly",
   "Against Malaria Foundation": "against-malaria-foundation",
-  // FTX Future Fund grantees
+  AMF: "against-malaria-foundation",
+  Manifund: "manifund",
+  "Long-Term Future Fund": "ltff",
+  "Long Term Future Fund": "ltff",
+  LTFF: "ltff",
+  "Schmidt Futures": "schmidt-futures",
+  "Hewlett Foundation": "hewlett-foundation",
+  "William and Flora Hewlett Foundation": "hewlett-foundation",
+  "MacArthur Foundation": "macarthur-foundation",
+  "John D. and Catherine T. MacArthur Foundation": "macarthur-foundation",
+  "Chan Zuckerberg Initiative": "chan-zuckerberg-initiative",
+  CZI: "chan-zuckerberg-initiative",
+  "FTX Future Fund": "ftx-future-fund",
+  "FTX Foundation": "ftx-future-fund",
+  "Astralis Foundation": "astralis-foundation",
+
+  // --- Forecasting/Epistemic ---
+  Metaculus: "metaculus",
+  "Quantified Uncertainty Research Institute": "quri",
+  QURI: "quri",
+  "Forecasting Research Institute": "fri",
+  FRI: "fri",
+  Elicit: "elicit",
   Ought: "elicit",
   "Manifold Markets": "manifold",
-  "Rethink Priorities": "rethink-priorities",
+  Manifold: "manifold",
   "Good Judgment Project": "good-judgment",
-  "Giving What We Can": "giving-what-we-can",
-  "Council on Strategic Risks": "council-on-strategic-risks",
-  "1Day Sooner": "1day-sooner",
-  "Quantified Uncertainty Research Institute": "quri",
+  "Good Judgment Inc": "good-judgment",
+  "Good Judgment Open": "good-judgment",
+  Samotsvety: "samotsvety",
+  Polymarket: "polymarket",
+  Metaforecast: "metaforecast",
+  Kalshi: "kalshi",
+
+  // --- Biosecurity ---
+  "Nuclear Threat Initiative": "nti-bio",
+  "NTI | Bio": "nti-bio",
+  "NTI Bio": "nti-bio",
+  NTI: "nti-bio",
+  SecureBio: "securebio",
+  "Secure Bio": "securebio",
+  SecureDNA: "securedna",
+  "Secure DNA": "securedna",
+  "Blueprint Biosecurity": "blueprint-biosecurity",
+  "Johns Hopkins Center for Health Security": "johns-hopkins-center-for-health-security",
+  "Johns Hopkins Bloomberg School of Public Health": "johns-hopkins-center-for-health-security",
+  IBBIS: "ibbis",
+  "International Biosecurity and Biosafety Initiative for Science": "ibbis",
+  "Coalition for Epidemic Preparedness Innovations": "coalition-for-epidemic-preparedness-innovations",
+  CEPI: "coalition-for-epidemic-preparedness-innovations",
+  "Red Queen Bio": "red-queen-bio",
+  "Center for Applied Rationality": "center-for-applied-rationality",
+  CFAR: "center-for-applied-rationality",
+
+  // --- Research/Analysis ---
   "AI Impacts": "ai-impacts",
+  "Epoch AI": "epoch-ai",
+  Epoch: "epoch-ai",
+  "ARB Research": "arb-research",
+
+  // --- Tech Companies ---
+  Microsoft: "microsoft",
+  "Microsoft Corporation": "microsoft",
+  NVIDIA: "nvidia",
+  "Nvidia Corporation": "nvidia",
+  Meta: "meta-ai",
+  "Meta AI": "meta-ai",
+  "Meta Platforms": "meta-ai",
+  "Meta Platforms, Inc.": "meta-ai",
+
+  // --- People (common grant recipients) ---
+  "Paul Christiano": "paul-christiano",
+  "Nuno Sempere": "nuno-sempere",
+  "Leopold Aschenbrenner": "leopold-aschenbrenner",
+
+  // --- Other ---
+  "FutureSearch": "futuresearch",
+  Sentinel: "sentinel",
+  "Squiggle": "squiggle",
 };
 
 export function buildEntityMatcher(): EntityMatcher {
@@ -147,7 +332,10 @@ export function buildEntityMatcher(): EntityMatcher {
 }
 
 /**
- * Match a grantee name to an entity, checking manual overrides first.
+ * Match a grantee name to an entity, checking manual overrides first,
+ * then trying the entity matcher directly, then trying again after
+ * normalizing the name (stripping corporate suffixes like Inc., LLC, etc.).
+ *
  * Returns the entity stableId if matched, null otherwise.
  */
 export function matchGrantee(
@@ -159,11 +347,30 @@ export function matchGrantee(
     ? { ...MANUAL_GRANTEE_OVERRIDES, ...extraOverrides }
     : MANUAL_GRANTEE_OVERRIDES;
 
+  // 1. Try exact override lookup
   const overrideSlug = overrides[name];
   if (overrideSlug) {
     const match = matcher.match(overrideSlug);
     if (match) return match.stableId;
   }
-  const match = matcher.match(name);
-  return match?.stableId ?? null;
+
+  // 2. Try direct entity matcher lookup
+  const directMatch = matcher.match(name);
+  if (directMatch) return directMatch.stableId;
+
+  // 3. Try after normalizing (strip Inc., LLC, etc.)
+  const normalized = normalizeGranteeName(name);
+  if (normalized !== name) {
+    // Check override with normalized name
+    const normalizedOverrideSlug = overrides[normalized];
+    if (normalizedOverrideSlug) {
+      const match = matcher.match(normalizedOverrideSlug);
+      if (match) return match.stableId;
+    }
+    // Check direct match with normalized name
+    const normalizedMatch = matcher.match(normalized);
+    if (normalizedMatch) return normalizedMatch.stableId;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Expand `MANUAL_GRANTEE_OVERRIDES` from ~60 to ~170 entries, organized by category (AI safety labs, policy/governance, EA orgs, funders, forecasting, biosecurity, tech companies, people)
- Add `normalizeGranteeName()` function that strips common corporate/legal suffixes (Inc., LLC, Ltd., Foundation, Corporation, etc.) before matching
- Update `matchGrantee()` to try normalized names as a fallback when exact match fails, checking both overrides and entity matcher with the normalized form
- New overrides include acronyms (FHI, CSER, FLI, CLTR, CEPI, CFAR, QURI, etc.), name variants (Google DeepMind, Effective Ventures, Open Phil), and legal name variants (Anthropic PBC, OpenAI LP)

## Test plan
- [x] 40 entity-matcher tests pass (up from 12)
- [x] All 162 grant-import tests pass
- [x] New tests cover normalization edge cases (suffix stripping, case insensitivity, partial word safety, whitespace handling)
- [x] New tests verify override coverage across all categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)