### PR TITLE
refactor: remove entities from factbase-data.json, delegate to TableBase

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -2326,9 +2326,8 @@ async function main() {
     });
     const serializedKB = serialize(graph, filenameMap);
     database.kb = serializedKB;
-    const entityCount = serializedKB.entities?.length ?? 0;
     const factCount = Object.keys(serializedKB.facts ?? {}).length;
-    console.log(`  kb: ${entityCount} entities, ${factCount} fact groups (${tableBaseEntityMap.size} TableBase entities injected)`);
+    console.log(`  kb: ${factCount} fact groups (${tableBaseEntityMap.size} TableBase entities injected, entities owned by TableBase)`);
   } else {
     console.warn('  kb: skipped (data directory not found at packages/factbase/data)');
   }
@@ -2913,7 +2912,7 @@ async function main() {
   const FACTBASE_OUTPUT_FILE = join(OUTPUT_DIR, 'factbase-data.json');
   if (_kbData) {
     writeFileSync(FACTBASE_OUTPUT_FILE, JSON.stringify(_kbData, null, 2));
-    console.log(`✓ Written: ${FACTBASE_OUTPUT_FILE} (FactBase entities, facts, records, schemas)`);
+    console.log(`✓ Written: ${FACTBASE_OUTPUT_FILE} (FactBase facts, records, schemas — entities owned by TableBase)`);
   } else {
     console.warn('⚠ FactBase data not available — factbase-data.json not written');
   }

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -22,7 +22,7 @@
 
 import fs from "fs";
 import path from "path";
-import { getDatabase } from "@data";
+import { getDatabase, getIdRegistry, getTypedEntityByStableId, getTypedEntities } from "@/data/tablebase";
 import type { Fact, Property, Entity } from "@longterm-wiki/factbase";
 import type { SerializedKB } from "@longterm-wiki/factbase";
 
@@ -50,21 +50,21 @@ export function getFactBase(): SerializedKB | undefined {
  * Accepts either an entity ID (10-char alphanumeric) or a YAML filename/slug.
  * MDX components pass slugs like "anthropic"; entity pages pass IDs like "mK9pX3rQ7n".
  *
- * Resolution chain: FactBase slugToEntityId → idRegistry stableIdBySlug → identity
+ * Resolution chain: idRegistry stableIdBySlug → FactBase slugToEntityId (legacy fallback) → identity
  */
 function resolveEntityKey(entityOrSlug: string, fb?: SerializedKB): string {
-  const resolved = fb ?? getFactBase();
-  // Try FactBase's own slug map first (most complete for FactBase entities)
-  if (resolved?.slugToEntityId?.[entityOrSlug]) {
-    return resolved.slugToEntityId[entityOrSlug];
-  }
-  // Fall back to idRegistry stableIdBySlug (works for all TableBase entities)
+  // Primary: use idRegistry from TableBase (covers all entities)
   try {
-    const db = getDatabase();
-    const stableId = db.idRegistry?.stableIdBySlug?.[entityOrSlug];
+    const registry = getIdRegistry();
+    const stableId = registry.stableIdBySlug?.[entityOrSlug];
     if (stableId) return stableId;
   } catch {
     // database.json not available yet (during build) — ignore
+  }
+  // Legacy fallback: try FactBase's own slug map if it still exists
+  const resolved = fb ?? getFactBase();
+  if (resolved?.slugToEntityId?.[entityOrSlug]) {
+    return resolved.slugToEntityId[entityOrSlug];
   }
   return entityOrSlug;
 }
@@ -219,43 +219,65 @@ export function getFactBaseProperty(propertyId: string): Property | undefined {
   return propertyByIdIndex.get(propertyId);
 }
 
-/** Lazy-initialized index: entityId → Entity. Built once on first call. */
-let entityByIdIndex: Map<string, Entity> | undefined;
+/**
+ * Convert a TableBase AnyEntity to a FactBase Entity compat shim.
+ * Maps TypedEntity fields to the FactBase Entity interface so existing callers
+ * continue working without changes.
+ */
+function toFactBaseEntity(typed: { id: string; entityType: string; title: string; stableId?: string; wikiId?: string; [key: string]: unknown }): Entity {
+  return {
+    id: typed.stableId ?? typed.id,
+    type: typed.entityType,
+    name: typed.title,
+    stableId: typed.stableId ?? typed.id,
+    wikiPageId: typed.wikiId,
+    wikiId: typed.wikiId,
+  };
+}
 
 /**
  * Get a FactBase entity definition by ID or slug.
  * Accepts either an internal entity ID (e.g. "mK9pX3rQ7n") or a YAML slug
- * (e.g. "anthropic"). Uses a lazy-built index for O(1) lookups after initial build.
+ * (e.g. "anthropic"). Delegates to TableBase for entity data.
  *
- * Note: Entity ownership is moving to TableBase. For new code, prefer
- * `getTypedEntityById()` or `getTypedEntityByStableId()` from tablebase.ts.
- * This function still works because entities are in factbase-data.json.
+ * Returns a compat shim mapping TableBase fields to the FactBase Entity interface.
  */
 export function getFactBaseEntity(entityId: string): Entity | undefined {
-  const fb = getFactBase();
-  if (!fb) return undefined;
+  // Resolve the entityId — it might be a slug, stableId, or wikiId
+  const resolvedId = resolveEntityKey(entityId);
 
-  if (!entityByIdIndex) {
-    entityByIdIndex = new Map();
-    for (const e of fb.entities) {
-      entityByIdIndex.set(e.id, e);
-    }
+  // Try to find in TableBase by stableId
+  const typed = getTypedEntityByStableId(resolvedId);
+  if (typed) return toFactBaseEntity(typed);
+
+  // If the original ID is different from resolved, also try original as stableId
+  if (resolvedId !== entityId) {
+    const typedDirect = getTypedEntityByStableId(entityId);
+    if (typedDirect) return toFactBaseEntity(typedDirect);
   }
-  // Try direct ID lookup first, then resolve as slug
-  const direct = entityByIdIndex.get(entityId);
-  if (direct) return direct;
-  const resolvedId = resolveEntityKey(entityId, fb);
-  return resolvedId !== entityId ? entityByIdIndex.get(resolvedId) : undefined;
+
+  // Legacy fallback: try FactBase entities if they still exist in the data
+  const fb = getFactBase();
+  if (fb?.entities) {
+    const found = fb.entities.find((e) => e.id === entityId || e.id === resolvedId);
+    if (found) return found;
+  }
+
+  return undefined;
 }
 
 /**
  * Get all FactBase entities.
+ * Delegates to TableBase's getTypedEntities() and returns compat shims.
  */
 export function getFactBaseEntities(): Entity[] {
-  const fb = getFactBase();
-  if (!fb) return [];
-
-  return fb.entities;
+  try {
+    return getTypedEntities().map(toFactBaseEntity);
+  } catch {
+    // Fallback: use FactBase entities if TableBase not available
+    const fb = getFactBase();
+    return fb?.entities ?? [];
+  }
 }
 
 /**
@@ -320,7 +342,8 @@ export function getFactBaseFactsByProperty(
   const fb = getFactBase();
   if (!fb) return new Map();
 
-  const ids = entityIds ?? fb.entities.map((e) => e.id);
+  // Use provided entity IDs, or fall back to all entities that have facts
+  const ids = entityIds ?? Object.keys(fb.facts);
   const result = new Map<string, Fact>();
 
   for (const entityId of ids) {
@@ -345,7 +368,8 @@ export function getFactBaseAllFactsByProperty(
   const fb = getFactBase();
   if (!fb) return new Map();
 
-  const ids = entityIds ?? fb.entities.map((e) => e.id);
+  // Use provided entity IDs, or fall back to all entities that have facts
+  const ids = entityIds ?? Object.keys(fb.facts);
   const result = new Map<string, Fact[]>();
 
   for (const entityId of ids) {
@@ -541,10 +565,20 @@ export function getFactBaseRecordSchemas(): FactBaseRecordSchema[] {
 // ── Slug resolution (public) ─────────────────────────────────────
 
 /**
- * Resolve a YAML filename slug (e.g. "anthropic") to a FactBase entity ID.
+ * Resolve a YAML filename slug (e.g. "anthropic") to a FactBase entity ID (stableId).
+ * Uses idRegistry from TableBase as primary source.
  * Returns undefined if the slug is not in the mapping.
  */
 export function resolveFactBaseSlug(slug: string): string | undefined {
+  // Primary: idRegistry from TableBase
+  try {
+    const registry = getIdRegistry();
+    const stableId = registry.stableIdBySlug?.[slug];
+    if (stableId) return stableId;
+  } catch {
+    // database.json not available yet — fall through
+  }
+  // Legacy fallback
   const fb = getFactBase();
   if (!fb?.slugToEntityId) return undefined;
   return fb.slugToEntityId[slug];
@@ -552,9 +586,20 @@ export function resolveFactBaseSlug(slug: string): string | undefined {
 
 /**
  * Get the full slug→entityId mapping.
+ * Uses idRegistry from TableBase as primary source.
  * Useful for building static params or reverse lookups.
  */
 export function getFactBaseSlugMap(): Record<string, string> {
+  // Primary: idRegistry.stableIdBySlug from TableBase
+  try {
+    const registry = getIdRegistry();
+    if (registry.stableIdBySlug && Object.keys(registry.stableIdBySlug).length > 0) {
+      return registry.stableIdBySlug;
+    }
+  } catch {
+    // database.json not available yet — fall through
+  }
+  // Legacy fallback
   const fb = getFactBase();
   return fb?.slugToEntityId ?? {};
 }
@@ -570,27 +615,29 @@ export function resolveSlugAlias(slug: string): string | undefined {
   return fb.previousSlugToCurrentSlug[slug];
 }
 
-/** Lazy-initialized inverted index: entityId → slug. Built once on first call. */
-let entityIdToSlugIndex: Map<string, string> | undefined;
-
 /**
- * Reverse lookup: find the YAML slug for a given entity ID.
- * Uses a lazy-built inverted index for O(1) lookups.
+ * Reverse lookup: find the YAML slug for a given entity ID (stableId).
+ * Uses idRegistry from TableBase as primary source.
  */
 export function getFactBaseEntitySlug(entityId: string): string | undefined {
-  if (!entityIdToSlugIndex) {
-    const map = getFactBaseSlugMap();
-    entityIdToSlugIndex = new Map();
-    for (const [slug, id] of Object.entries(map)) {
-      entityIdToSlugIndex.set(id, slug);
-    }
+  // Primary: idRegistry.stableIdToSlug or byStableId from TableBase
+  try {
+    const registry = getIdRegistry();
+    const slug = registry.stableIdToSlug?.[entityId] ?? registry.byStableId?.[entityId];
+    if (slug) return slug;
+  } catch {
+    // database.json not available yet — fall through
   }
-  return entityIdToSlugIndex.get(entityId);
+  // Legacy fallback: invert the slug map from FactBase
+  const map = getFactBaseSlugMap();
+  for (const [slug, id] of Object.entries(map)) {
+    if (id === entityId) return slug;
+  }
+  return undefined;
 }
 
 // ── Backwards compatibility aliases ─────────────────────────────
 // These aliases allow consumers to migrate incrementally.
-// TODO: Remove after all call sites are updated.
 
 /** @deprecated Use getFactBase() */
 export const getKB = getFactBase;

--- a/packages/factbase/src/serialize.ts
+++ b/packages/factbase/src/serialize.ts
@@ -5,11 +5,19 @@
 import type { Graph } from "./graph";
 
 export interface SerializedKB {
-  entities: ReturnType<Graph["getAllEntities"]>;
+  /**
+   * @deprecated Entities are now owned by TableBase. This field is no longer
+   * emitted by serialize() and will be removed in a future version.
+   * Use getTypedEntities() / getTypedEntityByStableId() from tablebase.ts instead.
+   */
+  entities?: ReturnType<Graph["getAllEntities"]>;
   facts: Record<string, ReturnType<Graph["getFacts"]>>;
   properties: ReturnType<Graph["getAllProperties"]>;
   schemas: ReturnType<Graph["getAllSchemas"]>;
-  /** Maps YAML filename/slug → entity ID, for resolving slug-based lookups */
+  /**
+   * @deprecated Slug resolution is now handled by idRegistry.stableIdBySlug
+   * in TableBase (database.json). This field is no longer emitted by serialize().
+   */
   slugToEntityId?: Record<string, string>;
   /** Maps previous slugs → current slug, for URL redirects when slugs change */
   previousSlugToCurrentSlug?: Record<string, string>;
@@ -44,13 +52,8 @@ export function serialize(
     }
   }
 
-  // Build slug → entity ID map for resolving slug-based lookups from MDX components
-  const slugToEntityId: Record<string, string> = {};
-  for (const [entityId, filename] of filenameMap) {
-    slugToEntityId[filename] = entityId;
-  }
-
   // Build previousSlug → currentSlug map for URL redirects
+  // (entities are still in the graph for fact iteration; we just don't emit them)
   const previousSlugToCurrentSlug: Record<string, string> = {};
   for (const entity of entities) {
     if (entity.previousSlugs) {
@@ -63,9 +66,11 @@ export function serialize(
     }
   }
 
+  // Note: entities array and slugToEntityId are no longer emitted.
+  // Entities are owned by TableBase (database.json typedEntities).
+  // Slug→entityId resolution uses idRegistry.stableIdBySlug from database.json.
   return {
-    entities, facts, properties, schemas,
-    slugToEntityId,
+    facts, properties, schemas,
     ...(Object.keys(previousSlugToCurrentSlug).length > 0 && { previousSlugToCurrentSlug }),
   };
 }


### PR DESCRIPTION
## Summary

- Removes `entities` array and `slugToEntityId` from factbase-data.json output
- `getFactBaseEntity()` now delegates to `getTypedEntityByStableId()` with a compat shim
- `getFactBaseEntities()` delegates to `getTypedEntities()` with field mapping
- Slug resolution uses `idRegistry.stableIdBySlug` as primary, FactBase as fallback
- FactBase is now facts-only — no entity ownership

Part of Entity Unification follow-up (merged in #2566).

Depends on #2610 (caller migration should merge first).

## Test plan
- [x] `pnpm build-data:content` succeeds
- [x] `factbase-data.json` no longer contains entities/slugToEntityId
- [x] TypeScript compiles clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)