### PR TITLE
fix: correct factual errors in people.yaml (Vestager, Ellison)

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2277,17 +2277,18 @@
   type: person
   title: Margrethe Vestager
   description: >-
-    Executive Vice-President of the European Commission and EU Commissioner for
-    Competition. Led European Union digital policy including the EU AI Act, which
-    established the world's first comprehensive AI regulatory framework. Defended
-    the AI Act against industry criticism, emphasizing it would enhance rather than
-    hinder innovation. Collaborated with the US on developing a voluntary AI Code
-    of Conduct in 2023 ahead of formal regulation.
+    Executive Vice-President of the European Commission for A Europe Fit for the
+    Digital Age and EU Commissioner for Competition (2019–2024). Led EU competition
+    policy and antitrust enforcement against major tech companies. The EU AI Act
+    was primarily driven by Internal Market Commissioner Thierry Breton and MEPs
+    Dragos Tudorache and Brando Benifei; Vestager's role was in broader digital
+    and competition policy rather than leading the AI Act itself. Collaborated
+    with the US on developing a voluntary AI Code of Conduct in 2023.
   customFields:
     - label: Role
-      value: Executive Vice-President, European Commission
+      value: Executive Vice-President, European Commission (2019–2024)
     - label: Known For
-      value: EU AI Act, EU digital policy, competition regulation
+      value: EU competition policy, tech antitrust enforcement, EU digital policy
   tags:
     - ai-governance
     - ai-policy
@@ -2514,11 +2515,11 @@
   type: person
   title: Caroline Ellison
   description: >-
-    Former CEO of Alameda Research and one of the executives who provided funding
-    for the FTX Future Fund alongside Sam Bankman-Fried, Gary Wang, and Nishad
-    Singh. Pleaded guilty to fraud charges following FTX's collapse in November
-    2022. Cooperated with federal prosecutors, providing testimony against Sam
-    Bankman-Fried in his trial.
+    Former CEO of Alameda Research, the crypto trading firm closely tied to FTX.
+    Alameda's commingling of customer funds with FTX was central to FTX's collapse
+    in November 2022. Pleaded guilty to fraud charges and cooperated with federal
+    prosecutors, providing key testimony against Sam Bankman-Fried in his trial.
+    Sentenced to two years in prison in September 2024.
   customFields:
     - label: Role
       value: Former CEO, Alameda Research


### PR DESCRIPTION
## Summary

Fixes factual errors introduced in PR #2677 (garbled org people names), identified in post-merge review.

### Bug 1: Margrethe Vestager — EU AI Act attribution
**Before:** Description said she "Led European Union digital policy including the EU AI Act"
**After:** Clarifies she was Competition Commissioner / EVP for Digital. The EU AI Act was driven by Internal Market Commissioner Thierry Breton and MEPs Dragos Tudorache and Brando Benifei. Vestager's role was competition enforcement and broader digital policy.

### Bug 2: Caroline Ellison — inaccurate funding claim
**Before:** "one of the executives who provided funding for the FTX Future Fund"
**After:** Accurate description of her role as CEO of Alameda Research (the trading firm whose funds were commingled with FTX), her guilty plea, cooperation with prosecutors, and sentence.

### Bug 3: Anthony Aguirre stableId — no duplicate found
Investigated the reported inconsistency between stableIds `9Siz0momEQ` and `dVQzYIAN3A`. Confirmed: only one entry exists in `data/entities/people.yaml` with `dVQzYIAN3A`. The `9Siz0momEQ` listed in PR #2677's table was not added to the YAML (the pre-existing entry already covered this person). No action needed.

## Test plan
- [x] `pnpm crux validate gate --scope=content --fix` passes (4/4 checks green)
- [x] No broken EntityLinks, schema validation clean (847 entities)
- [x] Descriptions reviewed against known facts about both individuals

🤖 Generated with [Claude Code](https://claude.com/claude-code)