### PR TITLE
refactor: consolidate orphan CLI domains into parent domains

### DIFF
--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -18,6 +18,7 @@ import type { Graph } from '../../packages/factbase/src/graph.ts';
 import type { Entity, Fact, ValidationResult } from '../../packages/factbase/src/types.ts';
 import { commands as kbMigrateCommands } from './factbase-migrate.ts';
 import { verifyCommand } from './factbase-verify.ts';
+import { commands as migrateEntitiesCommands } from './factbase-migrate-entities.ts';
 import { lookupResourceByUrl, upsertResource } from '../lib/wiki-server/resources.ts';
 import { hashId, guessResourceType } from '../resource-utils.ts';
 import { loadGraphFull, loadGraph, resolveEntity, KB_DATA_DIR } from '../lib/factbase-loader.ts';
@@ -1110,6 +1111,9 @@ export const commands = {
   'sync-sources': syncSourcesCommand,
   verify: verifyCommand,
   'add-fact': addFactCommand,
+  // Consolidated from factbase-migrate-entities domain
+  'migrate-entities': migrateEntitiesCommands.run,
+  'migrate-entities-status': migrateEntitiesCommands.status,
 };
 
 export function getHelp(): string {
@@ -1131,6 +1135,8 @@ Commands:
   migrate <slug>        Migrate entity from old system to KB [--dry-run] [--stub-old]
   sync-sources          Sync KB fact source URLs to wiki-server as Resources
   verify                Verify KB facts against source URLs using LLM
+  migrate-entities [--dry-run]  Transform YAML files from thing: to entity: format
+  migrate-entities-status       Show migration status (files in each format)
 
 Options:
   --type=X              Filter list/search/coverage by entity type (e.g. organization, person)

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -18,6 +18,15 @@ import type { CommandOptions as BaseOptions, CommandResult } from '../lib/comman
 import type { TaskType } from '../tablebase/types.ts';
 import { TASK_TYPES, toSlug } from '../tablebase/types.ts';
 
+// Consolidated orphan domain imports
+import { commands as backfillGranteeIdsCommands } from './backfill-grantee-ids.ts';
+import { commands as backfillProgramIdsCommands } from './backfill-program-ids.ts';
+import { commands as backfillStableIdsCommands } from './backfill-stable-ids.ts';
+import { commands as backfillYamlStableIdsCommands } from './backfill-yaml-stable-ids.ts';
+import { commands as importGrantsCommands } from './import-grants.ts';
+import { commands as importDivisionsCommands } from './import-divisions.ts';
+import { commands as importFundingProgramsCommands } from './import-funding-programs.ts';
+
 interface CommandOptions extends BaseOptions {
   top?: string;
   limit?: string;
@@ -953,6 +962,20 @@ export const commands = {
   prepare: prepareCommand,
   'sync-careers': syncCareersCommand,
   default: scanCommand,
+  // Consolidated from backfill-* orphan domains
+  'backfill-grantee-ids': backfillGranteeIdsCommands.default,
+  'backfill-program-ids': backfillProgramIdsCommands.default,
+  'backfill-stable-ids': backfillStableIdsCommands.run,
+  'backfill-yaml-stable-ids': backfillYamlStableIdsCommands.run,
+  // Consolidated from import-* orphan domains
+  'import-grants': importGrantsCommands.default,
+  'import-grants-sync': importGrantsCommands.sync,
+  'import-grants-dedup': importGrantsCommands.dedup,
+  'import-grants-download': importGrantsCommands.download,
+  'import-divisions': importDivisionsCommands.default,
+  'import-divisions-sync': importDivisionsCommands.sync,
+  'import-funding-programs': importFundingProgramsCommands.default,
+  'import-funding-programs-sync': importFundingProgramsCommands.sync,
 };
 
 export function getHelp(): string {
@@ -971,6 +994,22 @@ Commands:
   submit         Submit records to a table (for Claude Code skill)
   existing       Query existing records for an entity (for Claude Code skill)
   sync-careers   Sync FactBase career data to the personnel table
+
+  Backfill (consolidated from backfill-* domains):
+  backfill-grantee-ids [--dry-run]       Link grants to grantee entity stableIds
+  backfill-program-ids [--dry-run]       Link grants to funding programs
+  backfill-stable-ids [--dry-run]        Push KB stableIds to wiki-server entity_ids
+  backfill-yaml-stable-ids [--dry-run]   Insert stableIds into entity YAML files
+
+  Import (consolidated from import-* domains):
+  import-grants               Analyze grant import stats (default)
+  import-grants-sync          Import grants to wiki-server
+  import-grants-dedup         Remove cross-source duplicates
+  import-grants-download      Download grant data files
+  import-divisions            List known organizational divisions (default)
+  import-divisions-sync       Sync divisions to wiki-server
+  import-funding-programs     List known funding programs (default)
+  import-funding-programs-sync  Sync programs to wiki-server
 
 Options:
   --table=<name>            Filter scan to specific table; required for submit/existing

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -42,11 +42,7 @@
  *   ids         Entity ID allocation and lookup (allocate, check, list)
  *   audits      System-level behavioral verification (ongoing + post-merge)
  *   release     Production release management (create release PRs from main → production)
- *   import-grants Import external grant databases (Coefficient Giving, EA Funds)
- *   backfill-grantee-ids Backfill granteeId with matched entity stableIds
- *   backfill-program-ids Backfill programId linking grants to funding programs
- *   import-divisions Import curated organizational divisions
- *   import-funding-programs Import curated funding programs
+ *   tablebase     Structured data enrichment via LLM agents (scan, gaps, improve, loop, backfill-*, import-*)
  *   people       Person discovery and data tools (discover, create, link-resources, enrich)
  *   orgs         Organization data tools (enrich from Wikidata)
  *   research-areas Research area linking (link-grants, backfill-papers, discover-orgs, stats)
@@ -161,6 +157,7 @@ const domains = {
   release: releaseCommands,
   'pr-patrol': prPatrolCommands,
   factbase: factbaseCommands,
+  fb: factbaseCommands, // short alias
   kb: factbaseCommands, // deprecated alias
   footnotes: footnotesCommands,
   'agent-workspace': agentWorkspaceCommands,
@@ -179,6 +176,7 @@ const domains = {
   'qa-sweep': qaSweepCommands,
   matrix: matrixCommands,
   tablebase: tablebaseCommands,
+  tb: tablebaseCommands, // short alias
   pages: pagesCommands,
 };
 
@@ -266,17 +264,12 @@ ${'\x1b[1m'}Domains:${'\x1b[0m'}
   kb          Knowledge base readability tools (show, list, lookup)
   footnotes        Footnote migration tools (migrate-cr)
   agent-workspace  Multi-agent directory management (setup, sync-env, list, clean)
-  import-grants    Import external grant databases (Coefficient Giving, EA Funds)
-  backfill-grantee-ids  Backfill granteeId with matched entity stableIds
-  backfill-program-ids  Backfill programId linking grants to funding programs
-  import-divisions Import curated organizational divisions
-  import-funding-programs Import curated funding programs
   people           Person discovery and data tools (discover, create, link-resources, enrich)
   orgs             Organization data tools (enrich from Wikidata)
   research-areas   Research area linking (link-grants, backfill-papers, discover-orgs, stats)
   verify           Verify structured data records against source URLs (grants, personnel, etc.)
   matrix           Entity matrix analysis and improvement targeting
-  tablebase        Structured data enrichment via LLM agents (scan, gaps, improve, loop)
+  tablebase        Structured data enrichment (scan, gaps, improve, backfill-*, import-*)
   pages            Page prioritization (next-action: NBA scoring for editorial attention)
 
 ${'\x1b[1m'}Global Options:${'\x1b[0m'}


### PR DESCRIPTION
## Summary

- Backfill commands (`backfill-grantee-ids`, `backfill-program-ids`, `backfill-stable-ids`, `backfill-yaml-stable-ids`) are now accessible as subcommands of the `tablebase` domain
- Import commands (`import-grants`, `import-divisions`, `import-funding-programs`) are now accessible as subcommands of the `tablebase` domain
- `factbase-migrate-entities` commands (`run`, `status`) are now accessible as subcommands of the `factbase` domain
- Added `fb` and `tb` short aliases for `factbase` and `tablebase`
- Old flat syntax (e.g., `crux backfill-grantee-ids`) is preserved via original domain entries in `crux.mjs`
- Orphan entries removed from help output to reduce clutter

## Test plan

- [x] `crux tb backfill-grantee-ids --help` shows tablebase help
- [x] `crux fb migrate-entities-status` runs the status command correctly
- [x] `crux tb backfill-yaml-stable-ids --dry-run` runs the backfill preview
- [x] `crux backfill-grantee-ids --help` still works (old flat syntax)
- [x] `crux factbase-migrate-entities --help` still works (old flat syntax)
- [x] `crux tb --help` lists the new consolidated commands
- [x] `crux fb --help` lists the new migrate-entities commands
- [x] Crux test suite passes (155/156 files, 3337/3338 tests — 1 pre-existing timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)