### PR TITLE
fix: hide empty Career and Funding tabs on people profiles

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -335,41 +335,47 @@ export default async function PersonProfilePage({
     ),
   });
 
-  // Career history
-  tabs.push({
-    id: "career",
-    label: "Career",
-    count: careerHistory.length,
-    content: <CareerHistory careerHistory={careerHistory} />,
-  });
+  // Career history (hidden when empty to avoid unfulfilled expectations)
+  if (careerHistory.length > 0) {
+    tabs.push({
+      id: "career",
+      label: "Career",
+      count: careerHistory.length,
+      content: <CareerHistory careerHistory={careerHistory} />,
+    });
+  }
 
-  // Publications
-  tabs.push({
-    id: "publications",
-    label: "Publications",
-    count: effectivePubCount,
-    content: (
-      <>
-        <PublicationsSection publications={publications} />
-        {publications.length === 0 && metaPubCount > 0 && (
-          <div className="border border-border/40 border-dashed rounded-xl px-6 py-6 text-center">
-            <p className="text-sm text-muted-foreground/70">
-              {metaPubCount} publication{metaPubCount !== 1 ? "s" : ""} attributed to this person
-              in the index, but detailed records are not yet linked.
-            </p>
-          </div>
-        )}
-      </>
-    ),
-  });
+  // Publications (hidden when no publications exist locally or in the index)
+  if (effectivePubCount > 0) {
+    tabs.push({
+      id: "publications",
+      label: "Publications",
+      count: effectivePubCount,
+      content: (
+        <>
+          <PublicationsSection publications={publications} />
+          {publications.length === 0 && metaPubCount > 0 && (
+            <div className="border border-border/40 border-dashed rounded-xl px-6 py-6 text-center">
+              <p className="text-sm text-muted-foreground/70">
+                {metaPubCount} publication{metaPubCount !== 1 ? "s" : ""} attributed to this person
+                in the index, but detailed records are not yet linked.
+              </p>
+            </div>
+          )}
+        </>
+      ),
+    });
+  }
 
-  // Funding connections
-  tabs.push({
-    id: "funding",
-    label: "Funding",
-    count: fundingConnections.length,
-    content: <FundingConnections fundingConnections={fundingConnections} />,
-  });
+  // Funding connections (hidden when empty to avoid unfulfilled expectations)
+  if (fundingConnections.length > 0) {
+    tabs.push({
+      id: "funding",
+      label: "Funding",
+      count: fundingConnections.length,
+      content: <FundingConnections fundingConnections={fundingConnections} />,
+    });
+  }
 
   return (
     <div className="max-w-[70rem] mx-auto px-6 py-8">


### PR DESCRIPTION
## Summary
- Hide Career, Publications, and Funding tabs on people profile pages when they contain 0 items
- Previously these tabs always appeared with `(0)` count, creating unfulfilled expectations on nearly all profiles
- The Overview tab always renders (it has its own empty-state message)

## Test plan
- [ ] Visit a person profile with career history data — Career tab should still appear with correct count
- [ ] Visit a person profile with no career/funding data — only Overview tab should show (no empty Career/Funding/Publications tabs)
- [ ] Verify Publications tab still appears when publications exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of empty tabs on profile pages—Career, Publications, and Funding tabs now only appear when they contain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->