### PR TITLE
fix: add LIMIT to unbounded queries and fix wellness check

### DIFF
--- a/apps/wiki-server/src/routes/operational/monitoring.ts
+++ b/apps/wiki-server/src/routes/operational/monitoring.ts
@@ -33,7 +33,7 @@ const SERVICES = [
 
 // Expected migration count — update this when adding new drizzle migrations.
 // Read from apps/wiki-server/drizzle/meta/_journal.json entries length.
-const EXPECTED_MIGRATION_COUNT = 98;
+const EXPECTED_MIGRATION_COUNT = 108;
 
 // ── Typed row interfaces for raw SQL results ────────────────────────────
 interface DbCountsRow {

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -324,6 +324,7 @@ const grantsApp = new Hono()
   // Returns all grant IDs and their current granteeId values.
   // Used by the backfill command to identify grants needing entity linking.
   .get("/all-grantee-ids", async (c) => {
+    const HARD_LIMIT = 10000;
     const db = getDrizzleDb();
 
     const rows = await db
@@ -332,7 +333,8 @@ const grantsApp = new Hono()
         granteeId: grants.granteeId,
         name: grants.name,
       })
-      .from(grants);
+      .from(grants)
+      .limit(HARD_LIMIT);
 
     return c.json({
       grants: rows.map((r) => ({
@@ -341,6 +343,7 @@ const grantsApp = new Hono()
         name: r.name,
       })),
       total: rows.length,
+      truncated: rows.length >= HARD_LIMIT,
     });
   })
 
@@ -397,6 +400,7 @@ const grantsApp = new Hono()
   // source, name, and notes. Used by backfill-program-ids to match grants
   // to funding programs.
   .get("/all-program-ids", async (c) => {
+    const HARD_LIMIT = 10000;
     const db = getDrizzleDb();
 
     const rows = await db
@@ -408,7 +412,8 @@ const grantsApp = new Hono()
         name: grants.name,
         notes: grants.notes,
       })
-      .from(grants);
+      .from(grants)
+      .limit(HARD_LIMIT);
 
     return c.json({
       grants: rows.map((r) => ({
@@ -420,6 +425,7 @@ const grantsApp = new Hono()
         notes: r.notes,
       })),
       total: rows.length,
+      truncated: rows.length >= HARD_LIMIT,
     });
   })
 
@@ -474,6 +480,7 @@ const grantsApp = new Hono()
   // ---- GET /all-for-matching ----
   // Returns lightweight grant data for research area matching.
   .get("/all-for-matching", async (c) => {
+    const HARD_LIMIT = 10000;
     const db = getDrizzleDb();
 
     const rows = await db
@@ -485,7 +492,8 @@ const grantsApp = new Hono()
         organizationId: grants.organizationId,
         granteeId: grants.granteeId,
       })
-      .from(grants);
+      .from(grants)
+      .limit(HARD_LIMIT);
 
     return c.json({
       grants: rows.map((r) => ({
@@ -497,6 +505,7 @@ const grantsApp = new Hono()
         granteeId: r.granteeId,
       })),
       total: rows.length,
+      truncated: rows.length >= HARD_LIMIT,
     });
   })
 

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -777,9 +777,10 @@ const citationsApp = new Hono()
     }
 
     // --- 4. Per-page aggregation (GROUP BY pageId) ---
-    // No LIMIT here: JS sorts by inaccuracy rate afterward, so all pages must be
-    // fetched before slicing. The dataset is bounded by the number of wiki pages
-    // (~700), so this is safe.
+    // GROUP BY pageId — bounded by number of wiki pages (~700) but a safety LIMIT
+    // prevents unbounded result sets if data grows unexpectedly.
+    // JS sorts by inaccuracy rate afterward, so all pages must be fetched before slicing.
+    const PAGES_HARD_LIMIT = 5000;
     const pageRows = await db.select({
       pageId: citationQuotes.pageId,
       totalCitations: count(),
@@ -792,7 +793,8 @@ const citationsApp = new Hono()
       avgScore: avg(sql`CASE WHEN ${citationQuotes.accuracyVerdict} IS NOT NULL THEN ${citationQuotes.accuracyScore} END`),
     })
       .from(citationQuotes)
-      .groupBy(citationQuotes.pageId);
+      .groupBy(citationQuotes.pageId)
+      .limit(PAGES_HARD_LIMIT);
 
     const pages = pageRows.map((r) => {
       const checked = Number(r.checked);

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -53,8 +53,10 @@ const MIN_ENTITIES = 500;
 const MIN_FACTS = 40; // Currently ~54; alert if drops dramatically
 
 // Workflow staleness thresholds (hours)
+// auto-update.yml schedule is disabled — it runs only via manual workflow_dispatch,
+// so the threshold must be generous to avoid false alarms.
 const MAX_AGE: Record<string, number> = {
-  'auto-update.yml': 36,
+  'auto-update.yml': 336, // 14 days — schedule disabled, manual runs only
   'database-backup.yml': 36,
   'scheduled-maintenance.yml': 216, // 9 days
   'server-health-monitor.yml': 192, // weekly dead-man-switch (8 days)
@@ -258,7 +260,8 @@ interface WorkflowRunsResponse {
 // Workflows that are inherently flaky — depends on LLMs, external URLs,
 // citation verification. For these, we check if ANY of the last 5 runs
 // succeeded rather than requiring the most recent one to succeed.
-const FLAKY_WORKFLOWS = new Set(['auto-update.yml']);
+// scheduled-maintenance.yml uses Claude Code which can fail transiently.
+const FLAKY_WORKFLOWS = new Set(['auto-update.yml', 'scheduled-maintenance.yml']);
 
 // Workflows that only run on schedule or workflow_dispatch (not push).
 // For these, we filter out push-triggered runs which can be spurious


### PR DESCRIPTION
## Summary

- Add LIMIT (10000) to 3 grants endpoints (`/all-grantee-ids`, `/all-program-ids`, `/all-for-matching`) that had unbounded full-table scans, plus a `truncated` flag in the response
- Add safety LIMIT (5000) to citations accuracy-dashboard GROUP BY query
- Fix auto-update.yml staleness threshold: schedule is disabled (manual only), raised from 36h to 14 days (336h) to stop false wellness alarms
- Add `scheduled-maintenance.yml` to FLAKY_WORKFLOWS set so transient Claude Code failures don't trigger wellness issues
- Update EXPECTED_MIGRATION_COUNT from 98 to 108 to match current drizzle journal

## Test plan

- [x] Wiki-server tests pass (657 passed, 21 skipped)
- [x] Crux health tests pass (31 passed)
- [x] TypeScript compiles clean (wiki-server + web)
- [ ] CI green

Closes #2685
Closes #2692

Agent slot: a8

Generated with [Claude Code](https://claude.com/claude-code)