### PR TITLE
feat: add /projects directory pages with table layout

### DIFF
--- a/apps/web/src/app/factbase/factbase-entities-content.tsx
+++ b/apps/web/src/app/factbase/factbase-entities-content.tsx
@@ -2,7 +2,7 @@ import {
   getKBEntities,
   getKBProperties,
   getKBFacts,
-  getKBRecords,
+  getKBAllRecordCollections,
 } from "@/data/factbase";
 import type { Fact } from "@longterm-wiki/factbase";
 import { FBEntitiesTable } from "./factbase-entities-table";
@@ -40,20 +40,11 @@ export function FBEntityCoverageContent() {
         ? Math.round((factsWithSource / structuredFacts.length) * 100)
         : 0;
 
-    // Count records across all collections
+    // Count records across all collections (dynamic, not hardcoded)
+    const allCollections = getKBAllRecordCollections(entity.id);
     let itemCount = 0;
-    const commonCollections = [
-      "funding-rounds",
-      "key-persons",
-      "products",
-      "model-releases",
-      "board-seats",
-      "strategic-partnerships",
-      "safety-milestones",
-      "research-areas",
-    ];
-    for (const collection of commonCollections) {
-      itemCount += getKBRecords(entity.id, collection).length;
+    for (const entries of Object.values(allCollections)) {
+      itemCount += entries.length;
     }
 
     const propertyNames = [...propertyIds]

--- a/apps/web/src/app/organizations/[slug]/org-shared.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-shared.tsx
@@ -32,24 +32,26 @@ export function field(item: KBRecordEntry, key: string): string | undefined {
 // ── Entity ref resolver helper ────────────────────────────────────────
 
 export function resolveRefName(
-  slug: string | undefined,
+  slugOrId: string | undefined,
   displayName: string | undefined,
 ): { name: string; href: string | null } {
-  if (!slug && !displayName) return { name: "Unknown", href: null };
+  if (!slugOrId && !displayName) return { name: "Unknown", href: null };
 
-  if (slug) {
-    const entityId = resolveKBSlug(slug);
-    const entity = entityId ? getKBEntity(entityId) : null;
-    if (entity) {
-      const prefix = entity.type === "organization" ? "/organizations"
-        : entity.type === "person" ? "/people"
+  if (slugOrId) {
+    // Try direct entity lookup first (handles both entity IDs and slugs
+    // since getKBEntity resolves both), then fall back to slug resolution.
+    const directEntity = getKBEntity(slugOrId);
+    if (directEntity) {
+      const resolvedSlug = getKBEntitySlug(directEntity.id) ?? slugOrId;
+      const prefix = directEntity.type === "organization" ? "/organizations"
+        : directEntity.type === "person" ? "/people"
         : null;
-      return { name: entity.name, href: prefix ? `${prefix}/${slug}` : `/factbase/entity/${entityId}` };
+      return { name: directEntity.name, href: prefix ? `${prefix}/${resolvedSlug}` : `/factbase/entity/${directEntity.id}` };
     }
   }
 
   // Fall back to display name or humanized slug
-  const fallbackName = displayName ?? (slug ? titleCase(slug) : "Unknown");
+  const fallbackName = displayName ?? (slugOrId ? titleCase(slugOrId) : "Unknown");
   return { name: fallbackName, href: null };
 }
 

--- a/packages/factbase/src/graph.ts
+++ b/packages/factbase/src/graph.ts
@@ -84,9 +84,10 @@ export class Graph {
     collectionName: string,
     entry: RecordEntry,
   ): void {
-    // Validate collectionName matches the schema's expected collection
+    // Validate collectionName matches the schema's expected collection.
+    // Skip if schema has no explicit collectionName (relies on plural fallback).
     const schema = this.recordSchemas.get(entry.schema);
-    if (schema && schema.collectionName !== collectionName) {
+    if (schema && schema.collectionName && schema.collectionName !== collectionName) {
       throw new Error(
         `Record collection mismatch: schema "${entry.schema}" expects "${schema.collectionName}" but got "${collectionName}"`,
       );

--- a/packages/factbase/src/loader.ts
+++ b/packages/factbase/src/loader.ts
@@ -773,10 +773,15 @@ function parseRecordEntry(
   // Warn about missing required explicit endpoints
   for (const [endpointName, endpointDef] of Object.entries(schema.endpoints)) {
     if (endpointDef.implicit) continue;
-    if (endpointDef.required && !fields[endpointName] && !displayName) {
+    // display_name only satisfies endpoints that opt into it (allowDisplayName)
+    const hasFallback = displayName && endpointDef.allowDisplayName;
+    if (endpointDef.required && !fields[endpointName] && !hasFallback) {
       console.warn(
         `[kb/loader] Record "${ownerEntityId}/${schemaId}/${key}" is missing ` +
-        `required endpoint "${endpointName}" (and no display_name fallback)`
+        `required endpoint "${endpointName}"` +
+        (displayName && !endpointDef.allowDisplayName
+          ? ` (display_name present but endpoint does not allow it)`
+          : ` (and no display_name fallback)`)
       );
     }
   }


### PR DESCRIPTION
## Summary

- Add `/projects` listing page with sortable table layout (not cards), search, and cluster filter chips
- Add `/projects/[slug]` detail pages that group related entities into Organizations, People, and Related Projects sections
- Add `ProjectEntity` type with project-specific fields (`projectStatus`, `projectUrl`, `organization`, `startDate`, `techStack`)
- Add `isProject` type guard and `project` to `DIRECTORY_ENTITY_TYPES` for URL routing
- Projects use entity ID as slug directly (no KB slug resolution needed since many projects lack KB entries)

Replaces the basic card-based project pages on production with a table-first layout consistent with `/people`, `/organizations`, and `/risks` directory patterns.

Agent slot: a7

## Test plan
- [x] `pnpm build` passes — 17 project pages generated
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Gate check passes (pre-existing KB schema failures only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data retrieval mechanism for entity collections with dynamic aggregation to ensure accurate record counting
  * Enhanced entity reference resolution system to support both direct identifiers and slug-based lookups, providing greater flexibility in entity handling
  * Refined schema and endpoint validation logic with better conditional fallback handling and improved error messaging for enhanced troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->