### PR TITLE
fix: move extractEarliestYear to client-safe module

### DIFF
--- a/apps/web/src/app/risks/risk-constants.ts
+++ b/apps/web/src/app/risks/risk-constants.ts
@@ -98,3 +98,14 @@ export const LIKELIHOOD_COLORS_DISPLAY: Record<string, string> = {
   "Very High":
     "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
 };
+
+// ── Pure helpers (client-safe) ────────────────────────────────────────
+
+/** Extract the earliest 4-digit year from a timeframe string like "2025-2030". */
+export function extractEarliestYear(
+  timeframe: string | null | undefined,
+): number | null {
+  if (!timeframe) return null;
+  const match = timeframe.match(/(\d{4})/);
+  return match ? parseInt(match[1], 10) : null;
+}

--- a/apps/web/src/app/risks/risk-utils.ts
+++ b/apps/web/src/app/risks/risk-utils.ts
@@ -71,10 +71,5 @@ export function getTimeframeDisplay(
  *   "By 2040" → 2040
  *   "unknown" → null
  */
-export function extractEarliestYear(
-  timeframe: string | null | undefined,
-): number | null {
-  if (!timeframe) return null;
-  const match = timeframe.match(/(\d{4})/);
-  return match ? parseInt(match[1], 10) : null;
-}
+// extractEarliestYear moved to risk-constants.ts (client-safe)
+export { extractEarliestYear } from "./risk-constants";

--- a/apps/web/src/app/risks/risks-sort.ts
+++ b/apps/web/src/app/risks/risks-sort.ts
@@ -3,8 +3,7 @@ export type { SortDir } from "@/lib/sort-utils";
 import type { SortDir } from "@/lib/sort-utils";
 
 import type { RiskRow } from "./risks-table";
-import { SEVERITY_ORDER, LIKELIHOOD_ORDER } from "./risk-constants";
-import { extractEarliestYear } from "./risk-utils";
+import { SEVERITY_ORDER, LIKELIHOOD_ORDER, extractEarliestYear } from "./risk-constants";
 
 export type RiskSortKey = "name" | "category" | "severity" | "likelihood" | "timeHorizon";
 


### PR DESCRIPTION
## Summary

Fixes Next.js build failure on main: `Module not found: Can't resolve 'fs'`

The import chain `risks-table.tsx` ("use client") → `risks-sort.ts` → `risk-utils.ts` → `directory-utils.ts` → `kb.ts` pulled server-only `fs` module into a client component bundle.

Fix: moved `extractEarliestYear` (a pure string function) from `risk-utils.ts` to `risk-constants.ts` which has no server dependencies. Re-exported from `risk-utils.ts` for backward compatibility.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm build` passes (no webpack fs error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)