### PR TITLE
feat: convert Events directory from card grid to searchable table

### DIFF
--- a/apps/web/src/app/events/events-table.tsx
+++ b/apps/web/src/app/events/events-table.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { SortHeader } from "@/components/directory/SortHeader";
+
+export interface EventRow {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string | null;
+  tags: string[];
+  numericId: string | null;
+}
+
+type SortKey = "title" | "status";
+type SortDir = "asc" | "desc";
+
+export function EventsTable({ rows }: { rows: EventRow[] }) {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("title");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const filtered = useMemo(() => {
+    let result = rows;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.title.toLowerCase().includes(q) ||
+          (r.description && r.description.toLowerCase().includes(q)) ||
+          (r.status && r.status.toLowerCase().includes(q)) ||
+          r.tags.some((t) => t.toLowerCase().includes(q)),
+      );
+    }
+
+    const dir = sortDir === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      switch (sortKey) {
+        case "title":
+          return a.title.localeCompare(b.title) * dir;
+        case "status":
+          return (a.status ?? "").localeCompare(b.status ?? "") * dir;
+      }
+    });
+
+    return result;
+  }, [rows, search, sortKey, sortDir]);
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row gap-3 mb-5">
+        <input
+          type="text"
+          placeholder="Search events by name, description, status, or tag..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-80"
+        />
+      </div>
+
+      <div className="text-xs text-muted-foreground mb-3">
+        Showing {filtered.length} of {rows.length}{" "}
+        {rows.length === 1 ? "event" : "events"}
+      </div>
+
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <SortHeader
+                label="Name"
+                sortKey="title"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <SortHeader
+                label="Status"
+                sortKey="status"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <th className="text-left py-2 px-3 font-medium">Description</th>
+              <th className="text-left py-2 px-3 font-medium">Tags</th>
+              <th className="text-center py-2 px-3 font-medium">Wiki</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {filtered.map((row) => (
+              <tr
+                key={row.id}
+                className="hover:bg-muted/20 transition-colors"
+              >
+                <td className="py-2.5 px-3 min-w-[180px]">
+                  <Link
+                    href={`/events/${row.id}`}
+                    className="font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    {row.title}
+                  </Link>
+                </td>
+
+                <td className="py-2.5 px-3 whitespace-nowrap">
+                  {row.status && (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                      {row.status}
+                    </span>
+                  )}
+                </td>
+
+                <td className="py-2.5 px-3 text-muted-foreground max-w-[400px]">
+                  {row.description && (
+                    <span className="line-clamp-2 text-xs">
+                      {row.description}
+                    </span>
+                  )}
+                </td>
+
+                <td className="py-2.5 px-3 max-w-[200px]">
+                  {row.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {row.tags.slice(0, 3).map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                      {row.tags.length > 3 && (
+                        <span className="text-[10px] text-muted-foreground/60">
+                          +{row.tags.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </td>
+
+                <td className="py-2.5 px-3 text-center whitespace-nowrap">
+                  {row.numericId && (
+                    <Link
+                      href={`/wiki/${row.numericId}`}
+                      className="text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                      title="Wiki page"
+                    >
+                      wiki
+                    </Link>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No events match your search.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -1,7 +1,8 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
-import Link from "next/link";
 import { getTypedEntities, isEvent } from "@/data";
-import { getWikiHref } from "@/data/entity-nav";
+import { ProfileStatCard } from "@/components/directory";
+import { EventsTable, type EventRow } from "./events-table";
 
 export const metadata: Metadata = {
   title: "Events",
@@ -12,6 +13,29 @@ export const metadata: Metadata = {
 export default function EventsPage() {
   const events = getTypedEntities().filter(isEvent);
   const isSparse = events.length < 5;
+
+  const rows: EventRow[] = events.map((e) => {
+    const statusField = e.customFields.find((f) => f.label === "Status");
+    return {
+      id: e.id,
+      title: e.title,
+      description: e.description ?? null,
+      status: statusField?.value ?? null,
+      tags: e.tags ?? [],
+      numericId: e.numericId ?? null,
+    };
+  });
+
+  const uniqueTagCount = new Set(rows.flatMap((r) => r.tags)).size;
+
+  const stats = [
+    { label: "Events", value: String(rows.length) },
+    {
+      label: "With Description",
+      value: String(rows.filter((r) => r.description).length),
+    },
+    { label: "Unique Tags", value: String(uniqueTagCount) },
+  ];
 
   return (
     <div className="max-w-[90rem] mx-auto px-6 py-8">
@@ -29,73 +53,19 @@ export default function EventsPage() {
         </div>
       )}
 
-      <div
-        className={
-          isSparse
-            ? "grid grid-cols-1 gap-4 max-w-xl"
-            : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
-        }
-      >
-        {events
-          .sort((a, b) => a.title.localeCompare(b.title))
-          .map((event) => {
-            const wikiHref = getWikiHref(event.id);
-            // Extract key fields from customFields
-            const statusField = event.customFields.find(
-              (f) => f.label === "Status",
-            );
-            const triggerField = event.customFields.find(
-              (f) => f.label === "Trigger Event",
-            );
-            return (
-              <div
-                key={event.id}
-                className="rounded-xl border border-border/60 bg-card p-4 hover:bg-muted/20 transition-colors"
-              >
-                <div className="flex items-start justify-between gap-2 mb-2">
-                  <Link
-                    href={`/events/${event.id}`}
-                    className="font-semibold text-sm hover:text-primary transition-colors line-clamp-2"
-                  >
-                    {event.title}
-                  </Link>
-                  {statusField && (
-                    <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                      {statusField.value}
-                    </span>
-                  )}
-                </div>
-                {event.description && (
-                  <p className="text-xs text-muted-foreground line-clamp-3 mb-3">
-                    {event.description}
-                  </p>
-                )}
-                {triggerField && (
-                  <p className="text-xs text-muted-foreground mb-2">
-                    <span className="font-medium">Trigger:</span>{" "}
-                    {triggerField.value}
-                  </p>
-                )}
-                <div className="flex items-center gap-3 text-xs">
-                  {event.tags.length > 0 && (
-                    <span className="text-muted-foreground">
-                      {event.tags.slice(0, 3).join(", ")}
-                      {event.tags.length > 3 && " ..."}
-                    </span>
-                  )}
-                  {wikiHref && (
-                    <Link
-                      href={wikiHref}
-                      className="text-primary hover:underline ml-auto"
-                    >
-                      Wiki &rarr;
-                    </Link>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-8">
+        {stats.map((stat) => (
+          <ProfileStatCard
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+          />
+        ))}
       </div>
+
+      <Suspense fallback={<div>Loading...</div>}>
+        <EventsTable rows={rows} />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the card grid layout on `/events` with a sortable, searchable table matching the Approaches directory pattern (PR #2474)
- Adds stat cards (event count, with description, unique tags) and a search box filtering by name, description, status, and tags
- Sortable columns: Name, Status; plus Description, Tags, and Wiki link columns
- Preserves the sparse directory banner (shown when <5 entries) from PR #2480
- Detail pages (`/events/[slug]`) are unchanged

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `pnpm test` -- all 39 tests pass (pre-existing failures in discord-bot/claude-agent unrelated)
- [ ] Verify `/events` renders the table with the single existing event
- [ ] Verify `/events/anthropic-government-standoff` detail page still works
- [ ] Verify search box filters correctly
- [ ] Verify sort toggles work on Name and Status columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)