### PR TITLE
refactor: decompose divisions and funding-programs detail pages

### DIFF
--- a/apps/web/src/app/divisions/[slug]/division-data.ts
+++ b/apps/web/src/app/divisions/[slug]/division-data.ts
@@ -1,0 +1,256 @@
+/**
+ * Data-fetching, parsing, and type definitions for division detail pages.
+ * Extracted from page.tsx as a pure refactor — no behavioral changes.
+ */
+import {
+  getAllKBRecords,
+  getKBEntity,
+  getKBEntitySlug,
+  getKBRecords,
+} from "@/data/kb";
+import type { KBRecordEntry } from "@/data/kb";
+import { getTypedEntityById } from "@/data/database";
+import {
+  titleCase,
+} from "@/components/wiki/kb/format";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ParsedDivision {
+  key: string;
+  ownerEntityId: string;
+  name: string;
+  slug: string | null;
+  divisionType: string;
+  lead: string | null;
+  status: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  website: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+export interface ParsedFundingProgram {
+  key: string;
+  name: string;
+  programType: string;
+  description: string | null;
+  totalBudget: number | null;
+  status: string | null;
+  deadline: string | null;
+  openDate: string | null;
+}
+
+export interface ParsedDivisionPersonnel {
+  key: string;
+  personId: string;
+  personName: string;
+  personHref: string | null;
+  role: string;
+  startDate: string | null;
+  endDate: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+// ── Resolution helpers ─────────────────────────────────────────────────
+
+export function resolveEntityLink(entityId: string): { name: string; href: string | null } {
+  const entity = getKBEntity(entityId);
+  if (entity) {
+    const slug = getKBEntitySlug(entityId);
+    if (slug) {
+      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
+      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
+    }
+    return { name: entity.name, href: `/kb/entity/${entityId}` };
+  }
+  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
+}
+
+// ── Record parsers ────────────────────────────────────────────────────
+
+export function parseDivision(record: KBRecordEntry): ParsedDivision {
+  const f = record.fields;
+  return {
+    key: record.key,
+    ownerEntityId: record.ownerEntityId,
+    name: (f.name as string) ?? record.key,
+    slug: (f.slug as string) ?? null,
+    divisionType: (f.divisionType as string) ?? "team",
+    lead: (f.lead as string) ?? null,
+    status: (f.status as string) ?? null,
+    startDate: (f.startDate as string) ?? null,
+    endDate: (f.endDate as string) ?? null,
+    website: (f.website as string) ?? null,
+    source: (f.source as string) ?? null,
+    notes: (f.notes as string) ?? null,
+  };
+}
+
+export function parseFundingProgram(record: KBRecordEntry): ParsedFundingProgram {
+  const f = record.fields;
+  return {
+    key: record.key,
+    name: (f.name as string) ?? record.key,
+    programType: (f.programType as string) ?? "grant-round",
+    description: (f.description as string) ?? null,
+    totalBudget: typeof f.totalBudget === "number" ? f.totalBudget : null,
+    status: (f.status as string) ?? null,
+    deadline: (f.deadline as string) ?? null,
+    openDate: (f.openDate as string) ?? null,
+  };
+}
+
+export function parseDivisionPersonnel(record: KBRecordEntry): ParsedDivisionPersonnel {
+  const f = record.fields;
+  const personId = (f.personId as string) ?? "";
+  const person = personId ? resolveEntityLink(personId) : { name: personId, href: null };
+
+  return {
+    key: record.key,
+    personId,
+    personName: person.name,
+    personHref: person.href,
+    role: (f.role as string) ?? "",
+    startDate: (f.startDate as string) ?? null,
+    endDate: (f.endDate as string) ?? null,
+    source: (f.source as string) ?? null,
+    notes: (f.notes as string) ?? null,
+  };
+}
+
+// ── Lookup helpers ────────────────────────────────────────────────────
+
+export function findDivisionBySlug(slug: string): KBRecordEntry | undefined {
+  const allDivisions = getAllKBRecords("divisions");
+  return allDivisions.find((d) => {
+    const divSlug = d.fields.slug as string | undefined;
+    return divSlug === slug || d.key === slug;
+  });
+}
+
+export function getAllDivisionSlugs(): string[] {
+  const allDivisions = getAllKBRecords("divisions");
+  const slugs: string[] = [];
+  for (const d of allDivisions) {
+    const slug = d.fields.slug as string | undefined;
+    if (slug) {
+      slugs.push(slug);
+    } else {
+      slugs.push(d.key);
+    }
+  }
+  return slugs;
+}
+
+// ── Status / type labels & colors ──────────────────────────────────────
+
+export const DIVISION_TYPE_LABELS: Record<string, string> = {
+  fund: "Fund",
+  team: "Team",
+  department: "Department",
+  lab: "Lab",
+  "program-area": "Program Area",
+};
+
+export const DIVISION_TYPE_COLORS: Record<string, string> = {
+  fund: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  team: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  department: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  lab: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  "program-area": "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
+};
+
+export const STATUS_COLORS: Record<string, string> = {
+  active: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  inactive: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  dissolved: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+};
+
+export const PROGRAM_TYPE_LABELS: Record<string, string> = {
+  rfp: "RFP",
+  "grant-round": "Grant Round",
+  fellowship: "Fellowship",
+  prize: "Prize",
+  solicitation: "Solicitation",
+  call: "Call",
+  fund: "Fund",
+  program: "Program",
+  initiative: "Initiative",
+  round: "Round",
+  "big-bet": "Big Bet",
+  commitment: "Commitment",
+};
+
+export const PROGRAM_TYPE_COLORS: Record<string, string> = {
+  rfp: "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
+  "grant-round": "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  fellowship: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  prize: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  solicitation: "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
+  call: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
+  fund: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
+  program: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
+  initiative: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  round: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  "big-bet": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  commitment: "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
+};
+
+// ── Main data loader ─────────────────────────────────────────────────
+
+export interface DivisionPageData {
+  division: ParsedDivision;
+  parent: { name: string; href: string | null };
+  parentWikiPageId: string | null;
+  leadName: string | null;
+  leadHref: string | null;
+  personnel: ParsedDivisionPersonnel[];
+  divisionPrograms: ParsedFundingProgram[];
+}
+
+export function loadDivisionPageData(record: import("@/data/kb").KBRecordEntry): DivisionPageData {
+  const division = parseDivision(record);
+  const parent = resolveEntityLink(division.ownerEntityId);
+
+  // Resolve lead if present (may be a person entity ID or a plain name)
+  let leadName: string | null = null;
+  let leadHref: string | null = null;
+  if (division.lead) {
+    const resolved = resolveEntityLink(division.lead);
+    leadName = resolved.name;
+    leadHref = resolved.href;
+  }
+
+  // Find funding programs linked to this division
+  const allPrograms = getAllKBRecords("funding-programs");
+  const divisionPrograms = allPrograms
+    .filter((p) => {
+      const divId = p.fields.divisionId;
+      return typeof divId === "string" && divId === division.key;
+    })
+    .map(parseFundingProgram)
+    .sort((a, b) => (b.totalBudget ?? 0) - (a.totalBudget ?? 0));
+
+  // Find division personnel (stored under synthetic key __division__<divisionId>)
+  const personnelRecords = getKBRecords(`__division__${division.key}`, "division-personnel");
+  const personnel = personnelRecords
+    .map(parseDivisionPersonnel)
+    .sort((a, b) => a.personName.localeCompare(b.personName));
+
+  // Parent wiki page link
+  const parentTypedEntity = getTypedEntityById(division.ownerEntityId);
+  const parentWikiPageId = parentTypedEntity?.numericId ?? null;
+
+  return {
+    division,
+    parent,
+    parentWikiPageId,
+    leadName,
+    leadHref,
+    personnel,
+    divisionPrograms,
+  };
+}

--- a/apps/web/src/app/divisions/[slug]/division-sections.tsx
+++ b/apps/web/src/app/divisions/[slug]/division-sections.tsx
@@ -1,0 +1,194 @@
+/**
+ * Section components for division detail pages.
+ * Extracted from page.tsx as a pure refactor — no visual changes.
+ */
+import Link from "next/link";
+import { formatCompactCurrency } from "@/lib/format-compact";
+import { titleCase } from "@/components/wiki/kb/format";
+
+import type {
+  ParsedDivisionPersonnel,
+  ParsedFundingProgram,
+} from "./division-data";
+import {
+  PROGRAM_TYPE_LABELS,
+  PROGRAM_TYPE_COLORS,
+} from "./division-data";
+
+// ── Team Members Section ─────────────────────────────────────────────
+
+export function TeamMembersSection({
+  personnel,
+}: {
+  personnel: ParsedDivisionPersonnel[];
+}) {
+  if (personnel.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold tracking-tight">Team Members</h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          {personnel.length}
+        </span>
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+      </div>
+      <div className="border border-border/60 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th className="text-left py-2 px-3 font-medium">Name</th>
+              <th className="text-left py-2 px-3 font-medium">Role</th>
+              <th className="text-center py-2 px-3 font-medium">Dates</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {personnel.map((p) => (
+              <tr key={p.key} className="hover:bg-muted/20 transition-colors">
+                <td className="py-2 px-3">
+                  {p.personHref ? (
+                    <Link
+                      href={p.personHref}
+                      className="font-medium text-primary text-xs hover:underline"
+                    >
+                      {p.personName}
+                    </Link>
+                  ) : (
+                    <span className="font-medium text-foreground text-xs">
+                      {p.personName}
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-xs text-muted-foreground">
+                  {p.role}
+                </td>
+                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                  {p.startDate && (
+                    <span>
+                      {p.startDate}
+                      {p.endDate ? ` - ${p.endDate}` : " - present"}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ── Funding Programs Section ─────────────────────────────────────────
+
+export function FundingProgramsSection({
+  programs,
+}: {
+  programs: ParsedFundingProgram[];
+}) {
+  if (programs.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold tracking-tight">Funding Programs</h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          {programs.length}
+        </span>
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+      </div>
+      <div className="border border-border/60 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th className="text-left py-2 px-3 font-medium">Program</th>
+              <th className="text-left py-2 px-3 font-medium">Type</th>
+              <th className="text-right py-2 px-3 font-medium">Budget</th>
+              <th className="text-center py-2 px-3 font-medium">Status</th>
+              <th className="text-center py-2 px-3 font-medium">Deadline</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {programs.map((p) => (
+              <tr key={p.key} className="hover:bg-muted/20 transition-colors">
+                <td className="py-2 px-3">
+                  <Link
+                    href={`/funding-programs/${p.key}`}
+                    className="font-medium text-foreground text-xs hover:text-primary transition-colors"
+                  >
+                    {p.name}
+                  </Link>
+                  {p.description && (
+                    <div className="text-[10px] text-muted-foreground/60 mt-0.5 line-clamp-2">
+                      {p.description}
+                    </div>
+                  )}
+                </td>
+                <td className="py-2 px-3">
+                  <span
+                    className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
+                      PROGRAM_TYPE_COLORS[p.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                    }`}
+                  >
+                    {PROGRAM_TYPE_LABELS[p.programType] ?? p.programType}
+                  </span>
+                </td>
+                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                  {p.totalBudget != null && (
+                    <span className="font-semibold">{formatCompactCurrency(p.totalBudget)}</span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-center text-xs">
+                  {p.status && (
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${
+                        p.status === "open"
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                          : p.status === "awarded"
+                            ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                            : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {titleCase(p.status)}
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                  {p.deadline ?? p.openDate ?? ""}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ── Back to Parent Link ──────────────────────────────────────────────
+
+export function BackToParentLink({
+  parent,
+}: {
+  parent: { name: string; href: string | null };
+}) {
+  return (
+    <div className="mt-8 pt-6 border-t border-border/60">
+      {parent.href ? (
+        <Link
+          href={parent.href}
+          className="text-sm text-primary hover:underline"
+        >
+          &larr; Back to {parent.name}
+        </Link>
+      ) : (
+        <Link
+          href="/organizations"
+          className="text-sm text-primary hover:underline"
+        >
+          &larr; Back to organizations
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/divisions/[slug]/division-shared.tsx
+++ b/apps/web/src/app/divisions/[slug]/division-shared.tsx
@@ -1,0 +1,45 @@
+/**
+ * Shared UI components for division detail pages.
+ * Extracted from page.tsx as a pure refactor — no visual changes.
+ */
+import type React from "react";
+import Link from "next/link";
+
+// ── Subcomponents ──────────────────────────────────────────────────────
+
+export function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
+        {title}
+      </div>
+      <div className="flex items-center gap-1 flex-wrap">{children}</div>
+    </div>
+  );
+}
+
+export function EntityLinkDisplay({
+  name,
+  href,
+}: {
+  name: string;
+  href: string | null;
+}) {
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="text-sm font-medium text-primary hover:underline"
+      >
+        {name}
+      </Link>
+    );
+  }
+  return <span className="text-sm font-medium text-foreground">{name}</span>;
+}

--- a/apps/web/src/app/divisions/[slug]/page.tsx
+++ b/apps/web/src/app/divisions/[slug]/page.tsx
@@ -1,152 +1,30 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import {
-  getAllKBRecords,
-  getKBEntity,
-  getKBEntitySlug,
-  getKBRecords,
-} from "@/data/kb";
-import type { KBRecordEntry } from "@/data/kb";
-import { getTypedEntityById } from "@/data/database";
-import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
 import { safeHref } from "@/lib/directory-utils";
 import {
-  formatKBDate,
   titleCase,
   isUrl,
   shortDomain,
 } from "@/components/wiki/kb/format";
 
-// ── Types ──────────────────────────────────────────────────────────────
-
-interface ParsedDivision {
-  key: string;
-  ownerEntityId: string;
-  name: string;
-  slug: string | null;
-  divisionType: string;
-  lead: string | null;
-  status: string | null;
-  startDate: string | null;
-  endDate: string | null;
-  website: string | null;
-  source: string | null;
-  notes: string | null;
-}
-
-interface ParsedFundingProgram {
-  key: string;
-  name: string;
-  programType: string;
-  description: string | null;
-  totalBudget: number | null;
-  status: string | null;
-  deadline: string | null;
-  openDate: string | null;
-}
-
-interface ParsedDivisionPersonnel {
-  key: string;
-  personId: string;
-  personName: string;
-  personHref: string | null;
-  role: string;
-  startDate: string | null;
-  endDate: string | null;
-  source: string | null;
-  notes: string | null;
-}
-
-// ── Resolution helpers ─────────────────────────────────────────────────
-
-function resolveEntityLink(entityId: string): { name: string; href: string | null } {
-  const entity = getKBEntity(entityId);
-  if (entity) {
-    const slug = getKBEntitySlug(entityId);
-    if (slug) {
-      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
-      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
-    }
-    return { name: entity.name, href: `/kb/entity/${entityId}` };
-  }
-  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
-}
-
-function parseDivision(record: KBRecordEntry): ParsedDivision {
-  const f = record.fields;
-  return {
-    key: record.key,
-    ownerEntityId: record.ownerEntityId,
-    name: (f.name as string) ?? record.key,
-    slug: (f.slug as string) ?? null,
-    divisionType: (f.divisionType as string) ?? "team",
-    lead: (f.lead as string) ?? null,
-    status: (f.status as string) ?? null,
-    startDate: (f.startDate as string) ?? null,
-    endDate: (f.endDate as string) ?? null,
-    website: (f.website as string) ?? null,
-    source: (f.source as string) ?? null,
-    notes: (f.notes as string) ?? null,
-  };
-}
-
-function parseFundingProgram(record: KBRecordEntry): ParsedFundingProgram {
-  const f = record.fields;
-  return {
-    key: record.key,
-    name: (f.name as string) ?? record.key,
-    programType: (f.programType as string) ?? "grant-round",
-    description: (f.description as string) ?? null,
-    totalBudget: typeof f.totalBudget === "number" ? f.totalBudget : null,
-    status: (f.status as string) ?? null,
-    deadline: (f.deadline as string) ?? null,
-    openDate: (f.openDate as string) ?? null,
-  };
-}
-
-function parseDivisionPersonnel(record: KBRecordEntry): ParsedDivisionPersonnel {
-  const f = record.fields;
-  const personId = (f.personId as string) ?? "";
-  const person = personId ? resolveEntityLink(personId) : { name: personId, href: null };
-
-  return {
-    key: record.key,
-    personId,
-    personName: person.name,
-    personHref: person.href,
-    role: (f.role as string) ?? "",
-    startDate: (f.startDate as string) ?? null,
-    endDate: (f.endDate as string) ?? null,
-    source: (f.source as string) ?? null,
-    notes: (f.notes as string) ?? null,
-  };
-}
-
-// ── Lookup helpers ────────────────────────────────────────────────────
-
-function findDivisionBySlug(slug: string): KBRecordEntry | undefined {
-  const allDivisions = getAllKBRecords("divisions");
-  return allDivisions.find((d) => {
-    const divSlug = d.fields.slug as string | undefined;
-    return divSlug === slug || d.key === slug;
-  });
-}
-
-function getAllDivisionSlugs(): string[] {
-  const allDivisions = getAllKBRecords("divisions");
-  const slugs: string[] = [];
-  for (const d of allDivisions) {
-    const slug = d.fields.slug as string | undefined;
-    if (slug) {
-      slugs.push(slug);
-    } else {
-      slugs.push(d.key);
-    }
-  }
-  return slugs;
-}
+import {
+  findDivisionBySlug,
+  getAllDivisionSlugs,
+  loadDivisionPageData,
+  resolveEntityLink,
+  parseDivision,
+  DIVISION_TYPE_LABELS,
+  DIVISION_TYPE_COLORS,
+  STATUS_COLORS,
+} from "./division-data";
+import { DetailSection, EntityLinkDisplay } from "./division-shared";
+import {
+  TeamMembersSection,
+  FundingProgramsSection,
+  BackToParentLink,
+} from "./division-sections";
 
 // ── Static params ──────────────────────────────────────────────────────
 
@@ -175,99 +53,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-// ── Status / type labels & colors ──────────────────────────────────────
-
-const DIVISION_TYPE_LABELS: Record<string, string> = {
-  fund: "Fund",
-  team: "Team",
-  department: "Department",
-  lab: "Lab",
-  "program-area": "Program Area",
-};
-
-const DIVISION_TYPE_COLORS: Record<string, string> = {
-  fund: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  team: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  department: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  lab: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  "program-area": "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  active: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  inactive: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  dissolved: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-};
-
-const PROGRAM_TYPE_LABELS: Record<string, string> = {
-  rfp: "RFP",
-  "grant-round": "Grant Round",
-  fellowship: "Fellowship",
-  prize: "Prize",
-  solicitation: "Solicitation",
-  call: "Call",
-  fund: "Fund",
-  program: "Program",
-  initiative: "Initiative",
-  round: "Round",
-  "big-bet": "Big Bet",
-  commitment: "Commitment",
-};
-
-const PROGRAM_TYPE_COLORS: Record<string, string> = {
-  rfp: "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
-  "grant-round": "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  fellowship: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  prize: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  solicitation: "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
-  call: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
-  fund: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-  program: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-  initiative: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  round: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  "big-bet": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  commitment: "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
-};
-
 // ── Page ───────────────────────────────────────────────────────────────
 
 export default async function DivisionDetailPage({ params }: PageProps) {
   const { slug } = await params;
   const record = findDivisionBySlug(slug);
 
-  if (!record) notFound();
+  if (!record) return notFound();
 
-  const division = parseDivision(record);
-  const parent = resolveEntityLink(division.ownerEntityId);
-
-  // Resolve lead if present (may be a person entity ID or a plain name)
-  let leadName: string | null = null;
-  let leadHref: string | null = null;
-  if (division.lead) {
-    const resolved = resolveEntityLink(division.lead);
-    leadName = resolved.name;
-    leadHref = resolved.href;
-  }
-
-  // Find funding programs linked to this division
-  const allPrograms = getAllKBRecords("funding-programs");
-  const divisionPrograms = allPrograms
-    .filter((p) => {
-      const divId = p.fields.divisionId;
-      return typeof divId === "string" && divId === division.key;
-    })
-    .map(parseFundingProgram)
-    .sort((a, b) => (b.totalBudget ?? 0) - (a.totalBudget ?? 0));
-
-  // Find division personnel (stored under synthetic key __division__<divisionId>)
-  const personnelRecords = getKBRecords(`__division__${division.key}`, "division-personnel");
-  const personnel = personnelRecords
-    .map(parseDivisionPersonnel)
-    .sort((a, b) => a.personName.localeCompare(b.personName));
-
-  // Parent wiki page link
-  const parentTypedEntity = getTypedEntityById(division.ownerEntityId);
-  const parentWikiPageId = parentTypedEntity?.numericId ?? null;
+  const data = loadDivisionPageData(record);
 
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
@@ -275,10 +69,10 @@ export default async function DivisionDetailPage({ params }: PageProps) {
       <Breadcrumbs
         items={[
           { label: "Organizations", href: "/organizations" },
-          ...(parent.href
-            ? [{ label: parent.name, href: parent.href }]
+          ...(data.parent.href
+            ? [{ label: data.parent.name, href: data.parent.href }]
             : []),
-          { label: division.name },
+          { label: data.division.name },
         ]}
       />
 
@@ -286,15 +80,15 @@ export default async function DivisionDetailPage({ params }: PageProps) {
       <div className="mb-8">
         <div className="flex items-start gap-3 mb-3">
           <h1 className="text-2xl font-extrabold tracking-tight flex-1">
-            {division.name}
+            {data.division.name}
           </h1>
-          {division.status && (
+          {data.division.status && (
             <span
               className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${
-                STATUS_COLORS[division.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                STATUS_COLORS[data.division.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
               }`}
             >
-              {titleCase(division.status)}
+              {titleCase(data.division.status)}
             </span>
           )}
         </div>
@@ -302,10 +96,10 @@ export default async function DivisionDetailPage({ params }: PageProps) {
         <div className="flex items-center gap-3 flex-wrap">
           <span
             className={`inline-block px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
-              DIVISION_TYPE_COLORS[division.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+              DIVISION_TYPE_COLORS[data.division.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
             }`}
           >
-            {DIVISION_TYPE_LABELS[division.divisionType] ?? titleCase(division.divisionType)}
+            {DIVISION_TYPE_LABELS[data.division.divisionType] ?? titleCase(data.division.divisionType)}
           </span>
         </div>
       </div>
@@ -316,12 +110,12 @@ export default async function DivisionDetailPage({ params }: PageProps) {
         <div className="space-y-4">
           <DetailSection title="Parent Organization">
             <EntityLinkDisplay
-              name={parent.name}
-              href={parent.href}
+              name={data.parent.name}
+              href={data.parent.href}
             />
-            {parentWikiPageId && (
+            {data.parentWikiPageId && (
               <Link
-                href={`/wiki/${parentWikiPageId}`}
+                href={`/wiki/${data.parentWikiPageId}`}
                 className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
                 title="Wiki page"
               >
@@ -330,27 +124,27 @@ export default async function DivisionDetailPage({ params }: PageProps) {
             )}
           </DetailSection>
 
-          {leadName && (
+          {data.leadName && (
             <DetailSection title="Lead">
-              {leadHref ? (
+              {data.leadHref ? (
                 <Link
-                  href={leadHref}
+                  href={data.leadHref}
                   className="text-sm font-medium text-primary hover:underline"
                 >
-                  {leadName}
+                  {data.leadName}
                 </Link>
               ) : (
-                <span className="text-sm text-foreground">{leadName}</span>
+                <span className="text-sm text-foreground">{data.leadName}</span>
               )}
             </DetailSection>
           )}
 
-          {(division.startDate || division.endDate) && (
+          {(data.division.startDate || data.division.endDate) && (
             <DetailSection title="Active Period">
               <span className="text-sm text-foreground">
-                {division.startDate ?? "?"}
+                {data.division.startDate ?? "?"}
                 {" — "}
-                {division.endDate ?? "present"}
+                {data.division.endDate ?? "present"}
               </span>
             </DetailSection>
           )}
@@ -358,42 +152,42 @@ export default async function DivisionDetailPage({ params }: PageProps) {
 
         {/* Right column: supplementary info */}
         <div className="space-y-4">
-          {division.website && (
+          {data.division.website && (
             <DetailSection title="Website">
               <a
-                href={safeHref(division.website)}
+                href={safeHref(data.division.website)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-primary hover:underline break-all"
               >
-                {shortDomain(division.website)}
+                {shortDomain(data.division.website)}
                 <span className="text-muted-foreground ml-1">{"\u2197"}</span>
               </a>
             </DetailSection>
           )}
 
-          {division.source && (
+          {data.division.source && (
             <DetailSection title="Source">
-              {isUrl(division.source) ? (
+              {isUrl(data.division.source) ? (
                 <a
-                  href={safeHref(division.source)}
+                  href={safeHref(data.division.source)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-primary hover:underline break-all"
                 >
-                  {shortDomain(division.source)}
+                  {shortDomain(data.division.source)}
                   <span className="text-muted-foreground ml-1">{"\u2197"}</span>
                 </a>
               ) : (
-                <span className="text-sm text-foreground">{division.source}</span>
+                <span className="text-sm text-foreground">{data.division.source}</span>
               )}
             </DetailSection>
           )}
 
-          {division.notes && (
+          {data.division.notes && (
             <DetailSection title="Notes">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                {division.notes}
+                {data.division.notes}
               </p>
             </DetailSection>
           )}
@@ -401,194 +195,13 @@ export default async function DivisionDetailPage({ params }: PageProps) {
       </div>
 
       {/* Team Members */}
-      {personnel.length > 0 && (
-        <section className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-base font-bold tracking-tight">Team Members</h2>
-            <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              {personnel.length}
-            </span>
-            <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
-          </div>
-          <div className="border border-border/60 rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="text-left py-2 px-3 font-medium">Name</th>
-                  <th className="text-left py-2 px-3 font-medium">Role</th>
-                  <th className="text-center py-2 px-3 font-medium">Dates</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {personnel.map((p) => (
-                  <tr key={p.key} className="hover:bg-muted/20 transition-colors">
-                    <td className="py-2 px-3">
-                      {p.personHref ? (
-                        <Link
-                          href={p.personHref}
-                          className="font-medium text-primary text-xs hover:underline"
-                        >
-                          {p.personName}
-                        </Link>
-                      ) : (
-                        <span className="font-medium text-foreground text-xs">
-                          {p.personName}
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-xs text-muted-foreground">
-                      {p.role}
-                    </td>
-                    <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                      {p.startDate && (
-                        <span>
-                          {p.startDate}
-                          {p.endDate ? ` - ${p.endDate}` : " - present"}
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      <TeamMembersSection personnel={data.personnel} />
 
       {/* Funding Programs */}
-      {divisionPrograms.length > 0 && (
-        <section className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-base font-bold tracking-tight">Funding Programs</h2>
-            <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              {divisionPrograms.length}
-            </span>
-            <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
-          </div>
-          <div className="border border-border/60 rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="text-left py-2 px-3 font-medium">Program</th>
-                  <th className="text-left py-2 px-3 font-medium">Type</th>
-                  <th className="text-right py-2 px-3 font-medium">Budget</th>
-                  <th className="text-center py-2 px-3 font-medium">Status</th>
-                  <th className="text-center py-2 px-3 font-medium">Deadline</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {divisionPrograms.map((p) => (
-                  <tr key={p.key} className="hover:bg-muted/20 transition-colors">
-                    <td className="py-2 px-3">
-                      <Link
-                        href={`/funding-programs/${p.key}`}
-                        className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                      >
-                        {p.name}
-                      </Link>
-                      {p.description && (
-                        <div className="text-[10px] text-muted-foreground/60 mt-0.5 line-clamp-2">
-                          {p.description}
-                        </div>
-                      )}
-                    </td>
-                    <td className="py-2 px-3">
-                      <span
-                        className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
-                          PROGRAM_TYPE_COLORS[p.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                        }`}
-                      >
-                        {PROGRAM_TYPE_LABELS[p.programType] ?? p.programType}
-                      </span>
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                      {p.totalBudget != null && (
-                        <span className="font-semibold">{formatCompactCurrency(p.totalBudget)}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-center text-xs">
-                      {p.status && (
-                        <span
-                          className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${
-                            p.status === "open"
-                              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-                              : p.status === "awarded"
-                                ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-                                : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                          }`}
-                        >
-                          {titleCase(p.status)}
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                      {p.deadline ?? p.openDate ?? ""}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      <FundingProgramsSection programs={data.divisionPrograms} />
 
       {/* Back to parent org */}
-      <div className="mt-8 pt-6 border-t border-border/60">
-        {parent.href ? (
-          <Link
-            href={parent.href}
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to {parent.name}
-          </Link>
-        ) : (
-          <Link
-            href="/organizations"
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to organizations
-          </Link>
-        )}
-      </div>
+      <BackToParentLink parent={data.parent} />
     </div>
   );
-}
-
-// ── Subcomponents ──────────────────────────────────────────────────────
-
-function DetailSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
-        {title}
-      </div>
-      <div className="flex items-center gap-1 flex-wrap">{children}</div>
-    </div>
-  );
-}
-
-function EntityLinkDisplay({
-  name,
-  href,
-}: {
-  name: string;
-  href: string | null;
-}) {
-  if (href) {
-    return (
-      <Link
-        href={href}
-        className="text-sm font-medium text-primary hover:underline"
-      >
-        {name}
-      </Link>
-    );
-  }
-  return <span className="text-sm font-medium text-foreground">{name}</span>;
 }

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -1,13 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import {
-  getAllKBRecords,
-  getKBEntity,
-  getKBEntitySlug,
-} from "@/data/kb";
-import type { KBRecordEntry } from "@/data/kb";
-import { getTypedEntityById } from "@/data/database";
+import { getAllKBRecords } from "@/data/kb";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
 import { safeHref } from "@/lib/directory-utils";
@@ -18,97 +12,16 @@ import {
   shortDomain,
 } from "@/components/wiki/kb/format";
 
-// ── Types ──────────────────────────────────────────────────────────────
-
-interface ParsedFundingProgram {
-  key: string;
-  ownerEntityId: string;
-  name: string;
-  programType: string;
-  description: string | null;
-  divisionId: string | null;
-  totalBudget: number | null;
-  currency: string;
-  applicationUrl: string | null;
-  openDate: string | null;
-  deadline: string | null;
-  status: string | null;
-  source: string | null;
-  notes: string | null;
-}
-
-interface ParsedGrant {
-  key: string;
-  ownerEntityId: string;
-  name: string;
-  recipientId: string | null;
-  recipientName: string;
-  recipientHref: string | null;
-  amount: number | null;
-  date: string | null;
-  period: string | null;
-  status: string | null;
-  source: string | null;
-  programId: string | null;
-}
-
-// ── Resolution helpers ─────────────────────────────────────────────────
-
-function resolveEntityLink(entityId: string): { name: string; href: string | null } {
-  const entity = getKBEntity(entityId);
-  if (entity) {
-    const slug = getKBEntitySlug(entityId);
-    if (slug) {
-      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
-      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
-    }
-    return { name: entity.name, href: `/kb/entity/${entityId}` };
-  }
-  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
-}
-
-function parseFundingProgram(record: KBRecordEntry): ParsedFundingProgram {
-  const f = record.fields;
-  return {
-    key: record.key,
-    ownerEntityId: record.ownerEntityId,
-    name: (f.name as string) ?? record.key,
-    programType: (f.programType as string) ?? "grant-round",
-    description: (f.description as string) ?? null,
-    divisionId: (f.divisionId as string) ?? null,
-    totalBudget: typeof f.totalBudget === "number" ? f.totalBudget : null,
-    currency: (f.currency as string) ?? "USD",
-    applicationUrl: (f.applicationUrl as string) ?? null,
-    openDate: (f.openDate as string) ?? null,
-    deadline: (f.deadline as string) ?? null,
-    status: (f.status as string) ?? null,
-    source: (f.source as string) ?? null,
-    notes: (f.notes as string) ?? null,
-  };
-}
-
-function parseGrant(record: KBRecordEntry): ParsedGrant {
-  const f = record.fields;
-  const recipientId = typeof f.recipient === "string" ? f.recipient : null;
-  const recipient = recipientId
-    ? resolveEntityLink(recipientId)
-    : { name: "", href: null };
-
-  return {
-    key: record.key,
-    ownerEntityId: record.ownerEntityId,
-    name: (f.name as string) ?? record.key,
-    recipientId,
-    recipientName: recipient.name,
-    recipientHref: recipient.href,
-    amount: typeof f.amount === "number" ? f.amount : null,
-    date: typeof f.date === "string" ? f.date : null,
-    period: typeof f.period === "string" ? f.period : null,
-    status: typeof f.status === "string" ? f.status : null,
-    source: typeof f.source === "string" ? f.source : null,
-    programId: typeof f.programId === "string" ? f.programId : null,
-  };
-}
+import {
+  parseFundingProgram,
+  resolveEntityLink,
+  loadProgramPageData,
+  STATUS_COLORS,
+  PROGRAM_TYPE_LABELS,
+  PROGRAM_TYPE_COLORS,
+} from "./program-data";
+import { DetailSection, EntityLinkDisplay } from "./program-shared";
+import { GrantsAwardedSection, BackToFunderLink } from "./program-sections";
 
 // ── Static params ──────────────────────────────────────────────────────
 
@@ -142,48 +55,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-// ── Status badge colors ────────────────────────────────────────────────
-
-const STATUS_COLORS: Record<string, string> = {
-  open: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  awarded: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  completed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  closed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  "winding-down": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  terminated: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-};
-
-const PROGRAM_TYPE_LABELS: Record<string, string> = {
-  rfp: "RFP",
-  "grant-round": "Grant Round",
-  fellowship: "Fellowship",
-  prize: "Prize",
-  solicitation: "Solicitation",
-  call: "Call",
-  fund: "Fund",
-  program: "Program",
-  initiative: "Initiative",
-  round: "Round",
-  "big-bet": "Big Bet",
-  commitment: "Commitment",
-};
-
-const PROGRAM_TYPE_COLORS: Record<string, string> = {
-  rfp: "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
-  "grant-round": "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  fellowship: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  prize: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  solicitation: "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
-  call: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
-  fund: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-  program: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-  initiative: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  round: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  "big-bet": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  commitment: "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
-};
-
 // ── Page ───────────────────────────────────────────────────────────────
 
 export default async function FundingProgramDetailPage({ params }: PageProps) {
@@ -191,46 +62,9 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
   const allPrograms = getAllKBRecords("funding-programs");
   const record = allPrograms.find((r) => r.key === id);
 
-  if (!record) notFound();
+  if (!record) return notFound();
 
-  const program = parseFundingProgram(record);
-  const funder = resolveEntityLink(program.ownerEntityId);
-
-  // Resolve division if present
-  let divisionName: string | null = null;
-  let divisionHref: string | null = null;
-  if (program.divisionId) {
-    // Look up division in KB records
-    const allDivisions = getAllKBRecords("divisions");
-    const divRecord = allDivisions.find((d) => d.key === program.divisionId);
-    if (divRecord) {
-      divisionName = (divRecord.fields.name as string) ?? program.divisionId;
-      const divSlug = (divRecord.fields.slug as string) ?? null;
-      if (divSlug) {
-        divisionHref = `/divisions/${divSlug}`;
-      }
-    }
-  }
-
-  // Find grants linked to this program (by programId)
-  const allGrants = getAllKBRecords("grants");
-  const programGrants = allGrants
-    .filter((g) => {
-      const grantProgramId = g.fields.programId;
-      if (typeof grantProgramId === "string" && grantProgramId === program.key) return true;
-      // Also match by program field (YAML grants use program name as string)
-      const grantProgram = g.fields.program;
-      if (typeof grantProgram === "string" && grantProgram === program.key) return true;
-      return false;
-    })
-    .map(parseGrant)
-    .sort((a, b) => (b.amount ?? 0) - (a.amount ?? 0));
-
-  const totalGranted = programGrants.reduce((sum, g) => sum + (g.amount ?? 0), 0);
-
-  // Funder wiki page link
-  const funderTypedEntity = getTypedEntityById(program.ownerEntityId);
-  const funderWikiPageId = funderTypedEntity?.numericId ?? null;
+  const data = loadProgramPageData(record);
 
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
@@ -238,10 +72,10 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
       <Breadcrumbs
         items={[
           { label: "Organizations", href: "/organizations" },
-          ...(funder.href
-            ? [{ label: funder.name, href: funder.href }]
+          ...(data.funder.href
+            ? [{ label: data.funder.name, href: data.funder.href }]
             : []),
-          { label: program.name },
+          { label: data.program.name },
         ]}
       />
 
@@ -249,15 +83,15 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
       <div className="mb-8">
         <div className="flex items-start gap-3 mb-3">
           <h1 className="text-2xl font-extrabold tracking-tight flex-1">
-            {program.name}
+            {data.program.name}
           </h1>
-          {program.status && (
+          {data.program.status && (
             <span
               className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${
-                STATUS_COLORS[program.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                STATUS_COLORS[data.program.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
               }`}
             >
-              {titleCase(program.status)}
+              {titleCase(data.program.status)}
             </span>
           )}
         </div>
@@ -265,20 +99,20 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
         <div className="flex items-center gap-3 flex-wrap">
           <span
             className={`inline-block px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
-              PROGRAM_TYPE_COLORS[program.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+              PROGRAM_TYPE_COLORS[data.program.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
             }`}
           >
-            {PROGRAM_TYPE_LABELS[program.programType] ?? titleCase(program.programType)}
+            {PROGRAM_TYPE_LABELS[data.program.programType] ?? titleCase(data.program.programType)}
           </span>
         </div>
 
         {/* Budget hero */}
-        {program.totalBudget != null && (
+        {data.program.totalBudget != null && (
           <div className="text-3xl font-bold tabular-nums tracking-tight text-primary mt-3 mb-1">
-            {formatCompactCurrency(program.totalBudget)}
-            {program.currency && program.currency !== "USD" && (
+            {formatCompactCurrency(data.program.totalBudget)}
+            {data.program.currency && data.program.currency !== "USD" && (
               <span className="text-base font-medium text-muted-foreground ml-2">
-                {program.currency}
+                {data.program.currency}
               </span>
             )}
             <span className="text-sm font-normal text-muted-foreground ml-2">budget</span>
@@ -292,12 +126,12 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
         <div className="space-y-4">
           <DetailSection title="Funder Organization">
             <EntityLinkDisplay
-              name={funder.name}
-              href={funder.href}
+              name={data.funder.name}
+              href={data.funder.href}
             />
-            {funderWikiPageId && (
+            {data.funderWikiPageId && (
               <Link
-                href={`/wiki/${funderWikiPageId}`}
+                href={`/wiki/${data.funderWikiPageId}`}
                 className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
                 title="Wiki page"
               >
@@ -306,35 +140,35 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
             )}
           </DetailSection>
 
-          {divisionName && (
+          {data.divisionName && (
             <DetailSection title="Division">
-              {divisionHref ? (
+              {data.divisionHref ? (
                 <Link
-                  href={divisionHref}
+                  href={data.divisionHref}
                   className="text-sm font-medium text-primary hover:underline"
                 >
-                  {divisionName}
+                  {data.divisionName}
                 </Link>
               ) : (
-                <span className="text-sm text-foreground">{divisionName}</span>
+                <span className="text-sm text-foreground">{data.divisionName}</span>
               )}
             </DetailSection>
           )}
 
-          {(program.openDate || program.deadline) && (
+          {(data.program.openDate || data.program.deadline) && (
             <DetailSection title="Timeline">
               <span className="text-sm text-foreground">
-                {program.openDate && (
+                {data.program.openDate && (
                   <>
                     <span className="text-muted-foreground text-xs">Opens:</span>{" "}
-                    {formatKBDate(program.openDate)}
+                    {formatKBDate(data.program.openDate)}
                   </>
                 )}
-                {program.openDate && program.deadline && " — "}
-                {program.deadline && (
+                {data.program.openDate && data.program.deadline && " — "}
+                {data.program.deadline && (
                   <>
                     <span className="text-muted-foreground text-xs">Deadline:</span>{" "}
-                    {formatKBDate(program.deadline)}
+                    {formatKBDate(data.program.deadline)}
                   </>
                 )}
               </span>
@@ -344,50 +178,50 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
 
         {/* Right column: supplementary info */}
         <div className="space-y-4">
-          {program.applicationUrl && (
+          {data.program.applicationUrl && (
             <DetailSection title="Application">
               <a
-                href={safeHref(program.applicationUrl)}
+                href={safeHref(data.program.applicationUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-primary hover:underline break-all"
               >
-                {shortDomain(program.applicationUrl)}
+                {shortDomain(data.program.applicationUrl)}
                 <span className="text-muted-foreground ml-1">{"\u2197"}</span>
               </a>
             </DetailSection>
           )}
 
-          {program.source && (
+          {data.program.source && (
             <DetailSection title="Source">
-              {isUrl(program.source) ? (
+              {isUrl(data.program.source) ? (
                 <a
-                  href={safeHref(program.source)}
+                  href={safeHref(data.program.source)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-primary hover:underline break-all"
                 >
-                  {shortDomain(program.source)}
+                  {shortDomain(data.program.source)}
                   <span className="text-muted-foreground ml-1">{"\u2197"}</span>
                 </a>
               ) : (
-                <span className="text-sm text-foreground">{program.source}</span>
+                <span className="text-sm text-foreground">{data.program.source}</span>
               )}
             </DetailSection>
           )}
 
-          {program.description && (
+          {data.program.description && (
             <DetailSection title="Description">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                {program.description}
+                {data.program.description}
               </p>
             </DetailSection>
           )}
 
-          {program.notes && (
+          {data.program.notes && (
             <DetailSection title="Notes">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                {program.notes}
+                {data.program.notes}
               </p>
             </DetailSection>
           )}
@@ -395,141 +229,13 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
       </div>
 
       {/* Grants awarded through this program */}
-      {programGrants.length > 0 && (
-        <section className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-base font-bold tracking-tight">Grants Awarded</h2>
-            <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              {programGrants.length}
-            </span>
-            {totalGranted > 0 && (
-              <span className="text-xs text-muted-foreground">
-                Total: {formatCompactCurrency(totalGranted)}
-              </span>
-            )}
-            <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
-          </div>
-          <div className="border border-border/60 rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="text-left py-2 px-3 font-medium">Grant</th>
-                  <th className="text-left py-2 px-3 font-medium">Recipient</th>
-                  <th className="text-right py-2 px-3 font-medium">Amount</th>
-                  <th className="text-center py-2 px-3 font-medium">Date</th>
-                  <th className="text-center py-2 px-3 font-medium">Status</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {programGrants.map((g) => (
-                  <tr key={g.key} className="hover:bg-muted/20 transition-colors">
-                    <td className="py-2 px-3">
-                      <Link
-                        href={`/grants/${g.key}`}
-                        className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                      >
-                        {g.name}
-                      </Link>
-                    </td>
-                    <td className="py-2 px-3 text-xs">
-                      {g.recipientHref ? (
-                        <Link href={g.recipientHref} className="text-primary hover:underline">
-                          {g.recipientName}
-                        </Link>
-                      ) : (
-                        <span className="text-muted-foreground">{g.recipientName}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                      {g.amount != null && (
-                        <span className="font-semibold">
-                          {formatCompactCurrency(g.amount)}
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                      {g.date ? formatKBDate(g.date) : g.period ?? ""}
-                    </td>
-                    <td className="py-2 px-3 text-center text-xs">
-                      {g.status && (
-                        <span
-                          className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${
-                            g.status === "active"
-                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
-                              : g.status === "completed"
-                                ? "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300"
-                                : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                          }`}
-                        >
-                          {titleCase(g.status)}
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      <GrantsAwardedSection
+        grants={data.programGrants}
+        totalGranted={data.totalGranted}
+      />
 
       {/* Back to funder */}
-      <div className="mt-8 pt-6 border-t border-border/60">
-        {funder.href ? (
-          <Link
-            href={funder.href}
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to {funder.name}
-          </Link>
-        ) : (
-          <Link
-            href="/organizations"
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to organizations
-          </Link>
-        )}
-      </div>
+      <BackToFunderLink funder={data.funder} />
     </div>
   );
-}
-
-// ── Subcomponents ──────────────────────────────────────────────────────
-
-function DetailSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
-        {title}
-      </div>
-      <div className="flex items-center gap-1 flex-wrap">{children}</div>
-    </div>
-  );
-}
-
-function EntityLinkDisplay({
-  name,
-  href,
-}: {
-  name: string;
-  href: string | null;
-}) {
-  if (href) {
-    return (
-      <Link
-        href={href}
-        className="text-sm font-medium text-primary hover:underline"
-      >
-        {name}
-      </Link>
-    );
-  }
-  return <span className="text-sm font-medium text-foreground">{name}</span>;
 }

--- a/apps/web/src/app/funding-programs/[id]/program-data.ts
+++ b/apps/web/src/app/funding-programs/[id]/program-data.ts
@@ -1,0 +1,213 @@
+/**
+ * Data-fetching, parsing, and type definitions for funding program detail pages.
+ * Extracted from page.tsx as a pure refactor — no behavioral changes.
+ */
+import {
+  getAllKBRecords,
+  getKBEntity,
+  getKBEntitySlug,
+} from "@/data/kb";
+import type { KBRecordEntry } from "@/data/kb";
+import { getTypedEntityById } from "@/data/database";
+import {
+  titleCase,
+} from "@/components/wiki/kb/format";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ParsedFundingProgram {
+  key: string;
+  ownerEntityId: string;
+  name: string;
+  programType: string;
+  description: string | null;
+  divisionId: string | null;
+  totalBudget: number | null;
+  currency: string;
+  applicationUrl: string | null;
+  openDate: string | null;
+  deadline: string | null;
+  status: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+export interface ParsedGrant {
+  key: string;
+  ownerEntityId: string;
+  name: string;
+  recipientId: string | null;
+  recipientName: string;
+  recipientHref: string | null;
+  amount: number | null;
+  date: string | null;
+  period: string | null;
+  status: string | null;
+  source: string | null;
+  programId: string | null;
+}
+
+// ── Resolution helpers ─────────────────────────────────────────────────
+
+export function resolveEntityLink(entityId: string): { name: string; href: string | null } {
+  const entity = getKBEntity(entityId);
+  if (entity) {
+    const slug = getKBEntitySlug(entityId);
+    if (slug) {
+      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
+      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
+    }
+    return { name: entity.name, href: `/kb/entity/${entityId}` };
+  }
+  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
+}
+
+// ── Record parsers ────────────────────────────────────────────────────
+
+export function parseFundingProgram(record: KBRecordEntry): ParsedFundingProgram {
+  const f = record.fields;
+  return {
+    key: record.key,
+    ownerEntityId: record.ownerEntityId,
+    name: (f.name as string) ?? record.key,
+    programType: (f.programType as string) ?? "grant-round",
+    description: (f.description as string) ?? null,
+    divisionId: (f.divisionId as string) ?? null,
+    totalBudget: typeof f.totalBudget === "number" ? f.totalBudget : null,
+    currency: (f.currency as string) ?? "USD",
+    applicationUrl: (f.applicationUrl as string) ?? null,
+    openDate: (f.openDate as string) ?? null,
+    deadline: (f.deadline as string) ?? null,
+    status: (f.status as string) ?? null,
+    source: (f.source as string) ?? null,
+    notes: (f.notes as string) ?? null,
+  };
+}
+
+export function parseGrant(record: KBRecordEntry): ParsedGrant {
+  const f = record.fields;
+  const recipientId = typeof f.recipient === "string" ? f.recipient : null;
+  const recipient = recipientId
+    ? resolveEntityLink(recipientId)
+    : { name: "", href: null };
+
+  return {
+    key: record.key,
+    ownerEntityId: record.ownerEntityId,
+    name: (f.name as string) ?? record.key,
+    recipientId,
+    recipientName: recipient.name,
+    recipientHref: recipient.href,
+    amount: typeof f.amount === "number" ? f.amount : null,
+    date: typeof f.date === "string" ? f.date : null,
+    period: typeof f.period === "string" ? f.period : null,
+    status: typeof f.status === "string" ? f.status : null,
+    source: typeof f.source === "string" ? f.source : null,
+    programId: typeof f.programId === "string" ? f.programId : null,
+  };
+}
+
+// ── Status badge colors ────────────────────────────────────────────────
+
+export const STATUS_COLORS: Record<string, string> = {
+  open: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  awarded: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  completed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
+  closed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
+  "winding-down": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  terminated: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};
+
+export const PROGRAM_TYPE_LABELS: Record<string, string> = {
+  rfp: "RFP",
+  "grant-round": "Grant Round",
+  fellowship: "Fellowship",
+  prize: "Prize",
+  solicitation: "Solicitation",
+  call: "Call",
+  fund: "Fund",
+  program: "Program",
+  initiative: "Initiative",
+  round: "Round",
+  "big-bet": "Big Bet",
+  commitment: "Commitment",
+};
+
+export const PROGRAM_TYPE_COLORS: Record<string, string> = {
+  rfp: "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
+  "grant-round": "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  fellowship: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  prize: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  solicitation: "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
+  call: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
+  fund: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
+  program: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
+  initiative: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  round: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  "big-bet": "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  commitment: "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
+};
+
+// ── Main data loader ─────────────────────────────────────────────────
+
+export interface ProgramPageData {
+  program: ParsedFundingProgram;
+  funder: { name: string; href: string | null };
+  funderWikiPageId: string | null;
+  divisionName: string | null;
+  divisionHref: string | null;
+  programGrants: ParsedGrant[];
+  totalGranted: number;
+}
+
+export function loadProgramPageData(record: import("@/data/kb").KBRecordEntry): ProgramPageData {
+  const program = parseFundingProgram(record);
+  const funder = resolveEntityLink(program.ownerEntityId);
+
+  // Resolve division if present
+  let divisionName: string | null = null;
+  let divisionHref: string | null = null;
+  if (program.divisionId) {
+    // Look up division in KB records
+    const allDivisions = getAllKBRecords("divisions");
+    const divRecord = allDivisions.find((d) => d.key === program.divisionId);
+    if (divRecord) {
+      divisionName = (divRecord.fields.name as string) ?? program.divisionId;
+      const divSlug = (divRecord.fields.slug as string) ?? null;
+      if (divSlug) {
+        divisionHref = `/divisions/${divSlug}`;
+      }
+    }
+  }
+
+  // Find grants linked to this program (by programId)
+  const allGrants = getAllKBRecords("grants");
+  const programGrants = allGrants
+    .filter((g) => {
+      const grantProgramId = g.fields.programId;
+      if (typeof grantProgramId === "string" && grantProgramId === program.key) return true;
+      // Also match by program field (YAML grants use program name as string)
+      const grantProgram = g.fields.program;
+      if (typeof grantProgram === "string" && grantProgram === program.key) return true;
+      return false;
+    })
+    .map(parseGrant)
+    .sort((a, b) => (b.amount ?? 0) - (a.amount ?? 0));
+
+  const totalGranted = programGrants.reduce((sum, g) => sum + (g.amount ?? 0), 0);
+
+  // Funder wiki page link
+  const funderTypedEntity = getTypedEntityById(program.ownerEntityId);
+  const funderWikiPageId = funderTypedEntity?.numericId ?? null;
+
+  return {
+    program,
+    funder,
+    funderWikiPageId,
+    divisionName,
+    divisionHref,
+    programGrants,
+    totalGranted,
+  };
+}

--- a/apps/web/src/app/funding-programs/[id]/program-sections.tsx
+++ b/apps/web/src/app/funding-programs/[id]/program-sections.tsx
@@ -1,0 +1,130 @@
+/**
+ * Section components for funding program detail pages.
+ * Extracted from page.tsx as a pure refactor — no visual changes.
+ */
+import Link from "next/link";
+import { formatCompactCurrency } from "@/lib/format-compact";
+import {
+  formatKBDate,
+  titleCase,
+} from "@/components/wiki/kb/format";
+
+import type { ParsedGrant } from "./program-data";
+
+// ── Grants Awarded Section ───────────────────────────────────────────
+
+export function GrantsAwardedSection({
+  grants,
+  totalGranted,
+}: {
+  grants: ParsedGrant[];
+  totalGranted: number;
+}) {
+  if (grants.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold tracking-tight">Grants Awarded</h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          {grants.length}
+        </span>
+        {totalGranted > 0 && (
+          <span className="text-xs text-muted-foreground">
+            Total: {formatCompactCurrency(totalGranted)}
+          </span>
+        )}
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+      </div>
+      <div className="border border-border/60 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th className="text-left py-2 px-3 font-medium">Grant</th>
+              <th className="text-left py-2 px-3 font-medium">Recipient</th>
+              <th className="text-right py-2 px-3 font-medium">Amount</th>
+              <th className="text-center py-2 px-3 font-medium">Date</th>
+              <th className="text-center py-2 px-3 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {grants.map((g) => (
+              <tr key={g.key} className="hover:bg-muted/20 transition-colors">
+                <td className="py-2 px-3">
+                  <Link
+                    href={`/grants/${g.key}`}
+                    className="font-medium text-foreground text-xs hover:text-primary transition-colors"
+                  >
+                    {g.name}
+                  </Link>
+                </td>
+                <td className="py-2 px-3 text-xs">
+                  {g.recipientHref ? (
+                    <Link href={g.recipientHref} className="text-primary hover:underline">
+                      {g.recipientName}
+                    </Link>
+                  ) : (
+                    <span className="text-muted-foreground">{g.recipientName}</span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                  {g.amount != null && (
+                    <span className="font-semibold">
+                      {formatCompactCurrency(g.amount)}
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                  {g.date ? formatKBDate(g.date) : g.period ?? ""}
+                </td>
+                <td className="py-2 px-3 text-center text-xs">
+                  {g.status && (
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${
+                        g.status === "active"
+                          ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                          : g.status === "completed"
+                            ? "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                            : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {titleCase(g.status)}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ── Back to Funder Link ──────────────────────────────────────────────
+
+export function BackToFunderLink({
+  funder,
+}: {
+  funder: { name: string; href: string | null };
+}) {
+  return (
+    <div className="mt-8 pt-6 border-t border-border/60">
+      {funder.href ? (
+        <Link
+          href={funder.href}
+          className="text-sm text-primary hover:underline"
+        >
+          &larr; Back to {funder.name}
+        </Link>
+      ) : (
+        <Link
+          href="/organizations"
+          className="text-sm text-primary hover:underline"
+        >
+          &larr; Back to organizations
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/funding-programs/[id]/program-shared.tsx
+++ b/apps/web/src/app/funding-programs/[id]/program-shared.tsx
@@ -1,0 +1,45 @@
+/**
+ * Shared UI components for funding program detail pages.
+ * Extracted from page.tsx as a pure refactor — no visual changes.
+ */
+import type React from "react";
+import Link from "next/link";
+
+// ── Subcomponents ──────────────────────────────────────────────────────
+
+export function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
+        {title}
+      </div>
+      <div className="flex items-center gap-1 flex-wrap">{children}</div>
+    </div>
+  );
+}
+
+export function EntityLinkDisplay({
+  name,
+  href,
+}: {
+  name: string;
+  href: string | null;
+}) {
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="text-sm font-medium text-primary hover:underline"
+      >
+        {name}
+      </Link>
+    );
+  }
+  return <span className="text-sm font-medium text-foreground">{name}</span>;
+}


### PR DESCRIPTION
## Summary

- Extract type definitions, data parsing logic, and constants from `divisions/[slug]/page.tsx` (594 lines) and `funding-programs/[id]/page.tsx` (535 lines) into focused modules
- Each page is split into `*-data.ts` (types, parsers, constants, data loader), `*-shared.tsx` (reusable UI primitives), and `*-sections.tsx` (section-level components)
- Page files are now thin orchestrators (~200-240 lines) that import and compose the extracted pieces
- Follows the same decomposition pattern already established in `organizations/[slug]/`

### New files

**Divisions:**
- `division-data.ts` — types (`ParsedDivision`, `ParsedFundingProgram`, `ParsedDivisionPersonnel`), record parsers, lookup helpers, color/label constants, `loadDivisionPageData()`
- `division-shared.tsx` — `DetailSection`, `EntityLinkDisplay` components
- `division-sections.tsx` — `TeamMembersSection`, `FundingProgramsSection`, `BackToParentLink`

**Funding Programs:**
- `program-data.ts` — types (`ParsedFundingProgram`, `ParsedGrant`), record parsers, color/label constants, `loadProgramPageData()`
- `program-shared.tsx` — `DetailSection`, `EntityLinkDisplay` components
- `program-sections.tsx` — `GrantsAwardedSection`, `BackToFunderLink`

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit` — 0 errors from main repo)
- [x] Pre-existing test failures only (2 wiki-nav tests about unregistered dashboard EIDs, present on main)
- [x] No functional or visual changes — pure structural refactoring
- [x] Page files remain server components (no `"use client"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)