### PR TITLE
feat: paginate grants table and sync Coefficient Giving grants

### DIFF
--- a/apps/web/src/app/organizations/[slug]/expandable-grants-table.tsx
+++ b/apps/web/src/app/organizations/[slug]/expandable-grants-table.tsx
@@ -3,41 +3,68 @@
 import { useState } from "react";
 
 const INITIAL_DISPLAY_COUNT = 10;
+const PAGE_SIZE = 50;
 
 /**
  * A client-side wrapper that shows a limited number of children (table rows)
- * with an expand/collapse toggle button.
+ * with progressive "show more" loading.
+ *
+ * `totalCount` is the full number of grants (may exceed rendered children).
+ * `renderedCount` is how many children were actually server-rendered (capped
+ * to keep RSC payload manageable for orgs with thousands of grants).
  */
 export function ExpandableGrantsTable({
   totalCount,
+  renderedCount,
   children,
 }: {
   totalCount: number;
+  renderedCount: number;
   children: React.ReactNode[];
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [displayCount, setDisplayCount] = useState(INITIAL_DISPLAY_COUNT);
 
-  const visibleChildren = expanded
-    ? children
-    : children.slice(0, INITIAL_DISPLAY_COUNT);
-
-  const hasMore = totalCount > INITIAL_DISPLAY_COUNT;
+  const visibleChildren = children.slice(0, displayCount);
+  const canShowMore = displayCount < renderedCount;
+  const remaining = renderedCount - displayCount;
+  const truncated = totalCount > renderedCount;
 
   return (
     <>
       {visibleChildren}
-      {hasMore && (
+      {(canShowMore || displayCount > INITIAL_DISPLAY_COUNT || truncated) && (
         <tr>
           <td colSpan={4} className="py-2 text-center">
-            <button
-              type="button"
-              onClick={() => setExpanded((prev) => !prev)}
-              className="text-xs text-primary hover:underline cursor-pointer"
-            >
-              {expanded
-                ? "Show fewer"
-                : `Show all ${totalCount} grants`}
-            </button>
+            <div className="flex items-center justify-center gap-3">
+              {canShowMore && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setDisplayCount((prev) =>
+                      Math.min(prev + PAGE_SIZE, renderedCount),
+                    )
+                  }
+                  className="text-xs text-primary hover:underline cursor-pointer"
+                >
+                  Show {Math.min(PAGE_SIZE, remaining)} more
+                </button>
+              )}
+              {displayCount > INITIAL_DISPLAY_COUNT && (
+                <button
+                  type="button"
+                  onClick={() => setDisplayCount(INITIAL_DISPLAY_COUNT)}
+                  className="text-xs text-muted-foreground hover:underline cursor-pointer"
+                >
+                  Collapse
+                </button>
+              )}
+            </div>
+            <div className="text-[11px] text-muted-foreground mt-1">
+              Showing {Math.min(displayCount, renderedCount)} of {totalCount}
+              {truncated && !canShowMore
+                ? ` (top ${renderedCount} by amount)`
+                : ""}
+            </div>
           </td>
         </tr>
       )}

--- a/apps/web/src/app/organizations/[slug]/grants-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants-section.tsx
@@ -2,7 +2,9 @@
  * Grants Given / Grants Received sections for organization profile pages.
  *
  * Placed in the main content column with summary stats, expandable tables,
- * and full-width layout. Shows first 10 grants with a "Show all" toggle.
+ * and progressive loading. Only the first MAX_RENDERED_ROWS rows are
+ * serialized to the client to keep the RSC payload manageable for orgs
+ * with thousands of grants (e.g. Coefficient Giving: 2,627).
  */
 import Link from "next/link";
 import { formatCompactCurrency } from "@/lib/format-compact";
@@ -12,6 +14,9 @@ import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedGrantRecord, ReceivedGrant } from "./org-data";
 import { formatAmount, numericValue } from "./org-data";
 import { ExpandableGrantsTable } from "./expandable-grants-table";
+
+/** Cap server-rendered rows to keep RSC payload reasonable. */
+const MAX_RENDERED_ROWS = 200;
 
 /** Grants Given section — for orgs that are funders. */
 export function GrantsGivenSection({
@@ -28,7 +33,8 @@ export function GrantsGivenSection({
     0,
   );
 
-  const rows = grants.map((g) => {
+  const renderedGrants = grants.slice(0, MAX_RENDERED_ROWS);
+  const rows = renderedGrants.map((g) => {
     const verdict = getRecordVerdict("grant", String(g.key));
     return (
       <tr key={g.key} className="hover:bg-muted/20 transition-colors">
@@ -98,7 +104,10 @@ export function GrantsGivenSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            <ExpandableGrantsTable totalCount={grants.length}>
+            <ExpandableGrantsTable
+              totalCount={grants.length}
+              renderedCount={renderedGrants.length}
+            >
               {rows}
             </ExpandableGrantsTable>
           </tbody>
@@ -121,7 +130,8 @@ export function GrantsReceivedSection({
     0,
   );
 
-  const rows = grants.map((g) => {
+  const renderedGrants = grants.slice(0, MAX_RENDERED_ROWS);
+  const rows = renderedGrants.map((g) => {
     const verdict = getRecordVerdict("grant", String(g.key));
     return (
       <tr
@@ -191,7 +201,10 @@ export function GrantsReceivedSection({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            <ExpandableGrantsTable totalCount={grants.length}>
+            <ExpandableGrantsTable
+              totalCount={grants.length}
+              renderedCount={renderedGrants.length}
+            >
               {rows}
             </ExpandableGrantsTable>
           </tbody>


### PR DESCRIPTION
## Summary

- Synced 2,627 Coefficient Giving grants from CSV import pipeline to production wiki-server
- Replaced "Show all" toggle with progressive "Show 50 more" pagination for org grant tables
- Capped server-rendered rows at 200 to keep RSC payload manageable (prevents shipping ~500KB+ of hidden table rows to the client)
- Summary stats (total count, total amount) still reflect all grants; truncated view shows "top 200 by amount" label

Closes #2290

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (704 tests)
- [x] `pnpm crux validate gate --fix` passes (15/15 checks)
- [x] TypeScript compiles with no errors in modified files
- [x] Verified Coefficient Giving org page renders correctly via Playwright screenshot
- [x] Grants sync verified: 2,627 grants upserted to prod wiki-server in 6 batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive "show more" loading for grant tables. Users can now view grants in batches and load additional content on demand.
  * Enhanced display to show current vs. total grant counts.

* **Performance**
  * Optimized initial page load by limiting server-rendered grant rows, reducing payload size while maintaining full data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->