### PR TITLE
fix: add stance to ResourceSearchRow type

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -55,6 +55,7 @@ interface ResourceSearchRow {
   fetch_status: string | null;
   last_fetched_at: string | null;
   archive_url: string | null;
+  stance: string | null;
   created_at: string;
   updated_at: string;
   rank: number;


### PR DESCRIPTION
Fixes main CI. The `stance` column was added to the resources table in #2765 but the `ResourceSearchRow` type wasn't updated, causing:

```
src/routes/wikibase/resources.ts(435,19): error TS2339: Property 'stance' does not exist on type 'ResourceSearchRow'.
```

One-line fix: added `stance: string | null` to the `ResourceSearchRow` interface.