### PR TITLE
feat: add funding connections to person pages

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   getOrgRolesForPerson,
   getBoardSeatsForPerson,
   getCareerHistory,
+  getFundingConnectionsForPerson,
 } from "../people-utils";
 import {
   getKBFacts,
@@ -19,6 +20,7 @@ import {
   formatDateRange,
   getEntityWikiHref,
   fieldStr,
+  formatCompactCurrency,
 } from "@/lib/directory-utils";
 import {
   ProfileStatCard,
@@ -83,6 +85,9 @@ export default async function PersonProfilePage({
 
   // Career history from KB records (populated via personnel table)
   const careerHistory = getCareerHistory(entity.id);
+
+  // Funding connections (grants via org affiliations or personal grants)
+  const fundingConnections = getFundingConnectionsForPerson(entity.id);
 
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
@@ -359,6 +364,166 @@ export default async function PersonProfilePage({
                       </div>
                     </div>
                   ))}
+              </div>
+            </section>
+          )}
+
+          {/* Funding Connections */}
+          {fundingConnections.length > 0 && (
+            <section>
+              <h2 className="text-lg font-bold tracking-tight mb-4">
+                Funding Connections
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {fundingConnections.length}
+                </span>
+              </h2>
+              <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+                {/* Summary stats */}
+                {(() => {
+                  const totalAmount = fundingConnections.reduce(
+                    (sum, c) => sum + (c.amount ?? 0),
+                    0,
+                  );
+                  const gaveCount = fundingConnections.filter(
+                    (c) => c.direction === "gave",
+                  ).length;
+                  const receivedCount = fundingConnections.filter(
+                    (c) =>
+                      c.direction === "received" || c.direction === "personal",
+                  ).length;
+                  return (
+                    <div className="px-5 py-3 bg-muted/30 border-b border-border/40 flex items-center gap-4 text-xs text-muted-foreground">
+                      {totalAmount > 0 && (
+                        <span>
+                          Total:{" "}
+                          <span className="font-semibold text-foreground">
+                            {formatCompactCurrency(totalAmount)}
+                          </span>
+                        </span>
+                      )}
+                      {gaveCount > 0 && (
+                        <span>
+                          Gave:{" "}
+                          <span className="font-medium">{gaveCount}</span>
+                        </span>
+                      )}
+                      {receivedCount > 0 && (
+                        <span>
+                          Received:{" "}
+                          <span className="font-medium">{receivedCount}</span>
+                        </span>
+                      )}
+                    </div>
+                  );
+                })()}
+                <div className="divide-y divide-border/40">
+                  {fundingConnections.slice(0, 20).map((conn) => (
+                    <div key={conn.key} className="px-5 py-3.5">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span
+                          className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                            conn.direction === "gave"
+                              ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                              : conn.direction === "personal"
+                                ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
+                                : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                          }`}
+                        >
+                          {conn.direction === "gave"
+                            ? "Funded"
+                            : conn.direction === "personal"
+                              ? "Received"
+                              : "Org received"}
+                        </span>
+                        <span className="font-semibold text-sm">
+                          {conn.name}
+                        </span>
+                        {conn.amount != null && (
+                          <span className="text-sm font-semibold tabular-nums text-foreground">
+                            {formatCompactCurrency(conn.amount)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-sm text-muted-foreground mt-0.5 flex items-center gap-1.5 flex-wrap">
+                        {conn.direction === "gave" && conn.counterparty && (
+                          <span>
+                            to{" "}
+                            {conn.counterparty.href ? (
+                              <Link
+                                href={conn.counterparty.href}
+                                className="hover:text-primary transition-colors"
+                              >
+                                {conn.counterparty.name}
+                              </Link>
+                            ) : (
+                              conn.counterparty.name
+                            )}
+                          </span>
+                        )}
+                        {(conn.direction === "received" ||
+                          conn.direction === "personal") &&
+                          conn.counterparty && (
+                            <span>
+                              from{" "}
+                              {conn.counterparty.href ? (
+                                <Link
+                                  href={conn.counterparty.href}
+                                  className="hover:text-primary transition-colors"
+                                >
+                                  {conn.counterparty.name}
+                                </Link>
+                              ) : (
+                                conn.counterparty.name
+                              )}
+                            </span>
+                          )}
+                        {conn.viaOrg && (
+                          <span className="text-muted-foreground/60">
+                            via{" "}
+                            {conn.viaOrg.slug ? (
+                              <Link
+                                href={`/organizations/${conn.viaOrg.slug}`}
+                                className="hover:text-primary transition-colors"
+                              >
+                                {conn.viaOrg.name}
+                              </Link>
+                            ) : (
+                              conn.viaOrg.name
+                            )}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground/60">
+                        {conn.date && <span>{conn.date}</span>}
+                        {conn.program && (
+                          <span className="text-muted-foreground/40">
+                            {conn.program}
+                          </span>
+                        )}
+                        {conn.status && (
+                          <span
+                            className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold ${
+                              conn.status === "active"
+                                ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
+                                : conn.status === "completed"
+                                  ? "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300"
+                                  : "bg-gray-100 text-gray-600"
+                            }`}
+                          >
+                            {conn.status}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                {fundingConnections.length > 20 && (
+                  <div className="px-5 py-3 border-t border-border/40 text-center">
+                    <span className="text-xs text-muted-foreground">
+                      Showing 20 of {fundingConnections.length} connections
+                    </span>
+                  </div>
+                )}
               </div>
             </section>
           )}

--- a/apps/web/src/app/people/people-utils.ts
+++ b/apps/web/src/app/people/people-utils.ts
@@ -12,6 +12,7 @@ import {
   getKBRecords,
   getKBEntitySlug,
   getAllKBRecords,
+  getAllKBRecordsByCollection,
   getKBEntity,
   type KBRecordEntry,
 } from "@/data/kb";
@@ -173,4 +174,238 @@ export function getCareerHistory(personEntityId: string): CareerHistoryEntry[] {
   });
 
   return entries;
+}
+
+// -- Funding connections ---------------------------------------------------
+
+export interface FundingConnection {
+  /** Unique key for React rendering */
+  key: string;
+  /** Grant display name */
+  name: string;
+  /** Whether this person's org gave or received the grant, or the person directly received it */
+  direction: "gave" | "received" | "personal";
+  /** The affiliated org through which the connection exists (null for personal grants) */
+  viaOrg: { id: string; name: string; slug: string | undefined } | null;
+  /** The counterparty (funder for received, recipient for gave) */
+  counterparty: { name: string; href: string | null } | null;
+  /** Grant amount in USD */
+  amount: number | null;
+  /** Grant date or period */
+  date: string | null;
+  /** Grant program name */
+  program: string | null;
+  /** Grant status */
+  status: string | null;
+  /** Source URL */
+  source: string | null;
+}
+
+/**
+ * Derive funding connections for a person through their organization affiliations.
+ *
+ * Strategy:
+ * 1. Collect all affiliated org IDs (from career history, key-person records, board seats)
+ * 2. Find grants where those orgs are the funder (ownerEntityId) → "gave"
+ * 3. Find grants where those orgs are the recipient → "received"
+ * 4. Find grants where the person themselves is the recipient → "personal"
+ *
+ * Deduplicates by grant record key to avoid showing the same grant multiple times
+ * when a person has multiple affiliations with the same org.
+ */
+export function getFundingConnectionsForPerson(
+  personEntityId: string,
+): FundingConnection[] {
+  const entity = getKBEntity(personEntityId);
+  if (!entity) return [];
+
+  const personSlug = getKBEntitySlug(personEntityId);
+
+  // Collect affiliated org IDs from all relationship types
+  const affiliatedOrgIds = new Set<string>();
+
+  // From career history
+  const careerRecords = getKBRecords(personEntityId, "career-history");
+  for (const r of careerRecords) {
+    const orgId = r.fields.organization;
+    if (typeof orgId === "string" && orgId) {
+      affiliatedOrgIds.add(orgId);
+    }
+  }
+
+  // From key-person records (org → person references)
+  const allKeyPersons = getAllKBRecords("key-persons");
+  for (const rec of allKeyPersons) {
+    if (rec.fields.person === personEntityId) {
+      affiliatedOrgIds.add(rec.ownerEntityId);
+    }
+  }
+
+  // From board seats
+  const allBoardSeats = getAllKBRecords("board-seats");
+  for (const rec of allBoardSeats) {
+    if (rec.fields.member === personEntityId) {
+      affiliatedOrgIds.add(rec.ownerEntityId);
+    }
+  }
+
+  // Build a set of names/slugs to match for personal grants
+  const personalMatchNames = new Set<string>([
+    personEntityId.toLowerCase(),
+    entity.name.toLowerCase(),
+    ...(personSlug ? [personSlug.toLowerCase()] : []),
+    ...(entity.aliases?.map((a: string) => a.toLowerCase()) ?? []),
+  ]);
+
+  // Resolve an org ID to display info
+  function resolveOrg(orgId: string) {
+    const orgEntity = getKBEntity(orgId);
+    if (!orgEntity) return { id: orgId, name: orgId, slug: undefined };
+    return {
+      id: orgEntity.id,
+      name: orgEntity.name,
+      slug: getKBEntitySlug(orgEntity.id),
+    };
+  }
+
+  // Resolve a recipient or funder to a display name + href
+  function resolveCounterparty(
+    id: string,
+  ): { name: string; href: string | null } {
+    const e = getKBEntity(id);
+    if (e) {
+      const slug = getKBEntitySlug(id);
+      const href =
+        slug && e.type === "organization"
+          ? `/organizations/${slug}`
+          : slug && e.type === "person"
+            ? `/people/${slug}`
+            : `/kb/entity/${id}`;
+      return { name: e.name, href };
+    }
+    // Title-case the slug as fallback
+    const name = id
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+    return { name, href: null };
+  }
+
+  const allGrants = getAllKBRecordsByCollection("grants");
+  const seen = new Set<string>();
+  const connections: FundingConnection[] = [];
+
+  function parseGrantFields(record: KBRecordEntry) {
+    const f = record.fields;
+    return {
+      name: (f.name as string) ?? record.key,
+      amount: typeof f.amount === "number" ? f.amount : null,
+      date: (f.date as string) ?? (f.period as string) ?? null,
+      program: (f.program as string) ?? null,
+      status: (f.status as string) ?? null,
+      source: (f.source as string) ?? null,
+      recipient: (f.recipient as string) ?? null,
+    };
+  }
+
+  for (const record of allGrants) {
+    const compositeKey = `${record.ownerEntityId}-${record.key}`;
+    const parsed = parseGrantFields(record);
+    const funderOrgId = record.ownerEntityId;
+    const recipientRaw = parsed.recipient;
+
+    // Check if funder org is one of person's affiliated orgs → "gave"
+    if (affiliatedOrgIds.has(funderOrgId) && !seen.has(compositeKey)) {
+      seen.add(compositeKey);
+      const recipientInfo = recipientRaw
+        ? resolveCounterparty(recipientRaw)
+        : null;
+      connections.push({
+        key: compositeKey,
+        name: parsed.name,
+        direction: "gave",
+        viaOrg: resolveOrg(funderOrgId),
+        counterparty: recipientInfo,
+        amount: parsed.amount,
+        date: parsed.date,
+        program: parsed.program,
+        status: parsed.status,
+        source: parsed.source,
+      });
+      continue;
+    }
+
+    // Check if person themselves is the recipient → "personal"
+    if (
+      recipientRaw &&
+      personalMatchNames.has(recipientRaw.toLowerCase()) &&
+      !seen.has(compositeKey)
+    ) {
+      seen.add(compositeKey);
+      connections.push({
+        key: compositeKey,
+        name: parsed.name,
+        direction: "personal",
+        viaOrg: null,
+        counterparty: resolveCounterparty(funderOrgId),
+        amount: parsed.amount,
+        date: parsed.date,
+        program: parsed.program,
+        status: parsed.status,
+        source: parsed.source,
+      });
+      continue;
+    }
+
+    // Check if recipient org is one of person's affiliated orgs → "received"
+    if (recipientRaw && !seen.has(compositeKey)) {
+      // Try to resolve recipient to an entity ID
+      let recipientEntityId: string | null = null;
+      const recipientEntity = getKBEntity(recipientRaw);
+      if (recipientEntity) {
+        recipientEntityId = recipientEntity.id;
+      } else {
+        // Try matching by slug
+        for (const orgId of affiliatedOrgIds) {
+          const orgEntity = getKBEntity(orgId);
+          if (!orgEntity) continue;
+          const orgSlug = getKBEntitySlug(orgId);
+          const matchNames = new Set([
+            orgId.toLowerCase(),
+            orgEntity.name.toLowerCase(),
+            ...(orgSlug ? [orgSlug.toLowerCase()] : []),
+            ...(orgEntity.aliases?.map((a: string) => a.toLowerCase()) ?? []),
+          ]);
+          if (matchNames.has(recipientRaw.toLowerCase())) {
+            recipientEntityId = orgId;
+            break;
+          }
+        }
+      }
+
+      if (recipientEntityId && affiliatedOrgIds.has(recipientEntityId)) {
+        seen.add(compositeKey);
+        connections.push({
+          key: compositeKey,
+          name: parsed.name,
+          direction: "received",
+          viaOrg: resolveOrg(recipientEntityId),
+          counterparty: resolveCounterparty(funderOrgId),
+          amount: parsed.amount,
+          date: parsed.date,
+          program: parsed.program,
+          status: parsed.status,
+          source: parsed.source,
+        });
+      }
+    }
+  }
+
+  // Sort: by amount descending (nulls last)
+  connections.sort((a, b) => {
+    const amtA = a.amount ?? -1;
+    const amtB = b.amount ?? -1;
+    return amtB - amtA;
+  });
+
+  return connections;
 }


### PR DESCRIPTION
## Summary

- Add a "Funding Connections" section to person profile pages that shows grants related to a person through their organization affiliations
- Derive connections via three paths: career history orgs, key-person roles, and board seats
- Support three connection types: "Funded" (person's org gave the grant), "Org received" (person's org received the grant), and "Received" (person directly received the grant)
- Display grant amount, counterparty (funder/recipient), via-org attribution, date, program, and status
- Summary bar shows total funding amount and gave/received counts
- Capped at 20 items with overflow indicator

## Implementation

New `getFundingConnectionsForPerson()` function in `people-utils.ts`:
1. Collects affiliated org IDs from career-history, key-persons, and board-seats KB records
2. Scans all grants in the KB, matching by funder org ID, recipient org ID/name/slug, or personal name match
3. Deduplicates by composite key to avoid showing the same grant multiple times

No new runtime API calls -- all data comes from `database.json` at build time, consistent with the existing pattern.

## Test plan

- [x] `pnpm build` passes -- all 48 person pages statically generated successfully
- [x] `pnpm test` passes (7 pre-existing failures in source-fetcher.test.ts, unrelated)
- [x] TypeScript check passes (no new errors introduced)
- [ ] Verify person pages with known grant connections display the section (e.g., people affiliated with LTFF, Open Philanthropy)

Agent slot: a5

