### PR TITLE
refactor: use shared FUNDER_IDS constant in seed-divisions script

### DIFF
--- a/apps/wiki-server/scripts/seed-divisions.ts
+++ b/apps/wiki-server/scripts/seed-divisions.ts
@@ -19,12 +19,10 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { sql } from "drizzle-orm";
 import * as schema from "../src/schema.js";
+import { FUNDER_IDS } from "../../../crux/lib/grant-import/constants.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Coefficient Giving's stableId
-const COEFF_GIVING_STABLE_ID = "ULjDXpSLCI";
 
 // Characters used for 10-char IDs (matching the wiki-server ID convention)
 const ID_CHARS =
@@ -107,7 +105,7 @@ export async function seedDivisions() {
       divisionRows.push({
         id,
         slug: `coefficient-giving-${slug}`,
-        parentOrgId: COEFF_GIVING_STABLE_ID,
+        parentOrgId: FUNDER_IDS.COEFFICIENT_GIVING,
         name: record.name,
         divisionType: "fund",
         lead: record.lead ?? null,
@@ -135,7 +133,7 @@ export async function seedDivisions() {
 
       fundingProgramRows.push({
         id: deterministicId(`coeff-giving-program-${slug}`),
-        orgId: COEFF_GIVING_STABLE_ID,
+        orgId: FUNDER_IDS.COEFFICIENT_GIVING,
         divisionId: parentDivisionId,
         name: record.name,
         programType: "rfp",

--- a/apps/wiki-server/tsconfig.json
+++ b/apps/wiki-server/tsconfig.json
@@ -6,8 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "rootDir": "."
+    "outDir": "dist"
   },
   "include": ["src/**/*", "scripts/**/*"]
 }

--- a/crux/lib/grant-import/constants.ts
+++ b/crux/lib/grant-import/constants.ts
@@ -5,6 +5,8 @@
  */
 export const FUNDER_IDS = {
   OPEN_PHILANTHROPY: "ULjDXpSLCI",
+  // Coefficient Giving is Open Philanthropy's grantmaking arm — same entity
+  COEFFICIENT_GIVING: "ULjDXpSLCI",
   SFF: "sIFjGbxVct",
   FTX_FUTURE_FUND: "JhIGCaI3Ng",
   MANIFUND: "fFVOuFZCRf",


### PR DESCRIPTION
## Summary

- Replace hardcoded `COEFF_GIVING_STABLE_ID` in `seed-divisions.ts` with shared `FUNDER_IDS.COEFFICIENT_GIVING` from `crux/lib/grant-import/constants.ts`
- Add `COEFFICIENT_GIVING` alias to `FUNDER_IDS` (same entity as `OPEN_PHILANTHROPY`)
- Remove `rootDir` from wiki-server `tsconfig.json` to allow cross-package import (no functional impact — wiki-server runs via tsx, not tsc emit)

Follows up on #2132 (divisions tables) and #2142 (centralized funder IDs).

## Test plan
- [x] TypeScript compiles cleanly
- [x] Tests pass
- [x] `FUNDER_IDS.COEFFICIENT_GIVING === FUNDER_IDS.OPEN_PHILANTHROPY === "ULjDXpSLCI"`
