### PR TITLE
fix: improve entity resolution fallback for funding rounds and divisions

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -2240,9 +2240,18 @@ async function main() {
   // =========================================================================
   const { slugToWikiId, wikiIdToSlug, nextId: nextIdInit } = buildIdRegistry(entities);
   let nextId = nextIdInit;
+  // Build stableId → slug mapping from YAML entities (for entity resolution
+  // in directory pages where ownerEntityId is a stableId rather than a slug)
+  const stableIdToSlug = {};
+  for (const e of entities) {
+    if (e.stableId) {
+      stableIdToSlug[e.stableId] = e.id;
+    }
+  }
   const idRegistryOutput = {
     byWikiId: { ...wikiIdToSlug },
     bySlug: { ...slugToWikiId },
+    stableIdToSlug,
   };
   database.idRegistry = idRegistryOutput;
 

--- a/apps/web/src/app/divisions/[slug]/division-data.ts
+++ b/apps/web/src/app/divisions/[slug]/division-data.ts
@@ -4,15 +4,12 @@
  */
 import {
   getAllKBRecords,
-  getKBEntity,
   getKBEntitySlug,
   getKBRecords,
 } from "@/data/factbase";
 import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById } from "@/data/tablebase";
-import {
-  titleCase,
-} from "@/components/wiki/factbase/format";
+import { resolveEntityLink } from "@/lib/record-detail-ui";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -73,18 +70,8 @@ export interface ParsedDivisionPersonnel {
 
 // ── Resolution helpers ─────────────────────────────────────────────────
 
-export function resolveEntityLink(entityId: string): { name: string; href: string | null } {
-  const entity = getKBEntity(entityId);
-  if (entity) {
-    const slug = getKBEntitySlug(entityId);
-    if (slug) {
-      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
-      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
-    }
-    return { name: entity.name, href: `/factbase/entity/${entityId}` };
-  }
-  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
-}
+// Re-export the shared resolveEntityLink (with TableBase fallback for stableIds and numeric IDs)
+export { resolveEntityLink };
 
 // ── Record parsers ────────────────────────────────────────────────────
 

--- a/apps/web/src/app/funding-programs/[id]/program-data.ts
+++ b/apps/web/src/app/funding-programs/[id]/program-data.ts
@@ -4,14 +4,11 @@
  */
 import {
   getAllKBRecords,
-  getKBEntity,
   getKBEntitySlug,
 } from "@/data/factbase";
 import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById } from "@/data/tablebase";
-import {
-  titleCase,
-} from "@/components/wiki/factbase/format";
+import { resolveEntityLink } from "@/lib/record-detail-ui";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -50,18 +47,8 @@ export interface ParsedGrant {
 
 // ── Resolution helpers ─────────────────────────────────────────────────
 
-export function resolveEntityLink(entityId: string): { name: string; href: string | null } {
-  const entity = getKBEntity(entityId);
-  if (entity) {
-    const slug = getKBEntitySlug(entityId);
-    if (slug) {
-      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
-      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
-    }
-    return { name: entity.name, href: `/factbase/entity/${entityId}` };
-  }
-  return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
-}
+// Re-export the shared resolveEntityLink (with TableBase fallback for stableIds and numeric IDs)
+export { resolveEntityLink };
 
 // ── Record parsers ────────────────────────────────────────────────────
 

--- a/apps/web/src/app/grants/grant-shared.tsx
+++ b/apps/web/src/app/grants/grant-shared.tsx
@@ -9,10 +9,8 @@ import {
 } from "@/data/factbase";
 import type { KBRecordEntry } from "@/data/factbase";
 import { formatCompactCurrency } from "@/lib/format-compact";
-import {
-  formatKBDate,
-  titleCase,
-} from "@/components/wiki/factbase/format";
+import { formatKBDate } from "@/components/wiki/factbase/format";
+import { resolveEntityLink as resolveEntityLinkBase } from "@/lib/record-detail-ui";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -39,11 +37,17 @@ export interface ParsedGrantDetail {
 
 // ── Resolution helpers ─────────────────────────────────────────────────
 
+/**
+ * Grant-specific variant that also returns the entity slug.
+ * Delegates to the shared resolveEntityLink for fallback resolution,
+ * then extracts the slug from the href when available.
+ */
 export function resolveEntityLink(entityId: string): {
   name: string;
   slug: string | null;
   href: string | null;
 } {
+  // Try FactBase first for slug extraction (slug is not in the base return type)
   const entity = getKBEntity(entityId);
   if (entity) {
     const slug = getKBEntitySlug(entityId);
@@ -55,7 +59,16 @@ export function resolveEntityLink(entityId: string): {
     }
     return { name: entity.name, slug: null, href: `/factbase/entity/${entityId}` };
   }
-  return { name: titleCase(entityId.replace(/-/g, " ")), slug: null, href: null };
+
+  // Fall back to the shared resolution (handles bare numeric IDs and stableIds)
+  const base = resolveEntityLinkBase(entityId);
+  // Extract slug from href if it is a directory URL (e.g. /organizations/anthropic)
+  let slug: string | null = null;
+  if (base.href) {
+    const dirMatch = base.href.match(/^\/(organizations|people)\/(.+)$/);
+    if (dirMatch) slug = dirMatch[2];
+  }
+  return { name: base.name, slug, href: base.href };
 }
 
 export function parseGrantDetail(record: KBRecordEntry): ParsedGrantDetail {

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -50,6 +50,7 @@ export const DATA_DIR = path.resolve(process.cwd(), "../../data");
 export interface IdRegistryMaps {
   byWikiId: Record<string, string>; // E1 → slug
   bySlug: Record<string, string>; // slug → E1
+  stableIdToSlug?: Record<string, string>; // 10-char stableId → slug (from YAML entities)
 }
 
 /**

--- a/apps/web/src/lib/record-detail-ui.tsx
+++ b/apps/web/src/lib/record-detail-ui.tsx
@@ -3,36 +3,116 @@
  * (grants, funding-rounds, investments, divisions, funding-programs).
  */
 import Link from "next/link";
-import {
-  getKBEntity,
-  getKBEntitySlug,
-} from "@/data/factbase";
+import { getKBEntity, getKBEntitySlug } from "@/data/factbase";
+import { getTypedEntityById, getIdRegistry } from "@/data";
 import { titleCase } from "@/components/wiki/factbase/format";
 
 /**
- * Resolve a KB entity ID to a display name and optional href.
- * Equivalent to `resolveRecipient` in org-shared.tsx.
+ * Build a { name, href } result from a typed entity and its slug.
  */
-export function resolveEntityLink(entityId: string): { name: string; href: string | null } {
+function buildEntityResult(
+  entity: { entityType: string; title: string; wikiId?: string },
+  slug: string,
+): { name: string; href: string | null } {
+  if (entity.entityType === "organization")
+    return { name: entity.title, href: `/organizations/${slug}` };
+  if (entity.entityType === "person")
+    return { name: entity.title, href: `/people/${slug}` };
+  return {
+    name: entity.title,
+    href: entity.wikiId ? `/wiki/${entity.wikiId}` : null,
+  };
+}
+
+/**
+ * Try to resolve an entity through the TableBase (typed entities in database.json).
+ * Handles three cases that FactBase cannot resolve:
+ * 1. Bare numeric IDs (e.g. "175") - legacy wiki page IDs from PG, resolved via E-number lookup
+ * 2. StableIds (e.g. "8grDoD8kig") - entities that exist in YAML but not in FactBase,
+ *    resolved via the stableIdToSlug mapping in the id registry
+ * 3. Direct slug matches - entityIds that happen to be entity slugs
+ */
+function resolveViaTableBase(
+  entityId: string,
+): { name: string; href: string | null } | null {
+  const registry = getIdRegistry();
+
+  // Case 1: bare numeric ID -> try as wiki page ID (E-number)
+  if (/^\d+$/.test(entityId)) {
+    const slug = registry.byWikiId[`E${entityId}`];
+    if (slug) {
+      const entity = getTypedEntityById(slug);
+      if (entity) return buildEntityResult(entity, slug);
+    }
+  }
+
+  // Case 2: stableId -> look up in the stableIdToSlug mapping from the id registry
+  if (registry.stableIdToSlug) {
+    const slugFromStableId = registry.stableIdToSlug[entityId];
+    if (slugFromStableId) {
+      const entity = getTypedEntityById(slugFromStableId);
+      if (entity) return buildEntityResult(entity, slugFromStableId);
+    }
+  }
+
+  // Case 3: try direct TableBase lookup (entityId might already be a slug)
+  const directEntity = getTypedEntityById(entityId);
+  if (directEntity) return buildEntityResult(directEntity, directEntity.id);
+
+  return null;
+}
+
+/**
+ * Check whether an ID looks like a raw internal identifier that should not be
+ * displayed to users (bare numbers, 10-char alphanumeric stableIds).
+ */
+function isRawInternalId(id: string): boolean {
+  return /^\d+$/.test(id) || /^[A-Za-z0-9]{10}$/.test(id);
+}
+
+/**
+ * Resolve a KB entity ID to a display name and optional href.
+ * Tries FactBase first, then falls back to TableBase for entities that only
+ * exist in YAML (not in FactBase) or use legacy numeric wiki page IDs.
+ */
+export function resolveEntityLink(
+  entityId: string,
+): { name: string; href: string | null } {
+  // Primary: try FactBase (handles 10-char entity IDs and slugs)
   const entity = getKBEntity(entityId);
   if (entity) {
     const slug = getKBEntitySlug(entityId);
     if (slug) {
-      if (entity.type === "organization") return { name: entity.name, href: `/organizations/${slug}` };
-      if (entity.type === "person") return { name: entity.name, href: `/people/${slug}` };
+      if (entity.type === "organization")
+        return { name: entity.name, href: `/organizations/${slug}` };
+      if (entity.type === "person")
+        return { name: entity.name, href: `/people/${slug}` };
     }
     return { name: entity.name, href: `/factbase/entity/${entityId}` };
   }
+
+  // Fallback: try TableBase (handles bare numeric IDs and stableIds not in FactBase)
+  const tableBaseResult = resolveViaTableBase(entityId);
+  if (tableBaseResult) return tableBaseResult;
+
+  // Last resort: if the ID looks like an internal ID, show "Unknown" instead of the raw value
+  if (isRawInternalId(entityId)) {
+    return { name: "Unknown", href: null };
+  }
+
   return { name: titleCase(entityId.replace(/-/g, " ")), href: null };
 }
 
 /** Badge color maps shared across funding-round and investment detail pages. */
 export const INSTRUMENT_COLORS: Record<string, string> = {
-  equity: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  "convertible-note": "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  equity:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  "convertible-note":
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
   safe: "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
   debt: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-  grant: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
+  grant:
+    "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
 };
 
 /** Label + children layout for detail page fields. */
@@ -71,5 +151,7 @@ export function EntityLinkDisplay({
       </Link>
     );
   }
-  return <span className="text-sm font-medium text-foreground">{name}</span>;
+  return (
+    <span className="text-sm font-medium text-foreground">{name}</span>
+  );
 }


### PR DESCRIPTION
## Summary

Fixes entity resolution failures on the Funding Rounds and Divisions directory pages where raw internal IDs were displayed instead of entity names.

**Funding Rounds**: 10 of 20 entries showed raw numeric IDs (175, 265, 335, 378) instead of company names. These are legacy wiki page IDs from PG stored without the "E" prefix.

**Divisions**: 6 entries showed raw 10-char stableIds (e.g. `8grDoD8kig` for RAND Corporation) instead of parent organization names. These entities exist in YAML but have no FactBase entity files.

### Changes

- **`apps/web/src/lib/record-detail-ui.tsx`**: Enhanced `resolveEntityLink` with a three-tier fallback:
  1. Primary: FactBase lookup (existing behavior)
  2. Fallback: TableBase lookup handling bare numeric IDs (via E-number registry), stableIds (via new `stableIdToSlug` mapping), and direct slug matches
  3. Last resort: Show "Unknown" instead of raw internal IDs
- **`apps/web/scripts/build-data.mjs`**: Added `stableIdToSlug` mapping to the id registry, built from YAML entity stableId fields during build-data
- **`apps/web/src/data/tablebase.ts`**: Added `stableIdToSlug` to `IdRegistryMaps` type
- **`apps/web/src/app/divisions/[slug]/division-data.ts`** and **`apps/web/src/app/funding-programs/[id]/program-data.ts`**: Consolidated duplicate `resolveEntityLink` copies to use the shared implementation
- **`apps/web/src/app/grants/grant-shared.tsx`**: Updated to delegate to the shared fallback logic for the grant-specific variant

## Test plan

- [ ] Verify funding rounds page shows company names instead of raw numbers
- [ ] Verify divisions page shows "RAND Corporation" instead of `8grDoD8kig`
- [ ] Verify divisions with non-existent parent org (`Y4bieqSeag`) show "Unknown" instead of raw ID
- [ ] Verify grants and funding programs pages still resolve entities correctly
- [ ] TypeScript check passes (`tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)