### PR TITLE
fix: stance never written on resource upsert UPDATE path

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -200,6 +200,7 @@ async function upsertResource(
         // stableId is generate-once: preserve existing, only set if row didn't have one
         stableId: sql`COALESCE(${resources.stableId}, ${vals.stableId})`,
         archiveUrl: sql`COALESCE(${vals.archiveUrl}, ${resources.archiveUrl})`,
+        stance: sql`COALESCE(${vals.stance}, ${resources.stance})`,
         updatedAt: sql`now()`,
       },
     })
@@ -521,6 +522,8 @@ const resourcesApp = new Hono()
         publicationId: resources.publicationId,
         authors: resources.authors,
         publishedDate: resources.publishedDate,
+        summary: resources.summary,
+        stance: resources.stance,
       })
       .from(resourceCitations)
       .innerJoin(resources, eq(resourceCitations.resourceId, resources.id))

--- a/crux/commands/resources/classify-stance.ts
+++ b/crux/commands/resources/classify-stance.ts
@@ -45,13 +45,7 @@ function buildUserPrompt(resources: Array<{ id: string; title: string; summary: 
     id: r.id,
     title: r.title,
     summary: r.summary?.slice(0, 200) ?? null,
-    source: r.domain ?? (() => {
-      try {
-        return new URL(r.url).hostname;
-      } catch {
-        return 'unknown';
-      }
-    })(),
+    source: r.domain ?? extractDomain(r.url) ?? 'unknown',
   }));
   return JSON.stringify(items, null, 2);
 }


### PR DESCRIPTION
## Summary

Critical bug from adversarial review of #2774: the resource upsert's `ON CONFLICT DO UPDATE SET` was missing the `stance` field. This meant stance was silently dropped when updating **existing** resources — it only worked on INSERT of new resources.

Since all legislation resources already existed in the DB, `classify-stance --apply` appeared to succeed (returned 201) but the stance field remained null.

### Fixes
1. **Critical**: Add `stance: COALESCE(incoming, existing)` to the upsert ON CONFLICT set
2. **Medium**: Add `stance` + `summary` to `/by-page/:pageId` endpoint response — fixes the idempotency check (`!r.stance`) which always returned true because stance wasn't in the response
3. **Low**: Use `extractDomain()` instead of `new URL()` in `buildUserPrompt` to avoid throwing on malformed URLs

### After merge
Re-run stance classification on legislation pages (the previous run's data was silently dropped):
```bash
WIKI_SERVER_ENV=prod pnpm crux resources classify-stance --page=california-sb1047 --apply
WIKI_SERVER_ENV=prod pnpm crux resources classify-stance --page=eu-ai-act --apply
WIKI_SERVER_ENV=prod pnpm crux resources classify-stance --page=california-sb53 --apply
```

## Test plan

- [ ] **Upsert fix**: Run `classify-stance --apply` on a legislation page with pre-existing resources; confirm that the `stance` field is persisted to the DB (check via wiki-server `/by-page/:pageId` or direct SQL query — `SELECT id, stance FROM resources WHERE ...`)
- [ ] **Idempotency check**: Re-run `classify-stance --apply` on the same page; confirm the command detects already-classified resources and skips them (previously `!r.stance` was always `true` because `stance` was absent from the API response)
- [ ] **`/by-page/:pageId` response**: Verify the endpoint now returns `stance` and `summary` fields for each resource
- [ ] **No regression on INSERT path**: Classify stance on a newly added resource to confirm the INSERT path still writes `stance` correctly
- [ ] CI passes (TypeScript build + test DB migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)