### PR TITLE
fix: redirect /organizations/google-deepmind to /organizations/deepmind

### DIFF
--- a/packages/factbase/data/things/deepmind.yaml
+++ b/packages/factbase/data/things/deepmind.yaml
@@ -8,6 +8,8 @@ thing:
     - DeepMind
     - DeepMind Technologies
     - Google DeepMind
+  previousSlugs:
+    - google-deepmind
 
 facts:
   - id: f_mEKUPPFYRg


### PR DESCRIPTION
## Summary
- Adds `google-deepmind` as a `previousSlugs` entry on the DeepMind FactBase entity
- This triggers the existing `resolveSlugAlias` mechanism in the org detail page to issue a 308 permanent redirect from `/organizations/google-deepmind` to `/organizations/deepmind`

## Context
The entity's display name is "Google DeepMind" but its YAML slug is `deepmind`. Users who guess the URL `/organizations/google-deepmind` currently get a 404.

## Test plan
- [x] Verified the factbase loader reads `previousSlugs` and the serializer outputs `previousSlugToCurrentSlug: { "google-deepmind": "deepmind" }` (confirmed locally via `npx tsx` script)
- [x] All existing tests pass (746 tests, 2 pre-existing failures unrelated to this change)
- [x] Gate check passed

Generated with [Claude Code](https://claude.com/claude-code)