### PR TITLE
fix: exclude future-dated entries from getFactBaseLatest()

### DIFF
--- a/apps/web/src/data/__tests__/factbase-future-dated.test.ts
+++ b/apps/web/src/data/__tests__/factbase-future-dated.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isFactFutureDated } from "../factbase";
+import type { Fact } from "@longterm-wiki/factbase";
+
+/** Create a minimal fact stub for testing. */
+function makeFact(overrides: Partial<Fact> = {}): Fact {
+  return {
+    id: "f_test",
+    subjectId: "test-entity",
+    propertyId: "test-property",
+    value: { type: "number", value: 42, unit: "%" },
+    ...overrides,
+  };
+}
+
+describe("isFactFutureDated", () => {
+  beforeEach(() => {
+    // Pin "today" to 2026-03-17 for deterministic tests
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false for facts without asOf", () => {
+    expect(isFactFutureDated(makeFact({ asOf: undefined }))).toBe(false);
+  });
+
+  it("returns false for a YYYY date in the past", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2024" }))).toBe(false);
+  });
+
+  it("returns false for a YYYY-MM date in the past", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2025-12" }))).toBe(false);
+  });
+
+  it("returns false for a YYYY-MM-DD date in the past", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2026-03-16" }))).toBe(false);
+  });
+
+  it("returns false for today's date (YYYY-MM-DD)", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2026-03-17" }))).toBe(false);
+  });
+
+  it("returns false for current month (YYYY-MM padded to first of month)", () => {
+    // "2026-03" pads to "2026-03-01" which is <= today (2026-03-17)
+    expect(isFactFutureDated(makeFact({ asOf: "2026-03" }))).toBe(false);
+  });
+
+  it("returns true for a YYYY date in the future", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2027" }))).toBe(true);
+  });
+
+  it("returns true for a YYYY-MM date in the future", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2026-12" }))).toBe(true);
+  });
+
+  it("returns true for a YYYY-MM-DD date in the future", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2026-03-18" }))).toBe(true);
+  });
+
+  it("returns true for a far-future date", () => {
+    expect(isFactFutureDated(makeFact({ asOf: "2099-12-31" }))).toBe(true);
+  });
+});
+
+describe("getFactBaseLatest future-date filtering", () => {
+  /**
+   * We can't easily test getFactBaseLatest directly since it depends on
+   * getFactBase() loading factbase-data.json. Instead, we verify the
+   * composition logic by testing isFactFutureDated + isFactExpired which
+   * are the filter predicates used by getFactBaseLatest.
+   *
+   * The key scenario (Anthropic gross margin bug):
+   *   - Fact A: asOf="2025-12", value=40% (actual)
+   *   - Fact B: asOf="2026-12", value=63% (2026 target)
+   *
+   * With today = 2026-03-17:
+   *   - Fact B is future-dated (2026-12 > today) → filtered out
+   *   - Fact A is NOT future-dated (2025-12 < today) → selected as latest
+   */
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("correctly identifies the Anthropic gross margin scenario", () => {
+    const actualFact = makeFact({ asOf: "2025-12", value: { type: "number", value: 40, unit: "%" } });
+    const targetFact = makeFact({ asOf: "2026-12", value: { type: "number", value: 63, unit: "%" } });
+
+    // The target (63%) is future-dated and should be filtered out
+    expect(isFactFutureDated(targetFact)).toBe(true);
+    // The actual (40%) is NOT future-dated and should be selected
+    expect(isFactFutureDated(actualFact)).toBe(false);
+  });
+
+  it("simulates the full filter pipeline: sorted desc, filter future, take first", () => {
+    // Simulate what getFactBaseLatest does internally
+    const facts = [
+      makeFact({ id: "target", asOf: "2026-12", value: { type: "number", value: 63, unit: "%" } }),
+      makeFact({ id: "actual", asOf: "2025-12", value: { type: "number", value: 40, unit: "%" } }),
+      makeFact({ id: "old", asOf: "2024-06", value: { type: "number", value: 50, unit: "%" } }),
+    ]; // Already sorted most-recent-first (as getFactBaseFacts returns)
+
+    const nonFuture = facts.filter((f) => !isFactFutureDated(f));
+    expect(nonFuture).toHaveLength(2);
+    expect(nonFuture[0].id).toBe("actual"); // 2025-12
+    expect(nonFuture[1].id).toBe("old"); // 2024-06
+  });
+
+  it("falls back to most recent future fact when all facts are future-dated", () => {
+    const facts = [
+      makeFact({ id: "far_future", asOf: "2028-12" }),
+      makeFact({ id: "near_future", asOf: "2027-06" }),
+    ];
+
+    const nonFuture = facts.filter((f) => !isFactFutureDated(f));
+    expect(nonFuture).toHaveLength(0);
+
+    // Fallback: last element (closest to today) from the sorted-desc array
+    const fallback = facts[facts.length - 1];
+    expect(fallback.id).toBe("near_future");
+  });
+});

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -107,6 +107,17 @@ export function getFactBaseFacts(entity: string, property?: string): Fact[] {
 }
 
 /**
+ * Pad a partial date string to YYYY-MM-DD for lexicographic comparison.
+ * "2024" → "2024-01-01", "2024-06" → "2024-06-01", "2024-06-15" → "2024-06-15".
+ */
+function padDateToFull(date: string): string {
+  const parts = date.split("-");
+  if (parts.length === 1) return `${parts[0]}-01-01`;
+  if (parts.length === 2) return `${parts[0]}-${parts[1]}-01`;
+  return date;
+}
+
+/**
  * Check whether a fact has expired based on its validEnd field.
  * A fact is expired if validEnd is set AND validEnd < today's date.
  * Supports YYYY, YYYY-MM, and YYYY-MM-DD formats.
@@ -114,33 +125,66 @@ export function getFactBaseFacts(entity: string, property?: string): Fact[] {
  */
 export function isFactExpired(fact: Fact): boolean {
   if (!fact.validEnd) return false;
-  // Pad partial dates so comparison works: "2024" → "2024-01-01", "2024-06" → "2024-06-01"
-  const parts = fact.validEnd.split("-");
-  const padded =
-    parts.length === 1
-      ? `${parts[0]}-01-01`
-      : parts.length === 2
-        ? `${parts[0]}-${parts[1]}-01`
-        : fact.validEnd;
+  const padded = padDateToFull(fact.validEnd);
   const today = new Date().toISOString().slice(0, 10);
   return padded < today;
 }
 
 /**
+ * Check whether a fact's asOf date is in the future (after today).
+ * A fact is future-dated if asOf is set AND asOf > today's date.
+ * Supports YYYY, YYYY-MM, and YYYY-MM-DD formats.
+ * Facts without asOf are never considered future-dated.
+ */
+export function isFactFutureDated(fact: Fact): boolean {
+  if (!fact.asOf) return false;
+  const padded = padDateToFull(fact.asOf);
+  const today = new Date().toISOString().slice(0, 10);
+  return padded > today;
+}
+
+/**
  * Get the latest (most recent by asOf) fact for an entity + property.
- * By default, excludes expired facts (those with a validEnd in the past).
+ * By default, excludes expired facts (those with a validEnd in the past)
+ * and future-dated facts (those with an asOf after today).
+ *
+ * This prevents forecasts/targets (e.g., "2026 target gross margin: 63%")
+ * from being returned over actual reported values (e.g., "2024 actual: 40%").
+ *
+ * If all facts are future-dated, falls back to the most recent one
+ * (after expiry filtering) to avoid returning nothing.
+ *
  * Set includeExpired=true to return expired facts as well.
+ * Set includeFuture=true to include future-dated facts in selection.
  */
 export function getFactBaseLatest(
   entity: string,
   property: string,
-  options?: { includeExpired?: boolean },
+  options?: { includeExpired?: boolean; includeFuture?: boolean },
 ): Fact | undefined {
   const facts = getFactBaseFacts(entity, property);
-  if (options?.includeExpired) {
+  if (options?.includeExpired && options?.includeFuture) {
     return facts[0]; // Already sorted most-recent-first
   }
-  return facts.find((f) => !isFactExpired(f));
+
+  // Apply expiry filter
+  const afterExpiry = options?.includeExpired
+    ? facts
+    : facts.filter((f) => !isFactExpired(f));
+
+  if (afterExpiry.length === 0) return undefined;
+
+  // Apply future-date filter
+  if (options?.includeFuture) {
+    return afterExpiry[0];
+  }
+
+  const nonFuture = afterExpiry.filter((f) => !isFactFutureDated(f));
+  // Fallback: if all remaining facts are future-dated, return the most recent
+  // (closest to today) to avoid returning nothing
+  if (nonFuture.length === 0) return afterExpiry[afterExpiry.length - 1];
+
+  return nonFuture[0];
 }
 
 /** Lazy-initialized index: propertyId → Property. Built once on first call. */

--- a/packages/factbase/data/things/anthropic.yaml
+++ b/packages/factbase/data/things/anthropic.yaml
@@ -248,15 +248,15 @@ facts:
     value: 40
     asOf: 2025-12
     source: https://www.theinformation.com/articles/anthropics-finances
-    notes: "10 percentage points below previous estimate; inference costs surged 23%
-      more than expected"
+    notes: "Actual 2025 gross margin; 10 percentage points below previous estimate;
+      inference costs surged 23% more than expected"
 
   - id: f_VeJPtr2gAQ
     property: gross-margin
     value: 63
     asOf: 2026-12
     source: https://www.theinformation.com/articles/anthropics-finances
-    notes: "2026 target gross margin; 2028 target is 77%"
+    notes: "2026 target gross margin (forward-looking); 2028 target is 77%"
 
   - id: f_TaHnceQDdQ
     property: cash-burn


### PR DESCRIPTION
## Summary

- `getFactBaseLatest()` picked the entry with the highest `asOf` date without checking if that date is in the future
- This caused Anthropic's org page to show gross margin as **63%** (a 2026 target from `asOf: 2026-12`) instead of the actual **40%** (2025 reported value from `asOf: 2025-12`)
- Now filters out future-dated entries by default, with a fallback to the nearest-future entry if all entries are future-dated (to avoid showing nothing)
- Added `includeFuture` option for callers that need forward-looking data
- Refactored date-padding logic into shared `padDateToFull()` helper
- Clarified Anthropic gross-margin YAML notes to distinguish "actual" vs "target (forward-looking)"

## Test plan

- [x] New test file `factbase-future-dated.test.ts` with 13 tests covering:
  - `isFactFutureDated()` for all date formats (YYYY, YYYY-MM, YYYY-MM-DD)
  - Edge cases: today's date, current month, no asOf
  - The exact Anthropic gross margin scenario
  - Fallback behavior when all entries are future-dated
- [x] Existing `factbase-expired.test.ts` still passes (no regression from `padDateToFull` refactor)
- [x] TypeScript type checking passes (`tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)