### PR TITLE
Fix search: acronym boost + trigram fallback for things

### DIFF
--- a/apps/wiki-server/src/__tests__/search-utils.test.ts
+++ b/apps/wiki-server/src/__tests__/search-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildPrefixTsquery,
   titleMatchBoostExpr,
+  isAcronymQuery,
   TRIGRAM_SIMILARITY_THRESHOLD,
   TRIGRAM_FALLBACK_THRESHOLD,
   TS_HEADLINE_OPTIONS,
@@ -44,6 +45,36 @@ describe("buildPrefixTsquery", () => {
   });
 });
 
+describe("isAcronymQuery", () => {
+  it("detects uppercase acronyms of 2-4 chars", () => {
+    expect(isAcronymQuery("ARC")).toBe(true);
+    expect(isAcronymQuery("AI")).toBe(true);
+    expect(isAcronymQuery("MIRI")).toBe(true);
+  });
+
+  it("rejects lowercase or mixed-case strings", () => {
+    expect(isAcronymQuery("arc")).toBe(false);
+    expect(isAcronymQuery("Arc")).toBe(false);
+    expect(isAcronymQuery("aRC")).toBe(false);
+  });
+
+  it("rejects strings that are too short or too long", () => {
+    expect(isAcronymQuery("A")).toBe(false);
+    expect(isAcronymQuery("ABCDE")).toBe(false);
+  });
+
+  it("rejects strings with non-alpha characters", () => {
+    expect(isAcronymQuery("A1")).toBe(false);
+    expect(isAcronymQuery("AI!")).toBe(false);
+    expect(isAcronymQuery("")).toBe(false);
+  });
+
+  it("trims whitespace before checking", () => {
+    expect(isAcronymQuery("  ARC  ")).toBe(true);
+    expect(isAcronymQuery(" AI ")).toBe(true);
+  });
+});
+
 describe("titleMatchBoostExpr", () => {
   it("returns valid SQL CASE expression with starts_with instead of LIKE", () => {
     const expr = titleMatchBoostExpr("title", "$1");
@@ -51,15 +82,24 @@ describe("titleMatchBoostExpr", () => {
     expect(expr).toContain("lower(title)");
     expect(expr).toContain("lower($1)");
     expect(expr).toContain("1000");  // exact match bonus
+    expect(expr).toContain("500");   // acronym-in-parentheses bonus
     expect(expr).toContain("100");   // prefix match bonus
     expect(expr).toContain("starts_with");  // safe: no LIKE special chars
     expect(expr).not.toContain("LIKE");     // no LIKE = no %, _ issues
+  });
+
+  it("includes acronym-in-parentheses boost via position()", () => {
+    const expr = titleMatchBoostExpr("title", "$1");
+    // The expression should look for "(QUERY)" in the title using upper()
+    expect(expr).toContain("upper($1)");
+    expect(expr).toContain("500");
   });
 
   it("uses the provided column and param references", () => {
     const expr = titleMatchBoostExpr("wp.title", "$3");
     expect(expr).toContain("lower(wp.title)");
     expect(expr).toContain("lower($3)");
+    expect(expr).toContain("upper($3)");
   });
 });
 

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -12,7 +12,7 @@ import {
   isNull,
   isNotNull,
 } from "drizzle-orm";
-import { getDrizzleDb } from "../../db.js";
+import { getDrizzleDb, getDb } from "../../db.js";
 import { things, thingResourceVerifications, thingVerdicts, VALID_THING_TYPES } from "../../schema.js";
 import { thingHref } from "../shared/thing-sync.js";
 import {
@@ -22,6 +22,10 @@ import {
   invalidJsonError,
   escapeIlike,
 } from "../shared/utils.js";
+import {
+  TRIGRAM_SIMILARITY_THRESHOLD,
+  TRIGRAM_FALLBACK_THRESHOLD,
+} from "../../search-utils.js";
 
 // ---- Constants ----
 
@@ -84,6 +88,30 @@ const PostVerdictSchema = z.object({
   sourcesChecked: z.number().int().min(0).optional(),
   needsRecheck: z.boolean().optional(),
 });
+
+// ---- Raw SQL row types ----
+
+/** Row shape returned by the trigram search fallback query. */
+interface ThingSearchRow {
+  id: string;
+  thing_type: string;
+  title: string;
+  parent_thing_id: string | null;
+  source_table: string;
+  source_id: string;
+  entity_type: string | null;
+  description: string | null;
+  source_url: string | null;
+  wiki_id: string | null;
+  parent_title: string | null;
+  verdict: string | null;
+  verdict_confidence: number | null;
+  verdict_at: string | null;
+  created_at: string;
+  updated_at: string;
+  synced_at: string | null;
+  similarity: number;
+}
 
 // ---- Helpers ----
 
@@ -180,7 +208,7 @@ const thingsApp = new Hono()
       )
       .limit(limit);
 
-    // Fall back to ILIKE if FTS returned nothing
+    // Phase 2: ILIKE fallback if FTS returned nothing
     if (rows.length === 0) {
       const pattern = `%${escapeIlike(q)}%`;
       const ilikeConditions = [
@@ -201,19 +229,98 @@ const thingsApp = new Hono()
         .orderBy(things.title)
         .limit(limit);
 
-      return c.json({
-        results: fallbackRows.map(formatThing),
-        query: q,
-        total: fallbackRows.length,
-        searchMethod: "ilike" as const,
-      });
+      if (fallbackRows.length > 0) {
+        return c.json({
+          results: fallbackRows.map(formatThing),
+          query: q,
+          total: fallbackRows.length,
+          searchMethod: "ilike" as const,
+        });
+      }
+    }
+
+    // Phase 3: Trigram similarity fallback for typo tolerance
+    // (e.g. "Antrhopic" -> "Anthropic"). Only triggered when FTS + ILIKE
+    // returned few results and query is >= 2 chars (short queries produce
+    // too many low-quality trigram matches).
+    if (rows.length < TRIGRAM_FALLBACK_THRESHOLD && q.trim().length >= 2) {
+      const rawDb = getDb();
+      const existingIds = rows.map((r) => r.id);
+      const thingTypeFilter = thing_type
+        ? `AND thing_type = $4`
+        : "";
+      const params: (string | number | string[])[] = [
+        q,
+        limit - rows.length,
+        existingIds.length > 0 ? existingIds : ["__none__"],
+      ];
+      if (thing_type) {
+        params.push(thing_type);
+      }
+
+      const trigramRows = await rawDb.unsafe<ThingSearchRow[]>(
+        `SELECT
+          id, thing_type, title, parent_thing_id, source_table, source_id,
+          entity_type, description, source_url, wiki_id, parent_title,
+          verdict, verdict_confidence, verdict_at,
+          created_at, updated_at, synced_at,
+          similarity(title, $1) AS similarity
+        FROM things
+        WHERE similarity(title, $1) > ${TRIGRAM_SIMILARITY_THRESHOLD}
+          AND id NOT IN (SELECT unnest($3::text[]))
+          ${thingTypeFilter}
+        ORDER BY similarity(title, $1) DESC
+        LIMIT $2`,
+        params,
+      );
+
+      if (trigramRows.length > 0) {
+        // Convert raw SQL rows to the same shape as Drizzle results
+        const trigramFormatted = trigramRows.map((r) => ({
+          id: r.id,
+          thingType: r.thing_type,
+          title: r.title,
+          parentThingId: r.parent_thing_id,
+          sourceTable: r.source_table,
+          sourceId: r.source_id,
+          entityType: r.entity_type,
+          description: r.description,
+          sourceUrl: r.source_url,
+          wikiId: r.wiki_id,
+          href: thingHref({
+            thingType: r.thing_type,
+            sourceTable: r.source_table,
+            sourceId: r.source_id,
+            wikiId: r.wiki_id,
+            entityType: r.entity_type,
+          }),
+          parentTitle: r.parent_title,
+          verdict: r.verdict,
+          verdictConfidence: r.verdict_confidence,
+          verdictAt: r.verdict_at,
+          createdAt: r.created_at,
+          updatedAt: r.updated_at,
+          syncedAt: r.synced_at,
+        }));
+
+        const combined = [
+          ...rows.map(formatThing),
+          ...trigramFormatted,
+        ];
+        return c.json({
+          results: combined,
+          query: q,
+          total: combined.length,
+          searchMethod: rows.length > 0 ? ("fts+trigram" as const) : ("trigram" as const),
+        });
+      }
     }
 
     return c.json({
       results: rows.map(formatThing),
       query: q,
       total: rows.length,
-      searchMethod: "fts" as const,
+      searchMethod: rows.length > 0 ? ("fts" as const) : ("none" as const),
     });
   })
 

--- a/apps/wiki-server/src/search-utils.ts
+++ b/apps/wiki-server/src/search-utils.ts
@@ -23,13 +23,23 @@ export function buildPrefixTsquery(q: string): string {
 }
 
 /**
+ * Detect whether a query string looks like an acronym.
+ * An acronym is 2-4 characters, all uppercase letters (e.g. "ARC", "AI", "MIRI").
+ */
+export function isAcronymQuery(q: string): boolean {
+  return /^[A-Z]{2,4}$/.test(q.trim());
+}
+
+/**
  * Build a SQL expression that boosts the FTS rank for exact or prefix title matches.
  * - Exact match (case-insensitive): +1000 bonus (guarantees top result)
+ * - Acronym in parentheses (e.g. "(ARC)" in title): +500 bonus
  * - Title starts with query: +100 bonus
  * - Query found at a word boundary in title: +10 bonus
  *
  * This ensures that a page titled "Anthropic" ranks above "Anthropic IPO"
- * when the user searches for "Anthropic".
+ * when the user searches for "Anthropic", and "Alignment Research Center (ARC)"
+ * ranks above "System Architecture" when searching for "ARC".
  *
  * @param titleColumn - SQL column reference for the title (e.g. "title" or "wp.title")
  * @param queryParamRef - SQL parameter reference (e.g. "$1")
@@ -40,9 +50,12 @@ export function titleMatchBoostExpr(
 ): string {
   // Uses starts_with() and position() instead of LIKE to avoid
   // LIKE special characters (%, _) in user input affecting results.
+  // The acronym-in-parentheses boost uses position() to find "(QUERY)" in the title,
+  // matching case-sensitively since acronyms are uppercase by convention.
   return `(
     CASE
       WHEN lower(${titleColumn}) = lower(${queryParamRef}) THEN 1000
+      WHEN position('(' || upper(${queryParamRef}) || ')' in ${titleColumn}) > 0 THEN 500
       WHEN starts_with(lower(${titleColumn}), lower(${queryParamRef}) || ' ') THEN 100
       WHEN position(' ' || lower(${queryParamRef}) in lower(${titleColumn})) > 0 THEN 10
       ELSE 0


### PR DESCRIPTION
## Summary

- **Acronym boost**: Adds a +500 ranking bonus in `titleMatchBoostExpr` when the query appears as a parenthesized acronym in the title (e.g. searching "ARC" now ranks "Alignment Research Center (ARC)" above "System Architecture"). Uses `position('(' || upper(query) || ')' in title)` for case-sensitive acronym matching.
- **Things trigram fallback**: Adds pg_trgm similarity fallback to the things search endpoint (`/api/things/search`), matching the existing pattern in pages search. When FTS + ILIKE return fewer than 3 results and query is >= 2 chars, falls back to `similarity(title, query) > 0.15` for typo tolerance (e.g. "Antrhopic" matches "Anthropic").
- **New `isAcronymQuery` utility**: Exported from `search-utils.ts` for detecting 2-4 char all-uppercase queries. Currently used for documentation; the SQL boost is self-selecting via the `position()` check.

Closes #2781

## Test plan

- [x] `isAcronymQuery` tests: detects valid acronyms, rejects lowercase/mixed-case/too-short/too-long/non-alpha
- [x] `titleMatchBoostExpr` tests: updated to verify the new +500 acronym-in-parentheses boost and `upper()` usage
- [x] All 673 wiki-server tests pass
- [x] TypeScript compiles clean (no new errors in changed files)
- [ ] Manual verification: search "ARC" on production after deploy, verify ARC entity ranks above architecture pages
- [ ] Manual verification: search a typo like "Antrhopic" on `/api/things/search`, verify trigram fallback returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)