### PR TITLE
fix: normalize legislation introduced date display and fix prose date value

### DIFF
--- a/apps/web/src/app/legislation/legislation-table.tsx
+++ b/apps/web/src/app/legislation/legislation-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { STATUS_COLORS, SCOPE_COLORS, normalizeStatus } from "./legislation-constants";
+import { formatIntroducedDate } from "@/lib/format-compact";
 
 export interface LegislationRow {
   id: string;
@@ -315,7 +316,7 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
 
                 {/* Introduced */}
                 <td className="py-2.5 px-3 text-muted-foreground whitespace-nowrap">
-                  {row.introduced ?? (
+                  {formatIntroducedDate(row.introduced) ?? (
                     <span className="text-muted-foreground/40">&mdash;</span>
                   )}
                 </td>

--- a/apps/web/src/lib/__tests__/format-compact.test.ts
+++ b/apps/web/src/lib/__tests__/format-compact.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { formatIntroducedDate } from "../format-compact";
+
+describe("formatIntroducedDate", () => {
+  describe("year-only format", () => {
+    it("returns year as-is for 4-digit year", () => {
+      expect(formatIntroducedDate("2021")).toBe("2021");
+    });
+
+    it("returns year as-is for recent year", () => {
+      expect(formatIntroducedDate("2024")).toBe("2024");
+    });
+
+    it("returns year as-is for older year", () => {
+      expect(formatIntroducedDate("2019")).toBe("2019");
+    });
+  });
+
+  describe("year-month format", () => {
+    it("formats YYYY-MM as Mon YYYY", () => {
+      expect(formatIntroducedDate("2021-04")).toBe("Apr 2021");
+    });
+
+    it("formats January correctly", () => {
+      expect(formatIntroducedDate("2023-01")).toBe("Jan 2023");
+    });
+
+    it("formats December correctly", () => {
+      expect(formatIntroducedDate("2024-12")).toBe("Dec 2024");
+    });
+
+    it("formats November correctly", () => {
+      expect(formatIntroducedDate("2023-11")).toBe("Nov 2023");
+    });
+
+    it("formats February correctly", () => {
+      expect(formatIntroducedDate("2024-02")).toBe("Feb 2024");
+    });
+
+    it("formats May correctly", () => {
+      expect(formatIntroducedDate("2024-05")).toBe("May 2024");
+    });
+  });
+
+  describe("full ISO date format", () => {
+    it("formats YYYY-MM-DD as Mon DD, YYYY", () => {
+      expect(formatIntroducedDate("2022-06-16")).toBe("Jun 16, 2022");
+    });
+
+    it("formats November 1 correctly", () => {
+      expect(formatIntroducedDate("2023-11-01")).toBe("Nov 1, 2023");
+    });
+
+    it("formats October 30 correctly", () => {
+      expect(formatIntroducedDate("2023-10-30")).toBe("Oct 30, 2023");
+    });
+
+    it("formats a May date correctly", () => {
+      expect(formatIntroducedDate("2024-05-22")).toBe("May 22, 2024");
+    });
+
+    it("formats a January date correctly", () => {
+      expect(formatIntroducedDate("2023-01-01")).toBe("Jan 1, 2023");
+    });
+  });
+
+  describe("null and undefined handling", () => {
+    it("returns null for null input", () => {
+      expect(formatIntroducedDate(null)).toBeNull();
+    });
+
+    it("returns null for undefined input", () => {
+      expect(formatIntroducedDate(undefined)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(formatIntroducedDate("")).toBeNull();
+    });
+  });
+
+  describe("invalid / unknown formats", () => {
+    it("returns the raw value for prose text", () => {
+      expect(formatIntroducedDate("UK (2023), US (2024), others planned")).toBe(
+        "UK (2023), US (2024), others planned"
+      );
+    });
+
+    it("returns the raw value for unrecognized patterns", () => {
+      expect(formatIntroducedDate("unknown")).toBe("unknown");
+    });
+
+    it("trims whitespace from the value", () => {
+      expect(formatIntroducedDate("  2021  ")).toBe("2021");
+    });
+
+    it("returns raw value for out-of-range month in YYYY-MM", () => {
+      // Month 13 is invalid — fall through to unknown-format branch
+      expect(formatIntroducedDate("2021-13")).toBe("2021-13");
+    });
+
+    it("returns raw value for out-of-range day in YYYY-MM-DD", () => {
+      // Day 32 is invalid — fall through to unknown-format branch
+      expect(formatIntroducedDate("2021-01-32")).toBe("2021-01-32");
+    });
+  });
+});

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -27,3 +27,49 @@ export function formatCompactNumber(n: number | null | undefined): string {
 export function safeHref(url: string): string {
   return /^https?:\/\//i.test(url) ? url : "#";
 }
+
+const MONTH_ABBR = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Format a legislation `introduced` date string with appropriate precision:
+ * - Year-only ("2021")        → "2021"
+ * - Year-month ("2021-04")    → "Apr 2021"
+ * - Full ISO ("2021-04-15")   → "Apr 15, 2021"
+ * Returns the raw value as-is if it does not match any of these patterns.
+ */
+export function formatIntroducedDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+
+  // Full ISO date: YYYY-MM-DD
+  const fullMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (fullMatch) {
+    const year = fullMatch[1];
+    const month = parseInt(fullMatch[2], 10);
+    const day = parseInt(fullMatch[3], 10);
+    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+      return `${MONTH_ABBR[month - 1]} ${day}, ${year}`;
+    }
+  }
+
+  // Year-month: YYYY-MM
+  const ymMatch = /^(\d{4})-(\d{2})$/.exec(trimmed);
+  if (ymMatch) {
+    const year = ymMatch[1];
+    const month = parseInt(ymMatch[2], 10);
+    if (month >= 1 && month <= 12) {
+      return `${MONTH_ABBR[month - 1]} ${year}`;
+    }
+  }
+
+  // Year-only: YYYY
+  if (/^\d{4}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Unknown format: return as-is
+  return trimmed;
+}

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -13,7 +13,7 @@
     - label: Status
       value: active
     - label: Established
-      value: UK (2023), US (2024), others planned
+      value: "2023"
     - label: Function
       value: Evaluation, research, policy advice
     - label: Network


### PR DESCRIPTION
## Summary
- Added `formatIntroducedDate()` utility to `apps/web/src/lib/format-compact.ts` that handles three date precisions used in legislation entities: year-only (`2021` → `"2021"`), year-month (`2021-04` → `"Apr 2021"`), and full ISO (`2021-04-15` → `"Apr 15, 2021"`)
- Updated `apps/web/src/app/legislation/legislation-table.tsx` to use the formatter for the `introduced` column instead of displaying raw string values
- Fixed AI Safety Institutes entity `Established` customField from prose text (`UK (2023), US (2024), others planned`) to year-only format (`2023`) per issue guidance

## Test plan
- [x] 22 unit tests added for `formatIntroducedDate` covering all three precision levels, null/undefined/empty, whitespace trimming, out-of-range month/day, and unknown formats — all pass
- [x] Content gate check passes (`pnpm crux validate gate --scope=content --fix`)
- [x] YAML schema validation passes (792 entities loaded, all pass)

Closes #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
