### PR TITLE
feat: add funding connections to person pages

### DIFF
--- a/apps/web/src/app/people/[slug]/funding-connections.tsx
+++ b/apps/web/src/app/people/[slug]/funding-connections.tsx
@@ -1,0 +1,203 @@
+import Link from "next/link";
+import { formatCompactCurrency } from "@/lib/format-compact";
+import type { PersonGrant } from "../people-utils";
+
+const MAX_SHOWN = 8;
+
+function GrantRow({ grant }: { grant: PersonGrant }) {
+  const funderHref = grant.funder.slug
+    ? `/organizations/${grant.funder.slug}`
+    : null;
+
+  return (
+    <tr className="hover:bg-muted/20 transition-colors">
+      {/* Grant name + source link */}
+      <td className="py-2 px-3">
+        <span className="font-medium text-foreground text-xs">
+          {grant.name}
+        </span>
+        {grant.source && (
+          <a
+            href={grant.source}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-1.5 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+          >
+            source
+          </a>
+        )}
+        {grant.connectionType === "via-org" && grant.viaOrg && (
+          <span className="ml-1.5 text-[10px] text-muted-foreground/50">
+            via{" "}
+            {grant.viaOrg.slug ? (
+              <Link
+                href={`/organizations/${grant.viaOrg.slug}`}
+                className="hover:text-primary transition-colors"
+              >
+                {grant.viaOrg.name}
+              </Link>
+            ) : (
+              grant.viaOrg.name
+            )}
+          </span>
+        )}
+      </td>
+
+      {/* Counterparty: funder for received, recipient for given */}
+      <td className="py-2 px-3 text-xs">
+        {grant.direction === "received" ? (
+          funderHref ? (
+            <Link
+              href={funderHref}
+              className="text-primary hover:underline"
+            >
+              {grant.funder.name}
+            </Link>
+          ) : (
+            <span className="text-muted-foreground">
+              {grant.funder.name}
+            </span>
+          )
+        ) : grant.recipientHref ? (
+          <Link
+            href={grant.recipientHref}
+            className="text-primary hover:underline"
+          >
+            {grant.recipientName}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground">
+            {grant.recipientName ?? "Unknown"}
+          </span>
+        )}
+      </td>
+
+      {/* Amount */}
+      <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+        {grant.amount != null && (
+          <span className="font-semibold">
+            {formatCompactCurrency(grant.amount)}
+          </span>
+        )}
+      </td>
+
+      {/* Date */}
+      <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+        {grant.date ?? ""}
+      </td>
+    </tr>
+  );
+}
+
+function GrantTable({
+  grants,
+  direction,
+}: {
+  grants: PersonGrant[];
+  direction: "received" | "given";
+}) {
+  if (grants.length === 0) return null;
+
+  const totalAmount = grants.reduce(
+    (sum, g) => sum + (g.amount ?? 0),
+    0,
+  );
+  const shown = grants.slice(0, MAX_SHOWN);
+  const remaining = grants.length - shown.length;
+
+  return (
+    <div>
+      {totalAmount > 0 && (
+        <div className="text-xs text-muted-foreground mb-2">
+          Total tracked: {formatCompactCurrency(totalAmount)}
+        </div>
+      )}
+      <div className="border border-border/60 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th className="text-left py-2 px-3 font-medium">Grant</th>
+              <th className="text-left py-2 px-3 font-medium">
+                {direction === "received" ? "Funder" : "Recipient"}
+              </th>
+              <th className="text-right py-2 px-3 font-medium">Amount</th>
+              <th className="text-center py-2 px-3 font-medium">Date</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {shown.map((g) => (
+              <GrantRow key={g.key} grant={g} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {remaining > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground text-center">
+          +{remaining} more grant{remaining !== 1 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function FundingConnections({
+  directGrants,
+  orgGrantsReceived,
+  orgGrantsGiven,
+}: {
+  directGrants: PersonGrant[];
+  orgGrantsReceived: PersonGrant[];
+  orgGrantsGiven: PersonGrant[];
+}) {
+  const totalCount =
+    directGrants.length + orgGrantsReceived.length + orgGrantsGiven.length;
+
+  if (totalCount === 0) return null;
+
+  // Merge direct + org-received for "Funding Received" section
+  const allReceived = [...directGrants, ...orgGrantsReceived].sort(
+    (a, b) => (b.amount ?? 0) - (a.amount ?? 0),
+  );
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold tracking-tight mb-4">
+        Funding Connections
+        <span className="ml-2 text-sm font-normal text-muted-foreground">
+          {totalCount}
+        </span>
+      </h2>
+
+      <div className="space-y-6">
+        {/* Grants received (direct + via org) */}
+        {allReceived.length > 0 && (
+          <div>
+            <h3 className="text-sm font-semibold text-muted-foreground mb-2">
+              Funding Received
+              {orgGrantsReceived.length > 0 &&
+                directGrants.length === 0 && (
+                  <span className="font-normal ml-1">
+                    (via affiliated organizations)
+                  </span>
+                )}
+            </h3>
+            <GrantTable grants={allReceived} direction="received" />
+          </div>
+        )}
+
+        {/* Grants given (via org) */}
+        {orgGrantsGiven.length > 0 && (
+          <div>
+            <h3 className="text-sm font-semibold text-muted-foreground mb-2">
+              Grants Made
+              <span className="font-normal ml-1">
+                (via affiliated organizations)
+              </span>
+            </h3>
+            <GrantTable grants={orgGrantsGiven} direction="given" />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -7,6 +7,9 @@ import {
   getOrgRolesForPerson,
   getBoardSeatsForPerson,
   getCareerHistory,
+  getAffiliatedOrgIds,
+  getDirectGrantsForPerson,
+  getOrgGrantsForPerson,
 } from "../people-utils";
 import {
   getKBFacts,
@@ -30,6 +33,7 @@ import {
 import { formatKBDate } from "@/components/wiki/kb/format";
 import { getExpertById, getPublicationsForPerson } from "@/data";
 import { ExpertPositions } from "./expert-positions";
+import { FundingConnections } from "./funding-connections";
 
 export function generateStaticParams() {
   return getPersonSlugs().map((slug) => ({ slug }));
@@ -83,6 +87,25 @@ export default async function PersonProfilePage({
 
   // Career history from KB records (populated via personnel table)
   const careerHistory = getCareerHistory(entity.id);
+
+  // Funding connections
+  const affiliatedOrgIds = getAffiliatedOrgIds(entity.id);
+  // Also include employed-by org if it resolves
+  if (employedByFact?.value.type === "ref") {
+    affiliatedOrgIds.add(employedByFact.value.value);
+  }
+
+  const directGrants = getDirectGrantsForPerson(
+    entity.id,
+    entity.name,
+    slug,
+    entity.aliases ?? [],
+  );
+  const orgGrants = getOrgGrantsForPerson(entity.id, affiliatedOrgIds);
+
+  // Split org grants into received vs given
+  const orgGrantsReceived = orgGrants.filter((g) => g.direction === "received");
+  const orgGrantsGiven = orgGrants.filter((g) => g.direction === "given");
 
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
@@ -362,6 +385,13 @@ export default async function PersonProfilePage({
               </div>
             </section>
           )}
+
+          {/* Funding Connections */}
+          <FundingConnections
+            directGrants={directGrants}
+            orgGrantsReceived={orgGrantsReceived}
+            orgGrantsGiven={orgGrantsGiven}
+          />
         </div>
 
         {/* Sidebar */}

--- a/apps/web/src/app/people/people-utils.ts
+++ b/apps/web/src/app/people/people-utils.ts
@@ -129,6 +129,240 @@ export function resolveOrgForCareer(
   };
 }
 
+// ── Grant / funding connection types and helpers ──────────────────
+
+export interface PersonGrant {
+  key: string;
+  name: string;
+  amount: number | null;
+  date: string | null;
+  status: string | null;
+  source: string | null;
+  /** "direct" = person is the named recipient; "via-org" = through an affiliated org */
+  connectionType: "direct" | "via-org";
+  /** For "via-org" grants, the org through which the grant connects */
+  viaOrg: { id: string; name: string; slug: string | undefined } | null;
+  /** The funder organization (ownerEntityId of the grant record) */
+  funder: { id: string; name: string; slug: string | undefined };
+  /** Direction: "received" or "given" (when person leads a funder org) */
+  direction: "received" | "given";
+  /** Grant recipient display name (for "given" grants) */
+  recipientName: string | null;
+  recipientHref: string | null;
+}
+
+/**
+ * Collect all organization IDs affiliated with a person:
+ *  - key-person records (org roles)
+ *  - board seats
+ *  - career history (current positions only, i.e. no end date)
+ */
+export function getAffiliatedOrgIds(
+  personEntityId: string,
+): Set<string> {
+  const orgIds = new Set<string>();
+
+  // From key-person records
+  const orgRoles = getOrgRolesForPerson(personEntityId);
+  for (const { org } of orgRoles) {
+    orgIds.add(org.id);
+  }
+
+  // From board seats
+  const boardSeats = getBoardSeatsForPerson(personEntityId);
+  for (const { org } of boardSeats) {
+    orgIds.add(org.id);
+  }
+
+  // From career history (current only -- no end date)
+  const career = getCareerHistoryForPerson(personEntityId);
+  for (const rec of career) {
+    const orgId = rec.fields.organization as string | undefined;
+    if (orgId && !rec.fields.end) {
+      orgIds.add(orgId);
+    }
+  }
+
+  return orgIds;
+}
+
+/**
+ * Find grants where this person is the direct named recipient.
+ * Scans all grants across all orgs, matching the recipient field against
+ * the person's entity ID, slug, name, and aliases.
+ */
+export function getDirectGrantsForPerson(
+  personEntityId: string,
+  personName: string,
+  personSlug: string,
+  personAliases: string[],
+): PersonGrant[] {
+  const allGrants = getAllKBRecords("grants");
+
+  const matchNames = new Set<string>([
+    personEntityId.toLowerCase(),
+    personSlug.toLowerCase(),
+    personName.toLowerCase(),
+    ...personAliases.map((a) => a.toLowerCase()),
+  ]);
+
+  const results: PersonGrant[] = [];
+
+  for (const rec of allGrants) {
+    const recipientRaw = rec.fields.recipient as string | undefined;
+    if (!recipientRaw) continue;
+    if (!matchNames.has(recipientRaw.toLowerCase())) continue;
+
+    const funderEntity = getKBEntity(rec.ownerEntityId);
+    results.push({
+      key: `${rec.ownerEntityId}-${rec.key}`,
+      name: (rec.fields.name as string) ?? rec.key,
+      amount: typeof rec.fields.amount === "number" ? rec.fields.amount : null,
+      date:
+        (rec.fields.date as string) ??
+        (rec.fields.period as string) ??
+        null,
+      status: (rec.fields.status as string) ?? null,
+      source: (rec.fields.source as string) ?? null,
+      connectionType: "direct",
+      viaOrg: null,
+      funder: {
+        id: rec.ownerEntityId,
+        name: funderEntity?.name ?? rec.ownerEntityId,
+        slug: getKBEntitySlug(rec.ownerEntityId),
+      },
+      direction: "received",
+      recipientName: null,
+      recipientHref: null,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Find grants connected to this person through their affiliated organizations.
+ * For each affiliated org:
+ *  - "received": grants where the org is the named recipient
+ *  - "given": grants where the org is the funder (ownerEntityId)
+ */
+export function getOrgGrantsForPerson(
+  personEntityId: string,
+  affiliatedOrgIds: Set<string>,
+): PersonGrant[] {
+  const allGrants = getAllKBRecords("grants");
+  const results: PersonGrant[] = [];
+
+  // Build match sets for each org: name, slug, id, aliases
+  const orgMatchSets = new Map<string, Set<string>>();
+  for (const orgId of affiliatedOrgIds) {
+    const orgEntity = getKBEntity(orgId);
+    const matchNames = new Set<string>([orgId.toLowerCase()]);
+    if (orgEntity) {
+      matchNames.add(orgEntity.name.toLowerCase());
+      const slug = getKBEntitySlug(orgId);
+      if (slug) matchNames.add(slug.toLowerCase());
+    }
+    orgMatchSets.set(orgId, matchNames);
+  }
+
+  for (const rec of allGrants) {
+    // Check if this org is the funder (grants made by affiliated org)
+    if (affiliatedOrgIds.has(rec.ownerEntityId)) {
+      const funderEntity = getKBEntity(rec.ownerEntityId);
+      const recipientId = rec.fields.recipient as string | undefined;
+      let recipientName: string | null = null;
+      let recipientHref: string | null = null;
+      if (recipientId) {
+        const recipientEntity = getKBEntity(recipientId);
+        if (recipientEntity) {
+          recipientName = recipientEntity.name;
+          const recipientSlug = getKBEntitySlug(recipientId);
+          recipientHref = recipientSlug
+            ? (recipientEntity.type === "person"
+                ? `/people/${recipientSlug}`
+                : `/organizations/${recipientSlug}`)
+            : `/kb/entity/${recipientId}`;
+        } else {
+          // Humanize the slug
+          recipientName = recipientId
+            .replace(/-/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+        }
+      }
+
+      results.push({
+        key: `via-${rec.ownerEntityId}-${rec.key}`,
+        name: (rec.fields.name as string) ?? rec.key,
+        amount:
+          typeof rec.fields.amount === "number" ? rec.fields.amount : null,
+        date:
+          (rec.fields.date as string) ??
+          (rec.fields.period as string) ??
+          null,
+        status: (rec.fields.status as string) ?? null,
+        source: (rec.fields.source as string) ?? null,
+        connectionType: "via-org",
+        viaOrg: {
+          id: rec.ownerEntityId,
+          name: funderEntity?.name ?? rec.ownerEntityId,
+          slug: getKBEntitySlug(rec.ownerEntityId),
+        },
+        funder: {
+          id: rec.ownerEntityId,
+          name: funderEntity?.name ?? rec.ownerEntityId,
+          slug: getKBEntitySlug(rec.ownerEntityId),
+        },
+        direction: "given",
+        recipientName,
+        recipientHref,
+      });
+      continue;
+    }
+
+    // Check if this org is the recipient (grants received by affiliated org)
+    const recipientRaw = rec.fields.recipient as string | undefined;
+    if (!recipientRaw) continue;
+
+    for (const [orgId, matchNames] of orgMatchSets) {
+      if (!matchNames.has(recipientRaw.toLowerCase())) continue;
+
+      const funderEntity = getKBEntity(rec.ownerEntityId);
+      const orgEntity = getKBEntity(orgId);
+
+      results.push({
+        key: `via-${orgId}-${rec.key}`,
+        name: (rec.fields.name as string) ?? rec.key,
+        amount:
+          typeof rec.fields.amount === "number" ? rec.fields.amount : null,
+        date:
+          (rec.fields.date as string) ??
+          (rec.fields.period as string) ??
+          null,
+        status: (rec.fields.status as string) ?? null,
+        source: (rec.fields.source as string) ?? null,
+        connectionType: "via-org",
+        viaOrg: {
+          id: orgId,
+          name: orgEntity?.name ?? orgId,
+          slug: getKBEntitySlug(orgId),
+        },
+        funder: {
+          id: rec.ownerEntityId,
+          name: funderEntity?.name ?? rec.ownerEntityId,
+          slug: getKBEntitySlug(rec.ownerEntityId),
+        },
+        direction: "received",
+        recipientName: null,
+        recipientHref: null,
+      });
+      break; // Avoid duplicate entries if multiple match names hit
+    }
+  }
+
+  return results;
+}
+
 // -- Career history -------------------------------------------------------
 
 export interface CareerHistoryEntry {


### PR DESCRIPTION
## Summary

- Adds a "Funding Connections" section to person detail pages (`/people/[slug]`)
- Shows grants the person received directly (matched by entity ID, slug, name, or aliases)
- Shows grants received by or given through organizations the person is affiliated with (via key-person records, board seats, career history, and employed-by KB fact)
- Each grant links to its funder/recipient org page and source URL when available
- Follows the same table design pattern used on organization pages for grants

## Changes

- **`apps/web/src/app/people/[slug]/funding-connections.tsx`** (new): `FundingConnections` component with `GrantTable` and `GrantRow` sub-components
- **`apps/web/src/app/people/people-utils.ts`**: Added `PersonGrant` type, `getAffiliatedOrgIds()`, `getDirectGrantsForPerson()`, and `getOrgGrantsForPerson()` utility functions
- **`apps/web/src/app/people/[slug]/page.tsx`**: Integrated FundingConnections into the main content area below Publications

## Test plan

- [ ] Verify TypeScript compiles clean (confirmed locally)
- [ ] Check person pages with known grant recipients (e.g., alexander-turner, david-krueger, robert-miles, vanessa-kosoy) show direct grants
- [ ] Check person pages for org leaders (e.g., dustin-moskovitz) show grants via affiliated orgs
- [ ] Verify the section is hidden when no grants exist for a person
- [ ] Verify grant links to funder/recipient org pages work correctly

Generated with [Claude Code](https://claude.com/claude-code)