### PR TITLE
fix: derive agent slot number from directory name, not .agent-slot file

### DIFF
--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -53,17 +53,6 @@ function getGitRemoteUrl(): string {
   }
 }
 
-/** Read the slot number from a directory's .agent-slot file */
-function readSlot(dir: string): number | null {
-  try {
-    const raw = readFileSync(join(dir, '.agent-slot'), 'utf-8').trim();
-    const n = parseInt(raw, 10);
-    return Number.isInteger(n) && n > 0 ? n : null;
-  } catch {
-    return null;
-  }
-}
-
 /** Find all agent slot directories under lw/ */
 function findSlotDirs(lwDir: string): Array<{ dir: string; slot: number }> {
   if (!existsSync(lwDir)) return [];
@@ -74,10 +63,11 @@ function findSlotDirs(lwDir: string): Array<{ dir: string; slot: number }> {
   for (const name of entries) {
     const dir = join(lwDir, name);
     if (!statSync(dir).isDirectory()) continue;
-    const slot = readSlot(dir);
-    if (slot !== null) {
-      results.push({ dir, slot });
-    }
+    // Derive slot from directory name — .agent-slot files can be corrupted
+    const match = name.match(/^a(\d+)$/);
+    if (!match) continue;
+    const slot = parseInt(match[1], 10);
+    results.push({ dir, slot });
   }
 
   return results.sort((a, b) => a.slot - b.slot);
@@ -173,14 +163,13 @@ Options:
   // Clone if needed
   if (existsSync(slotDir)) {
     if (!options.force) {
-      const existingSlot = readSlot(slotDir);
-      if (existingSlot !== null) {
-        return {
-          exitCode: 0,
-          output: `Slot a${slot} already exists at ${slotDir}. Use --force to re-initialize .env and .agent-slot.`,
-        };
-      }
+      // Directory exists — no need to read .agent-slot, the dir name is enough
+      return {
+        exitCode: 0,
+        output: `Slot a${slot} already exists at ${slotDir}. Use --force to re-initialize .env and .agent-slot.`,
+      };
     }
+    // --force: fall through to regenerate .env and repair .agent-slot below
   } else {
     const remote = getGitRemoteUrl();
     console.error(`Cloning ${remote} → ${slotDir}...`);
@@ -228,6 +217,9 @@ async function syncEnv(_args: string[], _options: CommandOptions): Promise<Comma
   for (const { dir, slot } of slots) {
     const envContent = generateEnv(envBasePath, slot);
     writeFileSync(join(dir, '.env'), envContent);
+    // Repair .agent-slot — the directory name is the source of truth, so
+    // overwrite whatever (possibly corrupted) value was there before.
+    writeFileSync(join(dir, '.agent-slot'), String(slot) + '\n');
     lines.push(`  ✓ a${slot}/.env regenerated (ports ${3010 + slot}/${3110 + slot})`);
   }
 


### PR DESCRIPTION
## Summary

- `findSlotDirs()` previously read `.agent-slot` to get the slot number, but many of these files are corrupted (often containing `8` regardless of the real slot). Replaced with regex parse of the directory name (`/^a(\d+)$/`), which is always correct.
- `sync-env` now also repairs `.agent-slot` after writing `.env`, so corrupted files get fixed automatically on the next sync.
- `setup --force` no longer reads `.agent-slot` — it uses the slot number derived from the directory name argument, simplifying the logic.
- Removed the now-unused `readSlot()` helper function.

## Test plan

- [x] TypeScript type check passes: `tsc --noEmit` exits 0
- [ ] Run `pnpm crux agent-workspace sync-env` and verify it processes all `aN` dirs and writes correct port numbers
- [ ] Verify `.agent-slot` files in each slot directory now contain the correct slot number after `sync-env`
- [ ] Run `pnpm crux agent-workspace list` and confirm port columns match the dir names
- [ ] Run `pnpm crux agent-workspace setup <N> --force` on an existing slot and confirm `.agent-slot` and `.env` are repaired correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
