### PR TITLE
feat: add topic filtering to people directory

### DIFF
--- a/apps/web/src/app/people/[slug]/expert-positions.tsx
+++ b/apps/web/src/app/people/[slug]/expert-positions.tsx
@@ -1,26 +1,5 @@
 import type { ExpertPosition } from "@/data/database";
-
-/** Human-readable labels for position topic slugs */
-const TOPIC_LABELS: Record<string, string> = {
-  "p-doom": "P(doom)",
-  timelines: "AGI Timelines",
-  "current-approaches-scale": "Current Approaches Scale",
-  "how-hard-is-alignment": "How Hard Is Alignment?",
-  "inner-alignment-solvability": "Inner Alignment Solvability",
-  "likelihood-of-deceptive-alignment": "Likelihood of Deceptive Alignment",
-  "would-misalignment-be-catastrophic": "Would Misalignment Be Catastrophic?",
-  "p-ai-catastrophe": "P(AI Catastrophe)",
-  "p-ai-x-risk-this-century": "P(AI X-Risk This Century)",
-  "how-fast-would-takeoff-be": "Takeoff Speed",
-  "will-advanced-ai-systems-be-deceptive":
-    "Will Advanced AI Be Deceptive?",
-  "will-we-get-adequate-warning-before-catastrophic-ai":
-    "Will We Get Adequate Warning?",
-};
-
-function topicLabel(topic: string): string {
-  return TOPIC_LABELS[topic] ?? topic.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
+import { topicLabel } from "@/data/topic-labels";
 
 const CONFIDENCE_STYLES: Record<string, string> = {
   high: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -42,6 +42,7 @@ export default function PeoplePage() {
     const slug = getKBEntitySlug(entity.id) ?? entity.id;
     const expert = getExpertById(slug);
     const positionCount = expert?.positions?.length ?? 0;
+    const topics = expert?.positions?.map((p) => p.topic) ?? [];
     const publicationCount = getPublicationsForPerson(slug).length;
 
     return {
@@ -60,6 +61,7 @@ export default function PeoplePage() {
       netWorthNum: numericValue(netWorthFact),
 
       positionCount,
+      topics,
       publicationCount,
       careerHistoryCount: careerHistory.length,
     };
@@ -72,6 +74,7 @@ export default function PeoplePage() {
   const withPositions = rows.filter((r) => r.positionCount > 0).length;
   const withPublications = rows.filter((r) => r.publicationCount > 0).length;
   const totalCareerEntries = rows.reduce((s, r) => s + r.careerHistoryCount, 0);
+  const uniqueTopics = new Set(rows.flatMap((r) => r.topics)).size;
 
   const stats = [
     { label: "People", value: String(rows.length) },
@@ -82,6 +85,7 @@ export default function PeoplePage() {
     { label: "With Expert Positions", value: String(withPositions) },
     { label: "With Publications", value: String(withPublications) },
     { label: "Career Entries", value: String(totalCareerEntries) },
+    { label: "Topics Covered", value: String(uniqueTopics) },
   ];
 
   return (
@@ -97,7 +101,7 @@ export default function PeoplePage() {
       </div>
 
       {/* Summary stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3 mb-8">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-9 gap-3 mb-8">
         {stats.map((stat) => (
           <ProfileStatCard key={stat.label} label={stat.label} value={stat.value} />
         ))}

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { topicLabel } from "@/data/topic-labels";
 
 export interface PersonRow {
   id: string;
@@ -22,6 +23,7 @@ export interface PersonRow {
   netWorthNum: number | null;
 
   positionCount: number;
+  topics: string[];
 
   publicationCount: number;
   careerHistoryCount: number;
@@ -42,6 +44,7 @@ type SortDir = "asc" | "desc";
 export function PeopleTable({ rows }: { rows: PersonRow[] }) {
   const [search, setSearch] = useState("");
   const [affiliationFilter, setAffiliationFilter] = useState<string>("all");
+  const [topicFilter, setTopicFilter] = useState<string>("all");
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -59,6 +62,18 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
       .slice(0, 10);
   }, [rows]);
 
+  // Collect all topics with person counts, sorted by count descending
+  const topicOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of rows) {
+      for (const t of r.topics) {
+        counts.set(t, (counts.get(t) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1]);
+  }, [rows]);
+
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -73,6 +88,10 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
 
     if (affiliationFilter !== "all") {
       result = result.filter((r) => r.employerName === affiliationFilter);
+    }
+
+    if (topicFilter !== "all") {
+      result = result.filter((r) => r.topics.includes(topicFilter));
     }
 
     if (search.trim()) {
@@ -123,43 +142,76 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
     });
 
     return result;
-  }, [rows, search, affiliationFilter, sortKey, sortDir]);
+  }, [rows, search, affiliationFilter, topicFilter, sortKey, sortDir]);
 
   return (
     <div>
       {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-5">
-        <input
-          type="text"
-          placeholder="Search people..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
-        />
-        {affiliations.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            <button
-              onClick={() => setAffiliationFilter("all")}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                affiliationFilter === "all"
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              All
-              <span className="ml-1 text-[10px] opacity-60">{rows.length}</span>
-            </button>
-            {affiliations.map(([name, count]) => (
+      <div className="flex flex-col gap-3 mb-5">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            type="text"
+            placeholder="Search people..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
+          />
+          {affiliations.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
               <button
-                key={name}
-                onClick={() => setAffiliationFilter(affiliationFilter === name ? "all" : name)}
+                onClick={() => setAffiliationFilter("all")}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                  affiliationFilter === name
+                  affiliationFilter === "all"
                     ? "bg-primary/10 border-primary/30 text-primary font-semibold"
                     : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
                 }`}
               >
-                {name}
+                All
+                <span className="ml-1 text-[10px] opacity-60">{rows.length}</span>
+              </button>
+              {affiliations.map(([name, count]) => (
+                <button
+                  key={name}
+                  onClick={() => setAffiliationFilter(affiliationFilter === name ? "all" : name)}
+                  className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                    affiliationFilter === name
+                      ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                      : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+                  }`}
+                >
+                  {name}
+                  <span className="ml-1 text-[10px] opacity-60">{count}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Topic filter */}
+        {topicOptions.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-muted-foreground font-medium mr-1">Topics:</span>
+            <button
+              onClick={() => setTopicFilter("all")}
+              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                topicFilter === "all"
+                  ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-700 dark:text-emerald-400 font-semibold"
+                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+              }`}
+            >
+              All Topics
+            </button>
+            {topicOptions.map(([slug, count]) => (
+              <button
+                key={slug}
+                onClick={() => setTopicFilter(topicFilter === slug ? "all" : slug)}
+                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                  topicFilter === slug
+                    ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-700 dark:text-emerald-400 font-semibold"
+                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+                }`}
+              >
+                {topicLabel(slug)}
                 <span className="ml-1 text-[10px] opacity-60">{count}</span>
               </button>
             ))}

--- a/apps/web/src/data/topic-labels.ts
+++ b/apps/web/src/data/topic-labels.ts
@@ -1,0 +1,27 @@
+/** Human-readable labels for expert position topic slugs.
+ *
+ * Shared between the people directory and individual expert-positions component.
+ */
+export const TOPIC_LABELS: Record<string, string> = {
+  "p-doom": "P(doom)",
+  timelines: "AGI Timelines",
+  "current-approaches-scale": "Current Approaches Scale",
+  "how-hard-is-alignment": "How Hard Is Alignment?",
+  "inner-alignment-solvability": "Inner Alignment Solvability",
+  "likelihood-of-deceptive-alignment": "Likelihood of Deceptive Alignment",
+  "would-misalignment-be-catastrophic": "Would Misalignment Be Catastrophic?",
+  "p-ai-catastrophe": "P(AI Catastrophe)",
+  "p-ai-x-risk-this-century": "P(AI X-Risk This Century)",
+  "how-fast-would-takeoff-be": "Takeoff Speed",
+  "will-advanced-ai-systems-be-deceptive": "Will Advanced AI Be Deceptive?",
+  "will-we-get-adequate-warning-before-catastrophic-ai":
+    "Will We Get Adequate Warning?",
+};
+
+/** Convert a topic slug to a human-readable label, falling back to title-case. */
+export function topicLabel(topic: string): string {
+  return (
+    TOPIC_LABELS[topic] ??
+    topic.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `TOPIC_LABELS` and `topicLabel()` to a shared module (`apps/web/src/data/topic-labels.ts`) so both the people directory and individual expert-positions pages use the same source of truth
- Add topic filter chips to the people directory table — users can click a topic (e.g., "P(doom)", "AGI Timelines") to show only people who have stated positions on that topic
- Add `topics: string[]` to `PersonRow` and pass it from the server component to the client table
- Add a "Topics Covered" stat card showing the count of unique topics across all people
- Topic filters use a distinct emerald color scheme to visually differentiate them from the existing affiliation filters
- Filters compose: users can combine search, affiliation, and topic filters simultaneously

Agent slot: a$(echo ${SLOT:-5})

## Test plan
- [ ] Verify the people directory page loads without errors
- [ ] Click a topic chip and confirm the table filters to only people with positions on that topic
- [ ] Combine topic filter with affiliation filter and search — all three should compose correctly
- [ ] Verify the "Topics Covered" stat card shows the correct count
- [ ] Verify the expert-positions component on individual person pages still renders correctly (uses shared `topicLabel`)
- [ ] Confirm "All Topics" button resets the topic filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added topic-based filtering for people directory with dedicated filter controls
  * Introduced "Topics Covered" metric displaying the total number of unique topics across experts
  * Improved topic label display with human-readable formatting

* **Improvements**
  * Adjusted summary grid layout for better responsive design across viewports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->