### PR TITLE
fix: format legislation dates, normalize status, redirect deprecated entity

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,6 +36,12 @@ const nextConfig: NextConfig = {
         destination: "/resources",
         permanent: true,
       },
+      // Deprecated stub E8 redirects to the canonical full page E366 (#2688)
+      {
+        source: "/legislation/ai-executive-order",
+        destination: "/legislation/us-executive-order",
+        permanent: true,
+      },
       // Research area title-slug → canonical short-ID redirects (#2634)
       {
         source: "/research-areas/mechanistic-interpretability",

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -31,6 +31,7 @@ import {
   SCOPE_COLORS,
   normalizeStatus,
 } from "../legislation-constants";
+import { formatIntroducedDate } from "@/lib/format-compact";
 
 export function generateStaticParams() {
   return getPolicySlugs().map((slug) => ({ slug }));
@@ -564,7 +565,7 @@ export default async function LegislationDetailPage({
             <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap mt-1">
               {jurisdiction && <span>{jurisdiction}</span>}
               {author && <span>by {author}</span>}
-              {introduced && <span>Introduced {introduced}</span>}
+              {introduced && <span>Introduced {formatIntroducedDate(introduced)}</span>}
               {entity.fullTextUrl && (
                 <a href={entity.fullTextUrl} target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary/80 font-medium transition-colors">
                   Full text &#8599;
@@ -603,8 +604,8 @@ export default async function LegislationDetailPage({
               {jurisdiction && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Jurisdiction</dt><dd>{jurisdiction}</dd></div>}
               {entity.session && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Session</dt><dd>{entity.session}</dd></div>}
               {author && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Author / Sponsor</dt><dd>{author}</dd></div>}
-              {introduced && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Introduced</dt><dd>{introduced}</dd></div>}
-              {rawStatus && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Status</dt><dd>{rawStatus}</dd></div>}
+              {introduced && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Introduced</dt><dd>{formatIntroducedDate(introduced)}</dd></div>}
+              {statusKey && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Status</dt><dd className="capitalize">{statusKey}</dd></div>}
               {scope && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Scope</dt><dd>{scope}</dd></div>}
             </dl>
           </section>


### PR DESCRIPTION
## Summary

- **Issue 1 — Raw ISO dates**: Import `formatIntroducedDate` from `@/lib/format-compact` in the legislation detail page and apply it to both the header subtitle and the Quick Facts sidebar. Dates like `"2023-11"` now render as `"Nov 2023"` and `"2022-06-16"` as `"Jun 16, 2022"`. The index page already used this function; the detail page was missing it.
- **Issue 2 — Status inconsistency**: The Quick Facts sidebar was rendering `rawStatus` (the raw `policyStatus` field value, e.g., `"active"`) instead of `statusKey` (the normalized value from `normalizeStatus()`, e.g., `"in-effect"`). Changed the sidebar to use `statusKey` with `capitalize` CSS class, consistent with the status badge in the header.
- **Issue 3 — Deprecated entity redirect**: Added a permanent redirect from `/legislation/ai-executive-order` (deprecated stub E8) to `/legislation/us-executive-order` (canonical E366) in `apps/web/next.config.ts`. The stub was already filtered from directory listings but was still accessible directly.

## Files changed

- `apps/web/src/app/legislation/[slug]/page.tsx` — import + apply `formatIntroducedDate`, switch status sidebar to use `statusKey`
- `apps/web/next.config.ts` — add permanent redirect for deprecated entity slug

## Test plan

- [x] TypeScript check passes — no new errors introduced in modified files
- [ ] Verify a legislation page with year-month introduced date shows "Apr 2021" not "2021-04"
- [ ] Verify a legislation page with full ISO introduced date shows "Jun 16, 2022" not "2022-06-16"
- [ ] Check Quick Facts sidebar on legislation with `policyStatus: active` shows "in-effect" not "active"
- [ ] Verify `/legislation/ai-executive-order` redirects to `/legislation/us-executive-order`

Closes #2688

🤖 Generated with [Claude Code](https://claude.com/claude-code)