### PR TITLE
fix: use correct wikiId frontmatter key for entity-profile dashboard

### DIFF
--- a/content/docs/internal/entity-profile-dashboard.mdx
+++ b/content/docs/internal/entity-profile-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-numericId: E1929
+wikiId: E1929
 title: "Entity Profile"
 description: "Raw data explorer showing all TableBase records for any entity, with schema metadata and record verdicts."
 subcategory: dashboards


### PR DESCRIPTION
## Summary

- Fixed `content/docs/internal/entity-profile-dashboard.mdx` frontmatter: changed `numericId: E1929` to `wikiId: E1929`
- The `numericId` key is not recognized by `build-data.mjs`, so E1929 was not registered in `database.json`
- This caused the wiki-nav test to fail when resolving the sidebar entry for this dashboard

## Test plan

- [x] `wiki-nav.test.ts` passes (27/27 tests)
- [x] `data.test.ts` passes (27/27 tests)
- [x] No other files affected — single-line frontmatter key fix

Found during QA sweep, not associated with a specific issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata identifiers in internal documentation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->