### PR TITLE
refactor: remove deprecated mark-accuracy-batch citations route

### DIFF
--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -1005,45 +1005,6 @@ describe("Citation Server API", () => {
     });
   });
 
-  // ---- Mark Accuracy Batch ----
-
-  describe("POST /api/citations/quotes/mark-accuracy-batch", () => {
-    it("marks accuracy for multiple citations", async () => {
-      await upsertQuote(app, "batch-acc", 1);
-      await upsertQuote(app, "batch-acc", 2);
-      await upsertQuote(app, "batch-acc", 3);
-
-      const res = await postJson(app, "/api/citations/quotes/mark-accuracy-batch", {
-        items: [
-          { pageId: "batch-acc", footnote: 1, verdict: "accurate", score: 0.95 },
-          { pageId: "batch-acc", footnote: 2, verdict: "inaccurate", score: 0.3, issues: "Wrong number" },
-          { pageId: "batch-acc", footnote: 3, verdict: "minor_issues", score: 0.7, verificationDifficulty: "easy" },
-        ],
-      });
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body.updated).toBe(3);
-      expect(body.results).toHaveLength(3);
-      expect(body.results[1].verdict).toBe("inaccurate");
-    });
-
-    it("rejects invalid verdict in batch", async () => {
-      const res = await postJson(app, "/api/citations/quotes/mark-accuracy-batch", {
-        items: [
-          { pageId: "batch-acc", footnote: 1, verdict: "maybe", score: 0.5 },
-        ],
-      });
-      expect(res.status).toBe(400);
-    });
-
-    it("rejects empty batch", async () => {
-      const res = await postJson(app, "/api/citations/quotes/mark-accuracy-batch", {
-        items: [],
-      });
-      expect(res.status).toBe(400);
-    });
-  });
-
   // ---- Accuracy Snapshot ----
 
   describe("POST /api/citations/accuracy-snapshot", () => {

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -147,10 +147,6 @@ export const MarkAccuracySchema = z.object({
 });
 export type MarkAccuracy = z.infer<typeof MarkAccuracySchema>;
 
-export const MarkAccuracyBatchSchema = z.object({
-  items: z.array(MarkAccuracySchema).min(1).max(100),
-});
-
 export interface AccuracyDashboardData {
   exportedAt: string;
   summary: {

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -16,7 +16,6 @@ import {
   UpsertCitationQuoteSchema,
   UpsertCitationQuoteBatchSchema,
   MarkAccuracySchema as SharedMarkAccuracySchema,
-  MarkAccuracyBatchSchema as SharedMarkAccuracyBatchSchema,
   UpsertCitationContentSchema,
   CITATION_CONTENT_PREVIEW_MAX,
 } from "../../api-types.js";
@@ -50,7 +49,6 @@ const MarkVerifiedSchema = z.object({
 });
 
 const MarkAccuracySchema = SharedMarkAccuracySchema;
-const MarkAccuracyBatchSchema = SharedMarkAccuracyBatchSchema;
 
 const UpsertContentSchema = UpsertCitationContentSchema;
 
@@ -604,55 +602,6 @@ const citationsApp = new Hono()
       });
 
     return c.json({ url: d.url });
-  })
-
-  // ---- POST /quotes/mark-accuracy-batch ---- [DEPRECATED: batch update claims.claimVerdict instead]
-  .post("/quotes/mark-accuracy-batch", zv("json", MarkAccuracyBatchSchema), async (c) => {
-    deprecationWarning("POST /quotes/mark-accuracy-batch");
-    const { items } = c.req.valid("json");
-    const db = getDrizzleDb();
-    // Phase 4b: resolve all page slugs to integer IDs upfront
-    const uniquePageIds = [...new Set(items.map((d) => d.pageId))];
-    const intIdMap = await resolvePageIntIds(db, uniquePageIds);
-    const results: Array<{ pageId: string; footnote: number; verdict: string }> = [];
-
-    try {
-      await db.transaction(async (tx) => {
-        for (const d of items) {
-          const intId = intIdMap.get(d.pageId);
-          if (intId == null) continue; // page absent from entity_ids, row cannot exist
-          const rows = await tx
-            .update(citationQuotes)
-            .set({
-              accuracyVerdict: d.verdict,
-              accuracyScore: d.score,
-              accuracyIssues: d.issues ?? null,
-              accuracySupportingQuotes: d.supportingQuotes ?? null,
-              verificationDifficulty: d.verificationDifficulty ?? null,
-              accuracyCheckedAt: sql`now()`,
-              updatedAt: sql`now()`,
-            })
-            .where(
-              and(
-                eq(citationQuotes.pageIdInt, intId),
-                eq(citationQuotes.footnote, d.footnote)
-              )
-            )
-            .returning({
-              pageId: citationQuotes.pageId,
-              footnote: citationQuotes.footnote,
-            });
-
-          if (rows.length > 0) {
-            results.push({ pageId: rows[0].pageId, footnote: rows[0].footnote, verdict: d.verdict });
-          }
-        }
-      });
-    } catch (err) {
-      return dbError(c, "citation quotes mark-accuracy-batch", err, { itemCount: items.length });
-    }
-
-    return c.json({ updated: results.length, results });
   })
 
   // ---- POST /accuracy-snapshot ----

--- a/crux/lib/wiki-server/backward-compat.test.ts
+++ b/crux/lib/wiki-server/backward-compat.test.ts
@@ -46,7 +46,6 @@ describe('wiki-server-client barrel exports', () => {
     expect(typeof client.upsertCitationQuote).toBe('function');
     expect(typeof client.upsertCitationQuoteBatch).toBe('function');
     expect(typeof client.markCitationAccuracy).toBe('function');
-    expect(typeof client.markCitationAccuracyBatch).toBe('function');
     expect(typeof client.createAccuracySnapshot).toBe('function');
     expect(typeof client.getAccuracyDashboard).toBe('function');
   });

--- a/crux/lib/wiki-server/citations.ts
+++ b/crux/lib/wiki-server/citations.ts
@@ -24,7 +24,6 @@ type RpcClient = ReturnType<typeof hc<CitationsRoute>>;
 type UpsertCitationQuoteResult = InferResponseType<RpcClient['quotes']['upsert']['$post'], 200>;
 type UpsertCitationQuoteBatchResult = InferResponseType<RpcClient['quotes']['upsert-batch']['$post'], 200>;
 type MarkAccuracyResult = InferResponseType<RpcClient['quotes']['mark-accuracy']['$post'], 200>;
-type MarkAccuracyBatchResult = InferResponseType<RpcClient['quotes']['mark-accuracy-batch']['$post'], 200>;
 type SnapshotResult = InferResponseType<RpcClient['accuracy-snapshot']['$post'], 201>;
 type AccuracyDashboardData = InferResponseType<RpcClient['accuracy-dashboard']['$get'], 200>;
 type CitationHealthResult = InferResponseType<RpcClient['health'][':pageId']['$get'], 200>;
@@ -85,7 +84,7 @@ export type MarkAccuracyItem = MarkAccuracy;
 // Citation Accuracy Types — response (re-exported for consumers)
 // ---------------------------------------------------------------------------
 
-export type { MarkAccuracyResult, MarkAccuracyBatchResult, SnapshotResult, AccuracyDashboardData, CitationHealthResult };
+export type { MarkAccuracyResult, SnapshotResult, AccuracyDashboardData, CitationHealthResult };
 
 // ---------------------------------------------------------------------------
 // Citation Quotes API functions
@@ -128,16 +127,6 @@ export async function markCitationAccuracy(
   item: MarkAccuracyItem,
 ): Promise<ApiResult<MarkAccuracyResult>> {
   return apiRequest<MarkAccuracyResult>('POST', '/api/citations/quotes/mark-accuracy', item);
-}
-
-export async function markCitationAccuracyBatch(
-  items: MarkAccuracyItem[],
-): Promise<ApiResult<MarkAccuracyBatchResult>> {
-  return apiRequest<MarkAccuracyBatchResult>(
-    'POST',
-    '/api/citations/quotes/mark-accuracy-batch',
-    { items }
-  );
 }
 
 export async function createAccuracySnapshot(): Promise<ApiResult<SnapshotResult>> {

--- a/crux/lib/wiki-server/index.ts
+++ b/crux/lib/wiki-server/index.ts
@@ -77,7 +77,6 @@ export {
   upsertCitationQuote,
   upsertCitationQuoteBatch,
   markCitationAccuracy,
-  markCitationAccuracyBatch,
   createAccuracySnapshot,
   getAccuracyDashboard,
 } from './citations.ts';


### PR DESCRIPTION
## Summary

- Removes `POST /api/citations/quotes/mark-accuracy-batch` which was already marked `[DEPRECATED: batch update claims.claimVerdict instead]` and had **zero active callers** — it was exported from `crux/lib/wiki-server/citations.ts` but never invoked in any command or web code.
- Eliminates the N+1 UPDATE pattern (sequential per-row Drizzle UPDATEs inside a transaction) by removing dead code rather than fixing it.
- Removes `MarkAccuracyBatchSchema` from `api-types.ts`, the crux client function `markCitationAccuracyBatch` and its re-export in `index.ts`, three test cases in `citations.test.ts`, and the backward-compat test assertion.

## Decision rationale

The task spec said: "If no active callers exist: delete the route." Caller search confirmed the function appeared in `crux/lib/wiki-server/index.ts` (re-export) and `backward-compat.test.ts` (existence check) but was never actually called anywhere in crux commands or the web app. Deletion is cleaner than fixing dead code.

## Test plan

- [x] `tsc --noEmit` on wiki-server — no new errors introduced (pre-existing errors are unrelated worktree env issues)
- [x] `pnpm test` — 628 tests pass; 22 failures are pre-existing worktree missing-package issues, not related to this change
- [x] `citations.test.ts` and `backward-compat.test.ts` both pass
- [x] No remaining references to `mark-accuracy-batch`, `MarkAccuracyBatchSchema`, or `markCitationAccuracyBatch` in the codebase

Generated with Claude Code