### PR TITLE
fix: restore migration 0083 hash, add 0084 safety cleanup

### DIFF
--- a/apps/wiki-server/drizzle/0083_facts_entity_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0083_facts_entity_id_to_stable_id.sql
@@ -1,7 +1,10 @@
 -- Migrate facts.entity_id and facts.subject from entity slugs to stable IDs.
 -- This is part of the unified ID migration (Discussion #2169).
 --
--- Handles entities with NULL stable_id by deleting affected facts (Step 5).
+-- Pre-conditions:
+--   - entities.stable_id is populated for all entities referenced by facts
+--   - entity_ids.stable_id backfill has been run
+--
 -- With only ~145 facts in production, this runs in milliseconds.
 
 -- Step 1: Delete orphaned facts (entities that no longer exist).
@@ -27,17 +30,7 @@ FROM entities e
 WHERE facts.subject = e.id
   AND e.stable_id IS NOT NULL;
 
--- Step 5: Delete facts whose entity_id couldn't be converted (entity exists
--- but has NULL stable_id). Without this, leftover slug values violate the FK.
-DELETE FROM facts
-WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL);
-
--- Step 6: Null out subject values that couldn't be converted.
-UPDATE facts SET subject = NULL
-WHERE subject IS NOT NULL
-  AND subject NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL);
-
--- Step 7: Add new FK constraints referencing entities.stable_id.
+-- Step 5: Add new FK constraints referencing entities.stable_id.
 ALTER TABLE "facts"
   ADD CONSTRAINT "facts_entity_id_entities_stable_id_fk"
   FOREIGN KEY ("entity_id") REFERENCES "entities"("stable_id")

--- a/apps/wiki-server/drizzle/0084_facts_fk_safety_cleanup.sql
+++ b/apps/wiki-server/drizzle/0084_facts_fk_safety_cleanup.sql
@@ -1,0 +1,18 @@
+-- Safety cleanup for facts FK migration (0083).
+--
+-- Migration 0083 assumes entities.stable_id is fully populated. On fresh
+-- deployments where the backfill hasn't run, some facts may still have slug
+-- entity_ids or dangling subject references after 0083's conversion steps.
+-- This migration deletes/nulls those leftovers so the FK constraints hold.
+--
+-- On production this is a no-op (data was manually fixed during the 2026-03-13
+-- outage before 0083 was applied).
+
+-- Delete facts whose entity_id is still a slug (not in entities.stable_id).
+DELETE FROM facts
+WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL);
+
+-- Null out subject values that are still slugs.
+UPDATE facts SET subject = NULL
+WHERE subject IS NOT NULL
+  AND subject NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1775808000000,
       "tag": "0083_facts_entity_id_to_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1775894400000,
+      "tag": "0084_facts_fk_safety_cleanup",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Restores migration 0083 to its original SQL content, matching the hash already recorded in the production Drizzle journal
- Moves the safety cleanup steps (from PR #2277) into a new migration 0084
- Fixes the "Check migration file integrity" CI failure on main

## Context

During the 2026-03-13 outage, migration 0083 was applied to production with its original SQL (after manual data fixes). PR #2277 then modified 0083's SQL to add safety steps, but this created a hash mismatch between the code and the production journal. The migration integrity CI check correctly flagged this.

## Changes

- **0083**: Reverted to original SQL (matches production journal hash `3b5e41...`)
- **0084** (new): Safety cleanup — deletes facts with unconverted entity_ids, nulls unconverted subjects. No-op on production but protects fresh deployments.
- **_journal.json**: Added entry for 0084

## Test plan

- [x] Gate passes locally (17/17)
- [ ] Migration integrity CI check passes (needs `migration-override` label since 0083 is being reverted)
- [ ] Fresh deployment would run 0083 then 0084 without errors

Closes the migration integrity failure visible on https://www.longtermwiki.com/wiki/E927

🤖 Generated with [Claude Code](https://claude.com/claude-code)