### PR TITLE
feat: migrate summaries.entity_id from slug to stableId (Phase 0d)

### DIFF
--- a/apps/wiki-server/drizzle/0085_summaries_entity_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0085_summaries_entity_id_to_stable_id.sql
@@ -1,0 +1,27 @@
+-- Migration: Convert summaries.entity_id from slug-based to stableId-based FK
+-- This is the Phase 0d migration for the Unified things Table plan (discussion #2169).
+-- After this migration, summaries.entity_id references entities.stable_id instead of entities.id.
+
+-- Step 1: Delete orphaned summaries (entity_id not in entities.id)
+DELETE FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities);
+
+-- Step 2: Drop existing FK constraint
+ALTER TABLE "summaries" DROP CONSTRAINT IF EXISTS "summaries_entity_id_entities_id_fk";
+
+-- Step 3: Drop the primary key (needed to update entity_id values)
+ALTER TABLE "summaries" DROP CONSTRAINT IF EXISTS "summaries_pkey";
+
+-- Step 4: Convert entity_id from slug to stable_id
+UPDATE summaries SET entity_id = e.stable_id
+FROM entities e
+WHERE summaries.entity_id = e.id AND e.stable_id IS NOT NULL;
+
+-- Step 5: Delete any rows that could not be converted (entity has no stable_id)
+DELETE FROM summaries WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL);
+
+-- Step 6: Re-add primary key
+ALTER TABLE "summaries" ADD PRIMARY KEY ("entity_id");
+
+-- Step 7: Add new FK constraint referencing entities.stable_id
+ALTER TABLE "summaries" ADD CONSTRAINT "summaries_entity_id_entities_stable_id_fk"
+  FOREIGN KEY ("entity_id") REFERENCES "entities"("stable_id") ON DELETE CASCADE;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1775894400000,
       "tag": "0084_facts_fk_safety_cleanup",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1775980800000,
+      "tag": "0085_summaries_entity_id_to_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/summaries.test.ts
+++ b/apps/wiki-server/src/__tests__/summaries.test.ts
@@ -21,6 +21,12 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ last_value: 0, is_called: false }];
   }
 
+  // ---- entity resolution: SELECT stable_id FROM entities WHERE stable_id/id/numeric_id = ... ----
+  if (q.includes("stable_id") && q.includes('"entities"') && q.includes("limit")) {
+    // Return the identifier as-is as the stableId (simulating resolution)
+    return params.length > 0 ? [{ stable_id: params[0] }] : [];
+  }
+
   // ---- ref-check: SELECT id FROM entities/resources/wiki_pages WHERE id IN (...) ----
   if (q.includes("as id from") && q.includes("where") && q.includes(" in ")) {
     return params.map((p) => ({ id: p }));

--- a/apps/wiki-server/src/routes/entity-resolution.ts
+++ b/apps/wiki-server/src/routes/entity-resolution.ts
@@ -1,0 +1,25 @@
+import { eq, or } from "drizzle-orm";
+import { getDrizzleDb } from "../db.js";
+import { entities } from "../schema.js";
+
+/**
+ * Resolve an entity identifier (stableId, slug, or numericId) to a stableId.
+ * Returns null if the entity is not found.
+ */
+export async function resolveEntityStableId(
+  db: ReturnType<typeof getDrizzleDb>,
+  identifier: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ stableId: entities.stableId })
+    .from(entities)
+    .where(
+      or(
+        eq(entities.stableId, identifier),
+        eq(entities.id, identifier),
+        eq(entities.numericId, identifier),
+      )
+    )
+    .limit(1);
+  return rows[0]?.stableId ?? null;
+}

--- a/apps/wiki-server/src/routes/facts.ts
+++ b/apps/wiki-server/src/routes/facts.ts
@@ -1,9 +1,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, asc, sql, isNotNull, lte, or } from "drizzle-orm";
+import { eq, and, count, asc, sql, isNotNull, lte } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
 import { facts, entities, resources } from "../schema.js";
 import { checkRefsExist } from "./ref-check.js";
+import { resolveEntityStableId } from "./entity-resolution.js";
 import {
   parseJsonBody,
   validationError,
@@ -36,28 +37,6 @@ const StalenessQuery = z.object({
 });
 
 // ---- Helpers ----
-
-/**
- * Resolve an entity identifier (stableId, slug, or numericId) to a stableId.
- * Returns null if the entity is not found.
- */
-async function resolveEntityStableId(
-  db: ReturnType<typeof getDrizzleDb>,
-  identifier: string,
-): Promise<string | null> {
-  const rows = await db
-    .select({ stableId: entities.stableId })
-    .from(entities)
-    .where(
-      or(
-        eq(entities.stableId, identifier),
-        eq(entities.id, identifier),
-        eq(entities.numericId, identifier),
-      )
-    )
-    .limit(1);
-  return rows[0]?.stableId ?? null;
-}
 
 function formatFact(f: typeof facts.$inferSelect) {
   return {

--- a/apps/wiki-server/src/routes/integrity.ts
+++ b/apps/wiki-server/src/routes/integrity.ts
@@ -48,10 +48,10 @@ const integrityApp = new Hono()
         "entity_id",
         "entities"
       ),
-      // 2. summaries.entity_id → entities
+      // 2. summaries.entity_id → entities.stable_id
       checkDangling(
         db,
-        sql`SELECT DISTINCT entity_id AS ref FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities)`,
+        sql`SELECT DISTINCT entity_id AS ref FROM summaries WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL)`,
         "summaries",
         "entity_id",
         "entities"

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -518,7 +518,7 @@ async function fetchIntegritySummary(rawDb: ReturnType<typeof getDb>) {
   const result = await rawDb`
     SELECT
       (SELECT count(*) FROM facts WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL))::int AS dangling_facts,
-      (SELECT count(*) FROM summaries WHERE entity_id NOT IN (SELECT id FROM entities))::int AS dangling_summaries,
+      (SELECT count(*) FROM summaries WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL))::int AS dangling_summaries,
       -- Only flag truly orphaned records where BOTH the legacy text page_id and the new integer
       -- page_id_int are NULL. Records with page_id_old populated but page_id_int NULL are
       -- pre-migration artifacts (Phase D / Phase 4a), not data corruption.

--- a/apps/wiki-server/src/routes/summaries.ts
+++ b/apps/wiki-server/src/routes/summaries.ts
@@ -2,8 +2,8 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, count, sql, desc, asc } from "drizzle-orm";
 import { getDrizzleDb } from "../db.js";
-import { summaries, entities } from "../schema.js";
-import { checkRefsExist } from "./ref-check.js";
+import { summaries } from "../schema.js";
+import { resolveEntityStableId } from "./entity-resolution.js";
 import {
   parseJsonBody,
   validationError,
@@ -34,9 +34,9 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({
 
 type SummaryInput = z.infer<typeof UpsertSummarySchema>;
 
-function summaryValues(d: SummaryInput) {
+function summaryValues(d: SummaryInput, resolvedEntityId: string) {
   return {
-    entityId: d.entityId,
+    entityId: resolvedEntityId,
     entityType: d.entityType,
     oneLiner: d.oneLiner ?? null,
     summary: d.summary ?? null,
@@ -78,13 +78,13 @@ const summariesApp = new Hono()
 
     const db = getDrizzleDb();
 
-    // Validate entity reference
-    const missing = await checkRefsExist(db, entities, entities.id, [parsed.data.entityId]);
-    if (missing.length > 0) {
-      return validationError(c, `Referenced entity not found: ${missing.join(", ")}`);
+    // Resolve entity identifier to stableId
+    const stableId = await resolveEntityStableId(db, parsed.data.entityId);
+    if (!stableId) {
+      return validationError(c, `Referenced entity not found: ${parsed.data.entityId}`);
     }
 
-    const vals = summaryValues(parsed.data);
+    const vals = summaryValues(parsed.data, stableId);
 
     const rows = await db
       .insert(summaries)
@@ -123,14 +123,27 @@ const summariesApp = new Hono()
     const { items } = parsed.data;
     const db = getDrizzleDb();
 
-    // Validate entity references
-    const entityIds = [...new Set(items.map((i) => i.entityId))];
-    const missing = await checkRefsExist(db, entities, entities.id, entityIds);
-    if (missing.length > 0) {
-      return validationError(c, `Referenced entities not found: ${missing.join(", ")}`);
+    // Resolve all entity identifiers to stableIds
+    const uniqueIds = [...new Set(items.map((i) => i.entityId))];
+    const resolvedMap = new Map<string, string>();
+    const missingIds: string[] = [];
+
+    for (const id of uniqueIds) {
+      const stableId = await resolveEntityStableId(db, id);
+      if (stableId) {
+        resolvedMap.set(id, stableId);
+      } else {
+        missingIds.push(id);
+      }
     }
 
-    const allVals = items.map(summaryValues);
+    if (missingIds.length > 0) {
+      return validationError(c, `Referenced entities not found: ${missingIds.join(", ")}`);
+    }
+
+    const allVals = items.map((item) =>
+      summaryValues(item, resolvedMap.get(item.entityId)!)
+    );
 
     const results = await db
       .insert(summaries)
@@ -230,17 +243,21 @@ const summariesApp = new Hono()
 
   // ---- GET /:entityId (get by entity ID) ----
   .get("/:entityId", async (c) => {
-    const entityId = c.req.param("entityId");
+    const rawId = c.req.param("entityId");
     const db = getDrizzleDb();
+
+    // Resolve identifier (slug, stableId, or numericId) to stableId
+    const stableId = await resolveEntityStableId(db, rawId);
+    const lookupId = stableId ?? rawId;
 
     const rows = await db
       .select()
       .from(summaries)
-      .where(eq(summaries.entityId, entityId))
+      .where(eq(summaries.entityId, lookupId))
       .limit(1);
 
     if (rows.length === 0) {
-      return notFoundError(c, `Summary not found: ${entityId}`);
+      return notFoundError(c, `Summary not found: ${rawId}`);
     }
 
     return c.json(formatSummary(rows[0]));

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -343,7 +343,7 @@ export const summaries = pgTable(
   {
     entityId: text("entity_id")
       .primaryKey()
-      .references(() => entities.id, { onDelete: "cascade" }),
+      .references(() => entities.stableId, { onDelete: "cascade" }),
     entityType: text("entity_type").notNull(),
     oneLiner: text("one_liner"),
     summary: text("summary"),


### PR DESCRIPTION
## Summary

Phase 0d of the Unified things Table plan (discussion #2169): migrate the `summaries` table FK from `entities.id` (slug) to `entities.stable_id`.

This is the last active table using slug-based entity references (the other tables -- `claims`, `statements`, `entityCoverageScores` -- are all archived).

- **Migration 0085**: Converts `summaries.entity_id` values from slugs to stableIds, drops the old FK, and adds a new FK referencing `entities.stable_id`
- **Schema**: Updated `summaries.entityId` FK reference from `entities.id` to `entities.stableId`
- **Summaries route**: Replaced `checkRefsExist` with `resolveEntityStableId()` for backward-compatible entity lookup (accepts slug, stableId, or numericId)
- **Shared module**: Extracted `resolveEntityStableId()` into `entity-resolution.ts` to eliminate duplication between `facts.ts` and `summaries.ts`
- **Integrity/monitoring**: Updated SQL queries to check summaries against `entities.stable_id` instead of `entities.id`

Closes #2169

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 3127 tests pass (`pnpm test`)
- [x] Drizzle journal validation passes (migration 0085 registered)
- [ ] Verify migration runs cleanly on staging/production DB
- [ ] Verify summaries API still accepts slugs, stableIds, and numericIds as input

🤖 Generated with [Claude Code](https://claude.com/claude-code)