### PR TITLE
fix: remove dead network graph link and fix people pub count

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -97,6 +97,33 @@ async function resolvePersonFromServer(slug: string): Promise<Entity | undefined
   }
 }
 
+/**
+ * Fetch the publication count from wiki-server entity metadata.
+ * The wiki-server stores publicationCount (from experts.yaml + people-resources.yaml)
+ * in the entity metadata, which may differ from local getPublicationsForPerson().
+ * Returns 0 if unavailable.
+ */
+async function getMetaPublicationCount(slug: string): Promise<number> {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL || process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl) return 0;
+  try {
+    const res = await fetch(`${serverUrl}/api/entities/${encodeURIComponent(slug)}`, {
+      headers: {
+        ...(process.env.LONGTERMWIKI_SERVER_API_KEY && {
+          Authorization: `Bearer ${process.env.LONGTERMWIKI_SERVER_API_KEY}`,
+        }),
+      },
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return 0;
+    const data = await res.json();
+    return (data.metadata?.publicationCount as number) ?? 0;
+  } catch {
+    // Non-critical: fall back to local count silently
+    return 0;
+  }
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -169,8 +196,15 @@ export default async function PersonProfilePage({
   const personEntity = getPersonEntityById(slug);
   const positions = personEntity?.positions ?? [];
 
-  // Publications linked to this person
+  // Publications linked to this person (from people-resources.yaml via database.json).
+  // The wiki-server API may report a different (typically higher) publicationCount
+  // from experts.yaml metadata. When local data has 0 publications but the server
+  // knows about some, use the server count so the tab badge isn't misleadingly zero.
   const publications = getPublicationsForPerson(slug);
+  const metaPubCount = publications.length === 0
+    ? await getMetaPublicationCount(slug)
+    : 0;
+  const effectivePubCount = publications.length > 0 ? publications.length : metaPubCount;
 
   // Reverse lookup: org key-person records referencing this person
   const orgRoles = getOrgRolesForPerson(entity.id);
@@ -311,8 +345,20 @@ export default async function PersonProfilePage({
   tabs.push({
     id: "publications",
     label: "Publications",
-    count: publications.length,
-    content: <PublicationsSection publications={publications} />,
+    count: effectivePubCount,
+    content: (
+      <>
+        <PublicationsSection publications={publications} />
+        {publications.length === 0 && metaPubCount > 0 && (
+          <div className="border border-border/40 border-dashed rounded-xl px-6 py-6 text-center">
+            <p className="text-sm text-muted-foreground/70">
+              {metaPubCount} publication{metaPubCount !== 1 ? "s" : ""} attributed to this person
+              in the index, but detailed records are not yet linked.
+            </p>
+          </div>
+        )}
+      </>
+    ),
   });
 
   // Funding connections

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -6,7 +6,6 @@ import { ProfileStatCard } from "@/components/directory";
 import { PeopleTable, type PersonRow } from "./people-table";
 import { getPublicationsForPerson, getTypedEntities, getPersonEntityById, isPerson } from "@/data";
 import { fetchDetailed } from "@lib/wiki-server";
-import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "People",
@@ -311,29 +310,6 @@ export default async function PeoplePage() {
           Directory of key people in AI safety, frontier AI research, policy,
           and effective altruism tracked in the knowledge base.
         </p>
-        <Link
-          href="/people/network"
-          className="inline-flex items-center gap-1.5 mt-3 text-sm font-medium text-primary hover:underline"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="18" cy="5" r="3" />
-            <circle cx="6" cy="12" r="3" />
-            <circle cx="18" cy="19" r="3" />
-            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-            <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-          </svg>
-          View Network Graph
-        </Link>
       </div>
 
       {source === "local" && (


### PR DESCRIPTION
## Summary

- **Remove dead "View Network Graph" link**: The `/people` page had a prominent link to `/people/network` which returns a 404 (the page was never implemented). Removed the link and its unused `next/link` import.

- **Fix publication count discrepancy on detail pages**: The index page (`/people`) shows publication counts from `meta.publicationCount` (wiki-server API / experts.yaml metadata), while detail pages (`/people/[slug]`) used only `getPublicationsForPerson(slug)` which reads from `people-resources.yaml` via `database.json`. These are different data sources that can diverge. Now, when local data returns 0 publications but the wiki-server metadata reports a non-zero count, the detail page fetches the meta count and displays it with an explanatory note ("N publications attributed to this person in the index, but detailed records are not yet linked.").

## Test plan

- [ ] Visit `/people` and confirm the "View Network Graph" link is gone
- [ ] Visit a person detail page where the index shows publications but the detail page previously showed 0 — confirm the tab now shows the correct count with the explanatory note
- [ ] Visit a person detail page that has local publications — confirm nothing changed (local data takes priority)
- [ ] Verify no TypeScript errors introduced (`npx tsc --noEmit` in `apps/web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)