### PR TITLE
fix: hide empty Investments directory and sparse Events from main navigation

### DIFF
--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -25,7 +25,6 @@ export const NAV_ITEMS: NavItem[] = [
       { href: "/people", label: "People" },
       { href: "/ai-models", label: "AI Models" },
       { href: "/projects", label: "Projects" },
-      { href: "/events", label: "Events" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Removed the **Events** directory link from the "Entities" dropdown in the main header navigation. The Events directory currently has only 1 entry, adding clutter without providing meaningful browsing value.
- The **Investments** directory (0 entries, $0 total) was already absent from header navigation, so no change was needed there.

Both `/events` and `/investments` pages remain accessible via direct URL. Entity links pointing to events (e.g., `getDirectoryHref()` in `entity-nav.ts`) continue to resolve correctly — only the top-level navigation entry was removed.

### What changed

- `apps/web/src/lib/nav-links.ts`: Removed `{ href: "/events", label: "Events" }` from the Entities dropdown

### Verification

- `tsc --noEmit` passes (all errors are pre-existing in wiki-server schema files, unrelated to this change)
- The change is a single line removal from a static configuration array — no runtime logic affected

## Test plan

- [ ] Verify the header "Entities" dropdown no longer shows "Events"
- [ ] Verify `/events` page still loads when accessed directly
- [ ] Verify entity links to events (e.g., from org pages) still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)