### PR TITLE
fix: add citation for ASL-3/Claude Opus 4 claim in governance-policy

### DIFF
--- a/content/docs/knowledge-base/responses/governance-policy.mdx
+++ b/content/docs/knowledge-base/responses/governance-policy.mdx
@@ -209,7 +209,7 @@ Industry-led initiatives aim to establish safety norms before mandatory regulati
 - **THEN** implement corresponding safeguards (e.g., enhanced containment)
 
 Current adoption:
-- **Anthropic:** ASL-3 now in production (Claude Opus 4 released under ASL-3), with ASL-2 still applied to lower-capability models
+- **Anthropic:** <R id="NDA5OTUyY2">ASL-3 now in production (Claude Opus 4 released under ASL-3)</R>, with ASL-2 still applied to lower-capability models
 - **OpenAI:** <R id="ZmYxMGI2Yj">Preparedness Framework</R> with risk assessment scorecards
 - **Google DeepMind:** <R id="NzZkNWU4MT">Frontier Safety Framework</R> for responsible deployment
 - **Meta:** <R id="NzJlNTNkY2">System-level safety approach</R> focusing on red-teaming


### PR DESCRIPTION
## Summary

- Adds an inline `<R>` citation to the uncited "ASL-3 now in production (Claude Opus 4 released under ASL-3)" claim added in PR #2653
- Uses the existing Anthropic RSP resource (`NDA5OTUyY2`, `anthropic.com/responsible-scaling-policy`) which documents the ASL framework and level definitions
- Citation format now matches the three other bullets in the same adoption list (OpenAI, Google DeepMind, Meta)

## What was wrong

In PR #2653, the Anthropic bullet in the "Current adoption" table was updated to add the ASL-3 production claim without any citation. The other bullets in the list all have `<R>` inline citations.

## Test plan

- [x] `pnpm crux validate gate --scope=content --fix` — all 4 checks pass
- [x] `pnpm crux fix escaping` — no fixable issues found
- [x] `pnpm crux fix markdown` — no fixable issues found
- [x] Single-line diff; only adds citation markup around existing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)