### PR TITLE
fix: correct Unicode slug for Andreas Stuhlmüller and similar names

### DIFF
--- a/crux/authoring/creator/creator.test.ts
+++ b/crux/authoring/creator/creator.test.ts
@@ -66,6 +66,22 @@ describe('Duplicate Detection', () => {
   it('toSlug: handles numbers', () => {
     expect(toSlug('80000 Hours')).toBe('80000-hours');
   });
+
+  it('toSlug: transliterates German umlauts', () => {
+    expect(toSlug('Andreas Stuhlmüller')).toBe('andreas-stuhlmuller');
+  });
+
+  it('toSlug: transliterates Spanish ñ', () => {
+    expect(toSlug('Nuño Sempere')).toBe('nuno-sempere');
+  });
+
+  it('toSlug: transliterates accented characters', () => {
+    expect(toSlug('café résumé')).toBe('cafe-resume');
+  });
+
+  it('toSlug: transliterates Nordic characters', () => {
+    expect(toSlug('Jörgen Björk')).toBe('jorgen-bjork');
+  });
 });
 
 // ─── URL Extraction Tests ───

--- a/crux/authoring/creator/duplicate-detection.ts
+++ b/crux/authoring/creator/duplicate-detection.ts
@@ -65,10 +65,13 @@ export function similarity(a: string, b: string): number {
 }
 
 /**
- * Normalize a string to a slug for comparison
+ * Normalize a string to a slug for comparison. Transliterates Unicode (e.g. ü→u).
  */
 export function toSlug(str: string): string {
-  return str.toLowerCase()
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip combining diacritical marks (ü→u, ñ→n, etc.)
+    .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 }

--- a/crux/generate/generate-yaml.ts
+++ b/crux/generate/generate-yaml.ts
@@ -177,7 +177,7 @@ function normalizeTopic(topic: string): string {
     'Primary Source of AI Catastrophic Risk': 'primary-risk-source',
     'How Difficult is Alignment?': 'alignment-difficulty',
   };
-  return mappings[topic] || topic.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return mappings[topic] || topic.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
 
 function normalizeOrgName(name: string | undefined): string | undefined {
@@ -192,7 +192,7 @@ function normalizeOrgName(name: string | undefined): string | undefined {
     'Alignment Research Center (ARC)': 'arc',
     'ARC': 'arc',
   };
-  return mappings[name] || name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return mappings[name] || name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
 
 function parseKnownFor(knownFor: string | string[] | undefined): string[] | undefined {
@@ -241,6 +241,8 @@ function transformEstimates(rawEstimates: RawEstimate[]): TransformedEstimate[] 
 
 function normalizeEstimateVariable(variable: string): string {
   return variable
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')

--- a/crux/lib/rules/person-org-affiliation.ts
+++ b/crux/lib/rules/person-org-affiliation.ts
@@ -26,6 +26,8 @@ import { loadPathRegistry } from '../content-types.ts';
 /** Convert display name to likely entity slug: "Paul Christiano" → "paul-christiano" */
 function nameToSlug(name: string): string {
   return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip combining diacritical marks (ü→u, ñ→n, etc.)
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, '-')

--- a/crux/tablebase/tablebase.test.ts
+++ b/crux/tablebase/tablebase.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ScanSummary, EnrichmentTask, TableProfile } from './types.ts';
-import { TASK_TYPE_WEIGHTS } from './types.ts';
+import { TASK_TYPE_WEIGHTS, toSlug } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Task Ranker Tests
@@ -156,6 +156,39 @@ describe('types', () => {
       expect(weights[tt]).toBeDefined();
       expect(typeof weights[tt]).toBe('number');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toSlug Tests
+// ---------------------------------------------------------------------------
+
+describe('toSlug', () => {
+  it('converts basic names', () => {
+    expect(toSlug('Dario Amodei')).toBe('dario-amodei');
+  });
+
+  it('transliterates German umlauts (ü→u, ö→o, ä→a)', () => {
+    expect(toSlug('Andreas Stuhlmüller')).toBe('andreas-stuhlmuller');
+    expect(toSlug('Jörgen Björk')).toBe('jorgen-bjork');
+    expect(toSlug('Bäcker')).toBe('backer');
+  });
+
+  it('transliterates Spanish ñ', () => {
+    expect(toSlug('Nuño Sempere')).toBe('nuno-sempere');
+  });
+
+  it('transliterates accented vowels', () => {
+    expect(toSlug('café résumé')).toBe('cafe-resume');
+    expect(toSlug('Fei-Fei Lì')).toBe('fei-fei-li');
+  });
+
+  it('trims leading/trailing dashes', () => {
+    expect(toSlug('--hello--')).toBe('hello');
+  });
+
+  it('handles numbers', () => {
+    expect(toSlug('80000 Hours')).toBe('80000-hours');
   });
 });
 

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -2,9 +2,14 @@
  * Core types for the TableBase enrichment system.
  */
 
-/** Convert a display name to a URL-safe slug. */
+/** Convert a display name to a URL-safe slug. Transliterates Unicode (e.g. ü→u). */
 export function toSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip combining diacritical marks (ü→u, ñ→n, etc.)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
 }
 
 export const TASK_TYPES = [

--- a/crux/vitest.config.ts
+++ b/crux/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       'evals/**/*.test.ts',
       'health/**/*.test.ts',
       'pr-patrol/**/*.test.ts',
+      'tablebase/**/*.test.ts',
     ],
     exclude: [],
     root: __dirname,

--- a/packages/factbase/scripts/migrate-items-to-records.ts
+++ b/packages/factbase/scripts/migrate-items-to-records.ts
@@ -23,9 +23,11 @@ const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 const entityFilter = args.find(a => a.startsWith("--entity="))?.split("=")[1];
 
-// Slug generation: lowercase, replace spaces/special chars with hyphens
+// Slug generation: lowercase, replace spaces/special chars with hyphens. Transliterates Unicode (e.g. ü→u).
 function toSlug(name: string): string {
   return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip combining diacritical marks (ü→u, ñ→n, etc.)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")


### PR DESCRIPTION
## Summary

- Fix Unicode character handling in `toSlug`/`nameToSlug` functions across the codebase
- Names with diacritics (umlauts, accents, tildes) were having characters stripped instead of transliterated, producing broken slugs like `andreas-stuhlm-ller` instead of `andreas-stuhlmuller`
- The fix applies NFD Unicode normalization before the ASCII-only regex filter, decomposing accented characters to base+combining mark and stripping only the combining marks

## Details

Six slug generation functions lacked Unicode transliteration. The correct pattern (already used in `crux/commands/people/shared.ts:nameToSlug`) is:

```typescript
name.normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '') // strip combining marks
    .toLowerCase()
    .replace(/[^a-z0-9]+/g, '-')
```

**Files fixed:**
| File | Function | Used by |
|------|----------|---------|
| `crux/tablebase/types.ts` | `toSlug()` | Entity creation via TableBase enrichment (primary bug source) |
| `crux/authoring/creator/duplicate-detection.ts` | `toSlug()` | Page title slug comparison |
| `crux/lib/rules/person-org-affiliation.ts` | `nameToSlug()` | Person-org affiliation validation |
| `crux/generate/generate-yaml.ts` | `normalizeTopic()`, `normalizeOrgName()`, `normalizeEstimateVariable()` | YAML generation |
| `packages/factbase/scripts/migrate-items-to-records.ts` | `toSlug()` | FactBase migration script |

**Note:** Existing entities already stored in PostgreSQL with broken slugs (e.g., `andreas-stuhlm-ller`) will need a separate data migration to correct. This PR prevents the bug from occurring for new entities.

## Test plan

- [x] Added 10 new test cases covering German umlauts (ü, ö, ä), Spanish ñ, accented vowels (é, è), and Nordic characters (ö in names)
- [x] All 39 tests pass (existing + new)
- [x] Added `tablebase/**/*.test.ts` to vitest include config
- [ ] After merge: verify the People directory on production no longer shows "Stuhlm ller" once the PG entity slug is corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)