### PR TITLE
fix: filter expired facts from FactsPanel

### DIFF
--- a/apps/web/src/components/directory/FactsSection.tsx
+++ b/apps/web/src/components/directory/FactsSection.tsx
@@ -7,6 +7,7 @@ import {
   getKBProperty,
   getKBEntity,
   getKBEntitySlug,
+  isFactExpired,
 } from "@/data/factbase";
 import {
   formatKBFactValue,
@@ -27,11 +28,12 @@ export const FACT_CATEGORIES: { id: string; label: string; order: number }[] = [
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Group facts by property, taking only the latest per property. */
+/** Group facts by property, taking only the latest non-expired per property. */
 export function getLatestFactsByProperty(facts: Fact[]): Map<string, Fact> {
   const latest = new Map<string, Fact>();
   for (const fact of facts) {
     if (fact.propertyId === "description") continue;
+    if (isFactExpired(fact)) continue;
     if (!latest.has(fact.propertyId)) {
       latest.set(fact.propertyId, fact);
     }


### PR DESCRIPTION
## Summary

- The `getLatestFactsByProperty()` function in `FactsSection.tsx` was displaying expired facts in the FactsPanel (e.g., showing Hinton as "Employed By: Google DeepMind" despite his 2023 resignation)
- Added `isFactExpired()` filtering to skip facts with a `validEnd` date in the past, matching the pattern already used by `getFactBaseLatest()` and person page stat cards
- The `isFactExpired()` utility already existed in `@/data/factbase` with full test coverage; this change simply wires it into the FactsPanel's fact selection logic

## Test plan

- [x] Verified `isFactExpired` test suite passes (in `factbase-expired.test.ts`)
- [x] All 746 tests pass (2 pre-existing failures from unrelated missing `@longterm-wiki/factbase/currencies` module)
- [x] Build failure is pre-existing on `main` (same `currencies` module issue), not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)