### PR TITLE
fix: resolve numericId conflict E1303

### DIFF
--- a/apps/web/src/app/internal/entity-matrix/page.tsx
+++ b/apps/web/src/app/internal/entity-matrix/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function EntityMatrixPage() {
-  redirect("/wiki/E1303");
+  redirect("/wiki/E1309");
 }

--- a/content/docs/internal/entity-matrix-dashboard.mdx
+++ b/content/docs/internal/entity-matrix-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-numericId: E1303
+numericId: E1309
 title: "Entity Matrix"
 description: "Completeness heatmap tracking infrastructure coverage across all entity and sub-entity types"
 subcategory: dashboards


### PR DESCRIPTION
## Summary
- `entity-matrix-dashboard` (from PR #2401) and `fei-fei-li` (from PR #2399) both claimed `E1303`
- Reassigns dashboard to `E1309` (next available ID)
- Updates redirect in `page.tsx` to match

This fixes the CI build failure on the release PR #2402.

## Test plan
- [ ] `pnpm build` succeeds (no numericId conflict)
- [ ] `/internal/entity-matrix` redirects to `/wiki/E1309`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal entity references across the application and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->