### PR TITLE
Group header nav into dropdown menus

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { DevModeToggle } from "@/components/DevModeToggle";
 import { SearchButton, SearchDialog } from "@/components/SearchDialog";
 import { MobileNav } from "@/components/MobileNav";
-import { NAV_LINKS } from "@/lib/nav-links";
+import { DesktopNav } from "@/components/DesktopNav";
 import { SITE_URL } from "@/lib/site-config";
 import "./globals.css";
 import "katex/dist/katex.min.css";
@@ -57,15 +57,9 @@ export default function RootLayout({
               Longterm Wiki
             </Link>
             <nav className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
-              {NAV_LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="hidden md:inline text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
-                >
-                  {link.label}
-                </Link>
-              ))}
+              <div className="hidden md:flex items-center gap-4">
+                <DesktopNav />
+              </div>
               <Link
                 href="/feed.xml"
                 className="hidden md:inline text-muted-foreground no-underline hover:text-foreground transition-colors"

--- a/apps/web/src/components/DesktopNav.tsx
+++ b/apps/web/src/components/DesktopNav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NAV_ITEMS, isDropdown } from "@/lib/nav-links";
+import { NavDropdown } from "@/components/NavDropdown";
+
+export function DesktopNav() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {NAV_ITEMS.map((item) => {
+        if (isDropdown(item)) {
+          return (
+            <NavDropdown key={item.label} label={item.label} items={item.items} />
+          );
+        }
+        const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`text-sm no-underline transition-colors ${
+              isActive
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { NAV_LINKS } from "@/lib/nav-links";
+import { NAV_ITEMS, isDropdown } from "@/lib/nav-links";
 
 export function MobileNav() {
   const [open, setOpen] = useState(false);
@@ -62,18 +62,38 @@ export function MobileNav() {
 
       {open && (
         <nav
-          className="absolute right-0 top-full mt-1 w-48 bg-card border border-border rounded-lg shadow-lg py-1 z-50"
+          className="absolute right-0 top-full mt-1 w-52 bg-card border border-border rounded-lg shadow-lg py-1 z-50"
           aria-label="Mobile navigation"
         >
-          {NAV_LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="block px-4 py-2.5 text-sm text-foreground no-underline hover:bg-muted transition-colors"
-            >
-              {link.label}
-            </Link>
-          ))}
+          {NAV_ITEMS.map((item) => {
+            if (isDropdown(item)) {
+              return (
+                <div key={item.label}>
+                  <div className="px-4 py-1.5 text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">
+                    {item.label}
+                  </div>
+                  {item.items.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="block px-4 py-2 pl-6 text-sm text-foreground no-underline hover:bg-muted transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                </div>
+              );
+            }
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="block px-4 py-2.5 text-sm text-foreground no-underline hover:bg-muted transition-colors"
+              >
+                {item.label}
+              </Link>
+            );
+          })}
         </nav>
       )}
     </div>

--- a/apps/web/src/components/NavDropdown.tsx
+++ b/apps/web/src/components/NavDropdown.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { NavDropdown as NavDropdownType } from "@/lib/nav-links";
+
+export function NavDropdown({ label, items }: NavDropdownType) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  // Close on route change
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const isActive = items.some((item) => pathname.startsWith(item.href));
+
+  function handleEnter() {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setOpen(true);
+  }
+
+  function handleLeave() {
+    timeoutRef.current = setTimeout(() => setOpen(false), 150);
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="relative"
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`text-sm transition-colors inline-flex items-center gap-0.5 ${
+          isActive
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        {label}
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`transition-transform ${open ? "rotate-180" : ""}`}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full pt-1 z-50">
+          <div className="bg-card border border-border rounded-lg shadow-lg py-1 min-w-[10rem]">
+            {items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`block px-4 py-2 text-sm no-underline transition-colors ${
+                  pathname.startsWith(item.href)
+                    ? "text-foreground bg-muted"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -1,17 +1,59 @@
-/** Shared navigation links used in both desktop and mobile nav bars. */
-export const NAV_LINKS = [
+/** Navigation link types */
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+export interface NavDropdown {
+  label: string;
+  items: NavLink[];
+}
+
+export type NavItem = NavLink | NavDropdown;
+
+export function isDropdown(item: NavItem): item is NavDropdown {
+  return "items" in item;
+}
+
+/** Header navigation — mix of standalone links and grouped dropdowns. */
+export const NAV_ITEMS: NavItem[] = [
   { href: "/wiki", label: "Explore" },
-  { href: "/organizations", label: "Organizations" },
-  { href: "/people", label: "People" },
-  { href: "/risks", label: "Risks" },
-  { href: "/legislation", label: "Legislation" },
-  { href: "/ai-models", label: "AI Models" },
-  { href: "/benchmarks", label: "Benchmarks" },
-  { href: "/projects", label: "Projects" },
-  { href: "/research-areas", label: "Research Areas" },
-  { href: "/sources", label: "Sources" },
-  { href: "/funding-programs", label: "Funding" },
-  { href: "/factbase", label: "Data" },
+  {
+    label: "Entities",
+    items: [
+      { href: "/organizations", label: "Organizations" },
+      { href: "/people", label: "People" },
+      { href: "/ai-models", label: "AI Models" },
+      { href: "/projects", label: "Projects" },
+    ],
+  },
+  {
+    label: "Research",
+    items: [
+      { href: "/risks", label: "Risks" },
+      { href: "/research-areas", label: "Research Areas" },
+      { href: "/benchmarks", label: "Benchmarks" },
+    ],
+  },
+  {
+    label: "Policy",
+    items: [
+      { href: "/legislation", label: "Legislation" },
+      { href: "/funding-programs", label: "Funding" },
+    ],
+  },
+  {
+    label: "Data",
+    items: [
+      { href: "/sources", label: "Sources" },
+      { href: "/factbase", label: "FactBase" },
+    ],
+  },
   { href: "/wiki/E755", label: "About" },
   { href: "/wiki/E779", label: "Internal" },
-] as const;
+];
+
+/** Flat list of all nav links (for mobile nav and anywhere needing a simple list). */
+export const NAV_LINKS: NavLink[] = NAV_ITEMS.flatMap((item) =>
+  isDropdown(item) ? item.items : [item]
+);


### PR DESCRIPTION
## Summary
- Consolidate 13 flat header nav links into 7 top-level items using grouped dropdowns
- **Entities** ▾: Organizations, People, AI Models, Projects
- **Research** ▾: Risks, Research Areas, Benchmarks
- **Policy** ▾: Legislation, Funding
- **Data** ▾: Sources, FactBase
- Standalone: Explore, About, Internal
- Desktop dropdowns open on hover with 150ms close delay, also clickable, with chevron indicator
- Mobile nav shows grouped sections with uppercase category headers and indented links
- Closes on escape, click outside, or route change

## Test plan
- [ ] Verify desktop dropdowns open on hover and close when mouse leaves
- [ ] Verify clicking dropdown toggle opens/closes
- [ ] Verify all dropdown links navigate correctly
- [ ] Verify mobile hamburger menu shows grouped sections
- [ ] Verify active state highlighting works for items inside dropdowns
- [ ] Check header no longer overflows on typical screen widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)