### PR TITLE
fix: hide always-empty Sources column from legislation index

### DIFF
--- a/apps/web/src/app/legislation/legislation-table.tsx
+++ b/apps/web/src/app/legislation/legislation-table.tsx
@@ -18,7 +18,6 @@ export interface LegislationRow {
   scope: string | null;
   description: string | null;
   tags: string[];
-  sourceCount: number;
 }
 
 type SortKey =
@@ -26,8 +25,7 @@ type SortKey =
   | "introduced"
   | "status"
   | "author"
-  | "scope"
-  | "sources";
+  | "scope";
 
 export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
   const [search, setSearch] = useState("");
@@ -102,8 +100,6 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
           return (row.author ?? "").toLowerCase();
         case "scope":
           return (row.scope ?? "").toLowerCase();
-        case "sources":
-          return row.sourceCount;
       }
     };
     result = [...result].sort((a, b) =>
@@ -243,14 +239,6 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
                 onSort={handleSort}
                 className="text-left"
               />
-              <SortHeader
-                label="Sources"
-                sortKey="sources"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={handleSort}
-                className="text-right"
-              />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -316,15 +304,6 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
                 {/* Introduced */}
                 <td className="py-2.5 px-3 text-muted-foreground whitespace-nowrap">
                   {row.introduced ?? (
-                    <span className="text-muted-foreground/40">&mdash;</span>
-                  )}
-                </td>
-
-                {/* Sources */}
-                <td className="py-2.5 px-3 text-right tabular-nums text-muted-foreground">
-                  {row.sourceCount > 0 ? (
-                    row.sourceCount
-                  ) : (
                     <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>

--- a/apps/web/src/app/legislation/page.tsx
+++ b/apps/web/src/app/legislation/page.tsx
@@ -78,8 +78,6 @@ function apiEntityToRow(e: DirectoryEntity): LegislationRow {
     scope,
     description: e.description ?? null,
     tags: e.tags ?? [],
-    // sources column is not included in directory API response; sourceCount unavailable
-    sourceCount: 0,
   };
 }
 
@@ -118,7 +116,6 @@ function loadFromLocal(): LegislationPageData {
       scope,
       description: entity.description ?? null,
       tags: entity.tags,
-      sourceCount: entity.sources.length,
     };
   });
 


### PR DESCRIPTION
## Summary
- Removed the Sources column from the legislation directory table
- The column showed 0/— for all 40 rows because the API path hardcodes `sourceCount: 0` (the directory API endpoint doesn't return source counts)
- Declutters the table and removes misleading empty data
- Also cleaned up the now-unused `sourceCount` field from `LegislationRow` interface and the local data loading path

## Test plan
- [x] TypeScript: no errors in legislation files
- [x] Visual: Sources column no longer appears in the legislation table at `/legislation`
- [x] No regressions: other table columns (Status, Scope, Author, Introduced) still sort and filter correctly

Closes #2527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
