### PR TITLE
fix: recalibrate quality scoring for structural content

### DIFF
--- a/crux/authoring/grading/steps.test.ts
+++ b/crux/authoring/grading/steps.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { computeMetrics, computeQuality } from './steps.ts';
+import type { Ratings, Metrics } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// computeMetrics — citation counting
+// ---------------------------------------------------------------------------
+
+describe('computeMetrics', () => {
+  it('counts named footnotes (e.g., [^mixtral])', () => {
+    const content = `---
+title: Test
+---
+
+Some claim about MoE[^mixtral] and another about GPT-4[^gpt4].
+
+[^mixtral]: Jiang et al. (2024). Mixtral of Experts.
+[^gpt4]: OpenAI (2023). GPT-4 Technical Report.
+`;
+    const metrics = computeMetrics(content);
+    // Should count 2 named footnotes (+ 0 external links in definitions)
+    expect(metrics.citations).toBeGreaterThanOrEqual(2);
+  });
+
+  it('counts numeric footnotes', () => {
+    const content = `---
+title: Test
+---
+
+A claim[^1] and another[^2].
+
+[^1]: Source one.
+[^2]: Source two.
+`;
+    const metrics = computeMetrics(content);
+    expect(metrics.citations).toBeGreaterThanOrEqual(2);
+  });
+
+  it('counts R components as citations', () => {
+    const content = `---
+title: Test
+---
+
+Some text with <R id="ref-1" /> and <R id="ref-2" />.
+`;
+    const metrics = computeMetrics(content);
+    expect(metrics.citations).toBeGreaterThanOrEqual(2);
+  });
+
+  it('counts external links as citations', () => {
+    const content = `---
+title: Test
+---
+
+See [this paper](https://arxiv.org/abs/2401.04088) and [that report](https://example.com/report).
+`;
+    const metrics = computeMetrics(content);
+    expect(metrics.citations).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles mixed citation types', () => {
+    const content = `---
+title: Test
+---
+
+Named footnote[^mixtral], numeric footnote[^1], <R id="ref-1" />, and [external link](https://example.com).
+
+[^mixtral]: Source.
+[^1]: Source.
+`;
+    const metrics = computeMetrics(content);
+    // 1 named footnote + 1 numeric footnote + 1 R component + 1 external link = 4
+    expect(metrics.citations).toBeGreaterThanOrEqual(4);
+  });
+
+  it('counts Mermaid diagrams', () => {
+    const content = `---
+title: Test
+---
+
+<Mermaid chart={\`graph TD\`} />
+
+<Mermaid chart={\`flowchart LR\`} />
+`;
+    const metrics = computeMetrics(content);
+    expect(metrics.diagrams).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeQuality — formula tests
+// ---------------------------------------------------------------------------
+
+describe('computeQuality', () => {
+  const midRatings: Ratings = {
+    focus: 5, novelty: 5, rigor: 5,
+    completeness: 5, concreteness: 5,
+    actionability: 5, objectivity: 5,
+  };
+
+  const highRatings: Ratings = {
+    focus: 7, novelty: 7, rigor: 7,
+    completeness: 7, concreteness: 7,
+    actionability: 7, objectivity: 7,
+  };
+
+  const lowRatings: Ratings = {
+    focus: 3, novelty: 3, rigor: 3,
+    completeness: 3, concreteness: 3,
+    actionability: 3, objectivity: 3,
+  };
+
+  const richMetrics: Metrics = {
+    wordCount: 3000,
+    citations: 20,
+    tables: 10,
+    diagrams: 2,
+  };
+
+  const sparseMetrics: Metrics = {
+    wordCount: 200,
+    citations: 0,
+    tables: 0,
+    diagrams: 0,
+  };
+
+  it('mid-rated page with rich structure scores above 65', () => {
+    // A page with all-5 ratings, 3000 words, 20 citations, 10 tables, 2 diagrams
+    // should score well above the old ceiling of ~55
+    const quality = computeQuality(midRatings, richMetrics);
+    expect(quality).toBeGreaterThanOrEqual(65);
+  });
+
+  it('high-rated page with rich structure scores above 80', () => {
+    const quality = computeQuality(highRatings, richMetrics);
+    expect(quality).toBeGreaterThanOrEqual(80);
+  });
+
+  it('low-rated sparse page scores below 40', () => {
+    const quality = computeQuality(lowRatings, sparseMetrics);
+    expect(quality).toBeLessThanOrEqual(40);
+  });
+
+  it('stub pages are capped at 35', () => {
+    const quality = computeQuality(highRatings, richMetrics, { pageType: 'stub' });
+    expect(quality).toBeLessThanOrEqual(35);
+  });
+
+  it('very short pages are capped at 40', () => {
+    const shortMetrics: Metrics = { wordCount: 50, citations: 5, tables: 2, diagrams: 1 };
+    const quality = computeQuality(highRatings, shortMetrics);
+    expect(quality).toBeLessThanOrEqual(40);
+  });
+
+  it('tables add up to 3 bonus points', () => {
+    const noTables: Metrics = { wordCount: 3000, citations: 20, tables: 0, diagrams: 0 };
+    const withTables: Metrics = { wordCount: 3000, citations: 20, tables: 10, diagrams: 0 };
+    const qNoTables = computeQuality(midRatings, noTables);
+    const qWithTables = computeQuality(midRatings, withTables);
+    expect(qWithTables - qNoTables).toBe(3);
+  });
+
+  it('diagrams add up to 2 bonus points', () => {
+    const noDiagrams: Metrics = { wordCount: 3000, citations: 20, tables: 0, diagrams: 0 };
+    const withDiagrams: Metrics = { wordCount: 3000, citations: 20, tables: 0, diagrams: 2 };
+    const qNoDiagrams = computeQuality(midRatings, noDiagrams);
+    const qWithDiagrams = computeQuality(midRatings, withDiagrams);
+    expect(qWithDiagrams - qNoDiagrams).toBe(2);
+  });
+
+  it('quality is clamped to 100', () => {
+    const perfectRatings: Ratings = {
+      focus: 10, novelty: 10, rigor: 10,
+      completeness: 10, concreteness: 10,
+      actionability: 10, objectivity: 10,
+    };
+    const quality = computeQuality(perfectRatings, richMetrics);
+    expect(quality).toBeLessThanOrEqual(100);
+  });
+
+  it('analysis content type adjusts weights', () => {
+    // Analysis weights novelty 1.5x vs reference 0.8x
+    const highNovelty: Ratings = {
+      focus: 5, novelty: 9, rigor: 5,
+      completeness: 5, concreteness: 5,
+      actionability: 5, objectivity: 5,
+    };
+    const analysisQ = computeQuality(highNovelty, richMetrics, { contentType: 'analysis' });
+    const referenceQ = computeQuality(highNovelty, richMetrics);
+    // Analysis should score higher because novelty is weighted 1.5x vs 0.8x
+    expect(analysisQ).toBeGreaterThan(referenceQ);
+  });
+});

--- a/crux/authoring/grading/steps.ts
+++ b/crux/authoring/grading/steps.ts
@@ -15,6 +15,7 @@ import { readFileSync } from 'fs';
 import { stripFrontmatter } from '../../lib/patterns.ts';
 import { ValidationEngine, ContentFile } from '../../lib/validation/validation-engine.ts';
 import { countFootnoteRefs } from '../../lib/metrics-extractor.ts';
+import { countAllFootnoteRefs } from '../../lib/content-integrity.ts';
 import {
   insiderJargonRule,
   falseCertaintyRule,
@@ -71,7 +72,12 @@ export function computeMetrics(content: string): Metrics {
   const proseWords = withoutComponents.split(/\s+/).filter(w => w.length > 0).length;
 
   const rComponents = (withoutFm.match(/<R\s+id=/g) || []).length;
-  const citations = rComponents + countFootnoteRefs(withoutFm);
+  // Count both numeric [^1] and named [^mixtral] footnotes
+  const footnoteRefs = countAllFootnoteRefs(withoutFm);
+  // Count external markdown links as evidence sources
+  const externalLinks = (withoutFm.match(/\]\(https?:\/\/[^)]+\)/g) || []).length;
+  // Citations = R components + all footnote refs + external links
+  const citations = rComponents + footnoteRefs + externalLinks;
 
   const tables = (withoutFm.match(/\|[-:]+\|/g) || []).length;
 
@@ -234,7 +240,18 @@ export async function gradePage(client: Anthropic, page: PageInfo, warningsSumma
  * - reference: rigor, completeness weighted 1.5x
  * - explainer: completeness, rigor weighted 1.5x
  *
- * Formula: weightedAvg x 8 + min(8, words/600) + min(7, citations x 0.35)
+ * Formula:
+ *   weightedAvg x 10 + min(8, words/600) + min(7, citations x 0.35)
+ *     + min(3, tables x 0.3) + min(2, diagrams x 1.0)
+ *
+ * The base multiplier is 10 (was 8) to expand the scoring range for
+ * well-rated content. The LLM prompt instructs harsh scoring (3-5 typical),
+ * so the previous multiplier of 8 created a ceiling around 55 for good pages.
+ * With 10, a page scoring 5/10 across all dimensions gets a base of 50,
+ * and a page scoring 7/10 ("exceptional") reaches 70.
+ *
+ * Structural bonuses for tables and diagrams reward well-structured
+ * technical content that was previously unrecognized.
  */
 export function computeQuality(ratings: Ratings, metrics: Metrics, frontmatter: Frontmatter = {}, relativePath: string = ''): number {
   const contentType = detectContentType(frontmatter, relativePath);
@@ -263,11 +280,14 @@ export function computeQuality(ratings: Ratings, metrics: Metrics, frontmatter: 
     actionability * weights.actionability + objectivity * weights.objectivity;
 
   const weightedAvg: number = weightedSum / totalWeight;
-  const baseScore: number = weightedAvg * 8;
+  const baseScore: number = weightedAvg * 10;
   const lengthScore: number = Math.min(8, metrics.wordCount / 600);
   const evidenceScore: number = Math.min(7, metrics.citations * 0.35);
+  // Structural bonuses: tables (max 3) and diagrams (max 2)
+  const tableScore: number = Math.min(3, metrics.tables * 0.3);
+  const diagramScore: number = Math.min(2, metrics.diagrams * 1.0);
 
-  let quality: number = baseScore + lengthScore + evidenceScore;
+  let quality: number = baseScore + lengthScore + evidenceScore + tableScore + diagramScore;
 
   if (frontmatter.pageType === 'stub') {
     quality = Math.min(quality, 35);
@@ -276,5 +296,6 @@ export function computeQuality(ratings: Ratings, metrics: Metrics, frontmatter: 
     quality = Math.min(quality, 40);
   }
 
-  return Math.round(Math.max(0, quality));
+  // Clamp to 0-100
+  return Math.round(Math.max(0, Math.min(100, quality)));
 }

--- a/crux/lib/content-integrity.test.ts
+++ b/crux/lib/content-integrity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   findFootnoteRefs,
+  countAllFootnoteRefs,
   findFootnoteDefs,
   detectOrphanedFootnotes,
   detectDuplicateFootnoteDefs,
@@ -10,6 +11,49 @@ import {
   assessContentIntegrity,
   isPlausibleArxivPrefix,
 } from './content-integrity.ts';
+
+// ---------------------------------------------------------------------------
+// countAllFootnoteRefs (named + numeric)
+// ---------------------------------------------------------------------------
+
+describe('countAllFootnoteRefs', () => {
+  it('counts named footnotes', () => {
+    const body = 'Claim[^mixtral] and another[^gpt4].';
+    expect(countAllFootnoteRefs(body)).toBe(2);
+  });
+
+  it('counts numeric footnotes', () => {
+    const body = 'Claim[^1] and another[^2] and repeated[^1].';
+    expect(countAllFootnoteRefs(body)).toBe(2); // deduped
+  });
+
+  it('counts mixed named and numeric footnotes', () => {
+    const body = 'Claim[^1] and[^mixtral] and[^2] and[^gpt4].';
+    expect(countAllFootnoteRefs(body)).toBe(4);
+  });
+
+  it('excludes named definition lines', () => {
+    const body = `Claim[^mixtral] here.
+
+[^mixtral]: This is the definition with [^gpt4] inside it.`;
+    // Only [^mixtral] from body, not [^gpt4] from definition line
+    expect(countAllFootnoteRefs(body)).toBe(1);
+  });
+
+  it('returns 0 for no footnotes', () => {
+    expect(countAllFootnoteRefs('No footnotes here.')).toBe(0);
+  });
+
+  it('handles hyphenated footnote names', () => {
+    const body = 'Claim[^gpt-4-rumors] and[^deep-seek].';
+    expect(countAllFootnoteRefs(body)).toBe(2);
+  });
+
+  it('deduplicates repeated references', () => {
+    const body = 'First[^mixtral] and second[^mixtral] and third[^mixtral].';
+    expect(countAllFootnoteRefs(body)).toBe(1);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // findFootnoteRefs

--- a/crux/lib/content-integrity.ts
+++ b/crux/lib/content-integrity.ts
@@ -34,6 +34,27 @@ export function findFootnoteRefs(body: string): Set<number> {
   return refs;
 }
 
+
+/**
+ * Count all unique footnote references (both numeric [^1] and named [^mixtral]).
+ * Used by metrics/grading code where we need a total citation count,
+ * not just numeric IDs for orphan detection.
+ */
+export function countAllFootnoteRefs(body: string): number {
+  const refs = new Set<string>();
+  // Match both numeric [^1] and named [^mixtral] footnote references
+  const pattern = /\[\^([\w-]+)\]/g;
+  for (const line of body.split('\n')) {
+    // Skip definition lines (both numeric and named)
+    if (/^\[\^[\w-]+\]:/.test(line.trim())) continue;
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(line)) !== null) {
+      refs.add(match[1]);
+    }
+  }
+  return refs.size;
+}
 /**
  * Find footnote definition numbers [^N]: at the start of lines.
  */

--- a/crux/lib/metrics-extractor.test.ts
+++ b/crux/lib/metrics-extractor.test.ts
@@ -142,6 +142,23 @@ describe('countFootnoteRefs', () => {
     const content = 'A[^1] B[^2] C[^3] D[^4] E[^5] F[^6] G[^7] H[^8] I[^9] J[^10]';
     expect(countFootnoteRefs(content)).toBe(10);
   });
+
+  it('counts named footnotes like [^mixtral]', () => {
+    const content = 'MoE claim[^mixtral] and GPT-4[^gpt4-rumors] and Switch[^switch].';
+    expect(countFootnoteRefs(content)).toBe(3);
+  });
+
+  it('counts mixed named and numeric footnotes', () => {
+    const content = 'Claim[^1] and[^mixtral] and[^2].';
+    expect(countFootnoteRefs(content)).toBe(3);
+  });
+
+  it('skips named footnote definitions', () => {
+    const content = `Text[^mixtral] here.
+
+[^mixtral]: This is the definition.`;
+    expect(countFootnoteRefs(content)).toBe(1);
+  });
 });
 
 describe('suggestQuality', () => {

--- a/crux/lib/metrics-extractor.ts
+++ b/crux/lib/metrics-extractor.ts
@@ -15,7 +15,7 @@ import {
   type VisualCounts,
 } from './visual-detection.ts';
 import { stripFrontmatter } from './patterns.ts';
-import { findFootnoteRefs } from './content-integrity.ts';
+import { countAllFootnoteRefs } from './content-integrity.ts';
 
 export type { VisualCounts } from './visual-detection.ts';
 export { countVisuals, countDiagrams, countTables } from './visual-detection.ts';
@@ -166,11 +166,15 @@ export function countExternalLinks(content: string): number {
 }
 
 /**
- * Count unique GFM footnote references [^N] (excluding definitions).
- * Delegates to findFootnoteRefs() from content-integrity.ts (DRY, issue #417).
+ * Count unique footnote references (both numeric [^1] and named [^mixtral]).
+ * Delegates to countAllFootnoteRefs() from content-integrity.ts.
+ *
+ * Previously only counted numeric footnotes via findFootnoteRefs(), which
+ * systematically undercounted citations on pages using named footnotes
+ * (175 files affected). See quality-scoring-recalibration.
  */
 export function countFootnoteRefs(content: string): number {
-  return findFootnoteRefs(content).size;
+  return countAllFootnoteRefs(content);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes three systematic biases in `computeQuality` that were causing well-structured technical pages to be severely underrated. The audit found E500 (Sparse/MoE Transformers) scored 55 when structural analysis suggested 87.

**Root causes found and fixed:**

- **Named footnotes invisible to citation counting**: `findFootnoteRefs` only matched numeric `[^1]` patterns, completely missing named footnotes like `[^mixtral]`. 175 files use named footnotes. Added `countAllFootnoteRefs()` that handles both types.

- **Base score multiplier too low (8)**: The LLM prompt instructs harsh scoring (3-5 = typical). With multiplier 8, a page scoring 5/10 across all dimensions could only reach base 40, creating a ceiling of ~55 with bonuses. Increased to 10 so the same ratings yield base 50, and "exceptional" 7/10 ratings reach 70.

- **Tables and diagrams had zero weight**: A page with 19 tables and Mermaid diagrams got no quality credit for them. Added structural bonuses: tables (max +3) and diagrams (max +2).

- **External links not counted as evidence**: `computeMetrics` only counted `<R>` components and footnote refs as citations, missing external markdown links (E500 has 55 external links).

**New scoring formula:**
```
quality = weightedAvg * 10 + min(8, words/600) + min(7, citations * 0.35)
        + min(3, tables * 0.3) + min(2, diagrams * 1.0)
```

## Test plan

- [x] All 3208 crux tests pass
- [x] All 828 web tests pass
- [x] New `countAllFootnoteRefs` tests cover named, numeric, mixed, hyphenated, deduplication, and definition-line exclusion
- [x] New `computeQuality` tests verify mid/high/low ratings, stub caps, structural bonuses, content type weighting, and 0-100 clamping
- [x] New `computeMetrics` tests verify named footnotes, external links, R components, and mixed citation types

🤖 Generated with [Claude Code](https://claude.com/claude-code)