### PR TITLE
fix: correct Coefficient Giving founding date and clarify MIRI funding label

### DIFF
--- a/packages/factbase/data/things/coefficient-giving.yaml
+++ b/packages/factbase/data/things/coefficient-giving.yaml
@@ -76,9 +76,9 @@ facts:
     notes: "150+ staff after rebrand to Coefficient Giving (November 2025)"
   - id: 6cG2oupsZg
     property: founded-date
-    value: 2017-06
+    value: "2014"
     source: https://www.wikidata.org/wiki/Q25345685
-    notes: From Wikidata Q25345685
+    notes: "Grantmaking began 2014 as Open Philanthropy Project within GiveWell; independent LLC June 2017; rebranded from Open Philanthropy to Coefficient Giving November 2025"
   - id: Dyf2V67PFg
     property: headquarters
     value: San Francisco

--- a/packages/factbase/data/things/miri.yaml
+++ b/packages/factbase/data/things/miri.yaml
@@ -37,7 +37,7 @@ facts:
     property: total-funding
     value: 1.5e+7
     asOf: "2025"
-    notes: "Estimated cumulative SFF grants to MIRI; lower bound"
+    notes: "Estimated total from SFF grants only; actual total funding raised (including Open Philanthropy, individual donors, crypto donations) is significantly higher. SFF grants are the largest trackable component."
 
   - id: f_DgTzpJumMg
     property: revenue


### PR DESCRIPTION
## Summary

- **Coefficient Giving founding date**: Changed `founded-date` from `2017-06` (LLC incorporation date) to `2014` (when grantmaking began as the Open Philanthropy Project within GiveWell). The old date created a data paradox — grants from 2015 and 2016 predated the org's recorded founding. Updated notes capture the full org history: started 2014, independent LLC June 2017, rebranded to Coefficient Giving November 2025.

- **MIRI total-funding label**: The `total-funding` fact ($15M) previously only noted "Estimated cumulative SFF grants to MIRI; lower bound" — but the property displays as "Total Funding Raised" on the org page, which is misleading. MIRI has received significant funding from Open Philanthropy, individual donors, and crypto donations. Updated notes now make explicit that the figure covers SFF grants only and that actual total is significantly higher.

## Files changed

- `packages/factbase/data/things/coefficient-giving.yaml` — fact id `6cG2oupsZg`
- `packages/factbase/data/things/miri.yaml` — fact id `f_L3HohIdUBA`

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` passes (all 4 checks green)
- [x] Coefficient Giving founded-date changed from `2017-06` to `"2014"` with full org-history notes
- [x] MIRI total-funding notes updated to clarify SFF-only scope and note higher actual total

🤖 Generated with [Claude Code](https://claude.com/claude-code)