### PR TITLE
fix: DateHint bounds check and missing aria-labels on directory tables

### DIFF
--- a/apps/web/src/app/approaches/approaches-table.tsx
+++ b/apps/web/src/app/approaches/approaches-table.tsx
@@ -61,6 +61,7 @@ export function ApproachesTable({ rows }: { rows: ApproachRow[] }) {
         <input
           type="text"
           placeholder="Search approaches by name, description, or tag..."
+          aria-label="Search approaches"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-80"

--- a/apps/web/src/app/legislation/legislation-table.tsx
+++ b/apps/web/src/app/legislation/legislation-table.tsx
@@ -118,6 +118,7 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
           <input
             type="text"
             placeholder="Search legislation..."
+            aria-label="Search legislation"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -70,8 +70,9 @@ function DateHint({ date }: { date: string | null }) {
   if (!date) return null;
   const parts = date.split("-");
   const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-  const label = parts.length >= 2
-    ? `${MONTHS[parseInt(parts[1], 10) - 1]} ${parts[0]}`
+  const monthIdx = parts.length >= 2 ? parseInt(parts[1], 10) - 1 : NaN;
+  const label = parts.length >= 2 && monthIdx >= 0 && monthIdx < 12
+    ? `${MONTHS[monthIdx]} ${parts[0]}`
     : date;
   return (
     <span className="text-[10px] text-muted-foreground/50 ml-1">


### PR DESCRIPTION
## Summary
- Fix `DateHint` month parsing in `organizations-table.tsx` that could produce "undefined" when month values are out of bounds (e.g., `00`, `13`, or non-numeric). Now falls back to the raw date string for invalid months.
- Add missing `aria-label="Search legislation"` to the legislation table search input.
- Add missing `aria-label="Search approaches"` to the approaches table search input, matching the pattern used by other directory tables.

## Test plan
- [ ] Verify organizations table renders dates correctly for valid months
- [ ] Verify organizations table falls back gracefully for edge-case date strings
- [ ] Verify legislation and approaches search inputs have proper aria-labels for screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added ARIA labels to search inputs across approaches, legislation, and organizations tables to improve accessibility and compatibility with screen readers and assistive technologies.

* **Bug Fixes**
  * Fixed date formatting logic to properly validate month values before processing, preventing potential undefined results when handling incomplete or invalid date data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->