### PR TITLE
feat: auto-select content tier based on page quality grade and citation health

### DIFF
--- a/crux/authoring/page-improver/phases/triage.test.ts
+++ b/crux/authoring/page-improver/phases/triage.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for triage phase quality-based tier selection logic.
+ *
+ * Tests cover:
+ *   - qualityScoreToGrade: numeric score → letter grade mapping
+ *   - qualityBasedTier: grade + citation count → tier recommendation
+ *
+ * The full triagePhase function requires LLM calls + file I/O and is tested
+ * via manual integration testing with `--tier=triage` on real pages.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { qualityScoreToGrade, qualityBasedTier } from './triage.ts';
+
+// ── qualityScoreToGrade ───────────────────────────────────────────────────────
+
+describe('qualityScoreToGrade', () => {
+  it('assigns A for scores >= 80', () => {
+    expect(qualityScoreToGrade(80)).toBe('A');
+    expect(qualityScoreToGrade(90)).toBe('A');
+    expect(qualityScoreToGrade(100)).toBe('A');
+  });
+
+  it('assigns B for scores 70–79', () => {
+    expect(qualityScoreToGrade(70)).toBe('B');
+    expect(qualityScoreToGrade(75)).toBe('B');
+    expect(qualityScoreToGrade(79)).toBe('B');
+  });
+
+  it('assigns C for scores 60–69', () => {
+    expect(qualityScoreToGrade(60)).toBe('C');
+    expect(qualityScoreToGrade(65)).toBe('C');
+    expect(qualityScoreToGrade(69)).toBe('C');
+  });
+
+  it('assigns D for scores 40–59', () => {
+    expect(qualityScoreToGrade(40)).toBe('D');
+    expect(qualityScoreToGrade(50)).toBe('D');
+    expect(qualityScoreToGrade(59)).toBe('D');
+  });
+
+  it('assigns F for scores below 40', () => {
+    expect(qualityScoreToGrade(39)).toBe('F');
+    expect(qualityScoreToGrade(20)).toBe('F');
+    expect(qualityScoreToGrade(0)).toBe('F');
+  });
+
+  it('boundary: 79 is B not A', () => {
+    expect(qualityScoreToGrade(79)).toBe('B');
+    expect(qualityScoreToGrade(80)).toBe('A');
+  });
+
+  it('boundary: 69 is C not B', () => {
+    expect(qualityScoreToGrade(69)).toBe('C');
+    expect(qualityScoreToGrade(70)).toBe('B');
+  });
+
+  it('boundary: 59 is D not C', () => {
+    expect(qualityScoreToGrade(59)).toBe('D');
+    expect(qualityScoreToGrade(60)).toBe('C');
+  });
+
+  it('boundary: 39 is F not D', () => {
+    expect(qualityScoreToGrade(39)).toBe('F');
+    expect(qualityScoreToGrade(40)).toBe('D');
+  });
+});
+
+// ── qualityBasedTier ──────────────────────────────────────────────────────────
+
+describe('qualityBasedTier', () => {
+  // === Grade >= B AND well-cited → polish ===
+
+  it('returns polish for grade A with 10+ citations', () => {
+    const result = qualityBasedTier(85, 10);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('polish');
+    expect(result!.grade).toBe('A');
+  });
+
+  it('returns polish for grade B with exactly 10 citations', () => {
+    const result = qualityBasedTier(72, 10);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('polish');
+    expect(result!.grade).toBe('B');
+  });
+
+  it('returns polish for grade B with many citations', () => {
+    const result = qualityBasedTier(70, 25);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('polish');
+    expect(result!.grade).toBe('B');
+  });
+
+  it('reason mentions quality score and citation count for polish', () => {
+    const result = qualityBasedTier(75, 15);
+    expect(result!.reason).toContain('75');
+    expect(result!.reason).toContain('15');
+    expect(result!.reason).toContain('polish');
+  });
+
+  // === Grade >= B BUT low citations → standard (needs more sourcing) ===
+
+  it('returns standard for grade B with 9 citations (below threshold)', () => {
+    const result = qualityBasedTier(70, 9);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('standard');
+    expect(result!.grade).toBe('B');
+  });
+
+  it('returns standard for grade A with 0 citations', () => {
+    const result = qualityBasedTier(90, 0);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('standard');
+    expect(result!.grade).toBe('A');
+  });
+
+  it('reason mentions citation note when grade >= B but citations < 10', () => {
+    const result = qualityBasedTier(75, 5);
+    expect(result!.reason).toContain('5');
+    expect(result!.reason).toContain('citations');
+  });
+
+  // === Grade C (60-69) → standard ===
+
+  it('returns standard for grade C regardless of citations', () => {
+    const result = qualityBasedTier(65, 20);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('standard');
+    expect(result!.grade).toBe('C');
+  });
+
+  it('returns standard for grade C with no citations', () => {
+    const result = qualityBasedTier(60, 0);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('standard');
+    expect(result!.grade).toBe('C');
+  });
+
+  // === Grade < C (quality < 60) → deep ===
+
+  it('returns deep for grade D', () => {
+    const result = qualityBasedTier(50, 5);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('deep');
+    expect(result!.grade).toBe('D');
+  });
+
+  it('returns deep for grade F', () => {
+    const result = qualityBasedTier(20, 0);
+    expect(result).not.toBeNull();
+    expect(result!.tier).toBe('deep');
+    expect(result!.grade).toBe('F');
+  });
+
+  it('returns deep even for grade D with many citations', () => {
+    // Citation count should not override the need for deep improvement when grade < C
+    const result = qualityBasedTier(55, 30);
+    expect(result!.tier).toBe('deep');
+  });
+
+  it('returns deep for quality score 0', () => {
+    const result = qualityBasedTier(0, 0);
+    expect(result!.tier).toBe('deep');
+  });
+
+  it('reason mentions quality score for deep tier', () => {
+    const result = qualityBasedTier(45, 0);
+    expect(result!.reason).toContain('45');
+  });
+
+  // === No quality data → null ===
+
+  it('returns null when quality score is null', () => {
+    expect(qualityBasedTier(null, 10)).toBeNull();
+  });
+
+  it('returns null when quality score is undefined', () => {
+    expect(qualityBasedTier(undefined, 10)).toBeNull();
+  });
+
+  // === Boundary cases ===
+
+  it('boundary: quality 59 → deep (grade D, not standard)', () => {
+    expect(qualityBasedTier(59, 0)!.tier).toBe('deep');
+  });
+
+  it('boundary: quality 60 → standard (grade C threshold)', () => {
+    expect(qualityBasedTier(60, 0)!.tier).toBe('standard');
+  });
+
+  it('boundary: quality 69 + 10 citations → standard (grade C, not polish)', () => {
+    // Even with 10 citations, C-grade does not qualify for polish
+    expect(qualityBasedTier(69, 10)!.tier).toBe('standard');
+  });
+
+  it('boundary: quality 70 + 10 citations → polish (grade B threshold)', () => {
+    expect(qualityBasedTier(70, 10)!.tier).toBe('polish');
+  });
+
+  it('boundary: quality 70 + 9 citations → standard (just below citation threshold)', () => {
+    expect(qualityBasedTier(70, 9)!.tier).toBe('standard');
+  });
+});

--- a/crux/authoring/page-improver/phases/triage.ts
+++ b/crux/authoring/page-improver/phases/triage.ts
@@ -1,16 +1,149 @@
 /**
  * Triage Phase
  *
- * Performs a cheap news check to auto-select the appropriate improvement tier.
+ * Performs a cheap news check AND a quality/citation health check to
+ * auto-select the appropriate improvement tier.
+ *
+ * ## Tier selection logic
+ *
+ * Two signals are combined; the more intensive tier wins:
+ *
+ * ### News signal (LLM-based)
+ * - skip     → no meaningful new developments found
+ * - polish   → minor updates only
+ * - standard → notable new developments
+ * - deep     → major developments requiring thorough research
+ *
+ * ### Quality signal (rule-based, no LLM)
+ * Based on the page's numeric quality score (0–100) and footnote citation count:
+ *
+ *   - Grade >= B (quality >= 70) AND citations >= 10 → polish
+ *     The page is already good and well-cited; only minor touch-ups needed.
+ *   - Grade < B  (quality < 70)                     → standard
+ *     The page has notable quality gaps; a standard improvement pass is warranted.
+ *   - Grade < C  (quality < 60)                     → deep
+ *     The page has significant quality deficits; a deep research pass is needed.
+ *   - No quality score in frontmatter               → no quality signal (news signal used)
+ *
+ * Grade–to–score mapping (0–100 numeric quality field):
+ *   A  ≥ 80   (high-quality, well-researched)
+ *   B  ≥ 70   (good, solid content)
+ *   C  ≥ 60   (adequate, some gaps)
+ *   D  ≥ 40   (draft-quality, significant gaps)
+ *   F  < 40   (stub or very low quality)
+ *
+ * ### Combining signals
+ * The TIER_ORDER ranking (skip < polish < standard < deep) is used to take
+ * the more intensive of the two signals. "skip" from news is only preserved
+ * if there is no quality signal or the quality signal also says skip/polish
+ * with strong citations.
+ *
+ * Exception: if news says "skip" and quality says "polish", the final result
+ * is "polish" because the page quality warrants improvement even without
+ * breaking news.
  */
 
 import fs from 'fs';
 import { MODELS } from '../../../lib/anthropic.ts';
 import { stripFrontmatter } from '../../../lib/patterns.ts';
+import { countFootnoteRefs } from '../../../lib/metrics-extractor.ts';
 import type { PageData, TriageResult } from '../types.ts';
 import { log, getFilePath, writeTemp } from '../utils.ts';
 import { runAgent, executeWebSearch, executeScrySearch } from '../api.ts';
 import { parseJsonFromLlm } from './json-parsing.ts';
+
+// ── Tier ordering ─────────────────────────────────────────────────────────────
+
+/**
+ * Numeric order for tiers — higher = more intensive improvement.
+ * Used to take the max of two signals.
+ */
+const TIER_ORDER: Record<string, number> = {
+  skip: 0,
+  polish: 1,
+  standard: 2,
+  deep: 3,
+};
+
+type Tier = 'skip' | 'polish' | 'standard' | 'deep';
+
+/** Return the more intensive of two tiers. */
+function maxTier(a: Tier, b: Tier): Tier {
+  return (TIER_ORDER[a] >= TIER_ORDER[b] ? a : b) as Tier;
+}
+
+// ── Quality signal ────────────────────────────────────────────────────────────
+
+/**
+ * Map a numeric quality score (0–100) to a letter grade.
+ *
+ * Thresholds are aligned with the quality distribution ranges used in the
+ * grading pipeline:
+ *   A ≥ 80   (Comprehensive / high-quality)
+ *   B ≥ 70   (Good)
+ *   C ≥ 60   (Adequate)
+ *   D ≥ 40   (Draft)
+ *   F < 40   (Stub)
+ */
+export function qualityScoreToGrade(score: number): string {
+  if (score >= 80) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 60) return 'C';
+  if (score >= 40) return 'D';
+  return 'F';
+}
+
+/**
+ * Determine the improvement tier based on page quality score and citation count.
+ *
+ * Returns null when quality data is unavailable (so the caller falls back to
+ * the news signal alone).
+ *
+ * Logic (documented in module docblock above):
+ *   - Grade >= B (quality >= 70) AND citations >= 10 → polish
+ *   - Grade < B  (quality < 70)                     → standard
+ *   - Grade < C  (quality < 60)                     → deep
+ */
+export function qualityBasedTier(
+  qualityScore: number | null | undefined,
+  citationCount: number,
+): { tier: Tier; grade: string; reason: string } | null {
+  if (qualityScore == null) {
+    return null; // No quality signal available
+  }
+
+  const grade = qualityScoreToGrade(qualityScore);
+
+  // Grade >= B AND well-cited → page is already good, polish is sufficient
+  if (qualityScore >= 70 && citationCount >= 10) {
+    return {
+      tier: 'polish',
+      grade,
+      reason: `Grade ${grade} (quality ${qualityScore}) with ${citationCount} citations — page is solid and well-cited; polish tier sufficient`,
+    };
+  }
+
+  // Grade < C → significant quality deficits; deep pass needed
+  if (qualityScore < 60) {
+    return {
+      tier: 'deep',
+      grade,
+      reason: `Grade ${grade} (quality ${qualityScore}) — significant quality gaps; deep research pass warranted`,
+    };
+  }
+
+  // Grade < B (70 > quality >= 60) OR Grade >= B but low citations → standard
+  const citationNote = qualityScore >= 70 && citationCount < 10
+    ? ` (only ${citationCount} citations; needs more sourcing)`
+    : '';
+  return {
+    tier: 'standard',
+    grade,
+    reason: `Grade ${grade} (quality ${qualityScore})${citationNote} — standard improvement pass warranted`,
+  };
+}
+
+// ── Main triage phase ────────────────────────────────────────────────────────
 
 export async function triagePhase(page: PageData, lastEdited: string): Promise<TriageResult> {
   log('triage', `Checking for news since ${lastEdited}: "${page.title}"`);
@@ -21,6 +154,17 @@ export async function triagePhase(page: PageData, lastEdited: string): Promise<T
   const contentAfterFm = stripFrontmatter(currentContent);
   const contentPreview = contentAfterFm.slice(0, 500);
 
+  // ── Quality signal (rule-based, free) ─────────────────────────────────────
+  const citationCount = countFootnoteRefs(contentAfterFm);
+  const qualityResult = qualityBasedTier(page.quality, citationCount);
+
+  if (qualityResult) {
+    log('triage', `Quality signal: ${qualityResult.tier} — ${qualityResult.reason}`);
+  } else {
+    log('triage', 'No quality score in frontmatter — quality signal skipped');
+  }
+
+  // ── News signal (LLM-based, ~$0.08) ──────────────────────────────────────
   const searchQuery = `${page.title} developments news ${lastEdited} to ${new Date().toISOString().slice(0, 10)}`;
   const scryQuery = page.title;
 
@@ -73,9 +217,42 @@ Output ONLY a JSON object:
   );
 
   const validTiers: string[] = ['skip', 'polish', 'standard', 'deep'];
-  const tier = (validTiers.includes(parsed.recommendedTier)
+  const newsTier = (validTiers.includes(parsed.recommendedTier)
     ? parsed.recommendedTier
-    : 'standard') as TriageResult['recommendedTier'];
+    : 'standard') as Tier;
+
+  // ── Combine signals ────────────────────────────────────────────────────────
+  //
+  // Take the more intensive tier from news and quality signals.
+  // This means:
+  //   - If news is "deep" and quality is "polish", result is "deep" (news urgency wins)
+  //   - If news is "skip" and quality is "standard", result is "standard" (quality gaps win)
+  //   - If news is "skip" and no quality signal, result is "skip"
+  //
+  // Rationale: quality deficits are independent of news freshness. A page that
+  // is outdated AND low-quality needs at least as much work as the higher signal demands.
+
+  const qualityTier = qualityResult?.tier ?? null;
+  let finalTier: Tier;
+  let finalReason: string;
+
+  if (qualityTier === null) {
+    // No quality signal — use news signal alone
+    finalTier = newsTier;
+    finalReason = parsed.reason || '';
+  } else {
+    finalTier = maxTier(newsTier, qualityTier);
+    if (finalTier === newsTier && finalTier !== qualityTier) {
+      // News signal was dominant
+      finalReason = `${parsed.reason || ''} (quality signal: ${qualityResult!.reason})`;
+    } else if (finalTier === qualityTier && finalTier !== newsTier) {
+      // Quality signal was dominant
+      finalReason = `${qualityResult!.reason} (news signal: ${parsed.reason || 'no significant developments'})`;
+    } else {
+      // Both signals agree
+      finalReason = `${parsed.reason || ''} | ${qualityResult!.reason}`;
+    }
+  }
 
   const costMap = { skip: '$0', polish: '$2-3', standard: '$5-8', deep: '$10-15' };
 
@@ -83,14 +260,23 @@ Output ONLY a JSON object:
     pageId: page.id,
     title: page.title,
     lastEdited,
-    recommendedTier: tier,
-    reason: parsed.reason || '',
+    recommendedTier: finalTier,
+    reason: finalReason,
     newDevelopments: parsed.newDevelopments || [],
-    estimatedCost: costMap[tier],
+    estimatedCost: costMap[finalTier],
     triageCost: '~$0.08',
+    ...(qualityResult !== null && {
+      qualitySignal: {
+        qualityScore: page.quality!,
+        qualityGrade: qualityResult.grade,
+        citationCount,
+        qualityRecommendedTier: qualityResult.tier,
+        qualityReason: qualityResult.reason,
+      },
+    }),
   };
 
   writeTemp(page.id, 'triage.json', triageResult);
-  log('triage', `Result: ${tier} — ${parsed.reason}`);
+  log('triage', `Result: ${finalTier} — ${finalReason}`);
   return triageResult;
 }

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -200,6 +200,22 @@ export interface TriageResult {
   newDevelopments: string[];
   estimatedCost: string;
   triageCost: string;
+  /**
+   * Quality-based tier selection signal, included when the page has a quality
+   * score. Separate from the news-based tier so callers can see both signals.
+   */
+  qualitySignal?: {
+    /** Numeric quality score (0–100) from the page's frontmatter. */
+    qualityScore: number;
+    /** Letter grade derived from quality score (A/B/C/D/F). */
+    qualityGrade: string;
+    /** Total citation count (footnote refs in page body). */
+    citationCount: number;
+    /** Tier recommended by quality/citation analysis alone. */
+    qualityRecommendedTier: 'skip' | 'polish' | 'standard' | 'deep';
+    /** Human-readable explanation of the quality-based recommendation. */
+    qualityReason: string;
+  };
 }
 
 export type AdversarialGapType =


### PR DESCRIPTION
## Summary

- Enhanced the triage phase (`--tier=triage`) to factor in page quality grade and citation health alongside the existing news-based LLM signal
- Two signals are combined and the more intensive tier wins:
  - **News signal** (LLM-based, ~$0.08): existing logic unchanged
  - **Quality signal** (rule-based, free): derived from the page's numeric `quality` frontmatter field and footnote citation count
- Quality-based tier logic:
  - Grade >= B (quality >= 70) AND citations >= 10 → `polish` (page is solid and well-cited)
  - Grade < B (quality < 70) → `standard` (notable quality gaps)
  - Grade < C (quality < 60) → `deep` (significant quality deficits)
  - No quality score in frontmatter → quality signal skipped, news signal used alone
- The `TriageResult` type gains an optional `qualitySignal` field for transparency
- Decision logic is documented in module-level comments in `triage.ts`

Closes #823

## Test plan

- [x] 30 new unit tests for `qualityScoreToGrade` and `qualityBasedTier` — all pass
- [x] Tests cover all tiers, all grade boundaries (79/80, 69/70, 59/60, 39/40), null/undefined quality score, and citation count threshold (9 vs 10)
- [x] Full crux test suite: 151 test files / 3238+ tests pass
- [x] TypeScript check: `tsc --noEmit -p crux/tsconfig.json` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
