### PR TITLE
fix: hide empty research area sub-areas with Has data toggle

### DIFF
--- a/apps/web/src/app/research-areas/page.tsx
+++ b/apps/web/src/app/research-areas/page.tsx
@@ -25,6 +25,8 @@ export default function ResearchAreasPage() {
     cluster: a.cluster ?? null,
     parentAreaId: a.parentAreaId ?? null,
     firstProposedYear: a.firstProposedYear ?? null,
+    orgCount: a.orgCount,
+    paperCount: a.paperCount,
   }));
 
   // Summary stats

--- a/apps/web/src/app/research-areas/research-areas-table.tsx
+++ b/apps/web/src/app/research-areas/research-areas-table.tsx
@@ -15,6 +15,8 @@ export interface ResearchAreaRow {
   cluster: string | null;
   parentAreaId: string | null;
   firstProposedYear: number | null;
+  orgCount: number;
+  paperCount: number;
 }
 
 type SortKey = "title" | "cluster" | "status" | "firstProposedYear";
@@ -23,8 +25,15 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
   const [search, setSearch] = useState("");
   const [clusterFilter, setClusterFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [hasDataOnly, setHasDataOnly] = useState(true);
   const [sortKey, setSortKey] = useState<SortKey>("title");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  // Count rows that have no organizations and no papers
+  const emptyCount = useMemo(
+    () => rows.filter((r) => r.orgCount === 0 && r.paperCount === 0).length,
+    [rows]
+  );
 
   const clusters = useMemo(() => {
     const set = new Set<string>();
@@ -47,6 +56,8 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
     const q = search.toLowerCase();
     return rows
       .filter((r) => {
+        // Hide entries with no organizations and no papers when filter is active
+        if (hasDataOnly && r.orgCount === 0 && r.paperCount === 0) return false;
         if (clusterFilter !== "all" && r.cluster !== clusterFilter) return false;
         if (statusFilter !== "all" && r.status !== statusFilter) return false;
         if (q) {
@@ -69,7 +80,7 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
         };
         return compareByValue(a, b, getValue, sortDir);
       });
-  }, [rows, search, clusterFilter, statusFilter, sortKey, sortDir]);
+  }, [rows, search, clusterFilter, statusFilter, hasDataOnly, sortKey, sortDir]);
 
   const handleSort = (key: string) => {
     const k = key as SortKey;
@@ -104,6 +115,18 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
           <option value="declining">Declining</option>
           <option value="archived">Archived</option>
         </select>
+        {emptyCount > 0 && (
+          <label className="flex items-center gap-2 cursor-pointer select-none text-sm text-muted-foreground whitespace-nowrap">
+            <input
+              type="checkbox"
+              checked={hasDataOnly}
+              onChange={(e) => setHasDataOnly(e.target.checked)}
+              className="rounded border-border"
+            />
+            Has data
+            <span className="text-xs">({emptyCount} hidden)</span>
+          </label>
+        )}
       </div>
 
       {/* Cluster filter pills */}


### PR DESCRIPTION
## Summary

- Adds `orgCount` and `paperCount` fields to `ResearchAreaRow` interface so counts are passed from server to the client table component
- Adds a "Has data" checkbox filter (default on) that hides research area entries with 0 organizations and 0 papers
- The checkbox displays the count of hidden entries (e.g. "Has data (68 hidden)") for discoverability
- The checkbox only renders when there are actually empty entries in the dataset, so it won't appear on datasets that are fully populated

## Approach

Option 3 from the issue — a "Has data" toggle (default on). This is the cleanest UX: users see the meaningful subset by default, but can easily reveal all entries. The hidden count ensures they know sub-areas exist.

## Test plan
- [x] No TypeScript errors in modified research-areas files (verified via `tsc --noEmit`)
- [x] All 619 vitest tests pass (22 pre-existing failures from missing `next` modules in worktree, unrelated to this change)
- [x] `orgCount` and `paperCount` pass through from `PGResearchArea` to `ResearchAreaRow` correctly
- [x] "Has data" filter logic: `hasDataOnly && r.orgCount === 0 && r.paperCount === 0` correctly excludes empty rows
- [x] Checkbox renders only when `emptyCount > 0` (no UI noise on fully-populated datasets)

Closes #2647