### PR TITLE
fix: use matched entity ID for granteeId instead of display name

### DIFF
--- a/crux/lib/grant-import/__tests__/sync.test.ts
+++ b/crux/lib/grant-import/__tests__/sync.test.ts
@@ -23,7 +23,7 @@ describe("toSyncGrant", () => {
     expect(sync1.id).toHaveLength(10);
   });
 
-  it("uses granteeName as display granteeId", () => {
+  it("uses matched entity stableId as granteeId when available", () => {
     const raw: RawGrant = {
       source: "ea-funds",
       funderId: "yA12C1KcjQ",
@@ -36,7 +36,23 @@ describe("toSyncGrant", () => {
       description: null,
     };
     const sync = toSyncGrant(raw, defaultSourceUrl);
-    expect(sync.granteeId).toBe("Redwood Research");
+    expect(sync.granteeId).toBe("someEntityId");
+  });
+
+  it("falls back to granteeName when no entity match", () => {
+    const raw: RawGrant = {
+      source: "ea-funds",
+      funderId: "yA12C1KcjQ",
+      granteeName: "Unknown Org",
+      granteeId: null,
+      name: "Grant to Unknown",
+      amount: 500000,
+      date: "2024-01",
+      focusArea: null,
+      description: null,
+    };
+    const sync = toSyncGrant(raw, defaultSourceUrl);
+    expect(sync.granteeId).toBe("Unknown Org");
   });
 
   it("uses defaultSourceUrl when no sourceUrl on raw grant", () => {

--- a/crux/lib/grant-import/sync.ts
+++ b/crux/lib/grant-import/sync.ts
@@ -13,10 +13,9 @@ export function toSyncGrant(raw: RawGrant, defaultSourceUrl: string): SyncGrant 
   const idInput = `${raw.source}|${raw.funderId}|${raw.granteeName}|${raw.date || ""}|${raw.amount || ""}|${raw.name.substring(0, 100)}`;
   const id = generateId(idInput);
 
-  // granteeId: always store the human-readable name (max 200 chars).
-  // The entity stableId is useful for linking but the grants table renders
-  // this field directly, so it must always be a display name.
-  const granteeId = raw.granteeName.substring(0, 200);
+  // Use the matched entity stableId when available; fall back to display name.
+  // This allows the grants table to link grantees to their entity pages.
+  const granteeId = (raw.granteeId ?? raw.granteeName).substring(0, 200);
 
   // Truncate notes
   let notes: string | null = null;

--- a/crux/lib/grant-import/types.ts
+++ b/crux/lib/grant-import/types.ts
@@ -26,10 +26,9 @@ export interface SyncGrant {
   id: string;
   organizationId: string;
   /**
-   * Despite the name, this stores the human-readable display name (not an entity
-   * stableId). The wiki-server grants schema expects this field name, so it cannot
-   * be renamed without a coordinated server migration. Compare with RawGrant.granteeId,
-   * which IS an entity stableId (or null if unmatched).
+   * Entity stableId when the grantee was matched to a known entity (e.g. "OwXl35e7bg"),
+   * or the raw display name as a fallback when no entity match was found.
+   * Compare with organizationId which is always an entity stableId.
    */
   granteeId: string | null;
   name: string;


### PR DESCRIPTION
## Summary

- Fixes the core grantee linking bug: `toSyncGrant()` was discarding the entity matcher result and always storing the display name in `granteeId`
- Now uses `raw.granteeId` (matched entity stableId) when available, falls back to `raw.granteeName` when no match exists
- Updates JSDoc to accurately describe the field semantics
- Updates existing test and adds fallback test case

## Context

All 7 grant source parsers already call `matchGrantee()` and populate `raw.granteeId` with the entity stableId. But `sync.ts` line 19 was: `granteeId: raw.granteeName.substring(0, 200)` — completely ignoring the match result.

This takes grantee→entity linking from 0% to ~60-75% (the entity matcher's match rate with 169 manual overrides).

Related: [Data Integration Synthesis (#2170)](https://github.com/quantified-uncertainty/longterm-wiki/discussions/2170)

## Test plan

- [x] Existing grant-import tests pass (163 tests)
- [x] New test confirms fallback to display name when no match
- [ ] After merge, re-run `pnpm crux import-grants` to backfill granteeId with entity IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>