### PR TITLE
refactor: risks page — shared display helpers, badge colors, timeframe sort

### DIFF
--- a/apps/web/src/app/risks/[slug]/page.tsx
+++ b/apps/web/src/app/risks/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { resolveRiskBySlug, getRiskSlugs } from "@/app/risks/risk-utils";
+import {
+  resolveRiskBySlug,
+  getRiskSlugs,
+  getLikelihoodDisplay,
+  getTimeframeDisplay,
+} from "@/app/risks/risk-utils";
 import { resolveSlugAlias } from "@/data/kb";
 import { getKBEntity, getKBEntitySlug } from "@/data/kb";
 import { getTypedEntityById, isRisk } from "@/data";
@@ -11,11 +16,11 @@ import {
   Breadcrumbs,
 } from "@/components/directory";
 import { titleCase } from "@/components/wiki/kb/format";
-import type { RiskEntity } from "@/data/entity-schemas";
 import {
   RISK_CATEGORY_COLORS,
   RISK_CATEGORY_LABELS,
   SEVERITY_COLORS,
+  DEFAULT_BADGE_COLOR,
 } from "@/app/risks/risk-constants";
 
 export function generateStaticParams() {
@@ -35,36 +40,6 @@ export async function generateMetadata({
       ? `Profile and assessment data for ${entity.name}.`
       : undefined,
   };
-}
-
-// ── Helpers to extract display values from entity data ─────────────────
-
-function getLikelihoodDisplay(risk: RiskEntity): string | null {
-  if (!risk.likelihood) return null;
-  if (typeof risk.likelihood === "string") return titleCase(risk.likelihood);
-  const parts: string[] = [];
-  if (risk.likelihood.level) parts.push(titleCase(risk.likelihood.level));
-  if (risk.likelihood.status) parts.push(`(${risk.likelihood.status})`);
-  if (risk.likelihood.display) return risk.likelihood.display;
-  return parts.length > 0 ? parts.join(" ") : null;
-}
-
-function getTimeframeDisplay(risk: RiskEntity): string | null {
-  if (!risk.timeframe) return null;
-  if (typeof risk.timeframe === "string") return risk.timeframe;
-  if (risk.timeframe.display) return risk.timeframe.display;
-  const parts: string[] = [];
-  if (risk.timeframe.earliest && risk.timeframe.latest) {
-    parts.push(`${risk.timeframe.earliest}\u2013${risk.timeframe.latest}`);
-  }
-  if (risk.timeframe.median) {
-    if (parts.length > 0) {
-      parts.push(`(median ${risk.timeframe.median})`);
-    } else {
-      parts.push(`~${risk.timeframe.median}`);
-    }
-  }
-  return parts.length > 0 ? parts.join(" ") : null;
 }
 
 // ── Main page ─────────────────────────────────────────────────────────
@@ -101,11 +76,11 @@ export default async function RiskProfilePage({
   if (risk?.severity) {
     stats.push({ label: "Severity", value: titleCase(risk.severity) });
   }
-  const likelihoodStr = risk ? getLikelihoodDisplay(risk) : null;
+  const likelihoodStr = risk ? getLikelihoodDisplay(risk.likelihood) : null;
   if (likelihoodStr) {
     stats.push({ label: "Likelihood", value: likelihoodStr });
   }
-  const timeframeStr = risk ? getTimeframeDisplay(risk) : null;
+  const timeframeStr = risk ? getTimeframeDisplay(risk.timeframe) : null;
   if (timeframeStr) {
     stats.push({ label: "Time Horizon", value: timeframeStr });
   }
@@ -162,7 +137,7 @@ export default async function RiskProfilePage({
           {riskCategory && (
             <span
               className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
-                RISK_CATEGORY_COLORS[riskCategory] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                RISK_CATEGORY_COLORS[riskCategory] ?? DEFAULT_BADGE_COLOR
               }`}
             >
               {RISK_CATEGORY_LABELS[riskCategory] ?? riskCategory}
@@ -171,7 +146,7 @@ export default async function RiskProfilePage({
           {risk?.severity && (
             <span
               className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
-                SEVERITY_COLORS[risk.severity] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                SEVERITY_COLORS[risk.severity] ?? DEFAULT_BADGE_COLOR
               }`}
             >
               {titleCase(risk.severity)}

--- a/apps/web/src/app/risks/page.tsx
+++ b/apps/web/src/app/risks/page.tsx
@@ -1,34 +1,15 @@
 import type { Metadata } from "next";
 import { getTypedEntities, isRisk } from "@/data";
-import type { RiskEntity } from "@/data/entity-schemas";
 import { titleCase } from "@/components/wiki/kb/format";
 import { ProfileStatCard } from "@/components/directory";
 import { RisksTable, type RiskRow } from "./risks-table";
+import { getLikelihoodDisplay, getTimeframeDisplay } from "./risk-utils";
 
 export const metadata: Metadata = {
   title: "Risks",
   description:
     "Directory of AI-related risks tracked in the knowledge base, including accident risks, misuse risks, structural risks, and epistemic risks.",
 };
-
-/** Extract a display string from a likelihood field (string or object). */
-function getLikelihoodStr(likelihood: RiskEntity["likelihood"]): string | null {
-  if (!likelihood) return null;
-  if (typeof likelihood === "string") return titleCase(likelihood);
-  if (likelihood.display) return likelihood.display;
-  if (likelihood.level) return titleCase(likelihood.level);
-  return null;
-}
-
-/** Extract a display string from a timeframe field (string or object). */
-function getTimeframeStr(timeframe: RiskEntity["timeframe"]): string | null {
-  if (!timeframe) return null;
-  if (typeof timeframe === "string") return timeframe;
-  if (timeframe.display) return timeframe.display;
-  if (timeframe.earliest && timeframe.latest) return `${timeframe.earliest}–${timeframe.latest}`;
-  if (timeframe.median) return `~${timeframe.median}`;
-  return null;
-}
 
 export default function RisksPage() {
   const allEntities = getTypedEntities();
@@ -41,8 +22,8 @@ export default function RisksPage() {
     wikiPageId: risk.numericId ?? null,
     riskCategory: risk.riskCategory ?? null,
     severity: risk.severity ? titleCase(risk.severity) : null,
-    likelihood: getLikelihoodStr(risk.likelihood),
-    timeHorizon: getTimeframeStr(risk.timeframe),
+    likelihood: getLikelihoodDisplay(risk.likelihood),
+    timeHorizon: getTimeframeDisplay(risk.timeframe),
   }));
 
   // Compute summary stats

--- a/apps/web/src/app/risks/risk-constants.ts
+++ b/apps/web/src/app/risks/risk-constants.ts
@@ -4,6 +4,12 @@
  * Centralised here so the listing table and detail pages stay in sync.
  */
 
+// ── Default fallback ──────────────────────────────────────────────────
+
+/** Fallback badge colour used when a value has no specific colour mapping. */
+export const DEFAULT_BADGE_COLOR =
+  "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400";
+
 // ── Risk category ──────────────────────────────────────────────────────
 
 export const RISK_CATEGORY_LABELS: Record<string, string> = {

--- a/apps/web/src/app/risks/risk-utils.ts
+++ b/apps/web/src/app/risks/risk-utils.ts
@@ -4,6 +4,8 @@
  */
 import { resolveEntityBySlug, getEntitySlugs } from "@/lib/directory-utils";
 import type { Entity } from "@longterm-wiki/kb";
+import { titleCase } from "@/components/wiki/kb/format";
+import type { RiskEntity } from "@/data/entity-schemas";
 
 /** Resolve a URL slug to a KB risk entity. */
 export function resolveRiskBySlug(slug: string): Entity | undefined {
@@ -13,4 +15,66 @@ export function resolveRiskBySlug(slug: string): Entity | undefined {
 /** Get all risk slugs for generateStaticParams. */
 export function getRiskSlugs(): string[] {
   return getEntitySlugs("risk");
+}
+
+/**
+ * Extract a display string from a likelihood field (string or object).
+ *
+ * Returns the most complete representation, including status in parentheses
+ * when present (e.g. "High (increasing)").
+ */
+export function getLikelihoodDisplay(
+  likelihood: RiskEntity["likelihood"],
+): string | null {
+  if (!likelihood) return null;
+  if (typeof likelihood === "string") return titleCase(likelihood);
+  if (likelihood.display) return likelihood.display;
+  const parts: string[] = [];
+  if (likelihood.level) parts.push(titleCase(likelihood.level));
+  if (likelihood.status) parts.push(`(${likelihood.status})`);
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+/**
+ * Extract a display string from a timeframe field (string or object).
+ *
+ * Returns the most complete representation, including both range and median
+ * when available (e.g. "2025-2030 (median 2028)").
+ */
+export function getTimeframeDisplay(
+  timeframe: RiskEntity["timeframe"],
+): string | null {
+  if (!timeframe) return null;
+  if (typeof timeframe === "string") return timeframe;
+  if (timeframe.display) return timeframe.display;
+  const parts: string[] = [];
+  if (timeframe.earliest && timeframe.latest) {
+    parts.push(`${timeframe.earliest}\u2013${timeframe.latest}`);
+  }
+  if (timeframe.median) {
+    if (parts.length > 0) {
+      parts.push(`(median ${timeframe.median})`);
+    } else {
+      parts.push(`~${timeframe.median}`);
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+/**
+ * Extract the earliest numeric year from a timeframe string for sorting.
+ *
+ * Examples:
+ *   "~2030" → 2030
+ *   "2025-2030" → 2025
+ *   "2025–2030" → 2025 (en-dash)
+ *   "By 2040" → 2040
+ *   "unknown" → null
+ */
+export function extractEarliestYear(
+  timeframe: string | null | undefined,
+): number | null {
+  if (!timeframe) return null;
+  const match = timeframe.match(/(\d{4})/);
+  return match ? parseInt(match[1], 10) : null;
 }

--- a/apps/web/src/app/risks/risks-sort.ts
+++ b/apps/web/src/app/risks/risks-sort.ts
@@ -4,6 +4,7 @@ import type { SortDir } from "@/lib/sort-utils";
 
 import type { RiskRow } from "./risks-table";
 import { SEVERITY_ORDER, LIKELIHOOD_ORDER } from "./risk-constants";
+import { extractEarliestYear } from "./risk-utils";
 
 export type RiskSortKey = "name" | "category" | "severity" | "likelihood" | "timeHorizon";
 
@@ -21,7 +22,7 @@ export function getRiskSortValue(
     case "likelihood":
       return row.likelihood ? (LIKELIHOOD_ORDER[row.likelihood] ?? 0) : null;
     case "timeHorizon":
-      return row.timeHorizon ?? null;
+      return extractEarliestYear(row.timeHorizon);
   }
 }
 

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -9,6 +9,7 @@ import {
   RISK_CATEGORY_COLORS,
   SEVERITY_COLORS_DISPLAY,
   LIKELIHOOD_COLORS_DISPLAY,
+  DEFAULT_BADGE_COLOR,
 } from "./risk-constants";
 import { compareRiskRows, type RiskSortKey } from "./risks-sort";
 
@@ -171,7 +172,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
                   {row.riskCategory ? (
                     <span
                       className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                        RISK_CATEGORY_COLORS[row.riskCategory] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        RISK_CATEGORY_COLORS[row.riskCategory] ?? DEFAULT_BADGE_COLOR
                       }`}
                     >
                       {RISK_CATEGORY_LABELS[row.riskCategory] ?? row.riskCategory}
@@ -186,7 +187,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
                   {row.severity ? (
                     <span
                       className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                        SEVERITY_COLORS_DISPLAY[row.severity] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        SEVERITY_COLORS_DISPLAY[row.severity] ?? DEFAULT_BADGE_COLOR
                       }`}
                     >
                       {row.severity}
@@ -201,7 +202,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
                   {row.likelihood ? (
                     <span
                       className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                        LIKELIHOOD_COLORS_DISPLAY[row.likelihood] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        LIKELIHOOD_COLORS_DISPLAY[row.likelihood] ?? DEFAULT_BADGE_COLOR
                       }`}
                     >
                       {row.likelihood}


### PR DESCRIPTION
## Summary
- Extract shared `getLikelihoodDisplay()` and `getTimeframeDisplay()` to `risk-utils.ts` — listing and detail pages now show consistent output (including status in parentheses)
- Add `DEFAULT_BADGE_COLOR` constant to `risk-constants.ts`, replacing 6 hardcoded fallback strings
- Fix timeframe sorting: `extractEarliestYear()` parses the first 4-digit year for chronological ordering instead of naive string sort

## Test plan
- [x] TypeScript check passes
- [x] Listing and detail pages display identical likelihood/timeframe formatting
- [x] Timeframe sorting orders chronologically ("2025-2030" before "~2030")

🤖 Generated with [Claude Code](https://claude.com/claude-code)