### PR TITLE
fix: correct aria-label on publications credibility filter

### DIFF
--- a/apps/web/src/app/publications/publications-table.tsx
+++ b/apps/web/src/app/publications/publications-table.tsx
@@ -236,7 +236,7 @@ export function PublicationsTable({
         {/* Credibility filter */}
         <select
           value={credFilter}
-          aria-label="Filter by year"
+          aria-label="Filter by credibility"
           onChange={(e) => setCredFilter(e.target.value)}
           className="h-9 rounded-lg border border-border bg-background px-3 text-sm shadow-sm"
         >


### PR DESCRIPTION
## Summary
- The credibility dropdown in `publications-table.tsx` had `aria-label="Filter by year"` — a copy-paste error from the year filter above it
- Fixed to `aria-label="Filter by credibility"` so screen readers correctly identify the control

## Test plan
- [x] Verified the fix is a single-line aria-label string change
- [ ] Screen reader or accessibility audit confirms correct label

🤖 Generated with [Claude Code](https://claude.com/claude-code)