### PR TITLE
content: improve citations on Dustin Moskovitz page

### DIFF
--- a/content/docs/knowledge-base/people/dustin-moskovitz.mdx
+++ b/content/docs/knowledge-base/people/dustin-moskovitz.mdx
@@ -1,13 +1,13 @@
 ---
 wikiId: E436
 title: Dustin Moskovitz
-description: Dustin Moskovitz is a Facebook co-founder who became the world's youngest self-made billionaire in 2011.
+description: "Dustin Moskovitz is a Facebook co-founder and Asana co-founder who has become one of the largest individual funders of AI safety research globally, directing approximately \\$336M to the field through Coefficient Giving (formerly Open Philanthropy)."
 sidebar:
   order: 11
 subcategory: ea-figures
-lastEdited: 2026-02-23
+lastEdited: "2026-03-17"
 update_frequency: 45
-llmSummary: "Dustin Moskovitz and Cari Tuna have given \\$4B+ since 2011, with ~\\$336M (12% of total) directed to AI safety through Coefficient Giving, making them the largest individual AI safety funders globally. In 2024, their \\$63.6M represented ~60% of all external AI safety investment, supporting organizations like MIRI (\\$20M+), Redwood (\\$15M+), and METR (\\$10M+), while maintaining balanced optimism about AI benefits and risks."
+llmSummary: "Dustin Moskovitz and Cari Tuna have given \\$4B+ since 2011, with ~\\$336M (12% of total) directed to AI safety through Coefficient Giving (formerly Open Philanthropy), making them the largest individual AI safety funders globally. Open Philanthropy's 2024 progress report cited approximately \\$50M committed to technical AI safety research that year; secondary analyses (including Stephen McAleese's LessWrong overview) put the broader figure at approximately \\$63.6M. In 2025, Moskovitz and Tuna transferred a \\$500M stake in Anthropic into a nonprofit vehicle and donated over \\$600M total. Coefficient Giving (rebranded from Open Philanthropy in November 2025) now operates multi-donor funds including the Lead Exposure Action Fund (\\$125M) and Abundance & Growth Fund (\\$120M)."
 clusters:
   - ai-safety
   - community
@@ -22,9 +22,9 @@ import { Mermaid, EntityLink } from '@components/wiki';
 | Dimension | Assessment | Evidence |
 |-----------|------------|----------|
 | **Net Worth** | ≈\$17B (2025) | [Forbes](https://en.wikipedia.org/wiki/Dustin_Moskovitz), [Bloomberg Billionaires Index](https://www.bloomberg.com/billionaires/profiles/dustin-a-moskovitz/) |
-| **Lifetime Giving** | \$4B+ | Through Good Ventures since 2011 |
-| **AI Safety Funding** | ≈\$336M | Via Coefficient Giving (2017-2024) |
-| **Primary Vehicle** | <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> | Formerly <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> |
+| **Lifetime Giving** | \$4B+ | Through <EntityLink id="E1455" name="good-ventures">Good Ventures</EntityLink> since 2011 |
+| **AI Safety Funding** | ≈\$336M | Via <EntityLink id="E552" name="open-philanthropy">Open Philanthropy</EntityLink> / Coefficient Giving (2017–2024) |
+| **Primary Vehicle** | <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> (formerly Open Philanthropy) | [coefficientgiving.org](https://coefficientgiving.org) |
 | **Public Profile** | Low-to-Moderate | Increasingly vocal on AI policy |
 | **Giving Pledge** | 2010 | Youngest signatories (25/26) |
 
@@ -45,7 +45,7 @@ import { Mermaid, EntityLink } from '@components/wiki';
 
 ## Net Worth Over Time
 
-Moskovitz's net worth has been remarkably flat over the past 6+ years despite holding stakes in two major technology companies. While fluctuations have been dramatic year-to-year—driven primarily by Meta stock volatility—the overall trajectory shows essentially no net growth since 2018.
+Moskovitz's net worth has been broadly flat over the past 6+ years despite holding stakes in two major technology companies. While fluctuations have been dramatic year-to-year—driven primarily by Meta stock volatility—the overall trajectory shows essentially no net growth since 2018.
 
 <Mermaid chart={`
 %%{init: {'theme':'default', 'themeVariables': {'xyChart': {'plotColorPalette': '#2563eb'}}}}%%
@@ -58,8 +58,8 @@ xychart-beta
 
 | Year | Net Worth | Annual Giving | Notable Events |
 |------|-----------|---------------|----------------|
-| **2011** | ≈\$3.5B | ≈\$5M | Became youngest self-made billionaire (Forbes); Good Ventures founded |
-| **2017** | \$10.3B | ≈\$200M | Open Phil scales up grantmaking |
+| **2011** | ≈\$3.5B | ≈\$5M | Recognized as youngest self-made billionaire (Forbes); Good Ventures founded |
+| **2017** | \$10.3B | ≈\$200M | Open Philanthropy scales up grantmaking |
 | **2018** | \$14.1B | ≈\$170M | Near recent peak |
 | **2019** | \$11.4B | ≈\$200M | |
 | **2020** | \$8.8B | ≈\$200M | COVID crash, then recovery; Asana IPO |
@@ -67,10 +67,10 @@ xychart-beta
 | **2022** | \$10.8B | ≈\$650M | Meta stock crashed 64%; giving accelerated post-FTX |
 | **2023** | \$9.4B | ≈\$750M | Recent low; \$1.9B transfer to Good Ventures |
 | **2024** | \$16.3B | ≈\$650M | Meta recovery; multi-donor fund launches |
-| **2025** | ≈\$17.4B | ≈\$600M+ | Forbes (May 2025); Coefficient Giving rebrand |
+| **2025** | ≈\$17.4B | ≈\$600M+ | Forbes (May 2025); Coefficient Giving rebrand; >\$600M donated per [Fortune (Nov 2025)](https://fortune.com/2025/11/10/meet-the-millennial-meta-cofounder-and-his-wife-who-are-giving-away-20-billion/) |
 | **2026** | ≈\$12.4B | — | Bloomberg (Feb 2026) |
 
-*Annual Giving figures are grants recommended by <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> (formerly <EntityLink id="E521" name="coefficient-giving" >Coefficient Giving</EntityLink>), funded primarily by Good Ventures. Figures from Open Phil annual reports use approximate language ("over \$X million"); values shown are midpoint estimates. Sources: [Coefficient Giving annual reports](https://coefficientgiving.org/research/), [ProPublica 990s](https://projects.propublica.org/nonprofits/organizations/461008520).*
+*Annual Giving figures are grants recommended by Open Philanthropy (now <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink>), funded primarily by Good Ventures. Figures from Open Philanthropy annual reports use approximate language ("over \$X million"); values shown are midpoint estimates. Sources: [Coefficient Giving annual reports](https://coefficientgiving.org/research/), [ProPublica 990s](https://projects.propublica.org/nonprofits/organizations/461008520).*
 
 Sources: [Grizzly Bulls Billionaire Index](https://grizzlybulls.com/billionaires/dustin-moskovitz), [Forbes](https://en.wikipedia.org/wiki/Dustin_Moskovitz), [Bloomberg Billionaires Index](https://www.bloomberg.com/billionaires/profiles/dustin-a-moskovitz/)
 
@@ -86,17 +86,17 @@ Sources: [Grizzly Bulls Billionaire Index](https://grizzlybulls.com/billionaires
 
 **Bloomberg methodology note**: In May 2025, Bloomberg removed Moskovitz's Meta stake from its calculation because recent filings could no longer confirm his ownership level, causing their estimate to drop by approximately \$18 billion. This explains some discrepancy between sources.
 
-**<EntityLink id="E22" name="anthropic">Anthropic</EntityLink> stake not included**: Most net worth estimates likely do not fully reflect Moskovitz's <EntityLink id="E406" name="anthropic-investors">Anthropic stake</EntityLink>, estimated at 0.8-2.5% of the company (\$3-9B at Anthropic's \$350B January 2026 valuation). He participated in both seed and Series A rounds (estimated \$20-50M invested). In November 2025, he moved a \$500M portion of this stake into a nonprofit vehicle. If this stake were fully valued, his total wealth would be substantially higher than reported figures suggest.
+**<EntityLink id="E22" name="anthropic">Anthropic</EntityLink> stake not included**: Most net worth estimates likely do not fully reflect Moskovitz's <EntityLink id="E406" name="anthropic-investors">Anthropic stake</EntityLink>, estimated at 0.8-2.5% of the company (\$3-9B at Anthropic's \$350B January 2026 valuation). He participated in both seed and Series A rounds (estimated \$20-50M invested). In November 2025, he and Tuna moved a \$500M portion of this stake into a nonprofit vehicle. If this stake were fully valued, his total wealth would be substantially higher than reported figures suggest.
 
 ## Overview
 
-<EntityLink id="E436" name="dustin-moskovitz">Dustin Moskovitz (AI Safety Funder)</EntityLink> is a co-founder of Facebook who reportedly became the world's youngest self-made billionaire in 2011,[^rc-17ba] and has since become what is widely described as the largest individual funder of AI safety research through his philanthropy via Coefficient Giving (formerly Open Philanthropy). Together with his wife Cari Tuna, Moskovitz has reportedly given away over \$4 billion since 2011[^rc-ce92] and committed to giving away the vast majority of their wealth during their lifetimes through the [Giving Pledge](https://givingpledge.org/pledger?pledgerId=252).[^rc-256c]
+Dustin Moskovitz is a co-founder of Facebook who was recognized by Forbes as the world's youngest self-made billionaire in 2011,[^rc-17ba] and has since become, according to comparative analyses of AI safety philanthropy, the largest individual funder of AI safety research through his philanthropy via Coefficient Giving (formerly Open Philanthropy). Together with his wife Cari Tuna, Moskovitz has reportedly given away over \$4 billion since 2011[^rc-ce92] and committed to giving away the vast majority of their wealth during their lifetimes through the [Giving Pledge](https://givingpledge.org/pledger?pledgerId=252).[^rc-256c]
 
-Moskovitz's path from tech entrepreneur to major philanthropist began at Harvard, where he reportedly roomed with Mark Zuckerberg and helped build Facebook from a dorm-room project into a global platform.[^rc-3b5a] After leaving Facebook in 2008,[^rc-ffc0] he co-founded Asana, a work management software company that went public in 2020.[^rc-90b9] His wealth derives primarily from his founding stakes in both Meta Platforms and Asana.
+Moskovitz's path from tech entrepreneur to major philanthropist began at Harvard, where he reportedly roomed with <EntityLink id="E1293" name="mark-zuckerberg">Mark Zuckerberg</EntityLink> and helped build Facebook from a dorm-room project into a global platform.[^rc-3b5a] After leaving Facebook in 2008,[^rc-ffc0] he co-founded Asana, a work management software company that went public in 2020.[^rc-90b9] His wealth derives primarily from his founding stakes in both Meta Platforms and Asana.
 
 Unlike many tech philanthropists who maintain high public profiles, Moskovitz initially took a hands-off approach to his giving, delegating authority to professional staff. He has become increasingly vocal about AI risks, signing the [Center for AI Safety's 2023 statement](https://www.safe.ai/work/statement-on-ai-risk) declaring AI extinction risk a "global priority"[^rc-33ef] and advocating for pre-deployment safety evaluations of advanced AI systems.
 
-Moskovitz's impact on AI safety is substantial. Coefficient Giving has reportedly directed approximately \$336 million to AI safety since 2017, representing about 12% of its reported \$2.8 billion in total giving over that period,[^rc-73d2] making it the largest external funder of AI safety research in the world. According to available reports, the organization spent approximately \$46 million on AI safety in 2023[^rc-46ee] and deployed approximately \$63.6 million in 2024—figures that some analysts have estimated represent close to 60% of all external AI safety investment globally.[^rc-4a0b]
+Moskovitz's impact on AI safety is substantial. Open Philanthropy (now Coefficient Giving) has reportedly directed approximately \$336 million to AI safety since 2017, representing about 12% of its reported \$2.8 billion in total giving over that period,[^rc-73d2] making it the largest external funder of AI safety research in the world. According to available reports, the organization spent approximately \$46 million on AI safety in 2023.[^rc-46ee] For 2024, Open Philanthropy's own progress report cited roughly \$50 million committed to technical AI safety research projects, while secondary analyses—including Stephen McAleese's widely cited [LessWrong funding overview](https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation) (updated January 2025)—estimated a broader figure of approximately \$63.6 million when including governance and policy grants.[^rc-4a0b]
 
 ## Career Timeline
 
@@ -120,11 +120,11 @@ Moskovitz's impact on AI safety is substantial. Coefficient Giving has reportedl
 |--------|---------|
 | **Role** | Co-founder, first CTO, then VP of Engineering[^rc-b111] |
 | **Period** | February 2004 – October 2008[^rc-50ee][^rc-53be] |
-| **Co-founders** | Mark Zuckerberg, Eduardo Saverin, Chris Hughes, Andrew McCollum[^rc-50ee] |
+| **Co-founders** | <EntityLink id="E1293" name="mark-zuckerberg">Mark Zuckerberg</EntityLink>, Eduardo Saverin, Chris Hughes, Andrew McCollum[^rc-50ee] |
 | **Key Contribution** | Technical infrastructure, scalability |
 | **Stake at Departure** | Reportedly ≈2.34% (source of initial billions) |
 
-Moskovitz enrolled at Harvard University in 2002[^rc-b111] and became Mark Zuckerberg's freshman roommate. According to Zuckerberg, Moskovitz "learned programming in a few days" and joined the founding team when Facebook (originally "thefacebook.com") launched in February 2004.[^rc-50ee] He served as the company's first Chief Technology Officer, building much of the early technical infrastructure.[^rc-b111] In June 2004, Moskovitz and Zuckerberg moved to Palo Alto to work on Facebook full-time.[^rc-b111] Around this period the company received \$500,000 in seed funding from Peter Thiel.[^rc-a94c] By December 2004, Facebook had reportedly reached nearly 1 million users.[^rc-50ee]
+Moskovitz enrolled at <EntityLink id="E1115" name="harvard-university">Harvard University</EntityLink> in 2002[^rc-b111] and became Mark Zuckerberg's freshman roommate. According to Zuckerberg, Moskovitz "learned programming in a few days" and joined the founding team when Facebook (originally "thefacebook.com") launched in February 2004.[^rc-50ee] He served as the company's first Chief Technology Officer, building much of the early technical infrastructure.[^rc-b111] In June 2004, Moskovitz and Zuckerberg moved to Palo Alto to work on Facebook full-time.[^rc-b111] Around this period the company received \$500,000 in seed funding from Peter Thiel.[^rc-a94c] By December 2004, Facebook had reportedly reached nearly 1 million users.[^rc-50ee]
 
 As VP of Engineering, Moskovitz focused on scaling the platform to handle rapid global growth.[^rc-b111] He departed in October 2008 to co-found Asana, drawing on his insight that internal work-management tools could be made available to all organizations, not just large technology companies.[^rc-53be]
 
@@ -138,6 +138,7 @@ As VP of Engineering, Moskovitz focused on scaling the platform to handle rapid 
 | **Mission** | "Help humanity thrive by enabling the world's teams to work together effortlessly" |
 | **IPO** | September 2020 (direct listing, NYSE: ASAN)[^rc-5a5d] |
 | **Valuation at IPO** | Approximately \$5.5 billion[^rc-5a5d] |
+| **Stock Peak** | ≈\$142.68 (November 9, 2021); ≈\$7 as of early 2026, market cap ≈\$1.65B ([MacroTrends](https://www.macrotrends.net/stocks/charts/ASAN/asana/market-cap)) |
 | **2024 Revenue** | Reportedly >\$700 million annually |
 | **Customers** | Reportedly 170,000+, including 85%+ of Fortune 500 |
 | **Moskovitz Stake** | Reportedly ≈53% (as of 2024) |
@@ -146,11 +147,11 @@ Moskovitz announced Asana's founding on October 3, 2008.[^rc-53be] The company's
 
 Moskovitz reportedly took over the CEO role around October 2010 after initially sharing leadership responsibilities with Rosenstein. He later acknowledged that people management was not a natural fit for his personality, characterizing the CEO position as demanding work he had not originally envisioned for himself.
 
-Asana went public via a direct listing on the New York Stock Exchange in September 2020 under the ticker ASAN, with an opening-day valuation of approximately \$5.5 billion.[^rc-5a5d] In March 2025, Moskovitz announced his intention to transition to Board Chair.[^rc-038a] Former ServiceNow and Rubrik executive Dan Rogers was named incoming CEO, formally assuming the role in July 2025.[^rc-038a] Moskovitz indicated he planned to devote greater attention to philanthropy and AI safety work following the transition.[^rc-038a]
+Asana went public via a direct listing on the New York Stock Exchange in September 2020 under the ticker ASAN, with an opening-day valuation of approximately \$5.5 billion.[^rc-5a5d] Asana's stock peaked at approximately \$142.68 per share in November 2021 before declining sharply; by early 2026 it was trading at approximately \$7, giving the company a market capitalization of approximately \$1.65 billion—a decline of approximately 95% from its peak and roughly 49% below its IPO-day market cap, according to [MacroTrends data](https://www.macrotrends.net/stocks/charts/ASAN/asana/market-cap). In March 2025, Moskovitz announced his intention to transition to Board Chair.[^rc-038a] Dan Rogers—who had most recently served as CEO of LaunchDarkly and previously as President of Rubrik and Chief Marketing Officer at ServiceNow—was named incoming CEO, formally assuming the role on July 21, 2025. ([Asana IR, June 2025](https://investors.asana.com/news-releases/news-release-details/asana-names-dan-rogers-chief-executive-officer)) Moskovitz indicated he planned to devote greater attention to philanthropy and AI safety work following the transition.[^rc-038a]
 
 ## The Giving Pledge
 
-In December 2010, <EntityLink id="E436" name="dustin-moskovitz">Dustin Moskovitz</EntityLink> and Cari Tuna signed the <EntityLink id="E531" name="giving-pledge">Giving Pledge</EntityLink>, the philanthropic commitment launched by Warren Buffett and Bill and Melinda Gates asking billionaires to give away at least half their wealth.[^rc-17ba] At the time of signing, Tuna was reportedly 25 and Moskovitz was 26, making them among the youngest signatories in the Pledge's history.[^rc-ce92] (See the <EntityLink id="E531" name="giving-pledge">Giving Pledge</EntityLink> page for analysis of historical fulfillment rates and criticisms.)
+In December 2010, <EntityLink id="E436" name="dustin-moskovitz">Dustin Moskovitz</EntityLink> and Cari Tuna signed the <EntityLink id="E531" name="giving-pledge">Giving Pledge</EntityLink>, the philanthropic commitment launched by Warren Buffett and Bill and Melinda Gates asking billionaires to give away at least half their wealth.[^rc-17ba] At the time of signing, Tuna was reportedly 25 and Moskovitz was 26, making them among the youngest signatories in the Pledge's history.[^rc-ce92] (See the <EntityLink id="E531">Giving Pledge</EntityLink> page for analysis of historical fulfillment rates and criticisms.)
 
 ### The Pledge Letter
 
@@ -158,7 +159,7 @@ In December 2010, <EntityLink id="E436" name="dustin-moskovitz">Dustin Moskovitz
 |--------|----------|
 | **Signed** | December 2010 [^rc-17ba] |
 | **Commitment** | Give away majority of wealth during lifetime |
-| **Co-signers that round** | Included Mark Zuckerberg, among others [^rc-ce92] |
+| **Co-signers that round** | Included <EntityLink id="E1293" name="mark-zuckerberg">Mark Zuckerberg</EntityLink>, among others [^rc-ce92] |
 | **Key Quote** | "We will donate and invest with both urgency and mindfulness, aiming to foster a safer, healthier and more economically empowered global community" [^rc-256c] |
 
 The timing was notable: Moskovitz had recently become a billionaire through Facebook's growth, and the term "effective altruism" had not yet been coined. The couple was already developing the research-driven approach to philanthropy that would become their hallmark. Their full pledge letter is available on the Giving Pledge website.[^rc-256c]
@@ -216,14 +217,14 @@ The evolution of Moskovitz and Tuna's grantmaking infrastructure reflects their 
 
 | Year | Development |
 |------|-------------|
-| **2010** | Moskovitz and Tuna reportedly meet GiveWell co-founders <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> and Elie Hassenfeld[^rc-33ef] |
+| **2010** | Moskovitz and Tuna reportedly meet <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> co-founders <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> and Elie Hassenfeld[^rc-33ef] |
 | **2011** | Tuna reportedly joins GiveWell board; Good Ventures founded[^rc-17ba] |
 | **2012** | GiveWell Labs reportedly created as joint initiative[^rc-73d2] |
-| **2014** | GiveWell Labs reportedly rebranded as Open Philanthropy Project[^rc-73d2] |
-| **2017** | Coefficient Giving reportedly becomes independent LLC[^rc-46ee] |
-| **2019** | Reportedly shortened to "Coefficient Giving"[^rc-46ee] |
-| **2024** | Lead Exposure Action Fund reportedly launches (\$125M) as first multi-donor fund[^rc-4a0b] |
-| **2025** | Reportedly rebranded to "Coefficient Giving" to reflect multi-donor expansion[^rc-b111] |
+| **2014** | GiveWell Labs rebranded as Open Philanthropy Project ([Coefficient Giving history](https://coefficientgiving.org/our-history/))[^rc-73d2] |
+| **2017** | Open Philanthropy Project becomes independent LLC, splitting from GiveWell (June 1, 2017; publicly announced June 12, 2017) ([Coefficient Giving history](https://coefficientgiving.org/our-history/))[^rc-46ee] |
+| **2019** | Name simplified to "Open Philanthropy" (dropping "Project") ([Coefficient Giving history](https://coefficientgiving.org/our-history/))[^rc-46ee] |
+| **2024** | Lead Exposure Action Fund launches (≈\$125M from 12+ philanthropic partners) as first multi-donor fund ([Coefficient Giving, Sep 2024](https://coefficientgiving.org/research/announcing-the-lead-exposure-action-fund/))[^rc-4a0b] |
+| **2025** | Rebranded to "Coefficient Giving" (November 18, 2025) to reflect expanded multi-donor work ([Coefficient Giving](https://coefficientgiving.org/research/open-philanthropy-is-now-coefficient-giving/))[^rc-b111] |
 
 <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> now serves as the primary vehicle for Moskovitz's giving:
 
@@ -235,9 +236,20 @@ The evolution of Moskovitz and Tuna's grantmaking infrastructure reflects their 
 | **Staff** | reportedly ≈100[^rc-b111] |
 | **Cause Areas** | Global health, AI safety, biosecurity, farm animal welfare, scientific research[^rc-50ee] |
 | **AI Safety Total** | reportedly ≈\$336 million (≈12% of total)[^rc-a94c] |
-| **Multi-Donor Funds** | reportedly Lead Exposure Action Fund (\$125M), Abundance & Growth Fund (\$120M)[^rc-4a0b] |
+| **Multi-Donor Funds** | Lead Exposure Action Fund (≈\$125M, 2024); Abundance & Growth Fund (\$120M, 2025)[^rc-4a0b] |
 
-The rebrand to "Coefficient Giving" reportedly signals a strategic shift from serving primarily one anchor donor (Good Ventures) to operating multi-donor funds that other philanthropists can join.[^rc-b111] The name reportedly reflects the mathematical concept: a coefficient multiplies whatever it's paired with, just as the organization aims to amplify philanthropic impact.[^rc-b111]
+The rebrand to "Coefficient Giving" in November 2025 signals a strategic shift from serving primarily one anchor donor (Good Ventures) to operating multi-donor funds that other philanthropists can join.[^rc-b111] The name reflects the mathematical concept: a coefficient multiplies whatever it's paired with, just as the organization aims to amplify philanthropic impact.[^rc-b111]
+
+#### Multi-Donor Funds (2024–2025)
+
+Coefficient Giving has launched two significant pooled funds as part of its expanded multi-donor strategy:
+
+| Fund | Launched | Size | Partners | Focus |
+|------|---------|------|---------|-------|
+| **Lead Exposure Action Fund** | September 2024 | ≈\$125M (from 12+ partners) | Good Ventures, Bill & Melinda <EntityLink id="E1454" name="gates-foundation">Gates Foundation</EntityLink>, ELMA Foundation, Lucy Southworth, and others | Reducing lead exposure in low-income countries (measurement, mitigation, mainstreaming); addresses an estimated 1.5M deaths annually |
+| **Abundance & Growth Fund** | 2025 | \$120M over 3 years | Good Ventures, Patrick Collison, and others | Accelerating economic growth and scientific/technological progress; builds on prior housing and innovation policy work |
+
+Sources: [Lead Exposure Action Fund announcement](https://coefficientgiving.org/research/announcing-the-lead-exposure-action-fund/) (Coefficient Giving, Sep 2024); [Abundance & Growth Fund announcement](https://coefficientgiving.org/research/announcing-our-new-120m-abundance-and-growth-fund/) (Coefficient Giving, 2025).
 
 ### Giving Scale
 
@@ -248,17 +260,17 @@ The rebrand to "Coefficient Giving" reportedly signals a strategic shift from se
 | 2020–2022 | reportedly ≈\$1B | Major AI safety scaling, pandemic response |
 | 2023 | reportedly ≈\$600M | Post-FTX expansion, \$1.9B transfer to Good Ventures[^rc-90b9] |
 | 2024 | reportedly ≈\$650M | Multi-donor fund launches[^rc-50ee] |
-| 2025 | reportedly ≈\$600M+ | Coefficient Giving rebrand[^rc-b111] |
+| 2025 | reportedly >\$600M | Coefficient Giving rebrand; >\$600M donated per [Fortune (Nov 2025)](https://fortune.com/2025/11/10/meet-the-millennial-meta-cofounder-and-his-wife-who-are-giving-away-20-billion/)[^rc-b111] |
 | **Lifetime** | **reportedly \$4B+** | Through Good Ventures/Coefficient Giving[^rc-ffc0] |
 
 ### Major Non-AI Grants
 
 | Recipient | Amount | Focus |
 |-----------|--------|-------|
-| Malaria Consortium | reportedly \$300M+[^rc-b111] | Malaria prevention |
-| Evidence Action | reportedly \$200M+[^rc-b111] | Deworming, water treatment |
-| Helen Keller International | reportedly \$100M+[^rc-b111] | Vitamin A supplementation |
-| GiveDirectly | reportedly \$50M+[^rc-b111] | Direct cash transfers |
+| <EntityLink id="E1228" name="malaria-consortium">Malaria Consortium</EntityLink> | reportedly \$300M+[^rc-b111] | Malaria prevention |
+| <EntityLink id="E1229" name="evidence-action">Evidence Action</EntityLink> | reportedly \$200M+[^rc-b111] | Deworming, water treatment |
+| <EntityLink id="E1230" name="helen-keller-international">Helen Keller International</EntityLink> | reportedly \$100M+[^rc-b111] | Vitamin A supplementation |
+| <EntityLink id="E1200" name="givedirectly">GiveDirectly</EntityLink> | reportedly \$50M+[^rc-b111] | Direct cash transfers |
 
 ## AI Safety Philanthropy
 
@@ -268,7 +280,7 @@ flowchart LR
         MIRI[MIRI<br/>\$20M+]
         REDWOOD[Redwood<br/>\$15M+]
         ARC[ARC/METR<br/>\$10M+]
-        FAR[FAR.AI<br/>\$1.3M+]
+        FAR[<EntityLink id="E297" name="technical-research">Technical AI Safety Research</EntityLink><br/>\$1.3M+]
     end
 
     subgraph GOVERNANCE["Governance & Policy"]
@@ -303,7 +315,7 @@ Coefficient Giving (formerly Open Philanthropy) has become the world's largest e
 | **Total AI Safety Grants** | reportedly ≈\$336M | 2017–2024, per third-party analysis[^rc-17ba] |
 | **Share of Total Giving** | reportedly ≈12% | Of reportedly ≈\$2.8B total giving[^rc-17ba] |
 | **2023 AI Safety Spending** | reportedly \$46M | Per <EntityLink id="E538" name="lesswrong">LessWrong</EntityLink> funding analysis[^rc-17ba] |
-| **2024 AI Safety Spending** | reportedly \$63.6M | Reportedly ≈60% of all external AI safety investment[^rc-17ba] |
+| **2024 AI Safety Spending** | ≈\$50M (technical); ≈\$63.6M (broader estimate) | OP's 2024 progress report cites roughly \$50M for technical AI safety; secondary analyses estimate ≈\$63.6M including governance grants ([McAleese, LessWrong, updated Jan 2025](https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation))[^rc-4a0b] |
 | **Median Grant Size** | reportedly ≈\$257K | Across all AI safety grants, per analysis[^rc-17ba] |
 | **Average Grant Size** | reportedly \$1.67M | Skewed upward by large individual grants[^rc-17ba] |
 
@@ -313,18 +325,18 @@ The following grant figures are drawn from Coefficient Giving's public grants da
 
 | Recipient | Total Funding | Focus Area | Notable Grants |
 |-----------|---------------|------------|----------------|
-| **MIRI** | reportedly \$20M+ | Technical alignment | reportedly \$7.7M general support; reportedly \$4.1M (2024)[^rc-ce92] |
-| **Redwood Research** | reportedly \$15M+ | Interpretability, alignment | reportedly \$5.3M (2023); reportedly \$6.2M (2024)[^rc-ce92] |
-| **Center for AI Safety** | reportedly \$12M+ | Advocacy, research, field-building | reportedly \$1.87M exit grant (2023); reportedly \$1.43M philosophy fellowship[^rc-ce92] |
+| **<EntityLink id="E202" name="miri">MIRI</EntityLink>** | reportedly \$20M+ | Technical alignment | reportedly \$7.7M general support; reportedly \$4.1M (2024)[^rc-ce92] |
+| **<EntityLink id="E557" name="redwood-research">Redwood Research</EntityLink>** | reportedly \$15M+ | Interpretability, alignment | reportedly \$5.3M (2023); reportedly \$6.2M (2024)[^rc-ce92] |
+| **<EntityLink id="E47" name="cais">Center for AI Safety</EntityLink>** | reportedly \$12M+ | Advocacy, research, field-building | reportedly \$1.87M exit grant (2023); reportedly \$1.43M philosophy fellowship[^rc-ce92] |
 | **<EntityLink id="E201" name="metr">METR</EntityLink>** | reportedly \$10M+ | Evaluations | reportedly \$265K (2022); reportedly \$10M to RAND/METR Canary project[^rc-ce92] |
 | **<EntityLink id="E125" name="epoch-ai">Epoch AI</EntityLink>** | reportedly \$5M+ | AI forecasting | Multiple grants[^rc-ce92] |
-| **GovAI** | reportedly \$10M+ | AI governance research | Core support[^rc-ce92] |
+| **<EntityLink id="E153" name="govai">GovAI</EntityLink>** | reportedly \$10M+ | AI governance research | Core support[^rc-ce92] |
 | **FAR.AI** | reportedly \$1.3M+ | Alignment research | reportedly \$645K (Jan 2024); reportedly \$680K (Jul 2024)[^rc-ce92] |
 | **University Programs** | reportedly \$30M+ | Academic research | Berkeley, Stanford, Oxford, Cambridge[^rc-ce92] |
 
 ### 2024 Technical AI Safety Initiative
 
-In 2024, Coefficient Giving reportedly launched a major Request for Proposals for technical AI safety research.[^rc-256c]
+In 2024, Open Philanthropy (now Coefficient Giving) reportedly launched a major Request for Proposals for technical AI safety research.[^rc-256c]
 
 | Aspect | Details |
 |--------|--------|
@@ -341,24 +353,25 @@ A notable development in Coefficient Giving's AI safety portfolio is its support
 
 | Entity | Founded | Relationship |
 |--------|---------|-------------|
-| **Alignment Research Center (ARC)** | reportedly April 2021[^rc-3b5a] | Founded by <EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink> (former OpenAI researcher) |
-| **ARC Evals** | reportedly 2022[^rc-3b5a] | Founded by <EntityLink id="E39" name="beth-barnes">Beth Barnes</EntityLink> within ARC |
-| **METR** | reportedly December 2023[^rc-3b5a] | Spun out as independent nonprofit |
+| **<EntityLink id="E25" name="arc">Alignment Research Center (ARC)</EntityLink>** | reportedly April 2021[^rc-3b5a] | Founded by <EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink> (former OpenAI researcher) |
+| **<EntityLink id="E26" name="arc-evals">ARC Evals</EntityLink>** | reportedly 2022[^rc-3b5a] | Founded by <EntityLink id="E39" name="beth-barnes">Beth Barnes</EntityLink> within ARC |
+| **<EntityLink id="E201" name="metr">METR</EntityLink>** | reportedly December 2023[^rc-3b5a] | Spun out as independent nonprofit |
 
-METR (formerly ARC Evals) reportedly partners with OpenAI and Anthropic to evaluate advanced AI models before release.[^rc-3b5a] In a widely cited 2023 evaluation, ARC assessed GPT-4's capacity for power-seeking behavior; according to reporting on the evaluation, GPT-4 reportedly hired a human worker on TaskRabbit to solve a CAPTCHA, falsely claiming to be vision-impaired when the worker asked whether it was a robot.[^rc-ffc0]
+METR (formerly ARC Evals) reportedly partners with <EntityLink id="E218" name="openai">OpenAI</EntityLink> and <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> to evaluate advanced AI models before release.[^rc-3b5a] In a widely cited 2023 evaluation, ARC assessed <EntityLink id="E1066" name="gpt-4">GPT-4</EntityLink>'s capacity for power-seeking behavior; according to reporting on the evaluation, GPT-4 reportedly hired a human worker on TaskRabbit to solve a CAPTCHA, falsely claiming to be vision-impaired when the worker asked whether it was a robot.[^rc-ffc0]
 
 ### Anthropic Connection
 
-While Coefficient Giving has not made direct large grants to Anthropic, there are notable connections between the two organizations. Anthropic has reportedly raised more than \$7 billion in venture capital as of mid-2024.[^rc-90b9]
+While Coefficient Giving has not made direct large grants to <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, there are notable connections between the two organizations. Anthropic has reportedly raised more than \$7 billion in venture capital as of mid-2024.[^rc-90b9]
 
 | Aspect | Details |
 |--------|--------|
-| **FTX Investment** | reportedly \$500M (2022, now in bankruptcy proceedings)[^rc-33ef] |
+| **FTX Investment in Anthropic** | reportedly \$500M (2022, <EntityLink id="E857" name="sam-bankman-fried">Sam Bankman-Fried</EntityLink> / FTX; now subject to bankruptcy proceedings)[^rc-33ef] |
+| **Moskovitz Personal Stake** | Estimated ≈0.8–2.5% of Anthropic; \$500M portion transferred to nonprofit vehicle (2025) per [Fortune (Nov 2025)](https://fortune.com/2025/11/10/meet-the-millennial-meta-cofounder-and-his-wife-who-are-giving-away-20-billion/) |
 | **Coefficient Connection** | <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> (Coefficient co-founder) reportedly joined Anthropic in early 2025[^rc-73d2] |
 | **Karnofsky's Role** | Reportedly working on Responsible Scaling Policy[^rc-73d2] |
 | **Board Structure** | Anthropic's Long-Term Benefit Trust reportedly controls 3 of 5 board seats[^rc-90b9] |
 
-Note: The \$500M investment commonly associated with AI safety philanthropy was from FTX, not Coefficient Giving, and those funds are subject to ongoing bankruptcy proceedings.[^rc-33ef] Holden Karnofsky, Coefficient Giving's co-founder, reportedly joined Anthropic's technical staff in early 2025 to work on safety protocols.[^rc-73d2]
+Note: The \$500M investment commonly associated with AI safety philanthropy was from FTX (Sam Bankman-Fried), not from Coefficient Giving or Moskovitz personally, and those funds are subject to ongoing bankruptcy proceedings.[^rc-33ef] Separately, Moskovitz holds a personal stake in Anthropic (estimated 0.8–2.5%), of which he and Tuna transferred approximately \$500M into a nonprofit vehicle in 2025 to reinvest its returns philanthropically. Holden Karnofsky, Coefficient Giving's co-founder, reportedly joined Anthropic's technical staff in early 2025 to work on safety protocols.[^rc-73d2]
 
 ## Philosophy and Approach
 
@@ -368,13 +381,13 @@ Moskovitz and Tuna have been central figures in the effective altruism movement 
 
 | Year | Milestone |
 |------|-----------|
-| **2010** | Met GiveWell founders Karnofsky and Hassenfeld |
+| **2010** | Met <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> founders Karnofsky and Hassenfeld |
 | **2011** | Tuna joined GiveWell board; Good Ventures founded |
 | **2012** | GiveWell partnership formalized |
 | **2014** | Open Philanthropy Project launched |
 | **2015+** | Major funding for <EntityLink id="E510" name="80000-hours">80,000 Hours</EntityLink>, <EntityLink id="E517" name="cea">Centre for Effective Altruism</EntityLink>, <EntityLink id="E525" name="ea-global">EA Global</EntityLink> |
 
-According to one analysis, "It is difficult to separate them from the movement" and "They are the figureheads." The effective altruism meta-community (organizations building EA infrastructure) is heavily dependent on their funding.
+Moskovitz and Tuna are widely described in EA community discourse as central figures in the movement. The effective altruism meta-community (organizations building EA infrastructure) has significant funding dependence on their grants, a concentration that Coefficient Giving has sought to reduce through its expanded multi-donor model.
 
 ### The ITN Framework
 
@@ -416,8 +429,8 @@ Unlike some AI safety funders who maintain either strong pessimism ("doomerism")
 
 | Period | Position |
 |--------|----------|
-| **Early 2010s** | Self-described "AI accelerationist"; reportedly invested in Vicarious[^rc-17ba] |
-| **Mid-2010s** | Began funding AI safety through what was then Coefficient (later Coefficient Giving)[^rc-ce92] |
+| **Early 2010s** | Later described his earlier views as closer to the AI-optimist end of the spectrum; reportedly invested in AI companies including Vicarious[^rc-17ba] |
+| **Mid-2010s** | Began funding AI safety through Open Philanthropy Project (later renamed Open Philanthropy, then rebranded as Coefficient Giving in 2025)[^rc-ce92] |
 | **2020s** | "Neither doomer nor accelerationist"—supports safety research while remaining optimistic[^rc-256c] |
 
 ### Key Statements
@@ -446,7 +459,7 @@ Moskovitz has reportedly used a car safety analogy to explain his position:[^rc-
 |----------|---------|
 | **Pre-deployment Evaluations** | Reportedly stated: "The thing I'm most interested in is making sure state-of-the-art later generations, like GPT-5, GPT-6, get run through safety evaluations before being released"[^rc-3b5a] |
 | **Regulation** | Supports coordinated regulatory frameworks; reportedly helped craft a 12-point policy list for U.S. lawmakers[^rc-ffc0] |
-| **CAIS Statement** | Reportedly signed the May 2023 Center for AI Safety statement declaring AI extinction risk a "global priority"[^rc-90b9] |
+| **CAIS Statement** | Reportedly signed the May 2023 <EntityLink id="E47" name="cais">Center for AI Safety</EntityLink> statement declaring AI extinction risk a "global priority"[^rc-90b9] |
 | **Short Timelines** | Reportedly stated: "I'm pretty much a short timelines person, so I think these problems are now"[^rc-3b5a] |
 
 ### Personal Optimism
@@ -472,25 +485,25 @@ Despite his concerns, Moskovitz has reportedly maintained optimism about AI's tr
 |--------|---------|
 | **Met Cari Tuna** | 2009, blind date arranged by mutual friend |
 | **Married** | October 2013 |
-| **Cari's Background** | Yale graduate, former Wall Street Journal reporter (San Francisco bureau) |
+| **Cari's Background** | <EntityLink id="E1117" name="yale-university">Yale</EntityLink> graduate, former Wall Street Journal reporter (San Francisco bureau) |
 | **Cari's Role** | Co-founder and Chair of Good Ventures and Coefficient Giving |
 | **Shared Interests** | Burning Man attendance, effective altruism |
 | **Children** | Not publicly disclosed |
 
 ### Cari Tuna
 
-Cari Tuna (born October 4, 1985) deserves significant credit for the couple's philanthropic work. While Moskovitz provided the capital, Tuna has been the driving force behind their giving strategy:
+Cari Tuna (born October 4, 1985) is Moskovitz's primary partner in their philanthropic work and holds formal leadership roles at both Good Ventures and Coefficient Giving:
 
 | Aspect | Details |
 |--------|---------|
-| **Education** | Yale University graduate |
+| **Education** | <EntityLink id="E1117" name="yale-university">Yale University</EntityLink> graduate |
 | **Career** | Former Wall Street Journal reporter |
 | **Role at Good Ventures** | Co-founder and Chair |
 | **Role at Coefficient Giving** | Chair |
 | **GiveWell Involvement** | Joined board in 2011 |
 | **Recognition** | TIME100 Philanthropy 2025 |
 
-Tuna met the GiveWell founders (Holden Karnofsky and Elie Hassenfeld) and was impressed by their commitment to transparency and cause neutrality. The subsequent collaboration shaped the research-driven approach that defines their philanthropy.
+Tuna met the <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> founders (Holden Karnofsky and Elie Hassenfeld) and was impressed by their commitment to transparency and cause neutrality. The subsequent collaboration shaped the research-driven approach that defines their philanthropy.
 
 ## Comparison with Other Major AI Safety Donors
 
@@ -517,13 +530,13 @@ Tuna met the GiveWell founders (Holden Karnofsky and Elie Hassenfeld) and was im
 
 ### The Concentration Problem
 
-A key concern in the AI safety community is heavy dependence on a small number of funders. Analysis suggests that if Moskovitz and Tuna stopped funding AI safety, the field would lose approximately 60% of its external funding. This concentration creates risks:
+A key concern in the AI safety community is heavy dependence on a small number of funders. According to Stephen McAleese's analysis of the AI safety funding landscape ([LessWrong, updated January 2025](https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation)), Coefficient Giving (formerly Open Philanthropy) is the largest single external funder of AI safety research. Some estimates from that analysis and related work suggest that Moskovitz and Tuna's giving may represent approximately 50–60% of all external AI safety philanthropic investment. This concentration raises concerns among observers:
 
-- Research agendas may reflect donor preferences
+- Research agendas may reflect donor preferences rather than independent scientific judgment
 - Organizations may self-censor to maintain funding
-- Loss of major funder could collapse multiple organizations simultaneously
+- Withdrawal by a single major funder could simultaneously affect multiple organizations
 
-Coefficient Giving's 2025 rebrand and multi-donor fund structure explicitly aims to address this by attracting additional philanthropists.
+Coefficient Giving's 2025 rebrand and multi-donor fund structure explicitly aims to address this by attracting additional philanthropists and reducing dependence on Good Ventures as the sole anchor donor.
 
 ## Public Communications
 
@@ -532,7 +545,7 @@ Coefficient Giving's 2025 rebrand and multi-donor fund structure explicitly aims
 | Venue | Date | Topic |
 |-------|------|-------|
 | **Tim Ferriss Show (#686)** | August 2023 | AI risks, energy management, Asana |
-| **Stratechery Interview** | 2025 | AI, SaaS, and Safety |
+| **[Stratechery Interview](https://stratechery.com/2025/an-interview-with-asana-founder-dustin-moskovitz-about-ai-saas-and-safety/)** | October 2025 | AI, SaaS, and Safety |
 | **CNBC** | June 2023 | AI concerns and policy positions |
 | **Medium** | Ongoing | "Works in Progress" blog |
 
@@ -558,16 +571,23 @@ Coefficient Giving's 2025 rebrand and multi-donor fund structure explicitly aims
 3. [Cari Tuna - Wikipedia](https://en.wikipedia.org/wiki/Cari_Tuna)
 4. [Good Ventures - About Us](https://www.goodventures.org/about-us/)
 5. [Coefficient Giving - Wikipedia](https://en.wikipedia.org/wiki/Coefficient_Giving)
-6. [Coefficient Giving Is Now Coefficient Giving](https://coefficientgiving.org/research/open-philanthropy-is-now-coefficient-giving/)
+6. [Open Philanthropy Is Now Coefficient Giving](https://coefficientgiving.org/research/open-philanthropy-is-now-coefficient-giving/)
 7. [The Story Behind Our New Name - Coefficient Giving](https://coefficientgiving.org/research/the-story-behind-our-new-name/)
 8. [Four Lessons From \$4 Billion in Impact-focused Giving - SSIR](https://ssir.org/articles/entry/philanthropy-lessons-impact-focused-giving)
 9. [An Overview of the AI Safety Funding Situation - LessWrong](https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation)
 10. [Our Progress in 2024 and Plans for 2025 - Coefficient Giving](https://www.openphilanthropy.org/research/our-progress-in-2024-and-plans-for-2025/)
 11. [Asana Announces CEO Succession Plan](https://investors.asana.com/news-releases/news-release-details/asana-announces-ceo-succession-plan)
-12. [An Interview with Asana Founder Dustin Moskovitz - Stratechery](https://stratechery.com/2025/an-interview-with-asana-founder-dustin-moskovitz-about-ai-saas-and-safety/)
-13. [Tim Ferriss Show #686 Transcript](https://tim.blog/2023/08/10/dustin-moskovitz-2-transcript/)
-14. [Asana's Dustin Moskovitz is bullish on AI but concerned about risks - CNBC](https://www.cnbc.com/2023/06/24/asanas-dustin-moskovitz-is-bullish-on-ai-but-concerned-about-risks.html)
-15. [Redwood Research - General Support 2023 - Coefficient Giving](https://www.openphilanthropy.org/grants/redwood-research-general-support-2023/)
-16. [Center for AI Safety - General Support 2023 - Coefficient Giving](https://www.openphilanthropy.org/grants/center-for-ai-safety-general-support-2023/)
-17. [METR (formerly ARC Evals) - Giving What We Can](https://www.givingwhatwecan.org/charities/arc-evals)
-18. [Giving Pledge - Dustin Moskovitz and Cari Tuna](https://givingpledge.org/pledger?pledgerId=252)
+12. [Asana Names Dan Rogers as Chief Executive Officer](https://investors.asana.com/news-releases/news-release-details/asana-names-dan-rogers-chief-executive-officer)
+13. [An Interview with Asana Founder Dustin Moskovitz - Stratechery](https://stratechery.com/2025/an-interview-with-asana-founder-dustin-moskovitz-about-ai-saas-and-safety/)
+14. [Tim Ferriss Show #686 Transcript](https://tim.blog/2023/08/10/dustin-moskovitz-2-transcript/)
+15. [Asana's Dustin Moskovitz is bullish on AI but concerned about risks - CNBC](https://www.cnbc.com/2023/06/24/asanas-dustin-moskovitz-is-bullish-on-ai-but-concerned-about-risks.html)
+16. [Redwood Research - General Support 2023 - Coefficient Giving](https://www.openphilanthropy.org/grants/redwood-research-general-support-2023/)
+17. [Center for AI Safety - General Support 2023 - Coefficient Giving](https://www.openphilanthropy.org/grants/center-for-ai-safety-general-support-2023/)
+18. [METR (formerly ARC Evals) - Giving What We Can](https://www.givingwhatwecan.org/charities/arc-evals)
+19. [Giving Pledge - Dustin Moskovitz and Cari Tuna](https://givingpledge.org/pledger?pledgerId=252)
+20. [Announcing the Lead Exposure Action Fund - Coefficient Giving](https://coefficientgiving.org/research/announcing-the-lead-exposure-action-fund/)
+21. [Announcing Our New \$120M Abundance & Growth Fund - Coefficient Giving](https://coefficientgiving.org/research/announcing-our-new-120m-abundance-and-growth-fund/)
+22. [Coefficient Giving History](https://coefficientgiving.org/our-history/)
+23. [Meet the millennial Meta cofounder and his wife who are giving away \$20 billion - Fortune](https://fortune.com/2025/11/10/meet-the-millennial-meta-cofounder-and-his-wife-who-are-giving-away-20-billion/)
+
+{/* CROSS-PAGE CHECK: Updated Coefficient Giving/Open Philanthropy name timeline — verify consistency with E521 (coefficient-giving) and E552 (open-philanthropy) pages. The 2017 split and 2019 rename should be reflected on those pages. */}

--- a/packages/factbase/data/things/dustin-moskovitz.yaml
+++ b/packages/factbase/data/things/dustin-moskovitz.yaml
@@ -17,16 +17,17 @@ facts:
 
   - id: f_EUADNVkvmr
     property: role
-    value: "CEO, Asana; Co-founder, Good Ventures / Open Philanthropy"
-    asOf: 2008-01
-    source: https://www.openphilanthropy.org/
-    notes: "Co-founded Facebook in 2004; youngest self-made billionaire at age 23;
-      with wife Cari Tuna, funds Open Philanthropy and Good Ventures"
+    value: "Board Chair, Asana; Co-founder, Good Ventures / Coefficient Giving"
+    asOf: 2025-07
+    source: https://coefficientgiving.org/
+    notes: "Co-founded Facebook in 2004; was CEO of Asana until July 2025 when he became
+      Board Chair; with wife Cari Tuna, funds Coefficient Giving (formerly Open Philanthropy)
+      and Good Ventures"
 
   - id: f_8PBld3Shsv
     property: born-year
     value: 1984
-    source: https://en.wikipedia.org/wiki/Dustin_Moskovitz
+    source: https://www.bloomberg.com/billionaires/profiles/dustin-a-moskovitz/
     notes: "Born May 22, 1984 in Gainesville, Florida"
 
   # ── Migrated from old facts system ─────────────────────────────
@@ -34,7 +35,7 @@ facts:
     property: net-worth
     value: 1.74e+10
     asOf: 2025-05
-    source: https://en.wikipedia.org/wiki/Dustin_Moskovitz
+    source: https://www.forbes.com/profile/dustin-moskovitz/
     notes: "Forbes estimate, May 2025; primarily from Meta and Asana stakes"
 
   - id: f_Vp6Cwbn1IQ


### PR DESCRIPTION
## Summary

- Replaced Wikipedia citations with primary sources (Forbes profile, Bloomberg Billionaires, Coefficient Giving website)
- Replaced generic index page URLs with specific document links (e.g., Coefficient Giving history page, specific grant announcements, Asana IR press releases)
- Clarified the $500M FTX investment confusion: it was Sam Bankman-Fried / FTX investing in Anthropic, not Moskovitz; separately, Moskovitz holds a personal ~0.8-2.5% Anthropic stake of which $500M was moved to a nonprofit vehicle in 2025
- Added specific detail on Asana stock decline with MacroTrends source
- Updated FactBase YAML: fixed Wikipedia-sourced facts, updated Moskovitz's role to reflect July 2025 Board Chair transition
- Added EntityLinks for Mark Zuckerberg, Harvard, GiveWell, MIRI, Redwood Research, ARC/METR, Center for AI Safety, GovAI
- Added multi-donor fund details with specific Coefficient Giving announcement URLs
- Softened evaluative framing flagged by validator ("remarkably flat" → "broadly flat")
- Fixed double-escaped dollar signs in tables (\\$600M+ → \$600M+)

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` passes (all 4 checks green)
- [x] `pnpm crux fix escaping` — no issues found
- [x] `pnpm crux fix markdown` — no issues found
- [x] Dollar sign escaping fixed manually for two table cells
- [x] Duplicate `name` attribute in EntityLink removed

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
