### PR TITLE
fix: add retry logic to smoke test DELETE cleanup

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -312,6 +312,7 @@ jobs:
           #    Retries up to 3 times with backoff to handle transient errors during rolling deploys.
           #    Uses -s without -f so the response body is always captured for debugging.
           DELETED=""
+          CLEANUP_OK=false
           DELETE_HTTP_CODE=""
           DELETE_RESPONSE=""
           for i in 1 2 3; do
@@ -321,11 +322,21 @@ jobs:
             DELETE_HTTP_CODE=$(echo "$DELETE_RAW" | tail -1)
             DELETE_RESPONSE=$(echo "$DELETE_RAW" | sed '$d')
             DELETED=$(echo "$DELETE_RESPONSE" | jq -r '.deleted // empty' 2>/dev/null || true)
-            if [ "$DELETED" = "1" ]; then break; fi
+            if [ "$DELETED" = "1" ]; then
+              CLEANUP_OK=true
+              break
+            fi
+            # A prior attempt may have deleted successfully but its response was lost;
+            # retries then return 404 — treat as success since the page is already gone.
+            if [ "$DELETE_HTTP_CODE" = "404" ]; then
+              CLEANUP_OK=true
+              echo "Delete cleanup already complete (HTTP 404 on attempt $i)."
+              break
+            fi
             echo "Delete cleanup attempt $i/3 failed (HTTP $DELETE_HTTP_CODE): $DELETE_RESPONSE"
             if [ "$i" -lt 3 ]; then sleep $((i * 3)); fi
           done
-          if [ "$DELETED" != "1" ]; then
+          if [ "$CLEANUP_OK" != "true" ]; then
             echo "::error::Smoke test cleanup failed after 3 attempts (HTTP $DELETE_HTTP_CODE): $DELETE_RESPONSE"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- The post-deploy smoke test DELETE step used `curl -sf` which hides error responses and fails immediately on any HTTP error
- During rolling deploys, transient failures (requests hitting pods mid-transition) caused the deploy to fail and roll back unnecessarily — this is what happened on the last production deploy (#2387)
- Replaced with a 3-attempt retry loop with backoff that captures response bodies for debugging

## Context
Production deploy #2387 failed at the DELETE cleanup step with exit code 22. Manual testing confirmed the endpoint was healthy — the failure was transient during the rolling update window. The `__smoke-test__` page was left in the DB and had to be cleaned up manually.

## Test plan
- [ ] Merge this PR
- [ ] Create a new release PR (main → production) to trigger deploy
- [ ] Verify the deploy succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test cleanup reliability by adding a 3-attempt retry with backoff, per-attempt logging, and clearer error messages on persistent failure.
  * Treat HTTP 404 during cleanup as a successful outcome and capture HTTP response details for better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->