### PR TITLE
fix: deduplicate RSP entity (remove E252 shell, keep E461)

### DIFF
--- a/.claude/design/statements-strategy.md
+++ b/.claude/design/statements-strategy.md
@@ -157,7 +157,7 @@ Do the full ontology draft exercise for OpenAI (244 statements, 76% unclassified
 |---|----------|--------|------|-------|
 | 1 | Statement model vs tables for funding rounds | Open | | Need Experiment 1, 4 |
 | 2 | Where do model releases live? (parent vs individual entity) | Decided: individual | 2026-03-06 | Each model entity gets its own release-date |
-| 3 | RSP version history: Anthropic entity or RSP entity? | Decided: RSP entity (E252) | 2026-03-06 | Anthropic keeps "published RSP" fact only |
+| 3 | RSP version history: Anthropic entity or RSP entity? | Decided: RSP entity (E461) | 2026-03-06 | Anthropic keeps "published RSP" fact only; E252 shell removed |
 | 4 | Property naming convention (-count vs -size) | Open | | Propose standardizing on -count |
 | 5 | LTBT board tracking | Open | | Need to decide if this is a statement or a table |
 | 6 | Qualifier system for linking related statements | Open | | Could solve funding round join problem |

--- a/apps/web/src/data/external-links.yaml
+++ b/apps/web/src/data/external-links.yaml
@@ -977,9 +977,6 @@
   links:
     eaForum: https://forum.effectivealtruism.org/topics/global-catastrophic-risk
     eightyK: https://80000hours.org/problem-profiles/catastrophic-ai-misuse/
-- pageId: rsp
-  links:
-    lesswrong: https://www.lesswrong.com/tag/responsible-scaling-policies
 - pageId: s-risk
   links:
     eaForum: https://forum.effectivealtruism.org/topics/s-risk

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -43,20 +43,6 @@
     - ai-safety
     - governance
   lastUpdated: 2026-03
-- id: responsible-scaling-policies
-  stableId: Gone2rYYpD
-  numericId: E252
-  type: policy
-  summaryPage: governance-overview
-  title: Responsible Scaling Policies
-  description: >-
-    Industry self-regulation frameworks establishing capability thresholds that
-    trigger safety evaluations before further scaling. Pioneered by Anthropic's
-    RSP and adopted in various forms by major AI labs.
-  clusters:
-    - ai-safety
-    - governance
-  lastUpdated: 2026-03
 - id: california-sb1047
   stableId: XcGTez1oFw
   numericId: E48

--- a/data/external-links.yaml
+++ b/data/external-links.yaml
@@ -973,9 +973,6 @@
   links:
     eaForum: https://forum.effectivealtruism.org/topics/global-catastrophic-risk
     eightyK: https://80000hours.org/problem-profiles/catastrophic-ai-misuse/
-- pageId: rsp
-  links:
-    lesswrong: https://www.lesswrong.com/tag/responsible-scaling-policies
 - pageId: s-risk
   links:
     eaForum: https://forum.effectivealtruism.org/topics/s-risk


### PR DESCRIPTION
## Summary

- Removed E252 (`responsible-scaling-policies`), an empty shell entity with no policyStatus, scope, or dates
- E461 (`rsp`) is the canonical, fully-populated version with status, related entries, sources, and FactBase data
- Removed duplicate `pageId: rsp` entry in both `data/external-links.yaml` and `apps/web/src/data/external-links.yaml`
- Updated `.claude/design/statements-strategy.md` to reference E461 instead of E252

## Context

E252 was already listed in the `DELETED_ENTITIES` array in `crux/qa-sweep/sweep.ts`, confirming it was known to be defunct. No wiki page existed for E252 (no `numericId: 252` in content/docs/), no FactBase data referenced it, and no content pages or relatedEntries pointed to `responsible-scaling-policies`.

## Test plan

- [x] All 3256 tests pass (148 test files)
- [x] All 15 gate checks pass
- [x] `pnpm build` has pre-existing failure unrelated to this change (missing `@longterm-wiki/factbase/currencies` module)
- [x] No broken entity references (grep confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)