### PR TITLE
fix: ensure all government organizations appear in directory filter

### DIFF
--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -135,9 +135,15 @@ interface OrgPageData {
 /**
  * Try loading organizations from the wiki-server API.
  * orgTypeMap is always built from local data since orgType is not in the DB.
+ *
+ * After building rows from the API, merges in any local-only organizations
+ * that the API didn't return. This ensures entities that haven't been synced
+ * to the wiki-server PG database (e.g., recently added YAML entities) still
+ * appear in the directory with their correct orgType.
  */
 async function loadFromApi(
   orgTypeMap: Record<string, string>,
+  localOrgs: OrganizationEntity[],
 ): Promise<FetchResult<OrgPageData>> {
   const result = await fetchDetailed<ApiOrgsResponse>(
     "/api/entities/organizations?limit=500",
@@ -184,6 +190,56 @@ async function loadFromApi(
       searchText: searchParts.join(" ").toLowerCase(),
     };
   });
+
+  // Merge local-only orgs that the API didn't return (not yet synced to PG).
+  // This prevents entities added to YAML but not yet synced from disappearing
+  // in the directory. Without this, orgType filter tabs show incorrect counts.
+  const apiIds = new Set(organizations.map((o) => o.id));
+  for (const org of localOrgs) {
+    if (apiIds.has(org.id)) continue;
+    const orgType = org.orgType ?? null;
+    const searchParts = [org.title];
+    if (org.description) searchParts.push(org.description);
+    if (orgType) searchParts.push(orgType);
+    const foundedFact = getKBLatest(org.id, "founded-date");
+    const foundedDate = foundedFact?.value.type === "date"
+      ? foundedFact.value.value
+      : foundedFact?.value.type === "text"
+        ? foundedFact.value.value
+        : foundedFact?.value.type === "number"
+          ? String(foundedFact.value.value)
+          : null;
+
+    rows.push({
+      id: org.id,
+      slug: org.id,
+      name: org.title,
+      wikiId: org.wikiId ?? null,
+      orgType,
+      wikiPageId: org.wikiId && getPageById(org.id) ? org.wikiId : null,
+
+      revenue: null,
+      revenueNum: null,
+      revenueDate: null,
+
+      valuation: null,
+      valuationNum: null,
+      valuationDate: null,
+
+      headcount: null,
+      headcountDate: null,
+
+      totalFunding: null,
+      totalFundingNum: null,
+
+      foundedDate,
+
+      peopleCount: null,
+      completionScore: computeCompletionScore({}),
+
+      searchText: searchParts.join(" ").toLowerCase(),
+    });
+  }
 
   const stats = buildStats(rows);
 
@@ -313,7 +369,7 @@ export default async function OrganizationsPage() {
   }
 
   const { data, source, apiError } = await withApiFallback(
-    () => loadFromApi(orgTypeMap),
+    () => loadFromApi(orgTypeMap, orgs),
     () => loadFromLocal(),
   );
 


### PR DESCRIPTION
## Summary

- **Root cause**: The Organizations directory page (`/organizations`) in API mode only shows orgs returned by the wiki-server PG database. Six of the eight `orgType: government` organizations were added to `data/entities/organizations.yaml` but never existed in the legacy `data/organizations.yaml` file. If the wiki-server PG hasn't been synced after these YAML additions, those 6 orgs silently disappear from the directory and its filter tabs.

- **Which orgs were missing**: japan-aisi, singapore-aisi, canada-aisi, eu-ai-office, nist-ai, gpai. Only uk-aisi and us-aisi appeared because they also exist in the legacy `data/organizations.yaml`.

- **Fix**: `loadFromApi()` now merges any local `OrganizationEntity` entries that the wiki-server API didn't return. After building rows from the API response, it checks the local typed entities for any orgs absent from PG and appends them with metadata from `database.json` and FactBase data. This ensures:
  - All orgType filter tab counts are accurate (8 Government, not 2)
  - Recently added YAML entities appear immediately in the directory
  - No orgs are silently dropped when PG is behind on syncing

## Changed files

- `apps/web/src/app/organizations/page.tsx` — `loadFromApi()` accepts local orgs and merges missing ones into API results

## Test plan

- [ ] Verify the Government filter tab shows 8 organizations after deploy
- [ ] Verify no duplicate rows when all orgs are synced to PG (the `apiIds` set prevents duplicates)
- [ ] Verify local fallback mode (`loadFromLocal`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)