### PR TITLE
feat: add verification badges to record detail pages

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -2062,11 +2062,10 @@ async function main() {
     database.benchmarkResults = await fetchBenchmarkResults();
   }
 
-  // TODO: Enable when record verification dashboard is built (see #2243)
-  // Fetch record verification verdicts from PG — currently no frontend consumer
-  // if (!CONTENT_ONLY) {
-  //   database.recordVerdicts = await fetchRecordVerdicts();
-  // }
+  // Fetch record verification verdicts from PG (used by VerificationBadge on detail pages)
+  if (!CONTENT_ONLY) {
+    database.recordVerdicts = await fetchRecordVerdicts();
+  }
 
   // Build URL → resource map for unconverted link detection
   const resources = database.resources || [];

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -7,9 +7,10 @@ import {
 } from "@/data/kb";
 import { formatStake } from "@/app/organizations/[slug]/org-data";
 import type { KBRecordEntry } from "@/data/kb";
-import { getTypedEntityById } from "@/data/database";
+import { getTypedEntityById, getRecordVerdict } from "@/data/database";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -139,6 +140,7 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
   if (!record) notFound();
 
   const round = parseFundingRound(record);
+  const roundVerdict = getRecordVerdict("funding-round", String(round.key));
 
   // Company wiki page link
   const companyTypedEntity = getTypedEntityById(round.ownerEntityId);
@@ -192,6 +194,7 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
               {titleCase(round.instrument)}
             </span>
           )}
+          <VerificationBadge verdict={roundVerdict} />
         </div>
 
         {/* Amount hero */}

--- a/apps/web/src/app/grants/[id]/page.tsx
+++ b/apps/web/src/app/grants/[id]/page.tsx
@@ -7,9 +7,10 @@ import {
   getKBEntitySlug,
 } from "@/data/kb";
 import type { KBRecordEntry } from "@/data/kb";
-import { getTypedEntityById } from "@/data/database";
+import { getTypedEntityById, getRecordVerdict } from "@/data/database";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { safeHref } from "@/lib/directory-utils";
 import {
   formatKBDate,
@@ -132,6 +133,7 @@ export default async function GrantDetailPage({ params }: PageProps) {
   if (!record) notFound();
 
   const grant = parseGrant(record);
+  const grantVerdict = getRecordVerdict("grant", String(grant.key));
 
   // Find related grants: same funder or same recipient
   const relatedByFunder = allGrants
@@ -179,6 +181,7 @@ export default async function GrantDetailPage({ params }: PageProps) {
               {titleCase(grant.status)}
             </span>
           )}
+          <VerificationBadge verdict={grantVerdict} />
         </div>
 
         {/* Amount hero */}

--- a/apps/web/src/app/investments/[id]/page.tsx
+++ b/apps/web/src/app/investments/[id]/page.tsx
@@ -7,9 +7,10 @@ import {
 } from "@/data/kb";
 import { formatStake } from "@/app/organizations/[slug]/org-data";
 import type { KBRecordEntry } from "@/data/kb";
-import { getTypedEntityById } from "@/data/database";
+import { getTypedEntityById, getRecordVerdict } from "@/data/database";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -117,6 +118,7 @@ export default async function InvestmentDetailPage({ params }: PageProps) {
   if (!record) notFound();
 
   const investment = parseInvestment(record);
+  const investmentVerdict = getRecordVerdict("investment", String(investment.key));
 
   // Company wiki page link
   const companyTypedEntity = getTypedEntityById(investment.ownerEntityId);
@@ -195,6 +197,7 @@ export default async function InvestmentDetailPage({ params }: PageProps) {
                 {titleCase(investment.instrument)}
               </span>
             )}
+            <VerificationBadge verdict={investmentVerdict} />
           </div>
         </div>
 

--- a/apps/web/src/app/organizations/[slug]/board-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/board-section.tsx
@@ -4,6 +4,8 @@
  */
 import Link from "next/link";
 import { formatKBDate } from "@/components/wiki/kb/format";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader } from "./org-shared";
 import type { BoardMember } from "./org-data";
 
@@ -19,29 +21,33 @@ export function BoardOfDirectorsSection({ members }: { members: BoardMember[] })
       <div className="border border-border/60 rounded-xl bg-card">
         {current.length > 0 && (
           <div className="divide-y divide-border/40">
-            {current.map((m) => (
-              <div key={m.key} className="px-4 py-3">
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  {m.personHref ? (
-                    <Link href={m.personHref} className="font-semibold text-sm text-primary hover:underline">
-                      {m.personName}
-                    </Link>
-                  ) : (
-                    <span className="font-semibold text-sm">{m.personName}</span>
+            {current.map((m) => {
+              const verdict = getRecordVerdict("personnel", String(m.key));
+              return (
+                <div key={m.key} className="px-4 py-3">
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    {m.personHref ? (
+                      <Link href={m.personHref} className="font-semibold text-sm text-primary hover:underline">
+                        {m.personName}
+                      </Link>
+                    ) : (
+                      <span className="font-semibold text-sm">{m.personName}</span>
+                    )}
+                    <span className="px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                      Current
+                    </span>
+                    <VerificationBadge verdict={verdict} />
+                  </div>
+                  {m.role && (
+                    <div className="text-xs text-muted-foreground mt-0.5">{m.role}</div>
                   )}
-                  <span className="px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
-                    Current
-                  </span>
+                  <div className="text-[11px] text-muted-foreground mt-1">
+                    {m.appointed ? `Since ${formatKBDate(m.appointed)}` : ""}
+                    {m.appointedBy ? ` (${m.appointedBy})` : ""}
+                  </div>
                 </div>
-                {m.role && (
-                  <div className="text-xs text-muted-foreground mt-0.5">{m.role}</div>
-                )}
-                <div className="text-[11px] text-muted-foreground mt-1">
-                  {m.appointed ? `Since ${formatKBDate(m.appointed)}` : ""}
-                  {m.appointedBy ? ` (${m.appointedBy})` : ""}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
         {former.length > 0 && (
@@ -52,26 +58,30 @@ export function BoardOfDirectorsSection({ members }: { members: BoardMember[] })
               </div>
             )}
             <div className="divide-y divide-border/40">
-              {former.map((m) => (
-                <div key={m.key} className="px-4 py-2.5 opacity-70">
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    {m.personHref ? (
-                      <Link href={m.personHref} className="font-semibold text-sm hover:text-primary transition-colors">
-                        {m.personName}
-                      </Link>
-                    ) : (
-                      <span className="font-semibold text-sm">{m.personName}</span>
+              {former.map((m) => {
+                const verdict = getRecordVerdict("personnel", String(m.key));
+                return (
+                  <div key={m.key} className="px-4 py-2.5 opacity-70">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      {m.personHref ? (
+                        <Link href={m.personHref} className="font-semibold text-sm hover:text-primary transition-colors">
+                          {m.personName}
+                        </Link>
+                      ) : (
+                        <span className="font-semibold text-sm">{m.personName}</span>
+                      )}
+                      <VerificationBadge verdict={verdict} />
+                    </div>
+                    {m.role && (
+                      <div className="text-xs text-muted-foreground mt-0.5">{m.role}</div>
                     )}
+                    <div className="text-[11px] text-muted-foreground mt-1">
+                      {m.appointed ? formatKBDate(m.appointed) : ""}
+                      {m.departed ? ` \u2013 ${formatKBDate(m.departed)}` : ""}
+                    </div>
                   </div>
-                  {m.role && (
-                    <div className="text-xs text-muted-foreground mt-0.5">{m.role}</div>
-                  )}
-                  <div className="text-[11px] text-muted-foreground mt-1">
-                    {m.appointed ? formatKBDate(m.appointed) : ""}
-                    {m.departed ? ` \u2013 ${formatKBDate(m.departed)}` : ""}
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </>
         )}

--- a/apps/web/src/app/organizations/[slug]/divisions-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions-section.tsx
@@ -4,6 +4,8 @@
  */
 import Link from "next/link";
 import { titleCase, formatKBDate } from "@/components/wiki/kb/format";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedDivisionRecord } from "./org-data";
 
@@ -46,69 +48,73 @@ export function DivisionsSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {divisions.map((d) => (
-              <tr key={d.key} className="hover:bg-muted/20 transition-colors">
-                <td className="py-2 px-3">
-                  <span className="font-medium text-foreground text-xs">
-                    {d.slug ? (
-                      <Link
-                        href={`/divisions/${d.slug}`}
-                        className="text-primary hover:underline"
+            {divisions.map((d) => {
+              const verdict = getRecordVerdict("division", String(d.key));
+              return (
+                <tr key={d.key} className="hover:bg-muted/20 transition-colors">
+                  <td className="py-2 px-3">
+                    <span className="font-medium text-foreground text-xs">
+                      {d.slug ? (
+                        <Link
+                          href={`/divisions/${d.slug}`}
+                          className="text-primary hover:underline"
+                        >
+                          {d.name}
+                        </Link>
+                      ) : (
+                        d.name
+                      )}
+                    </span>
+                    {d.source && (
+                      <a
+                        href={safeHref(d.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
                       >
-                        {d.name}
-                      </Link>
-                    ) : (
-                      d.name
+                        source
+                      </a>
                     )}
-                  </span>
-                  {d.source && (
-                    <a
-                      href={safeHref(d.source)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
-                    >
-                      source
-                    </a>
-                  )}
-                </td>
-                <td className="py-2 px-3">
-                  <span
-                    className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
-                      DIVISION_TYPE_COLORS[d.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                    }`}
-                  >
-                    {DIVISION_TYPE_LABELS[d.divisionType] ?? d.divisionType}
-                  </span>
-                </td>
-                <td className="py-2 px-3 text-xs text-muted-foreground">
-                  {d.lead ?? ""}
-                </td>
-                <td className="py-2 px-3 text-center text-xs">
-                  {d.status && (
+                    <VerificationBadge verdict={verdict} />
+                  </td>
+                  <td className="py-2 px-3">
                     <span
-                      className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-medium ${
-                        d.status === "active"
-                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-                          : d.status === "inactive"
-                            ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
-                            : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
+                        DIVISION_TYPE_COLORS[d.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
                       }`}
                     >
-                      {titleCase(d.status)}
+                      {DIVISION_TYPE_LABELS[d.divisionType] ?? d.divisionType}
                     </span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                  {d.startDate && (
-                    <span>
-                      {formatKBDate(d.startDate)}
-                      {d.endDate ? ` \u2013 ${formatKBDate(d.endDate)}` : " \u2013 present"}
-                    </span>
-                  )}
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className="py-2 px-3 text-xs text-muted-foreground">
+                    {d.lead ?? ""}
+                  </td>
+                  <td className="py-2 px-3 text-center text-xs">
+                    {d.status && (
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-medium ${
+                          d.status === "active"
+                            ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                            : d.status === "inactive"
+                              ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+                              : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        }`}
+                      >
+                        {titleCase(d.status)}
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                    {d.startDate && (
+                      <span>
+                        {formatKBDate(d.startDate)}
+                        {d.endDate ? ` \u2013 ${formatKBDate(d.endDate)}` : " \u2013 present"}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/organizations/[slug]/equity-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/equity-section.tsx
@@ -3,6 +3,8 @@
  * Extracted from page.tsx as a pure refactor — no visual changes.
  */
 import Link from "next/link";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedEquityPositionRecord } from "./org-data";
 import { formatStake } from "./org-data";
@@ -27,39 +29,43 @@ export function EquityPositionsSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {positions.map((pos) => (
-              <tr key={pos.key} className="hover:bg-muted/20 transition-colors">
-                <td className="py-2 px-3">
-                  <span className="font-medium text-foreground text-xs">
-                    {pos.holderHref ? (
-                      <Link href={pos.holderHref} className="text-primary hover:underline">
-                        {pos.holderName}
-                      </Link>
-                    ) : (
-                      pos.holderName
+            {positions.map((pos) => {
+              const verdict = getRecordVerdict("equity-position", String(pos.key));
+              return (
+                <tr key={pos.key} className="hover:bg-muted/20 transition-colors">
+                  <td className="py-2 px-3">
+                    <span className="font-medium text-foreground text-xs">
+                      {pos.holderHref ? (
+                        <Link href={pos.holderHref} className="text-primary hover:underline">
+                          {pos.holderName}
+                        </Link>
+                      ) : (
+                        pos.holderName
+                      )}
+                    </span>
+                    {pos.source && (
+                      <a
+                        href={safeHref(pos.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        source
+                      </a>
                     )}
-                  </span>
-                  {pos.source && (
-                    <a
-                      href={safeHref(pos.source)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
-                    >
-                      source
-                    </a>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                  {pos.stake != null && (
-                    <span className="font-semibold">{formatStake(pos.stake)}</span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                  {pos.asOf ?? ""}
-                </td>
-              </tr>
-            ))}
+                    <VerificationBadge verdict={verdict} />
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                    {pos.stake != null && (
+                      <span className="font-semibold">{formatStake(pos.stake)}</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                    {pos.asOf ?? ""}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/organizations/[slug]/funding-rounds-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/funding-rounds-section.tsx
@@ -4,6 +4,8 @@
  */
 import Link from "next/link";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedFundingRoundRecord } from "./org-data";
 
@@ -36,55 +38,59 @@ export function FundingRoundsSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {rounds.map((r) => (
-              <tr key={r.key} className="hover:bg-muted/20 transition-colors">
-                <td className="py-2 px-3">
-                  <Link
-                    href={`/funding-rounds/${r.key}`}
-                    className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                  >
-                    {r.name}
-                  </Link>
-                  {r.instrument && (
-                    <span className="ml-1.5 text-[11px] text-muted-foreground">
-                      ({r.instrument})
-                    </span>
-                  )}
-                  {r.source && (
-                    <a
-                      href={safeHref(r.source)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+            {rounds.map((r) => {
+              const verdict = getRecordVerdict("funding-round", String(r.key));
+              return (
+                <tr key={r.key} className="hover:bg-muted/20 transition-colors">
+                  <td className="py-2 px-3">
+                    <Link
+                      href={`/funding-rounds/${r.key}`}
+                      className="font-medium text-foreground text-xs hover:text-primary transition-colors"
                     >
-                      source
-                    </a>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                  {r.raised != null && (
-                    <span className="font-semibold">{formatCompactCurrency(r.raised)}</span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                  {r.valuation != null && (
-                    <span className="text-muted-foreground">{formatCompactCurrency(r.valuation)}</span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-xs">
-                  {r.leadInvestorHref ? (
-                    <Link href={r.leadInvestorHref} className="text-primary hover:underline">
-                      {r.leadInvestorName}
+                      {r.name}
                     </Link>
-                  ) : r.leadInvestorName ? (
-                    <span className="text-muted-foreground">{r.leadInvestorName}</span>
-                  ) : null}
-                </td>
-                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                  {r.date ?? ""}
-                </td>
-              </tr>
-            ))}
+                    {r.instrument && (
+                      <span className="ml-1.5 text-[11px] text-muted-foreground">
+                        ({r.instrument})
+                      </span>
+                    )}
+                    {r.source && (
+                      <a
+                        href={safeHref(r.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        source
+                      </a>
+                    )}
+                    <VerificationBadge verdict={verdict} />
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                    {r.raised != null && (
+                      <span className="font-semibold">{formatCompactCurrency(r.raised)}</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                    {r.valuation != null && (
+                      <span className="text-muted-foreground">{formatCompactCurrency(r.valuation)}</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-xs">
+                    {r.leadInvestorHref ? (
+                      <Link href={r.leadInvestorHref} className="text-primary hover:underline">
+                        {r.leadInvestorName}
+                      </Link>
+                    ) : r.leadInvestorName ? (
+                      <span className="text-muted-foreground">{r.leadInvestorName}</span>
+                    ) : null}
+                  </td>
+                  <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                    {r.date ?? ""}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/organizations/[slug]/grants-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants-section.tsx
@@ -6,6 +6,8 @@
  */
 import Link from "next/link";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedGrantRecord, ReceivedGrant } from "./org-data";
 import { formatAmount, numericValue } from "./org-data";
@@ -26,43 +28,47 @@ export function GrantsGivenSection({
     0,
   );
 
-  const rows = grants.map((g) => (
-    <tr key={g.key} className="hover:bg-muted/20 transition-colors">
-      <td className="py-2.5 px-4">
-        <span className="font-medium text-foreground text-sm">{g.name}</span>
-        {g.source && (
-          <a
-            href={safeHref(g.source)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
-          >
-            source
-          </a>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-sm">
-        {g.recipientHref ? (
-          <Link
-            href={g.recipientHref}
-            className="text-primary hover:underline"
-          >
-            {g.recipientName}
-          </Link>
-        ) : (
-          <span className="text-muted-foreground">{g.recipientName}</span>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-right tabular-nums whitespace-nowrap text-sm">
-        {g.amount != null && (
-          <span className="font-semibold">{formatAmount(g.amount)}</span>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-center text-muted-foreground text-sm">
-        {g.date ?? ""}
-      </td>
-    </tr>
-  ));
+  const rows = grants.map((g) => {
+    const verdict = getRecordVerdict("grant", String(g.key));
+    return (
+      <tr key={g.key} className="hover:bg-muted/20 transition-colors">
+        <td className="py-2.5 px-4">
+          <span className="font-medium text-foreground text-sm">{g.name}</span>
+          {g.source && (
+            <a
+              href={safeHref(g.source)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+            >
+              source
+            </a>
+          )}
+          <VerificationBadge verdict={verdict} />
+        </td>
+        <td className="py-2.5 px-4 text-sm">
+          {g.recipientHref ? (
+            <Link
+              href={g.recipientHref}
+              className="text-primary hover:underline"
+            >
+              {g.recipientName}
+            </Link>
+          ) : (
+            <span className="text-muted-foreground">{g.recipientName}</span>
+          )}
+        </td>
+        <td className="py-2.5 px-4 text-right tabular-nums whitespace-nowrap text-sm">
+          {g.amount != null && (
+            <span className="font-semibold">{formatAmount(g.amount)}</span>
+          )}
+        </td>
+        <td className="py-2.5 px-4 text-center text-muted-foreground text-sm">
+          {g.date ?? ""}
+        </td>
+      </tr>
+    );
+  });
 
   return (
     <section>
@@ -115,43 +121,47 @@ export function GrantsReceivedSection({
     0,
   );
 
-  const rows = grants.map((g) => (
-    <tr
-      key={`received-${g.key}`}
-      className="hover:bg-muted/20 transition-colors"
-    >
-      <td className="py-2.5 px-4">
-        <span className="font-medium text-foreground text-sm">{g.name}</span>
-        {g.source && (
-          <a
-            href={safeHref(g.source)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
-          >
-            source
-          </a>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-sm">
-        {g.funderHref ? (
-          <Link href={g.funderHref} className="text-primary hover:underline">
-            {g.funderName}
-          </Link>
-        ) : (
-          <span className="text-muted-foreground">{g.funderName}</span>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-right tabular-nums whitespace-nowrap text-sm">
-        {g.amount != null && (
-          <span className="font-semibold">{formatAmount(g.amount)}</span>
-        )}
-      </td>
-      <td className="py-2.5 px-4 text-center text-muted-foreground text-sm">
-        {g.date ?? ""}
-      </td>
-    </tr>
-  ));
+  const rows = grants.map((g) => {
+    const verdict = getRecordVerdict("grant", String(g.key));
+    return (
+      <tr
+        key={`received-${g.key}`}
+        className="hover:bg-muted/20 transition-colors"
+      >
+        <td className="py-2.5 px-4">
+          <span className="font-medium text-foreground text-sm">{g.name}</span>
+          {g.source && (
+            <a
+              href={safeHref(g.source)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+            >
+              source
+            </a>
+          )}
+          <VerificationBadge verdict={verdict} />
+        </td>
+        <td className="py-2.5 px-4 text-sm">
+          {g.funderHref ? (
+            <Link href={g.funderHref} className="text-primary hover:underline">
+              {g.funderName}
+            </Link>
+          ) : (
+            <span className="text-muted-foreground">{g.funderName}</span>
+          )}
+        </td>
+        <td className="py-2.5 px-4 text-right tabular-nums whitespace-nowrap text-sm">
+          {g.amount != null && (
+            <span className="font-semibold">{formatAmount(g.amount)}</span>
+          )}
+        </td>
+        <td className="py-2.5 px-4 text-center text-muted-foreground text-sm">
+          {g.date ?? ""}
+        </td>
+      </tr>
+    );
+  });
 
   return (
     <section>

--- a/apps/web/src/app/organizations/[slug]/investments-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/investments-section.tsx
@@ -4,6 +4,8 @@
  */
 import Link from "next/link";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedInvestmentRecord } from "@/app/organizations/[slug]/org-data";
 import { formatAmount, numericValue } from "@/app/organizations/[slug]/org-data";
@@ -36,54 +38,58 @@ export function InvestmentsReceivedSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {investments.map((inv) => (
-              <tr key={inv.key} className="hover:bg-muted/20 transition-colors">
-                <td className="py-2 px-3">
-                  <span className="font-medium text-foreground text-xs">
-                    {inv.investorHref ? (
-                      <Link href={inv.investorHref} className="text-primary hover:underline">
-                        {inv.investorName}
-                      </Link>
-                    ) : (
-                      inv.investorName
-                    )}
-                  </span>
-                  <Link
-                    href={`/investments/${inv.key}`}
-                    className="ml-1.5 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
-                    title="Investment details"
-                  >
-                    details
-                  </Link>
-                  {inv.role && (
-                    <span className="ml-1.5 text-[11px] text-muted-foreground">
-                      ({inv.role})
+            {investments.map((inv) => {
+              const verdict = getRecordVerdict("investment", String(inv.key));
+              return (
+                <tr key={inv.key} className="hover:bg-muted/20 transition-colors">
+                  <td className="py-2 px-3">
+                    <span className="font-medium text-foreground text-xs">
+                      {inv.investorHref ? (
+                        <Link href={inv.investorHref} className="text-primary hover:underline">
+                          {inv.investorName}
+                        </Link>
+                      ) : (
+                        inv.investorName
+                      )}
                     </span>
-                  )}
-                  {inv.source && (
-                    <a
-                      href={safeHref(inv.source)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+                    <Link
+                      href={`/investments/${inv.key}`}
+                      className="ml-1.5 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                      title="Investment details"
                     >
-                      source
-                    </a>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-xs text-muted-foreground">
-                  {inv.roundName ?? ""}
-                </td>
-                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                  {inv.amount != null && (
-                    <span className="font-semibold">{formatAmount(inv.amount)}</span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                  {inv.date ?? ""}
-                </td>
-              </tr>
-            ))}
+                      details
+                    </Link>
+                    {inv.role && (
+                      <span className="ml-1.5 text-[11px] text-muted-foreground">
+                        ({inv.role})
+                      </span>
+                    )}
+                    {inv.source && (
+                      <a
+                        href={safeHref(inv.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        source
+                      </a>
+                    )}
+                    <VerificationBadge verdict={verdict} />
+                  </td>
+                  <td className="py-2 px-3 text-xs text-muted-foreground">
+                    {inv.roundName ?? ""}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                    {inv.amount != null && (
+                      <span className="font-semibold">{formatAmount(inv.amount)}</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                    {inv.date ?? ""}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/organizations/[slug]/programs-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/programs-section.tsx
@@ -5,6 +5,8 @@
 import Link from "next/link";
 import { titleCase } from "@/components/wiki/kb/format";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { getRecordVerdict } from "@data/database";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedFundingProgramRecord } from "./org-data";
 
@@ -56,67 +58,71 @@ export function FundingProgramsSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {programs.map((p) => (
-              <tr key={p.key} className="hover:bg-muted/20 transition-colors">
-                <td className="py-2 px-3">
-                  <span className="font-medium text-foreground text-xs">
-                    <Link
-                      href={`/funding-programs/${p.key}`}
-                      className="text-primary hover:underline"
-                    >
-                      {p.name}
-                    </Link>
-                  </span>
-                  {p.source && (
-                    <a
-                      href={safeHref(p.source)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
-                    >
-                      source
-                    </a>
-                  )}
-                  {p.description && (
-                    <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
-                      {p.description}
-                    </div>
-                  )}
-                </td>
-                <td className="py-2 px-3">
-                  <span
-                    className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
-                      PROGRAM_TYPE_COLORS[p.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                    }`}
-                  >
-                    {PROGRAM_TYPE_LABELS[p.programType] ?? p.programType}
-                  </span>
-                </td>
-                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                  {p.totalBudget != null && (
-                    <span className="font-semibold">{formatCompactCurrency(p.totalBudget)}</span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-center text-xs">
-                  {p.status && (
+            {programs.map((p) => {
+              const verdict = getRecordVerdict("funding-program", String(p.key));
+              return (
+                <tr key={p.key} className="hover:bg-muted/20 transition-colors">
+                  <td className="py-2 px-3">
+                    <span className="font-medium text-foreground text-xs">
+                      <Link
+                        href={`/funding-programs/${p.key}`}
+                        className="text-primary hover:underline"
+                      >
+                        {p.name}
+                      </Link>
+                    </span>
+                    {p.source && (
+                      <a
+                        href={safeHref(p.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 text-[11px] text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        source
+                      </a>
+                    )}
+                    <VerificationBadge verdict={verdict} />
+                    {p.description && (
+                      <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
+                        {p.description}
+                      </div>
+                    )}
+                  </td>
+                  <td className="py-2 px-3">
                     <span
-                      className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-medium ${
-                        p.status === "open"
-                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-                          : p.status === "awarded"
-                            ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-                            : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
+                        PROGRAM_TYPE_COLORS[p.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
                       }`}
                     >
-                      {titleCase(p.status)}
+                      {PROGRAM_TYPE_LABELS[p.programType] ?? p.programType}
                     </span>
-                  )}
-                </td>
-                <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                  {p.deadline ?? p.openDate ?? ""}
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                    {p.totalBudget != null && (
+                      <span className="font-semibold">{formatCompactCurrency(p.totalBudget)}</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-center text-xs">
+                    {p.status && (
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-medium ${
+                          p.status === "open"
+                            ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                            : p.status === "awarded"
+                              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                              : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        }`}
+                      >
+                        {titleCase(p.status)}
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                    {p.deadline ?? p.openDate ?? ""}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/people/[slug]/career-history.tsx
+++ b/apps/web/src/app/people/[slug]/career-history.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { resolveEntityRef, formatDateRange } from "@/lib/directory-utils";
 import { getKBEntitySlug } from "@/data/kb";
+import { getRecordVerdict } from "@data/database";
 import { CurrentBadge, FounderBadge } from "@/components/directory";
+import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import type { CareerHistoryEntry } from "../people-utils";
 
 export function CareerHistory({
@@ -25,6 +27,7 @@ export function CareerHistory({
           const orgSlug = orgRef ? getKBEntitySlug(orgRef.id) : undefined;
           const isCurrent = !entry.endDate;
           const isFounder = /founder/i.test(entry.title);
+          const verdict = getRecordVerdict("personnel", String(entry.key));
 
           return (
             <div key={entry.key} className="px-5 py-3.5">
@@ -32,6 +35,7 @@ export function CareerHistory({
                 <span className="font-semibold text-sm">{entry.title}</span>
                 {isFounder && <FounderBadge />}
                 {isCurrent && <CurrentBadge />}
+                <VerificationBadge verdict={verdict} />
               </div>
               <div className="text-sm text-muted-foreground mt-0.5">
                 {orgSlug ? (

--- a/apps/web/src/components/directory/VerificationBadge.tsx
+++ b/apps/web/src/components/directory/VerificationBadge.tsx
@@ -1,0 +1,124 @@
+/**
+ * Verification status badge for structured data records (grants, personnel, etc.).
+ *
+ * Shows a small colored indicator next to record data points on detail pages.
+ * The verdict comes from the record verification system (wiki-server + LLM checks).
+ *
+ * Only renders when a verdict exists — unchecked records show nothing.
+ */
+import type { RecordVerdict } from "@data/database";
+
+// ── Verdict display config ───────────────────────────────────────────
+
+interface VerdictConfig {
+  label: string;
+  /** Short tooltip description */
+  title: string;
+  className: string;
+}
+
+const VERDICT_CONFIG: Record<string, VerdictConfig> = {
+  confirmed: {
+    label: "Verified",
+    title: "Confirmed by source",
+    className:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+  },
+  contradicted: {
+    label: "Disputed",
+    title: "Source contradicts this data",
+    className:
+      "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  },
+  outdated: {
+    label: "Outdated",
+    title: "Source has newer data",
+    className:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  },
+  partial: {
+    label: "Partial",
+    title: "Partially confirmed by source",
+    className:
+      "bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300",
+  },
+  unverifiable: {
+    label: "Unverifiable",
+    title: "Source does not address this data",
+    className:
+      "bg-gray-100 text-gray-500 dark:bg-gray-800/40 dark:text-gray-400",
+  },
+};
+
+// ── Component ────────────────────────────────────────────────────────
+
+export function VerificationBadge({
+  verdict,
+}: {
+  verdict: RecordVerdict | null | undefined;
+}) {
+  if (!verdict) return null;
+
+  const config = VERDICT_CONFIG[verdict.verdict];
+  if (!config) return null;
+
+  // Build confidence suffix if available
+  const confidencePct =
+    verdict.confidence != null
+      ? `${Math.round(verdict.confidence * 100)}%`
+      : null;
+
+  const titleText = confidencePct
+    ? `${config.title} (${confidencePct} confidence)`
+    : config.title;
+
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold leading-none ${config.className}`}
+      title={titleText}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+// ── Mapping helper ───────────────────────────────────────────────────
+
+/**
+ * Map a KB record collection name to the verification record type.
+ * Returns null for collections that don't have verification support.
+ */
+export function collectionToRecordType(
+  collection: string,
+): string | null {
+  const MAP: Record<string, string> = {
+    grants: "grant",
+    personnel: "personnel",
+    divisions: "division",
+    "funding-programs": "funding-program",
+    "funding-rounds": "funding-round",
+    investments: "investment",
+    "equity-positions": "equity-position",
+  };
+  return MAP[collection] ?? null;
+}
+
+/**
+ * Map a KB record schema to the verification record type.
+ * Handles personnel subtypes (key-person, board-seat, career-history all map to "personnel").
+ */
+export function schemaToRecordType(schema: string): string | null {
+  const MAP: Record<string, string> = {
+    grant: "grant",
+    "key-person": "personnel",
+    "board-seat": "personnel",
+    "career-history": "personnel",
+    division: "division",
+    "funding-program": "funding-program",
+    "funding-round": "funding-round",
+    investment: "investment",
+    "equity-position": "equity-position",
+    "division-personnel": "personnel",
+  };
+  return MAP[schema] ?? null;
+}

--- a/apps/web/src/data/database.ts
+++ b/apps/web/src/data/database.ts
@@ -853,9 +853,7 @@ export function getBenchmarkResultsByModel(modelId: string): PGBenchmarkResult[]
 
 // ============================================================================
 // RECORD VERDICTS
-// Note: These functions have no frontend consumer yet. The fetchRecordVerdicts()
-// call in build-data.mjs is commented out to save build time. Re-enable when
-// the record verification dashboard is built (see #2243).
+// Used by VerificationBadge on organization, grant, and funding-round detail pages.
 // ============================================================================
 
 export interface RecordVerdict {


### PR DESCRIPTION
## Summary

- Enables the `fetchRecordVerdicts()` call in the build-data pipeline (was commented out pending frontend consumers)
- Creates `VerificationBadge` component showing record verification status (confirmed/disputed/outdated/partial/unverifiable) with confidence tooltips
- Wires badges into all 7 organization section tables: grants given/received, funding rounds, divisions, programs, equity positions, investments, board of directors
- Wires badges into 3 standalone record detail pages: `/grants/[id]`, `/funding-rounds/[id]`, `/investments/[id]`
- Wires badges into people career history on `/people/[slug]` pages

Records without verification verdicts show nothing (graceful no-op).

Part of the Funding & Grants Integration Plan (discussion #2159, Tier 4).

## Test plan

- [ ] TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] Production build succeeds
- [ ] Organization pages with grants/funding rounds render correctly
- [ ] Detail pages (grants, funding rounds, investments) render with badge in header
- [ ] People pages with career history render with badges
- [ ] Records without verdicts show no badge (no visual regression)

Generated with [Claude Code](https://claude.com/claude-code)