### PR TITLE
fix: scan only MDX frontmatter for wikiId duplicates, not code blocks

### DIFF
--- a/crux/qa-sweep/sweep.ts
+++ b/crux/qa-sweep/sweep.ts
@@ -121,14 +121,22 @@ function checkDuplicateWikiIds(): CheckResult {
     }
   } catch { /* empty */ }
 
-  // Scan MDX frontmatter
+  // Scan MDX frontmatter only (lines between the first --- delimiters, not code blocks)
   try {
-    const mdxOutput = run(`grep -rh 'wikiId:' ${contentDir} --include='*.mdx' --include='*.md'`);
-    for (const line of mdxOutput.split('\n')) {
-      const match = line.match(/wikiId:\s*"?(E\d+)"?/);
-      if (match) {
-        mdxIds.set(match[1], (mdxIds.get(match[1]) ?? 0) + 1);
-      }
+    const mdxFiles = run(`find ${contentDir} -type f \\( -name '*.mdx' -o -name '*.md' \\)`);
+    for (const filePath of mdxFiles.split('\n').filter(Boolean)) {
+      try {
+        const content = readFileSync(filePath, 'utf-8');
+        // Extract only the YAML frontmatter block (between first pair of ---)
+        const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        if (!frontmatterMatch) continue;
+        for (const line of frontmatterMatch[1].split('\n')) {
+          const match = line.match(/^wikiId:\s*"?(E\d+)"?/);
+          if (match) {
+            mdxIds.set(match[1], (mdxIds.get(match[1]) ?? 0) + 1);
+          }
+        }
+      } catch { /* skip unreadable files */ }
     }
   } catch { /* empty */ }
 


### PR DESCRIPTION
## Summary

- The `qa-sweep` duplicate wikiId check was a false positive: it grepped all lines in MDX files, so the code block example `wikiId: "E22"` inside `content/docs/internal/structured-data-architecture.mdx` (a documentation page showing an example YAML entity) was being counted alongside the actual `wikiId: E22` in `content/docs/knowledge-base/organizations/anthropic.mdx`
- Fixed the check to read each MDX file and extract only the YAML frontmatter block (between the first `---` delimiters) before scanning for wikiId values
- After the fix, `crux qa-sweep checks` reports "958 unique IDs, no duplicates within sources" and passes cleanly

## Test plan

- [x] `pnpm crux qa-sweep checks` passes with no duplicate wikiId errors
- [x] `pnpm crux validate gate --scope=content --fix` passes all 4 checks
- [x] `structured-data-architecture.mdx` code block example no longer causes false positive

Closes #2532

🤖 Generated with [Claude Code](https://claude.com/claude-code)
