### PR TITLE
fix: QA sweep deep — broken employer links + test fix

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -273,7 +273,7 @@ export default async function PersonProfilePage({
       value: employer.name,
       href: employer.slug
         ? `/organizations/${employer.slug}`
-        : `/factbase/entity/${employer.id}`,
+        : undefined,
     });
   }
   if (bornYearFact?.value.type === "number") {


### PR DESCRIPTION
## Summary
Comprehensive QA sweep fixes — P0 + P1 issues across code, data, wiki-server, and content.

### P0 Fixes (commits 1-2)
1. **People detail pages**: Remove broken `/factbase/entity/` employer link fallback — display names with spaces in URLs caused 404s (Hinton, Bostrom, Russell, Bengio)
2. **FLI/CG data**: Add `parent-org` property (fixes raw ID display), remove `wikiId: null` (fixes `/wiki/Enull` 404), fix nested headcount YAML (fixes blank value), guard `parseEntity` null, update CG website URL

### P1 Fixes (commits 3-4)
3. **Entity YAML**: Migrate 12 `relatedEntries` from `open-philanthropy` to `coefficient-giving` across people.yaml, organizations.yaml, responses.yaml, misc.yaml. Update 3 org descriptions for rebrand accuracy.
4. **Seven P1 fixes across code, data, and content**:
   - `entity-transform.mjs`: propagate 4 missing ai-model fields (modality, openWeight, parameterCount, trainingCutoff) — was silently dropping data at build
   - `links.ts`: replace prohibited `as unknown as SqlQuery` double-cast with runtime type-narrowing
   - `resources.ts`: add LIMIT 50000 + truncated flag to `GET /citations/all`
   - `entities.ts`, `facts.ts`, `sessions.ts`: wrap 5 transactional DB operations in try/catch with `dbError()`
   - `nick-bostrom.yaml`: fix unicode escape `\u00F6` → literal `ö`
   - `coefficient-giving.mdx`: fix self-referencing EntityLink, 5 stale "OP" abbreviations, broken citation text

### Rebuilt database.json
- Includes E1929 (entity-profile-dashboard) — fixes test failure

## Filed Issues (P0s requiring separate work)
- #2601: Organizations financial columns 100% empty in production
- #2602: Organizations raw FactBase IDs as people names on 8+ pages  
- #2603: SB 1047 compute threshold "100000000000000 trillion"
- #2516: Legislation ghost entities (confirmed, existing issue)

## Test plan
- [x] `pnpm test` — all 3309 tests pass
- [x] `npx tsc --noEmit` (wiki-server) — no type errors
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 gate checks pass
- [x] Data rebuild successful (807 entities)
- [ ] Verify `/people/geoffrey-hinton` employer shows as plain text
- [ ] Verify `/organizations/future-of-life-foundation` Parent Org shows "Future of Life Institute (FLI)"
- [ ] Verify FLF headcount shows "5"
- [ ] Verify `/people/nick-bostrom` alias shows "Niklas Boström" (with ö)

🤖 Generated with [Claude Code](https://claude.com/claude-code)