### PR TITLE
fix: add missing fields to ParsedGrantRecord breaking build on main

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -94,6 +94,9 @@ export type ParsedGrantRecord = {
   date: string | null;
   status: string | null;
   source: string | null;
+  programName: string | null;
+  divisionName: string | null;
+  notes: string | null;
 };
 
 export type ReceivedGrant = ParsedGrantRecord & {
@@ -269,6 +272,9 @@ export function parseGrantRecord(record: KBRecordEntry): ParsedGrantRecord {
     date: (f.date as string) ?? (f.period as string) ?? null,
     status: (f.status as string) ?? null,
     source: (f.source as string) ?? null,
+    programName: (f.programName as string) ?? null,
+    divisionName: (f.divisionName as string) ?? null,
+    notes: (f.notes as string) ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- `grants-section.tsx` references `programName`, `divisionName`, and `notes` on `ParsedGrantRecord` but these fields were missing from both the type definition and the parser function in `org-data.ts`
- This breaks TypeScript compilation on main and is blocking the release PR #2306

## Test plan
- [x] `npx tsc --noEmit` passes clean (exit 0)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)