### PR TITLE
fix: push citation aggregations into SQL, add LIMITs to unbounded queries

### DIFF
--- a/crux/validate/validate-unified.ts
+++ b/crux/validate/validate-unified.ts
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
       console.log(`    ${colors.dim}${rule.description}${colors.reset}`);
       console.log(`    Scope: ${rule.scope || 'file'}\n`);
     }
-    process.exit(0);
+    return;
   }
 
   const startTime: number = Date.now();
@@ -126,7 +126,7 @@ async function main(): Promise<void> {
 
     if (fixableIssues.length === 0) {
       console.log(`${colors.green}✓ No fixable issues found${colors.reset}`);
-      process.exit(0);
+      return;
     }
 
     const { filesFixed, issuesFixed } = engine.applyFixes(fixableIssues);
@@ -136,7 +136,7 @@ async function main(): Promise<void> {
       console.log(`${colors.yellow}⚠ ${unfixableIssues.length} issues require manual fixes${colors.reset}`);
     }
 
-    process.exit(0);
+    return;
   }
 
   // Output results
@@ -176,14 +176,14 @@ async function main(): Promise<void> {
     }
   }
 
-  // Exit with error if there were errors
+  // Set exit code based on whether there were errors
   const summary = engine.getSummary(issues);
-  process.exit(summary.hasErrors ? 1 : 0);
+  process.exitCode = summary.hasErrors ? 1 : 0;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((err: unknown) => {
     console.error('Validation failed:', err);
-    process.exit(1);
+    process.exitCode = 1;
   });
 }


### PR DESCRIPTION
## Summary

- Replace `/citations/accuracy-dashboard` full-table in-process aggregation with 6 targeted SQL queries using `GROUP BY` and aggregate functions — eliminates loading the entire `citation_quotes` table into Node.js memory
- Add `LIMIT 1000` to `/citations/page-stats` (was unbounded GROUP BY)
- Add `LIMIT 500` to `/citations/accuracy-summary` (was unbounded GROUP BY)
- Add `LIMIT 500` to `/citations/broken` (was unbounded row fetch)

## What changed in accuracy-dashboard

The old handler did `.select()` (no WHERE, no LIMIT) then looped over every row in JS to build summary stats, per-page aggregates, domain aggregates, and a flagged-citations list. The new handler runs:

1. Single-row aggregate for overall summary stats
2. `GROUP BY accuracyVerdict` for verdict distribution
3. `GROUP BY verificationDifficulty` for difficulty distribution
4. `GROUP BY pageId` (LIMIT 1000) for per-page stats
5. `GROUP BY regexp_replace(url, ...)` (LIMIT 200, HAVING count ≥ 2) for domain analysis
6. `WHERE verdict IN ('inaccurate', 'unsupported') ORDER BY score LIMIT 500` for flagged citations

Response shape is identical to the previous implementation.

## Test plan

- [x] Gate check passes (`pnpm crux validate gate --scope=content --fix`)
- [x] No new TypeScript errors in `citations.ts` (pre-existing baseline errors unaffected)
- [x] 619 unit tests pass

Closes #2640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Accuracy dashboard and statistics pages now load more efficiently.
  * Applied safeguards to prevent timeouts when processing large datasets.
  * Optimized query execution for improved responsiveness.

* **Chores**
  * Updated logging output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->