### PR TITLE
fix: AI models & benchmarks — safety colors, family detection, accessibility

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   resolveAiModelBySlug,
   getAiModelSlugs,
   getRelatedModels,
+  isModelFamily,
 } from "../ai-model-utils";
 import { resolveSlugAlias } from "@/data/kb";
 import {
@@ -67,7 +68,7 @@ export default async function AiModelDetailPage({
   );
 
   // Is this a family entry?
-  const isFamily = !entity.modelTier && !entity.releaseDate;
+  const isFamily = isModelFamily(entity);
 
   // Build stat cards
   const stats: Array<{
@@ -311,15 +312,15 @@ export default async function AiModelDetailPage({
                             </Link>
                           </td>
                           <td className="py-2.5 px-4 text-muted-foreground capitalize">
-                            {m.modelTier ?? ""}
+                            {m.modelTier ?? <span className="text-muted-foreground/40">&mdash;</span>}
                           </td>
                           <td className="py-2.5 px-4 text-muted-foreground">
-                            {m.releaseDate ?? ""}
+                            {m.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
                           </td>
                           <td className="py-2.5 px-4 text-right tabular-nums">
                             {m.inputPrice != null
                               ? formatPrice(m.inputPrice)
-                              : ""}
+                              : <span className="text-muted-foreground/40">&mdash;</span>}
                           </td>
                         </tr>
                       ))}
@@ -354,7 +355,7 @@ export default async function AiModelDetailPage({
                           {m.title}
                         </Link>
                         <span className="text-xs text-muted-foreground tabular-nums">
-                          {m.releaseDate ?? ""}
+                          {m.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
                         </span>
                       </div>
                       {m.modelFamily && (

--- a/apps/web/src/app/ai-models/ai-model-utils.ts
+++ b/apps/web/src/app/ai-models/ai-model-utils.ts
@@ -36,12 +36,12 @@ export function getRelatedModels(
   return allModels.filter(
     (m) =>
       m.id !== model.id &&
-      !isFamily(m) &&
+      !isModelFamily(m) &&
       (m.modelFamily === model.modelFamily || m.developer === model.developer),
   );
 }
 
 /** Check if an entity is a family entry (no tier, no release date). */
-function isFamily(entity: AiModelEntity): boolean {
+export function isModelFamily(entity: Pick<AiModelEntity, "modelTier" | "releaseDate">): boolean {
   return !entity.modelTier && !entity.releaseDate;
 }

--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -306,7 +306,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 <td className="py-2.5 px-3">
                   {row.safetyLevel ? (
                     <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${
-                      SAFETY_LEVEL_COLORS[row.safetyLevel] ?? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
+                      SAFETY_LEVEL_COLORS[row.safetyLevel] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
                     }`}>
                       {row.safetyLevel}
                     </span>

--- a/apps/web/src/app/ai-models/page.tsx
+++ b/apps/web/src/app/ai-models/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getTypedEntities, getTypedEntityById, isAiModel } from "@/data";
 import { AiModelsTable, type AiModelRow } from "./ai-models-table";
+import { isModelFamily } from "./ai-model-utils";
 
 export const metadata: Metadata = {
   title: "AI Models",
@@ -36,7 +37,7 @@ export default function AiModelsPage() {
       entity.benchmarks?.find((b) => !isSweBench(b.name)) ?? null;
 
     // Is this a family entry (no tier, no release date)?
-    const isFamily = !entity.modelTier && !entity.releaseDate;
+    const isFamily = isModelFamily(entity);
 
     return {
       id: entity.id,

--- a/apps/web/src/app/benchmarks/benchmarks-table.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-table.tsx
@@ -110,6 +110,7 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
           <input
             type="text"
             placeholder="Search benchmarks..."
+            aria-label="Search benchmarks"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
@@ -117,6 +118,7 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
           <div className="flex flex-wrap gap-1.5">
             <button
               onClick={() => setCategoryFilter("all")}
+              aria-pressed={categoryFilter === "all"}
               className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                 categoryFilter === "all"
                   ? "bg-primary/10 border-primary/30 text-primary font-semibold"
@@ -130,6 +132,7 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
               <button
                 key={cat}
                 onClick={() => setCategoryFilter(categoryFilter === cat ? "all" : cat)}
+                aria-pressed={categoryFilter === cat}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                   categoryFilter === cat
                     ? "bg-primary/10 border-primary/30 text-primary font-semibold"


### PR DESCRIPTION
## Summary
- Fix safety level badge: use proper gray fallback instead of hardcoded yellow (SAFETY_LEVEL_COLORS already handles per-level colors)
- Extract `isModelFamily()` to shared utility in `ai-model-utils.ts` (was duplicated 3x)
- Add `aria-label` to benchmarks search input
- Add `aria-pressed` to benchmarks category filter buttons
- Replace `?? ""` with em-dashes in AI model detail page family table

## Test plan
- [x] TypeScript check passes
- [x] Safety level badges show correct per-level colors
- [x] Benchmarks table has proper accessibility attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)