### PR TITLE
fix: link benchmark leaderboard models directly to /ai-models/{slug}

### DIFF
--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -261,16 +261,12 @@ export default async function BenchmarkDetailPage({
                         )}
                       </td>
                       <td className="py-2.5 px-3">
-                        {row.numericId ? (
-                          <Link
-                            href={`/wiki/${row.numericId}`}
-                            className="hover:text-primary transition-colors"
-                          >
-                            {row.modelTitle}
-                          </Link>
-                        ) : (
-                          <span>{row.modelTitle}</span>
-                        )}
+                        <Link
+                          href={`/ai-models/${row.modelId}`}
+                          className="hover:text-primary transition-colors"
+                        >
+                          {row.modelTitle}
+                        </Link>
                       </td>
                       <td className="py-2.5 px-3">
                         {row.developer && row.developerName && (


### PR DESCRIPTION
## Summary
- Model names in the benchmark leaderboard table were linking to `/wiki/E*` (e.g., `/wiki/E123`) which triggers an unnecessary 301 redirect to `/ai-models/{slug}`
- Changed to link directly to `/ai-models/${row.modelId}`, eliminating the redirect hop
- Also simplified the template by removing the `numericId` null check, since every model row has a `modelId` that resolves to a valid ai-models directory page

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm test` passes (3168 tests)
- [ ] Verify on a benchmark detail page (e.g., `/benchmarks/mmlu`) that model names link to `/ai-models/...` instead of `/wiki/E...`

Generated with [Claude Code](https://claude.com/claude-code)