### PR TITLE
fix: resolve slug-in-display for Robin Hanson and Leopold Aschenbrenner affiliations

### DIFF
--- a/data/organizations.yaml
+++ b/data/organizations.yaml
@@ -228,6 +228,33 @@
     Pursuing superintelligence with safety as the core goal.
 
 # =============================================================================
+# ADDITIONAL ACADEMIC / OTHER
+# =============================================================================
+
+- id: george-mason-university
+  name: George Mason University
+  type: academic
+  founded: "1972"
+  headquarters: Fairfax, VA
+  website: https://www.gmu.edu
+  description: >
+    Public research university in Virginia. Home to the economics department
+    where Robin Hanson is Associate Professor.
+
+- id: situational-awareness-lp
+  name: Situational Awareness LP
+  type: other
+  founded: "2024"
+  headquarters: San Francisco, CA
+  website: https://situationalawarenesslp.com/
+  description: >
+    AI-focused hedge fund founded by Leopold Aschenbrenner in 2024.
+    Manages public equities in semiconductors, energy infrastructure,
+    and data centers.
+  keyPeople:
+    - leopold-aschenbrenner
+
+# =============================================================================
 # FUNDERS
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Added George Mason University and Situational Awareness LP to `data/organizations.yaml` so the entity-transform build step can resolve affiliation slugs to proper display names
- Fixes 2 "slug-in-display" issues flagged by `pnpm crux validate directory-pages`: Robin Hanson showing "george-mason-university" and Leopold Aschenbrenner showing "situational-awareness-lp" instead of human-readable names

## Test plan
- [ ] `pnpm crux validate directory-pages` shows 0 slug-in-display issues (down from 2)
- [ ] `pnpm build-data:content` completes with 17 organizations (up from 15)
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)