### PR TITLE
feat: subscription-mode auto-update skill

### DIFF
--- a/.claude/commands/auto-update.md
+++ b/.claude/commands/auto-update.md
@@ -1,0 +1,107 @@
+# Auto-Update (Subscription Mode)
+
+Run the daily wiki auto-update using Claude Code's subscription instead of API billing.
+
+This replaces the CI-based auto-update pipeline (~$6.50/page via Opus API) with Claude Code's native editing capabilities ($0/page via subscription). The cheap digest/routing stage still uses Haiku API (~$0.15 total).
+
+**Do NOT run `/agent-session-start` — this skill manages its own workflow.**
+
+## Phase 1: Fetch & Plan
+
+Run the digest and routing pipeline to determine which pages need updating:
+
+```bash
+pnpm crux auto-update plan --count=3
+```
+
+Parse the output to identify:
+- Which pages need updating (page IDs and titles)
+- What news triggered each update (relevant news items)
+- Suggested tier and specific directions for each page
+
+If the plan shows no pages to update, report "No updates needed today" and stop.
+
+## Phase 2: Prepare workspace
+
+```bash
+git checkout main && git pull
+BRANCH="auto-update/$(date +%Y-%m-%d)"
+git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
+```
+
+## Phase 3: Update each page
+
+For EACH page in the plan (up to 3 pages):
+
+### 3a. Gather context
+
+1. Read the full MDX file from `content/docs/` using the Read tool
+2. Run `pnpm crux context for-page <id>` for structured context (entity data, links, etc.)
+3. Review the relevant news items from the plan output
+
+### 3b. Research & verify
+
+Before editing, verify key claims from the news:
+- Use WebSearch to cross-reference important facts
+- Check dates, numbers, and names against multiple sources
+- Do NOT add unverified claims
+
+### 3c. Make targeted edits
+
+Use the Edit tool to make surgical additions:
+- Add new information from verified news items to the most relevant existing section
+- Update outdated facts that the news contradicts
+- Add footnote citations: `[^N]` in text, `[^N]: URL` at the bottom of the references section
+- Update `lastEdited` in frontmatter to today's date (YYYY-MM-DD format)
+- Keep existing content intact unless it contradicts verified new information
+- Do NOT rewrite sections wholesale — make incremental additions
+
+### Editing rules
+
+- **Be conservative**: Only add well-sourced information. Don't speculate or editorialize.
+- **Match voice**: Keep the existing page's encyclopedic tone.
+- **Citations required**: Every new factual claim needs a footnote with a URL.
+- **No new sections** unless the information truly doesn't fit existing structure.
+- **Escape MDX**: `\$100` not `$100`, `\<100` not `<100`.
+- **EntityLinks**: Use `<EntityLink id="slug">Name</EntityLink>` for entities that exist in `data/entities/`.
+
+## Phase 4: Post-edit cleanup
+
+After editing all pages:
+
+```bash
+pnpm crux fix escaping
+pnpm crux fix markdown
+pnpm crux validate gate --scope=content --fix
+```
+
+Fix any issues the gate reports. Re-run until clean.
+
+## Phase 5: Commit and ship
+
+Stage only the changed content files:
+
+```bash
+git add content/docs/
+```
+
+Create a commit with a descriptive message listing the pages updated.
+
+Push and create a PR:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+Then create the PR with `gh pr create`. The PR body should include:
+- A "Pages updated" section listing each page and a one-line summary of what changed
+- A "News sources" section listing the key news items that triggered updates
+- A note that this was a subscription-mode run (no API costs for page improvement)
+
+## Phase 6: Summary
+
+Print a brief summary:
+- Pages updated (count and names)
+- Key news incorporated
+- Any pages skipped and why
+- Any validation issues encountered

--- a/.claude/scripts/auto-update-cron.sh
+++ b/.claude/scripts/auto-update-cron.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Auto-update cron script — runs the wiki auto-update via Claude Code subscription.
+#
+# Uses `claude -p "/auto-update"` which runs through your Claude Code
+# Max/Pro subscription. No API credits consumed for page improvement.
+# (The digest/routing stage still uses ~$0.15 of Haiku API.)
+#
+# Usage:
+#   ./auto-update-cron.sh              # normal run
+#   DRY_RUN=1 ./auto-update-cron.sh    # log what would happen, don't edit
+
+set -euo pipefail
+
+REPO_DIR="/Users/ozziegooen/Documents/GitHub.nosync/lw/a10"
+LOG_DIR="$HOME/.claude/auto-update-logs"
+LOG_FILE="$LOG_DIR/$(date +%Y-%m-%d).log"
+
+mkdir -p "$LOG_DIR"
+
+echo "=== Auto-update started at $(date) ===" | tee -a "$LOG_FILE"
+
+# Pull latest main
+cd "$REPO_DIR"
+git checkout main 2>&1 | tee -a "$LOG_FILE"
+git pull 2>&1 | tee -a "$LOG_FILE"
+
+# Run the auto-update skill via Claude Code subscription
+if [ "${DRY_RUN:-}" = "1" ]; then
+  echo "DRY RUN — would execute: claude -p '/auto-update' --max-turns 50" | tee -a "$LOG_FILE"
+else
+  claude -p "/auto-update" \
+    --max-turns 50 \
+    --allowedTools "Bash,Read,Edit,Write,Glob,Grep,Agent,WebFetch,WebSearch" \
+    2>&1 | tee -a "$LOG_FILE"
+fi
+
+echo "=== Auto-update finished at $(date) ===" | tee -a "$LOG_FILE"
+
+# Clean up logs older than 30 days
+find "$LOG_DIR" -name "*.log" -mtime +30 -delete 2>/dev/null || true

--- a/.claude/scripts/com.longtermwiki.auto-update.plist
+++ b/.claude/scripts/com.longtermwiki.auto-update.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.longtermwiki.auto-update</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/ozziegooen/Documents/GitHub.nosync/lw/a10/.claude/scripts/auto-update-cron.sh</string>
+    </array>
+
+    <!-- Run daily at 9:00 AM -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/ozziegooen/.claude/auto-update-logs/launchd-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/ozziegooen/.claude/auto-update-logs/launchd-stderr.log</string>
+
+    <!-- Environment for Claude Code CLI -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/ozziegooen/Documents/GitHub.nosync/lw/a10</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds infrastructure to run the daily wiki auto-update through Claude Code's subscription instead of direct API billing.

- **`/auto-update` skill** (`.claude/commands/auto-update.md`) — run manually in Claude Code. Uses cheap Haiku digest/routing (~$0.15), then Claude Code edits pages directly via subscription.
- **Cron script** (`.claude/scripts/auto-update-cron.sh`) — wraps `claude -p "/auto-update" --max-turns 50`. Uses subscription billing, not API.
- **launchd plist** (`.claude/scripts/com.longtermwiki.auto-update.plist`) — daily 9 AM schedule.

### Cost comparison

| Component | CI pipeline (current) | Subscription mode (new) |
|-----------|----------------------|------------------------|
| Digest + routing | ~$0.15 (Haiku) | ~$0.15 (Haiku) |
| Page improvement (3 pages) | ~$19.50 (Opus) | $0 (subscription) |
| **Total per run** | **~$19.65** | **~$0.15** |

### To activate daily runs

```bash
mkdir -p ~/.claude/auto-update-logs
cp .claude/scripts/com.longtermwiki.auto-update.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.longtermwiki.auto-update.plist
```

### Test run

Tested in PR #2382 — successfully updated 2 pages with verified new information.

## Test plan

- [x] `/auto-update` skill tested manually (PR #2382)
- [ ] Verify `auto-update-cron.sh` runs cleanly: `DRY_RUN=1 .claude/scripts/auto-update-cron.sh`
- [ ] Verify launchd plist loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)