### PR TITLE
fix: relabel events Date column to Last Updated

### DIFF
--- a/apps/web/src/app/events/events-table.tsx
+++ b/apps/web/src/app/events/events-table.tsx
@@ -9,17 +9,17 @@ export interface EventRow {
   title: string;
   description: string | null;
   status: string | null;
-  date: string | null;
+  lastUpdated: string | null;
   tags: string[];
   wikiId: string | null;
 }
 
-type SortKey = "title" | "status" | "date";
+type SortKey = "title" | "status" | "lastUpdated";
 type SortDir = "asc" | "desc";
 
 export function EventsTable({ rows }: { rows: EventRow[] }) {
   const [search, setSearch] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [sortKey, setSortKey] = useState<SortKey>("lastUpdated");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const handleSort = (key: SortKey) => {
@@ -52,8 +52,8 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
           return a.title.localeCompare(b.title) * dir;
         case "status":
           return (a.status ?? "").localeCompare(b.status ?? "") * dir;
-        case "date":
-          return (a.date ?? "").localeCompare(b.date ?? "") * dir;
+        case "lastUpdated":
+          return (a.lastUpdated ?? "").localeCompare(b.lastUpdated ?? "") * dir;
       }
     });
 
@@ -90,8 +90,8 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                 className="text-left"
               />
               <SortHeader
-                label="Date"
-                sortKey="date"
+                label="Last Updated"
+                sortKey="lastUpdated"
                 currentSort={sortKey}
                 currentDir={sortDir}
                 onSort={handleSort}
@@ -126,7 +126,7 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                 </td>
 
                 <td className="py-2.5 px-3 whitespace-nowrap text-muted-foreground text-xs">
-                  {row.date ?? <span className="text-muted-foreground/40">&mdash;</span>}
+                  {row.lastUpdated ?? <span className="text-muted-foreground/40">&mdash;</span>}
                 </td>
 
                 <td className="py-2.5 px-3 whitespace-nowrap">

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -21,7 +21,7 @@ export default function EventsPage() {
       title: e.title,
       description: e.description ?? null,
       status: statusField?.value ?? null,
-      date: e.lastUpdated ?? null,
+      lastUpdated: e.lastUpdated ?? null,
       tags: e.tags ?? [],
       wikiId: e.wikiId ?? null,
     };


### PR DESCRIPTION
## Summary

Fixes issue found in review of PR #2710 (already merged).

- **Events "Date" column mislabeling**: The column was labeled "Date" but displayed `e.lastUpdated` (the wiki edit date, not an event date). The `EventEntitySchema` has no event-specific date fields (`date`, `startDate`, `eventDate`). Relabeled to "Last Updated" to be honest about the data source.
- Also renamed the `EventRow.date` field to `EventRow.lastUpdated` and the `SortKey` value to match, keeping the interface self-documenting.

**Note on Issue 2 (Params column fill rate claim):** PR #2710 is already merged. The PR description claimed "0% fill rate" for `parameterCount` but the field does have data for 8+ open-weight models (~18% fill). Since the PR is merged, no code change is needed for that issue — the column removal itself is a reasonable call (18% is still sparse), only the PR description was inaccurate, and that's now historical.

## Test plan

- [x] TypeScript: no new errors in `events-table.tsx` or `events/page.tsx`
- [x] `EventRow` interface is self-consistent (`lastUpdated` field maps from `e.lastUpdated`)
- [x] Column still sorts descending by default (most recently edited first)
- [x] 633 unit tests pass (22 test files fail due to pre-existing missing node_modules in worktree, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)