### PR TITLE
fix: add 'research-area' to YAML entity type enum

### DIFF
--- a/data/schema.ts
+++ b/data/schema.ts
@@ -456,6 +456,7 @@ export const EntityType = z.enum([
   'internal',
   'ai-model',
   'benchmark',
+  'research-area',
   // --- Aliases (legacy/plural forms kept for backward compat) ---
   'researcher',        // → person
   'lab',               // → organization


### PR DESCRIPTION
## Summary
- Add `research-area` to the Zod `EntityType` enum in `data/schema.ts`
- This was missed when PR #2383 added research-area entities — the type was added to `entity-type-names.ts` but not the YAML validation schema
- Fixes CI on main (YAML schema validation rejects all research-area entities)

## Test plan
- [x] CI should pass — YAML validation will accept `research-area` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)