### PR TITLE
Un-stub person detail pages with personnel data

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -5,6 +5,9 @@ import {
   resolvePersonBySlug,
   getPersonSlugs,
   getOrgRolesForPerson,
+  getBoardSeatsForPerson,
+  getCareerHistoryForPerson,
+  resolveOrgForCareer,
 } from "../people-utils";
 import {
   getKBFacts,
@@ -73,6 +76,12 @@ export default async function PersonProfilePage({
   // Reverse lookup: org key-person records referencing this person
   const orgRoles = getOrgRolesForPerson(entity.id);
 
+  // Board seats across all organizations referencing this person
+  const boardSeats = getBoardSeatsForPerson(entity.id);
+
+  // Career history records owned by this person
+  const careerHistory = getCareerHistoryForPerson(entity.id);
+
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
     (f) => f.propertyId !== "description",
@@ -91,6 +100,30 @@ export default async function PersonProfilePage({
     if (endA !== endB) return endA - endB;
     const sa = a.record.fields.start ? String(a.record.fields.start) : "";
     const sb = b.record.fields.start ? String(b.record.fields.start) : "";
+    return sb.localeCompare(sa);
+  });
+
+  // Sort board seats: current first, then by appointment date
+  const sortedBoardSeats = [...boardSeats].sort((a, b) => {
+    const endA = a.record.fields.departed ? 1 : 0;
+    const endB = b.record.fields.departed ? 1 : 0;
+    if (endA !== endB) return endA - endB;
+    const sa = a.record.fields.appointed
+      ? String(a.record.fields.appointed)
+      : "";
+    const sb = b.record.fields.appointed
+      ? String(b.record.fields.appointed)
+      : "";
+    return sb.localeCompare(sa);
+  });
+
+  // Sort career history: current first, then by start date
+  const sortedCareer = [...careerHistory].sort((a, b) => {
+    const endA = a.fields.end ? 1 : 0;
+    const endB = b.fields.end ? 1 : 0;
+    if (endA !== endB) return endA - endB;
+    const sa = a.fields.start ? String(a.fields.start) : "";
+    const sb = b.fields.start ? String(b.fields.start) : "";
     return sb.localeCompare(sa);
   });
 
@@ -210,6 +243,62 @@ export default async function PersonProfilePage({
           {/* Expert Positions */}
           <ExpertPositions positions={positions} />
 
+          {/* Career History */}
+          {sortedCareer.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Career History
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {sortedCareer.length}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card">
+                {sortedCareer.map((rec) => {
+                  const title = fieldStr(rec.fields, "title");
+                  const start = fieldStr(rec.fields, "start");
+                  const end = fieldStr(rec.fields, "end");
+                  const orgId = rec.fields.organization as string | undefined;
+                  const org = orgId ? resolveOrgForCareer(orgId) : null;
+
+                  return (
+                    <div
+                      key={rec.key}
+                      className="px-4 py-3 border-b border-border/40 last:border-b-0"
+                    >
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        {org?.slug ? (
+                          <Link
+                            href={`/organizations/${org.slug}`}
+                            className="font-semibold text-sm hover:text-primary transition-colors"
+                          >
+                            {org.name}
+                          </Link>
+                        ) : org ? (
+                          <span className="font-semibold text-sm">
+                            {org.name}
+                          </span>
+                        ) : orgId ? (
+                          <span className="font-semibold text-sm text-muted-foreground">
+                            {orgId}
+                          </span>
+                        ) : null}
+                        {!end && <CurrentBadge />}
+                      </div>
+                      {title && (
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {title}
+                        </div>
+                      )}
+                      <div className="text-[10px] text-muted-foreground/50 mt-1">
+                        {formatDateRange(start, end)}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
           {/* Education */}
           {educationFact?.value.type === "text" && (
             <section>
@@ -270,6 +359,57 @@ export default async function PersonProfilePage({
                       )}
                       <div className="text-[10px] text-muted-foreground/50 mt-1">
                         {formatDateRange(start, end)}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Board Seats */}
+          {sortedBoardSeats.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Board Seats
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {sortedBoardSeats.length}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card">
+                {sortedBoardSeats.map(({ org, record }) => {
+                  const role = fieldStr(record.fields, "role");
+                  const appointed = fieldStr(record.fields, "appointed");
+                  const departed = fieldStr(record.fields, "departed");
+                  const orgSlug = getKBEntitySlug(org.id);
+
+                  return (
+                    <div
+                      key={`${org.id}-${record.key}`}
+                      className="px-4 py-3 border-b border-border/40 last:border-b-0"
+                    >
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        {orgSlug ? (
+                          <Link
+                            href={`/organizations/${orgSlug}`}
+                            className="font-semibold text-sm hover:text-primary transition-colors"
+                          >
+                            {org.name}
+                          </Link>
+                        ) : (
+                          <span className="font-semibold text-sm">
+                            {org.name}
+                          </span>
+                        )}
+                        {!departed && <CurrentBadge />}
+                      </div>
+                      {role && (
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {role}
+                        </div>
+                      )}
+                      <div className="text-[10px] text-muted-foreground/50 mt-1">
+                        {formatDateRange(appointed, departed)}
                       </div>
                     </div>
                   );

--- a/apps/web/src/app/people/people-utils.ts
+++ b/apps/web/src/app/people/people-utils.ts
@@ -1,13 +1,20 @@
 /**
  * Shared utilities for /people routes.
  *
- * Note: Record-based org role lookups (key-persons) have been removed.
- * The getOrgRolesForPerson function now returns an empty array.
+ * Personnel data (key-persons, board-seats, career-history) is fetched
+ * from PostgreSQL during build and merged into kb-data.json as KB records.
  */
 import {
   resolveEntityBySlug,
   getEntitySlugs,
 } from "@/lib/directory-utils";
+import {
+  getAllKBRecords,
+  getKBRecords,
+  getKBEntity,
+  getKBEntitySlug,
+  type KBRecordEntry,
+} from "@/data/kb";
 
 // Re-export generic utilities with people-specific signatures
 export const resolvePersonBySlug = (slug: string) =>
@@ -17,10 +24,103 @@ export const getPersonSlugs = () => getEntitySlugs("person");
 
 /**
  * Find all key-person records across all organizations that reference this person.
- * STUB: Records infrastructure has been removed. Returns empty array.
+ * Uses getAllKBRecords to scan all orgs' key-persons collections,
+ * filtering by fields.person === personEntityId.
  */
 export function getOrgRolesForPerson(
-  _personEntityId: string,
-): Array<{ org: { id: string; name: string; type: string }; record: { key: string; fields: Record<string, unknown> } }> {
-  return [];
+  personEntityId: string,
+): Array<{
+  org: { id: string; name: string; type: string };
+  record: { key: string; fields: Record<string, unknown> };
+}> {
+  const allKeyPersons = getAllKBRecords("key-persons");
+  const results: Array<{
+    org: { id: string; name: string; type: string };
+    record: { key: string; fields: Record<string, unknown> };
+  }> = [];
+
+  for (const rec of allKeyPersons) {
+    if (rec.fields.person !== personEntityId) continue;
+
+    const orgEntity = getKBEntity(rec.ownerEntityId);
+    if (!orgEntity) continue;
+
+    results.push({
+      org: {
+        id: orgEntity.id,
+        name: orgEntity.name,
+        type: orgEntity.type ?? "organization",
+      },
+      record: {
+        key: rec.key,
+        fields: rec.fields,
+      },
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Find all board-seat records across all organizations that reference this person.
+ * Uses getAllKBRecords to scan all orgs' board-seats collections,
+ * filtering by fields.member === personEntityId.
+ */
+export function getBoardSeatsForPerson(
+  personEntityId: string,
+): Array<{
+  org: { id: string; name: string; type: string };
+  record: { key: string; fields: Record<string, unknown> };
+}> {
+  const allBoardSeats = getAllKBRecords("board-seats");
+  const results: Array<{
+    org: { id: string; name: string; type: string };
+    record: { key: string; fields: Record<string, unknown> };
+  }> = [];
+
+  for (const rec of allBoardSeats) {
+    if (rec.fields.member !== personEntityId) continue;
+
+    const orgEntity = getKBEntity(rec.ownerEntityId);
+    if (!orgEntity) continue;
+
+    results.push({
+      org: {
+        id: orgEntity.id,
+        name: orgEntity.name,
+        type: orgEntity.type ?? "organization",
+      },
+      record: {
+        key: rec.key,
+        fields: rec.fields,
+      },
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Get career history records for a person.
+ * Career records have ownerEntityId === personEntityId, so we can look up directly.
+ */
+export function getCareerHistoryForPerson(
+  personEntityId: string,
+): KBRecordEntry[] {
+  return getKBRecords(personEntityId, "career-history");
+}
+
+/**
+ * Resolve an organization entity ID to a display-friendly object.
+ */
+export function resolveOrgForCareer(
+  orgId: string,
+): { id: string; name: string; slug: string | undefined } | null {
+  const orgEntity = getKBEntity(orgId);
+  if (!orgEntity) return null;
+  return {
+    id: orgEntity.id,
+    name: orgEntity.name,
+    slug: getKBEntitySlug(orgEntity.id),
+  };
 }


### PR DESCRIPTION
## Summary
- Re-implement the three stubbed personnel data sections on `/people/[slug]` detail pages
- **Organization Roles**: scans all `key-persons` KB records, filtering by `fields.person` matching the person entity ID (reverse lookup since these records are owned by organizations)
- **Board Seats**: scans all `board-seats` KB records, filtering by `fields.member` matching the person entity ID (same reverse lookup pattern)
- **Career History**: reads `career-history` records directly via `getKBRecords(personId, "career-history")` since these records are owned by the person entity
- All data comes from build-time `kb-data.json` (populated from PostgreSQL during `build-data.mjs`) -- zero runtime wiki-server queries
- Sections are sorted current-first (no end date), then by most recent start/appointment date

## What changed
- `apps/web/src/app/people/people-utils.ts`: Replaced stub `getOrgRolesForPerson()` with real implementation using `getAllKBRecords("key-persons")`. Added `getBoardSeatsForPerson()`, `getCareerHistoryForPerson()`, and `resolveOrgForCareer()` helper functions.
- `apps/web/src/app/people/[slug]/page.tsx`: Added Career History section (main content area, between Expert Positions and Education) and Board Seats section (sidebar, between Organization Roles and Facts). Both use the same card styling as the existing Organization Roles section.

## Test plan
- [ ] TypeScript check passes (verified: `tsc --noEmit` exits clean)
- [ ] Existing 562 tests still pass (verified: only pre-existing worktree failures)
- [ ] Verify person pages with known personnel data display Career History, Board Seats, and Organization Roles sections
- [ ] Verify person pages without personnel data still render correctly (empty sections are hidden)
- [ ] Verify org links in career history and board seats navigate correctly

Generated with [Claude Code](https://claude.com/claude-code)