### PR TITLE
fix: add action logging before DELETE /api/pages/:id

### DIFF
--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -229,8 +229,15 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return filtered.slice(offset, offset + limit);
   }
 
-  // --- wiki_pages: DELETE WHERE id = ? RETURNING id ---
-  if (q.includes("delete from") && q.includes("wiki_pages") && q.includes("returning")) {
+  // --- wiki_pages: SELECT WHERE id = ? (no OR — pre-delete fetch) ---
+  if (q.includes("wiki_pages") && q.includes("where") && !q.includes(" or ") && !q.includes("count(*)") && !q.includes("order by") && !q.includes("search_vector") && !q.includes("similarity") && !q.includes("delete from") && !q.includes("entity_ids")) {
+    const id = params[0] as string;
+    const row = pagesStore.get(id);
+    return row ? [row] : [];
+  }
+
+  // --- wiki_pages: DELETE WHERE id = ? (with or without RETURNING) ---
+  if (q.includes("delete from") && q.includes("wiki_pages")) {
     const id = params[0] as string;
     if (pagesStore.has(id)) {
       pagesStore.delete(id);

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -11,6 +11,7 @@ import {
   dbError,
   paginationQuery,
 } from "../shared/utils.js";
+import { logger } from "../../logger.js";
 import {
   SyncPageSchema as SharedSyncPageSchema,
   SyncPagesBatchSchema,
@@ -256,16 +257,23 @@ const pagesApp = new Hono()
 
     const db = getDrizzleDb();
 
-    const deleted = await db
-      .delete(wikiPages)
-      .where(eq(wikiPages.id, id))
-      .returning({ id: wikiPages.id });
+    // Fetch the page before deleting so we can log identifying info.
+    // Per code-review-guidelines: destructive endpoints must log before executing.
+    const existing = await db
+      .select({ id: wikiPages.id, wikiId: wikiPages.wikiId, title: wikiPages.title })
+      .from(wikiPages)
+      .where(eq(wikiPages.id, id));
 
-    if (deleted.length === 0) {
+    if (existing.length === 0) {
       return notFoundError(c, `No page found for id: ${id}`);
     }
 
-    return c.json({ deleted: deleted.length });
+    const page = existing[0];
+    logger.info({ pageId: page.id, wikiId: page.wikiId, title: page.title }, "Deleting page");
+
+    await db.delete(wikiPages).where(eq(wikiPages.id, id));
+
+    return c.json({ deleted: 1 });
   })
 
   // ---- POST /sync ----


### PR DESCRIPTION
## Summary
- Added pre-delete logging to the `DELETE /api/pages/:id` endpoint in `apps/wiki-server/src/routes/wikibase/pages.ts`
- Before deleting, the handler now fetches the page (id, wikiId, title) and logs it via the pino logger at `info` level
- Updated the test mock in `pages.test.ts` to handle the new SELECT-then-DELETE pattern (no `RETURNING` clause)
- Follows the code review guideline: "Destructive endpoints (DELETE, bulk UPDATE) must log actions before executing"

## Test plan
- [x] `pnpm build` passes (TypeScript compiles clean)
- [x] `pnpm test` — all 3209 tests pass, including `DELETE /api/pages/:id` tests
- [x] Verified logger import pattern matches `grants.ts` reference implementation

Closes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)