### PR TITLE
chore: maintenance sweep — close stale issues, fix AISI entity data

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -5,6 +5,8 @@
   stableId: aCEdTooCBw
   wikiId: E13
   type: policy
+  policyStatus: active
+  introduced: "2023-11"
   summaryPage: governance-overview
   title: AI Safety Institutes (AISIs)
   customFields:


### PR DESCRIPTION
## Summary

Periodic maintenance sweep covering:

- **Closed #2510**: CI broken on main — already resolved by merge of #2506, verified and closed
- **Commented on #2463**: Parallel patrol stale labels — PR #2455 partially fixed (criterion 3 of 3), noted remaining work
- **Fixed AISI entity data**: Added missing `policyStatus: active` and `introduced: "2023-11"` fields to AI Safety Institutes (E13), resolving directory-pages validator warning about non-standard date format
- **Verified**: Gate passes (22/22 checks), tests pass (3208/3208), CI green on main

## Test plan
- [x] `pnpm crux validate gate --fix` passes
- [x] `pnpm test` passes
- [x] Directory-pages validator no longer flags AISI bad date format

Closes #2510
