### PR TITLE
fix: replace ANY() with IN() in directory endpoint SQL

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -58,6 +58,21 @@ const DirectoryQuery = z.object({
 
 // ---- Helpers ----
 
+/**
+ * Build a parameterized SQL value list for use with `IN (...)`.
+ *
+ * Drizzle's `sql` tag expands JS arrays as value-lists `($1,$2,...)` which is
+ * a row constructor — valid for `IN` but **not** for PostgreSQL `ANY()` (which
+ * expects an array type). Use `IN (${sqlInList(arr)})` instead of
+ * `= ANY(${arr})` in raw `db.execute()` queries.
+ */
+function sqlInList(values: string[]) {
+  return sql.join(
+    values.map((v) => sql`${v}`),
+    sql`, `,
+  );
+}
+
 function formatEntity(e: typeof entities.$inferSelect) {
   return {
     id: e.id,
@@ -324,8 +339,8 @@ const entitiesApp = new Hono()
             f.format,
             f.format_divisor AS "formatDivisor"
           FROM facts f
-          WHERE f.entity_id = ANY(${stableIds})
-            AND f.measure = ANY(${measureList})
+          WHERE f.entity_id IN (${sqlInList(stableIds)})
+            AND f.measure IN (${sqlInList(measureList)})
           ORDER BY f.entity_id, f.measure, f.as_of DESC NULLS LAST
         `);
       }
@@ -389,7 +404,7 @@ const entitiesApp = new Hono()
       const personnelCounts = await db.execute<PersonnelCountRow>(sql`
         SELECT person_id AS "personId", COUNT(*)::int AS cnt
         FROM personnel
-        WHERE person_id = ANY(${stableIds})
+        WHERE person_id IN (${sqlInList(stableIds)})
           AND role_type = 'career'
         GROUP BY person_id
       `);
@@ -406,7 +421,7 @@ const entitiesApp = new Hono()
       const grantsGiven = await db.execute<GrantCountRow>(sql`
         SELECT organization_id AS "entityId", COUNT(*)::int AS cnt
         FROM grants
-        WHERE organization_id = ANY(${stableIds})
+        WHERE organization_id IN (${sqlInList(stableIds)})
         GROUP BY organization_id
       `);
       for (const r of grantsGiven) {
@@ -416,7 +431,7 @@ const entitiesApp = new Hono()
       const grantsReceived = await db.execute<GrantCountRow>(sql`
         SELECT grantee_id AS "entityId", COUNT(*)::int AS cnt
         FROM grants
-        WHERE grantee_id = ANY(${stableIds})
+        WHERE grantee_id IN (${sqlInList(stableIds)})
         GROUP BY grantee_id
       `);
       for (const r of grantsReceived) {


### PR DESCRIPTION
## Summary

Fixes HTTP 500 errors on all directory pages (/legislation, /projects, /ai-models, /benchmarks, /people, /organizations, etc.) that use the wiki-server `/api/entities/directory` endpoint.

**Root cause**: Drizzle ORM's `sql` template tag expands JavaScript arrays as parameterized value-lists `($1, $2, ...)` -- a PostgreSQL row constructor. The code used `= ANY(${array})` which produced `= ANY(($1, $2, ...))`, but PostgreSQL's `ANY()` operator expects an array type, not a row constructor. This caused every query in the `/directory` endpoint to fail.

**Fix**: Replace all 5 occurrences of `= ANY(${array})` with `IN (${sqlInList(array)})` using a new `sqlInList()` helper that builds parameterized `IN` lists via `sql.join()` -- the same pattern used in `ref-check.ts`, `pages.ts`, and `resources.ts` throughout the codebase.

**Affected queries (all in the `/directory` handler)**:
- Facts lookup by entity_id and measure
- Personnel career history counts
- Grants given/received counts

**Impact**: All directory pages showed a red error banner ("Wiki-server returned HTTP 500 -- showing local data") and fell back to stale local data. After this fix, directory pages will load enriched data from the wiki-server (FactBase facts, personnel counts, grant counts).

## Verification

- Confirmed the HTTP 500 by curling the production endpoint directly
- Error message: `Failed query: SELECT person_id AS "personId"... FROM personnel WHERE person_id = ANY(($1,$2,...))`
- TypeScript compilation passes (`tsc --noEmit`)
- No test regressions (all 827 tests pass; 1 pre-existing failure unrelated)

## Test plan

- [ ] Deploy to production wiki-server
- [ ] Verify `/api/entities/directory?entityType=policy` returns 200
- [ ] Verify `/legislation`, `/ai-models`, `/projects`, `/benchmarks` pages no longer show the error banner