### PR TITLE
fix: add previousIds indexing to FactBase graph, update stale SFF stableId

### DIFF
--- a/crux/lib/grant-import/constants.ts
+++ b/crux/lib/grant-import/constants.ts
@@ -10,7 +10,11 @@ export const FUNDER_IDS = {
   OPEN_PHILANTHROPY: "ULjDXpSLCI",
   // Coefficient Giving is Open Philanthropy's grantmaking arm — same entity
   COEFFICIENT_GIVING: "ULjDXpSLCI",
-  SFF: "sIFjGbxVct",
+  // Updated from "sIFjGbxVct" to match TableBase entity after Entity Unification.
+  // Existing SFF grants in the DB have organizationId = "sIFjGbxVct" and grant IDs
+  // generated with the old funderId. A re-import of SFF will generate new grant IDs;
+  // run a DB migration to update organization_id and delete stale rows before re-importing.
+  SFF: "pvJ50HupEQ",
   FTX_FUTURE_FUND: "JhIGCaI3Ng",
   MANIFUND: "fFVOuFZCRf",
   LTFF: "yA12C1KcjQ",

--- a/crux/lib/grant-import/program-matcher.test.ts
+++ b/crux/lib/grant-import/program-matcher.test.ts
@@ -455,7 +455,7 @@ describe("matchProgram", () => {
   it("matches SFF grants to S-Process by default", () => {
     const result = matchProgram({
       source: "sff",
-      funderId: "sIFjGbxVct",
+      funderId: "pvJ50HupEQ",
       focusArea: null,
       name: "Grant to MIRI",
       description: "Round: SFF-2024-H1; Source: SFF",
@@ -466,7 +466,7 @@ describe("matchProgram", () => {
   it("matches SFF speculation grants", () => {
     const result = matchProgram({
       source: "sff",
-      funderId: "sIFjGbxVct",
+      funderId: "pvJ50HupEQ",
       focusArea: null,
       name: "Grant to MIRI",
       description: "Round: SFF-2024 Speculation; Source: SFF",

--- a/packages/factbase/src/graph.ts
+++ b/packages/factbase/src/graph.ts
@@ -14,6 +14,8 @@ import type {
 
 export class Graph {
   private entities: Map<string, Entity> = new Map(); // keyed by entity.id (stableId)
+  /** Maps previousIds → current entity.id for backward-compat lookups */
+  private previousIdAliases: Map<string, string> = new Map();
   /** Tracks duplicate entity IDs detected during loading */
   private _duplicateIds: Array<{ id: string; name: string; existingName: string }> = [];
   private facts: Map<string, Fact[]> = new Map(); // keyed by entity.id (subjectId)
@@ -33,6 +35,28 @@ export class Graph {
       });
     }
     this.entities.set(entity.id, entity);
+
+    // Register previousIds as aliases so !ref tags using old IDs still resolve.
+    // A previousId must not collide with any current entity's primary ID.
+    if (entity.previousIds) {
+      for (const prevId of entity.previousIds) {
+        if (this.entities.has(prevId)) {
+          console.warn(
+            `[kb/graph] previousId "${prevId}" on entity "${entity.id}" (${entity.name}) ` +
+            `collides with an existing entity's primary ID — skipping alias`
+          );
+          continue;
+        }
+        const existingAlias = this.previousIdAliases.get(prevId);
+        if (existingAlias && existingAlias !== entity.id) {
+          console.warn(
+            `[kb/graph] previousId "${prevId}" claimed by both "${existingAlias}" and ` +
+            `"${entity.id}" (${entity.name}) — last writer wins`
+          );
+        }
+        this.previousIdAliases.set(prevId, entity.id);
+      }
+    }
   }
 
   /** Returns duplicate entity IDs detected during loading. */
@@ -68,9 +92,19 @@ export class Graph {
 
   /**
    * Look up an entity by its ID (stable 10-char).
+   * Also checks previousIds aliases so that !ref tags using old IDs still resolve.
    */
   getEntity(id: string): Entity | undefined {
-    return this.entities.get(id);
+    const direct = this.entities.get(id);
+    if (direct) return direct;
+
+    // Check previousIds aliases
+    const aliasedId = this.previousIdAliases.get(id);
+    if (aliasedId) {
+      return this.entities.get(aliasedId);
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/factbase/tests/graph.test.ts
+++ b/packages/factbase/tests/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import type { Graph } from "../src/graph";
+import { Graph } from "../src/graph";
 import { loadTestKB } from "./test-helpers";
 
 describe("graph", () => {
@@ -224,5 +224,114 @@ describe("graph", () => {
     it("getSchema returns undefined for missing schema", () => {
       expect(graph.getSchema("nonexistent")).toBeUndefined();
     });
+  });
+
+  describe("previousIds resolution", () => {
+    it("resolves CAIS old stableId to current entity", () => {
+      // center-for-ai-safety was oa9A0OV0RX, now y4bieqSeag
+      const entity = graph.getEntity("oa9A0OV0RX");
+      expect(entity).toBeDefined();
+      expect(entity!.id).toBe("y4bieqSeag");
+      expect(entity!.name).toBe("Center for AI Safety");
+    });
+
+    it("resolves SFF old stableId to current entity", () => {
+      // survival-and-flourishing-fund was sIFjGbxVct, now pvJ50HupEQ
+      const entity = graph.getEntity("sIFjGbxVct");
+      expect(entity).toBeDefined();
+      expect(entity!.id).toBe("pvJ50HupEQ");
+      expect(entity!.name).toBe("Survival and Flourishing Fund");
+    });
+
+    it("still resolves current IDs directly", () => {
+      const cais = graph.getEntity("y4bieqSeag");
+      expect(cais).toBeDefined();
+      expect(cais!.name).toBe("Center for AI Safety");
+
+      const sff = graph.getEntity("pvJ50HupEQ");
+      expect(sff).toBeDefined();
+      expect(sff!.name).toBe("Survival and Flourishing Fund");
+    });
+  });
+});
+
+describe("Graph previousIds (unit)", () => {
+  it("resolves previousId to the entity", () => {
+    const g = new Graph();
+    g.addEntity({
+      id: "currentId01",
+      stableId: "currentId01",
+      type: "organization",
+      name: "Test Org",
+      previousIds: ["oldId00001"],
+    });
+
+    const byOld = g.getEntity("oldId00001");
+    expect(byOld).toBeDefined();
+    expect(byOld!.id).toBe("currentId01");
+    expect(byOld!.name).toBe("Test Org");
+  });
+
+  it("prefers primary ID over previousId alias", () => {
+    const g = new Graph();
+    g.addEntity({
+      id: "entityAAAA",
+      stableId: "entityAAAA",
+      type: "organization",
+      name: "Entity A",
+      previousIds: ["entityBBBB"],
+    });
+    g.addEntity({
+      id: "entityBBBB",
+      stableId: "entityBBBB",
+      type: "organization",
+      name: "Entity B",
+    });
+
+    // entityBBBB should resolve to Entity B (primary), not Entity A (previousId)
+    const result = g.getEntity("entityBBBB");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("Entity B");
+  });
+
+  it("returns undefined for unknown ID", () => {
+    const g = new Graph();
+    g.addEntity({
+      id: "entityAAAA",
+      stableId: "entityAAAA",
+      type: "organization",
+      name: "Entity A",
+    });
+
+    expect(g.getEntity("nonexistent")).toBeUndefined();
+  });
+
+  it("handles entity with no previousIds", () => {
+    const g = new Graph();
+    g.addEntity({
+      id: "entityAAAA",
+      stableId: "entityAAAA",
+      type: "organization",
+      name: "Entity A",
+    });
+
+    const result = g.getEntity("entityAAAA");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("Entity A");
+  });
+
+  it("handles multiple previousIds on one entity", () => {
+    const g = new Graph();
+    g.addEntity({
+      id: "currentId01",
+      stableId: "currentId01",
+      type: "organization",
+      name: "Test Org",
+      previousIds: ["oldId00001", "oldId00002"],
+    });
+
+    expect(g.getEntity("oldId00001")?.id).toBe("currentId01");
+    expect(g.getEntity("oldId00002")?.id).toBe("currentId01");
+    expect(g.getEntity("currentId01")?.id).toBe("currentId01");
   });
 });


### PR DESCRIPTION
## Summary

- `Graph.addEntity()` now indexes `previousIds` as lookup aliases
- `Graph.getEntity()` falls back to alias map (primary IDs take precedence)
- Updated `FUNDER_IDS.SFF` from old stableId `sIFjGbxVct` to current `pvJ50HupEQ`
- Added 8 tests: 3 integration tests verifying real CAIS/SFF previousIds resolve, 5 unit tests for edge cases

No remaining references to old stableIds found in YAML, MDX, or app code.

Part of Entity Unification follow-up (merged in #2566).

## Test plan
- [x] 8 new tests for previousIds indexing
- [x] TypeScript compiles clean
- [x] All existing tests pass
- [x] No unresolved !ref warnings for old IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)