### PR TITLE
fix: restore getAllKBRecordsByCollection export lost in merge

### DIFF
--- a/apps/web/src/data/kb.ts
+++ b/apps/web/src/data/kb.ts
@@ -377,6 +377,14 @@ export function getAllKBRecords(collection: string): KBRecordEntry[] {
 }
 
 /**
+ * Get all records across all entities for a specific collection name.
+ * Returns a flat array of record entries (convenience alias).
+ */
+export function getAllKBRecordsByCollection(collection: string): KBRecordEntry[] {
+  return getAllKBRecords(collection);
+}
+
+/**
  * Get a record schema by ID.
  */
 export function getKBRecordSchema(schemaId: string): RecordSchema | undefined {


### PR DESCRIPTION
## Summary

- Restores the `getAllKBRecordsByCollection` export in `apps/web/src/data/kb.ts`
- This function was accidentally removed when PR #2245 merged with a rebased branch that had an older base

## Context

PR #2245's branch was rebased by an external process onto an older version of main (before PR #2232 which added divisions/funding-programs pages). When merged, the older version of `kb.ts` overwrote the current one, removing the `getAllKBRecordsByCollection` function. This breaks the divisions and funding-programs detail pages.

## Test plan

- [x] `npx tsc --noEmit` passes locally
- [ ] CI should pass (this fixes the TS errors blocking all PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)