### PR TITLE
fix: remove sparse columns from Research Areas directory

### DIFF
--- a/apps/web/src/app/research-areas/page.tsx
+++ b/apps/web/src/app/research-areas/page.tsx
@@ -5,7 +5,7 @@ import { ResearchAreasTable, type ResearchAreaRow } from "./research-areas-table
 export const metadata: Metadata = {
   title: "Research Areas",
   description:
-    "Directory of AI safety research areas — fields, techniques, and programs with key papers, organizations, and grant funding.",
+    "Directory of AI safety research areas — fields, techniques, and programs organized by cluster and status.",
 };
 
 export default function ResearchAreasPage() {
@@ -25,11 +25,6 @@ export default function ResearchAreasPage() {
     cluster: a.cluster ?? null,
     parentAreaId: a.parentAreaId ?? null,
     firstProposedYear: a.firstProposedYear ?? null,
-    orgCount: a.orgCount ?? 0,
-    paperCount: a.paperCount ?? 0,
-    grantCount: a.grantCount ?? 0,
-    totalFunding: a.totalFunding ?? "0",
-    riskCount: a.riskCount ?? 0,
   }));
 
   // Summary stats
@@ -52,8 +47,8 @@ export default function ResearchAreasPage() {
           Research Areas
         </h1>
         <p className="text-muted-foreground text-sm max-w-2xl">
-          AI safety research fields, techniques, and programs — with key papers,
-          active organizations, and grant funding data.
+          AI safety research fields, techniques, and programs — organized by
+          cluster and status.
         </p>
       </div>
 

--- a/apps/web/src/app/research-areas/research-areas-table.tsx
+++ b/apps/web/src/app/research-areas/research-areas-table.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
-import { CLUSTER_COLORS, STATUS_COLORS, formatCluster, formatFunding } from "./research-area-constants";
+import { CLUSTER_COLORS, STATUS_COLORS, formatCluster } from "./research-area-constants";
 
 export interface ResearchAreaRow {
   id: string;
@@ -15,21 +15,16 @@ export interface ResearchAreaRow {
   cluster: string | null;
   parentAreaId: string | null;
   firstProposedYear: number | null;
-  orgCount: number;
-  paperCount: number;
-  grantCount: number;
-  totalFunding: string;
-  riskCount: number;
 }
 
-type SortKey = "title" | "cluster" | "status" | "orgCount" | "paperCount" | "grantCount" | "totalFunding" | "firstProposedYear";
+type SortKey = "title" | "cluster" | "status" | "firstProposedYear";
 
 export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
   const [search, setSearch] = useState("");
   const [clusterFilter, setClusterFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<string>("all");
-  const [sortKey, setSortKey] = useState<SortKey>("grantCount");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [sortKey, setSortKey] = useState<SortKey>("title");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const clusters = useMemo(() => {
     const set = new Set<string>();
@@ -69,10 +64,6 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
             case "title": return row.title.toLowerCase();
             case "cluster": return row.cluster ?? "";
             case "status": return row.status;
-            case "orgCount": return row.orgCount;
-            case "paperCount": return row.paperCount;
-            case "grantCount": return row.grantCount;
-            case "totalFunding": return parseFloat(row.totalFunding);
             case "firstProposedYear": return row.firstProposedYear ?? 0;
           }
         };
@@ -154,17 +145,13 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
               <SortHeader label="Name" sortKey="title" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} />
               <SortHeader label="Cluster" sortKey="cluster" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} />
               <SortHeader label="Status" sortKey="status" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} />
-              <SortHeader label="Orgs" sortKey="orgCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
-              <SortHeader label="Papers" sortKey="paperCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
-              <SortHeader label="Grants" sortKey="grantCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
-              <SortHeader label="Funding" sortKey="totalFunding" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Since" sortKey="firstProposedYear" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
             </tr>
           </thead>
           <tbody>
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={8} className="px-3 py-12 text-center text-muted-foreground">
+                <td colSpan={4} className="px-3 py-12 text-center text-muted-foreground">
                   No research areas match your filters.
                 </td>
               </tr>
@@ -205,10 +192,6 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
                     {row.status}
                   </span>
                 </td>
-                <td className="px-3 py-2.5 text-right tabular-nums">{row.orgCount ?? "-"}</td>
-                <td className="px-3 py-2.5 text-right tabular-nums">{row.paperCount ?? "-"}</td>
-                <td className="px-3 py-2.5 text-right tabular-nums">{row.grantCount ?? "-"}</td>
-                <td className="px-3 py-2.5 text-right tabular-nums">{formatFunding(row.totalFunding)}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground">
                   {row.firstProposedYear ?? "-"}
                 </td>


### PR DESCRIPTION
## Summary
- Removed 4 mostly-empty columns (Orgs, Papers, Grants, Funding) from the Research Areas directory table
- Grants and Funding were 100% zeros; Organizations and Papers were ~87-88% empty
- Table now shows Name, Cluster, Status, and Since -- columns with meaningful data coverage
- Default sort changed from grantCount (always 0) to title (alphabetical)
- Detail pages still show all data conditionally when available

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` passes (3168 tests)
- [ ] Visual check: `/research-areas` page no longer shows empty columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified the research areas table display by removing columns for organization count, paper count, grant count, total funding, and risk metrics.
  * Reorganized the research areas page layout to prioritize grouping by cluster and status.
  * Streamlined sorting functionality and refined default sort order for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->