### PR TITLE
Fix duplicate entity entries in responses.yaml

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -1,20 +1,6 @@
 # Responses Entities
 # Auto-generated from entities.yaml - edit this file directly
 
-- id: ai-executive-order
-  stableId: DltF1Zn3KQ
-  numericId: E8
-  type: policy
-  title: "AI Executive Order"
-  description: "US executive orders establishing AI safety requirements and oversight"
-
-- id: responsible-scaling-policies
-  stableId: 13l06h7veg
-  numericId: E252
-  type: policy
-  title: "Responsible Scaling Policies"
-  description: "Industry self-regulation frameworks establishing capability thresholds that trigger safety evaluations."
-
 - id: ai-safety-institutes
   stableId: aCEdTooCBw
   numericId: E13


### PR DESCRIPTION
## Summary
Remove duplicate `ai-executive-order` and `responsible-scaling-policies` entity entries created during merge queue processing of PR #2363.

## Test plan
- [x] Only one entry per entity ID in responses.yaml
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed two entries from the content database to maintain accuracy and relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->