### PR TITLE
fix: correct emptyCount overcounting and missing netWorthNum in has-data filter

### DIFF
--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -178,7 +178,8 @@ export function PeopleTable({
         r.role != null ||
         r.positionCount > 0 ||
         r.publicationCount > 0 ||
-        r.careerHistoryCount > 0,
+        r.careerHistoryCount > 0 ||
+        r.netWorthNum != null,
     ).length;
   }, [allRows, serverMode]);
 
@@ -267,7 +268,8 @@ export function PeopleTable({
           r.role != null ||
           r.positionCount > 0 ||
           r.publicationCount > 0 ||
-          r.careerHistoryCount > 0,
+          r.careerHistoryCount > 0 ||
+          r.netWorthNum != null,
       );
     }
 
@@ -399,8 +401,8 @@ export function PeopleTable({
             </button>
             {hasDataFilter && (
               <span className="text-xs text-muted-foreground/60">
-                Showing only people with role, position, publication, or career
-                data
+                Showing only people with role, position, publication, career,
+                or net worth data
               </span>
             )}
           </div>

--- a/apps/web/src/app/research-areas/research-areas-table.tsx
+++ b/apps/web/src/app/research-areas/research-areas-table.tsx
@@ -29,10 +29,18 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
   const [sortKey, setSortKey] = useState<SortKey>("title");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
-  // Count rows that have no organizations and no papers
+  // Count rows (after cluster/status filters) that have no organizations and no papers.
+  // This must be post-filter so "(N hidden)" reflects the active view, not the full dataset.
   const emptyCount = useMemo(
-    () => rows.filter((r) => r.orgCount === 0 && r.paperCount === 0).length,
-    [rows]
+    () =>
+      rows
+        .filter((r) => {
+          if (clusterFilter !== "all" && r.cluster !== clusterFilter) return false;
+          if (statusFilter !== "all" && r.status !== statusFilter) return false;
+          return true;
+        })
+        .filter((r) => r.orgCount === 0 && r.paperCount === 0).length,
+    [rows, clusterFilter, statusFilter]
   );
 
   const clusters = useMemo(() => {


### PR DESCRIPTION
## Summary

Two follow-up bug fixes from recent UX PRs:

- **Issue #2673** (`research-areas-table`): `emptyCount` was computed from the full unfiltered `rows` prop, so the "(N hidden)" label overcounted when cluster or status filters were active. Now recomputed after applying cluster/status filters but before the hasData gate — matching what the user actually sees.

- **Issue #2676** (`people-table`): The "Has data" filter excluded people whose only structured data is `netWorthNum` (e.g. major funders with net worth but no formal role/positions). Added `r.netWorthNum != null` to both the `withDataCount` memo and the `localFiltered` has-data predicate. Also updated the tooltip description to mention net worth.

## Test plan
- [x] `people-utils.test.ts` and `people-sort.test.ts` pass (confirmed locally — 25 + 22 tests green)
- [x] TypeScript check passes with `npx tsc --noEmit` on modified files (no errors)
- [ ] On /research-areas: activate a cluster filter, confirm "(N hidden)" count reflects only items in that cluster
- [ ] On /people: toggle "Has data", confirm funders with only net worth data appear

Closes #2673
Closes #2676