### PR TITLE
Unified ProfileTabs, author linking, empty tab hiding

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -8,6 +8,7 @@ import {
   getKBFacts,
   getKBProperty,
   getKBEntity,
+  getKBEntities,
   getKBAllRecordCollections,
   resolveKBSlug,
   getKBEntitySlug,
@@ -403,6 +404,11 @@ export function parseBoardSeatRecord(record: KBRecordEntry): Omit<BoardMember, "
 
 // ── Resource helpers ─────────────────────────────────────────────────
 
+export interface AuthorRef {
+  name: string;
+  href: string | null;
+}
+
 export interface OrgResourceRow {
   id: string;
   title: string;
@@ -412,7 +418,7 @@ export interface OrgResourceRow {
   credibility: number | null;
   citingPageCount: number;
   publishedDate: string | null;
-  authors: string[];
+  authors: AuthorRef[];
 }
 
 /** Extract the bare domain (no www) from a URL. Returns null on parse failure. */
@@ -516,6 +522,33 @@ function titleFromUrl(url: string): string | null {
   }
 }
 
+/** Lazy-init: name (lowercase) → person slug for author linking. */
+let _personNameIndex: Map<string, string> | null = null;
+
+function getPersonNameIndex(): Map<string, string> {
+  if (_personNameIndex) return _personNameIndex;
+  _personNameIndex = new Map();
+  for (const entity of getKBEntities()) {
+    if (entity.type !== "person") continue;
+    const slug = getKBEntitySlug(entity.id);
+    if (!slug) continue;
+    _personNameIndex.set(entity.name.toLowerCase(), slug);
+    // Also index aliases
+    if (entity.aliases) {
+      for (const alias of entity.aliases) {
+        _personNameIndex.set(alias.toLowerCase(), slug);
+      }
+    }
+  }
+  return _personNameIndex;
+}
+
+/** Resolve an author name string to an AuthorRef with optional link. */
+function resolveAuthor(name: string): AuthorRef {
+  const slug = getPersonNameIndex().get(name.toLowerCase().trim());
+  return { name, href: slug ? `/people/${slug}` : null };
+}
+
 /** Convert a Resource to an OrgResourceRow. */
 function toOrgResourceRow(r: Resource): OrgResourceRow {
   const publication = getResourcePublication(r);
@@ -530,7 +563,7 @@ function toOrgResourceRow(r: Resource): OrgResourceRow {
     credibility: credibility ?? null,
     citingPageCount: citingPages.length,
     publishedDate: r.published_date ?? null,
-    authors: r.authors ?? [],
+    authors: (r.authors ?? []).map(resolveAuthor),
   };
 }
 

--- a/apps/web/src/app/organizations/[slug]/org-tabs.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-tabs.tsx
@@ -1,49 +1,7 @@
 "use client";
 
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-
-export interface OrgTab {
-  id: string;
-  label: string;
-  count?: number;
-  content: React.ReactNode;
-}
-
 /**
- * Client-side tab container for organization profile pages.
- * Receives pre-rendered server content as ReactNode children in each tab.
+ * Re-export ProfileTabs for backward compatibility with existing org page imports.
  */
-export function OrgProfileTabs({ tabs }: { tabs: OrgTab[] }) {
-  if (tabs.length === 0) return null;
-
-  // If only one tab, render its content directly without tab chrome
-  if (tabs.length === 1) {
-    return <>{tabs[0].content}</>;
-  }
-
-  return (
-    <Tabs defaultValue={tabs[0].id}>
-      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0">
-        {tabs.map((tab) => (
-          <TabsTrigger
-            key={tab.id}
-            value={tab.id}
-            className="rounded-none border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-          >
-            {tab.label}
-            {tab.count != null && tab.count > 0 && (
-              <span className="ml-1.5 text-[11px] tabular-nums px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
-                {tab.count}
-              </span>
-            )}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-      {tabs.map((tab) => (
-        <TabsContent key={tab.id} value={tab.id} className="mt-6">
-          {tab.content}
-        </TabsContent>
-      ))}
-    </Tabs>
-  );
-}
+export { ProfileTabs as OrgProfileTabs } from "@/components/directory/ProfileTabs";
+export type { ProfileTab as OrgTab } from "@/components/directory/ProfileTabs";

--- a/apps/web/src/app/organizations/[slug]/resources-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/resources-section.tsx
@@ -23,7 +23,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { safeHref } from "@/lib/format-compact";
-import type { OrgResourceRow } from "./org-data";
+import type { OrgResourceRow, AuthorRef } from "./org-data";
 
 const TYPE_COLORS: Record<string, string> = {
   paper: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
@@ -73,7 +73,18 @@ function makeColumns(opts: {
           </Link>
           {row.original.authors.length > 0 && (
             <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">
-              {row.original.authors.slice(0, 3).join(", ")}
+              {row.original.authors.slice(0, 3).map((a, i) => (
+                <span key={i}>
+                  {i > 0 && ", "}
+                  {a.href ? (
+                    <Link href={a.href} className="hover:text-primary hover:underline">
+                      {a.name}
+                    </Link>
+                  ) : (
+                    a.name
+                  )}
+                </span>
+              ))}
               {row.original.authors.length > 3 &&
                 ` +${row.original.authors.length - 3}`}
             </div>

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -23,6 +23,8 @@ import {
   ProfileStatCard,
   Breadcrumbs,
   FactsPanel,
+  ProfileTabs,
+  type ProfileTab,
 } from "@/components/directory";
 import { formatKBDate } from "@/components/wiki/kb/format";
 import { getExpertById, getPublicationsForPerson } from "@/data";
@@ -72,12 +74,6 @@ export async function generateMetadata({
     title: `${entity.name} | People`,
     description,
   };
-}
-
-function EmptyPlaceholder({ label }: { label: string }) {
-  return (
-    <p className="text-xs text-muted-foreground/40 italic">{label}</p>
-  );
 }
 
 export default async function PersonProfilePage({
@@ -222,14 +218,56 @@ export default async function PersonProfilePage({
   const educationText =
     educationFact?.value.type === "text" ? educationFact.value.value : null;
 
-  // Determine which main sections have content
-  const hasPositions = positions.length > 0;
-  const hasCareer = careerHistory.length > 0;
-  const hasEducation = !!educationText;
-  const hasPublications = publications.length > 0;
-  const hasFunding = fundingConnections.length > 0;
-  const hasAnyMainContent =
-    hasPositions || hasCareer || hasEducation || hasPublications || hasFunding;
+  // ── Build tabs from available data ──
+  const overviewCount =
+    positions.length + sortedOrgRoles.length + sortedBoardSeats.length + (educationText ? 1 : 0);
+
+  const tabs: ProfileTab[] = [];
+
+  // Overview: expert positions, org roles, board seats, education
+  tabs.push({
+    id: "overview",
+    label: "Overview",
+    content: (
+      <div className="space-y-8">
+        <ExpertPositions positions={positions} />
+        <OrgRoles orgRoles={sortedOrgRoles} />
+        <BoardSeats boardSeats={sortedBoardSeats} />
+        {educationText && <EducationSection education={educationText} />}
+        {overviewCount === 0 && (
+          <div className="border border-border/40 border-dashed rounded-xl px-6 py-10 text-center">
+            <p className="text-sm text-muted-foreground/60">
+              No positions, roles, or education recorded yet.
+            </p>
+          </div>
+        )}
+      </div>
+    ),
+  });
+
+  // Career history
+  tabs.push({
+    id: "career",
+    label: "Career",
+    count: careerHistory.length,
+    content: <CareerHistory careerHistory={careerHistory} />,
+  });
+
+  // Publications
+  tabs.push({
+    id: "publications",
+    label: "Publications",
+    count: publications.length,
+    content: <PublicationsSection publications={publications} />,
+  });
+
+  // Funding connections
+  tabs.push({
+    id: "funding",
+    label: "Funding",
+    count: fundingConnections.length,
+    content: <FundingConnections fundingConnections={fundingConnections} />,
+  });
 
   return (
     <div className="max-w-[70rem] mx-auto px-6 py-8">
@@ -288,49 +326,14 @@ export default async function PersonProfilePage({
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main content */}
-        <div className="lg:col-span-2 space-y-8">
-          <ExpertPositions positions={positions} />
-          <CareerHistory careerHistory={careerHistory} />
-          {educationText && <EducationSection education={educationText} />}
-          <PublicationsSection publications={publications} />
-          <FundingConnections fundingConnections={fundingConnections} />
-
-          {/* Empty-state placeholders for sections with no data */}
-          {!hasAnyMainContent && (
-            <div className="border border-border/40 border-dashed rounded-xl px-6 py-10 text-center">
-              <p className="text-sm text-muted-foreground/60">
-                No career history, positions, education, publications, or
-                funding connections recorded yet.
-              </p>
-            </div>
-          )}
-          {hasAnyMainContent && (
-            <div className="space-y-2 pt-2">
-              {!hasPositions && (
-                <EmptyPlaceholder label="No expert positions recorded." />
-              )}
-              {!hasCareer && (
-                <EmptyPlaceholder label="No career history recorded." />
-              )}
-              {!hasEducation && (
-                <EmptyPlaceholder label="No education information recorded." />
-              )}
-              {!hasPublications && (
-                <EmptyPlaceholder label="No publications recorded." />
-              )}
-              {!hasFunding && (
-                <EmptyPlaceholder label="No funding connections recorded." />
-              )}
-            </div>
-          )}
+        {/* Main content — tabbed */}
+        <div className="lg:col-span-2">
+          <ProfileTabs tabs={tabs} />
         </div>
 
         {/* Sidebar */}
         <div className="space-y-8">
           <SocialLinks facts={socialLinkFacts} />
-          <OrgRoles orgRoles={sortedOrgRoles} />
-          <BoardSeats boardSeats={sortedBoardSeats} />
           {allFacts.length > 0 && (
             <FactsPanel facts={allFacts} entityId={entity.id} />
           )}

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+export interface ProfileTab {
+  id: string;
+  label: string;
+  count?: number;
+  content: React.ReactNode;
+}
+
+/**
+ * Reusable tabbed layout for profile pages (organizations, people, etc.).
+ * - Automatically hides tabs where count is 0
+ * - Renders content directly (no tab chrome) when only one tab remains
+ */
+export function ProfileTabs({ tabs }: { tabs: ProfileTab[] }) {
+  // Filter out tabs with explicit count of 0
+  const visibleTabs = tabs.filter((t) => t.count !== 0);
+
+  if (visibleTabs.length === 0) return null;
+
+  // If only one tab, render its content directly without tab chrome
+  if (visibleTabs.length === 1) {
+    return <>{visibleTabs[0].content}</>;
+  }
+
+  return (
+    <Tabs defaultValue={visibleTabs[0].id}>
+      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0">
+        {visibleTabs.map((tab) => (
+          <TabsTrigger
+            key={tab.id}
+            value={tab.id}
+            className="rounded-none border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+          >
+            {tab.label}
+            {tab.count != null && tab.count > 0 && (
+              <span className="ml-1.5 text-[11px] tabular-nums px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+                {tab.count}
+              </span>
+            )}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {visibleTabs.map((tab) => (
+        <TabsContent key={tab.id} value={tab.id} className="mt-6">
+          {tab.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/apps/web/src/components/directory/index.ts
+++ b/apps/web/src/components/directory/index.ts
@@ -11,3 +11,4 @@ export {
   groupByCategory,
   FACT_CATEGORIES,
 } from "./FactsSection";
+export { ProfileTabs, type ProfileTab } from "./ProfileTabs";


### PR DESCRIPTION
## Summary

- **Unified ProfileTabs component** — Extracted `OrgProfileTabs` into a shared `ProfileTabs` component at `components/directory/ProfileTabs.tsx`, reusable across organization pages, person pages, and future profile page types. OrgProfileTabs re-exports for backward compatibility.
- **Empty tab hiding** — Tabs with `count === 0` are automatically filtered out, so pages only show relevant sections.
- **Author linking** — Resource author names are now resolved to person entity pages via KB name/alias matching. Authors with matching entities render as clickable links to `/people/[slug]`.
- **Person page tabs** — Converted person pages from flat layout to tabbed layout using ProfileTabs: Overview (expert positions, org roles, board seats, education), Career, Publications, Funding. Empty tabs auto-hidden.

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All 704 tests pass (`pnpm test`)
- [x] TypeScript type check passes
- [ ] Verify org pages still render correctly with tabs
- [ ] Verify person pages show tabs with correct counts
- [ ] Verify empty tabs are hidden on person pages with sparse data
- [ ] Verify author names link to person pages when entity exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)