### PR TITLE
fix: hide legislative pipeline bar for non-legislative policy entities

### DIFF
--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -117,6 +117,16 @@ export default async function LegislationDetailPage({
 
   const reachedStage = getReachedStage(timelineEvents, statusKey);
 
+  // Only show the pipeline bar if the entity has actual legislative process data.
+  // Frameworks, declarations, and voluntary commitments have policyStatus: active
+  // which maps to "in-effect", but they are not legislation and have no timeline
+  // events, votes, or amendments — so the pipeline would falsely show "Enacted".
+  const hasLegislativeProcessData =
+    timelineEvents.length > 0 ||
+    entity.votes.length > 0 ||
+    entity.amendments.length > 0;
+  const showPipelineBar = reachedStage >= 0 && hasLegislativeProcessData;
+
   // ── Build tabs ────────────────────────────────────────────
   const tabs: ProfileTab[] = [];
 
@@ -124,7 +134,7 @@ export default async function LegislationDetailPage({
   const overviewContent = (
     <div className="space-y-8">
       {/* Status pipeline */}
-      {reachedStage >= 0 && (
+      {showPipelineBar && (
         <div className="flex items-center gap-1 overflow-x-auto pb-2">
           {PIPELINE_STAGES.map((stage, i) => {
             const reached = i <= reachedStage;


### PR DESCRIPTION
## Summary
- Gate the pipeline bar on presence of actual legislative process data (timeline events, votes, or amendments)
- Frameworks, declarations, and voluntary commitments with `policyStatus: active` mapped to `"in-effect"`, which caused `getReachedStage()` to return stage 4 (Enacted), incorrectly showing a fully-completed "Enacted" pipeline bar for ~18 non-legislative entities
- Bletchley Declaration, NIST AI RMF, voluntary commitments, and similar entities no longer show the misleading legislative pipeline

## Test plan
- [x] TypeScript type check passes — no new errors in the changed file
- [x] Confirmed `634` vitest tests all pass (20 test file failures are pre-existing worktree env issues, unrelated to this change)
- [ ] Manual: verify pipeline bar still shows on SB 1047, EU AI Act (real legislation with timeline events/votes)
- [ ] Manual: verify pipeline bar hidden on Bletchley Declaration, NIST AI RMF, voluntary commitments

Closes #2517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
