### PR TITLE
fix: convert raw recipient slugs to title case on grants page

### DIFF
--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -47,8 +47,11 @@ function resolveRecipient(recipientId: string): {
     }
     return { name: entity.name, slug, href, wikiPageId };
   }
-  // Not a known entity — return the raw ID as the display name
-  return { name: recipientId, slug: null, href: null, wikiPageId: null };
+  // Not a known entity — convert slug to readable title case
+  const displayName = recipientId
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return { name: displayName, slug: null, href: null, wikiPageId: null };
 }
 
 export default function GrantsPage() {


### PR DESCRIPTION
## Summary
- Fix the `resolveRecipient()` fallback in the grants page to convert hyphenated slugs (e.g., `helen-keller-international`) to readable title case (e.g., "Helen Keller International") instead of displaying the raw slug
- Affects ~400 rows on `/grants` where the recipient entity is not found in FactBase
- Matches the existing pattern used in `funding-programs/[id]/program-data.ts` line 63

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 3256 tests pass (`pnpm test`)
- [ ] Visual check: visit `/grants` and verify recipient names display as title case instead of slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)