### PR TITLE
fix: directory table columns empty due to fact_id/measure column mismatch

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -81,9 +81,16 @@ function apiEntityToRow(e: DirectoryEntity): ProjectRow {
   if (!orgName && meta.organization) {
     const orgId = meta.organization as string;
     // The directory API includes resolvedRefs for fact-based refs but not YAML fields,
-    // so we use the orgId as a display name fallback and link to the entity page
-    orgName = orgId;
-    orgHref = getEntityHref(orgId);
+    // so resolve the entity title from the slug using local data.
+    const orgEntity = getTypedEntityById(orgId);
+    if (orgEntity) {
+      orgName = orgEntity.title;
+      orgHref = getEntityHref(orgEntity.id);
+    } else {
+      // Fallback: use the slug as display name if entity not found locally
+      orgName = orgId;
+      orgHref = getEntityHref(orgId);
+    }
   }
 
   return {

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -265,32 +265,34 @@ const entitiesApp = new Hono()
 
     const where = conditions.length === 1 ? conditions[0] : and(...conditions)!;
 
-    // Subquery for latest fact value by factId
-    const latestFact = (factId: string) => sql`(
+    // Subquery for latest fact value by measure (property name).
+    // Note: fact_id is the unique fact ID (e.g. "f_qR5tY9wE1a"),
+    // measure is the property name (e.g. "revenue", "headcount").
+    const latestFact = (measureName: string) => sql`(
       SELECT f.numeric
       FROM facts f
       WHERE f.entity_id = ${entities.stableId}
-        AND f.fact_id = ${factId}
+        AND f.measure = ${measureName}
         AND f.numeric IS NOT NULL
       ORDER BY f.as_of DESC NULLS LAST, f.id DESC
       LIMIT 1
     )`;
 
-    const latestFactAsOf = (factId: string) => sql`(
+    const latestFactAsOf = (measureName: string) => sql`(
       SELECT f.as_of
       FROM facts f
       WHERE f.entity_id = ${entities.stableId}
-        AND f.fact_id = ${factId}
+        AND f.measure = ${measureName}
         AND f.numeric IS NOT NULL
       ORDER BY f.as_of DESC NULLS LAST, f.id DESC
       LIMIT 1
     )`;
 
-    const latestFactText = (factId: string) => sql`(
+    const latestFactText = (measureName: string) => sql`(
       SELECT COALESCE(f.value, CAST(f.numeric AS TEXT))
       FROM facts f
       WHERE f.entity_id = ${entities.stableId}
-        AND f.fact_id = ${factId}
+        AND f.measure = ${measureName}
       ORDER BY f.as_of DESC NULLS LAST, f.id DESC
       LIMIT 1
     )`;

--- a/apps/wiki-server/src/routes/tablebase/people.ts
+++ b/apps/wiki-server/src/routes/tablebase/people.ts
@@ -89,13 +89,13 @@ const peopleApp = new Hono()
         OR EXISTS (
           SELECT 1 FROM facts f_s
           WHERE f_s.entity_id = t.id
-          AND f_s.fact_id = 'role'
+          AND f_s.measure = 'role'
           AND f_s.value ILIKE ${pattern}
         )
         OR EXISTS (
           SELECT 1 FROM facts f_s2
           WHERE f_s2.entity_id = t.id
-          AND f_s2.fact_id = 'employed-by'
+          AND f_s2.measure = 'employed-by'
           AND (
             f_s2.value ILIKE ${pattern}
             OR EXISTS (
@@ -112,7 +112,7 @@ const peopleApp = new Hono()
       extraConditions.push(sql`EXISTS (
         SELECT 1 FROM facts f_aff
         WHERE f_aff.entity_id = t.id
-        AND f_aff.fact_id = 'employed-by'
+        AND f_aff.measure = 'employed-by'
         AND (
           f_aff.value = ${affiliation}
           OR EXISTS (
@@ -134,10 +134,10 @@ const peopleApp = new Hono()
     const { field, dir } = parseSort(sort, SORT_ALLOWED, "name", "asc");
 
     // Define sort expressions as parameterized SQL fragments
-    const roleSubquery = sql`(SELECT f_r.value FROM facts f_r WHERE f_r.entity_id = t.id AND f_r.fact_id = 'role' LIMIT 1)`;
-    const employerSubquery = sql`(SELECT COALESCE(emp.title, f_e.value) FROM facts f_e LEFT JOIN entities emp ON emp.stable_id = f_e.value WHERE f_e.entity_id = t.id AND f_e.fact_id = 'employed-by' LIMIT 1)`;
-    const bornYearSubquery = sql`(SELECT f_b.numeric FROM facts f_b WHERE f_b.entity_id = t.id AND f_b.fact_id = 'born-year' LIMIT 1)`;
-    const netWorthSubquery = sql`(SELECT f_n.numeric FROM facts f_n WHERE f_n.entity_id = t.id AND f_n.fact_id = 'net-worth' LIMIT 1)`;
+    const roleSubquery = sql`(SELECT f_r.value FROM facts f_r WHERE f_r.entity_id = t.id AND f_r.measure = 'role' LIMIT 1)`;
+    const employerSubquery = sql`(SELECT COALESCE(emp.title, f_e.value) FROM facts f_e LEFT JOIN entities emp ON emp.stable_id = f_e.value WHERE f_e.entity_id = t.id AND f_e.measure = 'employed-by' LIMIT 1)`;
+    const bornYearSubquery = sql`(SELECT f_b.numeric FROM facts f_b WHERE f_b.entity_id = t.id AND f_b.measure = 'born-year' LIMIT 1)`;
+    const netWorthSubquery = sql`(SELECT f_n.numeric FROM facts f_n WHERE f_n.entity_id = t.id AND f_n.measure = 'net-worth' LIMIT 1)`;
 
     const sortExprMap: Record<string, ReturnType<typeof sql>> = {
       name: sql`t.title`,
@@ -171,7 +171,7 @@ const peopleApp = new Hono()
         t.wiki_id AS "wikiId",
         t.description,
         ${roleSubquery} AS role,
-        (SELECT f_e.value FROM facts f_e WHERE f_e.entity_id = t.id AND f_e.fact_id = 'employed-by' LIMIT 1) AS "employerId",
+        (SELECT f_e.value FROM facts f_e WHERE f_e.entity_id = t.id AND f_e.measure = 'employed-by' LIMIT 1) AS "employerId",
         ${employerSubquery} AS "employerName",
         ${bornYearSubquery} AS "bornYear",
         ${netWorthSubquery} AS "netWorth"
@@ -202,7 +202,7 @@ const peopleApp = new Hono()
         COALESCE(emp.title, f.value) AS "employerName",
         COUNT(DISTINCT t.id)::int AS count
       FROM things t
-      JOIN facts f ON f.entity_id = t.id AND f.fact_id = 'employed-by'
+      JOIN facts f ON f.entity_id = t.id AND f.measure = 'employed-by'
       LEFT JOIN entities emp ON emp.stable_id = f.value
       WHERE t.thing_type = 'entity' AND t.entity_type = 'person'
       GROUP BY COALESCE(emp.title, f.value)


### PR DESCRIPTION
## Summary

- **Organizations financial columns 100% empty (#2601)**: The `/api/entities/organizations` endpoint used `f.fact_id = 'revenue'` in SQL subqueries, but `fact_id` stores unique IDs like `0ed4db9e` while `measure` stores property names like `revenue`. Changed to `f.measure` so the subqueries actually match rows in the facts table.

- **People role/employer columns empty**: Same bug in `/api/people` -- all fact lookups (`role`, `employed-by`, `born-year`, `net-worth`) used `f.fact_id` instead of `f.measure`, returning null for every person.

- **Projects Organization column not resolving (#2619)**: The API path displayed raw slugs (e.g. `quantified-uncertainty`) instead of entity titles. Added `getTypedEntityById()` resolution to show proper names like "QURI (Quantified Uncertainty Research Institute)".

- **Legislation 404s (#2682)**: Investigated and found the 4 entities mentioned (`monitoring`, `thresholds`, `rsp`, `international-regimes`) are correctly typed as `approach`/`concept` in both PG and YAML -- they do NOT appear in the legislation directory. The issue was likely filed against a stale PG state that has since been corrected.

## Root Cause

The `facts` PG table has two key columns:
- `fact_id`: unique fact identifier (e.g. `0ed4db9e`, `f_qR5tY9wE1a`)
- `measure`: property name (e.g. `revenue`, `headcount`, `role`, `employed-by`)

The organizations and people endpoints were filtering on `f.fact_id = 'revenue'` etc., which matched zero rows because `fact_id` never contains property names. The generic `/directory` endpoint already used `f.measure` correctly -- this bug was specific to the dedicated organizations and people endpoints.

## Files Changed

- `apps/wiki-server/src/routes/tablebase/entities.ts` -- Fix 3 SQL subquery helpers
- `apps/wiki-server/src/routes/tablebase/people.ts` -- Fix 10 SQL fact lookups
- `apps/web/src/app/projects/page.tsx` -- Resolve org slug to title

## Test plan

- [x] `pnpm build` passes
- [x] Schema validation passes
- [ ] After deploy, verify `/api/entities/organizations?limit=5` returns non-null `revenueNum` for orgs with FactBase revenue data (e.g. Anthropic)
- [ ] After deploy, verify `/api/people?limit=5` returns non-null `role` and `employerName`
- [ ] Verify `/projects` shows organization names, not raw slugs

Closes #2601
Closes #2619
Closes #2682

Agent slot: a8

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>