### PR TITLE
feat: add policy positions to person pages

### DIFF
--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -37,6 +37,7 @@ import { PublicationsSection } from "./publications-section";
 import { FundingConnections } from "./funding-connections";
 import { OrgRoles } from "./org-roles";
 import { BoardSeats } from "./board-seats";
+import { getPersonPolicyPositions, PolicyPositionsSection } from "./policy-positions";
 
 // Allow dynamic rendering of person pages not in generateStaticParams
 // (e.g., entities created via tablebase enrichment in the wiki-server DB)
@@ -227,6 +228,9 @@ export default async function PersonProfilePage({
   // Funding connections
   const fundingConnections = getFundingConnectionsForPerson(entity.id);
 
+  // Policy positions (reverse lookup: find legislation where this person is a stakeholder)
+  const policyPositions = getPersonPolicyPositions(entity.id, entity.name);
+
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
     (f) => f.propertyId !== "description",
@@ -319,7 +323,7 @@ export default async function PersonProfilePage({
 
   // ── Build tabs from available data ──
   const overviewCount =
-    positions.length + sortedOrgRoles.length + sortedBoardSeats.length + (educationText ? 1 : 0);
+    positions.length + sortedOrgRoles.length + sortedBoardSeats.length + policyPositions.length + (educationText ? 1 : 0);
 
   const tabs: ProfileTab[] = [];
 
@@ -330,6 +334,7 @@ export default async function PersonProfilePage({
     content: (
       <div className="space-y-8">
         <ExpertPositions positions={positions} />
+        <PolicyPositionsSection positions={policyPositions} />
         <OrgRoles orgRoles={sortedOrgRoles} />
         <BoardSeats boardSeats={sortedBoardSeats} />
         {educationText && <EducationSection education={educationText} />}

--- a/apps/web/src/app/people/[slug]/policy-positions.tsx
+++ b/apps/web/src/app/people/[slug]/policy-positions.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { getTypedEntities, isPolicy, type PolicyEntity } from "@/data";
+import { STATUS_COLORS, normalizeStatus } from "@/app/legislation/legislation-constants";
+import { deriveStatus } from "@/app/legislation/legislation-utils";
+
+export interface PersonPolicyPosition {
+  policyId: string;
+  policyTitle: string;
+  position: string;
+  reason: string | undefined;
+  statusKey: string | null;
+}
+
+/**
+ * Find all policy entities where a person appears as a stakeholder.
+ * Matches by entity ID or name (case-insensitive).
+ */
+export function getPersonPolicyPositions(
+  personEntityId: string,
+  personName: string,
+): PersonPolicyPosition[] {
+  const allEntities = getTypedEntities();
+  const policies = allEntities.filter(isPolicy);
+
+  const positions: PersonPolicyPosition[] = [];
+  for (const policy of policies) {
+    for (const stakeholder of policy.stakeholders) {
+      if (
+        stakeholder.entityId === personEntityId ||
+        stakeholder.name.toLowerCase() === personName.toLowerCase()
+      ) {
+        positions.push({
+          policyId: policy.id,
+          policyTitle: policy.title,
+          position: stakeholder.position,
+          reason: stakeholder.reason,
+          statusKey: normalizeStatus(deriveStatus(policy)),
+        });
+        break; // Don't double-count
+      }
+    }
+  }
+
+  return positions;
+}
+
+const POSITION_COLORS: Record<string, string> = {
+  support: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  oppose: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  neutral: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
+  mixed: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+};
+
+export function PolicyPositionsSection({
+  positions,
+}: {
+  positions: PersonPolicyPosition[];
+}) {
+  if (positions.length === 0) return null;
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold tracking-tight mb-4">
+        Policy Positions
+        <span className="ml-2 text-sm font-normal text-muted-foreground">
+          {positions.length} {positions.length === 1 ? "policy" : "policies"}
+        </span>
+      </h2>
+      <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60 bg-muted/30">
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Policy
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Position
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Status
+                </th>
+                <th className="text-left px-4 py-2.5 font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Reason
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map((pos) => (
+                <tr
+                  key={pos.policyId}
+                  className="border-b border-border/30 last:border-b-0 hover:bg-muted/20 transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/legislation/${pos.policyId}`}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      {pos.policyTitle}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${
+                        POSITION_COLORS[pos.position] ?? "bg-gray-100 text-gray-600"
+                      }`}
+                    >
+                      {pos.position}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    {pos.statusKey ? (
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${
+                          STATUS_COLORS[pos.statusKey] ?? "bg-gray-100 text-gray-600"
+                        }`}
+                      >
+                        {pos.statusKey}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground/40">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs max-w-xs">
+                    {pos.reason ?? (
+                      <span className="text-muted-foreground/40">&mdash;</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

**1. Policy positions on person pages** — Surfaces legislation stakeholder data on person profile pages by scanning all policy entities for stakeholders matching the person. Follows the existing pattern from organization pages.

**2. Gate check for stakeholder entity linking** — New `validate-stakeholder-links` blocking gate check that:
- Errors when a stakeholder/keyPolitician name matches an existing entity but is missing `entityId`
- Errors when `entityId` is set but doesn't resolve to any known entity
- Prevents future drift where names are added without entity links

**3. Backfill of all unlinked references** — One-time sweep that:
- Added `entityId` to all 47 linkable stakeholder/keyPolitician entries across 10 legislation pages
- Created 39 new lightweight entities (16 persons, 23 orgs) for politicians, advocacy groups, tech companies, and government bodies
- 11 entries intentionally left unlinked (vague groups like "Tech industry", "113+ AI Company Employees")

## Test plan
- [ ] Visit `/people/max-tegmark` — should show SB1047 "Support" badge in Policy Positions section
- [ ] Visit `/legislation/california-sb1047` — Key Politicians should now link to person pages
- [ ] Visit a person with no policy positions — section should not render
- [ ] Run `npx tsx crux/validate/validate-stakeholder-links.ts` — should pass
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (902 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)