### PR TITLE
feat: add interactive people/org network visualization

### DIFF
--- a/apps/web/src/app/people/network/network-graph.tsx
+++ b/apps/web/src/app/people/network/network-graph.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: "person" | "organization";
+  href: string;
+  /** Extra detail shown on hover (role, affiliation) */
+  detail?: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label?: string;
+}
+
+interface SimNode extends GraphNode {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  fx?: number;
+  fy?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PERSON_RADIUS = 8;
+const ORG_SIZE = 12;
+const LINK_DISTANCE = 100;
+const CHARGE_STRENGTH = -300;
+const CENTER_STRENGTH = 0.05;
+const DAMPING = 0.92;
+const MIN_ALPHA = 0.001;
+const INITIAL_ALPHA = 1.0;
+
+// Colors
+const PERSON_FILL = "#6366f1"; // indigo-500
+const PERSON_FILL_HIGHLIGHT = "#818cf8"; // indigo-400
+const ORG_FILL = "#f59e0b"; // amber-500
+const ORG_FILL_HIGHLIGHT = "#fbbf24"; // amber-400
+const EDGE_STROKE = "#d1d5db"; // gray-300
+const EDGE_STROKE_HIGHLIGHT = "#6366f1"; // indigo-500
+const TEXT_FILL = "#374151"; // gray-700
+const TOOLTIP_BG = "#1f2937"; // gray-800
+const TOOLTIP_TEXT = "#f9fafb"; // gray-50
+
+// ---------------------------------------------------------------------------
+// Force simulation (simple, no dependencies)
+// ---------------------------------------------------------------------------
+
+function initPositions(nodes: GraphNode[], w: number, h: number): SimNode[] {
+  return nodes.map((n, i) => {
+    const angle = (2 * Math.PI * i) / nodes.length;
+    const radius = Math.min(w, h) * 0.35;
+    return {
+      ...n,
+      x: w / 2 + radius * Math.cos(angle),
+      y: h / 2 + radius * Math.sin(angle),
+      vx: 0,
+      vy: 0,
+    };
+  });
+}
+
+function tick(
+  nodes: SimNode[],
+  edges: GraphEdge[],
+  w: number,
+  h: number,
+  alpha: number,
+): number {
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
+  // Charge repulsion (all pairs)
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const a = nodes[i];
+      const b = nodes[j];
+      let dx = b.x - a.x;
+      let dy = b.y - a.y;
+      let dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < 1) dist = 1;
+      const force = (CHARGE_STRENGTH * alpha) / (dist * dist);
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      a.vx -= fx;
+      a.vy -= fy;
+      b.vx += fx;
+      b.vy += fy;
+    }
+  }
+
+  // Spring forces along edges
+  for (const edge of edges) {
+    const s = nodeMap.get(edge.source);
+    const t = nodeMap.get(edge.target);
+    if (!s || !t) continue;
+    let dx = t.x - s.x;
+    let dy = t.y - s.y;
+    let dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < 1) dist = 1;
+    const force = ((dist - LINK_DISTANCE) * alpha * 0.3) / dist;
+    const fx = dx * force;
+    const fy = dy * force;
+    s.vx += fx;
+    s.vy += fy;
+    t.vx -= fx;
+    t.vy -= fy;
+  }
+
+  // Center gravity
+  for (const n of nodes) {
+    n.vx += (w / 2 - n.x) * CENTER_STRENGTH * alpha;
+    n.vy += (h / 2 - n.y) * CENTER_STRENGTH * alpha;
+  }
+
+  // Update positions
+  const padding = 30;
+  for (const n of nodes) {
+    if (n.fx !== undefined) {
+      n.x = n.fx;
+      n.y = n.fy!;
+      n.vx = 0;
+      n.vy = 0;
+      continue;
+    }
+    n.vx *= DAMPING;
+    n.vy *= DAMPING;
+    n.x += n.vx;
+    n.y += n.vy;
+    // Keep inside bounds
+    n.x = Math.max(padding, Math.min(w - padding, n.x));
+    n.y = Math.max(padding, Math.min(h - padding, n.y));
+  }
+
+  return alpha * 0.99; // decay
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NetworkGraph({
+  nodes,
+  edges,
+}: {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 900, height: 600 });
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
+  // Track drag state
+  const dragRef = useRef<{
+    nodeId: string | null;
+    wasDragged: boolean;
+  }>({ nodeId: null, wasDragged: false });
+
+  // Simulation state
+  const simNodesRef = useRef<SimNode[]>([]);
+  const alphaRef = useRef(INITIAL_ALPHA);
+  const rafRef = useRef<number>(0);
+  const [renderTick, setRenderTick] = useState(0);
+
+  // Resize observer
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width } = entry.contentRect;
+        const height = Math.max(400, Math.min(800, width * 0.65));
+        setDimensions({ width, height });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Initialize simulation
+  useEffect(() => {
+    simNodesRef.current = initPositions(
+      nodes,
+      dimensions.width,
+      dimensions.height,
+    );
+    alphaRef.current = INITIAL_ALPHA;
+  }, [nodes, dimensions.width, dimensions.height]);
+
+  // Run simulation loop
+  useEffect(() => {
+    let running = true;
+    const loop = () => {
+      if (!running) return;
+      alphaRef.current = tick(
+        simNodesRef.current,
+        edges,
+        dimensions.width,
+        dimensions.height,
+        alphaRef.current,
+      );
+      setRenderTick((t) => t + 1);
+      if (alphaRef.current > MIN_ALPHA) {
+        rafRef.current = requestAnimationFrame(loop);
+      }
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      running = false;
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [edges, dimensions.width, dimensions.height]);
+
+  // Connected nodes for highlighting
+  const connectedTo = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const e of edges) {
+      if (!map.has(e.source)) map.set(e.source, new Set());
+      if (!map.has(e.target)) map.set(e.target, new Set());
+      map.get(e.source)!.add(e.target);
+      map.get(e.target)!.add(e.source);
+    }
+    return map;
+  }, [edges]);
+
+  const activeId = selectedNodeId ?? hoveredNodeId;
+  const activeNeighbors = activeId ? connectedTo.get(activeId) : null;
+
+  const isHighlighted = useCallback(
+    (nodeId: string) => {
+      if (!activeId) return true;
+      return nodeId === activeId || (activeNeighbors?.has(nodeId) ?? false);
+    },
+    [activeId, activeNeighbors],
+  );
+
+  const isEdgeHighlighted = useCallback(
+    (e: GraphEdge) => {
+      if (!activeId) return false;
+      return e.source === activeId || e.target === activeId;
+    },
+    [activeId],
+  );
+
+  // Drag handlers
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent, nodeId: string) => {
+      e.preventDefault();
+      (e.target as Element).setPointerCapture(e.pointerId);
+      dragRef.current = { nodeId, wasDragged: false };
+      const node = simNodesRef.current.find((n) => n.id === nodeId);
+      if (node) {
+        node.fx = node.x;
+        node.fy = node.y;
+      }
+    },
+    [],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current.nodeId) return;
+      dragRef.current.wasDragged = true;
+
+      const svg = svgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+
+      const node = simNodesRef.current.find(
+        (n) => n.id === dragRef.current.nodeId,
+      );
+      if (node) {
+        node.fx = x;
+        node.fy = y;
+        // Re-energize simulation
+        alphaRef.current = Math.max(alphaRef.current, 0.3);
+      }
+    },
+    [],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (dragRef.current.nodeId) {
+      const node = simNodesRef.current.find(
+        (n) => n.id === dragRef.current.nodeId,
+      );
+      if (node) {
+        node.fx = undefined;
+        node.fy = undefined;
+      }
+      // If it was a click (not drag), toggle selection
+      if (!dragRef.current.wasDragged) {
+        setSelectedNodeId((prev) =>
+          prev === dragRef.current.nodeId ? null : dragRef.current.nodeId,
+        );
+      }
+    }
+    dragRef.current = { nodeId: null, wasDragged: false };
+  }, []);
+
+  // Hover tooltip
+  const hoveredNode = hoveredNodeId
+    ? simNodesRef.current.find((n) => n.id === hoveredNodeId)
+    : null;
+
+  // Suppress the "renderTick is unused" by reading it
+  void renderTick;
+
+  const simNodes = simNodesRef.current;
+  const nodeMap = new Map(simNodes.map((n) => [n.id, n]));
+
+  return (
+    <div ref={containerRef} className="w-full">
+      {/* Legend */}
+      <div className="flex items-center gap-6 mb-3 text-sm text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <svg width="16" height="16">
+            <circle cx="8" cy="8" r="6" fill={PERSON_FILL} />
+          </svg>
+          <span>Person</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <svg width="16" height="16">
+            <rect x="2" y="2" width="12" height="12" rx="2" fill={ORG_FILL} />
+          </svg>
+          <span>Organization</span>
+        </div>
+        <div className="text-xs">
+          Click a node to highlight connections. Drag to reposition.
+        </div>
+      </div>
+
+      <div className="relative border rounded-lg overflow-hidden bg-gray-50 dark:bg-gray-900">
+        <svg
+          ref={svgRef}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          className="select-none"
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerUp}
+        >
+          {/* Edges */}
+          <g>
+            {edges.map((e, i) => {
+              const s = nodeMap.get(e.source);
+              const t = nodeMap.get(e.target);
+              if (!s || !t) return null;
+              const highlighted = isEdgeHighlighted(e);
+              return (
+                <line
+                  key={`${e.source}-${e.target}-${i}`}
+                  x1={s.x}
+                  y1={s.y}
+                  x2={t.x}
+                  y2={t.y}
+                  stroke={highlighted ? EDGE_STROKE_HIGHLIGHT : EDGE_STROKE}
+                  strokeWidth={highlighted ? 2 : 1}
+                  opacity={activeId && !highlighted ? 0.15 : highlighted ? 0.9 : 0.4}
+                />
+              );
+            })}
+          </g>
+
+          {/* Nodes */}
+          <g>
+            {simNodes.map((node) => {
+              const highlighted = isHighlighted(node.id);
+              const isActive = node.id === activeId;
+              const opacity = activeId && !highlighted ? 0.2 : 1;
+              const fill =
+                node.type === "person"
+                  ? isActive
+                    ? PERSON_FILL_HIGHLIGHT
+                    : PERSON_FILL
+                  : isActive
+                    ? ORG_FILL_HIGHLIGHT
+                    : ORG_FILL;
+
+              return (
+                <g
+                  key={node.id}
+                  className="cursor-pointer"
+                  opacity={opacity}
+                  onPointerDown={(e) => handlePointerDown(e, node.id)}
+                  onPointerEnter={(e) => {
+                    setHoveredNodeId(node.id);
+                    setMousePos({ x: e.clientX, y: e.clientY });
+                  }}
+                  onPointerLeave={() => {
+                    setHoveredNodeId(null);
+                    setMousePos(null);
+                  }}
+                >
+                  {node.type === "person" ? (
+                    <circle
+                      cx={node.x}
+                      cy={node.y}
+                      r={isActive ? PERSON_RADIUS + 2 : PERSON_RADIUS}
+                      fill={fill}
+                      stroke={isActive ? "#4338ca" : "white"}
+                      strokeWidth={isActive ? 2.5 : 1.5}
+                    />
+                  ) : (
+                    <rect
+                      x={
+                        node.x -
+                        (isActive ? (ORG_SIZE + 2) : ORG_SIZE) / 2
+                      }
+                      y={
+                        node.y -
+                        (isActive ? (ORG_SIZE + 2) : ORG_SIZE) / 2
+                      }
+                      width={isActive ? ORG_SIZE + 2 : ORG_SIZE}
+                      height={isActive ? ORG_SIZE + 2 : ORG_SIZE}
+                      rx={2}
+                      fill={fill}
+                      stroke={isActive ? "#b45309" : "white"}
+                      strokeWidth={isActive ? 2.5 : 1.5}
+                    />
+                  )}
+                  {/* Label */}
+                  <text
+                    x={node.x}
+                    y={
+                      node.y +
+                      (node.type === "person"
+                        ? PERSON_RADIUS + 12
+                        : ORG_SIZE / 2 + 12)
+                    }
+                    textAnchor="middle"
+                    fill={TEXT_FILL}
+                    className="dark:fill-gray-300"
+                    fontSize={isActive ? 11 : 10}
+                    fontWeight={isActive ? 600 : 400}
+                    pointerEvents="none"
+                  >
+                    {node.label}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+
+        {/* Tooltip */}
+        {hoveredNode && mousePos && (
+          <div
+            className="fixed z-50 pointer-events-none px-3 py-2 rounded-md shadow-lg text-sm"
+            style={{
+              left: mousePos.x + 12,
+              top: mousePos.y - 10,
+              backgroundColor: TOOLTIP_BG,
+              color: TOOLTIP_TEXT,
+              maxWidth: 280,
+            }}
+          >
+            <div className="font-semibold">{hoveredNode.label}</div>
+            <div className="text-xs opacity-80 capitalize">
+              {hoveredNode.type}
+            </div>
+            {hoveredNode.detail && (
+              <div className="text-xs mt-1 opacity-90">{hoveredNode.detail}</div>
+            )}
+            <div className="text-xs mt-1 opacity-60">
+              {connectedTo.get(hoveredNode.id)?.size ?? 0} connections
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/people/network/page.tsx
+++ b/apps/web/src/app/people/network/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  getKBEntities,
+  getKBLatest,
+  getKBEntitySlug,
+  getAllKBRecords,
+} from "@/data/kb";
+import { getExpertById } from "@/data";
+import { getEntityHref } from "@/data/entity-nav";
+import { NetworkGraph, type GraphNode, type GraphEdge } from "./network-graph";
+
+export const metadata: Metadata = {
+  title: "People & Organizations Network",
+  description:
+    "Interactive network visualization showing relationships between people and organizations in AI safety.",
+};
+
+/**
+ * Build graph data from KB entities + relationships.
+ *
+ * Sources of relationships (in priority order):
+ * 1. KB `employed-by` facts — current employer for each person
+ * 2. KB `key-persons` records — orgs listing their key people
+ * 3. YAML `relatedEntries` — entity-level associations
+ * 4. `experts.yaml` `affiliation` field via getExpertById
+ */
+function buildGraphData(): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const allEntities = getKBEntities();
+  const people = allEntities.filter((e) => e.type === "person");
+  const orgSet = new Set<string>();
+  const edgeSet = new Set<string>(); // "personId->orgId" dedup
+  const edges: GraphEdge[] = [];
+
+  function addEdge(personId: string, orgId: string, label?: string) {
+    const key = `${personId}->${orgId}`;
+    if (edgeSet.has(key)) return;
+    edgeSet.add(key);
+    orgSet.add(orgId);
+    edges.push({ source: personId, target: orgId, label });
+  }
+
+  // 1. KB employed-by facts
+  for (const person of people) {
+    const employedBy = getKBLatest(person.id, "employed-by");
+    if (employedBy?.value.type === "ref") {
+      const slug = getKBEntitySlug(employedBy.value.value);
+      if (slug) {
+        addEdge(person.id, slug, "employed");
+      }
+    }
+  }
+
+  // 2. KB key-persons records (org -> person links)
+  const allKeyPersons = getAllKBRecords("key-persons");
+  for (const rec of allKeyPersons) {
+    const personId = rec.fields.person as string | undefined;
+    if (!personId) continue;
+    // ownerEntityId is the org's KB entity ID; get its slug
+    const orgSlug = getKBEntitySlug(rec.ownerEntityId);
+    if (!orgSlug) continue;
+    // personId here is a KB entity ID; get slug
+    const personSlug = getKBEntitySlug(personId);
+    if (!personSlug) continue;
+    const title = rec.fields.title as string | undefined;
+    addEdge(personSlug, orgSlug, title ?? "key person");
+  }
+
+  // 3. Entity relatedEntries from YAML (for people without KB employed-by)
+  for (const person of people) {
+    const slug = getKBEntitySlug(person.id) ?? person.id;
+    // Check if this person already has edges from KB data
+    const entity = allEntities.find((e) => e.id === person.id);
+    if (!entity) continue;
+
+    // relatedEntries are not directly on KB entities; we use expert data instead
+    // (covered by source 4 below)
+  }
+
+  // 4. Expert affiliation data
+  for (const person of people) {
+    const slug = getKBEntitySlug(person.id) ?? person.id;
+    const expert = getExpertById(slug);
+    if (expert?.affiliation) {
+      const aff = expert.affiliation as string;
+      if (aff && aff !== "independent") {
+        addEdge(slug, aff, "affiliated");
+      }
+    }
+  }
+
+  // Build organization nodes (only for orgs that have connections)
+  const orgEntities = allEntities.filter(
+    (e) => e.type === "organization" || e.type?.startsWith("lab"),
+  );
+  const orgMap = new Map(
+    orgEntities.map((e) => [getKBEntitySlug(e.id) ?? e.id, e]),
+  );
+
+  // Build people nodes (only those that have at least one connection)
+  const connectedPeople = new Set(edges.map((e) => e.source));
+  const personNodes: GraphNode[] = [];
+
+  for (const person of people) {
+    const slug = getKBEntitySlug(person.id) ?? person.id;
+    if (!connectedPeople.has(slug)) continue;
+
+    const roleFact = getKBLatest(person.id, "role");
+    const role =
+      roleFact?.value.type === "text" ? roleFact.value.value : undefined;
+    const expert = getExpertById(slug);
+
+    personNodes.push({
+      id: slug,
+      label: person.name,
+      type: "person",
+      href: getEntityHref(slug),
+      detail: role ?? expert?.role ?? undefined,
+    });
+  }
+
+  const orgNodes: GraphNode[] = [];
+  for (const orgId of orgSet) {
+    const orgEntity = orgMap.get(orgId);
+    orgNodes.push({
+      id: orgId,
+      label: orgEntity?.name ?? orgId,
+      type: "organization",
+      href: getEntityHref(orgId),
+      detail: orgEntity?.name ?? undefined,
+    });
+  }
+
+  // Remap edges to use slugs consistently (they already use slugs from addEdge)
+  // Filter edges where both source and target exist as nodes
+  const nodeIds = new Set([
+    ...personNodes.map((n) => n.id),
+    ...orgNodes.map((n) => n.id),
+  ]);
+  const validEdges = edges.filter(
+    (e) => nodeIds.has(e.source) && nodeIds.has(e.target),
+  );
+
+  return {
+    nodes: [...personNodes, ...orgNodes],
+    edges: validEdges,
+  };
+}
+
+export default function PeopleNetworkPage() {
+  const { nodes, edges } = buildGraphData();
+
+  const personCount = nodes.filter((n) => n.type === "person").length;
+  const orgCount = nodes.filter((n) => n.type === "organization").length;
+
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-2">
+          <Link
+            href="/people"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            People
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <h1 className="text-2xl font-extrabold tracking-tight">
+            Relationship Network
+          </h1>
+        </div>
+        <p className="text-muted-foreground text-sm max-w-2xl">
+          Interactive network showing employment and affiliation relationships
+          between {personCount} people and {orgCount} organizations in the AI
+          safety ecosystem. Data sourced from the knowledge base.
+        </p>
+      </div>
+
+      <NetworkGraph nodes={nodes} edges={edges} />
+
+      {/* Stats summary */}
+      <div className="mt-6 grid grid-cols-3 gap-4 max-w-md">
+        <div className="text-center p-3 rounded-lg bg-indigo-50 dark:bg-indigo-950">
+          <div className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+            {personCount}
+          </div>
+          <div className="text-xs text-muted-foreground">People</div>
+        </div>
+        <div className="text-center p-3 rounded-lg bg-amber-50 dark:bg-amber-950">
+          <div className="text-2xl font-bold text-amber-600 dark:text-amber-400">
+            {orgCount}
+          </div>
+          <div className="text-xs text-muted-foreground">Organizations</div>
+        </div>
+        <div className="text-center p-3 rounded-lg bg-gray-50 dark:bg-gray-800">
+          <div className="text-2xl font-bold">{edges.length}</div>
+          <div className="text-xs text-muted-foreground">Connections</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { getKBEntities, getKBLatest, getKBRecords, getKBEntity, getKBEntitySlug } from "@/data/kb";
 import type { Fact } from "@longterm-wiki/kb";
 import { ProfileStatCard } from "@/components/directory";
@@ -98,6 +99,20 @@ export default function PeoplePage() {
           Directory of key people in AI safety, frontier AI research, policy,
           and effective altruism tracked in the knowledge base.
         </p>
+        <Link
+          href="/people/network"
+          className="inline-flex items-center gap-1.5 mt-3 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4"
+          >
+            <path d="M15.5 2A1.5 1.5 0 0014 3.5v13a1.5 1.5 0 001.5 1.5h1a1.5 1.5 0 001.5-1.5v-13A1.5 1.5 0 0016.5 2h-1zM9.5 6A1.5 1.5 0 008 7.5v9A1.5 1.5 0 009.5 18h1a1.5 1.5 0 001.5-1.5v-9A1.5 1.5 0 0010.5 6h-1zM3.5 10A1.5 1.5 0 002 11.5v5A1.5 1.5 0 003.5 18h1A1.5 1.5 0 006 16.5v-5A1.5 1.5 0 004.5 10h-1z" />
+          </svg>
+          View relationship network
+        </Link>
       </div>
 
       {/* Summary stats */}


### PR DESCRIPTION
## Summary
- Adds a new page at `/people/network` with an interactive force-directed graph showing relationships between people and organizations in the AI safety ecosystem
- Nodes represent people (indigo circles) and organizations (amber squares); edges represent employment/affiliation relationships
- Data sourced from KB employed-by facts, key-persons records, and expert affiliation data — no new dependencies added
- Includes click-to-highlight connections, drag-to-reposition nodes, and hover tooltips with role details
- Adds a "View relationship network" link from the `/people` directory page

## Implementation details
- **Zero external dependencies**: Pure SVG rendering with a custom force-directed layout simulation (charge repulsion + spring forces + center gravity)
- **Server component** (`page.tsx`) collects graph data at build time from KB entities
- **Client component** (`network-graph.tsx`) handles interactive rendering with `requestAnimationFrame` loop
- The graph renders ~48 people + ~20 organizations — small enough that no WebGL or complex optimizations are needed

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] Full production build succeeds (`/people/network` renders as static page)
- [x] All 577 web app tests pass
- [ ] Visual verification: navigate to `/people/network` and verify nodes render, click/drag/hover interactions work

Generated with [Claude Code](https://claude.com/claude-code)