### PR TITLE
fix: defensive null checks for E927 System Health dashboard

### DIFF
--- a/apps/web/src/app/internal/__tests__/system-health-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/system-health-content.test.tsx
@@ -120,6 +120,37 @@ const mockExtendedData = {
       model: "claude-opus-4-6",
     },
   ],
+  migrations: {
+    appliedCount: 48,
+    expectedCount: 48,
+    inSync: true,
+    recent: [{ id: 48, hash: "abc123", createdAt: "2025-01-01T10:00:00Z" }],
+  },
+  deploys: {
+    recent: [
+      {
+        id: 1,
+        status: "completed",
+        conclusion: "success",
+        createdAt: "2025-01-01T10:00:00Z",
+        headSha: "abc12345def67890",
+        runNumber: 100,
+        durationSeconds: 300,
+      },
+    ],
+  },
+  agentActivity: {
+    activeNow: 1,
+    sessionsThisWeek: 5,
+    prsThisWeek: 3,
+    completedThisWeek: 4,
+    completionRate: 80,
+  },
+  apiKeys: {
+    github: { configured: true, healthy: true },
+    anthropic: { configured: true, healthy: true },
+    openrouter: { configured: true, healthy: false },
+  },
 };
 
 const mockOpenPRs = {
@@ -423,6 +454,66 @@ describe("SystemHealthContent", () => {
       data: mockExtendedData,
     });
     vi.mocked(fetchFromWikiServer).mockResolvedValue(conflictingPRs);
+
+    const element = await SystemHealthContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when agentActivity is null in extended data", async () => {
+    const extendedWithNullActivity = {
+      ...mockExtendedData,
+      agentActivity: null,
+    };
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockMonitoringStatus,
+      source: "api" as const,
+    });
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: extendedWithNullActivity,
+    });
+    vi.mocked(fetchFromWikiServer).mockResolvedValue({ pulls: [] });
+
+    const element = await SystemHealthContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when agentActivity is undefined in extended data (server version mismatch)", async () => {
+    // Simulates a server that doesn't have the agentActivity field yet
+    const { agentActivity: _, ...extendedWithoutActivity } = mockExtendedData;
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockMonitoringStatus,
+      source: "api" as const,
+    });
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: extendedWithoutActivity as typeof mockExtendedData,
+    });
+    vi.mocked(fetchFromWikiServer).mockResolvedValue({ pulls: [] });
+
+    const element = await SystemHealthContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when extended data has null migrations and deploys", async () => {
+    const extendedWithNulls = {
+      ...mockExtendedData,
+      migrations: null,
+      deploys: null,
+      apiKeys: null,
+    };
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockMonitoringStatus,
+      source: "api" as const,
+    });
+    vi.mocked(fetchDetailed).mockResolvedValue({
+      ok: true,
+      data: extendedWithNulls,
+    });
+    vi.mocked(fetchFromWikiServer).mockResolvedValue({ pulls: [] });
 
     const element = await SystemHealthContent();
     expect(element).toBeTruthy();

--- a/apps/web/src/app/internal/system-health/system-health-content.tsx
+++ b/apps/web/src/app/internal/system-health/system-health-content.tsx
@@ -433,7 +433,7 @@ function GroundskeeperSection({
 }: {
   tasks: ExtendedHealthData["groundskeeperTasks"];
 }) {
-  if (tasks.length === 0) {
+  if (!tasks || tasks.length === 0) {
     return (
       <>
         <SectionHeader>Groundskeeper Tasks (last 24h)</SectionHeader>
@@ -551,6 +551,17 @@ function IntegritySection({
 }: {
   integrity: ExtendedHealthData["integrity"];
 }) {
+  if (!integrity) {
+    return (
+      <>
+        <SectionHeader>Data Integrity</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          Integrity data unavailable
+        </div>
+      </>
+    );
+  }
+
   const isClean = integrity.status === "clean";
   const isError = integrity.status === "error";
 
@@ -602,6 +613,17 @@ function AutoUpdateSection({
 }: {
   autoUpdate: ExtendedHealthData["autoUpdate"];
 }) {
+  if (!autoUpdate) {
+    return (
+      <>
+        <SectionHeader>Auto-Update System</SectionHeader>
+        <div className="rounded-lg border border-border/60 p-4 text-muted-foreground text-sm mb-6">
+          Auto-update data unavailable
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <SectionHeader>Auto-Update System</SectionHeader>
@@ -1020,6 +1042,8 @@ function BrokenEntityLinksSection({ data }: { data: BrokenEntityLinksData | null
 }
 
 function AgentActivitySection({ activity }: { activity: ExtendedHealthData["agentActivity"] | undefined }) {
+  // Defensive null check — during CI prerendering the API may return
+  // extended data without agentActivity (e.g. server version mismatch).
   if (!activity) {
     return (
       <>
@@ -1030,28 +1054,30 @@ function AgentActivitySection({ activity }: { activity: ExtendedHealthData["agen
       </>
     );
   }
+
+
   return (
     <>
       <SectionHeader>Agent Activity (last 7 days)</SectionHeader>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
         <StatCard
           label="Active Now"
-          value={activity.activeNow}
-          colorClass={activity.activeNow > 0 ? "text-green-600" : ""}
+          value={activity.activeNow ?? 0}
+          colorClass={(activity.activeNow ?? 0) > 0 ? "text-green-600" : ""}
         />
         <StatCard
           label="Sessions (7d)"
-          value={activity.sessionsThisWeek}
+          value={activity.sessionsThisWeek ?? 0}
         />
         <StatCard
           label="PRs Created (7d)"
-          value={activity.prsThisWeek}
+          value={activity.prsThisWeek ?? 0}
         />
         <StatCard
           label="Completion Rate (7d)"
-          value={activity.completionRate !== null ? `${activity.completionRate}%` : null}
+          value={activity.completionRate != null ? `${activity.completionRate}%` : null}
           colorClass={
-            activity.completionRate !== null
+            activity.completionRate != null
               ? activity.completionRate >= 80
                 ? "text-green-600"
                 : activity.completionRate >= 50
@@ -1240,7 +1266,7 @@ export async function SystemHealthContent() {
       )}
 
       {/* Agent Activity Summary */}
-      {extended?.agentActivity ? (
+      {extended ? (
         <AgentActivitySection activity={extended.agentActivity} />
       ) : extendedError ? (
         <SectionUnavailable title="Agent Activity (last 7 days)" error={extendedError} />


### PR DESCRIPTION
## Summary
- Add defensive null guards to `AgentActivitySection`, `IntegritySection`, `GroundskeeperSection`, and `AutoUpdateSection` so they render a graceful fallback instead of crashing when the wiki-server API returns data missing expected fields (e.g. server version mismatch during CI builds)
- Use nullish coalescing (`??`) for individual field access inside `AgentActivitySection` as a belt-and-suspenders measure against `undefined` values
- Update test mock data to include all fields added by PR #2481 (`migrations`, `deploys`, `agentActivity`, `apiKeys`)
- Add 3 new test cases covering null `agentActivity`, undefined `agentActivity` (server version mismatch), and null `migrations`/`deploys`/`apiKeys`

## Test plan
- [x] All 13 tests pass in `system-health-content.test.tsx` (10 existing + 3 new)
- [x] TypeScript compiles without errors
- [x] Full `pnpm build` succeeds with E927 prerendering cleanly
- [x] All 17 gate checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)