### PR TITLE
Fix TS2339: rename numericId to wikiId in entity-profile

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/entity-profile.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile.ts
@@ -255,7 +255,7 @@ const SECTIONS: SectionDef[] = [
     query: (db, _stableId, slug) =>
       db.select({
         id: wikiPages.id,
-        numericId: wikiPages.numericId,
+        wikiId: wikiPages.wikiId,
         slug: wikiPages.slug,
         title: wikiPages.title,
         description: wikiPages.description,


### PR DESCRIPTION
## Summary
- Fix CI build failure on main: `entity-profile.ts(258,30): error TS2339: Property 'numericId' does not exist`
- The `numericId` column on the `wikiPages` schema was renamed to `wikiId` but this one reference in the entity-profile route was missed

## Test plan
- [ ] CI passes (TypeScript compilation succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)