### PR TITLE
fix: grants funder filter to correctly show only selected funder's grants

### DIFF
--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -84,8 +84,22 @@ function PaginationControls({
   );
 }
 
-export function GrantsTable({ rows }: { rows: GrantRow[] }) {
+export interface FunderSummary {
+  id: string;
+  name: string;
+  count: number;
+  total: number;
+}
+
+export function GrantsTable({
+  rows,
+  funders,
+}: {
+  rows: GrantRow[];
+  funders: FunderSummary[];
+}) {
   const [search, setSearch] = useState("");
+  const [funderFilter, setFunderFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [sortKey, setSortKey] = useState<SortKey>("amount");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -121,6 +135,10 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
   const filtered = useMemo(() => {
     let result = rows;
 
+    if (funderFilter !== "all") {
+      result = result.filter((r) => r.organizationId === funderFilter);
+    }
+
     if (statusFilter !== "all") {
       result = result.filter((r) => r.status === statusFilter);
     }
@@ -140,7 +158,7 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
     result = [...result].sort((a, b) => compareGrantRows(a, b, sortKey, sortDir));
 
     return result;
-  }, [rows, search, statusFilter, sortKey, sortDir]);
+  }, [rows, search, funderFilter, statusFilter, sortKey, sortDir]);
 
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
   const pageRows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
@@ -148,59 +166,108 @@ export function GrantsTable({ rows }: { rows: GrantRow[] }) {
   return (
     <div>
       {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-5">
-        <input
-          type="text"
-          placeholder="Search grants, recipients, or funders..."
-          aria-label="Search grants"
-          value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setPage(0);
-          }}
-          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
-        />
-        <div className="flex flex-wrap gap-1.5">
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter("all");
+      <div className="flex flex-col gap-3 mb-5">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            type="text"
+            placeholder="Search grants, recipients, or funders..."
+            aria-label="Search grants"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
               setPage(0);
             }}
-            aria-pressed={statusFilter === "all"}
-            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-              statusFilter === "all"
-                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-            }`}
-          >
-            All
-            <span className="ml-1 text-[10px] opacity-60">
-              {statusCounts.all}
-            </span>
-          </button>
-          {statuses.map((s) => (
+            className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
+          />
+          {/* Status filter */}
+          <div className="flex flex-wrap gap-1.5">
             <button
               type="button"
-              key={s}
               onClick={() => {
-                setStatusFilter(statusFilter === s ? "all" : s);
+                setStatusFilter("all");
                 setPage(0);
               }}
-              aria-pressed={statusFilter === s}
+              aria-pressed={statusFilter === "all"}
               className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                statusFilter === s
+                statusFilter === "all"
                   ? "bg-primary/10 border-primary/30 text-primary font-semibold"
                   : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
               }`}
             >
-              {s}
+              All
               <span className="ml-1 text-[10px] opacity-60">
-                {statusCounts[s] ?? 0}
+                {statusCounts.all}
               </span>
             </button>
-          ))}
+            {statuses.map((s) => (
+              <button
+                type="button"
+                key={s}
+                onClick={() => {
+                  setStatusFilter(statusFilter === s ? "all" : s);
+                  setPage(0);
+                }}
+                aria-pressed={statusFilter === s}
+                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                  statusFilter === s
+                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+                }`}
+              >
+                {s}
+                <span className="ml-1 text-[10px] opacity-60">
+                  {statusCounts[s] ?? 0}
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
+
+        {/* Funder filter */}
+        {funders.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            <span className="text-xs text-muted-foreground self-center mr-1">Funder:</span>
+            <button
+              type="button"
+              onClick={() => {
+                setFunderFilter("all");
+                setPage(0);
+              }}
+              aria-pressed={funderFilter === "all"}
+              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                funderFilter === "all"
+                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+              }`}
+            >
+              All funders
+              <span className="ml-1 text-[10px] opacity-60">
+                {rows.length}
+              </span>
+            </button>
+            {funders.map((f) => (
+              <button
+                type="button"
+                key={f.id}
+                onClick={() => {
+                  setFunderFilter(funderFilter === f.id ? "all" : f.id);
+                  setPage(0);
+                }}
+                aria-pressed={funderFilter === f.id}
+                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                  funderFilter === f.id
+                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+                }`}
+              >
+                {f.name}
+                <span className="ml-1 text-[10px] opacity-60">
+                  {f.count}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Results count + pagination */}

--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -5,7 +5,7 @@ import { getEntityHref } from "@/data/entity-nav";
 import { getTypedEntityById } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
 import { formatCompactCurrency } from "@/lib/format-compact";
-import { GrantsTable, type GrantRow } from "./grants-table";
+import { GrantsTable, type GrantRow, type FunderSummary } from "./grants-table";
 
 export const metadata: Metadata = {
   title: "Grants",
@@ -150,6 +150,14 @@ export default function GrantsPage() {
     (a, b) => b.total - a.total,
   );
 
+  // Build lightweight funder summaries for the table filter tabs
+  const funderSummaries: FunderSummary[] = topFunders.map((f) => ({
+    id: f.id,
+    name: f.name,
+    count: f.count,
+    total: f.total,
+  }));
+
   const stats = [
     { label: "Total Grants", value: totalGrants.toLocaleString() },
     { label: "Total Funding", value: formatCompactCurrency(totalAmount) },
@@ -214,7 +222,7 @@ export default function GrantsPage() {
 
       {/* Grants table */}
       {totalGrants > 0 ? (
-        <GrantsTable rows={rows} />
+        <GrantsTable rows={rows} funders={funderSummaries} />
       ) : (
         <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
           <p className="text-lg font-medium mb-2">No grants data available</p>


### PR DESCRIPTION
## Summary

- The grants page (`/grants`) had a "By Funder" summary section with static cards showing funder names and totals, but clicking them did nothing — the `GrantsTable` component had no funder filtering capability
- Added a `funderFilter` state and clickable funder filter tabs to `GrantsTable`, matching the existing status filter pattern
- The funder filter compares `organizationId` (the canonical entity ID) so it works reliably across all grants regardless of name formatting
- Filter tabs show grant counts per funder, sorted by total funding amount (descending)
- Pagination resets correctly when changing the funder filter

## Root cause

The `GrantsTable` client component only had `statusFilter` and text `search` state. The "By Funder" section in `page.tsx` rendered purely static `<div>` cards with no click handlers or connection to the table's filter logic. There was no `funderFilter` state, no filter tabs for funders, and no filtering logic in the `filtered` useMemo.

## Test plan

- [x] Existing grants sort tests pass (24 tests)
- [x] TypeScript types are consistent (FunderSummary interface, organizationId matching)
- [ ] Manual: visit `/grants`, click a funder tab, verify only that funder's grants appear
- [ ] Manual: click "All funders" tab to clear the filter
- [ ] Manual: combine funder filter with status filter and text search
- [ ] Manual: verify pagination resets when switching funders

Generated with [Claude Code](https://claude.com/claude-code)