### PR TITLE
fix: stabilize sort toggle in server mode and memoize grant table transform

### DIFF
--- a/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
+++ b/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
@@ -190,12 +190,17 @@ export function InteractiveGrantsTable({
 }) {
   const serverMode = !!entityId;
 
+  // Memoize the transform function so its reference is stable across renders.
+  // Without this, makeTransform(orgSlug) would produce a new function each render,
+  // which could cause unnecessary re-fetches if useServerTable ever checks referential equality.
+  const transform = useMemo(() => makeTransform(orgSlug), [orgSlug]);
+
   // ── Server-side state (hook always called for consistent hook order) ──
   const server = useServerTable<GrantRow>({
     endpoint: `/api/grants/by-entity/${entityId ?? ""}`,
     defaultPageSize: PAGE_SIZE,
     defaultSort: { field: "date", dir: "desc" },
-    transform: makeTransform(orgSlug),
+    transform,
     enabled: serverMode,
   });
 

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -231,13 +231,17 @@ export function OrganizationsTable({
     if (serverMode) {
       const serverField = SORT_KEY_TO_SERVER_FIELD[key];
       if (serverField) {
-        const { dir } = toggleSort(urlSort, key, ["name"]);
+        // Read from server.sort (not urlSort) so toggling the same column correctly
+        // flips direction. urlSort is never updated in server mode, so using it
+        // always produces the same direction for repeated clicks on the same column.
+        const currentServerSort = { field: server.sort.field as SortKey, dir: server.sort.dir };
+        const { dir } = toggleSort(currentServerSort, key, ["name"]);
         serverSetSort(serverField, dir);
       }
     } else {
       urlSetSort(toggleSort(urlSort, key, ["name"]));
     }
-  }, [serverMode, serverSetSort, urlSetSort, urlSort]);
+  }, [serverMode, server.sort, serverSetSort, urlSetSort, urlSort]);
 
   // ── Enrich server data with orgType from static map ──
   const enrichedServerData = useMemo(() => {


### PR DESCRIPTION
## Summary

- **Sort toggle bug (organizations-table.tsx)**: `handleSort` was calling `toggleSort(urlSort, key)` in server mode, but `urlSort` is never updated when the server is active. This meant clicking a column header twice always produced the same sort direction. Fixed by reading from `server.sort` instead, which reflects the actual current sort state.

- **Transform memoization (interactive-grants-table.tsx)**: `makeTransform(orgSlug)` was called bare during render, creating a new function reference on every render cycle. Wrapped with `useMemo(() => makeTransform(orgSlug), [orgSlug])` to stabilize the reference. The `useServerTable` hook already guards against this via `transformRef`, but memoizing is the correct pattern and protects against future refactors that might remove the ref workaround.

## Files changed

- `apps/web/src/app/organizations/organizations-table.tsx` — read `server.sort` in server-mode sort handler
- `apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx` — memoize transform function

## Test plan

- [ ] On `/organizations` with server mode enabled: click a column header once → sorts asc/desc; click same header again → direction toggles correctly
- [ ] TypeScript: no new type errors in the two modified files (verified with `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**Bug Fixes**
- Fixed sort column direction toggle on tables to properly cycle through directions when repeatedly clicking the same column header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->