### PR TITLE
docs: register Entity Profile dashboard E1929 in internal-dashboards.md

### DIFF
--- a/.claude/rules/internal-dashboards.md
+++ b/.claude/rules/internal-dashboards.md
@@ -40,6 +40,6 @@ Follow existing patterns in `apps/web/src/app/internal/entities/` (Pattern A ref
 
 All dashboards have entity IDs and use Pattern A (MDX stub + content component + redirect).
 
-**Dashboards:** Entities & Pages (E908), Page Changes (E909), Update Schedule (E900), Suggested Pages (E910), Improve Runs (E911), Agent Sessions (E912), Session Insights (E913), Auto-Update Runs (E914), Auto-Update News (E915), Active Agents (E925), Groundskeeper Runs (E926), System Health (E927). *(E899 deprecated — merged into E908.)*
+**Dashboards:** Entities & Pages (E908), Page Changes (E909), Update Schedule (E900), Suggested Pages (E910), Improve Runs (E911), Agent Sessions (E912), Session Insights (E913), Auto-Update Runs (E914), Auto-Update News (E915), Active Agents (E925), Groundskeeper Runs (E926), System Health (E927), Entity Profile (E1929). *(E899 deprecated — merged into E908.)*
 
 **Citations:** Fact Dashboard (E898), Resources, Citation Accuracy (E917), Citation Content (E918), Hallucination Risk (E919), Hallucination Evals (E920).


### PR DESCRIPTION
## Summary

- Entity Profile dashboard (E1929) was added by PR #2556 but not listed in `.claude/rules/internal-dashboards.md` catalog
- The `wikiId: E1929` frontmatter was already correctly set in `content/docs/internal/entity-profile-dashboard.mdx` and sidebar entry exists in `wiki-nav.ts`
- This PR adds E1929 to the existing dashboards documentation so future agents have a complete catalog

## Root Cause

The original PR #2556 skipped updating the dashboards catalog in `.claude/rules/internal-dashboards.md`. Multiple subsequent "fix" commits corrected the `wikiId` frontmatter key (from `numericId` to `wikiId`), but the documentation was still missing the entry.

## Note for Reviewer

This PR modifies `.claude/rules/internal-dashboards.md` which is a protected path requiring the `gate:rules-ok` label. The change is a single-line documentation update adding `Entity Profile (E1929)` to the existing dashboards list — no logic or behavior changes.

## Test plan

- [x] Both wiki-nav.test.ts integration tests pass: `every internal MDX page appears in database.json` and `every redirect page.tsx points to an EID that exists in database.json`
- [x] All 27 wiki-nav tests pass locally after `pnpm build-data:content`
- [x] `wikiId: E1929` is present in `content/docs/internal/entity-profile-dashboard.mdx` frontmatter
- [x] wiki-id-integrity validation passes (`pnpm crux validate unified --rules=wiki-id-integrity --errors-only`)

Closes #2636