### PR TITLE
feat: migrate !ref tag slugs to bare stableIds

### DIFF
--- a/crux/scripts/migrate-ref-slugs.ts
+++ b/crux/scripts/migrate-ref-slugs.ts
@@ -1,0 +1,85 @@
+/**
+ * Migrate !ref tags in KB YAML files from `!ref stableId:slug` to `!ref stableId`.
+ *
+ * Part of the KB data migration backlog (discussion #2023).
+ * Removes the `:slug` suffix from !ref YAML tags, since slugs are being
+ * phased out in favor of bare stableIds.
+ *
+ * Usage:
+ *   pnpm tsx crux/scripts/migrate-ref-slugs.ts --dry-run   # preview changes (default)
+ *   pnpm tsx crux/scripts/migrate-ref-slugs.ts --apply      # apply changes
+ */
+
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { join, extname } from "node:path";
+
+const THINGS_DIR = join(
+  import.meta.dirname,
+  "../../packages/kb/data/things"
+);
+
+// Matches `!ref <stableId>:<slug>` and captures the stableId and slug portions.
+// stableId is a 10-char alphanumeric string; slug is a kebab-case identifier.
+const REF_WITH_SLUG_RE = /!ref ([A-Za-z0-9]{10}):([a-z0-9-]+)/g;
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const dryRun = !apply;
+
+  if (dryRun) {
+    console.log("DRY RUN — pass --apply to write changes\n");
+  }
+
+  const entries = await readdir(THINGS_DIR);
+  const yamlFiles = entries.filter(
+    (e) => extname(e) === ".yaml" || extname(e) === ".yml"
+  );
+
+  let totalReplacements = 0;
+  let filesChanged = 0;
+
+  for (const filename of yamlFiles.sort()) {
+    const filepath = join(THINGS_DIR, filename);
+    const content = await readFile(filepath, "utf-8");
+
+    // Count matches first
+    const matches = [...content.matchAll(REF_WITH_SLUG_RE)];
+    if (matches.length === 0) continue;
+
+    // Replace all `!ref stableId:slug` with `!ref stableId`
+    const updated = content.replace(
+      REF_WITH_SLUG_RE,
+      (_match, stableId: string, _slug: string) => `!ref ${stableId}`
+    );
+
+    if (updated === content) continue; // idempotent: no changes needed
+
+    filesChanged++;
+    totalReplacements += matches.length;
+
+    for (const match of matches) {
+      const [full, stableId, slug] = match;
+      console.log(
+        `  ${filename}: ${full} -> !ref ${stableId}  (removed :${slug})`
+      );
+    }
+
+    if (apply) {
+      await writeFile(filepath, updated, "utf-8");
+    }
+  }
+
+  console.log(
+    `\n${dryRun ? "Would change" : "Changed"} ${totalReplacements} !ref tags across ${filesChanged} files.`
+  );
+
+  if (dryRun && totalReplacements > 0) {
+    console.log("\nRun with --apply to write changes.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/kb/data/things/ajeya-cotra.yaml
+++ b/packages/kb/data/things/ajeya-cotra.yaml
@@ -32,6 +32,6 @@ facts:
 
   - id: f_aC3oMx0qZs
     property: employed-by
-    value: !ref rQEkFJxS5w:metr
+    value: !ref rQEkFJxS5w
     asOf: "2026-03"
     notes: "Migrated from entity customFields"

--- a/packages/kb/data/things/anthropic-government-standoff.yaml
+++ b/packages/kb/data/things/anthropic-government-standoff.yaml
@@ -42,9 +42,9 @@ facts:
   - id: f_O44njDhfpA
     property: organizations-involved
     value:
-      - !ref mK9pX3rQ7n:anthropic
-      - !ref 1LcLlMGLbw:openai
-      - !ref GLXKjYAEKw:xai
+      - !ref mK9pX3rQ7n
+      - !ref 1LcLlMGLbw
+      - !ref GLXKjYAEKw
     source: https://www.nbcnews.com/tech/security/anthropic-ai-defense-war-venezuela-maduro-rcna259603
     notes: "Pentagon awarded AI contracts to Anthropic, OpenAI, Google, and xAI"
 

--- a/packages/kb/data/things/anthropic.yaml
+++ b/packages/kb/data/things/anthropic.yaml
@@ -163,10 +163,10 @@ facts:
   - id: f_tAtOfKqDjg
     property: founded-by
     value:
-      - !ref zR4nW8xB2f:dario-amodei
-      - !ref tKMznr07QA:daniela-amodei
+      - !ref zR4nW8xB2f
+      - !ref tKMznr07QA
       - tom-brown
-      - !ref Tz48rTriBg:chris-olah
+      - !ref Tz48rTriBg
       - jared-kaplan
       - sam-mccandlish
       - jack-clark

--- a/packages/kb/data/things/arc.yaml
+++ b/packages/kb/data/things/arc.yaml
@@ -28,7 +28,7 @@ facts:
   - id: f_tC3M5pbZUg
     property: founded-by
     value:
-      - !ref vzxfzxBITd:paul-christiano
+      - !ref vzxfzxBITd
     source: https://alignment.org/
   - id: xU3JVFJnrQ
     property: website

--- a/packages/kb/data/things/beth-barnes.yaml
+++ b/packages/kb/data/things/beth-barnes.yaml
@@ -25,7 +25,7 @@ facts:
 
   - id: f_bB9wS5jH1d
     property: employed-by
-    value: !ref rQEkFJxS5w:metr
+    value: !ref rQEkFJxS5w
     asOf: 2023-01
     notes: Enriched from entity description; METR rebranded from ARC Evals
 

--- a/packages/kb/data/things/buck-shlegeris.yaml
+++ b/packages/kb/data/things/buck-shlegeris.yaml
@@ -28,6 +28,6 @@ facts:
 
   - id: f_bS3oMx0qZs
     property: employed-by
-    value: !ref dwMzc9WzPa:redwood-research
+    value: !ref dwMzc9WzPa
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"

--- a/packages/kb/data/things/chris-olah.yaml
+++ b/packages/kb/data/things/chris-olah.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_PbzJNYhoQQ
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2021-01
     source: https://anthropic.com/company
     notes: "Co-founded Anthropic in January 2021; leads interpretability research"
@@ -24,14 +24,14 @@ facts:
 
   - id: f_RewqjBXgsA
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: "2018"
     validEnd: 2021-01
     notes: "Researcher at OpenAI before co-founding Anthropic"
 
   - id: f_fUPJ9kzk8w
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: "2015"
     validEnd: "2018"
     notes: "Research scientist at Google Brain (prior to DeepMind merger); published influential work on neural network visualization"

--- a/packages/kb/data/things/conjecture.yaml
+++ b/packages/kb/data/things/conjecture.yaml
@@ -35,7 +35,7 @@ facts:
   - id: f_Tu50nzl3OA
     property: founded-by
     value:
-      - !ref CrXoCsIucX:connor-leahy
+      - !ref CrXoCsIucX
       - sid-black
       - gabriel-alfour
     source: https://www.conjecture.dev/

--- a/packages/kb/data/things/connor-leahy.yaml
+++ b/packages/kb/data/things/connor-leahy.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_6RTYYOtNHd
     property: employed-by
-    value: !ref 0u4J70VqFY:conjecture
+    value: !ref 0u4J70VqFY
     asOf: 2022-03
     source: https://www.conjecture.dev/
     notes: "Co-founded Conjecture in 2022; previously co-founded EleutherAI"

--- a/packages/kb/data/things/dan-hendrycks.yaml
+++ b/packages/kb/data/things/dan-hendrycks.yaml
@@ -44,7 +44,7 @@ facts:
 
   - id: f_dH3oMx0qZs
     property: employed-by
-    value: !ref oa9A0OV0RX:center-for-ai-safety
+    value: !ref oa9A0OV0RX
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"
 

--- a/packages/kb/data/things/daniela-amodei.yaml
+++ b/packages/kb/data/things/daniela-amodei.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_R5GtlfjvmA
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: "2018"
     validEnd: 2021-01
     source: https://anthropic.com/company
@@ -24,7 +24,7 @@ facts:
 
   - id: f_9N4b6WjtiA
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2021-01
     source: https://anthropic.com/company
     notes: "Co-founded Anthropic in January 2021 with Dario Amodei and others; serves as President"

--- a/packages/kb/data/things/dario-amodei.yaml
+++ b/packages/kb/data/things/dario-amodei.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_aE3mK7pQ9x
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2021-01
     source: https://anthropic.com/company
     notes: "Co-founded Anthropic in January 2021; serves as CEO"
@@ -60,7 +60,7 @@ facts:
 
   - id: f_nuoya5WHmQ
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: "2016"
     validEnd: 2021-01
     source: https://en.wikipedia.org/wiki/Dario_Amodei

--- a/packages/kb/data/things/deepmind.yaml
+++ b/packages/kb/data/things/deepmind.yaml
@@ -34,7 +34,7 @@ facts:
   - id: f_AX7AnnLZQQ
     property: founded-by
     value:
-      - !ref Aqcyu3onCA:demis-hassabis
+      - !ref Aqcyu3onCA
       - shane-legg
       - mustafa-suleyman
     source: https://en.wikipedia.org/wiki/Google_DeepMind

--- a/packages/kb/data/things/demis-hassabis.yaml
+++ b/packages/kb/data/things/demis-hassabis.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_86Rr7EPOYw
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: 2010-09
     source: https://deepmind.google/about/
     notes: "Co-founded DeepMind in September 2010; became CEO of Google DeepMind after the 2023 merger with Google Brain"

--- a/packages/kb/data/things/eli-lifland.yaml
+++ b/packages/kb/data/things/eli-lifland.yaml
@@ -27,7 +27,7 @@ facts:
 
   - id: f_eL9wS5jH4d
     property: employed-by
-    value: !ref KDYvrwkgtw:ai-futures-project
+    value: !ref KDYvrwkgtw
     asOf: 2025-01
     notes: Enriched from wiki page; co-founded with Daniel Kokotajlo and Thomas Larsen
 

--- a/packages/kb/data/things/eliezer-yudkowsky.yaml
+++ b/packages/kb/data/things/eliezer-yudkowsky.yaml
@@ -11,7 +11,7 @@ thing:
 facts:
   - id: f_pMYY3GyUXY
     property: employed-by
-    value: !ref puAffUjWSS:miri
+    value: !ref puAffUjWSS
     asOf: 2000-01
     source: https://intelligence.org/about/
     notes: "Founded MIRI (originally Singularity Institute) in 2000; has been its primary researcher and intellectual leader"

--- a/packages/kb/data/things/elizabeth-kelly.yaml
+++ b/packages/kb/data/things/elizabeth-kelly.yaml
@@ -25,6 +25,6 @@ facts:
 
   - id: f_eK3oMx0qZs
     property: employed-by
-    value: !ref fYyAxYlHDQ:us-aisi
+    value: !ref fYyAxYlHDQ
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"

--- a/packages/kb/data/things/elon-musk.yaml
+++ b/packages/kb/data/things/elon-musk.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_N2rrW9c6JA
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2015-12
     validEnd: 2018-02
     source: https://openai.com/blog/introducing-openai
@@ -25,7 +25,7 @@ facts:
 
   - id: f_7FJCjl4c9Q
     property: employed-by
-    value: !ref GLXKjYAEKw:xai
+    value: !ref GLXKjYAEKw
     asOf: 2023-03
     source: https://x.ai
     notes: "Founded xAI in March 2023 to develop AI; also CEO of Tesla and SpaceX"

--- a/packages/kb/data/things/evan-hubinger.yaml
+++ b/packages/kb/data/things/evan-hubinger.yaml
@@ -33,13 +33,13 @@ facts:
 
   - id: f_eH9wS5jH8d
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2023-01
     notes: Enriched from wiki page; Head of Alignment Stress-Testing
 
   - id: f_eHcY8fL1kA
     property: employed-by
-    value: !ref puAffUjWSS:miri
+    value: !ref puAffUjWSS
     asOf: 2019-01
     validEnd: 2023-01
     notes: Enriched from wiki page; Research Fellow at MIRI 2019-2023

--- a/packages/kb/data/things/geoffrey-hinton.yaml
+++ b/packages/kb/data/things/geoffrey-hinton.yaml
@@ -11,7 +11,7 @@ thing:
 facts:
   - id: f_CQptGEFesw
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: 2013-03
     validEnd: 2023-05
     source: https://www.nytimes.com/2023/05/01/technology/ai-google-chatbot-engineer-quits-hinton.html

--- a/packages/kb/data/things/greg-brockman.yaml
+++ b/packages/kb/data/things/greg-brockman.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_tZxixtemow
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2015-12
     source: https://openai.com/blog/introducing-openai
     notes: "Co-founded OpenAI December 2015; took leave of absence August 2024 but

--- a/packages/kb/data/things/helen-toner.yaml
+++ b/packages/kb/data/things/helen-toner.yaml
@@ -39,7 +39,7 @@ facts:
 
   - id: f_hT9wS5jH7d
     property: employed-by
-    value: !ref lvsDuyzPcg:cset
+    value: !ref lvsDuyzPcg
     asOf: 2019-01
     notes: Enriched from wiki page; joined CSET in January 2019, became Interim Executive Director September 2025
 

--- a/packages/kb/data/things/holden-karnofsky.yaml
+++ b/packages/kb/data/things/holden-karnofsky.yaml
@@ -26,7 +26,7 @@ facts:
 
   - id: f_vAidx4lhTo
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2025-01
     source: https://www.anthropic.com/
     notes: "Joined Anthropic as Member of Technical Staff in early 2025; works on responsible scaling policy"

--- a/packages/kb/data/things/ian-hogarth.yaml
+++ b/packages/kb/data/things/ian-hogarth.yaml
@@ -25,7 +25,7 @@ facts:
 
   - id: f_iH3oMx0qZs
     property: employed-by
-    value: !ref aX0jkoaekQ:uk-aisi
+    value: !ref aX0jkoaekQ
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"
 

--- a/packages/kb/data/things/ilya-sutskever.yaml
+++ b/packages/kb/data/things/ilya-sutskever.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_qfd3qL21HQ
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2015-12
     validEnd: 2024-06
     source: https://openai.com/blog/introducing-openai
@@ -25,7 +25,7 @@ facts:
 
   - id: f_QtqNoKoBgw
     property: employed-by
-    value: !ref 1OSiYOaWVL:ssi
+    value: !ref 1OSiYOaWVL
     asOf: 2024-06
     source: https://ssi.inc
     notes: "Co-founded Safe Superintelligence Inc (SSI) in June 2024 with Daniel Gross and Daniel Levy"

--- a/packages/kb/data/things/jan-leike.yaml
+++ b/packages/kb/data/things/jan-leike.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_dF5bX8wC3g
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2021-01
     validEnd: 2024-05
     source: https://openai.com/blog/introducing-superalignment
@@ -18,7 +18,7 @@ facts:
 
   - id: f_eH9jV6nK4t
     property: employed-by
-    value: !ref mK9pX3rQ7n:anthropic
+    value: !ref mK9pX3rQ7n
     asOf: 2024-05
     source: https://anthropic.com/news/jan-leike-joins-anthropic
     notes: "Resigned from OpenAI in May 2024, citing safety concerns; joined Anthropic same month to lead Alignment Science team"
@@ -48,7 +48,7 @@ facts:
 
   - id: f_chtWwYTL4w
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: "2017"
     validEnd: "2021"
     source: https://jan.leike.name/

--- a/packages/kb/data/things/leopold-aschenbrenner.yaml
+++ b/packages/kb/data/things/leopold-aschenbrenner.yaml
@@ -27,7 +27,7 @@ facts:
 
   - id: f_lA9wS5jH5d
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2023-01
     validEnd: 2024-04
     notes: Enriched from wiki page; fired in April 2024 from Superalignment team

--- a/packages/kb/data/things/max-tegmark.yaml
+++ b/packages/kb/data/things/max-tegmark.yaml
@@ -39,7 +39,7 @@ facts:
 
   - id: f_mT9wS5jH6d
     property: employed-by
-    value: !ref d9sWZtyVwg:fli
+    value: !ref d9sWZtyVwg
     asOf: 2014-01
     notes: Enriched from wiki page; co-founded FLI in 2014 and serves as president
 

--- a/packages/kb/data/things/meta-ai.yaml
+++ b/packages/kb/data/things/meta-ai.yaml
@@ -28,7 +28,7 @@ facts:
   - id: f_lhQD26Idvw
     property: founded-by
     value:
-      - !ref cMbVUVK29Q:yann-lecun
+      - !ref cMbVUVK29Q
     source: https://ai.meta.com/research/
 
   - id: f_Hh20Dvc90g

--- a/packages/kb/data/things/miri.yaml
+++ b/packages/kb/data/things/miri.yaml
@@ -32,7 +32,7 @@ facts:
   - id: f_QYWh1IZqjA
     property: founded-by
     value:
-      - !ref fS1tEGKuNq:eliezer-yudkowsky
+      - !ref fS1tEGKuNq
     source: https://intelligence.org/about/
 
   - id: f_EUnXQGwIzd

--- a/packages/kb/data/things/nate-soares.yaml
+++ b/packages/kb/data/things/nate-soares.yaml
@@ -28,7 +28,7 @@ facts:
 
   - id: f_nS9wS5jH8d
     property: employed-by
-    value: !ref puAffUjWSS:miri
+    value: !ref puAffUjWSS
     asOf: 2015-01
     notes: Enriched from entity description; became Executive Director around 2015
 

--- a/packages/kb/data/things/neel-nanda.yaml
+++ b/packages/kb/data/things/neel-nanda.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_MC1O0jwEcB
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: 2023-01
     source: https://www.neelnanda.io/
     notes: "Research Scientist at Google DeepMind working on mechanistic interpretability"

--- a/packages/kb/data/things/nuno-sempere.yaml
+++ b/packages/kb/data/things/nuno-sempere.yaml
@@ -27,7 +27,7 @@ facts:
 
   - id: f_nP9wS5jH3d
     property: employed-by
-    value: !ref JzhBAecjaA:sentinel
+    value: !ref JzhBAecjaA
     asOf: 2023-01
     notes: Enriched from wiki page; leads Sentinel early detection and response for global catastrophes
 

--- a/packages/kb/data/things/openai.yaml
+++ b/packages/kb/data/things/openai.yaml
@@ -48,10 +48,10 @@ facts:
   - id: f_A4ImW0y2sw
     property: founded-by
     value:
-      - !ref JKsVHQ5stQ:sam-altman
-      - !ref eYrBgMLJDw:ilya-sutskever
-      - !ref Yq4s2cI7ng:greg-brockman
-      - !ref 69vftmr1jg:elon-musk
+      - !ref JKsVHQ5stQ
+      - !ref eYrBgMLJDw
+      - !ref Yq4s2cI7ng
+      - !ref 69vftmr1jg
       - wojciech-zaremba
       - john-schulman
     source: https://openai.com/blog/introducing-openai

--- a/packages/kb/data/things/paul-christiano.yaml
+++ b/packages/kb/data/things/paul-christiano.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_rPQmiVa1LH
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2017-01
     validEnd: 2021-10
     source: https://paulfchristiano.com/
@@ -18,7 +18,7 @@ facts:
 
   - id: f_qPXcXJF3Uv
     property: employed-by
-    value: !ref QsXVXtQ0zE:arc
+    value: !ref QsXVXtQ0zE
     asOf: 2021-10
     source: https://alignment.org/
     notes: "Founded Alignment Research Center (ARC) in 2021; stepped back from day-to-day operations in 2023 due to a brain injury"

--- a/packages/kb/data/things/philip-tetlock.yaml
+++ b/packages/kb/data/things/philip-tetlock.yaml
@@ -38,7 +38,7 @@ facts:
 
   - id: f_pT9wS5jH4d
     property: employed-by
-    value: !ref Zx7ckq6syw:good-judgment
+    value: !ref Zx7ckq6syw
     asOf: 2011-01
     notes: Enriched from wiki page; co-founded Good Judgment Project and Good Judgment Inc.
 

--- a/packages/kb/data/things/sam-altman.yaml
+++ b/packages/kb/data/things/sam-altman.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_StIAxD850A
     property: employed-by
-    value: !ref 1LcLlMGLbw:openai
+    value: !ref 1LcLlMGLbw
     asOf: 2015-12
     source: https://openai.com/about
     notes: "Co-founded OpenAI in December 2015; co-chairman initially, became CEO in 2019 when capped-profit entity was created"

--- a/packages/kb/data/things/shane-legg.yaml
+++ b/packages/kb/data/things/shane-legg.yaml
@@ -28,7 +28,7 @@ facts:
 
   - id: f_sL3oMx0qZs
     property: employed-by
-    value: !ref A4XoubikkQ:deepmind
+    value: !ref A4XoubikkQ
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"
 

--- a/packages/kb/data/things/ssi.yaml
+++ b/packages/kb/data/things/ssi.yaml
@@ -30,7 +30,7 @@ facts:
   - id: f_TUP4Wxpwqg
     property: founded-by
     value:
-      - !ref eYrBgMLJDw:ilya-sutskever
+      - !ref eYrBgMLJDw
       - daniel-gross
       - daniel-levy
     source: https://ssi.inc

--- a/packages/kb/data/things/toby-ord.yaml
+++ b/packages/kb/data/things/toby-ord.yaml
@@ -46,7 +46,7 @@ facts:
 
   - id: f_tO3oMx0qZs
     property: employed-by
-    value: !ref Zmw9nfUYWA:fhi
+    value: !ref Zmw9nfUYWA
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"
 

--- a/packages/kb/data/things/vidur-kapur.yaml
+++ b/packages/kb/data/things/vidur-kapur.yaml
@@ -27,7 +27,7 @@ facts:
 
   - id: f_vK9wS5jH7d
     property: employed-by
-    value: !ref uhTh3ndt0Q:controlai
+    value: !ref uhTh3ndt0Q
     asOf: 2026-03
     notes: Enriched from wiki page; AI Policy Researcher at ControlAI
 

--- a/packages/kb/data/things/xai.yaml
+++ b/packages/kb/data/things/xai.yaml
@@ -30,7 +30,7 @@ facts:
   - id: f_qr3MjbUa4Q
     property: founded-by
     value:
-      - !ref 69vftmr1jg:elon-musk
+      - !ref 69vftmr1jg
     source: https://x.ai/about
 
   - id: f_Uxbvs82r3w

--- a/packages/kb/data/things/yann-lecun.yaml
+++ b/packages/kb/data/things/yann-lecun.yaml
@@ -10,7 +10,7 @@ thing:
 facts:
   - id: f_y9K773heIw
     property: employed-by
-    value: !ref tt0f5PYDCw:meta-ai
+    value: !ref tt0f5PYDCw
     asOf: 2013-12
     source: https://ai.meta.com/people/yann-lecun/
     notes: "Joined Facebook AI Research (FAIR) as founding director in December 2013; became Chief AI Scientist at Meta"

--- a/packages/kb/src/loader.ts
+++ b/packages/kb/src/loader.ts
@@ -3,8 +3,8 @@
  * Reads properties.yaml, schemas/*.yaml, and things/*.yaml from a data directory.
  *
  * Supports !ref YAML tags for stable references between entities:
- *   value: !ref mK9pX3rQ7n:dario-amodei   → resolves stableId, cross-validates slug
- *   value: !ref mK9pX3rQ7n                 → bare stableId (deprecated, still works)
+ *   value: !ref mK9pX3rQ7n                 → bare stableId (preferred)
+ *   value: !ref mK9pX3rQ7n:dario-amodei   → stableId with slug hint (deprecated, still works)
  *
  * Supports !date YAML tags for explicit date typing:
  *   founded: !date 2019        → { type: "date", value: "2019" }
@@ -51,8 +51,8 @@ import type {
  * Marker class for !ref YAML tags. Created during YAML parsing,
  * resolved to entity IDs after all things are loaded.
  *
- * Format: !ref <entityId>:<slug>  (preferred — enables cross-validation)
- *         !ref <entityId>         (bare — still works)
+ * Format: !ref <entityId>         (preferred — bare stableId)
+ *         !ref <entityId>:<slug>  (deprecated — slug suffix still supported for cross-validation)
  */
 export class RefMarker {
   constructor(
@@ -63,7 +63,7 @@ export class RefMarker {
   ) {}
 }
 
-/** Custom YAML tag: !ref <stableId> or !ref <stableId>:<slug> */
+/** Custom YAML tag: !ref <stableId> (preferred) or !ref <stableId>:<slug> (deprecated) */
 const refTag: ScalarTag = {
   tag: "!ref",
   resolve(str: string): RefMarker {


### PR DESCRIPTION
## Summary

- Removes `:slug` suffixes from all 60 `!ref` tags across 43 KB YAML files (e.g., `!ref mK9pX3rQ7n:anthropic` becomes `!ref mK9pX3rQ7n`)
- Updates `packages/kb/src/loader.ts` docstrings to mark bare stableId as the preferred format and `:slug` suffix as deprecated
- The loader continues to support the `:slug` suffix for backward compatibility -- no breaking changes
- Includes the idempotent migration script at `crux/scripts/migrate-ref-slugs.ts` (supports `--dry-run` and `--apply`)

Continues the KB data migration backlog from discussion #2023. Companion to PR #2280 which handled `<KBF>`/`<Calc>` slug-to-stableId migration in MDX files.

## Test plan

- [x] Migration script runs idempotently (0 changes on second run)
- [x] `pnpm crux validate gate --fix` passes (all 21 gate checks)
- [x] `pnpm build` succeeds (all wiki pages compile and render)
- [x] `pnpm test` passes (all 3127 tests across 145 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)