### PR TITLE
fix: align program-matcher tests with CG_* IDs

### DIFF
--- a/crux/lib/grant-import/program-matcher.test.ts
+++ b/crux/lib/grant-import/program-matcher.test.ts
@@ -139,7 +139,7 @@ describe("matchProgram", () => {
       name: "Humane Society campaign",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_FARM_ANIMAL_WELFARE);
+    expect(result).toBe(PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE);
   });
 
   it("matches Cage-Free Reforms to farm animal welfare", () => {
@@ -150,7 +150,7 @@ describe("matchProgram", () => {
       name: "Corporate campaign",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_FARM_ANIMAL_WELFARE);
+    expect(result).toBe(PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE);
   });
 
   it("matches Alternatives to Animal Products to farm animal welfare", () => {
@@ -161,7 +161,7 @@ describe("matchProgram", () => {
       name: "Alt protein research",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_FARM_ANIMAL_WELFARE);
+    expect(result).toBe(PROGRAM_IDS.CG_FARM_ANIMAL_WELFARE);
   });
 
   it("matches Criminal Justice Reform to dedicated program", () => {
@@ -183,7 +183,7 @@ describe("matchProgram", () => {
       name: "EA community support",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_GCR_OPPORTUNITIES);
+    expect(result).toBe(PROGRAM_IDS.CG_GCR_OPPORTUNITIES);
   });
 
   it("matches Effective Giving & Careers to dedicated program", () => {
@@ -194,7 +194,7 @@ describe("matchProgram", () => {
       name: "80,000 Hours support",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_EFFECTIVE_GIVING);
+    expect(result).toBe(PROGRAM_IDS.CG_EFFECTIVE_GIVING);
   });
 
   it("matches Forecasting to dedicated program", () => {
@@ -205,7 +205,7 @@ describe("matchProgram", () => {
       name: "Metaculus support",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_FORECASTING);
+    expect(result).toBe(PROGRAM_IDS.CG_FORECASTING);
   });
 
   it("matches Abundance & Growth to dedicated program", () => {
@@ -216,7 +216,7 @@ describe("matchProgram", () => {
       name: "Innovation policy",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_ABUNDANCE_GROWTH);
+    expect(result).toBe(PROGRAM_IDS.CG_ABUNDANCE_GROWTH);
   });
 
   it("matches Innovation Policy to abundance & growth", () => {
@@ -227,7 +227,7 @@ describe("matchProgram", () => {
       name: "Tech policy project",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_ABUNDANCE_GROWTH);
+    expect(result).toBe(PROGRAM_IDS.CG_ABUNDANCE_GROWTH);
   });
 
   it("matches Scientific Research to science & health R&D", () => {
@@ -238,7 +238,7 @@ describe("matchProgram", () => {
       name: "Research grant",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_SCIENCE_HEALTH_RD);
+    expect(result).toBe(PROGRAM_IDS.CG_SCIENCE_RD);
   });
 
   it("matches Global Health R&D to science & health R&D", () => {
@@ -249,7 +249,7 @@ describe("matchProgram", () => {
       name: "Vaccine research",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_SCIENCE_HEALTH_RD);
+    expect(result).toBe(PROGRAM_IDS.CG_SCIENCE_RD);
   });
 
   it("matches GiveWell-Recommended Charities to global health", () => {
@@ -263,7 +263,7 @@ describe("matchProgram", () => {
     expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
   });
 
-  it("matches South Asian Air Quality to global health", () => {
+  it("matches South Asian Air Quality to air quality program", () => {
     const result = matchProgram({
       source: "coefficient-giving",
       funderId: "ULjDXpSLCI",
@@ -271,10 +271,10 @@ describe("matchProgram", () => {
       name: "Air quality research",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
+    expect(result).toBe(PROGRAM_IDS.CG_AIR_QUALITY);
   });
 
-  it("matches Global Aid Policy to global health", () => {
+  it("matches Global Aid Policy to global aid program", () => {
     const result = matchProgram({
       source: "coefficient-giving",
       funderId: "ULjDXpSLCI",
@@ -282,7 +282,7 @@ describe("matchProgram", () => {
       name: "Policy research",
       description: null,
     });
-    expect(result).toBe(PROGRAM_IDS.OP_GLOBAL_HEALTH);
+    expect(result).toBe(PROGRAM_IDS.CG_GLOBAL_AID);
   });
 
   it("matches GCR opportunities", () => {

--- a/crux/lib/grant-import/program-matcher.ts
+++ b/crux/lib/grant-import/program-matcher.ts
@@ -27,13 +27,7 @@ export const PROGRAM_IDS = {
   OP_AI_SAFETY: progId("prog|open-philanthropy|ai-safety"),
   OP_BIOSECURITY: progId("prog|open-philanthropy|biosecurity"),
   OP_GLOBAL_HEALTH: progId("prog|open-philanthropy|global-health"),
-  OP_FARM_ANIMAL_WELFARE: progId("prog|coefficient-giving|farm-animal-welfare"),
-  OP_SCIENCE_HEALTH_RD: progId("prog|coefficient-giving|science-health-rd"),
-  OP_GCR_OPPORTUNITIES: progId("prog|coefficient-giving|gcr-opportunities"),
   OP_CRIMINAL_JUSTICE: progId("prog|coefficient-giving|criminal-justice"),
-  OP_EFFECTIVE_GIVING: progId("prog|coefficient-giving|effective-giving"),
-  OP_FORECASTING: progId("prog|coefficient-giving|forecasting"),
-  OP_ABUNDANCE_GROWTH: progId("prog|coefficient-giving|abundance-growth-grants"),
 
   // Coefficient Giving — specific programs
   CG_GCR_OPPORTUNITIES: progId("prog|coefficient-giving|gcr-opportunities"),


### PR DESCRIPTION
## Summary
- Remove unused `OP_*` duplicate entries from `PROGRAM_IDS` that had the same seeds as `CG_*` counterparts (causing duplicate ID assertion failures)
- Update test expectations to use the `CG_*` IDs that the matcher rules actually reference
- Fix test descriptions for air quality and global aid focus areas

This fixes the 7 test failures introduced by the #2381 rebase merge.

## Test plan
- [x] `npx vitest run crux/lib/grant-import/program-matcher.test.ts` — 54/54 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded program identification system to use more granular and specific categorization.
  * Enhanced program matching capabilities with expanded classification options for improved precision in funding area identification.
  * Updated test suite to validate new program categorization structure and mappings across all funded areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->