### PR TITLE
Populate divisions and funding programs for major funders

### DIFF
--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -26,6 +26,8 @@ const ORG_IDS = {
   OPENAI: "1LcLlMGLbw",
   DEEPMIND: "A4XoubikkQ",
   MIRI: "puAffUjWSS",
+  FLI: "d9sWZtyVwg",
+  SCHMIDT_FUTURES: "h6ntSGk8fg",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -50,15 +52,15 @@ interface DivisionDef {
 // ---------------------------------------------------------------------------
 
 const DIVISIONS: DivisionDef[] = [
-  // ---- Open Philanthropy program areas ----
+  // ---- Coefficient Giving / Open Philanthropy program areas ----
   {
     idSeed: "div|open-philanthropy|global-health-and-wellbeing",
     parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
     name: "Global Health and Wellbeing",
     divisionType: "program-area",
     status: "active",
-    source: "https://www.openphilanthropy.org/focus/global-health-and-wellbeing/",
-    notes: "Covers global health, farm animal welfare, and scientific research",
+    source: "https://coefficientgiving.org/funds/global-health-wellbeing-opportunities",
+    notes: "Covers global health, farm animal welfare, and scientific research. 360+ grants; largest program area.",
   },
   {
     idSeed: "div|open-philanthropy|global-catastrophic-risks",
@@ -66,8 +68,83 @@ const DIVISIONS: DivisionDef[] = [
     name: "Global Catastrophic Risks",
     divisionType: "program-area",
     status: "active",
-    source: "https://www.openphilanthropy.org/focus/global-catastrophic-risks/",
-    notes: "Covers AI safety, biosecurity, and other GCR-related grantmaking",
+    source: "https://coefficientgiving.org/funds/global-catastrophic-risks-opportunities",
+    notes: "Covers AI safety, biosecurity, and other GCR-related grantmaking. 250+ grants across cause areas.",
+  },
+  {
+    idSeed: "div|coefficient-giving|navigating-transformative-ai",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Navigating Transformative AI",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/navigating-transformative-ai",
+    notes:
+      "480+ grants totaling ~$500M. Sub-areas: Technical Safety (Favaloro, O'Keeffe-O'Donovan), AI Governance (Muehlhauser), Short Timelines (Zabel). ~$63.6M in 2024 (~60% of all external AI safety funding).",
+  },
+  {
+    idSeed: "div|coefficient-giving|biosecurity",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Biosecurity & Pandemic Preparedness",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/biosecurity-pandemic-preparedness",
+    notes: "140+ grants totaling ~$260M. Led by Andrew Snyder-Beattie. Work began ~2015, five years before COVID-19.",
+  },
+  {
+    idSeed: "div|coefficient-giving|farm-animal-welfare",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Farm Animal Welfare",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/farm-animal-welfare",
+    notes: "Led by Lewis Bollard. Corporate cage-free campaigns, alt-protein research, advocacy.",
+  },
+  {
+    idSeed: "div|coefficient-giving|science-rd",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Science and Global Health R&D",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/science-and-global-health-rd",
+    notes: "330+ grants + 30+ social investments ($90M+). Led by Jacob Trefethen. Treatments, vaccines, diagnostics.",
+  },
+  {
+    idSeed: "div|coefficient-giving|forecasting",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Forecasting",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/forecasting",
+    notes: "30+ grants totaling ~$50M. Led by Benjamin Tereick. Forecasting infrastructure and research.",
+  },
+  {
+    idSeed: "div|coefficient-giving|effective-giving-careers",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Effective Giving & Careers",
+    divisionType: "fund",
+    status: "active",
+    source: "https://coefficientgiving.org/funds/effective-giving-and-careers",
+    notes: "Led by Melanie Basnak and Sam Donald. Support for CEA, 80,000 Hours, EA Funds, and community infrastructure.",
+  },
+  {
+    idSeed: "div|coefficient-giving|abundance-growth",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Abundance & Growth",
+    divisionType: "fund",
+    status: "active",
+    startDate: "2025-03",
+    source: "https://coefficientgiving.org/funds/abundance-and-growth",
+    notes: "$120M committed over 3 years. Led by Matt Clancy. Economic growth, scientific progress, US-focused.",
+  },
+  {
+    idSeed: "div|coefficient-giving|criminal-justice",
+    parentOrgId: ORG_IDS.OPEN_PHILANTHROPY,
+    name: "Criminal Justice Reform",
+    divisionType: "fund",
+    status: "dissolved",
+    startDate: "2014",
+    endDate: "2022",
+    notes: "Focused on reducing incarceration; wound down in 2022. ~$200M total grants.",
   },
 
   // ---- EA Funds ----
@@ -115,12 +192,109 @@ const DIVISIONS: DivisionDef[] = [
   {
     idSeed: "div|sff|sff-main",
     parentOrgId: ORG_IDS.SFF,
-    name: "Survival and Flourishing Fund",
+    name: "Survival and Flourishing Fund (Main)",
     divisionType: "fund",
     status: "active",
     source: "https://survivalandflourishing.fund/",
     notes:
-      "SFF uses a simulation-based allocation process (S-Process) to distribute grants to organizations working on existential risk reduction",
+      "SFF's primary fund distributing grants via the S-Process simulation-based allocation. ~$152M cumulative since 2019. Three tracks since 2025: Main, Freedom, Fairness.",
+  },
+  {
+    idSeed: "div|sff|initiative-committee",
+    parentOrgId: ORG_IDS.SFF,
+    name: "Initiative Committee",
+    divisionType: "team",
+    status: "active",
+    startDate: "2024",
+    source: "https://survivalandflourishing.fund/",
+    notes:
+      "Small group (Jaan Tallinn, SFF Advisors, 2-5 anonymous voters) that makes proactive grants outside the S-Process rounds.",
+  },
+
+  // ---- Future of Life Institute ----
+  {
+    idSeed: "div|fli|grants-program",
+    parentOrgId: ORG_IDS.FLI,
+    name: "FLI Grants Program",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://futureoflife.org/grant-program/",
+    notes:
+      "FLI's grantmaking arm. $25M+ distributed since 2015 across AI safety, nuclear risk, governance, and existential risk reduction.",
+  },
+  {
+    idSeed: "div|fli|policy-advocacy",
+    parentOrgId: ORG_IDS.FLI,
+    name: "Policy & Advocacy",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://futureoflife.org/",
+    notes:
+      "Campaigns include Asilomar Principles (5,700+ signatories), 2023 Pause Letter (33,000+ signatories), AI Act advocacy. EU and UN engagement.",
+  },
+  {
+    idSeed: "div|fli|fellowships",
+    parentOrgId: ORG_IDS.FLI,
+    name: "Fellowship Programs",
+    divisionType: "program-area",
+    status: "active",
+    startDate: "2022",
+    source: "https://futureoflife.org/grant-program/phd-fellowships/",
+    notes:
+      "Vitalik Buterin PhD and Postdoctoral Fellowships in AI Existential Safety. Run with BAIF. 14+ PhD fellows and 4+ postdocs at top universities.",
+  },
+
+  // ---- Schmidt Futures / Schmidt Sciences ----
+  {
+    idSeed: "div|schmidt|ai-advanced-computing",
+    parentOrgId: ORG_IDS.SCHMIDT_FUTURES,
+    name: "AI & Advanced Computing",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://www.schmidtsciences.org/",
+    notes:
+      "One of five Schmidt Sciences centers. Includes AI2050, AI in Science, and Science of Trustworthy AI programs. $125M+ AI commitment.",
+  },
+  {
+    idSeed: "div|schmidt|climate",
+    parentOrgId: ORG_IDS.SCHMIDT_FUTURES,
+    name: "Climate",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://www.schmidtsciences.org/",
+    notes: "One of five Schmidt Sciences centers. $45M for carbon cycle research. Focuses on bending the carbon curve.",
+  },
+  {
+    idSeed: "div|schmidt|science-systems",
+    parentOrgId: ORG_IDS.SCHMIDT_FUTURES,
+    name: "Science Systems",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://www.schmidtsciences.org/",
+    notes:
+      "One of five Schmidt Sciences centers. Breaking down barriers to scientific discovery by supporting people, tools, and communities.",
+  },
+
+  // ---- Manifund ----
+  {
+    idSeed: "div|manifund|regranting",
+    parentOrgId: ORG_IDS.MANIFUND,
+    name: "Regranting Platform",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://manifund.org/about/regranting",
+    notes:
+      "Platform enabling individuals to receive tax-deductible donations for regranting. Provides fiscal sponsorship for individual regranters.",
+  },
+  {
+    idSeed: "div|manifund|impact-certs",
+    parentOrgId: ORG_IDS.MANIFUND,
+    name: "Impact Certificates",
+    divisionType: "program-area",
+    status: "active",
+    source: "https://manifund.org",
+    notes:
+      "Experimental impact certificate marketplace where project creators sell shares of their impact to retroactive funders.",
   },
 
   // ---- DeepMind ----
@@ -212,6 +386,18 @@ const DIVISIONS: DivisionDef[] = [
     source: "https://intelligence.org/research/",
     notes:
       "Core technical research on mathematical foundations of AI alignment, including agent foundations and decision theory",
+  },
+
+  // ---- GiveWell ----
+  {
+    idSeed: "div|givewell|research",
+    parentOrgId: ORG_IDS.GIVEWELL,
+    name: "GiveWell Research",
+    divisionType: "team",
+    status: "active",
+    source: "https://www.givewell.org/research",
+    notes:
+      "Cost-effectiveness research team evaluating global health and development interventions. Recommends ~$500M+ annually in grants.",
   },
 ];
 

--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -25,6 +25,8 @@ const ORG_IDS = {
   OPENAI: "1LcLlMGLbw",
   DEEPMIND: "A4XoubikkQ",
   MIRI: "puAffUjWSS",
+  FLI: "d9sWZtyVwg",
+  SCHMIDT_FUTURES: "h6ntSGk8fg",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -59,30 +61,42 @@ interface FundingProgramDef {
 // ---------------------------------------------------------------------------
 
 const PROGRAMS: FundingProgramDef[] = [
-  // ---- Open Philanthropy focus areas ----
+  // ---- Coefficient Giving / Open Philanthropy ----
   {
     idSeed: "prog|open-philanthropy|ai-safety",
     orgId: ORG_IDS.OPEN_PHILANTHROPY,
-    divisionIdSeed: "div|open-philanthropy|global-catastrophic-risks",
+    divisionIdSeed: "div|coefficient-giving|navigating-transformative-ai",
     name: "AI Safety Grantmaking",
     description:
-      "Open Philanthropy's ongoing AI safety grantmaking, covering technical alignment research, governance, and field-building",
+      "Coefficient Giving's ongoing AI safety grantmaking, covering technical alignment research, governance, and field-building",
     programType: "grant-round",
     status: "open",
-    source: "https://www.openphilanthropy.org/focus/artificial-intelligence/",
-    notes: "Largest funder of AI safety research by total dollars committed",
+    source: "https://coefficientgiving.org/funds/navigating-transformative-ai",
+    notes: "Largest funder of AI safety research by total dollars committed. ~$63.6M in 2024.",
+  },
+  {
+    idSeed: "prog|coefficient-giving|technical-ai-safety-rfp-2025",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|coefficient-giving|navigating-transformative-ai",
+    name: "Technical AI Safety RFP (2025)",
+    description:
+      "RFP across 21 research areas under Navigating Transformative AI; $40M committed with more available based on quality",
+    programType: "rfp",
+    totalBudget: 40_000_000,
+    status: "open",
+    source: "https://coefficientgiving.org/funds/navigating-transformative-ai/request-for-proposals-technical-ai-safety-research/",
+    notes: "21 research areas including interpretability, alignment, evaluations, and governance.",
   },
   {
     idSeed: "prog|open-philanthropy|biosecurity",
     orgId: ORG_IDS.OPEN_PHILANTHROPY,
-    divisionIdSeed: "div|open-philanthropy|global-catastrophic-risks",
+    divisionIdSeed: "div|coefficient-giving|biosecurity",
     name: "Biosecurity and Pandemic Preparedness",
     description:
       "Grantmaking for biosecurity, pandemic preparedness, and related policy work",
     programType: "grant-round",
     status: "open",
-    source:
-      "https://www.openphilanthropy.org/focus/biosecurity-and-pandemic-preparedness/",
+    source: "https://coefficientgiving.org/funds/biosecurity-pandemic-preparedness",
   },
   {
     idSeed: "prog|open-philanthropy|global-health",
@@ -90,11 +104,48 @@ const PROGRAMS: FundingProgramDef[] = [
     divisionIdSeed: "div|open-philanthropy|global-health-and-wellbeing",
     name: "Global Health and Wellbeing Grantmaking",
     description:
-      "Open Philanthropy's grantmaking for global health, development, and farm animal welfare",
+      "Coefficient Giving's grantmaking for global health, development, and farm animal welfare",
     programType: "grant-round",
     status: "open",
-    source:
-      "https://www.openphilanthropy.org/focus/global-health-and-wellbeing/",
+    source: "https://coefficientgiving.org/funds/global-health-wellbeing-opportunities",
+  },
+  {
+    idSeed: "prog|coefficient-giving|gcr-opportunities",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|open-philanthropy|global-catastrophic-risks",
+    name: "Global Catastrophic Risks Opportunities",
+    description:
+      "Grantmaking across GCR cause areas and EA community capacity building. 250+ grants totaling ~$400M.",
+    programType: "grant-round",
+    status: "open",
+    source: "https://coefficientgiving.org/funds/global-catastrophic-risks-opportunities",
+    notes: "Led by Eli Rose. Covers GCR cause areas beyond AI safety and biosecurity.",
+  },
+  {
+    idSeed: "prog|coefficient-giving|lead-exposure",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|open-philanthropy|global-health-and-wellbeing",
+    name: "Lead Exposure Action Fund (LEAF)",
+    description:
+      "Multi-donor pooled fund addressing lead exposure globally. $100-125M raised with Gates Foundation, UNICEF, and others.",
+    programType: "grant-round",
+    totalBudget: 125_000_000,
+    status: "open",
+    source: "https://coefficientgiving.org/funds/lead-exposure-action-fund",
+    notes: "20+ grants. Launched 2024. Partners include Gates Foundation, UNICEF.",
+  },
+  {
+    idSeed: "prog|coefficient-giving|abundance-growth-grants",
+    orgId: ORG_IDS.OPEN_PHILANTHROPY,
+    divisionIdSeed: "div|coefficient-giving|abundance-growth",
+    name: "Abundance & Growth Grants",
+    description:
+      "$120M committed over 3 years for economic growth, scientific progress, and US-focused innovation.",
+    programType: "grant-round",
+    totalBudget: 120_000_000,
+    status: "open",
+    source: "https://coefficientgiving.org/funds/abundance-and-growth",
+    notes: "Led by Matt Clancy. Launched March 2025.",
   },
 
   // ---- EA Funds grant rounds ----
@@ -157,7 +208,7 @@ const PROGRAMS: FundingProgramDef[] = [
     status: "open",
     source: "https://survivalandflourishing.fund/",
     notes:
-      "Uses a novel mechanism where multiple recommenders submit rankings and a simulation allocates funds based on convergence",
+      "~$152M cumulative since 2019. $34.33M in 2025, $19.86M in 2024. Three tracks since 2025: Main, Freedom, Fairness. ~89 orgs funded in 2025.",
   },
   {
     idSeed: "prog|sff|speculation-grants",
@@ -165,12 +216,294 @@ const PROGRAMS: FundingProgramDef[] = [
     divisionIdSeed: "div|sff|sff-main",
     name: "Speculation Grants",
     description:
-      "Smaller, faster-turnaround grants from SFF for promising early-stage projects and individuals",
+      "Faster-turnaround grants from SFF using novel donor coordination with ~35 grantors",
+    programType: "grant-round",
+    status: "open",
+    source: "https://survivalandflourishing.fund/speculation-grants",
+    notes:
+      "Budget grown from $4M to $16M. Complementary to S-Process; allows faster funding decisions.",
+    totalBudget: 16_000_000,
+  },
+  {
+    idSeed: "prog|sff|matching-pledges",
+    orgId: ORG_IDS.SFF,
+    divisionIdSeed: "div|sff|sff-main",
+    name: "Matching Pledges Program",
+    description:
+      "Funders commit to matching outside donations to S-Process recipients at specified ratios (e.g., 2-to-1)",
     programType: "grant-round",
     status: "open",
     source: "https://survivalandflourishing.fund/",
+    notes: "Launched 2025. Enables funders to leverage outside donations through matching commitments.",
+  },
+  {
+    idSeed: "prog|sff|initiative-grants",
+    orgId: ORG_IDS.SFF,
+    divisionIdSeed: "div|sff|initiative-committee",
+    name: "Initiative Committee Grants",
+    description:
+      "Proactive grants made by the Initiative Committee (Jaan Tallinn, SFF Advisors, and anonymous voters) outside the S-Process",
+    programType: "grant-round",
+    status: "open",
+    source: "https://survivalandflourishing.fund/",
+    notes: "Established 2024. Allows SFF to fund opportunities that arise outside regular S-Process rounds.",
+  },
+
+  // ---- Future of Life Institute ----
+  {
+    idSeed: "prog|fli|2015-ai-safety",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "2015 AI Safety Research Grant Program",
+    description:
+      "First peer-reviewed AI safety grant program; 37 grants funded from Elon Musk's $10M donation",
+    programType: "grant-round",
+    totalBudget: 6_500_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/2015-grant-program/",
+    notes: "$6.5M distributed. Largest grant $1.5M to FHI (Nick Bostrom). Recipients included MIRI, UC Berkeley (Stuart Russell).",
+  },
+  {
+    idSeed: "prog|fli|2018-agi-safety",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "2018 AGI Safety Grant Program",
+    description:
+      "10 projects focused on AGI safety; recipients at Stanford, MIT, Oxford, Yale, ANU",
+    programType: "grant-round",
+    totalBudget: 1_780_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/2018-grant-program/",
+    notes: "$1.78M total. Funded what became GovAI at Oxford (Allan Dafoe).",
+  },
+  {
+    idSeed: "prog|fli|2023-grants",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "2023 Grants",
+    description:
+      "16 grants for AI safety research, policy, and governance",
+    programType: "grant-round",
+    totalBudget: 8_438_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/2023-grants/",
+    notes: "Largest to FAR AI ($1.86M) and ARC ($1.4M).",
+  },
+  {
+    idSeed: "prog|fli|2024-grants",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "2024 Grants",
+    description:
+      "6 grants including AI-nuclear nexus and journalism",
+    programType: "grant-round",
+    totalBudget: 4_154_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/2024-grants/",
+    notes: "Largest $1.85M to IASEAI and $1.5M to FAS.",
+  },
+  {
+    idSeed: "prog|fli|nuclear-war-research",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "Nuclear War Research Grant Program",
+    description:
+      "10 grants studying nuclear war environmental impacts: climate, agriculture, ozone, fire modeling",
+    programType: "grant-round",
+    totalBudget: 4_058_000,
+    status: "open",
+    source: "https://futureoflife.org/grant-program/nuclear-war-research/",
+    notes: "Recipients at MIT, Rutgers, Exeter, Colorado, IIASA, PIK. 2023-2025.",
+  },
+  {
+    idSeed: "prog|fli|ai-power-concentration",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "How to Mitigate AI-Driven Power Concentration",
+    description:
+      "13 projects addressing AI-driven power concentration. Largest $1.66M to OpenMined Foundation.",
+    programType: "rfp",
+    totalBudget: 5_637_000,
+    status: "open",
+    source: "https://futureoflife.org/grant-program/mitigate-ai-driven-power-concentration/",
+    notes: "Two review rounds (July and October 2024).",
+  },
+  {
+    idSeed: "prog|fli|global-institutions-ai",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "Global Institutions Governing AI",
+    description:
+      "6 research papers at $15K each designing governance institutions for AGI",
+    programType: "rfp",
+    totalBudget: 90_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/global-institutions-governing-ai/",
+  },
+  {
+    idSeed: "prog|fli|ai-sdgs",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "Impact of AI on SDGs",
+    description:
+      "10 research grants at $15K each on AI impact on poverty, health, energy and climate. Primarily Global South recipients.",
+    programType: "rfp",
+    totalBudget: 150_000,
+    status: "awarded",
+    source: "https://futureoflife.org/grant-program/impact-of-ai-on-sdgs/",
+  },
+  {
+    idSeed: "prog|fli|phd-fellowships",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|fellowships",
+    name: "Vitalik Buterin PhD Fellowship in AI Existential Safety",
+    description:
+      "5-year tuition + $40K/year stipend + $10K research fund. 14 fellows at UC Berkeley, Stanford, MIT, Cambridge.",
+    programType: "fellowship",
+    status: "open",
+    source: "https://futureoflife.org/grant-program/phd-fellowships/",
+    notes: "Run with BAIF (Berkeley AI Foundation). Funded by Vitalik Buterin's $665.8M donation.",
+  },
+  {
+    idSeed: "prog|fli|postdoc-fellowships",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|fellowships",
+    name: "Vitalik Buterin Postdoctoral Fellowship in AI Existential Safety",
+    description:
+      "$80K/year stipend + $10K research fund. Fellows at Berkeley/CHAI, MIT, Oxford.",
+    programType: "fellowship",
+    status: "open",
+    source: "https://futureoflife.org/grant-program/postdoctoral-fellowships/",
+    notes: "Run with BAIF. Fellows include Nisan Stiennon (Berkeley), Peter S. Park (MIT).",
+  },
+  {
+    idSeed: "prog|fli|us-china-fellowships",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|fellowships",
+    name: "US-China AI Governance PhD Fellowship",
+    description:
+      "Same structure as technical PhD fellowship. Focused on US-China AI governance.",
+    programType: "fellowship",
+    status: "open",
+    source: "https://futureoflife.org/grant-program/us-china-ai-governance-phd-fellowship/",
+    notes: "2025 class: Ruofei Wang, John Ferguson, Kayla Blomquist.",
+  },
+  {
+    idSeed: "prog|fli|multistakeholder-engagement",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "Multistakeholder Engagement for Safe and Prosperous AI",
+    description:
+      "Up to $5M for multi-stakeholder engagement projects. Individual grants $100K-$500K, multi-year up to 3 years.",
+    programType: "rfp",
+    totalBudget: 5_000_000,
+    status: "open",
+    source: "https://futureoflife.org/grant-program/multistakeholder-engagement-for-safe-and-prosperous-ai/",
+  },
+  {
+    idSeed: "prog|fli|religious-projects",
+    orgId: ORG_IDS.FLI,
+    divisionIdSeed: "div|fli|grants-program",
+    name: "Request for Proposals on Religious Projects",
+    description:
+      "Up to $1.5M total; individual grants $30K-$300K. Faith community engagement with AI risks.",
+    programType: "rfp",
+    totalBudget: 1_500_000,
+    status: "open",
+    source: "https://futureoflife.org/grant-program/rfp-on-religious-projects/",
+    notes: "Launched 2026.",
+  },
+
+  // ---- Schmidt Futures / Schmidt Sciences ----
+  {
+    idSeed: "prog|schmidt|ai2050",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|ai-advanced-computing",
+    name: "AI2050 Fellowships",
+    description:
+      "Fellowships for researchers working on the Hard Problems in AI. $125M five-year commitment from Eric and Wendy Schmidt.",
+    programType: "fellowship",
+    totalBudget: 125_000_000,
+    status: "open",
+    source: "https://www.schmidtsciences.org/ai2050/",
     notes:
-      "Complementary to S-Process; allows faster funding decisions for smaller amounts",
+      "2025 cohort: 28 scholars (21 early-career, 7 senior). Up to $300K per fellow over 2 years. Includes Dan Hendrycks (CAIS), Chelsea Finn (Stanford). Co-chaired by Eric Schmidt and James Manyika.",
+  },
+  {
+    idSeed: "prog|schmidt|ai-in-science",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|ai-advanced-computing",
+    name: "AI in Science Postdoctoral Fellowship",
+    description:
+      "Part of $400M broader commitment. 160 fellows across 9 universities (UChicago, Oxford, Cornell, Toronto, UCSD, etc.).",
+    programType: "fellowship",
+    totalBudget: 148_000_000,
+    status: "open",
+    source: "https://www.ox.ac.uk/news/2022-10-26-oxford-joins-schmidt-futures-148-million-global-initiative-accelerate-use-ai",
+    notes: "$148M program. 2022-2028. Training postdocs to apply AI to scientific research.",
+  },
+  {
+    idSeed: "prog|schmidt|trustworthy-ai",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|ai-advanced-computing",
+    name: "Science of Trustworthy AI",
+    description:
+      "Funding program for research on making AI systems trustworthy, reliable, and aligned with human values.",
+    programType: "rfp",
+    status: "open",
+    source: "https://www.schmidtsciences.org/",
+    notes: "Part of AI & Advanced Computing center. 2026 round announced.",
+  },
+  {
+    idSeed: "prog|schmidt|science-fellows",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|science-systems",
+    name: "Schmidt Science Fellows",
+    description:
+      "1-2 year postdoctoral placements; fellows must pivot disciplines from PhD. ~$100K/yr stipend.",
+    programType: "fellowship",
+    status: "open",
+    source: "https://schmidtsciencefellows.org/selection/who-can-apply/",
+    notes: "With Rhodes Trust. 2018-present. Designed for interdisciplinary scientific breakthroughs.",
+  },
+  {
+    idSeed: "prog|schmidt|polymath",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|science-systems",
+    name: "Schmidt Science Polymaths Program",
+    description:
+      "Up to $2.5M per researcher for post-tenure disciplinary pivots. 21 Polymaths across 6 countries.",
+    programType: "fellowship",
+    totalBudget: 2_500_000,
+    status: "open",
+    source: "https://www.synbiobeta.com/read/schmidt-sciences-polymath-program-awards-2-5m-grants-to-six-pioneering-researchers",
+    notes: "2022-2025. Designed for established researchers to make major disciplinary shifts.",
+  },
+  {
+    idSeed: "prog|schmidt|rise",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|science-systems",
+    name: "Rise Global Talent Program",
+    description:
+      "100 winners/year ages 15-17 from 170+ countries. Lifetime scholarships, mentoring, funding.",
+    programType: "fellowship",
+    totalBudget: 1_000_000_000,
+    status: "open",
+    source: "https://www.prnewswire.com/news-releases/schmidt-futures-and-rhodes-trust-launch-global-rise-program-to-find-the-next-generation-of-leaders-and-support-them-for-life-301173368.html",
+    notes: "$1B commitment with Rhodes Trust. Launched 2020.",
+  },
+  {
+    idSeed: "prog|schmidt|havi",
+    orgId: ORG_IDS.SCHMIDT_FUTURES,
+    divisionIdSeed: "div|schmidt|ai-advanced-computing",
+    name: "Humanities and AI Virtual Institute (HAVI)",
+    description:
+      "23 research teams applying AI to archaeology, history, literature. $11M awarded.",
+    programType: "grant-round",
+    totalBudget: 11_000_000,
+    status: "open",
+    source: "https://www.schmidtsciences.org/havi-2025-announcement/",
+    notes: "2025 program. Bringing AI tools to humanities disciplines.",
   },
 
   // ---- FTX Future Fund (historical) ----
@@ -203,6 +536,7 @@ const PROGRAMS: FundingProgramDef[] = [
   {
     idSeed: "prog|manifund|regranters",
     orgId: ORG_IDS.MANIFUND,
+    divisionIdSeed: "div|manifund|regranting",
     name: "Manifund Regranting",
     description:
       "Platform enabling individuals to receive tax-deductible donations for regranting to effective projects",
@@ -212,15 +546,41 @@ const PROGRAMS: FundingProgramDef[] = [
     notes: "Manifund provides fiscal sponsorship for individual regranters",
   },
   {
+    idSeed: "prog|manifund|ai-safety-regranting-2025",
+    orgId: ORG_IDS.MANIFUND,
+    divisionIdSeed: "div|manifund|regranting",
+    name: "AI Safety Regranting (2025)",
+    description:
+      "10 regrantors distributing AI safety funding; individual regrantors have $100K-$500K budgets.",
+    programType: "grant-round",
+    totalBudget: 2_250_000,
+    status: "open",
+    source: "https://manifund.org/about/regranting",
+    notes: "$2.25M pool. First 10 AI safety regrantors announced 2025.",
+  },
+  {
+    idSeed: "prog|manifund|ai-safety-regranting-2024",
+    orgId: ORG_IDS.MANIFUND,
+    divisionIdSeed: "div|manifund|regranting",
+    name: "AI Safety Regranting (2024)",
+    description:
+      "Regranting program funded primarily by Coefficient Giving; multiple regrantors.",
+    programType: "grant-round",
+    totalBudget: 1_400_000,
+    status: "awarded",
+    source: "https://manifund.org/about/regranting",
+  },
+  {
     idSeed: "prog|manifund|impact-certificates",
     orgId: ORG_IDS.MANIFUND,
+    divisionIdSeed: "div|manifund|impact-certs",
     name: "Manifund Impact Certificates",
     description:
       "Experimental impact certificate marketplace where project creators sell shares of their impact to retroactive funders",
     programType: "grant-round",
     status: "open",
     source: "https://manifund.org/",
-    notes: "Novel funding mechanism using impact certificates/retroactive public goods funding",
+    notes: "Novel funding mechanism using impact certificates/retroactive public goods funding. Since 2023.",
   },
 
   // ---- ACX Grants ----

--- a/crux/lib/grant-import/constants.ts
+++ b/crux/lib/grant-import/constants.ts
@@ -14,4 +14,6 @@ export const FUNDER_IDS = {
   CEA: "gNsqAes7Dw",
   GIVEWELL: "OwXl35e7bg",
   ACX_GRANTS: "LBr3ocKKyQ",
+  FLI: "d9sWZtyVwg",
+  SCHMIDT_FUTURES: "h6ntSGk8fg",
 } as const;


### PR DESCRIPTION
## Summary

Expands the curated divisions and funding programs data for major AI safety and EA funders, roughly doubling the coverage:

- **Divisions**: 16 -> 33 (new entries for FLI, Schmidt Futures, Manifund, GiveWell, and expanded Coefficient Giving/Open Phil)
- **Funding programs**: 17 -> 43 (new entries for FLI, Schmidt Futures, Manifund, and expanded Coefficient Giving, SFF)
- **FUNDER_IDS**: Added `FLI` and `SCHMIDT_FUTURES` to the shared constants

### New funder coverage

| Funder | Divisions | Programs | Key additions |
|--------|-----------|----------|---------------|
| FLI | 3 | 13 | Grant rounds 2015-2024, fellowship programs, RFPs |
| Schmidt Futures | 3 | 7 | AI2050, AI in Science, Science Fellows, Rise, HAVI |
| Manifund | 2 | 4 | AI safety regranting 2024/2025, impact certificates |
| GiveWell | 1 | 0 | Research team |
| Coefficient Giving | +8 | +4 | Navigating TAI, biosecurity, forecasting, abundance funds |
| SFF | +1 | +2 | Initiative Committee, matching pledges |

### Data sources
All data sourced from organization websites, KB YAML files (`packages/kb/data/things/`), and publicly available information. No new entity IDs were required.

## Test plan
- [x] `pnpm crux import-divisions list` runs with no ID collisions (33 divisions)
- [x] `pnpm crux import-funding-programs list` runs with no ID collisions (43 programs)
- [x] `pnpm build` passes
- [x] All division-to-program linkages verified (divisionIdSeeds match)

Generated with [Claude Code](https://claude.com/claude-code)
