### PR TITLE
feat: add backfill-grantee-ids command for entity linking

### DIFF
--- a/apps/wiki-server/src/routes/grants.ts
+++ b/apps/wiki-server/src/routes/grants.ts
@@ -47,6 +47,17 @@ const SyncGrantsBatchSchema = z.object({
   items: z.array(SyncGrantItemSchema).min(1).max(500),
 });
 
+// ---- Batch grantee update schema ----
+
+const BatchUpdateGranteeItemSchema = z.object({
+  id: z.string().length(10),
+  granteeId: z.string().max(200),
+});
+
+const BatchUpdateGranteeSchema = z.object({
+  items: z.array(BatchUpdateGranteeItemSchema).min(1).max(500),
+});
+
 // ---- Helpers ----
 
 function formatRow(r: typeof grants.$inferSelect) {
@@ -196,6 +207,62 @@ const grantsApp = new Hono()
         totalAmount: Number(r.totalAmount),
       })),
     });
+  })
+
+  // ---- GET /all-grantee-ids ----
+  // Returns all grant IDs and their current granteeId values.
+  // Used by the backfill command to identify grants needing entity linking.
+  .get("/all-grantee-ids", async (c) => {
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        id: grants.id,
+        granteeId: grants.granteeId,
+        name: grants.name,
+      })
+      .from(grants);
+
+    return c.json({
+      grants: rows.map((r) => ({
+        id: r.id,
+        granteeId: r.granteeId,
+        name: r.name,
+      })),
+      total: rows.length,
+    });
+  })
+
+  // ---- PATCH /batch-update-grantee ----
+  // Updates granteeId for multiple grants in a single transaction.
+  // Used by the backfill command to link grantees to entity stableIds.
+  .patch("/batch-update-grantee", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = BatchUpdateGranteeSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    let updated = 0;
+
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        await tx
+          .update(grants)
+          .set({
+            granteeId: item.granteeId,
+            updatedAt: sql`now()`,
+          })
+          .where(eq(grants.id, item.id));
+
+        updated++;
+      }
+    });
+
+    return c.json({ updated });
   })
 
   // ---- POST /sync ----

--- a/crux/commands/backfill-grantee-ids.ts
+++ b/crux/commands/backfill-grantee-ids.ts
@@ -1,0 +1,236 @@
+/**
+ * Backfill granteeId in the grants table with matched entity stableIds.
+ *
+ * Existing grants may have display names (e.g. "OpenAI") in granteeId instead
+ * of entity stableIds (e.g. "OwXl35e7bg"). This command uses the entity matcher
+ * to retroactively link grantees to their entity pages.
+ *
+ * Usage:
+ *   pnpm crux backfill-grantee-ids run                # Apply updates
+ *   pnpm crux backfill-grantee-ids run --dry-run      # Preview without writing
+ */
+
+import {
+  buildEntityMatcher,
+  matchGrantee,
+} from "../lib/grant-import/entity-matcher.ts";
+import {
+  batchedRequest,
+  getServerUrl,
+} from "../lib/wiki-server/client.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GrantIdRow {
+  id: string;
+  granteeId: string | null;
+  name: string;
+}
+
+interface AllGranteeIdsResponse {
+  grants: GrantIdRow[];
+  total: number;
+}
+
+interface BatchUpdateResult {
+  updated: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A 10-char alphanumeric stableId looks like "aB3cD4eF5g".
+ * Display names are typically longer or contain spaces/punctuation.
+ */
+function looksLikeStableId(value: string): boolean {
+  return /^[A-Za-z0-9]{10}$/.test(value);
+}
+
+const BATCH_SIZE = 200;
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+async function runBackfill(dryRun: boolean): Promise<void> {
+  const serverUrl = getServerUrl();
+  if (!serverUrl) {
+    throw new Error(
+      "wiki-server URL not configured. Set LONGTERMWIKI_SERVER_URL or use WIKI_SERVER_ENV=prod."
+    );
+  }
+
+  // 1. Build entity matcher
+  console.log("Building entity matcher...");
+  const matcher = buildEntityMatcher();
+  console.log(`  Entity matcher loaded (${matcher.allNames.size} known names)\n`);
+
+  // 2. Fetch all grant IDs and granteeIds
+  console.log(`Fetching grants from ${serverUrl}...`);
+  const result = await batchedRequest<AllGranteeIdsResponse>(
+    "GET",
+    "/api/grants/all-grantee-ids"
+  );
+
+  if (!result.ok) {
+    throw new Error(`Failed to fetch grants: ${result.message}`);
+  }
+
+  const allGrants = result.data.grants;
+  console.log(`  Total grants: ${allGrants.length}\n`);
+
+  // 3. Categorize grants
+  const alreadyLinked: GrantIdRow[] = [];
+  const noGranteeId: GrantIdRow[] = [];
+  const needsMatching: GrantIdRow[] = [];
+
+  for (const grant of allGrants) {
+    if (!grant.granteeId) {
+      noGranteeId.push(grant);
+    } else if (looksLikeStableId(grant.granteeId)) {
+      alreadyLinked.push(grant);
+    } else {
+      needsMatching.push(grant);
+    }
+  }
+
+  console.log("=== Grant Categorization ===");
+  console.log(`  Already linked (stableId):  ${alreadyLinked.length}`);
+  console.log(`  No granteeId (null):        ${noGranteeId.length}`);
+  console.log(`  Display names (to match):   ${needsMatching.length}\n`);
+
+  // 4. Match display names to entity stableIds
+  const matched: Array<{ id: string; granteeId: string; oldValue: string }> = [];
+  const unmatched: Map<string, number> = new Map(); // name -> count
+
+  for (const grant of needsMatching) {
+    const displayName = grant.granteeId!;
+    const stableId = matchGrantee(displayName, matcher);
+
+    if (stableId) {
+      matched.push({ id: grant.id, granteeId: stableId, oldValue: displayName });
+    } else {
+      const count = unmatched.get(displayName) || 0;
+      unmatched.set(displayName, count + 1);
+    }
+  }
+
+  console.log("=== Matching Results ===");
+  console.log(`  Newly matched:   ${matched.length}`);
+  console.log(`  Still unmatched:  ${needsMatching.length - matched.length}\n`);
+
+  // 5. Show sample matches
+  if (matched.length > 0) {
+    console.log("Sample matches (first 20):");
+    for (const m of matched.slice(0, 20)) {
+      console.log(`  "${m.oldValue}" -> ${m.granteeId}`);
+    }
+    if (matched.length > 20) {
+      console.log(`  ... and ${matched.length - 20} more\n`);
+    } else {
+      console.log("");
+    }
+  }
+
+  // 6. Show unmatched names (sorted by frequency)
+  if (unmatched.size > 0) {
+    const sorted = [...unmatched.entries()].sort((a, b) => b[1] - a[1]);
+    console.log(`Unmatched names (${sorted.length} unique, top 30 by frequency):`);
+    for (const [name, count] of sorted.slice(0, 30)) {
+      console.log(`  ${count.toString().padStart(4)}x  "${name}"`);
+    }
+    if (sorted.length > 30) {
+      console.log(`  ... and ${sorted.length - 30} more unique names\n`);
+    } else {
+      console.log("");
+    }
+  }
+
+  // 7. Apply updates
+  if (matched.length === 0) {
+    console.log("No grants to update.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`Dry run — would update ${matched.length} grants. Use without --dry-run to apply.`);
+    return;
+  }
+
+  console.log(`Updating ${matched.length} grants...`);
+
+  let totalUpdated = 0;
+  let failedBatches = 0;
+
+  for (let i = 0; i < matched.length; i += BATCH_SIZE) {
+    const batch = matched.slice(i, i + BATCH_SIZE);
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(matched.length / BATCH_SIZE);
+
+    console.log(`  Batch ${batchNum}/${totalBatches}: ${batch.length} grants...`);
+
+    const updateResult = await batchedRequest<BatchUpdateResult>(
+      "PATCH",
+      "/api/grants/batch-update-grantee",
+      {
+        items: batch.map((m) => ({ id: m.id, granteeId: m.granteeId })),
+      }
+    );
+
+    if (updateResult.ok) {
+      totalUpdated += updateResult.data.updated;
+      console.log(`    -> ${updateResult.data.updated} updated`);
+    } else {
+      failedBatches++;
+      console.error(`    x Batch ${batchNum} failed: ${updateResult.message}`);
+    }
+  }
+
+  console.log(`\nTotal updated: ${totalUpdated}`);
+  if (failedBatches > 0) {
+    throw new Error(`${failedBatches} batch(es) failed`);
+  }
+
+  console.log("Done.");
+}
+
+// ---------------------------------------------------------------------------
+// Crux command exports
+// ---------------------------------------------------------------------------
+
+type CommandResult = { exitCode?: number; output?: string };
+
+async function runCommand(
+  _args: string[],
+  options: Record<string, unknown>
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun || !!options["dry-run"];
+  await runBackfill(dryRun);
+  return { exitCode: 0 };
+}
+
+export const commands = {
+  run: runCommand,
+  default: runCommand,
+};
+
+export function getHelp(): string {
+  return `
+Backfill Grantee IDs — Link existing grants to entity stableIds
+
+Commands:
+  run                  Run the backfill (default)
+  run --dry-run        Preview matches without writing
+
+This command:
+  1. Fetches all grants from the wiki-server
+  2. Identifies grants where granteeId is a display name (not a 10-char stableId)
+  3. Runs the entity matcher (manual overrides + name normalization)
+  4. Updates matched grants with the entity stableId
+  5. Reports unmatched names (can be added as manual overrides)
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -43,6 +43,7 @@
  *   audits      System-level behavioral verification (ongoing + post-merge)
  *   release     Production release management (create release PRs from main → production)
  *   import-grants Import external grant databases (Coefficient Giving, EA Funds)
+ *   backfill-grantee-ids Backfill granteeId with matched entity stableIds
  *   import-divisions Import curated organizational divisions
  *   import-funding-programs Import curated funding programs
  *   people       Person discovery and data tools (discover, enrich)
@@ -102,6 +103,7 @@ import * as kbCommands from './commands/kb.ts';
 import * as footnotesCommands from './commands/footnotes.ts';
 import * as agentWorkspaceCommands from './commands/agent-workspace.ts';
 import * as importGrantsCommands from './commands/import-grants.ts';
+import * as backfillGranteeIdsCommands from './commands/backfill-grantee-ids.ts';
 import * as importDivisionsCommands from './commands/import-divisions.ts';
 import * as importFundingProgramsCommands from './commands/import-funding-programs.ts';
 import * as peopleCommands from './commands/people.ts';
@@ -148,6 +150,7 @@ const domains = {
   footnotes: footnotesCommands,
   'agent-workspace': agentWorkspaceCommands,
   'import-grants': importGrantsCommands,
+  'backfill-grantee-ids': backfillGranteeIdsCommands,
   'import-divisions': importDivisionsCommands,
   'import-funding-programs': importFundingProgramsCommands,
   people: peopleCommands,
@@ -238,6 +241,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   footnotes        Footnote migration tools (migrate-cr)
   agent-workspace  Multi-agent directory management (setup, sync-env, list, clean)
   import-grants    Import external grant databases (Coefficient Giving, EA Funds)
+  backfill-grantee-ids  Backfill granteeId with matched entity stableIds
   import-divisions Import curated organizational divisions
   import-funding-programs Import curated funding programs
   people           Person discovery and data tools (discover, enrich)


### PR DESCRIPTION
## Summary

- Adds a new crux command (`pnpm crux backfill-grantee-ids run`) that retroactively updates existing grants where `granteeId` contains a display name (e.g. "OpenAI") instead of an entity stableId (e.g. "OwXl35e7bg")
- Adds two new wiki-server endpoints: `GET /api/grants/all-grantee-ids` for lightweight fetching and `PATCH /api/grants/batch-update-grantee` for batch updates
- Complements PR #2172 which fixed forward-going grant imports to write entity IDs

### How it works

1. Fetches all grant IDs and granteeId values via the new lightweight endpoint
2. Categorizes grants into: already-linked (10-char stableId), null, or display-name
3. Runs the existing entity matcher (manual overrides + name normalization from `entity-matcher.ts`) against display names
4. Updates matched grants via batch PATCH endpoint (batches of 200, within transactions)
5. Reports unmatched names sorted by frequency so they can be added as manual overrides

### Usage

```bash
pnpm crux backfill-grantee-ids run --dry-run   # Preview without writing
pnpm crux backfill-grantee-ids run             # Apply updates
WIKI_SERVER_ENV=prod pnpm crux backfill-grantee-ids run --dry-run  # Against prod
```

## Test plan

- [x] `pnpm build` succeeds (TypeScript compiles, all 2848 static pages generated)
- [x] `pnpm test` passes (137/138 test files; the 1 failure is a pre-existing timeout in `to-rdjsonl.test.ts`)
- [x] `pnpm crux backfill-grantee-ids --help` displays correct usage info
- [ ] Run with `--dry-run` against prod to verify matching works as expected
- [ ] Run without `--dry-run` to apply the backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)