### PR TITLE
ci: add monthly Wikidata enrichment workflow

### DIFF
--- a/.github/workflows/wikidata-enrich.yml
+++ b/.github/workflows/wikidata-enrich.yml
@@ -1,0 +1,114 @@
+name: Wikidata Enrichment
+run-name: "Wikidata Enrichment${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
+
+# Runs `crux people enrich --source=wikidata` monthly to add birth years
+# and education data from Wikidata to person KB files.
+# Creates a PR if any new facts were added.
+#
+# Requires: PR #2179 (crux people enrich command) to be merged first.
+
+on:
+  schedule:
+    - cron: "0 8 1 * *" # 1st of each month at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: wikidata-enrich
+  cancel-in-progress: false
+
+jobs:
+  paused-notice:
+    uses: ./.github/workflows/_paused-notice.yml
+
+  enrich:
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Wikidata enrichment
+        id: enrich
+        run: |
+          # Capture output for the PR body
+          OUTPUT=$(pnpm crux people enrich --source=wikidata --apply 2>&1) || true
+          echo "$OUTPUT"
+          {
+            echo "output<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet packages/kb/data/things/; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No KB files changed — nothing to do."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            CHANGED=$(git diff --name-only packages/kb/data/things/ | wc -l | tr -d ' ')
+            echo "changed_count=$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED KB files changed."
+          fi
+
+      - name: Create PR with enriched data
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m)
+          BRANCH="auto/wikidata-enrich-${DATE}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packages/kb/data/things/
+          git commit -m "data: enrich person KB files from Wikidata (${DATE})"
+          git push -u origin "$BRANCH"
+
+          cat > /tmp/pr-body.md <<PRBODY
+          ## Summary
+
+          Monthly automated enrichment of person KB files with data from Wikidata.
+          Adds birth years (P569) and education (P69) facts where missing.
+
+          **Files changed:** ${{ steps.changes.outputs.changed_count }}
+
+          ## Enrichment output
+
+          \`\`\`
+          ${{ steps.enrich.outputs.output }}
+          \`\`\`
+
+          ## Review notes
+
+          - All facts are sourced from Wikidata with conservative matching
+          - Only missing facts are added; existing facts are never overwritten
+          - Verify the YAML is well-formed and facts look reasonable
+
+          Triggered by: \`wikidata-enrich.yml\` scheduled workflow
+          PRBODY
+
+          gh pr create \
+            --title "data: Wikidata person enrichment ${DATE}" \
+            --body-file /tmp/pr-body.md \
+            --base main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/wikidata-enrich.yml` -- a monthly scheduled GitHub Action that runs `crux people enrich --source=wikidata --apply` to keep person KB files up to date with birth years and education data from Wikidata
- Runs on the 1st of each month at 08:00 UTC, with manual `workflow_dispatch` support
- Only creates a PR if actual changes are detected in `packages/kb/data/things/`
- Uses branch naming convention `auto/wikidata-enrich-YYYY-MM`

## Dependencies

Requires PR #2179 (`crux people enrich` command) to be merged first. The workflow will fail gracefully until then.

## Design decisions

- Follows existing workflow patterns: `_paused-notice.yml` reusable workflow, `AUTOMATION_PAUSED` circuit breaker, `actions/checkout@v4` with `fetch-depth: 0`
- 15-minute timeout (Wikidata queries for ~100 entities should complete well within this)
- No wiki-server dependency -- this workflow only modifies local YAML files and creates a PR
- PR includes the enrichment output in the body for easy review

## Test plan

- [x] `actionlint` passes with no errors
- [ ] Manual `workflow_dispatch` trigger after #2179 merges (post-merge verification)

