### PR TITLE
fix: sync role titles for Sutskever and Leike across data sources

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -192,6 +192,8 @@
   relatedEntries:
     - id: anthropic
       type: organization
+    - id: openai
+      type: organization
     - id: anthropic-core-views
       type: safety-agenda
     - id: jan-leike
@@ -483,6 +485,8 @@
   title: Ilya Sutskever
   website: https://ssi.inc
   relatedEntries:
+    - id: ssi
+      type: organization
     - id: openai
       type: organization
     - id: jan-leike
@@ -545,7 +549,7 @@
       type: person
   customFields:
     - label: Role
-      value: Head of Alignment
+      value: VP of Alignment Science
     - label: Known For
       value: Alignment research, scalable oversight, RLHF
   sources:
@@ -558,7 +562,7 @@
     - title: Departure Statement
       url: https://twitter.com/janleike/status/1790517668677865835
   description: >
-    Jan Leike is the Head of Alignment at Anthropic, where he leads research on ensuring AI systems remain beneficial as
+    Jan Leike is the VP of Alignment Science at Anthropic, where he leads research on ensuring AI systems remain beneficial as
     they become more capable. Before joining Anthropic in 2024, he co-led OpenAI's Superalignment team, which was tasked
     with solving alignment for superintelligent AI systems within four years.
 

--- a/packages/factbase/data/things/jan-leike.yaml
+++ b/packages/factbase/data/things/jan-leike.yaml
@@ -23,10 +23,10 @@ facts:
 
   - id: f_gW2pL8rA7m
     property: role
-    value: "Head of Alignment Science"
+    value: "VP of Alignment Science"
     asOf: 2024-05
     source: https://anthropic.com/news/jan-leike-joins-anthropic
-    notes: "Leads alignment science at Anthropic; focuses on scalable oversight, weak-to-strong generalization, and robustness to jailbreaks"
+    notes: "VP leading alignment science at Anthropic; focuses on scalable oversight, weak-to-strong generalization, and robustness to jailbreaks"
 
   - id: f_jL1aB2cD3e
     property: education
@@ -36,7 +36,7 @@ facts:
 
   - id: f_jL4fG5hI6j
     property: notable-for
-    value: "Head of Alignment Science at Anthropic; former co-lead of OpenAI Superalignment team; prominent advocate for AI safety resource allocation"
+    value: "VP of Alignment Science at Anthropic; former co-lead of OpenAI Superalignment team; prominent advocate for AI safety resource allocation"
     source: https://en.wikipedia.org/wiki/Jan_Leike
 
   - id: f_jL7kL8mN9o


### PR DESCRIPTION
## Summary

- **Jan Leike**: Updated role from "Head of Alignment" (YAML entity) and "Head of Alignment Science" (FactBase) to **"VP of Alignment Science"** in both sources, matching his actual Anthropic title. Also updated his description paragraph and notable-for fact.
- **Ilya Sutskever**: Added missing `ssi` to `relatedEntries` — SSI is his current employer but was not listed. Role title ("Co-founder & Chief Scientist") was already correct in YAML and FactBase.
- **Dario Amodei**: Added missing `openai` to `relatedEntries` — he was VP of Research at OpenAI before founding Anthropic.

## Context

Three data sources (YAML entities in `data/entities/`, FactBase YAML in `packages/factbase/data/things/`, and PG records) had contradictory role titles for the same people. This PR aligns the two YAML sources to the correct real-world titles. PG records are mirrors that will update on next data sync.

## Files changed

- `data/entities/people.yaml` — role title fix (Leike), relatedEntries additions (Sutskever, Amodei)
- `packages/factbase/data/things/jan-leike.yaml` — role title and notes fix

## Test plan

- [x] YAML schema validation passes (`pnpm crux validate schema`)
- [x] Gate failure is pre-existing (`entity-profile-dashboard.mdx` numericId issue), not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)