### PR TITLE
test: add render smoke tests for internal dashboards

### DIFF
--- a/apps/web/src/app/internal/__tests__/auto-update-news-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/auto-update-news-content.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Render smoke tests for the Auto-Update News dashboard content component.
+ *
+ * AutoUpdateNewsContent fetches news items from the wiki-server API with a
+ * YAML file fallback, plus reads sources config from the filesystem. These
+ * tests mock all external dependencies and verify the component renders
+ * without throwing for key data scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type React from "react";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+// Mock fs so the YAML fallback and sources loading don't hit the real filesystem
+vi.mock("fs", () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(false),
+    readdirSync: vi.fn().mockReturnValue([]),
+    readFileSync: vi.fn().mockReturnValue(""),
+  },
+  existsSync: vi.fn().mockReturnValue(false),
+  readdirSync: vi.fn().mockReturnValue([]),
+  readFileSync: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("@lib/yaml", () => ({
+  loadYaml: vi.fn().mockReturnValue({ sources: [] }),
+}));
+
+vi.mock("@/app/internal/auto-update-news/news-table", () => ({
+  NewsTable: () => null,
+}));
+
+vi.mock("@/app/internal/auto-update-news/sources-table", () => ({
+  SourcesTable: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@lib/wiki-server";
+import { AutoUpdateNewsContent } from "@/app/internal/auto-update-news/auto-update-news-content";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockNewsItems = [
+  {
+    title: "OpenAI announces new safety framework",
+    url: "https://example.com/openai-safety",
+    sourceId: "rss-openai-blog",
+    publishedAt: "2025-01-15T10:00:00Z",
+    summary: "OpenAI released a new preparedness framework for frontier models",
+    relevanceScore: 85,
+    topics: ["safety", "governance"],
+    routedTo: "OpenAI",
+    routedTier: "standard",
+    runDate: "2025-01-15",
+  },
+  {
+    title: "Anthropic publishes responsible scaling update",
+    url: "https://example.com/anthropic-rsp",
+    sourceId: "rss-anthropic-blog",
+    publishedAt: "2025-01-14T09:00:00Z",
+    summary: "Update to Anthropic's responsible scaling policy",
+    relevanceScore: 90,
+    topics: ["responsible-scaling", "policy"],
+    routedTo: "Anthropic",
+    routedTier: "budget",
+    runDate: "2025-01-15",
+  },
+  {
+    title: "Minor AI news article",
+    url: "https://example.com/minor-news",
+    sourceId: "web-search-general",
+    publishedAt: "2025-01-13T15:00:00Z",
+    summary: "A minor development in AI",
+    relevanceScore: 30,
+    topics: ["general"],
+    routedTo: null,
+    routedTier: null,
+    runDate: "2025-01-15",
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AutoUpdateNewsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with news data", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { items: mockNewsItems, runDates: ["2025-01-15"] },
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing with empty news", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { items: [], runDates: [] },
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API is not configured", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { items: [], runDates: [] },
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { items: [], runDates: [] },
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with multiple run dates", async () => {
+    const multiRunNews = [
+      ...mockNewsItems,
+      {
+        ...mockNewsItems[0],
+        title: "Another article from a different run",
+        runDate: "2025-01-14",
+      },
+    ];
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: {
+        items: multiRunNews,
+        runDates: ["2025-01-15", "2025-01-14"],
+      },
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing when no items are routed", async () => {
+    const unroutedItems = mockNewsItems.map((i) => ({
+      ...i,
+      routedTo: null,
+      routedTier: null,
+    }));
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { items: unroutedItems, runDates: ["2025-01-15"] },
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateNewsContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/auto-update-runs-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/auto-update-runs-content.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Render smoke tests for the Auto-Update Runs dashboard content component.
+ *
+ * AutoUpdateRunsContent fetches run data from the wiki-server API with a
+ * YAML file fallback. These tests mock both paths and verify the component
+ * renders without throwing for key data scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type React from "react";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+// Mock fs so the YAML fallback doesn't hit the real filesystem
+vi.mock("fs", () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(false),
+    readdirSync: vi.fn().mockReturnValue([]),
+    readFileSync: vi.fn().mockReturnValue(""),
+  },
+  existsSync: vi.fn().mockReturnValue(false),
+  readdirSync: vi.fn().mockReturnValue([]),
+  readFileSync: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("@lib/yaml", () => ({
+  loadYaml: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/app/internal/auto-update-runs/runs-table", () => ({
+  RunsTable: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@lib/wiki-server";
+import { AutoUpdateRunsContent } from "@/app/internal/auto-update-runs/auto-update-runs-content";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockRuns = [
+  {
+    date: "2025-01-15",
+    startedAt: "2025-01-15T06:00:00Z",
+    trigger: "scheduled",
+    sourcesChecked: 12,
+    sourcesFailed: 1,
+    itemsFetched: 45,
+    itemsRelevant: 8,
+    pagesPlanned: 5,
+    pagesUpdated: 4,
+    pagesFailed: 1,
+    pagesSkipped: 0,
+    budgetLimit: 30,
+    budgetSpent: 12.5,
+    durationMinutes: 25,
+    results: [
+      {
+        pageId: "openai",
+        status: "success" as const,
+        tier: "standard",
+        durationMs: 15000,
+      },
+      {
+        pageId: "anthropic",
+        status: "success" as const,
+        tier: "budget",
+        durationMs: 8000,
+      },
+      {
+        pageId: "alignment",
+        status: "failed" as const,
+        tier: "standard",
+        error: "Quality gate failed",
+      },
+    ],
+  },
+  {
+    date: "2025-01-14",
+    startedAt: "2025-01-14T06:00:00Z",
+    trigger: "manual",
+    sourcesChecked: 10,
+    sourcesFailed: 0,
+    itemsFetched: 30,
+    itemsRelevant: 5,
+    pagesPlanned: 3,
+    pagesUpdated: 3,
+    pagesFailed: 0,
+    pagesSkipped: 0,
+    budgetLimit: 20,
+    budgetSpent: 8.0,
+    durationMinutes: 15,
+    results: [],
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AutoUpdateRunsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with run data", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockRuns,
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing with empty runs", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API is not configured", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with runs that have failures", async () => {
+    const runsWithFailures = [
+      {
+        ...mockRuns[0],
+        pagesFailed: 5,
+        pagesUpdated: 0,
+      },
+    ];
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: runsWithFailures,
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing with zero budget spent", async () => {
+    const zeroBudget = mockRuns.map((r) => ({
+      ...r,
+      budgetSpent: 0,
+      pagesUpdated: 0,
+    }));
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: zeroBudget,
+      source: "api" as const,
+    });
+
+    const element = await AutoUpdateRunsContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/entities-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/entities-content.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Render smoke tests for the Entities dashboard content component.
+ *
+ * EntitiesContent reads from local database.json via multiple data functions
+ * and builds a unified entity row view. These tests verify the component
+ * renders without throwing for typical and edge-case data shapes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/data", () => ({
+  getTypedEntities: vi.fn(),
+  getEntityHref: vi.fn(),
+  getPageById: vi.fn(),
+  getPageCoverageItems: vi.fn(),
+  getPageRankings: vi.fn(),
+}));
+
+vi.mock("@/app/internal/entities/entities-data-table", () => ({
+  EntitiesDataTable: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import {
+  getTypedEntities,
+  getEntityHref,
+  getPageById,
+  getPageCoverageItems,
+  getPageRankings,
+} from "@/data";
+import { EntitiesContent } from "@/app/internal/entities/entities-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockEntities = [
+  {
+    id: "openai",
+    numericId: "E1",
+    entityType: "organization",
+    title: "OpenAI",
+    description: "AI research laboratory",
+    status: "active",
+    tags: ["frontier-lab"],
+    relatedEntries: [{ id: "anthropic" }],
+    lastUpdated: "2025-01-01",
+  },
+  {
+    id: "anthropic",
+    numericId: "E2",
+    entityType: "organization",
+    title: "Anthropic",
+    description: null,
+    status: null,
+    tags: [],
+    relatedEntries: null,
+    lastUpdated: null,
+  },
+  {
+    id: "existential-risk",
+    numericId: null,
+    entityType: "concept",
+    title: "Existential Risk",
+    description: "Risks that threaten human extinction",
+    status: null,
+    tags: ["core-concept"],
+    relatedEntries: [],
+    lastUpdated: "2024-12-01",
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("EntitiesContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getPageCoverageItems).mockReturnValue([]);
+    vi.mocked(getPageRankings).mockReturnValue([]);
+    vi.mocked(getEntityHref).mockReturnValue("/wiki/E1");
+    vi.mocked(getPageById).mockReturnValue(undefined);
+  });
+
+  it("renders without throwing with entity data", () => {
+    vi.mocked(getTypedEntities).mockReturnValue(mockEntities as never);
+
+    const element = EntitiesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with empty entities", () => {
+    vi.mocked(getTypedEntities).mockReturnValue([]);
+
+    const element = EntitiesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when entities have pages", () => {
+    vi.mocked(getTypedEntities).mockReturnValue(mockEntities as never);
+    vi.mocked(getPageById).mockImplementation((id: string) => {
+      if (id === "openai")
+        return { id: "openai", title: "OpenAI" } as never;
+      return undefined;
+    });
+
+    const element = EntitiesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with coverage and ranking data", () => {
+    vi.mocked(getTypedEntities).mockReturnValue(mockEntities as never);
+    vi.mocked(getPageCoverageItems).mockReturnValue([
+      {
+        id: "openai",
+        quality: 80,
+        readerImportance: 90,
+        researchImportance: 85,
+        tacticalValue: 70,
+        score: 75,
+        total: 100,
+        riskLevel: "low",
+        riskScore: 15,
+        category: "knowledge-base",
+        subcategory: "organizations",
+        lastUpdated: "2025-01-01",
+        wordCount: 5000,
+      },
+    ] as never);
+    vi.mocked(getPageRankings).mockReturnValue([
+      {
+        id: "openai",
+        quality: 80,
+        readerImportance: 90,
+        researchImportance: 85,
+        readerRank: 1,
+        researchRank: 2,
+        wordCount: 5000,
+        category: "knowledge-base",
+      },
+    ] as never);
+
+    const element = EntitiesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when all descriptions are null", () => {
+    const entitiesNoDesc = mockEntities.map((e) => ({
+      ...e,
+      description: null,
+    }));
+    vi.mocked(getTypedEntities).mockReturnValue(entitiesNoDesc as never);
+
+    const element = EntitiesContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/improve-runs-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/improve-runs-content.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Render smoke tests for the Improve Runs dashboard content component.
+ *
+ * ImproveRunsContent fetches artifact data from the wiki-server API and
+ * transforms it into run rows with cost, quality gate, and phase data.
+ * These tests verify the component renders without throwing for key
+ * data scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+}));
+
+vi.mock("@/app/internal/improve-runs/runs-table", () => ({
+  RunsTable: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { fetchDetailed } from "@lib/wiki-server";
+import { ImproveRunsContent } from "@/app/internal/improve-runs/improve-runs-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockArtifacts = [
+  {
+    id: 1,
+    pageId: "existential-risk",
+    engine: "v2",
+    tier: "standard",
+    directions: "Improve clarity and add citations",
+    startedAt: "2025-01-01T10:00:00Z",
+    completedAt: "2025-01-01T10:15:00Z",
+    durationS: 900,
+    totalCost: 2.5,
+    qualityGatePassed: true,
+    qualityGaps: null,
+    toolCallCount: 12,
+    refinementCycles: 2,
+    phasesRun: ["research", "enrich", "review"],
+    sourceCache: [{ url: "https://example.com" }],
+    citationAudit: { total: 5, verified: 4 },
+    sectionDiffs: [{ section: "Overview", added: 3, removed: 1 }],
+    costBreakdown: { research: 1.0, enrich: 1.0, review: 0.5 },
+  },
+  {
+    id: 2,
+    pageId: "alignment",
+    engine: "v1",
+    tier: "budget",
+    directions: null,
+    startedAt: "2025-01-02T09:00:00Z",
+    completedAt: "2025-01-02T09:05:00Z",
+    durationS: 300,
+    totalCost: 0.8,
+    qualityGatePassed: false,
+    qualityGaps: ["missing citations", "too short"],
+    toolCallCount: 5,
+    refinementCycles: 1,
+    phasesRun: ["enrich"],
+    sourceCache: [],
+    citationAudit: null,
+    sectionDiffs: [],
+    costBreakdown: null,
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ImproveRunsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with run data", async () => {
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: { entries: mockArtifacts, total: mockArtifacts.length },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with empty runs", async () => {
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: { entries: [], total: 0 },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API fails", async () => {
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: false,
+      error: { type: "not-configured" as const },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API has connection error", async () => {
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: false,
+      error: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with null costs and durations", async () => {
+    const runsWithNulls = mockArtifacts.map((a) => ({
+      ...a,
+      totalCost: null,
+      durationS: null,
+      completedAt: null,
+    }));
+
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: { entries: runsWithNulls, total: runsWithNulls.length },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when all runs fail quality gate", async () => {
+    const allFailed = mockArtifacts.map((a) => ({
+      ...a,
+      qualityGatePassed: false,
+      qualityGaps: ["insufficient citations"],
+    }));
+
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: { entries: allFailed, total: allFailed.length },
+    });
+
+    const element = await ImproveRunsContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/page-changes-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/page-changes-content.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Render smoke tests for the Page Changes dashboard content component.
+ *
+ * PageChangesContent fetches session data from the wiki-server API and
+ * enriches it with local page metadata from database.json. These tests
+ * verify the component renders without throwing for the key data scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+vi.mock("@/data", () => ({
+  getPageChangeSessions: vi.fn(),
+  getAllPages: vi.fn(),
+  getIdRegistry: vi.fn(),
+}));
+
+vi.mock("@/app/internal/page-changes/page-changes-sessions", () => ({
+  PageChangesSessions: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@lib/wiki-server";
+import { PageChangesContent } from "@/app/internal/page-changes/page-changes-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockSessions = [
+  {
+    sessionKey: "2025-01-01|claude/fix-auth",
+    date: "2025-01-01",
+    branch: "claude/fix-auth",
+    sessionTitle: "Fix authentication flow",
+    summary: "Updated auth middleware",
+    pr: 123,
+    model: "claude-opus-4-6",
+    duration: "45 min",
+    cost: "$1.50",
+    pages: [
+      {
+        pageId: "existential-risk",
+        pageTitle: "Existential Risk",
+        pagePath: "/wiki/E42",
+        numericId: "E42",
+        category: "knowledge-base",
+      },
+      {
+        pageId: "alignment",
+        pageTitle: "Alignment",
+        pagePath: "/wiki/E43",
+        numericId: "E43",
+        category: "knowledge-base",
+      },
+    ],
+  },
+  {
+    sessionKey: "2025-01-02|claude/feature-dashboard",
+    date: "2025-01-02",
+    branch: "claude/feature-dashboard",
+    sessionTitle: "Add dashboard feature",
+    summary: "",
+    pages: [
+      {
+        pageId: "openai",
+        pageTitle: "OpenAI",
+        pagePath: "/wiki/E1",
+        numericId: "E1",
+        category: "knowledge-base",
+      },
+    ],
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PageChangesContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with session data", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockSessions,
+      source: "api" as const,
+    });
+
+    const element = await PageChangesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with empty sessions", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "api" as const,
+    });
+
+    const element = await PageChangesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API is not configured", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await PageChangesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with sessions missing optional fields", async () => {
+    const minimalSessions = [
+      {
+        sessionKey: "2025-01-01|unknown",
+        date: "2025-01-01",
+        branch: "unknown",
+        sessionTitle: "",
+        summary: "",
+        pages: [
+          {
+            pageId: "some-page",
+            pageTitle: "some-page",
+            pagePath: "/wiki/some-page",
+            numericId: "some-page",
+            category: "unknown",
+          },
+        ],
+      },
+    ];
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: minimalSessions,
+      source: "local" as const,
+    });
+
+    const element = await PageChangesContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await PageChangesContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/page-coverage-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/page-coverage-content.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Render smoke tests for the Page Coverage dashboard content component.
+ *
+ * PageCoverageContent reads from local database.json via getPageCoverageItems().
+ * These tests mock the data layer to verify the component renders without
+ * throwing for typical and edge-case data shapes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/data", () => ({
+  getPageCoverageItems: vi.fn(),
+}));
+
+vi.mock("@/app/internal/page-coverage/coverage-table", () => ({
+  CoverageTable: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { getPageCoverageItems } from "@/data";
+import { PageCoverageContent } from "@/app/internal/page-coverage/page-coverage-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockCoverageItems = [
+  {
+    id: "existential-risk",
+    title: "Existential Risk",
+    quality: 85,
+    riskLevel: "low",
+    score: 72,
+    total: 100,
+    category: "knowledge-base",
+    subcategory: "concepts",
+    lastUpdated: "2025-01-01",
+    wordCount: 3500,
+    readerImportance: 90,
+    researchImportance: 80,
+    tacticalValue: 70,
+  },
+  {
+    id: "alignment",
+    title: "Alignment",
+    quality: null,
+    riskLevel: "high",
+    score: 45,
+    total: 100,
+    category: "knowledge-base",
+    subcategory: "concepts",
+    lastUpdated: "2024-06-15",
+    wordCount: 1200,
+    readerImportance: 95,
+    researchImportance: 95,
+    tacticalValue: 60,
+  },
+  {
+    id: "rlhf",
+    title: "RLHF",
+    quality: 60,
+    riskLevel: "medium",
+    score: 58,
+    total: 100,
+    category: "knowledge-base",
+    subcategory: "approaches",
+    lastUpdated: "2025-02-01",
+    wordCount: 2800,
+    readerImportance: 75,
+    researchImportance: 85,
+    tacticalValue: 50,
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PageCoverageContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with coverage data", () => {
+    vi.mocked(getPageCoverageItems).mockReturnValue(mockCoverageItems as never);
+
+    const element = PageCoverageContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with empty data", () => {
+    vi.mocked(getPageCoverageItems).mockReturnValue([]);
+
+    const element = PageCoverageContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when all quality values are null", () => {
+    const itemsWithoutQuality = mockCoverageItems.map((i) => ({
+      ...i,
+      quality: null,
+    }));
+    vi.mocked(getPageCoverageItems).mockReturnValue(
+      itemsWithoutQuality as never
+    );
+
+    const element = PageCoverageContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when all items are high risk", () => {
+    const allHighRisk = mockCoverageItems.map((i) => ({
+      ...i,
+      riskLevel: "high",
+    }));
+    vi.mocked(getPageCoverageItems).mockReturnValue(allHighRisk as never);
+
+    const element = PageCoverageContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/session-insights-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/session-insights-content.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Render smoke tests for the Session Insights dashboard content component.
+ *
+ * SessionInsightsContent fetches learnings and recommendations from the
+ * wiki-server API. These tests verify the component renders without
+ * throwing for the key data scenarios including empty state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type React from "react";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+vi.mock("@/app/internal/session-insights/insights-table", () => ({
+  InsightsTable: () => null,
+}));
+
+vi.mock("@/components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@/lib/wiki-server";
+import { SessionInsightsContent } from "@/app/internal/session-insights/session-insights-content";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockInsights = {
+  insights: [
+    {
+      date: "2025-01-01",
+      branch: "claude/fix-auth",
+      title: "Fix auth session",
+      type: "learning" as const,
+      text: "The auth middleware needs to check token expiry before validation",
+    },
+    {
+      date: "2025-01-02",
+      branch: "claude/add-dashboard",
+      title: "Add dashboard",
+      type: "recommendation" as const,
+      text: "Consider adding caching for dashboard API calls",
+    },
+    {
+      date: null,
+      branch: null,
+      title: null,
+      type: "learning" as const,
+      text: "Some insight without session metadata",
+    },
+  ],
+  summary: {
+    total: 3,
+    byType: { learning: 2, recommendation: 1 },
+  },
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SessionInsightsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with insights data", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockInsights,
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing with empty insights", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { insights: [], summary: { total: 0, byType: {} } },
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API returns null (no local fallback)", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: null,
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: null,
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when summary has many types", async () => {
+    const manyTypes = {
+      insights: mockInsights.insights,
+      summary: {
+        total: 10,
+        byType: { learning: 5, recommendation: 3, observation: 2 },
+      },
+    };
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: manyTypes,
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+});

--- a/apps/web/src/app/internal/__tests__/suggested-pages-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/suggested-pages-content.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Render smoke tests for the Suggested Pages dashboard content component.
+ *
+ * SuggestedPagesContent uses a static data file with page suggestions.
+ * These tests verify the component renders without throwing. The data
+ * is a constant array so the main risk is UI rendering bugs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/app/internal/suggested-pages/suggested-pages-table", () => ({
+  SuggestedPagesTable: () => null,
+}));
+
+// We don't need to mock the data file since it's a plain constant array.
+// But if it causes import issues, we can mock it.
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { SuggestedPagesContent } from "@/app/internal/suggested-pages/suggested-pages-content";
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SuggestedPagesContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with the static suggestions data", () => {
+    const element = SuggestedPagesContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/update-schedule-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/update-schedule-content.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Render smoke tests for the Update Schedule dashboard content component.
+ *
+ * UpdateScheduleContent uses getUpdateSchedule() which returns local data
+ * with a source indicator. These tests verify the component renders without
+ * throwing for typical and edge-case data shapes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/data", () => ({
+  getUpdateSchedule: vi.fn(),
+}));
+
+vi.mock("@/app/internal/updates/updates-table", () => ({
+  UpdatesTable: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { getUpdateSchedule } from "@/data";
+import { UpdateScheduleContent } from "@/app/internal/updates/updates-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockScheduleItems = [
+  {
+    id: "existential-risk",
+    title: "Existential Risk",
+    category: "knowledge-base",
+    quality: 85,
+    importance: 95,
+    lastEdited: "2024-06-01",
+    updateFrequency: 90,
+    daysUntilDue: -30,
+    staleness: 1.5,
+    priority: 95,
+  },
+  {
+    id: "alignment",
+    title: "Alignment",
+    category: "knowledge-base",
+    quality: 70,
+    importance: 90,
+    lastEdited: "2025-01-01",
+    updateFrequency: 180,
+    daysUntilDue: 120,
+    staleness: 0.3,
+    priority: 60,
+  },
+  {
+    id: "openai",
+    title: "OpenAI",
+    category: "knowledge-base",
+    quality: 60,
+    importance: 80,
+    lastEdited: "2024-12-01",
+    updateFrequency: 30,
+    daysUntilDue: -45,
+    staleness: 2.5,
+    priority: 88,
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("UpdateScheduleContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with schedule data", async () => {
+    vi.mocked(getUpdateSchedule).mockResolvedValue({
+      data: mockScheduleItems as never,
+      source: "api" as const,
+    });
+
+    const element = await UpdateScheduleContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with empty schedule", async () => {
+    vi.mocked(getUpdateSchedule).mockResolvedValue({
+      data: [],
+      source: "api" as const,
+    });
+
+    const element = await UpdateScheduleContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when all pages are overdue", async () => {
+    const allOverdue = mockScheduleItems.map((i) => ({
+      ...i,
+      daysUntilDue: -10,
+    }));
+    vi.mocked(getUpdateSchedule).mockResolvedValue({
+      data: allOverdue as never,
+      source: "api" as const,
+    });
+
+    const element = await UpdateScheduleContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when no pages are overdue", async () => {
+    const noneOverdue = mockScheduleItems.map((i) => ({
+      ...i,
+      daysUntilDue: 30,
+    }));
+    vi.mocked(getUpdateSchedule).mockResolvedValue({
+      data: noneOverdue as never,
+      source: "local" as const,
+    });
+
+    const element = await UpdateScheduleContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       "@components": path.resolve(__dirname, "./src/components"),
       "@data": path.resolve(__dirname, "./src/data/index.ts"),
       "@lib": path.resolve(__dirname, "./src/lib"),
+      "@wiki-server/api-response-types": path.resolve(__dirname, "../wiki-server/src/api-response-types.ts"),
+      "@wiki-server/api-types": path.resolve(__dirname, "../wiki-server/src/api-types.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add render smoke tests for **9 untested internal dashboards**: page-coverage (E899), entities (E908), page-changes (E909), update-schedule (E900), suggested-pages (E910), improve-runs (E911), session-insights (E913), auto-update-runs (E914), auto-update-news (E915)
- Add `@wiki-server/*` path aliases to `vitest.config.ts` so components importing wiki-server types resolve correctly in tests
- Brings total dashboard test coverage from 4 dashboards to all 13 listed in the issue

Each test file follows the established pattern (mock data layer, mock client components, call async server component, assert truthy). Tests cover: normal data, empty state, API not configured, connection errors, and edge cases like null fields and all-failed states.

**72 total test cases** across 13 dashboard test files, all passing.

## Test plan

- [x] `npx vitest run src/app/internal/__tests__/` passes all 72 tests across 13 files
- [x] Full `npx vitest run` passes (2 pre-existing failures unrelated to this PR, caused by missing build artifacts in worktree)
- [x] No changes to production code (except adding vitest aliases)

Closes #1654