### PR TITLE
refactor: remove dead claim-linking schemas from api-types

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -435,20 +435,6 @@ export interface PageCitationRow {
   createdAt: string;
 }
 
-// -- Citation linking types --------------------------------------------------
-
-export const LinkCitationClaimSchema = z.object({
-  claimId: z.number().int().positive(),
-});
-export type LinkCitationClaim = z.infer<typeof LinkCitationClaimSchema>;
-
-export const LinkCitationsClaimsBatchSchema = z.object({
-  items: z.array(z.object({
-    quoteId: z.number().int().positive(),
-    claimId: z.number().int().positive(),
-  })).min(1).max(200),
-});
-
 // ---------------------------------------------------------------------------
 // Page Links
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed `LinkCitationClaimSchema`, `LinkCitationClaim` type, and `LinkCitationsClaimsBatchSchema` from `apps/wiki-server/src/api-types.ts`
- These were part of the claims system archived in migration 0065 and are no longer imported anywhere

## Verification
- Searched entire codebase: no imports or references outside the definition site
- `tsc --noEmit` passes for both `apps/web` and `apps/wiki-server`

Agent slot: ${SLOT:-n/a}

🤖 Generated with [Claude Code](https://claude.com/claude-code)