### PR TITLE
fix: add SB1047 cross-references to stakeholder entity pages

### DIFF
--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -108,6 +108,8 @@
     - id: concentration-of-power
       type: risk
       relationship: affects
+    - id: california-sb1047
+      type: policy
   sources:
     - title: Google DeepMind Website
       url: https://deepmind.google
@@ -1977,6 +1979,9 @@
     - ai-safety
     - community
     - governance
+  relatedEntries:
+    - id: california-sb1047
+      type: policy
   lastUpdated: 2026-02
 - id: microsoft
   stableId: OIY5gaPpBA

--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -952,6 +952,8 @@
       type: organization
     - id: openai
       type: organization
+    - id: california-sb1047
+      type: policy
   tags:
     - entrepreneur
     - ai-labs

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -112,6 +112,7 @@
       position: support
       reason: Frontier models pose catastrophic risks; industry self-regulation is insufficient
     - name: Future of Life Institute
+      entityId: fli
       position: support
       reason: Supports proactive regulation of frontier AI
     - name: Yoshua Bengio


### PR DESCRIPTION
## Summary
- Added `california-sb1047` to `relatedEntries` for Google DeepMind (E98) — listed as SB1047 opponent but page had no back-reference
- Added `california-sb1047` to `relatedEntries` for Elon Musk (E116) — listed as SB1047 supporter but page had no back-reference
- Added `relatedEntries` with `california-sb1047` to Meta AI (E549) — listed as SB1047 opponent but entity had no relatedEntries at all
- Added `entityId: fli` to the Future of Life Institute stakeholder entry in the SB1047 YAML — FLI entity exists at `data/entities/organizations.yaml` but wasn't linked

## Test plan
- [x] Gate check: `pnpm crux validate gate --scope=content --fix` — all 4 checks passed
- [x] Schema validation passed (871 items)
- [x] Unified blocking rules passed (0 errors)

Closes #2530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
