### PR TITLE
fix: add LIMIT and entityType allowlist to GET /api/entities/directory

### DIFF
--- a/apps/wiki-server/src/__tests__/entities.test.ts
+++ b/apps/wiki-server/src/__tests__/entities.test.ts
@@ -554,6 +554,61 @@ describe("Entities API", () => {
     });
   });
 
+  // ---- Directory endpoint ----
+
+  describe("GET /api/entities/directory", () => {
+    it("returns entities for a valid entityType", async () => {
+      await seedEntity(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+      });
+      await seedEntity(app, "openai", "OpenAI", {
+        entityType: "organization",
+      });
+
+      const res = await app.request(
+        "/api/entities/directory?entityType=organization"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body.entities)).toBe(true);
+      expect(body.total).toBeGreaterThanOrEqual(0);
+    });
+
+    it("rejects unknown entityType with 400", async () => {
+      const res = await app.request(
+        "/api/entities/directory?entityType=unknown-type-xyz"
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("Unknown entityType");
+      expect(body.error).toContain("unknown-type-xyz");
+    });
+
+    it("rejects SQL-injection-style entityType with 400", async () => {
+      const res = await app.request(
+        "/api/entities/directory?entityType='; DROP TABLE entities;--"
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("accepts a valid alias entityType", async () => {
+      await seedEntity(app, "researcher-1", "A Researcher", {
+        entityType: "researcher",
+      });
+
+      // "researcher" is a known alias — should be accepted (200), not rejected
+      const res = await app.request(
+        "/api/entities/directory?entityType=researcher"
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("requires entityType parameter", async () => {
+      const res = await app.request("/api/entities/directory");
+      expect(res.status).toBe(400);
+    });
+  });
+
   // ---- Auth ----
 
   describe("Bearer auth", () => {

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -25,6 +25,59 @@ import { buildSearchCondition, parseSort } from "../shared/query-helpers.js";
 
 const MAX_PAGE_SIZE = 500;
 
+/** Maximum number of entities returned by the /directory endpoint. */
+const DIRECTORY_MAX_ENTITIES = 2000;
+
+/**
+ * Valid entity type names accepted by the /directory endpoint.
+ * Mirrors CANONICAL_ENTITY_TYPE_NAMES + ENTITY_TYPE_ALIAS_NAMES from
+ * apps/web/src/data/entity-type-names.ts — keep in sync when adding types.
+ */
+const VALID_DIRECTORY_ENTITY_TYPES = new Set([
+  // Canonical types
+  "risk",
+  "risk-factor",
+  "capability",
+  "safety-agenda",
+  "approach",
+  "project",
+  "policy",
+  "organization",
+  "crux",
+  "concept",
+  "case-study",
+  "person",
+  "resource",
+  "historical",
+  "analysis",
+  "parameter",
+  "argument",
+  "table",
+  "diagram",
+  "event",
+  "debate",
+  "overview",
+  "intelligence-paradigm",
+  "internal",
+  "ai-model",
+  "benchmark",
+  "research-area",
+  // Aliases (legacy / alternate names)
+  "researcher",
+  "lab",
+  "lab-frontier",
+  "lab-research",
+  "lab-startup",
+  "lab-academic",
+  "funder",
+  "safety-approaches",
+  "policies",
+  "concepts",
+  "events",
+  "models",
+  "model",
+]);
+
 // ---- Schemas (from shared api-types) ----
 
 const SyncEntitySchema = SharedSyncEntitySchema;
@@ -293,14 +346,25 @@ const entitiesApp = new Hono()
   // Returns all entities of a type with their latest facts for directory pages.
   .get("/directory", zv("query", DirectoryQuery), async (c) => {
     const { entityType, measures } = c.req.valid("query");
+
+    // Reject unknown entity types to prevent arbitrary string injection and
+    // to surface misconfigured callers early.
+    if (!VALID_DIRECTORY_ENTITY_TYPES.has(entityType)) {
+      return c.json(
+        { error: `Unknown entityType: "${entityType}". Must be one of the known entity types.` },
+        400
+      );
+    }
+
     const db = getDrizzleDb();
 
-    // 1. Get all entities of the requested type
+    // 1. Get all entities of the requested type (capped to prevent unbounded scans)
     const entityRows = await db
       .select()
       .from(entities)
       .where(eq(entities.entityType, entityType))
-      .orderBy(asc(entities.title));
+      .orderBy(asc(entities.title))
+      .limit(DIRECTORY_MAX_ENTITIES);
 
     // 2. Get latest facts for these entities (if measures requested)
     const measureList = measures


### PR DESCRIPTION
## Summary

- Added `DIRECTORY_MAX_ENTITIES = 2000` limit to the entity SELECT query in the `/api/entities/directory` endpoint to prevent unbounded full-table scans
- Added `VALID_DIRECTORY_ENTITY_TYPES` allowlist (mirrors `CANONICAL_ENTITY_TYPE_NAMES + ENTITY_TYPE_ALIAS_NAMES` from `apps/web/src/data/entity-type-names.ts`) and returns HTTP 400 for unknown entity types
- Added 5 unit tests covering: valid type returns 200, unknown type returns 400 with informative error, SQL injection-style type is rejected, alias type is accepted, missing parameter returns 400

## Why

Without a LIMIT, a request for a common entity type (e.g. `analysis`) could fetch hundreds of rows with zero throttling. Without an allowlist, the `entityType` parameter accepts arbitrary strings that get interpolated into Drizzle ORM queries — even though Drizzle parameterizes the actual value, rejecting unknown types provides defense-in-depth and surfaces misconfigured callers immediately.

## Test plan

- [x] New unit tests for `/directory` endpoint cover: valid type, unknown type (400), SQL-injection string (400), alias type (200), missing param (400)
- [x] All 24 pre-existing entities test suite tests pass
- [x] TypeScript check shows no new errors in `entities.ts`
- [x] `pnpm build` data pipeline completes successfully

Closes #2525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
