### PR TITLE
feat: surface expert positions on person pages and directory

### DIFF
--- a/apps/web/src/app/people/[slug]/expert-positions.tsx
+++ b/apps/web/src/app/people/[slug]/expert-positions.tsx
@@ -1,0 +1,124 @@
+import type { ExpertPosition } from "@/data/database";
+
+/** Human-readable labels for position topic slugs */
+const TOPIC_LABELS: Record<string, string> = {
+  "p-doom": "P(doom)",
+  timelines: "AGI Timelines",
+  "current-approaches-scale": "Current Approaches Scale",
+  "how-hard-is-alignment-": "How Hard Is Alignment?",
+  "inner-alignment-solvability": "Inner Alignment Solvability",
+  "likelihood-of-deceptive-alignment": "Likelihood of Deceptive Alignment",
+  "would-misalignment-be-catastrophic-": "Would Misalignment Be Catastrophic?",
+  "p-ai-catastrophe-": "P(AI Catastrophe)",
+  "p-ai-x-risk-this-century-": "P(AI X-Risk This Century)",
+  "how-fast-would-takeoff-be-": "Takeoff Speed",
+  "will-advanced-ai-systems-be-deceptive-":
+    "Will Advanced AI Be Deceptive?",
+  "will-we-get-adequate-warning-before-catastrophic-ai-":
+    "Will We Get Adequate Warning?",
+};
+
+function topicLabel(topic: string): string {
+  return TOPIC_LABELS[topic] ?? topic.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const CONFIDENCE_STYLES: Record<string, string> = {
+  high: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  medium:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  low: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};
+
+export function ExpertPositions({
+  positions,
+}: {
+  positions: ExpertPosition[];
+}) {
+  if (positions.length === 0) return null;
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold tracking-tight mb-4">
+        Expert Positions
+        <span className="ml-2 text-sm font-normal text-muted-foreground">
+          {positions.length} topics
+        </span>
+      </h2>
+      <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60 bg-muted/30">
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Topic
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  View
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Estimate
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Confidence
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map((pos) => (
+                <tr
+                  key={pos.topic}
+                  className="border-b border-border/30 last:border-b-0 hover:bg-muted/20 transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium">
+                    {topicLabel(pos.topic)}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {pos.view}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs">
+                    {pos.estimate ?? "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    {pos.confidence && (
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${CONFIDENCE_STYLES[pos.confidence] ?? "bg-muted text-muted-foreground"}`}
+                      >
+                        {pos.confidence}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {positions.some((p) => p.source) && (
+          <div className="px-4 py-2.5 border-t border-border/40 bg-muted/20">
+            <p className="text-xs text-muted-foreground">
+              Sources:{" "}
+              {positions
+                .filter((p) => p.source)
+                .map((p, i) => (
+                  <span key={p.topic}>
+                    {i > 0 && " · "}
+                    {p.sourceUrl ? (
+                      <a
+                        href={p.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        {p.source}
+                      </a>
+                    ) : (
+                      p.source
+                    )}
+                  </span>
+                ))}
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -23,11 +23,11 @@ import {
   Breadcrumbs,
   CurrentBadge,
   FounderBadge,
-  SourceLink,
-  DirectoryEntityLink,
   FactsPanel,
 } from "@/components/directory";
 import { formatKBDate } from "@/components/wiki/kb/format";
+import { getExpertById } from "@/data";
+import { ExpertPositions } from "./expert-positions";
 
 export function generateStaticParams() {
   return getPersonSlugs().map((slug) => ({ slug }));
@@ -66,9 +66,9 @@ export default async function PersonProfilePage({
   const notableForFact = getKBLatest(entity.id, "notable-for");
   const socialMediaFact = getKBLatest(entity.id, "social-media");
 
-  // Records removed — these collections now return empty arrays
-  const careerHistory: Array<{ key: string; fields: Record<string, unknown> }> = [];
-  const boardSeats: Array<{ key: string; fields: Record<string, unknown> }> = [];
+  // Expert positions from experts.yaml
+  const expert = getExpertById(slug);
+  const positions = expert?.positions ?? [];
 
   // Reverse lookup: org key-person records referencing this person
   const orgRoles = getOrgRolesForPerson(entity.id);
@@ -83,13 +83,6 @@ export default async function PersonProfilePage({
     employedByFact?.value.type === "ref"
       ? resolveEntityRef(employedByFact.value.value)
       : null;
-
-  // Sort career history by start date (most recent first)
-  const sortedCareer = [...careerHistory].sort((a, b) => {
-    const sa = a.fields.start ? String(a.fields.start) : "";
-    const sb = b.fields.start ? String(b.fields.start) : "";
-    return sb.localeCompare(sa);
-  });
 
   // Sort org roles: current first, then by start date
   const sortedOrgRoles = [...orgRoles].sort((a, b) => {
@@ -214,74 +207,8 @@ export default async function PersonProfilePage({
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main content */}
         <div className="lg:col-span-2 space-y-8">
-          {/* Career History Timeline */}
-          {sortedCareer.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Career History
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {sortedCareer.length} positions
-                </span>
-              </h2>
-              <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
-                {sortedCareer.map((entry) => {
-                  const org = resolveEntityRef(entry.fields.organization);
-                  const title = fieldStr(entry.fields, "title");
-                  const start = fieldStr(entry.fields, "start");
-                  const end = fieldStr(entry.fields, "end");
-                  const notes = fieldStr(entry.fields, "notes");
-                  const source = fieldStr(entry.fields, "source");
-
-                  return (
-                    <div
-                      key={entry.key}
-                      className="flex gap-4 px-5 py-4 border-b border-border/40 last:border-b-0 group hover:bg-muted/20 transition-colors"
-                    >
-                      {/* Timeline dot */}
-                      <div className="flex flex-col items-center pt-1.5">
-                        <div
-                          className={`w-3 h-3 rounded-full border-2 shrink-0 transition-colors ${
-                            !end
-                              ? "border-primary bg-primary/20 group-hover:bg-primary/30"
-                              : "border-border bg-card group-hover:border-primary/50"
-                          }`}
-                        />
-                        <div className="w-px flex-1 bg-gradient-to-b from-border/50 to-transparent mt-1" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-baseline gap-2 flex-wrap">
-                          {title && (
-                            <span className="font-semibold text-sm">
-                              {title}
-                            </span>
-                          )}
-                          {!end && <CurrentBadge />}
-                        </div>
-                        {org && (
-                          <div className="text-sm mt-0.5">
-                            <DirectoryEntityLink
-                              entity={org}
-                              basePath="/organizations"
-                              className="text-primary hover:underline font-medium"
-                            />
-                          </div>
-                        )}
-                        <div className="text-[10px] text-muted-foreground/60 mt-1">
-                          {formatDateRange(start, end)}
-                        </div>
-                        {notes && (
-                          <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">
-                            {notes}
-                          </p>
-                        )}
-                        <SourceLink source={source} />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
+          {/* Expert Positions */}
+          <ExpertPositions positions={positions} />
 
           {/* Education */}
           {educationFact?.value.type === "text" && (
@@ -341,47 +268,6 @@ export default async function PersonProfilePage({
                           {title}
                         </div>
                       )}
-                      <div className="text-[10px] text-muted-foreground/50 mt-1">
-                        {formatDateRange(start, end)}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
-
-          {/* Board Seats */}
-          {boardSeats.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Board Seats
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {boardSeats.length}
-                </span>
-              </h2>
-              <div className="border border-border/60 rounded-xl bg-card">
-                {boardSeats.map((seat) => {
-                  const org = resolveEntityRef(seat.fields.organization);
-                  const role = fieldStr(seat.fields, "role") ?? "Board Member";
-                  const start = fieldStr(seat.fields, "start");
-                  const end = fieldStr(seat.fields, "end");
-
-                  return (
-                    <div
-                      key={seat.key}
-                      className="px-4 py-3 border-b border-border/40 last:border-b-0"
-                    >
-                      <div className="flex items-baseline gap-2">
-                        <DirectoryEntityLink
-                          entity={org}
-                          basePath="/organizations"
-                          className="font-semibold text-sm hover:text-primary transition-colors"
-                        />
-                        <span className="text-xs text-muted-foreground">
-                          {role}
-                        </span>
-                      </div>
                       <div className="text-[10px] text-muted-foreground/50 mt-1">
                         {formatDateRange(start, end)}
                       </div>

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -3,6 +3,7 @@ import { getKBEntities, getKBLatest, getKBEntity, getKBEntitySlug } from "@/data
 import type { Fact } from "@longterm-wiki/kb";
 import { ProfileStatCard } from "@/components/directory";
 import { PeopleTable, type PersonRow } from "./people-table";
+import { getExpertById } from "@/data";
 
 export const metadata: Metadata = {
   title: "People",
@@ -37,9 +38,13 @@ export default function PeoplePage() {
 
     const employer = resolveRef(employedByFact);
 
+    const slug = getKBEntitySlug(entity.id) ?? entity.id;
+    const expert = getExpertById(slug);
+    const positionCount = expert?.positions?.length ?? 0;
+
     return {
       id: entity.id,
-      slug: getKBEntitySlug(entity.id) ?? entity.id,
+      slug,
       name: entity.name,
       numericId: entity.numericId ?? null,
       wikiPageId: entity.wikiPageId ?? entity.numericId ?? null,
@@ -51,6 +56,8 @@ export default function PeoplePage() {
 
       bornYear: numericValue(bornYearFact),
       netWorthNum: numericValue(netWorthFact),
+
+      positionCount,
     };
   });
 
@@ -58,6 +65,7 @@ export default function PeoplePage() {
   const withEmployer = rows.filter((r) => r.employerName != null).length;
   const withBornYear = rows.filter((r) => r.bornYear != null).length;
   const withNetWorth = rows.filter((r) => r.netWorthNum != null).length;
+  const withPositions = rows.filter((r) => r.positionCount > 0).length;
 
   const stats = [
     { label: "People", value: String(rows.length) },
@@ -65,6 +73,7 @@ export default function PeoplePage() {
     { label: "With Employer", value: String(withEmployer) },
     { label: "With Birth Year", value: String(withBornYear) },
     { label: "With Net Worth", value: String(withNetWorth) },
+    { label: "With Expert Positions", value: String(withPositions) },
   ];
 
   return (

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -20,6 +20,8 @@ export interface PersonRow {
   bornYear: number | null;
 
   netWorthNum: number | null;
+
+  positionCount: number;
 }
 
 type SortKey =
@@ -27,7 +29,8 @@ type SortKey =
   | "role"
   | "employer"
   | "bornYear"
-  | "netWorth";
+  | "netWorth"
+  | "positions";
 
 type SortDir = "asc" | "desc";
 
@@ -91,6 +94,8 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
             return row.bornYear;
           case "netWorth":
             return row.netWorthNum;
+          case "positions":
+            return row.positionCount || null;
         }
       };
 
@@ -168,6 +173,7 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
               <SortHeader label="Affiliation" sortKey="employer" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Born" sortKey="bornYear" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
               <SortHeader label="Net Worth" sortKey="netWorth" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
+              <SortHeader label="Positions" sortKey="positions" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -223,6 +229,15 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
                 <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap">
                   {row.netWorthNum != null && (
                     <span className="font-semibold">{formatCompactCurrency(row.netWorthNum)}</span>
+                  )}
+                </td>
+
+                {/* Positions */}
+                <td className="py-2.5 px-3 text-center tabular-nums">
+                  {row.positionCount > 0 && (
+                    <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                      {row.positionCount}
+                    </span>
                   )}
                 </td>
 

--- a/apps/web/src/data/database.ts
+++ b/apps/web/src/data/database.ts
@@ -202,6 +202,15 @@ export interface Publication {
   website?: string;
 }
 
+export interface ExpertPosition {
+  topic: string;
+  view: string;
+  estimate?: string;
+  confidence?: string;
+  source?: string;
+  sourceUrl?: string;
+}
+
 export interface Expert {
   id: string;
   name: string;
@@ -209,6 +218,7 @@ export interface Expert {
   role?: string;
   website?: string;
   knownFor?: string[];
+  positions?: ExpertPosition[];
 }
 
 export interface Organization {
@@ -709,6 +719,10 @@ export function getResourcesForPublication(publicationId: string): Resource[] {
 
 export function getExpertById(id: string): Expert | undefined {
   return expertIndex().get(id);
+}
+
+export function getAllExperts(): Expert[] {
+  return getDatabase().experts ?? [];
 }
 
 export function getOrganizationById(id: string): Organization | undefined {


### PR DESCRIPTION
## Summary

Surfaces the expert positions data from `experts.yaml` (previously invisible to users) on person detail pages and the people directory.

- **Person detail pages**: New "Expert Positions" table showing structured views on AI safety topics (P(doom), AGI timelines, takeoff speed, alignment difficulty, etc.) with confidence badges and source citations
- **People directory**: New "Positions" column showing count of tracked positions per person, sortable; new "With Expert Positions" stat card
- **Type system**: Added `ExpertPosition` interface and `positions` field to `Expert` type (data was already in `database.json`, just missing from the TypeScript type)
- **Cleanup**: Removed dead career history and board seats code that was rendering empty arrays since records infrastructure was removed

26 experts have structured position data that was sitting unused — this makes it visible.

## Test plan

- [x] `pnpm build` passes (all 720+ pages generated)
- [x] `pnpm test` passes (577 tests)
- [x] `npx tsc --noEmit` clean
- [ ] Verify `/people` directory shows "With Expert Positions" stat and Positions column
- [ ] Verify `/people/paul-christiano` shows Expert Positions table with 12 topics
- [ ] Verify `/people/eliezer-yudkowsky` shows Expert Positions with high-confidence badges
- [ ] Verify `/people/ajeya-cotra` (no expert positions) shows no positions section

Closes #2167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
