### PR TITLE
docs: add PG-primary vs YAML guidance to CLAUDE.md

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,6 +15,9 @@
 - **Array spread overflow**: `array.push(...largeArray)` causes "Maximum call stack size exceeded" when `largeArray` has >65k elements. Use a for-of loop instead.
 - **Vercel ignoreCommand exit codes are counterintuitive**: Exit 0 = **skip** build, exit 1 = **proceed** with build. The command answers "should I ignore?", so 0 (success/yes) means skip. This has been incorrectly inverted multiple times. See `apps/web/vercel.json`.
 
+## Feedback
+- [PG-primary for new features](feedback_pg_primary_for_new_features.md) — strongly prefer PG tables over YAML for new features with dedicated UI/directory pages
+
 ## Architecture Notes
 - **SCRY_PUBLIC_KEY** is defined in `crux/lib/api-keys.ts`. All consumers import from there (consolidated Feb 2026).
 - **crux/ import direction**: `lib → authoring`, never `authoring → lib`.

--- a/.claude/memory/feedback_pg_primary_for_new_features.md
+++ b/.claude/memory/feedback_pg_primary_for_new_features.md
@@ -1,0 +1,11 @@
+---
+name: PG-primary for new features with dedicated UI
+description: Strongly prefer PG-primary tables over YAML entities when building new features with dedicated directory pages and structured data
+type: feedback
+---
+
+Strongly prefer PG-primary tables (grants/investments/funding-rounds/benchmarks pattern) for new features with dedicated UI/directory pages.
+
+**Why:** When asked to design a "political races" feature, I defaulted to the YAML entity pattern (data/entities/*.yaml) because most entity types use it. The user had to redirect me to the PG-primary pattern, which was clearly a better fit for structured relational data with numeric aggregation, many-to-many relationships, and its own directory page.
+
+**How to apply:** When designing storage for a new data type, ask: does it have numeric fields to sort/aggregate? Many-to-many relationships? Its own directory page? If yes to any, use PG-primary tables following the grants/investments pattern — not YAML entities. YAML entities are for lightweight catalog entries (link targets, wiki page metadata). Added guidance to CLAUDE.md Entity Directory Pages section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Entity types without directories (too abstract or sparse for tables): `risk`, `c
 
 Adding a new directory requires: schema in `entity-schemas.ts`, transform in `entity-transform.mjs`, route in `entity-nav.ts`, and App Router pages.
 
+**YAML entities vs PG-primary tables**: Strongly prefer PG-primary tables for new features with dedicated UI/directory pages and structured relational data (the grants, investments, funding-rounds, benchmarks, divisions pattern). YAML entities (`data/entities/`) are for lightweight catalog entries that mainly serve as link targets or wiki page metadata. If the data has numeric fields to aggregate, many-to-many relationships, or its own directory page — use PG.
+
 ## Data Layer Terminology — Three Bases
 
 | Name | What it is | Key files |


### PR DESCRIPTION
## Summary
- Adds guidance to CLAUDE.md clarifying when to use PG-primary tables vs YAML entities for new features
- Rule: strongly prefer PG-primary tables (grants/investments/funding-rounds pattern) for new features with dedicated UI/directory pages and structured relational data
- Adds corresponding feedback memory for cross-session recall

## Context
During a design session for political race tracking, the agent defaulted to YAML entities when PG-primary tables were clearly the better fit. The user had to redirect. This guidance prevents that wasted iteration in future sessions.

## Test plan
- [x] Documentation-only change, no code impact
- [x] CLAUDE.md renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)