### PR TITLE
chore: enrich person KB data from Wikidata

### DIFF
--- a/packages/kb/data/things/nate-soares.yaml
+++ b/packages/kb/data/things/nate-soares.yaml
@@ -7,8 +7,8 @@ thing:
 facts:
   - id: f_MCKelTrhAw
     property: description
-    value: Executive Director of the Machine Intelligence Research Institute (MIRI), focused on mathematical foundations of
-      AI alignment.
+    value: Executive Director of the Machine Intelligence Research Institute (MIRI),
+      focused on mathematical foundations of AI alignment.
     asOf: 2026-03
     notes: Migrated from old entity system
 
@@ -20,7 +20,9 @@ facts:
 
   - id: f_nS6tN2pQ5v
     property: notable-for
-    value: "Executive Director of MIRI; focuses on mathematical foundations of AI alignment including logical uncertainty, decision theory, and corrigibility; author of MIRI technical agenda papers"
+    value: "Executive Director of MIRI; focuses on mathematical foundations of AI
+      alignment including logical uncertainty, decision theory, and
+      corrigibility; author of MIRI technical agenda papers"
     asOf: 2026-03
     notes: Enriched from entity description
 
@@ -35,3 +37,8 @@ facts:
     value: "B.S. in Computer Science, University of California, Berkeley"
     source: https://intelligence.org/team/
     notes: Enriched from public information
+  - id: F7wEM1Rqcw
+    property: born-year
+    value: 1989
+    source: https://www.wikidata.org/wiki/Q136721135
+    notes: From Wikidata Q136721135


### PR DESCRIPTION
## Summary
- Ran `pnpm crux people enrich --source=wikidata --apply` to fetch fresh data from Wikidata for all 48 person KB entities
- 39 of 48 persons matched Wikidata entries; 9 had no Wikidata match (e.g., Ajeya Cotra, Beth Barnes, Buck Shlegeris)
- **1 new fact added**: Nate Soares birth year (1989) from Wikidata Q136721135
- 55 facts were already up-to-date and skipped

## Changes
- `packages/kb/data/things/nate-soares.yaml`: Added `born-year: 1989` fact with Wikidata source

## Test plan
- [x] Content gate check passed (`pnpm crux validate gate --scope=content --fix`)
- [x] KB schema validation passed (362 entities, 0 blocking errors)
- [x] Spot-checked new fact: Nate Soares born 1989 is consistent with public information

Generated with [Claude Code](https://claude.com/claude-code)