### PR TITLE
fix: remove DB records debug link from all directory detail pages

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -169,12 +169,6 @@ export default async function AiModelDetailPage({
               Source &rarr;
             </a>
           )}
-          <Link
-            href={`/ai-models/${slug}/db`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            DB records &rarr;
-          </Link>
         </div>
       </div>
 

--- a/apps/web/src/app/approaches/[slug]/page.tsx
+++ b/apps/web/src/app/approaches/[slug]/page.tsx
@@ -113,12 +113,6 @@ export default async function ApproachDetailPage({
                   Wiki article &rarr;
                 </Link>
               )}
-              <Link
-                href={`/approaches/${slug}/db`}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                DB records &rarr;
-              </Link>
             </div>
             {entity.description && (
               <p className="text-sm text-muted-foreground leading-relaxed mt-2 max-w-prose">

--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -170,12 +170,6 @@ export default async function BenchmarkDetailPage({
               Website &rarr;
             </a>
           )}
-          <Link
-            href={`/benchmarks/${slug}/db`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            DB records &rarr;
-          </Link>
         </div>
       </div>
 

--- a/apps/web/src/app/events/[slug]/page.tsx
+++ b/apps/web/src/app/events/[slug]/page.tsx
@@ -104,12 +104,6 @@ export default async function EventDetailPage({
                   Wiki article &rarr;
                 </Link>
               )}
-              <Link
-                href={`/events/${slug}/db`}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                DB records &rarr;
-              </Link>
             </div>
             {entity.description && (
               <p className="text-sm text-muted-foreground leading-relaxed mt-2 max-w-prose">

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -575,9 +575,6 @@ export default async function LegislationDetailPage({
                   Wiki article &rarr;
                 </Link>
               )}
-              <Link href={`/legislation/${slug}/db`} className="text-primary hover:text-primary/80 font-medium transition-colors">
-                DB records &rarr;
-              </Link>
             </div>
             {entity.description && (
               <p className="text-sm text-muted-foreground leading-relaxed mt-2 max-w-prose">

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -721,9 +721,6 @@ export default async function OrgProfilePage({
               <Link href={`/factbase/entity/${entity.id}`} className="text-primary hover:text-primary/80 font-medium transition-colors">
                 KB data &rarr;
               </Link>
-              <Link href={`/organizations/${slug}/db`} className="text-primary hover:text-primary/80 font-medium transition-colors">
-                DB records &rarr;
-              </Link>
             </div>
 
             {data.founders.length > 0 && (

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -429,12 +429,6 @@ export default async function PersonProfilePage({
             >
               KB data &rarr;
             </Link>
-            <Link
-              href={`/people/${slug}/db`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              DB records &rarr;
-            </Link>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -426,12 +426,6 @@ export default async function ProjectDetailPage({
               >
                 KB data &rarr;
               </Link>
-              <Link
-                href={`/projects/${slug}/db`}
-                className="text-xs text-primary hover:underline"
-              >
-                DB records &rarr;
-              </Link>
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary

- Removes the "DB records →" debug link from all 8 directory detail pages: organizations, ai-models, benchmarks, legislation, approaches, projects, events, and people
- These links pointed to internal `/[dir]/[slug]/db` pages not intended for end users
- Follows the same approach used in PR #2676 which partially fixed this for people profiles

## Pages Fixed

- `apps/web/src/app/organizations/[slug]/page.tsx`
- `apps/web/src/app/ai-models/[slug]/page.tsx`
- `apps/web/src/app/benchmarks/[slug]/page.tsx`
- `apps/web/src/app/legislation/[slug]/page.tsx`
- `apps/web/src/app/approaches/[slug]/page.tsx`
- `apps/web/src/app/projects/[slug]/page.tsx`
- `apps/web/src/app/events/[slug]/page.tsx`
- `apps/web/src/app/people/[slug]/page.tsx`

## Test plan

- [x] TypeScript check passes — `tsc --noEmit` exits 0 with no errors in the modified files
- [x] No remaining "DB records" links — `grep -r "DB records" apps/web/src/app/` returns empty
- [x] Pre-existing test failures (wiki-nav completeness tests) confirmed unrelated to this change by running tests on the base branch before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)