### PR TITLE
fix: replace dead link and update stale Movie Gen claim

### DIFF
--- a/content/docs/knowledge-base/debates/interpretability-sufficient.mdx
+++ b/content/docs/knowledge-base/debates/interpretability-sufficient.mdx
@@ -19,7 +19,7 @@ import {DisagreementMap, InfoBox, KeyQuestions, Mermaid, R, EntityLink} from '@c
 
 | Source | Link |
 |--------|------|
-| Official Website | [ea-crux-project.vercel.app](https://ea-crux-project.vercel.app/knowledge-base/responses/epistemic-tools/) |
+| Epistemic Tools Overview | [Tools & Platforms (Overview)](/wiki/E656) |
 
 
 <InfoBox

--- a/content/docs/knowledge-base/organizations/meta-ai.mdx
+++ b/content/docs/knowledge-base/organizations/meta-ai.mdx
@@ -155,7 +155,7 @@ The February 2023 release of [LLaMA](https://ai.meta.com/llama/) (Large Language
 
 ### Video and Audio Generation
 
-Meta has made significant advances in multimodal AI capabilities. [Movie Gen enables creation of realistic, personalized HD videos](https://venturebeat.com/ai/meta-is-entering-the-ai-video-wars-with-powerful-movie-gen-set-to-hit-instagram-in-2025) up to 16 seconds at 16 FPS, generates 48kHz audio, and provides video editing capabilities. The system is set to debut on Instagram in 2025 with multimodal generation capabilities.
+Meta has made significant advances in multimodal AI capabilities. [Movie Gen enables creation of realistic, personalized HD videos](https://venturebeat.com/ai/meta-is-entering-the-ai-video-wars-with-powerful-movie-gen-set-to-hit-instagram-in-2025) up to 16 seconds at 16 FPS, generates 48kHz audio, and provides video editing capabilities. The system was announced for debut on Instagram in 2025 with multimodal generation capabilities; its current rollout status as of early 2026 is unclear.
 
 The company has also [open-sourced Perception Encoder Audiovisual (PE-AV)](https://www.marktechpost.com/2025/12/22/meta-ai-open-sourced-perception-encoder-audiovisual-pe-av-the-audiovisual-encoder-powering-sam-audio-and-large-scale-multimodal-retrieval/), a unified encoder for audio, video, and text trained on over 100 million videos. PEAV embeds audio, video, audio-video, and text into a single joint space and serves as the core perception engine behind Meta's SAM Audio model.
 


### PR DESCRIPTION
## Summary

- **interpretability-sufficient.mdx line 22**: Replaced dead link to `https://ea-crux-project.vercel.app/knowledge-base/responses/epistemic-tools/` (returns 404) with an internal link to `/wiki/E656` — the "Tools & Platforms (Overview)" page on longtermwiki.com. Also updated the table row label from "Official Website" to "Epistemic Tools Overview" to be more accurate.

- **meta-ai.mdx line 158**: Updated the Movie Gen Instagram debut sentence from future tense ("The system is set to debut on Instagram in 2025") to past tense with a clarifying note ("was announced for debut on Instagram in 2025; its current rollout status as of early 2026 is unclear"), reflecting that it is now March 2026.

## Test plan

- [x] `pnpm crux fix escaping` — no issues
- [x] `pnpm crux fix markdown` — no issues
- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)