### PR TITLE
fix: remove duplicate Technical AI Safety RFP (2025) funding program

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/funding-programs.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-programs.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, sql, desc } from "drizzle-orm";
+import { eq, and, count, sql, desc, inArray } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { fundingPrograms } from "../../schema.js";
+import { fundingPrograms, things } from "../../schema.js";
+import { logger } from "../../logger.js";
 import {
   paginationQuery,
   noDuplicateIds,
@@ -331,6 +332,42 @@ const fundingProgramsApp = new Hono()
     });
 
     return c.json({ upserted });
+  })
+
+  // ---- POST /delete-batch ----
+  // Delete funding programs by ID (for deduplication). Also removes corresponding things.
+  .post("/delete-batch", async (c) => {
+    const raw = await parseJsonBody(c);
+    if (!raw) return invalidJsonError(c);
+
+    const parsed = z.object({
+      ids: z.array(z.string().min(1).max(20)).min(1).max(100),
+    }).safeParse(raw);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { ids } = parsed.data;
+    const db = getDrizzleDb();
+
+    logger.info({ count: ids.length }, "Deleting funding programs batch");
+
+    await db.transaction(async (tx) => {
+      // Delete from things table first (FK-safe)
+      await tx
+        .delete(things)
+        .where(
+          and(
+            eq(things.sourceTable, "funding_programs"),
+            inArray(things.sourceId, ids),
+          ),
+        );
+
+      // Delete the funding programs
+      await tx
+        .delete(fundingPrograms)
+        .where(inArray(fundingPrograms.id, ids));
+    });
+
+    return c.json({ deleted: ids.length });
   });
 
 // ---- Exports ----

--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -795,6 +795,45 @@ function cmdList() {
   }
 }
 
+async function cmdDelete(ids: string[], dryRun: boolean) {
+  if (ids.length === 0) {
+    console.error("No IDs provided. Usage: import-funding-programs delete <id1> [id2 ...]");
+    process.exit(1);
+  }
+
+  console.log(`\nDeleting ${ids.length} funding program(s):`);
+  for (const id of ids) {
+    console.log(`  - ${id}`);
+  }
+
+  if (dryRun) {
+    console.log("  (dry run -- no data deleted)");
+    return;
+  }
+
+  const serverUrl = getServerUrl();
+
+  if (!serverUrl) {
+    throw new Error(
+      "wiki-server URL not configured. Set LONGTERMWIKI_SERVER_URL or use WIKI_SERVER_ENV=prod."
+    );
+  }
+
+  console.log(`  Sending delete request to ${serverUrl}...`);
+
+  const result = await apiRequest<{ deleted: number }>(
+    "POST",
+    "/api/funding-programs/delete-batch",
+    { ids }
+  );
+
+  if (result.ok) {
+    console.log(`Deleted ${result.data.deleted} funding program(s)`);
+  } else {
+    throw new Error(`Funding program delete failed: ${result.message}`);
+  }
+}
+
 async function cmdSync(dryRun: boolean) {
   const items = PROGRAMS.map(toSyncProgram);
   const serverUrl = getServerUrl();
@@ -851,9 +890,21 @@ async function syncCommand(
   return { exitCode: 0 };
 }
 
+async function deleteCommand(
+  args: string[],
+  options: Record<string, unknown>
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun || !!options["dry-run"];
+  // Filter out flag args (--flag or --key=value) — only IDs are positional
+  const ids = args.filter((a) => !a.startsWith("--"));
+  await cmdDelete(ids, dryRun);
+  return { exitCode: 0 };
+}
+
 export const commands = {
   list: listCommand,
   sync: syncCommand,
+  delete: deleteCommand,
   default: listCommand,
 };
 
@@ -865,6 +916,8 @@ Commands:
   list               Show all known funding programs (default)
   sync               Sync programs to wiki-server Postgres
   sync --dry-run     Preview what would be synced without writing
+  delete <id...>     Delete funding programs by ID (for deduplication)
+  delete <id...> --dry-run  Preview deletion without writing
 
 Program Types:
   rfp            Request for proposals


### PR DESCRIPTION
## Summary

- Adds `POST /api/funding-programs/delete-batch` endpoint to wiki-server, following the existing `/api/grants/delete-batch` pattern
- Adds `pnpm crux import-funding-programs delete <id...> [--dry-run]` command for audited deletion of funding program records
- Designed to remove the duplicate `a2NsC7Lk0g` entry that mirrors the canonical `Kb9uB1Zp1E` entry for "Technical AI Safety RFP (2025)"

## Investigation

The duplicate ID `a2NsC7Lk0g` does not appear anywhere in the codebase — it exists only in the production database. The canonical entry `Kb9uB1Zp1E` is deterministically generated from the seed `prog|coefficient-giving|technical-ai-safety-rfp-2025` in `crux/commands/import-funding-programs.ts`. The duplicate was likely created during an earlier import run with a different seed string. Since funding programs are PG-primary (not YAML-backed), the fix requires a DB-level delete.

## Production cleanup required after merge

```bash
WIKI_SERVER_ENV=prod pnpm crux import-funding-programs delete a2NsC7Lk0g
```

Dry-run preview first:
```bash
WIKI_SERVER_ENV=prod pnpm crux import-funding-programs delete a2NsC7Lk0g --dry-run
```

## Test plan

- [x] TypeScript compiles cleanly (`apps/wiki-server/node_modules/.bin/tsc --noEmit -p apps/wiki-server/tsconfig.json`)
- [x] `pnpm crux import-funding-programs --help` shows the new `delete` command
- [x] `pnpm crux import-funding-programs delete a2NsC7Lk0g --dry-run` works without server
- [ ] After merge: run production cleanup and verify `/funding-programs` shows only one "Technical AI Safety RFP (2025)" entry

Closes #2690

🤖 Generated with [Claude Code](https://claude.com/claude-code)