### PR TITLE
feat: add programId column to grants table

### DIFF
--- a/apps/wiki-server/drizzle/0078_add_grants_program_id.sql
+++ b/apps/wiki-server/drizzle/0078_add_grants_program_id.sql
@@ -1,0 +1,7 @@
+-- Add program_id column to grants, linking individual grants to funding programs.
+-- Nullable because most existing grants won't have a program association initially.
+-- Soft reference (no FK constraint), consistent with how organizationId works.
+
+ALTER TABLE grants ADD COLUMN IF NOT EXISTS program_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_grants_program ON grants(program_id);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1775289600000,
       "tag": "0077_add_divisions_and_funding_programs",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1775376000000,
+      "tag": "0078_add_grants_program_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/grants.ts
+++ b/apps/wiki-server/src/routes/grants.ts
@@ -40,6 +40,7 @@ const SyncGrantItemSchema = z.object({
   status: z.string().max(50).nullable().optional(),
   source: z.string().max(2000).nullable().optional(),
   notes: z.string().max(5000).nullable().optional(),
+  programId: z.string().max(200).nullable().optional(),
 });
 
 const SyncGrantsBatchSchema = z.object({
@@ -61,6 +62,7 @@ function formatRow(r: typeof grants.$inferSelect) {
     status: r.status,
     source: r.source,
     notes: r.notes,
+    programId: r.programId,
     syncedAt: r.syncedAt,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
@@ -222,6 +224,7 @@ const grantsApp = new Hono()
         status: item.status ?? null,
         source: item.source ?? null,
         notes: item.notes ?? null,
+        programId: item.programId ?? null,
       }));
 
       await tx
@@ -240,6 +243,7 @@ const grantsApp = new Hono()
             status: sql`excluded.status`,
             source: sql`excluded.source`,
             notes: sql`excluded.notes`,
+            programId: sql`excluded.program_id`,
             syncedAt: sql`now()`,
             updatedAt: sql`now()`,
           },

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1465,6 +1465,7 @@ export const grants = pgTable(
     status: text("status"), // active | completed | winding-down
     source: text("source"), // URL to announcement or report
     notes: text("notes"),
+    programId: text("program_id"), // soft ref to funding_programs.id (nullable)
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -1479,6 +1480,7 @@ export const grants = pgTable(
     index("idx_grants_org").on(table.organizationId),
     index("idx_grants_grantee").on(table.granteeId),
     index("idx_grants_status").on(table.status),
+    index("idx_grants_program").on(table.programId),
   ]
 );
 
@@ -1658,8 +1660,8 @@ export const divisionPersonnel = pgTable(
 
 /**
  * Funding programs — RFPs, grant rounds, fellowships, prizes, solicitations.
- * Complementary to `grants` (individual awards). A future `grants.programId` column
- * will link individual grants to their parent program.
+ * Complementary to `grants` (individual awards). Individual grants link to their
+ * parent program via `grants.programId`.
  */
 export const fundingPrograms = pgTable(
   "funding_programs",

--- a/crux/lib/grant-import/types.ts
+++ b/crux/lib/grant-import/types.ts
@@ -41,6 +41,8 @@ export interface SyncGrant {
   status: string | null;
   source: string | null;
   notes: string | null;
+  /** Soft reference to funding_programs.id (nullable -- most grants won't have one) */
+  programId?: string | null;
 }
 
 export interface GrantSource {


### PR DESCRIPTION
## Summary
- Add nullable `program_id TEXT` column to the `grants` table, linking individual grants to their parent `funding_programs` entry
- Uses soft reference (no FK constraint), consistent with how `organizationId` works in the same table
- Add index `idx_grants_program` on `program_id` for query performance
- Update `formatRow()`, `SyncGrantItemSchema`, and sync upsert in the grants route to include `programId`
- Add `programId` to the `SyncGrant` type in the grant import pipeline

## Changes
- **Migration**: `apps/wiki-server/drizzle/0078_add_grants_program_id.sql` — `ALTER TABLE ADD COLUMN` + `CREATE INDEX`
- **Schema**: `apps/wiki-server/src/schema.ts` — add `programId` field and index to grants table definition
- **Route**: `apps/wiki-server/src/routes/grants.ts` — add `programId` to formatRow, Zod schema, and upsert
- **Types**: `crux/lib/grant-import/types.ts` — add optional `programId` to `SyncGrant` interface
- **Journal**: `apps/wiki-server/drizzle/meta/_journal.json` — register migration 0078

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit` from wiki-server)
- [x] Migration applies cleanly on deploy (simple `ALTER TABLE ADD COLUMN IF NOT EXISTS`)
- [x] Existing grant sync still works (programId is optional/nullable throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grants can now be optionally linked to funding programs for improved organization and program-level tracking of grant relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->