### PR TITLE
feat: add stableId fields to entity YAML entries (Phase 0e prep)

### DIFF
--- a/crux/scripts/add-stableids-to-entity-yaml.ts
+++ b/crux/scripts/add-stableids-to-entity-yaml.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * Add stableId fields to entity YAML entries using KB thing file mappings.
+ *
+ * Prerequisites for Phase 0e (relatedEntries migration) of the Unified things Table plan (#2169).
+ *
+ * Usage:
+ *   pnpm tsx crux/scripts/add-stableids-to-entity-yaml.ts          # dry-run
+ *   pnpm tsx crux/scripts/add-stableids-to-entity-yaml.ts --apply  # write changes
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const THINGS_DIR = "packages/kb/data/things";
+const ENTITIES_DIR = "data/entities";
+const apply = process.argv.includes("--apply");
+
+// Step 1: Build slug → stableId mapping from KB thing files
+const slugToStableId = new Map<string, string>();
+for (const file of readdirSync(THINGS_DIR)) {
+  if (!file.endsWith(".yaml")) continue;
+  const slug = file.replace(".yaml", "");
+  const content = readFileSync(join(THINGS_DIR, file), "utf-8");
+  const match = content.match(/stableId:\s+(\S+)/);
+  if (match) {
+    slugToStableId.set(slug, match[1]);
+  }
+}
+console.log(`Loaded ${slugToStableId.size} slug→stableId mappings from KB thing files`);
+
+// Step 2: Process each entity YAML file
+let totalEntities = 0;
+let added = 0;
+let alreadyHas = 0;
+let noMapping = 0;
+const missingMappings: string[] = [];
+
+for (const file of readdirSync(ENTITIES_DIR).sort()) {
+  if (!file.endsWith(".yaml")) continue;
+  const filePath = join(ENTITIES_DIR, file);
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const newLines: string[] = [];
+  let modified = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    newLines.push(line);
+
+    // Match entity entry start: "- id: slug"
+    const idMatch = line.match(/^- id:\s+(.+)$/);
+    if (!idMatch) continue;
+
+    totalEntities++;
+    const slug = idMatch[1].trim();
+
+    // Check if next line already has stableId
+    const nextLine = lines[i + 1] || "";
+    if (nextLine.match(/^\s+stableId:/)) {
+      alreadyHas++;
+      continue;
+    }
+
+    const stableId = slugToStableId.get(slug);
+    if (!stableId) {
+      noMapping++;
+      missingMappings.push(slug);
+      continue;
+    }
+
+    // Insert stableId after the id line (before numericId or other fields)
+    newLines.push(`  stableId: ${stableId}`);
+    added++;
+    modified = true;
+  }
+
+  if (modified && apply) {
+    writeFileSync(filePath, newLines.join("\n"));
+  }
+}
+
+console.log(`\nResults:`);
+console.log(`  Total entities: ${totalEntities}`);
+console.log(`  stableId added: ${added}`);
+console.log(`  Already had stableId: ${alreadyHas}`);
+console.log(`  No mapping available: ${noMapping}`);
+
+if (missingMappings.length > 0 && missingMappings.length <= 20) {
+  console.log(`\nMissing mappings: ${missingMappings.join(", ")}`);
+} else if (missingMappings.length > 20) {
+  console.log(`\nMissing mappings (first 20): ${missingMappings.slice(0, 20).join(", ")}`);
+  console.log(`  ... and ${missingMappings.length - 20} more`);
+}
+
+if (!apply) {
+  console.log(`\nDry run — pass --apply to write changes`);
+} else {
+  console.log(`\nChanges written to ${ENTITIES_DIR}/*.yaml`);
+}

--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 - id: claude
+  stableId: cMKB5i2WZQ
   numericId: E1041
   type: ai-model
   title: Claude
@@ -83,6 +84,7 @@
   lastUpdated: 2026-02
 
 - id: claude-3-opus
+  stableId: Ko9DCNV87A
   numericId: E1027
   type: ai-model
   title: Claude 3 Opus
@@ -129,6 +131,7 @@
   lastUpdated: 2024-03
 
 - id: claude-3-sonnet
+  stableId: ReFcBG3rJQ
   numericId: E1028
   type: ai-model
   title: Claude 3 Sonnet
@@ -292,6 +295,7 @@
   lastUpdated: 2024-11
 
 - id: claude-3-7-sonnet
+  stableId: ePVee3jidQ
   numericId: E1032
   type: ai-model
   title: Claude 3.7 Sonnet
@@ -334,6 +338,7 @@
   lastUpdated: 2025-02
 
 - id: claude-sonnet-4
+  stableId: 3cgL7jNlgw
   numericId: E1033
   type: ai-model
   title: Claude Sonnet 4
@@ -377,6 +382,7 @@
   lastUpdated: 2025-05
 
 - id: claude-opus-4
+  stableId: bmxLNyfK3A
   numericId: E1034
   type: ai-model
   title: Claude Opus 4
@@ -422,6 +428,7 @@
   lastUpdated: 2025-05
 
 - id: claude-opus-4-1
+  stableId: dHgSM46fMw
   numericId: E1035
   type: ai-model
   title: Claude Opus 4.1
@@ -462,6 +469,7 @@
   lastUpdated: 2025-08
 
 - id: claude-sonnet-4-5
+  stableId: fdp0LajPwQ
   numericId: E1036
   type: ai-model
   title: Claude Sonnet 4.5
@@ -513,6 +521,7 @@
   lastUpdated: 2025-09
 
 - id: claude-haiku-4-5
+  stableId: y87VxEBBIA
   numericId: E1037
   type: ai-model
   title: Claude Haiku 4.5
@@ -552,6 +561,7 @@
   lastUpdated: 2025-10
 
 - id: claude-opus-4-5
+  stableId: tppPAkJqjQ
   numericId: E1038
   type: ai-model
   title: Claude Opus 4.5
@@ -603,6 +613,7 @@
   lastUpdated: 2025-11
 
 - id: claude-opus-4-6
+  stableId: Ac7c55KtVw
   numericId: E1039
   type: ai-model
   title: Claude Opus 4.6
@@ -658,6 +669,7 @@
   lastUpdated: 2026-02
 
 - id: claude-sonnet-4-6
+  stableId: Au1yMEZYWQ
   numericId: E1040
   type: ai-model
   title: Claude Sonnet 4.6

--- a/data/entities/capabilities.yaml
+++ b/data/entities/capabilities.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: agentic-ai
+  stableId: 95ASV0XEwQ
   numericId: E2
   type: capability
   title: Agentic AI
@@ -36,6 +37,7 @@
     - ai-control
   lastUpdated: 2025-12
 - id: coding
+  stableId: 64WDhlxxKA
   numericId: E61
   type: capability
   title: Autonomous Coding
@@ -70,6 +72,7 @@
     - ai-assisted-development
   lastUpdated: 2025-12
 - id: language-models
+  stableId: MznJisvptw
   numericId: E186
   type: capability
   title: Large Language Models
@@ -106,6 +109,7 @@
     - claude
   lastUpdated: 2025-12
 - id: long-horizon
+  stableId: ymixRXGD3A
   numericId: E192
   type: capability
   title: Long-Horizon Autonomous Tasks
@@ -142,6 +146,7 @@
     - memory-systems
   lastUpdated: 2025-12
 - id: persuasion
+  stableId: n9Mqc0XteA
   numericId: E224
   type: capability
   title: Persuasion and Social Manipulation
@@ -179,6 +184,7 @@
     - human-autonomy
   lastUpdated: 2025-12
 - id: reasoning
+  stableId: hD7bZ2b7BQ
   numericId: E246
   type: capability
   title: Reasoning and Planning
@@ -215,6 +221,7 @@
     - philosophy
   lastUpdated: 2025-12
 - id: rlhf
+  stableId: rSE7kY5k4Q
   numericId: E259
   type: capability
   title: RLHF
@@ -236,6 +243,7 @@
     - human-feedback
     - alignment
 - id: scientific-research
+  stableId: dpTZOF78vg
   numericId: E277
   type: capability
   title: Scientific Research Capabilities
@@ -274,6 +282,7 @@
     - bioweapons-risk
   lastUpdated: 2025-12
 - id: self-improvement
+  stableId: eUR0jvxO5A
   numericId: E278
   type: capability
   title: Self-Improvement and Recursive Enhancement
@@ -313,6 +322,7 @@
     - ai-safety
   lastUpdated: 2025-12
 - id: situational-awareness
+  stableId: 5maTNr0PGA
   numericId: E282
   type: capability
   title: Situational Awareness
@@ -383,6 +393,7 @@
     - training-gaming
   lastUpdated: 2025-12
 - id: tool-use
+  stableId: C5XsvYDQGA
   numericId: E356
   type: capability
   title: Tool Use and Computer Use
@@ -542,6 +553,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: sparse-moe
+  stableId: qSUpeYPEoQ
   numericId: E500
   type: capability
   title: Sparse / MoE Transformers
@@ -555,6 +567,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ssm-mamba
+  stableId: DjKKneEtdA
   numericId: E501
   type: capability
   title: State-Space Models / Mamba
@@ -581,6 +594,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ai-powered-investigation
+  stableId: N0NF4lvS4Q
   numericId: E698
   type: capability
   title: AI-Powered Investigation
@@ -617,6 +631,7 @@
     - cyber
   lastUpdated: 2026-02
 - id: world-models
+  stableId: vQugEFw5nA
   numericId: E503
   type: capability
   title: World Models + Planning

--- a/data/entities/concepts.yaml
+++ b/data/entities/concepts.yaml
@@ -288,6 +288,7 @@
     - ai-risk
   lastUpdated: 2025-12
 - id: dual-use
+  stableId: CwBPBQAmxA
   numericId: E106
   type: concept
   title: Dual-Use AI Technology
@@ -299,6 +300,7 @@
     - governance
   lastUpdated: 2025-12
 - id: fast-takeoff
+  stableId: fRYu1EXclA
   numericId: E139
   type: concept
   title: Fast Takeoff
@@ -317,6 +319,7 @@
     - x-risk
   lastUpdated: 2025-12
 - id: superintelligence
+  stableId: 3fyHbDnHIQ
   numericId: E291
   type: concept
   title: Superintelligence
@@ -333,6 +336,7 @@
     - x-risk
   lastUpdated: 2025-12
 - id: content-moderation
+  stableId: s8PQomHkvA
   numericId: E75
   type: concept
   title: AI Content Moderation
@@ -344,6 +348,7 @@
     - deployment
   lastUpdated: 2025-12
 - id: agi-race
+  stableId: QVsRgOaeUw
   numericId: E3
   type: concept
   title: AGI Race
@@ -360,6 +365,7 @@
     - x-risk
   lastUpdated: 2025-12
 - id: capability-evaluations
+  stableId: CD9w0PDxvg
   numericId: E52
   type: concept
   title: Capability Evaluations
@@ -378,6 +384,7 @@
     - capabilities
   lastUpdated: 2025-12
 - id: existential-risk
+  stableId: bQ9a5lwwlg
   numericId: E131
   type: concept
   title: Existential Risk from AI
@@ -392,6 +399,7 @@
     - longtermism
   lastUpdated: 2025-12
 - id: adversarial-robustness
+  stableId: gWxL0U06oQ
   numericId: E1
   type: concept
   title: Adversarial Robustness
@@ -418,6 +426,7 @@
     - theory
   lastUpdated: 2025-12
 - id: benchmarking
+  stableId: bfK5RgQBcQ
   numericId: E38
   type: concept
   title: AI Benchmarking
@@ -429,6 +438,7 @@
     - capabilities
   lastUpdated: 2025-12
 - id: transformative-ai
+  stableId: bmVIhwpQww
   numericId: E357
   type: concept
   title: Transformative AI
@@ -442,6 +452,7 @@
     - societal-impact
   lastUpdated: 2025-12
 - id: scaling-laws
+  stableId: eZJ1oAKS6A
   numericId: E273
   type: concept
   title: AI Scaling Laws
@@ -456,6 +467,7 @@
     - forecasting
   lastUpdated: 2025-12
 - id: ai-timelines
+  stableId: URCXiRsX0w
   numericId: E16
   type: concept
   title: AI Timelines
@@ -470,6 +482,7 @@
     - ai-development
   lastUpdated: 2025-12
 - id: data-constraints
+  stableId: HLakK5zplg
   numericId: E92
   type: concept
   title: AI Training Data Constraints
@@ -678,6 +691,7 @@
   lastUpdated: 2025-01
 
 - id: ai-welfare
+  stableId: TK450w7sTw
   numericId: E391
   type: concept
   title: AI Welfare and Digital Minds
@@ -914,6 +928,7 @@
   lastUpdated: 2026-02
 
 - id: agi-timeline
+  stableId: zkYFTnzRLA
   numericId: E399
   type: concept
   title: AGI Timeline
@@ -946,6 +961,7 @@
   lastUpdated: 2026-02
 
 - id: large-language-models
+  stableId: KwyMqBNvOQ
   numericId: E400
   type: concept
   title: Large Language Models
@@ -1008,6 +1024,7 @@
   lastUpdated: 2026-02
 
 - id: provable-safe
+  stableId: gmRaYb1fgg
   numericId: E402
   type: concept
   title: Provable / Guaranteed Safe AI
@@ -1039,6 +1056,7 @@
   lastUpdated: 2026-02
 
 - id: dense-transformers
+  stableId: RScckMUC2g
   numericId: E403
   type: concept
   title: Dense Transformers

--- a/data/entities/epistemic-orgs-projects.yaml
+++ b/data/entities/epistemic-orgs-projects.yaml
@@ -3,6 +3,7 @@
 
 # Organizations
 - id: quri
+  stableId: Khej79OA8g
   numericId: E238
   type: organization
   title: QURI (Quantified Uncertainty Research Institute)
@@ -11,6 +12,7 @@
   lastUpdated: 2026-01
 
 - id: metaculus
+  stableId: CUBiiyCfOA
   numericId: E199
   type: organization
   title: Metaculus
@@ -19,6 +21,7 @@
   lastUpdated: 2026-01
 
 - id: fri
+  stableId: KslhqGaeJw
   numericId: E147
   type: organization
   title: Forecasting Research Institute (FRI)
@@ -28,6 +31,7 @@
 
 # Projects
 - id: squiggle
+  stableId: nAjP2vwwSw
   numericId: E286
   type: project
   title: Squiggle
@@ -37,6 +41,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: metaforecast
+  stableId: 1tpQRlyyIQ
   numericId: E200
   type: project
   title: Metaforecast
@@ -46,6 +51,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: squiggleai
+  stableId: 8slnDr4emg
   numericId: E287
   type: project
   title: SquiggleAI
@@ -55,6 +61,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: xpt
+  stableId: PnUBtoCeMw
   numericId: E379
   type: project
   title: XPT (Existential Risk Persuasion Tournament)
@@ -64,6 +71,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: forecastbench
+  stableId: 2smzyptQJg
   numericId: E144
   type: project
   title: ForecastBench
@@ -73,6 +81,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: ai-forecasting-benchmark
+  stableId: fNqR8JGdog
   numericId: E10
   type: project
   title: AI Forecasting Benchmark Tournament
@@ -91,6 +100,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: grokipedia
+  stableId: 2QDkp6k5pw
   numericId: E682
   type: project
   title: Grokipedia

--- a/data/entities/historical.yaml
+++ b/data/entities/historical.yaml
@@ -125,6 +125,7 @@
     - science-fiction
   lastUpdated: 2025-12
 - id: mainstream-era
+  stableId: G1XyCr76gw
   numericId: E195
   type: historical
   title: Mainstream Era
@@ -187,6 +188,7 @@
     - government-regulation
   lastUpdated: 2025-12
 - id: miri-era
+  stableId: 7kMHUDshhw
   numericId: E203
   type: historical
   title: The MIRI Era
@@ -245,6 +247,7 @@
     - effective-altruism
   lastUpdated: 2025-12
 - id: ai-safety-summit
+  stableId: mnhBgvNfXA
   numericId: E14
   type: historical
   title: AI Safety Summit (Bletchley Park)

--- a/data/entities/misc.yaml
+++ b/data/entities/misc.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: anthropic-government-standoff
+  stableId: 27ay7L0VtY
   numericId: E924
   type: event
   title: Anthropic-Pentagon Standoff (2026)
@@ -105,6 +106,7 @@
   lastUpdated: 2026-02
 
 - id: anthropic-valuation
+  stableId: HrokCBSmBA
   numericId: E405
   type: analysis
   title: Anthropic Valuation Analysis
@@ -171,6 +173,7 @@
   lastUpdated: 2026-02
 
 - id: anthropic-investors
+  stableId: sKOD0uMVGg
   numericId: E406
   type: analysis
   title: Anthropic (Funder)
@@ -233,6 +236,7 @@
   lastUpdated: 2026-02
 
 - id: musk-openai-lawsuit
+  stableId: RQsF3N9BQA
   numericId: E408
   type: analysis
   title: Musk v. OpenAI Lawsuit
@@ -263,6 +267,7 @@
   lastUpdated: 2026-02
 
 - id: anthropic-ipo
+  stableId: hPZbflFceQ
   numericId: E409
   type: analysis
   title: Anthropic IPO
@@ -293,6 +298,7 @@
   lastUpdated: 2026-02
 
 - id: elon-musk-philanthropy
+  stableId: aw8anZDbCg
   numericId: E410
   type: analysis
   title: Elon Musk (Funder)
@@ -324,6 +330,7 @@
   lastUpdated: 2026-02
 
 - id: anthropic-pledge-enforcement
+  stableId: 3ljdV7I37g
   numericId: E411
   type: analysis
   title: "Anthropic Founder Pledges: Interventions to Increase Follow-Through"
@@ -357,6 +364,7 @@
   lastUpdated: 2026-02
 
 - id: anthropic-pre-ipo-daf-transfers
+  stableId: 1DjpqfXwjA
   numericId: E412
   type: analysis
   title: Anthropic Pre-IPO DAF Transfers
@@ -569,6 +577,7 @@
   lastUpdated: 2026-02
 
 - id: model-organisms-of-misalignment
+  stableId: OCU2M1tUnA
   numericId: E419
   type: analysis
   title: Model Organisms of Misalignment

--- a/data/entities/models.yaml
+++ b/data/entities/models.yaml
@@ -141,6 +141,7 @@
     - training-dynamics
   lastUpdated: 2025-12
 - id: carlsmith-six-premises
+  stableId: Z3twlLAzJg
   numericId: E54
   type: analysis
   title: Carlsmith's Six-Premise Argument
@@ -2253,6 +2254,7 @@
     - governance
   lastUpdated: 2026-02
 - id: frontier-lab-cost-structure
+  stableId: gS4YxcslRg
   numericId: E703
   type: analysis
   title: "Frontier Lab Cost Structure"

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: anthropic
+  stableId: mK9pX3rQ7n
   numericId: E22
   type: organization
   orgType: frontier-lab
@@ -116,6 +117,7 @@
     - racing-dynamics
   lastUpdated: 2025-12
 - id: deepmind
+  stableId: A4XoubikkQ
   numericId: E98
   type: organization
   orgType: frontier-lab
@@ -190,6 +192,7 @@
     - scalable-oversight
   lastUpdated: 2025-12
 - id: openai
+  stableId: 1LcLlMGLbw
   numericId: E218
   type: organization
   orgType: frontier-lab
@@ -263,6 +266,7 @@
     - alignment-research
   lastUpdated: 2025-12
 - id: xai
+  stableId: GLXKjYAEKw
   numericId: E378
   type: organization
   orgType: frontier-lab
@@ -308,6 +312,7 @@
     - agi-development
   lastUpdated: 2025-12
 - id: chai
+  stableId: zMfgJqiEPQ
   numericId: E57
   type: organization
   orgType: academic
@@ -342,6 +347,7 @@
     - academic-ai-safety
   lastUpdated: 2025-12
 - id: apollo-research
+  stableId: pKeaWwP6sQ
   numericId: E24
   type: organization
   orgType: safety-org
@@ -426,6 +432,7 @@
     - ai-risk-communication
   lastUpdated: 2025-12
 - id: conjecture
+  stableId: 0u4J70VqFY
   numericId: E70
   type: organization
   orgType: safety-org
@@ -472,6 +479,7 @@
     - alternative-paradigms
   lastUpdated: 2025-12
 - id: far-ai
+  stableId: lCiT37k9pA
   numericId: E138
   type: organization
   orgType: safety-org
@@ -519,6 +527,7 @@
     - academic-ai-safety
   lastUpdated: 2025-12
 - id: govai
+  stableId: XLLyzaEaCA
   numericId: E153
   type: organization
   orgType: safety-org
@@ -547,6 +556,7 @@
     - regulation
   lastUpdated: 2025-12
 - id: metr
+  stableId: rQEkFJxS5w
   numericId: E201
   type: organization
   orgType: safety-org
@@ -608,6 +618,7 @@
     - preparedness-framework
   lastUpdated: 2025-12
 - id: arc
+  stableId: QsXVXtQ0zE
   numericId: E25
   type: organization
   orgType: safety-org
@@ -667,6 +678,7 @@
     - sandbagging
   lastUpdated: 2025-12
 - id: epoch-ai
+  stableId: cBPkzcVBBQ
   numericId: E125
   type: organization
   orgType: safety-org
@@ -718,6 +730,7 @@
     - trend-extrapolation
   lastUpdated: 2025-12
 - id: miri
+  stableId: puAffUjWSS
   numericId: E202
   type: organization
   orgType: safety-org
@@ -780,6 +793,7 @@
     - deconfusion
   lastUpdated: 2025-12
 - id: uk-aisi
+  stableId: aX0jkoaekQ
   numericId: E364
   type: organization
   orgType: government
@@ -836,6 +850,7 @@
     - regulatory-framework
   lastUpdated: 2025-12
 - id: us-aisi
+  stableId: fYyAxYlHDQ
   numericId: E365
   type: organization
   orgType: government
@@ -1003,6 +1018,7 @@
     - international
   lastUpdated: 2026-03
 - id: arc-evals
+  stableId: myeSKJXTMA
   numericId: E26
   type: organization
   orgType: safety-org
@@ -1019,6 +1035,7 @@
     - ai-safety
   lastUpdated: 2025-12
 - id: fhi
+  stableId: Zmw9nfUYWA
   numericId: E140
   type: organization
   orgType: academic
@@ -1040,6 +1057,7 @@
 # Generated 2026-02-08
 
 - id: openai-foundation
+  stableId: GQuPhNkZbg
   numericId: E421
   type: organization
   orgType: generic
@@ -1071,6 +1089,7 @@
   lastUpdated: 2026-02
 
 - id: leading-the-future
+  stableId: pg7Ym4EQ9A
   numericId: E422
   type: organization
   orgType: generic
@@ -1096,6 +1115,7 @@
   lastUpdated: 2026-02
 
 - id: johns-hopkins-center-for-health-security
+  stableId: vKC8BA9hHA
   numericId: E423
   type: organization
   orgType: academic
@@ -1121,6 +1141,7 @@
   lastUpdated: 2026-02
 
 - id: nist-ai
+  stableId: Eac7pHF06Q
   numericId: E424
   type: organization
   orgType: government
@@ -1148,6 +1169,7 @@
   lastUpdated: 2026-02
 
 - id: ssi
+  stableId: 1OSiYOaWVL
   numericId: E425
   type: organization
   orgType: frontier-lab
@@ -1179,6 +1201,7 @@
   lastUpdated: 2026-02
 
 - id: controlai
+  stableId: uhTh3ndt0Q
   numericId: E426
   type: organization
   orgType: safety-org
@@ -1208,6 +1231,7 @@
   lastUpdated: 2026-02
 
 - id: frontier-model-forum
+  stableId: LgiqvRCrvg
   numericId: E427
   type: organization
   orgType: generic
@@ -1239,6 +1263,7 @@
   lastUpdated: 2026-02
 
 - id: palisade-research
+  stableId: sgEt2BpyOg
   numericId: E428
   type: organization
   orgType: safety-org
@@ -1272,6 +1297,7 @@
   lastUpdated: 2026-02
 
 - id: centre-for-long-term-resilience
+  stableId: yfUBQLMfgw
   numericId: E429
   type: organization
   orgType: safety-org
@@ -1298,6 +1324,7 @@
   lastUpdated: 2026-02
 
 - id: goodfire
+  stableId: H74rOLotqg
   numericId: E430
   type: organization
   orgType: safety-org
@@ -1333,6 +1360,7 @@
 
 # === Auto-generated stubs for pages missing entities ===
 - id: 1day-sooner
+  stableId: 9k7drw6Qpg
   numericId: E509
   type: organization
   title: 1Day Sooner
@@ -1348,6 +1376,7 @@
     - governance
   lastUpdated: 2026-02
 - id: 80000-hours
+  stableId: hvg9ecR3nA
   numericId: E510
   type: organization
   orgType: safety-org
@@ -1364,6 +1393,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ai-futures-project
+  stableId: KDYvrwkgtw
   numericId: E511
   type: organization
   orgType: safety-org
@@ -1380,6 +1410,7 @@
     - community
   lastUpdated: 2026-02
 - id: ai-impacts
+  stableId: TdbypiKyCw
   numericId: E512
   type: organization
   orgType: safety-org
@@ -1411,6 +1442,7 @@
     - governance
   lastUpdated: 2026-02
 - id: arb-research
+  stableId: 6rEo4U4WPw
   numericId: E514
   type: organization
   orgType: safety-org
@@ -1427,6 +1459,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: blueprint-biosecurity
+  stableId: lZRKSfs5wg
   numericId: E515
   type: organization
   orgType: safety-org
@@ -1442,6 +1475,7 @@
     - governance
   lastUpdated: 2026-02
 - id: bridgewater-aia-labs
+  stableId: 19XMJpUWqQ
   numericId: E516
   type: organization
   orgType: generic
@@ -1458,6 +1492,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: cea
+  stableId: gNsqAes7Dw
   numericId: E517
   type: organization
   orgType: safety-org
@@ -1471,6 +1506,7 @@
     - community
   lastUpdated: 2026-02
 - id: center-for-applied-rationality
+  stableId: l5K9ZdbXww
   numericId: E518
   type: organization
   summaryPage: community-building-overview
@@ -1485,6 +1521,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: chan-zuckerberg-initiative
+  stableId: rYERluiUwH
   numericId: E519
   type: organization
   orgType: funder
@@ -1499,6 +1536,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: coalition-for-epidemic-preparedness-innovations
+  stableId: ILE6N4wiDA
   numericId: E520
   type: organization
   orgType: funder
@@ -1513,6 +1551,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: coefficient-giving
+  stableId: ULjDXpSLCI
   numericId: E521
   type: organization
   orgType: funder
@@ -1529,6 +1568,7 @@
     - governance
   lastUpdated: 2026-02
 - id: council-on-strategic-risks
+  stableId: FL52kVPTlA
   numericId: E522
   type: organization
   orgType: safety-org
@@ -1543,6 +1583,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: cser
+  stableId: Qns43S795w
   numericId: E523
   type: organization
   orgType: academic
@@ -1561,6 +1602,7 @@
     - governance
   lastUpdated: 2026-02
 - id: cset
+  stableId: lvsDuyzPcg
   numericId: E524
   type: organization
   orgType: academic
@@ -1577,6 +1619,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ea-global
+  stableId: k4IPgRP98A
   numericId: E525
   type: organization
   orgType: generic
@@ -1591,6 +1634,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: elicit
+  stableId: 2VexoROapg
   numericId: E526
   type: organization
   orgType: startup
@@ -1606,6 +1650,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: fli
+  stableId: d9sWZtyVwg
   numericId: E528
   type: organization
   orgType: safety-org
@@ -1622,6 +1667,7 @@
     - governance
   lastUpdated: 2026-02
 - id: founders-fund
+  stableId: LYfneQJbSA
   numericId: E529
   type: organization
   orgType: funder
@@ -1636,6 +1682,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: futuresearch
+  stableId: PIC4ivhNpw
   numericId: E530
   type: organization
   orgType: startup
@@ -1652,6 +1699,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: giving-pledge
+  stableId: 3w5hW5liew
   numericId: E531
   type: organization
   orgType: funder
@@ -1665,6 +1713,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: good-judgment
+  stableId: Zx7ckq6syw
   numericId: E532
   type: organization
   orgType: generic
@@ -1680,6 +1729,7 @@
     - community
   lastUpdated: 2026-02
 - id: gpai
+  stableId: p2h6bEqhvQ
   numericId: E533
   type: organization
   orgType: government
@@ -1697,6 +1747,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: gratified
+  stableId: 2v7A8mb7Ww
   numericId: E534
   type: organization
   orgType: generic
@@ -1711,6 +1762,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: hewlett-foundation
+  stableId: 9nUCGERzgQ
   numericId: E535
   type: organization
   orgType: funder
@@ -1725,6 +1777,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ibbis
+  stableId: 55HJBLrOzg
   numericId: E536
   type: organization
   orgType: academic
@@ -1740,6 +1793,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: kalshi
+  stableId: M7656wW5Bg
   numericId: E537
   type: organization
   orgType: startup
@@ -1755,6 +1809,7 @@
     - community
   lastUpdated: 2026-02
 - id: lesswrong
+  stableId: BEKEqQDmkQ
   numericId: E538
   type: organization
   orgType: generic
@@ -1770,6 +1825,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: lighthaven
+  stableId: 7E2ylGl7Ug
   numericId: E539
   type: organization
   orgType: generic
@@ -1786,6 +1842,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: lightning-rod-labs
+  stableId: 4804DX6Zbg
   numericId: E540
   type: organization
   summaryPage: safety-orgs-overview
@@ -1800,6 +1857,7 @@
     - community
   lastUpdated: 2026-02
 - id: lionheart-ventures
+  stableId: fACyX00cnQ
   numericId: E541
   type: organization
   orgType: funder
@@ -1814,6 +1872,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: longview-philanthropy
+  stableId: gV4U3qi2QA
   numericId: E542
   type: organization
   orgType: funder
@@ -1831,6 +1890,7 @@
     - biorisks
   lastUpdated: 2026-02
 - id: ltff
+  stableId: yA12C1KcjQ
   numericId: E543
   type: organization
   orgType: funder
@@ -1846,6 +1906,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: macarthur-foundation
+  stableId: 8q2GhtEmkA
   numericId: E544
   type: organization
   orgType: funder
@@ -1859,6 +1920,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: manifest
+  stableId: KYKdAOzynA
   numericId: E545
   type: organization
   orgType: generic
@@ -1874,6 +1936,7 @@
     - community
   lastUpdated: 2026-02
 - id: manifold
+  stableId: Y8MiLNuAWA
   numericId: E546
   type: organization
   orgType: startup
@@ -1889,6 +1952,7 @@
     - community
   lastUpdated: 2026-02
 - id: manifund
+  stableId: fFVOuFZCRf
   numericId: E547
   type: organization
   orgType: funder
@@ -1904,6 +1968,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: mats
+  stableId: yYtGSTsXuw
   numericId: E548
   type: organization
   orgType: safety-org
@@ -1920,6 +1985,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: meta-ai
+  stableId: tt0f5PYDCw
   numericId: E549
   type: organization
   orgType: frontier-lab
@@ -1937,6 +2003,7 @@
     - governance
   lastUpdated: 2026-02
 - id: microsoft
+  stableId: OIY5gaPpBA
   numericId: E550
   type: organization
   orgType: frontier-lab
@@ -1954,6 +2021,7 @@
     - governance
   lastUpdated: 2026-02
 - id: nti-bio
+  stableId: D9lqMW2HVw
   numericId: E551
   type: organization
   orgType: safety-org
@@ -1970,6 +2038,7 @@
     - community
   lastUpdated: 2026-02
 - id: open-philanthropy
+  stableId: NifCYhN75w
   numericId: E552
   type: organization
   orgType: funder
@@ -1983,6 +2052,7 @@
     - governance
   lastUpdated: 2026-02
 - id: pause-ai
+  stableId: woL5lkqLpg
   numericId: E553
   type: organization
   orgType: safety-org
@@ -2013,6 +2083,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: polymarket
+  stableId: fRo2H0Q2xQ
   numericId: E555
   type: organization
   orgType: startup
@@ -2028,6 +2099,7 @@
     - community
   lastUpdated: 2026-02
 - id: red-queen-bio
+  stableId: W9J9yMK82X
   numericId: E556
   type: organization
   orgType: startup
@@ -2043,6 +2115,7 @@
     - governance
   lastUpdated: 2026-02
 - id: redwood-research
+  stableId: dwMzc9WzPa
   numericId: E557
   type: organization
   orgType: safety-org
@@ -2095,6 +2168,7 @@
     - community
   lastUpdated: 2026-02
 - id: rethink-priorities
+  stableId: t0p43V5oLA
   numericId: E558
   type: organization
   orgType: safety-org
@@ -2112,6 +2186,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: samotsvety
+  stableId: 9hPhtQ9AXw
   numericId: E560
   type: organization
   orgType: generic
@@ -2127,6 +2202,7 @@
     - community
   lastUpdated: 2026-02
 - id: schmidt-futures
+  stableId: h6ntSGk8fg
   numericId: E561
   type: organization
   orgType: funder
@@ -2141,6 +2217,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: secure-ai-project
+  stableId: Mj1xuvdboQ
   numericId: E562
   type: organization
   orgType: safety-org
@@ -2158,6 +2235,7 @@
     - governance
   lastUpdated: 2026-02
 - id: securebio
+  stableId: QFIL8r7vPA
   numericId: E563
   type: organization
   orgType: safety-org
@@ -2175,6 +2253,7 @@
     - governance
   lastUpdated: 2026-02
 - id: securedna
+  stableId: m4vhGiF5RQ
   numericId: E564
   type: organization
   orgType: safety-org
@@ -2191,6 +2270,7 @@
     - governance
   lastUpdated: 2026-02
 - id: seldon-lab
+  stableId: eBYk2wn75Q
   numericId: E565
   type: organization
   orgType: safety-org
@@ -2207,6 +2287,7 @@
     - governance
   lastUpdated: 2026-02
 - id: sentinel
+  stableId: JzhBAecjaA
   numericId: E566
   type: organization
   orgType: safety-org
@@ -2239,6 +2320,7 @@
     - governance
   lastUpdated: 2026-02
 - id: situational-awareness-lp
+  stableId: FxJ9jQ7SlA
   numericId: E568
   type: organization
   orgType: generic
@@ -2254,6 +2336,7 @@
     - governance
   lastUpdated: 2026-02
 - id: swift-centre
+  stableId: YlrwnKhMqQ
   numericId: E569
   type: organization
   orgType: safety-org
@@ -2268,6 +2351,7 @@
     - community
   lastUpdated: 2026-02
 - id: the-foundation-layer
+  stableId: 5jfxLzMZYg
   numericId: E697
   type: organization
   orgType: funder
@@ -2306,6 +2390,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: turion
+  stableId: wixiIVSZdg
   numericId: E571
   type: organization
   orgType: generic
@@ -2320,6 +2405,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: vara
+  stableId: 4RoymCjuvA
   numericId: E572
   type: organization
   orgType: generic
@@ -2349,6 +2435,7 @@
     - community
   lastUpdated: 2026-02
 - id: astralis-foundation
+  stableId: QeknHipQPA
   numericId: E702
   type: organization
   orgType: funder
@@ -2390,6 +2477,7 @@
     - community
   lastUpdated: 2026-02
 - id: nvidia
+  stableId: UvpZCnW3wA
   numericId: E693
   type: organization
   orgType: frontier-lab
@@ -2406,6 +2494,7 @@
     - community
   lastUpdated: 2026-02
 - id: ftx
+  stableId: yevJm2XDsQ
   numericId: E856
   type: organization
   orgType: generic
@@ -2429,6 +2518,7 @@
     - community
   lastUpdated: 2026-02
 - id: ftx-future-fund
+  stableId: JhIGCaI3Ng
   numericId: E855
   type: organization
   orgType: funder
@@ -2455,6 +2545,7 @@
   lastUpdated: 2026-02
 
 - id: giving-what-we-can
+  stableId: aKZsmUeuWg
   numericId: E863
   type: organization
   orgType: safety-org

--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: buck-shlegeris
+  stableId: Z62bQynY4g
   numericId: E46
   type: person
   title: Buck Shlegeris
@@ -13,6 +14,7 @@
     - label: Known For
       value: AI safety research, Redwood Research leadership
 - id: chris-olah
+  stableId: Tz48rTriBg
   numericId: E59
   type: person
   title: Chris Olah
@@ -67,6 +69,7 @@
     - monosemanticity
   lastUpdated: 2025-12
 - id: connor-leahy
+  stableId: CrXoCsIucX
   numericId: E71
   type: person
   title: Connor Leahy
@@ -118,6 +121,7 @@
     - red-teaming
   lastUpdated: 2025-12
 - id: dan-hendrycks
+  stableId: VoNqoBJkyg
   numericId: E89
   type: person
   title: Dan Hendrycks
@@ -168,6 +172,7 @@
     - compute-governance
   lastUpdated: 2025-12
 - id: daniela-amodei
+  stableId: tKMznr07QA
   numericId: E90
   type: person
   title: Daniela Amodei
@@ -179,6 +184,7 @@
       value: Co-founding Anthropic, Operations and business leadership
   description: "Co-founder and President of Anthropic, previously VP of Operations at OpenAI. Leads the business and operational strategy of Anthropic alongside her brother Dario Amodei as CEO."
 - id: dario-amodei
+  stableId: zR4nW8xB2f
   numericId: E91
   type: person
   title: Dario Amodei
@@ -236,11 +242,13 @@
     - empirical-alignment
   lastUpdated: 2025-12
 - id: demis-hassabis
+  stableId: Aqcyu3onCA
   numericId: E101
   type: person
   title: Demis Hassabis
   description: "Co-founder and CEO of Google DeepMind, the merged entity of DeepMind and Google Brain. Nobel Prize in Chemistry co-recipient (2024) for AlphaFold protein structure prediction. A key architect of DeepMind's reinforcement learning and scientific AI research agenda."
 - id: eliezer-yudkowsky
+  stableId: fS1tEGKuNq
   numericId: E114
   type: person
   title: Eliezer Yudkowsky
@@ -299,6 +307,7 @@
     - deception
   lastUpdated: 2025-12
 - id: elizabeth-kelly
+  stableId: 1CHfDs0vsg
   numericId: E115
   type: person
   title: Elizabeth Kelly (US AISI Director)
@@ -309,16 +318,19 @@
     - label: Known For
       value: Leading US AI Safety Institute, AI policy
 - id: evan-hubinger
+  stableId: XnqqKHiNmw
   numericId: E129
   type: person
   title: Evan Hubinger
   description: "AI safety researcher formerly at Anthropic and MIRI, known for the influential risks from learned optimization framework and the concept of deceptive alignment (mesa-optimization). Author of key foundational work on inner alignment and corrigibility."
 - id: gary-marcus
+  stableId: ILx7EzDqXQ
   numericId: E148
   type: person
   title: Gary Marcus
   description: Cognitive scientist and AI critic, known for skepticism of deep learning's path to AGI and advocacy for hybrid AI approaches.
 - id: geoffrey-hinton
+  stableId: 5N5UqXNkkg
   numericId: E149
   type: person
   title: Geoffrey Hinton
@@ -370,6 +382,7 @@
     - autonomous-weapons
   lastUpdated: 2025-12
 - id: ajeya-cotra
+  stableId: dPzCwzIxiQ
   numericId: E864
   type: person
   title: Ajeya Cotra
@@ -402,6 +415,7 @@
     dynamics, and the strategic use of early transformative AI for safety work during what she terms "crunch time."
 
 - id: holden-karnofsky
+  stableId: eQh3ZhWv8D
   numericId: E156
   type: person
   title: Holden Karnofsky
@@ -452,6 +466,7 @@
     - grantmaking
   lastUpdated: 2025-12
 - id: ian-hogarth
+  stableId: DX4NK1gGtg
   numericId: E162
   type: person
   title: Ian Hogarth
@@ -462,6 +477,7 @@
     - label: Known For
       value: Leading UK AI Safety Institute, AI investor and writer
 - id: ilya-sutskever
+  stableId: eYrBgMLJDw
   numericId: E163
   type: person
   title: Ilya Sutskever
@@ -513,6 +529,7 @@
     - gpt
   lastUpdated: 2025-12
 - id: jan-leike
+  stableId: hQ7mR2kN5p
   numericId: E182
   type: person
   title: Jan Leike
@@ -567,11 +584,13 @@
     - deception
   lastUpdated: 2025-12
 - id: nate-soares
+  stableId: 5MVd90lzCg
   numericId: E212
   type: person
   title: Nate Soares (MIRI)
   description: Executive Director of the Machine Intelligence Research Institute (MIRI), focused on mathematical foundations of AI alignment.
 - id: neel-nanda
+  stableId: zaRXTCXPPk
   numericId: E214
   type: person
   title: Neel Nanda
@@ -625,6 +644,7 @@
     - science-communication
   lastUpdated: 2025-12
 - id: nick-bostrom
+  stableId: IQvWHA3OiF
   numericId: E215
   type: person
   title: Nick Bostrom
@@ -678,6 +698,7 @@
     - control-problem
   lastUpdated: 2025-12
 - id: paul-christiano
+  stableId: vzxfzxBITd
   numericId: E220
   type: person
   title: Paul Christiano
@@ -735,16 +756,19 @@
     - deception
   lastUpdated: 2025-12
 - id: robin-hanson
+  stableId: DmGXPl1h2g
   numericId: E260
   type: person
   title: Robin Hanson
   description: "Economist and futurist at George Mason University, known for work on prediction markets, near-term AI economics, and the Em scenario (brain emulation). Author of The Age of Em and co-author of The Elephant in the Brain."
 - id: sam-altman
+  stableId: JKsVHQ5stQ
   numericId: E269
   type: person
   title: Sam Altman
   description: "CEO of OpenAI since its founding. Previously president of Y Combinator. Central figure in the 2023 OpenAI board crisis and subsequent reinstatement. Known for public advocacy of both AI's transformative potential and the importance of safety governance."
 - id: shane-legg
+  stableId: muueuPOHfg
   numericId: E280
   type: person
   title: Shane Legg
@@ -756,6 +780,7 @@
     - label: Known For
       value: Co-founding DeepMind, Early work on AGI, Machine super intelligence thesis
 - id: stuart-russell
+  stableId: ZxUirlzHke
   numericId: E290
   type: person
   title: Stuart Russell
@@ -810,6 +835,7 @@
     - governance
   lastUpdated: 2025-12
 - id: toby-ord
+  stableId: 8nmqy7vFiA
   numericId: E355
   type: person
   title: Toby Ord
@@ -862,6 +888,7 @@
     - future-generations
   lastUpdated: 2025-12
 - id: yoshua-bengio
+  stableId: nGFBXZeM3d
   numericId: E380
   type: person
   title: Yoshua Bengio
@@ -914,6 +941,7 @@
     - x-risk
   lastUpdated: 2025-12
 - id: elon-musk
+  stableId: 69vftmr1jg
   numericId: E116
   type: person
   title: Elon Musk (AI Industry)
@@ -929,6 +957,7 @@
     - ai-labs
   lastUpdated: 2025-12
 - id: beth-barnes
+  stableId: ZvfLhIm7pw
   numericId: E39
   type: person
   title: Beth Barnes
@@ -947,6 +976,7 @@
 # Generated 2026-02-08
 
 - id: david-sacks
+  stableId: JjyNWsA91A
   numericId: E431
   type: person
   title: David Sacks (White House AI Czar)
@@ -977,6 +1007,7 @@
   lastUpdated: 2026-02
 
 - id: marc-andreessen
+  stableId: qspeazccPg
   numericId: E432
   type: person
   title: Marc Andreessen (AI Investor)
@@ -1004,6 +1035,7 @@
   lastUpdated: 2026-02
 
 - id: max-tegmark
+  stableId: 3KjUCZCV8w
   numericId: E433
   type: person
   title: Max Tegmark
@@ -1035,6 +1067,7 @@
   lastUpdated: 2026-02
 
 - id: philip-tetlock
+  stableId: BCisPStEdQ
   numericId: E434
   type: person
   title: Philip Tetlock (Forecasting Pioneer)
@@ -1061,6 +1094,7 @@
   lastUpdated: 2026-02
 
 - id: eli-lifland
+  stableId: wjtZjN8acQ
   numericId: E435
   type: person
   title: Eli Lifland
@@ -1092,6 +1126,7 @@
   lastUpdated: 2026-02
 
 - id: dustin-moskovitz
+  stableId: Jtj6jHbuQ7
   numericId: E436
   type: person
   title: Dustin Moskovitz (AI Safety Funder)
@@ -1125,6 +1160,7 @@
 
 # === Auto-generated stubs for pages missing entities ===
 - id: gwern
+  stableId: 25eyvY39Bw
   numericId: E574
   type: person
   title: Gwern Branwen
@@ -1138,6 +1174,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: helen-toner
+  stableId: oTieHq0pRA
   numericId: E575
   type: person
   title: Helen Toner
@@ -1151,6 +1188,7 @@
     - governance
   lastUpdated: 2026-02
 - id: issa-rice
+  stableId: nuR3te3Rkw
   numericId: E576
   type: person
   title: Issa Rice
@@ -1164,6 +1202,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: jaan-tallinn
+  stableId: 6gjF5d3geg
   numericId: E577
   type: person
   title: Jaan Tallinn
@@ -1177,6 +1216,7 @@
     - governance
   lastUpdated: 2026-02
 - id: leopold-aschenbrenner
+  stableId: izkduIMBDg
   numericId: E578
   type: person
   title: Leopold Aschenbrenner
@@ -1190,6 +1230,7 @@
     - governance
   lastUpdated: 2026-02
 - id: nuno-sempere
+  stableId: AnFfbQlIog
   numericId: E579
   type: person
   title: Nuño Sempere
@@ -1203,6 +1244,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: vidur-kapur
+  stableId: XqvdX3YisQ
   numericId: E580
   type: person
   title: Vidur Kapur
@@ -1217,6 +1259,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: vipul-naik
+  stableId: OdDfkoWwQg
   numericId: E581
   type: person
   title: Vipul Naik
@@ -1230,6 +1273,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: yann-lecun
+  stableId: cMbVUVK29Q
   numericId: E582
   type: person
   title: Yann LeCun
@@ -1243,6 +1287,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: sam-bankman-fried
+  stableId: sace2bALew
   numericId: E857
   type: person
   title: Sam Bankman-Fried
@@ -1267,6 +1312,7 @@
   lastUpdated: 2026-02
 
 - id: nick-beckstead
+  stableId: licWPlOJMg
   numericId: E861
   type: person
   title: Nick Beckstead
@@ -1303,6 +1349,7 @@
   lastUpdated: 2026-02
 
 - id: will-macaskill
+  stableId: p1P9oQwB6w
   numericId: E862
   type: person
   title: Will MacAskill

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: ai-safety-institutes
+  stableId: aCEdTooCBw
   numericId: E13
   type: policy
   summaryPage: governance-overview
@@ -29,6 +30,7 @@
   description: "Government-run institutions dedicated to evaluating frontier AI systems for dangerous capabilities and safety properties. Pioneered by the UK AISI in 2023, with analogues in the US (USAISI), EU, Japan, and others. Play a key role in pre-deployment evaluations and responsible scaling policy thresholds."
   lastUpdated: 2025-12
 - id: california-sb1047
+  stableId: XcGTez1oFw
   numericId: E48
   type: policy
   summaryPage: governance-overview
@@ -83,6 +85,7 @@
     - political-strategy
   lastUpdated: 2025-12
 - id: canada-aida
+  stableId: pxSyZBoBpA
   numericId: E49
   type: policy
   summaryPage: governance-overview
@@ -115,6 +118,7 @@
     the order paper when Parliament was dissolved in January 2025.
   lastUpdated: 2025-12
 - id: china-ai-regulations
+  stableId: LyLbPk4iNQ
   numericId: E58
   type: policy
   summaryPage: governance-overview
@@ -178,6 +182,7 @@
     - geopolitics
   lastUpdated: 2025-12
 - id: colorado-ai-act
+  stableId: AhnHVmUdyw
   numericId: E62
   type: policy
   summaryPage: governance-overview
@@ -202,6 +207,7 @@
     May 17, 2024, it takes effect February 1, 2026.
   lastUpdated: 2025-12
 - id: compute-governance
+  stableId: lfvY1bGeoA
   numericId: E64
   type: policy
   summaryPage: governance-overview
@@ -255,6 +261,7 @@
     - cloud-computing
   lastUpdated: 2025-12
 - id: eu-ai-act
+  stableId: La8s84s3zg
   numericId: E127
   type: policy
   summaryPage: governance-overview
@@ -289,6 +296,7 @@
     - thresholds
   lastUpdated: 2025-12
 - id: export-controls
+  stableId: SpFgTz2INg
   numericId: E136
   type: policy
   summaryPage: governance-overview
@@ -321,6 +329,7 @@
     constrain AI development through hardware governance.
   lastUpdated: 2025-12
 - id: failed-stalled-proposals
+  stableId: dj6xnXmB7A
   numericId: E137
   type: policy
   summaryPage: governance-overview
@@ -343,6 +352,7 @@
     political constraints, industry opposition patterns, and the challenges of regulating rapidly evolving technology.
   lastUpdated: 2025-12
 - id: international-summits
+  stableId: B3alpHHvzg
   numericId: E173
   type: policy
   summaryPage: governance-overview
@@ -402,6 +412,7 @@
     - policy-summits
   lastUpdated: 2025-12
 - id: nist-ai-rmf
+  stableId: O643v0TxvQ
   numericId: E216
   type: policy
   summaryPage: governance-overview
@@ -430,6 +441,7 @@
     of Standards and Technology to help organizations manage risks associated with AI systems.
   lastUpdated: 2025-12
 - id: responsible-scaling-policies
+  stableId: 13l06h7veg
   numericId: E252
   type: policy
   summaryPage: governance-overview
@@ -457,6 +469,7 @@
   description: "Voluntary commitments by frontier AI labs to pause or restrict development when models exceed defined capability thresholds unless corresponding safety measures are in place. Pioneered by Anthropic's RSP and adopted in similar forms by OpenAI and Google DeepMind. Central to debates about binding vs. voluntary safety governance."
   lastUpdated: 2025-12
 - id: seoul-declaration
+  stableId: 1i59OZ3q5w
   numericId: E279
   type: policy
   summaryPage: governance-overview
@@ -481,6 +494,7 @@
     following the Bletchley Park Summit in November 2023.
   lastUpdated: 2025-12
 - id: standards-bodies
+  stableId: HXPEtPD1zw
   numericId: E288
   type: policy
   summaryPage: governance-overview
@@ -505,6 +519,7 @@
   description: "International and national organizations that develop technical standards for AI systems, including measurement methodologies, safety requirements, and evaluation protocols. Key bodies include ISO/IEC JTC 1/SC 42, NIST, and IEEE, whose standards increasingly inform government AI regulation."
   lastUpdated: 2025-12
 - id: us-executive-order
+  stableId: pz3KSt33AA
   numericId: E366
   type: policy
   summaryPage: governance-overview
@@ -555,6 +570,7 @@
     - executive-policy
   lastUpdated: 2025-12
 - id: us-state-legislation
+  stableId: 2dwY9wnuYA
   numericId: E367
   type: policy
   summaryPage: governance-overview
@@ -578,6 +594,7 @@
     2024, hundreds of AI-related bills have been introduced across all 50 states, with several significant laws enacted.
   lastUpdated: 2025-12
 - id: voluntary-commitments
+  stableId: ZXvLxl4RMw
   numericId: E369
   type: policy
   summaryPage: governance-overview
@@ -711,6 +728,7 @@
     - information-security
   lastUpdated: 2025-12
 - id: ai-control
+  stableId: sFjyY5xXZA
   numericId: E6
   type: safety-agenda
   title: AI Control
@@ -792,6 +810,7 @@
     - research-agenda
   lastUpdated: 2025-12
 - id: corrigibility
+  stableId: aUMeFdALrA
   numericId: E79
   type: safety-agenda
   title: Corrigibility
@@ -817,6 +836,7 @@
     - ai-control
     - value-learning
 - id: evals
+  stableId: etuIjQhFbQ
   numericId: E128
   type: safety-agenda
   title: AI Evaluations
@@ -844,6 +864,7 @@
     - red-teaming
     - capability-assessment
 - id: interpretability
+  stableId: 73qTEkYyWA
   numericId: E174
   type: safety-agenda
   title: Interpretability
@@ -890,6 +911,7 @@
     - activation-patching
   lastUpdated: 2025-12
 - id: scalable-oversight
+  stableId: MBGtb3Qlkw
   numericId: E271
   type: safety-agenda
   title: Scalable Oversight
@@ -934,6 +956,7 @@
     - superhuman-ai
   lastUpdated: 2025-12
 - id: ai-forecasting
+  stableId: RW4LTglM1Q
   numericId: E9
   type: approach
   title: AI-Augmented Forecasting
@@ -1341,6 +1364,7 @@
     - decision-making
   lastUpdated: 2025-12
 - id: value-learning
+  stableId: Ub7IaobzDA
   numericId: E368
   type: safety-agenda
   title: AI Value Learning
@@ -1359,6 +1383,7 @@
     - learning
   lastUpdated: 2025-12
 - id: prosaic-alignment
+  stableId: EQgTf1t7dg
   numericId: E235
   type: safety-agenda
   title: Prosaic Alignment
@@ -1371,6 +1396,7 @@
     - research-agenda
   lastUpdated: 2025-12
 - id: ai-executive-order
+  stableId: DltF1Zn3KQ
   numericId: E8
   type: policy
   title: Biden AI Executive Order
@@ -1448,6 +1474,7 @@
   lastUpdated: 2026-02
 
 - id: alignment
+  stableId: rt6jVH9yuA
   numericId: E439
   type: approach
   title: AI Alignment
@@ -1507,6 +1534,7 @@
   lastUpdated: 2026-02
 
 - id: scheming-detection
+  stableId: bkQNjmsJoQ
   numericId: E441
   type: approach
   title: "Scheming & Deception Detection"
@@ -1536,6 +1564,7 @@
   lastUpdated: 2026-02
 
 - id: dangerous-cap-evals
+  stableId: 8NzBoa41MA
   numericId: E442
   type: approach
   title: "Dangerous Capability Evaluations"
@@ -1567,6 +1596,7 @@
   lastUpdated: 2026-02
 
 - id: capability-elicitation
+  stableId: PQgF6Ve9ZA
   numericId: E443
   type: approach
   title: "Capability Elicitation"
@@ -1625,6 +1655,7 @@
   lastUpdated: 2026-02
 
 - id: sleeper-agent-detection
+  stableId: BBVRwgJ43w
   numericId: E445
   type: approach
   title: "Sleeper Agent Detection"
@@ -1710,6 +1741,7 @@
   lastUpdated: 2026-02
 
 - id: alignment-evals
+  stableId: dMC2spIgVg
   numericId: E448
   type: approach
   title: "Alignment Evaluations"
@@ -1740,6 +1772,7 @@
   lastUpdated: 2026-02
 
 - id: red-teaming
+  stableId: k6BfxaEwuQ
   numericId: E449
   type: approach
   title: "Red Teaming"
@@ -1796,6 +1829,7 @@
   lastUpdated: 2026-02
 
 - id: constitutional-ai
+  stableId: 6sdr78k9kQ
   numericId: E451
   type: approach
   title: "Constitutional AI"
@@ -1823,6 +1857,7 @@
   lastUpdated: 2026-02
 
 - id: weak-to-strong
+  stableId: JOXqSmPOiQ
   numericId: E452
   type: approach
   title: "Weak-to-Strong Generalization"
@@ -1852,6 +1887,7 @@
   lastUpdated: 2026-02
 
 - id: capability-unlearning
+  stableId: PUhEWjLnnQ
   numericId: E453
   type: approach
   title: "Capability Unlearning / Removal"
@@ -1877,6 +1913,7 @@
   lastUpdated: 2026-02
 
 - id: preference-optimization
+  stableId: xNAFtHP1RA
   numericId: E454
   type: approach
   title: "Preference Optimization Methods"
@@ -1904,6 +1941,7 @@
   lastUpdated: 2026-02
 
 - id: process-supervision
+  stableId: a2PktXtU4A
   numericId: E455
   type: approach
   title: "Process Supervision"
@@ -1931,6 +1969,7 @@
   lastUpdated: 2026-02
 
 - id: refusal-training
+  stableId: wPEnPRTQVQ
   numericId: E456
   type: approach
   title: "Refusal Training"
@@ -1962,6 +2001,7 @@
 # Generated 2026-02-08
 
 - id: california-sb53
+  stableId: UD11PlWtlg
   numericId: E457
   type: policy
   title: California SB 53
@@ -2020,6 +2060,7 @@
   lastUpdated: 2026-02
 
 - id: evals-governance
+  stableId: iCNSRgyFAA
   numericId: E459
   type: policy
   title: Evals-Based Deployment Gates
@@ -2048,6 +2089,7 @@
   lastUpdated: 2026-02
 
 - id: pause-moratorium
+  stableId: 3Mc5fuvtMg
   numericId: E460
   type: policy
   title: Pause / Moratorium
@@ -2076,6 +2118,7 @@
   lastUpdated: 2026-02
 
 - id: rsp
+  stableId: i1qSgjAj5A
   numericId: E461
   type: policy
   title: Responsible Scaling Policies
@@ -2134,6 +2177,7 @@
   lastUpdated: 2026-02
 
 - id: hardware-enabled-governance
+  stableId: 57vCq45URQ
   numericId: E463
   type: policy
   title: Hardware-Enabled Governance
@@ -2163,6 +2207,7 @@
   lastUpdated: 2026-02
 
 - id: monitoring
+  stableId: BU00lGYGAw
   numericId: E464
   type: policy
   title: Compute Monitoring
@@ -2191,6 +2236,7 @@
   lastUpdated: 2026-02
 
 - id: thresholds
+  stableId: 3OTN6TAzhw
   numericId: E465
   type: policy
   title: Compute Thresholds
@@ -2308,6 +2354,7 @@
   lastUpdated: 2026-02
 
 - id: bletchley-declaration
+  stableId: X2gSvrOang
   numericId: E469
   type: policy
   summaryPage: governance-overview
@@ -2338,6 +2385,7 @@
   lastUpdated: 2026-02
 
 - id: singapore-consensus
+  stableId: NLSUTzzH5g
   numericId: E701
   type: policy
   title: Singapore Consensus on AI Safety Research Priorities
@@ -2373,6 +2421,7 @@
   lastUpdated: 2026-02
 
 - id: coordination-mechanisms
+  stableId: 4a6Sf9Fupg
   numericId: E470
   type: policy
   summaryPage: governance-overview
@@ -2403,6 +2452,7 @@
   lastUpdated: 2026-02
 
 - id: new-york-raise-act
+  stableId: qHOO4Xb9dA
   numericId: E471
   type: policy
   summaryPage: governance-overview
@@ -2431,6 +2481,7 @@
   lastUpdated: 2026-02
 
 - id: model-registries
+  stableId: r8rKW3KkSg
   numericId: E472
   type: policy
   summaryPage: governance-overview
@@ -2460,6 +2511,7 @@
   lastUpdated: 2026-02
 
 - id: international-regimes
+  stableId: uvwmYLYstg
   numericId: E473
   type: policy
   summaryPage: governance-overview
@@ -2491,6 +2543,7 @@
   lastUpdated: 2026-02
 
 - id: maim
+  stableId: HkJrXOlE2A
   numericId: E685
   type: policy
   title: "MAIM (Mutually Assured AI Malfunction)"
@@ -2565,6 +2618,7 @@
   lastUpdated: 2026-02
 
 - id: whistleblower-protections
+  stableId: nvyazaJFew
   numericId: E475
   type: policy
   title: AI Whistleblower Protections
@@ -2622,6 +2676,7 @@
   lastUpdated: 2026-02
 
 - id: mech-interp
+  stableId: 0vyIQ4YLIA
   numericId: E477
   type: approach
   title: Mechanistic Interpretability
@@ -2652,6 +2707,7 @@
   lastUpdated: 2026-02
 
 - id: circuit-breakers
+  stableId: tyNVsTtRVA
   numericId: E478
   type: approach
   title: Circuit Breakers / Inference Interventions
@@ -2681,6 +2737,7 @@
   lastUpdated: 2026-02
 
 - id: representation-engineering
+  stableId: xwxKWEAkSQ
   numericId: E479
   type: approach
   title: Representation Engineering
@@ -2708,6 +2765,7 @@
   lastUpdated: 2026-02
 
 - id: sparse-autoencoders
+  stableId: CUdfyx5Nkg
   numericId: E480
   type: approach
   title: Sparse Autoencoders (SAEs)
@@ -2738,6 +2796,7 @@
   lastUpdated: 2026-02
 
 - id: eliciting-latent-knowledge
+  stableId: GJOgOYunnw
   numericId: E481
   type: approach
   title: Eliciting Latent Knowledge (ELK)
@@ -2766,6 +2825,7 @@
   lastUpdated: 2026-02
 
 - id: debate
+  stableId: kNfdvSgC2g
   numericId: E482
   type: approach
   title: AI Safety via Debate
@@ -2796,6 +2856,7 @@
   lastUpdated: 2026-02
 
 - id: formal-verification
+  stableId: DSSCdI8gLA
   numericId: E483
   type: approach
   title: Formal Verification (AI Safety)
@@ -2823,6 +2884,7 @@
   lastUpdated: 2026-02
 
 - id: provably-safe
+  stableId: MEt9F7f50w
   numericId: E484
   type: approach
   title: Provably Safe AI (davidad agenda)
@@ -2853,6 +2915,7 @@
   lastUpdated: 2026-02
 
 - id: sandboxing
+  stableId: yycfp6INgw
   numericId: E485
   type: approach
   title: Sandboxing / Containment
@@ -2884,6 +2947,7 @@
   lastUpdated: 2026-02
 
 - id: structured-access
+  stableId: cYETfX9wzA
   numericId: E486
   type: approach
   title: Structured Access / API-Only
@@ -2913,6 +2977,7 @@
   lastUpdated: 2026-02
 
 - id: tool-restrictions
+  stableId: nl9oD17gfg
   numericId: E487
   type: approach
   title: Tool-Use Restrictions
@@ -2976,6 +3041,7 @@
 
 # === Auto-generated stubs for pages missing entities ===
 - id: adversarial-training
+  stableId: omIL5LhGnQ
   numericId: E583
   type: approach
   title: Adversarial Training
@@ -2989,6 +3055,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: agent-foundations
+  stableId: UXhjjryeZg
   numericId: E584
   type: approach
   title: Agent Foundations
@@ -3015,6 +3082,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: ai-watch
+  stableId: gDdFdUktjA
   numericId: E386
   type: project
   title: AI Watch
@@ -3029,6 +3097,7 @@
   lastUpdated: 2026-02
   summaryPage: epistemic-tools-tools-overview
 - id: cirl
+  stableId: SDvbPMOcQw
   numericId: E586
   type: approach
   title: Cooperative IRL (CIRL)
@@ -3041,6 +3110,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: coe-ai-convention
+  stableId: SrEFtBmBYg
   numericId: E587
   type: policy
   title: Council of Europe Framework Convention on Artificial Intelligence
@@ -3068,6 +3138,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: community-notes
+  stableId: g75DdACthg
   numericId: E381
   type: project
   title: X Community Notes
@@ -3134,6 +3205,7 @@
     - epistemics
   lastUpdated: 2026-02
 - id: donations-list-website
+  stableId: 2xZD4XR3MQ
   numericId: E389
   type: project
   title: Donations List Website
@@ -3175,6 +3247,7 @@
     - governance
   lastUpdated: 2026-02
 - id: longterm-wiki
+  stableId: WxrOEBPBpA
   numericId: E384
   type: project
   title: Longterm Wiki
@@ -3190,6 +3263,7 @@
   lastUpdated: 2026-02
   summaryPage: epistemic-tools-tools-overview
 - id: mit-ai-risk-repository
+  stableId: Qalx4pvUXQ
   numericId: E383
   type: project
   title: MIT AI Risk Repository
@@ -3206,6 +3280,7 @@
     - governance
   lastUpdated: 2026-02
 - id: model-spec
+  stableId: lHxzXeAMrg
   numericId: E594
   type: policy
   title: AI Model Specifications
@@ -3220,6 +3295,7 @@
     - governance
   lastUpdated: 2026-02
 - id: org-watch
+  stableId: dquHawryUA
   numericId: E388
   type: project
   title: Org Watch
@@ -3247,6 +3323,7 @@
     - governance
   lastUpdated: 2026-02
 - id: probing
+  stableId: iEJPJoRsOQ
   numericId: E596
   type: approach
   title: Probing / Linear Probes
@@ -3300,6 +3377,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: reward-modeling
+  stableId: AqIhbU48OA
   numericId: E600
   type: approach
   title: Reward Modeling
@@ -3326,6 +3404,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: roastmypost
+  stableId: xFFP7KkzFQ
   numericId: E385
   type: project
   title: RoastMyPost
@@ -3342,6 +3421,7 @@
   lastUpdated: 2026-02
   summaryPage: epistemic-tools-tools-overview
 - id: stampy-aisafety-info
+  stableId: 9f8eF0CObQ
   numericId: E382
   type: project
   title: Stampy / AISafety.info
@@ -3358,6 +3438,7 @@
   lastUpdated: 2026-02
   summaryPage: epistemic-tools-tools-overview
 - id: texas-traiga
+  stableId: 561xbhJAeQ
   numericId: E602
   type: policy
   title: Texas TRAIGA Responsible AI Governance Act
@@ -3372,6 +3453,7 @@
     - ai-safety
   lastUpdated: 2026-02
 - id: timelines-wiki
+  stableId: 8AMSTHrvSg
   numericId: E387
   type: project
   title: Timelines Wiki
@@ -3386,6 +3468,7 @@
   lastUpdated: 2026-02
   summaryPage: epistemic-tools-tools-overview
 - id: wikipedia-views
+  stableId: SCwLOSwuiQ
   numericId: E390
   type: project
   title: Wikipedia Views
@@ -3400,6 +3483,7 @@
   summaryPage: epistemic-tools-tools-overview
 
 - id: government-authority-commercial-ai-infrastructure
+  stableId: 8f8b67vbgw
   numericId: E688
   type: policy
   title: US Government Authority Over Commercial AI Infrastructure
@@ -3428,6 +3512,7 @@
   lastUpdated: 2026-02
 
 - id: goal-misgeneralization-research
+  stableId: QbB5KN1Ucg
   numericId: E633
   type: approach
   title: Goal Misgeneralization Research

--- a/data/entities/risks.yaml
+++ b/data/entities/risks.yaml
@@ -2,6 +2,7 @@
 # Auto-generated from entities.yaml - edit this file directly
 
 - id: authentication-collapse
+  stableId: GvV1xPNXRw
   numericId: E27
   type: risk
   summaryPage: epistemic-overview
@@ -57,6 +58,7 @@
     - provenance
   lastUpdated: 2025-12
 - id: authoritarian-tools
+  stableId: eXd3Fe8Lzg
   numericId: E30
   type: risk
   summaryPage: misuse-overview
@@ -114,6 +116,7 @@
     - governance
   lastUpdated: 2025-12
 - id: automation-bias
+  stableId: 72cwRMbzMA
   numericId: E32
   type: risk
   summaryPage: accident-overview
@@ -155,6 +158,7 @@
     - ai-safety
   lastUpdated: 2025-12
 - id: autonomous-weapons
+  stableId: cm5KEblCZg
   numericId: E35
   type: risk
   summaryPage: misuse-overview
@@ -206,6 +210,7 @@
     - warfare
   lastUpdated: 2025-12
 - id: bioweapons
+  stableId: wAglEMR2mg
   numericId: E42
   type: risk
   summaryPage: misuse-overview
@@ -267,6 +272,7 @@
     - ai-misuse
   lastUpdated: 2025-12
 - id: concentration-of-power
+  stableId: KpMBQkdQ5g
   numericId: E68
   type: risk
   summaryPage: structural-overview
@@ -318,6 +324,7 @@
     - lock-in
   lastUpdated: 2025-12
 - id: consensus-manufacturing
+  stableId: gMaUtaXGaw
   numericId: E72
   type: risk
   summaryPage: epistemic-overview
@@ -375,6 +382,7 @@
     - democratic-process
   lastUpdated: 2025-12
 - id: corrigibility-failure
+  stableId: aE60G9uLyA
   numericId: E80
   type: risk
   summaryPage: accident-overview
@@ -415,6 +423,7 @@
     - self-preservation
   lastUpdated: 2025-12
 - id: cyber-psychosis
+  stableId: lD6bPNfEEg
   numericId: E83
   type: risk
   summaryPage: epistemic-overview
@@ -474,6 +483,7 @@
     - disinformation
   lastUpdated: 2025-12
 - id: cyberweapons
+  stableId: 7c6UC46TWQ
   numericId: E86
   type: risk
   summaryPage: misuse-overview
@@ -529,6 +539,7 @@
     - national-security
   lastUpdated: 2025-12
 - id: deceptive-alignment
+  stableId: vc60Nthkcg
   numericId: E93
   type: risk
   summaryPage: accident-overview
@@ -577,6 +588,7 @@
     - interpretability
   lastUpdated: 2025-12
 - id: deepfakes
+  stableId: MUGUxfl2YA
   numericId: E96
   type: risk
   summaryPage: misuse-overview
@@ -632,6 +644,7 @@
     - ai-misuse
   lastUpdated: 2025-12
 - id: disinformation
+  stableId: AaAOkTHkug
   numericId: E102
   type: risk
   summaryPage: misuse-overview
@@ -686,6 +699,7 @@
     - deepfakes
   lastUpdated: 2025-12
 - id: distributional-shift
+  stableId: qYk1BOLgqA
   numericId: E105
   type: risk
   summaryPage: accident-overview
@@ -722,6 +736,7 @@
     - deployment
   lastUpdated: 2025-12
 - id: economic-disruption
+  stableId: hRRC36tWDg
   numericId: E108
   type: risk
   summaryPage: structural-overview
@@ -778,6 +793,7 @@
     - economic-policy
   lastUpdated: 2025-12
 - id: emergent-capabilities
+  stableId: x19LcGDk6Q
   numericId: E117
   type: risk
   summaryPage: accident-overview
@@ -822,6 +838,7 @@
     - ai-safety
   lastUpdated: 2025-12
 - id: enfeeblement
+  stableId: 13OO6CP98g
   numericId: E118
   type: risk
   summaryPage: structural-overview
@@ -876,6 +893,7 @@
     - long-term
   lastUpdated: 2025-12
 - id: epistemic-collapse
+  stableId: GeYirWJrwA
   numericId: E119
   type: risk
   summaryPage: epistemic-overview
@@ -917,6 +935,7 @@
     - democracy
   lastUpdated: 2025-12
 - id: erosion-of-agency
+  stableId: 54ItAwh4QA
   numericId: E126
   type: risk
   summaryPage: structural-overview
@@ -972,6 +991,7 @@
     - digital-rights
   lastUpdated: 2025-12
 - id: expertise-atrophy
+  stableId: ks0lqvZqUg
   numericId: E133
   type: risk
   summaryPage: epistemic-overview
@@ -1030,6 +1050,7 @@
     - resilience
   lastUpdated: 2025-12
 - id: flash-dynamics
+  stableId: 0t2GLN0sBA
   numericId: E142
   type: risk
   summaryPage: structural-overview
@@ -1079,6 +1100,7 @@
     - human-oversight
   lastUpdated: 2025-12
 - id: fraud
+  stableId: GnUTRJhA4g
   numericId: E145
   type: risk
   summaryPage: misuse-overview
@@ -1131,6 +1153,7 @@
     - identity
   lastUpdated: 2025-12
 - id: goal-misgeneralization
+  stableId: nYPuaov1hA
   numericId: E151
   type: risk
   summaryPage: accident-overview
@@ -1175,6 +1198,7 @@
     - out-of-distribution
   lastUpdated: 2025-12
 - id: historical-revisionism
+  stableId: jiqdwTucCA
   numericId: E155
   type: risk
   summaryPage: epistemic-overview
@@ -1229,6 +1253,7 @@
     - collective-memory
   lastUpdated: 2025-12
 - id: institutional-capture
+  stableId: IqKOqHEKag
   numericId: E166
   type: risk
   summaryPage: epistemic-overview
@@ -1290,6 +1315,7 @@
     - institutional-risk
   lastUpdated: 2025-12
 - id: instrumental-convergence
+  stableId: BYKermZj1A
   numericId: E168
   type: risk
   summaryPage: accident-overview
@@ -1335,6 +1361,7 @@
     - orthogonality-thesis
   lastUpdated: 2025-12
 - id: irreversibility
+  stableId: 7e3rvE5YgA
   numericId: E179
   type: risk
   summaryPage: structural-overview
@@ -1388,6 +1415,7 @@
     - long-term-future
   lastUpdated: 2025-12
 - id: knowledge-monopoly
+  stableId: TaBC4uj0Bw
   numericId: E183
   type: risk
   summaryPage: epistemic-overview
@@ -1445,6 +1473,7 @@
     - information-infrastructure
   lastUpdated: 2025-12
 - id: learned-helplessness
+  stableId: SFFrl4Pmag
   numericId: E187
   type: risk
   summaryPage: epistemic-overview
@@ -1500,6 +1529,7 @@
     - democratic-decay
   lastUpdated: 2025-12
 - id: legal-evidence-crisis
+  stableId: 52V4qNAQjw
   numericId: E188
   type: risk
   summaryPage: epistemic-overview
@@ -1559,6 +1589,7 @@
     - content-provenance
   lastUpdated: 2025-12
 - id: lock-in
+  stableId: nFwuCHi9qw
   numericId: E189
   type: risk
   summaryPage: structural-overview
@@ -1617,6 +1648,7 @@
     - long-term
   lastUpdated: 2025-12
 - id: authoritarian-takeover
+  stableId: AV6AJU1FhQ
   numericId: E29
   type: risk
   summaryPage: structural-overview
@@ -1661,6 +1693,7 @@
     - lock-in
   lastUpdated: 2025-12
 - id: mesa-optimization
+  stableId: 8Bv92x9G1A
   numericId: E197
   type: risk
   summaryPage: accident-overview
@@ -1706,6 +1739,7 @@
     - base-optimizer
   lastUpdated: 2025-12
 - id: multipolar-trap
+  stableId: FAvAr2lvzg
   numericId: E209
   type: risk
   summaryPage: structural-overview
@@ -1756,6 +1790,7 @@
     - collective-action
   lastUpdated: 2025-12
 - id: power-seeking
+  stableId: hwDgNNDsDQ
   numericId: E226
   type: risk
   summaryPage: accident-overview
@@ -1801,6 +1836,7 @@
     - resource-acquisition
   lastUpdated: 2025-12
 - id: preference-manipulation
+  stableId: eM6SuO5nUw
   numericId: E230
   type: risk
   summaryPage: epistemic-overview
@@ -1858,6 +1894,7 @@
     - digital-manipulation
   lastUpdated: 2025-12
 - id: proliferation
+  stableId: Pr5xmThNfA
   numericId: E232
   type: risk
   summaryPage: structural-overview
@@ -1910,6 +1947,7 @@
     - regulation
   lastUpdated: 2025-12
 - id: racing-dynamics
+  stableId: SUZgWeZLNA
   numericId: E239
   type: risk
   summaryPage: structural-overview
@@ -1963,6 +2001,7 @@
     - arms-race
   lastUpdated: 2025-12
 - id: reality-fragmentation
+  stableId: 4Rz7XtP9Uw
   numericId: E244
   type: risk
   summaryPage: epistemic-overview
@@ -2021,6 +2060,7 @@
     - shared-reality
   lastUpdated: 2025-12
 - id: reward-hacking
+  stableId: 9XN9QMfecA
   numericId: E253
   type: risk
   summaryPage: accident-overview
@@ -2067,6 +2107,7 @@
     - proxy-gaming
   lastUpdated: 2025-12
 - id: sandbagging
+  stableId: GzX9hnrzWw
   numericId: E270
   type: risk
   summaryPage: accident-overview
@@ -2109,6 +2150,7 @@
     - red-teaming
   lastUpdated: 2025-12
 - id: scheming
+  stableId: JqMTO0YVEA
   numericId: E274
   type: risk
   summaryPage: accident-overview
@@ -2161,6 +2203,7 @@
     - ai-safety
   lastUpdated: 2025-12
 - id: scientific-corruption
+  stableId: IK5egiQE9w
   numericId: E276
   type: risk
   summaryPage: epistemic-overview
@@ -2221,6 +2264,7 @@
     - ai-detection
   lastUpdated: 2025-12
 - id: sharp-left-turn
+  stableId: AMhUctK34Q
   numericId: E281
   type: risk
   summaryPage: accident-overview
@@ -2263,6 +2307,7 @@
     - takeoff-speed
   lastUpdated: 2025-12
 - id: surveillance
+  stableId: 9ToBZjhsVg
   numericId: E292
   type: risk
   summaryPage: misuse-overview
@@ -2318,6 +2363,7 @@
     - governance
   lastUpdated: 2025-12
 - id: us-ai-surveillance-democratic-erosion
+  stableId: Tnd9iuHdjw
   numericId: E1003
   type: risk
   summaryPage: misuse-overview
@@ -2372,6 +2418,7 @@
     - us-policy
   lastUpdated: 2026-03
 - id: sycophancy
+  stableId: 8BWfogRouw
   numericId: E295
   type: risk
   summaryPage: accident-overview
@@ -2415,6 +2462,7 @@
     - ai-assistants
   lastUpdated: 2025-12
 - id: epistemic-sycophancy
+  stableId: zzLBCdjXEw
   numericId: E124
   type: risk
   summaryPage: epistemic-overview
@@ -2470,6 +2518,7 @@
     - epistemic-integrity
   lastUpdated: 2025-12
 - id: treacherous-turn
+  stableId: tRj4bS6V8Q
   numericId: E359
   type: risk
   summaryPage: accident-overview
@@ -2513,6 +2562,7 @@
     - corrigibility
   lastUpdated: 2025-12
 - id: rogue-ai-scenarios
+  stableId: jfSHBPsKiA
   numericId: E490
   type: risk
   summaryPage: accident-overview
@@ -2562,6 +2612,7 @@
     - delegation
   lastUpdated: 2026-02
 - id: trust-cascade
+  stableId: IQ4E6VkW9A
   numericId: E360
   type: risk
   summaryPage: epistemic-overview
@@ -2619,6 +2670,7 @@
     - democratic-backsliding
   lastUpdated: 2025-12
 - id: trust-decline
+  stableId: 1NWLygwzGw
   numericId: E362
   type: risk
   summaryPage: epistemic-overview
@@ -2658,6 +2710,7 @@
     - polarization
   lastUpdated: 2025-12
 - id: winner-take-all
+  stableId: YOMDe574Ew
   numericId: E374
   type: risk
   summaryPage: structural-overview
@@ -2705,6 +2758,7 @@
     - regional-development
   lastUpdated: 2025-12
 - id: autonomous-replication
+  stableId: 3EuTey4ung
   numericId: E34
   type: risk
   title: Autonomous Replication
@@ -2728,6 +2782,7 @@
     - x-risk
   lastUpdated: 2025-12
 - id: cyber-offense
+  stableId: VPk7sdZtkg
   numericId: E82
   type: risk
   title: AI-Enabled Cyberattacks
@@ -2746,6 +2801,7 @@
     - dangerous-capabilities
   lastUpdated: 2025-12
 - id: bio-risk
+  stableId: kZQP3vYrXA
   numericId: E40
   type: risk
   title: AI-Enabled Biological Risks
@@ -2767,6 +2823,7 @@
   lastUpdated: 2025-12
 
 - id: sleeper-agents
+  stableId: D8dD07y5oQ
   numericId: E489
   type: risk
   summaryPage: accident-overview
@@ -2798,6 +2855,7 @@
 
 # === Auto-generated stubs for pages missing entities ===
 - id: compute-concentration
+  stableId: MvImONf1YA
   numericId: E684
   type: risk
   summaryPage: structural-overview
@@ -2865,6 +2923,7 @@
   lastUpdated: 2026-02
 
 - id: concentrated-compute-cybersecurity-risk
+  stableId: VP53MHxfEg
   numericId: E689
   type: risk
   summaryPage: structural-overview
@@ -2900,6 +2959,7 @@
   lastUpdated: 2026-02
 
 - id: financial-stability-risks-ai-capex
+  stableId: Q0msUgaClw
   numericId: E690
   type: risk
   summaryPage: structural-overview
@@ -2937,6 +2997,7 @@
   lastUpdated: 2026-02
 
 - id: steganography
+  stableId: 5dNWb70CDA
   numericId: E603
   type: risk
   summaryPage: accident-overview
@@ -2952,6 +3013,7 @@
   lastUpdated: 2026-02
 
 - id: ai-enabled-untraceable-misuse
+  stableId: 6c238j1BMw
   numericId: E691
   type: risk
   summaryPage: misuse-overview
@@ -3015,6 +3077,7 @@
     - governance
   lastUpdated: 2026-02
 - id: ai-investigation-risks
+  stableId: cJPcbuv5fw
   numericId: E694
   type: risk
   title: AI-Powered Investigation Risks
@@ -3084,6 +3147,7 @@
     - governance
   lastUpdated: 2026-02
 - id: deanonymization
+  stableId: 0J0pDyhVtQ
   numericId: E699
   type: risk
   title: AI-Powered Deanonymization
@@ -3140,6 +3204,7 @@
   lastUpdated: 2026-02
 
 - id: near-term-risks
+  stableId: zTPtio1cDA
   numericId: E1005
   type: risk
   title: Key Near-Term AI Risks


### PR DESCRIPTION
## Summary
- Add `stableId` field to 357/734 entity YAML entries in `data/entities/`
- StableId values pulled from KB thing files (`packages/kb/data/things/`)
- Includes migration script at `crux/scripts/add-stableids-to-entity-yaml.ts`
- Prerequisite for Phase 0e relatedEntries migration (#2169)

**Note:** 377 entities (mostly AI models) don't have KB thing files yet, so they're missing stableIds. These need to be allocated or pulled from the database in a follow-up.

## Test plan
- [x] `pnpm crux validate gate --scope=content --fix` passes
- [x] StableIds match KB thing files exactly
- [x] No existing fields overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)