### PR TITLE
feat: add PG temporal consistency validator

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -166,6 +166,11 @@ const SCRIPTS = {
     description: 'Check that soft FK fields in PG tables resolve to entities (advisory, requires wiki-server)',
     passthrough: ['ci', 'verbose'],
   },
+  'pg-temporal': {
+    script: 'validate/validate-pg-temporal.ts',
+    description: 'PG temporal consistency (startDate < endDate, date range validation)',
+    passthrough: ['ci'],
+  },
   'to-rdjsonl': {
     script: 'validate/to-rdjsonl.ts',
     description: 'Convert unified --ci JSON to Reviewdog rdjsonl (reads stdin)',

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -428,6 +428,17 @@ const PARALLEL_STEPS: Step[] = [
     advisory: true,
     emitOutputInCi: true,
   },
+  {
+    id: 'pg-temporal',
+    name: 'PG temporal consistency (startDate < endDate, date ranges)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-pg-temporal.ts'],
+    cwd: PROJECT_ROOT,
+    // Advisory: depends on wiki-server being reachable. The check skips
+    // gracefully when the server is unavailable (fail-open).
+    advisory: true,
+    emitOutputInCi: true,
+  },
 ];
 
 // Phase 4 (--full only): Runs after all validations pass

--- a/crux/validate/validate-pg-temporal.test.ts
+++ b/crux/validate/validate-pg-temporal.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDateToNumeric,
+  extractYear,
+  validateDateField,
+  validateDatePair,
+  validateRecords,
+  TABLE_CONFIGS,
+  type TemporalViolation,
+  type DatePairTableConfig,
+  type SingleDateTableConfig,
+} from "./validate-pg-temporal.ts";
+
+// ---------------------------------------------------------------------------
+// parseDateToNumeric
+// ---------------------------------------------------------------------------
+
+describe("parseDateToNumeric", () => {
+  it("parses YYYY format", () => {
+    expect(parseDateToNumeric("2024")).toBe(20240101);
+  });
+
+  it("parses YYYY-MM format", () => {
+    expect(parseDateToNumeric("2024-03")).toBe(20240301);
+  });
+
+  it("parses YYYY-MM-DD format", () => {
+    expect(parseDateToNumeric("2024-03-15")).toBe(20240315);
+  });
+
+  it("parses ISO datetime format", () => {
+    expect(parseDateToNumeric("2024-03-15T10:30:00Z")).toBe(20240315);
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseDateToNumeric("")).toBeNull();
+  });
+
+  it("returns null for garbage input", () => {
+    expect(parseDateToNumeric("not-a-date")).toBeNull();
+  });
+
+  it("returns null for partial date with invalid month", () => {
+    expect(parseDateToNumeric("2024-13")).toBeNull();
+  });
+
+  it("returns null for partial date with zero month", () => {
+    expect(parseDateToNumeric("2024-00")).toBeNull();
+  });
+
+  it("returns null for date with invalid day", () => {
+    expect(parseDateToNumeric("2024-03-32")).toBeNull();
+  });
+
+  it("returns null for date with zero day", () => {
+    expect(parseDateToNumeric("2024-03-00")).toBeNull();
+  });
+
+  it("preserves ordering: 2020 < 2024", () => {
+    const a = parseDateToNumeric("2020");
+    const b = parseDateToNumeric("2024");
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!).toBeLessThan(b!);
+  });
+
+  it("preserves ordering: 2024-01 < 2024-12", () => {
+    const a = parseDateToNumeric("2024-01");
+    const b = parseDateToNumeric("2024-12");
+    expect(a!).toBeLessThan(b!);
+  });
+
+  it("preserves ordering: 2024-03-01 < 2024-03-31", () => {
+    const a = parseDateToNumeric("2024-03-01");
+    const b = parseDateToNumeric("2024-03-31");
+    expect(a!).toBeLessThan(b!);
+  });
+
+  it("handles YYYY correctly when compared with YYYY-MM (same year)", () => {
+    // YYYY defaults to YYYY-01-01, so 2024 == 2024-01 in terms of numeric
+    const a = parseDateToNumeric("2024");
+    const b = parseDateToNumeric("2024-01");
+    expect(a).toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractYear
+// ---------------------------------------------------------------------------
+
+describe("extractYear", () => {
+  it("extracts year from YYYY", () => {
+    expect(extractYear("2024")).toBe(2024);
+  });
+
+  it("extracts year from YYYY-MM", () => {
+    expect(extractYear("2024-06")).toBe(2024);
+  });
+
+  it("extracts year from YYYY-MM-DD", () => {
+    expect(extractYear("2024-06-15")).toBe(2024);
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractYear("")).toBeNull();
+  });
+
+  it("returns null for non-date string", () => {
+    expect(extractYear("abc")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDateField
+// ---------------------------------------------------------------------------
+
+describe("validateDateField", () => {
+  it("returns no violations for valid YYYY date", () => {
+    const violations = validateDateField("test", "r1", "date", "2024");
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations for valid YYYY-MM date", () => {
+    const violations = validateDateField("test", "r1", "date", "2024-06");
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations for valid YYYY-MM-DD date", () => {
+    const violations = validateDateField("test", "r1", "date", "2024-06-15");
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns a warning for invalid format", () => {
+    const violations = validateDateField("test", "r1", "date", "June 2024");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe("warning");
+    expect(violations[0].issue).toContain("Invalid date format");
+    expect(violations[0].table).toBe("test");
+    expect(violations[0].recordId).toBe("r1");
+    expect(violations[0].field).toBe("date");
+    expect(violations[0].value).toBe("June 2024");
+  });
+
+  it("returns a warning for date before MIN_YEAR (1900)", () => {
+    const violations = validateDateField("test", "r1", "date", "1899");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe("warning");
+    expect(violations[0].issue).toContain("outside reasonable range");
+  });
+
+  it("returns a warning for date after MAX_YEAR (2100)", () => {
+    const violations = validateDateField("test", "r1", "date", "2101");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe("warning");
+    expect(violations[0].issue).toContain("outside reasonable range");
+  });
+
+  it("accepts boundary year 1900", () => {
+    const violations = validateDateField("test", "r1", "date", "1900");
+    expect(violations).toHaveLength(0);
+  });
+
+  it("accepts boundary year 2100", () => {
+    const violations = validateDateField("test", "r1", "date", "2100");
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDatePair
+// ---------------------------------------------------------------------------
+
+describe("validateDatePair", () => {
+  it("returns no violations when both dates are null", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", null, "endDate", null,
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations when only start date exists", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "2024", "endDate", null,
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations when only end date exists", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", null, "endDate", "2024",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations for valid ordering (start < end)", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "2020", "endDate", "2024",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns no violations for equal dates", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "2024-06", "endDate", "2024-06",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns an error when start date is after end date", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "2025", "endDate", "2020",
+    );
+    const errors = violations.filter((v) => v.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].issue).toContain("Start date (2025) is after end date (2020)");
+    expect(errors[0].field).toBe("startDate / endDate");
+    expect(errors[0].value).toBe("2025 → 2020");
+  });
+
+  it("detects reversed YYYY-MM dates", () => {
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "2024-12", "endDate", "2024-01",
+    );
+    const errors = violations.filter((v) => v.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].issue).toContain("is after end date");
+  });
+
+  it("reports format errors alongside ordering errors", () => {
+    // Start is bad format, end is valid — only format warning for start
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "garbage", "endDate", "2024",
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations.some((v) => v.issue.includes("Invalid date format"))).toBe(true);
+  });
+
+  it("validates both start and end individually", () => {
+    // Both have out-of-range years
+    const violations = validateDatePair(
+      "test", "r1", "startDate", "1800", "endDate", "2200",
+    );
+    const rangeWarnings = violations.filter((v) =>
+      v.issue.includes("outside reasonable range"),
+    );
+    expect(rangeWarnings).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRecords
+// ---------------------------------------------------------------------------
+
+describe("validateRecords", () => {
+  const pairConfig: DatePairTableConfig = {
+    kind: "pair",
+    table: "personnel",
+    apiPath: "/api/personnel/all",
+    recordsKey: "personnel",
+    startField: "startDate",
+    endField: "endDate",
+  };
+
+  const singleConfig: SingleDateTableConfig = {
+    kind: "single",
+    table: "grants",
+    apiPath: "/api/grants/all",
+    recordsKey: "grants",
+    dateField: "date",
+  };
+
+  it("returns no violations for valid pair records", () => {
+    const records = [
+      { id: "r1", startDate: "2020", endDate: "2024" },
+      { id: "r2", startDate: "2018-06", endDate: null },
+      { id: "r3", startDate: null, endDate: null },
+    ];
+    const violations = validateRecords(pairConfig, records);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects start > end in pair records", () => {
+    const records = [
+      { id: "r1", startDate: "2025", endDate: "2020" },
+    ];
+    const violations = validateRecords(pairConfig, records);
+    expect(violations.some((v) => v.severity === "error")).toBe(true);
+  });
+
+  it("returns no violations for valid single date records", () => {
+    const records = [
+      { id: "g1", date: "2024-03" },
+      { id: "g2", date: null },
+      { id: "g3", date: "" },
+    ];
+    const violations = validateRecords(singleConfig, records);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects bad format in single date records", () => {
+    const records = [
+      { id: "g1", date: "next year" },
+    ];
+    const violations = validateRecords(singleConfig, records);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].issue).toContain("Invalid date format");
+  });
+
+  it("detects out-of-range year in single date records", () => {
+    const records = [
+      { id: "g1", date: "1850" },
+    ];
+    const violations = validateRecords(singleConfig, records);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].issue).toContain("outside reasonable range");
+  });
+
+  it("handles missing id field gracefully", () => {
+    const records = [
+      { date: "2024-03" } as Record<string, unknown>,
+    ];
+    const violations = validateRecords(singleConfig, records);
+    // Should not crash; id defaults to "unknown"
+    expect(violations).toHaveLength(0);
+  });
+
+  it("handles non-string date field gracefully", () => {
+    const records = [
+      { id: "g1", date: 2024 },
+    ];
+    const violations = validateRecords(singleConfig, records);
+    // Numbers are not typeof string, so they're skipped
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TABLE_CONFIGS
+// ---------------------------------------------------------------------------
+
+describe("TABLE_CONFIGS", () => {
+  it("has configs for all expected tables", () => {
+    const tables = TABLE_CONFIGS.map((c) => c.table);
+    expect(tables).toContain("personnel");
+    expect(tables).toContain("divisions");
+    expect(tables).toContain("division_personnel");
+    expect(tables).toContain("equity_positions");
+    expect(tables).toContain("funding_programs");
+    expect(tables).toContain("funding_rounds");
+    expect(tables).toContain("investments");
+    expect(tables).toContain("grants");
+    expect(tables).toContain("benchmarks");
+    expect(tables).toContain("benchmark_results");
+  });
+
+  it("pair configs have startField and endField", () => {
+    const pairConfigs = TABLE_CONFIGS.filter((c) => c.kind === "pair");
+    expect(pairConfigs.length).toBeGreaterThan(0);
+    for (const c of pairConfigs) {
+      expect(c).toHaveProperty("startField");
+      expect(c).toHaveProperty("endField");
+    }
+  });
+
+  it("single configs have dateField", () => {
+    const singleConfigs = TABLE_CONFIGS.filter((c) => c.kind === "single");
+    expect(singleConfigs.length).toBeGreaterThan(0);
+    for (const c of singleConfigs) {
+      expect(c).toHaveProperty("dateField");
+    }
+  });
+
+  it("all configs have non-empty apiPath and recordsKey", () => {
+    for (const c of TABLE_CONFIGS) {
+      expect(c.apiPath).toBeTruthy();
+      expect(c.recordsKey).toBeTruthy();
+    }
+  });
+});

--- a/crux/validate/validate-pg-temporal.ts
+++ b/crux/validate/validate-pg-temporal.ts
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+
+/**
+ * PG Temporal Consistency Validator
+ *
+ * Validates temporal consistency of date fields in PG tables:
+ *   - startDate < endDate when both exist (start/end pairs)
+ *   - All dates are in a reasonable range (1900–2100)
+ *   - Date format is valid (YYYY, YYYY-MM, or ISO date)
+ *
+ * Tables checked:
+ *   - personnel: startDate, endDate
+ *   - divisions: startDate, endDate
+ *   - division_personnel: startDate, endDate
+ *   - equity_positions: asOf, validEnd
+ *   - funding_programs: openDate, deadline
+ *   - funding_rounds: date (single)
+ *   - investments: date (single)
+ *   - grants: date (single)
+ *   - benchmarks: introducedDate (single)
+ *   - benchmark_results: date (single)
+ *
+ * Network dependency: Requires wiki-server access. If unavailable, the check
+ * is skipped gracefully (fail-open).
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-pg-temporal.ts
+ *   npx tsx crux/validate/validate-pg-temporal.ts --ci
+ *
+ * Exit codes:
+ *   0 = No issues found (or server unavailable — skipped)
+ *   1 = Issues found
+ */
+
+import { fileURLToPath } from "url";
+import { getColors } from "../lib/output.ts";
+import type { ValidatorResult, ValidatorOptions } from "./types.ts";
+import type { Colors } from "../lib/output.ts";
+import {
+  getServerUrl,
+  apiRequest,
+} from "../lib/wiki-server/client.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single temporal violation found in a PG record. */
+export interface TemporalViolation {
+  table: string;
+  recordId: string;
+  field: string;
+  value: string;
+  issue: string;
+  severity: "error" | "warning";
+}
+
+/** Configuration for a table with a start/end date pair. */
+export interface DatePairTableConfig {
+  kind: "pair";
+  table: string;
+  apiPath: string;
+  /** JSON key for the array of records in the API response. */
+  recordsKey: string;
+  startField: string;
+  endField: string;
+}
+
+/** Configuration for a table with a single date field. */
+export interface SingleDateTableConfig {
+  kind: "single";
+  table: string;
+  apiPath: string;
+  /** JSON key for the array of records in the API response. */
+  recordsKey: string;
+  dateField: string;
+}
+
+export type TableConfig = DatePairTableConfig | SingleDateTableConfig;
+
+// ---------------------------------------------------------------------------
+// Date validation helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/** Matches YYYY, YYYY-MM, YYYY-MM-DD, or full ISO date strings. */
+const DATE_PATTERN = /^\d{4}(?:-\d{2}(?:-\d{2}(?:T[\d:.Z+-]+)?)?)?$/;
+
+/** Minimum reasonable year for the knowledge base. */
+const MIN_YEAR = 1900;
+/** Maximum reasonable year (far enough in the future for deadlines). */
+const MAX_YEAR = 2100;
+
+/**
+ * Parse a flexible date string into a comparable numeric value.
+ * Returns null if the date string is invalid.
+ *
+ * Supports: YYYY, YYYY-MM, YYYY-MM-DD, ISO datetime.
+ * Returns a numeric representation for ordering (YYYYMMDD).
+ */
+export function parseDateToNumeric(dateStr: string): number | null {
+  if (!DATE_PATTERN.test(dateStr)) return null;
+
+  const parts = dateStr.split(/[-T]/);
+  const year = parseInt(parts[0], 10);
+  const month = parts.length > 1 ? parseInt(parts[1], 10) : 1;
+  const day = parts.length > 2 ? parseInt(parts[2], 10) : 1;
+
+  if (isNaN(year) || isNaN(month) || isNaN(day)) return null;
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  return year * 10000 + month * 100 + day;
+}
+
+/**
+ * Extract the year from a flexible date string. Returns null if invalid.
+ */
+export function extractYear(dateStr: string): number | null {
+  const match = dateStr.match(/^(\d{4})/);
+  if (!match) return null;
+  const year = parseInt(match[1], 10);
+  return isNaN(year) ? null : year;
+}
+
+/**
+ * Validate a single date string for format and range.
+ * Returns violations found, if any.
+ */
+export function validateDateField(
+  table: string,
+  recordId: string,
+  field: string,
+  value: string,
+): TemporalViolation[] {
+  const violations: TemporalViolation[] = [];
+
+  // Check format
+  if (!DATE_PATTERN.test(value)) {
+    violations.push({
+      table,
+      recordId,
+      field,
+      value,
+      issue: `Invalid date format (expected YYYY, YYYY-MM, or YYYY-MM-DD)`,
+      severity: "warning",
+    });
+    return violations; // Skip range check if format is bad
+  }
+
+  // Check range
+  const year = extractYear(value);
+  if (year !== null && (year < MIN_YEAR || year > MAX_YEAR)) {
+    violations.push({
+      table,
+      recordId,
+      field,
+      value,
+      issue: `Date year ${year} is outside reasonable range (${MIN_YEAR}–${MAX_YEAR})`,
+      severity: "warning",
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * Validate a start/end date pair for temporal consistency.
+ * Returns violations found, if any.
+ */
+export function validateDatePair(
+  table: string,
+  recordId: string,
+  startField: string,
+  startValue: string | null | undefined,
+  endField: string,
+  endValue: string | null | undefined,
+): TemporalViolation[] {
+  const violations: TemporalViolation[] = [];
+
+  // Validate individual fields
+  if (startValue) {
+    violations.push(...validateDateField(table, recordId, startField, startValue));
+  }
+  if (endValue) {
+    violations.push(...validateDateField(table, recordId, endField, endValue));
+  }
+
+  // Check ordering: start < end
+  if (startValue && endValue) {
+    const startNum = parseDateToNumeric(startValue);
+    const endNum = parseDateToNumeric(endValue);
+
+    if (startNum !== null && endNum !== null && startNum > endNum) {
+      violations.push({
+        table,
+        recordId,
+        field: `${startField} / ${endField}`,
+        value: `${startValue} → ${endValue}`,
+        issue: `Start date (${startValue}) is after end date (${endValue})`,
+        severity: "error",
+      });
+    }
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Table configurations
+// ---------------------------------------------------------------------------
+
+export const TABLE_CONFIGS: TableConfig[] = [
+  // Tables with start/end date pairs
+  {
+    kind: "pair",
+    table: "personnel",
+    apiPath: "/api/personnel/all",
+    recordsKey: "personnel",
+    startField: "startDate",
+    endField: "endDate",
+  },
+  {
+    kind: "pair",
+    table: "divisions",
+    apiPath: "/api/divisions/all",
+    recordsKey: "divisions",
+    startField: "startDate",
+    endField: "endDate",
+  },
+  {
+    kind: "pair",
+    table: "division_personnel",
+    apiPath: "/api/division-personnel/all",
+    recordsKey: "divisionPersonnel",
+    startField: "startDate",
+    endField: "endDate",
+  },
+  {
+    kind: "pair",
+    table: "equity_positions",
+    apiPath: "/api/equity-positions/all",
+    recordsKey: "equityPositions",
+    startField: "asOf",
+    endField: "validEnd",
+  },
+  {
+    kind: "pair",
+    table: "funding_programs",
+    apiPath: "/api/funding-programs/all",
+    recordsKey: "fundingPrograms",
+    startField: "openDate",
+    endField: "deadline",
+  },
+  // Tables with single date fields
+  {
+    kind: "single",
+    table: "funding_rounds",
+    apiPath: "/api/funding-rounds/all",
+    recordsKey: "fundingRounds",
+    dateField: "date",
+  },
+  {
+    kind: "single",
+    table: "investments",
+    apiPath: "/api/investments/all",
+    recordsKey: "investments",
+    dateField: "date",
+  },
+  {
+    kind: "single",
+    table: "grants",
+    apiPath: "/api/grants/all",
+    recordsKey: "grants",
+    dateField: "date",
+  },
+  {
+    kind: "single",
+    table: "benchmarks",
+    apiPath: "/api/benchmarks/all",
+    recordsKey: "benchmarks",
+    dateField: "introducedDate",
+  },
+  {
+    kind: "single",
+    table: "benchmark_results",
+    apiPath: "/api/benchmark-results/all",
+    recordsKey: "results",
+    dateField: "date",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Fetch and validate logic
+// ---------------------------------------------------------------------------
+
+/** Pagination parameters that all /all endpoints accept. */
+const MAX_PAGE_SIZE = 200;
+const MAX_PAGES = 100; // safety cap: 20,000 records per table
+
+/**
+ * Fetch all records from a paginated /all endpoint.
+ * Returns null if the API is unreachable.
+ */
+async function fetchAllRecords(
+  config: TableConfig,
+): Promise<Record<string, unknown>[] | null> {
+  const allRecords: Record<string, unknown>[] = [];
+  let offset = 0;
+  let total = Infinity;
+  let pageCount = 0;
+
+  while (offset < total && pageCount < MAX_PAGES) {
+    pageCount++;
+    const result = await apiRequest<Record<string, unknown>>(
+      "GET",
+      `${config.apiPath}?limit=${MAX_PAGE_SIZE}&offset=${offset}`,
+    );
+
+    if (!result.ok) {
+      return null;
+    }
+
+    const data = result.data;
+    const records = data[config.recordsKey];
+    if (!Array.isArray(records)) {
+      console.warn(
+        `  WARN: Expected array at key "${config.recordsKey}" for ${config.table}, got ${typeof records}`,
+      );
+      return null;
+    }
+
+    allRecords.push(...records);
+    total = typeof data.total === "number" ? data.total : allRecords.length;
+    offset += MAX_PAGE_SIZE;
+
+    // If we got fewer records than page size, we're done
+    if (records.length < MAX_PAGE_SIZE) break;
+  }
+
+  return allRecords;
+}
+
+/**
+ * Validate all records from one table config.
+ */
+export function validateRecords(
+  config: TableConfig,
+  records: Record<string, unknown>[],
+): TemporalViolation[] {
+  const violations: TemporalViolation[] = [];
+
+  for (const record of records) {
+    const id = String(record.id ?? "unknown");
+
+    if (config.kind === "pair") {
+      const startVal = record[config.startField];
+      const endVal = record[config.endField];
+      violations.push(
+        ...validateDatePair(
+          config.table,
+          id,
+          config.startField,
+          typeof startVal === "string" ? startVal : null,
+          config.endField,
+          typeof endVal === "string" ? endVal : null,
+        ),
+      );
+    } else {
+      const dateVal = record[config.dateField];
+      if (typeof dateVal === "string" && dateVal.length > 0) {
+        violations.push(
+          ...validateDateField(config.table, id, config.dateField, dateVal),
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// runCheck (for orchestrator / gate)
+// ---------------------------------------------------------------------------
+
+export async function runCheck(
+  options: ValidatorOptions = {},
+): Promise<ValidatorResult> {
+  const ciMode = options.ci ?? false;
+  const colors: Colors = getColors(ciMode);
+
+  const serverUrl = getServerUrl();
+
+  // Fail-open: if wiki-server is not configured, skip gracefully.
+  if (!serverUrl) {
+    if (!ciMode) {
+      console.log(
+        `${colors.dim}PG temporal check skipped — LONGTERMWIKI_SERVER_URL not set${colors.reset}`,
+      );
+    }
+    return { passed: true, errors: 0, warnings: 1 };
+  }
+
+  if (!ciMode) {
+    console.log(
+      `${colors.blue}Checking PG temporal consistency...${colors.reset}\n`,
+    );
+  }
+
+  const allViolations: TemporalViolation[] = [];
+  let tablesChecked = 0;
+  let totalRecords = 0;
+  let serverUnavailable = false;
+
+  for (const config of TABLE_CONFIGS) {
+    const records = await fetchAllRecords(config);
+
+    if (records === null) {
+      // First table failure — check if server is unreachable
+      if (tablesChecked === 0) {
+        serverUnavailable = true;
+        break;
+      }
+      // Partial failure — log and continue with other tables
+      if (!ciMode) {
+        console.log(
+          `${colors.yellow}  Skipping ${config.table} — API unavailable${colors.reset}`,
+        );
+      }
+      continue;
+    }
+
+    tablesChecked++;
+    totalRecords += records.length;
+
+    const violations = validateRecords(config, records);
+    allViolations.push(...violations);
+
+    if (!ciMode) {
+      const violationCount = violations.length;
+      if (violationCount === 0) {
+        console.log(
+          `  ${colors.green}✓${colors.reset} ${config.table}: ${records.length} records OK`,
+        );
+      } else {
+        console.log(
+          `  ${colors.yellow}⚠${colors.reset} ${config.table}: ${violationCount} issue(s) in ${records.length} records`,
+        );
+      }
+    }
+  }
+
+  if (serverUnavailable) {
+    if (!ciMode) {
+      console.log(
+        `${colors.yellow}  Wiki-server unavailable — skipping PG temporal check${colors.reset}`,
+      );
+    }
+    return { passed: true, errors: 0, warnings: 1 };
+  }
+
+  // Summarize
+  const errorCount = allViolations.filter((v) => v.severity === "error").length;
+  const warningCount = allViolations.filter(
+    (v) => v.severity === "warning",
+  ).length;
+
+  if (ciMode) {
+    console.log(
+      JSON.stringify(
+        {
+          tablesChecked,
+          totalRecords,
+          errors: errorCount,
+          warnings: warningCount,
+          violations: allViolations,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    if (allViolations.length === 0) {
+      console.log(
+        `\n${colors.green}✓ No temporal issues found across ${tablesChecked} tables (${totalRecords} records)${colors.reset}`,
+      );
+    } else {
+      console.log(
+        `\n${colors.yellow}Found ${allViolations.length} temporal issue(s):${colors.reset}\n`,
+      );
+
+      // Group by table for readability
+      const byTable = new Map<string, TemporalViolation[]>();
+      for (const v of allViolations) {
+        const list = byTable.get(v.table) ?? [];
+        list.push(v);
+        byTable.set(v.table, list);
+      }
+
+      for (const [table, violations] of byTable) {
+        console.log(`  ${colors.bold}${table}:${colors.reset}`);
+        for (const v of violations) {
+          const icon =
+            v.severity === "error"
+              ? `${colors.red}✗`
+              : `${colors.yellow}⚠`;
+          console.log(
+            `    ${icon}${colors.reset} [${v.recordId}] ${v.field}: ${v.issue}`,
+          );
+          console.log(`      ${colors.dim}value: ${v.value}${colors.reset}`);
+        }
+      }
+
+      console.log(
+        `\n${"─".repeat(50)}`,
+      );
+      console.log(
+        `Tables: ${tablesChecked}, Records: ${totalRecords}, Errors: ${errorCount}, Warnings: ${warningCount}`,
+      );
+    }
+  }
+
+  return {
+    passed: errorCount === 0,
+    errors: errorCount,
+    warnings: warningCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Standalone main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const result = await runCheck({
+    ci: args.includes("--ci"),
+  });
+  process.exit(result.passed ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Adds `crux/validate/validate-pg-temporal.ts` that validates date fields across 10 PG tables for temporal consistency
- Checks: startDate < endDate ordering, dates in reasonable range (1900-2100), valid format (YYYY, YYYY-MM, YYYY-MM-DD)
- Tables covered: personnel, divisions, division_personnel, equity_positions, funding_programs, funding_rounds, investments, grants, benchmarks, benchmark_results
- Registered as `crux validate pg-temporal` CLI subcommand and as an advisory gate step
- Fails open when wiki-server is unavailable (network dependency)
- 47 unit tests covering date parsing, format validation, range checks, pair ordering, and record-level validation

## Test plan

- [x] 47 unit tests pass (`npx vitest run crux/validate/validate-pg-temporal.test.ts`)
- [x] All 3470 crux tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm crux validate pg-temporal` runs and fails open when server unavailable
- [ ] Verify against production wiki-server (`WIKI_SERVER_ENV=prod pnpm crux validate pg-temporal`)

Generated with [Claude Code](https://claude.com/claude-code)