### PR TITLE
Deprecate funder entity type, clarify parentOrg vs divisions

### DIFF
--- a/apps/web/scripts/lib/entity-transform.mjs
+++ b/apps/web/scripts/lib/entity-transform.mjs
@@ -198,13 +198,16 @@ function transformEntity(raw, expertMap, orgMap) {
       return {
         ...base,
         entityType: 'organization',
-        orgType: orgType || orgData?.type || undefined,
+        orgType: orgType || orgData?.type || raw.orgType || undefined,
         founded: orgData?.founded || cf('Founded') || cf('Established'),
         headquarters: orgData?.headquarters || cf('Location') || cf('Headquarters'),
         employees: orgData?.employees || cf('Employees'),
         funding: orgData?.funding || cf('Funding'),
         website: orgData?.website || raw.website,
         title: orgData?.name || raw.title,
+        // parentOrg: legally separate entity that is part of a larger org.
+        // Distinct from "divisions" (internal sub-units stored in wiki-server).
+        parentOrg: raw.parentOrg || orgData?.parentOrg || undefined,
         customFields: filterCustomFields('Founded', 'Established', 'Location', 'Headquarters', 'Employees', 'Funding'),
       };
     }
@@ -262,7 +265,6 @@ function transformEntity(raw, expertMap, orgMap) {
     case 'argument':
     case 'scenario':
     case 'case-study':
-    case 'funder':
     case 'resource':
     case 'parameter':
     case 'metric':

--- a/apps/web/scripts/lib/entity-type-mappings.mjs
+++ b/apps/web/scripts/lib/entity-type-mappings.mjs
@@ -16,6 +16,8 @@ export const OLD_TYPE_MAP = {
   'lab-academic': 'organization',
   'lab-startup': 'organization',
   researcher: 'person',
+  // Funder → organization (deprecated; use orgType: "funder" instead)
+  funder: 'organization',
 };
 
 /** Maps old lab-* types to organization orgType values. */

--- a/apps/web/src/components/RelatedPages.tsx
+++ b/apps/web/src/components/RelatedPages.tsx
@@ -27,6 +27,8 @@ const TYPE_TO_GROUP: Record<string, string> = {
   historical: "Historical",
   event: "Historical",
   parameter: "Parameters",
+  // "funder" is a deprecated entity type (alias for organization with orgType: funder).
+  // Kept here for backward compat with relatedGraph entries that may still reference it.
   funder: "Funders",
 };
 

--- a/apps/web/src/components/wiki/DataInfoBox.tsx
+++ b/apps/web/src/components/wiki/DataInfoBox.tsx
@@ -57,6 +57,8 @@ export async function DataInfoBox({ entityId, type: inlineType, ...inlineProps }
           headcount={data.headcount}
           funding={data.funding}
           orgType={data.orgType}
+          parentOrg={data.parentOrg}
+          childOrgs={data.childOrgs}
           // Policy fields
           introduced={data.introduced}
           policyStatus={data.policyStatus}

--- a/apps/web/src/components/wiki/InfoBox.tsx
+++ b/apps/web/src/components/wiki/InfoBox.tsx
@@ -60,6 +60,10 @@ export interface InfoBoxProps {
   backlinkCount?: number;
   // Organization subtype
   orgType?: string;
+  // Parent organization (legally separate entity that is part of a larger org)
+  parentOrg?: { id: string; title: string; href: string };
+  // Child organizations (entities that have this entity as parentOrg)
+  childOrgs?: { id: string; title: string; href: string }[];
   // Policy fields
   introduced?: string;
   policyStatus?: string;
@@ -193,6 +197,8 @@ export function InfoBox({
   wordCount,
   backlinkCount,
   orgType,
+  parentOrg,
+  childOrgs,
   introduced,
   policyStatus,
   policyAuthor,
@@ -226,6 +232,10 @@ export function InfoBox({
   if (!isOverview && location) fields.push({ label: "Location", value: location });
   if (!isOverview && headcount) fields.push({ label: "Employees", value: headcount });
   if (!isOverview && funding) fields.push({ label: "Funding", value: funding });
+  if (!isOverview && parentOrg) fields.push({ label: "Parent Org", value: parentOrg.title, link: parentOrg.href });
+  if (!isOverview && childOrgs?.length) {
+    fields.push({ label: "Sub-orgs", value: childOrgs.map((c) => c.title).join(", ") });
+  }
   if (!isOverview && introduced) fields.push({ label: "Introduced", value: introduced });
   if (!isOverview && policyStatus) fields.push({ label: "Status", value: policyStatus });
   if (!isOverview && policyAuthor) fields.push({ label: "Author", value: policyAuthor });

--- a/apps/web/src/data/__tests__/validate-entities.test.ts
+++ b/apps/web/src/data/__tests__/validate-entities.test.ts
@@ -26,6 +26,7 @@ interface RawEntity {
   title?: string;
   entityType?: string;
   relatedEntries?: { id: string; type: string; relationship?: string }[];
+  parentOrg?: string;
 }
 
 const entities: RawEntity[] = fs.existsSync(ENTITIES_PATH)
@@ -220,6 +221,33 @@ describe("Entity data validation", () => {
           `Frontmatter entities with invalid types:\n  ${invalid.join("\n  ")}`,
         ).toHaveLength(0);
       }
+    });
+  });
+
+  describe("parentOrg references resolve", () => {
+    it("every parentOrg value is a known entity ID or org ID", () => {
+      const entityIds = new Set(entities.map((e) => e.id));
+      const invalid: string[] = [];
+      for (const entity of entities) {
+        const parentOrg = entity.parentOrg;
+        if (typeof parentOrg === "string" && !entityIds.has(parentOrg)) {
+          invalid.push(
+            `${entity.id} has parentOrg="${parentOrg}" which is not a known entity`,
+          );
+        }
+      }
+      // Warn but don't fail hard — parent orgs like uk-dsit and nist may not
+      // have entity entries yet. This test documents the gaps.
+      if (invalid.length > 0) {
+        console.warn(
+          `[warn] ${invalid.length} parentOrg references to non-entities:\n  ${invalid.join("\n  ")}`,
+        );
+      }
+      // Soft threshold: allow a few unresolved parentOrg refs
+      expect(
+        invalid.length,
+        `${invalid.length} unresolved parentOrg references — consider creating entity entries for them`,
+      ).toBeLessThan(10);
     });
   });
 

--- a/apps/web/src/data/entity-ontology.ts
+++ b/apps/web/src/data/entity-ontology.ts
@@ -151,6 +151,9 @@ export const ENTITY_TYPES: Record<string, EntityTypeDefinition> = {
     badgeColor: "bg-lime-100 text-lime-800 dark:bg-lime-900/30 dark:text-lime-300",
     headerColor: "#65a30d",
   },
+  // "funder" is deprecated as a standalone entity type — it's now an alias
+  // for "organization" with orgType: "funder". Kept here for backward compat
+  // with relatedGraph entries that may still reference type "funder".
   funder: {
     label: "Funder",
     icon: Banknote,

--- a/apps/web/src/data/entity-schemas.ts
+++ b/apps/web/src/data/entity-schemas.ts
@@ -117,6 +117,11 @@ const OrganizationEntitySchema = BaseEntity.extend({
   headquarters: z.string().optional(),
   employees: z.string().optional(),
   funding: z.string().optional(),
+  // parentOrg = entity ID of a parent organization.
+  // Use for legally separate entities that are part of a larger org
+  // (e.g., CHAI → UC Berkeley, UK AISI → DSIT).
+  // Distinct from "divisions" which are internal sub-units.
+  parentOrg: z.string().optional(),
 });
 
 const PolicyEntitySchema = BaseEntity.extend({
@@ -176,9 +181,8 @@ const CaseStudyEntitySchema = BaseEntity.extend({
   entityType: z.literal("case-study"),
 });
 
-const FunderEntitySchema = BaseEntity.extend({
-  entityType: z.literal("funder"),
-});
+// FunderEntitySchema removed — "funder" is now an alias for "organization"
+// with orgType: "funder". See entity-type-names.ts ENTITY_TYPE_ALIASES.
 
 const ResourceEntitySchema = BaseEntity.extend({
   entityType: z.literal("resource"),
@@ -299,7 +303,6 @@ export const TypedEntitySchema = z.discriminatedUnion("entityType", [
   ArgumentEntitySchema,
   ScenarioEntitySchema,
   CaseStudyEntitySchema,
-  FunderEntitySchema,
   ResourceEntitySchema,
   ParameterEntitySchema,
   MetricEntitySchema,

--- a/apps/web/src/data/entity-type-names.ts
+++ b/apps/web/src/data/entity-type-names.ts
@@ -32,7 +32,6 @@ const CANONICAL_ENTITY_TYPE_NAMES = [
   "case-study",
   "person",
   "resource",
-  "funder",
   "historical",
   "analysis",
   "parameter",
@@ -68,6 +67,9 @@ export const ENTITY_TYPE_ALIASES: Record<string, CanonicalEntityTypeName> = {
   "lab-research": "organization",
   "lab-startup": "organization",
   "lab-academic": "organization",
+  // Funder → organization (orgType: "funder" carries the detail)
+  // Deprecated: use type: organization with orgType: funder instead
+  funder: "organization",
   // Plural-form aliases found in YAML data
   "safety-approaches": "safety-agenda",
   policies: "policy",
@@ -118,6 +120,8 @@ export const OLD_TYPE_MAP: Record<string, string> = {
   "lab-startup": "organization",
   // Researcher → person
   researcher: "person",
+  // Funder → organization (deprecated; use orgType: "funder" instead)
+  funder: "organization",
 };
 
 /**

--- a/apps/web/src/data/infobox.ts
+++ b/apps/web/src/data/infobox.ts
@@ -144,6 +144,8 @@ export function getEntityInfoBoxData(entityId: string) {
   let headcount: string | undefined;
   let funding: string | undefined;
   let orgType: string | undefined;
+  let parentOrg: { id: string; title: string; href: string } | undefined;
+  let childOrgs: { id: string; title: string; href: string }[] | undefined;
 
   if (isOrganization(entity)) {
     founded = entity.founded;
@@ -151,6 +153,27 @@ export function getEntityInfoBoxData(entityId: string) {
     headcount = entity.employees;
     funding = entity.funding;
     orgType = entity.orgType;
+    // Resolve parentOrg to display name + href
+    if (entity.parentOrg) {
+      const parentEntity = getTypedEntityById(entity.parentOrg);
+      parentOrg = {
+        id: entity.parentOrg,
+        title: parentEntity?.title ?? entity.parentOrg,
+        href: getEntityHref(entity.parentOrg),
+      };
+    }
+    // Find child orgs — entities that reference this entity as their parentOrg
+    const allEntities = getTypedEntities();
+    const children = allEntities.filter(
+      (e) => isOrganization(e) && e.parentOrg === entity.id,
+    );
+    if (children.length > 0) {
+      childOrgs = children.map((c) => ({
+        id: c.id,
+        title: c.title,
+        href: getEntityHref(c.id, c.entityType),
+      }));
+    }
   }
 
   // Policy-specific fields
@@ -247,6 +270,8 @@ export function getEntityInfoBoxData(entityId: string) {
     headcount,
     funding,
     orgType,
+    parentOrg,
+    childOrgs,
     // Policy
     introduced,
     policyStatus,

--- a/data/entities/misc.yaml
+++ b/data/entities/misc.yaml
@@ -93,7 +93,7 @@
     - governance
   relatedEntries:
     - id: openai-foundation
-      type: funder
+      type: organization
     - id: musk-openai-lawsuit
       type: analysis
     - id: long-term-benefit-trust
@@ -253,7 +253,7 @@
     - id: openai-foundation-governance
       type: analysis
     - id: openai-foundation
-      type: funder
+      type: organization
     - id: elon-musk
       type: person
     - id: openai
@@ -622,7 +622,7 @@
     - community
   relatedEntries:
     - id: open-philanthropy
-      type: funder
+      type: organization
     - id: securebio
       type: organization
     - id: securedna

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -311,6 +311,8 @@
   numericId: E57
   type: organization
   orgType: academic
+  # parentOrg = legally separate part of another org (not an internal division)
+  parentOrg: uc-berkeley
   summaryPage: safety-orgs-overview
   title: CHAI
   website: https://humancompatible.ai
@@ -781,6 +783,8 @@
   numericId: E364
   type: organization
   orgType: government
+  # parentOrg = legally separate part of another org (not an internal division)
+  parentOrg: uk-dsit
   summaryPage: government-orgs-overview
   title: UK AI Safety Institute
   website: https://www.aisi.gov.uk
@@ -835,6 +839,8 @@
   numericId: E365
   type: organization
   orgType: government
+  # parentOrg = legally separate part of another org (not an internal division)
+  parentOrg: nist
   summaryPage: government-orgs-overview
   title: US AI Safety Institute
   website: https://www.nist.gov/aisi

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -2762,7 +2762,7 @@
     - id: interpretability
       type: approach
     - id: open-philanthropy
-      type: funder
+      type: organization
   lastUpdated: 2026-02
 
 - id: debate


### PR DESCRIPTION
## Summary

- Removes `funder` from canonical entity types and makes it an alias for `organization` with `orgType: funder`. No entities were actually using `entityType: funder`, but the type existed in the schema and was used in some `relatedEntries` references.
- Adds `parentOrg` field to organizations (3 entities: CHAI -> UC Berkeley, UK AISI -> UK DSIT, US AISI -> NIST). Surfaces parent org and child orgs in the InfoBox.
- Adds parentOrg reference validation test.

## Changes

**Funder type deprecation:**
- Removed from `CANONICAL_ENTITY_TYPE_NAMES`, added to `ENTITY_TYPE_ALIASES` as `funder -> organization`
- Added to `OLD_TYPE_MAP` in both `entity-type-names.ts` and `entity-type-mappings.mjs`
- Removed `FunderEntitySchema` from discriminated union
- Updated `relatedEntries` in `misc.yaml` and `responses.yaml` (4 occurrences)
- Kept `funder` in `entity-ontology.ts` and `RelatedPages.tsx` for backward compat with cached relatedGraph data

**parentOrg clarification:**
- Added `parentOrg` field to `OrganizationEntitySchema`
- Added to entity transform passthrough
- Surfaced in InfoBox (shows "Parent Org" link and "Sub-orgs" for parent entities)
- Added validation test for parentOrg references
- Documented the rule: `parentOrg` = legally separate part of another org; `divisions` = internal sub-units

## Test plan
- [x] `pnpm build-data:content` succeeds, no entities have `entityType: funder`
- [x] `parentOrg` flows through to database.json for chai, uk-aisi, us-aisi
- [x] TypeScript compiles without errors
- [x] `pnpm crux validate gate --scope=content --fix` passes
- [x] Pre-existing test failure (duplicate entity IDs) is unrelated to these changes

Note: `uk-dsit` and `nist` do not yet exist as entities, so the parentOrg validation test uses a soft threshold. The test warns about unresolved references but does not fail.

Generated with [Claude Code](https://claude.com/claude-code)