### PR TITLE
feat: add LLM stance classifier for legislation resources

### DIFF
--- a/crux/commands/resources.ts
+++ b/crux/commands/resources.ts
@@ -115,10 +115,19 @@ commands['classify-stance'] = async function (args: string[], options: Record<st
   if (!page) {
     return { output: 'Usage: pnpm crux resources classify-stance --page=<slug>\n  Options: --apply, --limit=N, --verbose', exitCode: 1 };
   }
+  let limit: number | undefined;
+  if (options.limit !== undefined) {
+    const parsedLimit = Number(options.limit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+      return { output: '--limit must be a positive integer', exitCode: 1 };
+    }
+    limit = parsedLimit;
+  }
+
   await classifyStance({
     page,
     apply: !!options.apply,
-    limit: options.limit ? Number(options.limit) : undefined,
+    limit,
     verbose: !!options.verbose,
   });
   return { output: '', exitCode: 0 };

--- a/crux/commands/resources/classify-stance.ts
+++ b/crux/commands/resources/classify-stance.ts
@@ -45,7 +45,13 @@ function buildUserPrompt(resources: Array<{ id: string; title: string; summary: 
     id: r.id,
     title: r.title,
     summary: r.summary?.slice(0, 200) ?? null,
-    source: r.domain ?? new URL(r.url).hostname,
+    source: r.domain ?? (() => {
+      try {
+        return new URL(r.url).hostname;
+      } catch {
+        return 'unknown';
+      }
+    })(),
   }));
   return JSON.stringify(items, null, 2);
 }
@@ -64,8 +70,7 @@ export async function classifyStance(args: {
   // Load resources for the page
   const result = await getResourcesByPage(page);
   if (!result.ok) {
-    console.error(`Failed to load resources for page "${page}": ${result.error}`);
-    return;
+    throw new Error(`Failed to load resources for page "${page}": ${result.error}`);
   }
 
   let resources = result.data.resources;
@@ -139,10 +144,14 @@ export async function classifyStance(args: {
           continue;
         }
         const matchedItem = items.find((r) => r.id === item.id);
+        if (!matchedItem) {
+          if (verbose) console.log(`  ⚠ Unknown resource id "${item.id}", skipping`);
+          continue;
+        }
         allResults.push({
           resourceId: item.id,
-          title: matchedItem?.title ?? item.id,
-          url: matchedItem?.url ?? '',
+          title: matchedItem.title,
+          url: matchedItem.url,
           stance: item.stance,
           confidence: item.confidence ?? 'medium',
           reasoning: item.reasoning ?? '',


### PR DESCRIPTION
## Summary

New crux command for classifying resource stance on legislation pages:

```bash
pnpm crux resources classify-stance --page=california-sb1047 --verbose
pnpm crux resources classify-stance --page=california-sb1047 --apply
```

Uses Haiku (~$0.003 per 10 resources) to classify each resource as support/oppose/neutral/mixed/analysis based on title, summary, and domain. Batches 20 resources per LLM call.

### Already applied to production
- **california-sb1047**: 20 resources (7 analysis, 5 support, 4 neutral, 3 oppose, 1 mixed)
- **eu-ai-act**: 13 resources (9 neutral, 4 analysis)
- **california-sb53**: 2 resources

### Also ran title refresh
- `pnpm crux resources refresh-titles --limit 500 --force-all --apply`
- 70 titles improved across 700 resources checked

## Test plan
- [x] Dry-run mode shows classifications without applying
- [x] Apply mode updates stance in wiki-server
- [x] Classifications are sensible (a16z→oppose, CalMatters→neutral, law firms→analysis)
- [x] Cost tracking works ($0.006 for 20 resources)
- [x] Handles missing summaries gracefully
- [x] Already-classified resources are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `classify-stance` command to automatically classify legislation resources by stance category (support, oppose, neutral, mixed, or analysis)
  * Supports dry-run mode to preview classifications before applying changes
  * Includes options to limit workload and enable verbose reporting of individual classification results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->