### PR TITLE
fix: correct Evan Hubinger description and founding dates

### DIFF
--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -340,7 +340,7 @@
     - title: Apollo Research Blog
       url: https://www.apolloresearch.ai/blog
   description: >-
-    Apollo Research is an AI safety research organization founded in 2022 with a specific focus on one of the most
+    Apollo Research is an AI safety research organization founded in 2023 with a specific focus on one of the most
     concerning potential failure modes: deceptive alignment and scheming behavior in advanced AI systems.
   tags:
     - deception
@@ -419,7 +419,7 @@
       url: https://conjecture.dev/research
     - title: Connor Leahy Podcast Appearances
   description: >-
-    Conjecture is an AI safety research organization founded in 2021 by Connor Leahy and a team of researchers concerned
+    Conjecture is an AI safety research organization founded in 2022 by Connor Leahy and a team of researchers concerned
     about existential risks from advanced AI.
   tags:
     - cognitive-emulation

--- a/packages/factbase/data/things/evan-hubinger.yaml
+++ b/packages/factbase/data/things/evan-hubinger.yaml
@@ -2,9 +2,9 @@ entity: XnqqKHiNmw
 facts:
   - id: f_ENQaaYa3Gw
     property: description
-    value: AI safety researcher formerly at Anthropic and MIRI, known for the
-      influential risks from learned optimization framework and the concept of
-      deceptive alignment (mesa-optimization). Author of key foundational work
+    value: AI safety researcher currently at Anthropic and formerly at MIRI, known
+      for the influential risks from learned optimization framework and the concept
+      of deceptive alignment (mesa-optimization). Author of key foundational work
       on inner alignment and corrigibility.
     asOf: 2026-03
     notes: Migrated from old entity system


### PR DESCRIPTION
## Summary

- Fix Evan Hubinger FactBase description: changed "formerly at Anthropic" to "currently at Anthropic and formerly at MIRI" — aligns with employed-by fact (no validEnd) and MDX page
- Fix Conjecture founding year: 2021 → 2022 (March 2022 per detail page and co-founders)
- Fix Apollo Research founding year: 2022 → 2023 (May 2023 per detail page)

## Files changed

- `packages/factbase/data/things/evan-hubinger.yaml` — description fact value
- `data/entities/organizations.yaml` — Conjecture and Apollo Research descriptions

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks passed

Closes #2642
Closes #2644
