### PR TITLE
fix: resolve data quality issues from validator sweep

### DIFF
--- a/apps/wiki-server/scripts/prune-tmc-entities.ts
+++ b/apps/wiki-server/scripts/prune-tmc-entities.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * One-time script to prune TMC (AI Transition Model) orphan entities from prod PG.
+ *
+ * These entity types were bulk-imported but have no YAML source files,
+ * no wiki pages, and link to 404s on directory pages.
+ *
+ * Usage:
+ *   WIKI_SERVER_ENV=prod npx tsx apps/wiki-server/scripts/prune-tmc-entities.ts
+ *   WIKI_SERVER_ENV=prod npx tsx apps/wiki-server/scripts/prune-tmc-entities.ts --dry-run
+ *
+ * Requires the prune endpoint to accept empty keepIds (server change in this PR).
+ */
+
+const TMC_ENTITY_TYPES = [
+  "ai-transition-model-factor",
+  "ai-transition-model-parameter",
+  "ai-transition-model-scenario",
+  "ai-transition-model-metric",
+  "ai-transition-model-subitem",
+];
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  // Resolve server URL from environment
+  const envPrefix = process.env.WIKI_SERVER_ENV === "prod" ? "PROD_" : "";
+  const serverUrl = process.env[`${envPrefix}LONGTERMWIKI_SERVER_URL`];
+  const apiKey = process.env[`${envPrefix}LONGTERMWIKI_SERVER_API_KEY`];
+
+  if (!serverUrl) {
+    console.error("Error: No wiki-server URL configured. Set WIKI_SERVER_ENV=prod or LONGTERMWIKI_SERVER_URL.");
+    process.exit(1);
+  }
+
+  console.log(`Server: ${serverUrl}`);
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}\n`);
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+
+  let totalDeleted = 0;
+
+  for (const entityType of TMC_ENTITY_TYPES) {
+    try {
+      if (dryRun) {
+        // In dry-run mode, just count how many would be deleted
+        const countRes = await fetch(
+          `${serverUrl}/api/entities?entityType=${encodeURIComponent(entityType)}&limit=1`,
+          { headers },
+        );
+        if (countRes.ok) {
+          const data = await countRes.json();
+          const count = Array.isArray(data) ? data.length : (data.total ?? "?");
+          console.log(`  ${entityType}: would prune (count endpoint not available, will delete all)`);
+        } else {
+          console.log(`  ${entityType}: query returned ${countRes.status}`);
+        }
+        continue;
+      }
+
+      const res = await fetch(`${serverUrl}/api/entities/prune`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ entityType, keepIds: [] }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(`  ${entityType}: HTTP ${res.status} — ${body}`);
+        continue;
+      }
+
+      const result = await res.json() as { deleted: number; ids: string[] };
+      console.log(`  ${entityType}: deleted ${result.deleted} entities`);
+      totalDeleted += result.deleted;
+    } catch (err) {
+      console.error(`  ${entityType}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log(`\nTotal deleted: ${totalDeleted}`);
+}
+
+main().catch((err) => {
+  console.error("Script failed:", err);
+  process.exit(1);
+});

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -62,6 +62,12 @@ const VALID_DIRECTORY_ENTITY_TYPES = new Set([
   "ai-model",
   "benchmark",
   "research-area",
+  // TMC (AI Transition Model) types — bulk-imported, no YAML source
+  "ai-transition-model-factor",
+  "ai-transition-model-parameter",
+  "ai-transition-model-scenario",
+  "ai-transition-model-metric",
+  "ai-transition-model-subitem",
   // Aliases (legacy / alternate names)
   "researcher",
   "lab",
@@ -814,7 +820,7 @@ const entitiesApp = new Hono()
       "json",
       z.object({
         entityType: z.string().min(1).max(100),
-        keepIds: z.array(z.string().min(1).max(500)).min(1).max(5000),
+        keepIds: z.array(z.string().min(1).max(500)).min(0).max(5000),
       })
     ),
     async (c) => {
@@ -829,15 +835,18 @@ const entitiesApp = new Hono()
 
       const db = getDrizzleDb();
 
-      // Find stale entities: same type but ID not in the keep list
+      // Find stale entities: same type but ID not in the keep list.
+      // When keepIds is empty, all entities of this type are stale.
       const staleRows = await db
         .select({ id: entities.id })
         .from(entities)
         .where(
-          and(
-            eq(entities.entityType, entityType),
-            notInArray(entities.id, keepIds),
-          )
+          keepIds.length > 0
+            ? and(
+                eq(entities.entityType, entityType),
+                notInArray(entities.id, keepIds),
+              )
+            : eq(entities.entityType, entityType)
         );
 
       if (staleRows.length === 0) {

--- a/content/docs/knowledge-base/risks/concentrated-compute-cybersecurity-risk.mdx
+++ b/content/docs/knowledge-base/risks/concentrated-compute-cybersecurity-risk.mdx
@@ -13,6 +13,7 @@ clusters:
   - governance
 ---
 import {DataInfoBox, EntityLink} from '@components/wiki';
+
 ## Quick Assessment
 
 | Dimension | Assessment | Evidence |

--- a/content/docs/knowledge-base/risks/financial-stability-risks-ai-capex.mdx
+++ b/content/docs/knowledge-base/risks/financial-stability-risks-ai-capex.mdx
@@ -1,7 +1,7 @@
 ---
 wikiId: E690
 title: Financial Stability Risks from AI Capital Expenditure
-description: "The \\\\$700B+ AI infrastructure investment in 2026 — with a 6-14x gap between capex and direct AI revenue, growing debt-financed construction, free cash flow destruction at major tech companies."
+description: "The \\$700B+ AI infrastructure investment in 2026 — with a 6-14x gap between capex and direct AI revenue, growing debt-financed construction, free cash flow destruction at major tech companies."
 sidebar:
   order: 50
 subcategory: structural
@@ -13,6 +13,7 @@ clusters:
   - governance
 ---
 import {DataInfoBox, EntityLink} from '@components/wiki';
+
 ## Quick Assessment
 
 | Dimension | Assessment | Evidence |

--- a/crux/lib/file-utils.ts
+++ b/crux/lib/file-utils.ts
@@ -4,9 +4,10 @@
  * Common file discovery and traversal functions used across validators and generators.
  */
 
-import { existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { basename, join } from 'path';
 import { CONTENT_DIR_ABS } from './content-types.ts';
+import { parseFrontmatter } from './mdx-utils.ts';
 
 /**
  * Find all MDX/MD files recursively in a directory
@@ -64,6 +65,45 @@ export function findPageFile(pageId: string): string | null {
     if (basename(f, '.mdx') === pageId) return f;
   }
   return null;
+}
+
+/**
+ * Build a Set of all wikiId values found in MDX frontmatter.
+ * Used by link validators to recognize `/wiki/E*` dynamic routes.
+ * Cached after first call.
+ */
+let _wikiIdCache: Set<string> | null = null;
+
+export function getWikiIdSet(contentDir: string = CONTENT_DIR_ABS): Set<string> {
+  if (_wikiIdCache) return _wikiIdCache;
+
+  const ids = new Set<string>();
+  const files = findMdxFiles(contentDir);
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(file, 'utf-8');
+      const fm = parseFrontmatter(content);
+      if (typeof fm.wikiId === 'string' && fm.wikiId) {
+        ids.add(fm.wikiId);
+      }
+    } catch {
+      // Skip files that can't be read
+    }
+  }
+
+  _wikiIdCache = ids;
+  return ids;
+}
+
+/**
+ * Check if a `/wiki/Exxx` path resolves to a page with that wikiId.
+ */
+export function isValidWikiRoute(href: string, contentDir: string = CONTENT_DIR_ABS): boolean {
+  // Match /wiki/E123 or /wiki/E123/ patterns
+  const match = href.match(/^\/wiki\/(E\d+)\/?$/);
+  if (!match) return false;
+  return getWikiIdSet(contentDir).has(match[1]);
 }
 
 /**

--- a/crux/lib/rules/broken-links.ts
+++ b/crux/lib/rules/broken-links.ts
@@ -14,6 +14,7 @@ import { createRule, Issue, Severity, type ContentFile, type ValidationEngine } 
 import { isInCodeBlock, isInComment, getLineNumber, shouldSkipValidation } from '../mdx-utils.ts';
 import { MARKDOWN_LINK_RE } from '../patterns.ts';
 import { CONTENT_DIR_ABS, PROJECT_ROOT } from '../content-types.ts';
+import { isValidWikiRoute } from '../file-utils.ts';
 
 const APP_DIR = join(PROJECT_ROOT, 'apps/web/src/app');
 
@@ -25,6 +26,9 @@ function linkTargetExists(href: string): boolean {
 
   // Skip placeholder/template links
   if (path.includes('${') || path.includes('...')) return true;
+
+  // Check /wiki/E* dynamic routes against wikiId index
+  if (isValidWikiRoute(path)) return true;
 
   path = path.replace(/\/$/, '');
   if (path.startsWith('/')) path = path.slice(1);

--- a/crux/lib/rules/internal-links.ts
+++ b/crux/lib/rules/internal-links.ts
@@ -13,6 +13,7 @@ import { createRule, Issue, Severity, type ContentFile, type ValidationEngine } 
 import { isInCodeBlock } from '../mdx-utils.ts';
 import { CONTENT_DIR_ABS as CONTENT_DIR, PROJECT_ROOT } from '../content-types.ts';
 import { MARKDOWN_LINK_RE } from '../patterns.ts';
+import { isValidWikiRoute } from '../file-utils.ts';
 
 const APP_DIR = join(PROJECT_ROOT, 'apps/web/src/app');
 
@@ -26,6 +27,11 @@ function resolveLink(href: string, sourceFile: string): { exists: boolean; isPla
   // Skip placeholder links
   if (path.includes('...')) {
     return { exists: true, isPlaceholder: true };
+  }
+
+  // Check /wiki/E* dynamic routes against wikiId index
+  if (isValidWikiRoute(path, CONTENT_DIR)) {
+    return { exists: true };
   }
 
   // Remove trailing slash for file lookup

--- a/crux/validate/validate-internal-links.ts
+++ b/crux/validate/validate-internal-links.ts
@@ -25,7 +25,7 @@
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
-import { findMdxFiles } from '../lib/file-utils.ts';
+import { findMdxFiles, isValidWikiRoute } from '../lib/file-utils.ts';
 import { getColors, formatPath } from '../lib/output.ts';
 import { CONTENT_DIR, PROJECT_ROOT } from '../lib/content-types.ts';
 import { MARKDOWN_LINK_RE } from '../lib/patterns.ts';
@@ -152,6 +152,11 @@ function resolveLink(href: string, sourceFile: string): LinkResolution {
   // Skip placeholder links (contain ...)
   if (path.includes('...')) {
     return { exists: true, isPlaceholder: true };
+  }
+
+  // Check /wiki/E* dynamic routes against wikiId index
+  if (isValidWikiRoute(path)) {
+    return { exists: true };
   }
 
   // Remove trailing slash for file lookup

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -33,7 +33,19 @@
     - id: eQh3ZhWv8D
       type: person
       relationship: leads-to
-    - id: cMKB5i2WZQ
+    - id: evan-hubinger
+      type: person
+      relationship: research
+    - id: jack-clark
+      type: person
+      relationship: leads-to
+    - id: sam-mccandlish
+      type: person
+      relationship: research
+    - id: jared-kaplan
+      type: person
+      relationship: research
+    - id: claude
       type: ai-model
       relationship: composed-of
     - id: D8dD07y5oQ
@@ -110,6 +122,18 @@
       relationship: affects
     - id: XcGTez1oFw
       type: policy
+    - id: neel-nanda
+      type: person
+      relationship: research
+    - id: victoria-krakovna
+      type: person
+      relationship: research
+    - id: rohin-shah
+      type: person
+      relationship: research
+    - id: richard-ngo
+      type: person
+      relationship: research
   sources:
     - title: Google DeepMind Website
       url: https://deepmind.google
@@ -285,6 +309,9 @@
       type: risk
     - id: aUMeFdALrA
       type: safety-agenda
+    - id: stuart-russell
+      type: person
+      relationship: leads-to
   sources:
     - title: CHAI Website
       url: https://humancompatible.ai
@@ -370,6 +397,9 @@
       type: risk
     - id: mK9pX3rQ7n
       type: organization
+    - id: dan-hendrycks
+      type: person
+      relationship: leads-to
   sources:
     - title: CAIS Website
       url: https://safe.ai
@@ -406,6 +436,9 @@
       type: safety-agenda
     - id: aX0jkoaekQ
       type: organization
+    - id: vidur-kapur
+      type: person
+      relationship: research
   sources:
     - title: Conjecture Website
       url: https://conjecture.dev
@@ -493,6 +526,9 @@
   relatedEntries:
     - id: A4XoubikkQ
       type: organization
+    - id: allan-dafoe
+      type: person
+      relationship: leads-to
   sources:
     - title: GovAI Website
       url: https://governance.ai
@@ -538,6 +574,12 @@
       type: organization
     - id: aX0jkoaekQ
       type: organization
+    - id: ajeya-cotra
+      type: person
+      relationship: research
+    - id: eli-lifland
+      type: person
+      relationship: research
   sources:
     - title: METR Website
       url: https://metr.org
@@ -817,6 +859,9 @@
       type: organization
     - id: 1LcLlMGLbw
       type: organization
+    - id: elizabeth-kelly
+      type: person
+      relationship: leads-to
   sources:
     - title: US AI Safety Institute Website
       url: https://www.nist.gov/aisi
@@ -986,6 +1031,9 @@
       type: person
     - id: bQ9a5lwwlg
       type: concept
+    - id: toby-ord
+      type: person
+      relationship: research
   tags:
     - research-org
     - existential-risk
@@ -1368,6 +1416,10 @@
     contributing valuable data to AI safety discourse. While their work provides
     useful evidence synthesis and expert opinion surveys, it faces inherent
     limitations in survey methodology and response bias.
+  relatedEntries:
+    - id: katja-grace
+      type: person
+      relationship: leads-to
   clusters:
     - ai-safety
     - community
@@ -1519,6 +1571,13 @@
     organization spent ~$50M on AI safety in 2024, with 68% going to
     evaluations/benchmarking, and launched a $40M Technical AI Safety RFP in
     2025 covering 8 research areas.
+  relatedEntries:
+    - id: nick-beckstead
+      type: person
+      relationship: leads-to
+    - id: luke-muehlhauser
+      type: person
+      relationship: leads-to
   clusters:
     - community
     - ai-safety
@@ -1573,6 +1632,10 @@
     policy research, particularly on U.S.-China competition and export controls.
     The center conducts hundreds of annual government briefings and operates the
     Emerging Technology Observatory with 10 public tools and 8 datasets.
+  relatedEntries:
+    - id: helen-toner
+      type: person
+      relationship: research
   clusters:
     - community
     - governance
@@ -2003,6 +2066,9 @@
   relatedEntries:
     - id: XcGTez1oFw
       type: policy
+    - id: mark-zuckerberg
+      type: person
+      relationship: leads-to
   lastUpdated: 2026-02
 - id: microsoft
   stableId: OIY5gaPpBA
@@ -2018,6 +2084,13 @@
     growth) and 16 percentage points of Azure's 39% growth. GitHub Copilot
     reached 20M users generating 46% of code, while responsible AI framework
     conducts hundreds of internal audits annually.
+  relatedEntries:
+    - id: mustafa-suleyman
+      type: person
+      relationship: leads-to
+    - id: satya-nadella
+      type: person
+      relationship: leads-to
   clusters:
     - community
     - ai-safety
@@ -2145,6 +2218,9 @@
       type: organization
     - id: XcGTez1oFw
       type: policy
+    - id: buck-shlegeris
+      type: person
+      relationship: leads-to
   sources:
     - title: Redwood Research Website
       url: https://redwoodresearch.org
@@ -2332,6 +2408,10 @@
     unique S-process mechanism where 6-12 recommenders express utility functions
     and an algorithm allocates grants favoring projects with enthusiastic
     champions, though the mechanism can produce volatile grant distributions year-to-year.
+  relatedEntries:
+    - id: jaan-tallinn
+      type: person
+      relationship: leads-to
   clusters:
     - community
     - ai-safety
@@ -2349,6 +2429,10 @@
     2024 that manages ~$2B in AI-focused public equities (semiconductors, energy
     infrastructure, data centers), delivering 47% gains in H1 2025. The fund's
     concentrated portfolio (100% in top 10 positions) includes major holdings in Nvidia, TSMC, and energy infrastructure companies.
+  relatedEntries:
+    - id: leopold-aschenbrenner
+      type: person
+      relationship: leads-to
   clusters:
     - community
     - ai-safety
@@ -2511,6 +2595,10 @@
     $130.5B in FY2025 (114% YoY growth), driven almost entirely by data center
     GPU sales. Its proprietary CUDA software ecosystem creates deep lock-in
     across the AI training stack.
+  relatedEntries:
+    - id: jensen-huang
+      type: person
+      relationship: leads-to
   clusters:
     - ai-safety
     - community
@@ -2535,6 +2623,9 @@
       type: organization
     - id: gNsqAes7Dw
       type: organization
+    - id: sam-bankman-fried
+      type: person
+      relationship: leads-to
   clusters:
     - ai-safety
     - community
@@ -2675,6 +2766,10 @@
   description: >-
     Major public research university and a leading center for AI safety research,
     home to CHAI (Center for Human-Compatible AI) and numerous AI alignment researchers.
+  relatedEntries:
+    - id: jacob-steinhardt
+      type: person
+      relationship: research
   tags:
     - academic
     - ai-safety
@@ -2691,6 +2786,13 @@
     Private research university in Stanford, California. Home to the Stanford
     Institute for Human-Centered Artificial Intelligence (HAI) and the Center for
     International Security and Cooperation (CISAC).
+  relatedEntries:
+    - id: andrew-ng
+      type: person
+      relationship: research
+    - id: fei-fei-li
+      type: person
+      relationship: research
   tags:
     - academic
     - ai-safety
@@ -2707,6 +2809,10 @@
   description: >-
     Historic UK research university, home to the Global Priorities Institute and
     formerly the Future of Humanity Institute.
+  relatedEntries:
+    - id: will-macaskill
+      type: person
+      relationship: research
   tags:
     - academic
     - ai-safety
@@ -2735,6 +2841,10 @@
   website: https://www.upenn.edu
   description: >-
     Private Ivy League research university in Philadelphia.
+  relatedEntries:
+    - id: philip-tetlock
+      type: person
+      relationship: research
   tags:
     - academic
   lastUpdated: 2026-03
@@ -2788,6 +2898,10 @@
   website: https://www.nyu.edu
   description: >-
     Private research university in New York City.
+  relatedEntries:
+    - id: gary-marcus
+      type: person
+      relationship: research
   tags:
     - academic
   lastUpdated: 2026-03
@@ -3071,6 +3185,10 @@
   website: https://www.cam.ac.uk
   description: >-
     Historic UK research university. Home to CSER.
+  relatedEntries:
+    - id: david-krueger
+      type: person
+      relationship: research
   tags:
     - academic
     - existential-risk
@@ -4489,6 +4607,9 @@
     - id: ULjDXpSLCI
       type: organization
       relationship: related
+    - id: dustin-moskovitz
+      type: person
+      relationship: leads-to
   tags:
     - ea-community
     - philanthropy


### PR DESCRIPTION
## Summary

Fixes multiple data quality issues identified by running the full validator suite:

- **15 broken internal links fixed** — Link validators (`internal-links`, `broken-links`) now recognize `/wiki/E*` dynamic routes by building a wikiId index from MDX frontmatter. Previously these were false positives because the validators only checked for static file existence, not dynamic App Router routes.

- **2 MDX compilation errors fixed** — Two risk pages (`concentrated-compute-cybersecurity-risk.mdx`, `financial-stability-risks-ai-capex.mdx`) had missing blank lines between import statements and headings, causing acorn parse failures. Also fixed an over-escaped dollar sign in the financial-stability-risks description.

- **TMC orphan entity pruning enabled** — The prune endpoint now accepts empty `keepIds` arrays (was `.min(1)`, now `.min(0)`) and recognizes TMC entity types (`ai-transition-model-*`). A one-time script `apps/wiki-server/scripts/prune-tmc-entities.ts` is included to delete ~100 TMC entities from prod PG after this deploys. These entities have zero YAML source files, no wiki pages, and link to 404s on directory pages.

- **35 missing reciprocal references added** — Person->Org affiliation references that were one-directional are now bidirectional in `organizations.yaml`. Covers Anthropic (4 people), DeepMind (4), Microsoft (2), METR (2), and 21 other organizations.

## Post-merge action

After the wiki-server deploys with this change, run:
```bash
WIKI_SERVER_ENV=prod npx tsx apps/wiki-server/scripts/prune-tmc-entities.ts
```

## Validation

- `pnpm crux validate gate --scope=content --fix` — all 4 gate checks pass
- `pnpm crux validate kb-schema` — all 26 checks pass (was 23/26)
- `pnpm test` — all 3338 tests pass
- Cross-entity warnings reduced from 288 to ~253

## Test plan

- [x] Gate checks pass (`pnpm crux validate gate --scope=content --fix`)
- [x] KB schema validation passes (26/26, was 23/26)
- [x] All tests pass (3338/3338)
- [ ] After merge + deploy: run TMC prune script against prod
- [ ] Verify TMC entities no longer appear on directory pages

Generated with [Claude Code](https://claude.com/claude-code)