### PR TITLE
Enrich org divisions with clickable leads and key members

### DIFF
--- a/apps/web/src/app/organizations/[slug]/divisions-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions-section.tsx
@@ -10,6 +10,7 @@ import type { ParsedDivisionRecord } from "./org-data";
 import { getDivisionHref } from "@/app/divisions/[slug]/division-data";
 
 type LeadMap = Map<string, { name: string; href: string | null }>;
+type MembersMap = Map<string, Array<{ name: string; href: string | null; role: string | null }>>;
 
 const DIVISION_TYPE_LABELS: Record<string, string> = {
   fund: "Fund",
@@ -40,9 +41,11 @@ const DIVISION_ACCENT_BORDER: Record<string, string> = {
 export function DivisionsOverview({
   divisions,
   leadResolved,
+  members,
 }: {
   divisions: ParsedDivisionRecord[];
   leadResolved?: LeadMap;
+  members?: MembersMap;
 }) {
   if (divisions.length === 0) return null;
 
@@ -55,7 +58,7 @@ export function DivisionsOverview({
       <SectionHeader title="Divisions" count={divisions.length} />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
         {active.map((d) => (
-          <DivisionCard key={d.key} division={d} leadResolved={leadResolved} />
+          <DivisionCard key={d.key} division={d} leadResolved={leadResolved} members={members} />
         ))}
       </div>
       {inactive.length > 0 && (
@@ -65,7 +68,7 @@ export function DivisionsOverview({
           </summary>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-2 opacity-60">
             {inactive.map((d) => (
-              <DivisionCard key={d.key} division={d} leadResolved={leadResolved} />
+              <DivisionCard key={d.key} division={d} leadResolved={leadResolved} members={members} />
             ))}
           </div>
         </details>
@@ -77,12 +80,16 @@ export function DivisionsOverview({
 function DivisionCard({
   division: d,
   leadResolved,
+  members,
 }: {
   division: ParsedDivisionRecord;
   leadResolved?: LeadMap;
+  members?: MembersMap;
 }) {
   const resolvedLead = leadResolved?.get(d.key);
   const leadDisplay = resolvedLead?.name ?? d.lead;
+  const leadHref = resolvedLead?.href ?? null;
+  const divMembers = members?.get(d.key) ?? [];
   const accentBorder = DIVISION_ACCENT_BORDER[d.divisionType] ?? "border-l-gray-300 dark:border-l-gray-600";
 
   const inner = (
@@ -103,19 +110,54 @@ function DivisionCard({
           </svg>
         )}
       </div>
-      <div className="flex items-center gap-2 mt-0.5">
+      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/50">
           {DIVISION_TYPE_LABELS[d.divisionType] ?? d.divisionType}
         </span>
         {leadDisplay && (
           <>
             <span className="text-muted-foreground/30">&middot;</span>
-            <span className="text-xs text-muted-foreground truncate">
-              {leadDisplay}
-            </span>
+            {leadHref ? (
+              <Link
+                href={leadHref}
+                className="text-xs text-primary hover:underline truncate"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {leadDisplay}
+              </Link>
+            ) : (
+              <span className="text-xs text-muted-foreground truncate">
+                {leadDisplay}
+              </span>
+            )}
           </>
         )}
       </div>
+      {divMembers.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+          {divMembers.slice(0, 3).map((m, i) => (
+            <span key={i} className="text-[10px] text-muted-foreground/60">
+              {i > 0 && <span className="mr-1">&middot;</span>}
+              {m.href ? (
+                <Link
+                  href={m.href}
+                  className="hover:text-primary hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {m.name}
+                </Link>
+              ) : (
+                m.name
+              )}
+            </span>
+          ))}
+          {divMembers.length > 3 && (
+            <span className="text-[10px] text-muted-foreground/40">
+              +{divMembers.length - 3} more
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 
@@ -136,10 +178,12 @@ export function DivisionsSection({
   divisions,
   leadResolved,
   spending,
+  members,
 }: {
   divisions: ParsedDivisionRecord[];
   leadResolved?: LeadMap;
   spending?: SpendingMap;
+  members?: MembersMap;
 }) {
   if (divisions.length === 0) return null;
 
@@ -150,6 +194,7 @@ export function DivisionsSection({
   const grouped = [...departments, ...teams, ...other];
 
   const hasSpending = spending && spending.size > 0;
+  const hasMembers = members && members.size > 0;
 
   return (
     <section>
@@ -161,6 +206,9 @@ export function DivisionsSection({
               <th scope="col" className="text-left py-2.5 px-3 font-medium">Name</th>
               <th scope="col" className="text-left py-2.5 px-3 font-medium">Type</th>
               <th scope="col" className="text-left py-2.5 px-3 font-medium">Lead</th>
+              {hasMembers && (
+                <th scope="col" className="text-left py-2.5 px-3 font-medium">Key Members</th>
+              )}
               {hasSpending && (
                 <th scope="col" className="text-right py-2.5 px-3 font-medium">Total Spending</th>
               )}
@@ -175,6 +223,7 @@ export function DivisionsSection({
             {grouped.map((d) => {
               const resolvedLead = leadResolved?.get(d.key);
               const stats = spending?.get(d.key);
+              const divMembers = members?.get(d.key) ?? [];
               return (
                 <tr key={d.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-2.5 px-3">
@@ -229,6 +278,30 @@ export function DivisionsSection({
                       d.lead ?? ""
                     )}
                   </td>
+                  {hasMembers && (
+                    <td className="py-2.5 px-3 text-xs text-muted-foreground">
+                      {divMembers.length > 0 ? (
+                        <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+                          {divMembers.slice(0, 3).map((m, i) => (
+                            <span key={i}>
+                              {m.href ? (
+                                <Link href={m.href} className="text-primary hover:underline">
+                                  {m.name}
+                                </Link>
+                              ) : (
+                                m.name
+                              )}
+                            </span>
+                          ))}
+                          {divMembers.length > 3 && (
+                            <span className="text-muted-foreground/50">
+                              +{divMembers.length - 3}
+                            </span>
+                          )}
+                        </div>
+                      ) : null}
+                    </td>
+                  )}
                   {hasSpending && (
                     <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap text-xs">
                       {stats && stats.totalAmount > 0 && (

--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -1266,6 +1266,31 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     }
   }
 
+  // ── Division key members (match personnel to divisions by title keywords) ──
+  const divisionMembers = new Map<string, Array<{ name: string; href: string | null; role: string | null }>>();
+  for (const d of divisions) {
+    const members: Array<{ name: string; href: string | null; role: string | null }> = [];
+    const divNameLower = d.name.toLowerCase();
+    // Build matching keywords from division name/key
+    const divKeyLower = d.key.toLowerCase().replace(/-/g, " ");
+    for (const p of personnel) {
+      // Skip the lead — they're already shown separately
+      const resolvedLeadSlug = d.lead?.toLowerCase();
+      if (resolvedLeadSlug && p.personId?.toLowerCase() === resolvedLeadSlug) continue;
+      if (!p.role) continue;
+      // Skip people who have ended their tenure
+      if (p.endDate) continue;
+      const roleLower = p.role.toLowerCase();
+      // Match if role mentions the division name or key
+      if (roleLower.includes(divNameLower) || roleLower.includes(divKeyLower)) {
+        members.push({ name: p.personName, href: p.personHref, role: p.role });
+      }
+    }
+    if (members.length > 0) {
+      divisionMembers.set(d.key, members);
+    }
+  }
+
   // ── Division spending stats ──
   // Compute total grant spending per division via: division → funding programs → grants.
   // Uses ALL alternate keys (from merged duplicates) to match funding programs.
@@ -1360,6 +1385,7 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     keyPublications,
     modelBenchmarks,
     divisionLeadResolved,
+    divisionMembers,
     divisionSpending,
     chartData,
     dilutionStages,

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -205,7 +205,7 @@ export default async function OrgProfilePage({
 
       {/* Divisions overview */}
       {data.divisions.length > 0 && (
-        <DivisionsOverview divisions={data.divisions} leadResolved={data.divisionLeadResolved} />
+        <DivisionsOverview divisions={data.divisions} leadResolved={data.divisionLeadResolved} members={data.divisionMembers} />
       )}
 
       {/* Related Orgs */}
@@ -529,7 +529,7 @@ export default async function OrgProfilePage({
       count: data.divisions.length,
       content: (
         <div className="space-y-8">
-          <DivisionsSection divisions={data.divisions} leadResolved={data.divisionLeadResolved} spending={data.divisionSpending} />
+          <DivisionsSection divisions={data.divisions} leadResolved={data.divisionLeadResolved} spending={data.divisionSpending} members={data.divisionMembers} />
         </div>
       ),
     });


### PR DESCRIPTION
## Summary
- Division overview cards now show lead names as clickable links to person pages (previously plain text)
- Divisions table gains a "Key Members" column that matches personnel to divisions by title keyword heuristics
- Division overview cards show up to 3 additional team members below the lead, with links to person pages

## Context
Issue #2291 requested publications, benchmark scores, and divisions with team leads for org pages. The publications section and AI models + benchmarks table were already fully implemented. The divisions section showed lead names but as plain text. This PR enriches divisions with:
1. Clickable lead links in overview cards
2. Key member cross-referencing from personnel records
3. Key Members column in the full divisions table

## Test plan
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit` in `apps/web/`)
- [ ] Check org pages with divisions (e.g., Anthropic) show clickable lead names in overview cards
- [ ] Check division table shows "Key Members" column when personnel match division names
- [ ] Verify existing tests pass (`pnpm test`)

Closes #2291

Generated with [Claude Code](https://claude.com/claude-code)