### PR TITLE
fix: update OpenAI user count timeseries and Jan Leike title

### DIFF
--- a/content/docs/knowledge-base/people/jan-leike.mdx
+++ b/content/docs/knowledge-base/people/jan-leike.mdx
@@ -1,13 +1,13 @@
 ---
 wikiId: E182
 title: Jan Leike
-description: Head of Alignment Science at Anthropic, formerly co-led OpenAI's Superalignment team
+description: VP of Alignment Science at Anthropic, formerly co-led OpenAI's Superalignment team
 sidebar:
   order: 4
 subcategory: safety-researchers
-lastEdited: 2026-02-23
+lastEdited: 2026-03-19
 update_frequency: 21
-summary: Biography of Jan Leike covering his career from Australian National University through DeepMind, OpenAI's Superalignment team, to his current role as head of the Alignment Science team at Anthropic. Documents his research on RLHF and scalable oversight, his May 2024 departure from OpenAI, and his current research priorities including weak-to-strong generalization and automated alignment techniques.
+summary: Biography of Jan Leike covering his career from Australian National University through DeepMind, OpenAI's Superalignment team, to his current role as VP of Alignment Science at Anthropic. Documents his research on RLHF and scalable oversight, his May 2024 departure from OpenAI, and his current research priorities including weak-to-strong generalization and automated alignment techniques.
 clusters:
   - ai-safety
 ---
@@ -19,7 +19,7 @@ import {DataInfoBox, EntityLink} from '@components/wiki';
 
 | Dimension | Assessment |
 |-----------|------------|
-| **Primary Role** | Head of Alignment Science at <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> (2024–present) |
+| **Primary Role** | VP of Alignment Science at <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> (2024–present) |
 | **Key Contributions** | Co-authored early <EntityLink id="E259" name="rlhf">RLHF</EntityLink> research; led the Agent Alignment Team at <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink>; co-led <EntityLink id="E218" name="openai">OpenAI</EntityLink>'s Superalignment team; developed <EntityLink id="E600" name="reward-modeling">Reward Modeling</EntityLink> frameworks |
 | **Key Publications** | "Deep Reinforcement Learning from Human Preferences" (NeurIPS 2017); "Scalable agent alignment via reward modeling" (arXiv 2018); "AI Safety Gridworlds" (arXiv 2017); "Recursively Summarizing Books with Human Feedback" (arXiv 2021) |
 | **Career Trajectory** | PhD, Australian National University (2016) → FHI postdoc (2016) → Senior Research Scientist, <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink> (2016–2021) → Head of Alignment / Superalignment co-lead, <EntityLink id="E218" name="openai">OpenAI</EntityLink> (January 2021 – May 2024) → Anthropic (2024–present) |

--- a/packages/factbase/data/things/openai.yaml
+++ b/packages/factbase/data/things/openai.yaml
@@ -84,6 +84,13 @@ facts:
     notes: "ChatGPT reached 100M monthly active users within 2 months of launch;
       fastest-growing consumer application in history at that time"
 
+  - id: f_br0wYi0tog
+    property: user-count
+    value: 4e+8
+    asOf: 2025-02
+    source: https://openai.com/index/400-million-users/
+    notes: "ChatGPT weekly active users as of February 2025; reported by OpenAI CEO Sam Altman"
+
   - id: f_o1tcwe2T0w
     property: headcount
     value: 3500


### PR DESCRIPTION
## Summary

- **OpenAI user count**: Added a new `user-count` fact entry in `packages/factbase/data/things/openai.yaml` for 400M weekly active users as of February 2025, sourced from Sam Altman's official announcement. The previous entry (100M MAU, Feb 2023) is preserved as a historical data point in the timeseries.

- **Jan Leike title**: Corrected "Head of Alignment Science" to "VP of Alignment Science" in `content/docs/knowledge-base/people/jan-leike.mdx` (frontmatter description, Quick Assessment table, and summary field). The factbase (`packages/factbase/data/things/jan-leike.yaml`) and `data/entities/people.yaml` already had the correct VP title — this fixes the MDX page to match.

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` passes clean (all 4 content checks)
- [x] `pnpm build-data:content` succeeds with 0 broken EntityLinks
- [x] Fact ID `f_br0wYi0tog` is unique — no collision with existing IDs in openai.yaml
- [x] Source URL for new user count fact is the official OpenAI announcement page

🤖 Generated with [Claude Code](https://claude.com/claude-code)