### PR TITLE
fix: people page — import path, funding stats, empty cell consistency

### DIFF
--- a/apps/web/src/app/people/[slug]/career-history.tsx
+++ b/apps/web/src/app/people/[slug]/career-history.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { resolveEntityRef, formatDateRange } from "@/lib/directory-utils";
 import { getKBEntitySlug } from "@/data/kb";
-import { getRecordVerdict } from "@data/database";
+import { getRecordVerdict } from "@/data/database";
 import { CurrentBadge, FounderBadge } from "@/components/directory";
 import { VerificationBadge } from "@/components/directory/VerificationBadge";
 import type { CareerHistoryEntry } from "../people-utils";

--- a/apps/web/src/app/people/[slug]/funding-connections.tsx
+++ b/apps/web/src/app/people/[slug]/funding-connections.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { formatCompactCurrency } from "@/lib/directory-utils";
 import type { FundingConnection } from "../people-utils";
 
+const FUNDING_CONNECTIONS_LIMIT = 20;
+
 export function FundingConnections({
   fundingConnections,
 }: {
@@ -9,6 +11,7 @@ export function FundingConnections({
 }) {
   if (fundingConnections.length === 0) return null;
 
+  // Calculate stats from ALL connections (not just the displayed slice)
   const totalAmount = fundingConnections.reduce(
     (sum, c) => sum + (c.amount ?? 0),
     0,
@@ -19,6 +22,8 @@ export function FundingConnections({
   const receivedCount = fundingConnections.filter(
     (c) => c.direction === "received" || c.direction === "personal",
   ).length;
+
+  const displayed = fundingConnections.slice(0, FUNDING_CONNECTIONS_LIMIT);
 
   return (
     <section>
@@ -51,7 +56,7 @@ export function FundingConnections({
           )}
         </div>
         <div className="divide-y divide-border/40">
-          {fundingConnections.slice(0, 20).map((conn) => (
+          {displayed.map((conn) => (
             <div key={conn.key} className="px-5 py-3.5">
               <div className="flex items-center gap-2 flex-wrap">
                 <span
@@ -149,10 +154,10 @@ export function FundingConnections({
             </div>
           ))}
         </div>
-        {fundingConnections.length > 20 && (
+        {fundingConnections.length > FUNDING_CONNECTIONS_LIMIT && (
           <div className="px-5 py-3 border-t border-border/40 text-center">
             <span className="text-xs text-muted-foreground">
-              Showing 20 of {fundingConnections.length} connections
+              Showing {FUNDING_CONNECTIONS_LIMIT} of {fundingConnections.length} connections
             </span>
           </div>
         )}

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -269,26 +269,32 @@ export function PeopleTable({ rows }: { rows: PersonRow[] }) {
 
                 {/* Positions */}
                 <td className="py-2.5 px-3 text-center tabular-nums">
-                  {row.positionCount > 0 && (
+                  {row.positionCount > 0 ? (
                     <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
                       {row.positionCount}
                     </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
 
                 {/* Publications */}
                 <td className="py-2.5 px-3 text-center tabular-nums">
-                  {row.publicationCount > 0 && (
+                  {row.publicationCount > 0 ? (
                     <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400">
                       {row.publicationCount}
                     </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
 
                 {/* Career History */}
                 <td className="py-2.5 px-3 text-center">
-                  {row.careerHistoryCount > 0 && (
+                  {row.careerHistoryCount > 0 ? (
                     <span className="tabular-nums">{row.careerHistoryCount}</span>
+                  ) : (
+                    <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- Fix `@data/database` → `@/data/database` import convention in career-history.tsx
- Extract magic number 20 to `FUNDING_CONNECTIONS_LIMIT` constant with clear documentation
- Standardize empty cells: zero-count positions/publications/career history now show em-dash instead of blank

## Test plan
- [x] TypeScript check passes
- [x] All existing people tests pass
- [x] Empty cells display consistently across all columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)