### PR TITLE
Add implementation quality rules for Claude Code

### DIFF
--- a/.claude/rules/implementation-quality.md
+++ b/.claude/rules/implementation-quality.md
@@ -1,0 +1,33 @@
+# Implementation Quality
+
+Applies to sessions that write or modify code (not content-only MDX/YAML edits).
+
+## Persistence
+
+- When stuck after 3 approaches, stop and document what failed. Research alternatives or file a GitHub issue with findings and ask the user — do not ship a broken version.
+- If scope is too large to do thoroughly, split into independently-shippable pieces. A thorough version of a smaller thing beats a shallow version of the whole thing.
+
+## Testing Depth
+
+**Test core functionality first.** Before writing any test, ask: "What is the one thing this code absolutely must do?" Write that test first, then edge cases. Do not write peripheral tests while skipping the main behavior.
+
+- Every error path the code handles (`.catch()`, `try/catch`, `if (error)`) must have a test that triggers it — except intentional fire-and-forget paths documented per `error-handling.md`.
+- Test with adversarial inputs: empty strings, null/undefined, boundary values (0, -1, MAX_INT), malformed data, very large inputs.
+- No trivial assertions (`typeof result === 'object'`). Assert on specific values and shapes that would catch regressions.
+
+**Bug fixes — TDD workflow:**
+1. Write a failing test that reproduces the bug FIRST
+2. Confirm the test fails
+3. Fix the bug
+4. Confirm the test passes
+5. Do NOT edit code without a reproducing test
+
+## Pre-Commit Review
+
+Before committing, re-read the diff and actively look for problems:
+
+1. **Adversarial inputs**: What breaks this? null, empty, huge, concurrent, malformed, missing fields
+2. **Callers and dependents**: Does this change break anything that uses this code or depends on its output shape?
+3. **Race conditions**: Shared mutable state without synchronization? Assumptions about async execution order?
+4. **No TODO/FIXME without issue number**: No `// TODO`, `// HACK`, `// FIXME` in committed code without a `#<issue-number>`
+5. **Discoverability**: New feature/endpoint linked from navigation, help text, or parent pages?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 3. Next.js app reads `database.json` and `factbase-data.json` at build time
 4. MDX pages in `content/docs/` are compiled via next-mdx-remote
 
+## Implementation Quality
+
+- **Thorough over fast.** Robust implementations that handle edge cases beat quick ones that only cover the happy path. See `.claude/rules/implementation-quality.md`.
+
 ## Key Conventions
 
 - **Path aliases**: `@/`, `@components/`, `@data/`, `@lib/` in app code
@@ -137,4 +141,5 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/database-migrations.md` — Migration patterns and deploy flow
 - `.claude/rules/wiki-server-rpc-migration.md` — Hono RPC migration guide
 - `.claude/rules/internal-dashboards.md` — Dashboard creation pattern
+- `.claude/rules/implementation-quality.md` — Thoroughness, testing depth, self-review
 - `.claude/rules/auto-update-system.md` — Auto-update system


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/implementation-quality.md` — a focused 30-line rules file addressing recurring issues with shallow implementations, basic tests, and insufficient self-review
- Adds a one-line pointer in `CLAUDE.md` under a new "Implementation Quality" section

## What the rules cover
- **Persistence**: Escalation path when stuck (document, research alternatives, file issue) instead of shipping broken code
- **Testing depth**: Test core functionality first (not peripherals), TDD for bug fixes, adversarial input testing, error path coverage
- **Pre-commit review**: Checklist for adversarial inputs, caller/dependent breakage, race conditions, TODO/FIXME hygiene, discoverability

## Design decisions
- **30 lines, not 70**: Red-teamed by an independent subagent that identified ~40% duplication with existing rules (`error-handling.md`, `pre-pr-verification.md`, `code-review-guidelines.md`). Cut everything redundant.
- **Scope limiter**: Rules explicitly apply to code sessions only, not content-only MDX/YAML edits
- **No anthropomorphic language**: Removed "spend 2 minutes looking" and "nagging feeling" — meaningless to an LLM
- **Fire-and-forget exception**: Testing requirement explicitly exempts intentional fire-and-forget `.catch()` paths documented per `error-handling.md`
- **One-line CLAUDE.md summary**: Since `.claude/rules/` files are auto-loaded, a multi-line summary would be pure redundancy

## Test plan
- [x] Gate passes (`pnpm crux validate gate`)
- [x] No contradictions with existing rules (verified during red team review)
- [x] No duplication with `error-handling.md`, `pre-pr-verification.md`, or `code-review-guidelines.md`
- [ ] Observe quality improvement in subsequent Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)