### PR TITLE
feat: add people suggest-links command for EntityLink detection

### DIFF
--- a/crux/commands/people.ts
+++ b/crux/commands/people.ts
@@ -1639,7 +1639,7 @@ function scanMdxFiles(
           results.push({
             filePath: relativePath,
             mentions,
-            unlinkedMentions: mentions.filter((m) => !m.alreadyLinked),
+            unlinkedMentions: mentions.filter((m) => !m.excluded),
           });
         }
       }
@@ -1699,8 +1699,8 @@ async function suggestLinksCommand(
     for (const page of allPages) {
       lines.push(`\n  \x1b[36m${page.filePath}\x1b[0m`);
       for (const m of page.mentions) {
-        const status = m.alreadyLinked
-          ? '\x1b[32m[linked]\x1b[0m'
+        const status = m.excluded
+          ? '\x1b[32m[excluded]\x1b[0m'
           : '\x1b[33m[unlinked]\x1b[0m';
         lines.push(
           `    L${m.line}: ${status} "${m.matchedText}" -> ${m.personId}`,

--- a/crux/lib/person-mention-detector.test.ts
+++ b/crux/lib/person-mention-detector.test.ts
@@ -33,9 +33,9 @@ describe('buildPersonLookup', () => {
     expect(lookup.get('sam bankman-fried (ftx)')).toBeUndefined();
   });
 
-  it('includes manual aliases for known variations', () => {
+  it('maps diacritic-stripped names (Nuño -> nuno)', () => {
     const lookup = buildPersonLookup(samplePeople);
-    // "Nuno Sempere" (without tilde) should match "Nuño Sempere"
+    // normalizeName("Nuño Sempere") strips the tilde, so "nuno sempere" maps naturally
     expect(lookup.get('nuno sempere')?.id).toBe('nuno-sempere');
   });
 });
@@ -83,6 +83,24 @@ describe('findExcludedZones', () => {
     const zones = findExcludedZones(content);
     expect(zones.some((z) => content.substring(z.start, z.end).includes('Dario Amodei'))).toBe(true);
   });
+
+  it('excludes markdown inline links', () => {
+    const content = 'See [Dario Amodei](https://example.com) for details';
+    const zones = findExcludedZones(content);
+    expect(zones.some((z) => content.substring(z.start, z.end).includes('Dario Amodei'))).toBe(true);
+  });
+
+  it('excludes markdown image alt text', () => {
+    const content = '![Dario Amodei speaking](https://example.com/photo.jpg)';
+    const zones = findExcludedZones(content);
+    expect(zones.some((z) => content.substring(z.start, z.end).includes('Dario Amodei'))).toBe(true);
+  });
+
+  it('excludes markdown reference links', () => {
+    const content = 'See [Dario Amodei][ref1] for details';
+    const zones = findExcludedZones(content);
+    expect(zones.some((z) => content.substring(z.start, z.end).includes('Dario Amodei'))).toBe(true);
+  });
 });
 
 describe('buildPositionMap', () => {
@@ -119,7 +137,7 @@ describe('detectPersonMentions', () => {
     expect(mentions.length).toBe(1);
     expect(mentions[0].personId).toBe('dario-amodei');
     expect(mentions[0].matchedText).toBe('Dario Amodei');
-    expect(mentions[0].alreadyLinked).toBe(false);
+    expect(mentions[0].excluded).toBe(false);
   });
 
   it('detects multiple different people', () => {
@@ -134,13 +152,13 @@ describe('detectPersonMentions', () => {
       '<EntityLink id="E91" name="dario-amodei">Dario Amodei</EntityLink> said something.';
     const mentions = detectPersonMentions(content, lookup);
     expect(mentions.length).toBe(1);
-    expect(mentions[0].alreadyLinked).toBe(true);
+    expect(mentions[0].excluded).toBe(true);
   });
 
   it('skips mentions in frontmatter', () => {
     const content = '---\ntitle: Dario Amodei Profile\n---\nContent here.';
     const mentions = detectPersonMentions(content, lookup);
-    const unlinked = mentions.filter((m) => !m.alreadyLinked);
+    const unlinked = mentions.filter((m) => !m.excluded);
     // "Dario Amodei" in frontmatter should be marked as already linked (excluded)
     expect(unlinked.length).toBe(0);
   });
@@ -148,7 +166,7 @@ describe('detectPersonMentions', () => {
   it('skips mentions in code blocks', () => {
     const content = '```\nDario Amodei in code\n```\nDario Amodei in text.';
     const mentions = detectPersonMentions(content, lookup);
-    const unlinked = mentions.filter((m) => !m.alreadyLinked);
+    const unlinked = mentions.filter((m) => !m.excluded);
     expect(unlinked.length).toBe(1);
     expect(unlinked[0].matchedText).toBe('Dario Amodei');
   });
@@ -156,7 +174,7 @@ describe('detectPersonMentions', () => {
   it('skips mentions in headings', () => {
     const content = '## Dario Amodei\nDario Amodei is a CEO.';
     const mentions = detectPersonMentions(content, lookup);
-    const unlinked = mentions.filter((m) => !m.alreadyLinked);
+    const unlinked = mentions.filter((m) => !m.excluded);
     expect(unlinked.length).toBe(1);
   });
 
@@ -166,7 +184,7 @@ describe('detectPersonMentions', () => {
     expect(mentions.length).toBe(1);
     expect(mentions[0].personId).toBe('nuno-sempere');
     expect(mentions[0].matchedText).toBe('Nuno Sempere');
-    expect(mentions[0].alreadyLinked).toBe(false);
+    expect(mentions[0].excluded).toBe(false);
   });
 
   it('is case-insensitive', () => {
@@ -193,8 +211,28 @@ describe('detectPersonMentions', () => {
   it('handles multiple mentions of the same person', () => {
     const content = 'Dario Amodei said X. Later, Dario Amodei said Y.';
     const mentions = detectPersonMentions(content, lookup);
-    const unlinked = mentions.filter((m) => !m.alreadyLinked);
+    const unlinked = mentions.filter((m) => !m.excluded);
     expect(unlinked.length).toBe(2);
+  });
+
+  it('excludes person name inside markdown link', () => {
+    const content = 'Read about [Dario Amodei](https://example.com/dario) and his work.';
+    const mentions = detectPersonMentions(content, lookup);
+    // The mention inside the markdown link should be excluded
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].excluded).toBe(true);
+  });
+
+  it('same name twice on one line: first in EntityLink (excluded), second plain text (detected)', () => {
+    const content = '<EntityLink id="E91" name="dario-amodei">Dario Amodei</EntityLink> met with Dario Amodei again.';
+    const mentions = detectPersonMentions(content, lookup);
+    expect(mentions.length).toBe(2);
+    // First occurrence (inside EntityLink) should be excluded
+    const excludedMentions = mentions.filter((m) => m.excluded);
+    const unlinkedMentions = mentions.filter((m) => !m.excluded);
+    expect(excludedMentions.length).toBe(1);
+    expect(unlinkedMentions.length).toBe(1);
+    expect(unlinkedMentions[0].matchedText).toBe('Dario Amodei');
   });
 });
 
@@ -256,6 +294,27 @@ describe('applyEntityLinks', () => {
     const content = 'No person names here.';
     const mentions = detectPersonMentions(content, lookup);
     const result = applyEntityLinks(content, mentions);
+    expect(result.appliedCount).toBe(0);
+    expect(result.content).toBe(content);
+  });
+
+  it('links the second occurrence when first is in EntityLink on same line', () => {
+    const content = '<EntityLink id="E91" name="dario-amodei">Dario Amodei</EntityLink> met with Dario Amodei again.';
+    const mentions = detectPersonMentions(content, lookup);
+    const result = applyEntityLinks(content, mentions);
+    // Should link the second (plain text) occurrence, not try to re-link inside EntityLink
+    expect(result.appliedCount).toBe(1);
+    // The second "Dario Amodei" should be wrapped
+    expect(result.content).toMatch(
+      /met with <EntityLink id="E91" name="dario-amodei">Dario Amodei<\/EntityLink> again\./,
+    );
+  });
+
+  it('does not wrap person name inside markdown link', () => {
+    const content = 'Read about [Dario Amodei](https://example.com/dario) for details.';
+    const mentions = detectPersonMentions(content, lookup);
+    const result = applyEntityLinks(content, mentions);
+    // Should not wrap the name since it is inside a markdown link
     expect(result.appliedCount).toBe(0);
     expect(result.content).toBe(content);
   });

--- a/crux/lib/person-mention-detector.ts
+++ b/crux/lib/person-mention-detector.ts
@@ -34,8 +34,10 @@ export interface PersonMention {
   canonicalName: string;
   /** 1-based line number in the file */
   line: number;
-  /** Whether this mention is already inside an EntityLink */
-  alreadyLinked: boolean;
+  /** Character offset within the line (0-based) */
+  lineOffset: number;
+  /** Whether this mention is in an excluded zone (EntityLink, heading, code, markdown link, etc.) */
+  excluded: boolean;
 }
 
 export interface PageMentions {
@@ -57,8 +59,7 @@ export interface PageMentions {
  *
  * Includes:
  * - Full name (cleaned of parentheticals)
- * - Diacritic-stripped variant
- * - Manual aliases for known variations
+ * - Diacritic-stripped variant (via normalizeName)
  */
 export function buildPersonLookup(
   people: PersonEntity[],
@@ -71,18 +72,6 @@ export function buildPersonLookup(
     const normalized = normalizeName(cleanName);
     if (normalized.length > 0) {
       lookup.set(normalized, person);
-    }
-  }
-
-  // Manual aliases for known name variations
-  const aliases: Record<string, string> = {
-    'nuno sempere': 'nuno-sempere',
-  };
-
-  for (const [alias, entityId] of Object.entries(aliases)) {
-    const person = people.find((p) => p.id === entityId);
-    if (person) {
-      lookup.set(normalizeName(alias), person);
     }
   }
 
@@ -111,6 +100,7 @@ interface ExcludedZone {
  * - Headings (lines starting with #)
  * - MDX comments (curly-brace-slash-star blocks)
  * - Import/export statements
+ * - Markdown links: inline `[text](url)`, images `![alt](url)`, reference `[text][ref]`
  */
 export function findExcludedZones(content: string): ExcludedZone[] {
   const zones: ExcludedZone[] = [];
@@ -190,6 +180,33 @@ export function findExcludedZones(content: string): ExcludedZone[] {
   // Footnote reference definitions: [^...]: ...
   const footnoteDefRegex = /^\[\^[^\]]+\]:\s+.*$/gm;
   for (const match of content.matchAll(footnoteDefRegex)) {
+    zones.push({
+      start: match.index!,
+      end: match.index! + match[0].length,
+    });
+  }
+
+  // Markdown inline links: [text](url)
+  const inlineLinkRegex = /\[([^\]]*)\]\([^)]*\)/g;
+  for (const match of content.matchAll(inlineLinkRegex)) {
+    zones.push({
+      start: match.index!,
+      end: match.index! + match[0].length,
+    });
+  }
+
+  // Markdown images: ![alt](url)
+  const imageRegex = /!\[([^\]]*)\]\([^)]*\)/g;
+  for (const match of content.matchAll(imageRegex)) {
+    zones.push({
+      start: match.index!,
+      end: match.index! + match[0].length,
+    });
+  }
+
+  // Markdown reference links: [text][ref]
+  const refLinkRegex = /\[([^\]]*)\]\[[^\]]*\]/g;
+  for (const match of content.matchAll(refLinkRegex)) {
     zones.push({
       start: match.index!,
       end: match.index! + match[0].length,
@@ -318,6 +335,10 @@ export function detectPersonMentions(
       // Check if in excluded zone
       const inExcluded = isInExcludedZone(origPos, origLength, excludedZones);
 
+      // Compute character offset within the line
+      const lineStartPos = lineStarts[lineNum - 1];
+      const lineOffset = origPos - lineStartPos;
+
       // Mark positions as matched
       for (let i = origPos; i < origPos + origLength; i++) {
         matchedPositions.add(i);
@@ -329,7 +350,8 @@ export function detectPersonMentions(
         matchedText,
         canonicalName: person.title.replace(/\s*\(.*?\)\s*$/, '').trim(),
         line: lineNum,
-        alreadyLinked: inExcluded,
+        lineOffset,
+        excluded: inExcluded,
       });
     }
   }
@@ -397,15 +419,6 @@ export function buildPositionMap(original: string): number[] {
 // Apply logic — wrap first occurrence of each person in EntityLink
 // ---------------------------------------------------------------------------
 
-export interface ApplyResult {
-  filePath: string;
-  originalContent: string;
-  modifiedContent: string;
-  appliedCount: number;
-  /** Person IDs that were linked */
-  linkedPersons: string[];
-}
-
 /**
  * Apply EntityLink wrapping to the first unlinked occurrence of each person
  * in the given content.
@@ -417,7 +430,7 @@ export function applyEntityLinks(
   // Group by personId, take only unlinked, and pick the first occurrence
   const firstByPerson = new Map<string, PersonMention>();
   for (const m of mentions) {
-    if (m.alreadyLinked) continue;
+    if (m.excluded) continue;
     if (!firstByPerson.has(m.personId)) {
       firstByPerson.set(m.personId, m);
     }
@@ -442,12 +455,14 @@ export function applyEntityLinks(
     const replacement = `<EntityLink id="${idAttr}" name="${nameAttr}">${mention.matchedText}</EntityLink>`;
 
     // Find the exact position of this mention in the content
-    // We search line by line to find the right occurrence
+    // We search line by line, starting from the stored lineOffset to find the right occurrence
     const lines = result.split('\n');
     const targetLine = mention.line - 1; // 0-indexed
     if (targetLine >= 0 && targetLine < lines.length) {
       const line = lines[targetLine];
-      const idx = line.indexOf(mention.matchedText);
+      // Use lineOffset as the starting search position to avoid matching
+      // an earlier occurrence that might be inside an excluded zone (e.g., EntityLink)
+      const idx = line.indexOf(mention.matchedText, mention.lineOffset);
       if (idx !== -1) {
         // Verify this position is not inside an excluded zone in the current content
         const excludedZones = findExcludedZones(result);


### PR DESCRIPTION
## Summary

Adds a new `crux people suggest-links` command that scans all MDX content pages for plain-text mentions of person entities that are not already wrapped in `<EntityLink>` components.

- **Detection**: Scans 668 MDX files against 48 person entities from `data/entities/people.yaml`
- **Results**: Finds 2055 total person mentions across 286 pages, of which 1029 are unlinked across 217 pages
- **Conservative matching**: Only exact full-name matches with word boundaries (no partial/fuzzy)
- **Diacritic-tolerant**: "Nuno Sempere" correctly matches entity titled "Nuño Sempere"
- **Exclusion zones**: Skips frontmatter, code blocks, headings, JSX components, MDX comments, URLs, footnote definitions
- **`--apply` mode**: Wraps the first unlinked occurrence of each person per page in `<EntityLink>`
- **`--verbose` mode**: Shows all mentions including already-linked ones
- **Top unlinked**: Elon Musk (64), Dario Amodei (61), Sam Altman (57), Jaan Tallinn (51), Yann LeCun (49)

### Files changed

| File | Purpose |
|------|---------|
| `crux/lib/person-mention-detector.ts` | Core detection logic with position mapping for Unicode/emoji support |
| `crux/lib/person-mention-detector.test.ts` | 29 tests covering detection, exclusion zones, position mapping, apply logic |
| `crux/commands/people.ts` | New `suggest-links` subcommand integration |

## Test plan

- [x] 29 unit tests pass (detection, exclusion zones, position mapping, emoji handling, apply)
- [x] Existing 13 people.test.ts tests still pass
- [x] Command runs successfully on full content: `pnpm crux people suggest-links`
- [x] No new TypeScript errors introduced
- [x] Full crux test suite: 3062 passed (7 pre-existing failures in unrelated source-fetcher/rules tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
