### PR TITLE
fix: AI models filter badge spacing and context window formatting

### DIFF
--- a/apps/web/src/app/ai-models/ai-model-constants.ts
+++ b/apps/web/src/app/ai-models/ai-model-constants.ts
@@ -31,11 +31,11 @@ export const SAFETY_LEVEL_COLORS: Record<string, string> = {
 
 /**
  * Format a context window token count for display.
- * Values < 10,000 are shown as plain numbers with commas (e.g., "4,096").
- * Values >= 10,000 are shown with K/M suffix (e.g., "128K", "1M").
+ * Values < 1,000 are shown as plain numbers (e.g., "512").
+ * Values >= 1,000 are shown with K/M suffix (e.g., "8K", "128K", "1M").
  */
 export function formatContext(tokens: number): string {
   if (tokens >= 1_000_000) return `${Math.floor(tokens / 1_000_000)}M`;
-  if (tokens >= 10_000) return `${Math.floor(tokens / 1_000)}K`;
+  if (tokens >= 1_000) return `${Math.floor(tokens / 1_000)}K`;
   return tokens.toLocaleString("en-US");
 }

--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -176,8 +176,8 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                   : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
               }`}
             >
-              All
-              <span className="ml-1 text-[10px] opacity-60">{developerCounts.all}</span>
+              All{" "}
+              <span className="text-[10px] opacity-60">{developerCounts.all}</span>
             </button>
             {developers.map(([devId, devName]) => (
               <button
@@ -193,15 +193,15 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                     : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
                 }`}
               >
-                {devName}
-                <span className="ml-1 text-[10px] opacity-60">
+                {devName}{" "}
+                <span className="text-[10px] opacity-60">
                   {developerCounts[devId] ?? 0}
                 </span>
               </button>
             ))}
           </div>
         </div>
-        <div className="flex gap-4">
+        <div className="flex flex-wrap gap-4">
           <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <input
               type="checkbox"


### PR DESCRIPTION
## Summary

- **Filter badge spacing**: The count badge after each filter tab label (e.g. "All", "Anthropic") was rendering without visual separation — showing as "All45" — because JSX collapses whitespace between text nodes and sibling elements. Fixed by inserting an explicit \`{" "}\` space character and removing the now-redundant \`ml-1\` margin on the count span.
- **Checkbox row wrapping**: Added \`flex-wrap\` to the "Show families / Open weight only" row so the labels don't run together on narrow viewports.
- **Context window formatting**: \`formatContext\` used a threshold of 10,000 for K-suffix formatting, so values like 8,192 appeared as "8,192" while all others showed as "8K", "128K", "1M". Lowered the threshold to 1,000 so any value ≥ 1,000 tokens is formatted with a K suffix (e.g. Llama 3's 8,192 → "8K").

## Test plan

- [ ] Visit \`/ai-models\` and verify filter tabs show "All 45", "Anthropic 12", etc. with a visible space before the count
- [ ] Verify the "Show families / Open weight only" checkboxes have correct spacing at all viewport widths
- [ ] Verify Llama 3 context window shows "8K" instead of "8,192"
- [ ] Verify other context windows (128K, 200K, 1M) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)