### PR TITLE
refactor: use SAFETY_LEVEL_COLORS and shared SortHeader in AI models/benchmarks

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
-import { DEVELOPER_COLORS, formatContext } from "./ai-model-constants";
+import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS, formatContext } from "./ai-model-constants";
 
 export interface AiModelRow {
   id: string;
@@ -305,7 +305,9 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* Safety Level */}
                 <td className="py-2.5 px-3">
                   {row.safetyLevel ? (
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                      SAFETY_LEVEL_COLORS[row.safetyLevel] ?? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
+                    }`}>
                       {row.safetyLevel}
                     </span>
                   ) : (

--- a/apps/web/src/app/benchmarks/benchmarks-table.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
+import { SortHeader } from "@/components/directory/SortHeader";
 
 export interface BenchmarkRow {
   id: string;
@@ -29,42 +30,6 @@ const CATEGORY_COLORS: Record<string, string> = {
 };
 
 type SortKey = "name" | "category" | "modelsCount" | "introducedDate" | "maintainer";
-
-function SortHeader({
-  label,
-  sortKey,
-  currentSort,
-  currentDir,
-  onSort,
-  className,
-}: {
-  label: string;
-  sortKey: SortKey;
-  currentSort: SortKey;
-  currentDir: SortDir;
-  onSort: (key: SortKey) => void;
-  className?: string;
-}) {
-  const isActive = currentSort === sortKey;
-  return (
-    <th className={`py-2.5 px-3 font-medium ${className ?? ""}`}>
-      <button
-        type="button"
-        className={`inline-flex items-center gap-1 cursor-pointer select-none hover:text-foreground transition-colors ${
-          isActive ? "text-foreground" : ""
-        }`}
-        onClick={() => onSort(sortKey)}
-      >
-        {label}
-        {isActive && (
-          <span className="text-[10px]">
-            {currentDir === "asc" ? "\u25B2" : "\u25BC"}
-          </span>
-        )}
-      </button>
-    </th>
-  );
-}
 
 export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
   const [search, setSearch] = useState("");


### PR DESCRIPTION
## Summary
- Use `SAFETY_LEVEL_COLORS` from `ai-model-constants.ts` in the AI models table for colored safety level badges
- Replace 36-line inline SortHeader in benchmarks table with shared `@/components/directory/SortHeader`

## Files changed
- `ai-models-table.tsx` — import and use SAFETY_LEVEL_COLORS for badge styling
- `benchmarks-table.tsx` — remove inline SortHeader, import shared component

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [x] Safety level badges show correct colors
- [x] Benchmarks table sorting still works with shared SortHeader

🤖 Generated with [Claude Code](https://claude.com/claude-code)