### PR TITLE
fix: review follow-up cleanup (3 minor fixes)

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -636,7 +636,29 @@ function extractPrNumber(prUrl) {
   return m ? parseInt(m[1], 10) : undefined;
 }
 
-// maxDate was removed — see lastUpdated fallback chain comment in buildPagesRegistry.
+/**
+ * Resolve the last-updated date for a page using a priority fallback chain.
+ *
+ * Priority:
+ *   1. frontmatter `lastEdited` (set by content editing tools)
+ *   2. frontmatter `lastUpdated` (legacy field)
+ *   3. edit log date from wiki-server
+ *   4. git modified date (last resort — includes metadata-only commits)
+ *
+ * @param {object} fm           - parsed frontmatter object
+ * @param {string|null} editLogDate - date string from wiki-server edit logs
+ * @param {string|null} gitDate     - date string from git modified map
+ * @returns {string|null}
+ */
+function resolveLastUpdated(fm, editLogDate, gitDate) {
+  return toDateString(fm.lastEdited)
+    || toDateString(fm.lastUpdated)
+    || editLogDate
+    || gitDate
+    || null;
+}
+
+// maxDate was removed — see resolveLastUpdated above.
 // dateCreated already uses a fallback chain (resolveDateCreated in git-date-utils.mjs).
 
 /**
@@ -1948,17 +1970,12 @@ function buildPagesRegistry(urlToResource, editLogDates, gitDateMaps, earliestEd
           // Content format: article (default), table, diagram, index, dashboard
           contentFormat: fm.contentFormat || 'article',
           causalLevel: fm.causalLevel || null,
-          // Use a fallback chain instead of maxDate to avoid metadata-only
-          // git commits (e.g. bulk frontmatter reformatting) from overriding
-          // the actual content change date with today's date.
-          // Priority: frontmatter lastEdited (set by content editing tools)
-          //   → frontmatter lastUpdated (legacy) → edit log date (wiki-server)
-          //   → git modified date (last resort, includes metadata commits).
-          lastUpdated: toDateString(fm.lastEdited)
-            || toDateString(fm.lastUpdated)
-            || editLogDates.get(isIndexFile ? null : id)
-            || gitModifiedMap.get(relative(REPO_ROOT, fullPath))
-            || null,
+          // Fallback chain — see resolveLastUpdated() for priority order.
+          lastUpdated: resolveLastUpdated(
+            fm,
+            editLogDates.get(isIndexFile ? null : id),
+            gitModifiedMap.get(relative(REPO_ROOT, fullPath)),
+          ),
           // Derive creation date: prefer explicit frontmatter, then non-bulk git
           // first-commit, then earliest edit log from wiki-server, then legacy
           // frontmatter. Bulk-import git dates are already filtered out of

--- a/apps/web/src/app/internal/entities/entities-content.tsx
+++ b/apps/web/src/app/internal/entities/entities-content.tsx
@@ -5,6 +5,9 @@ import type { UnifiedEntityRow } from "./entities-data-table";
 /**
  * Compute "Next Best Action" priority score for a page.
  * priority = importance * qualityDeficit * stalenessFactor * riskFactor
+ *
+ * Priority formula duplicated from crux/lib/next-best-action.ts — keep in sync.
+ * Cross-package import not feasible (crux/ cannot be imported into apps/web/).
  */
 function computePriorityScore(row: {
   quality: number | null;

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -243,7 +243,7 @@ function loadFromLocal(): PersonRow[] {
       positionCount,
       topics,
       publicationCount: publications.length,
-      careerHistoryCount: careerHistory.length,
+      careerHistoryCount: getLocalCareerCount(entity.id),
       searchText: searchParts.join(" ").toLowerCase(),
     };
   });


### PR DESCRIPTION
## Summary

Three small review follow-up fixes bundled into one cleanup PR:

- **Fix 1 — People page career count consistency**: In `loadFromLocal()`, the `careerHistoryCount` field was using `careerHistory.length` (raw records array) instead of `getLocalCareerCount(entity.id)`, which is what the API fallback path uses. The helper takes the max of career-history records and employed-by facts, so both code paths now produce consistent counts.

- **Fix 2 — Priority formula cross-reference comment**: The `computePriorityScore` function in `entities-content.tsx` duplicates the formula from `crux/lib/next-best-action.ts`. Added a comment noting the duplication and why a cross-package import is not feasible.

- **Fix 3 — Extract `resolveLastUpdated` helper**: The inline `lastUpdated` fallback chain in `buildPagesRegistry` (4-level `||` chain) is now a named `resolveLastUpdated(fm, editLogDate, gitDate)` function, making it independently testable and easier to read.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` passes (150 files, 3208 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal date resolution logic for consistency across data sources.
  * Optimized career history count calculation to align local and API data handling.

* **Documentation**
  * Added clarification on priority score computation methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->