### PR TITLE
feat: add 5 new sections to System Health dashboard

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -86,6 +86,73 @@ const DATA_FILES = [
   { key: 'peopleResources', file: 'people-resources.yaml' },
 ];
 
+/**
+ * Scan MDX files for <EntityLink id="..."> references and check each against
+ * the entity registry. Returns a summary of broken and unreachable links.
+ *
+ * @param {Map<string, string>} numericIdToSlug - Maps numeric IDs (E42) to slugs
+ * @param {object} pathRegistry - Maps slugs to URL paths
+ */
+/**
+ * Scan MDX files for <EntityLink id="..."> references and check each against
+ * the entity registry. Returns a summary of broken and unreachable links.
+ * EntityLink ids can be numeric (E42) or slug-based (geoffrey-hinton).
+ *
+ * @param {object} numericIdToSlug - Maps numeric IDs (E42) to slugs
+ * @param {object} slugToNumericId - Maps slugs to numeric IDs (E42)
+ * @param {object} pathRegistry - Maps slugs to URL paths
+ */
+function scanBrokenEntityLinks(numericIdToSlug, slugToNumericId, pathRegistry) {
+  const entityLinkRegex = /<EntityLink\s+id="([^"]+)"/g;
+  const knownNumericIds = new Set(Object.keys(numericIdToSlug));
+  const knownSlugs = new Set(Object.keys(slugToNumericId));
+  const reachableSlugs = new Set(Object.keys(pathRegistry));
+  const broken = [];
+  const unreachable = [];
+
+  const mdxFiles = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.mdx')) mdxFiles.push(full);
+    }
+  }
+  walk(CONTENT_DIR);
+
+  for (const filePath of mdxFiles) {
+    const content = readFileSync(filePath, 'utf-8');
+    entityLinkRegex.lastIndex = 0;
+    let match;
+    while ((match = entityLinkRegex.exec(content)) !== null) {
+      const id = match[1];
+      const pageId = relative(CONTENT_DIR, filePath).replace(/\.mdx$/, '');
+
+      // Resolve to slug: id can be numeric (E42) or slug-based
+      let slug;
+      if (knownNumericIds.has(id)) {
+        slug = numericIdToSlug[id];
+      } else if (knownSlugs.has(id)) {
+        slug = id;
+      } else {
+        broken.push({ pageId, entityId: id, reason: 'not_found' });
+        continue;
+      }
+
+      if (slug && !reachableSlugs.has(slug)) {
+        unreachable.push({ pageId, entityId: id, reason: 'no_page' });
+      }
+    }
+  }
+
+  return {
+    checkedAt: new Date().toISOString(),
+    totalBroken: broken.length,
+    totalUnreachable: unreachable.length,
+    sample: [...broken, ...unreachable].slice(0, 20),
+  };
+}
+
 function loadYaml(filename) {
   const filepath = join(DATA_DIR, filename);
   if (!existsSync(filepath)) {
@@ -2934,6 +3001,14 @@ async function main() {
       console.error('⚠️  Link health generation failed:', linkValidation.stderr);
     }
   }
+
+  // ==========================================================================
+  // Broken EntityLink scan
+  // ==========================================================================
+  console.log('\nScanning for broken EntityLink references...');
+  const brokenLinksResult = scanBrokenEntityLinks(numericIdToSlug, slugToNumericId, pathRegistry);
+  writeFileSync(join(OUTPUT_DIR, 'broken-entity-links.json'), JSON.stringify(brokenLinksResult, null, 2));
+  console.log(`✓ EntityLink scan: ${brokenLinksResult.totalBroken} broken, ${brokenLinksResult.totalUnreachable} unreachable`);
 
   // Print summary stats
   console.log('\n--- Summary ---');

--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -1,3 +1,5 @@
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
 import {
   fetchDetailed,
   withApiFallback,
@@ -101,6 +103,46 @@ interface ExtendedHealthData {
     startedAt: string | null;
     completedAt: string | null;
     model: string | null;
+  }>;
+  migrations: {
+    appliedCount: number;
+    expectedCount: number;
+    inSync: boolean;
+    recent: Array<{ id: number; hash: string; createdAt: string }>;
+  } | null;
+  deploys: {
+    recent: Array<{
+      id: number;
+      status: string;
+      conclusion: string;
+      createdAt: string;
+      headSha: string;
+      runNumber: number;
+      durationSeconds: number | null;
+    }>;
+  } | null;
+  agentActivity: {
+    activeNow: number;
+    sessionsThisWeek: number;
+    prsThisWeek: number;
+    completedThisWeek: number;
+    completionRate: number | null;
+  };
+  apiKeys: {
+    github: { configured: boolean; healthy: boolean };
+    anthropic: { configured: boolean; healthy: boolean };
+    openrouter: { configured: boolean; healthy: boolean };
+  } | null;
+}
+
+interface BrokenEntityLinksData {
+  checkedAt: string;
+  totalBroken: number;
+  totalUnreachable: number;
+  sample: Array<{
+    pageId: string;
+    entityId: string;
+    reason: "not_found" | "no_page";
   }>;
 }
 
@@ -739,6 +781,282 @@ function CurrentDeploymentSection() {
   );
 }
 
+// ── New section components ────────────────────────────────────────────────
+
+function ApiKeyHealthSection({ apiKeys }: { apiKeys: ExtendedHealthData["apiKeys"] }) {
+  if (!apiKeys) {
+    return (
+      <>
+        <SectionHeader>API Key Health</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          API key health check unavailable
+        </div>
+      </>
+    );
+  }
+
+  const keys = [
+    { name: "GitHub", ...apiKeys.github },
+    { name: "Anthropic", ...apiKeys.anthropic },
+    { name: "OpenRouter", ...apiKeys.openrouter },
+  ];
+
+  return (
+    <>
+      <SectionHeader>API Key Health</SectionHeader>
+      <div className="flex flex-wrap gap-2 mb-6">
+        {keys.map((key) => {
+          const bg = !key.configured
+            ? "bg-muted"
+            : key.healthy
+              ? "bg-green-500/15"
+              : "bg-red-500/15";
+          const text = !key.configured
+            ? "text-muted-foreground"
+            : key.healthy
+              ? "text-green-600"
+              : "text-red-500";
+          const label = !key.configured
+            ? "not configured"
+            : key.healthy
+              ? "OK"
+              : "unreachable";
+          return (
+            <span
+              key={key.name}
+              className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold ${bg} ${text}`}
+            >
+              {key.name}: {label}
+            </span>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function MigrationStatusSection({ migrations }: { migrations: ExtendedHealthData["migrations"] }) {
+  if (!migrations) {
+    return (
+      <>
+        <SectionHeader>Migration Status</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          Migration status unavailable
+        </div>
+      </>
+    );
+  }
+
+  const statusColor = migrations.inSync ? "text-green-600" : "text-yellow-600";
+  const statusBg = migrations.inSync ? "bg-green-500/10" : "bg-yellow-500/10";
+
+  return (
+    <>
+      <SectionHeader>Migration Status</SectionHeader>
+      <div className={`rounded-lg border border-border/60 p-4 mb-4 ${statusBg}`}>
+        <div className="flex items-center justify-between">
+          <span className={`text-sm font-semibold ${statusColor}`}>
+            {migrations.appliedCount}/{migrations.expectedCount} migrations applied
+          </span>
+          {!migrations.inSync && (
+            <span className="text-xs text-yellow-600 font-medium">
+              {migrations.expectedCount - migrations.appliedCount} pending
+            </span>
+          )}
+        </div>
+      </div>
+      {migrations.recent.length > 0 && (
+        <details className="mb-6">
+          <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground mb-2">
+            Recent migrations ({Math.min(migrations.recent.length, 5)})
+          </summary>
+          <div className="space-y-1 pl-2">
+            {migrations.recent.slice(0, 5).map((m) => (
+              <div key={m.id} className="text-xs text-muted-foreground flex items-center gap-2">
+                <span className="font-mono">{m.hash.slice(0, 12)}</span>
+                <span suppressHydrationWarning>{formatRelativeTime(m.createdAt)}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </>
+  );
+}
+
+function DeployHistorySection({ deploys }: { deploys: ExtendedHealthData["deploys"] }) {
+  if (!deploys) {
+    return (
+      <>
+        <SectionHeader>Deploy History</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          Deploy history unavailable (GITHUB_TOKEN not configured on server)
+        </div>
+      </>
+    );
+  }
+
+  if (deploys.recent.length === 0) {
+    return (
+      <>
+        <SectionHeader>Deploy History</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          No recent deploys found
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SectionHeader>Deploy History</SectionHeader>
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60">
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 pr-4">Run</th>
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 px-3">Status</th>
+              <th className="text-left text-xs text-muted-foreground font-medium py-2 px-3">Commit</th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 px-3">Duration</th>
+              <th className="text-right text-xs text-muted-foreground font-medium py-2 pl-3">When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {deploys.recent.map((deploy) => {
+              const isSuccess = deploy.conclusion === "success";
+              const isFailed = deploy.conclusion === "failure";
+              const conclusionColor = isFailed
+                ? "text-red-500"
+                : isSuccess
+                  ? "text-green-600"
+                  : "text-yellow-600";
+              const rowBg = isFailed ? "bg-red-500/5" : "";
+              const durationStr = deploy.durationSeconds !== null
+                ? deploy.durationSeconds > 60
+                  ? `${Math.floor(deploy.durationSeconds / 60)}m ${deploy.durationSeconds % 60}s`
+                  : `${deploy.durationSeconds}s`
+                : "-";
+              return (
+                <tr key={deploy.id} className={`border-b border-border/30 ${rowBg}`}>
+                  <td className="py-2 pr-4 text-xs font-mono">#{deploy.runNumber}</td>
+                  <td className={`py-2 px-3 text-xs font-medium ${conclusionColor}`}>
+                    {deploy.conclusion}
+                  </td>
+                  <td className="py-2 px-3 text-xs font-mono">
+                    <a
+                      href={`https://github.com/${GITHUB_REPO}/commit/${deploy.headSha}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      {deploy.headSha}
+                    </a>
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums text-muted-foreground text-xs">
+                    {durationStr}
+                  </td>
+                  <td className="py-2 pl-3 text-right text-xs text-muted-foreground" suppressHydrationWarning>
+                    {formatRelativeTime(deploy.createdAt)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function BrokenEntityLinksSection({ data }: { data: BrokenEntityLinksData | null }) {
+  if (!data) {
+    return (
+      <>
+        <SectionHeader>EntityLink Integrity</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          EntityLink scan data not available (run build-data first)
+        </div>
+      </>
+    );
+  }
+
+  const total = data.totalBroken + data.totalUnreachable;
+  const isClean = total === 0;
+  const statusBg = isClean ? "bg-green-500/10" : "bg-yellow-500/10";
+  const statusColor = isClean ? "text-green-600" : "text-yellow-600";
+
+  return (
+    <>
+      <SectionHeader>EntityLink Integrity</SectionHeader>
+      <div className={`rounded-lg border border-border/60 p-4 mb-6 ${statusBg}`}>
+        <span className={`text-sm font-semibold ${statusColor}`}>
+          {isClean
+            ? "No broken EntityLinks"
+            : `${data.totalBroken} broken, ${data.totalUnreachable} unreachable`}
+        </span>
+        {data.sample.length > 0 && (
+          <details className="mt-2">
+            <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+              Show details ({data.sample.length})
+            </summary>
+            <div className="mt-2 space-y-1">
+              {data.sample.map((item, i) => (
+                <div key={i} className="text-xs text-muted-foreground">
+                  <span className="font-mono">{item.pageId}</span>
+                  {" \u2192 "}
+                  <span className={`font-medium ${item.reason === "not_found" ? "text-red-500" : "text-yellow-600"}`}>
+                    {item.entityId}
+                  </span>
+                  <span className="ml-1">({item.reason === "not_found" ? "entity not found" : "no page"})</span>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+        <p className="text-xs text-muted-foreground mt-2" suppressHydrationWarning>
+          Checked at build time: {formatRelativeTime(data.checkedAt)}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function AgentActivitySection({ activity }: { activity: ExtendedHealthData["agentActivity"] }) {
+  return (
+    <>
+      <SectionHeader>Agent Activity (last 7 days)</SectionHeader>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <StatCard
+          label="Active Now"
+          value={activity.activeNow}
+          colorClass={activity.activeNow > 0 ? "text-green-600" : ""}
+        />
+        <StatCard
+          label="Sessions (7d)"
+          value={activity.sessionsThisWeek}
+        />
+        <StatCard
+          label="PRs Created (7d)"
+          value={activity.prsThisWeek}
+        />
+        <StatCard
+          label="Completion Rate (7d)"
+          value={activity.completionRate !== null ? `${activity.completionRate}%` : null}
+          colorClass={
+            activity.completionRate !== null
+              ? activity.completionRate >= 80
+                ? "text-green-600"
+                : activity.completionRate >= 50
+                  ? "text-yellow-600"
+                  : "text-red-500"
+              : ""
+          }
+        />
+      </div>
+    </>
+  );
+}
+
 function formatRelativeTime(isoString: string): string {
   const now = Date.now();
   const then = new Date(isoString).getTime();
@@ -784,6 +1102,17 @@ export async function SystemHealthContent() {
         : pullsApiError.type
     : pullsData?.error ?? null;
   const openPRs: OpenPRDisplayRow[] = pullsData?.pulls ?? [];
+
+  // Load broken EntityLinks data from build-time scan
+  let brokenEntityLinks: BrokenEntityLinksData | null = null;
+  try {
+    const brokenLinksPath = join(process.cwd(), "src/data/broken-entity-links.json");
+    if (existsSync(brokenLinksPath)) {
+      brokenEntityLinks = JSON.parse(readFileSync(brokenLinksPath, "utf-8"));
+    }
+  } catch {
+    // Build-time data not available — section will show fallback
+  }
 
   const { overall, checkedAt, services: rawServices, recentIncidents } =
     data;
@@ -835,8 +1164,29 @@ export async function SystemHealthContent() {
         </div>
       )}
 
+      {/* API Key Health */}
+      {extended ? (
+        <ApiKeyHealthSection apiKeys={extended.apiKeys} />
+      ) : extendedError ? (
+        <SectionUnavailable title="API Key Health" error={extendedError} />
+      ) : null}
+
       {/* Current deployment */}
       <CurrentDeploymentSection />
+
+      {/* Migration Status */}
+      {extended ? (
+        <MigrationStatusSection migrations={extended.migrations} />
+      ) : extendedError ? (
+        <SectionUnavailable title="Migration Status" error={extendedError} />
+      ) : null}
+
+      {/* Deploy History */}
+      {extended ? (
+        <DeployHistorySection deploys={extended.deploys} />
+      ) : extendedError ? (
+        <SectionUnavailable title="Deploy History" error={extendedError} />
+      ) : null}
 
       {/* CI Pipeline Status */}
       {extended ? (
@@ -851,6 +1201,9 @@ export async function SystemHealthContent() {
       ) : extendedError ? (
         <SectionUnavailable title="Data Integrity" error={extendedError} />
       ) : null}
+
+      {/* Broken EntityLinks */}
+      <BrokenEntityLinksSection data={brokenEntityLinks} />
 
       {/* Open Pull Requests */}
       {pullsError ? (
@@ -879,6 +1232,13 @@ export async function SystemHealthContent() {
           )}
         </>
       )}
+
+      {/* Agent Activity Summary */}
+      {extended ? (
+        <AgentActivitySection activity={extended.agentActivity} />
+      ) : extendedError ? (
+        <SectionUnavailable title="Agent Activity (last 7 days)" error={extendedError} />
+      ) : null}
 
       {/* Recent incidents */}
       <SectionHeader>Recent incidents (last 24h)</SectionHeader>

--- a/apps/wiki-server/src/routes/operational/monitoring.ts
+++ b/apps/wiki-server/src/routes/operational/monitoring.ts
@@ -31,6 +31,10 @@ const SERVICES = [
   "github-actions",
 ] as const;
 
+// Expected migration count — update this when adding new drizzle migrations.
+// Read from apps/wiki-server/drizzle/meta/_journal.json entries length.
+const EXPECTED_MIGRATION_COUNT = 98;
+
 // ── Typed row interfaces for raw SQL results ────────────────────────────
 interface DbCountsRow {
   pages: number;
@@ -56,6 +60,19 @@ interface ActiveAgentRow {
   started_at: string | null;
   completed_at: string | null;
   model: string | null;
+}
+
+interface MigrationRow {
+  id: number;
+  hash: string;
+  created_at: number;
+}
+
+interface AgentActivityRow {
+  active_now: number;
+  sessions_this_week: number;
+  prs_this_week: number;
+  completed_this_week: number;
 }
 
 const monitoringApp = new Hono()
@@ -350,6 +367,10 @@ const monitoringApp = new Hono()
       integrityResult,
       autoUpdateResult,
       recentSessionsResult,
+      migrationsResult,
+      deploysResult,
+      agentActivityResult,
+      apiKeysResult,
     ] = await Promise.all([
       // 1. GitHub CI status for main branch
       fetchCiStatus().catch((err) => {
@@ -380,6 +401,30 @@ const monitoringApp = new Hono()
         logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch recent sessions");
         return [];
       }),
+
+      // 6. Migration status
+      fetchMigrationStatus(rawDb).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch migration status");
+        return null;
+      }),
+
+      // 7. Deploy history
+      fetchDeployHistory().catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch deploy history");
+        return null;
+      }),
+
+      // 8. Agent activity summary
+      fetchAgentActivity(rawDb).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch agent activity");
+        return { activeNow: 0, sessionsThisWeek: 0, prsThisWeek: 0, completedThisWeek: 0, completionRate: null as number | null };
+      }),
+
+      // 9. API key health
+      fetchApiKeyHealth().catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to fetch API key health");
+        return null;
+      }),
     ]);
 
     return c.json({
@@ -388,6 +433,10 @@ const monitoringApp = new Hono()
       integrity: integrityResult,
       autoUpdate: autoUpdateResult,
       recentSessions: recentSessionsResult,
+      migrations: migrationsResult,
+      deploys: deploysResult,
+      agentActivity: agentActivityResult,
+      apiKeys: apiKeysResult,
     });
   });
 
@@ -584,6 +633,172 @@ async function fetchRecentSessions(rawDb: ReturnType<typeof getDb>) {
     completedAt: r.completed_at ? String(r.completed_at) : null,
     model: (r.model as ActiveAgentRow["model"]) ?? null,
   }));
+}
+
+// ---- Migration status ----
+
+async function fetchMigrationStatus(rawDb: ReturnType<typeof getDb>) {
+  const [countResult, recentResult] = await Promise.all([
+    rawDb`SELECT count(*)::int AS total FROM drizzle.__drizzle_migrations`,
+    rawDb`
+      SELECT id, hash, created_at
+      FROM drizzle.__drizzle_migrations
+      ORDER BY id DESC
+      LIMIT 10
+    `,
+  ]);
+
+  const appliedCount = (countResult[0] as { total: number }).total;
+  const recent = recentResult.map((r) => ({
+    id: r.id as MigrationRow["id"],
+    hash: r.hash as MigrationRow["hash"],
+    createdAt: String(r.created_at),
+  }));
+
+  return {
+    appliedCount,
+    expectedCount: EXPECTED_MIGRATION_COUNT,
+    inSync: appliedCount >= EXPECTED_MIGRATION_COUNT,
+    recent,
+  };
+}
+
+// ---- Deploy history ----
+
+async function fetchDeployHistory() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return null;
+
+  const resp = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/actions/workflows/wiki-server-docker.yml/runs?per_page=10&status=completed`,
+    {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: AbortSignal.timeout(8000),
+    }
+  );
+  if (!resp.ok) return null;
+
+  const data = (await resp.json()) as {
+    workflow_runs: Array<{
+      id: number;
+      status: string;
+      conclusion: string | null;
+      created_at: string;
+      updated_at: string;
+      head_sha: string;
+      run_number: number;
+    }>;
+  };
+
+  return {
+    recent: data.workflow_runs.map((run) => {
+      const createdMs = new Date(run.created_at).getTime();
+      const updatedMs = new Date(run.updated_at).getTime();
+      const durationSeconds =
+        createdMs && updatedMs ? Math.round((updatedMs - createdMs) / 1000) : null;
+
+      return {
+        id: run.id,
+        status: run.status,
+        conclusion: run.conclusion ?? "unknown",
+        createdAt: run.created_at,
+        headSha: run.head_sha.slice(0, 8),
+        runNumber: run.run_number,
+        durationSeconds,
+      };
+    }),
+  };
+}
+
+// ---- Agent activity summary ----
+
+async function fetchAgentActivity(rawDb: ReturnType<typeof getDb>) {
+  const result = await rawDb`
+    SELECT
+      count(*) FILTER (WHERE status = 'active' AND heartbeat_at >= now() - interval '15 minutes')::int AS active_now,
+      count(*) FILTER (WHERE started_at >= now() - interval '7 days')::int AS sessions_this_week,
+      count(*) FILTER (WHERE started_at >= now() - interval '7 days' AND pr_number IS NOT NULL)::int AS prs_this_week,
+      count(*) FILTER (WHERE started_at >= now() - interval '7 days' AND status = 'completed')::int AS completed_this_week
+    FROM active_agents
+  `;
+
+  const row = result[0] as AgentActivityRow;
+  const completionRate =
+    row.sessions_this_week > 0
+      ? Math.round((row.completed_this_week / row.sessions_this_week) * 100)
+      : null;
+
+  return {
+    activeNow: row.active_now,
+    sessionsThisWeek: row.sessions_this_week,
+    prsThisWeek: row.prs_this_week,
+    completedThisWeek: row.completed_this_week,
+    completionRate,
+  };
+}
+
+// ---- API key health ----
+
+async function fetchApiKeyHealth() {
+  const checkKey = async (
+    name: string,
+    envVar: string,
+    testFn: (key: string) => Promise<boolean>
+  ): Promise<{ configured: boolean; healthy: boolean }> => {
+    const key = process.env[envVar];
+    if (!key) return { configured: false, healthy: false };
+    try {
+      const healthy = await testFn(key);
+      return { configured: true, healthy };
+    } catch {
+      return { configured: true, healthy: false };
+    }
+  };
+
+  const [github, anthropic, openrouter] = await Promise.all([
+    // GitHub — reuse CI status logic: if GITHUB_TOKEN exists and can hit the API
+    checkKey("github", "GITHUB_TOKEN", async (token) => {
+      const resp = await fetch(
+        `https://api.github.com/repos/${GITHUB_REPO}`,
+        {
+          headers: {
+            Authorization: `token ${token}`,
+            Accept: "application/vnd.github+json",
+          },
+          signal: AbortSignal.timeout(5000),
+        }
+      );
+      return resp.ok;
+    }),
+
+    // Anthropic
+    checkKey("anthropic", "ANTHROPIC_API_KEY", async (key) => {
+      const resp = await fetch("https://api.anthropic.com/v1/models", {
+        headers: {
+          "x-api-key": key,
+          "anthropic-version": "2023-06-01",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      return resp.ok;
+    }),
+
+    // OpenRouter
+    checkKey("openrouter", "OPENROUTER_API_KEY", async (key) => {
+      const resp = await fetch("https://openrouter.ai/api/v1/models", {
+        headers: {
+          Authorization: `Bearer ${key}`,
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      return resp.ok;
+    }),
+  ]);
+
+  return { github, anthropic, openrouter };
 }
 
 export const monitoringRoute = monitoringApp;


### PR DESCRIPTION
## Summary

Adds 5 new sections to the System Health dashboard (`/wiki/E927`) for better operational visibility:

- **API Key Health**: Parallel pings to GitHub, Anthropic, and OpenRouter APIs with compact status badges
- **Migration Status**: Queries `drizzle.__drizzle_migrations` to show applied vs expected count with collapsible recent migration list
- **Deploy History**: Fetches `wiki-server-docker.yml` workflow runs from GitHub Actions API with status, duration, and commit links
- **Broken EntityLinks**: Build-time scan of MDX files checking `<EntityLink id="...">` references against the entity registry (0 broken, 152 unreachable currently)
- **Agent Activity Summary**: 7-day stats from `active_agents` table — active now, sessions, PRs created, completion rate

All sections follow the established pattern: `fetch*()` helper in `monitoring.ts` with `.catch()` fallback, added to the `Promise.all()` in `/extended`, with corresponding UI section components.

## Files changed

| File | Changes |
|------|---------|
| `apps/wiki-server/src/routes/monitoring.ts` | 4 new `fetch*()` functions + extended `/extended` response |
| `apps/web/src/app/internal/system-health/system-health-content.tsx` | 5 new section components + extended `ExtendedHealthData` interface |
| `apps/web/scripts/build-data.mjs` | `scanBrokenEntityLinks()` function + writes `broken-entity-links.json` |

## Test plan

- [x] `pnpm build` passes (TypeScript compiles, broken-entity-links.json generated)
- [x] `pnpm test` — all 3256 tests pass
- [x] TypeScript type-check passes for both `apps/web` and `apps/wiki-server`
- [ ] Verify all 5 sections render on `/wiki/E927` in dev
- [ ] Each section shows graceful fallback when wiki-server is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)