### PR TITLE
fix: correct GPT-4 training cutoff, CEA date, and E2 escape char

### DIFF
--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -882,7 +882,7 @@
   openWeight: false
   modality:
     - text
-  trainingCutoff: "2023-04"
+  trainingCutoff: "2021-09"
   benchmarks:
     - name: MMLU
       score: 86.4

--- a/packages/factbase/data/things/cea.yaml
+++ b/packages/factbase/data/things/cea.yaml
@@ -10,9 +10,9 @@ facts:
   - id: 3SeNHyi3JA
     property: headcount
     value: 109
-    asOf: 2024-00
+    asOf: 2024
     source: https://www.wikidata.org/wiki/Q58844186
-    notes: From Wikidata Q58844186 (as of 2024-00)
+    notes: From Wikidata Q58844186 (as of 2024, month unknown)
   - id: vrQK8e7bPQ
     property: website
     value: https://www.centreforeffectivealtruism.org


### PR DESCRIPTION
## Summary

- **GPT-4 training cutoff (#2680)**: Fixed `trainingCutoff` in `data/entities/ai-models.yaml` from `"2023-04"` (after release date 2023-03-14 — impossible) to `"2021-09"` per the GPT-4 Technical Report.
- **CEA malformed date (#2691)**: Fixed `asOf: 2024-00` (invalid month 00) to `asOf: 2024` in `packages/factbase/data/things/cea.yaml`. Year-only is the correct FactBase convention when the exact month is unknown.
- **E2 visible backslash (Issue 3)**: Investigated — the `\\$199B` in the YAML frontmatter `summary` field is enforced by the `dollar-signs` validation rule (`crux/lib/rules/dollar-signs.ts`). The `pnpm crux fix escaping` tool reverts any change to `$`. The visible backslash in plain-text UI contexts (EntityLink tooltips, PageStatus) is a rendering bug needing a code fix in the components, not a data fix. Not included in this PR.

## Test plan

- [x] `pnpm crux fix escaping` — no issues found
- [x] `pnpm crux fix markdown` — no issues found
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 gate checks passed
- [x] GPT-4 `trainingCutoff` confirmed as `"2021-09"` in ai-models.yaml
- [x] CEA `asOf` confirmed as `2024` (no month) in cea.yaml

Closes #2680
Closes #2691