### PR TITLE
fix: replace invalid fact IDs with FACTID_RE-compliant format

### DIFF
--- a/packages/kb/data/things/acx-grants.yaml
+++ b/packages/kb/data/things/acx-grants.yaml
@@ -8,7 +8,7 @@ thing:
     - Astral Codex Ten Grants
 
 facts:
-  - id: f_acx_grants_desc
+  - id: f_grc0ej37ka
     property: description
     value: >-
       ACX Grants is a grant program run by Scott Alexander through his Astral Codex Ten blog.
@@ -16,6 +16,6 @@ facts:
       research, and other areas. Multiple rounds have been conducted since 2021, distributing
       grants typically ranging from a few thousand to several hundred thousand dollars.
     asOf: 2026-03
-  - id: f_acx_grants_web
+  - id: f_hkrt42xnt0
     property: website
     value: https://www.astralcodexten.com/p/acx-grants-results

--- a/packages/kb/data/things/chris-olah.yaml
+++ b/packages/kb/data/things/chris-olah.yaml
@@ -52,15 +52,15 @@ facts:
     value: "@ch402"
     source: https://x.com/ch402
 
-  - id: f_cO_website
+  - id: f_pdsb5nkkx7
     property: website
     value: "https://colah.github.io"
 
-  - id: f_cO_github
+  - id: f_qzkd7k85wt
     property: github-profile
     value: "https://github.com/colah"
 
-  - id: f_cO_scholar
+  - id: f_s2rmoloko5
     property: google-scholar
     value: "https://scholar.google.com/citations?user=vKAKE1gAAAAJ"
 

--- a/packages/kb/data/things/dario-amodei.yaml
+++ b/packages/kb/data/things/dario-amodei.yaml
@@ -42,11 +42,11 @@ facts:
     value: "@DarioAmodei"
     source: https://x.com/DarioAmodei
 
-  - id: f_dA_wiki_url
+  - id: f_b0znrdd1a0
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Dario_Amodei"
 
-  - id: f_dA_scholar
+  - id: f_c85liwnyxb
     property: google-scholar
     value: "https://scholar.google.com/citations?user=0tSbNNgAAAAJ"
 

--- a/packages/kb/data/things/demis-hassabis.yaml
+++ b/packages/kb/data/things/demis-hassabis.yaml
@@ -42,11 +42,11 @@ facts:
     value: "@demaborns"
     source: https://x.com/demishassabis
 
-  - id: f_dH_wiki_url
+  - id: f_lpkq3z8f0a
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Demis_Hassabis"
 
-  - id: f_dH_scholar
+  - id: f_o8sy73d82s
     property: google-scholar
     value: "https://scholar.google.com/citations?user=tdb0t88AAAAJ"
 

--- a/packages/kb/data/things/eliezer-yudkowsky.yaml
+++ b/packages/kb/data/things/eliezer-yudkowsky.yaml
@@ -45,11 +45,11 @@ facts:
     value: "@ESYudkowsky"
     source: https://x.com/ESYudkowsky
 
-  - id: f_eY_wiki_url
+  - id: f_sjaxkelbxa
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Eliezer_Yudkowsky"
 
-  - id: f_eY_website
+  - id: f_tcr35bkwp1
     property: website
     value: "https://www.yudkowsky.net"
 

--- a/packages/kb/data/things/geoffrey-hinton.yaml
+++ b/packages/kb/data/things/geoffrey-hinton.yaml
@@ -51,15 +51,15 @@ facts:
     value: "@geoffreyhinton"
     source: https://x.com/geoffreyhinton
 
-  - id: f_gH_wiki_url
+  - id: f_diekhjz5ad
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Geoffrey_Hinton"
 
-  - id: f_gH_scholar
+  - id: f_dmbr3kfcpp
     property: google-scholar
     value: "https://scholar.google.com/citations?user=JicYPdAAAAAJ"
 
-  - id: f_gH_website
+  - id: f_dx6qemfhow
     property: website
     value: "https://www.cs.toronto.edu/~hinton/"
 

--- a/packages/kb/data/things/givewell.yaml
+++ b/packages/kb/data/things/givewell.yaml
@@ -8,13 +8,13 @@ thing:
     - GiveWell.org
 
 facts:
-  - id: f_givewell_desc
+  - id: f_afp7cku2dp
     property: description
     value: >-
       GiveWell is a nonprofit charity evaluator founded in 2007 by Holden Karnofsky and Elie Hassenfeld.
       It conducts in-depth research to identify the most cost-effective charities in global health and
       development, and directs hundreds of millions of dollars annually to its top-recommended organizations.
     asOf: 2026-03
-  - id: f_givewell_web
+  - id: f_b3f24fq272
     property: website
     value: https://www.givewell.org

--- a/packages/kb/data/things/holden-karnofsky.yaml
+++ b/packages/kb/data/things/holden-karnofsky.yaml
@@ -73,11 +73,11 @@ facts:
     value: "@HoldenKarnofsky"
     source: https://x.com/HoldenKarnofsky
 
-  - id: f_hK_wiki_url
+  - id: f_ipz9p2zvf6
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Holden_Karnofsky"
 
-  - id: f_hK_website
+  - id: f_lagva40ag7
     property: website
     value: "https://www.cold-takes.com"
 

--- a/packages/kb/data/things/ilya-sutskever.yaml
+++ b/packages/kb/data/things/ilya-sutskever.yaml
@@ -57,11 +57,11 @@ facts:
     value: "@iabornamore"
     source: https://x.com/iabornamore
 
-  - id: f_iS_wiki_url
+  - id: f_37luvw3faa
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Ilya_Sutskever"
 
-  - id: f_iS_scholar
+  - id: f_38lts4pojf
     property: google-scholar
     value: "https://scholar.google.com/citations?user=x04W_mMAAAAJ"
 

--- a/packages/kb/data/things/nick-bostrom.yaml
+++ b/packages/kb/data/things/nick-bostrom.yaml
@@ -44,15 +44,15 @@ facts:
     value: "@NickBostrom"
     source: https://x.com/NickBostrom
 
-  - id: f_nB_wiki_url
+  - id: f_efk4yuk5lq
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Nick_Bostrom"
 
-  - id: f_nB_website
+  - id: f_hzwm2k1t58
     property: website
     value: "https://nickbostrom.com"
 
-  - id: f_nB_scholar
+  - id: f_ikrzfocsqt
     property: google-scholar
     value: "https://scholar.google.com/citations?user=gk5PjEkAAAAJ"
 

--- a/packages/kb/data/things/paul-christiano.yaml
+++ b/packages/kb/data/things/paul-christiano.yaml
@@ -50,15 +50,15 @@ facts:
     value: "@paulfchristiano"
     source: https://x.com/paulfchristiano
 
-  - id: f_pC_wiki_url
+  - id: f_tpbbdlppar
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Paul_Christiano"
 
-  - id: f_pC_website
+  - id: f_ur092jojlz
     property: website
     value: "https://paulfchristiano.com"
 
-  - id: f_pC_scholar
+  - id: f_vbteu6smt2
     property: google-scholar
     value: "https://scholar.google.com/citations?user=6gHkYDgAAAAJ"
 

--- a/packages/kb/data/things/sam-altman.yaml
+++ b/packages/kb/data/things/sam-altman.yaml
@@ -51,15 +51,15 @@ facts:
     value: "@sama"
     source: https://x.com/sama
 
-  - id: f_sA_wiki_url
+  - id: f_4wv2f7drz7
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Sam_Altman"
 
-  - id: f_sA_website
+  - id: f_68fi4nulwx
     property: website
     value: "https://blog.samaltman.com"
 
-  - id: f_sA_github
+  - id: f_a0agpci09z
     property: github-profile
     value: "https://github.com/sama"
 

--- a/packages/kb/data/things/stuart-russell.yaml
+++ b/packages/kb/data/things/stuart-russell.yaml
@@ -44,15 +44,15 @@ facts:
     value: "@StuartJRussell"
     source: https://x.com/StuartJRussell
 
-  - id: f_sR_wiki_url
+  - id: f_w7yt58axq6
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Stuart_J._Russell"
 
-  - id: f_sR_website
+  - id: f_ws3y2ichnm
     property: website
     value: "https://people.eecs.berkeley.edu/~russell/"
 
-  - id: f_sR_scholar
+  - id: f_ytjh35xr0n
     property: google-scholar
     value: "https://scholar.google.com/citations?user=2oy3OXYAAAAJ"
 

--- a/packages/kb/data/things/yann-lecun.yaml
+++ b/packages/kb/data/things/yann-lecun.yaml
@@ -43,15 +43,15 @@ facts:
     value: "@ylecun"
     source: https://x.com/ylecun
 
-  - id: f_yL_wiki_url
+  - id: f_38uo2p1lbe
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Yann_LeCun"
 
-  - id: f_yL_scholar
+  - id: f_4bmkyq2hx6
     property: google-scholar
     value: "https://scholar.google.com/citations?user=WLN3QrAAAAAJ"
 
-  - id: f_yL_website
+  - id: f_4eqnc2klts
     property: website
     value: "http://yann.lecun.com"
 


### PR DESCRIPTION
## Summary

- Fix 35 invalid fact IDs across 14 KB YAML files that violate the `FACTID_RE` regex pattern (`/^([A-Za-z0-9]{10}|f_[A-Za-z0-9]{10}|inv_.+)$/`)
- Invalid IDs used descriptive formats with underscores (e.g., `f_dH_wiki_url`, `f_sA_github`, `f_givewell_desc`) instead of the required `f_` + 10 alphanumeric characters
- Introduced by PR #2211 (social links) and related changes to `givewell.yaml` and `acx-grants.yaml`
- All 35 IDs replaced with randomly generated compliant IDs
- KB validation test (`packages/kb/tests/validate.test.ts`) now passes all 58 tests

## Affected files

14 files in `packages/kb/data/things/`: ilya-sutskever, yann-lecun, sam-altman, dario-amodei, geoffrey-hinton, nick-bostrom, holden-karnofsky, demis-hassabis, chris-olah, eliezer-yudkowsky, paul-christiano, stuart-russell, givewell, acx-grants.

## Test plan

- [x] `npx vitest run tests/validate.test.ts` passes (58/58 tests, including the `factid-format` check on real data)
- [x] No remaining fact IDs with underscores after the `f_` prefix
- [x] No MDX pages reference these fact IDs (confirmed via grep)

Generated with [Claude Code](https://claude.com/claude-code)
