### PR TITLE
fix: populate organization field for project entities

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -71,11 +71,20 @@ function apiEntityToRow(e: DirectoryEntity): ProjectRow {
     e.website ??
     null;
 
-  // Org: from resolved ref of "founded-by" fact
-  const orgName = foundedBy?.name ?? null;
-  const orgHref = foundedBy?.entityId
+  // Org: from resolved ref of "founded-by" fact, then YAML organization field
+  let orgName = foundedBy?.name ?? null;
+  let orgHref = foundedBy?.entityId
     ? getEntityHref(foundedBy.entityId)
     : null;
+
+  // Fallback: use the organization field from entity metadata (YAML)
+  if (!orgName && meta.organization) {
+    const orgId = meta.organization as string;
+    // The directory API includes resolvedRefs for fact-based refs but not YAML fields,
+    // so we use the orgId as a display name fallback and link to the entity page
+    orgName = orgId;
+    orgHref = getEntityHref(orgId);
+  }
 
   return {
     id: e.id,
@@ -113,13 +122,22 @@ function loadFromLocal(): ProjectsPageData {
   const projects = getTypedEntities().filter(isProject);
 
   const rows: ProjectRow[] = projects.map((p) => {
-    // Resolve org from founded-by KB fact
+    // Resolve org from founded-by KB fact, then YAML organization field
     let orgName: string | null = null;
     let orgHref: string | null = null;
     const foundedBy = getKBLatest(p.id, "founded-by");
     if (foundedBy?.value.type === "refs" && foundedBy.value.value.length > 0) {
       const orgRef = foundedBy.value.value[0];
       const orgEntity = getTypedEntityById(orgRef);
+      if (orgEntity) {
+        orgName = orgEntity.title;
+        orgHref = getEntityHref(orgEntity.id);
+      }
+    }
+
+    // Fallback: use the organization field from entity YAML
+    if (!orgName && p.organization) {
+      const orgEntity = getTypedEntityById(p.organization);
       if (orgEntity) {
         orgName = orgEntity.title;
         orgHref = getEntityHref(orgEntity.id);

--- a/data/entities/epistemic-orgs-projects.yaml
+++ b/data/entities/epistemic-orgs-projects.yaml
@@ -84,6 +84,7 @@
   title: XPT (Existential Risk Persuasion Tournament)
   projectStatus: active
   projectUrl: https://xpt.forecastingresearch.org
+  organization: fri
   description: Four-month structured forecasting tournament bringing together superforecasters and domain experts through adversarial collaboration.
   path: /knowledge-base/responses/xpt/
   lastUpdated: 2026-01
@@ -96,6 +97,7 @@
   title: ForecastBench
   projectStatus: active
   projectUrl: https://forecastbench.org
+  organization: fri
   description: Dynamic, contamination-free benchmark for evaluating LLM forecasting capabilities, published at ICLR 2025.
   path: /knowledge-base/responses/forecastbench/
   lastUpdated: 2026-01
@@ -107,6 +109,7 @@
   type: project
   title: AI Forecasting Benchmark Tournament
   projectStatus: active
+  organization: metaculus
   description: Quarterly competition run by Metaculus comparing human Pro Forecasters against AI forecasting bots.
   path: /knowledge-base/responses/ai-forecasting-benchmark/
   lastUpdated: 2026-01
@@ -129,6 +132,7 @@
   title: Grokipedia
   projectStatus: active
   projectUrl: https://grokipedia.com
+  organization: xai
   description: xAI's AI-generated encyclopedia launched October 2025, growing to 6M+ articles with documented quality concerns including political bias and scientific inaccuracies.
   path: /knowledge-base/responses/grokipedia/
   lastUpdated: 2026-02

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -3647,6 +3647,7 @@
   type: project
   title: MIT AI Risk Repository
   projectStatus: active
+  organization: mit
   summaryPage: epistemic-tools-tools-overview
   description: >-
     The MIT AI Risk Repository catalogs 1,700+ AI risks from 65+ frameworks into


### PR DESCRIPTION
## Summary
- Added `organization` field to 5 project entities in YAML that were missing it: `xpt` and `forecastbench` (-> `fri`), `ai-forecasting-benchmark` (-> `metaculus`), `grokipedia` (-> `xai`), `mit-ai-risk-repository` (-> `mit`)
- Updated `/projects` page to fall back to the YAML `organization` field when no FactBase `founded-by` fact exists, fixing the 0% fill rate in the Organization column
- Projects that already had the field (`squiggle`, `metaforecast`, `squiggleai`, `longterm-wiki`) now correctly display their organizations too, since the page code was previously ignoring the YAML field entirely

## Test plan
- [ ] Verify `/projects` directory page shows organizations for projects with the `organization` field
- [ ] Verify projects without an `organization` field still show blank (not errors)
- [ ] YAML schema validation passes (`pnpm crux validate schema`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)