### PR TITLE
Migrate Resources listing to standalone /resources page

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -27,6 +27,16 @@ const nextConfig: NextConfig = {
   // wiki-server API calls that compete with hundreds of other pages for
   // server resources during concurrent static generation.
   staticPageGenerationTimeout: 300,
+
+  async redirects() {
+    return [
+      {
+        source: "/wiki/E1043",
+        destination: "/resources",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/internal/resources/page.tsx
+++ b/apps/web/src/app/internal/resources/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function ResourcesPage() {
-  redirect("/wiki/E1043");
+  redirect("/resources");
 }

--- a/apps/web/src/app/resources/page.tsx
+++ b/apps/web/src/app/resources/page.tsx
@@ -1,5 +1,89 @@
-import { permanentRedirect } from "next/navigation";
+import type { Metadata } from "next";
+import {
+  getAllResources,
+  getPagesForResource,
+  getResourceCredibility,
+  getResourcePublication,
+} from "@/data";
+import { ProfileStatCard } from "@/components/directory";
+import { ResourcesTable, type ResourceRow } from "./resources-table";
 
-export default function ResourcesListingPage() {
-  permanentRedirect("/wiki/E1043");
+export const metadata: Metadata = {
+  title: "Resources",
+  description:
+    "Directory of external resources — papers, articles, reports, and other sources cited across the wiki.",
+};
+
+export default function ResourcesPage() {
+  const resources = getAllResources();
+
+  const rows: ResourceRow[] = resources.map((r) => {
+    const publication = getResourcePublication(r);
+    const credibility = getResourceCredibility(r);
+    const citingPages = getPagesForResource(r.id);
+
+    return {
+      id: r.id,
+      title: r.title,
+      url: r.url,
+      type: r.type,
+      publicationName: publication?.name ?? null,
+      credibility: credibility ?? null,
+      citingPageCount: citingPages.length,
+      tags: r.tags ?? [],
+      publishedDate: r.published_date ?? null,
+    };
+  });
+
+  // Compute summary stats
+  const typeCounts = new Map<string, number>();
+  for (const r of rows) {
+    typeCounts.set(r.type, (typeCounts.get(r.type) || 0) + 1);
+  }
+  const topTypes = [...typeCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+
+  const withPublication = rows.filter((r) => r.publicationName != null).length;
+  const withCredibility = rows.filter((r) => r.credibility != null).length;
+  const citedByPages = rows.filter((r) => r.citingPageCount > 0).length;
+
+  const stats = [
+    { label: "Total Resources", value: String(rows.length) },
+    ...topTypes.map(([type, count]) => ({
+      label: type.charAt(0).toUpperCase() + type.slice(1) + "s",
+      value: String(count),
+    })),
+    { label: "With Publication", value: String(withPublication) },
+    { label: "With Credibility", value: String(withCredibility) },
+    { label: "Cited by Pages", value: String(citedByPages) },
+  ];
+
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
+          Resources
+        </h1>
+        <p className="text-muted-foreground text-sm max-w-2xl">
+          Directory of external resources — papers, articles, reports, and other
+          sources cited across the wiki. Each resource includes metadata,
+          publication venue, and credibility ratings.
+        </p>
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3 mb-8">
+        {stats.map((stat) => (
+          <ProfileStatCard
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+          />
+        ))}
+      </div>
+
+      <ResourcesTable rows={rows} />
+    </div>
+  );
 }

--- a/apps/web/src/app/resources/resources-table.tsx
+++ b/apps/web/src/app/resources/resources-table.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type {
+  ColumnDef,
+  SortingState,
+  VisibilityState,
+} from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Columns3,
+} from "lucide-react";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export interface ResourceRow {
+  id: string;
+  title: string;
+  url: string;
+  type: string;
+  publicationName: string | null;
+  credibility: number | null;
+  citingPageCount: number;
+  tags: string[];
+  publishedDate: string | null;
+}
+
+const RESOURCE_TYPE_COLORS: Record<string, string> = {
+  paper: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  blog: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+  report: "bg-teal-100 text-teal-700 dark:bg-teal-900 dark:text-teal-300",
+  book: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+  web: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  government:
+    "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300",
+  talk: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+  podcast: "bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-300",
+  reference: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900 dark:text-cyan-300",
+};
+
+const DEFAULT_TYPE_COLOR =
+  "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+
+function makeColumns(): ColumnDef<ResourceRow>[] {
+  return [
+    {
+      accessorKey: "title",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Title</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          href={`/resources/${row.original.id}`}
+          className="text-primary hover:underline text-xs font-medium max-w-[300px] truncate block"
+          title={row.original.title}
+        >
+          {row.original.title}
+        </Link>
+      ),
+      filterFn: "includesString",
+    },
+    {
+      accessorKey: "type",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Type</SortableHeader>
+      ),
+      cell: ({ row }) => {
+        const t = row.original.type;
+        const color = RESOURCE_TYPE_COLORS[t] || DEFAULT_TYPE_COLOR;
+        return (
+          <span className={`text-xs px-1.5 py-0.5 rounded ${color}`}>{t}</span>
+        );
+      },
+      filterFn: "includesString",
+    },
+    {
+      accessorKey: "publicationName",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Publication</SortableHeader>
+      ),
+      cell: ({ row }) => {
+        const p = row.original.publicationName;
+        if (!p)
+          return (
+            <span className="text-muted-foreground/40 text-xs">-</span>
+          );
+        return (
+          <span
+            className="text-xs text-muted-foreground italic max-w-[140px] truncate block"
+            title={p}
+          >
+            {p}
+          </span>
+        );
+      },
+      sortUndefined: "last",
+    },
+    {
+      accessorKey: "credibility",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Credibility</SortableHeader>
+      ),
+      cell: ({ row }) => {
+        const c = row.original.credibility;
+        if (c == null)
+          return (
+            <span className="text-muted-foreground/40 text-xs">-</span>
+          );
+        const color =
+          c >= 4
+            ? "text-emerald-600"
+            : c >= 3
+              ? "text-blue-500"
+              : c >= 2
+                ? "text-amber-600"
+                : "text-red-500";
+        return (
+          <span className={`text-xs font-medium tabular-nums ${color}`}>
+            {c}/5
+          </span>
+        );
+      },
+      sortUndefined: "last",
+    },
+    {
+      accessorKey: "citingPageCount",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Pages</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {row.original.citingPageCount}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "publishedDate",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Published</SortableHeader>
+      ),
+      cell: ({ row }) => {
+        const d = row.original.publishedDate;
+        if (!d)
+          return (
+            <span className="text-muted-foreground/40 text-xs">-</span>
+          );
+        return (
+          <span className="text-xs text-muted-foreground font-mono">
+            {d.length > 7 ? d.slice(0, 10) : d}
+          </span>
+        );
+      },
+      sortUndefined: "last",
+    },
+    {
+      accessorKey: "tags",
+      header: "Tags",
+      cell: ({ row }) => {
+        const tags = row.original.tags;
+        if (!tags.length)
+          return (
+            <span className="text-muted-foreground/40 text-xs">-</span>
+          );
+        const display = tags.slice(0, 3);
+        const remaining = tags.length - display.length;
+        return (
+          <span className="flex flex-wrap gap-0.5 max-w-[160px]">
+            {display.map((tag) => (
+              <span
+                key={tag}
+                className="text-[10px] px-1 py-px bg-muted rounded text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+            {remaining > 0 && (
+              <span className="text-[10px] text-muted-foreground/60">
+                +{remaining}
+              </span>
+            )}
+          </span>
+        );
+      },
+      filterFn: (row, _columnId, filterValue: string) => {
+        return row.original.tags.some((tag) =>
+          tag.toLowerCase().includes(filterValue.toLowerCase()),
+        );
+      },
+    },
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <SortableHeader column={column}>ID</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <span
+          className="text-xs font-mono text-muted-foreground/60 max-w-[100px] truncate block"
+          title={row.original.id}
+        >
+          {row.original.id}
+        </span>
+      ),
+    },
+  ];
+}
+
+const DEFAULT_HIDDEN: Record<string, boolean> = {
+  id: false,
+  tags: false,
+};
+
+export function ResourcesTable({ rows }: { rows: ResourceRow[] }) {
+  const columns = useMemo(() => makeColumns(), []);
+
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "citingPageCount", desc: true },
+  ]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [columnVisibility, setColumnVisibility] =
+    useState<VisibilityState>(DEFAULT_HIDDEN);
+  const [showColumnPicker, setShowColumnPicker] = useState(false);
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
+  const [typeFilter, setTypeFilter] = useState<string>("");
+
+  const types = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of rows) {
+      counts.set(r.type, (counts.get(r.type) || 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [rows]);
+
+  const filteredData = useMemo(() => {
+    let data = rows;
+    if (typeFilter) data = data.filter((r) => r.type === typeFilter);
+    return data;
+  }, [rows, typeFilter]);
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: "includesString",
+    onColumnVisibilityChange: setColumnVisibility,
+    getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: setPagination,
+    state: {
+      sorting,
+      globalFilter,
+      columnVisibility,
+      pagination,
+    },
+  });
+
+  const filtered = table.getFilteredRowModel().rows.length;
+  const total = rows.length;
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[200px] max-w-md">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            placeholder="Search resources..."
+            value={globalFilter ?? ""}
+            onChange={(e) => {
+              setGlobalFilter(e.target.value);
+              setPagination((p) => ({ ...p, pageIndex: 0 }));
+            }}
+            className="h-9 w-full rounded-lg border border-border bg-background pl-10 pr-4 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+          />
+        </div>
+
+        {/* Type filter */}
+        <select
+          value={typeFilter}
+          onChange={(e) => {
+            setTypeFilter(e.target.value);
+            setPagination((p) => ({ ...p, pageIndex: 0 }));
+          }}
+          className="h-9 rounded-lg border border-border bg-background px-3 text-sm shadow-sm"
+        >
+          <option value="">All types</option>
+          {types.map(([type, count]) => (
+            <option key={type} value={type}>
+              {type} ({count})
+            </option>
+          ))}
+        </select>
+
+        {/* Column picker */}
+        <div className="relative">
+          <button
+            onClick={() => setShowColumnPicker((v) => !v)}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium border border-border rounded-md bg-background text-muted-foreground hover:bg-muted transition-colors"
+          >
+            <Columns3 className="h-3.5 w-3.5" />
+            Columns
+          </button>
+          {showColumnPicker && (
+            <div className="absolute right-0 top-full mt-1 z-50 bg-background border border-border rounded-lg shadow-lg p-2 min-w-[180px]">
+              {table.getAllLeafColumns().map((col) => (
+                <label
+                  key={col.id}
+                  className="flex items-center gap-2 px-2 py-1 text-xs hover:bg-muted rounded cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={col.getIsVisible()}
+                    onChange={col.getToggleVisibilityHandler()}
+                    className="rounded"
+                  />
+                  {typeof col.columnDef.header === "string"
+                    ? col.columnDef.header
+                    : col.id.charAt(0).toUpperCase() +
+                      col.id.slice(1).replace(/([A-Z])/g, " $1")}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {filtered === total
+            ? `${total.toLocaleString()} resources`
+            : `${filtered.toLocaleString()} of ${total.toLocaleString()} resources`}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-border/60 shadow-sm max-h-[70vh] overflow-auto">
+        <Table>
+          <TableHeader className="sticky top-0 z-20">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow
+                key={headerGroup.id}
+                className="hover:bg-transparent border-b-2 border-border/60"
+              >
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} className="whitespace-nowrap">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className="py-1.5">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-muted-foreground"
+                >
+                  No resources match your search.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between px-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Rows per page:</span>
+          <select
+            value={pagination.pageSize}
+            onChange={(e) =>
+              setPagination({ pageIndex: 0, pageSize: Number(e.target.value) })
+            }
+            className="h-7 rounded border border-border bg-background px-2 text-xs"
+          >
+            {[25, 50, 100, 200].map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            Page {pagination.pageIndex + 1} of {table.getPageCount() || 1}
+          </span>
+          <button
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sources/sources-overview-content.tsx
+++ b/apps/web/src/app/sources/sources-overview-content.tsx
@@ -12,7 +12,7 @@ export function SourcesOverviewContent() {
   ).length;
 
   const stats = [
-    { label: "Resources", value: resources.length, href: "/wiki/E1043" },
+    { label: "Resources", value: resources.length, href: "/resources" },
     { label: "Publications", value: publications.length, href: "/wiki/E1044" },
     { label: "Peer-Reviewed Venues", value: peerReviewed },
     { label: "With Summaries", value: withSummary },
@@ -54,7 +54,7 @@ export function SourcesOverviewContent() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <Link
-          href="/wiki/E1043"
+          href="/resources"
           className="group block rounded-xl border border-border/60 bg-card p-6 no-underline transition-all hover:shadow-md hover:border-border"
         >
           <h3 className="text-lg font-bold mb-2 group-hover:text-primary transition-colors">

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -404,7 +404,7 @@ export function getSourcesNav(): NavSection[] {
       defaultOpen: true,
       items: [
         { label: "Overview", href: "/wiki/E1049" },
-        { label: "Resources", href: "/wiki/E1043" },
+        { label: "Resources", href: "/resources" },
         { label: "Publications", href: "/wiki/E1044" },
       ],
     },


### PR DESCRIPTION
## Summary

- Replaces the MDX wiki page (E1043) with a standalone App Router page at `/resources`, matching the pattern used by `/organizations`, `/people`, `/risks`, and `/ai-models`
- New `ResourcesTable` client component using TanStack React Table with pagination, search, type filter, and column visibility toggle (appropriate for ~4,948 entries)
- Removed internal infrastructure columns (fetch status, S/R/K content indicators) from the public-facing table
- Added permanent redirect from `/wiki/E1043` to `/resources` via `next.config.ts`
- Updated `/internal/resources/` redirect, sources overview links, and sidebar nav to point to `/resources`
- MDX stub and old content component are preserved (not deleted)

## Test plan

- [x] `pnpm build` passes (page renders as static at `/resources` with 4.06 kB)
- [x] `pnpm test` passes (704/704 web app tests green)
- [ ] Verify `/wiki/E1043` redirects to `/resources`
- [ ] Verify `/internal/resources/` redirects to `/resources`
- [ ] Verify sidebar "Resources" link under Sources section points to `/resources`
- [ ] Verify table renders with search, type filter, pagination, and column visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)