### PR TITLE
fix: resolve company names on /funding-rounds instead of showing numeric IDs

### DIFF
--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -583,11 +583,16 @@ function fundingRoundRowToRecordEntry(row) {
   if (row.leadInvestor) fields.lead_investor = row.leadInvestor;
   if (row.source) fields.source = row.source;
   if (row.notes) fields.notes = row.notes;
+  // Embed the server-side-resolved company name so the frontend can display it
+  // even when companyEntityId is null (legacy numeric companyId rows).
+  if (row.companyResolvedName) fields.company_name = row.companyResolvedName;
 
   const entry = {
     key: row.id,
     schema: 'funding-round',
-    ownerEntityId: row.companyId,
+    // Prefer companyEntityId (proper stableId FK) over legacy companyId for entity resolution.
+    // Falls back to companyId for backward compatibility.
+    ownerEntityId: row.companyEntityId ?? row.companyId,
     fields,
   };
   // Embed resolved lead investor display name from API JOIN

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -61,7 +61,8 @@ interface ParsedInvestment {
 
 function parseFundingRound(record: KBRecordEntry): ParsedFundingRound {
   const f = record.fields;
-  const company = resolveEntityLink(record.ownerEntityId);
+  const preResolvedCompanyName = typeof f.company_name === "string" ? f.company_name : null;
+  const company = resolveEntityLink(record.ownerEntityId, preResolvedCompanyName);
   const leadInvestorId = typeof f.lead_investor === "string" ? f.lead_investor : null;
   const leadInvestor = leadInvestorId
     ? resolveEntityLink(leadInvestorId)

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -33,7 +33,8 @@ export default function FundingRoundsPage() {
 
   const rows: FundingRoundRow[] = allRecords.map((record) => {
     const f = record.fields;
-    const company = resolveEntityLink(record.ownerEntityId);
+    const preResolvedCompanyName = typeof f.company_name === "string" ? f.company_name : null;
+    const company = resolveEntityLink(record.ownerEntityId, preResolvedCompanyName);
     const leadInvestorId =
       typeof f.lead_investor === "string" ? f.lead_investor : null;
     const leadInvestor = leadInvestorId


### PR DESCRIPTION
## Summary

- `/funding-rounds` was showing raw numeric IDs (175, 265, 335, 378) for 11 of 20 companies instead of their names (Goodfire, OpenAI, SSI, xAI).
- Root cause: the funding rounds table has a legacy `companyId` field that stores old numeric strings, and a newer `companyEntityId` FK to `entities.stable_id`. When `companyEntityId` is null, `resolveEntityName` couldn't look up the company and fell back to displaying the raw ID.
- The SQL JOIN in the API already resolves the company name via `companyResolvedName` — that value just wasn't being passed through to the frontend.

## Changes

**`apps/web/scripts/lib/wiki-server-data.mjs`** (`fundingRoundRowToRecordEntry`):
- Embed `row.companyResolvedName` into `fields.company_name` so the pre-resolved name survives into the static data layer.
- Use `row.companyEntityId ?? row.companyId` as `ownerEntityId` so entities with a proper stableId FK get resolved correctly.

**`apps/web/src/app/funding-rounds/page.tsx`** and **`[id]/page.tsx`**:
- Read `fields.company_name` as a pre-resolved display name and pass it to `resolveEntityLink` as the `displayName` argument, which takes priority over entity ID lookup.

## Test plan

- [x] TypeScript: no new errors introduced in changed files (verified with tsc --noEmit).
- [ ] Manual: verify `/funding-rounds` shows company names after next build with live wiki-server.
- [ ] Manual: verify detail pages `/funding-rounds/[id]` show correct company name.

Closes #2678

🤖 Generated with [Claude Code](https://claude.com/claude-code)