### PR TITLE
fix: drop redundant non-unique index on things table

### DIFF
--- a/apps/wiki-server/drizzle/0089_drop_redundant_things_index.sql
+++ b/apps/wiki-server/drizzle/0089_drop_redundant_things_index.sql
@@ -1,0 +1,4 @@
+-- Drop the redundant non-unique index on (source_table, source_id).
+-- The unique index idx_things_source_unique already covers all queries
+-- that idx_things_source would serve, making it unnecessary overhead.
+DROP INDEX IF EXISTS idx_things_source;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1776240000000,
       "tag": "0088_create_thing_verification_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1776326400000,
+      "tag": "0089_drop_redundant_things_index",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Migration 0086 created both `idx_things_source` (non-unique) and `idx_things_source_unique` (unique) on `(source_table, source_id)`
- The unique index already serves all query needs — the non-unique one is redundant storage and write overhead
- Adds migration 0089 to `DROP INDEX IF EXISTS idx_things_source`

## Test plan
- [x] Migration is idempotent (`IF EXISTS`)
- [x] No code references `idx_things_source` by name
- [ ] Verify migration runs cleanly on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)