### PR TITLE
Add sticky table headers and clickable stat cards

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -210,7 +210,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Model" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Developer" sortKey="developer" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Released" sortKey="releaseDate" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />

--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -223,7 +223,7 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Grant" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Funder" sortKey="organization" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Recipient" sortKey="recipient" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -70,9 +70,18 @@ function DateHint({ date }: { date: string | null }) {
   );
 }
 
-export function OrganizationsTable({ rows }: { rows: OrgRow[] }) {
+export type StatFilterKey = "all" | "withRevenue" | "withValuation" | "withHeadcount";
+
+export interface OrgStatDef {
+  key: StatFilterKey;
+  label: string;
+  value: string;
+}
+
+export function OrganizationsTable({ rows, stats }: { rows: OrgRow[]; stats?: OrgStatDef[] }) {
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [statFilter, setStatFilter] = useState<StatFilterKey>("all");
   const [sortKey, setSortKey] = useState<SortKey>("revenue");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
@@ -111,6 +120,20 @@ export function OrganizationsTable({ rows }: { rows: OrgRow[] }) {
       result = result.filter((r) => r.orgType === typeFilter);
     }
 
+    if (statFilter !== "all") {
+      switch (statFilter) {
+        case "withRevenue":
+          result = result.filter((r) => r.revenueNum != null);
+          break;
+        case "withValuation":
+          result = result.filter((r) => r.valuationNum != null);
+          break;
+        case "withHeadcount":
+          result = result.filter((r) => r.headcount != null);
+          break;
+      }
+    }
+
     if (search.trim()) {
       const q = search.toLowerCase();
       result = result.filter((r) => r.searchText.includes(q));
@@ -121,10 +144,35 @@ export function OrganizationsTable({ rows }: { rows: OrgRow[] }) {
     );
 
     return result;
-  }, [rows, search, typeFilter, sortKey, sortDir]);
+  }, [rows, search, typeFilter, statFilter, sortKey, sortDir]);
 
   return (
     <div>
+      {/* Clickable stat cards */}
+      {stats && stats.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+          {stats.map((stat) => (
+            <button
+              key={stat.key}
+              type="button"
+              onClick={() => setStatFilter(statFilter === stat.key ? "all" : stat.key)}
+              className={`rounded-xl border p-4 text-left transition-all ${
+                statFilter === stat.key
+                  ? "border-primary/50 bg-primary/5 ring-2 ring-primary/20 shadow-sm"
+                  : "border-border/60 bg-gradient-to-br from-card to-muted/30 hover:border-primary/30 hover:shadow-md"
+              }`}
+            >
+              <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1.5">
+                {stat.label}
+              </div>
+              <div className="text-xl font-bold tabular-nums tracking-tight">
+                {stat.value}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-3 mb-5">
         <input
@@ -174,7 +222,7 @@ export function OrganizationsTable({ rows }: { rows: OrgRow[] }) {
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Organization" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Type" sortKey="orgType" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Revenue" sortKey="revenue" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -3,8 +3,7 @@ import { getKBLatest, getKBFacts, getKBEntity, getKBRecords, getKBEntities } fro
 import { getTypedEntities, isOrganization, type OrganizationEntity } from "@/data";
 import { formatKBFactValue } from "@/components/wiki/kb/format";
 import type { Fact, Property } from "@longterm-wiki/kb";
-import { OrganizationsTable, type OrgRow } from "@/app/organizations/organizations-table";
-import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
+import { OrganizationsTable, type OrgRow, type OrgStatDef } from "@/app/organizations/organizations-table";
 
 export const metadata: Metadata = {
   title: "Organizations",
@@ -154,15 +153,15 @@ export default function OrganizationsPage() {
     };
   });
 
-  // Compute summary stats
+  // Compute summary stats (clickable in the client component)
   const withRevenue = rows.filter((r) => r.revenueNum != null).length;
   const withValuation = rows.filter((r) => r.valuationNum != null).length;
   const withHeadcount = rows.filter((r) => r.headcount != null).length;
-  const stats = [
-    { label: "Organizations", value: String(rows.length) },
-    { label: "With Revenue Data", value: String(withRevenue) },
-    { label: "With Valuation Data", value: String(withValuation) },
-    { label: "With Headcount", value: String(withHeadcount) },
+  const stats: OrgStatDef[] = [
+    { key: "all", label: "Organizations", value: String(rows.length) },
+    { key: "withRevenue", label: "With Revenue Data", value: String(withRevenue) },
+    { key: "withValuation", label: "With Valuation Data", value: String(withValuation) },
+    { key: "withHeadcount", label: "With Headcount", value: String(withHeadcount) },
   ];
 
   return (
@@ -177,18 +176,7 @@ export default function OrganizationsPage() {
         </p>
       </div>
 
-      {/* Summary stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-        {stats.map((stat) => (
-          <ProfileStatCard
-            key={stat.label}
-            label={stat.label}
-            value={stat.value}
-          />
-        ))}
-      </div>
-
-      <OrganizationsTable rows={rows} />
+      <OrganizationsTable rows={rows} stats={stats} />
     </div>
   );
 }

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -184,7 +184,7 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Name" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Role" sortKey="role" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Affiliation" sortKey="employer" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -150,7 +150,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Risk" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Category" sortKey="category" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Severity" sortKey="severity" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />


### PR DESCRIPTION
## Summary
- Add `sticky top-0 z-10 bg-muted backdrop-blur-sm` to table header rows on all 5 listing pages (organizations, people, risks, AI models, grants) so column headers stay visible when scrolling long tables
- Make stat cards on the organizations page clickable to filter the table by "With Revenue Data", "With Valuation Data", or "With Headcount" — clicking toggles the filter on/off with a ring highlight on the active card
- Stat cards moved from server component (`page.tsx`) into the client `OrganizationsTable` component to support interactivity

## Test plan
- [x] `pnpm build` passes
- [x] All 704 web app tests pass (`pnpm test` in `apps/web`)
- [ ] Manually verify sticky headers stay visible when scrolling on `/organizations`, `/people`, `/risks`, `/ai-models`, `/grants`
- [ ] Manually verify clicking stat cards on `/organizations` filters the table and shows ring highlight

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stat-based filtering to the organizations table: users can now filter results by revenue, valuation, and headcount through clickable stat cards.

* **Improvements**
  * Enhanced table usability by making headers sticky and visible during scrolling across all tables with a subtle blur effect for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->