### PR TITLE
fix: prune garbled/inverted/duplicate person records in people directory

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2173,3 +2173,67 @@
   tags:
     - ai
 
+# Entries below were created by personnel enrichment tasks. They are added here
+# explicitly so that the YAML sync keeps them with correct titles and prunes
+# the stale/garbled duplicates (askell-amanda, bowman-samuel-r, andrew-y-ng,
+# andreas-stuhlm-ller, alex-kaskasoli, ben-weinstein-raun, buck).
+
+- id: amanda-askell
+  stableId: 2qcak72NwQ
+  type: person
+  title: Amanda Askell
+  description: AI safety researcher at Anthropic, known for work on language model alignment and sycophancy.
+  customFields:
+    - label: Role
+      value: Researcher
+  tags:
+    - ai
+
+- id: samuel-r-bowman
+  stableId: DikTuUb39Q
+  type: person
+  title: Samuel R. Bowman
+  description: AI safety researcher and NLP professor, known for work on language model evaluation and safety.
+  customFields:
+    - label: Role
+      value: Professor and Researcher
+  tags:
+    - ai
+
+- id: alexandre-kaskasoli
+  stableId: KnHneaUKew
+  type: person
+  title: Alexandre Kaskasoli
+  description: AI safety researcher known for work on dangerous capability evaluations of frontier models.
+  customFields:
+    - label: Role
+      value: Researcher
+  tags:
+    - ai
+
+- id: benjamin-weinstein-raun
+  stableId: eg18B7rL4g
+  type: person
+  title: Benjamin Weinstein-Raun
+  description: Senior Researcher and acting director at Palisade Research, focused on AI safety.
+  customFields:
+    - label: Role
+      value: Senior Researcher
+  tags:
+    - ai
+
+- id: andreas-stuhlmuller
+  stableId: SqupPjf6AJ
+  type: person
+  title: Andreas Stuhlmüller
+  description: >-
+    Co-founder of Elicit (formerly Ought), an AI research tool focused on
+    language model assistance for research tasks. Pioneer in using ML to
+    assist human reasoning and decision-making.
+  website: https://elicit.com
+  customFields:
+    - label: Role
+      value: Co-founder, Elicit
+  tags:
+    - ai
+


### PR DESCRIPTION
## Summary

- Adds 5 correct person entries to `data/entities/people.yaml` with their existing production DB `stableId`s (Amanda Askell, Samuel R. Bowman, Alexandre Kaskasoli, Benjamin Weinstein-Raun, Andreas Stuhlmüller)
- When `sync-entities` runs on the production branch, these entries will be upserted with correct titles and the 7 stale/bad DB entries will be pruned

## Root Cause

The people directory page at `/people` fetches data from the wiki-server API, which reads from the `entities` PostgreSQL table. That table contained 9 problematic entries created by past `crux tablebase ensure-entities` / `create-entity` personnel enrichment tasks:

**Garbled name** (umlaut stripped then misformatted):
- `andreas-stuhlm-ller` → "Andreas Stuhlm Ller" (correct: `andreas-stuhlmuller` → "Andreas Stuhlmüller")

**Inverted names** (stored as `lastname-firstname`):
- `askell-amanda` → "Askell Amanda" (correct: `amanda-askell` → "Amanda Askell")
- `bowman-samuel-r` → "Bowman Samuel R" (correct: `samuel-r-bowman` → "Samuel R. Bowman")

**Duplicates** (second entry for an already-correct slug):
- `andrew-y-ng` — duplicate of `andrew-ng`
- `alex-kaskasoli` — duplicate of `alexandre-kaskasoli`
- `ben-weinstein-raun` — duplicate of `benjamin-weinstein-raun`
- `buck` — duplicate of `buck-shlegeris`

## How the fix works

The `sync-entities` CI job (`sync-entities-facts.yml`) runs on changes to `data/entities/**` on the production branch. It:
1. Upserts all YAML entries to the DB (fixing titles)
2. Prunes all DB entries whose `id` (slug) is **not** in the YAML keepIds list

By adding the 5 correct entries to `people.yaml` with their existing `stableId`s from the DB, the sync will update their titles correctly and the 7 bad entries will be pruned automatically.

## Test plan

- [x] Gate check passes (`pnpm crux validate gate --fix --scope=content`)
- [x] Schema validation passes (826 entities loaded, all pass)
- [x] New entries use correct existing `stableId`s from production DB to avoid unique constraint violations on upsert
- [x] `andreas-stuhlmuller` gets a new `stableId` since it doesn't exist in DB yet
- [ ] After merge to production: verify `/people` directory no longer shows the 9 bad entries

Closes #2645
