### PR TITLE
Harden backfill endpoint: IS NULL guard, tests, validation

### DIFF
--- a/apps/wiki-server/src/__tests__/ids.test.ts
+++ b/apps/wiki-server/src/__tests__/ids.test.ts
@@ -64,6 +64,25 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [row];
   }
 
+  // UPDATE entity_ids SET stable_id = ... WHERE slug = ... AND stable_id IS NULL
+  // Must come before SELECT-by-slug since both match "entity_ids" + "where" + "slug"
+  if (q.includes("update") && q.includes("entity_ids") && q.includes("stable_id")) {
+    const stableId = params[0] as string;
+    const slug = params[1] as string;
+    const row = store.get(slug);
+    if (row && !row.stable_id) {
+      row.stable_id = stableId;
+      return [row];
+    }
+    return [];
+  }
+
+  // SELECT ... WHERE stable_id IS NULL
+  // Must come before SELECT-by-slug since both match "entity_ids" + "where"
+  if (q.includes("entity_ids") && q.includes("is null") && !q.includes("update")) {
+    return Array.from(store.values()).filter(r => !r.stable_id);
+  }
+
   // SELECT ... WHERE ... slug = $1
   if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
     const slug = params[0] as string;
@@ -79,23 +98,6 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       (a, b) => a.numeric_id - b.numeric_id
     );
     return all.slice(offset, offset + limit);
-  }
-
-  // UPDATE entity_ids SET stable_id = ... WHERE slug = ...
-  if (q.includes("update") && q.includes("entity_ids") && q.includes("stable_id")) {
-    const stableId = params[0] as string;
-    const slug = params[1] as string;
-    const row = store.get(slug);
-    if (row) {
-      row.stable_id = stableId;
-      return [row];
-    }
-    return [];
-  }
-
-  // SELECT ... WHERE stable_id IS NULL
-  if (q.includes("entity_ids") && q.includes("is null")) {
-    return Array.from(store.values()).filter(r => !r.stable_id);
   }
 
   // setval
@@ -295,6 +297,81 @@ describe("ID Server API", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.ids[0].stableId).toBeDefined();
+    });
+  });
+
+  describe("POST /api/ids/backfill-stable-ids", () => {
+    it("backfills stableIds for existing slugs", async () => {
+      await postJson(app, "/api/ids/allocate", { slug: "entity-a" });
+      await postJson(app, "/api/ids/allocate", { slug: "entity-b" });
+
+      // Clear auto-generated stableIds to simulate pre-existing rows
+      store.get("entity-a")!.stable_id = null;
+      store.get("entity-b")!.stable_id = null;
+
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [
+          { slug: "entity-a", stableId: "aaaaaaaaaa" },
+          { slug: "entity-b", stableId: "bbbbbbbbbb" },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updated).toBe(2);
+      expect(store.get("entity-a")!.stable_id).toBe("aaaaaaaaaa");
+      expect(store.get("entity-b")!.stable_id).toBe("bbbbbbbbbb");
+    });
+
+    it("does not overwrite existing stableIds", async () => {
+      await postJson(app, "/api/ids/allocate", { slug: "has-id" });
+      const originalStableId = store.get("has-id")!.stable_id;
+      expect(originalStableId).toBeTruthy();
+
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [{ slug: "has-id", stableId: "zzzzzzzzzz" }],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updated).toBe(0);
+      expect(store.get("has-id")!.stable_id).toBe(originalStableId);
+    });
+
+    it("generates stableIds for rows that still lack one when finalize=true", async () => {
+      await postJson(app, "/api/ids/allocate", { slug: "no-stable" });
+      store.get("no-stable")!.stable_id = null;
+
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [{ slug: "nonexistent-slug", stableId: "xxxxxxxxxx" }],
+        finalize: true,
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.totalMissing).toBe(1);
+      expect(body.generated).toBe(1);
+      expect(store.get("no-stable")!.stable_id).toBeTruthy();
+    });
+
+    it("rejects invalid stableId format", async () => {
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [{ slug: "test", stableId: "too-short" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects non-alphanumeric stableId", async () => {
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [{ slug: "test", stableId: "abc!!def!!" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns updated=0 for non-existent slugs", async () => {
+      const res = await postJson(app, "/api/ids/backfill-stable-ids", {
+        items: [{ slug: "does-not-exist", stableId: "aaaaaaaaaa" }],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updated).toBe(0);
     });
   });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -661,7 +661,7 @@ export interface ResourceListResult {
 export const SyncEntitySchema = z.object({
   id: z.string().min(1).max(300),
   numericId: z.string().max(20).nullable().optional(),
-  stableId: z.string().max(20).nullable().optional(),
+  stableId: z.string().regex(/^[A-Za-z0-9]{10}$/).nullable().optional(),
   entityType: z.string().min(1).max(100),
   title: z.string().min(1).max(500),
   description: z.string().max(50000).nullable().optional(),

--- a/apps/wiki-server/src/routes/ids.ts
+++ b/apps/wiki-server/src/routes/ids.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, sql, asc } from "drizzle-orm";
+import { eq, and, count, sql, asc } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 import { entityIds } from "../schema.js";
 import {
@@ -253,10 +253,11 @@ const idsApp = new Hono()
     if (items.length > 0) {
       await db.transaction(async (tx) => {
         for (const item of items) {
+          // Only set stableId if the row doesn't already have one
           const result = await tx
             .update(entityIds)
             .set({ stableId: item.stableId })
-            .where(eq(entityIds.slug, item.slug))
+            .where(and(eq(entityIds.slug, item.slug), sql`${entityIds.stableId} IS NULL`))
             .returning();
           if (result.length > 0) updated++;
         }
@@ -278,7 +279,7 @@ const idsApp = new Hono()
             await tx
               .update(entityIds)
               .set({ stableId: generateStableId() })
-              .where(eq(entityIds.slug, row.slug));
+              .where(and(eq(entityIds.slug, row.slug), sql`${entityIds.stableId} IS NULL`));
             generated++;
           }
         });

--- a/crux/commands/ids.ts
+++ b/crux/commands/ids.ts
@@ -157,7 +157,7 @@ async function listCommand(
   ];
 
   for (const entry of ids) {
-    const stableId = (entry as { stableId?: string | null }).stableId ?? '—';
+    const stableId = entry.stableId ?? '—';
     lines.push(`  ${entry.numericId.padEnd(8)} ${stableId.padEnd(12)} ${entry.slug}`);
   }
 


### PR DESCRIPTION
## Summary

Follow-up safety fixes from code review of #2178 that didn't make it into the merge:

- **Prevent stableId overwriting**: Add `AND stable_id IS NULL` guard to both the explicit backfill UPDATE and the finalize auto-generation UPDATE. Without this, re-running backfill or a race with `/allocate` could silently replace an existing stableId.
- **6 new backfill tests**: Basic backfill, no-overwrite protection, finalize auto-generation, invalid format rejection, non-alphanumeric rejection, missing slug handling.
- **Tighten SyncEntitySchema**: stableId validation changed from `.max(20)` to `.regex(/^[A-Za-z0-9]{10}$/)` to match the backfill endpoint's validation.
- **Remove type assertion**: `(entry as { stableId?: ... })` replaced with direct property access since RPC types already include `stableId`.

## Test plan

- [x] All 571 wiki-server tests pass (6 new backfill tests)
- [x] `tsc --noEmit` clean
- [x] No changes to migration or schema — purely logic + test fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)