### PR TITLE
fix: factbase pages missing — content dir not in scanner list

### DIFF
--- a/apps/web/scripts/lib/content-types.mjs
+++ b/apps/web/scripts/lib/content-types.mjs
@@ -162,6 +162,6 @@ export const TOP_LEVEL_CONTENT_DIRS = [
   'insight-hunting',
   'dashboard',
   'project',
-  'kb',
+  'factbase',
   'sources',
 ];


### PR DESCRIPTION
## Summary

- The KB→FactBase rename (6adf9fb) moved `content/docs/kb/` to `content/docs/factbase/` but didn't update `TOP_LEVEL_CONTENT_DIRS` in `content-types.mjs`
- This caused all 5 factbase pages (E1019 index, facts, properties, records, entity-coverage) to be excluded from `database.json`
- Result: `/wiki/E1019` returns 404 in production, and `/factbase` redirects to a nonexistent page

One-line fix: `'kb'` → `'factbase'` in the content scanner list.

Agent slot: a1

## Test plan

- [x] Verified `content/docs/kb/` no longer exists and `content/docs/factbase/` has 5 MDX files
- [x] No other references to old `'kb'` content dir in build scripts
- [ ] After merge: verify `/wiki/E1019` loads on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)