### PR TITLE
fix: entity ref validator accepts stableIds + fix 5 dangling refs

### DIFF
--- a/crux/validate/yaml-entity-ref-check.ts
+++ b/crux/validate/yaml-entity-ref-check.ts
@@ -120,14 +120,12 @@ export function loadEntitySlugs(entitiesDir: string): Set<string> {
       continue;
     }
 
-    if (Array.isArray(parsed)) {
-      for (const entity of parsed) {
-        if (entity && typeof entity === "object" && typeof entity.id === "string") {
-          slugs.add(entity.id);
-        }
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    for (const entity of items) {
+      if (entity && typeof entity === "object") {
+        if (typeof entity.id === "string") slugs.add(entity.id);
+        if (typeof entity.stableId === "string") slugs.add(entity.stableId);
       }
-    } else if (parsed && typeof parsed === "object" && typeof (parsed as ParsedEntity).id === "string") {
-      slugs.add((parsed as ParsedEntity).id!);
     }
   }
 

--- a/data/entities/epistemic-orgs-projects.yaml
+++ b/data/entities/epistemic-orgs-projects.yaml
@@ -54,10 +54,10 @@
     - id: rethink-priorities
       type: organization
       relationship: related
-    - id: survival-and-flourishing-fund
+    - id: sff
       type: organization
       relationship: supports
-    - id: long-term-future-fund
+    - id: ltff
       type: organization
       relationship: supports
   sources:
@@ -153,7 +153,7 @@
   title: Squiggle Hub
   projectStatus: active
   projectUrl: https://squigglehub.org
-  organization: quantified-uncertainty
+  organization: quri
   description: >-
     Web platform for creating, sharing, and discovering Squiggle models. Features
     include model groups, version history, AI-assisted editing via SquiggleAI,
@@ -175,7 +175,7 @@
   title: Guesstimate
   projectStatus: maintained
   projectUrl: https://www.getguesstimate.com
-  organization: quantified-uncertainty
+  organization: quri
   description: >-
     Web-based spreadsheet for making estimates with probability distributions.
     Precursor to Squiggle. Originally created by Ozzie Gooen in 2016.

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -4628,7 +4628,7 @@
   title: RoastMyPost
   projectStatus: active
   projectUrl: https://roastmypost.com
-  organization: quantified-uncertainty
+  organization: quri
   description: >-
     LLM-powered tool for evaluating blog posts, research papers, and other written
     content. Runs multiple AI evaluator personas (skeptic, methodologist, clarity


### PR DESCRIPTION
## Summary

- **Validator fix**: `loadEntitySlugs()` now collects both `id` (slug) and `stableId` fields from entity YAML. Previously, `relatedEntries` using stableIds (e.g., `mK9pX3rQ7n`) were flagged as 1,452 false-positive errors.
- **5 real dangling refs fixed**:
  - `survival-and-flourishing-fund` → `sff` (epistemic-orgs-projects.yaml)
  - `long-term-future-fund` → `ltff` (epistemic-orgs-projects.yaml)
  - `quantified-uncertainty` → `quri` (3 occurrences across epistemic-orgs-projects.yaml and responses.yaml)

## Validation results after fix

- 1,832 references checked, **0 errors**, 153 warnings (informational summaryPage refs)

## Test plan

- [x] `npx tsx crux/validate/validate-yaml-entity-refs.ts` — 0 errors
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced entity validation to correctly process all identifier fields and array data structures.

* **Chores**
  * Updated project-organization associations and consolidated organization reference identifiers across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->