### PR TITLE
fix: clarify AI models count messaging for family entries

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -232,7 +232,27 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
       {/* Results count + top pagination */}
       <div className="flex flex-col gap-2 mb-3">
         <div className="text-xs text-muted-foreground">
-          Showing {filtered.length} of {rows.length} models
+          {(() => {
+            const familyCount = rows.filter((r) => r.isFamily).length;
+            const modelCount = rows.length - familyCount;
+            const filteredFamilies = filtered.filter((r) => r.isFamily).length;
+            const filteredModels = filtered.length - filteredFamilies;
+
+            if (showFamilies) {
+              // Showing both models and families
+              const parts: string[] = [];
+              if (filteredModels > 0) parts.push(`${filteredModels} model${filteredModels !== 1 ? "s" : ""}`);
+              if (filteredFamilies > 0) parts.push(`${filteredFamilies} famil${filteredFamilies !== 1 ? "ies" : "y"}`);
+              const total = modelCount + familyCount;
+              return `Showing ${parts.join(" + ")} (${filtered.length} of ${total} entries)`;
+            } else {
+              // Families hidden — denominator is only models
+              if (filtered.length === modelCount) {
+                return `Showing ${filtered.length} model${filtered.length !== 1 ? "s" : ""}`;
+              }
+              return `Showing ${filtered.length} of ${modelCount} models`;
+            }
+          })()}
         </div>
         <PaginationControls
           page={safePage}


### PR DESCRIPTION
## Summary
- Fixed confusing "Showing 45 of 52 models" message on the AI Models directory page where the 7 hidden family groupings (Claude, GPT, Gemini, Llama, Mistral, Grok, DeepSeek) inflated the denominator without explanation
- When families are hidden (default): shows "Showing 45 models" with no misleading denominator
- When families are shown: shows "Showing 45 models + 7 families (52 of 52 entries)" to make the breakdown explicit
- When filters reduce the count: shows "Showing N of 45 models" (denominator correctly excludes families)
- The stat card "Models: 45" was already correct — `buildStats()` filters out family rows before counting

## Test plan
- [ ] Visit `/ai-models` — confirm message reads "Showing N models" (no "of 52")
- [ ] Toggle "Show families" checkbox — confirm message changes to "N models + M families (X of Y entries)"
- [ ] Apply a developer filter — confirm denominator stays consistent with visible row type
- [ ] Search for a model name — confirm count updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)