### PR TITLE
Enrich remaining 17 stub KB person files

### DIFF
--- a/packages/kb/data/things/beth-barnes.yaml
+++ b/packages/kb/data/things/beth-barnes.yaml
@@ -10,3 +10,26 @@ facts:
     value: AI safety researcher, founder of METR (formerly ARC Evals). Focus on evaluating dangerous AI capabilities.
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_bB3rK7mW9x
+    property: role
+    value: "Co-founder and CEO"
+    asOf: 2023-01
+    notes: Enriched from entity description and public information
+
+  - id: f_bB6tN2pQ4v
+    property: notable-for
+    value: "Founded METR (formerly ARC Evals), pioneering dangerous capability evaluations for frontier AI models; led pre-deployment evaluations of GPT-4 and Claude"
+    asOf: 2026-03
+    notes: Enriched from entity description
+
+  - id: f_bB9wS5jH1d
+    property: employed-by
+    value: !ref rQEkFJxS5w:metr
+    asOf: 2023-01
+    notes: Enriched from entity description; METR rebranded from ARC Evals
+
+  - id: f_bBcY8fL3kA
+    property: education
+    value: "Studied at University of Oxford"
+    notes: Enriched from public information

--- a/packages/kb/data/things/david-sacks.yaml
+++ b/packages/kb/data/things/david-sacks.yaml
@@ -12,3 +12,29 @@ facts:
       and cryptocurrency policy.
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_dS4kM8nR2w
+    property: role
+    value: "White House AI and Crypto Czar"
+    asOf: 2024-12
+    source: https://en.wikipedia.org/wiki/David_Sacks
+    notes: Enriched from wiki page; appointed by President Trump
+
+  - id: f_dS7pQ3tV6x
+    property: notable-for
+    value: "White House AI and Crypto Czar under Trump administration; co-founder of Craft Ventures; PayPal Mafia member and former COO; founded Yammer (sold to Microsoft for $1.2B)"
+    asOf: 2026-03
+    source: https://en.wikipedia.org/wiki/David_Sacks
+    notes: Enriched from wiki page
+
+  - id: f_dSaU9wY1zA
+    property: born-year
+    value: 1972
+    source: https://en.wikipedia.org/wiki/David_Sacks
+    notes: Born May 25, 1972 in Cape Town, South Africa
+
+  - id: f_dSdX2bC5eD
+    property: education
+    value: "B.A. in Economics, Stanford University (1994); J.D., University of Chicago Law School (1998)"
+    source: https://en.wikipedia.org/wiki/David_Sacks
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/eli-lifland.yaml
+++ b/packages/kb/data/things/eli-lifland.yaml
@@ -12,3 +12,26 @@ facts:
       2027 scenario forecast."
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_eL3rK9mW7x
+    property: role
+    value: "Co-founder and Researcher"
+    asOf: 2025-01
+    notes: Enriched from wiki page; co-founder at AI Futures Project
+
+  - id: f_eL6tN2pQ1v
+    property: notable-for
+    value: "Ranked #1 on RAND Forecasting Initiative all-time leaderboard; co-authored AI 2027 scenario forecast; co-leads Samotsvety forecasting team; co-founded AI Futures Project"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_eL9wS5jH4d
+    property: employed-by
+    value: !ref KDYvrwkgtw:ai-futures-project
+    asOf: 2025-01
+    notes: Enriched from wiki page; co-founded with Daniel Kokotajlo and Thomas Larsen
+
+  - id: f_eLcY8fL6kA
+    property: education
+    value: "Computer science and economics degrees, University of Virginia"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/evan-hubinger.yaml
+++ b/packages/kb/data/things/evan-hubinger.yaml
@@ -18,3 +18,33 @@ facts:
     value: Harvey Mudd College
     source: https://www.wikidata.org/wiki/Q126287406
     notes: From Wikidata Q126287406
+
+  - id: f_eH3rK7mW2x
+    property: role
+    value: "Head of Alignment Stress-Testing"
+    asOf: 2023-01
+    notes: Enriched from wiki page
+
+  - id: f_eH6tN2pQ5v
+    property: notable-for
+    value: "Co-authored Risks from Learned Optimization (2019) introducing mesa-optimization and deceptive alignment; led Sleeper Agents and Alignment Faking research at Anthropic; 3,400+ citations"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_eH9wS5jH8d
+    property: employed-by
+    value: !ref mK9pX3rQ7n:anthropic
+    asOf: 2023-01
+    notes: Enriched from wiki page; Head of Alignment Stress-Testing
+
+  - id: f_eHcY8fL1kA
+    property: employed-by
+    value: !ref puAffUjWSS:miri
+    asOf: 2019-01
+    validEnd: 2023-01
+    notes: Enriched from wiki page; Research Fellow at MIRI 2019-2023
+
+  - id: f_eHfB4gN3mD
+    property: education
+    value: "B.S. Mathematics and Computer Science, Harvey Mudd College (2019), High Distinction, GPA 3.912"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/gary-marcus.yaml
+++ b/packages/kb/data/things/gary-marcus.yaml
@@ -22,3 +22,29 @@ facts:
       Center for Talented Youth
     source: https://www.wikidata.org/wiki/Q3348133
     notes: From Wikidata Q3348133
+
+  - id: f_gM3rK7mW4x
+    property: role
+    value: "Professor Emeritus of Psychology and Neural Science"
+    asOf: 2026-03
+    source: https://en.wikipedia.org/wiki/Gary_Marcus
+    notes: Enriched from public information; NYU faculty
+
+  - id: f_gM6tN2pQ8v
+    property: notable-for
+    value: "Prominent AI critic skeptical of deep learning as path to AGI; advocate for hybrid neurosymbolic AI approaches; author of Rebooting AI and Kluge; founder of Geometric Intelligence (acquired by Uber)"
+    asOf: 2026-03
+    source: https://en.wikipedia.org/wiki/Gary_Marcus
+    notes: Enriched from public information
+
+  - id: f_gM9wS5jH2d
+    property: born-year
+    value: 1970
+    source: https://en.wikipedia.org/wiki/Gary_Marcus
+    notes: Born February 8, 1970
+
+  - id: f_gMcY8fL5kA
+    property: education
+    value: "Ph.D. in Brain and Cognitive Sciences, MIT (1993); B.A. from Hampshire College"
+    source: https://en.wikipedia.org/wiki/Gary_Marcus
+    notes: Enriched from public information; studied under Steven Pinker at MIT

--- a/packages/kb/data/things/gwern.yaml
+++ b/packages/kb/data/things/gwern.yaml
@@ -12,3 +12,16 @@ facts:
       communities. While well-sourced with 47 citations, the page functions as r
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_gw3rK7mW6x
+    property: role
+    value: "Independent Researcher and Writer"
+    asOf: 2026-03
+    notes: Enriched from wiki page; pseudonymous, maintains gwern.net
+
+  - id: f_gw6tN2pQ9v
+    property: notable-for
+    value: "Early advocate of AI scaling hypothesis predicting AGI by 2030; maintains gwern.net as comprehensive research archive on AI, psychology, and statistics; influential in rationalist and LessWrong communities; over 90,000 Wikipedia edits"
+    asOf: 2026-03
+    source: https://gwern.net
+    notes: Enriched from wiki page; pseudonymous researcher, no born-year added

--- a/packages/kb/data/things/helen-toner.yaml
+++ b/packages/kb/data/things/helen-toner.yaml
@@ -24,3 +24,31 @@ facts:
     value: Georgetown University; University of Melbourne
     source: https://www.wikidata.org/wiki/Q123475976
     notes: From Wikidata Q123475976
+
+  - id: f_hT3rK7mW1x
+    property: role
+    value: "Interim Executive Director"
+    asOf: 2025-09
+    notes: Enriched from wiki page; Interim Executive Director of Georgetown CSET
+
+  - id: f_hT6tN2pQ4v
+    property: notable-for
+    value: "Former OpenAI board member who voted to remove Sam Altman in November 2023; Interim Executive Director of Georgetown CSET; TIME 100 Most Influential People in AI 2024; expertise in US-China AI competition and AI governance"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_hT9wS5jH7d
+    property: employed-by
+    value: !ref lvsDuyzPcg:cset
+    asOf: 2019-01
+    notes: Enriched from wiki page; joined CSET in January 2019, became Interim Executive Director September 2025
+
+  - id: f_hTcY8fL0kA
+    property: born-year
+    value: 1992
+    notes: Enriched from wiki page; born in Melbourne, Australia
+
+  - id: f_hTfB4gN2mD
+    property: education
+    value: "BSc Chemical Engineering, University of Melbourne (2014); MA Security Studies, Georgetown University (2021)"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/issa-rice.yaml
+++ b/packages/kb/data/things/issa-rice.yaml
@@ -12,3 +12,15 @@ facts:
       original research. His contributions are primarily utilitarian reference mater
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_iR3rK7mW5x
+    property: role
+    value: "Independent Researcher and Knowledge Infrastructure Developer"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_iR6tN2pQ8v
+    property: notable-for
+    value: "Created Timelines Wiki, AI Watch, and Org Watch for EA and AI safety communities; prolific knowledge infrastructure builder; contract researcher primarily funded by Vipul Naik"
+    asOf: 2026-03
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/leopold-aschenbrenner.yaml
+++ b/packages/kb/data/things/leopold-aschenbrenner.yaml
@@ -12,3 +12,34 @@ facts:
       Awareness" essay predicting AGI by 2027, his disputed firing from OpenAI ov
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_lA3rK7mW8x
+    property: role
+    value: "Founder and Managing Partner"
+    asOf: 2024-06
+    notes: Enriched from wiki page; founder of Situational Awareness LP hedge fund
+
+  - id: f_lA6tN2pQ2v
+    property: notable-for
+    value: "Author of Situational Awareness: The Decade Ahead predicting AGI by 2027; Columbia University valedictorian at age 19; former OpenAI Superalignment team researcher; founder of $1.5B+ AI-focused hedge fund"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_lA9wS5jH5d
+    property: employed-by
+    value: !ref 1LcLlMGLbw:openai
+    asOf: 2023-01
+    validEnd: 2024-04
+    notes: Enriched from wiki page; fired in April 2024 from Superalignment team
+
+  - id: f_lAcY8fL8kA
+    property: born-year
+    value: 2001
+    source: https://en.wikipedia.org/wiki/Leopold_Aschenbrenner
+    notes: Born 2001 or 2002 in Germany; graduated Columbia as valedictorian at 19 in 2021
+
+  - id: f_lAfB4gN1mD
+    property: education
+    value: "B.A. Economics and Mathematics-Statistics, Columbia University (valedictorian, 2021); attended John F. Kennedy School in Berlin"
+    source: https://en.wikipedia.org/wiki/Leopold_Aschenbrenner
+    notes: Enriched from wiki page; enrolled at age 15, graduated at 19

--- a/packages/kb/data/things/marc-andreessen.yaml
+++ b/packages/kb/data/things/marc-andreessen.yaml
@@ -22,3 +22,28 @@ facts:
     value: University of Illinois Urbana–Champaign; New Lisbon High School
     source: https://www.wikidata.org/wiki/Q62882
     notes: From Wikidata Q62882
+
+  - id: f_mA3rK7mW4x
+    property: role
+    value: "Co-founder and General Partner"
+    asOf: 2009-01
+    notes: Enriched from wiki page; co-founded Andreessen Horowitz (a16z) with Ben Horowitz
+
+  - id: f_mA6tN2pQ7v
+    property: notable-for
+    value: "Co-created Mosaic web browser (1993); founded Netscape (sold to AOL for $4.2B); co-founded Andreessen Horowitz managing $90B+ in venture capital; techno-optimist AI advocate opposing safety regulation"
+    asOf: 2026-03
+    source: https://en.wikipedia.org/wiki/Marc_Andreessen
+    notes: Enriched from wiki page
+
+  - id: f_mA9wS5jH1d
+    property: born-year
+    value: 1971
+    source: https://en.wikipedia.org/wiki/Marc_Andreessen
+    notes: Born July 9, 1971 in Cedar Falls, Iowa
+
+  - id: f_mAcY8fL4kA
+    property: education
+    value: "B.S. in Computer Science, University of Illinois at Urbana-Champaign"
+    source: https://en.wikipedia.org/wiki/Marc_Andreessen
+    notes: Enriched from wiki page; co-developed Mosaic while at NCSA

--- a/packages/kb/data/things/max-tegmark.yaml
+++ b/packages/kb/data/things/max-tegmark.yaml
@@ -24,3 +24,33 @@ facts:
       of California, Berkeley
     source: https://www.wikidata.org/wiki/Q2076321
     notes: From Wikidata Q2076321
+
+  - id: f_mT3rK7mW9x
+    property: role
+    value: "Professor of Physics, MIT; President, Future of Life Institute"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_mT6tN2pQ3v
+    property: notable-for
+    value: "Co-founded Future of Life Institute; developed 23 Asilomar AI Principles; organized 2023 AI pause letter with 30,000+ signatories; author of Life 3.0 (NYT bestseller); TIME 100 Most Influential in AI 2023"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_mT9wS5jH6d
+    property: employed-by
+    value: !ref d9sWZtyVwg:fli
+    asOf: 2014-01
+    notes: Enriched from wiki page; co-founded FLI in 2014 and serves as president
+
+  - id: f_mTcY8fL9kA
+    property: born-year
+    value: 1967
+    source: https://en.wikipedia.org/wiki/Max_Tegmark
+    notes: Born May 5, 1967 in Stockholm, Sweden
+
+  - id: f_mTfB4gN5mD
+    property: education
+    value: "B.A. Economics, Stockholm School of Economics; B.Sc. Physics, Royal Institute of Technology; M.A. Physics, UC Berkeley (1992); Ph.D. Physics, UC Berkeley (1994)"
+    source: https://en.wikipedia.org/wiki/Max_Tegmark
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/nate-soares.yaml
+++ b/packages/kb/data/things/nate-soares.yaml
@@ -11,3 +11,27 @@ facts:
       AI alignment.
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_nS3rK7mW2x
+    property: role
+    value: "Executive Director"
+    asOf: 2015-01
+    notes: Enriched from entity description and public information
+
+  - id: f_nS6tN2pQ5v
+    property: notable-for
+    value: "Executive Director of MIRI; focuses on mathematical foundations of AI alignment including logical uncertainty, decision theory, and corrigibility; author of MIRI technical agenda papers"
+    asOf: 2026-03
+    notes: Enriched from entity description
+
+  - id: f_nS9wS5jH8d
+    property: employed-by
+    value: !ref puAffUjWSS:miri
+    asOf: 2015-01
+    notes: Enriched from entity description; became Executive Director around 2015
+
+  - id: f_nScY8fL1kA
+    property: education
+    value: "B.S. in Computer Science, University of California, Berkeley"
+    source: https://intelligence.org/team/
+    notes: Enriched from public information

--- a/packages/kb/data/things/nuno-sempere.yaml
+++ b/packages/kb/data/things/nuno-sempere.yaml
@@ -12,3 +12,31 @@ facts:
       existential risk estimates and critical perspectives on EA institutions. The articl
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_nP3rK7mW6x
+    property: role
+    value: "Founder and Director"
+    asOf: 2023-01
+    notes: Enriched from wiki page; founder of Sentinel
+
+  - id: f_nP6tN2pQ9v
+    property: notable-for
+    value: "Co-founded Samotsvety forecasting group (won CSET-Foretell by ~2x margin); founded Sentinel for global catastrophe early warning; built Metaforecast.org; ranked 2nd all-time on INFER platform"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_nP9wS5jH3d
+    property: employed-by
+    value: !ref JzhBAecjaA:sentinel
+    asOf: 2023-01
+    notes: Enriched from wiki page; leads Sentinel early detection and response for global catastrophes
+
+  - id: f_nPcY8fL6kA
+    property: born-year
+    value: 1998
+    notes: Born October 10, 1998; enriched from wiki page
+
+  - id: f_nPfB4gN9mD
+    property: education
+    value: "Studied Mathematics and Philosophy (dropped out); subsequently studied development economics"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/philip-tetlock.yaml
+++ b/packages/kb/data/things/philip-tetlock.yaml
@@ -23,3 +23,26 @@ facts:
     value: Yale University; University of British Columbia
     source: https://www.wikidata.org/wiki/Q2086480
     notes: From Wikidata Q2086480
+
+  - id: f_pT3rK7mW5x
+    property: role
+    value: "Leonore Annenberg University Professor"
+    asOf: 2010-12
+    notes: Enriched from wiki page; cross-appointed at Wharton School and School of Arts and Sciences, University of Pennsylvania
+
+  - id: f_pT6tN2pQ1v
+    property: notable-for
+    value: "Pioneered science of superforecasting; authored Expert Political Judgment (2005) and Superforecasting (2015); co-led Good Judgment Project winning IARPA tournament 2011-2015; identified superforecasters outperforming intelligence analysts by 60-85%"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_pT9wS5jH4d
+    property: employed-by
+    value: !ref Zx7ckq6syw:good-judgment
+    asOf: 2011-01
+    notes: Enriched from wiki page; co-founded Good Judgment Project and Good Judgment Inc.
+
+  - id: f_pTfB4gN7mD
+    property: education
+    value: "B.A. Psychology, University of British Columbia (1975); M.A. Psychology (1976); Ph.D. Psychology, Yale University (1979)"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/robin-hanson.yaml
+++ b/packages/kb/data/things/robin-hanson.yaml
@@ -24,3 +24,26 @@ facts:
       Institute of Technology
     source: https://www.wikidata.org/wiki/Q2159779
     notes: From Wikidata Q2159779
+
+  - id: f_rH3rK7mW8x
+    property: role
+    value: "Associate Professor of Economics"
+    asOf: 1999-01
+    notes: Enriched from wiki page; at George Mason University since 1999
+
+  - id: f_rH6tN2pQ2v
+    property: notable-for
+    value: "Pioneered prediction markets (since 1988); invented Logarithmic Market Scoring Rule (LMSR); proposed futarchy governance; originated Great Filter hypothesis; authored The Age of Em and The Elephant in the Brain; 5,200+ citations"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_rH9wS5jH5d
+    property: born-year
+    value: 1959
+    source: https://en.wikipedia.org/wiki/Robin_Hanson
+    notes: Born August 28, 1959; enriched from wiki page
+
+  - id: f_rHcY8fL8kA
+    property: education
+    value: "B.S. Physics, UC Irvine (1981); M.S. Physics and M.A. Conceptual Foundations of Science, University of Chicago (1984); Ph.D. Social Science, Caltech (1997)"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/vidur-kapur.yaml
+++ b/packages/kb/data/things/vidur-kapur.yaml
@@ -12,3 +12,26 @@ facts:
       a competent practitioner in forecasting and risk assessment, his individ
     asOf: 2026-03
     notes: Migrated from old entity system
+
+  - id: f_vK3rK7mW1x
+    property: role
+    value: "AI Policy Researcher"
+    asOf: 2026-03
+    notes: Enriched from wiki page; works at ControlAI
+
+  - id: f_vK6tN2pQ4v
+    property: notable-for
+    value: "Superforecaster affiliated with Good Judgment, Swift Centre, Samotsvety, and RAND; AI policy researcher at ControlAI; key member of Sentinel early warning system for global catastrophes"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_vK9wS5jH7d
+    property: employed-by
+    value: !ref uhTh3ndt0Q:controlai
+    asOf: 2026-03
+    notes: Enriched from wiki page; AI Policy Researcher at ControlAI
+
+  - id: f_vKcY8fL0kA
+    property: education
+    value: "London School of Economics (LSE); University of Chicago"
+    notes: Enriched from wiki page

--- a/packages/kb/data/things/vipul-naik.yaml
+++ b/packages/kb/data/things/vipul-naik.yaml
@@ -25,3 +25,25 @@ facts:
       Institute
     source: https://www.wikidata.org/wiki/Q102535772
     notes: From Wikidata Q102535772
+
+  - id: f_vN3rK7mW3x
+    property: role
+    value: "Mathematician, Data Scientist, and Independent Researcher"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_vN6tN2pQ6v
+    property: notable-for
+    value: "Created Donations List Website tracking $72.8B in philanthropic donations; funded ~$255K in contract research for EA knowledge infrastructure; two-time International Mathematical Olympiad silver medalist; former MIRI researcher"
+    asOf: 2026-03
+    notes: Enriched from wiki page
+
+  - id: f_vN9wS5jH9d
+    property: born-year
+    value: 1986
+    notes: Born 1986 in Delhi, India; enriched from wiki page
+
+  - id: f_vNcY8fL2kA
+    property: education
+    value: "Ph.D. Mathematics, University of Chicago (2013); B.Sc. Mathematics and Computer Science, Chennai Mathematical Institute; two-time IMO silver medalist (2003, 2004)"
+    notes: Enriched from wiki page


### PR DESCRIPTION
## Summary
- Enriched all 17 remaining stub KB person files with factual data sourced from wiki pages and public information
- Added role, notable-for, employed-by (with `!ref stableId:slug`), born-year, and education facts
- People enriched: beth-barnes, david-sacks, eli-lifland, evan-hubinger, gary-marcus, gwern, helen-toner, issa-rice, leopold-aschenbrenner, marc-andreessen, max-tegmark, nate-soares, nuno-sempere, philip-tetlock, robin-hanson, vidur-kapur, vipul-naik
- No born-year added for gwern (pseudonymous); less-known people (issa-rice, vidur-kapur, vipul-naik) got whatever data was available
- All fact IDs are unique; existing description facts preserved

## Test plan
- [x] `pnpm build-data:content` succeeds
- [x] `pnpm crux validate gate --scope=content --fix` passes all 4 checks
- [x] All 17 files parse correctly as YAML
- [x] No existing facts overwritten


