### PR TITLE
Add manual-only Wikidata enrichment workflow

### DIFF
--- a/.github/workflows/wikidata-enrich.yml
+++ b/.github/workflows/wikidata-enrich.yml
@@ -99,7 +99,15 @@ jobs:
           git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          # Only stage expected output files
+          git add -- 'packages/kb/data/things/*.yaml'
+
+          # Warn about any other modifications
+          OTHER_CHANGES=$(git diff --name-only | grep -v '^packages/kb/data/things/' || true)
+          if [ -n "$OTHER_CHANGES" ]; then
+            echo "::warning::Unexpected modifications detected (not staged): $OTHER_CHANGES"
+          fi
+
           git commit -m "data: enrich person entities with Wikidata facts ($DATE)"
           git push -u origin "$BRANCH"
 


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`.github/workflows/wikidata-enrich.yml`) for enriching person entities with structured Wikidata facts
- **Manual-only** (`workflow_dispatch`) — no scheduled/cron runs
- Supports optional `entity` input (specific person slug) and `dry_run` toggle
- On changes: creates a branch, commits, and opens a PR for review

## Design decisions
- **Security**: Inputs are passed via environment variables (`INPUT_ENTITY`, `INPUT_DRY_RUN`) instead of direct `${{ inputs.entity }}` interpolation in `run:` blocks, preventing script injection
- **Robustness**: Branch names include `$GITHUB_RUN_NUMBER` to avoid collisions between runs
- **Consistency**: Follows existing workflow patterns (`auto-update.yml`) — uses `_paused-notice.yml`, checks `vars.AUTOMATION_PAUSED`, proper concurrency group

## Test plan
- [x] YAML syntax validated locally with yaml-lint
- [ ] Post-merge: trigger workflow manually from Actions tab with `dry_run: true`
- [ ] Post-merge: trigger with a specific entity slug to confirm filtering works
- [ ] Post-merge: trigger without dry_run to confirm PR creation flow

Generated with [Claude Code](https://claude.com/claude-code)
