### PR TITLE
fix: strip MDX escape sequences in plain-text rendering contexts

### DIFF
--- a/apps/web/src/app/wiki/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/wiki/[id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { getTypedEntityById, getPageById } from "@/data";
 import { wikiIdToSlug } from "@/lib/mdx";
+import { stripMdxEscapes } from "@/lib/inline-markdown";
 
 export const runtime = "nodejs";
 export const alt = "Longterm Wiki";
@@ -24,7 +25,8 @@ export default async function OgImage({ params }: { params: Promise<{ id: string
   const entity = slug ? getTypedEntityById(slug) : null;
   const pageData = slug ? getPageById(slug) : null;
   const title = entity?.title || pageData?.title || slug || id;
-  const description = entity?.description || pageData?.description || null;
+  const rawDescription = entity?.description || pageData?.description || null;
+  const description = rawDescription ? stripMdxEscapes(rawDescription) : null;
 
   return new ImageResponse(
     (

--- a/apps/web/src/components/RelatedPages.tsx
+++ b/apps/web/src/components/RelatedPages.tsx
@@ -5,6 +5,7 @@ import { getEntityTypeIcon } from "./wiki/EntityTypeIcon";
 import { getTypeLabel, getTypeColor } from "./explore/explore-utils";
 import { EntityLink } from "./wiki/EntityLink";
 import { cn } from "@lib/utils";
+import { stripMdxEscapes } from "@lib/inline-markdown";
 
 // Map entity types to display group names
 const TYPE_TO_GROUP: Record<string, string> = {
@@ -198,7 +199,7 @@ export async function RelatedPages({
         type: entry.type,
         score: entry.score,
         label: entry.label,
-        description: desc ? truncate(desc, 150) : undefined,
+        description: desc ? truncate(stripMdxEscapes(desc), 150) : undefined,
       };
     });
 

--- a/apps/web/src/components/SearchDialog.tsx
+++ b/apps/web/src/components/SearchDialog.tsx
@@ -8,6 +8,7 @@ import {
   type MatchInfo,
 } from "@lib/search";
 import { ENTITY_TYPES, ENTITY_GROUPS } from "@data/entity-ontology";
+import { stripMdxEscapes } from "@lib/inline-markdown";
 
 // ---------------------------------------------------------------------------
 // Sort types
@@ -385,7 +386,8 @@ export function SearchDialog() {
  * when available, falling back to client-side term highlighting.
  */
 function HighlightedSnippet({ result }: { result: SearchResult }) {
-  const { description, match, terms, snippet } = result;
+  const { description: rawDescription, match, terms, snippet } = result;
+  const description = rawDescription ? stripMdxEscapes(rawDescription) : rawDescription;
 
   // Prefer server-generated snippet with <mark> tags from ts_headline()
   if (snippet && snippet.includes("<mark>")) {

--- a/apps/web/src/components/wiki/EntityLink.tsx
+++ b/apps/web/src/components/wiki/EntityLink.tsx
@@ -4,6 +4,7 @@ import { getTypedEntityById, getEntityHref, getPageById, getDirectoryHref } from
 import { getEntityTypeIcon } from "./EntityTypeIcon";
 import { cn } from "@lib/utils";
 import styles from "./tooltip.module.css";
+import { stripMdxEscapes } from "@lib/inline-markdown";
 
 interface EntityLinkProps {
   id: string;
@@ -112,7 +113,7 @@ export function EntityLink({
           </span>
           {summary && (
             <span className="block text-muted-foreground text-[0.8rem] leading-snug">
-              {truncateText(summary, 200)}
+              {truncateText(stripMdxEscapes(summary), 200)}
             </span>
           )}
           {page?.quality && (

--- a/apps/web/src/components/wiki/InfoBoxDescription.tsx
+++ b/apps/web/src/components/wiki/InfoBoxDescription.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { stripMdxEscapes } from "@lib/inline-markdown";
 
 interface InfoBoxDescriptionProps {
   description: string;
@@ -45,7 +46,7 @@ export function InfoBoxDescription({ description }: InfoBoxDescriptionProps) {
         ref={textRef}
         className={`text-xs text-muted-foreground leading-relaxed m-0 ${expanded ? "" : "line-clamp-3"}`}
       >
-        {description}
+        {stripMdxEscapes(description)}
       </p>
       {(isClamped || expanded) && (
         <button

--- a/apps/web/src/data/explore.ts
+++ b/apps/web/src/data/explore.ts
@@ -7,6 +7,7 @@ import type { ContentFormat, RawEntity, AnyEntity } from "./tablebase";
 import { getEntityHref } from "./entity-nav";
 import { getKB } from "./factbase";
 import type { SerializedKB } from "@longterm-wiki/factbase";
+import { stripMdxEscapes } from "@/lib/inline-markdown";
 
 export interface ExploreItem {
   id: string;
@@ -129,12 +130,13 @@ export function getExploreItems(): ExploreItem[] {
     const pageId = entityPageIdMap.get(entity.id)!;
     const page = pageMap.get(pageId)!;
     const kbCounts = getKBCounts(entity.id, kb);
+    const rawDesc = page?.summary || page?.description || entity.description || null;
     return {
       id: entity.id,
       wikiId: (entity.wikiId || db.idRegistry?.bySlug[pageId])!,
       title: entity.title,
       type: page?.contentFormat === "table" ? "table" : page?.contentFormat === "diagram" ? "diagram" : entity.entityType,
-      description: page?.summary || page?.description || entity.description || null,
+      description: rawDesc ? stripMdxEscapes(rawDesc) : null,
       tags: entity.tags || [],
       clusters: entity.clusters?.length ? entity.clusters : (page?.clusters || []),
       wordCount: page?.wordCount ?? null,
@@ -161,12 +163,13 @@ export function getExploreItems(): ExploreItem[] {
     .filter((p) => db.idRegistry?.bySlug[p.id])
     .map((page) => {
       const kbCounts = getKBCounts(page.id, kb);
+      const rawPageDesc = page.summary || page.description || null;
       return {
         id: page.id,
         wikiId: db.idRegistry!.bySlug[page.id],
         title: page.title,
         type: page.contentFormat === "table" ? "table" : page.contentFormat === "diagram" ? "diagram" : CATEGORY_TO_TYPE[page.category] || "concept",
-        description: page.summary || page.description || null,
+        description: rawPageDesc ? stripMdxEscapes(rawPageDesc) : null,
         tags: page.tags || [],
         clusters: page.clusters || [],
         wordCount: page.wordCount ?? null,

--- a/apps/web/src/lib/inline-markdown.tsx
+++ b/apps/web/src/lib/inline-markdown.tsx
@@ -1,5 +1,10 @@
 import React from "react";
 
+/** Strip MDX escape sequences for plain-text rendering contexts */
+export function stripMdxEscapes(text: string): string {
+  return text.replace(/\\([\$<>\{\}])/g, "$1");
+}
+
 /**
  * Render basic inline markdown: **bold**, *italic*, `code`, and
  * `<EntityLink id="...">text</EntityLink>` tags as styled spans.


### PR DESCRIPTION
## Summary

- Adds `stripMdxEscapes(text: string): string` utility to `apps/web/src/lib/inline-markdown.tsx` that strips MDX escape sequences (`\$`, `\<`, `\>`, `\{`, `\}`) for plain-text rendering contexts
- Applies the utility in 6 components where `summary`/`description` fields from `pages.json` are rendered as plain React text (not through the MDX compiler), fixing visible `\$` backslashes on 194+ affected pages

## Components fixed

1. **EntityLink.tsx** — hover tooltip summary text
2. **InfoBoxDescription.tsx** — InfoBox description panel
3. **RelatedPages.tsx** — featured card descriptions in the related pages section
4. **opengraph-image.tsx** — Open Graph social preview description
5. **SearchDialog.tsx** — search result snippet descriptions
6. **explore.ts** — description field for all ExploreItems (affects explore grid, content cards)

## Root cause

MDX source files use escape sequences like `\$100M` to prevent `$` from being interpreted as JSX expressions. The MDX compiler strips these backslashes correctly. But `summary` and `description` fields in `pages.json` are derived from MDX frontmatter and page content — they preserve the raw MDX escapes. When these strings are rendered as plain React text (not through MDX), the backslash shows literally.

## Test plan

- [x] `npx tsc --noEmit` passes with no new errors in `apps/web/`
- [x] All 3338 existing tests pass (`pnpm test`)
- [ ] Visual: hover an EntityLink for an entity whose page has `\$` in summary — verify no backslash shown
- [ ] Visual: check search results for pages with dollar amounts — verify clean rendering
- [ ] Visual: OG image for affected pages renders clean description

🤖 Generated with [Claude Code](https://claude.com/claude-code)