### PR TITLE
fix: resolve people page link, sorting, and birth year formatting bugs

### DIFF
--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -108,6 +108,7 @@ export default function PeoplePage() {
 
       employerId: employer?.id ?? null,
       employerName: employer?.name ?? null,
+      employerSlug: employer?.id ? getKBEntitySlug(employer.id) ?? null : null,
 
       bornYear: numericValue(bornYearFact),
       netWorthNum: numericValue(netWorthFact),

--- a/apps/web/src/app/people/people-sort.test.ts
+++ b/apps/web/src/app/people/people-sort.test.ts
@@ -17,6 +17,7 @@ function makeRow(overrides: Partial<PersonRow> = {}): PersonRow {
     role: null,
     employerId: null,
     employerName: null,
+    employerSlug: null,
     bornYear: null,
     netWorthNum: null,
     positionCount: 0,
@@ -81,10 +82,10 @@ describe("getPersonSortValue", () => {
     ).toBe(null);
   });
 
-  it("returns careerHistoryCount directly (including zero)", () => {
+  it("returns careerHistoryCount or null when zero", () => {
     expect(
       getPersonSortValue(makeRow({ careerHistoryCount: 0 }), "careerHistory"),
-    ).toBe(0);
+    ).toBe(null);
     expect(
       getPersonSortValue(makeRow({ careerHistoryCount: 7 }), "careerHistory"),
     ).toBe(7);

--- a/apps/web/src/app/people/people-sort.ts
+++ b/apps/web/src/app/people/people-sort.ts
@@ -34,7 +34,7 @@ export function getPersonSortValue(
     case "publications":
       return row.publicationCount || null;
     case "careerHistory":
-      return row.careerHistoryCount;
+      return row.careerHistoryCount || null;
   }
 }
 

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -19,6 +19,7 @@ export interface PersonRow {
 
   employerId: string | null;
   employerName: string | null;
+  employerSlug: string | null;
 
   bornYear: number | null;
 
@@ -226,7 +227,14 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
 
                 {/* Affiliation */}
                 <td className="py-2.5 px-3">
-                  {row.employerId ? (
+                  {row.employerSlug ? (
+                    <Link
+                      href={`/organizations/${row.employerSlug}`}
+                      className="text-foreground hover:text-primary transition-colors"
+                    >
+                      {row.employerName}
+                    </Link>
+                  ) : row.employerId ? (
                     <Link
                       href={`/kb/entity/${row.employerId}`}
                       className="text-foreground hover:text-primary transition-colors"

--- a/apps/web/src/components/wiki/kb/format.ts
+++ b/apps/web/src/components/wiki/kb/format.ts
@@ -65,9 +65,19 @@ export function formatKBNumber(
     if (display.divisor && display.divisor !== 0) {
       num = num / display.divisor;
     }
-    const formatted = Number.isInteger(num)
-      ? num.toLocaleString()
-      : num.toLocaleString("en-US", { maximumFractionDigits: 2 });
+    // Detect year-like values: 4-digit integers with no prefix/suffix/divisor
+    const isYearLike =
+      Number.isInteger(num) &&
+      num >= 1800 &&
+      num <= 2100 &&
+      !display.prefix &&
+      !display.suffix &&
+      !display.divisor;
+    const formatted = isYearLike
+      ? String(num)
+      : Number.isInteger(num)
+        ? num.toLocaleString()
+        : num.toLocaleString("en-US", { maximumFractionDigits: 2 });
     // If currency override provided and display has a currency-like prefix, use currency symbol
     let prefix = display.prefix ?? "";
     if (currency && Object.hasOwn(CURRENCIES, currency)) {
@@ -78,6 +88,10 @@ export function formatKBNumber(
   }
 
   // No unit, no display config — plain locale string
+  // Detect year-like values (4-digit integers 1800–2100) and skip thousands separator
+  if (Number.isInteger(value) && value >= 1800 && value <= 2100) {
+    return String(value);
+  }
   return value.toLocaleString();
 }
 


### PR DESCRIPTION
## Summary
- **Fix affiliation links**: Table linked to `/kb/entity/` instead of `/organizations/`. Now links to `/organizations/{slug}` with fallback
- **Fix zero-count sorting**: `careerHistory` sorted 0 numerically while `positions`/`publications` treated 0 as null. Made consistent
- **Fix birth year comma**: `formatKBNumber` showed "1,971" instead of "1971". Added year detection to skip thousands separator

## Test plan
- [x] `pnpm build` passes
- [x] All tests pass
- [ ] Verify /people affiliation links go to /organizations/
- [ ] Verify birth year without comma in Facts panel
- [ ] Verify sorting by career entries pushes 0-count to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)