### PR TITLE
fix: hide unresolvable stableIds in organization People tabs

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -318,14 +318,23 @@ export default async function OrgProfilePage({
       }
     }
 
-    const allPeople = [...peopleByName.values()].sort((a, b) => {
-      // Current before former
-      if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
-      // Founders first
-      if (a.isFounder !== b.isFounder) return a.isFounder ? -1 : 1;
-      // Then alphabetical
-      return a.name.localeCompare(b.name);
-    });
+    // Filter out entries where the display name is an unresolvable stableId
+    // (10-char alphanumeric strings with mixed case, e.g. "KKCwTYU4Zw").
+    // These appear when the person field contains a raw stableId that doesn't
+    // resolve to any known entity — displaying them is confusing for users.
+    const isUnresolvedStableId = (name: string): boolean =>
+      /^[A-Za-z0-9]{10}$/.test(name) && /[a-z]/.test(name) && /[A-Z]/.test(name);
+
+    const allPeople = [...peopleByName.values()]
+      .filter((p) => !isUnresolvedStableId(p.name))
+      .sort((a, b) => {
+        // Current before former
+        if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
+        // Founders first
+        if (a.isFounder !== b.isFounder) return a.isFounder ? -1 : 1;
+        // Then alphabetical
+        return a.name.localeCompare(b.name);
+      });
 
     tabs.push({
       id: "people",


### PR DESCRIPTION
## Summary

- Filter out people entries in organization People tabs where the display name is an unresolvable stableId (10-char alphanumeric string like "KKCwTYU4Zw")
- These raw IDs appeared because the person field fallback chain (`display_name -> entity name -> titleCase(personRef)`) passed through stableIds unchanged when no entity data was found
- Affected 15+ org pages including `/organizations/arc`, `/organizations/miri`, `/organizations/xai`, `/organizations/google-deepmind`, `/organizations/epoch-ai`

## How it works

Added an `isUnresolvedStableId()` check that matches exactly 10 alphanumeric characters with mixed case (both uppercase and lowercase required). People entries matching this pattern are filtered out before rendering, since they have no meaningful data to display.

## Test plan

- [ ] Verify `/organizations/arc` People tab no longer shows raw IDs like "KKCwTYU4Zw"
- [ ] Verify `/organizations/miri` People tab no longer shows raw IDs
- [ ] Verify legitimate short names (e.g., 10-char names with spaces, all-lowercase, or all-uppercase) are NOT filtered out
- [ ] TypeScript compiles without new errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The People tab now filters out entries with unresolved identifiers that would display incorrectly, ensuring a cleaner list while maintaining the existing sort order (current before former, founders first, then alphabetically).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->