### PR TITLE
fix: use fallback chain for lastUpdated to fix dashboard freshness tracking

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -581,14 +581,8 @@ function extractPrNumber(prUrl) {
   return m ? parseInt(m[1], 10) : undefined;
 }
 
-/**
- * Return the later of two YYYY-MM-DD date strings (null-safe).
- */
-function maxDate(a, b) {
-  if (!a) return b;
-  if (!b) return a;
-  return a > b ? a : b;
-}
+// maxDate was removed — see lastUpdated fallback chain comment in buildPagesRegistry.
+// dateCreated already uses a fallback chain (resolveDateCreated in git-date-utils.mjs).
 
 /**
  * Build git-based date maps for all content files.
@@ -1899,13 +1893,17 @@ function buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEd
           // Content format: article (default), table, diagram, index, dashboard
           contentFormat: fm.contentFormat || 'article',
           causalLevel: fm.causalLevel || null,
-          lastUpdated: maxDate(
-            editLogDates.get(isIndexFile ? null : id) || null,
-            maxDate(
-              gitModifiedMap.get(relative(REPO_ROOT, fullPath)) || null,
-              maxDate(toDateString(fm.lastUpdated), toDateString(fm.lastEdited))
-            )
-          ),
+          // Use a fallback chain instead of maxDate to avoid metadata-only
+          // git commits (e.g. bulk frontmatter reformatting) from overriding
+          // the actual content change date with today's date.
+          // Priority: frontmatter lastEdited (set by content editing tools)
+          //   → frontmatter lastUpdated (legacy) → edit log date (wiki-server)
+          //   → git modified date (last resort, includes metadata commits).
+          lastUpdated: toDateString(fm.lastEdited)
+            || toDateString(fm.lastUpdated)
+            || editLogDates.get(isIndexFile ? null : id)
+            || gitModifiedMap.get(relative(REPO_ROOT, fullPath))
+            || null,
           // Derive creation date: prefer explicit frontmatter, then non-bulk git
           // first-commit, then earliest edit log from wiki-server, then legacy
           // frontmatter. Bulk-import git dates are already filtered out of


### PR DESCRIPTION
## Summary

- Dashboard pages (E899, E908) were showing "0d" for every page's freshness because `lastUpdated` used `maxDate()` across all date sources. Any bulk git commit touching metadata (e.g. the recent `56be1213` that stripped scoring fields from 617 files) would set the git modified date to today, overriding the actual content change date for all affected pages.
- Changed `lastUpdated` from `maxDate(editLog, maxDate(git, maxDate(fm.lastUpdated, fm.lastEdited)))` to a priority-based fallback chain: `fm.lastEdited || fm.lastUpdated || editLogDate || gitModifiedDate`. This matches the pattern already used by `dateCreated`.
- Removed the now-unused `maxDate()` helper function.

**Before**: All 670+ pages show "0d" on dashboards after any bulk metadata commit.
**After**: Pages show their actual `lastEdited` date from frontmatter (set by the improve pipeline when content changes). Only ~36 pages without `lastEdited` fall through to git dates.

## Test plan

- [x] `pnpm build-data:content` succeeds, dates show proper distribution (not all today)
- [x] Full build with git dates: only 6/539 schedule items show 0d (legitimately edited today)
- [x] `pnpm test` passes (3168 tests, 148 files)
- [x] Verified production site currently shows "0d" for all pages (confirmed via WebFetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)