### PR TITLE
fix: correct KB import name breaking build on main

### DIFF
--- a/apps/web/src/app/divisions/[slug]/page.tsx
+++ b/apps/web/src/app/divisions/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
-  getAllKBRecordsByCollection,
+  getAllKBRecords,
   getKBEntity,
   getKBEntitySlug,
   getKBRecords,
@@ -126,7 +126,7 @@ function parseDivisionPersonnel(record: KBRecordEntry): ParsedDivisionPersonnel 
 // ── Lookup helpers ────────────────────────────────────────────────────
 
 function findDivisionBySlug(slug: string): KBRecordEntry | undefined {
-  const allDivisions = getAllKBRecordsByCollection("divisions");
+  const allDivisions = getAllKBRecords("divisions");
   return allDivisions.find((d) => {
     const divSlug = d.fields.slug as string | undefined;
     return divSlug === slug || d.key === slug;
@@ -134,7 +134,7 @@ function findDivisionBySlug(slug: string): KBRecordEntry | undefined {
 }
 
 function getAllDivisionSlugs(): string[] {
-  const allDivisions = getAllKBRecordsByCollection("divisions");
+  const allDivisions = getAllKBRecords("divisions");
   const slugs: string[] = [];
   for (const d of allDivisions) {
     const slug = d.fields.slug as string | undefined;
@@ -249,7 +249,7 @@ export default async function DivisionDetailPage({ params }: PageProps) {
   }
 
   // Find funding programs linked to this division
-  const allPrograms = getAllKBRecordsByCollection("funding-programs");
+  const allPrograms = getAllKBRecords("funding-programs");
   const divisionPrograms = allPrograms
     .filter((p) => {
       const divId = p.fields.divisionId;

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
-  getAllKBRecordsByCollection,
+  getAllKBRecords,
   getKBEntity,
   getKBEntitySlug,
 } from "@/data/kb";
@@ -112,7 +112,7 @@ function parseGrant(record: KBRecordEntry): ParsedGrant {
 // ── Static params ──────────────────────────────────────────────────────
 
 export function generateStaticParams() {
-  const allPrograms = getAllKBRecordsByCollection("funding-programs");
+  const allPrograms = getAllKBRecords("funding-programs");
   return allPrograms.map((record) => ({ id: record.key }));
 }
 
@@ -124,7 +124,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const allPrograms = getAllKBRecordsByCollection("funding-programs");
+  const allPrograms = getAllKBRecords("funding-programs");
   const record = allPrograms.find((r) => r.key === id);
   if (!record) {
     return { title: "Funding Program Not Found" };
@@ -187,7 +187,7 @@ const PROGRAM_TYPE_COLORS: Record<string, string> = {
 
 export default async function FundingProgramDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const allPrograms = getAllKBRecordsByCollection("funding-programs");
+  const allPrograms = getAllKBRecords("funding-programs");
   const record = allPrograms.find((r) => r.key === id);
 
   if (!record) notFound();
@@ -200,7 +200,7 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
   let divisionHref: string | null = null;
   if (program.divisionId) {
     // Look up division in KB records
-    const allDivisions = getAllKBRecordsByCollection("divisions");
+    const allDivisions = getAllKBRecords("divisions");
     const divRecord = allDivisions.find((d) => d.key === program.divisionId);
     if (divRecord) {
       divisionName = (divRecord.fields.name as string) ?? program.divisionId;
@@ -212,7 +212,7 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
   }
 
   // Find grants linked to this program (by programId)
-  const allGrants = getAllKBRecordsByCollection("grants");
+  const allGrants = getAllKBRecords("grants");
   const programGrants = allGrants
     .filter((g) => {
       const grantProgramId = g.fields.programId;


### PR DESCRIPTION
## Summary
- `getAllKBRecordsByCollection` does not exist in `@/data/kb` — the correct function is `getAllKBRecords`
- Both `divisions/[slug]/page.tsx` and `funding-programs/[id]/page.tsx` used the wrong name, introduced by PR #2232
- This breaks TypeScript compilation and is the root cause of CI failures on the release PR #2246

## Test plan
- [x] `npx tsc --noEmit` passes clean (exit 0)
- [ ] CI green on this PR

Agent slot: a2

🤖 Generated with [Claude Code](https://claude.com/claude-code)