### PR TITLE
fix: reduce bot-review-major timeout to 30m and skip large reviews

### DIFF
--- a/crux/pr-patrol/detection.test.ts
+++ b/crux/pr-patrol/detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectIssues, extractBotComments, detectAllPrIssuesFromNodes } from './detection.ts';
+import { detectIssues, extractBotComments, detectAllPrIssuesFromNodes, MAX_BOT_COMMENTS_FOR_AUTO_FIX } from './detection.ts';
 import type { GqlPrNode, PatrolConfig } from './types.ts';
 
 function makePrNode(overrides: Partial<GqlPrNode> = {}): GqlPrNode {
@@ -408,5 +408,77 @@ describe('detectAllPrIssuesFromNodes — bot/release PR skipping', () => {
     });
     const result = detectAllPrIssuesFromNodes([pr], verboseConfig);
     expect(result.find((r) => r.number === 41)).toBeUndefined();
+  });
+});
+
+// ── detectAllPrIssuesFromNodes — bot-review-major comment cap ─────────────
+
+/** Make a review thread node with a bot comment. */
+function makeBotThread(id: string, severity = '🟠 Major: Fix this') {
+  return {
+    id,
+    isResolved: false,
+    isOutdated: false,
+    path: `src/${id}.ts`,
+    line: 10,
+    startLine: null,
+    comments: {
+      nodes: [{ author: { login: 'coderabbitai' }, body: severity }],
+    },
+  };
+}
+
+/** Make a PR node with bot review threads. Uses a recent updatedAt to avoid stale detection. */
+function makeBotReviewPr(threadCount: number, severity = '🟠 Major: Fix this') {
+  const threads = Array.from({ length: threadCount }, (_, i) => makeBotThread(`thread-${i}`, severity));
+  return makePrNode({
+    number: 100,
+    // Include test plan and issue ref so bot-review is the ONLY issue,
+    // making it easy to assert on whether it gets stripped.
+    body: '## Test plan\n\nChecked.\n\nCloses #1',
+    // Use a very recent updatedAt so the PR is not flagged as stale
+    updatedAt: new Date().toISOString(),
+    reviewThreads: { nodes: threads },
+  });
+}
+
+describe('detectAllPrIssuesFromNodes — bot-review-major comment cap', () => {
+  it('includes bot-review-major when comment count is at the limit', () => {
+    const pr = makeBotReviewPr(MAX_BOT_COMMENTS_FOR_AUTO_FIX);
+    const result = detectAllPrIssuesFromNodes([pr], defaultConfig);
+    const found = result.find((r) => r.number === 100);
+    expect(found).toBeDefined();
+    expect(found?.issues).toContain('bot-review-major');
+  });
+
+  it('strips bot-review-major when comment count exceeds the limit', () => {
+    const pr = makeBotReviewPr(MAX_BOT_COMMENTS_FOR_AUTO_FIX + 1);
+    const result = detectAllPrIssuesFromNodes([pr], defaultConfig);
+    // With only bot-review-major stripped and no other issues, PR should be absent
+    const found = result.find((r) => r.number === 100);
+    expect(found).toBeUndefined(); // no remaining fixable issues
+  });
+
+  it('keeps remaining fixable issues after stripping bot-review-major', () => {
+    const pr = makeBotReviewPr(MAX_BOT_COMMENTS_FOR_AUTO_FIX + 1);
+    // Override to also have a conflict so there's still at least one fixable issue
+    const prWithConflict = { ...pr, mergeable: 'CONFLICTING' };
+    const result = detectAllPrIssuesFromNodes([prWithConflict], defaultConfig);
+    const found = result.find((r) => r.number === 100);
+    expect(found).toBeDefined();
+    expect(found?.issues).not.toContain('bot-review-major');
+    expect(found?.issues).toContain('conflict');
+  });
+
+  it('does not strip bot-review-nitpick when comment count exceeds limit', () => {
+    // bot-review-nitpick (all 🧹 Nitpick comments) should NOT be stripped by this logic
+    const pr = makeBotReviewPr(MAX_BOT_COMMENTS_FOR_AUTO_FIX + 1, '🧹 Nitpick: style');
+    const result = detectAllPrIssuesFromNodes([pr], defaultConfig);
+    // This PR has bot-review-nitpick (not major), which isn't subject to the cap
+    // — so it SHOULD appear in results
+    const found = result.find((r) => r.number === 100);
+    expect(found).toBeDefined();
+    expect(found?.issues).toContain('bot-review-nitpick');
+    expect(found?.issues).not.toContain('bot-review-major');
   });
 });

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -34,6 +34,16 @@ import {
   markProcessed,
 } from './state.ts';
 
+// ── Bot comment thresholds ────────────────────────────────────────────────────
+
+/**
+ * Maximum number of unresolved bot review comments a PR can have before
+ * bot-review-major is skipped. PRs with more than this many comments are
+ * unlikely to complete within the 30-minute budget and are better left for
+ * human review. See #1982 for context.
+ */
+export const MAX_BOT_COMMENTS_FOR_AUTO_FIX = 8;
+
 // ── Bot / release PR skip lists ──────────────────────────────────────────────
 
 /** PR authors that are bots — their PRs never reference issues. */
@@ -104,10 +114,25 @@ export function detectAllPrIssuesFromNodes(
     .map((pr) => {
       const { issues: allIssues, botComments, failingChecks } = libDetectIssues(pr, staleThresholdMs);
       const advisoryIssues = allIssues.filter((i) => ADVISORY_ISSUES.has(i));
-      const fixableIssues = allIssues.filter((i) => !ADVISORY_ISSUES.has(i));
+      let fixableIssues = allIssues.filter((i) => !ADVISORY_ISSUES.has(i));
+
       if (advisoryIssues.length > 0) {
         log(`  PR #${pr.number}: advisory issues (skipped): ${advisoryIssues.join(', ')}`);
       }
+
+      // Skip bot-review-major for PRs with too many unresolved bot comments (#1982).
+      // Reviews with more than MAX_BOT_COMMENTS_FOR_AUTO_FIX comments are unlikely
+      // to complete within the 30-minute budget and are better deferred for human review.
+      if (
+        fixableIssues.includes('bot-review-major') &&
+        botComments.length > MAX_BOT_COMMENTS_FOR_AUTO_FIX
+      ) {
+        log(
+          `  ${cl.yellow}PR #${pr.number}: skipping bot-review-major — ${botComments.length} bot comments exceeds limit of ${MAX_BOT_COMMENTS_FOR_AUTO_FIX} (needs human review)${cl.reset}`,
+        );
+        fixableIssues = fixableIssues.filter((i) => i !== 'bot-review-major');
+      }
+
       return {
         number: pr.number,
         title: pr.title,

--- a/crux/pr-patrol/prompts.test.ts
+++ b/crux/pr-patrol/prompts.test.ts
@@ -203,6 +203,41 @@ describe('buildPrompt', () => {
     const prompt = buildPrompt(pr, REPO);
     expect(prompt).toContain('lines 15-20');
   });
+
+  it('caps bot comments at 8 in the prompt and notes remaining count', () => {
+    const manyComments = Array.from({ length: 12 }, (_, i) => ({
+      threadId: `thread-${i}`,
+      path: `src/file${i}.ts`,
+      line: i + 1,
+      startLine: null,
+      body: `🟠 Major: Issue ${i}`,
+      author: 'coderabbitai',
+    }));
+    const pr = makeDetectedPr({ issues: ['bot-review-major'], botComments: manyComments });
+    const prompt = buildPrompt(pr, REPO);
+    // First 8 comments should be included
+    expect(prompt).toContain('src/file0.ts');
+    expect(prompt).toContain('src/file7.ts');
+    // Comments 9–12 should NOT be individually included
+    expect(prompt).not.toContain('src/file8.ts');
+    expect(prompt).not.toContain('src/file11.ts');
+    // Should note the remaining count
+    expect(prompt).toContain('4 more bot comment(s) omitted');
+  });
+
+  it('does not show omission note when comments fit within cap', () => {
+    const fewComments = Array.from({ length: 3 }, (_, i) => ({
+      threadId: `thread-${i}`,
+      path: `src/file${i}.ts`,
+      line: i + 1,
+      startLine: null,
+      body: `🟠 Major: Issue ${i}`,
+      author: 'coderabbitai',
+    }));
+    const pr = makeDetectedPr({ issues: ['bot-review-major'], botComments: fewComments });
+    const prompt = buildPrompt(pr, REPO);
+    expect(prompt).not.toContain('more bot comment(s) omitted');
+  });
 });
 
 describe('buildMainBranchPrompt', () => {

--- a/crux/pr-patrol/prompts.ts
+++ b/crux/pr-patrol/prompts.ts
@@ -110,12 +110,21 @@ ${failingCheckInfo}- Check CI status: gh pr checks ${num} --repo ${repo}
 
     if (pr.botComments.length > 0) {
       sections.push('\n#### Bot Comment Details\n');
-      for (const c of pr.botComments) {
+      // Cap at 8 comments in the prompt — overly large prompts correlate with
+      // sessions that run long or get distracted. Remaining comments will still
+      // be visible on GitHub. (#1982)
+      const MAX_PROMPT_COMMENTS = 8;
+      const commentsToShow = pr.botComments.slice(0, MAX_PROMPT_COMMENTS);
+      const remaining = pr.botComments.length - commentsToShow.length;
+      for (const c of commentsToShow) {
         const lineRange = c.startLine && c.startLine !== c.line
           ? `lines ${c.startLine}-${c.line}`
           : `line ${c.line}`;
         const body = c.body.length > 2000 ? c.body.slice(0, 2000) + '\n...(truncated)' : c.body;
         sections.push(`**${c.path}** (${lineRange}) — ${c.author}:\n${body}\n`);
+      }
+      if (remaining > 0) {
+        sections.push(`_(${remaining} more bot comment(s) omitted — see the PR on GitHub for the full list)_\n`);
       }
     }
   }

--- a/crux/pr-patrol/scoring.test.ts
+++ b/crux/pr-patrol/scoring.test.ts
@@ -107,10 +107,11 @@ describe('computeBudget', () => {
     expect(budget.timeoutMinutes).toBe(60);
   });
 
-  it('gives medium budget for bot-review-major', () => {
+  it('gives 30-turn / 30-min budget for bot-review-major', () => {
+    // Capped at 30 min/turns to prevent excessive compute on complex reviews (#1982)
     const budget = computeBudget(['bot-review-major']);
-    expect(budget.maxTurns).toBe(50);
-    expect(budget.timeoutMinutes).toBe(45);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(30);
   });
 
   it('gives small budget for bot-review-nitpick', () => {

--- a/crux/pr-patrol/scoring.ts
+++ b/crux/pr-patrol/scoring.ts
@@ -28,10 +28,14 @@ export interface IssueBudget {
 
 // Note: missing-issue-ref is an advisory-only issue (see ADVISORY_ISSUES in types.ts)
 // and is filtered out before reaching the budget system, so it's not listed here.
+//
+// bot-review-major is capped at 30 min / 30 turns (#1982): log data showed runs
+// hitting 30–67 min, which wastes compute. Reviews that need more than 30 min
+// are better deferred for human review rather than burning the entire budget.
 const ISSUE_BUDGETS: Partial<Record<PrIssueType, IssueBudget>> = {
   conflict:            { maxTurns: 60, timeoutMinutes: 60 },
   'ci-failure':        { maxTurns: 50, timeoutMinutes: 45 },
-  'bot-review-major':  { maxTurns: 50, timeoutMinutes: 45 },
+  'bot-review-major':  { maxTurns: 30, timeoutMinutes: 30 },
   stale:               { maxTurns: 10, timeoutMinutes: 5 },
   'missing-testplan':  { maxTurns: 8,  timeoutMinutes: 5 },
   'bot-review-nitpick':{ maxTurns: 8,  timeoutMinutes: 5 },


### PR DESCRIPTION
## Summary

- Reduces `bot-review-major` budget from 50 turns / 45 min to **30 turns / 30 min**. Log data showed 4 runs exceeding 30 minutes (up to 67 min) — the previous 45-minute budget was too generous and caused wasted compute.
- Adds `MAX_BOT_COMMENTS_FOR_AUTO_FIX = 8` skip threshold in `detection.ts`: PRs with more than 8 unresolved bot review threads have `bot-review-major` stripped during detection. These reviews are unlikely to complete within the 30-minute budget and are logged with a warning for human follow-up.
- Caps bot comments included in Claude's prompt at 8 (was unbounded), with a note directing to GitHub for the rest. Unbounded prompts were a secondary contributor to excessive run times.
- Updates existing tests and adds new coverage for the comment-count skip behavior and prompt cap.

## Test plan

- [x] `npx vitest run crux/pr-patrol/` — all 248 tests pass (no regressions)
- [x] New tests for `bot-review-major` comment-count skip in `detection.test.ts`
- [x] New tests for prompt comment cap in `prompts.test.ts`
- [x] Updated `scoring.test.ts` budget assertion for new 30/30 values
- [x] No TypeScript errors in pr-patrol files

Closes #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
