### PR TITLE
fix: correct stale future-tense claims in 4 MDX pages

### DIFF
--- a/content/docs/knowledge-base/capabilities/reasoning.mdx
+++ b/content/docs/knowledge-base/capabilities/reasoning.mdx
@@ -229,7 +229,7 @@ As of late 2024, state-of-the-art reasoning models demonstrate remarkable capabi
 
 In scientific domains, reasoning models show particular strength in physics and chemistry problems that require systematic application of principles and multi-step derivations. They can balance chemical equations, solve thermodynamics problems, and work through quantum mechanics calculations with high accuracy. For coding tasks, these models demonstrate sophisticated algorithmic thinking, code optimization, and debugging capabilities that rival experienced programmers.
 
-However, significant limitations persist in areas requiring creative insight, handling of fundamental uncertainty, and truly novel problem-solving. The models excel at applying known reasoning patterns to new problems but struggle with tasks that require genuine conceptual breakthroughs or radically new approaches. <R id="YWQ4OGQ2Nj">The upcoming ARC-AGI-2 benchmark</R> is projected to reduce o3's score to under 30% even at high compute, while "a smart human would still be able to score over 95% with no training."
+However, significant limitations persist in areas requiring creative insight, handling of fundamental uncertainty, and truly novel problem-solving. The models excel at applying known reasoning patterns to new problems but struggle with tasks that require genuine conceptual breakthroughs or radically new approaches. <R id="YWQ4OGQ2Nj">The ARC-AGI-2 benchmark</R>, launched in March 2025, reduced o3's score to under 30% even at high compute, while "a smart human would still be able to score over 95% with no training."
 
 ## Open-Source Reasoning: DeepSeek R1
 

--- a/content/docs/knowledge-base/organizations/cea.mdx
+++ b/content/docs/knowledge-base/organizations/cea.mdx
@@ -116,7 +116,7 @@ Coefficient Giving has also provided targeted grants including \$7,783,000 over 
 
 CEA operates through the Effective Ventures legal structure, which consists of two separate entities: Effective Ventures Foundation (UK), a registered charity in England and Wales (charity number 1149828) and a Netherlands registered tax-deductible entity (ANBI 825776867); and Effective Ventures Foundation USA, a section 501(c)(3) organization (EIN: 47-1988398).[^rc-f75b][^rc-9a2d]
 
-As of March 2024, CEA has approximately 40 staff members.[^rc-347a] Following the planned merger with EA Funds and spinout from Effective Ventures, the organization expects to operate independently by July 2025.[^rc-4f52]
+As of March 2024, CEA has approximately 40 staff members.[^rc-347a] Following the planned merger with EA Funds and spinout from Effective Ventures, the organization was targeting independent operation by July 2025.[^rc-4f52]
 
 <Section title="Leadership">
   <KeyPeople people={[

--- a/content/docs/knowledge-base/responses/eu-ai-act.mdx
+++ b/content/docs/knowledge-base/responses/eu-ai-act.mdx
@@ -67,7 +67,7 @@ France, Germany, and Italy emerged as key opponents of strict foundation model r
 
 ### Political Agreement and Adoption (2023-2024)
 
-After marathon negotiations, political agreement was expected to be reached in Late 2023.[^rc-a40e][^rc-df51][^rc-a40e] The compromise distinguished between:
+After marathon negotiations, political agreement was reached in December 2023.[^rc-a40e][^rc-df51][^rc-a40e] The compromise distinguished between:
 
 1. **General GPAI models**: Subject to transparency obligations, copyright disclosure requirements, and technical documentation
 2. **Systemic risk GPAI models**: Additional requirements for risk assessments, incident reporting, evaluations, and cybersecurity measures

--- a/content/docs/knowledge-base/responses/governance-policy.mdx
+++ b/content/docs/knowledge-base/responses/governance-policy.mdx
@@ -209,7 +209,7 @@ Industry-led initiatives aim to establish safety norms before mandatory regulati
 - **THEN** implement corresponding safeguards (e.g., enhanced containment)
 
 Current adoption:
-- **Anthropic:** ASL-2 containment for current models, ASL-3 planned for future systems
+- **Anthropic:** ASL-3 now in production (Claude Opus 4 released under ASL-3), with ASL-2 still applied to lower-capability models
 - **OpenAI:** <R id="ZmYxMGI2Yj">Preparedness Framework</R> with risk assessment scorecards
 - **Google DeepMind:** <R id="NzZkNWU4MT">Frontier Safety Framework</R> for responsible deployment
 - **Meta:** <R id="NzJlNTNkY2">System-level safety approach</R> focusing on red-teaming


### PR DESCRIPTION
## Summary

Fixes four places where the wiki described future events that have already occurred:

- **reasoning.mdx**: "The upcoming ARC-AGI-2 benchmark is projected to reduce o3's score" → past tense; ARC-AGI-2 launched March 2025 and results already appear on the same page
- **governance-policy.mdx**: "ASL-2 for current models, ASL-3 planned for future systems" → reflects that ASL-3 is now live with Claude Opus 4
- **cea.mdx**: "expects to operate independently by July 2025" → changed to "was targeting" since July 2025 is now past
- **eu-ai-act.mdx**: "political agreement was expected to be reached in Late 2023" → "political agreement was reached in December 2023"

All changes are minimal, fact-correcting wording adjustments only.

## Test plan

- [x] `pnpm crux fix escaping` — no issues
- [x] `pnpm crux fix markdown` — no issues
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks passed

Closes #2639
