### PR TITLE
fix: show Published column on Announcements/Press + fix resource metadata pipeline

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -470,6 +470,7 @@ export default async function OrgProfilePage({
           resources={data.resourceAnnouncements}
           title="News & Announcements"
           emptyMessage=""
+          alwaysShowColumns={{ date: true }}
         />
       ),
     });
@@ -486,6 +487,7 @@ export default async function OrgProfilePage({
           resources={data.resourcesAboutOrg}
           title="External Coverage & References"
           emptyMessage=""
+          alwaysShowColumns={{ date: true, publication: true }}
         />
       ),
     });

--- a/apps/web/src/app/organizations/[slug]/resources-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/resources-section.tsx
@@ -39,15 +39,18 @@ const TYPE_COLORS: Record<string, string> = {
 const DEFAULT_COLOR = "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
 
 /** Compute which optional columns have enough data to be worth showing. */
-function computeColumnVisibility(resources: OrgResourceRow[]) {
+function computeColumnVisibility(
+  resources: OrgResourceRow[],
+  alwaysShow?: { date?: boolean; publication?: boolean; credibility?: boolean },
+) {
   const total = resources.length || 1;
   const withDate = resources.filter((r) => r.publishedDate).length;
   const withPub = resources.filter((r) => r.publicationName).length;
   const withCred = resources.filter((r) => r.credibility != null).length;
   return {
-    showDate: withDate / total >= 0.2,
-    showPublication: withPub / total >= 0.15,
-    showCredibility: withCred / total >= 0.15,
+    showDate: alwaysShow?.date || withDate / total >= 0.2,
+    showPublication: alwaysShow?.publication || withPub / total >= 0.15,
+    showCredibility: alwaysShow?.credibility || withCred / total >= 0.15,
   };
 }
 
@@ -209,10 +212,12 @@ export function OrgResourcesSection({
   resources,
   title,
   emptyMessage,
+  alwaysShowColumns,
 }: {
   resources: OrgResourceRow[];
   title: string;
   emptyMessage: string;
+  alwaysShowColumns?: { date?: boolean; publication?: boolean; credibility?: boolean };
 }) {
   if (resources.length === 0) {
     return (
@@ -225,7 +230,7 @@ export function OrgResourcesSection({
 
   return (
     <section>
-      <OrgResourcesTable resources={resources} title={title} />
+      <OrgResourcesTable resources={resources} title={title} alwaysShowColumns={alwaysShowColumns} />
     </section>
   );
 }
@@ -233,11 +238,13 @@ export function OrgResourcesSection({
 function OrgResourcesTable({
   resources,
   title,
+  alwaysShowColumns,
 }: {
   resources: OrgResourceRow[];
   title: string;
+  alwaysShowColumns?: { date?: boolean; publication?: boolean; credibility?: boolean };
 }) {
-  const colVis = useMemo(() => computeColumnVisibility(resources), [resources]);
+  const colVis = useMemo(() => computeColumnVisibility(resources, alwaysShowColumns), [resources, alwaysShowColumns]);
   const columns = useMemo(() => makeColumns(colVis), [colVis]);
 
   const [sorting, setSorting] = useState<SortingState>(

--- a/apps/wiki-server/src/routes/resources.ts
+++ b/apps/wiki-server/src/routes/resources.ts
@@ -141,6 +141,22 @@ function resourceValues(d: ResourceInput) {
   };
 }
 
+/** Build a COALESCE expression for a jsonb column that correctly handles JS
+ *  arrays. Drizzle's `sql` template sends JS arrays as PG array parameters,
+ *  which can't be cast to jsonb. We pre-serialize to JSON text so the
+ *  `::jsonb` cast receives valid JSON. Null passes through to preserve
+ *  existing values via COALESCE. */
+function jsonbCoalesce(
+  incoming: unknown[] | null,
+  existing: unknown,
+) {
+  if (incoming == null) {
+    return sql`COALESCE(null::jsonb, ${existing})`;
+  }
+  const jsonText = JSON.stringify(incoming);
+  return sql`COALESCE(${jsonText}::jsonb, ${existing})`;
+}
+
 async function upsertResource(
   db: DbClient,
   d: ResourceInput,
@@ -164,11 +180,11 @@ async function upsertResource(
         summary: sql`COALESCE(${vals.summary}, ${resources.summary})`,
         review: sql`COALESCE(${vals.review}, ${resources.review})`,
         abstract: sql`COALESCE(${vals.abstract}, ${resources.abstract})`,
-        keyPoints: sql`COALESCE(${vals.keyPoints}::jsonb, ${resources.keyPoints})`,
+        keyPoints: jsonbCoalesce(vals.keyPoints, resources.keyPoints),
         publicationId: sql`COALESCE(${vals.publicationId}, ${resources.publicationId})`,
-        authors: sql`COALESCE(${vals.authors}::jsonb, ${resources.authors})`,
+        authors: jsonbCoalesce(vals.authors, resources.authors),
         publishedDate: sql`COALESCE(${vals.publishedDate}, ${resources.publishedDate})`,
-        tags: sql`COALESCE(${vals.tags}::jsonb, ${resources.tags})`,
+        tags: jsonbCoalesce(vals.tags, resources.tags),
         localFilename: sql`COALESCE(${vals.localFilename}, ${resources.localFilename})`,
         credibilityOverride: sql`COALESCE(${vals.credibilityOverride}, ${resources.credibilityOverride})`,
         fetchedAt: sql`COALESCE(${vals.fetchedAt}, ${resources.fetchedAt})`,

--- a/crux/resource-metadata.ts
+++ b/crux/resource-metadata.ts
@@ -87,6 +87,7 @@ export async function extractArxivMetadata(opts: ParsedOpts): Promise<number> {
 
   const allIds = Array.from(idToResource.keys());
   let updated = 0;
+  const updatedResources: Resource[] = [];
 
   for (let i = 0; i < allIds.length; i += 20) {
     const batchIds = allIds.slice(i, i + 20);
@@ -99,6 +100,7 @@ export async function extractArxivMetadata(opts: ParsedOpts): Promise<number> {
         if (meta.published) resource.published_date = meta.published;
         if (meta.abstract && !resource.abstract) resource.abstract = meta.abstract;
         updated++;
+        updatedResources.push(resource);
         if (verbose) console.log(`   ✓ ${resource.title}`);
       }
       if (i + 20 < allIds.length) await sleep(3000);
@@ -111,7 +113,7 @@ export async function extractArxivMetadata(opts: ParsedOpts): Promise<number> {
   if (!opts._skipSave) console.log(`   ✅ Updated ${updated} papers`);
 
   if (!dryRun && updated > 0 && !opts._skipSave) {
-    await saveResources(resources);
+    await saveResources(updatedResources);
     console.log('   Saved resources to PG');
   }
   return updated;
@@ -177,6 +179,7 @@ export async function extractForumMetadata(opts: ParsedOpts): Promise<number> {
   }
 
   let updated = 0;
+  const updatedResources: Resource[] = [];
   for (const r of toProcess) {
     const slug = extractForumSlug(r.url);
     const isEA = r.url.includes('forum.effectivealtruism.org');
@@ -186,6 +189,7 @@ export async function extractForumMetadata(opts: ParsedOpts): Promise<number> {
         r.authors = meta.authors;
         if (meta.published) r.published_date = meta.published;
         updated++;
+        updatedResources.push(r);
         if (verbose) console.log(`   ✓ ${r.title}`);
       }
       await sleep(200);
@@ -198,7 +202,7 @@ export async function extractForumMetadata(opts: ParsedOpts): Promise<number> {
   if (!opts._skipSave) console.log(`   ✅ Updated ${updated} posts`);
 
   if (!dryRun && updated > 0 && !opts._skipSave) {
-    await saveResources(resources);
+    await saveResources(updatedResources);
     console.log('   Saved resources to PG');
   }
   return updated;
@@ -255,6 +259,7 @@ export async function extractScholarMetadata(opts: ParsedOpts): Promise<number> 
 
   let updated = 0;
   let failed = 0;
+  const updatedResources: Resource[] = [];
 
   for (const r of toProcess) {
     // Try DOI first
@@ -278,6 +283,7 @@ export async function extractScholarMetadata(opts: ParsedOpts): Promise<number> 
         if (meta.published) r.published_date = meta.published;
         if (meta.abstract && !r.abstract) r.abstract = meta.abstract;
         updated++;
+        updatedResources.push(r);
         if (verbose) console.log(`   ✓ ${r.title}`);
       } else {
         failed++;
@@ -293,7 +299,7 @@ export async function extractScholarMetadata(opts: ParsedOpts): Promise<number> 
   if (!opts._skipSave) console.log(`   ✅ Updated ${updated} resources (${failed} failed/no data)`);
 
   if (!dryRun && updated > 0 && !opts._skipSave) {
-    await saveResources(resources);
+    await saveResources(updatedResources);
     console.log('   Saved resources to PG');
   }
   return updated;
@@ -353,11 +359,51 @@ export async function extractWebMetadata(opts: ParsedOpts): Promise<number> {
 
   const firecrawl = new (FirecrawlApp as new (opts: { apiKey: string }) => { batchScrape: (urls: string[], opts: unknown) => Promise<{ data?: Array<{ metadata?: Record<string, unknown> }> }>; scrapeUrl: (url: string, opts: unknown) => Promise<{ metadata?: Record<string, unknown> }> })({ apiKey: FIRECRAWL_KEY });
   let updated = 0;
+  const updatedResources: Resource[] = [];
 
   // Build URL to resource map
   const urlToResource = new Map<string, Resource>();
   for (const r of toProcess) {
     urlToResource.set(r.url, r);
+  }
+
+  /** Apply metadata from a scrape result to the matching resource. */
+  function applyMetadata(metadata: Record<string, unknown>, matchUrl?: string): void {
+    const r = urlToResource.get(matchUrl || (metadata.sourceURL as string) || (metadata.url as string));
+    if (!r) return;
+
+    const authorFields = ['author', 'authors', 'DC.Contributor', 'DC.Creator', 'article:author', 'og:article:author'];
+    let authors: string[] | null = null;
+    for (const field of authorFields) {
+      const value = metadata[field];
+      if (value) {
+        if (Array.isArray(value)) {
+          authors = value.filter((a): a is string => a && typeof a === 'string');
+        } else if (typeof value === 'string') {
+          authors = value.includes(',') ? value.split(',').map(a => a.trim()) : [value];
+        }
+        if (authors?.length && authors.length > 0) break;
+      }
+    }
+
+    const articleMeta = metadata.article as Record<string, unknown> | undefined;
+    const publishedDate = (metadata.publishedTime as string) || (metadata.datePublished as string) || (articleMeta?.publishedTime as string | undefined);
+
+    let changed = false;
+    if (authors?.length && authors.length > 0) {
+      r.authors = authors;
+      changed = true;
+      if (verbose) console.log(`   ✓ ${r.title} (authors: ${authors.join(', ')})`);
+    }
+    if (publishedDate) {
+      r.published_date = publishedDate.split('T')[0];
+      changed = true;
+      if (verbose && !authors?.length) console.log(`   ✓ ${r.title} (date: ${publishedDate})`);
+    }
+    if (changed) {
+      updated++;
+      updatedResources.push(r);
+    }
   }
 
   // Use batch scraping for efficiency
@@ -371,40 +417,8 @@ export async function extractWebMetadata(opts: ParsedOpts): Promise<number> {
       timeout: 300000, // 5 min timeout
     });
 
-    // Process results
     for (const result of results.data || []) {
-      const metadata = (result.metadata || {}) as Record<string, unknown>;
-      const r = urlToResource.get((metadata.sourceURL as string) || (metadata.url as string));
-      if (!r) continue;
-
-      // Extract authors from various metadata fields
-      const authorFields = ['author', 'authors', 'DC.Contributor', 'DC.Creator', 'article:author', 'og:article:author'];
-      let authors: string[] | null = null;
-      for (const field of authorFields) {
-        const value = metadata[field];
-        if (value) {
-          if (Array.isArray(value)) {
-            authors = value.filter((a): a is string => a && typeof a === 'string');
-          } else if (typeof value === 'string') {
-            authors = value.includes(',') ? value.split(',').map(a => a.trim()) : [value];
-          }
-          if (authors?.length && authors.length > 0) break;
-        }
-      }
-
-      const articleMeta = metadata.article as Record<string, unknown> | undefined;
-      const publishedDate = (metadata.publishedTime as string) || (metadata.datePublished as string) || (articleMeta?.publishedTime as string | undefined);
-
-      if (authors?.length && authors.length > 0) {
-        r.authors = authors;
-        updated++;
-        if (verbose) console.log(`   ✓ ${r.title} (authors: ${authors.join(', ')})`);
-      }
-      if (publishedDate) {
-        r.published_date = publishedDate.split('T')[0];
-        if (!authors?.length) updated++;
-        if (verbose && !authors?.length) console.log(`   ✓ ${r.title} (date: ${publishedDate})`);
-      }
+      applyMetadata((result.metadata || {}) as Record<string, unknown>);
     }
   } catch (err: unknown) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -414,34 +428,7 @@ export async function extractWebMetadata(opts: ParsedOpts): Promise<number> {
     for (const r of toProcess) {
       try {
         const result = await firecrawl.scrapeUrl(r.url, { formats: ['markdown'] });
-        const metadata = (result.metadata || {}) as Record<string, unknown>;
-
-        const authorFields = ['author', 'authors', 'DC.Contributor', 'DC.Creator', 'article:author', 'og:article:author'];
-        let authors: string[] | null = null;
-        for (const field of authorFields) {
-          const value = metadata[field];
-          if (value) {
-            if (Array.isArray(value)) {
-              authors = value.filter((a): a is string => a && typeof a === 'string');
-            } else if (typeof value === 'string') {
-              authors = value.includes(',') ? value.split(',').map(a => a.trim()) : [value];
-            }
-            if (authors?.length && authors.length > 0) break;
-          }
-        }
-
-        const articleMeta = metadata.article as Record<string, unknown> | undefined;
-        const publishedDate = (metadata.publishedTime as string) || (metadata.datePublished as string) || (articleMeta?.publishedTime as string | undefined);
-
-        if (authors?.length && authors.length > 0) {
-          r.authors = authors;
-          updated++;
-        }
-        if (publishedDate) {
-          r.published_date = publishedDate.split('T')[0];
-          if (!authors?.length) updated++;
-        }
-
+        applyMetadata((result.metadata || {}) as Record<string, unknown>, r.url);
         await sleep(7000);
       } catch (e: unknown) {
         const innerError = e instanceof Error ? e : new Error(String(e));
@@ -453,7 +440,7 @@ export async function extractWebMetadata(opts: ParsedOpts): Promise<number> {
   if (!opts._skipSave) console.log(`   ✅ Updated ${updated} resources`);
 
   if (!dryRun && updated > 0 && !opts._skipSave) {
-    await saveResources(resources);
+    await saveResources(updatedResources);
     console.log('   Saved resources to PG');
   }
   return updated;
@@ -534,6 +521,12 @@ export async function cmdMetadata(opts: ParsedOpts): Promise<void> {
     console.log('🚀 Running all extractors in parallel...\n');
 
     const resources = await loadResourcesPGFirst();
+    // Snapshot IDs before extraction so we can detect which resources were mutated
+    const originalHashes = new Map<string, string>();
+    for (const r of resources) {
+      originalHashes.set(r.id, `${r.authors?.join(',')}|${r.published_date}|${r.abstract}`);
+    }
+
     const sharedOpts: ParsedOpts = { ...opts, _resources: resources, _skipSave: true };
 
     const results = await Promise.allSettled([
@@ -553,10 +546,14 @@ export async function cmdMetadata(opts: ParsedOpts): Promise<void> {
       }
     });
 
-    // Save once at the end
+    // Save only the resources that were actually mutated
     if (totalUpdated > 0 && !opts['dry-run']) {
-      await saveResources(resources);
-      console.log('\n📁 Saved resources to PG');
+      const mutated = resources.filter(r => {
+        const orig = originalHashes.get(r.id);
+        return orig !== `${r.authors?.join(',')}|${r.published_date}|${r.abstract}`;
+      });
+      await saveResources(mutated);
+      console.log(`\n📁 Saved ${mutated.length} updated resources to PG`);
     }
   } else {
     // Sequential execution


### PR DESCRIPTION
## Summary

- **Always show Published date** on Announcements tab and Published date + Publication on Press tab (organization pages), regardless of data coverage threshold
- **Fix metadata extractor save bug**: all 5 extractors were saving ALL ~5000 resources instead of only the updated ones — now tracks and saves only mutated resources
- **Fix wiki-server JSONB COALESCE bug**: `COALESCE(${val}::jsonb, existing)` fails because drizzle sends JS arrays as PG array params instead of JSON text; added `jsonbCoalesce()` helper that pre-serializes via `JSON.stringify`

## Context

The Announcements and Press tabs on org pages were hiding the Published date column when <20% of resources had dates. For these tabs, the date is essential context regardless of coverage. The metadata enrichment pipeline (`pnpm crux resources metadata`) was also broken due to two bugs: (1) saving all resources instead of just updated ones, and (2) a server-side JSONB serialization issue in the batch upsert.

## Test plan

- [x] `pnpm crux validate gate --fix` passes (21/21 checks)
- [x] TypeScript clean (`tsc --noEmit` for both web and wiki-server)
- [x] Pre-existing test failure in `source-fetcher.test.ts` (not caused by these changes)
- [ ] After server deploys: run `pnpm crux resources metadata arxiv` and verify it saves successfully

Closes #2415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization resource tables now support always displaying date, publication, and credibility columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->