### PR TITLE
feat: add real FK columns to org-related tables for entity references

### DIFF
--- a/apps/wiki-server/drizzle/0093_org_tables_entity_fk_columns.sql
+++ b/apps/wiki-server/drizzle/0093_org_tables_entity_fk_columns.sql
@@ -1,0 +1,226 @@
+-- Add real FK columns to org-related tables (personnel, grants, investments,
+-- funding_rounds, equity_positions).
+--
+-- Pattern: for each text column that currently stores an entity ID or display
+-- name, add a nullable FK column referencing entities.stable_id plus a
+-- display_name fallback column. The original text columns are kept temporarily
+-- for migration compatibility.
+--
+-- These tables are small (60-200 rows), so direct ALTER is fine.
+
+-- ============================================================
+-- personnel: person_entity_id, person_display_name,
+--            org_entity_id, org_display_name
+-- ============================================================
+
+ALTER TABLE "personnel"
+  ADD COLUMN IF NOT EXISTS "person_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "person_display_name" text,
+  ADD COLUMN IF NOT EXISTS "org_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "org_display_name" text;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'personnel_person_entity_id_entities_stable_id_fk'
+      AND table_name = 'personnel'
+  ) THEN
+    ALTER TABLE "personnel" ADD CONSTRAINT "personnel_person_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("person_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'personnel_org_entity_id_entities_stable_id_fk'
+      AND table_name = 'personnel'
+  ) THEN
+    ALTER TABLE "personnel" ADD CONSTRAINT "personnel_org_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("org_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Backfill: copy existing entity IDs into the new FK columns where they
+-- match a valid entity stable_id. Non-matching values go into display_name.
+UPDATE personnel p SET
+  person_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = p.person_id) THEN p.person_id ELSE NULL END,
+  person_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = p.person_id) THEN p.person_id ELSE NULL END,
+  org_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = p.organization_id) THEN p.organization_id ELSE NULL END,
+  org_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = p.organization_id) THEN p.organization_id ELSE NULL END
+WHERE p.person_entity_id IS NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_personnel_person_entity" ON "personnel" ("person_entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_personnel_org_entity" ON "personnel" ("org_entity_id");--> statement-breakpoint
+
+-- ============================================================
+-- grants: org_entity_id, org_display_name,
+--         grantee_entity_id, grantee_display_name
+-- ============================================================
+
+ALTER TABLE "grants"
+  ADD COLUMN IF NOT EXISTS "org_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "org_display_name" text,
+  ADD COLUMN IF NOT EXISTS "grantee_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "grantee_display_name" text;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'grants_org_entity_id_entities_stable_id_fk'
+      AND table_name = 'grants'
+  ) THEN
+    ALTER TABLE "grants" ADD CONSTRAINT "grants_org_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("org_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'grants_grantee_entity_id_entities_stable_id_fk'
+      AND table_name = 'grants'
+  ) THEN
+    ALTER TABLE "grants" ADD CONSTRAINT "grants_grantee_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("grantee_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+UPDATE grants g SET
+  org_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = g.organization_id) THEN g.organization_id ELSE NULL END,
+  org_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = g.organization_id) THEN g.organization_id ELSE NULL END,
+  grantee_entity_id = CASE WHEN g.grantee_id IS NOT NULL AND EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = g.grantee_id) THEN g.grantee_id ELSE NULL END,
+  grantee_display_name = CASE WHEN g.grantee_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = g.grantee_id) THEN g.grantee_id ELSE NULL END
+WHERE g.org_entity_id IS NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_grants_org_entity" ON "grants" ("org_entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_grants_grantee_entity" ON "grants" ("grantee_entity_id");--> statement-breakpoint
+
+-- ============================================================
+-- funding_rounds: company_entity_id, company_display_name,
+--                 lead_investor_entity_id, lead_investor_display_name
+-- ============================================================
+
+ALTER TABLE "funding_rounds"
+  ADD COLUMN IF NOT EXISTS "company_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "company_display_name" text,
+  ADD COLUMN IF NOT EXISTS "lead_investor_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "lead_investor_display_name" text;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'funding_rounds_company_entity_id_entities_stable_id_fk'
+      AND table_name = 'funding_rounds'
+  ) THEN
+    ALTER TABLE "funding_rounds" ADD CONSTRAINT "funding_rounds_company_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("company_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'funding_rounds_lead_investor_entity_id_entities_stable_id_fk'
+      AND table_name = 'funding_rounds'
+  ) THEN
+    ALTER TABLE "funding_rounds" ADD CONSTRAINT "funding_rounds_lead_investor_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("lead_investor_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+UPDATE funding_rounds fr SET
+  company_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = fr.company_id) THEN fr.company_id ELSE NULL END,
+  company_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = fr.company_id) THEN fr.company_id ELSE NULL END,
+  lead_investor_entity_id = CASE WHEN fr.lead_investor IS NOT NULL AND EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = fr.lead_investor) THEN fr.lead_investor ELSE NULL END,
+  lead_investor_display_name = CASE WHEN fr.lead_investor IS NOT NULL AND NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = fr.lead_investor) THEN fr.lead_investor ELSE NULL END
+WHERE fr.company_entity_id IS NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_fr_company_entity" ON "funding_rounds" ("company_entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_fr_lead_investor_entity" ON "funding_rounds" ("lead_investor_entity_id");--> statement-breakpoint
+
+-- ============================================================
+-- investments: company_entity_id, company_display_name,
+--              investor_entity_id, investor_display_name
+-- ============================================================
+
+ALTER TABLE "investments"
+  ADD COLUMN IF NOT EXISTS "company_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "company_display_name" text,
+  ADD COLUMN IF NOT EXISTS "investor_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "investor_display_name" text;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'investments_company_entity_id_entities_stable_id_fk'
+      AND table_name = 'investments'
+  ) THEN
+    ALTER TABLE "investments" ADD CONSTRAINT "investments_company_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("company_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'investments_investor_entity_id_entities_stable_id_fk'
+      AND table_name = 'investments'
+  ) THEN
+    ALTER TABLE "investments" ADD CONSTRAINT "investments_investor_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("investor_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+UPDATE investments inv SET
+  company_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = inv.company_id) THEN inv.company_id ELSE NULL END,
+  company_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = inv.company_id) THEN inv.company_id ELSE NULL END,
+  investor_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = inv.investor_id) THEN inv.investor_id ELSE NULL END,
+  investor_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = inv.investor_id) THEN inv.investor_id ELSE NULL END
+WHERE inv.company_entity_id IS NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_inv_company_entity" ON "investments" ("company_entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_inv_investor_entity" ON "investments" ("investor_entity_id");--> statement-breakpoint
+
+-- ============================================================
+-- equity_positions: company_entity_id, company_display_name,
+--                   holder_entity_id, holder_display_name
+-- ============================================================
+
+ALTER TABLE "equity_positions"
+  ADD COLUMN IF NOT EXISTS "company_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "company_display_name" text,
+  ADD COLUMN IF NOT EXISTS "holder_entity_id" text,
+  ADD COLUMN IF NOT EXISTS "holder_display_name" text;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'equity_positions_company_entity_id_entities_stable_id_fk'
+      AND table_name = 'equity_positions'
+  ) THEN
+    ALTER TABLE "equity_positions" ADD CONSTRAINT "equity_positions_company_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("company_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'equity_positions_holder_entity_id_entities_stable_id_fk'
+      AND table_name = 'equity_positions'
+  ) THEN
+    ALTER TABLE "equity_positions" ADD CONSTRAINT "equity_positions_holder_entity_id_entities_stable_id_fk"
+    FOREIGN KEY ("holder_entity_id") REFERENCES "public"."entities"("stable_id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+
+UPDATE equity_positions ep SET
+  company_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = ep.company_id) THEN ep.company_id ELSE NULL END,
+  company_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = ep.company_id) THEN ep.company_id ELSE NULL END,
+  holder_entity_id = CASE WHEN EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = ep.holder_id) THEN ep.holder_id ELSE NULL END,
+  holder_display_name = CASE WHEN NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = ep.holder_id) THEN ep.holder_id ELSE NULL END
+WHERE ep.company_entity_id IS NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_ep_company_entity" ON "equity_positions" ("company_entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_ep_holder_entity" ON "equity_positions" ("holder_entity_id");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -652,6 +652,13 @@
       "when": 1776585600000,
       "tag": "0092_add_archive_url_and_fetch_method",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "7",
+      "when": 1776672000000,
+      "tag": "0093_org_tables_entity_fk_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1425,8 +1425,22 @@ export const personnel = pgTable(
   "personnel",
   {
     id: varchar("id", { length: 10 }).primaryKey(),
-    personId: text("person_id").notNull(), // entity ID or display name
-    organizationId: text("organization_id").notNull(), // entity ID or free text (career-history)
+    personId: text("person_id").notNull(), // legacy: entity ID or display name (kept for migration compat)
+    organizationId: text("organization_id").notNull(), // legacy: entity ID or free text (kept for migration compat)
+    /** FK to entities.stable_id for the person. Null when unresolved. */
+    personEntityId: text("person_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when person doesn't have an entity. */
+    personDisplayName: text("person_display_name"),
+    /** FK to entities.stable_id for the organization. Null when unresolved. */
+    orgEntityId: text("org_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when org doesn't have an entity. */
+    orgDisplayName: text("org_display_name"),
     role: text("role").notNull(), // job title or board role
     roleType: text("role_type").notNull(), // 'key-person' | 'board' | 'career'
     startDate: text("start_date"), // YYYY or YYYY-MM (flexible KB date format)
@@ -1449,6 +1463,8 @@ export const personnel = pgTable(
   (table) => [
     index("idx_personnel_person").on(table.personId),
     index("idx_personnel_org").on(table.organizationId),
+    index("idx_personnel_person_entity").on(table.personEntityId),
+    index("idx_personnel_org_entity").on(table.orgEntityId),
     index("idx_personnel_role_type").on(table.roleType),
   ]
 );
@@ -1462,8 +1478,22 @@ export const grants = pgTable(
   "grants",
   {
     id: varchar("id", { length: 10 }).primaryKey(),
-    organizationId: text("organization_id").notNull(), // grantor entity ID
-    granteeId: text("grantee_id"), // the recipient entity (nullable — many grants don't specify)
+    organizationId: text("organization_id").notNull(), // legacy: grantor entity ID (kept for migration compat)
+    granteeId: text("grantee_id"), // legacy: recipient entity (kept for migration compat)
+    /** FK to entities.stable_id for the grantor organization. Null when unresolved. */
+    orgEntityId: text("org_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when grantor org doesn't have an entity. */
+    orgDisplayName: text("org_display_name"),
+    /** FK to entities.stable_id for the grantee. Null when unresolved. */
+    granteeEntityId: text("grantee_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when grantee doesn't have an entity. */
+    granteeDisplayName: text("grantee_display_name"),
     name: text("name").notNull(), // program or grant name
     amount: numeric("amount"), // funding amount (NUMERIC for precise financial data; Drizzle returns string)
     currency: text("currency").notNull().default("USD"),
@@ -1486,6 +1516,8 @@ export const grants = pgTable(
   (table) => [
     index("idx_grants_org").on(table.organizationId),
     index("idx_grants_grantee").on(table.granteeId),
+    index("idx_grants_org_entity").on(table.orgEntityId),
+    index("idx_grants_grantee_entity").on(table.granteeEntityId),
     index("idx_grants_status").on(table.status),
     index("idx_grants_program").on(table.programId),
   ]
@@ -1503,13 +1535,27 @@ export const fundingRounds = pgTable(
   "funding_rounds",
   {
     id: varchar("id", { length: 10 }).primaryKey(),
-    companyId: text("company_id").notNull(), // entity ID of the company
+    companyId: text("company_id").notNull(), // legacy: entity ID of the company (kept for migration compat)
+    /** FK to entities.stable_id for the company. Null when unresolved. */
+    companyEntityId: text("company_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when company doesn't have an entity. */
+    companyDisplayName: text("company_display_name"),
     name: text("name").notNull(), // round name (e.g., "Series A", "Founding")
     date: text("date"), // YYYY or YYYY-MM
     raised: numeric("raised"), // capital raised (USD)
     valuation: numeric("valuation"), // post-money valuation (USD)
     instrument: text("instrument"), // equity, convertible-note, strategic-partnership, founding
-    leadInvestor: text("lead_investor"), // entity ID or display name
+    leadInvestor: text("lead_investor"), // legacy: entity ID or display name (kept for migration compat)
+    /** FK to entities.stable_id for the lead investor. Null when unresolved. */
+    leadInvestorEntityId: text("lead_investor_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when lead investor doesn't have an entity. */
+    leadInvestorDisplayName: text("lead_investor_display_name"),
     source: text("source"), // URL to announcement
     notes: text("notes"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
@@ -1524,6 +1570,8 @@ export const fundingRounds = pgTable(
   },
   (table) => [
     index("idx_fr_company").on(table.companyId),
+    index("idx_fr_company_entity").on(table.companyEntityId),
+    index("idx_fr_lead_investor_entity").on(table.leadInvestorEntityId),
     index("idx_fr_date").on(table.date),
   ]
 );
@@ -1538,8 +1586,22 @@ export const investments = pgTable(
   "investments",
   {
     id: varchar("id", { length: 10 }).primaryKey(),
-    companyId: text("company_id").notNull(), // entity ID of the company
-    investorId: text("investor_id").notNull(), // entity ID or display name
+    companyId: text("company_id").notNull(), // legacy: entity ID of the company (kept for migration compat)
+    investorId: text("investor_id").notNull(), // legacy: entity ID or display name (kept for migration compat)
+    /** FK to entities.stable_id for the company. Null when unresolved. */
+    companyEntityId: text("company_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when company doesn't have an entity. */
+    companyDisplayName: text("company_display_name"),
+    /** FK to entities.stable_id for the investor. Null when unresolved. */
+    investorEntityId: text("investor_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when investor doesn't have an entity. */
+    investorDisplayName: text("investor_display_name"),
     roundName: text("round_name"), // name of the funding round
     date: text("date"), // YYYY or YYYY-MM
     amount: numeric("amount"), // capital contributed (USD)
@@ -1562,6 +1624,8 @@ export const investments = pgTable(
   (table) => [
     index("idx_inv_company").on(table.companyId),
     index("idx_inv_investor").on(table.investorId),
+    index("idx_inv_company_entity").on(table.companyEntityId),
+    index("idx_inv_investor_entity").on(table.investorEntityId),
     index("idx_inv_date").on(table.date),
   ]
 );
@@ -1576,8 +1640,22 @@ export const equityPositions = pgTable(
   "equity_positions",
   {
     id: varchar("id", { length: 10 }).primaryKey(),
-    companyId: text("company_id").notNull(), // entity ID of the company
-    holderId: text("holder_id").notNull(), // entity ID or display name
+    companyId: text("company_id").notNull(), // legacy: entity ID of the company (kept for migration compat)
+    holderId: text("holder_id").notNull(), // legacy: entity ID or display name (kept for migration compat)
+    /** FK to entities.stable_id for the company. Null when unresolved. */
+    companyEntityId: text("company_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when company doesn't have an entity. */
+    companyDisplayName: text("company_display_name"),
+    /** FK to entities.stable_id for the holder. Null when unresolved. */
+    holderEntityId: text("holder_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when holder doesn't have an entity. */
+    holderDisplayName: text("holder_display_name"),
     stake: text("stake"), // current post-dilution equity stake (single or range as JSON string)
     source: text("source"), // URL to source
     notes: text("notes"),
@@ -1596,6 +1674,8 @@ export const equityPositions = pgTable(
   (table) => [
     index("idx_ep_company").on(table.companyId),
     index("idx_ep_holder").on(table.holderId),
+    index("idx_ep_company_entity").on(table.companyEntityId),
+    index("idx_ep_holder_entity").on(table.holderEntityId),
   ]
 );
 


### PR DESCRIPTION
## Summary
- Adds nullable FK columns referencing `entities.stable_id` to five org-related tables: `personnel`, `grants`, `investments`, `funding_rounds`, and `equity_positions`
- Each entity reference gets a pair of columns: an FK column (e.g., `person_entity_id`) and a `display_name` fallback (e.g., `person_display_name`)
- Migration 0093 backfills the new columns from existing text columns, routing values to FK or display_name based on whether they match a valid entity
- Original text columns kept temporarily for migration compatibility
- Also includes earlier commits: reclassified 20 non-legislation entities, deleted duplicate stubs, fixed grant recipient names, and corrected Coefficient Giving references

## Changes
- `apps/wiki-server/drizzle/0093_org_tables_entity_fk_columns.sql` - New migration with ALTER TABLE, FK constraints (idempotent), backfill UPDATEs, and indexes
- `apps/wiki-server/src/schema.ts` - Updated Drizzle schema with new columns and FK references
- `apps/wiki-server/drizzle/meta/_journal.json` - Migration journal entry

## Test plan
- [ ] Verify migration applies cleanly on a fresh DB
- [ ] Verify backfill correctly splits entity IDs vs display names
- [ ] Verify FK constraints reject invalid entity references
- [ ] Verify existing sync routes still work (new columns are nullable, no breaking changes)

Closes #2126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema to establish structured foreign key relationships between personnel, grants, funding rounds, investments, and equity positions with the entities system.
  * Added fallback display name fields to maintain data integrity when references are unavailable.
  * Implemented performance indexes to optimize entity-based lookups across all modified tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->