### PR TITLE
feat: convert approaches directory to searchable table

### DIFF
--- a/apps/web/src/app/approaches/approaches-table.tsx
+++ b/apps/web/src/app/approaches/approaches-table.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { SortHeader } from "@/components/directory/SortHeader";
+
+export interface ApproachRow {
+  id: string;
+  title: string;
+  description: string | null;
+  tags: string[];
+  numericId: string | null;
+}
+
+type SortKey = "title" | "tags";
+type SortDir = "asc" | "desc";
+
+export function ApproachesTable({ rows }: { rows: ApproachRow[] }) {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("title");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const filtered = useMemo(() => {
+    let result = rows;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.title.toLowerCase().includes(q) ||
+          (r.description && r.description.toLowerCase().includes(q)) ||
+          r.tags.some((t) => t.toLowerCase().includes(q)),
+      );
+    }
+
+    const dir = sortDir === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      switch (sortKey) {
+        case "title":
+          return a.title.localeCompare(b.title) * dir;
+        case "tags":
+          return (a.tags.length - b.tags.length) * dir;
+      }
+    });
+
+    return result;
+  }, [rows, search, sortKey, sortDir]);
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row gap-3 mb-5">
+        <input
+          type="text"
+          placeholder="Search approaches by name, description, or tag..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-80"
+        />
+      </div>
+
+      <div className="text-xs text-muted-foreground mb-3">
+        Showing {filtered.length} of {rows.length} approaches
+      </div>
+
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <SortHeader
+                label="Name"
+                sortKey="title"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <th className="text-left py-2 px-3 font-medium">Description</th>
+              <SortHeader
+                label="Tags"
+                sortKey="tags"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <th className="text-center py-2 px-3 font-medium">Wiki</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {filtered.map((row) => (
+              <tr
+                key={row.id}
+                className="hover:bg-muted/20 transition-colors"
+              >
+                <td className="py-2.5 px-3 min-w-[180px]">
+                  <Link
+                    href={`/approaches/${row.id}`}
+                    className="font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    {row.title}
+                  </Link>
+                </td>
+
+                <td className="py-2.5 px-3 text-muted-foreground max-w-[400px]">
+                  {row.description && (
+                    <span className="line-clamp-2 text-xs">
+                      {row.description}
+                    </span>
+                  )}
+                </td>
+
+                <td className="py-2.5 px-3 max-w-[200px]">
+                  {row.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {row.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </td>
+
+                <td className="py-2.5 px-3 text-center whitespace-nowrap">
+                  {row.numericId && (
+                    <Link
+                      href={`/wiki/${row.numericId}`}
+                      className="text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                      title="Wiki page"
+                    >
+                      wiki
+                    </Link>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No approaches match your search.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/approaches/page.tsx
+++ b/apps/web/src/app/approaches/page.tsx
@@ -1,8 +1,8 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
-import Link from "next/link";
 import { getTypedEntities, isApproach } from "@/data";
 import { ProfileStatCard } from "@/components/directory";
-import { getWikiHref } from "@/data/entity-nav";
+import { ApproachesTable, type ApproachRow } from "./approaches-table";
 
 export const metadata: Metadata = {
   title: "Approaches",
@@ -13,13 +13,21 @@ export const metadata: Metadata = {
 export default function ApproachesPage() {
   const approaches = getTypedEntities().filter(isApproach);
 
-  const uniqueTagCount = new Set(approaches.flatMap((a) => a.tags ?? [])).size;
+  const rows: ApproachRow[] = approaches.map((a) => ({
+    id: a.id,
+    title: a.title,
+    description: a.description ?? null,
+    tags: a.tags ?? [],
+    numericId: a.numericId ?? null,
+  }));
+
+  const uniqueTagCount = new Set(rows.flatMap((r) => r.tags)).size;
 
   const stats = [
-    { label: "Approaches", value: String(approaches.length) },
+    { label: "Approaches", value: String(rows.length) },
     {
       label: "With Description",
-      value: String(approaches.filter((a) => a.description).length),
+      value: String(rows.filter((r) => r.description).length),
     },
     { label: "Unique Tags", value: String(uniqueTagCount) },
   ];
@@ -47,49 +55,9 @@ export default function ApproachesPage() {
         ))}
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {approaches
-          .sort((a, b) => a.title.localeCompare(b.title))
-          .map((approach) => {
-            const wikiHref = getWikiHref(approach.id);
-            return (
-              <div
-                key={approach.id}
-                className="rounded-xl border border-border/60 bg-card p-4 hover:bg-muted/20 transition-colors"
-              >
-                <div className="flex items-start justify-between gap-2 mb-2">
-                  <Link
-                    href={`/approaches/${approach.id}`}
-                    className="font-semibold text-sm hover:text-primary transition-colors line-clamp-1"
-                  >
-                    {approach.title}
-                  </Link>
-                </div>
-                {approach.description && (
-                  <p className="text-xs text-muted-foreground line-clamp-3 mb-3">
-                    {approach.description}
-                  </p>
-                )}
-                <div className="flex items-center gap-3 text-xs">
-                  {approach.tags.length > 0 && (
-                    <span className="text-muted-foreground">
-                      {approach.tags.slice(0, 3).join(", ")}
-                      {approach.tags.length > 3 && " ..."}
-                    </span>
-                  )}
-                  {wikiHref && (
-                    <Link
-                      href={wikiHref}
-                      className="text-primary hover:underline ml-auto"
-                    >
-                      Wiki &rarr;
-                    </Link>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-      </div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <ApproachesTable rows={rows} />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the 3-column card grid on `/approaches` with a sortable, searchable table matching the pattern used by `/projects` and `/legislation`
- Add search box that filters by name, description, and tags
- Add sortable columns: Name (alphabetical, default) and Tags (by count)
- Display tag badges inline in the Tags column
- Wiki page links in a dedicated column

## Test plan
- [ ] Verify `/approaches` renders the table with all entries
- [ ] Search by name, description, and tag works correctly
- [ ] Sorting by Name and Tags toggles asc/desc
- [ ] Clicking an approach name navigates to `/approaches/{slug}` detail page
- [ ] Wiki links navigate to `/wiki/E{id}` pages
- [ ] `npx tsc --noEmit` passes
- [ ] `pnpm test` passes (3168 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)