### PR TITLE
fix: replace console.log with pino logger in entities prune route

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { eq, and, count, asc, sql, ilike, or, inArray, notInArray } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
+import { logger } from "../../logger.js";
 import { entities, facts, things } from "../../schema.js";
 import { checkRefsExist } from "../shared/ref-check.js";
 import {
@@ -773,8 +774,9 @@ const entitiesApp = new Hono()
       const staleIds = staleRows.map((r) => r.id);
 
       // Log before deleting (destructive operation)
-      console.log(
-        `[entities/prune] Deleting ${staleIds.length} stale ${entityType} entities: ${staleIds.join(", ")}`
+      logger.info(
+        { entityType, count: staleIds.length, ids: staleIds },
+        `Deleting ${staleIds.length} stale ${entityType} entities`
       );
 
       await db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary
- Replaces a `console.log` call in the entities prune endpoint with the pino structured logger (`logger.info`)
- This `console.log` was introduced in a recent merge and caused the `validate-no-console-log` CI check to fail on main

## Test plan
- [x] `pnpm exec vitest run crux/validate/validate-no-console-log.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)