### PR TITLE
feat: add cross-validation gate check for people role consistency

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -141,6 +141,11 @@ const SCRIPTS = {
     description: 'Cross-entity consistency (bidirectional refs, affiliation coherence)',
     passthrough: ['ci', 'verbose', 'type'],
   },
+  'cross-check': {
+    script: 'validate/cross-check-people.ts',
+    description: 'Cross-check people roles between YAML entities and FactBase (advisory)',
+    passthrough: ['ci', 'verbose'],
+  },
   'to-rdjsonl': {
     script: 'validate/to-rdjsonl.ts',
     description: 'Convert unified --ci JSON to Reviewdog rdjsonl (reads stdin)',

--- a/crux/validate/cross-check-people.test.ts
+++ b/crux/validate/cross-check-people.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for the people role cross-check validator.
+ *
+ * Tests the core comparison logic (normalizeRole, rolesAreSimilar),
+ * data extraction helpers, and the full cross-check function with
+ * mocked file system data.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  normalizeRole,
+  splitRoleParts,
+  extractCoreTokens,
+  rolesAreSimilar,
+  getEntityRole,
+  getFactBaseRoles,
+  crossCheckPeopleRoles,
+  type RoleMismatch,
+} from "./cross-check-people.ts";
+
+// ---------------------------------------------------------------------------
+// normalizeRole
+// ---------------------------------------------------------------------------
+
+describe("normalizeRole", () => {
+  it("lowercases the string", () => {
+    expect(normalizeRole("CEO")).toBe("ceo");
+  });
+
+  it("normalizes ampersand to 'and'", () => {
+    expect(normalizeRole("CEO & Co-founder")).toBe("ceo and co-founder");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeRole("  CEO  ")).toBe("ceo");
+  });
+
+  it("collapses multiple spaces", () => {
+    expect(normalizeRole("Head   of   Research")).toBe("head of research");
+  });
+
+  it("normalizes commas", () => {
+    expect(normalizeRole("CEO,  Co-founder")).toBe("ceo, co-founder");
+  });
+
+  it("normalizes semicolons to commas", () => {
+    expect(normalizeRole("Professor; Director")).toBe("professor, director");
+  });
+
+  it("strips parenthetical notes", () => {
+    expect(normalizeRole("Former Co-CEO (now at Anthropic)")).toBe(
+      "former co-ceo",
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeRole("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitRoleParts
+// ---------------------------------------------------------------------------
+
+describe("splitRoleParts", () => {
+  it("splits on comma", () => {
+    expect(splitRoleParts("CEO, Co-founder")).toEqual(["ceo", "co-founder"]);
+  });
+
+  it("splits on semicolon", () => {
+    expect(splitRoleParts("Professor; Director")).toEqual([
+      "professor",
+      "director",
+    ]);
+  });
+
+  it("splits on 'and'", () => {
+    expect(splitRoleParts("CEO and Co-founder")).toEqual([
+      "ceo",
+      "co-founder",
+    ]);
+  });
+
+  it("handles single role", () => {
+    expect(splitRoleParts("CEO")).toEqual(["ceo"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCoreTokens
+// ---------------------------------------------------------------------------
+
+describe("extractCoreTokens", () => {
+  it("splits on commas", () => {
+    const tokens = extractCoreTokens("CEO, Co-founder");
+    expect(tokens.has("ceo")).toBe(true);
+  });
+
+  it("splits on 'and'", () => {
+    const tokens = extractCoreTokens("CEO and Co-founder");
+    expect(tokens.has("ceo")).toBe(true);
+  });
+
+  it("strips 'co-founder' prefix for core comparison", () => {
+    const tokens = extractCoreTokens("Co-founder, Head of Research");
+    expect(tokens.has("head of research")).toBe(true);
+  });
+
+  it("handles single role", () => {
+    const tokens = extractCoreTokens("Chief Scientist");
+    expect(tokens.has("chief scientist")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rolesAreSimilar — the core logic
+// ---------------------------------------------------------------------------
+
+describe("rolesAreSimilar", () => {
+  // Cases that SHOULD be considered similar (no warning)
+  describe("similar roles (should return true)", () => {
+    it("exact match", () => {
+      expect(rolesAreSimilar("CEO", "CEO")).toBe(true);
+    });
+
+    it("case difference", () => {
+      expect(rolesAreSimilar("ceo", "CEO")).toBe(true);
+    });
+
+    it("Co-Founder vs Co-founder capitalization", () => {
+      expect(rolesAreSimilar("Co-Founder", "Co-founder")).toBe(true);
+    });
+
+    it("ampersand vs 'and'", () => {
+      expect(rolesAreSimilar("CEO & Co-founder", "CEO and Co-founder")).toBe(
+        true,
+      );
+    });
+
+    it("one is substring of the other", () => {
+      expect(rolesAreSimilar("CEO", "CEO and Co-founder")).toBe(true);
+    });
+
+    it("comma-separated vs ampersand-separated", () => {
+      expect(
+        rolesAreSimilar("Co-founder, CEO", "Co-founder & CEO"),
+      ).toBe(true);
+    });
+
+    it("extra whitespace", () => {
+      expect(rolesAreSimilar("Head of Research", "Head  of  Research")).toBe(
+        true,
+      );
+    });
+
+    it("head of interpretability variations", () => {
+      expect(
+        rolesAreSimilar(
+          "Co-founder, Head of Interpretability",
+          "Co-founder and Head of Interpretability",
+        ),
+      ).toBe(true);
+    });
+
+    it("co-founder chief scientist", () => {
+      expect(
+        rolesAreSimilar(
+          "Co-founder & Chief Scientist",
+          "Co-founder and Chief Scientist",
+        ),
+      ).toBe(true);
+    });
+
+    it("professor with and without institution", () => {
+      expect(
+        rolesAreSimilar(
+          "Professor of Computer Science, CHAI Founder",
+          "Professor of Computer Science, UC Berkeley; Founder of CHAI",
+        ),
+      ).toBe(true);
+    });
+
+    it("scientific director with and without institution", () => {
+      expect(
+        rolesAreSimilar(
+          "Scientific Director of Mila, Professor",
+          "Scientific Director, Mila; Professor, Universite de Montreal",
+        ),
+      ).toBe(true);
+    });
+
+    it("co-founder with vs without 'Head of' qualifier", () => {
+      expect(
+        rolesAreSimilar(
+          "Co-founder, Head of Interpretability",
+          "Co-founder, Interpretability",
+        ),
+      ).toBe(true);
+    });
+
+    it("co-founder vs founder with similar modifier", () => {
+      expect(
+        rolesAreSimilar(
+          "Co-founder & Research Fellow",
+          "Founder & Senior Research Fellow",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // Cases that SHOULD be considered different (should warn)
+  describe("different roles (should return false)", () => {
+    it("CEO vs Chief Scientist", () => {
+      expect(rolesAreSimilar("CEO", "Chief Scientist")).toBe(false);
+    });
+
+    it("CEO vs Head of Alignment Science", () => {
+      expect(rolesAreSimilar("CEO", "Head of Alignment Science")).toBe(false);
+    });
+
+    it("Research Scientist vs CEO", () => {
+      expect(rolesAreSimilar("Research Scientist", "CEO")).toBe(false);
+    });
+
+    it("VP of Research vs CEO", () => {
+      expect(rolesAreSimilar("VP of Research", "CEO")).toBe(false);
+    });
+
+    it("Head of Alignment vs President", () => {
+      expect(rolesAreSimilar("Head of Alignment", "President")).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEntityRole
+// ---------------------------------------------------------------------------
+
+describe("getEntityRole", () => {
+  it("returns the Role value from customFields", () => {
+    const person = {
+      id: "test",
+      title: "Test Person",
+      customFields: [
+        { label: "Role", value: "CEO" },
+        { label: "Known For", value: "Testing" },
+      ],
+    };
+    expect(getEntityRole(person)).toBe("CEO");
+  });
+
+  it("returns null when no customFields", () => {
+    const person = { id: "test", title: "Test Person" };
+    expect(getEntityRole(person)).toBe(null);
+  });
+
+  it("returns null when no Role field exists", () => {
+    const person = {
+      id: "test",
+      title: "Test Person",
+      customFields: [{ label: "Known For", value: "Testing" }],
+    };
+    expect(getEntityRole(person)).toBe(null);
+  });
+
+  it("returns null for empty customFields", () => {
+    const person = {
+      id: "test",
+      title: "Test Person",
+      customFields: [],
+    };
+    expect(getEntityRole(person)).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFactBaseRoles
+// ---------------------------------------------------------------------------
+
+describe("getFactBaseRoles", () => {
+  it("extracts current roles (no validEnd)", () => {
+    const thing = {
+      thing: { id: "test", type: "person", name: "Test" },
+      facts: [
+        { id: "f1", property: "role", value: "CEO" },
+        {
+          id: "f2",
+          property: "role",
+          value: "Research Scientist",
+          validEnd: "2024-01",
+        },
+      ],
+    };
+    const result = getFactBaseRoles(thing);
+    expect(result.currentRoles).toEqual(["CEO"]);
+    expect(result.allRoles).toEqual(["CEO", "Research Scientist"]);
+  });
+
+  it("returns empty arrays for no role facts", () => {
+    const thing = {
+      thing: { id: "test", type: "person", name: "Test" },
+      facts: [{ id: "f1", property: "employed-by", value: "some-org" }],
+    };
+    const result = getFactBaseRoles(thing);
+    expect(result.currentRoles).toEqual([]);
+    expect(result.allRoles).toEqual([]);
+  });
+
+  it("handles missing facts array", () => {
+    const thing = {
+      thing: { id: "test", type: "person", name: "Test" },
+      facts: [] as any[],
+    };
+    const result = getFactBaseRoles(thing);
+    expect(result.currentRoles).toEqual([]);
+    expect(result.allRoles).toEqual([]);
+  });
+
+  it("distinguishes multiple current roles", () => {
+    const thing = {
+      thing: { id: "test", type: "person", name: "Test" },
+      facts: [
+        { id: "f1", property: "role", value: "CEO" },
+        { id: "f2", property: "role", value: "Board Chair" },
+      ],
+    };
+    const result = getFactBaseRoles(thing);
+    expect(result.currentRoles).toEqual(["CEO", "Board Chair"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// crossCheckPeopleRoles (integration with mocked filesystem)
+// ---------------------------------------------------------------------------
+
+describe("crossCheckPeopleRoles", () => {
+  let mockReadFileSync: ReturnType<typeof vi.fn>;
+  let mockExistsSync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // We test via the real function against the actual project data
+    // to ensure it runs without crashing. Detailed logic is tested
+    // by the unit tests above.
+  });
+
+  it("runs without crashing on the real project data", () => {
+    // Use the actual project root two directories up
+    const projectRoot = `${__dirname}/../..`;
+    // This should not throw even if there are mismatches
+    const result = crossCheckPeopleRoles(projectRoot);
+    expect(Array.isArray(result)).toBe(true);
+    // Every result should have the expected shape
+    for (const mismatch of result) {
+      expect(mismatch).toHaveProperty("personId");
+      expect(mismatch).toHaveProperty("personName");
+      expect(mismatch).toHaveProperty("entityRole");
+      expect(mismatch).toHaveProperty("factbaseRoles");
+      expect(mismatch).toHaveProperty("currentFactbaseRole");
+      expect(mismatch).toHaveProperty("severity");
+      expect(mismatch).toHaveProperty("description");
+      expect(["warning", "info"]).toContain(mismatch.severity);
+    }
+  }, 30_000);
+});

--- a/crux/validate/cross-check-people.ts
+++ b/crux/validate/cross-check-people.ts
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+
+/**
+ * Cross-Check People Roles
+ *
+ * Validates that person role titles are consistent across the two authoritative
+ * data sources:
+ *
+ *   1. YAML entities (`data/entities/people.yaml`) — `customFields.Role`
+ *   2. FactBase YAML (`packages/factbase/data/things/<slug>.yaml`) — `property: role` facts
+ *
+ * This catches the class of bugs where e.g. Sutskever shows "Chief Scientist"
+ * in one place and "CEO" in another, or Leike has 3 different titles.
+ *
+ * Usage:
+ *   npx tsx crux/validate/cross-check-people.ts              # human-readable
+ *   npx tsx crux/validate/cross-check-people.ts --ci          # JSON output
+ *   npx tsx crux/validate/cross-check-people.ts --verbose     # show all details
+ *
+ * Exit codes:
+ *   0 = No mismatches (advisory — never blocks CI)
+ *   1 = Mismatches found
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PersonEntity {
+  id: string;
+  title: string;
+  customFields?: Array<{ label: string; value: string }>;
+}
+
+interface FactBaseFact {
+  id: string;
+  property: string;
+  value: string;
+  asOf?: string;
+  validEnd?: string;
+  notes?: string;
+}
+
+interface FactBaseThing {
+  thing: {
+    id: string;
+    type: string;
+    name: string;
+  };
+  facts: FactBaseFact[];
+}
+
+export interface RoleMismatch {
+  personId: string;
+  personName: string;
+  entityRole: string;
+  factbaseRoles: string[];
+  currentFactbaseRole: string | null;
+  severity: "warning" | "info";
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Normalization helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a role string for comparison purposes.
+ * Strips noise like "& ", extra whitespace, normalizes casing and delimiters.
+ */
+export function normalizeRole(role: string): string {
+  return role
+    .toLowerCase()
+    .replace(/\s*&\s*/g, " and ")
+    .replace(/\s*;\s*/g, ", ")   // normalize semicolons to commas
+    .replace(/\s*,\s*/g, ", ")
+    .replace(/\s+/g, " ")
+    .replace(/\s*\(.*?\)\s*/g, " ") // strip parenthetical notes like "(until 2024)"
+    .trim();
+}
+
+/**
+ * Split a role string into individual role parts, splitting on comma, semicolon,
+ * and " and " boundaries. Each part is normalized.
+ */
+export function splitRoleParts(role: string): string[] {
+  const normalized = normalizeRole(role);
+  return normalized
+    .split(/,\s*|\s+and\s+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Extract the "core" tokens from a role for fuzzy matching.
+ * Strips common prefixes like "Co-founder" and connecting words,
+ * and also strips institutional suffixes for comparison.
+ */
+export function extractCoreTokens(role: string): Set<string> {
+  const parts = splitRoleParts(role);
+  const tokens = new Set<string>();
+  for (const part of parts) {
+    // Add full part
+    tokens.add(part);
+
+    // Strip "co-founder" / "founder" prefix
+    const withoutFounder = part
+      .replace(/^(co-)?founder\s*/i, "")
+      .trim();
+    if (withoutFounder.length > 0) {
+      tokens.add(withoutFounder);
+    }
+
+    // Strip "of <Institution>" or ", <Institution>" suffix
+    // e.g., "scientific director of mila" -> "scientific director"
+    // e.g., "professor, universite de montreal" -> "professor"
+    const withoutInstitution = part
+      .replace(/\s+of\s+\w[\w\s]*/i, "")
+      .replace(/,\s+\w[\w\s]*/i, "")
+      .trim();
+    if (withoutInstitution.length > 0 && withoutInstitution !== part) {
+      tokens.add(withoutInstitution);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Extract "significant words" from a role — lowercase words that convey meaning,
+ * excluding common noise words.
+ */
+function significantWords(role: string): Set<string> {
+  const NOISE = new Set([
+    "a", "an", "the", "of", "at", "in", "for", "and", "or", "to",
+    "co", "former", "now", "until", "since",
+  ]);
+  const normalized = normalizeRole(role);
+  const words = normalized.split(/[\s,;]+/).filter((w) => w.length > 1);
+  return new Set(words.filter((w) => !NOISE.has(w)));
+}
+
+/**
+ * Determine if two role strings are semantically similar enough to not warn.
+ * Returns true if roles are considered "close enough" (just formatting differences).
+ *
+ * The matching is intentionally generous — we only want to flag cases where the
+ * roles are clearly different titles (e.g., "CEO" vs "Chief Scientist").
+ */
+export function rolesAreSimilar(roleA: string, roleB: string): boolean {
+  const normA = normalizeRole(roleA);
+  const normB = normalizeRole(roleB);
+
+  // Exact match after normalization
+  if (normA === normB) return true;
+
+  // One is a substring of the other (e.g., "CEO" vs "CEO and Co-founder")
+  const shorter = normA.length <= normB.length ? normA : normB;
+  const longer = normA.length <= normB.length ? normB : normA;
+  if (longer.includes(shorter) && shorter.length >= 2) return true;
+
+  // Split into role parts and check if the key parts match.
+  // e.g., "Professor of CS, CHAI Founder" vs "Professor of CS, UC Berkeley; Founder of CHAI"
+  // The core tokens ("professor", "founder") should overlap significantly.
+  const tokensA = extractCoreTokens(roleA);
+  const tokensB = extractCoreTokens(roleB);
+
+  let overlapCount = 0;
+  for (const t of tokensA) {
+    if (tokensB.has(t)) overlapCount++;
+  }
+  const totalUnique = new Set([...tokensA, ...tokensB]).size;
+  if (totalUnique > 0 && overlapCount / totalUnique >= 0.4) return true;
+
+  // Significant word overlap: if 60%+ of the important words are shared,
+  // the roles are likely describing the same position with formatting differences.
+  // e.g., "Scientific Director of Mila, Professor" vs "Scientific Director, Mila; Professor, Universite de Montreal"
+  const wordsA = significantWords(roleA);
+  const wordsB = significantWords(roleB);
+  let wordOverlap = 0;
+  for (const w of wordsA) {
+    if (wordsB.has(w)) wordOverlap++;
+  }
+  const minWords = Math.min(wordsA.size, wordsB.size);
+  if (minWords >= 2 && wordOverlap / minWords >= 0.6) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Data loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load people from data/entities/people.yaml
+ */
+export function loadPeopleEntities(projectRoot: string): PersonEntity[] {
+  const peoplePath = join(projectRoot, "data/entities/people.yaml");
+  if (!existsSync(peoplePath)) {
+    throw new Error(`people.yaml not found at ${peoplePath}`);
+  }
+  const raw = readFileSync(peoplePath, "utf-8");
+  const parsed = parseYaml(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error("people.yaml does not contain an array");
+  }
+  return parsed as PersonEntity[];
+}
+
+/**
+ * Load a FactBase thing file for a given slug.
+ * Returns null if the file doesn't exist.
+ */
+export function loadFactBaseThing(
+  projectRoot: string,
+  slug: string,
+): FactBaseThing | null {
+  const thingPath = join(
+    projectRoot,
+    "packages/factbase/data/things",
+    `${slug}.yaml`,
+  );
+  if (!existsSync(thingPath)) {
+    return null;
+  }
+  const raw = readFileSync(thingPath, "utf-8");
+  const parsed = parseYaml(raw);
+  return parsed as FactBaseThing;
+}
+
+/**
+ * Get the "current" role facts from a FactBase thing (no validEnd set).
+ * Also returns all role facts for context.
+ */
+export function getFactBaseRoles(thing: FactBaseThing): {
+  currentRoles: string[];
+  allRoles: string[];
+} {
+  const roleFacts = (thing.facts || []).filter((f) => f.property === "role");
+  const allRoles = roleFacts.map((f) => f.value);
+  const currentRoles = roleFacts
+    .filter((f) => !f.validEnd)
+    .map((f) => f.value);
+  return { currentRoles, allRoles };
+}
+
+/**
+ * Get the Role value from a person entity's customFields.
+ */
+export function getEntityRole(person: PersonEntity): string | null {
+  if (!person.customFields) return null;
+  const roleField = person.customFields.find((f) => f.label === "Role");
+  return roleField?.value ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Core check logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the cross-check between YAML entities and FactBase for all people.
+ */
+export function crossCheckPeopleRoles(
+  projectRoot: string,
+): RoleMismatch[] {
+  const people = loadPeopleEntities(projectRoot);
+  const mismatches: RoleMismatch[] = [];
+
+  for (const person of people) {
+    const entityRole = getEntityRole(person);
+    if (!entityRole) continue;
+
+    const factbaseThing = loadFactBaseThing(projectRoot, person.id);
+    if (!factbaseThing) continue; // No FactBase file — nothing to compare
+
+    const { currentRoles, allRoles } = getFactBaseRoles(factbaseThing);
+
+    if (currentRoles.length === 0) continue; // No current role in FactBase — nothing to compare
+
+    // Check if any current FactBase role is similar to the entity role
+    const hasSimilar = currentRoles.some((fbRole) =>
+      rolesAreSimilar(entityRole, fbRole),
+    );
+
+    if (!hasSimilar) {
+      // Determine severity: if there is a historical FactBase role that matches,
+      // it's likely a staleness issue (info). Otherwise it's a real mismatch (warning).
+      const historicalMatch = allRoles.some((fbRole) =>
+        rolesAreSimilar(entityRole, fbRole),
+      );
+
+      const severity: "warning" | "info" = historicalMatch ? "info" : "warning";
+
+      const currentFbDisplay = currentRoles.join(" / ");
+      mismatches.push({
+        personId: person.id,
+        personName: person.title,
+        entityRole,
+        factbaseRoles: allRoles,
+        currentFactbaseRole: currentFbDisplay,
+        severity,
+        description: historicalMatch
+          ? `${person.title}: entity role "${entityRole}" matches a historical FactBase role but not the current one "${currentFbDisplay}" — likely stale`
+          : `${person.title}: entity role "${entityRole}" differs from FactBase current role "${currentFbDisplay}"`,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+// ---------------------------------------------------------------------------
+// Main CLI
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const verbose = process.argv.includes("--verbose");
+  const ci = process.argv.includes("--ci");
+  const c = getColors(ci);
+
+  const mismatches = crossCheckPeopleRoles(PROJECT_ROOT);
+
+  const warnings = mismatches.filter((m) => m.severity === "warning");
+  const infos = mismatches.filter((m) => m.severity === "info");
+
+  // ── CI JSON output ──────────────────────────────────────────────
+  if (ci) {
+    const summary = {
+      passed: warnings.length === 0,
+      totalMismatches: mismatches.length,
+      warnings: warnings.length,
+      infos: infos.length,
+      mismatches,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    process.exit(warnings.length > 0 ? 1 : 0);
+    return;
+  }
+
+  // ── Human-readable output ───────────────────────────────────────
+  console.log(
+    "\n" +
+      c.bold +
+      c.blue +
+      "People Role Cross-Check" +
+      c.reset +
+      "\n",
+  );
+  console.log(
+    c.dim +
+      "Comparing roles between data/entities/people.yaml and packages/factbase/data/things/*.yaml" +
+      c.reset +
+      "\n",
+  );
+
+  if (mismatches.length === 0) {
+    console.log(
+      c.green + "No role mismatches found between YAML entities and FactBase." + c.reset,
+    );
+    console.log("");
+    process.exit(0);
+    return;
+  }
+
+  // Show warnings first
+  if (warnings.length > 0) {
+    console.log(
+      c.bold + c.yellow + `Warnings (${warnings.length})` + c.reset + "\n",
+    );
+    const toShow = verbose ? warnings : warnings.slice(0, 15);
+    for (const m of toShow) {
+      console.log(
+        `  ${c.yellow}!${c.reset} ${c.bold}${m.personName}${c.reset} (${m.personId})`,
+      );
+      console.log(
+        `    Entity role:   "${m.entityRole}"`,
+      );
+      console.log(
+        `    FactBase role: "${m.currentFactbaseRole}"`,
+      );
+      console.log(
+        `    ${c.dim}All FactBase roles: ${m.factbaseRoles.map((r) => `"${r}"`).join(", ")}${c.reset}`,
+      );
+      console.log("");
+    }
+    if (!verbose && warnings.length > 15) {
+      console.log(
+        `  ${c.dim}... and ${warnings.length - 15} more (use --verbose)${c.reset}\n`,
+      );
+    }
+  }
+
+  // Show infos
+  if (infos.length > 0) {
+    console.log(
+      c.bold + c.blue + `Info — likely stale (${infos.length})` + c.reset + "\n",
+    );
+    const toShow = verbose ? infos : infos.slice(0, 10);
+    for (const m of toShow) {
+      console.log(
+        `  ${c.blue}i${c.reset} ${c.dim}${m.personName}: entity="${m.entityRole}" factbase="${m.currentFactbaseRole}"${c.reset}`,
+      );
+    }
+    if (!verbose && infos.length > 10) {
+      console.log(
+        `\n  ${c.dim}... and ${infos.length - 10} more (use --verbose)${c.reset}`,
+      );
+    }
+    console.log("");
+  }
+
+  // Summary
+  console.log("-".repeat(50));
+  const parts: string[] = [];
+  if (warnings.length > 0)
+    parts.push(c.yellow + warnings.length + " warning(s)" + c.reset);
+  if (infos.length > 0)
+    parts.push(c.blue + infos.length + " info(s)" + c.reset);
+  console.log(`Found ${mismatches.length} role mismatches: ${parts.join(", ")}`);
+  console.log(
+    c.dim +
+      "This check is advisory — it does not block the gate." +
+      c.reset,
+  );
+  console.log("");
+
+  process.exit(warnings.length > 0 ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("People role cross-check crashed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Add new advisory validator `pnpm crux validate cross-check` that cross-validates person role titles between the two authoritative data sources: YAML entities (`data/entities/people.yaml` `customFields.Role`) and FactBase YAML (`packages/factbase/data/things/*.yaml` `property: role` facts)
- Uses fuzzy matching to avoid false positives on formatting differences (case, ampersand vs "and", semicolons vs commas, parenthetical notes, institutional suffixes) while flagging genuinely different titles (e.g., "CEO" vs "Chief Scientist")
- Distinguishes between "warning" (truly different titles) and "info" (entity matches a historical FactBase role, suggesting the entity is stale)

### Problem

Person role titles can drift silently between the YAML entity layer and FactBase without any check catching it. For example, Sutskever could show "Chief Scientist" in one place and "CEO" in another. This validator catches that class of bug.

### Current findings

The check currently finds 3 genuine mismatches:
- **Holden Karnofsky**: Entity says "Former Co-CEO (now at Anthropic)" but FactBase says "Member of Technical Staff, Anthropic"
- **Neel Nanda**: Entity says "Alignment Researcher" but FactBase says "Research Scientist, Google DeepMind"  
- **Nick Bostrom**: Entity says "Founding Director (until FHI closure in 2024)" but FactBase says "Professor of Philosophy, University of Oxford; Founder of FHI"

### Files changed

| File | Purpose |
|------|---------|
| `crux/validate/cross-check-people.ts` | Validator implementation |
| `crux/validate/cross-check-people.test.ts` | 43 unit tests |
| `crux/commands/validate.ts` | Register as `cross-check` command |

## Test plan

- [x] 43 unit tests pass covering normalization, fuzzy matching, data extraction, and integration with real project data
- [x] `pnpm crux validate cross-check` runs successfully and reports 3 genuine mismatches
- [x] `pnpm crux validate cross-check --ci` produces valid JSON output
- [x] No type errors in new files
- [x] Pre-existing crux test suite unaffected (3303 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)