### PR TITLE
fix: improve error handling patterns in wiki-server and crux

### DIFF
--- a/apps/wiki-server/src/routes/operational/active-agents.ts
+++ b/apps/wiki-server/src/routes/operational/active-agents.ts
@@ -219,6 +219,8 @@ const activeAgentsApp = new Hono()
 
   // ---- POST /sweep (mark stale agents) ----
   .post("/sweep", async (c) => {
+    // Intentional fallback: sweep is best-effort housekeeping; if the body can't
+    // be parsed we fall through to defaults (timeoutMinutes). No user-facing impact.
     const body = await parseJsonBody(c).catch(() => ({}));
     const raw = Number((body as Record<string, unknown>)?.timeoutMinutes || STALE_TIMEOUT_MINUTES);
     const timeoutMinutes = Math.max(5, Math.min(Number.isFinite(raw) ? raw : STALE_TIMEOUT_MINUTES, 43200));
@@ -244,6 +246,8 @@ const activeAgentsApp = new Hono()
 
   // ---- POST /cleanup (delete old completed/errored/stale agents) ----
   .post("/cleanup", async (c) => {
+    // Intentional fallback: cleanup is best-effort housekeeping; if the body can't
+    // be parsed we fall through to defaults (ageDays). No user-facing impact.
     const body = await parseJsonBody(c).catch(() => ({}));
     const raw = Number((body as Record<string, unknown>)?.ageDays || CLEANUP_AGE_DAYS);
     const ageDays = Math.max(1, Math.min(Number.isFinite(raw) ? raw : CLEANUP_AGE_DAYS, 365));

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -318,6 +318,8 @@ const agentSessionsApp = new Hono()
     return c.json({ insights, summary: { total: insights.length, byType } });
   })
   .post("/sweep", async (c) => {
+    // Intentional fallback: sweep is best-effort housekeeping; if the body can't
+    // be parsed we fall through to defaults (timeoutHours=2). No user-facing impact.
     const body = await parseJsonBody(c).catch(() => ({}));
     const raw = Number((body as Record<string, unknown>)?.timeoutHours || 2);
     const timeoutHours = Math.max(1, Math.min(Number.isFinite(raw) ? raw : 2, 720));

--- a/apps/wiki-server/src/routes/operational/sessions.ts
+++ b/apps/wiki-server/src/routes/operational/sessions.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, count, sql, desc, inArray, gte, like } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
+import { logger as rootLogger } from "../../logger.js";
 import { sessions, sessionPages } from "../../schema.js";
 import { parseJsonBody, validationError, invalidJsonError, firstOrThrow, paginationQuery } from "../shared/utils.js";
 import {
@@ -10,6 +11,8 @@ import {
   DateStringSchema,
 } from "../../api-types.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
+
+const logger = rootLogger.child({ component: "sessions" });
 
 // ---- Constants ----
 
@@ -471,8 +474,9 @@ const sessionsApp = new Hono()
       .limit(INSIGHTS_LIMIT);
 
     if (rows.length === INSIGHTS_LIMIT) {
-      console.warn(
-        `[sessions/insights] Result count hit limit (${INSIGHTS_LIMIT}); insights may be truncated. Consider adding pagination.`
+      logger.warn(
+        { limit: INSIGHTS_LIMIT },
+        "sessions/insights result count hit limit; insights may be truncated — consider adding pagination"
       );
     }
 

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -34,7 +34,13 @@ export const INVALID_JSON_ERROR = "invalid_json" as const;
 
 /** Safely parse JSON body, returning null on parse failure. */
 export function parseJsonBody(c: Context) {
-  return c.req.json().catch(() => null);
+  return c.req.json().catch((e: unknown) => {
+    logger.debug(
+      { error: e instanceof Error ? e.message : String(e), path: c.req.path },
+      "parseJsonBody: failed to parse request body as JSON"
+    );
+    return null;
+  });
 }
 
 /** Return a 400 validation error response. */

--- a/apps/wiki-server/src/routes/tablebase/entity-profile.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { eq, or, inArray } from "drizzle-orm";
 import { getTableColumns } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
+import { logger as rootLogger } from "../../logger.js";
 import {
   entities,
   personnel,
@@ -29,6 +30,8 @@ import { resolveEntityStableId } from "../shared/entity-resolution.js";
 import { notFoundError } from "../shared/utils.js";
 import { COLUMN_DESCRIPTIONS } from "./entity-profile-descriptions.js";
 import type { PgTable } from "drizzle-orm/pg-core";
+
+const logger = rootLogger.child({ component: "entity-profile" });
 
 // ---- Schema introspection (cached at module level — schema is static) ----
 
@@ -337,7 +340,10 @@ const entityProfileApp = new Hono()
             truncated,
           };
         } catch (err) {
-          console.error(`Entity profile section ${section.key} failed:`, err);
+          logger.error(
+            { error: err instanceof Error ? err.message : String(err), section: section.key },
+            `Entity profile section ${section.key} failed`
+          );
           return {
             key: section.key,
             label: section.label,
@@ -346,7 +352,7 @@ const entityProfileApp = new Hono()
             rows: [],
             total: 0,
             truncated: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: `Failed to load section "${section.key}"`,
           };
         }
       })

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -119,6 +119,9 @@ function gitInDir(dir: string, ...args: string[]): string {
       timeout: 30000,
     }).trim();
   } catch {
+    // Intentionally silent: this runs during slot discovery where directories may
+    // not be git repos or may have missing refs. Returning '' lets callers skip
+    // non-functional slots gracefully.
     return '';
   }
 }
@@ -986,9 +989,7 @@ export async function runParallelDaemon(config: ParallelConfig): Promise<void> {
     return;
   }
 
-  let cycleCount = 0;
   while (!shuttingDown) {
-    cycleCount++;
     try {
       await runParallelCycle(config);
     } catch (e) {


### PR DESCRIPTION
## Summary

- **Silent `.catch(() => ({}))` in agent-sessions and active-agents**: Added comments explaining these are intentional fallbacks for best-effort housekeeping endpoints (sweep/cleanup) where unparseable bodies should fall through to defaults.
- **`parseJsonBody` swallows errors silently**: Added `logger.debug` with error message and request path before returning null.
- **Entity-profile error messages expose DB schema**: Replaced `err.message` in the JSON response with a generic `"Failed to load section"` message; kept the full error in structured `logger.error` server-side logging.
- **`console.warn` in sessions/insights**: Replaced with structured `logger.warn` using pino child logger.
- **Silent `catch { return ''; }` in pr-patrol `gitInDir`**: Added explanatory comment documenting why silence is acceptable (slot discovery probes directories that may not be git repos).
- **Dead `cycleCount` variable in pr-patrol**: Removed unused variable that was only assigned and incremented, never read.

## Test plan

- [ ] Verify `npx tsc --noEmit` passes for wiki-server (no new type errors introduced)
- [ ] Verify existing tests still pass (`pnpm test`)
- [ ] Visual review: all `.catch()` blocks now either log, re-throw, or have a comment per error-handling.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)