### PR TITLE
Add natural key uniqueness constraints

### DIFF
--- a/apps/wiki-server/drizzle/0108_natural_key_uniqueness.sql
+++ b/apps/wiki-server/drizzle/0108_natural_key_uniqueness.sql
@@ -1,0 +1,116 @@
+-- Add composite unique constraints on natural keys to prevent duplicate records.
+-- Tables are small (personnel ~230, investments ~56, division_personnel ~0)
+-- so no manual migration needed.
+
+-- ============================================================================
+-- Step 1: Deduplicate existing rows (keep the most recently updated record)
+-- ============================================================================
+
+-- Personnel: deduplicate on (person_entity_id, org_entity_id, role_type, role)
+-- Only considers rows where both entity IDs are resolved (non-null).
+-- Keeps the row with the most non-null fields; breaks ties by updated_at DESC.
+DELETE FROM personnel
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY person_entity_id, org_entity_id, role_type, role
+        ORDER BY
+          -- Prefer rows with more non-null optional fields
+          (CASE WHEN start_date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN end_date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN notes IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN appointed_by IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN background IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN person_display_name IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN org_display_name IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM personnel
+    WHERE person_entity_id IS NOT NULL
+      AND org_entity_id IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Division personnel: deduplicate on (division_id, person_id)
+DELETE FROM division_personnel
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY division_id, person_id
+        ORDER BY
+          (CASE WHEN start_date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN end_date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN notes IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM division_personnel
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Investments: deduplicate on (investor_entity_id, company_entity_id, COALESCE(round_name, ''))
+-- Only considers rows where both entity IDs are resolved (non-null).
+DELETE FROM investments
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY investor_entity_id, company_entity_id, COALESCE(round_name, '')
+        ORDER BY
+          (CASE WHEN date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN amount IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN stake_acquired IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN instrument IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN role IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN conditions IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN notes IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN investor_display_name IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN company_display_name IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM investments
+    WHERE investor_entity_id IS NOT NULL
+      AND company_entity_id IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+-- ============================================================================
+-- Step 2: Add unique constraints via partial indexes
+-- ============================================================================
+
+-- Personnel: unique on (person_entity_id, org_entity_id, role_type, role)
+-- Partial: only enforced when all entity IDs are resolved.
+-- Uses role (specific title) not just role_type, because a person can hold
+-- multiple distinct roles of the same type at one org (e.g. Executive Director
+-- then President, both key-person).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_personnel_natural_key
+  ON personnel (person_entity_id, org_entity_id, role_type, role)
+  WHERE person_entity_id IS NOT NULL AND org_entity_id IS NOT NULL;
+
+-- Division personnel: unique on (division_id, person_id)
+-- Both columns are NOT NULL, so no partial index needed.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_division_personnel_natural_key
+  ON division_personnel (division_id, person_id);
+
+-- Investments: unique on (investor_entity_id, company_entity_id, round_name)
+-- Uses COALESCE for round_name since it can be null (treats null as '').
+-- Partial: only enforced when entity IDs are resolved.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_investments_natural_key
+  ON investments (investor_entity_id, company_entity_id, COALESCE(round_name, ''))
+  WHERE investor_entity_id IS NOT NULL AND company_entity_id IS NOT NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -757,6 +757,13 @@
       "when": 1777881600000,
       "tag": "0107_mark_stub_entities",
       "breakpoints": true
+    },
+    {
+      "idx": 108,
+      "version": "7",
+      "when": 1777968000000,
+      "tag": "0108_natural_key_uniqueness",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1517,6 +1517,13 @@ export const personnel = pgTable(
     index("idx_personnel_person_entity").on(table.personEntityId),
     index("idx_personnel_org_entity").on(table.orgEntityId),
     index("idx_personnel_role_type").on(table.roleType),
+    // Natural key uniqueness: prevents duplicate role assignments.
+    // Partial index — only enforced when entity IDs are resolved (non-null).
+    uniqueIndex("uq_personnel_natural_key")
+      .on(table.personEntityId, table.orgEntityId, table.roleType, table.role)
+      .where(
+        sql`person_entity_id IS NOT NULL AND org_entity_id IS NOT NULL`
+      ),
   ]
 );
 
@@ -1686,6 +1693,10 @@ export const investments = pgTable(
     index("idx_inv_company_entity").on(table.companyEntityId),
     index("idx_inv_investor_entity").on(table.investorEntityId),
     index("idx_inv_date").on(table.date),
+    // Natural key uniqueness: uq_investments_natural_key
+    // Expression index on (investor_entity_id, company_entity_id, COALESCE(round_name, ''))
+    // WHERE investor_entity_id IS NOT NULL AND company_entity_id IS NOT NULL
+    // Managed in migration 0108_natural_key_uniqueness.sql (not representable in Drizzle API).
   ]
 );
 
@@ -1803,6 +1814,9 @@ export const divisionPersonnel = pgTable(
   (table) => [
     index("idx_dp_division").on(table.divisionId),
     index("idx_dp_person").on(table.personId),
+    // Natural key uniqueness: prevents duplicate person-division assignments.
+    uniqueIndex("uq_division_personnel_natural_key")
+      .on(table.divisionId, table.personId),
   ]
 );
 


### PR DESCRIPTION
## Summary
- Adds composite unique constraints on natural keys for `personnel`, `division_personnel`, and `investments` PG tables to prevent duplicate records
- Migration deduplicates any existing rows first (keeps the most complete record by non-null field count, then by `updated_at` DESC)
- Schema.ts updated with matching Drizzle index definitions (with comments for the expression-based index that Drizzle's API cannot represent)

## Details

**Personnel** (`uq_personnel_natural_key`): Partial unique index on `(person_entity_id, org_entity_id, role_type, role)` where entity IDs are non-null. Uses the specific `role` column (not just `role_type`) because a person can hold multiple distinct roles of the same type at one org -- e.g., Nate Soares was Executive Director then President at MIRI, both `key-person` type.

**Division personnel** (`uq_division_personnel_natural_key`): Unique index on `(division_id, person_id)`. Both columns are NOT NULL, so no partial index needed.

**Investments** (`uq_investments_natural_key`): Partial unique index on `(investor_entity_id, company_entity_id, COALESCE(round_name, ''))` where entity IDs are non-null. Uses COALESCE to treat null `round_name` as empty string for uniqueness purposes.

## Verification

- Queried production data: 229 personnel, 56 investments, 0 division_personnel
- Found only 1 potential false positive (Nate Soares at MIRI), which the 4-column key correctly handles as separate records
- No actual duplicates need deduplication in current production data
- TypeScript checks pass (wiki-server + web app)
- All 657 wiki-server tests pass, all 902 web app tests pass

## Post-merge

After this merges and deploys, the migration will run automatically. The unique constraints will be enforced going forward, and any future sync operations that attempt to insert duplicate natural keys will get a clear constraint violation error. The existing `crux/tablebase/dedup.ts` module already performs client-side dedup that aligns with these keys.

## Test plan
- [x] Verified no existing duplicates in production data
- [x] TypeScript compilation passes for wiki-server and web app
- [x] All 657 wiki-server tests pass
- [x] All 902 web app tests pass
- [x] Migration is idempotent (uses `IF NOT EXISTS` for index creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)