### PR TITLE
feat: resource display Phase 3A — categorize legislation resources

### DIFF
--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -492,6 +492,8 @@ export default async function LegislationDetailPage({
   // ── Press / Documents tab ──────────────────────────────────
   const resourceIds = getResourcesForPage(entity.id);
   const pressResources: OrgResourceRow[] = [];
+  /** Map resource id → publication type (e.g. "government", "think_tank", "news") for categorization. */
+  const pubTypeByResourceId = new Map<string, string>();
   for (const rid of resourceIds) {
     const r = getResourceById(rid);
     if (!r) continue;
@@ -502,6 +504,9 @@ export default async function LegislationDetailPage({
     const effectivePub = publication ?? domainPub;
     const credibility = getResourceCredibility(r) ?? domainPub?.credibility ?? null;
     const citingPages = getPagesForResource(rid);
+    if (effectivePub?.type) {
+      pubTypeByResourceId.set(rid, effectivePub.type);
+    }
     pressResources.push({
       id: rid,
       title: r.title ?? r.url,
@@ -519,18 +524,105 @@ export default async function LegislationDetailPage({
     });
   }
 
+  // Categorize resources into Official Documents, Analysis & Research, and Press Coverage
+  type ResourceCategory = "official" | "analysis" | "press";
+
+  const GOV_DOMAIN_PATTERNS = [
+    /\.gov$/,
+    /\.gov\./,          // e.g. gov.uk, gov.au
+    /legislature\./,
+    /congress\./,
+    /parliament\./,
+  ];
+
+  const ACADEMIC_DOMAIN_PATTERNS = [
+    /\.edu$/,
+    /\.edu\./,          // e.g. .edu.au
+    /\.ac\./,           // e.g. .ac.uk
+  ];
+
+  const OFFICIAL_TITLE_PATTERNS = [
+    /bill text/i,
+    /committee report/i,
+    /executive order/i,
+    /federal register/i,
+    /public law/i,
+    /enrolled bill/i,
+    /congressional record/i,
+  ];
+
+  const ANALYSIS_TITLE_PATTERNS = [
+    /\banalysis\b/i,
+    /\bassessment\b/i,
+    /\breview\b/i,
+    /\bworking paper\b/i,
+    /\bwhite paper\b/i,
+    /\bpolicy brief\b/i,
+  ];
+
+  function categorizeResource(r: OrgResourceRow): ResourceCategory {
+    const pubType = pubTypeByResourceId.get(r.id) ?? null;
+    const domain = r.domain ?? "";
+
+    // ── Official Documents ──
+    if (r.type === "government" || pubType === "government") return "official";
+    if (GOV_DOMAIN_PATTERNS.some((p) => p.test(domain))) return "official";
+    if (OFFICIAL_TITLE_PATTERNS.some((p) => p.test(r.title))) return "official";
+
+    // ── Analysis & Research ──
+    if (r.type === "paper" || r.type === "report" || r.type === "book") return "analysis";
+    if (
+      pubType === "think_tank" ||
+      pubType === "academic_journal" ||
+      pubType === "preprint_server" ||
+      pubType === "academic" ||
+      pubType === "academic_search"
+    ) {
+      return "analysis";
+    }
+    if (ACADEMIC_DOMAIN_PATTERNS.some((p) => p.test(domain))) return "analysis";
+    if (ANALYSIS_TITLE_PATTERNS.some((p) => p.test(r.title))) return "analysis";
+
+    // ── Press Coverage (default) ──
+    return "press";
+  }
+
+  const officialDocs = pressResources.filter((r) => categorizeResource(r) === "official");
+  const analysisResources = pressResources.filter((r) => categorizeResource(r) === "analysis");
+  const pressCoverage = pressResources.filter((r) => categorizeResource(r) === "press");
+
   if (pressResources.length > 0) {
     tabs.push({
       id: "press",
-      label: "Documents & Press",
+      label: "Coverage",
       count: pressResources.length,
       content: (
-        <OrgResourcesSection
-          resources={pressResources}
-          title="Official Documents, Analysis & Press Coverage"
-          emptyMessage=""
-          alwaysShowColumns={{ date: true, publication: true }}
-        />
+        <div className="space-y-8">
+          {officialDocs.length > 0 && (
+            <OrgResourcesSection
+              resources={officialDocs}
+              title="Official Documents"
+              emptyMessage=""
+              alwaysShowColumns={{ date: true }}
+            />
+          )}
+          {analysisResources.length > 0 && (
+            <OrgResourcesSection
+              resources={analysisResources}
+              title="Analysis & Research"
+              emptyMessage=""
+              alwaysShowColumns={{ date: true, publication: true }}
+            />
+          )}
+          {pressCoverage.length > 0 && (
+            <OrgResourcesSection
+              resources={pressCoverage}
+              title="Press Coverage"
+              emptyMessage=""
+              alwaysShowColumns={{ date: true, publication: true }}
+            />
+          )}
+        </div>
       ),
     });
   }


### PR DESCRIPTION
## Summary
Phase 3A of the [Resource Display Overhaul](https://github.com/quantified-uncertainty/longterm-wiki/discussions/2738). Stacked on #2742 (Phase 2).

Splits the legislation press tab into three categorized sections:

**Official Documents** — government sources, `.gov` domains, bill text, executive orders
**Analysis & Research** — papers, think tanks, `.edu` domains, policy briefs
**Press Coverage** — news articles, blogs, everything else (conservative default)

### Categorization heuristics
- Resource type (`government`, `paper`, `report`, `book`)
- Publication type (`think_tank`, `academic_journal`, `preprint_server`)
- Domain matching (`.gov`, `.edu`, `.ac.*`)
- Title patterns ("analysis", "assessment", "bill text", "executive order")

Tab renamed from "Documents & Press" to "Coverage". Each section shows appropriate column visibility.

## Test plan
- [ ] SB-1047 press tab shows resources grouped into sections
- [ ] Government sources appear in "Official Documents"
- [ ] Academic/think tank sources appear in "Analysis & Research"
- [ ] News/blog sources appear in "Press Coverage"
- [ ] Empty sections are hidden
- [ ] Type-checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)