### PR TITLE
fix: use appropriate scale for Elo-type benchmark progress bars

### DIFF
--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -77,9 +77,20 @@ export default async function BenchmarkDetailPage({
     entity.higherIsBetter ? b.score - a.score : a.score - b.score,
   );
 
-  // Compute score range for bar widths
+  // Compute score range for bar widths.
+  // For percentage-like benchmarks (accuracy, percentage, pass_at_1), scores are 0-100
+  // and relative comparison between dataset min/max works well.
+  // For Elo/points benchmarks (e.g., Codeforces Rating 0-3500, Chatbot Arena Elo),
+  // anchor bars at 0 so bar width reflects absolute score magnitude — otherwise a
+  // score of 1759 out of 3500 could render at ~15% width instead of ~50%.
   const allScores = sorted.map((r) => r.score);
-  const minScore = allScores.length > 0 ? Math.min(...allScores) : 0;
+  const isAbsoluteScale =
+    entity.scoringMethod === "elo" || entity.scoringMethod === "points";
+  const minScore = isAbsoluteScale
+    ? 0
+    : allScores.length > 0
+      ? Math.min(...allScores)
+      : 0;
   const maxScore = allScores.length > 0 ? Math.max(...allScores) : 1;
 
   // Compute stats

--- a/data/entities/benchmarks.yaml
+++ b/data/entities/benchmarks.yaml
@@ -118,6 +118,7 @@
   scoringMethod: percentage
   higherIsBetter: true
   introducedDate: "2025-01"
+  maintainer: "Terminal-Bench"
   sources:
     - title: "Terminal-Bench"
       url: "https://github.com/terminal-bench/terminal-bench"
@@ -132,6 +133,7 @@
   scoringMethod: percentage
   higherIsBetter: true
   introducedDate: "2025-06"
+  maintainer: "Terminal-Bench"
 
 - id: artificial-analysis-intelligence-index
   stableId: dEzoE9HQTg
@@ -156,6 +158,8 @@
   scoringMethod: percentage
   higherIsBetter: true
   introducedDate: "2024-04"
+  maintainer: "CMU / HKU"
+  website: "https://os-world.github.io"
   sources:
     - title: "OSWorld: Benchmarking Multimodal Agents for Open-Ended Tasks in Real Computer Environments"
       url: "https://arxiv.org/abs/2404.07972"


### PR DESCRIPTION
## Summary
- Fix misleading progress bars on Elo-scored benchmarks (Codeforces Rating, Chatbot Arena Elo) and points-based benchmarks (Artificial Analysis Intelligence Index). Previously, bars were normalized between the dataset min and max scores, making a Codeforces score of 1759 (out of 3500) render at ~15% width. Now, Elo/points benchmarks anchor bars at 0 so widths reflect absolute score magnitude (~50% for 1759/3500). Percentage-based benchmarks keep the existing relative scaling.
- Add missing maintainer data for three agentic benchmarks: OSWorld (CMU / HKU), Terminal-Bench Hard (Terminal-Bench), Terminal-Bench 2 (Terminal-Bench). Also add OSWorld website URL.

## Test plan
- [ ] Verify `/benchmarks/codeforces-rating` progress bars now show meaningful widths (top score near full width, mid-range scores near 50%)
- [ ] Verify `/benchmarks/chatbot-arena-elo` bars also display correctly with absolute scaling
- [ ] Verify percentage-based benchmarks (e.g., `/benchmarks/swe-bench-verified`) are unaffected
- [ ] Verify maintainer info appears on `/benchmarks/osworld`, `/benchmarks/terminal-bench-hard`, `/benchmarks/terminal-bench-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)