### PR TITLE
feat: add resource authorEntityIds/publicationId validation

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -181,6 +181,11 @@ const SCRIPTS = {
     description: 'Validate low <= high for paired range columns (requires wiki-server)',
     passthrough: ['ci'],
   },
+  'resource-refs': {
+    script: 'validate/validate-resource-refs.ts',
+    description: 'Validate resource authorEntityIds and publicationId references (advisory)',
+    passthrough: ['ci', 'verbose'],
+  },
   'to-rdjsonl': {
     script: 'validate/to-rdjsonl.ts',
     description: 'Convert unified --ci JSON to Reviewdog rdjsonl (reads stdin)',

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -463,6 +463,18 @@ const PARALLEL_STEPS: Step[] = [
     advisory: true,
     emitOutputInCi: true,
   },
+  {
+    id: 'resource-refs',
+    name: 'Resource reference validation (advisory)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-resource-refs.ts'],
+    cwd: PROJECT_ROOT,
+    // Advisory: requires wiki-server access. Validates that authorEntityIds
+    // and publicationId fields in the resources table reference valid entities
+    // and publications. Informational for now.
+    advisory: true,
+    emitOutputInCi: true,
+  },
 ];
 
 // Phase 4 (--full only): Runs after all validations pass

--- a/crux/validate/validate-resource-refs.test.ts
+++ b/crux/validate/validate-resource-refs.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Tests for resource reference validation.
+ *
+ * Unit tests with mocked API responses to verify the validation logic
+ * without requiring a running wiki-server.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ApiResult } from "../lib/wiki-server/client.ts";
+
+// Mock the apiRequest function so tests don't need a real wiki-server.
+vi.mock("../lib/wiki-server/client.ts", () => ({
+  apiRequest: vi.fn(),
+  getServerUrl: vi.fn(() => "http://localhost:3002"),
+  getApiKey: vi.fn(() => "test-key"),
+  buildHeaders: vi.fn(() => ({ "Content-Type": "application/json" })),
+}));
+
+// Mock fs for loadPublicationIds
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn((path: string) => {
+      if (typeof path === "string" && path.includes("publications.yaml")) {
+        return true;
+      }
+      return actual.existsSync(path);
+    }),
+    readFileSync: vi.fn((path: string, encoding?: string) => {
+      if (typeof path === "string" && path.includes("publications.yaml")) {
+        return `
+- id: nature
+  domains: [nature.com]
+  name: Nature
+  type: academic_journal
+  credibility: 5
+- id: arxiv
+  domains: [arxiv.org]
+  name: arXiv
+  type: preprint_server
+  credibility: 2
+- id: openai-blog
+  domains: [openai.com/blog]
+  name: OpenAI Blog
+  type: company_blog
+  credibility: 3
+`;
+      }
+      return actual.readFileSync(path, encoding as BufferEncoding);
+    }),
+  };
+});
+
+import { apiRequest } from "../lib/wiki-server/client.ts";
+import {
+  validateResources,
+  loadPublicationIds,
+  runValidation,
+  fetchAllRecords,
+  buildEntityStableIdSet,
+} from "./validate-resource-refs.ts";
+
+const mockApiRequest = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  mockApiRequest.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// loadPublicationIds
+// ---------------------------------------------------------------------------
+
+describe("loadPublicationIds", () => {
+  it("loads publication IDs from mocked YAML", () => {
+    const ids = loadPublicationIds();
+    expect(ids.has("nature")).toBe(true);
+    expect(ids.has("arxiv")).toBe(true);
+    expect(ids.has("openai-blog")).toBe(true);
+    expect(ids.size).toBe(3);
+  });
+
+  it("does not include non-existent IDs", () => {
+    const ids = loadPublicationIds();
+    expect(ids.has("nonexistent")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchAllRecords
+// ---------------------------------------------------------------------------
+
+describe("fetchAllRecords", () => {
+  it("returns records from a single page", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        resources: [
+          { id: "res-001", authorEntityIds: null, publicationId: null },
+        ],
+        total: 1,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await fetchAllRecords("/api/resources/all", "resources");
+    expect(result).toHaveLength(1);
+    expect(result![0].id).toBe("res-001");
+  });
+
+  it("paginates through multiple pages", async () => {
+    mockApiRequest
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          resources: [{ id: "a" }, { id: "b" }],
+          total: 3,
+        },
+      } as ApiResult<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          resources: [{ id: "c" }],
+          total: 3,
+        },
+      } as ApiResult<Record<string, unknown>>);
+
+    const result = await fetchAllRecords("/api/resources/all", "resources", 2);
+    expect(result).toHaveLength(3);
+    expect(result!.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns null when API is unavailable", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: "unavailable",
+      message: "ECONNREFUSED",
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await fetchAllRecords("/api/resources/all", "resources");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response key is missing", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { wrongKey: [] },
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await fetchAllRecords("/api/resources/all", "resources");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEntityStableIdSet
+// ---------------------------------------------------------------------------
+
+describe("buildEntityStableIdSet", () => {
+  it("builds set of entity stableIds", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        entities: [
+          { id: "anthropic", stableId: "ABCdef1234" },
+          { id: "openai", stableId: "XYZabc9876" },
+        ],
+        total: 2,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    const ids = await buildEntityStableIdSet();
+    expect(ids).not.toBeNull();
+    expect(ids!.has("ABCdef1234")).toBe(true);
+    expect(ids!.has("XYZabc9876")).toBe(true);
+    expect(ids!.size).toBe(2);
+  });
+
+  it("returns null on API failure", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: "unavailable",
+      message: "server down",
+    } as ApiResult<Record<string, unknown>>);
+
+    const ids = await buildEntityStableIdSet();
+    expect(ids).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResources — authorEntityIds
+// ---------------------------------------------------------------------------
+
+describe("validateResources — authorEntityIds", () => {
+  const entityStableIds = new Set(["ABCdef1234", "XYZabc9876", "QWErty5678"]);
+  const publicationIds = new Set(["nature", "arxiv"]);
+
+  it("validates all authorEntityIds when all exist", () => {
+    const resources = [
+      {
+        id: "res-001",
+        authorEntityIds: ["ABCdef1234", "XYZabc9876"],
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.authorEntityIdRefs).toBe(2);
+    expect(stats.validAuthorEntityIdRefs).toBe(2);
+    expect(stats.invalidAuthorEntityIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+
+  it("flags invalid authorEntityIds that don't exist in entities", () => {
+    const resources = [
+      {
+        id: "res-002",
+        authorEntityIds: ["ABCdef1234", "INVALID123"],
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.authorEntityIdRefs).toBe(2);
+    expect(stats.validAuthorEntityIdRefs).toBe(1);
+    expect(stats.invalidAuthorEntityIdRefs).toBe(1);
+    expect(stats.unresolvedList).toHaveLength(1);
+    expect(stats.unresolvedList[0]).toMatchObject({
+      resourceId: "res-002",
+      field: "authorEntityIds",
+      value: "INVALID123",
+    });
+  });
+
+  it("skips resources with null authorEntityIds", () => {
+    const resources = [
+      {
+        id: "res-003",
+        authorEntityIds: null,
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.authorEntityIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+
+  it("skips resources with empty authorEntityIds array", () => {
+    const resources = [
+      {
+        id: "res-004",
+        authorEntityIds: [],
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.authorEntityIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+
+  it("flags all invalid when none match", () => {
+    const resources = [
+      {
+        id: "res-005",
+        authorEntityIds: ["INVALID111", "INVALID222", "INVALID333"],
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.authorEntityIdRefs).toBe(3);
+    expect(stats.validAuthorEntityIdRefs).toBe(0);
+    expect(stats.invalidAuthorEntityIdRefs).toBe(3);
+    expect(stats.unresolvedList).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResources — publicationId
+// ---------------------------------------------------------------------------
+
+describe("validateResources — publicationId", () => {
+  const entityStableIds = new Set(["ABCdef1234"]);
+  const publicationIds = new Set(["nature", "arxiv", "openai-blog"]);
+
+  it("validates publicationId when it exists in publications", () => {
+    const resources = [
+      {
+        id: "res-010",
+        authorEntityIds: null,
+        publicationId: "nature",
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.publicationIdRefs).toBe(1);
+    expect(stats.validPublicationIdRefs).toBe(1);
+    expect(stats.invalidPublicationIdRefs).toBe(0);
+  });
+
+  it("flags invalid publicationId not in publications.yaml", () => {
+    const resources = [
+      {
+        id: "res-011",
+        authorEntityIds: null,
+        publicationId: "nonexistent-pub",
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.publicationIdRefs).toBe(1);
+    expect(stats.validPublicationIdRefs).toBe(0);
+    expect(stats.invalidPublicationIdRefs).toBe(1);
+    expect(stats.unresolvedList).toHaveLength(1);
+    expect(stats.unresolvedList[0]).toMatchObject({
+      resourceId: "res-011",
+      field: "publicationId",
+      value: "nonexistent-pub",
+    });
+  });
+
+  it("skips null publicationId", () => {
+    const resources = [
+      {
+        id: "res-012",
+        authorEntityIds: null,
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.publicationIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+
+  it("skips empty string publicationId", () => {
+    const resources = [
+      {
+        id: "res-013",
+        authorEntityIds: null,
+        publicationId: "",
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.publicationIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResources — combined
+// ---------------------------------------------------------------------------
+
+describe("validateResources — combined", () => {
+  const entityStableIds = new Set(["ABCdef1234", "XYZabc9876"]);
+  const publicationIds = new Set(["nature", "arxiv"]);
+
+  it("validates both fields across multiple resources", () => {
+    const resources = [
+      {
+        id: "res-020",
+        authorEntityIds: ["ABCdef1234"],
+        publicationId: "nature",
+      },
+      {
+        id: "res-021",
+        authorEntityIds: ["INVALID999"],
+        publicationId: "invalid-pub",
+      },
+      {
+        id: "res-022",
+        authorEntityIds: null,
+        publicationId: null,
+      },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.totalResources).toBe(3);
+    expect(stats.authorEntityIdRefs).toBe(2);
+    expect(stats.validAuthorEntityIdRefs).toBe(1);
+    expect(stats.invalidAuthorEntityIdRefs).toBe(1);
+    expect(stats.publicationIdRefs).toBe(2);
+    expect(stats.validPublicationIdRefs).toBe(1);
+    expect(stats.invalidPublicationIdRefs).toBe(1);
+    expect(stats.unresolvedList).toHaveLength(2);
+  });
+
+  it("handles resources with no reference fields at all", () => {
+    const resources = [
+      { id: "res-030" },
+      { id: "res-031", authorEntityIds: null },
+      { id: "res-032", publicationId: null },
+    ];
+
+    const stats = validateResources(resources, entityStableIds, publicationIds);
+    expect(stats.totalResources).toBe(3);
+    expect(stats.authorEntityIdRefs).toBe(0);
+    expect(stats.publicationIdRefs).toBe(0);
+    expect(stats.unresolvedList).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runValidation — integration with API mocking
+// ---------------------------------------------------------------------------
+
+describe("runValidation", () => {
+  it("returns passed=true with null stats when entities API fails", async () => {
+    // Entity lookup fails
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: "unavailable",
+      message: "ECONNREFUSED",
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await runValidation({ ci: true });
+    expect(result.passed).toBe(true);
+    expect(result.stats).toBeNull();
+  });
+
+  it("returns passed=true with null stats when resources API fails", async () => {
+    // Entity lookup succeeds
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        entities: [
+          { id: "anthropic", stableId: "ABCdef1234" },
+        ],
+        total: 1,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    // Resources API fails
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: "unavailable",
+      message: "ECONNREFUSED",
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await runValidation({ ci: true });
+    expect(result.passed).toBe(true);
+    expect(result.stats).toBeNull();
+  });
+
+  it("validates resources when API returns data", async () => {
+    // Entity lookup succeeds
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        entities: [
+          { id: "anthropic", stableId: "ABCdef1234" },
+          { id: "openai", stableId: "XYZabc9876" },
+        ],
+        total: 2,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    // Resources API succeeds
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        resources: [
+          {
+            id: "res-100",
+            authorEntityIds: ["ABCdef1234", "INVALID999"],
+            publicationId: "nature",
+          },
+          {
+            id: "res-101",
+            authorEntityIds: null,
+            publicationId: "nonexistent",
+          },
+        ],
+        total: 2,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await runValidation({ ci: true });
+    expect(result.passed).toBe(true);
+    expect(result.stats).not.toBeNull();
+    expect(result.stats!.totalResources).toBe(2);
+    expect(result.stats!.authorEntityIdRefs).toBe(2);
+    expect(result.stats!.validAuthorEntityIdRefs).toBe(1);
+    expect(result.stats!.invalidAuthorEntityIdRefs).toBe(1);
+    expect(result.stats!.publicationIdRefs).toBe(2);
+    expect(result.stats!.validPublicationIdRefs).toBe(1);
+    expect(result.stats!.invalidPublicationIdRefs).toBe(1);
+    expect(result.stats!.unresolvedList).toHaveLength(2);
+  });
+
+  it("reports zero invalid refs when all references are valid", async () => {
+    // Entity lookup succeeds
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        entities: [
+          { id: "anthropic", stableId: "ABCdef1234" },
+        ],
+        total: 1,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    // Resources with all valid refs
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        resources: [
+          {
+            id: "res-200",
+            authorEntityIds: ["ABCdef1234"],
+            publicationId: "arxiv",
+          },
+        ],
+        total: 1,
+      },
+    } as ApiResult<Record<string, unknown>>);
+
+    const result = await runValidation({ ci: true });
+    expect(result.stats!.invalidAuthorEntityIdRefs).toBe(0);
+    expect(result.stats!.invalidPublicationIdRefs).toBe(0);
+    expect(result.stats!.unresolvedList).toHaveLength(0);
+  });
+});

--- a/crux/validate/validate-resource-refs.ts
+++ b/crux/validate/validate-resource-refs.ts
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+
+/**
+ * Resource Reference Validation — checks that JSONB reference fields in the
+ * resources table point to valid entities and publications.
+ *
+ * Validates:
+ *   - author_entity_ids: each stableId in the JSONB array must exist in the entities table
+ *   - publication_id: must match an id in data/publications.yaml
+ *
+ * Requires wiki-server to be running (queries the API). Advisory — not CI-blocking.
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-resource-refs.ts              # advisory mode
+ *   npx tsx crux/validate/validate-resource-refs.ts --verbose     # show all unresolved refs
+ *   npx tsx crux/validate/validate-resource-refs.ts --ci          # JSON output
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+import {
+  apiRequest,
+  type ApiResult,
+} from "../lib/wiki-server/client.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single unresolved reference in a resource record. */
+export interface UnresolvedResourceRef {
+  resourceId: string;
+  field: "authorEntityIds" | "publicationId";
+  value: string;
+}
+
+/** Aggregated validation results. */
+export interface ResourceRefStats {
+  totalResources: number;
+  authorEntityIdRefs: number;
+  validAuthorEntityIdRefs: number;
+  invalidAuthorEntityIdRefs: number;
+  publicationIdRefs: number;
+  validPublicationIdRefs: number;
+  invalidPublicationIdRefs: number;
+  unresolvedList: UnresolvedResourceRef[];
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch all records from a paginated endpoint.
+ * Follows offset pagination until all records are retrieved.
+ */
+export async function fetchAllRecords(
+  apiPath: string,
+  responseKey: string,
+  maxLimit: number = 200,
+): Promise<Record<string, unknown>[] | null> {
+  const allRecords: Record<string, unknown>[] = [];
+  let offset = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const separator = apiPath.includes("?") ? "&" : "?";
+    const url = `${apiPath}${separator}limit=${maxLimit}&offset=${offset}`;
+    const result: ApiResult<Record<string, unknown>> = await apiRequest("GET", url);
+
+    if (!result.ok) {
+      return null;
+    }
+
+    const records = result.data[responseKey] as Record<string, unknown>[] | undefined;
+    if (!records || !Array.isArray(records)) {
+      return null;
+    }
+
+    allRecords.push(...records);
+
+    const total = result.data.total as number | undefined;
+    if (total === undefined || allRecords.length >= total) {
+      break;
+    }
+
+    offset += maxLimit;
+  }
+
+  return allRecords;
+}
+
+/**
+ * Build a set of entity stableIds from the entities API.
+ */
+export async function buildEntityStableIdSet(): Promise<Set<string> | null> {
+  const allEntities: Array<{ id: string; stableId: string }> = [];
+  let offset = 0;
+  const limit = 500;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await apiRequest<{
+      entities: Array<{ id: string; stableId: string }>;
+      total: number;
+    }>("GET", `/api/entities?limit=${limit}&offset=${offset}`);
+
+    if (!result.ok) return null;
+
+    allEntities.push(...result.data.entities);
+    if (allEntities.length >= result.data.total) break;
+    offset += limit;
+  }
+
+  return new Set(allEntities.map((e) => e.stableId));
+}
+
+// ---------------------------------------------------------------------------
+// Publication ID lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Load publication IDs from data/publications.yaml.
+ */
+export function loadPublicationIds(): Set<string> {
+  const pubPath = join(PROJECT_ROOT, "data", "publications.yaml");
+  if (!existsSync(pubPath)) {
+    return new Set();
+  }
+  const content = readFileSync(pubPath, "utf-8");
+  const data = parseYaml(content) as Array<{ id: string }> | null;
+  if (!Array.isArray(data)) {
+    return new Set();
+  }
+  return new Set(data.map((p) => p.id));
+}
+
+// ---------------------------------------------------------------------------
+// Core validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate resource reference fields against entity and publication lookups.
+ */
+export function validateResources(
+  resources: Array<Record<string, unknown>>,
+  entityStableIds: Set<string>,
+  publicationIds: Set<string>,
+): ResourceRefStats {
+  const stats: ResourceRefStats = {
+    totalResources: resources.length,
+    authorEntityIdRefs: 0,
+    validAuthorEntityIdRefs: 0,
+    invalidAuthorEntityIdRefs: 0,
+    publicationIdRefs: 0,
+    validPublicationIdRefs: 0,
+    invalidPublicationIdRefs: 0,
+    unresolvedList: [],
+  };
+
+  for (const resource of resources) {
+    const resourceId = resource.id as string;
+
+    // Validate authorEntityIds
+    const authorEntityIds = resource.authorEntityIds as string[] | null;
+    if (Array.isArray(authorEntityIds) && authorEntityIds.length > 0) {
+      for (const entityId of authorEntityIds) {
+        stats.authorEntityIdRefs++;
+        if (entityStableIds.has(entityId)) {
+          stats.validAuthorEntityIdRefs++;
+        } else {
+          stats.invalidAuthorEntityIdRefs++;
+          stats.unresolvedList.push({
+            resourceId,
+            field: "authorEntityIds",
+            value: entityId,
+          });
+        }
+      }
+    }
+
+    // Validate publicationId
+    const publicationId = resource.publicationId as string | null;
+    if (publicationId) {
+      stats.publicationIdRefs++;
+      if (publicationIds.has(publicationId)) {
+        stats.validPublicationIdRefs++;
+      } else {
+        stats.invalidPublicationIdRefs++;
+        stats.unresolvedList.push({
+          resourceId,
+          field: "publicationId",
+          value: publicationId,
+        });
+      }
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Main validation runner
+// ---------------------------------------------------------------------------
+
+export async function runValidation(opts: {
+  verbose?: boolean;
+  ci?: boolean;
+}): Promise<{
+  passed: boolean;
+  stats: ResourceRefStats | null;
+}> {
+  const { verbose = false, ci = false } = opts;
+  const c = getColors(ci);
+
+  // Step 1: Load entity lookup from wiki-server
+  if (!ci) {
+    console.log(
+      `${c.cyan}Loading entities from wiki-server...${c.reset}`
+    );
+  }
+
+  const entityStableIds = await buildEntityStableIdSet();
+  if (!entityStableIds) {
+    if (!ci) {
+      console.log(
+        `${c.red}Failed to load entities from wiki-server. Is the server running?${c.reset}`
+      );
+    }
+    return { passed: true, stats: null };
+  }
+
+  if (!ci) {
+    console.log(
+      `${c.dim}  Loaded ${entityStableIds.size} entity stableIds${c.reset}`
+    );
+  }
+
+  // Step 2: Load publication IDs from YAML
+  const publicationIds = loadPublicationIds();
+  if (!ci) {
+    console.log(
+      `${c.dim}  Loaded ${publicationIds.size} publication IDs from publications.yaml${c.reset}`
+    );
+  }
+
+  // Step 3: Fetch all resources from wiki-server
+  if (!ci) {
+    console.log(
+      `${c.cyan}Loading resources from wiki-server...${c.reset}`
+    );
+  }
+
+  const resources = await fetchAllRecords(
+    "/api/resources/all",
+    "resources",
+    200
+  );
+  if (!resources) {
+    if (!ci) {
+      console.log(
+        `${c.red}Failed to load resources from wiki-server.${c.reset}`
+      );
+    }
+    return { passed: true, stats: null };
+  }
+
+  if (!ci) {
+    console.log(
+      `${c.dim}  Loaded ${resources.length} resources${c.reset}`
+    );
+  }
+
+  // Step 4: Validate
+  const stats = validateResources(
+    resources,
+    entityStableIds,
+    publicationIds
+  );
+
+  // Step 5: Report
+  const totalRefs = stats.authorEntityIdRefs + stats.publicationIdRefs;
+  const totalValid =
+    stats.validAuthorEntityIdRefs + stats.validPublicationIdRefs;
+  const totalInvalid =
+    stats.invalidAuthorEntityIdRefs + stats.invalidPublicationIdRefs;
+  const linkRate =
+    totalRefs > 0 ? (totalValid / totalRefs) * 100 : 100;
+
+  if (!ci) {
+    console.log(
+      `\n${c.bold}${c.blue}Resource Reference Validation${c.reset}\n`
+    );
+
+    // Table
+    console.log(
+      "| Field              | Total Refs | Valid | Invalid | Rate    |"
+    );
+    console.log(
+      "|--------------------|------------|-------|---------|---------|"
+    );
+
+    const authorRate =
+      stats.authorEntityIdRefs > 0
+        ? (
+            (stats.validAuthorEntityIdRefs / stats.authorEntityIdRefs) *
+            100
+          ).toFixed(1) + "%"
+        : "N/A";
+    const pubRate =
+      stats.publicationIdRefs > 0
+        ? (
+            (stats.validPublicationIdRefs / stats.publicationIdRefs) *
+            100
+          ).toFixed(1) + "%"
+        : "N/A";
+
+    console.log(
+      `| authorEntityIds    | ${stats.authorEntityIdRefs.toString().padStart(10)} | ${stats.validAuthorEntityIdRefs.toString().padStart(5)} | ${stats.invalidAuthorEntityIdRefs.toString().padStart(7)} | ${authorRate.padStart(7)} |`
+    );
+    console.log(
+      `| publicationId      | ${stats.publicationIdRefs.toString().padStart(10)} | ${stats.validPublicationIdRefs.toString().padStart(5)} | ${stats.invalidPublicationIdRefs.toString().padStart(7)} | ${pubRate.padStart(7)} |`
+    );
+    console.log(
+      "|--------------------|------------|-------|---------|---------|"
+    );
+    console.log(
+      `| TOTAL              | ${totalRefs.toString().padStart(10)} | ${totalValid.toString().padStart(5)} | ${totalInvalid.toString().padStart(7)} | ${(linkRate.toFixed(1) + "%").padStart(7)} |`
+    );
+
+    // Print unresolved details
+    const authorErrors = stats.unresolvedList.filter(
+      (u) => u.field === "authorEntityIds"
+    );
+    const pubErrors = stats.unresolvedList.filter(
+      (u) => u.field === "publicationId"
+    );
+
+    if (authorErrors.length > 0) {
+      console.log(
+        `\n${c.red}Invalid authorEntityIds (entity stableId not found):${c.reset}`
+      );
+      const toShow = verbose ? authorErrors : authorErrors.slice(0, 10);
+      for (const ref of toShow) {
+        console.log(
+          `  ${c.red}x${c.reset} resource ${ref.resourceId} — authorEntityIds contains "${ref.value}"`
+        );
+      }
+      if (!verbose && authorErrors.length > 10) {
+        console.log(
+          `  ${c.dim}... and ${authorErrors.length - 10} more (use --verbose)${c.reset}`
+        );
+      }
+    }
+
+    if (pubErrors.length > 0) {
+      console.log(
+        `\n${c.yellow}Invalid publicationId (not in publications.yaml):${c.reset}`
+      );
+      const toShow = verbose ? pubErrors : pubErrors.slice(0, 10);
+      for (const ref of toShow) {
+        console.log(
+          `  ${c.yellow}~${c.reset} resource ${ref.resourceId} — publicationId = "${ref.value}"`
+        );
+      }
+      if (!verbose && pubErrors.length > 10) {
+        console.log(
+          `  ${c.dim}... and ${pubErrors.length - 10} more (use --verbose)${c.reset}`
+        );
+      }
+    }
+
+    // Summary
+    console.log("");
+    if (totalInvalid === 0) {
+      console.log(
+        `${c.green}All ${totalRefs} resource references are valid.${c.reset}`
+      );
+    } else {
+      console.log(
+        `${c.yellow}${totalInvalid} invalid reference(s) out of ${totalRefs} total (${linkRate.toFixed(1)}% link rate).${c.reset}`
+      );
+    }
+  }
+
+  // CI JSON output
+  if (ci) {
+    console.log(
+      JSON.stringify({
+        passed: true, // advisory — always passes
+        totalResources: stats.totalResources,
+        totalRefs,
+        validRefs: totalValid,
+        invalidRefs: totalInvalid,
+        linkRate: parseFloat(linkRate.toFixed(1)),
+        authorEntityIds: {
+          total: stats.authorEntityIdRefs,
+          valid: stats.validAuthorEntityIdRefs,
+          invalid: stats.invalidAuthorEntityIdRefs,
+        },
+        publicationId: {
+          total: stats.publicationIdRefs,
+          valid: stats.validPublicationIdRefs,
+          invalid: stats.invalidPublicationIdRefs,
+        },
+        unresolvedDetails: stats.unresolvedList.map((u) => ({
+          resourceId: u.resourceId,
+          field: u.field,
+          value: u.value,
+        })),
+      })
+    );
+  }
+
+  return { passed: true, stats };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const verbose = process.argv.includes("--verbose");
+  const ci = process.argv.includes("--ci");
+
+  await runValidation({ verbose, ci });
+}
+
+if (process.argv[1]?.includes("validate-resource-refs")) {
+  main().catch((err) => {
+    console.error("Resource reference validation crashed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Add a new advisory gate validator (`crux validate resource-refs`) that checks JSONB reference fields in the `resources` table
- Validates `author_entity_ids`: each stableId in the array must exist in the entities table
- Validates `publication_id`: must match an entry in `data/publications.yaml`
- Reports unresolved IDs with resource ID, field name, and invalid value
- Registered as an advisory step in the gate check and as a validate subcommand

## Test plan
- [x] 23 unit tests covering: `loadPublicationIds`, `fetchAllRecords`, `buildEntityStableIdSet`, `validateResources` (authorEntityIds, publicationId, combined), and `runValidation` integration
- [x] Tests mock wiki-server API and filesystem to run without external dependencies
- [x] All 3446 crux tests pass
- [x] TypeScript compiles without new errors
- [x] Advisory mode: gracefully returns `passed: true` when wiki-server is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)