### PR TITLE
feat: add social links to person profile pages

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -30,6 +30,7 @@ import {
 import { formatKBDate } from "@/components/wiki/kb/format";
 import { getExpertById, getPublicationsForPerson } from "@/data";
 import { ExpertPositions } from "./expert-positions";
+import { SocialLinks } from "./social-links";
 
 export function generateStaticParams() {
   return getPersonSlugs().map((slug) => ({ slug }));
@@ -67,6 +68,19 @@ export default async function PersonProfilePage({
   const educationFact = getKBLatest(entity.id, "education");
   const notableForFact = getKBLatest(entity.id, "notable-for");
   const socialMediaFact = getKBLatest(entity.id, "social-media");
+  const websiteFact = getKBLatest(entity.id, "website");
+  const googleScholarFact = getKBLatest(entity.id, "google-scholar");
+  const githubFact = getKBLatest(entity.id, "github-profile");
+  const wikipediaFact = getKBLatest(entity.id, "wikipedia-url");
+
+  // Social links facts for the sidebar component
+  const socialLinkFacts = {
+    "website": websiteFact,
+    "social-media": socialMediaFact,
+    "github-profile": githubFact,
+    "google-scholar": googleScholarFact,
+    "wikipedia-url": wikipediaFact,
+  };
 
   // Expert positions from experts.yaml
   const expert = getExpertById(slug);
@@ -212,9 +226,14 @@ export default async function PersonProfilePage({
               KB data &rarr;
             </Link>
             {socialMediaFact?.value.type === "text" && (
-              <span className="text-muted-foreground">
+              <a
+                href={`https://x.com/${socialMediaFact.value.value.replace(/^@/, "")}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-primary transition-colors"
+              >
                 {socialMediaFact.value.value}
-              </span>
+              </a>
             )}
           </div>
         </div>
@@ -366,6 +385,9 @@ export default async function PersonProfilePage({
 
         {/* Sidebar */}
         <div className="space-y-8">
+          {/* Social Links */}
+          <SocialLinks facts={socialLinkFacts} />
+
           {/* Organization Roles (from org key-person records) */}
           {sortedOrgRoles.length > 0 && (
             <section>

--- a/apps/web/src/app/people/[slug]/social-links.tsx
+++ b/apps/web/src/app/people/[slug]/social-links.tsx
@@ -1,0 +1,112 @@
+import type { Fact } from "@longterm-wiki/kb";
+
+/**
+ * Social link definition — maps a KB property to display config.
+ */
+interface SocialLinkDef {
+  /** KB property ID */
+  property: string;
+  /** Display label */
+  label: string;
+  /** SVG icon path data (rendered inside a 24x24 viewBox) */
+  iconPath: string;
+  /** Given the fact text value, return the full URL */
+  toUrl: (value: string) => string;
+}
+
+const SOCIAL_LINKS: SocialLinkDef[] = [
+  {
+    property: "website",
+    label: "Website",
+    // Globe icon
+    iconPath:
+      "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z",
+    toUrl: (v) => v,
+  },
+  {
+    property: "social-media",
+    label: "X / Twitter",
+    // X (Twitter) icon
+    iconPath:
+      "M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z",
+    toUrl: (v) => {
+      const handle = v.replace(/^@/, "");
+      return `https://x.com/${handle}`;
+    },
+  },
+  {
+    property: "github-profile",
+    label: "GitHub",
+    // GitHub icon
+    iconPath:
+      "M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z",
+    toUrl: (v) => v,
+  },
+  {
+    property: "google-scholar",
+    label: "Google Scholar",
+    // Graduation cap / scholar icon
+    iconPath:
+      "M12 3L1 9l4 2.18v6L12 21l7-3.82v-6l2-1.09V17h2V9L12 3zm6.82 6L12 12.72 5.18 9 12 5.28 18.82 9zM17 15.99l-5 2.73-5-2.73v-3.72L12 15l5-2.73v3.72z",
+    toUrl: (v) => v,
+  },
+  {
+    property: "wikipedia-url",
+    label: "Wikipedia",
+    // W icon (simplified Wikipedia)
+    iconPath:
+      "M12.09 13.119c-.14 1.064-.44 2.098-.876 3.076l-1.264 2.828-.252.504L6.476 12.2 4.75 17.092 3.5 21.5l-1-.34L5.7 12.03l.252-.672L3.356 4.5h1.36l2.1 5.88L8.424 4.5h1.26l-2.34 6.552c.816-.048 1.464.24 1.944.864.48.624.84 1.44 1.08 2.448l.252-.504 1.764-3.552L13.536 4.5h1.248L12.54 9.96l1.596 3.528L17.592 4.5h1.26l-4.2 9.372-2.16 4.632-.252.504c-.456-.96-.78-1.98-.936-3.06L12.09 13.12z",
+    toUrl: (v) => v,
+  },
+];
+
+interface SocialLinksProps {
+  /** All facts for this entity, keyed by property ID */
+  facts: Record<string, Fact | undefined>;
+}
+
+/**
+ * Renders a row of small social link icons for a person profile page.
+ * Reads from KB facts: website, social-media, github-profile, google-scholar, wikipedia-url.
+ */
+export function SocialLinks({ facts }: SocialLinksProps) {
+  const links: Array<{ label: string; url: string; iconPath: string }> = [];
+
+  for (const def of SOCIAL_LINKS) {
+    const fact = facts[def.property];
+    if (!fact || fact.value.type !== "text") continue;
+    const url = def.toUrl(fact.value.value);
+    if (!url) continue;
+    links.push({ label: def.label, url, iconPath: def.iconPath });
+  }
+
+  if (links.length === 0) return null;
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold tracking-tight mb-3">Links</h2>
+      <div className="flex flex-wrap gap-2">
+        {links.map((link) => (
+          <a
+            key={link.label}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={link.label}
+            className="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-border/60 bg-card text-muted-foreground hover:text-primary hover:border-primary/40 transition-colors"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-4.5 h-4.5"
+              aria-hidden="true"
+            >
+              <path d={link.iconPath} />
+            </svg>
+            <span className="sr-only">{link.label}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/kb/data/properties.yaml
+++ b/packages/kb/data/properties.yaml
@@ -116,6 +116,27 @@ properties:
     category: biographical
     appliesTo: [person]
 
+  google-scholar:
+    name: Google Scholar
+    description: "Google Scholar profile URL"
+    dataType: text
+    category: biographical
+    appliesTo: [person]
+
+  github-profile:
+    name: GitHub
+    description: "GitHub profile URL"
+    dataType: text
+    category: biographical
+    appliesTo: [person]
+
+  wikipedia-url:
+    name: Wikipedia
+    description: "Wikipedia article URL"
+    dataType: text
+    category: biographical
+    appliesTo: [person]
+
   founded-by:
     name: Founded By
     description: "Person(s) who founded this organization"

--- a/packages/kb/data/things/chris-olah.yaml
+++ b/packages/kb/data/things/chris-olah.yaml
@@ -52,6 +52,18 @@ facts:
     value: "@ch402"
     source: https://x.com/ch402
 
+  - id: f_cO_website
+    property: website
+    value: "https://colah.github.io"
+
+  - id: f_cO_github
+    property: github-profile
+    value: "https://github.com/colah"
+
+  - id: f_cO_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=vKAKE1gAAAAJ"
+
 records:
   career-history:
     i_cO1zA2bC3d:

--- a/packages/kb/data/things/dario-amodei.yaml
+++ b/packages/kb/data/things/dario-amodei.yaml
@@ -42,6 +42,14 @@ facts:
     value: "@DarioAmodei"
     source: https://x.com/DarioAmodei
 
+  - id: f_dA_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Dario_Amodei"
+
+  - id: f_dA_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=0tSbNNgAAAAJ"
+
   - id: f_9Rz2EK1pYA
     property: role
     value: "VP of Research"

--- a/packages/kb/data/things/demis-hassabis.yaml
+++ b/packages/kb/data/things/demis-hassabis.yaml
@@ -42,6 +42,14 @@ facts:
     value: "@demaborns"
     source: https://x.com/demishassabis
 
+  - id: f_dH_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Demis_Hassabis"
+
+  - id: f_dH_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=tdb0t88AAAAJ"
+
   - id: f_i5dpgqJDXg
     property: role
     value: "CEO, Google DeepMind"

--- a/packages/kb/data/things/eliezer-yudkowsky.yaml
+++ b/packages/kb/data/things/eliezer-yudkowsky.yaml
@@ -45,6 +45,14 @@ facts:
     value: "@ESYudkowsky"
     source: https://x.com/ESYudkowsky
 
+  - id: f_eY_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Eliezer_Yudkowsky"
+
+  - id: f_eY_website
+    property: website
+    value: "https://www.yudkowsky.net"
+
 records:
   career-history:
     i_eY1zA2bC3d:

--- a/packages/kb/data/things/geoffrey-hinton.yaml
+++ b/packages/kb/data/things/geoffrey-hinton.yaml
@@ -51,6 +51,18 @@ facts:
     value: "@geoffreyhinton"
     source: https://x.com/geoffreyhinton
 
+  - id: f_gH_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Geoffrey_Hinton"
+
+  - id: f_gH_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=JicYPdAAAAAJ"
+
+  - id: f_gH_website
+    property: website
+    value: "https://www.cs.toronto.edu/~hinton/"
+
   - id: f_lpaINqQFBw
     property: role
     value: "Professor of Computer Science"

--- a/packages/kb/data/things/holden-karnofsky.yaml
+++ b/packages/kb/data/things/holden-karnofsky.yaml
@@ -73,6 +73,14 @@ facts:
     value: "@HoldenKarnofsky"
     source: https://x.com/HoldenKarnofsky
 
+  - id: f_hK_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Holden_Karnofsky"
+
+  - id: f_hK_website
+    property: website
+    value: "https://www.cold-takes.com"
+
 records:
   career-history:
     i_hK1zA2bC3d:

--- a/packages/kb/data/things/ilya-sutskever.yaml
+++ b/packages/kb/data/things/ilya-sutskever.yaml
@@ -57,6 +57,14 @@ facts:
     value: "@iabornamore"
     source: https://x.com/iabornamore
 
+  - id: f_iS_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Ilya_Sutskever"
+
+  - id: f_iS_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=x04W_mMAAAAJ"
+
   - id: f_h3HeIqbtpA
     property: employed-by
     value: "Google Brain"

--- a/packages/kb/data/things/nick-bostrom.yaml
+++ b/packages/kb/data/things/nick-bostrom.yaml
@@ -44,6 +44,18 @@ facts:
     value: "@NickBostrom"
     source: https://x.com/NickBostrom
 
+  - id: f_nB_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Nick_Bostrom"
+
+  - id: f_nB_website
+    property: website
+    value: "https://nickbostrom.com"
+
+  - id: f_nB_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=gk5PjEkAAAAJ"
+
 records:
   career-history:
     i_nB1zA2bC3d:

--- a/packages/kb/data/things/paul-christiano.yaml
+++ b/packages/kb/data/things/paul-christiano.yaml
@@ -50,6 +50,18 @@ facts:
     value: "@paulfchristiano"
     source: https://x.com/paulfchristiano
 
+  - id: f_pC_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Paul_Christiano"
+
+  - id: f_pC_website
+    property: website
+    value: "https://paulfchristiano.com"
+
+  - id: f_pC_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=6gHkYDgAAAAJ"
+
   - id: f_DRwx53YvWw
     property: role
     value: "Head of AI Safety, US AI Safety Institute"

--- a/packages/kb/data/things/sam-altman.yaml
+++ b/packages/kb/data/things/sam-altman.yaml
@@ -51,6 +51,18 @@ facts:
     value: "@sama"
     source: https://x.com/sama
 
+  - id: f_sA_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Sam_Altman"
+
+  - id: f_sA_website
+    property: website
+    value: "https://blog.samaltman.com"
+
+  - id: f_sA_github
+    property: github-profile
+    value: "https://github.com/sama"
+
   - id: f_dL5uH8tF2n
     property: role
     value: "CEO & Co-founder, Loopt"

--- a/packages/kb/data/things/stuart-russell.yaml
+++ b/packages/kb/data/things/stuart-russell.yaml
@@ -44,6 +44,18 @@ facts:
     value: "@StuartJRussell"
     source: https://x.com/StuartJRussell
 
+  - id: f_sR_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Stuart_J._Russell"
+
+  - id: f_sR_website
+    property: website
+    value: "https://people.eecs.berkeley.edu/~russell/"
+
+  - id: f_sR_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=2oy3OXYAAAAJ"
+
 records:
   career-history:
     i_sR1zA2bC3d:

--- a/packages/kb/data/things/yann-lecun.yaml
+++ b/packages/kb/data/things/yann-lecun.yaml
@@ -43,6 +43,18 @@ facts:
     value: "@ylecun"
     source: https://x.com/ylecun
 
+  - id: f_yL_wiki_url
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/Yann_LeCun"
+
+  - id: f_yL_scholar
+    property: google-scholar
+    value: "https://scholar.google.com/citations?user=WLN3QrAAAAAJ"
+
+  - id: f_yL_website
+    property: website
+    value: "http://yann.lecun.com"
+
   - id: f_4vHT9Lh28Q
     property: role
     value: "Research Scientist"


### PR DESCRIPTION
## Summary
- Add a social links section to the person page sidebar showing icons for website, X/Twitter, GitHub, Google Scholar, and Wikipedia
- New KB properties: `google-scholar`, `github-profile`, `wikipedia-url` added to `properties.yaml`
- Social link data added for 12 people: Geoffrey Hinton, Dario Amodei, Sam Altman, Eliezer Yudkowsky, Paul Christiano, Stuart Russell, Nick Bostrom, Yann LeCun, Demis Hassabis, Chris Olah, Holden Karnofsky, Ilya Sutskever
- Made the inline @handle in the header area a clickable link to X/Twitter profile
- Component renders as small icon buttons in a flex row; returns null when no links available

## Test plan
- [ ] TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] Gate check passes (`pnpm crux validate gate --scope=content --fix`)
- [ ] Person pages with social data (e.g., Geoffrey Hinton, Sam Altman) show the Links section in sidebar
- [ ] Person pages without social data show no Links section
- [ ] All icon links open in new tabs with correct URLs
- [ ] @handle in header is now clickable and links to X profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)