### PR TITLE
fix: UI consistency — em-dashes, hydration warning, developer links, empty states

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -117,14 +117,15 @@ export default async function AiModelDetailPage({
             {entity.title}
           </h1>
           {entity.developer && (
-            <span
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+            <Link
+              href={`/organizations/${entity.developer}`}
+              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold hover:opacity-80 transition-opacity ${
                 DEVELOPER_COLORS[entity.developer] ??
                 "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
               }`}
             >
               {developerEntity?.title ?? entity.developer}
-            </span>
+            </Link>
           )}
           {entity.openWeight && (
             <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300">

--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -377,15 +377,16 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 </td>
               </tr>
             ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={11} className="text-center py-12 text-muted-foreground">
+                  No models match your search.
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
-
-      {filtered.length === 0 && (
-        <div className="text-center py-12 text-muted-foreground">
-          No models match your search.
-        </div>
-      )}
 
       {/* Bottom pagination */}
       <div className="mt-3">

--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -317,16 +317,18 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
 
                 {/* Amount */}
                 <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap">
-                  {row.amount != null && (
+                  {row.amount != null ? (
                     <span className="font-semibold">
                       {formatCompactCurrency(row.amount)}
                     </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">{"\u2014"}</span>
                   )}
                 </td>
 
                 {/* Date */}
                 <td className="py-2.5 px-3 text-center text-muted-foreground">
-                  {row.date ?? row.period ?? ""}
+                  {row.date ?? row.period ?? <span className="text-muted-foreground/40">{"\u2014"}</span>}
                 </td>
 
                 {/* Status */}

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -227,6 +227,7 @@ export default async function PersonProfilePage({
     value: string;
     sub?: string;
     href?: string;
+    suppressHydrationWarning?: boolean;
   }> = [];
 
   if (roleFact?.value.type === "text") {
@@ -247,6 +248,7 @@ export default async function PersonProfilePage({
       label: "Born",
       value: String(bornYearFact.value.value),
       sub: `Age ~${age}`,
+      suppressHydrationWarning: true,
     });
   }
   if (netWorthFact?.value.type === "number") {

--- a/apps/web/src/components/directory/ProfileStatCard.tsx
+++ b/apps/web/src/components/directory/ProfileStatCard.tsx
@@ -9,11 +9,14 @@ export function ProfileStatCard({
   value,
   sub,
   href,
+  suppressHydrationWarning,
 }: {
   label: string;
   value: string;
   sub?: string;
   href?: string;
+  /** Pass true for values derived from the current date (e.g., computed age) */
+  suppressHydrationWarning?: boolean;
 }) {
   const content = (
     <>
@@ -24,7 +27,7 @@ export function ProfileStatCard({
         {value}
       </div>
       {sub && (
-        <div className="text-[10px] text-muted-foreground/50 mt-1">{sub}</div>
+        <div className="text-[10px] text-muted-foreground/50 mt-1" suppressHydrationWarning={suppressHydrationWarning}>{sub}</div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- **Grants table**: Show em-dash (`—`) instead of empty cells when `amount` or `date`/`period` is null, matching the pattern used in other directory tables
- **Person page age display**: Add `suppressHydrationWarning` to the calculated age stat card to prevent SSR/client mismatch at year boundaries (matches the org page pattern)
- **AI models developer badge**: Change the developer `<span>` to a `<Link>` pointing to `/organizations/{slug}` so the badge is clickable
- **AI models empty state**: Move the "No models match" message inside `<tbody>` as a `<tr><td colSpan>` element, matching HTML table semantics and other directory tables

## Test plan
- [ ] Verify grants table shows em-dashes for grants with null amount or date
- [ ] Verify person profile pages render without hydration warnings for age display
- [ ] Verify AI model detail page developer badge links to the correct organization page
- [ ] Verify AI models table empty state renders correctly inside the table when filters match nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)