### PR TITLE
feat: dual-write facts to things table during sync

### DIFF
--- a/apps/wiki-server/src/routes/facts.ts
+++ b/apps/wiki-server/src/routes/facts.ts
@@ -290,17 +290,22 @@ const factsApp = new Hono()
           },
         });
       // Dual-write to things table
+      const toFactThingKey = (entityId: string, factId: string) =>
+        `${encodeURIComponent(entityId)}:${encodeURIComponent(factId)}`;
+
       await upsertThingsInTx(
         tx,
         items.map((f) => ({
-          id: `${f.entityId}:${f.factId}`,
+          id: toFactThingKey(f.entityId, f.factId),
           thingType: "fact" as const,
           title: f.label || `${f.factId} for ${f.entityId}`,
           sourceTable: "facts",
-          sourceId: `${f.entityId}:${f.factId}`,
+          sourceId: toFactThingKey(f.entityId, f.factId),
           description: f.value
             ? `${f.label || f.factId}: ${f.value}`
-            : undefined,
+            : f.numeric != null
+              ? `${f.label || f.factId}: ${f.numeric}`
+              : undefined,
         }))
       );
 


### PR DESCRIPTION
## Summary
- Adds dual-write to the `things` table in the facts sync endpoint (`POST /sync` in `facts.ts`)
- Uses `upsertThingsInTx` helper (same pattern as grants, entities, resources, etc.)
- Composite key `entityId:factId` used as both `id` and `sourceId` since facts have a compound primary key
- `title` uses `label` with fallback to `factId for entityId`; `description` combines label and value for searchability

## Test plan
- [ ] TypeScript compiles without new errors (`cd apps/wiki-server && npx tsc --noEmit`)
- [ ] Facts sync endpoint still upserts facts correctly
- [ ] Things table receives fact rows with `thing_type = 'fact'` and `source_table = 'facts'`
- [ ] Existing things sync behavior for other domain tables is unaffected

Closes #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data synchronization reliability by implementing atomic dual-write operations to maintain consistency across the fact database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->