### PR TITLE
Add public funding programs directory page

### DIFF
--- a/apps/web/src/app/funding-programs/funding-programs-constants.ts
+++ b/apps/web/src/app/funding-programs/funding-programs-constants.ts
@@ -1,0 +1,16 @@
+/** Status badge color classes for funding program statuses. */
+export const FP_STATUS_COLORS: Record<string, string> = {
+  open: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  closed: "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300",
+  awarded: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+};
+
+/** Program type display labels. */
+export const PROGRAM_TYPE_LABELS: Record<string, string> = {
+  rfp: "RFP",
+  "grant-round": "Grant Round",
+  fellowship: "Fellowship",
+  prize: "Prize",
+  solicitation: "Solicitation",
+  call: "Call",
+};

--- a/apps/web/src/app/funding-programs/funding-programs-sort.ts
+++ b/apps/web/src/app/funding-programs/funding-programs-sort.ts
@@ -1,0 +1,41 @@
+import { compareByValue } from "@/lib/sort-utils";
+import type { SortDir } from "@/lib/sort-utils";
+export type { SortDir };
+import type { FundingProgramListRow } from "./funding-programs-table";
+
+export type FPSortKey =
+  | "name"
+  | "organization"
+  | "type"
+  | "budget"
+  | "status"
+  | "deadline";
+
+export function getFPSortValue(
+  row: FundingProgramListRow,
+  sortKey: FPSortKey,
+): string | number | null {
+  switch (sortKey) {
+    case "name":
+      return row.name.toLowerCase();
+    case "organization":
+      return row.orgName.toLowerCase();
+    case "type":
+      return row.programType;
+    case "budget":
+      return row.totalBudget;
+    case "status":
+      return row.status;
+    case "deadline":
+      return row.deadline;
+  }
+}
+
+export function compareFPRows(
+  a: FundingProgramListRow,
+  b: FundingProgramListRow,
+  sortKey: FPSortKey,
+  sortDir: SortDir,
+): number {
+  return compareByValue(a, b, (row) => getFPSortValue(row, sortKey), sortDir);
+}

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { SortHeader } from "@/components/directory/SortHeader";
+import { formatCompactCurrency } from "@/lib/format-compact";
+import { compareFPRows, type SortDir } from "./funding-programs-sort";
+import { FP_STATUS_COLORS, PROGRAM_TYPE_LABELS } from "./funding-programs-constants";
+
+export interface FundingProgramListRow {
+  id: string;
+  name: string;
+  orgId: string;
+  orgName: string;
+  orgSlug: string | null;
+  divisionId: string | null;
+  programType: string;
+  totalBudget: number | null;
+  currency: string;
+  applicationUrl: string | null;
+  openDate: string | null;
+  deadline: string | null;
+  status: string | null;
+  source: string | null;
+  description: string | null;
+}
+
+type SortKey = "name" | "organization" | "type" | "budget" | "status" | "deadline";
+
+const PAGE_SIZE = 50;
+
+function PaginationControls({
+  page,
+  totalPages,
+  totalFiltered,
+  onPrev,
+  onNext,
+}: {
+  page: number;
+  totalPages: number;
+  totalFiltered: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  if (totalPages <= 1) return null;
+  const start = page * PAGE_SIZE + 1;
+  const end = Math.min((page + 1) * PAGE_SIZE, totalFiltered);
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {start}&ndash;{end} of {totalFiltered}
+      </span>
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={page === 0}
+        className="text-xs px-2.5 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        Prev
+      </button>
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {page + 1} / {totalPages}
+      </span>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={page >= totalPages - 1}
+        className="text-xs px-2.5 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
+export function FundingProgramsListTable({
+  rows,
+}: {
+  rows: FundingProgramListRow[];
+}) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [sortKey, setSortKey] = useState<SortKey>("budget");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [page, setPage] = useState(0);
+
+  const statuses = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows) {
+      if (r.status) set.add(r.status);
+    }
+    return [...set].sort();
+  }, [rows]);
+
+  const programTypes = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows) {
+      if (r.programType) set.add(r.programType);
+    }
+    return [...set].sort();
+  }, [rows]);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: rows.length };
+    for (const r of rows) {
+      const s = r.status ?? "unknown";
+      counts[s] = (counts[s] ?? 0) + 1;
+    }
+    return counts;
+  }, [rows]);
+
+  const typeCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: rows.length };
+    for (const r of rows) {
+      counts[r.programType] = (counts[r.programType] ?? 0) + 1;
+    }
+    return counts;
+  }, [rows]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(
+        key === "name" || key === "organization" || key === "type"
+          ? "asc"
+          : "desc",
+      );
+    }
+    setPage(0);
+  };
+
+  const filtered = useMemo(() => {
+    let result = rows;
+
+    if (statusFilter !== "all") {
+      result = result.filter((r) => r.status === statusFilter);
+    }
+
+    if (typeFilter !== "all") {
+      result = result.filter((r) => r.programType === typeFilter);
+    }
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.orgName.toLowerCase().includes(q) ||
+          (r.description && r.description.toLowerCase().includes(q)),
+      );
+    }
+
+    result = [...result].sort((a, b) => compareFPRows(a, b, sortKey, sortDir));
+
+    return result;
+  }, [rows, search, statusFilter, typeFilter, sortKey, sortDir]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const pageRows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="flex flex-col gap-3 mb-5">
+        <input
+          type="text"
+          placeholder="Search programs, organizations..."
+          aria-label="Search funding programs"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(0);
+          }}
+          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
+        />
+
+        {/* Status filter */}
+        <div className="flex flex-wrap gap-1.5">
+          <span className="text-xs text-muted-foreground mr-1 self-center">
+            Status:
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setStatusFilter("all");
+              setPage(0);
+            }}
+            aria-pressed={statusFilter === "all"}
+            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+              statusFilter === "all"
+                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+            }`}
+          >
+            All
+            <span className="ml-1 text-[10px] opacity-60">
+              {statusCounts.all}
+            </span>
+          </button>
+          {statuses.map((s) => (
+            <button
+              type="button"
+              key={s}
+              onClick={() => {
+                setStatusFilter(statusFilter === s ? "all" : s);
+                setPage(0);
+              }}
+              aria-pressed={statusFilter === s}
+              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                statusFilter === s
+                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+              }`}
+            >
+              {s}
+              <span className="ml-1 text-[10px] opacity-60">
+                {statusCounts[s] ?? 0}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Type filter */}
+        <div className="flex flex-wrap gap-1.5">
+          <span className="text-xs text-muted-foreground mr-1 self-center">
+            Type:
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setTypeFilter("all");
+              setPage(0);
+            }}
+            aria-pressed={typeFilter === "all"}
+            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+              typeFilter === "all"
+                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+            }`}
+          >
+            All
+            <span className="ml-1 text-[10px] opacity-60">
+              {typeCounts.all}
+            </span>
+          </button>
+          {programTypes.map((t) => (
+            <button
+              type="button"
+              key={t}
+              onClick={() => {
+                setTypeFilter(typeFilter === t ? "all" : t);
+                setPage(0);
+              }}
+              aria-pressed={typeFilter === t}
+              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                typeFilter === t
+                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+              }`}
+            >
+              {PROGRAM_TYPE_LABELS[t] ?? t}
+              <span className="ml-1 text-[10px] opacity-60">
+                {typeCounts[t] ?? 0}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Results count + pagination */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-xs text-muted-foreground">
+          Showing {filtered.length} of {rows.length} programs
+        </div>
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          totalFiltered={filtered.length}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      </div>
+
+      {/* Table */}
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
+              <SortHeader
+                label="Program"
+                sortKey="name"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <SortHeader
+                label="Organization"
+                sortKey="organization"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <SortHeader
+                label="Type"
+                sortKey="type"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <SortHeader
+                label="Budget"
+                sortKey="budget"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-right"
+              />
+              <SortHeader
+                label="Deadline"
+                sortKey="deadline"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-center"
+              />
+              <SortHeader
+                label="Status"
+                sortKey="status"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-center"
+              />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {pageRows.map((row) => (
+              <tr
+                key={row.id}
+                className="hover:bg-muted/20 transition-colors"
+              >
+                {/* Name */}
+                <td className="py-2.5 px-3">
+                  <Link
+                    href={`/funding-programs/${row.id}`}
+                    className="font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    {row.name}
+                  </Link>
+                  {row.applicationUrl && (
+                    <a
+                      href={row.applicationUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-2 text-xs text-muted-foreground hover:text-primary transition-colors"
+                      title="Apply"
+                    >
+                      apply
+                    </a>
+                  )}
+                </td>
+
+                {/* Organization */}
+                <td className="py-2.5 px-3">
+                  {row.orgSlug ? (
+                    <Link
+                      href={`/organizations/${row.orgSlug}`}
+                      className="text-foreground hover:text-primary transition-colors"
+                    >
+                      {row.orgName}
+                    </Link>
+                  ) : (
+                    <span>{row.orgName}</span>
+                  )}
+                </td>
+
+                {/* Type */}
+                <td className="py-2.5 px-3 text-muted-foreground text-xs">
+                  <span className="capitalize">
+                    {PROGRAM_TYPE_LABELS[row.programType] ?? row.programType}
+                  </span>
+                </td>
+
+                {/* Budget */}
+                <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap">
+                  {row.totalBudget != null ? (
+                    <span className="font-semibold">
+                      {formatCompactCurrency(row.totalBudget)}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">{"\u2014"}</span>
+                  )}
+                </td>
+
+                {/* Deadline */}
+                <td className="py-2.5 px-3 text-center text-muted-foreground text-xs">
+                  {row.deadline ?? (
+                    <span className="text-muted-foreground/40">{"\u2014"}</span>
+                  )}
+                </td>
+
+                {/* Status */}
+                <td className="py-2.5 px-3 text-center">
+                  {row.status ? (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        FP_STATUS_COLORS[row.status] ??
+                        "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {row.status}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">{"\u2014"}</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No funding programs match your search.
+        </div>
+      )}
+
+      {/* Bottom pagination */}
+      <div className="mt-3">
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          totalFiltered={filtered.length}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/funding-programs/page.tsx
+++ b/apps/web/src/app/funding-programs/page.tsx
@@ -1,0 +1,257 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  fetchDetailed,
+  type RpcFundingProgramsStatsResult,
+  type RpcFundingProgramsAllResult,
+  type RpcFundingProgramRow,
+} from "@lib/wiki-server";
+import { getKBEntity, getKBEntitySlug } from "@/data/kb";
+import { ProfileStatCard } from "@/components/directory";
+import { formatCompactCurrency } from "@/lib/format-compact";
+import {
+  FundingProgramsListTable,
+  type FundingProgramListRow,
+} from "./funding-programs-table";
+import { PROGRAM_TYPE_LABELS } from "./funding-programs-constants";
+
+export const metadata: Metadata = {
+  title: "Funding Programs",
+  description:
+    "Directory of funding programs across AI safety and related organizations, including RFPs, grant rounds, fellowships, and prizes.",
+};
+
+/** ISR revalidation: refresh every 5 minutes */
+export const revalidate = 300;
+
+/**
+ * Resolve an org entity ID to its display name and slug for linking.
+ */
+function resolveOrg(orgId: string): {
+  name: string;
+  slug: string | null;
+} {
+  const entity = getKBEntity(orgId);
+  if (entity) {
+    const slug = getKBEntitySlug(orgId) ?? null;
+    return { name: entity.name, slug };
+  }
+  return { name: orgId, slug: null };
+}
+
+/**
+ * Enrich raw API rows with resolved organization names and slugs.
+ */
+function enrichRows(programs: RpcFundingProgramRow[]): FundingProgramListRow[] {
+  return programs.map((p) => {
+    const org = resolveOrg(p.orgId);
+    return {
+      id: p.id,
+      name: p.name,
+      orgId: p.orgId,
+      orgName: org.name,
+      orgSlug: org.slug,
+      divisionId: p.divisionId,
+      programType: p.programType,
+      totalBudget: p.totalBudget,
+      currency: p.currency ?? "USD",
+      applicationUrl: p.applicationUrl,
+      openDate: p.openDate,
+      deadline: p.deadline,
+      status: p.status,
+      source: p.source,
+      description: p.description,
+    };
+  });
+}
+
+export default async function FundingProgramsPage() {
+  // Fetch stats and full program list from wiki-server in parallel
+  const [statsResult, allResult] = await Promise.all([
+    fetchDetailed<RpcFundingProgramsStatsResult>(
+      "/api/funding-programs/stats",
+      { revalidate: 300 },
+    ),
+    fetchDetailed<RpcFundingProgramsAllResult>(
+      "/api/funding-programs/all?limit=500",
+      { revalidate: 300 },
+    ),
+  ]);
+
+  const stats = statsResult.ok ? statsResult.data : null;
+  const programs = allResult.ok ? allResult.data.fundingPrograms : [];
+  const rows = enrichRows(programs);
+
+  // Compute summary stats
+  const totalPrograms = stats?.total ?? rows.length;
+  const totalBudget =
+    stats?.totalBudget ??
+    rows.reduce((sum, r) => sum + (r.totalBudget ?? 0), 0);
+  const uniqueOrgs = new Set(rows.map((r) => r.orgId)).size;
+  const openCount =
+    stats?.byStatus.open ??
+    rows.filter((r) => r.status === "open").length;
+
+  // Build org summary (sorted by total budget desc)
+  const orgTotals = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      count: number;
+      totalBudget: number;
+      slug: string | null;
+    }
+  >();
+  for (const r of rows) {
+    const existing = orgTotals.get(r.orgId);
+    if (existing) {
+      existing.count += 1;
+      existing.totalBudget += r.totalBudget ?? 0;
+    } else {
+      orgTotals.set(r.orgId, {
+        id: r.orgId,
+        name: r.orgName,
+        count: 1,
+        totalBudget: r.totalBudget ?? 0,
+        slug: r.orgSlug,
+      });
+    }
+  }
+  const topOrgs = [...orgTotals.values()].sort(
+    (a, b) => b.totalBudget - a.totalBudget,
+  );
+
+  // Build type summary
+  const typeSummary: { type: string; label: string; count: number }[] = [];
+  if (stats) {
+    for (const [type, count] of Object.entries(stats.byType)) {
+      if ((count as number) > 0) {
+        typeSummary.push({
+          type,
+          label: PROGRAM_TYPE_LABELS[type] ?? type,
+          count: count as number,
+        });
+      }
+    }
+  } else {
+    const typeCounts = new Map<string, number>();
+    for (const r of rows) {
+      typeCounts.set(r.programType, (typeCounts.get(r.programType) ?? 0) + 1);
+    }
+    for (const [type, count] of typeCounts) {
+      typeSummary.push({
+        type,
+        label: PROGRAM_TYPE_LABELS[type] ?? type,
+        count,
+      });
+    }
+  }
+  typeSummary.sort((a, b) => b.count - a.count);
+
+  const summaryStats = [
+    { label: "Total Programs", value: totalPrograms.toLocaleString() },
+    { label: "Total Budget", value: formatCompactCurrency(totalBudget) },
+    { label: "Organizations", value: String(uniqueOrgs) },
+    { label: "Currently Open", value: String(openCount) },
+  ];
+
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
+          Funding Programs
+        </h1>
+        <p className="text-muted-foreground text-sm max-w-2xl">
+          Directory of funding opportunities across AI safety and related
+          organizations, including RFPs, grant rounds, fellowships, prizes, and
+          open calls for proposals.
+        </p>
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        {summaryStats.map((stat) => (
+          <ProfileStatCard
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+          />
+        ))}
+      </div>
+
+      {/* By type summary */}
+      {typeSummary.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-3">By Type</h2>
+          <div className="flex gap-3 flex-wrap">
+            {typeSummary.map((t) => (
+              <div
+                key={t.type}
+                className="rounded-lg border border-border/60 px-4 py-2 flex items-center gap-2"
+              >
+                <span className="text-sm font-medium text-foreground">
+                  {t.label}
+                </span>
+                <span className="text-sm tabular-nums text-muted-foreground">
+                  {t.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* By organization summary */}
+      {topOrgs.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-3">By Organization</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {topOrgs.map((org) => (
+              <div
+                key={org.id}
+                className="flex items-center justify-between rounded-lg border border-border/60 px-4 py-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {org.slug ? (
+                      <Link
+                        href={`/organizations/${org.slug}`}
+                        className="hover:underline"
+                      >
+                        {org.name}
+                      </Link>
+                    ) : (
+                      org.name
+                    )}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {org.count} program{org.count !== 1 ? "s" : ""}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold tabular-nums">
+                  {formatCompactCurrency(org.totalBudget)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Programs table */}
+      {rows.length > 0 ? (
+        <FundingProgramsListTable rows={rows} />
+      ) : (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+          <p className="text-lg font-medium mb-2">
+            No funding programs available
+          </p>
+          <p className="text-sm">
+            Funding program data is loaded from the wiki-server API. Check that
+            the server is configured and reachable.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -8,6 +8,7 @@ export const NAV_LINKS = [
   { href: "/ai-models", label: "AI Models" },
   { href: "/benchmarks", label: "Benchmarks" },
   { href: "/sources", label: "Sources" },
+  { href: "/funding-programs", label: "Funding" },
   { href: "/kb", label: "Data" },
   { href: "/wiki/E755", label: "About" },
   { href: "/wiki/E779", label: "Internal" },


### PR DESCRIPTION
## Summary
- Add a public-facing `/funding-programs` page that displays all funding opportunities across organizations
- Shows summary stats (total programs, total budget, org count, currently open count)
- Includes breakdowns by program type (RFP, Grant Round, Fellowship, Prize, etc.) and by organization
- Filterable and sortable table with status filter (open/closed/awarded), type filter, text search, and sortable columns (name, organization, type, budget, deadline, status)
- Links program names to detail pages (`/funding-programs/[id]`), organization names to org pages
- Data fetched from wiki-server API at build/ISR time with 5-minute revalidation
- Added "Funding" nav link in the main navigation bar

## Files changed
- `apps/web/src/app/funding-programs/page.tsx` -- server component (data fetching, stats, layout)
- `apps/web/src/app/funding-programs/funding-programs-table.tsx` -- client component (interactive table with filters/sort/pagination)
- `apps/web/src/app/funding-programs/funding-programs-sort.ts` -- sort utilities
- `apps/web/src/app/funding-programs/funding-programs-constants.ts` -- status colors, type labels
- `apps/web/src/lib/nav-links.ts` -- added Funding nav link

## Test plan
- [x] TypeScript compiles cleanly (no new errors)
- [x] `pnpm build` succeeds with `SKIP_PREBUILD=1` (prebuild fails due to pre-existing wiki-server unavailability)
- [x] No new test failures (2 pre-existing failures confirmed on main)
- [ ] Verify page renders correctly with live wiki-server data in production
- [ ] Verify filters and sorting work interactively

Generated with [Claude Code](https://claude.com/claude-code)