### PR TITLE
feat: entity profile dashboard — aggregated TableBase data explorer

### DIFF
--- a/apps/web/src/app/api/entity-profile-proxy/route.ts
+++ b/apps/web/src/app/api/entity-profile-proxy/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getWikiServerConfig } from "@lib/wiki-server";
+
+/**
+ * GET /api/entity-profile-proxy?entity=...
+ *
+ * Proxies entity profile requests to the wiki-server so that the client-side
+ * viewer can fetch data without exposing wiki-server credentials.
+ * Streams the response body through without parsing/re-serializing.
+ */
+export async function GET(request: NextRequest) {
+  const entity = request.nextUrl.searchParams.get("entity");
+  if (!entity || !entity.trim()) {
+    return NextResponse.json(
+      { error: "validation_error", message: "entity parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  const config = getWikiServerConfig();
+  if (!config) {
+    return NextResponse.json(
+      { error: "not_configured", message: "Wiki server not configured" },
+      { status: 503 }
+    );
+  }
+
+  try {
+    const url = `${config.serverUrl}/api/entity-profile/${encodeURIComponent(entity.trim())}`;
+    const res = await fetch(url, {
+      headers: config.headers,
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    // Stream response body through without parse+reserialize
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "connection_error",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/src/app/internal/entity-profile/entity-profile-content.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-content.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from "react";
+import { EntityProfileViewer } from "./entity-profile-viewer";
+
+// ── Content Component ──────────────────────────────────────────────────────
+
+/**
+ * Server component rendered via MDX stub at /wiki/E1929.
+ * The EntityProfileViewer handles all interactivity client-side,
+ * including entity search and data fetching via the proxy API route.
+ *
+ * Wrapped in Suspense because EntityProfileViewer uses useSearchParams()
+ * which requires a Suspense boundary for SSG/SSR.
+ */
+export function EntityProfileContent() {
+  return (
+    <Suspense fallback={<div className="text-sm text-muted-foreground py-8 text-center">Loading...</div>}>
+      <EntityProfileViewer
+        initialData={null}
+        initialEntity=""
+      />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -1,0 +1,670 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Search,
+  ChevronDown,
+  ChevronRight,
+  Database,
+  Layers,
+  ExternalLink,
+  Loader2,
+  TableProperties,
+  ShieldCheck,
+} from "lucide-react";
+import Link from "next/link";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ColumnMeta {
+  name: string;
+  dataType: string;
+  columnType: string;
+  notNull: boolean;
+  hasDefault: boolean;
+  description?: string;
+}
+
+interface Section {
+  key: string;
+  label: string;
+  description: string;
+  schema: { columns: ColumnMeta[] };
+  rows: Record<string, unknown>[];
+  total: number;
+  error?: string;
+}
+
+interface EntityProfileData {
+  entity: Record<string, unknown>;
+  sections: Section[];
+  verdicts: Record<string, { verdict: string; confidence: number | null }>;
+}
+
+// ── Entity search ──────────────────────────────────────────────────────────
+
+function EntitySearch({
+  initialQuery,
+  onSearch,
+  isLoading,
+}: {
+  initialQuery: string;
+  onSearch: (q: string) => void;
+  isLoading: boolean;
+}) {
+  const [query, setQuery] = useState(initialQuery);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) onSearch(query.trim());
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 items-center mb-6">
+      <div className="relative flex-1">
+        {isLoading ? (
+          <Loader2 className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+        ) : (
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        )}
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Entity slug, stableId, or numericId (e.g. anthropic, E42)"
+          className="w-full h-10 pl-10 pr-4 border rounded-lg bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring transition-shadow"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={isLoading || !query.trim()}
+        className="h-10 px-5 bg-primary text-primary-foreground rounded-lg text-sm font-medium disabled:opacity-40 transition-opacity"
+      >
+        Look up
+      </button>
+    </form>
+  );
+}
+
+// ── Type badge ─────────────────────────────────────────────────────────────
+
+const TYPE_COLORS: Record<string, string> = {
+  string: "bg-sky-50 text-sky-700 dark:bg-sky-950/40 dark:text-sky-300",
+  number: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300",
+  boolean: "bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",
+  date: "bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+  json: "bg-orange-50 text-orange-700 dark:bg-orange-950/40 dark:text-orange-300",
+  bigint: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300",
+  array: "bg-orange-50 text-orange-700 dark:bg-orange-950/40 dark:text-orange-300",
+};
+
+function TypeBadge({ dataType }: { dataType: string }) {
+  const cls = TYPE_COLORS[dataType] ?? "bg-muted text-muted-foreground";
+  return (
+    <span className={`inline-block px-1.5 py-px rounded text-[10px] font-medium leading-tight ${cls}`}>
+      {dataType}
+    </span>
+  );
+}
+
+// ── Verdict badge ──────────────────────────────────────────────────────────
+
+const VERDICT_COLORS: Record<string, string> = {
+  confirmed: "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800",
+  contradicted: "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800",
+  unverifiable: "bg-muted text-muted-foreground border-border",
+  outdated: "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800",
+  partial: "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-950/40 dark:text-yellow-300 dark:border-yellow-800",
+  unchecked: "bg-muted/50 text-muted-foreground/60 border-border/50",
+};
+
+function VerdictBadge({ verdict, confidence }: { verdict: string; confidence: number | null }) {
+  const cls = VERDICT_COLORS[verdict] ?? "bg-muted text-muted-foreground border-border";
+  return (
+    <span className={`inline-flex items-center gap-1 px-1.5 py-px rounded border text-[10px] font-medium leading-tight ${cls}`}>
+      {verdict}
+      {confidence != null && (
+        <span className="opacity-60">{(confidence * 100).toFixed(0)}%</span>
+      )}
+    </span>
+  );
+}
+
+// ── Cell renderer ──────────────────────────────────────────────────────────
+
+function CellValue({ value, columnName }: { value: unknown; columnName: string }) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground/30 select-none">&mdash;</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? (
+      <span className="text-emerald-600 dark:text-emerald-400 font-medium">yes</span>
+    ) : (
+      <span className="text-muted-foreground/50">no</span>
+    );
+  }
+
+  if (typeof value === "object") {
+    return <JsonValue value={value} />;
+  }
+
+  // Entity reference columns -> link to same dashboard
+  const isEntityRef =
+    columnName.endsWith("EntityId") ||
+    columnName.endsWith("_entity_id") ||
+    columnName === "stableId" ||
+    columnName === "stable_id";
+
+  if (isEntityRef && typeof value === "string" && value.length === 10) {
+    return (
+      <Link
+        href={`/wiki/E1929?entity=${encodeURIComponent(value)}`}
+        className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline font-mono text-[11px]"
+      >
+        {value}
+        <ExternalLink className="h-2.5 w-2.5 opacity-40" />
+      </Link>
+    );
+  }
+
+  // URL values
+  if (typeof value === "string" && (value.startsWith("http://") || value.startsWith("https://"))) {
+    const domain = (() => {
+      try { return new URL(value).hostname.replace(/^www\./, ""); } catch { return null; }
+    })();
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline text-[11px] break-all"
+      >
+        {domain ?? (value.length > 50 ? value.slice(0, 50) + "\u2026" : value)}
+        <ExternalLink className="h-2.5 w-2.5 opacity-40 shrink-0" />
+      </a>
+    );
+  }
+
+  const str = String(value);
+  if (str.length > 200) {
+    return (
+      <span className="text-[11px]" title={str}>
+        {str.slice(0, 200)}<span className="text-muted-foreground">&hellip;</span>
+      </span>
+    );
+  }
+
+  return <span className="text-[11px]">{str}</span>;
+}
+
+function JsonValue({ value }: { value: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const json = JSON.stringify(value, null, 2);
+  const isShort = json.length < 100;
+
+  if (isShort) {
+    return (
+      <code className="text-[10px] font-mono bg-muted/80 px-1.5 py-0.5 rounded break-all leading-relaxed">
+        {json}
+      </code>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="text-[10px] text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-0.5"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        {expanded ? "collapse" : `JSON \u00b7 ${json.length} chars`}
+      </button>
+      {expanded && (
+        <pre className="text-[10px] font-mono bg-muted/80 p-2.5 rounded-md mt-1.5 overflow-x-auto max-h-64 leading-relaxed border border-border/40">
+          {json}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+// ── Section component ──────────────────────────────────────────────────────
+
+function ProfileSection({
+  section,
+  verdicts,
+  defaultExpanded,
+}: {
+  section: Section;
+  verdicts: Record<string, { verdict: string; confidence: number | null }>;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [showSchema, setShowSchema] = useState(false);
+
+  const isEmpty = section.total === 0;
+
+  return (
+    <div
+      className={`border rounded-lg overflow-hidden transition-colors ${
+        isEmpty
+          ? "border-border/40 bg-muted/10"
+          : "border-border/70 bg-background"
+      }`}
+    >
+      {/* Section header */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => !isEmpty && setExpanded(!expanded)}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); !isEmpty && setExpanded(!expanded); } }}
+        className={`w-full flex items-center justify-between px-4 py-2.5 text-left select-none transition-colors ${
+          isEmpty
+            ? "cursor-default"
+            : "cursor-pointer hover:bg-muted/40"
+        }`}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {isEmpty ? (
+            <span className="h-4 w-4 shrink-0" />
+          ) : expanded ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          )}
+          <span className={`font-medium text-sm truncate ${isEmpty ? "text-muted-foreground/60" : ""}`}>
+            {section.label}
+          </span>
+          {section.total > 0 ? (
+            <span className="shrink-0 inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 rounded-full bg-primary/10 text-primary text-[10px] font-semibold tabular-nums">
+              {section.total}
+            </span>
+          ) : (
+            <span className="text-[10px] text-muted-foreground/40 shrink-0">0</span>
+          )}
+          {section.error && (
+            <span className="text-[10px] text-red-500 font-medium shrink-0">error</span>
+          )}
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowSchema(!showSchema);
+          }}
+          className={`shrink-0 p-1.5 rounded-md transition-colors ${
+            showSchema
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/60"
+          }`}
+          title="Toggle schema info"
+          aria-label="Toggle schema info"
+        >
+          <TableProperties className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Schema panel */}
+      {showSchema && (
+        <div className="px-4 py-3 border-t border-dashed border-border/50 bg-muted/20">
+          <p className="text-[11px] text-muted-foreground mb-2.5 leading-relaxed">
+            {section.description}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {section.schema.columns.map((col) => (
+              <div
+                key={col.name}
+                className="inline-flex items-center gap-1 text-[10px] bg-background border border-border/50 rounded-md px-2 py-1 shadow-sm"
+                title={col.description ?? `${col.columnType}${col.notNull ? " NOT NULL" : ""}`}
+              >
+                <span className="font-mono text-foreground/80">{col.name}</span>
+                <TypeBadge dataType={col.dataType} />
+                {col.notNull && (
+                  <span className="text-red-400 dark:text-red-500 font-bold leading-none" title="NOT NULL">*</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Data rows */}
+      {expanded && !isEmpty && (
+        <div className="border-t border-border/50 overflow-x-auto">
+          <table className="w-full text-[11px]">
+            <thead>
+              <tr className="bg-muted/50 dark:bg-muted/30">
+                {section.schema.columns.map((col) => (
+                  <th
+                    key={col.name}
+                    className="px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap border-b border-border/40"
+                    title={col.description}
+                  >
+                    <span className="mr-1.5">{formatColumnHeader(col.name)}</span>
+                    <TypeBadge dataType={col.dataType} />
+                  </th>
+                ))}
+                <th className="px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap border-b border-border/40">
+                  <span className="inline-flex items-center gap-1">
+                    <ShieldCheck className="h-3 w-3" />
+                    Verdict
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/30">
+              {section.rows.map((row, i) => {
+                const recordId = row.id as string | undefined;
+                const verdict = recordId ? verdicts[recordId] : undefined;
+                return (
+                  <tr key={i} className="hover:bg-muted/20 transition-colors">
+                    {section.schema.columns.map((col) => {
+                      const camelKey = snakeToCamel(col.name);
+                      const value = camelKey in row ? row[camelKey] : row[col.name];
+                      return (
+                        <td key={col.name} className="px-3 py-2 align-top max-w-xs">
+                          <CellValue value={value} columnName={col.name} />
+                        </td>
+                      );
+                    })}
+                    <td className="px-3 py-2 align-top">
+                      {verdict ? (
+                        <VerdictBadge verdict={verdict.verdict} confidence={verdict.confidence} />
+                      ) : (
+                        <span className="text-muted-foreground/20 select-none">&mdash;</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {expanded && isEmpty && !section.error && (
+        <div className="border-t border-border/30 px-4 py-3 text-center text-[11px] text-muted-foreground/50">
+          No records
+        </div>
+      )}
+
+      {expanded && section.error && (
+        <div className="border-t border-red-200 dark:border-red-800/50 px-4 py-3 text-center text-[11px] text-red-600 dark:text-red-400 bg-red-50/50 dark:bg-red-950/20">
+          Query error: {section.error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+function formatColumnHeader(name: string): string {
+  return name
+    .replace(/_/g, " ")
+    .replace(/\b[a-z]/g, (c) => c.toUpperCase())
+    .replace(/\bId\b/g, "ID")
+    .replace(/\bUrl\b/g, "URL")
+    .replace(/\bFk\b/g, "FK");
+}
+
+// ── Stat pill ──────────────────────────────────────────────────────────────
+
+function StatPill({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-1.5">
+      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-xs font-semibold tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+// ── Entity summary ─────────────────────────────────────────────────────────
+
+function EntitySummary({ entity }: { entity: Record<string, unknown> }) {
+  const title = String(entity.title ?? "");
+  const entityType = String(entity.entityType ?? "");
+  const numericId = entity.numericId ? String(entity.numericId) : null;
+  const description = entity.description ? String(entity.description) : null;
+  const slug = String(entity.id ?? "");
+  const stableId = String(entity.stableId ?? "");
+  const website = entity.website ? String(entity.website) : null;
+  const status = entity.status ? String(entity.status) : null;
+
+  return (
+    <div className="rounded-lg border border-border/60 p-5 mb-5">
+      <div className="flex items-start justify-between gap-4 mb-2">
+        <div className="flex items-center gap-2.5 flex-wrap min-w-0">
+          <h2 className="text-lg font-semibold leading-tight">{title}</h2>
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium bg-primary/8 text-primary border border-primary/15 px-2 py-0.5 rounded-md">
+            {entityType}
+          </span>
+          {numericId && (
+            <span className="text-[11px] font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+              {numericId}
+            </span>
+          )}
+          {status && (
+            <span className={`text-[11px] font-medium px-2 py-0.5 rounded-md border ${
+              status === "active"
+                ? "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/30 dark:text-emerald-400 dark:border-emerald-800"
+                : "bg-muted text-muted-foreground border-border/50"
+            }`}>
+              {status}
+            </span>
+          )}
+        </div>
+        {website && (
+          <a
+            href={website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-1 text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            website
+          </a>
+        )}
+      </div>
+
+      {description && (
+        <p className="text-sm text-muted-foreground leading-relaxed mb-3">
+          {description}
+        </p>
+      )}
+
+      <div className="flex gap-x-5 gap-y-1 text-[11px] text-muted-foreground flex-wrap font-mono">
+        <span>
+          <span className="text-foreground/40 font-sans">slug</span>{" "}
+          {slug}
+        </span>
+        <span>
+          <span className="text-foreground/40 font-sans">stableId</span>{" "}
+          {stableId}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Empty state ────────────────────────────────────────────────────────────
+
+const EXAMPLE_ENTITIES = [
+  { slug: "anthropic", label: "Anthropic" },
+  { slug: "openai", label: "OpenAI" },
+  { slug: "google-deepmind", label: "DeepMind" },
+  { slug: "dario-amodei", label: "Dario Amodei" },
+  { slug: "open-philanthropy", label: "Open Philanthropy" },
+];
+
+function EmptyState({ onSearch }: { onSearch: (q: string) => void }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border/60 px-8 py-12 text-center">
+      <Database className="h-10 w-10 mx-auto mb-4 text-muted-foreground/25" />
+      <p className="text-base font-medium text-muted-foreground mb-1.5">
+        Entity Profile Explorer
+      </p>
+      <p className="text-sm text-muted-foreground/70 max-w-lg mx-auto mb-5">
+        View all database records for any entity &mdash;
+        personnel, grants, divisions, funding, benchmarks, and more.
+      </p>
+      <div className="flex items-center justify-center gap-2 flex-wrap">
+        <span className="text-xs text-muted-foreground/50">Try:</span>
+        {EXAMPLE_ENTITIES.map((e) => (
+          <button
+            key={e.slug}
+            onClick={() => onSearch(e.slug)}
+            className="text-xs font-mono px-2.5 py-1 rounded-md border border-border/50 bg-muted/30 text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
+          >
+            {e.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+
+// ── Main viewer ────────────────────────────────────────────────────────────
+
+export function EntityProfileViewer({
+  initialData,
+  initialEntity,
+}: {
+  initialData: EntityProfileData | null;
+  initialEntity: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlEntity = searchParams.get("entity") ?? "";
+  const effectiveInitial = initialEntity || urlEntity;
+  const [data, setData] = useState<EntityProfileData | null>(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-search on mount if URL has entity param
+  const hasAutoSearched = useRef(false);
+  useEffect(() => {
+    if (hasAutoSearched.current) return;
+    const urlEntity = searchParams.get("entity");
+    if (urlEntity && !initialData) {
+      hasAutoSearched.current = true;
+      doSearch(urlEntity);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const doSearch = useCallback(async (query: string) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/entity-profile-proxy?entity=${encodeURIComponent(query)}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.message || `HTTP ${res.status}`);
+        setData(null);
+      } else {
+        setData(await res.json());
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("entity", query);
+      router.push(`?${params.toString()}`, { scroll: false });
+      doSearch(query);
+    },
+    [router, searchParams, doSearch]
+  );
+
+  const stats = useMemo(() => {
+    if (!data) return null;
+    const totalRecords = data.sections.reduce((sum, s) => sum + s.total, 0);
+    const populated = data.sections.filter((s) => s.total > 0).length;
+    const verifiedCount = Object.keys(data.verdicts).length;
+    return { totalRecords, populated, total: data.sections.length, verifiedCount };
+  }, [data]);
+
+  // Sort populated sections first — memoized to avoid re-sorting on every render
+  const sortedSections = useMemo(() => {
+    if (!data) return [];
+    return data.sections
+      .slice()
+      .sort((a, b) => (b.total > 0 ? 1 : 0) - (a.total > 0 ? 1 : 0));
+  }, [data]);
+
+  return (
+    <div>
+      <EntitySearch
+        initialQuery={effectiveInitial}
+        onSearch={handleSearch}
+        isLoading={isLoading}
+      />
+
+      {error && (
+        <div className="rounded-lg border border-red-200 dark:border-red-800/50 bg-red-50 dark:bg-red-950/20 p-4 mb-5 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {data && stats && (
+        <>
+          <EntitySummary entity={data.entity} />
+
+          <div className="flex gap-2 mb-5 flex-wrap">
+            <StatPill icon={Database} label="Records" value={stats.totalRecords} />
+            <StatPill
+              icon={Layers}
+              label="Tables"
+              value={`${stats.populated}/${stats.total}`}
+            />
+            {stats.verifiedCount > 0 && (
+              <StatPill icon={ShieldCheck} label="Verified" value={stats.verifiedCount} />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            {sortedSections.map((section) => (
+                <ProfileSection
+                  key={section.key}
+                  section={section}
+                  verdicts={data.verdicts}
+                  defaultExpanded={section.total > 0 && section.total <= 50}
+                />
+              ))}
+          </div>
+        </>
+      )}
+
+      {!data && !error && !isLoading && <EmptyState onSearch={handleSearch} />}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/entity-profile/page.tsx
+++ b/apps/web/src/app/internal/entity-profile/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function EntityProfilePage() {
+  redirect("/wiki/E1929");
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -84,6 +84,7 @@ import { PeopleCoverageContent } from "@/app/internal/people-coverage/people-cov
 import { ThingsContent } from "@/app/internal/things/things-content";
 import { AgentActivityContent } from "@/app/internal/agent-activity/agent-activity-content";
 import { EntityMatrixContent } from "@/app/internal/entity-matrix/entity-matrix-content";
+import { EntityProfileContent } from "@/app/internal/entity-profile/entity-profile-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -249,6 +250,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   ThingsContent,
   AgentActivityContent,
   EntityMatrixContent,
+  EntityProfileContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -267,6 +267,7 @@ export function getInternalNav(): NavSection[] {
         { label: "People Coverage", href: internalHref("people-coverage-dashboard") },
         { label: "Things", href: internalHref("things-dashboard") },
         { label: "Entity Matrix", href: internalHref("entity-matrix-dashboard") },
+        { label: "Entity Profile", href: internalHref("entity-profile-dashboard") },
       ],
     },
     {

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -23,6 +23,7 @@ import { benchmarkResultsRoute } from "./routes/tablebase/benchmark-results.js";
 import { recordVerificationsRoute } from "./routes/tablebase/record-verifications.js";
 import { thingsRoute } from "./routes/tablebase/things.js";
 import { researchAreasRoute } from "./routes/tablebase/research-areas.js";
+import { entityProfileRoute } from "./routes/tablebase/entity-profile.js";
 
 // FactBase routes — structured triples with temporal data
 import { factsRoute } from "./routes/factbase/facts.js";
@@ -181,6 +182,9 @@ export function createApp() {
   // Cross-Base: unified things index
   app.route("/api/things", thingsRoute);
   app.route("/api/research-areas", researchAreasRoute);
+
+  // Aggregated entity profile (reads from all TableBase tables)
+  app.route("/api/entity-profile", entityProfileRoute);
 
 
   // Agent & session tracking (operational)

--- a/apps/wiki-server/src/routes/tablebase/entity-profile-descriptions.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile-descriptions.ts
@@ -1,0 +1,92 @@
+/**
+ * Human-readable column description overlay for entity-profile.
+ *
+ * Only columns where the snake_case name isn't self-explanatory need entries.
+ * Schema metadata (type, nullability, etc.) is auto-derived from Drizzle.
+ */
+export const COLUMN_DESCRIPTIONS: Record<string, Record<string, string>> = {
+  entities: {
+    id: "Entity slug (URL-safe identifier)",
+    stable_id: "10-char stable ID used as FK across tables",
+    numeric_id: "E-code (e.g. E42) for wiki page URLs",
+    custom_fields: "Arbitrary label/value pairs for entity-specific data",
+    related_entries: "Typed relationships to other entities",
+  },
+  personnel: {
+    person_entity_id: "FK to entities.stable_id for the person",
+    org_entity_id: "FK to entities.stable_id for the organization",
+    person_id: "Legacy: display name or entity ID (pre-migration)",
+    organization_id: "Legacy: display name or entity ID (pre-migration)",
+    role_type: "key-person | board | career",
+    is_founder: "Whether this person founded the organization",
+    appointed_by: "Board seats only: who appointed this member",
+  },
+  grants: {
+    org_entity_id: "FK to entities.stable_id for the grantor",
+    grantee_entity_id: "FK to entities.stable_id for the recipient",
+    program_id: "Soft ref to funding_programs.id",
+    amount: "Funding amount in specified currency (NUMERIC)",
+  },
+  funding_rounds: {
+    company_entity_id: "FK to entities.stable_id for the company",
+    lead_investor_entity_id: "FK to entities.stable_id for the lead investor",
+    raised: "Capital raised (USD, NUMERIC)",
+    valuation: "Post-money valuation (USD, NUMERIC)",
+    instrument: "equity | convertible-note | strategic-partnership | founding",
+  },
+  investments: {
+    company_entity_id: "FK to entities.stable_id for the company",
+    investor_entity_id: "FK to entities.stable_id for the investor",
+    stake_acquired: "Pre-dilution stake (text, may be a range)",
+    role: "lead | participant | founder",
+  },
+  equity_positions: {
+    company_entity_id: "FK to entities.stable_id for the company",
+    holder_entity_id: "FK to entities.stable_id for the holder",
+    stake: "Post-dilution equity stake (text, may be a range)",
+    as_of: "When this position was valid from",
+    valid_end: "When this position expired",
+  },
+  divisions: {
+    parent_org_id: "Parent org stableId (10-char)",
+    division_type: "fund | team | department | lab | program-area",
+  },
+  division_personnel: {
+    division_id: "FK to divisions.id",
+    person_id: "Person stableId or display name",
+  },
+  funding_programs: {
+    org_id: "Org stableId (10-char)",
+    division_id: "FK to divisions.id (nullable)",
+    program_type: "rfp | grant-round | fellowship | prize | solicitation | call",
+    total_budget: "Total budget in specified currency (NUMERIC)",
+  },
+  benchmark_results: {
+    benchmark_id: "FK to benchmarks.id",
+    model_id: "Entity slug of the ai-model",
+  },
+  facts: {
+    entity_id: "FK to entities.stable_id",
+    fact_id: "Unique fact identifier within the entity",
+    measure: "Timeseries grouping key",
+    subject: "FK to entities.stable_id for comparative facts",
+    format_divisor: "Divisor for formatted display (e.g. 1e9 for billions)",
+  },
+  things: {
+    parent_thing_id: "FK to things.id (self-referencing hierarchy)",
+    source_table: "Which PG table this thing originated from",
+    source_id: "PK in the source table",
+  },
+  wiki_pages: {
+    slug: "URL-safe page identifier",
+    integer_id: "Phase 4a migration integer PK",
+    content_plaintext: "Full page text (for search)",
+    coverage_items: "JSONB map of coverage check results",
+    synced_from_branch: "Git branch this data was synced from",
+  },
+  research_area_organizations: {
+    research_area_id: "FK to research_areas.id",
+    organization_id: "Entity stableId or slug",
+    role: "pioneer | active | major | funder | emerging",
+  },
+};

--- a/apps/wiki-server/src/routes/tablebase/entity-profile.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile.ts
@@ -1,0 +1,375 @@
+/**
+ * Entity Profile — aggregated view of ALL TableBase records for a single entity.
+ *
+ * Single endpoint that queries every relational table and returns sections
+ * with rows + auto-derived schema metadata from Drizzle table objects.
+ */
+import { Hono } from "hono";
+import { eq, or, inArray } from "drizzle-orm";
+import { getTableColumns } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import {
+  entities,
+  personnel,
+  grants,
+  fundingRounds,
+  investments,
+  equityPositions,
+  divisions,
+  divisionPersonnel,
+  fundingPrograms,
+  benchmarkResults,
+  facts,
+  things,
+  wikiPages,
+  researchAreaOrganizations,
+  recordVerdicts,
+} from "../../schema.js";
+import { resolveEntityStableId } from "../shared/entity-resolution.js";
+import { notFoundError } from "../shared/utils.js";
+import { COLUMN_DESCRIPTIONS } from "./entity-profile-descriptions.js";
+import type { PgTable } from "drizzle-orm/pg-core";
+
+// ---- Schema introspection (cached at module level — schema is static) ----
+
+interface ColumnMeta {
+  name: string;
+  dataType: string;
+  columnType: string;
+  notNull: boolean;
+  hasDefault: boolean;
+  description?: string;
+}
+
+function buildSchemaForTable(table: PgTable, tableName: string): ColumnMeta[] {
+  const columns = getTableColumns(table);
+  const descriptions = COLUMN_DESCRIPTIONS[tableName] ?? {};
+
+  return Object.values(columns).map((col) => {
+    // Drizzle Column objects have these properties at runtime
+    const c = col as { name: string; dataType: string; columnType: string; notNull: boolean; hasDefault: boolean };
+    const meta: ColumnMeta = {
+      name: c.name,
+      dataType: c.dataType,
+      columnType: c.columnType,
+      notNull: c.notNull,
+      hasDefault: c.hasDefault,
+    };
+    if (descriptions[c.name]) {
+      meta.description = descriptions[c.name];
+    }
+    return meta;
+  });
+}
+
+// ---- Columns to exclude from output (internal/noisy) ----
+
+const EXCLUDED_COLUMNS = new Set([
+  "synced_at",
+  "created_at",
+  "updated_at",
+  "content_plaintext",
+  "search_vector",
+  "synced_from_branch",
+  "synced_from_commit",
+]);
+
+// Also build a camelCase version for stripping from Drizzle query results
+const EXCLUDED_CAMEL = new Set(
+  [...EXCLUDED_COLUMNS].map((k) => k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()))
+);
+
+function stripInternalColumns(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (!EXCLUDED_CAMEL.has(key)) {
+        cleaned[key] = value;
+      }
+    }
+    return cleaned;
+  });
+}
+
+// ---- Section definition ----
+
+interface SectionDef {
+  key: string;
+  label: string;
+  description: string;
+  table: PgTable;
+  tableName: string;
+  query: (db: ReturnType<typeof getDrizzleDb>, stableId: string, slug: string) => Promise<Record<string, unknown>[]>;
+}
+
+const SECTIONS: SectionDef[] = [
+  {
+    key: "personnel",
+    label: "Personnel",
+    description: "People with roles at this entity (as org or person)",
+    table: personnel,
+    tableName: "personnel",
+    query: (db, stableId) =>
+      db.select().from(personnel).where(
+        or(eq(personnel.orgEntityId, stableId), eq(personnel.personEntityId, stableId))
+      ),
+  },
+  {
+    key: "divisions",
+    label: "Divisions",
+    description: "Organizational sub-units (funds, teams, departments, labs)",
+    table: divisions,
+    tableName: "divisions",
+    query: (db, stableId) =>
+      db.select().from(divisions).where(eq(divisions.parentOrgId, stableId)),
+  },
+  {
+    key: "divisionPersonnel",
+    label: "Division Personnel",
+    description: "People assigned to divisions of this entity",
+    table: divisionPersonnel,
+    tableName: "division_personnel",
+    query: async (db, stableId) => {
+      const orgDivisions = await db.select({ id: divisions.id }).from(divisions)
+        .where(eq(divisions.parentOrgId, stableId));
+      if (orgDivisions.length === 0) return [];
+      const divIds = orgDivisions.map((d) => d.id);
+      return db.select().from(divisionPersonnel).where(
+        inArray(divisionPersonnel.divisionId, divIds)
+      );
+    },
+  },
+  {
+    key: "grantsGiven",
+    label: "Grants Given",
+    description: "Grants made by this entity as grantor",
+    table: grants,
+    tableName: "grants",
+    query: (db, stableId) =>
+      db.select().from(grants).where(eq(grants.orgEntityId, stableId)),
+  },
+  {
+    key: "grantsReceived",
+    label: "Grants Received",
+    description: "Grants received by this entity as grantee",
+    table: grants,
+    tableName: "grants",
+    query: (db, stableId) =>
+      db.select().from(grants).where(eq(grants.granteeEntityId, stableId)),
+  },
+  {
+    key: "fundingRounds",
+    label: "Funding Rounds",
+    description: "Equity and strategic investment rounds",
+    table: fundingRounds,
+    tableName: "funding_rounds",
+    query: (db, stableId) =>
+      db.select().from(fundingRounds).where(eq(fundingRounds.companyEntityId, stableId)),
+  },
+  {
+    key: "investments",
+    label: "Investments",
+    description: "Investor participation in funding rounds (as company or investor)",
+    table: investments,
+    tableName: "investments",
+    query: (db, stableId) =>
+      db.select().from(investments).where(
+        or(eq(investments.companyEntityId, stableId), eq(investments.investorEntityId, stableId))
+      ),
+  },
+  {
+    key: "equityPositions",
+    label: "Equity Positions",
+    description: "Current/historical equity ownership stakes (as company or holder)",
+    table: equityPositions,
+    tableName: "equity_positions",
+    query: (db, stableId) =>
+      db.select().from(equityPositions).where(
+        or(eq(equityPositions.companyEntityId, stableId), eq(equityPositions.holderEntityId, stableId))
+      ),
+  },
+  {
+    key: "fundingPrograms",
+    label: "Funding Programs",
+    description: "RFPs, grant rounds, fellowships, prizes",
+    table: fundingPrograms,
+    tableName: "funding_programs",
+    query: (db, stableId) =>
+      db.select().from(fundingPrograms).where(eq(fundingPrograms.orgId, stableId)),
+  },
+  {
+    key: "researchAreaOrganizations",
+    label: "Research Areas",
+    description: "Research areas this entity is associated with",
+    table: researchAreaOrganizations,
+    tableName: "research_area_organizations",
+    query: (db, _stableId, slug) =>
+      db.select().from(researchAreaOrganizations).where(
+        eq(researchAreaOrganizations.organizationId, slug)
+      ),
+  },
+  {
+    key: "benchmarkResults",
+    label: "Benchmark Results",
+    description: "AI model benchmark scores (matched by slug)",
+    table: benchmarkResults,
+    tableName: "benchmark_results",
+    query: (db, _stableId, slug) =>
+      db.select().from(benchmarkResults).where(eq(benchmarkResults.modelId, slug)),
+  },
+  {
+    key: "facts",
+    label: "Facts",
+    description: "Structured facts from FactBase (timeseries, measures)",
+    table: facts,
+    tableName: "facts",
+    query: (db, stableId) =>
+      db.select().from(facts).where(eq(facts.entityId, stableId)),
+  },
+  {
+    key: "things",
+    label: "Things",
+    description: "Cross-base unified index entries parented to this entity",
+    table: things,
+    tableName: "things",
+    query: (db, stableId) =>
+      db.select().from(things).where(eq(things.parentThingId, stableId)),
+  },
+  {
+    key: "wikiPages",
+    label: "Wiki Pages",
+    description: "MDX wiki pages matching this entity slug",
+    table: wikiPages,
+    tableName: "wiki_pages",
+    query: (db, _stableId, slug) =>
+      db.select({
+        id: wikiPages.id,
+        numericId: wikiPages.numericId,
+        slug: wikiPages.slug,
+        title: wikiPages.title,
+        description: wikiPages.description,
+        category: wikiPages.category,
+        subcategory: wikiPages.subcategory,
+        entityType: wikiPages.entityType,
+        quality: wikiPages.quality,
+        readerImportance: wikiPages.readerImportance,
+        researchImportance: wikiPages.researchImportance,
+        wordCount: wikiPages.wordCount,
+        lastUpdated: wikiPages.lastUpdated,
+        contentFormat: wikiPages.contentFormat,
+        coveragePassing: wikiPages.coveragePassing,
+        coverageTotal: wikiPages.coverageTotal,
+        updateFrequency: wikiPages.updateFrequency,
+        daysSinceUpdate: wikiPages.daysSinceUpdate,
+        staleness: wikiPages.staleness,
+        readerRank: wikiPages.readerRank,
+        researchRank: wikiPages.researchRank,
+      }).from(wikiPages).where(eq(wikiPages.slug, slug)),
+  },
+];
+
+// Pre-compute schema metadata per unique tableName (static, never changes at runtime)
+const SCHEMA_CACHE = new Map<string, ColumnMeta[]>();
+for (const section of SECTIONS) {
+  if (!SCHEMA_CACHE.has(section.tableName)) {
+    SCHEMA_CACHE.set(
+      section.tableName,
+      buildSchemaForTable(section.table, section.tableName)
+        .filter((col) => !EXCLUDED_COLUMNS.has(col.name))
+    );
+  }
+}
+
+// Sections that have record verdicts
+const VERDICT_SECTIONS = new Set([
+  "personnel", "grantsGiven", "grantsReceived", "fundingRounds",
+  "investments", "equityPositions", "divisions", "fundingPrograms",
+]);
+
+// ---- Route definition (method-chained for Hono RPC type inference) ----
+
+const entityProfileApp = new Hono()
+
+  .get("/:identifier", async (c) => {
+    const identifier = c.req.param("identifier");
+    const db = getDrizzleDb();
+
+    // Resolve identifier and fetch entity row in one step
+    const stableId = await resolveEntityStableId(db, identifier);
+    if (!stableId) {
+      return notFoundError(c, `Entity not found: ${identifier}`);
+    }
+
+    const [entityRow] = await db.select().from(entities)
+      .where(eq(entities.stableId, stableId)).limit(1);
+
+    if (!entityRow) {
+      return notFoundError(c, `Entity row not found for stableId: ${stableId}`);
+    }
+
+    const slug = entityRow.id; // entity.id is the slug
+
+    // Run all section queries in parallel
+    const sectionResults = await Promise.all(
+      SECTIONS.map(async (section) => {
+        try {
+          const rows = await section.query(db, stableId, slug);
+          return {
+            key: section.key,
+            label: section.label,
+            description: section.description,
+            schema: { columns: SCHEMA_CACHE.get(section.tableName) ?? [] },
+            rows: stripInternalColumns(rows),
+            total: rows.length,
+          };
+        } catch (err) {
+          console.error(`Entity profile section ${section.key} failed:`, err);
+          return {
+            key: section.key,
+            label: section.label,
+            description: section.description,
+            schema: { columns: [] },
+            rows: [],
+            total: 0,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      })
+    );
+
+    // Batch-fetch record verdicts for all record IDs found
+    const recordIds: string[] = [];
+    for (const section of sectionResults) {
+      if (VERDICT_SECTIONS.has(section.key)) {
+        for (const row of section.rows) {
+          const id = row.id;
+          if (typeof id === "string") {
+            recordIds.push(id);
+          }
+        }
+      }
+    }
+
+    let verdicts: Record<string, { verdict: string; confidence: number | null }> = {};
+    if (recordIds.length > 0) {
+      const verdictRows = await db.select().from(recordVerdicts)
+        .where(inArray(recordVerdicts.recordId, recordIds));
+      for (const v of verdictRows) {
+        verdicts[v.recordId] = { verdict: v.verdict, confidence: v.confidence };
+      }
+    }
+
+    // Strip internal columns from entity row
+    const { syncedAt, createdAt, updatedAt, ...entityData } = entityRow;
+
+    return c.json({
+      entity: entityData,
+      sections: sectionResults,
+      verdicts,
+    });
+  });
+
+// ---- Exports ----
+
+export const entityProfileRoute = entityProfileApp;
+export type EntityProfileRoute = typeof entityProfileApp;

--- a/content/docs/internal/entity-profile-dashboard.mdx
+++ b/content/docs/internal/entity-profile-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+numericId: E1929
+title: "Entity Profile"
+description: "Raw data explorer showing all TableBase records for any entity, with schema metadata and record verdicts."
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-03-16"
+---
+
+<EntityProfileContent />


### PR DESCRIPTION
## Summary
- New wiki-server endpoint `GET /api/entity-profile/:identifier` that queries 14 tables in parallel and returns all records for any entity with auto-derived schema metadata from Drizzle
- New internal dashboard at `/wiki/E1929` (Entity Profile) with collapsible sections, type badges, verdict badges, entity reference links, and quick-access entity buttons
- Schema introspection cached at module level (static, computed once per server start)
- Proxy API route streams response without parse+reserialize

## Test plan
- [x] `pnpm build` passes (1823 static pages generated)
- [x] `pnpm test` — all tests pass
- [x] TypeScript compiles cleanly (both wiki-server and web app)
- [x] Empty state renders with entity suggestions (verified via Playwright screenshot)
- [x] Error state shows when wiki-server unavailable (verified via Playwright screenshot)
- [x] Search bar pre-fills from `?entity=` URL param
- [ ] Data view renders with populated sections when wiki-server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)