### PR TITLE
fix: update OpenAI total funding and Christiano AISI start date in FactBase

### DIFF
--- a/packages/factbase/data/things/openai.yaml
+++ b/packages/factbase/data/things/openai.yaml
@@ -58,10 +58,10 @@ facts:
 
   - id: f_HfB3WmNDFQ
     property: total-funding
-    value: 1.3e+10
-    asOf: 2024-01
-    source: https://blogs.microsoft.com/blog/2023/01/23/microsoftandopenai/
-    notes: "Microsoft cumulative investment across multiple rounds"
+    value: 1.79e+10
+    asOf: 2025-10
+    source: https://openai.com/index/openai-announces-a-new-funding-round/
+    notes: "Cumulative funding including $6.6B round in October 2024 (led by Thrive Capital, with Microsoft, NVIDIA, SoftBank, and others) on top of ~$11.3B in prior rounds"
 
   - id: f_b56n3kcD2g
     property: valuation

--- a/packages/factbase/data/things/paul-christiano.yaml
+++ b/packages/factbase/data/things/paul-christiano.yaml
@@ -65,13 +65,13 @@ facts:
   - id: f_DRwx53YvWw
     property: role
     value: "Head of AI Safety, US AI Safety Institute"
-    asOf: 2024-02
+    asOf: 2024-08
     source: https://www.nist.gov/people/paul-christiano
-    notes: "Joined the U.S. AI Safety Institute (under NIST) in 2024 as Head of AI Safety"
+    notes: "Publicly announced as Head of AI Safety at the U.S. AI Safety Institute (under NIST) in August 2024"
 
   - id: f_He1SsMRfAw
     property: employed-by
     value: us-aisi
-    asOf: 2024-02
+    asOf: 2024-08
     source: https://www.nist.gov/people/paul-christiano
-    notes: "Stepped back from day-to-day ARC operations in 2023 after a brain injury; joined US AISI in 2024"
+    notes: "Stepped back from day-to-day ARC operations in 2023 after a brain injury; joined US AISI in August 2024"


### PR DESCRIPTION
## Summary
- **OpenAI total funding**: Updated from $13B (asOf 2024-01) to $17.9B (asOf 2025-10), reflecting the $6.6B round in October 2024 led by Thrive Capital with Microsoft, NVIDIA, SoftBank, and others
- **Paul Christiano US AISI start date**: Corrected asOf from 2024-02 to 2024-08 for both his role and employment facts, matching the public announcement date

## Test plan
- [x] YAML schema validation passes (`pnpm crux validate gate --scope=content`)
- [x] Only FactBase YAML data changed — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)