### PR TITLE
fix: grants page — recipient routing, shared constants, dead code cleanup

### DIFF
--- a/apps/web/src/app/grants/[id]/page.tsx
+++ b/apps/web/src/app/grants/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   isUrl,
   shortDomain,
 } from "@/components/wiki/kb/format";
+import { STATUS_COLORS } from "../grants-constants";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -113,15 +114,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     description: parts.join(" — "),
   };
 }
-
-// ── Status badge colors ────────────────────────────────────────────────
-
-const STATUS_COLORS: Record<string, string> = {
-  active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  completed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  "winding-down": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  terminated: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-};
 
 // ── Page ───────────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/grants/grants-constants.ts
+++ b/apps/web/src/app/grants/grants-constants.ts
@@ -1,0 +1,7 @@
+/** Shared status badge color classes used by both the grants listing and detail pages. */
+export const STATUS_COLORS: Record<string, string> = {
+  active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  completed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
+  "winding-down": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  terminated: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};

--- a/apps/web/src/app/grants/grants-sort.test.ts
+++ b/apps/web/src/app/grants/grants-sort.test.ts
@@ -15,6 +15,7 @@ function makeRow(overrides: Partial<GrantRow> = {}): GrantRow {
     recipient: null,
     recipientName: null,
     recipientSlug: null,
+    recipientHref: null,
     recipientWikiPageId: null,
     program: null,
     amount: null,
@@ -72,13 +73,6 @@ describe("getGrantSortValue", () => {
       500000,
     );
     expect(getGrantSortValue(makeRow({ amount: null }), "amount")).toBe(null);
-  });
-
-  it("returns period as string", () => {
-    expect(
-      getGrantSortValue(makeRow({ period: "2023-2025" }), "period"),
-    ).toBe("2023-2025");
-    expect(getGrantSortValue(makeRow({ period: null }), "period")).toBe(null);
   });
 
   it("returns date as string", () => {

--- a/apps/web/src/app/grants/grants-sort.ts
+++ b/apps/web/src/app/grants/grants-sort.ts
@@ -9,7 +9,6 @@ export type GrantSortKey =
   | "recipient"
   | "program"
   | "amount"
-  | "period"
   | "date"
   | "status";
 
@@ -28,8 +27,6 @@ export function getGrantSortValue(
       return row.program?.toLowerCase() ?? null;
     case "amount":
       return row.amount;
-    case "period":
-      return row.period;
     case "date":
       return row.date;
     case "status":

--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { formatCompactCurrency, safeHref } from "@/lib/format-compact";
 import { compareGrantRows, type SortDir } from "./grants-sort";
+import { STATUS_COLORS } from "./grants-constants";
 
 export interface GrantRow {
   /** Composite key: entityId-recordKey for uniqueness */
@@ -23,6 +24,8 @@ export interface GrantRow {
   recipientName: string | null;
   /** Slug for linking to /organizations/ or /people/ */
   recipientSlug: string | null;
+  /** Computed href for the recipient (type-aware: /organizations/ or /people/) */
+  recipientHref: string | null;
   /** Numeric wiki page ID for the recipient entity */
   recipientWikiPageId: string | null;
   program: string | null;
@@ -33,16 +36,9 @@ export interface GrantRow {
   source: string | null;
 }
 
-type SortKey = "name" | "organization" | "recipient" | "program" | "amount" | "period" | "date" | "status";
+type SortKey = "name" | "organization" | "recipient" | "program" | "amount" | "date" | "status";
 
 const PAGE_SIZE = 100;
-
-const STATUS_COLORS: Record<string, string> = {
-  active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  completed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
-  "winding-down": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  terminated: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-};
 
 function PaginationControls({
   page,
@@ -288,9 +284,9 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
                 {/* Recipient */}
                 <td className="py-2.5 px-3 text-muted-foreground">
                   {row.recipientName ? (
-                    row.recipientSlug ? (
+                    row.recipientHref ? (
                       <Link
-                        href={`/organizations/${row.recipientSlug}`}
+                        href={row.recipientHref}
                         className="text-foreground hover:text-primary transition-colors"
                       >
                         {row.recipientName}
@@ -314,7 +310,7 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
 
                 {/* Program */}
                 <td className="py-2.5 px-3 text-muted-foreground text-xs">
-                  {row.program ?? ""}
+                  {row.program ?? <span className="text-muted-foreground/40">{"\u2014"}</span>}
                 </td>
 
                 {/* Amount */}

--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -28,6 +28,7 @@ const CEA_SLUG_ALIAS = "cea";
 function resolveRecipient(recipientId: string): {
   name: string;
   slug: string | null;
+  href: string | null;
   wikiPageId: string | null;
 } {
   const entity = getKBEntity(recipientId);
@@ -35,10 +36,19 @@ function resolveRecipient(recipientId: string): {
     const slug = getKBEntitySlug(recipientId) ?? null;
     const typedEntity = getTypedEntityById(recipientId);
     const wikiPageId = typedEntity?.numericId ?? null;
-    return { name: entity.name, slug, wikiPageId };
+    // Build type-aware href: /organizations/ for orgs, /people/ for people
+    let href: string | null = null;
+    if (slug) {
+      if (entity.type === "person") {
+        href = `/people/${slug}`;
+      } else {
+        href = `/organizations/${slug}`;
+      }
+    }
+    return { name: entity.name, slug, href, wikiPageId };
   }
   // Not a known entity — return the raw ID as the display name
-  return { name: recipientId, slug: null, wikiPageId: null };
+  return { name: recipientId, slug: null, href: null, wikiPageId: null };
 }
 
 export default function GrantsPage() {
@@ -77,6 +87,7 @@ export default function GrantsPage() {
       recipient: recipientId,
       recipientName: resolved?.name ?? null,
       recipientSlug: resolved?.slug ?? null,
+      recipientHref: resolved?.href ?? null,
       recipientWikiPageId: resolved?.wikiPageId ?? null,
       program:
         typeof record.fields.program === "string"


### PR DESCRIPTION
## Summary
- Fix critical bug: recipient links now route to `/people/` or `/organizations/` based on entity type (was always `/organizations/`)
- Extract duplicate `STATUS_COLORS` to shared `grants-constants.ts`
- Remove dead "period" sort key (was in types/sort logic but had no UI header)
- Replace empty program cells with em-dashes

## Test plan
- [x] TypeScript check passes
- [x] All 24 grants sort tests pass (minus removed period test)
- [x] Recipient links use correct route based on entity type

🤖 Generated with [Claude Code](https://claude.com/claude-code)