### PR TITLE
fix: legislation entity data quality — wrong types, links, and status values

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -40,7 +40,7 @@
   wikiId: E8
   type: policy
   summaryPage: governance-overview
-  title: AI Executive Order (deprecated alias — see us-executive-order)
+  title: AI Executive Order
   policyStatus: revoked
   deprecated: true
   deprecatedInFavorOf: us-executive-order


### PR DESCRIPTION
## Summary

- Fixed `uk-aisi` type from `policy` → `organization` in `relatedEntries` of `eu-ai-act`, `us-executive-order`, and `international-summits` (uk-aisi is an organization, not a policy)
- Fixed Colorado AI Act stakeholder: removed `entityId: deepmind` from Google stakeholder (Google ≠ Google DeepMind; no standalone `google` entity exists)
- Fixed Colorado AI Act source URL: `sb21-205` → `sb24-205` (correct bill number)
- Fixed `failed-stalled-proposals` `policyStatus: active` → `proposed` (this is an analysis page covering failed/stalled proposals, not an active policy itself)
- Normalized `standards-bodies`: added `policyStatus: active` and changed custom Status field from free-text "Rapidly developing" to "Active"
- Marked `ai-executive-order` (E8) as deprecated alias for `us-executive-order` (E366), which is the full page for EO 14110; kept for backward-compat link resolution

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` passes (all 4 gate checks green)
- [x] No MDX or YAML schema errors

Closes #2518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
