### PR TITLE
content: add EU AI Act post-enactment implementation timeline

### DIFF
--- a/content/docs/knowledge-base/responses/eu-ai-act.mdx
+++ b/content/docs/knowledge-base/responses/eu-ai-act.mdx
@@ -5,7 +5,7 @@ description: The world's first comprehensive AI regulation, adopting a risk-base
 sidebar:
   order: 70
 subcategory: legislation
-lastEdited: 2026-02-01
+lastEdited: 2026-03-19
 update_frequency: 7
 summary: Comprehensive overview of the EU AI Act's risk-based regulatory framework, particularly its two-tier approach to foundation models that distinguishes between standard and systemic risk AI systems. The analysis provides valuable implementation details and governance structure but cuts off before addressing key criticisms and global implications.
 clusters:
@@ -81,6 +81,46 @@ Subsequent milestones included:
 - **July 12, 2024**: Published in the Official Journal of the European Union[^rc-a554]
 - **August 1, 2024**: Entered into force[^rc-8331]
 
+## Post-Enactment Implementation Timeline
+
+Following entry into force, the Act applies via a phased schedule with obligations activating at 6-month, 12-month, and 24-month intervals:
+
+| Date | Milestone |
+|------|-----------|
+| **August 1, 2024** | Regulation enters into force (20 days after publication in the Official Journal on July 12, 2024) |
+| **February 2, 2025** | **6-month mark**: Prohibitions on unacceptable-risk AI systems take effect (Article 5). AI literacy obligations (Article 4) also apply from this date. |
+| **August 2, 2025** | **12-month mark**: GPAI/general-purpose AI model obligations take effect (Chapter V). The European AI Office becomes fully operational for GPAI enforcement. New GPAI models placed on the market must comply immediately. |
+| **August 2, 2026** | **24-month mark**: High-risk AI system obligations (Annex III) and most remaining provisions become fully applicable. Full enforcement begins across all risk tiers. |
+| **August 2, 2027** | GPAI models already on the market before August 2, 2025 must achieve full compliance (two-year grace period for legacy models). High-risk systems listed in Annex II also fall under full compliance. |
+
+### February 2025: Prohibited Systems and AI Literacy
+
+The first major enforcement milestone came on **February 2, 2025**, six months after entry into force. From this date:
+
+- The eight categories of **prohibited AI practices** (Article 5) became enforceable, including bans on social scoring, subliminal manipulation, real-time biometric identification in public spaces, emotion recognition in workplaces and schools, and untargeted facial image scraping
+- **AI literacy obligations** (Article 4) became applicable, requiring providers and deployers to ensure their staff have sufficient AI literacy through training and education measures
+
+Enforcement sanctions for prohibited practices (fines up to €35M or 7% of global turnover) apply from August 2, 2025 onward, as the enforcement powers granted to national authorities only became active six months after the prohibitions themselves took effect.
+
+### August 2025: GPAI Rules and AI Office Activation
+
+**August 2, 2025** marked the activation of GPAI obligations under Chapter V of the Act. From this date:
+
+- Providers of general-purpose AI (GPAI) models must comply with transparency, copyright, and technical documentation requirements
+- GPAI models above the 10²⁵ FLOP systemic-risk threshold face enhanced obligations including adversarial testing, incident reporting, and cybersecurity measures
+- The **European AI Office** became fully operational as the primary GPAI enforcement body, housed within DG CONNECT (established by Commission decision on January 24, 2024, and formally launched on February 21, 2024)
+- The **AI Board**, comprising Member State representatives, was formally established to coordinate national enforcement
+
+GPAI models already on the market before August 2, 2025 received a two-year grace period, with full compliance required by **August 2, 2027**.
+
+### August 2026: General Application
+
+**August 2, 2026** marks full general applicability of the Act. From this date:
+
+- High-risk AI systems listed in Annex III (employment, credit, education, law enforcement, border control, etc.) must meet all requirements: mandatory risk assessments, conformity assessments, CE marking, EU database registration, and human oversight
+- Limited-risk systems (chatbots, deepfakes, emotion recognition) face full transparency obligations
+- National market surveillance authorities are empowered to supervise and enforce compliance across all risk tiers
+
 ## Risk-Based Regulatory Framework
 
 ### Four-Tier Classification System
@@ -147,7 +187,7 @@ Designated based on <EntityLink id="E465" name="thresholds">compute thresholds</
 
 The EU AI legislation will be made applicable via a phased approach:[^rc-5a48][^rc-6ea8][^rc-5a48][^rc-6ea8]
 
-- **August 2, 2026**: GPAI obligations take effect for all general-purpose AI models
+- **August 2, 2025**: GPAI obligations take effect for all general-purpose AI models
 - **August 2, 2027**: Existing GPAI models placed on the market before August 2025 must achieve full compliance[^rc-8efa]
 
 New GPAI models released after August 2, 2025 must comply immediately, while existing models receive a two-year grace period.[^rc-e3ad]


### PR DESCRIPTION
## Summary

- Adds a dedicated **"Post-Enactment Implementation Timeline"** section to the EU AI Act wiki page (`content/docs/knowledge-base/responses/eu-ai-act.mdx`), placed between the Legislative History and Risk-Based Regulatory Framework sections
- The new section consolidates the five key enforcement milestones in one place: August 2024 entry into force, February 2025 prohibitions, August 2025 GPAI rules, August 2026 general applicability, and August 2027 GPAI grace period deadline
- Fixes a factual error in the existing "Implementation Timeline for GPAI" subsection where the GPAI obligation activation date was incorrectly listed as "August 2, 2026" (should be "August 2, 2025")

## What was added

The new section includes:
- A summary table with all five milestone dates and their significance
- A subsection on February 2025 (prohibited AI systems + AI literacy obligations)
- A subsection on August 2025 (GPAI rules + EU AI Office activation)
- A subsection on August 2026 (full general applicability across all risk tiers)

All dates verified against multiple authoritative sources including the EU AI Act official website, DLA Piper's August 2025 enforcement update, Baker McKenzie, and the European Commission's own AI Act pages.

## Test plan

- [x] \`pnpm crux fix escaping\` — no issues
- [x] \`pnpm crux fix markdown\` — no issues
- [x] \`pnpm crux validate gate --scope=content --fix\` — all 4 gate checks pass