### PR TITLE
feat: add bidirectional wiki-person page linking

### DIFF
--- a/apps/web/src/components/wiki/DataInfoBox.tsx
+++ b/apps/web/src/components/wiki/DataInfoBox.tsx
@@ -47,8 +47,10 @@ export async function DataInfoBox({ entityId, type: inlineType, ...inlineProps }
           backlinkCount={backlinkCount}
           // Person fields
           affiliation={data.affiliation}
+          affiliationId={data.affiliationId}
           role={data.role}
           knownFor={data.knownFor}
+          profileHref={data.profileHref}
           // Organization fields
           founded={data.founded}
           location={data.location}

--- a/apps/web/src/components/wiki/InfoBox.tsx
+++ b/apps/web/src/components/wiki/InfoBox.tsx
@@ -45,8 +45,10 @@ export interface InfoBoxProps {
   maturity?: string;
   relatedSolutions?: { id: string; title: string; type: string; href: string }[];
   affiliation?: string;
+  affiliationId?: string;
   role?: string;
   knownFor?: string;
+  profileHref?: string;
   customFields?: { label: string; value: string; link?: string }[];
   relatedTopics?: string[];
   relatedEntries?: { id?: string; type: string; title: string; href: string }[];
@@ -177,8 +179,10 @@ export function InfoBox({
   maturity,
   relatedSolutions,
   affiliation,
+  affiliationId,
   role,
   knownFor,
+  profileHref,
   customFields,
   relatedTopics,
   relatedEntries,
@@ -231,9 +235,10 @@ export function InfoBox({
   if (!isOverview && likelihood) fields.push({ label: "Likelihood", value: likelihood });
   if (!isOverview && timeframe) fields.push({ label: "Timeframe", value: timeframe });
   if (!isOverview && maturity) fields.push({ label: "Maturity", value: maturityLabels[maturity.toLowerCase()] || maturity });
-  if (!isOverview && affiliation) fields.push({ label: "Affiliation", value: affiliation });
+  if (!isOverview && affiliation) fields.push({ label: "Affiliation", value: affiliation, link: affiliationId ? `/organizations/${affiliationId}` : undefined });
   if (!isOverview && role) fields.push({ label: "Role", value: role });
   if (!isOverview && knownFor) fields.push({ label: "Known For", value: knownFor });
+  if (!isOverview && profileHref) fields.push({ label: "Profile", value: "View profile page", link: profileHref });
   // AI Model fields
   if (!isOverview && releaseDate) fields.push({ label: "Released", value: releaseDate });
   if (!isOverview && developer) fields.push({ label: "Developer", value: developer, link: developerId ? `/organizations/${developerId}` : undefined });

--- a/apps/web/src/data/infobox.ts
+++ b/apps/web/src/data/infobox.ts
@@ -7,6 +7,7 @@ import {
   getTypedEntities,
   getTypedEntityById,
   getPageById,
+  getExpertById,
   isRisk,
   isPerson,
   isOrganization,
@@ -14,6 +15,7 @@ import {
   isAiModel,
 } from "./database";
 import { getEntityHref } from "./entity-nav";
+import { resolveKBSlug } from "./kb";
 
 export interface ChildPageEntry {
   id: string;
@@ -111,13 +113,29 @@ export function getEntityInfoBoxData(entityId: string) {
 
   // Person-specific fields
   let affiliation: string | undefined;
+  let affiliationId: string | undefined;
   let role: string | undefined;
   let knownFor: string | undefined;
+  let profileHref: string | undefined;
 
   if (isPerson(entity)) {
     affiliation = entity.affiliation;
     role = entity.role;
     knownFor = entity.knownFor?.join(", ");
+
+    // Resolve affiliation to org slug for linking
+    const expert = getExpertById(entity.id);
+    if (expert?.affiliation) {
+      const orgEntity = getTypedEntityById(expert.affiliation);
+      if (orgEntity && orgEntity.entityType === "organization") {
+        affiliationId = expert.affiliation;
+      }
+    }
+
+    // Profile page link — only if this person has a KB entry (which generates a profile page)
+    if (resolveKBSlug(entity.id)) {
+      profileHref = `/people/${entity.id}`;
+    }
   }
 
   // Organization-specific fields
@@ -219,8 +237,10 @@ export function getEntityInfoBoxData(entityId: string) {
     summaryPage,
     // Person
     affiliation,
+    affiliationId,
     role,
     knownFor,
+    profileHref,
     // Organization
     founded,
     location,


### PR DESCRIPTION
## Summary
- Add a "Profile" link in the wiki InfoBox for person entities, linking to their `/people/<slug>` profile page (only shown when the person has a KB entry that generates a profile page)
- Make the "Affiliation" field in the InfoBox a clickable link to the org's `/organizations/<slug>` page when the org entity exists in the system
- Pass the new `affiliationId` and `profileHref` fields through the full InfoBox data pipeline (`infobox.ts` -> `DataInfoBox.tsx` -> `InfoBox.tsx`)

The existing "Wiki page" link on person profile pages (`/people/[slug]/page.tsx`) already works correctly and required no changes.

## Test plan
- [ ] Verify person wiki pages show a "Profile" link in the InfoBox that navigates to `/people/<slug>`
- [ ] Verify person wiki pages show the "Affiliation" as a clickable link to `/organizations/<slug>` when the org exists
- [ ] Verify non-person entity InfoBoxes are unaffected
- [ ] Verify person entities without KB entries do not show a "Profile" link
- [ ] TypeScript check passes (`tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)