### PR TITLE
fix: populate Will MacAskill profile with structured data

### DIFF
--- a/data/experts.yaml
+++ b/data/experts.yaml
@@ -839,8 +839,40 @@
 
 - id: will-macaskill
   name: Will MacAskill
-  affiliation: university-of-oxford
-  role: Associate Professor of Philosophy
+  affiliation: forethought
+  role: Senior Research Fellow
+  website: https://www.forethought.org/people/william-macaskill
+  knownFor:
+    - Effective altruism (co-founder)
+    - Longtermism
+    - Moral uncertainty
+    - What We Owe the Future (2022)
+    - Giving What We Can (co-founder)
+    - 80,000 Hours (co-founder)
+  positions:
+    - topic: timelines
+      view: Short
+      estimate: Years to decade
+      confidence: medium
+      date: "2025"
+      source: Preparing for the Intelligence Explosion (2025)
+      sourceUrl: https://www.forethought.org/research/preparing-for-the-intelligence-explosion
+    - topic: p-doom
+      view: Significant
+      estimate: Non-trivial
+      confidence: low
+      date: "2022"
+      source: What We Owe the Future (2022)
+    - topic: how-hard-is-alignment
+      view: Hard but tractable
+      confidence: medium
+      date: "2025"
+      source: Preparing for the Intelligence Explosion (2025)
+    - topic: power-concentration-risk
+      view: One of the most critical risks from AGI transition
+      confidence: high
+      date: "2025"
+      source: Preparing for the Intelligence Explosion (2025)
 
 - id: joe-biden
   name: Joe Biden

--- a/packages/factbase/data/things/will-macaskill.yaml
+++ b/packages/factbase/data/things/will-macaskill.yaml
@@ -2,28 +2,57 @@ entity: p1P9oQwB6w
 facts:
   - id: f_ai1K4HXqHA
     property: description
-    value: Will MacAskill is an Associate Professor of Philosophy at Oxford University and a central figure in the effective
-      altruism (EA) movement. In 2009, he co-founded Giving What We Can with Toby Ord, an organization that encourages
-      members to pledge 10% of their income to highly effective charities. He also co-founded the Centre for Effective
-      Altruism. His 2015 book "Doing Good Better" popularized EA principles to a mainstream audience. His 2022 book
-      "What We Owe the Future" made the case for longtermism—the view that we should give significant weight to the
-      wellbeing of future generations— and brought widespread attention to existential risk and AI safety. He coined the
-      term "effective altruism" and has been instrumental in directing billions of dollars toward high-impact causes
-      including global health, animal welfare, and existential risk reduction.
+    value: >-
+      Will MacAskill is a Scottish moral philosopher and a central figure in the effective altruism (EA) movement.
+      In 2009, he co-founded Giving What We Can with Toby Ord, encouraging members to pledge 10% of their income to
+      highly effective charities. He also co-founded the Centre for Effective Altruism and 80,000 Hours in 2011.
+      His 2015 book "Doing Good Better" popularized EA principles, and his 2022 book "What We Owe the Future" made
+      the case for longtermism—the view that we should give significant weight to future generations—bringing
+      widespread attention to existential risk and AI safety. He left his Associate Professor position at Oxford in
+      2024 to become Senior Research Fellow at Forethought, focusing on AGI preparedness, space governance, and AI rights.
     asOf: 2026-03
-    notes: Migrated from old entity system
+    notes: Updated to reflect current role at Forethought (left Oxford 2024)
+
   - id: f_zFKfTWKs8w
     property: website
     value: https://www.willmacaskill.com/
 
   - id: f_wM1rKz8mXq
     property: role
-    value: "Associate Professor of Philosophy at Oxford, co-founder of effective altruism movement"
-    asOf: "2026-03"
-    notes: "Migrated from entity customFields"
+    value: "Senior Research Fellow, Forethought"
+    asOf: "2024-01"
+    source: https://www.forethought.org/people/william-macaskill
+    notes: "Left Oxford Associate Professor position in 2024; now at Forethought"
 
   - id: f_wM2nLw9pYr
     property: notable-for
-    value: "Effective altruism, longtermism, \"What We Owe the Future\", Giving What We Can"
+    value: "Co-founder of effective altruism movement; longtermism; \"What We Owe the Future\" (2022); Giving What We Can; 80,000 Hours"
     asOf: "2026-03"
-    notes: "Migrated from entity customFields"
+
+  - id: f_wM3eBy7xZt
+    property: employed-by
+    value: "Forethought"
+    asOf: "2024-01"
+    source: https://www.forethought.org/people/william-macaskill
+    notes: "Senior Research Fellow at Forethought since 2024; previously Associate Professor at University of Oxford"
+
+  - id: f_wM4bY1987x
+    property: born-year
+    value: 1987
+    source: https://en.wikipedia.org/wiki/William_MacAskill
+    notes: "Born 24 March 1987 in Glasgow, Scotland"
+
+  - id: f_wM5eD2014o
+    property: education
+    value: "DPhil in Philosophy, St. Anne's College, Oxford (2014); BA, Cambridge; studied at Princeton"
+    source: https://en.wikipedia.org/wiki/William_MacAskill
+    notes: "Youngest person appointed as Associate Professor of Philosophy at time of appointment"
+
+  - id: f_wM6sM0twit
+    property: social-media
+    value: "@willmacaskill"
+    source: https://x.com/willmacaskill
+
+  - id: f_wM7wK1wiki
+    property: wikipedia-url
+    value: "https://en.wikipedia.org/wiki/William_MacAskill"


### PR DESCRIPTION
## Summary

- Updates `packages/factbase/data/things/will-macaskill.yaml` with 7 new FactBase facts: corrected role (Senior Research Fellow at Forethought, not Associate Professor), `employed-by`, `born-year` (1987), `education`, `social-media`, `wikipedia-url`, and updated `notable-for` and `description`
- Updates `data/experts.yaml` entry for will-macaskill: corrects affiliation to `forethought`, updates role, adds `knownFor` list (6 items), and adds 4 `positions` entries covering timelines, p-doom, alignment difficulty, and power-concentration risk

## What this fixes

The `/people/will-macaskill` profile was nearly empty — only showing "Current Role: Associate Professor" (outdated since 2024) with no Organization stat card, no notable-for description, no born year, no education, no social links, and no expert positions tab.

After this change:
- Stat cards show: "Senior Research Fellow" + "Forethought" + Born "1987"
- Notable-for tagline appears under his name
- Expert Positions tab shows 4 positions
- Social links sidebar shows Twitter/X handle and Wikipedia link
- Education section populated

## Test plan

- Gate check passes (`pnpm crux validate gate --scope=content --fix`)
- Pre-existing test/factbase validation failures confirmed on main branch (not introduced by this PR)
- Verify `/people/will-macaskill` renders correctly after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)