### PR TITLE
fix: sync-session auth error handling for WIKI_SERVER_ENV=prod

### DIFF
--- a/crux/lib/wiki-server/client.test.ts
+++ b/crux/lib/wiki-server/client.test.ts
@@ -158,6 +158,43 @@ describe('wiki-server/client', () => {
         expect(['timeout', 'unavailable']).toContain(result.error);
       }
     });
+
+    it('returns auth_error for 401 response', async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response('Bearer token required', { status: 401 }),
+      );
+      const result = await client.apiRequest('GET', '/api/test');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('auth_error');
+        expect(result.message).toContain('401');
+      }
+    });
+
+    it('returns auth_error for 403 response', async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response('Forbidden', { status: 403 }),
+      );
+      const result = await client.apiRequest('GET', '/api/test');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('auth_error');
+      }
+    });
+
+    it('returns bad_request for other 4xx responses', async () => {
+      process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response('Not Found', { status: 404 }),
+      );
+      const result = await client.apiRequest('GET', '/api/test');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('bad_request');
+      }
+    });
   });
 
   describe('isServerAvailable', () => {

--- a/crux/lib/wiki-server/client.ts
+++ b/crux/lib/wiki-server/client.ts
@@ -63,7 +63,7 @@ export function buildHeaders(): Record<string, string> {
 // ApiResult — discriminated union for typed errors
 // ---------------------------------------------------------------------------
 
-export type ApiError = 'unavailable' | 'timeout' | 'bad_request' | 'server_error';
+export type ApiError = 'unavailable' | 'timeout' | 'bad_request' | 'auth_error' | 'server_error';
 
 export type ApiResult<T> =
   | { ok: true; data: T }
@@ -87,6 +87,7 @@ export function unwrap<T>(result: ApiResult<T>): T | null {
 // ---------------------------------------------------------------------------
 
 function classifyStatus(status: number): ApiError {
+  if (status === 401 || status === 403) return 'auth_error';
   if (status >= 400 && status < 500) return 'bad_request';
   return 'server_error';
 }

--- a/crux/wiki-server/sync-common.ts
+++ b/crux/wiki-server/sync-common.ts
@@ -245,9 +245,16 @@ export async function batchSync<T>(
 
       if (!res.ok) {
         const resBody = await res.text();
-        console.error(
-          `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${resBody}`,
-        );
+        if (res.status === 401 || res.status === 403) {
+          console.error(
+            `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — Authentication failed. ` +
+            `Check LONGTERMWIKI_SERVER_API_KEY (or PROD_LONGTERMWIKI_SERVER_API_KEY with WIKI_SERVER_ENV=prod). Detail: ${resBody}`,
+          );
+        } else {
+          console.error(
+            `  Batch ${batchNum}/${totalBatches}: HTTP ${res.status} — ${resBody}`,
+          );
+        }
         onBatchError?.(resBody);
         totalErrors += batch.length;
         consecutiveFailures++;

--- a/crux/wiki-server/sync-session.test.ts
+++ b/crux/wiki-server/sync-session.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for sync-session.ts
+ *
+ * Covers the core behavior: parseSessionYaml and syncSessionFile,
+ * including auth failure handling (issue #2462).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseSessionYaml, syncSessionFile } from './sync-session.ts';
+
+describe('parseSessionYaml', () => {
+  it('parses a minimal valid YAML file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_test.yaml');
+    writeFileSync(filePath, `date: "2026-01-15"\ntitle: Test session\npages: []\n`);
+    const entry = parseSessionYaml(filePath);
+    expect(entry).not.toBeNull();
+    expect(entry!.date).toBe('2026-01-15');
+    expect(entry!.title).toBe('Test session');
+    expect(entry!.pages).toEqual([]);
+  });
+
+  it('returns null for non-existent file', () => {
+    const entry = parseSessionYaml('/tmp/does-not-exist-abc123.yaml');
+    expect(entry).toBeNull();
+  });
+
+  it('returns null for YAML missing required fields', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, 'missing-title.yaml');
+    writeFileSync(filePath, `date: "2026-01-15"\n`);
+    const entry = parseSessionYaml(filePath);
+    expect(entry).toBeNull();
+  });
+
+  it('normalizes PR number to URL', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_with-pr.yaml');
+    writeFileSync(filePath, `date: "2026-01-15"\ntitle: With PR\npr: 1234\npages: []\n`);
+    const entry = parseSessionYaml(filePath);
+    expect(entry!.prUrl).toBe(
+      'https://github.com/quantified-uncertainty/longterm-wiki/pull/1234',
+    );
+  });
+
+  it('serializes checks field to JSON string', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_with-checks.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: With Checks\nchecks:\n  initialized: true\n  items: []\npages: []\n`,
+    );
+    const entry = parseSessionYaml(filePath);
+    expect(entry!.checksYaml).not.toBeNull();
+    const parsed = JSON.parse(entry!.checksYaml!);
+    expect(parsed.initialized).toBe(true);
+  });
+
+  it('filters out invalid page IDs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_pages.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: Pages\npages:\n  - valid-page\n  - INVALID_PAGE\n  - another-valid\n`,
+    );
+    const entry = parseSessionYaml(filePath);
+    expect(entry!.pages).toEqual(['valid-page', 'another-valid']);
+  });
+});
+
+describe('syncSessionFile — auth error handling (issue #2462)', () => {
+  const origUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+  const origProdUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  const origProdKey = process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+  const origWikiServerEnv = process.env.WIKI_SERVER_ENV;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3000';
+    process.env.LONGTERMWIKI_SERVER_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    if (origUrl !== undefined) process.env.LONGTERMWIKI_SERVER_URL = origUrl;
+    else delete process.env.LONGTERMWIKI_SERVER_URL;
+    if (origKey !== undefined) process.env.LONGTERMWIKI_SERVER_API_KEY = origKey;
+    else delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    if (origProdUrl !== undefined) process.env.PROD_LONGTERMWIKI_SERVER_URL = origProdUrl;
+    else delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    if (origProdKey !== undefined) process.env.PROD_LONGTERMWIKI_SERVER_API_KEY = origProdKey;
+    else delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+    if (origWikiServerEnv !== undefined) process.env.WIKI_SERVER_ENV = origWikiServerEnv;
+    else delete process.env.WIKI_SERVER_ENV;
+  });
+
+  it('returns auth_error when server returns 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Bearer token required', { status: 401 }),
+    );
+
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_auth.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: Auth test\nbranch: claude/auth-test\npages: []\n`,
+    );
+
+    const result = await syncSessionFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('auth_error');
+    }
+  });
+
+  it('returns auth_error when server returns 401 with WIKI_SERVER_ENV=prod', async () => {
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    process.env.WIKI_SERVER_ENV = 'prod';
+    process.env.PROD_LONGTERMWIKI_SERVER_URL = 'https://prod.example.com';
+    process.env.PROD_LONGTERMWIKI_SERVER_API_KEY = 'wrong-prod-key';
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Bearer token required', { status: 401 }),
+    );
+
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_prod-auth.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: Prod auth test\nbranch: claude/prod-test\npages: []\n`,
+    );
+
+    const result = await syncSessionFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('auth_error');
+    }
+  });
+
+  it('returns unavailable when server is unreachable', async () => {
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
+
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_unavail.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: Unavail test\nbranch: claude/unavail-test\npages: []\n`,
+    );
+
+    const result = await syncSessionFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('unavailable');
+    }
+  });
+
+  it('returns bad_request when file has no branch field', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_no-branch.yaml');
+    writeFileSync(filePath, `date: "2026-01-15"\ntitle: No branch\npages: []\n`);
+
+    const result = await syncSessionFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('bad_request');
+    }
+  });
+
+  it('returns ok:true on successful sync', async () => {
+    const agentSession = {
+      id: 42,
+      branch: 'claude/test',
+      status: 'active',
+      title: null,
+      summary: null,
+      model: null,
+      duration: null,
+      cost: null,
+      prUrl: null,
+      checksYaml: null,
+      issuesJson: null,
+      learningsJson: null,
+      recommendationsJson: null,
+      reviewed: null,
+      pages: [],
+      date: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      initiatedAt: new Date().toISOString(),
+    };
+
+    vi.spyOn(globalThis, 'fetch')
+      // First call: getAgentSessionByBranch
+      .mockResolvedValueOnce(new Response(JSON.stringify(agentSession), { status: 200 }))
+      // Second call: updateAgentSession
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ...agentSession, status: 'completed' }), { status: 200 }));
+
+    const dir = mkdtempSync(join(tmpdir(), 'sync-session-'));
+    const filePath = join(dir, '2026-01-15_success.yaml');
+    writeFileSync(
+      filePath,
+      `date: "2026-01-15"\ntitle: Success test\nbranch: claude/test\npages: []\n`,
+    );
+
+    const result = await syncSessionFile(filePath);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/crux/wiki-server/sync-session.ts
+++ b/crux/wiki-server/sync-session.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'url';
 import { parse as parseYaml } from 'yaml';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getAgentSessionByBranch, updateAgentSession } from '../lib/wiki-server/agent-sessions.ts';
+import { type ApiResult, apiOk, apiErr } from '../lib/wiki-server/client.ts';
 
 const PAGE_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -128,7 +129,7 @@ export function parseSessionYaml(filePath: string): SessionApiEntry | null {
 
 /**
  * Sync a single session YAML file to the wiki-server.
- * Returns true if the update succeeded, false otherwise.
+ * Returns an ApiResult — ok on success, or a typed error with an actionable message.
  *
  * Writes all session log fields (title, summary, model, cost, duration, pages, etc.)
  * directly to the agent_sessions row matched by branch. This makes agent_sessions
@@ -137,12 +138,12 @@ export function parseSessionYaml(filePath: string): SessionApiEntry | null {
  * If no agent_session exists for the branch (e.g., pre-checklist sessions),
  * this is a no-op — those sessions are tracked in the sessions table by the pipeline.
  */
-export async function syncSessionFile(filePath: string): Promise<boolean> {
+export async function syncSessionFile(filePath: string): Promise<ApiResult<true>> {
   const entry = parseSessionYaml(filePath);
-  if (!entry || !entry.branch) return false;
+  if (!entry || !entry.branch) return apiErr('bad_request', 'Could not parse session YAML or missing branch field');
 
   const agentSessionResult = await getAgentSessionByBranch(entry.branch);
-  if (!agentSessionResult.ok) return false;
+  if (!agentSessionResult.ok) return agentSessionResult as ApiResult<true>;
 
   const updates = {
     date: entry.date,
@@ -162,7 +163,8 @@ export async function syncSessionFile(filePath: string): Promise<boolean> {
   };
 
   const result = await updateAgentSession(agentSessionResult.data.id, updates);
-  return result.ok;
+  if (!result.ok) return result as ApiResult<true>;
+  return apiOk(true as const);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,12 +199,20 @@ async function main() {
   console.log(`  Branch: ${entry.branch || '(none)'}`);
   console.log(`  Pages: ${entry.pages?.length || 0}`);
 
-  const ok = await syncSessionFile(resolved);
-  if (ok) {
+  const result = await syncSessionFile(resolved);
+  if (result.ok) {
     console.log(`\u2713 Session synced to wiki-server`);
   } else {
-    console.log('Warning: could not sync session to wiki-server (server unavailable or error)');
-    // Not a hard failure — YAML is authoritative
+    // Not a hard failure — YAML is authoritative, but give actionable message
+    if (result.error === 'auth_error') {
+      console.warn(
+        `Warning: authentication failed — check LONGTERMWIKI_SERVER_API_KEY (or PROD_LONGTERMWIKI_SERVER_API_KEY with WIKI_SERVER_ENV=prod)\n  Detail: ${result.message}`,
+      );
+    } else if (result.error === 'unavailable') {
+      console.warn(`Warning: wiki-server is unavailable — ${result.message}`);
+    } else {
+      console.warn(`Warning: could not sync session to wiki-server — ${result.message}`);
+    }
   }
 }
 

--- a/crux/wiki-server/sync-sessions.ts
+++ b/crux/wiki-server/sync-sessions.ts
@@ -98,12 +98,16 @@ async function main() {
   const serverUrl = getServerUrl();
   const apiKey = getApiKey();
 
+  const envPrefix = process.env.WIKI_SERVER_ENV === 'prod' || process.env.WIKI_SERVER_ENV === 'production'
+    ? 'PROD_'
+    : '';
+
   if (!serverUrl) {
-    console.error('Error: LONGTERMWIKI_SERVER_URL environment variable is required');
+    console.error(`Error: ${envPrefix}LONGTERMWIKI_SERVER_URL environment variable is required`);
     process.exit(1);
   }
   if (!apiKey) {
-    console.error('Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required');
+    console.error(`Error: ${envPrefix}LONGTERMWIKI_SERVER_API_KEY environment variable is required`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Added `auth_error` as a distinct `ApiError` type for HTTP 401/403 responses, separate from generic `bad_request`
- `syncSessionFile` now returns `ApiResult<true>` instead of `boolean`, propagating typed error details to callers
- CLI (`sync-session`) now shows actionable messages for auth failures, naming the correct env var with `PROD_` prefix when `WIKI_SERVER_ENV=prod`
- `batchSync` in `sync-common.ts` prints an auth-specific hint for 401/403 batch errors
- `sync-sessions` CLI error messages now respect the `WIKI_SERVER_ENV=prod` prefix
- Added 11 new tests covering the sync-session flows; added 3 new tests for `auth_error`, 403, and 404 classification in `client.test.ts`

Note: The issue description mentioned `x-api-key` header being sent — investigation showed the client already used `Authorization: Bearer` format correctly. The actual bug was that auth failures were silently swallowed and reported as "server unavailable or error" with no actionable detail.

## Test plan
- [x] `pnpm vitest run crux/lib/wiki-server/client.test.ts` passes (22 tests, including 3 new auth_error tests)
- [x] `pnpm vitest run crux/wiki-server/sync-session.test.ts` passes (11 new tests)
- [x] `pnpm vitest run crux/` passes (2 pre-existing failures unchanged, all new tests pass)
- [x] `pnpm crux validate gate --scope=content --fix` passes

Closes #2462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
