### PR TITLE
refactor: convert resources.ts safeParse to zv() for Hono RPC compliance

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -15,13 +15,12 @@ import { resources, resourceCitations, wikiPages, citationContent } from "../../
 import { checkRefsExist } from "../shared/ref-check.js";
 import type * as schema from "../../schema.js";
 import {
-  parseJsonBody,
   validationError,
-  invalidJsonError,
   notFoundError,
   firstOrThrow,
   dbError,
   paginationQuery,
+  zv,
 } from "../shared/utils.js";
 import {
   UpsertResourceSchema as SharedUpsertResourceSchema,
@@ -111,6 +110,13 @@ const SearchQuery = z.object({
 
 const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({
   type: z.string().max(50).optional(),
+});
+
+const AuthorEntityIdsSchema = z.object({
+  items: z.array(z.object({
+    resourceId: z.string().min(1),
+    authorEntityIds: z.array(z.string().min(1)),
+  })).min(1).max(500),
 });
 
 // ---- Helpers ----
@@ -270,18 +276,13 @@ const resourcesApp = new Hono()
 
   // ---- POST / (upsert single resource) ----
 
-  .post("/", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = UpsertResourceSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
+  .post("/", zv("json", UpsertResourceSchema), async (c) => {
+    const data = c.req.valid("json");
     const db = getDrizzleDb();
 
     // Validate citedBy page references (optional field)
-    if (parsed.data.citedBy && parsed.data.citedBy.length > 0) {
-      const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, parsed.data.citedBy);
+    if (data.citedBy && data.citedBy.length > 0) {
+      const missingPages = await checkRefsExist(db, wikiPages, wikiPages.id, data.citedBy);
       if (missingPages.length > 0) {
         return validationError(
           c,
@@ -291,27 +292,21 @@ const resourcesApp = new Hono()
     }
 
     try {
-      const result = await upsertResource(db, parsed.data);
+      const result = await upsertResource(db, data);
       return c.json(result, 201);
     } catch (err) {
       logger.error(
-        { err, resourceId: parsed.data.id },
+        { err, resourceId: data.id },
         "single resource upsert failed",
       );
-      return dbError(c, "resource upsert", err, { resourceId: parsed.data.id });
+      return dbError(c, "resource upsert", err, { resourceId: data.id });
     }
   })
 
   // ---- POST /batch (upsert multiple resources) ----
 
-  .post("/batch", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = UpsertBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
+  .post("/batch", zv("json", UpsertBatchSchema), async (c) => {
+    const { items } = c.req.valid("json");
 
     const db = getDrizzleDb();
 
@@ -388,11 +383,8 @@ const resourcesApp = new Hono()
 
   // ---- GET /search?q=X (full-text search by title/summary/abstract/review) ----
 
-  .get("/search", async (c) => {
-    const parsed = SearchQuery.safeParse(c.req.query());
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { q, limit } = parsed.data;
+  .get("/search", zv("query", SearchQuery), async (c) => {
+    const { q, limit } = c.req.valid("query");
     const rawDb = getDb();
 
     // Full-text search with prefix matching (same pattern as wiki_pages search)
@@ -573,11 +565,8 @@ const resourcesApp = new Hono()
 
   // ---- GET /all (paginated listing) ----
 
-  .get("/all", async (c) => {
-    const parsed = PaginationQuery.safeParse(c.req.query());
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { limit, offset, type } = parsed.data;
+  .get("/all", zv("query", PaginationQuery), async (c) => {
+    const { limit, offset, type } = c.req.valid("query");
     const db = getDrizzleDb();
 
     const conditions: SQL | undefined = type
@@ -674,17 +663,11 @@ const resourcesApp = new Hono()
 
   // ---- PATCH /:id/fetch-status (update fetch status from source-fetcher) ----
 
-  .patch("/:id/fetch-status", async (c) => {
+  .patch("/:id/fetch-status", zv("json", UpdateResourceFetchStatusSchema), async (c) => {
     const id = c.req.param("id");
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = UpdateResourceFetchStatusSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
     const db = getDrizzleDb();
 
-    const { fetchStatus, lastFetchedAt, fetchedTitle } = parsed.data;
+    const { fetchStatus, lastFetchedAt, fetchedTitle } = c.req.valid("json");
 
     const updateSet: Record<string, unknown> = {
       fetchStatus,
@@ -736,26 +719,13 @@ const resourcesApp = new Hono()
   // ---- PATCH /author-entity-ids ----
   // Batch update authorEntityIds for resources (used by crux people link-resources).
 
-  .patch("/author-entity-ids", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const schema = z.object({
-      items: z.array(z.object({
-        resourceId: z.string().min(1),
-        authorEntityIds: z.array(z.string().min(1)),
-      })).min(1).max(500),
-    });
-
-    const parsed = schema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
+  .patch("/author-entity-ids", zv("json", AuthorEntityIdsSchema), async (c) => {
     const db = getDrizzleDb();
     let updated = 0;
 
     // Batch update in a single transaction
     await db.transaction(async (tx) => {
-      for (const item of parsed.data.items) {
+      for (const item of c.req.valid("json").items) {
         const jsonText = JSON.stringify(item.authorEntityIds);
         await tx
           .update(resources)


### PR DESCRIPTION
## Summary

- Converts all 6 `safeParse` + `validationError` patterns in `apps/wiki-server/src/routes/wikibase/resources.ts` to use the `zv()` middleware helper, enabling Hono RPC type inference
- Endpoints converted: `POST /` (upsert), `POST /batch`, `GET /search`, `GET /all`, `PATCH /:id/fetch-status`, `PATCH /author-entity-ids`
- Lifts the inline `AuthorEntityIdsSchema` (previously defined inside the handler) to module scope alongside the other schemas
- Removes now-unused `parseJsonBody` and `invalidJsonError` imports

## Why

`zv()` integrates with Hono's method-chaining to enable compile-time type inference on response types via `InferResponseType<>`. Manual `safeParse` calls break this inference chain. See `.claude/rules/wiki-server-rpc-migration.md`.

## Test plan

- [x] TypeScript check passes (`tsc --noEmit` on wiki-server — confirmed clean, 0 errors)
- [x] No resource-related test failures (619 tests pass; other failures are pre-existing worktree env issues unrelated to this change)
- [ ] CI green (pending)

Closes #2641 (partial — resources.ts only)