### PR TITLE
fix: resolve risks page sorting bugs, miscategorization, and constant duplication

### DIFF
--- a/apps/web/scripts/lib/entity-transform.mjs
+++ b/apps/web/scripts/lib/entity-transform.mjs
@@ -19,7 +19,23 @@ import { extractDescriptionFromIntro } from './text-utils.mjs';
 // RISK CATEGORIES
 // ============================================================================
 
-const RISK_CATEGORIES = {
+/**
+ * Map from summaryPage value to risk category.
+ * This is the primary categorisation mechanism — entities with a summaryPage
+ * containing one of these overview slugs are assigned the corresponding category.
+ */
+const SUMMARY_PAGE_TO_CATEGORY = {
+  'accident-overview': 'accident',
+  'misuse-overview': 'misuse',
+  'structural-overview': 'structural',
+  'epistemic-overview': 'epistemic',
+};
+
+/**
+ * Legacy hardcoded fallback for entities that lack a summaryPage field.
+ * Kept for backward compatibility — new entities should always set summaryPage.
+ */
+const RISK_CATEGORIES_FALLBACK = {
   epistemic: [
     'authentication-collapse',
     'automation-bias',
@@ -49,10 +65,16 @@ const RISK_CATEGORIES = {
   ],
 };
 
-function getRiskCategory(riskId) {
-  if (RISK_CATEGORIES.epistemic.includes(riskId)) return 'epistemic';
-  if (RISK_CATEGORIES.misuse.includes(riskId)) return 'misuse';
-  if (RISK_CATEGORIES.structural.includes(riskId)) return 'structural';
+function getRiskCategory(riskId, summaryPage) {
+  // Primary: derive from summaryPage field
+  if (summaryPage && SUMMARY_PAGE_TO_CATEGORY[summaryPage]) {
+    return SUMMARY_PAGE_TO_CATEGORY[summaryPage];
+  }
+
+  // Fallback: hardcoded map for entities without summaryPage
+  if (RISK_CATEGORIES_FALLBACK.epistemic.includes(riskId)) return 'epistemic';
+  if (RISK_CATEGORIES_FALLBACK.misuse.includes(riskId)) return 'misuse';
+  if (RISK_CATEGORIES_FALLBACK.structural.includes(riskId)) return 'structural';
   return 'accident';
 }
 
@@ -168,7 +190,7 @@ function transformEntity(raw, expertMap, orgMap) {
         likelihood: raw.likelihood,
         timeframe: raw.timeframe,
         maturity: raw.maturity,
-        riskCategory: getRiskCategory(raw.id),
+        riskCategory: getRiskCategory(raw.id, raw.summaryPage),
       };
 
     case 'person': {

--- a/apps/web/src/app/risks/[slug]/page.tsx
+++ b/apps/web/src/app/risks/[slug]/page.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/components/directory";
 import { titleCase } from "@/components/wiki/kb/format";
 import type { RiskEntity } from "@/data/entity-schemas";
+import {
+  RISK_CATEGORY_COLORS,
+  RISK_CATEGORY_LABELS,
+  SEVERITY_COLORS,
+} from "@/app/risks/risk-constants";
 
 export function generateStaticParams() {
   return getRiskSlugs().map((slug) => ({ slug }));
@@ -31,31 +36,6 @@ export async function generateMetadata({
   };
 }
 
-// ── Risk category colors ──────────────────────────────────────────────
-const RISK_CATEGORY_COLORS: Record<string, string> = {
-  accident: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  misuse: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-  structural: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  epistemic: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-};
-
-const RISK_CATEGORY_LABELS: Record<string, string> = {
-  accident: "Accident",
-  misuse: "Misuse",
-  structural: "Structural",
-  epistemic: "Epistemic",
-};
-
-// ── Severity badge colors ─────────────────────────────────────────────
-const SEVERITY_COLORS: Record<string, string> = {
-  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
-  "medium-high": "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  high: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-  catastrophic: "bg-red-200 text-red-900 dark:bg-red-900/40 dark:text-red-200",
-};
-
 // ── Helpers to extract display values from entity data ─────────────────
 
 function getLikelihoodDisplay(risk: RiskEntity): string | null {
@@ -74,7 +54,7 @@ function getTimeframeDisplay(risk: RiskEntity): string | null {
   if (risk.timeframe.display) return risk.timeframe.display;
   const parts: string[] = [];
   if (risk.timeframe.earliest && risk.timeframe.latest) {
-    parts.push(`${risk.timeframe.earliest}--${risk.timeframe.latest}`);
+    parts.push(`${risk.timeframe.earliest}\u2013${risk.timeframe.latest}`);
   }
   if (risk.timeframe.median) {
     if (parts.length > 0) {

--- a/apps/web/src/app/risks/risk-constants.ts
+++ b/apps/web/src/app/risks/risk-constants.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared constants for the /risks pages.
+ *
+ * Centralised here so the listing table and detail pages stay in sync.
+ */
+
+// ── Risk category ──────────────────────────────────────────────────────
+
+export const RISK_CATEGORY_LABELS: Record<string, string> = {
+  accident: "Accident",
+  misuse: "Misuse",
+  structural: "Structural",
+  epistemic: "Epistemic",
+};
+
+export const RISK_CATEGORY_COLORS: Record<string, string> = {
+  accident:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  misuse: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  structural:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  epistemic:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+};
+
+// ── Severity ───────────────────────────────────────────────────────────
+
+/**
+ * Ordinal ranking for severity values (title-cased, matching the output of
+ * `titleCase()` applied to the raw YAML values).
+ */
+export const SEVERITY_ORDER: Record<string, number> = {
+  Low: 1,
+  Medium: 2,
+  "Medium High": 3,
+  High: 4,
+  Critical: 5,
+  Catastrophic: 6,
+};
+
+/** Badge colours keyed by the **raw** (lowercase-hyphenated) severity value. */
+export const SEVERITY_COLORS: Record<string, string> = {
+  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  medium:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+  "medium-high":
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  high: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  critical:
+    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  catastrophic:
+    "bg-red-200 text-red-900 dark:bg-red-900/40 dark:text-red-200",
+};
+
+/**
+ * Badge colours keyed by the **title-cased** severity value (as displayed in
+ * the table rows, which receive title-cased values from `page.tsx`).
+ */
+export const SEVERITY_COLORS_DISPLAY: Record<string, string> = {
+  Low: SEVERITY_COLORS.low,
+  Medium: SEVERITY_COLORS.medium,
+  "Medium High": SEVERITY_COLORS["medium-high"],
+  High: SEVERITY_COLORS.high,
+  Critical: SEVERITY_COLORS.critical,
+  Catastrophic: SEVERITY_COLORS.catastrophic,
+};
+
+// ── Likelihood ─────────────────────────────────────────────────────────
+
+/**
+ * Ordinal ranking for likelihood values (title-cased).
+ */
+export const LIKELIHOOD_ORDER: Record<string, number> = {
+  Low: 1,
+  "Medium Low": 2,
+  Medium: 3,
+  "Medium High": 4,
+  High: 5,
+  "Very High": 6,
+};
+
+/** Badge colours keyed by the **title-cased** likelihood value. */
+export const LIKELIHOOD_COLORS_DISPLAY: Record<string, string> = {
+  Low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  "Medium Low":
+    "bg-lime-100 text-lime-800 dark:bg-lime-900/30 dark:text-lime-300",
+  Medium:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+  "Medium High":
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  High: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  "Very High":
+    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -4,6 +4,14 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
+import {
+  RISK_CATEGORY_LABELS,
+  RISK_CATEGORY_COLORS,
+  SEVERITY_ORDER,
+  SEVERITY_COLORS_DISPLAY,
+  LIKELIHOOD_ORDER,
+  LIKELIHOOD_COLORS_DISPLAY,
+} from "./risk-constants";
 
 export interface RiskRow {
   id: string;
@@ -17,30 +25,7 @@ export interface RiskRow {
   timeHorizon: string | null;
 }
 
-const RISK_CATEGORY_LABELS: Record<string, string> = {
-  accident: "Accident",
-  misuse: "Misuse",
-  structural: "Structural",
-  epistemic: "Epistemic",
-};
-
-const RISK_CATEGORY_COLORS: Record<string, string> = {
-  accident: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  misuse: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-  structural: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  epistemic: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-};
-
 type SortKey = "name" | "category" | "severity" | "likelihood" | "timeHorizon";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  low: 1,
-  medium: 2,
-  "medium-high": 3,
-  high: 4,
-  critical: 5,
-  catastrophic: 6,
-};
 
 export function RisksTable({ rows }: { rows: RiskRow[] }) {
   const [search, setSearch] = useState("");
@@ -97,7 +82,9 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
         case "severity":
           return row.severity ? (SEVERITY_ORDER[row.severity] ?? 0) : null;
         case "likelihood":
-          return row.likelihood ?? null;
+          return row.likelihood
+            ? (LIKELIHOOD_ORDER[row.likelihood] ?? 0)
+            : null;
         case "timeHorizon":
           return row.timeHorizon ?? null;
       }
@@ -211,13 +198,33 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
                 </td>
 
                 {/* Severity */}
-                <td className="py-2.5 px-3 text-sm capitalize">
-                  {row.severity ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                <td className="py-2.5 px-3">
+                  {row.severity ? (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        SEVERITY_COLORS_DISPLAY[row.severity] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {row.severity}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
                 </td>
 
                 {/* Likelihood */}
-                <td className="py-2.5 px-3 text-sm capitalize">
-                  {row.likelihood ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                <td className="py-2.5 px-3">
+                  {row.likelihood ? (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        LIKELIHOOD_COLORS_DISPLAY[row.likelihood] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {row.likelihood}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
+                  )}
                 </td>
 
                 {/* Time Horizon */}


### PR DESCRIPTION
## Summary
- **Fix severity sorting**: `SEVERITY_ORDER` keys were lowercase-hyphenated but values were title-cased — sort always returned 0
- **Fix likelihood sorting**: Was alphabetical (wrong). Added `LIKELIHOOD_ORDER` ordinal map
- **Fix timeframe display**: Detail page used double-hyphen instead of en-dash
- **Fix risk miscategorization**: 44/65 risks defaulted to "accident". Now derives category from `summaryPage` (24 accident, 16 epistemic, 15 structural, 10 misuse)
- **Extract constants**: Deduplicated into shared `risk-constants.ts`
- **Add colored badges**: Severity/likelihood show colored badges in table

## Test plan
- [x] `pnpm build` passes
- [x] All 690 tests pass
- [ ] Verify /risks sorts correctly by severity and likelihood
- [ ] Verify risk categories are correct
- [ ] Verify en-dash in timeframe on detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)