### PR TITLE
fix: migrate facts.entity_id from slugs to stable IDs

### DIFF
--- a/apps/wiki-server/drizzle/0083_facts_entity_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0083_facts_entity_id_to_stable_id.sql
@@ -1,0 +1,42 @@
+-- Migrate facts.entity_id and facts.subject from entity slugs to stable IDs.
+-- This is part of the unified ID migration (Discussion #2169).
+--
+-- Pre-conditions:
+--   - entities.stable_id is populated for all entities referenced by facts
+--   - entity_ids.stable_id backfill has been run
+--
+-- With only ~145 facts in production, this runs in milliseconds.
+
+-- Step 1: Delete orphaned facts (entities that no longer exist).
+-- These are already dangling FK violations flagged by the integrity check.
+DELETE FROM facts
+WHERE entity_id NOT IN (SELECT id FROM entities);
+
+-- Step 2: Drop existing FK constraints (they reference entities.id = slug).
+ALTER TABLE "facts" DROP CONSTRAINT IF EXISTS "facts_entity_id_entities_id_fk";
+ALTER TABLE "facts" DROP CONSTRAINT IF EXISTS "facts_subject_entities_id_fk";
+
+-- Step 3: Convert entity_id from slug to stable_id.
+UPDATE facts
+SET entity_id = e.stable_id
+FROM entities e
+WHERE facts.entity_id = e.id
+  AND e.stable_id IS NOT NULL;
+
+-- Step 4: Convert subject from slug to stable_id (nullable column).
+UPDATE facts
+SET subject = e.stable_id
+FROM entities e
+WHERE facts.subject = e.id
+  AND e.stable_id IS NOT NULL;
+
+-- Step 5: Add new FK constraints referencing entities.stable_id.
+ALTER TABLE "facts"
+  ADD CONSTRAINT "facts_entity_id_entities_stable_id_fk"
+  FOREIGN KEY ("entity_id") REFERENCES "entities"("stable_id")
+  ON DELETE CASCADE;
+
+ALTER TABLE "facts"
+  ADD CONSTRAINT "facts_subject_entities_stable_id_fk"
+  FOREIGN KEY ("subject") REFERENCES "entities"("stable_id")
+  ON DELETE SET NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1775721600000,
       "tag": "0082_alter_benchmark_id_to_text",
       "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1775808000000,
+      "tag": "0083_facts_entity_id_to_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/facts.test.ts
+++ b/apps/wiki-server/src/__tests__/facts.test.ts
@@ -20,10 +20,16 @@ function factKey(entityId: string, factId: string) {
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
-  // --- ref-check: SELECT id FROM entities/resources WHERE id IN (...) ---
+  // --- ref-check: SELECT id/stable_id FROM entities/resources WHERE column IN (...) ---
   if (q.includes("as id from") && q.includes("where") && q.includes(" in ")) {
     // Return all queried IDs as existing (ref check passes)
     return params.map((p) => ({ id: p }));
+  }
+
+  // --- entity resolution: SELECT stable_id FROM entities WHERE stable_id/id/numeric_id = ... ---
+  if (q.includes("stable_id") && q.includes('"entities"') && q.includes("limit")) {
+    // Return the first param as both the entity stableId (pass-through for tests)
+    return params.length > 0 ? [{ stable_id: params[0] }] : [];
   }
 
   // --- facts: INSERT ... ON CONFLICT DO UPDATE (supports multi-row) ---

--- a/apps/wiki-server/src/routes/facts.ts
+++ b/apps/wiki-server/src/routes/facts.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, asc, sql, isNotNull, lte } from "drizzle-orm";
+import { eq, and, count, asc, sql, isNotNull, lte, or } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 import { facts, entities, resources } from "../schema.js";
 import { checkRefsExist } from "./ref-check.js";
@@ -36,6 +36,28 @@ const StalenessQuery = z.object({
 });
 
 // ---- Helpers ----
+
+/**
+ * Resolve an entity identifier (stableId, slug, or numericId) to a stableId.
+ * Returns null if the entity is not found.
+ */
+async function resolveEntityStableId(
+  db: ReturnType<typeof getDrizzleDb>,
+  identifier: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ stableId: entities.stableId })
+    .from(entities)
+    .where(
+      or(
+        eq(entities.stableId, identifier),
+        eq(entities.id, identifier),
+        eq(entities.numericId, identifier),
+      )
+    )
+    .limit(1);
+  return rows[0]?.stableId ?? null;
+}
 
 function formatFact(f: typeof facts.$inferSelect) {
   return {
@@ -132,10 +154,13 @@ const factsApp = new Hono()
 
   // ---- GET /timeseries/:entityId ----
   .get("/timeseries/:entityId", zv("query", TimeseriesQuery), async (c) => {
-    const entityId = c.req.param("entityId");
+    const rawId = c.req.param("entityId");
 
     const { measure, limit } = c.req.valid("query");
     const db = getDrizzleDb();
+
+    // Resolve slug/numericId/stableId to stableId (facts.entity_id stores stableIds)
+    const entityId = await resolveEntityStableId(db, rawId) ?? rawId;
 
     const rows = await db
       .select()
@@ -160,10 +185,13 @@ const factsApp = new Hono()
 
   // ---- GET /by-entity/:entityId ----
   .get("/by-entity/:entityId", zv("query", ByEntityQuery), async (c) => {
-    const entityId = c.req.param("entityId");
+    const rawId = c.req.param("entityId");
 
     const { limit, offset, measure } = c.req.valid("query");
     const db = getDrizzleDb();
+
+    // Resolve slug/numericId/stableId to stableId (facts.entity_id stores stableIds)
+    const entityId = await resolveEntityStableId(db, rawId) ?? rawId;
 
     const conditions = [eq(facts.entityId, entityId)];
     if (measure) conditions.push(eq(facts.measure, measure));
@@ -206,9 +234,9 @@ const factsApp = new Hono()
     const { facts: items } = parsed.data;
     const db = getDrizzleDb();
 
-    // Validate entity references
+    // Validate entity references (facts now use stable IDs, not slugs)
     const entityIds = [...new Set(items.map((f) => f.entityId))];
-    const missingEntities = await checkRefsExist(db, entities, entities.id, entityIds);
+    const missingEntities = await checkRefsExist(db, entities, entities.stableId, entityIds);
     if (missingEntities.length > 0) {
       return validationError(
         c,
@@ -225,7 +253,7 @@ const factsApp = new Hono()
     ];
     let missingSubjects: string[] = [];
     if (subjectIds.length > 0) {
-      missingSubjects = await checkRefsExist(db, entities, entities.id, subjectIds);
+      missingSubjects = await checkRefsExist(db, entities, entities.stableId, subjectIds);
       if (missingSubjects.length > 0) {
         console.warn(
           `Facts sync: nulling out ${missingSubjects.length} unresolved subject(s): ${missingSubjects.join(", ")}`

--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -40,10 +40,10 @@ const integrityApp = new Hono()
     const issues: IntegrityIssue[] = [];
 
     const checks = [
-      // 1. facts.entity_id → entities
+      // 1. facts.entity_id → entities.stable_id
       checkDangling(
         db,
-        sql`SELECT DISTINCT entity_id AS ref FROM facts WHERE entity_id NOT IN (SELECT id FROM entities)`,
+        sql`SELECT DISTINCT entity_id AS ref FROM facts WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL)`,
         "facts",
         "entity_id",
         "entities"

--- a/apps/wiki-server/src/routes/kb-verifications.ts
+++ b/apps/wiki-server/src/routes/kb-verifications.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, sql, desc } from "drizzle-orm";
+import { eq, and, count, sql, desc, or } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 import {
   kbFactVerdicts,
   kbFactResourceVerifications,
   facts,
+  entities,
 } from "../schema.js";
 import {
   zv,
@@ -109,9 +110,24 @@ const kbVerificationsApp = new Hono()
       conditions.push(eq(kbFactVerdicts.needsRecheck, needs_recheck));
     }
 
-    // Filter by entity_id via the joined facts table
+    // Filter by entity_id via the joined facts table.
+    // Resolve slug/numericId to stableId since facts.entity_id stores stableIds.
     if (entity_id) {
-      conditions.push(eq(facts.entityId, entity_id));
+      const resolved = await (async () => {
+        const rows = await db
+          .select({ stableId: entities.stableId })
+          .from(entities)
+          .where(
+            or(
+              eq(entities.stableId, entity_id),
+              eq(entities.id, entity_id),
+              eq(entities.numericId, entity_id),
+            )
+          )
+          .limit(1);
+        return rows[0]?.stableId ?? entity_id;
+      })();
+      conditions.push(eq(facts.entityId, resolved));
     }
 
     const whereClause =

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -517,7 +517,7 @@ async function fetchIntegritySummary(rawDb: ReturnType<typeof getDb>) {
   // Quick count of dangling refs across key tables
   const result = await rawDb`
     SELECT
-      (SELECT count(*) FROM facts WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_facts,
+      (SELECT count(*) FROM facts WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL))::int AS dangling_facts,
       (SELECT count(*) FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_summaries,
       -- Only flag truly orphaned records where BOTH the legacy text page_id and the new integer
       -- page_id_int are NULL. Records with page_id_old populated but page_id_int NULL are

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -675,7 +675,7 @@ export const facts = pgTable(
     id: bigserial("id", { mode: "number" }).primaryKey(),
     entityId: text("entity_id")
       .notNull()
-      .references(() => entities.id, { onDelete: "cascade" }),
+      .references(() => entities.stableId, { onDelete: "cascade" }),
     factId: text("fact_id").notNull(),
     label: text("label"),
     value: text("value"), // String representation of the value
@@ -684,7 +684,7 @@ export const facts = pgTable(
     high: real("high"), // Upper bound for range values
     asOf: text("as_of"), // Point-in-time (YYYY-MM, YYYY, or ISO date)
     measure: text("measure"), // Measure ID for timeseries grouping
-    subject: text("subject").references(() => entities.id, {
+    subject: text("subject").references(() => entities.stableId, {
       onDelete: "set null",
     }),
     note: text("note"),


### PR DESCRIPTION
## Summary

Part of the unified ID migration ([Discussion #2169](https://github.com/quantified-uncertainty/longterm-wiki/discussions/2169)).

- Migrates `facts.entity_id` and `facts.subject` from entity slugs to 10-char stable IDs
- Adds entity identifier resolution (slug/numericId/stableId) to facts query endpoints for backward compatibility
- Updates FK constraints, integrity checks, and monitoring queries

## Context

The KB sync pipeline already sends stableIds (all 918 facts use 10-char IDs), but the 145 facts currently in the DB were synced before the stableId migration and still contain slugs. This migration converts them and unblocks future fact syncs.

## Changes

**Migration 0083** (`facts_entity_id_to_stable_id.sql`):
- Deletes 5 orphaned facts with dangling entity refs (asana, center-for-ai-safety, google-deepmind, survival-and-flourishing-fund, worldcoin)
- Converts ~140 existing facts from slug to stableId format
- Drops old FK constraints (→ `entities.id`) and adds new ones (→ `entities.stable_id`)

**Code changes:**
- `schema.ts`: FK references point to `entities.stableId`
- `facts.ts`: Added `resolveEntityStableId()` for backward-compatible slug lookups; sync validation checks `entities.stableId`
- `kb-verifications.ts`: `entity_id` filter resolves identifiers before querying
- `integrity.ts` + `monitoring.ts`: Dangling ref checks compare against `stable_id`
- `facts.test.ts`: Mock updated for entity resolution queries

## Test plan

- [x] All 583 wiki-server tests pass
- [x] Full `pnpm build` succeeds
- [x] Migration is safe with only ~145 rows (runs in milliseconds)
- [ ] After deploy, verify `GET /api/integrity` shows no dangling facts
- [ ] After deploy, run `pnpm crux wiki-server sync-facts` to sync all 918 KB facts

Closes #2169

🤖 Generated with [Claude Code](https://claude.com/claude-code)