### PR TITLE
feat: improve benchmark discoverability

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -336,7 +336,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* MMLU */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
                   {row.mmluScore != null ? (
-                    <span className="font-semibold">{row.mmluScore}%</span>
+                    <Link href="/benchmarks/mmlu" className="font-semibold hover:text-primary transition-colors">{row.mmluScore}%</Link>
                   ) : (
                     ""
                   )}
@@ -345,7 +345,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* GPQA Diamond */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
                   {row.gpqaScore != null ? (
-                    <span className="font-semibold">{row.gpqaScore}%</span>
+                    <Link href="/benchmarks/gpqa-diamond" className="font-semibold hover:text-primary transition-colors">{row.gpqaScore}%</Link>
                   ) : (
                     ""
                   )}
@@ -354,7 +354,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* SWE-bench */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
                   {row.sweBenchScore != null ? (
-                    <span className="font-semibold">{row.sweBenchScore}%</span>
+                    <Link href="/benchmarks/swe-bench-verified" className="font-semibold hover:text-primary transition-colors">{row.sweBenchScore}%</Link>
                   ) : (
                     ""
                   )}

--- a/apps/web/src/app/benchmarks/benchmark-utils.ts
+++ b/apps/web/src/app/benchmarks/benchmark-utils.ts
@@ -55,6 +55,21 @@ const BENCHMARK_NAME_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Resolve a benchmark display name to its slug for linking.
+ * Returns undefined if no matching benchmark is found.
+ */
+export function getBenchmarkSlugByName(name: string): string | undefined {
+  const lower = name.toLowerCase();
+  const fromAlias = BENCHMARK_NAME_ALIASES[lower];
+  if (fromAlias) return fromAlias;
+  for (const e of getBenchmarkEntities()) {
+    if (e.title.toLowerCase() === lower) return e.id;
+  }
+  return undefined;
+}
+
+
+/**
  * Build a map of benchmarkId -> model results.
  *
  * Uses PG-sourced benchmark results from database.json when available,
@@ -129,6 +144,8 @@ function buildFromInlineData(
       nameToSlug.set(e.title.toLowerCase(), e.id);
     }
   }
+
+
   for (const [alias, slug] of Object.entries(BENCHMARK_NAME_ALIASES)) {
     nameToSlug.set(alias, slug);
   }

--- a/apps/web/src/components/wiki/InfoBox.tsx
+++ b/apps/web/src/components/wiki/InfoBox.tsx
@@ -12,6 +12,7 @@ import type { ExternalLinksData } from "@/data";
 import { InfoBoxDescription } from "./InfoBoxDescription";
 import { isSafeUrl } from "./resource-utils";
 import { formatCompactNumber } from "@lib/format-compact";
+import { getBenchmarkSlugByName } from "@/app/benchmarks/benchmark-utils";
 
 type LucideIcon = React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & { size?: number | string }>;
 
@@ -512,14 +513,25 @@ export function InfoBox({
         <div className="px-4 py-3 border-t border-border">
           <div className="text-[0.7rem] font-semibold uppercase tracking-wide text-muted-foreground mb-2">Benchmarks</div>
           <div className="flex flex-col gap-1">
-            {benchmarks.map((b, i) => (
+            {benchmarks.map((b, i) => {
+              const benchmarkSlug = getBenchmarkSlugByName(b.name);
+              return (
               <div key={i} className="flex justify-between items-baseline py-1 border-b border-border last:border-b-0">
-                <span className="text-xs text-muted-foreground pr-2">{b.name}</span>
+                <span className="text-xs text-muted-foreground pr-2">
+                  {benchmarkSlug ? (
+                    <Link href={`/benchmarks/${benchmarkSlug}`} className="hover:text-foreground hover:underline transition-colors">
+                      {b.name}
+                    </Link>
+                  ) : (
+                    b.name
+                  )}
+                </span>
                 <span className="text-xs font-semibold text-foreground whitespace-nowrap">
                   {b.score}{b.unit === "%" ? "%" : b.unit ? ` ${b.unit}` : ""}
                 </span>
               </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -5,6 +5,7 @@ export const NAV_LINKS = [
   { href: "/people", label: "People" },
   { href: "/risks", label: "Risks" },
   { href: "/ai-models", label: "AI Models" },
+  { href: "/benchmarks", label: "Benchmarks" },
   { href: "/sources", label: "Sources" },
   { href: "/kb", label: "Data" },
   { href: "/wiki/E755", label: "About" },


### PR DESCRIPTION
## Summary
- Benchmark names in the wiki InfoBox sidebar now link to `/benchmarks/[slug]` pages
- Benchmark scores (MMLU, GPQA, SWE-bench) in the AI models comparison table now link to their benchmark detail pages
- Added "Benchmarks" to the top navigation bar between "AI Models" and "Sources"
- Extracted benchmark name aliases into a shared constant and added `getBenchmarkSlugByName()` utility for reuse

## Test plan
- [ ] Verify `/benchmarks` appears in top nav and links correctly
- [ ] Visit an AI model wiki page (e.g., Claude Sonnet 4.6) and confirm benchmark names in the InfoBox are clickable links
- [ ] Visit `/ai-models` and confirm MMLU/GPQA/SWE-bench scores link to benchmark detail pages
- [ ] Verify unrecognized benchmark names gracefully fall back to plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)