### PR TITLE
feat: add Next Best Action priority scoring for wiki pages

### DIFF
--- a/apps/web/src/app/internal/entities/entities-content.tsx
+++ b/apps/web/src/app/internal/entities/entities-content.tsx
@@ -2,6 +2,39 @@ import { getTypedEntities, getEntityHref, getPageById, getPageCoverageItems, get
 import { EntitiesDataTable } from "./entities-data-table";
 import type { UnifiedEntityRow } from "./entities-data-table";
 
+/**
+ * Compute "Next Best Action" priority score for a page.
+ * priority = importance * qualityDeficit * stalenessFactor * riskFactor
+ */
+function computePriorityScore(row: {
+  quality: number | null;
+  readerImportance: number | null;
+  researchImportance: number | null;
+  lastUpdated: string | null;
+  riskLevel: "low" | "medium" | "high" | null;
+}): number | null {
+  const readerImp = row.readerImportance ?? 0;
+  const researchImp = row.researchImportance ?? 0;
+  if (readerImp === 0 && researchImp === 0) return null;
+
+  const importance = Math.min(Math.max(readerImp, researchImp) / 100, 1);
+  const qualityDeficit = 1 - Math.min((row.quality ?? 0) / 100, 1);
+
+  let daysSinceUpdate = 999;
+  if (row.lastUpdated) {
+    const d = new Date(row.lastUpdated);
+    if (!isNaN(d.getTime())) {
+      daysSinceUpdate = Math.round((Date.now() - d.getTime()) / 86400000);
+    }
+  }
+  const stalenessFactor = 1 + Math.min(daysSinceUpdate / 365, 1.0);
+
+  const riskBoost = row.riskLevel === "high" ? 0.5 : row.riskLevel === "medium" ? 0.25 : 0;
+  const riskFactor = 1 + riskBoost;
+
+  return Math.round(importance * qualityDeficit * stalenessFactor * riskFactor * 1000) / 1000;
+}
+
 export function EntitiesContent() {
   const entities = getTypedEntities();
   const coverageItems = getPageCoverageItems();
@@ -17,6 +50,12 @@ export function EntitiesContent() {
     const rank = rankingById.get(e.id);
     const href = getEntityHref(e.id);
 
+    const quality = cov?.quality ?? rank?.quality ?? null;
+    const readerImportance = cov?.readerImportance ?? rank?.readerImportance ?? null;
+    const researchImportance = cov?.researchImportance ?? rank?.researchImportance ?? null;
+    const lastUpdated = cov?.lastUpdated ?? (e.lastUpdated ?? null);
+    const riskLevel = cov?.riskLevel ?? null;
+
     return {
       // Entity core
       id: e.id,
@@ -30,10 +69,10 @@ export function EntitiesContent() {
       hasPage: !!page,
       href,
       // Importance / rankings
-      quality: cov?.quality ?? rank?.quality ?? null,
-      readerImportance: cov?.readerImportance ?? rank?.readerImportance ?? null,
+      quality,
+      readerImportance,
       readerRank: rank?.readerRank ?? null,
-      researchImportance: cov?.researchImportance ?? rank?.researchImportance ?? null,
+      researchImportance,
       researchRank: rank?.researchRank ?? null,
       tacticalValue: cov?.tacticalValue ?? rank?.tacticalValue ?? null,
       // Page classification
@@ -41,14 +80,16 @@ export function EntitiesContent() {
       wordCount: cov?.wordCount ?? rank?.wordCount ?? null,
       category: cov?.category ?? rank?.category ?? null,
       subcategory: cov?.subcategory ?? null,
-      lastUpdated: cov?.lastUpdated ?? (e.lastUpdated ?? null),
+      lastUpdated,
       updateFrequency: cov?.updateFrequency ?? null,
       // Coverage
       coverageScore: cov?.score ?? null,
       coverageTotal: cov?.total ?? null,
       // Risk
-      riskLevel: cov?.riskLevel ?? null,
+      riskLevel,
       riskScore: cov?.riskScore ?? null,
+      // Priority (NBA)
+      priorityScore: computePriorityScore({ quality, readerImportance, researchImportance, lastUpdated, riskLevel }),
       // Ratings
       novelty: cov?.novelty ?? null,
       rigor: cov?.rigor ?? null,
@@ -111,8 +152,8 @@ export function EntitiesContent() {
         <span className="font-medium text-foreground">{withCoverage}</span>{" "}
         have coverage data. Use{" "}
         <strong>preset buttons</strong> to switch between views (Overview,
-        Entities, Importance, Quality, Coverage, Citations, Updates) or toggle
-        individual columns.
+        Entities, Importance, Quality, Coverage, Citations, Updates, Priority)
+        or toggle individual columns.
       </p>
       <EntitiesDataTable entities={rows} />
     </>

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -54,6 +54,8 @@ export interface UnifiedEntityRow {
   // Hallucination risk
   riskLevel: "low" | "medium" | "high" | null;
   riskScore: number | null;
+  // Priority (NBA)
+  priorityScore: number | null;
   // Ratings (1-10)
   novelty: number | null;
   rigor: number | null;
@@ -324,6 +326,7 @@ const COLUMN_LABELS: Record<string, string> = {
   // Risk
   riskLevel: "Hallucination Risk",
   riskScore: "Risk Score",
+  priorityScore: "Priority (NBA)",
   // Ratings
   novelty: "Novelty",
   rigor: "Rigor",
@@ -561,6 +564,19 @@ const columns: ColumnDef<UnifiedEntityRow>[] = [
       if (v == null) return <Dash />;
       const color = v >= 70 ? "text-red-500" : v >= 40 ? "text-amber-500" : "text-emerald-500";
       return <span className={`text-xs tabular-nums font-medium ${color}`}>{Math.round(v)}</span>;
+    },
+  },
+
+  // --- Priority (NBA) ---
+  {
+    accessorKey: "priorityScore",
+    sortUndefined: "last",
+    header: ({ column }) => <SortableHeader column={column} title="Next Best Action priority: importance * qualityDeficit * staleness * riskFactor">NBA</SortableHeader>,
+    cell: ({ row }) => {
+      const v = row.original.priorityScore;
+      if (v == null) return <Dash />;
+      const color = v >= 0.8 ? "text-red-500" : v >= 0.4 ? "text-amber-500" : v >= 0.15 ? "text-blue-500" : "text-emerald-500";
+      return <span className={`text-xs tabular-nums font-bold ${color}`}>{v.toFixed(2)}</span>;
     },
   },
 
@@ -861,6 +877,12 @@ const PRESETS: Record<string, Preset> = {
     description: "Freshness and update scheduling",
     columns: ["title", "lastUpdated", "updateFrequency", "quality", "readerImportance", "riskLevel", "wordCount", "category"],
     defaultSort: [{ id: "lastUpdated", desc: false }],
+  },
+  priority: {
+    label: "Priority",
+    description: "Next Best Action score: importance x quality deficit x staleness x risk",
+    columns: ["title", "priorityScore", "quality", "readerImportance", "researchImportance", "riskLevel", "lastUpdated", "wordCount", "entityType"],
+    defaultSort: [{ id: "priorityScore", desc: true }],
   },
   all: {
     label: "All",

--- a/crux/commands/pages.ts
+++ b/crux/commands/pages.ts
@@ -1,0 +1,121 @@
+/**
+ * Pages Command Handlers
+ *
+ * Page-level analysis and prioritization tools.
+ *
+ * Usage:
+ *   crux pages next-action [--type=<entityType>] [--limit=20] [--all] [--ci]
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { computeNBABatch, type PageInput } from '../lib/next-best-action.ts';
+
+interface CommandOptions extends BaseOptions {
+  type?: string;
+  limit?: string;
+  all?: boolean;
+  ci?: boolean;
+}
+
+function loadPages(): PageInput[] {
+  const dbPath = join(PROJECT_ROOT, 'apps/web/src/data/database.json');
+  const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+  const idRegistry = db.idRegistry ?? { bySlug: {} };
+  return (db.pages || []).map((p: Record<string, unknown>) => ({
+    id: p.id as string,
+    numericId: (idRegistry.bySlug[p.id as string] as string) || (p.id as string),
+    title: p.title as string,
+    entityType: (p.entityType as string) ?? null,
+    quality: (p.quality as number) ?? null,
+    readerImportance: (p.readerImportance as number) ?? null,
+    researchImportance: (p.researchImportance as number) ?? null,
+    lastUpdated: (p.lastUpdated as string) ?? null,
+    hallucinationRisk: (p.hallucinationRisk as PageInput['hallucinationRisk']) ?? null,
+    wordCount: (p.wordCount as number) ?? 0,
+    contentFormat: (p.contentFormat as string) ?? 'article',
+    subcategory: (p.subcategory as string) ?? null,
+  }));
+}
+
+async function nextActionCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const pages = loadPages();
+  const limit = options.limit ? parseInt(options.limit as string, 10) : 20;
+  const includeNoImportance = !!options.all;
+  const entityType = options.type as string | undefined;
+
+  const scored = computeNBABatch(pages, { includeNoImportance, entityType });
+  const limited = scored.slice(0, limit);
+
+  if (options.ci) {
+    return { exitCode: 0, output: JSON.stringify(limited, null, 2) };
+  }
+
+  if (limited.length === 0) {
+    return { exitCode: 0, output: 'No pages found matching criteria.' };
+  }
+
+  const lines: string[] = [
+    `\x1b[1mNext Best Action: Top ${limited.length} pages needing attention\x1b[0m`,
+    `\x1b[2m${scored.length} eligible pages scored\x1b[0m`,
+    '',
+    `${'Rank'.padStart(4)}  ${'Score'.padStart(6)}  ${'Page'.padEnd(40)}  ${'Reason'}`,
+    `${'----'.padStart(4)}  ${'------'.padStart(6)}  ${'----'.padEnd(40)}  ${'------'}`,
+  ];
+
+  for (let i = 0; i < limited.length; i++) {
+    const s = limited[i];
+    const nid = s.numericId !== s.id ? ` (${s.numericId})` : '';
+    const label = `${s.title}${nid}`;
+    const truncLabel = label.length > 39 ? label.slice(0, 36) + '...' : label;
+    const scoreStr = s.priority.toFixed(2);
+    const color = s.priority >= 0.8 ? '\x1b[31m' : s.priority >= 0.4 ? '\x1b[33m' : '\x1b[32m';
+    const reason = s.reasons.length > 0 ? s.reasons.join(', ') : 'marginal deficit';
+
+    lines.push(
+      `${String(i + 1).padStart(4)}  ${color}${scoreStr.padStart(6)}\x1b[0m  ${truncLabel.padEnd(40)}  ${reason}`
+    );
+  }
+
+  lines.push('');
+  lines.push(`\x1b[2mFormula: importance * qualityDeficit * stalenessFactor * riskFactor\x1b[0m`);
+  lines.push(`\x1b[2mOptions: --type=<entityType> --limit=N --all (include 0-importance) --ci (JSON)\x1b[0m`);
+
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+export const commands = {
+  'next-action': nextActionCommand,
+  default: nextActionCommand,
+};
+
+export function getHelp(): string {
+  return `
+Pages Domain — Page-level analysis and prioritization
+
+Commands:
+  next-action   Show pages ranked by "Next Best Action" priority score (default)
+
+The NBA score combines:
+  - importance = max(readerImportance, researchImportance) / 100
+  - qualityDeficit = 1 - quality/100
+  - stalenessFactor = 1 + min(daysSinceUpdate/365, 1.0)
+  - hallucinationRiskFactor = 1 + (high: 0.5, medium: 0.25, low: 0)
+
+  priority = importance * qualityDeficit * stalenessFactor * hallucinationRiskFactor
+
+Options:
+  --type=<entityType>   Filter to specific entity type (e.g. person, organization)
+  --limit=N             Number of results (default: 20)
+  --all                 Include pages with 0 importance scores
+  --ci                  JSON output
+
+Examples:
+  crux pages                                  # Top 20 pages needing attention
+  crux pages next-action --type=person        # Top person pages
+  crux pages next-action --limit=50           # Top 50
+  crux pages next-action --ci                 # JSON output
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -119,6 +119,7 @@ import * as recordsVerifyCommands from './commands/records-verify.ts';
 import * as qaSweepCommands from './commands/qa-sweep.ts';
 import * as matrixCommands from './commands/matrix.ts';
 import * as tablebaseCommands from './commands/tablebase.ts';
+import * as pagesCommands from './commands/pages.ts';
 
 const domains = {
   validate: validateCommands,
@@ -176,6 +177,7 @@ const domains = {
   'qa-sweep': qaSweepCommands,
   matrix: matrixCommands,
   tablebase: tablebaseCommands,
+  pages: pagesCommands,
 };
 
 /**
@@ -273,6 +275,7 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   verify           Verify structured data records against source URLs (grants, personnel, etc.)
   matrix           Entity matrix analysis and improvement targeting
   tablebase        Structured data enrichment via LLM agents (scan, gaps, improve, loop)
+  pages            Page prioritization (next-action: NBA scoring for editorial attention)
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}
   --ci        JSON output for CI pipelines

--- a/crux/lib/next-best-action.test.ts
+++ b/crux/lib/next-best-action.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { computeNBA, computeNBABatch, type PageInput } from './next-best-action.ts';
+
+function makePage(overrides: Partial<PageInput> = {}): PageInput {
+  return {
+    id: 'test-page',
+    numericId: 'E1',
+    title: 'Test Page',
+    entityType: 'concept',
+    quality: 50,
+    readerImportance: 80,
+    researchImportance: 60,
+    lastUpdated: new Date(Date.now() - 90 * 86400000).toISOString(), // 90 days ago
+    hallucinationRisk: null,
+    wordCount: 2000,
+    contentFormat: 'article',
+    subcategory: null,
+    ...overrides,
+  };
+}
+
+describe('computeNBA', () => {
+  it('returns higher priority for high-importance, low-quality pages', () => {
+    const highPriority = computeNBA(makePage({ quality: 20, readerImportance: 90 }));
+    const lowPriority = computeNBA(makePage({ quality: 80, readerImportance: 30 }));
+    expect(highPriority.priority).toBeGreaterThan(lowPriority.priority);
+  });
+
+  it('returns higher priority for stale pages', () => {
+    const stale = computeNBA(makePage({
+      lastUpdated: new Date(Date.now() - 400 * 86400000).toISOString(),
+    }));
+    const fresh = computeNBA(makePage({
+      lastUpdated: new Date(Date.now() - 10 * 86400000).toISOString(),
+    }));
+    expect(stale.priority).toBeGreaterThan(fresh.priority);
+  });
+
+  it('boosts priority for high hallucination risk', () => {
+    const risky = computeNBA(makePage({
+      hallucinationRisk: { level: 'high', score: 80, factors: ['no-citations'] },
+    }));
+    const safe = computeNBA(makePage({
+      hallucinationRisk: { level: 'low', score: 10, factors: [] },
+    }));
+    expect(risky.priority).toBeGreaterThan(safe.priority);
+  });
+
+  it('returns 0 priority for pages with 0 importance', () => {
+    const noImportance = computeNBA(makePage({
+      readerImportance: 0,
+      researchImportance: 0,
+    }));
+    expect(noImportance.priority).toBe(0);
+  });
+
+  it('returns 0 priority for perfect quality (100)', () => {
+    const perfect = computeNBA(makePage({ quality: 100 }));
+    expect(perfect.priority).toBe(0);
+  });
+
+  it('uses researchImportance when it exceeds readerImportance', () => {
+    const result = computeNBA(makePage({
+      readerImportance: 30,
+      researchImportance: 90,
+    }));
+    expect(result.importance).toBe(0.9);
+  });
+
+  it('caps staleness factor at 2.0', () => {
+    const veryStale = computeNBA(makePage({
+      lastUpdated: new Date(Date.now() - 1000 * 86400000).toISOString(),
+    }));
+    expect(veryStale.stalenessFactor).toBe(2);
+  });
+
+  it('includes reasons for high importance', () => {
+    const result = computeNBA(makePage({ readerImportance: 80 }));
+    expect(result.reasons).toContain('high importance');
+  });
+
+  it('includes reasons for low quality', () => {
+    const result = computeNBA(makePage({ quality: 20 }));
+    expect(result.reasons.some(r => r.includes('low quality'))).toBe(true);
+  });
+
+  it('includes reasons for high hallucination risk', () => {
+    const result = computeNBA(makePage({
+      hallucinationRisk: { level: 'high', score: 80, factors: [] },
+    }));
+    expect(result.reasons).toContain('high hallucination risk');
+  });
+});
+
+describe('computeNBABatch', () => {
+  it('sorts results by priority descending', () => {
+    const pages = [
+      makePage({ id: 'low', quality: 80, readerImportance: 30 }),
+      makePage({ id: 'high', quality: 20, readerImportance: 90 }),
+      makePage({ id: 'mid', quality: 50, readerImportance: 60 }),
+    ];
+    const results = computeNBABatch(pages);
+    expect(results[0].id).toBe('high');
+    expect(results[results.length - 1].id).toBe('low');
+  });
+
+  it('filters out dashboard pages', () => {
+    const pages = [
+      makePage({ id: 'article', contentFormat: 'article' }),
+      makePage({ id: 'dashboard', contentFormat: 'dashboard' }),
+    ];
+    const results = computeNBABatch(pages);
+    expect(results.map(r => r.id)).toEqual(['article']);
+  });
+
+  it('filters out pages with no importance by default', () => {
+    const pages = [
+      makePage({ id: 'important', readerImportance: 80, researchImportance: 0 }),
+      makePage({ id: 'unimportant', readerImportance: 0, researchImportance: 0 }),
+    ];
+    const results = computeNBABatch(pages);
+    expect(results.map(r => r.id)).toEqual(['important']);
+  });
+
+  it('includes no-importance pages when opted in', () => {
+    const pages = [
+      makePage({ id: 'important', readerImportance: 80 }),
+      makePage({ id: 'unimportant', readerImportance: 0, researchImportance: 0 }),
+    ];
+    const results = computeNBABatch(pages, { includeNoImportance: true });
+    expect(results.map(r => r.id)).toContain('unimportant');
+  });
+
+  it('filters by entity type', () => {
+    const pages = [
+      makePage({ id: 'person', entityType: 'person' }),
+      makePage({ id: 'org', entityType: 'organization' }),
+    ];
+    const results = computeNBABatch(pages, { entityType: 'person' });
+    expect(results.map(r => r.id)).toEqual(['person']);
+  });
+});

--- a/crux/lib/next-best-action.ts
+++ b/crux/lib/next-best-action.ts
@@ -1,0 +1,150 @@
+/**
+ * Next Best Action — Priority scoring for wiki pages.
+ *
+ * Combines importance, quality deficit, staleness, and hallucination risk
+ * into a single actionable ranking that identifies which pages would
+ * benefit most from editorial attention.
+ *
+ * Formula:
+ *   priority = importance × qualityDeficit × stalenessFactor × hallucinationRiskFactor
+ *
+ * Where:
+ *   importance = max(readerImportance, researchImportance) / 100, clamped [0, 1]
+ *   qualityDeficit = 1 - (quality / 100), clamped [0, 1]
+ *   stalenessFactor = 1 + min(daysSinceUpdate / 365, 1.0)
+ *   hallucinationRiskFactor = 1 + (high: 0.5, medium: 0.25, low: 0)
+ */
+
+export interface NextBestActionScore {
+  id: string;
+  numericId: string;
+  title: string;
+  entityType: string | null;
+  priority: number;
+  // Component values for transparency
+  importance: number;
+  qualityDeficit: number;
+  stalenessFactor: number;
+  hallucinationRiskFactor: number;
+  // Raw inputs
+  quality: number | null;
+  readerImportance: number | null;
+  researchImportance: number | null;
+  daysSinceUpdate: number;
+  riskLevel: 'low' | 'medium' | 'high' | null;
+  wordCount: number;
+  // Human-readable reason
+  reasons: string[];
+}
+
+export interface PageInput {
+  id: string;
+  numericId?: string;
+  title: string;
+  entityType?: string | null;
+  quality: number | null;
+  readerImportance: number | null;
+  researchImportance: number | null;
+  lastUpdated: string | null;
+  hallucinationRisk?: {
+    level: 'low' | 'medium' | 'high';
+    score: number;
+    factors: string[];
+  } | null;
+  wordCount?: number;
+  contentFormat?: string;
+  subcategory?: string | null;
+}
+
+function daysSince(dateStr: string | null): number {
+  if (!dateStr) return 999;
+  const d = new Date(dateStr);
+  return isNaN(d.getTime()) ? 999 : Math.round((Date.now() - d.getTime()) / 86400000);
+}
+
+/**
+ * Compute the Next Best Action priority score for a single page.
+ */
+export function computeNBA(page: PageInput): NextBestActionScore {
+  const quality = page.quality ?? 0;
+  const readerImp = page.readerImportance ?? 0;
+  const researchImp = page.researchImportance ?? 0;
+  const days = daysSince(page.lastUpdated);
+  const riskLevel = page.hallucinationRisk?.level ?? null;
+  const wc = page.wordCount ?? 0;
+
+  // importance: max of reader and research importance, normalized 0-1
+  const importance = Math.min(Math.max(readerImp, researchImp) / 100, 1);
+
+  // qualityDeficit: how far quality is from 100, normalized 0-1
+  const qualityDeficit = 1 - Math.min(quality / 100, 1);
+
+  // stalenessFactor: 1.0 for just-updated, up to 2.0 for 365+ days stale
+  const stalenessFactor = 1 + Math.min(days / 365, 1.0);
+
+  // hallucinationRiskFactor: boost for risky pages
+  const riskBoost = riskLevel === 'high' ? 0.5 : riskLevel === 'medium' ? 0.25 : 0;
+  const hallucinationRiskFactor = 1 + riskBoost;
+
+  const priority = importance * qualityDeficit * stalenessFactor * hallucinationRiskFactor;
+
+  // Build human-readable reasons
+  const reasons: string[] = [];
+  if (importance >= 0.7) reasons.push('high importance');
+  else if (importance >= 0.4) reasons.push('moderate importance');
+  if (quality < 30) reasons.push(`low quality (${quality})`);
+  else if (quality < 50) reasons.push(`quality ${quality}`);
+  if (days > 365) reasons.push(`${days}d stale`);
+  else if (days > 180) reasons.push(`${days}d since update`);
+  if (riskLevel === 'high') reasons.push('high hallucination risk');
+  else if (riskLevel === 'medium') reasons.push('medium hallucination risk');
+  if (wc < 200 && wc > 0) reasons.push(`stub (${wc}w)`);
+
+  return {
+    id: page.id,
+    numericId: page.numericId ?? page.id,
+    title: page.title,
+    entityType: page.entityType ?? null,
+    priority: Math.round(priority * 1000) / 1000,
+    importance,
+    qualityDeficit,
+    stalenessFactor,
+    hallucinationRiskFactor,
+    quality: page.quality,
+    readerImportance: page.readerImportance,
+    researchImportance: page.researchImportance,
+    daysSinceUpdate: days,
+    riskLevel,
+    wordCount: wc,
+    reasons,
+  };
+}
+
+/**
+ * Compute NBA scores for a batch of pages, sorted by priority descending.
+ * Filters out dashboards, index pages, and pages with no importance data.
+ */
+export function computeNBABatch(
+  pages: PageInput[],
+  opts?: { includeNoImportance?: boolean; entityType?: string }
+): NextBestActionScore[] {
+  const results: NextBestActionScore[] = [];
+
+  for (const page of pages) {
+    // Skip dashboards and index pages
+    if (page.contentFormat === 'dashboard' || page.contentFormat === 'index') continue;
+    if (page.subcategory === 'dashboards') continue;
+
+    // Filter by entity type if specified
+    if (opts?.entityType && page.entityType !== opts.entityType) continue;
+
+    // Skip pages with zero importance unless opted in
+    if (!opts?.includeNoImportance) {
+      if ((page.readerImportance ?? 0) === 0 && (page.researchImportance ?? 0) === 0) continue;
+    }
+
+    results.push(computeNBA(page));
+  }
+
+  return results.sort((a, b) => b.priority - a.priority);
+}


### PR DESCRIPTION
## Summary
- Adds a "Next Best Action" (NBA) priority score that combines importance, quality deficit, staleness, and hallucination risk into a single actionable ranking for wiki pages
- New CLI command `crux pages next-action` shows top 20 pages needing editorial attention, with scores and reasons
- New "Priority" preset in the Entities dashboard (E908) that sorts by NBA score

## Formula

```
priority = importance * qualityDeficit * stalenessFactor * hallucinationRiskFactor
```

Where:
- `importance` = max(readerImportance, researchImportance) / 100, clamped [0, 1]
- `qualityDeficit` = 1 - quality/100, clamped [0, 1]
- `stalenessFactor` = 1 + min(daysSinceUpdate / 365, 1.0) -- ranges from 1.0 (fresh) to 2.0 (stale)
- `hallucinationRiskFactor` = 1 + (high: 0.5, medium: 0.25, low: 0)

## Files changed

- `crux/lib/next-best-action.ts` -- Core scoring module with `computeNBA` and `computeNBABatch`
- `crux/lib/next-best-action.test.ts` -- 15 unit tests covering all formula components and edge cases
- `crux/commands/pages.ts` -- CLI command handler for `crux pages next-action`
- `crux/crux.mjs` -- Register `pages` domain in CLI
- `apps/web/src/app/internal/entities/entities-content.tsx` -- Compute priorityScore server-side
- `apps/web/src/app/internal/entities/entities-data-table.tsx` -- NBA column + Priority preset

## Test plan
- [x] `npx tsc --noEmit` passes (web app and crux)
- [x] All 15 NBA unit tests pass
- [x] Full crux test suite passes (149 files, 3183 tests)
- [ ] Verify `crux pages next-action` output looks correct against database.json
- [ ] Verify Priority preset renders in Entities dashboard

Generated with [Claude Code](https://claude.com/claude-code)