### PR TITLE
feat: shared PaginationControls, add pagination to risks/ai-models, fix 200-org cap

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { PaginationControls } from "@/components/directory/PaginationControls";
 import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS, formatContext } from "./ai-model-constants";
 
 export interface AiModelRow {
@@ -43,6 +44,8 @@ type SortKey =
   | "gpqa"
   | "params";
 
+const PAGE_SIZE = 50;
+
 export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
   const [search, setSearch] = useState("");
   const [developerFilter, setDeveloperFilter] = useState<string>("all");
@@ -50,6 +53,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
   const [showOpenWeightOnly, setShowOpenWeightOnly] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("releaseDate");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [page, setPage] = useState(0);
 
   const developers = useMemo(() => {
     const map = new Map<string, string>();
@@ -80,6 +84,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
       setSortKey(key);
       setSortDir(key === "name" || key === "developer" ? "asc" : "desc");
     }
+    setPage(0);
   };
 
   const filtered = useMemo(() => {
@@ -138,6 +143,10 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
     return result;
   }, [rows, search, developerFilter, showFamilies, showOpenWeightOnly, sortKey, sortDir]);
 
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageRows = filtered.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
   return (
     <div>
       {/* Filters */}
@@ -148,12 +157,18 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             placeholder="Search models..."
             aria-label="Search models"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(0);
+            }}
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
           />
           <div className="flex flex-wrap gap-1.5">
             <button
-              onClick={() => setDeveloperFilter("all")}
+              onClick={() => {
+                setDeveloperFilter("all");
+                setPage(0);
+              }}
               aria-pressed={developerFilter === "all"}
               className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                 developerFilter === "all"
@@ -167,7 +182,10 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             {developers.map(([devId, devName]) => (
               <button
                 key={devId}
-                onClick={() => setDeveloperFilter(developerFilter === devId ? "all" : devId)}
+                onClick={() => {
+                  setDeveloperFilter(developerFilter === devId ? "all" : devId);
+                  setPage(0);
+                }}
                 aria-pressed={developerFilter === devId}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                   developerFilter === devId
@@ -188,7 +206,10 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             <input
               type="checkbox"
               checked={showFamilies}
-              onChange={(e) => setShowFamilies(e.target.checked)}
+              onChange={(e) => {
+                setShowFamilies(e.target.checked);
+                setPage(0);
+              }}
               className="rounded"
             />
             Show families
@@ -197,7 +218,10 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             <input
               type="checkbox"
               checked={showOpenWeightOnly}
-              onChange={(e) => setShowOpenWeightOnly(e.target.checked)}
+              onChange={(e) => {
+                setShowOpenWeightOnly(e.target.checked);
+                setPage(0);
+              }}
               className="rounded"
             />
             Open weight only
@@ -205,8 +229,18 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
         </div>
       </div>
 
-      <div className="text-xs text-muted-foreground mb-3">
-        Showing {filtered.length} of {rows.length} models
+      {/* Results count + top pagination */}
+      <div className="flex flex-col gap-2 mb-3">
+        <div className="text-xs text-muted-foreground">
+          Showing {filtered.length} of {rows.length} models
+        </div>
+        <PaginationControls
+          page={safePage}
+          pageCount={pageCount}
+          totalItems={filtered.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
       </div>
 
       {/* Table */}
@@ -228,7 +262,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {filtered.map((row) => (
+            {pageRows.map((row) => (
               <tr
                 key={row.id}
                 className={`hover:bg-muted/20 transition-colors ${row.isFamily ? "bg-muted/10" : ""}`}
@@ -352,6 +386,17 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
           No models match your search.
         </div>
       )}
+
+      {/* Bottom pagination */}
+      <div className="mt-3">
+        <PaginationControls
+          page={safePage}
+          pageCount={pageCount}
+          totalItems={filtered.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/risks/risks-table.tsx
+++ b/apps/web/src/app/risks/risks-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { PaginationControls } from "@/components/directory/PaginationControls";
 import type { SortDir } from "@/lib/sort-utils";
 import {
   RISK_CATEGORY_LABELS,
@@ -24,11 +25,14 @@ export interface RiskRow {
   timeHorizon: string | null;
 }
 
+const PAGE_SIZE = 50;
+
 export function RisksTable({ rows }: { rows: RiskRow[] }) {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [sortKey, setSortKey] = useState<RiskSortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [page, setPage] = useState(0);
 
   // Collect unique categories for filter
   const categories = useMemo(() => {
@@ -56,6 +60,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
       setSortKey(key);
       setSortDir(key === "name" ? "asc" : "desc");
     }
+    setPage(0);
   };
 
   const filtered = useMemo(() => {
@@ -80,6 +85,10 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
     return result;
   }, [rows, search, categoryFilter, sortKey, sortDir]);
 
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageRows = filtered.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
   return (
     <div>
       {/* Filters */}
@@ -89,12 +98,18 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
           placeholder="Search risks..."
           aria-label="Search risks"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(0);
+          }}
           className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
         />
         <div className="flex flex-wrap gap-1.5">
           <button
-            onClick={() => setCategoryFilter("all")}
+            onClick={() => {
+              setCategoryFilter("all");
+              setPage(0);
+            }}
             aria-pressed={categoryFilter === "all"}
             className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
               categoryFilter === "all"
@@ -108,7 +123,10 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
           {categories.map((c) => (
             <button
               key={c}
-              onClick={() => setCategoryFilter(categoryFilter === c ? "all" : c)}
+              onClick={() => {
+                setCategoryFilter(categoryFilter === c ? "all" : c);
+                setPage(0);
+              }}
               aria-pressed={categoryFilter === c}
               className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                 categoryFilter === c
@@ -125,9 +143,18 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
         </div>
       </div>
 
-      {/* Results count */}
-      <div className="text-xs text-muted-foreground mb-3">
-        Showing {filtered.length} of {rows.length} risks
+      {/* Results count + top pagination */}
+      <div className="flex flex-col gap-2 mb-3">
+        <div className="text-xs text-muted-foreground">
+          Showing {filtered.length} of {rows.length} risks
+        </div>
+        <PaginationControls
+          page={safePage}
+          pageCount={pageCount}
+          totalItems={filtered.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
       </div>
 
       {/* Table */}
@@ -143,7 +170,7 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {filtered.map((row) => (
+            {pageRows.map((row) => (
               <tr
                 key={row.id}
                 className="hover:bg-muted/20 transition-colors"
@@ -227,6 +254,17 @@ export function RisksTable({ rows }: { rows: RiskRow[] }) {
           No risks match your search.
         </div>
       )}
+
+      {/* Bottom pagination */}
+      <div className="mt-3">
+        <PaginationControls
+          page={safePage}
+          pageCount={pageCount}
+          totalItems={filtered.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/directory/PaginationControls.tsx
+++ b/apps/web/src/components/directory/PaginationControls.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+export interface PaginationControlsProps {
+  /** Zero-indexed current page */
+  page: number;
+  /** Total number of pages */
+  pageCount: number;
+  /** Total number of items (before pagination, after filtering) */
+  totalItems: number;
+  /** Number of items per page */
+  pageSize: number;
+  /** Called with the new zero-indexed page number */
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * Shared pagination controls for directory tables.
+ *
+ * Shows "Showing X-Y of Z items" on the left, First/Prev/Next/Last buttons
+ * and "Page X of Y" on the right. Renders nothing when there is only one page.
+ */
+export function PaginationControls({
+  page,
+  pageCount,
+  totalItems,
+  pageSize,
+  onPageChange,
+}: PaginationControlsProps) {
+  if (pageCount <= 1) return null;
+
+  const start = page * pageSize + 1;
+  const end = Math.min((page + 1) * pageSize, totalItems);
+
+  return (
+    <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <span className="tabular-nums">
+        Showing {start}&ndash;{end} of {totalItems} items
+      </span>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          disabled={page === 0}
+          onClick={() => onPageChange(0)}
+          className="px-2 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          First
+        </button>
+        <button
+          type="button"
+          disabled={page === 0}
+          onClick={() => onPageChange(Math.max(0, page - 1))}
+          className="px-2 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Prev
+        </button>
+        <span className="px-2 tabular-nums">
+          Page {page + 1} of {pageCount}
+        </span>
+        <button
+          type="button"
+          disabled={page >= pageCount - 1}
+          onClick={() => onPageChange(Math.min(pageCount - 1, page + 1))}
+          className="px-2 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Next
+        </button>
+        <button
+          type="button"
+          disabled={page >= pageCount - 1}
+          onClick={() => onPageChange(pageCount - 1)}
+          className="px-2 py-1 rounded border border-border bg-card hover:bg-muted/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Last
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/directory/index.ts
+++ b/apps/web/src/components/directory/index.ts
@@ -12,3 +12,7 @@ export {
   FACT_CATEGORIES,
 } from "./FactsSection";
 export { ProfileTabs, type ProfileTab } from "./ProfileTabs";
+export {
+  PaginationControls,
+  type PaginationControlsProps,
+} from "./PaginationControls";

--- a/apps/wiki-server/src/routes/entities.ts
+++ b/apps/wiki-server/src/routes/entities.ts
@@ -23,7 +23,7 @@ import { buildSearchCondition, parseSort } from "./query-helpers.js";
 
 // ---- Constants ----
 
-const MAX_PAGE_SIZE = 200;
+const MAX_PAGE_SIZE = 500;
 
 // ---- Schemas (from shared api-types) ----
 


### PR DESCRIPTION
## Summary

- **Shared `PaginationControls` component** in `components/directory/` — First/Prev/Next/Last buttons with "Showing X-Y of Z" text. Returns null when single page. Exported from directory barrel.
- **Risks table**: client-side pagination (50/page), resets on search/filter/sort
- **AI Models table**: client-side pagination (50/page), resets on search/filter/sort
- **Fix 200-org cap**: increase `MAX_PAGE_SIZE` from 200 to 500 in wiki-server entities endpoint

## Pagination status after this PR

| Directory | Pagination | Page Size |
|-----------|-----------|-----------|
| Organizations | Server-side (useServerTable) | 50 |
| People | Server-side (useServerTable) | 50 |
| Risks | Client-side (new) | 50 |
| AI Models | Client-side (new) | 50 |
| Grants | Client-side (existing) | 100 |
| Funding Programs | Client-side (existing) | 50 |
| Benchmarks | None (31 items) | n/a |

## Test plan
- [x] TypeScript clean
- [ ] Verify /risks shows pagination when >50 risks
- [ ] Verify /ai-models shows pagination when >50 models
- [ ] Verify /organizations shows >200 orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)