### PR TITLE
fix: add Date column to events directory and remove empty Params column from AI Models

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -41,8 +41,7 @@ type SortKey =
   | "safetyLevel"
   | "sweBench"
   | "mmlu"
-  | "gpqa"
-  | "params";
+  | "gpqa";
 
 const PAGE_SIZE = 50;
 
@@ -132,8 +131,6 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
           return row.mmluScore;
         case "gpqa":
           return row.gpqaScore;
-        case "params":
-          return row.parameterCount ? parseParamCount(row.parameterCount) : null;
       }
     };
     result = [...result].sort((a, b) =>
@@ -271,7 +268,6 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
               <SortHeader label="Model" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Developer" sortKey="developer" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Released" sortKey="releaseDate" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
-              <SortHeader label="Params" sortKey="params" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Input $/MTok" sortKey="inputPrice" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Output $/MTok" sortKey="outputPrice" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Context" sortKey="contextWindow" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
@@ -322,11 +318,6 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* Release Date */}
                 <td className="py-2.5 px-3 text-muted-foreground whitespace-nowrap">
                   {row.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
-                </td>
-
-                {/* Parameter Count */}
-                <td className="py-2.5 px-3 text-right tabular-nums text-muted-foreground">
-                  {row.parameterCount ?? <span className="text-muted-foreground/40">&mdash;</span>}
                 </td>
 
                 {/* Input Price */}
@@ -399,7 +390,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
             ))}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={11} className="text-center py-12 text-muted-foreground">
+                <td colSpan={10} className="text-center py-12 text-muted-foreground">
                   No models match your search.
                 </td>
               </tr>
@@ -422,12 +413,3 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
   );
 }
 
-/** Parse a parameter count string like "70B" or "1.8T" to a numeric value for sorting. */
-function parseParamCount(s: string): number {
-  const match = s.match(/^([\d.]+)\s*([KMBT])?$/i);
-  if (!match) return 0;
-  const num = parseFloat(match[1]);
-  const suffix = (match[2] ?? "").toUpperCase();
-  const multipliers: Record<string, number> = { K: 1e3, M: 1e6, B: 1e9, T: 1e12 };
-  return num * (multipliers[suffix] ?? 1);
-}

--- a/apps/web/src/app/events/events-table.tsx
+++ b/apps/web/src/app/events/events-table.tsx
@@ -9,17 +9,18 @@ export interface EventRow {
   title: string;
   description: string | null;
   status: string | null;
+  date: string | null;
   tags: string[];
   wikiId: string | null;
 }
 
-type SortKey = "title" | "status";
+type SortKey = "title" | "status" | "date";
 type SortDir = "asc" | "desc";
 
 export function EventsTable({ rows }: { rows: EventRow[] }) {
   const [search, setSearch] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("title");
-  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -51,6 +52,8 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
           return a.title.localeCompare(b.title) * dir;
         case "status":
           return (a.status ?? "").localeCompare(b.status ?? "") * dir;
+        case "date":
+          return (a.date ?? "").localeCompare(b.date ?? "") * dir;
       }
     });
 
@@ -87,6 +90,14 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                 className="text-left"
               />
               <SortHeader
+                label="Date"
+                sortKey="date"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+                className="text-left"
+              />
+              <SortHeader
                 label="Status"
                 sortKey="status"
                 currentSort={sortKey}
@@ -112,6 +123,10 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                   >
                     {row.title}
                   </Link>
+                </td>
+
+                <td className="py-2.5 px-3 whitespace-nowrap text-muted-foreground text-xs">
+                  {row.date ?? <span className="text-muted-foreground/40">&mdash;</span>}
                 </td>
 
                 <td className="py-2.5 px-3 whitespace-nowrap">

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -21,6 +21,7 @@ export default function EventsPage() {
       title: e.title,
       description: e.description ?? null,
       status: statusField?.value ?? null,
+      date: e.lastUpdated ?? null,
       tags: e.tags ?? [],
       wikiId: e.wikiId ?? null,
     };


### PR DESCRIPTION
## Summary

- **Events directory**: Added a Date column showing `lastUpdated` for each event. Default sort is now by date descending (most recent first), which is the most natural browsing order for events. The `EventRow` interface was extended with a `date: string | null` field.
- **AI Models directory**: Removed the Params column which showed "—" for all 45 models (0% fill rate). Also removed the now-unused `parseParamCount` helper function. Column span in the empty-state row updated from 11 to 10.

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Test suite passes (pre-existing failures on main are unrelated to these changes)
- [x] Events table renders a sortable Date column using `lastUpdated`
- [x] AI Models table no longer shows the Params column

🤖 Generated with [Claude Code](https://claude.com/claude-code)