### PR TITLE
fix: link people employer to /organizations/ instead of /factbase/entity/

### DIFF
--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -114,7 +114,7 @@ function apiEntityToPersonRow(e: DirectoryEntity): PersonRow {
 
     employerId: employer?.entityId ?? null,
     employerName: employer?.name ?? null,
-    employerSlug: employer ? getKBEntitySlug(employer.entityId) ?? null : null,
+    employerSlug: employer?.entityId ?? null,
 
     bornYear: bornYear?.numeric ?? null,
     netWorthNum: netWorth?.numeric ?? null,

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -483,13 +483,6 @@ export function PeopleTable({
                         >
                           {row.employerName}
                         </Link>
-                      ) : row.employerId ? (
-                        <Link
-                          href={`/factbase/entity/${row.employerId}`}
-                          className="text-foreground hover:text-primary transition-colors"
-                        >
-                          {row.employerName}
-                        </Link>
                       ) : row.employerName ? (
                         <span className="text-muted-foreground">
                           {row.employerName}


### PR DESCRIPTION
## Summary
- Fixed bug where employer links in the People index table went to `/factbase/entity/{id}` (an internal page) instead of `/organizations/{slug}`
- In the API directory path (`apiEntityToPersonRow`), `employerSlug` now uses `employer.entityId` directly since it's already the YAML entity slug from the entities table, instead of going through `getKBEntitySlug()` which could return null
- Removed the fallback that linked to `/factbase/entity/` — employer names without a resolvable slug now display as plain text

## Test plan
- [ ] Verify People directory page (`/people`) renders correctly
- [ ] Verify employer names with known organizations (e.g., Anthropic, OpenAI) link to `/organizations/{slug}`
- [ ] Verify employer names without a matching organization entity show as plain text (not a link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)