### PR TITLE
feat: add people coverage dashboard

### DIFF
--- a/apps/web/src/app/internal/people-coverage/page.tsx
+++ b/apps/web/src/app/internal/people-coverage/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function PeopleCoveragePage() {
+  redirect("/wiki/E1099");
+}

--- a/apps/web/src/app/internal/people-coverage/people-coverage-content.tsx
+++ b/apps/web/src/app/internal/people-coverage/people-coverage-content.tsx
@@ -1,0 +1,207 @@
+import {
+  getTypedEntities,
+  isPerson,
+  getAllExperts,
+  getAllPages,
+  getIdRegistry,
+} from "@/data";
+import { getKBFacts } from "@/data/kb";
+import { PeopleCoverageTable, type PersonCoverageRow } from "./people-coverage-table";
+
+/** Check whether a person entity has a wiki page. */
+function personHasPage(
+  personId: string,
+  pageIds: Set<string>,
+  slugToNumeric: Record<string, string>,
+): boolean {
+  if (pageIds.has(personId)) return true;
+  const numericId = slugToNumeric[personId];
+  return numericId ? pageIds.has(numericId) : false;
+}
+
+export function PeopleCoverageContent() {
+  // 1. Collect all person entities
+  const allEntities = getTypedEntities();
+  const people = allEntities.filter(isPerson);
+
+  // 2. Build expert index for positions lookup
+  const experts = getAllExperts();
+  const expertById = new Map(experts.map((e) => [e.id, e]));
+
+  // 3. Build page ID set
+  const pages = getAllPages();
+  const pageIdSet = new Set(pages.map((p) => p.id));
+
+  // 4. Build slug → numericId mapping
+  const idRegistry = getIdRegistry();
+
+  // 5. Build rows
+  const rows: PersonCoverageRow[] = people.map((person) => {
+    const kbFacts = getKBFacts(person.id);
+    const expert = expertById.get(person.id);
+
+    // KB fact property checks
+    const hasRole = kbFacts.some((f) => f.propertyId === "role");
+    const hasEmployer = kbFacts.some((f) => f.propertyId === "employed-by");
+    const hasBornYear = kbFacts.some((f) => f.propertyId === "born-year");
+    const hasNotableFor = kbFacts.some((f) => f.propertyId === "notable-for");
+
+    // Fall back to entity-level data if KB facts are missing
+    const hasRoleFallback = hasRole || !!person.role;
+    const hasEmployerFallback =
+      hasEmployer || !!person.affiliation;
+
+    // Expert positions
+    const hasExpertPositions =
+      (expert?.positions && expert.positions.length > 0) || false;
+
+    // Wiki page
+    const hasWikiPage = personHasPage(person.id, pageIdSet, idRegistry.bySlug);
+
+    // Career history: multiple employed-by facts indicate career history
+    const employedByFacts = kbFacts.filter(
+      (f) => f.propertyId === "employed-by",
+    );
+    const hasCareerHistory = employedByFacts.length >= 2;
+
+    // Compute completeness score (out of 8 fields)
+    const fields = [
+      hasRoleFallback,
+      hasEmployerFallback,
+      hasBornYear,
+      hasNotableFor,
+      hasExpertPositions,
+      hasWikiPage,
+      hasCareerHistory,
+      kbFacts.length > 0, // Has any KB facts at all
+    ];
+    const completenessScore = fields.filter(Boolean).length;
+
+    return {
+      id: person.id,
+      numericId: person.numericId ?? idRegistry.bySlug[person.id] ?? "",
+      name: person.title,
+      hasRole: hasRoleFallback,
+      hasEmployer: hasEmployerFallback,
+      hasBornYear,
+      hasNotableFor,
+      hasExpertPositions,
+      hasWikiPage,
+      hasCareerHistory,
+      hasKBFacts: kbFacts.length > 0,
+      kbFactCount: kbFacts.length,
+      completenessScore,
+      totalFields: 8,
+    };
+  });
+
+  // Sort ascending by completeness (least complete first)
+  rows.sort((a, b) => a.completenessScore - b.completenessScore);
+
+  // Compute summary stats
+  const total = rows.length;
+  const pct = (count: number) =>
+    total > 0 ? Math.round((count / total) * 100) : 0;
+
+  const withRole = rows.filter((r) => r.hasRole).length;
+  const withEmployer = rows.filter((r) => r.hasEmployer).length;
+  const withBornYear = rows.filter((r) => r.hasBornYear).length;
+  const withNotableFor = rows.filter((r) => r.hasNotableFor).length;
+  const withExpertPositions = rows.filter((r) => r.hasExpertPositions).length;
+  const withWikiPage = rows.filter((r) => r.hasWikiPage).length;
+  const withCareerHistory = rows.filter((r) => r.hasCareerHistory).length;
+  const withKBFacts = rows.filter((r) => r.hasKBFacts).length;
+
+  const avgCompleteness =
+    total > 0
+      ? Math.round(
+          (rows.reduce((sum, r) => sum + r.completenessScore, 0) / total / 8) *
+            100,
+        )
+      : 0;
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Data completeness overview for {total} person entities. Shows which
+        people have complete structured data across KB facts, expert positions,
+        wiki pages, and career history. Sorted by completeness (least complete
+        first) to prioritize data gaps.
+      </p>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
+        <StatCard label="Total People" value={total.toString()} />
+        <StatCard label="Avg Completeness" value={`${avgCompleteness}%`} />
+        <StatCard
+          label="With Wiki Page"
+          value={`${withWikiPage} (${pct(withWikiPage)}%)`}
+        />
+        <StatCard
+          label="With KB Facts"
+          value={`${withKBFacts} (${pct(withKBFacts)}%)`}
+        />
+      </div>
+
+      {/* Detailed coverage stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 my-4">
+        <MiniStat label="Has Role" count={withRole} total={total} />
+        <MiniStat label="Has Employer" count={withEmployer} total={total} />
+        <MiniStat label="Has Born Year" count={withBornYear} total={total} />
+        <MiniStat label="Has Notable For" count={withNotableFor} total={total} />
+        <MiniStat
+          label="Has Expert Positions"
+          count={withExpertPositions}
+          total={total}
+        />
+        <MiniStat label="Has Wiki Page" count={withWikiPage} total={total} />
+        <MiniStat
+          label="Has Career History"
+          count={withCareerHistory}
+          total={total}
+        />
+        <MiniStat label="Has Any KB Facts" count={withKBFacts} total={total} />
+      </div>
+
+      <PeopleCoverageTable data={rows} />
+    </>
+  );
+}
+
+// ── Helper Components ────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function MiniStat({
+  label,
+  count,
+  total,
+}: {
+  label: string;
+  count: number;
+  total: number;
+}) {
+  const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+  const color =
+    pct >= 75
+      ? "text-emerald-600"
+      : pct >= 50
+        ? "text-amber-600"
+        : "text-red-500";
+
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border/40 px-3 py-2">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className={`text-sm font-semibold tabular-nums ${color}`}>
+        {count}/{total} ({pct}%)
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/people-coverage/people-coverage-table.tsx
+++ b/apps/web/src/app/internal/people-coverage/people-coverage-table.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+
+export interface PersonCoverageRow {
+  id: string;
+  numericId: string;
+  name: string;
+  hasRole: boolean;
+  hasEmployer: boolean;
+  hasBornYear: boolean;
+  hasNotableFor: boolean;
+  hasExpertPositions: boolean;
+  hasWikiPage: boolean;
+  hasCareerHistory: boolean;
+  hasKBFacts: boolean;
+  kbFactCount: number;
+  completenessScore: number;
+  totalFields: number;
+}
+
+// ── Cell renderers ─────────────────────────────────────────────────────
+
+function BoolIcon({ value, label }: { value: boolean; label: string }) {
+  return value ? (
+    <span className="text-emerald-500 text-sm font-bold" title={label}>
+      ✓
+    </span>
+  ) : (
+    <span className="text-red-400/60 text-sm" title={label}>
+      ✗
+    </span>
+  );
+}
+
+function ScoreBadge({ score, total }: { score: number; total: number }) {
+  const pct = score / total;
+  const color =
+    pct >= 0.75
+      ? "bg-emerald-500/15 text-emerald-600"
+      : pct >= 0.5
+        ? "bg-amber-500/15 text-amber-600"
+        : "bg-red-500/15 text-red-600";
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] tabular-nums font-bold ${color}`}
+    >
+      {score}/{total}
+    </span>
+  );
+}
+
+// ── Column definitions ─────────────────────────────────────────────────
+
+const columns: ColumnDef<PersonCoverageRow>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Person name">
+        Name
+      </SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const { numericId, name, hasWikiPage } = row.original;
+      if (hasWikiPage && numericId) {
+        return (
+          <Link
+            href={`/wiki/${numericId}`}
+            className="text-sm font-medium text-accent-foreground hover:underline no-underline max-w-[200px] truncate block"
+          >
+            {name}
+          </Link>
+        );
+      }
+      return (
+        <span className="text-sm font-medium text-muted-foreground max-w-[200px] truncate block">
+          {name}
+        </span>
+      );
+    },
+    filterFn: "includesString",
+    size: 200,
+  },
+  {
+    accessorKey: "hasRole",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Has role in KB facts or entity data">
+        Role
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasRole} label="Has Role" />
+    ),
+  },
+  {
+    accessorKey: "hasEmployer",
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        title="Has employed-by in KB facts or affiliation in entity"
+      >
+        Employer
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasEmployer} label="Has Employer" />
+    ),
+  },
+  {
+    accessorKey: "hasBornYear",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Has born-year KB fact">
+        Born
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasBornYear} label="Has Born Year" />
+    ),
+  },
+  {
+    accessorKey: "hasNotableFor",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Has notable-for KB fact">
+        Notable
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasNotableFor} label="Has Notable For" />
+    ),
+  },
+  {
+    accessorKey: "hasExpertPositions",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Has expert positions in experts.yaml">
+        Positions
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon
+        value={row.original.hasExpertPositions}
+        label="Has Expert Positions"
+      />
+    ),
+  },
+  {
+    accessorKey: "hasWikiPage",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Has a wiki page in content/docs/">
+        Page
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasWikiPage} label="Has Wiki Page" />
+    ),
+  },
+  {
+    accessorKey: "hasCareerHistory",
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        title="Has 2+ employed-by KB facts (career history)"
+      >
+        Career
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <BoolIcon value={row.original.hasCareerHistory} label="Has Career History" />
+    ),
+  },
+  {
+    accessorKey: "kbFactCount",
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Total KB facts for this person">
+        Facts
+      </SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const count = row.original.kbFactCount;
+      const color =
+        count >= 5
+          ? "text-emerald-600"
+          : count >= 2
+            ? "text-amber-600"
+            : count > 0
+              ? "text-blue-500"
+              : "text-muted-foreground/30";
+      return (
+        <span className={`text-xs tabular-nums font-medium ${color}`}>
+          {count}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "completenessScore",
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        title="Completeness score: fields present out of 8"
+      >
+        Score
+      </SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <ScoreBadge
+        score={row.original.completenessScore}
+        total={row.original.totalFields}
+      />
+    ),
+  },
+];
+
+// ── Table component ────────────────────────────────────────────────────
+
+export function PeopleCoverageTable({ data }: { data: PersonCoverageRow[] }) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "completenessScore", desc: false },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: "includesString",
+    state: { sorting, globalFilter },
+  });
+
+  const filtered = table.getFilteredRowModel().rows.length;
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[200px] max-w-md">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            placeholder="Search people..."
+            value={globalFilter ?? ""}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="h-9 w-full rounded-lg border border-border bg-background pl-10 pr-4 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+          />
+        </div>
+
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {filtered === data.length
+            ? `${data.length} people`
+            : `${filtered} of ${data.length} people`}
+        </span>
+      </div>
+
+      <DataTable table={table} />
+    </div>
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -80,6 +80,7 @@ import { KbVerificationsContent } from "@/app/internal/kb-verifications/kb-verif
 import { GrantsDashboardContent } from "@/app/internal/grants-dashboard/grants-dashboard-content";
 import { DivisionsDashboardContent } from "@/app/internal/divisions-dashboard/divisions-dashboard-content";
 import { FundingProgramsDashboardContent } from "@/app/internal/funding-programs-dashboard/funding-programs-dashboard-content";
+import { PeopleCoverageContent } from "@/app/internal/people-coverage/people-coverage-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -232,6 +233,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   GrantsDashboardContent,
   DivisionsDashboardContent,
   FundingProgramsDashboardContent,
+  PeopleCoverageContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -266,6 +266,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Grants", href: internalHref("grants-dashboard") },
         { label: "Divisions", href: internalHref("divisions-dashboard") },
         { label: "Funding Programs", href: internalHref("funding-programs-dashboard") },
+        { label: "People Coverage", href: internalHref("people-coverage-dashboard") },
       ],
     },
     {

--- a/content/docs/internal/people-coverage-dashboard.mdx
+++ b/content/docs/internal/people-coverage-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+numericId: E1099
+title: "People Coverage"
+description: "Data completeness overview for person entities — KB facts, expert positions, wiki pages, and career history"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-03-12"
+---
+
+<PeopleCoverageContent />


### PR DESCRIPTION
## Summary
- New internal dashboard (E1099) showing data completeness for all person entities
- Shows summary stats: total people, % with role, employer, born year, notable-for, expert positions, wiki page, career history, KB facts
- Interactive DataTable with boolean indicators (green/red) for each data field, KB fact count, and completeness score (out of 8)
- Sorted by completeness score ascending to prioritize data gaps
- Follows mandatory Pattern A: MDX stub + server content component + client DataTable + redirect page + sidebar entry

## Files
- `apps/web/src/app/internal/people-coverage/people-coverage-content.tsx` — server component with data loading and summary stats
- `apps/web/src/app/internal/people-coverage/people-coverage-table.tsx` — client DataTable with sortable columns and search
- `apps/web/src/app/internal/people-coverage/page.tsx` — redirect to /wiki/E1099
- `content/docs/internal/people-coverage-dashboard.mdx` — MDX stub
- `apps/web/src/components/mdx-components.tsx` — register PeopleCoverageContent
- `apps/web/src/lib/wiki-nav.ts` — sidebar entry under Dashboards

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] Production build succeeds
- [x] Content validation gate passes
- [x] Entity ID E1099 allocated via `crux ids allocate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)