### PR TITLE
fix: resolve bugs and inconsistencies on /ai-models page

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -1,13 +1,18 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getTypedEntityById } from "@/data";
+import { getTypedEntityById, getPageById } from "@/data";
 import {
   resolveAiModelBySlug,
   getAiModelSlugs,
   getRelatedModels,
 } from "../ai-model-utils";
 import { resolveSlugAlias } from "@/data/kb";
+import {
+  DEVELOPER_COLORS,
+  SAFETY_LEVEL_COLORS,
+  formatContext,
+} from "../ai-model-constants";
 import { Breadcrumbs, ProfileStatCard } from "@/components/directory";
 import { safeHref } from "@/lib/directory-utils";
 
@@ -26,39 +31,6 @@ export async function generateMetadata({
     title: entity ? `${entity.title} | AI Models` : "AI Model Not Found",
     description: entity?.description ?? undefined,
   };
-}
-
-const DEVELOPER_COLORS: Record<string, string> = {
-  anthropic:
-    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  openai:
-    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  deepmind:
-    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  "meta-ai":
-    "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-  "mistral-ai":
-    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  xai: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  deepseek:
-    "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-};
-
-const SAFETY_LEVEL_COLORS: Record<string, string> = {
-  "ASL-1":
-    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  "ASL-2":
-    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
-  "ASL-3":
-    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  "ASL-4":
-    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-};
-
-function formatContext(tokens: number): string {
-  if (tokens >= 1_000_000) return `${tokens / 1_000_000}M tokens`;
-  if (tokens >= 1_000) return `${tokens / 1_000}K tokens`;
-  return `${tokens} tokens`;
 }
 
 function formatPrice(price: number): string {
@@ -120,7 +92,7 @@ export default async function AiModelDetailPage({
   if (entity.contextWindow != null) {
     stats.push({
       label: "Context Window",
-      value: formatContext(entity.contextWindow),
+      value: `${formatContext(entity.contextWindow)} tokens`,
     });
   }
 
@@ -177,7 +149,7 @@ export default async function AiModelDetailPage({
         )}
 
         <div className="flex items-center gap-4 mt-3 text-sm">
-          {entity.numericId && (
+          {entity.numericId && getPageById(entity.id) && (
             <Link
               href={`/wiki/${entity.numericId}`}
               className="text-primary hover:text-primary/80 font-medium transition-colors"
@@ -423,7 +395,7 @@ export default async function AiModelDetailPage({
                 label="Context Window"
                 value={
                   entity.contextWindow != null
-                    ? formatContext(entity.contextWindow)
+                    ? `${formatContext(entity.contextWindow)} tokens`
                     : undefined
                 }
               />

--- a/apps/web/src/app/ai-models/ai-model-constants.ts
+++ b/apps/web/src/app/ai-models/ai-model-constants.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared constants and formatting utilities for /ai-models routes.
+ */
+
+export const DEVELOPER_COLORS: Record<string, string> = {
+  anthropic:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  openai:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  deepmind:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  "meta-ai":
+    "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
+  "mistral-ai":
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  xai: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
+  deepseek:
+    "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
+};
+
+export const SAFETY_LEVEL_COLORS: Record<string, string> = {
+  "ASL-1":
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  "ASL-2":
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+  "ASL-3":
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  "ASL-4":
+    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};
+
+/**
+ * Format a context window token count for display.
+ * Values < 10,000 are shown as plain numbers with commas (e.g., "4,096").
+ * Values >= 10,000 are shown with K/M suffix (e.g., "128K", "1M").
+ */
+export function formatContext(tokens: number): string {
+  if (tokens >= 1_000_000) return `${tokens / 1_000_000}M`;
+  if (tokens >= 10_000) return `${tokens / 1_000}K`;
+  return tokens.toLocaleString("en-US");
+}

--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
+import { SortHeader } from "@/components/directory/SortHeader";
+import { DEVELOPER_COLORS, formatContext } from "./ai-model-constants";
 
 export interface AiModelRow {
   id: string;
@@ -28,16 +30,6 @@ export interface AiModelRow {
   parameterCount: string | null;
 }
 
-const DEVELOPER_COLORS: Record<string, string> = {
-  anthropic: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  openai: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  deepmind: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  "meta-ai": "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-  "mistral-ai": "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  xai: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  deepseek: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-};
-
 type SortKey =
   | "name"
   | "developer"
@@ -45,52 +37,11 @@ type SortKey =
   | "inputPrice"
   | "outputPrice"
   | "contextWindow"
+  | "safetyLevel"
   | "sweBench"
   | "mmlu"
   | "gpqa"
   | "params";
-
-function formatContext(tokens: number): string {
-  if (tokens >= 1_000_000) return `${tokens / 1_000_000}M`;
-  if (tokens >= 1_000) return `${tokens / 1_000}K`;
-  return String(tokens);
-}
-
-function SortHeader({
-  label,
-  sortKey,
-  currentSort,
-  currentDir,
-  onSort,
-  className,
-}: {
-  label: string;
-  sortKey: SortKey;
-  currentSort: SortKey;
-  currentDir: SortDir;
-  onSort: (key: SortKey) => void;
-  className?: string;
-}) {
-  const isActive = currentSort === sortKey;
-  return (
-    <th className={`py-2.5 px-3 font-medium ${className ?? ""}`}>
-      <button
-        type="button"
-        className={`inline-flex items-center gap-1 cursor-pointer select-none hover:text-foreground transition-colors ${
-          isActive ? "text-foreground" : ""
-        }`}
-        onClick={() => onSort(sortKey)}
-      >
-        {label}
-        {isActive && (
-          <span className="text-[10px]">
-            {currentDir === "asc" ? "\u25B2" : "\u25BC"}
-          </span>
-        )}
-      </button>
-    </th>
-  );
-}
 
 export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
   const [search, setSearch] = useState("");
@@ -170,6 +121,8 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
           return row.outputPrice;
         case "contextWindow":
           return row.contextWindow;
+        case "safetyLevel":
+          return row.safetyLevel;
         case "sweBench":
           return row.sweBenchScore;
         case "mmlu":
@@ -267,6 +220,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
               <SortHeader label="Input $/MTok" sortKey="inputPrice" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Output $/MTok" sortKey="outputPrice" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Context" sortKey="contextWindow" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
+              <SortHeader label="Safety" sortKey="safetyLevel" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="MMLU" sortKey="mmlu" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="GPQA" sortKey="gpqa" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="SWE-bench" sortKey="sweBench" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
@@ -297,7 +251,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
 
                 {/* Developer */}
                 <td className="py-2.5 px-3">
-                  {row.developer && row.developerName && (
+                  {row.developer && row.developerName ? (
                     <span
                       className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
                         DEVELOPER_COLORS[row.developer] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
@@ -305,32 +259,57 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                     >
                       {row.developerName}
                     </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
 
                 {/* Release Date */}
                 <td className="py-2.5 px-3 text-muted-foreground whitespace-nowrap">
-                  {row.releaseDate ?? ""}
+                  {row.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
                 </td>
 
                 {/* Parameter Count */}
                 <td className="py-2.5 px-3 text-right tabular-nums text-muted-foreground">
-                  {row.parameterCount ?? ""}
+                  {row.parameterCount ?? <span className="text-muted-foreground/40">&mdash;</span>}
                 </td>
 
                 {/* Input Price */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
-                  {row.inputPrice != null ? `$${row.inputPrice}` : ""}
+                  {row.inputPrice != null ? (
+                    `$${row.inputPrice}`
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
                 </td>
 
                 {/* Output Price */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
-                  {row.outputPrice != null ? `$${row.outputPrice}` : ""}
+                  {row.outputPrice != null ? (
+                    `$${row.outputPrice}`
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
                 </td>
 
                 {/* Context Window */}
                 <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap">
-                  {row.contextWindow != null ? formatContext(row.contextWindow) : ""}
+                  {row.contextWindow != null ? (
+                    formatContext(row.contextWindow)
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
+                </td>
+
+                {/* Safety Level */}
+                <td className="py-2.5 px-3">
+                  {row.safetyLevel ? (
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                      {row.safetyLevel}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
                 </td>
 
                 {/* MMLU */}
@@ -338,7 +317,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                   {row.mmluScore != null ? (
                     <Link href="/benchmarks/mmlu" className="font-semibold hover:text-primary transition-colors">{row.mmluScore}%</Link>
                   ) : (
-                    ""
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
 
@@ -347,7 +326,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                   {row.gpqaScore != null ? (
                     <Link href="/benchmarks/gpqa-diamond" className="font-semibold hover:text-primary transition-colors">{row.gpqaScore}%</Link>
                   ) : (
-                    ""
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
 
@@ -356,7 +335,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                   {row.sweBenchScore != null ? (
                     <Link href="/benchmarks/swe-bench-verified" className="font-semibold hover:text-primary transition-colors">{row.sweBenchScore}%</Link>
                   ) : (
-                    ""
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- Fix broken wiki page links that 404 because no MDX pages exist for AI model entities - now checks `getPageById()` before rendering the link
- Add Safety Level column to the main models table with sort support
- Replace inline `SortHeader` with shared `@/components/directory/SortHeader` component (adds `aria-sort` accessibility)
- Extract `DEVELOPER_COLORS`, `SAFETY_LEVEL_COLORS`, and `formatContext` to new `ai-model-constants.ts` (eliminates duplication between table and detail page)
- Fix "4.096K" context formatting bug: values under 10K now display as comma-formatted numbers (e.g., "4,096")
- Show em-dash for empty cells instead of blank whitespace

## Test plan
- [x] `pnpm build` passes with no TypeScript errors
- [x] `pnpm test` passes (1 pre-existing failure in source-fetcher.test.ts unrelated to these changes)
- [ ] Verify /ai-models table renders safety level column
- [ ] Verify model detail pages no longer show broken wiki links
- [ ] Verify context window values under 10K format correctly (e.g., "4,096" not "4.096K")
- [ ] Verify empty cells show em-dash instead of blank

Generated with [Claude Code](https://claude.com/claude-code)