### PR TITLE
fix: add redirects for 6 title-slug 404s (research areas + publications)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,6 +36,38 @@ const nextConfig: NextConfig = {
         destination: "/resources",
         permanent: true,
       },
+      // Research area title-slug → canonical short-ID redirects (#2634)
+      {
+        source: "/research-areas/mechanistic-interpretability",
+        destination: "/research-areas/mech-interp",
+        permanent: true,
+      },
+      {
+        source: "/research-areas/dangerous-capability-evaluations",
+        destination: "/research-areas/dangerous-capability-evals",
+        permanent: true,
+      },
+      {
+        source: "/research-areas/ai-evaluations",
+        destination: "/research-areas/evals",
+        permanent: true,
+      },
+      // Publication title-slug → canonical short-ID redirects (#2635)
+      {
+        source: "/publications/future-of-life-institute",
+        destination: "/publications/fli",
+        permanent: true,
+      },
+      {
+        source: "/publications/future-of-humanity-institute",
+        destination: "/publications/fhi",
+        permanent: true,
+      },
+      {
+        source: "/publications/world-economic-forum",
+        destination: "/publications/wef",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

QA sweep found 6 directory pages returning 404 when accessed via title-derived URL slugs. The site uses short IDs internally (e.g. `mech-interp`, `fli`) but users and crawlers expect full-name slugs to resolve.

**Root cause**: `next.config.ts` has no redirects for these common title-slug variations.

**Fix**: Added 6 permanent redirects.

### Research areas (#2634)
- `/research-areas/mechanistic-interpretability` → `/research-areas/mech-interp`
- `/research-areas/dangerous-capability-evaluations` → `/research-areas/dangerous-capability-evals`
- `/research-areas/ai-evaluations` → `/research-areas/evals`

### Publications (#2635)
- `/publications/future-of-life-institute` → `/publications/fli`
- `/publications/future-of-humanity-institute` → `/publications/fhi`
- `/publications/world-economic-forum` → `/publications/wef`

## Test plan

- [x] Target pages verified loading on production: `/research-areas/mech-interp`, `/research-areas/dangerous-capability-evals`, `/research-areas/evals`, `/publications/fli`, `/publications/fhi`, `/publications/wef`
- [x] All 6 source URLs confirmed returning 404 before fix (verified via WebFetch)
- [x] Config-only change — no TypeScript logic, no risk of regressions

Closes #2634
Closes #2635
