### PR TITLE
feat: server-side query normalization and internal page filtering

### DIFF
--- a/apps/wiki-server/src/__tests__/search-utils.test.ts
+++ b/apps/wiki-server/src/__tests__/search-utils.test.ts
@@ -3,6 +3,7 @@ import {
   buildPrefixTsquery,
   titleMatchBoostExpr,
   isAcronymQuery,
+  normalizeSearchQuery,
   TRIGRAM_SIMILARITY_THRESHOLD,
   TRIGRAM_FALLBACK_THRESHOLD,
   TS_HEADLINE_OPTIONS,
@@ -117,5 +118,34 @@ describe("search constants", () => {
   it("ts_headline options include mark tags", () => {
     expect(TS_HEADLINE_OPTIONS).toContain("<mark>");
     expect(TS_HEADLINE_OPTIONS).toContain("</mark>");
+  });
+});
+
+describe("normalizeSearchQuery", () => {
+  it("inserts space between letters and digits", () => {
+    expect(normalizeSearchQuery("sb1047")).toBe("sb 1047");
+    expect(normalizeSearchQuery("gpt4")).toBe("gpt 4");
+    expect(normalizeSearchQuery("AI2")).toBe("AI 2");
+  });
+
+  it("inserts space between digits and letters", () => {
+    expect(normalizeSearchQuery("4chan")).toBe("4 chan");
+    expect(normalizeSearchQuery("3Blue1Brown")).toBe("3 Blue 1 Brown");
+  });
+
+  it("leaves already-spaced queries unchanged", () => {
+    expect(normalizeSearchQuery("sb 1047")).toBe("sb 1047");
+    expect(normalizeSearchQuery("gpt 4")).toBe("gpt 4");
+    expect(normalizeSearchQuery("Anthropic")).toBe("Anthropic");
+  });
+
+  it("leaves pure text or pure numbers unchanged", () => {
+    expect(normalizeSearchQuery("alignment")).toBe("alignment");
+    expect(normalizeSearchQuery("12345")).toBe("12345");
+    expect(normalizeSearchQuery("")).toBe("");
+  });
+
+  it("handles multiple transitions", () => {
+    expect(normalizeSearchQuery("a1b2c3")).toBe("a 1 b 2 c 3");
   });
 });

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -23,6 +23,7 @@ import {
   escapeIlike,
 } from "../shared/utils.js";
 import {
+  normalizeSearchQuery,
   TRIGRAM_SIMILARITY_THRESHOLD,
   TRIGRAM_FALLBACK_THRESHOLD,
 } from "../../search-utils.js";
@@ -185,8 +186,11 @@ const thingsApp = new Hono()
 
   // ---- GET /search?q=...&thing_type=...&limit=20 ----
   .get("/search", zv("query", SearchQuery), async (c) => {
-    const { q, thing_type, limit } = c.req.valid("query");
+    const { q: rawQ, thing_type, limit } = c.req.valid("query");
     const db = getDrizzleDb();
+
+    // Normalize: insert spaces at letter/digit boundaries ("sb1047" → "sb 1047")
+    const q = normalizeSearchQuery(rawQ);
 
     const conditions = [];
 

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildPrefixTsquery,
   titleMatchBoostExpr,
+  normalizeSearchQuery,
   TRIGRAM_SIMILARITY_THRESHOLD,
   TRIGRAM_FALLBACK_THRESHOLD,
   TS_HEADLINE_OPTIONS,
@@ -63,12 +64,17 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({
 const pagesApp = new Hono()
   // ---- GET /search?q=...&limit=20 ----
   .get("/search", zv("query", SearchQuery), async (c) => {
-    const { q, limit } = c.req.valid("query");
+    const { q: rawQ, limit } = c.req.valid("query");
     const rawDb = getDb();
+
+    // Normalize query: insert spaces at letter/digit boundaries
+    // so "sb1047" → "sb 1047" matches FTS tokens.
+    const q = normalizeSearchQuery(rawQ);
 
     // Phase 1: Prefix search with to_tsquery — supports search-as-you-type.
     // Each word gets a :* suffix for prefix matching, ANDed together.
     // Weighted ranking: title (A=1.0), description (B=0.4), summary (C=0.2), tags+entityType (D=0.1).
+    // Internal pages (entity_type = 'internal') are excluded from public search.
     const prefixQuery = buildPrefixTsquery(q);
 
     let results: PageSearchRow[] = [];
@@ -87,6 +93,7 @@ const pagesApp = new Hono()
       FROM wiki_pages
       WHERE search_vector @@ to_tsquery('english', $1)
         AND wiki_id IS NOT NULL
+        AND (entity_type IS NULL OR entity_type != 'internal')
       ORDER BY rank DESC, reader_importance DESC NULLS LAST
       LIMIT $2`,
         [prefixQuery, limit, q],
@@ -105,6 +112,7 @@ const pagesApp = new Hono()
       FROM wiki_pages
       WHERE word_count > 0
         AND wiki_id IS NOT NULL
+        AND (entity_type IS NULL OR entity_type != 'internal')
         AND similarity(title, $1) > ${TRIGRAM_SIMILARITY_THRESHOLD}
         AND id NOT IN (SELECT unnest($3::text[]))
       ORDER BY similarity(title, $1) DESC, reader_importance DESC NULLS LAST

--- a/apps/wiki-server/src/search-utils.ts
+++ b/apps/wiki-server/src/search-utils.ts
@@ -63,6 +63,17 @@ export function titleMatchBoostExpr(
   )`;
 }
 
+/**
+ * Normalize a search query by inserting spaces at letter/digit boundaries.
+ * "sb1047" → "sb 1047", "gpt4" → "gpt 4", "AI2" → "AI 2".
+ * Returns the original query if no normalization is needed.
+ */
+export function normalizeSearchQuery(q: string): string {
+  return q
+    .replace(/([a-zA-Z])(\d)/g, "$1 $2")
+    .replace(/(\d)([a-zA-Z])/g, "$1 $2");
+}
+
 /** Minimum pg_trgm similarity score to include in trigram fallback results. */
 export const TRIGRAM_SIMILARITY_THRESHOLD = 0.15;
 


### PR DESCRIPTION
## Summary
- **Query normalization at the server level**: `normalizeSearchQuery()` inserts spaces at letter/digit boundaries ("sb1047" → "sb 1047") in both the pages and things search endpoints. Previously this only happened client-side, so API consumers missed it.
- **Internal page filtering at the server level**: Pages search now excludes `entity_type='internal'` in both FTS and trigram phases. Previously internal pages leaked through the API to the Cmd+K dialog and any direct API consumers.

## Test plan
- [x] All 3693 tests pass (including new `normalizeSearchQuery` tests)
- [x] TypeScript compiles clean
- [ ] After deploy: `curl /api/pages/search?q=sb1047` returns California SB 1047
- [ ] After deploy: `curl /api/pages/search?q=session` returns no internal pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search query handling to better interpret inputs with mixed letters and digits (e.g., `sb1047` → `sb 1047`).

* **Bug Fixes**
  * Internal pages are now excluded from public search results.

* **Tests**
  * Added comprehensive test coverage for search query normalization across various input patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->