### PR TITLE
feat: add import commands for divisions and funding programs

### DIFF
--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -1,0 +1,385 @@
+/**
+ * Import curated organizational divisions into wiki-server Postgres.
+ *
+ * Unlike grants, divisions have no external CSV source — they are a curated
+ * list of known organizational units (funds, teams, departments, labs,
+ * program areas) for major AI safety and EA organizations.
+ *
+ * Usage:
+ *   pnpm crux import-divisions list              # Show all divisions
+ *   pnpm crux import-divisions sync              # Sync to wiki-server
+ *   pnpm crux import-divisions sync --dry-run    # Preview without writing
+ */
+
+import { generateId } from "../lib/grant-import/id.ts";
+import { apiRequest, getServerUrl } from "../lib/wiki-server/client.ts";
+import { FUNDER_IDS } from "../lib/grant-import/constants.ts";
+
+// ---------------------------------------------------------------------------
+// Org entity stableIds (from kb-data.json slugToEntityId mapping)
+// ---------------------------------------------------------------------------
+
+const ORG_IDS = {
+  ...FUNDER_IDS,
+  OPEN_PHILANTHROPY: "ULjDXpSLCI", // Coefficient Giving / Open Philanthropy
+  ANTHROPIC: "mK9pX3rQ7n",
+  OPENAI: "1LcLlMGLbw",
+  DEEPMIND: "A4XoubikkQ",
+  MIRI: "puAffUjWSS",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Division type (matches wiki-server SyncDivisionItemSchema)
+// ---------------------------------------------------------------------------
+
+interface DivisionDef {
+  /** Deterministic ID seed — must be unique and stable across runs */
+  idSeed: string;
+  parentOrgId: string;
+  name: string;
+  divisionType: "fund" | "team" | "department" | "lab" | "program-area";
+  status: "active" | "inactive" | "dissolved";
+  startDate?: string;
+  endDate?: string;
+  source?: string;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Curated division data
+// ---------------------------------------------------------------------------
+
+const DIVISIONS: DivisionDef[] = [
+  // ---- Open Philanthropy program areas ----
+  {
+    idSeed: "div|open-philanthropy|global-health-and-wellbeing",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Global Health and Wellbeing",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://www.openphilanthropy.org/focus/global-health-and-wellbeing/",
+    notes: "Covers global health, farm animal welfare, and scientific research",
+  },
+  {
+    idSeed: "div|open-philanthropy|global-catastrophic-risks",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Global Catastrophic Risks",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://www.openphilanthropy.org/focus/global-catastrophic-risks/",
+    notes: "Covers AI safety, biosecurity, and other GCR-related grantmaking",
+  },
+
+  // ---- EA Funds ----
+  {
+    idSeed: "div|ea-funds|long-term-future-fund",
+    parentOrgId: ORG_IDS.CEA,
+    name: "Long-Term Future Fund",
+    divisionType: "fund",
+    status: "active",
+    source: "https://funds.effectivealtruism.org/funds/far-future",
+    notes:
+      "Supports organizations working on improving the long-term future, especially reducing existential risks from advanced AI",
+  },
+  {
+    idSeed: "div|ea-funds|animal-welfare-fund",
+    parentOrgId: ORG_IDS.CEA,
+    name: "Animal Welfare Fund",
+    divisionType: "fund",
+    status: "active",
+    source: "https://funds.effectivealtruism.org/funds/animal-welfare",
+    notes: "Supports organizations working to improve animal welfare",
+  },
+  {
+    idSeed: "div|ea-funds|ea-infrastructure-fund",
+    parentOrgId: ORG_IDS.CEA,
+    name: "EA Infrastructure Fund",
+    divisionType: "fund",
+    status: "active",
+    source: "https://funds.effectivealtruism.org/funds/ea-community",
+    notes:
+      "Supports organizations building the effective altruism community and infrastructure",
+  },
+  {
+    idSeed: "div|ea-funds|global-health-fund",
+    parentOrgId: ORG_IDS.CEA,
+    name: "Global Health and Development Fund",
+    divisionType: "fund",
+    status: "active",
+    source: "https://funds.effectivealtruism.org/funds/global-health",
+    notes:
+      "Supports evidence-based organizations working to improve global health and reduce poverty",
+  },
+
+  // ---- Survival and Flourishing Fund ----
+  {
+    idSeed: "div|sff|sff-main",
+    parentOrgId: ORG_IDS.SFF,
+    name: "Survival and Flourishing Fund",
+    divisionType: "fund",
+    status: "active",
+    source: "https://survivalandflourishing.fund/",
+    notes:
+      "SFF uses a simulation-based allocation process (S-Process) to distribute grants to organizations working on existential risk reduction",
+  },
+
+  // ---- DeepMind ----
+  {
+    idSeed: "div|deepmind|safety",
+    parentOrgId: ORG_IDS.DEEPMIND,
+    name: "DeepMind Safety",
+    divisionType: "team",
+    status: "active",
+    source: "https://deepmind.google/safety/",
+    notes:
+      "DeepMind's AI safety research team, focused on alignment, interpretability, and responsible development",
+  },
+
+  // ---- OpenAI ----
+  {
+    idSeed: "div|openai|safety-systems",
+    parentOrgId: ORG_IDS.OPENAI,
+    name: "Safety Systems",
+    divisionType: "team",
+    status: "active",
+    source: "https://openai.com/safety/",
+    notes:
+      "Responsible for content policy, monitoring, and safety tooling for deployed models",
+  },
+  {
+    idSeed: "div|openai|preparedness",
+    parentOrgId: ORG_IDS.OPENAI,
+    name: "Preparedness",
+    divisionType: "team",
+    status: "active",
+    startDate: "2023-10",
+    source: "https://openai.com/preparedness/",
+    notes:
+      "Tracks, evaluates, forecasts, and protects against catastrophic risks from frontier AI models. Led by Aleksander Madry (after Leopoldas Aschenbrenner left).",
+  },
+  {
+    idSeed: "div|openai|superalignment",
+    parentOrgId: ORG_IDS.OPENAI,
+    name: "Superalignment",
+    divisionType: "team",
+    status: "dissolved",
+    startDate: "2023-07",
+    endDate: "2024-05",
+    source: "https://openai.com/index/introducing-superalignment/",
+    notes:
+      "Led by Ilya Sutskever and Jan Leike. Aimed to solve alignment for superintelligent AI within 4 years using 20% of compute. Dissolved May 2024 after leadership departures.",
+  },
+
+  // ---- Anthropic ----
+  {
+    idSeed: "div|anthropic|alignment-science",
+    parentOrgId: ORG_IDS.ANTHROPIC,
+    name: "Alignment Science",
+    divisionType: "team",
+    status: "active",
+    source: "https://www.anthropic.com/research",
+    notes:
+      "Core alignment research team at Anthropic, working on interpretability, scalable oversight, and Constitutional AI",
+  },
+  {
+    idSeed: "div|anthropic|trust-and-safety",
+    parentOrgId: ORG_IDS.ANTHROPIC,
+    name: "Trust and Safety",
+    divisionType: "team",
+    status: "active",
+    source: "https://www.anthropic.com/",
+    notes:
+      "Responsible for content moderation, abuse prevention, and usage policy enforcement",
+  },
+  {
+    idSeed: "div|anthropic|policy",
+    parentOrgId: ORG_IDS.ANTHROPIC,
+    name: "Policy",
+    divisionType: "team",
+    status: "active",
+    source: "https://www.anthropic.com/policy",
+    notes:
+      "AI policy research and government engagement; publishes policy briefs and participates in regulatory processes",
+  },
+
+  // ---- MIRI ----
+  {
+    idSeed: "div|miri|research",
+    parentOrgId: ORG_IDS.MIRI,
+    name: "MIRI Research",
+    divisionType: "team",
+    status: "active",
+    source: "https://intelligence.org/research/",
+    notes:
+      "Core technical research on mathematical foundations of AI alignment, including agent foundations and decision theory",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Convert definitions to sync payloads
+// ---------------------------------------------------------------------------
+
+interface SyncDivision {
+  id: string;
+  parentOrgId: string;
+  name: string;
+  divisionType: string;
+  status: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+function toSyncDivision(def: DivisionDef): SyncDivision {
+  return {
+    id: generateId(def.idSeed),
+    parentOrgId: def.parentOrgId,
+    name: def.name,
+    divisionType: def.divisionType,
+    status: def.status,
+    startDate: def.startDate ?? null,
+    endDate: def.endDate ?? null,
+    source: def.source ?? null,
+    notes: def.notes ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+function cmdList() {
+  const items = DIVISIONS.map(toSyncDivision);
+  console.log(`=== Known Divisions (${items.length}) ===\n`);
+
+  // Group by parent org
+  const byOrg = new Map<string, SyncDivision[]>();
+  for (const item of items) {
+    const existing = byOrg.get(item.parentOrgId) || [];
+    existing.push(item);
+    byOrg.set(item.parentOrgId, existing);
+  }
+
+  // Reverse lookup org names from ORG_IDS
+  const idToLabel = new Map<string, string>();
+  for (const [key, val] of Object.entries(ORG_IDS)) {
+    if (!idToLabel.has(val)) {
+      idToLabel.set(val, key);
+    }
+  }
+
+  for (const [orgId, divisions] of byOrg) {
+    const label = idToLabel.get(orgId) || orgId;
+    console.log(`${label} (${orgId}):`);
+    for (const d of divisions) {
+      const statusBadge =
+        d.status === "active"
+          ? "\x1b[32mactive\x1b[0m"
+          : d.status === "dissolved"
+            ? "\x1b[31mdissolved\x1b[0m"
+            : "\x1b[33minactive\x1b[0m";
+      console.log(
+        `  ${d.id}  ${d.name} [${d.divisionType}] ${statusBadge}`
+      );
+    }
+    console.log("");
+  }
+
+  // Check for ID collisions
+  const ids = items.map((d) => d.id);
+  const uniqueIds = new Set(ids);
+  if (uniqueIds.size !== ids.length) {
+    console.error("WARNING: ID collisions detected!");
+    const seen = new Set<string>();
+    for (const id of ids) {
+      if (seen.has(id)) console.error(`  Duplicate ID: ${id}`);
+      seen.add(id);
+    }
+  }
+}
+
+async function cmdSync(dryRun: boolean) {
+  const items = DIVISIONS.map(toSyncDivision);
+  const serverUrl = getServerUrl();
+
+  if (!serverUrl) {
+    throw new Error(
+      "wiki-server URL not configured. Set LONGTERMWIKI_SERVER_URL or use WIKI_SERVER_ENV=prod."
+    );
+  }
+
+  console.log(`\nSyncing ${items.length} divisions to ${serverUrl}...`);
+
+  if (dryRun) {
+    console.log("  (dry run -- no data written)");
+    for (const d of items) {
+      console.log(`  ${d.id}  ${d.name} [${d.divisionType}]`);
+    }
+    return;
+  }
+
+  const result = await apiRequest<{ upserted: number }>(
+    "POST",
+    "/api/divisions/sync",
+    { items }
+  );
+
+  if (result.ok) {
+    console.log(`Upserted ${result.data.upserted} divisions`);
+  } else {
+    throw new Error(`Division sync failed: ${result.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Crux command exports
+// ---------------------------------------------------------------------------
+
+type CommandResult = { exitCode?: number; output?: string };
+
+async function listCommand(
+  _args: string[],
+  _options: Record<string, unknown>
+): Promise<CommandResult> {
+  cmdList();
+  return { exitCode: 0 };
+}
+
+async function syncCommand(
+  _args: string[],
+  options: Record<string, unknown>
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun || !!options["dry-run"];
+  await cmdSync(dryRun);
+  return { exitCode: 0 };
+}
+
+export const commands = {
+  list: listCommand,
+  sync: syncCommand,
+  default: listCommand,
+};
+
+export function getHelp(): string {
+  return `
+Import Divisions — Sync curated organizational divisions to wiki-server
+
+Commands:
+  list               Show all known divisions (default)
+  sync               Sync divisions to wiki-server Postgres
+  sync --dry-run     Preview what would be synced without writing
+
+Division Types:
+  fund           Grant-making fund (e.g., Long-Term Future Fund)
+  team           Internal team (e.g., Anthropic Alignment Science)
+  department     Formal department
+  lab            Research lab (e.g., DeepMind Safety)
+  program-area   Thematic program area (e.g., Open Phil GCR)
+
+Statuses:
+  active         Currently operating
+  inactive       Paused or dormant
+  dissolved      No longer exists (e.g., OpenAI Superalignment)
+`;
+}

--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -1,0 +1,425 @@
+/**
+ * Import curated funding programs into wiki-server Postgres.
+ *
+ * Funding programs represent structured giving activities: grant rounds,
+ * RFPs, fellowships, prizes, and solicitations from AI safety and EA funders.
+ *
+ * Usage:
+ *   pnpm crux import-funding-programs list              # Show all programs
+ *   pnpm crux import-funding-programs sync              # Sync to wiki-server
+ *   pnpm crux import-funding-programs sync --dry-run    # Preview without writing
+ */
+
+import { generateId } from "../lib/grant-import/id.ts";
+import { apiRequest, getServerUrl } from "../lib/wiki-server/client.ts";
+import { FUNDER_IDS } from "../lib/grant-import/constants.ts";
+
+// ---------------------------------------------------------------------------
+// Org entity stableIds (from kb-data.json slugToEntityId mapping)
+// ---------------------------------------------------------------------------
+
+const ORG_IDS = {
+  ...FUNDER_IDS,
+  OPEN_PHILANTHROPY: "ULjDXpSLCI", // Coefficient Giving / Open Philanthropy
+  ANTHROPIC: "mK9pX3rQ7n",
+  OPENAI: "1LcLlMGLbw",
+  DEEPMIND: "A4XoubikkQ",
+  MIRI: "puAffUjWSS",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Division ID helper — must match the seeds used in import-divisions.ts
+// ---------------------------------------------------------------------------
+
+function divisionId(seed: string): string {
+  return generateId(seed);
+}
+
+// ---------------------------------------------------------------------------
+// Funding program type (matches wiki-server SyncFundingProgramItemSchema)
+// ---------------------------------------------------------------------------
+
+interface FundingProgramDef {
+  /** Deterministic ID seed — must be unique and stable across runs */
+  idSeed: string;
+  orgId: string;
+  divisionIdSeed?: string;
+  name: string;
+  description?: string;
+  programType: "rfp" | "grant-round" | "fellowship" | "prize" | "solicitation" | "call";
+  totalBudget?: number;
+  currency?: string;
+  status: "open" | "closed" | "awarded";
+  source?: string;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Curated funding program data
+// ---------------------------------------------------------------------------
+
+const PROGRAMS: FundingProgramDef[] = [
+  // ---- Open Philanthropy focus areas ----
+  {
+    idSeed: "prog|open-philanthropy|ai-safety",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|open-philanthropy|global-catastrophic-risks",
+    name: "AI Safety Grantmaking",
+    description:
+      "Open Philanthropy's ongoing AI safety grantmaking, covering technical alignment research, governance, and field-building",
+    programType: "grant-round",
+    status: "open",
+    source: "https://www.openphilanthropy.org/focus/artificial-intelligence/",
+    notes: "Largest funder of AI safety research by total dollars committed",
+  },
+  {
+    idSeed: "prog|open-philanthropy|biosecurity",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|open-philanthropy|global-catastrophic-risks",
+    name: "Biosecurity and Pandemic Preparedness",
+    description:
+      "Grantmaking for biosecurity, pandemic preparedness, and related policy work",
+    programType: "grant-round",
+    status: "open",
+    source:
+      "https://www.openphilanthropy.org/focus/biosecurity-and-pandemic-preparedness/",
+  },
+  {
+    idSeed: "prog|open-philanthropy|global-health",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|open-philanthropy|global-health-and-wellbeing",
+    name: "Global Health and Wellbeing Grantmaking",
+    description:
+      "Open Philanthropy's grantmaking for global health, development, and farm animal welfare",
+    programType: "grant-round",
+    status: "open",
+    source:
+      "https://www.openphilanthropy.org/focus/global-health-and-wellbeing/",
+  },
+
+  // ---- EA Funds grant rounds ----
+  {
+    idSeed: "prog|ea-funds|ltff-grants",
+    orgId: ORG_IDS.LTFF,
+    divisionIdSeed: "div|ea-funds|long-term-future-fund",
+    name: "Long-Term Future Fund Grant Rounds",
+    description:
+      "Recurring grant rounds supporting organizations and individuals working on reducing existential risks, especially from advanced AI",
+    programType: "grant-round",
+    status: "open",
+    source: "https://funds.effectivealtruism.org/funds/far-future",
+    notes:
+      "Multiple rounds per year; managed by a committee of fund managers",
+  },
+  {
+    idSeed: "prog|ea-funds|awf-grants",
+    orgId: ORG_IDS.CEA,
+    divisionIdSeed: "div|ea-funds|animal-welfare-fund",
+    name: "Animal Welfare Fund Grant Rounds",
+    description:
+      "Recurring grant rounds for animal welfare organizations and projects",
+    programType: "grant-round",
+    status: "open",
+    source: "https://funds.effectivealtruism.org/funds/animal-welfare",
+  },
+  {
+    idSeed: "prog|ea-funds|eaif-grants",
+    orgId: ORG_IDS.CEA,
+    divisionIdSeed: "div|ea-funds|ea-infrastructure-fund",
+    name: "EA Infrastructure Fund Grant Rounds",
+    description:
+      "Recurring grant rounds for EA community building and infrastructure",
+    programType: "grant-round",
+    status: "open",
+    source: "https://funds.effectivealtruism.org/funds/ea-community",
+  },
+  {
+    idSeed: "prog|ea-funds|ghd-grants",
+    orgId: ORG_IDS.CEA,
+    divisionIdSeed: "div|ea-funds|global-health-fund",
+    name: "Global Health and Development Fund Grant Rounds",
+    description:
+      "Recurring grant rounds for evidence-based global health and development interventions",
+    programType: "grant-round",
+    status: "open",
+    source: "https://funds.effectivealtruism.org/funds/global-health",
+  },
+
+  // ---- Survival and Flourishing Fund ----
+  {
+    idSeed: "prog|sff|s-process",
+    orgId: ORG_IDS.SFF,
+    divisionIdSeed: "div|sff|sff-main",
+    name: "S-Process Grants",
+    description:
+      "SFF's primary grantmaking mechanism using a simulation-based allocation process where recommenders independently rank applicants",
+    programType: "grant-round",
+    status: "open",
+    source: "https://survivalandflourishing.fund/",
+    notes:
+      "Uses a novel mechanism where multiple recommenders submit rankings and a simulation allocates funds based on convergence",
+  },
+  {
+    idSeed: "prog|sff|speculation-grants",
+    orgId: ORG_IDS.SFF,
+    divisionIdSeed: "div|sff|sff-main",
+    name: "Speculation Grants",
+    description:
+      "Smaller, faster-turnaround grants from SFF for promising early-stage projects and individuals",
+    programType: "grant-round",
+    status: "open",
+    source: "https://survivalandflourishing.fund/",
+    notes:
+      "Complementary to S-Process; allows faster funding decisions for smaller amounts",
+  },
+
+  // ---- FTX Future Fund (historical) ----
+  {
+    idSeed: "prog|ftx|general-grants",
+    orgId: ORG_IDS.FTX_FUTURE_FUND,
+    name: "FTX Future Fund General Grants",
+    description:
+      "FTX Future Fund's main grantmaking program across AI safety, biosecurity, values, and institutions. Ceased operations November 2022 after FTX collapse.",
+    programType: "grant-round",
+    status: "closed",
+    source: "https://ftxfuturefund.org/",
+    notes:
+      "Operational Feb-Nov 2022. Committed approximately $160M before FTX collapse. Many grants were clawed back in bankruptcy proceedings.",
+  },
+  {
+    idSeed: "prog|ftx|regranting-program",
+    orgId: ORG_IDS.FTX_FUTURE_FUND,
+    name: "FTX Future Fund Regranting Program",
+    description:
+      "Program allowing designated regranters to make independent funding decisions using FTX Future Fund capital",
+    programType: "grant-round",
+    status: "closed",
+    source: "https://ftxfuturefund.org/",
+    notes:
+      "Notable regranters included Leopold Aschenbrenner, Nuno Sempere, and others. Program ceased with FTX collapse.",
+  },
+
+  // ---- Manifund ----
+  {
+    idSeed: "prog|manifund|regranters",
+    orgId: ORG_IDS.MANIFUND,
+    name: "Manifund Regranting",
+    description:
+      "Platform enabling individuals to receive tax-deductible donations for regranting to effective projects",
+    programType: "grant-round",
+    status: "open",
+    source: "https://manifund.org/",
+    notes: "Manifund provides fiscal sponsorship for individual regranters",
+  },
+  {
+    idSeed: "prog|manifund|impact-certificates",
+    orgId: ORG_IDS.MANIFUND,
+    name: "Manifund Impact Certificates",
+    description:
+      "Experimental impact certificate marketplace where project creators sell shares of their impact to retroactive funders",
+    programType: "grant-round",
+    status: "open",
+    source: "https://manifund.org/",
+    notes: "Novel funding mechanism using impact certificates/retroactive public goods funding",
+  },
+
+  // ---- ACX Grants ----
+  {
+    idSeed: "prog|acx|grants-2022",
+    orgId: ORG_IDS.ACX_GRANTS,
+    name: "ACX Grants 2022",
+    description:
+      "First round of ACX Grants from Astral Codex Ten blog, funding a variety of projects in rationality, EA, and scientific research",
+    programType: "grant-round",
+    status: "awarded",
+    source: "https://www.astralcodexten.com/p/acx-grants-results",
+    notes: "40+ grants from $1K-$100K+",
+  },
+  {
+    idSeed: "prog|acx|grants-2023",
+    orgId: ORG_IDS.ACX_GRANTS,
+    name: "ACX Grants 2023",
+    description:
+      "Second round of ACX Grants, continuing to fund projects in rationality, EA, and scientific research",
+    programType: "grant-round",
+    status: "awarded",
+    source: "https://www.astralcodexten.com/p/announcing-acx-grants-2",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Convert definitions to sync payloads
+// ---------------------------------------------------------------------------
+
+interface SyncFundingProgram {
+  id: string;
+  orgId: string;
+  divisionId: string | null;
+  name: string;
+  description: string | null;
+  programType: string;
+  totalBudget: number | null;
+  currency: string;
+  status: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+function toSyncProgram(def: FundingProgramDef): SyncFundingProgram {
+  return {
+    id: generateId(def.idSeed),
+    orgId: def.orgId,
+    divisionId: def.divisionIdSeed ? divisionId(def.divisionIdSeed) : null,
+    name: def.name,
+    description: def.description ?? null,
+    programType: def.programType,
+    totalBudget: def.totalBudget ?? null,
+    currency: def.currency ?? "USD",
+    status: def.status,
+    source: def.source ?? null,
+    notes: def.notes ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+function cmdList() {
+  const items = PROGRAMS.map(toSyncProgram);
+  console.log(`=== Known Funding Programs (${items.length}) ===\n`);
+
+  // Group by org
+  const byOrg = new Map<string, SyncFundingProgram[]>();
+  for (const item of items) {
+    const existing = byOrg.get(item.orgId) || [];
+    existing.push(item);
+    byOrg.set(item.orgId, existing);
+  }
+
+  // Reverse lookup org names from ORG_IDS
+  const idToLabel = new Map<string, string>();
+  for (const [key, val] of Object.entries(ORG_IDS)) {
+    if (!idToLabel.has(val)) {
+      idToLabel.set(val, key);
+    }
+  }
+
+  for (const [orgId, programs] of byOrg) {
+    const label = idToLabel.get(orgId) || orgId;
+    console.log(`${label} (${orgId}):`);
+    for (const p of programs) {
+      const statusBadge =
+        p.status === "open"
+          ? "\x1b[32mopen\x1b[0m"
+          : p.status === "closed"
+            ? "\x1b[31mclosed\x1b[0m"
+            : "\x1b[33mawarded\x1b[0m";
+      const divBadge = p.divisionId
+        ? ` div:${p.divisionId}`
+        : "";
+      console.log(
+        `  ${p.id}  ${p.name} [${p.programType}] ${statusBadge}${divBadge}`
+      );
+    }
+    console.log("");
+  }
+
+  // Check for ID collisions
+  const ids = items.map((p) => p.id);
+  const uniqueIds = new Set(ids);
+  if (uniqueIds.size !== ids.length) {
+    console.error("WARNING: ID collisions detected!");
+    const seen = new Set<string>();
+    for (const id of ids) {
+      if (seen.has(id)) console.error(`  Duplicate ID: ${id}`);
+      seen.add(id);
+    }
+  }
+}
+
+async function cmdSync(dryRun: boolean) {
+  const items = PROGRAMS.map(toSyncProgram);
+  const serverUrl = getServerUrl();
+
+  if (!serverUrl) {
+    throw new Error(
+      "wiki-server URL not configured. Set LONGTERMWIKI_SERVER_URL or use WIKI_SERVER_ENV=prod."
+    );
+  }
+
+  console.log(`\nSyncing ${items.length} funding programs to ${serverUrl}...`);
+
+  if (dryRun) {
+    console.log("  (dry run -- no data written)");
+    for (const p of items) {
+      console.log(`  ${p.id}  ${p.name} [${p.programType}]`);
+    }
+    return;
+  }
+
+  const result = await apiRequest<{ upserted: number }>(
+    "POST",
+    "/api/funding-programs/sync",
+    { items }
+  );
+
+  if (result.ok) {
+    console.log(`Upserted ${result.data.upserted} funding programs`);
+  } else {
+    throw new Error(`Funding program sync failed: ${result.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Crux command exports
+// ---------------------------------------------------------------------------
+
+type CommandResult = { exitCode?: number; output?: string };
+
+async function listCommand(
+  _args: string[],
+  _options: Record<string, unknown>
+): Promise<CommandResult> {
+  cmdList();
+  return { exitCode: 0 };
+}
+
+async function syncCommand(
+  _args: string[],
+  options: Record<string, unknown>
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun || !!options["dry-run"];
+  await cmdSync(dryRun);
+  return { exitCode: 0 };
+}
+
+export const commands = {
+  list: listCommand,
+  sync: syncCommand,
+  default: listCommand,
+};
+
+export function getHelp(): string {
+  return `
+Import Funding Programs — Sync curated funding programs to wiki-server
+
+Commands:
+  list               Show all known funding programs (default)
+  sync               Sync programs to wiki-server Postgres
+  sync --dry-run     Preview what would be synced without writing
+
+Program Types:
+  rfp            Request for proposals
+  grant-round    Recurring or one-time grant round
+  fellowship     Fellowship program
+  prize          Prize competition
+  solicitation   Open solicitation
+  call           Call for applications
+
+Statuses:
+  open           Currently accepting applications
+  closed         No longer accepting (e.g., FTX Future Fund)
+  awarded        Completed and awards made
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -43,6 +43,8 @@
  *   audits      System-level behavioral verification (ongoing + post-merge)
  *   release     Production release management (create release PRs from main → production)
  *   import-grants Import external grant databases (Coefficient Giving, EA Funds)
+ *   import-divisions Import curated organizational divisions
+ *   import-funding-programs Import curated funding programs
  *
  * Global Options:
  *   --ci        JSON output for CI pipelines
@@ -99,6 +101,8 @@ import * as kbCommands from './commands/kb.ts';
 import * as footnotesCommands from './commands/footnotes.ts';
 import * as agentWorkspaceCommands from './commands/agent-workspace.ts';
 import * as importGrantsCommands from './commands/import-grants.ts';
+import * as importDivisionsCommands from './commands/import-divisions.ts';
+import * as importFundingProgramsCommands from './commands/import-funding-programs.ts';
 
 const domains = {
   validate: validateCommands,
@@ -142,6 +146,8 @@ const domains = {
   footnotes: footnotesCommands,
   'agent-workspace': agentWorkspaceCommands,
   'import-grants': importGrantsCommands,
+  'import-divisions': importDivisionsCommands,
+  'import-funding-programs': importFundingProgramsCommands,
 };
 
 /**
@@ -229,6 +235,8 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   footnotes        Footnote migration tools (migrate-cr)
   agent-workspace  Multi-agent directory management (setup, sync-env, list, clean)
   import-grants    Import external grant databases (Coefficient Giving, EA Funds)
+  import-divisions Import curated organizational divisions
+  import-funding-programs Import curated funding programs
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines


### PR DESCRIPTION
## Summary

- Adds `pnpm crux import-divisions` command with 15 curated organizational divisions (funds, teams, departments, labs, program areas) for Open Philanthropy, EA Funds/CEA, SFF, DeepMind, OpenAI, Anthropic, and MIRI
- Adds `pnpm crux import-funding-programs` command with 15 curated funding programs (grant rounds, RFPs) with division cross-references linking to the divisions above
- Both commands support `list` (default), `sync`, and `sync --dry-run` subcommands
- Follows the established `import-grants` pattern: deterministic 10-char IDs via SHA-256 hashing, wiki-server sync via `POST /api/divisions/sync` and `POST /api/funding-programs/sync`
- Registered in `crux/crux.mjs` as `import-divisions` and `import-funding-programs` domains

## Division coverage

| Organization | Divisions | Types |
|---|---|---|
| Open Philanthropy | Global Health & Wellbeing, Global Catastrophic Risks | program-area |
| EA Funds/CEA | LTFF, Animal Welfare, EA Infrastructure, Global Health | fund |
| SFF | Main fund | fund |
| DeepMind | Safety | team |
| OpenAI | Safety Systems, Preparedness, Superalignment (dissolved) | team |
| Anthropic | Alignment Science, Trust & Safety, Policy | team |
| MIRI | Research | team |

## Funding program coverage

Open Philanthropy (AI Safety, Biosecurity, Global Health), EA Funds (4 fund grant rounds), SFF (S-Process, Speculation), FTX Future Fund (General, Regranting - both closed), Manifund (Regranting, Impact Certificates), ACX Grants (2022, 2023)

## Test plan

- [x] `pnpm crux import-divisions list` runs successfully, showing 15 divisions grouped by org
- [x] `pnpm crux import-divisions sync --dry-run` previews sync payload
- [x] `pnpm crux import-funding-programs list` runs successfully, showing 15 programs with division cross-references
- [x] `pnpm crux import-funding-programs sync --dry-run` previews sync payload
- [x] No ID collisions in either dataset
- [x] Division IDs generated in funding programs match those from import-divisions
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2932 tests)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `import-divisions` command to list and sync organizational divisions to the wiki server with ID collision detection
  * Added `import-funding-programs` command to list and sync funding programs to the wiki server, including dry-run mode to preview changes before syncing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->