### PR TITLE
perf: reduce static pages from 6650 to 1647 (75% reduction)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/divisions/[divSlug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions/[divSlug]/page.tsx
@@ -10,7 +10,6 @@ import {
 
 import {
   findDivision,
-  getAllDivisionParams,
   loadDivisionPageData,
   resolveEntityLink,
   parseDivision,
@@ -65,11 +64,11 @@ function DivisionTabs({ data }: { data: import("@/app/divisions/[slug]/division-
   return <ProfileTabs tabs={tabs} />;
 }
 
-// ── Static params ──────────────────────────────────────────────────────
-
-export function generateStaticParams() {
-  return getAllDivisionParams();
-}
+// ── Rendering strategy ──────────────────────────────────────────────────
+// Dynamic rendering with ISR — pre-rendering all ~1000 division×org
+// combinations added ~5 min to builds with minimal SEO benefit.
+export const dynamicParams = true;
+export const revalidate = 3600; // 1 hour
 
 // ── Metadata ───────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/organizations/[slug]/funding/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/funding/page.tsx
@@ -1,9 +1,7 @@
 import { permanentRedirect } from "next/navigation";
-import { getOrgSlugs } from "@/app/organizations/org-utils";
 
-export function generateStaticParams() {
-  return getOrgSlugs().map((slug) => ({ slug }));
-}
+// Dynamic rendering — this page only redirects, no need to pre-render 256 pages.
+export const dynamic = "force-dynamic";
 
 /**
  * The /organizations/[slug]/funding subpage is now handled by the Funding tab

--- a/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
@@ -16,7 +16,7 @@ import {
   isUrl,
   shortDomain,
 } from "@/components/wiki/factbase/format";
-import { resolveOrgBySlug, getOrgSlugs } from "@/app/organizations/org-utils";
+import { resolveOrgBySlug } from "@/app/organizations/org-utils";
 import { STATUS_COLORS } from "@/app/grants/grants-constants";
 import {
   parseGrantDetail,
@@ -25,22 +25,11 @@ import {
   RelatedGrantsSection,
 } from "@/app/grants/grant-shared";
 
-// ── Static params ─────────────────────────────────────────────────────
-
-export function generateStaticParams() {
-  const allGrants = getAllKBRecords("grants");
-  const orgSlugs = getOrgSlugs();
-  const orgSlugSet = new Set(orgSlugs);
-
-  const params: { slug: string; grantId: string }[] = [];
-  for (const record of allGrants) {
-    const funderSlug = getKBEntitySlug(record.ownerEntityId);
-    if (funderSlug && orgSlugSet.has(funderSlug)) {
-      params.push({ slug: funderSlug, grantId: record.key });
-    }
-  }
-  return params;
-}
+// ── Rendering strategy ────────────────────────────────────────────────
+// Dynamic rendering with ISR — these detail pages are low-traffic and
+// pre-rendering all ~3500 grant×org combinations added ~15 min to builds.
+export const dynamicParams = true;
+export const revalidate = 3600; // 1 hour
 
 // ── Metadata ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Remove `generateStaticParams()` from 3 org sub-routes that were pre-rendering ~5000 unnecessary static pages
- `/organizations/[slug]/grants/[grantId]`: ~3500 pages → ISR (revalidate 1h)
- `/organizations/[slug]/divisions/[divSlug]`: ~1000 pages → ISR (revalidate 1h)
- `/organizations/[slug]/funding`: 256 redirect-only pages → force-dynamic

Build time drops from ~20 min back to ~5 min. Main directory and profile pages remain fully static.

## Test plan

- [x] `pnpm build` succeeds with 1647 static pages (was 6650)
- [x] `pnpm test` — 3338 tests pass
- [x] Gate check passes (24/24)
- [x] Changed routes show `ƒ` (Dynamic) in build output
- [ ] Verify grant detail pages load correctly via ISR on staging

Closes #2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Organization divisions and grants pages now automatically refresh content every hour for improved data freshness.
  * Funding page now renders dynamically to ensure real-time accuracy and up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->