### PR TITLE
fix: eliminate redundant KB scans and improve matching in funding connections

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
   getFundingConnectionsForPerson,
 } from "../people-utils";
 import {
+  getAllKBRecords,
   getKBFacts,
   getKBLatest,
   getKBEntitySlug,
@@ -91,17 +92,26 @@ export default async function PersonProfilePage({
   // Publications linked to this person (from literature.yaml via people-resources.yaml)
   const publications = getPublicationsForPerson(slug);
 
+  // Fetch key-persons and board-seats once; shared across org roles,
+  // board seats, and funding connections to avoid redundant KB scans.
+  const allKeyPersons = getAllKBRecords("key-persons");
+  const allBoardSeats = getAllKBRecords("board-seats");
+
   // Reverse lookup: org key-person records referencing this person
-  const orgRoles = getOrgRolesForPerson(entity.id);
+  const orgRoles = getOrgRolesForPerson(entity.id, allKeyPersons);
 
   // Board seats across all organizations referencing this person
-  const boardSeats = getBoardSeatsForPerson(entity.id);
+  const boardSeats = getBoardSeatsForPerson(entity.id, allBoardSeats);
 
   // Career history from KB records (populated via personnel table)
   const careerHistory = getCareerHistory(entity.id);
 
   // Funding connections (grants via org affiliations or personal grants)
-  const fundingConnections = getFundingConnectionsForPerson(entity.id);
+  const fundingConnections = getFundingConnectionsForPerson(
+    entity.id,
+    allKeyPersons,
+    allBoardSeats,
+  );
 
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(

--- a/apps/web/src/app/people/people-utils.ts
+++ b/apps/web/src/app/people/people-utils.ts
@@ -50,22 +50,23 @@ export const getPersonSlugs = () => getEntitySlugs("person");
 
 /**
  * Find all key-person records across all organizations that reference this person.
- * Uses getAllKBRecords to scan all orgs' key-persons collections,
- * filtering by fields.person === personEntityId.
+ * Accepts pre-fetched key-person records to avoid redundant KB scans when the
+ * caller also needs the data for other lookups (e.g., funding connections).
  */
 export function getOrgRolesForPerson(
   personEntityId: string,
+  allKeyPersons?: KBRecordEntry[],
 ): Array<{
   org: { id: string; name: string; type: string };
   record: { key: string; fields: Record<string, unknown> };
 }> {
-  const allKeyPersons = getAllKBRecords("key-persons");
+  const records = allKeyPersons ?? getAllKBRecords("key-persons");
   const results: Array<{
     org: { id: string; name: string; type: string };
     record: { key: string; fields: Record<string, unknown> };
   }> = [];
 
-  for (const rec of allKeyPersons) {
+  for (const rec of records) {
     if (!matchesPersonField(rec.fields.person, personEntityId)) continue;
 
     const orgEntity = getKBEntity(rec.ownerEntityId);
@@ -89,22 +90,23 @@ export function getOrgRolesForPerson(
 
 /**
  * Find all board-seat records across all organizations that reference this person.
- * Uses getAllKBRecords to scan all orgs' board-seats collections,
- * filtering by fields.member === personEntityId.
+ * Accepts pre-fetched board-seat records to avoid redundant KB scans when the
+ * caller also needs the data for other lookups (e.g., funding connections).
  */
 export function getBoardSeatsForPerson(
   personEntityId: string,
+  allBoardSeats?: KBRecordEntry[],
 ): Array<{
   org: { id: string; name: string; type: string };
   record: { key: string; fields: Record<string, unknown> };
 }> {
-  const allBoardSeats = getAllKBRecords("board-seats");
+  const records = allBoardSeats ?? getAllKBRecords("board-seats");
   const results: Array<{
     org: { id: string; name: string; type: string };
     record: { key: string; fields: Record<string, unknown> };
   }> = [];
 
-  for (const rec of allBoardSeats) {
+  for (const rec of records) {
     if (!matchesPersonField(rec.fields.member, personEntityId)) continue;
 
     const orgEntity = getKBEntity(rec.ownerEntityId);
@@ -231,11 +233,16 @@ export interface FundingConnection {
  * 3. Find grants where those orgs are the recipient → "received"
  * 4. Find grants where the person themselves is the recipient → "personal"
  *
- * Deduplicates by grant record key to avoid showing the same grant multiple times
- * when a person has multiple affiliations with the same org.
+ * Deduplicates by composite key (ownerEntityId + record key) to avoid showing
+ * the same grant multiple times when a person has multiple affiliations with the same org.
+ *
+ * Accepts pre-fetched key-person and board-seat records to avoid redundant KB scans
+ * when the caller has already loaded them for other purposes.
  */
 export function getFundingConnectionsForPerson(
   personEntityId: string,
+  prefetchedKeyPersons?: KBRecordEntry[],
+  prefetchedBoardSeats?: KBRecordEntry[],
 ): FundingConnection[] {
   const entity = getKBEntity(personEntityId);
   if (!entity) return [];
@@ -255,17 +262,17 @@ export function getFundingConnectionsForPerson(
   }
 
   // From key-person records (org → person references)
-  const allKeyPersons = getAllKBRecords("key-persons");
-  for (const rec of allKeyPersons) {
-    if (rec.fields.person === personEntityId) {
+  const keyPersonRecords = prefetchedKeyPersons ?? getAllKBRecords("key-persons");
+  for (const rec of keyPersonRecords) {
+    if (matchesPersonField(rec.fields.person, personEntityId)) {
       affiliatedOrgIds.add(rec.ownerEntityId);
     }
   }
 
   // From board seats
-  const allBoardSeats = getAllKBRecords("board-seats");
-  for (const rec of allBoardSeats) {
-    if (rec.fields.member === personEntityId) {
+  const boardSeatRecords = prefetchedBoardSeats ?? getAllKBRecords("board-seats");
+  for (const rec of boardSeatRecords) {
+    if (matchesPersonField(rec.fields.member, personEntityId)) {
       affiliatedOrgIds.add(rec.ownerEntityId);
     }
   }


### PR DESCRIPTION
## Summary

Follow-up fixes to PR #2210 (funding connections on person pages):

- **Eliminate double KB scan**: `getOrgRolesForPerson`, `getBoardSeatsForPerson`, and `getFundingConnectionsForPerson` each independently called `getAllKBRecords("key-persons")` and/or `getAllKBRecords("board-seats")`. Now all three accept optional pre-fetched data parameters, and the page component fetches each collection once and passes it to all consumers.
- **Fix inconsistent person matching**: Inside `getFundingConnectionsForPerson`, key-person and board-seat matching used strict `===` comparison against `personEntityId`, which misses YAML-sourced records that store slugs instead of entity IDs. Now uses `matchesPersonField()` (which handles both formats), consistent with the standalone `getOrgRolesForPerson` and `getBoardSeatsForPerson` functions.
- **Deduplication**: The existing composite-key `seen` set already prevents duplicate grants. The `matchesPersonField` fix ensures affiliated orgs are correctly identified from slug-based data, which could have caused grants to be missed (not duplicated) previously.

## Notes on requested fixes

The original review mentioned an unused `personEntityId` parameter in `getOrgGrantsForPerson` -- this function does not exist in the merged code. The actual function `getFundingConnectionsForPerson` uses its parameter. The `matchesPersonField` consistency fix addresses the related concern about correct person matching.

Agent slot: a5

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify person pages still render correctly with funding connections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized person profile pages by refactoring data fetching logic to reduce redundant queries and improve page load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->