### PR TITLE
fix: remove dead monitoring-alert job creation

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -35,8 +35,8 @@ audits:
       "heartbeat OK" messages.
     frequency: weekly
     added: "2026-03-04"
-    last_checked: "2026-03-13"
-    last_result: fail
+    last_checked: "2026-03-14"
+    last_result: pass
 
   - id: agent-sessions-logged
     category: process

--- a/apps/wiki-server/src/routes/monitoring.ts
+++ b/apps/wiki-server/src/routes/monitoring.ts
@@ -294,28 +294,11 @@ const monitoringApp = new Hono()
 
     const incident = firstOrThrow(inserted, "incident insert");
 
-    // For critical incidents, create a monitoring-alert job for agents to claim
-    if (d.severity === "critical") {
-      await db
-        .insert(jobs)
-        .values({
-          type: "monitoring-alert",
-          params: {
-            incidentId: incident.id,
-            service: d.service,
-            title: d.title,
-            severity: d.severity,
-          },
-          priority: 100,
-          maxRetries: 1,
-        })
-        .catch((err: unknown) => {
-          logger.error(
-            { err: err instanceof Error ? err.message : String(err) },
-            "Failed to create monitoring-alert job",
-          );
-        });
-    }
+    // Note: Previously created a "monitoring-alert" job for critical incidents,
+    // but no job handler exists for this type — every such job permanently failed
+    // with "Unknown job type: monitoring-alert". Removed in #2193.
+    // The incident is already recorded in service_health_incidents and the
+    // groundskeeper handles alerting via GitHub issues and Discord.
 
     return c.json(incident, 201);
   })


### PR DESCRIPTION
## Summary

- **Removed dead `monitoring-alert` job creation** from the monitoring route's POST `/incidents` endpoint. No job handler exists for this type in the worker registry (`crux/lib/job-handlers/index.ts`), so every such job permanently failed with "Unknown job type: monitoring-alert". This left 2 stale failed jobs in the queue from March 2.
- **Updated the `groundskeeper-health` audit** to reflect the current healthy status (was marked `fail` on 2026-03-13 when the daemon was temporarily down; it has since recovered).

The incident recording itself is unaffected — critical incidents are still written to `service_health_incidents`. Alerting continues via the groundskeeper's GitHub issue creation and Discord notifications.

Closes #2193

## Test plan

- [x] TypeScript check passes (`npx tsc --noEmit` in wiki-server)
- [x] All 15 monitoring tests pass (`pnpm test`)
- [x] Verified groundskeeper currently reports healthy via `/api/monitoring/status`
- [x] Verified the 2 stale failed jobs are `monitoring-alert` type with no handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated groundskeeper-health audit status to passing.
  * Removed deprecated monitoring-alert job creation during incident insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->