### PR TITLE
Disable auto-update daily schedule

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -6,8 +6,9 @@ run-name: "Auto-Update Wiki${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' |
 # This workflow handles only: trigger, permissions, setup, and the single crux call.
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
+  # schedule disabled — run locally with `pnpm crux auto-update run` or trigger manually via workflow_dispatch
+  # schedule:
+  #   - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       budget:


### PR DESCRIPTION
## Summary

- Removes the daily cron trigger (`0 6 * * *`) from the auto-update GitHub Action
- Keeps `workflow_dispatch` so it can still be triggered manually if needed
- Local runs via `pnpm crux auto-update run` are unaffected

## Test plan

- [x] Workflow YAML is valid (only schedule block commented out)
- [ ] Verify no scheduled runs appear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
