### PR TITLE
Extend Coefficient Giving program matching rules

### DIFF
--- a/crux/lib/grant-import/program-matcher.test.ts
+++ b/crux/lib/grant-import/program-matcher.test.ts
@@ -87,7 +87,18 @@ describe("matchProgram", () => {
     expect(result).toBe(PROGRAM_IDS.OP_BIOSECURITY);
   });
 
-  it("matches OP global health grants", () => {
+  it("matches farm animal welfare to specific program", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Farm Animal Welfare",
+      name: "Good Food Institute",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE);
+  });
+
+  it("matches 'Global Health and Wellbeing — Farm Animal Welfare' to farm animal welfare", () => {
     const result = matchProgram({
       source: "coefficient-giving",
       funderId: "ULjDXpSLCI",
@@ -95,7 +106,7 @@ describe("matchProgram", () => {
       name: "Good Food Institute",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
+    expect(result).toBe(PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE);
   });
 
   it("matches OP criminal justice grants to global health program", () => {
@@ -104,6 +115,171 @@ describe("matchProgram", () => {
       funderId: "ULjDXpSLCI",
       focusArea: "Criminal Justice Reform",
       name: "Vera Institute support",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
+  });
+
+  it("matches GCR opportunities", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Global Catastrophic Risks",
+      name: "Some GCR grant",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_GCR_OPPORTUNITIES);
+  });
+
+  it("matches science and global health R&D", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Science and Global Health R&D",
+      name: "Vaccine research",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_SCIENCE_RD);
+  });
+
+  it("matches scientific research to science R&D", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Scientific Research",
+      name: "Lab equipment",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_SCIENCE_RD);
+  });
+
+  it("matches forecasting grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Forecasting",
+      name: "Metaculus support",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_FORECASTING);
+  });
+
+  it("matches effective giving grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Effective Giving",
+      name: "CEA support",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_EFFECTIVE_GIVING);
+  });
+
+  it("matches EA community building to effective giving", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Effective Altruism Community Building",
+      name: "Local group support",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_EFFECTIVE_GIVING);
+  });
+
+  it("matches global aid policy grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Global Aid Policy",
+      name: "Aid advocacy",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_GLOBAL_AID);
+  });
+
+  it("matches U.S. policy to global aid", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "U.S. Policy",
+      name: "Policy research",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_GLOBAL_AID);
+  });
+
+  it("matches global economic growth grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Global Economic Growth",
+      name: "Growth research",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_GLOBAL_GROWTH);
+  });
+
+  it("matches air quality grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "South Asian Air Quality",
+      name: "Air quality monitoring",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_AIR_QUALITY);
+  });
+
+  it("matches lead exposure grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Lead Exposure",
+      name: "LEAF grant",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_LEAF);
+  });
+
+  it("matches abundance grants", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Abundance and Growth",
+      name: "Innovation grant",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_ABUNDANCE_GROWTH);
+  });
+
+  it("matches technical AI safety RFP", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Technical AI Safety RFP",
+      name: "Alignment research",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.CG_TECHNICAL_AI_SAFETY_RFP);
+  });
+
+  it("falls back to OP_GLOBAL_HEALTH for unrecognized CG focus areas", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: "Some New Focus Area",
+      name: "Miscellaneous grant",
+      description: null,
+    });
+    expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
+  });
+
+  it("falls back to OP_GLOBAL_HEALTH for CG grants with no focus area", () => {
+    const result = matchProgram({
+      source: "coefficient-giving",
+      funderId: "ULjDXpSLCI",
+      focusArea: null,
+      name: "Miscellaneous grant",
       description: null,
     });
     expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);

--- a/crux/lib/grant-import/program-matcher.ts
+++ b/crux/lib/grant-import/program-matcher.ts
@@ -23,10 +23,23 @@ function progId(seed: string): string {
 
 // Pre-compute program IDs for all known programs
 export const PROGRAM_IDS = {
-  // Open Philanthropy
+  // Open Philanthropy / Coefficient Giving — broad programs
   OP_AI_SAFETY: progId("prog|open-philanthropy|ai-safety"),
   OP_BIOSECURITY: progId("prog|open-philanthropy|biosecurity"),
   OP_GLOBAL_HEALTH: progId("prog|open-philanthropy|global-health"),
+
+  // Coefficient Giving — specific programs
+  CG_GCR_OPPORTUNITIES: progId("prog|coefficient-giving|gcr-opportunities"),
+  CG_FARM_ANIMAL_WELFARE: progId("prog|coefficient-giving|farm-animal-welfare"),
+  CG_SCIENCE_RD: progId("prog|coefficient-giving|science-rd"),
+  CG_FORECASTING: progId("prog|coefficient-giving|forecasting"),
+  CG_EFFECTIVE_GIVING: progId("prog|coefficient-giving|effective-giving-careers"),
+  CG_GLOBAL_AID: progId("prog|coefficient-giving|global-aid-policy"),
+  CG_GLOBAL_GROWTH: progId("prog|coefficient-giving|global-growth"),
+  CG_AIR_QUALITY: progId("prog|coefficient-giving|air-quality"),
+  CG_LEAF: progId("prog|coefficient-giving|lead-exposure"),
+  CG_ABUNDANCE_GROWTH: progId("prog|coefficient-giving|abundance-growth-grants"),
+  CG_TECHNICAL_AI_SAFETY_RFP: progId("prog|coefficient-giving|technical-ai-safety-rfp-2025"),
 
   // EA Funds
   LTFF_GRANTS: progId("prog|ea-funds|ltff-grants"),
@@ -99,20 +112,114 @@ const RULES: ProgramRule[] = [
   },
 
   // ===== Coefficient Giving (Open Philanthropy) =====
-  // Coefficient Giving grants have focusArea for the program area
+  // Coefficient Giving grants have focusArea extracted from bracketed prefix in notes.
+  // More specific rules come first; general catch-all is last.
+
+  // --- Specific programs (most specific patterns first) ---
+
+  // Technical AI Safety RFP — specific RFP under the AI safety umbrella
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /technical ai safety rfp|technical ai safety research rfp/i,
+    programId: PROGRAM_IDS.CG_TECHNICAL_AI_SAFETY_RFP,
+  },
+
+  // AI Safety (broad) — covers AI governance, AI policy, alignment research
   {
     source: "coefficient-giving",
     focusAreaPattern: /potential risks from advanced ai|ai safety|ai governance|technical ai safety|ai policy/i,
     programId: PROGRAM_IDS.OP_AI_SAFETY,
   },
+
+  // Biosecurity and Pandemic Preparedness
   {
     source: "coefficient-giving",
     focusAreaPattern: /biosecurity|pandemic preparedness|global catastrophic biological/i,
     programId: PROGRAM_IDS.OP_BIOSECURITY,
   },
+
+  // GCR Opportunities — global catastrophic risks beyond AI/bio
   {
     source: "coefficient-giving",
-    focusAreaPattern: /global health|farm animal|criminal justice|land use|immigration|macroeconomic/i,
+    focusAreaPattern: /global catastrophic risks|gcr|existential risk/i,
+    programId: PROGRAM_IDS.CG_GCR_OPPORTUNITIES,
+  },
+
+  // Farm Animal Welfare — must match before general global health catch-all
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /farm animal welfare/i,
+    programId: PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE,
+  },
+
+  // Science & Global Health R&D
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /science.*global health r&d|scientific research|global health r&d/i,
+    programId: PROGRAM_IDS.CG_SCIENCE_RD,
+  },
+
+  // Forecasting
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /forecasting/i,
+    programId: PROGRAM_IDS.CG_FORECASTING,
+  },
+
+  // Effective Giving & Careers / EA Community Building
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /effective giving|effective altruism community|community building/i,
+    programId: PROGRAM_IDS.CG_EFFECTIVE_GIVING,
+  },
+
+  // Global Aid Policy
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /global aid|u\.s\. policy/i,
+    programId: PROGRAM_IDS.CG_GLOBAL_AID,
+  },
+
+  // Global Growth / Economic Growth in Developing Countries
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /global economic growth|economic growth.*developing/i,
+    programId: PROGRAM_IDS.CG_GLOBAL_GROWTH,
+  },
+
+  // Air Quality
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /air quality|south asian air quality/i,
+    programId: PROGRAM_IDS.CG_AIR_QUALITY,
+  },
+
+  // Lead Exposure Action Fund (LEAF)
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /lead exposure|lead poisoning/i,
+    programId: PROGRAM_IDS.CG_LEAF,
+  },
+
+  // Abundance & Growth Grants
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /abundance|scientific innovation/i,
+    programId: PROGRAM_IDS.CG_ABUNDANCE_GROWTH,
+  },
+
+  // --- General catch-all for remaining Coefficient Giving grants ---
+  // Catches global health, criminal justice, land use, immigration, macroeconomic, etc.
+  {
+    source: "coefficient-giving",
+    focusAreaPattern: /global health|criminal justice|land use|immigration|macroeconomic/i,
+    programId: PROGRAM_IDS.OP_GLOBAL_HEALTH,
+  },
+
+  // Final fallback for any coefficient-giving grant with a focus area
+  // that didn't match any specific program above
+  {
+    source: "coefficient-giving",
     programId: PROGRAM_IDS.OP_GLOBAL_HEALTH,
   },
 


### PR DESCRIPTION
## Summary

- Added 11 new program IDs for Coefficient Giving focus areas: GCR Opportunities, Farm Animal Welfare, Science & GH R&D, Forecasting, Effective Giving & Careers, Global Aid Policy, Global Growth, Air Quality, LEAF (Lead Exposure), Abundance & Growth, and Technical AI Safety RFP
- Split the former broad `OP_GLOBAL_HEALTH` catch-all rule into specific focus-area rules, ordered by specificity (most specific patterns first, general catch-all last)
- Added a final fallback rule for any `coefficient-giving` grant that doesn't match a specific program, mapping to `OP_GLOBAL_HEALTH`
- Added 18 new tests covering all new programs and fallback behavior (39 total tests, all passing)

## Motivation

Running `pnpm crux backfill-program-ids run` showed 1,489 Coefficient Giving grants unmatched because the matcher only had 3 broad rules (AI Safety, Biosecurity, Global Health catch-all). The new rules map grants to their specific funding programs based on focus area patterns extracted from grant notes.

## Test plan

- [x] All 39 program-matcher tests pass (`npx vitest run --config crux/vitest.config.ts crux/lib/grant-import/program-matcher.test.ts`)
- [x] TypeScript compiles cleanly (no new errors in changed files)
- [x] Program ID seeds match those in `import-funding-programs.ts`
- [ ] After merge: run `WIKI_SERVER_ENV=prod pnpm crux backfill-program-ids run --dry-run` to verify match counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)