### PR TITLE
feat: resource display Phase 4 — card view, hover preview, type taxonomy

### DIFF
--- a/apps/web/src/app/organizations/[slug]/resources-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/resources-section.tsx
@@ -12,7 +12,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
-import { Search, ChevronLeft, ChevronRight, AlertTriangle, Lock, Archive } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, AlertTriangle, Lock, Archive, LayoutList, Table2 } from "lucide-react";
 import { SortableHeader } from "@/components/ui/sortable-header";
 import {
   Table,
@@ -24,19 +24,11 @@ import {
 } from "@/components/ui/table";
 import { safeHref } from "@/lib/format-compact";
 import type { OrgResourceRow } from "./org-data";
+import { ResourceList } from "@/components/resources/ResourceList";
+import { RESOURCE_TYPE_COLORS, RESOURCE_TYPE_LABELS, STANCE_COLORS, CREDIBILITY_COLORS } from "@/components/resources/resource-constants";
 
-const TYPE_COLORS: Record<string, string> = {
-  paper: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
-  blog: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
-  report: "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300",
-  book: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
-  web: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
-  government: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
-  talk: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
-  podcast: "bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300",
-};
-
-const DEFAULT_COLOR = "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+const TYPE_COLORS = RESOURCE_TYPE_COLORS;
+const DEFAULT_COLOR = RESOURCE_TYPE_COLORS._default;
 
 /** Compute which optional columns have enough data to be worth showing. */
 function computeColumnVisibility(
@@ -58,13 +50,7 @@ function computeColumnVisibility(
   };
 }
 
-const STANCE_COLORS: Record<string, string> = {
-  support: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-  oppose: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-  neutral: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
-  mixed: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  analysis: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-};
+// STANCE_COLORS imported from resource-constants
 
 function makeColumns(opts: {
   showDate: boolean;
@@ -311,17 +297,23 @@ function makeColumns(opts: {
   return cols;
 }
 
+type ViewMode = "table" | "card";
+
 export function OrgResourcesSection({
   resources,
   title,
   emptyMessage,
   alwaysShowColumns,
+  defaultView = "table",
 }: {
   resources: OrgResourceRow[];
   title: string;
   emptyMessage: string;
   alwaysShowColumns?: { date?: boolean; publication?: boolean; credibility?: boolean };
+  defaultView?: ViewMode;
 }) {
+  const [view, setView] = useState<ViewMode>(defaultView);
+
   if (resources.length === 0) {
     return (
       <section>
@@ -331,10 +323,46 @@ export function OrgResourcesSection({
     );
   }
 
+  if (view === "card") {
+    return (
+      <section>
+        <div className="flex items-center justify-between mb-2">
+          <div /> {/* spacer — ResourceList renders its own header */}
+          <ViewToggle view={view} onChange={setView} />
+        </div>
+        <ResourceList resources={resources} title={title} emptyMessage={emptyMessage} />
+      </section>
+    );
+  }
+
   return (
     <section>
+      <div className="flex items-center justify-end mb-1">
+        <ViewToggle view={view} onChange={setView} />
+      </div>
       <OrgResourcesTable resources={resources} title={title} alwaysShowColumns={alwaysShowColumns} />
     </section>
+  );
+}
+
+function ViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode) => void }) {
+  return (
+    <div className="flex items-center gap-0.5 border border-border rounded-md p-0.5">
+      <button
+        onClick={() => onChange("table")}
+        className={`p-1 rounded transition-colors ${view === "table" ? "bg-muted text-foreground" : "text-muted-foreground/50 hover:text-muted-foreground"}`}
+        title="Table view"
+      >
+        <Table2 className="h-3.5 w-3.5" />
+      </button>
+      <button
+        onClick={() => onChange("card")}
+        className={`p-1 rounded transition-colors ${view === "card" ? "bg-muted text-foreground" : "text-muted-foreground/50 hover:text-muted-foreground"}`}
+        title="Card view"
+      >
+        <LayoutList className="h-3.5 w-3.5" />
+      </button>
+    </div>
   );
 }
 

--- a/apps/web/src/components/resources/ResourceCard.tsx
+++ b/apps/web/src/components/resources/ResourceCard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, Lock, ExternalLink, Archive } from "lucide-react";
+import { safeHref } from "@/lib/format-compact";
+import type { OrgResourceRow } from "@/app/organizations/[slug]/org-data";
+import { RESOURCE_TYPE_LABELS, RESOURCE_TYPE_COLORS, STANCE_COLORS, CREDIBILITY_COLORS } from "./resource-constants";
+import { ResourcePreview } from "./ResourcePreview";
+
+export function ResourceCard({ resource: r }: { resource: OrgResourceRow }) {
+  const typeLabel = RESOURCE_TYPE_LABELS[r.type] ?? r.type;
+  const typeColor = RESOURCE_TYPE_COLORS[r.type] ?? RESOURCE_TYPE_COLORS._default;
+  const isDead = r.fetchStatus === "dead";
+  const isPaywall = r.fetchStatus === "paywall";
+  const archiveHref = isDead && r.archiveUrl ? safeHref(r.archiveUrl) : null;
+  const source = r.publicationName || r.domain;
+
+  return (
+    <div className="group py-3 border-b border-border/40 last:border-0">
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          {/* Title row */}
+          <div className="flex items-start gap-2">
+            <ResourcePreview resource={r}>
+              <Link
+                href={`/resources/${r.id}`}
+                className="text-sm font-medium text-foreground hover:text-primary transition-colors line-clamp-2 leading-snug"
+              >
+                {r.title}
+              </Link>
+            </ResourcePreview>
+            {isDead && (
+              <span title="Link may be broken" className="shrink-0 mt-0.5">
+                <AlertTriangle className="h-3.5 w-3.5 text-red-400" />
+              </span>
+            )}
+            {isPaywall && (
+              <span title="Behind paywall" className="shrink-0 mt-0.5">
+                <Lock className="h-3.5 w-3.5 text-amber-400" />
+              </span>
+            )}
+          </div>
+
+          {/* Meta row: source + date + type */}
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            {source && (
+              <span className="text-xs text-muted-foreground">{source}</span>
+            )}
+            {r.publishedDate && (
+              <>
+                {source && <span className="text-muted-foreground/30">&middot;</span>}
+                <span className="text-xs text-muted-foreground tabular-nums">{r.publishedDate.slice(0, 10)}</span>
+              </>
+            )}
+            <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium whitespace-nowrap ${typeColor}`}>
+              {typeLabel}
+            </span>
+            {r.stance && (
+              <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium whitespace-nowrap capitalize ${STANCE_COLORS[r.stance] ?? STANCE_COLORS._default}`}>
+                {r.stance}
+              </span>
+            )}
+            {r.credibility != null && (
+              <span className={`text-[10px] font-medium tabular-nums ${CREDIBILITY_COLORS(r.credibility)}`}>
+                {r.credibility}/5
+              </span>
+            )}
+          </div>
+
+          {/* Authors */}
+          {r.authors.length > 0 && (
+            <div className="text-[11px] text-muted-foreground/70 mt-1 line-clamp-1">
+              {r.authors.slice(0, 4).map((a, i) => (
+                <span key={i}>
+                  {i > 0 && ", "}
+                  {a.href ? (
+                    <Link href={a.href} className="hover:text-primary hover:underline">{a.name}</Link>
+                  ) : (
+                    a.name
+                  )}
+                </span>
+              ))}
+              {r.authors.length > 4 && <span className="text-muted-foreground/40"> +{r.authors.length - 4}</span>}
+            </div>
+          )}
+
+          {/* Summary */}
+          {r.summary && (
+            <p className="text-xs text-muted-foreground/55 mt-1 line-clamp-2 leading-relaxed">
+              {r.summary}
+            </p>
+          )}
+        </div>
+
+        {/* Right side: external link + citing pages */}
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <div className="flex items-center gap-1">
+            {archiveHref && (
+              <a
+                href={archiveHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground/50 hover:text-primary transition-colors"
+                title="View archived version"
+              >
+                <Archive className="h-3.5 w-3.5" />
+              </a>
+            )}
+            <a
+              href={safeHref(r.url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`transition-colors ${isDead ? "text-muted-foreground/30" : "text-muted-foreground/50 hover:text-primary"}`}
+              title={isDead ? `Link may be broken: ${r.url}` : r.url}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+          {r.citingPageCount > 0 && (
+            <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+              {r.citingPageCount} citing
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/resources/ResourceList.tsx
+++ b/apps/web/src/components/resources/ResourceList.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Search, ChevronLeft, ChevronRight, LayoutList, Table2 } from "lucide-react";
+import type { OrgResourceRow } from "@/app/organizations/[slug]/org-data";
+import { ResourceCard } from "./ResourceCard";
+
+type ViewMode = "card" | "table";
+
+/**
+ * Resource list with card view, search, type filter, and pagination.
+ * Offers a card-based display as an alternative to the table view.
+ */
+export function ResourceList({
+  resources,
+  title,
+  emptyMessage = "No resources found.",
+}: {
+  resources: OrgResourceRow[];
+  title: string;
+  emptyMessage?: string;
+}) {
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+  const [page, setPage] = useState(0);
+  const pageSize = 25;
+
+  const types = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of resources) counts.set(r.type, (counts.get(r.type) ?? 0) + 1);
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [resources]);
+
+  const filtered = useMemo(() => {
+    let items = resources;
+    if (typeFilter) items = items.filter((r) => r.type === typeFilter);
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      items = items.filter((r) =>
+        r.title.toLowerCase().includes(q) ||
+        (r.publicationName?.toLowerCase().includes(q)) ||
+        (r.domain?.toLowerCase().includes(q)) ||
+        r.authors.some((a) => a.name.toLowerCase().includes(q)) ||
+        (r.summary?.toLowerCase().includes(q))
+      );
+    }
+    return items;
+  }, [resources, typeFilter, search]);
+
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);
+
+  if (resources.length === 0) {
+    return (
+      <section>
+        <h3 className="text-lg font-bold tracking-tight mb-2">{title}</h3>
+        <p className="text-sm text-muted-foreground py-4">{emptyMessage}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h3 className="text-lg font-bold tracking-tight">
+          {title}{" "}
+          <span className="text-sm font-normal text-muted-foreground">
+            ({filtered.length === resources.length ? resources.length : `${filtered.length} of ${resources.length}`})
+          </span>
+        </h3>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[180px] max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            placeholder="Search..."
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(0); }}
+            className="h-8 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+          />
+        </div>
+        {types.length > 1 && (
+          <select
+            value={typeFilter}
+            onChange={(e) => { setTypeFilter(e.target.value); setPage(0); }}
+            className="h-8 rounded-lg border border-border bg-background px-2 text-xs shadow-sm"
+          >
+            <option value="">All types</option>
+            {types.map(([t, c]) => (
+              <option key={t} value={t}>{t} ({c})</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Card list */}
+      <div className="rounded-lg border border-border/60 shadow-sm px-4">
+        {pageItems.length > 0 ? (
+          pageItems.map((r) => <ResourceCard key={r.id} resource={r} />)
+        ) : (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No resources match your filters.
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-1">
+          <select
+            value={pageSize}
+            disabled
+            className="h-7 rounded border border-border bg-background px-2 text-xs opacity-50"
+          >
+            <option value={25}>25 per page</option>
+          </select>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/resources/ResourcePreview.tsx
+++ b/apps/web/src/components/resources/ResourcePreview.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import type { OrgResourceRow } from "@/app/organizations/[slug]/org-data";
+
+/**
+ * Hover preview wrapper for a resource.
+ * Shows summary, abstract, and key metadata in a tooltip-like popover.
+ * Wraps its children (typically the title link).
+ */
+export function ResourcePreview({
+  resource: r,
+  children,
+}: {
+  resource: OrgResourceRow;
+  children: ReactNode;
+}) {
+  const [show, setShow] = useState(false);
+
+  // Only show preview if there's meaningful content to display
+  const hasPreviewContent = r.summary;
+  if (!hasPreviewContent) return <>{children}</>;
+
+  return (
+    <div
+      className="relative inline"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      {children}
+      {show && (
+        <div className="absolute z-50 left-0 top-full mt-1 w-80 max-w-[90vw] p-3 bg-popover border border-border rounded-lg shadow-lg text-xs space-y-2 pointer-events-none">
+          {/* Source + date */}
+          <div className="flex items-center gap-2 text-muted-foreground/70">
+            {r.publicationName && <span className="italic">{r.publicationName}</span>}
+            {!r.publicationName && r.domain && <span>{r.domain}</span>}
+            {r.publishedDate && <span className="tabular-nums">{r.publishedDate.slice(0, 10)}</span>}
+          </div>
+
+          {/* Summary */}
+          {r.summary && (
+            <p className="text-muted-foreground leading-relaxed line-clamp-4">
+              {r.summary}
+            </p>
+          )}
+
+          {/* Authors */}
+          {r.authors.length > 0 && (
+            <div className="text-[11px] text-muted-foreground/60">
+              By {r.authors.slice(0, 5).map((a) => a.name).join(", ")}
+              {r.authors.length > 5 && ` +${r.authors.length - 5}`}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/resources/resource-constants.ts
+++ b/apps/web/src/components/resources/resource-constants.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared constants for resource display: type labels, colors, stance colors.
+ * Used by both ResourceCard (card view) and OrgResourcesTable (table view).
+ */
+
+// ── Type taxonomy (4C) ──────────────────────────────────────────────
+// Maps raw resource types to human-readable labels.
+// Extends the original set (paper, blog, web, government, etc.) with
+// more specific types that can be assigned via domain heuristics or LLM.
+
+export const RESOURCE_TYPE_LABELS: Record<string, string> = {
+  paper: "Paper",
+  blog: "Blog",
+  report: "Report",
+  book: "Book",
+  web: "Web",
+  government: "Government",
+  talk: "Talk",
+  podcast: "Podcast",
+  reference: "Reference",
+  // Extended taxonomy (4C)
+  news_article: "News",
+  legal_analysis: "Legal Analysis",
+  government_doc: "Gov. Document",
+  academic_paper: "Academic",
+  blog_post: "Blog Post",
+  press_release: "Press Release",
+  think_tank: "Think Tank",
+  opinion: "Opinion",
+  transcript: "Transcript",
+};
+
+export const RESOURCE_TYPE_COLORS: Record<string, string> = {
+  paper: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  academic_paper: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  blog: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+  blog_post: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+  report: "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300",
+  think_tank: "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300",
+  book: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  web: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  news_article: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  government: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+  government_doc: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+  legal_analysis: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+  talk: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  transcript: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  podcast: "bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300",
+  press_release: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300",
+  opinion: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+  reference: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  _default: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+};
+
+// ── Stance colors ───────────────────────────────────────────────────
+
+export const STANCE_COLORS: Record<string, string> = {
+  support: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+  oppose: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  neutral: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
+  mixed: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  analysis: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  _default: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
+};
+
+// ── Credibility colors ──────────────────────────────────────────────
+
+export function CREDIBILITY_COLORS(c: number): string {
+  if (c >= 4) return "text-emerald-600";
+  if (c >= 3) return "text-blue-500";
+  if (c >= 2) return "text-amber-600";
+  return "text-red-500";
+}


### PR DESCRIPTION
## Summary
Phase 4 of the [Resource Display Overhaul](https://github.com/quantified-uncertainty/longterm-wiki/discussions/2738). Stacked on #2744 (Phase 3).

**4A — Card view:**
- New `ResourceCard` component: title, source/date, type+stance badges, authors, summary in a compact card layout
- New `ResourceList` wrapper: search, type filter, pagination for card view
- `OrgResourcesSection` now has a table/card view toggle (tiny icons in top-right)
- Table remains default; card is an alternative for denser info display

**4B — Hover preview:**
- `ResourcePreview` wraps title links with a hover popover
- Shows publication/domain, date, summary (4-line clamp), authors
- Only activates when the resource has meaningful content to preview

**4C — Type taxonomy:**
- `resource-constants.ts` with `RESOURCE_TYPE_LABELS` (19 types → human labels)
- Extended color palette for new types: news_article, legal_analysis, think_tank, press_release, opinion, transcript
- `STANCE_COLORS` and `CREDIBILITY_COLORS` shared across all resource components
- `resources-section.tsx` imports from shared constants (no more inline duplicates)

## New files
- `apps/web/src/components/resources/ResourceCard.tsx`
- `apps/web/src/components/resources/ResourceList.tsx`
- `apps/web/src/components/resources/ResourcePreview.tsx`
- `apps/web/src/components/resources/resource-constants.ts`

## Test plan
- [ ] Table/card view toggle works on org resource tabs
- [ ] Card view shows title, source, date, type badge, authors, summary
- [ ] Hover preview appears on resource titles with summary content
- [ ] Extended type labels render correctly for all resource types
- [ ] Type-checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)