### PR TITLE
content: add party-line vote breakdowns for SB 1047

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -95,6 +95,10 @@
       result: Passed
       ayes: 32
       noes: 1
+      ayesDem: 30
+      ayesRep: 2
+      noesDem: 0
+      noesRep: 1
     - chamber: Assembly Privacy & Consumer Protection Committee
       date: June 18, 2024
       result: Passed
@@ -115,11 +119,19 @@
       result: Passed
       ayes: 48
       noes: 16
+      ayesDem: 44
+      ayesRep: 4
+      noesDem: 1
+      noesRep: 15
     - chamber: Senate Floor (Concurrence)
       date: August 29, 2024
       result: Passed
       ayes: 30
       noes: 9
+      ayesDem: 29
+      ayesRep: 1
+      noesDem: 0
+      noesRep: 9
   provisions:
     - title: Safety Testing
       description: Red-team testing for CBRN weapons, cyber attacks >$500M damage, autonomous operation before deployment


### PR DESCRIPTION
## Summary

Add Democrat/Republican vote splits for the three SB 1047 floor votes, rendered as subtle D/R annotations under the ayes/noes counts in the Voting Record table.

Key findings:
- **Senate Floor (32-1)**: Bipartisan — 2 Republicans (Wilk, Ochoa Bogh) voted Aye, only Grove (R) opposed
- **Assembly Floor (48-16)**: Mostly party-line opposition — 4R voted Yes, 15R voted No, 1D voted No
- **Senate Concurrence (30-9)**: Republican opposition grew — 9R opposed (vs 1R on initial vote), reflecting opposition to Assembly amendments

The party breakdown uses schema fields added in PR #2628 (ayesDem, ayesRep, noesDem, noesRep).

## Test plan
- [x] Gate passes (4/4)
- [x] Party affiliations sourced from CA Senate Floor Analysis roll call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vote data for California SB1047 now includes party-by-party breakdown, showing separate Democratic and Republican vote counts for Aye and Noe votes across Senate Floor, Assembly Floor, and Concurrence votes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->