### PR TITLE
fix: hide DB debug link from people profiles and add has-data filter

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -429,12 +429,6 @@ export default async function PersonProfilePage({
             >
               KB data &rarr;
             </Link>
-            <Link
-              href={`/people/${slug}/db`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              DB records &rarr;
-            </Link>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -125,7 +125,7 @@ export function PeopleTable({
   // ── Local (static) state via URL-synced hook ──
   const url = useDirectoryUrl({
     defaultSort: { field: "name", dir: "asc" },
-    filters: ["affiliation", "topic"],
+    filters: ["affiliation", "topic", "hasData"],
   });
   const {
     search: urlSearch, setSearch: urlSetSearch,
@@ -135,6 +135,7 @@ export function PeopleTable({
   } = url;
   const affiliationFilter = url.filters.affiliation ?? "all";
   const topicFilter = url.filters.topic ?? "all";
+  const hasDataFilter = url.filters.hasData === "true";
 
   const allRows = staticRows ?? EMPTY_ROWS;
 
@@ -167,6 +168,18 @@ export function PeopleTable({
     return [...counts.entries()]
       .sort((a, b) => b[1] - a[1])
       .map(([slug, count]) => ({ key: slug, label: topicLabel(slug), count }));
+  }, [allRows, serverMode]);
+
+  // Count people with any structured data (static mode only)
+  const withDataCount = useMemo(() => {
+    if (serverMode) return 0;
+    return allRows.filter(
+      (r) =>
+        r.role != null ||
+        r.positionCount > 0 ||
+        r.publicationCount > 0 ||
+        r.careerHistoryCount > 0,
+    ).length;
   }, [allRows, serverMode]);
 
   // ── Unified search handler ──
@@ -248,6 +261,16 @@ export function PeopleTable({
       result = result.filter((r) => r.topics.includes(topicFilter));
     }
 
+    if (hasDataFilter) {
+      result = result.filter(
+        (r) =>
+          r.role != null ||
+          r.positionCount > 0 ||
+          r.publicationCount > 0 ||
+          r.careerHistoryCount > 0,
+      );
+    }
+
     if (urlSearch.trim()) {
       const q = urlSearch.toLowerCase();
       result = result.filter((r) => r.searchText.includes(q));
@@ -263,7 +286,7 @@ export function PeopleTable({
     );
 
     return result;
-  }, [serverMode, allRows, affiliationFilter, topicFilter, urlSearch, urlSort.field, urlSort.dir]);
+  }, [serverMode, allRows, affiliationFilter, topicFilter, hasDataFilter, urlSearch, urlSort.field, urlSort.dir]);
 
   const localTotalPages = Math.max(
     1,
@@ -347,6 +370,39 @@ export function PeopleTable({
               onSelect={(key) => urlSetFilter("topic", key)}
               allLabel="All Topics"
             />
+          </div>
+        )}
+
+        {/* Has data toggle (static mode only) */}
+        {!serverMode && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                urlSetFilter("hasData", hasDataFilter ? "all" : "true")
+              }
+              className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${
+                hasDataFilter
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-card text-muted-foreground border-border hover:border-primary/40 hover:text-foreground"
+              }`}
+              aria-pressed={hasDataFilter}
+            >
+              Has data
+              {withDataCount > 0 && (
+                <span
+                  className={`text-[10px] ${hasDataFilter ? "opacity-80" : "text-muted-foreground/60"}`}
+                >
+                  ({withDataCount})
+                </span>
+              )}
+            </button>
+            {hasDataFilter && (
+              <span className="text-xs text-muted-foreground/60">
+                Showing only people with role, position, publication, or career
+                data
+              </span>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Remove "DB records →" debug link** from all `/people/[slug]` profile pages. This link pointed to an internal database inspection page not intended for public visitors. The "Wiki page →" and "KB data →" links are retained.
- **Add "Has data" toggle filter** to the `/people` directory table. With ~93% of 649 profiles being empty stubs (only 46 have role data), users had no way to filter to populated entries. The toggle filters to people with any of: role, position, publication, or career data. Shows the matching count in the button label.

## Changes

- `apps/web/src/app/people/[slug]/page.tsx` — removed the "DB records →" link (6 lines)
- `apps/web/src/app/people/people-table.tsx` — added `hasData` filter to `useDirectoryUrl`, `withDataCount` memo, filter logic in `localFiltered`, and "Has data" toggle button in the UI

## Test plan

- [x] TypeScript check passes (`tsc --noEmit` on main repo = 0 errors)
- [x] Pre-existing test count unchanged (2 failing, 883 passing — unrelated to this PR)
- [ ] Visit `/people/sam-altman` — confirm "DB records →" link is gone, profile looks normal
- [ ] Visit `/people` — confirm "Has data" button appears, clicking it narrows list to ~46 entries
- [ ] Confirm `?hasData=true` appears in URL when filter is active and clears on second click

Closes #2646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Has data" filter toggle to the people table. This new feature allows users to quickly filter records and display only those containing structured data information across roles, positions, publications, and career history fields.

* **Updates**
  * Removed the "DB records" navigation link from person profile pages to streamline the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->