### PR TITLE
fix: enrichment pipeline bugs — GraphQL, options, categories, entity loading

### DIFF
--- a/crux/resource-enrichment/cross-reference.ts
+++ b/crux/resource-enrichment/cross-reference.ts
@@ -65,18 +65,11 @@ function buildDomainToOrgMap(entities: EntityEntry[]): Map<string, string> {
     map.set(domain, entityId);
   }
 
-  // Also try to match entity websites to domains
-  for (const entity of entities) {
-    if (entity.type === 'organization') {
-      // Use entity ID slug as a potential domain match
-      const slug = entity.stableId;
-      if (slug) {
-        // E.g., entity "anthropic" matches domain "anthropic.com"
-        map.set(`${slug}.com`, entity.stableId);
-        map.set(`${slug}.org`, entity.stableId);
-      }
-    }
-  }
+  // Note: Auto-generating domain mappings from entity slugs is intentionally
+  // not done here. The entity API returns stableIds (10-char hashes) not
+  // human-readable slugs, and even slug-based matching would produce false
+  // positives for short slugs (arc.com, meta.org, etc.). Extend the
+  // knownMappings object above for new publisher domains instead.
 
   return map;
 }


### PR DESCRIPTION
## Summary

- Remove dead code in `cross-reference.ts` that auto-generated domain-to-org mappings using `entity.stableId` (10-char alphanumeric hashes like `QsXVXtQ0zE`), which never match real URL domains
- Add explanatory comment directing future maintainers to extend the `knownMappings` object instead

Found during post-merge review of #2788 (resource system overhaul).

## Test plan

- [x] 1-file change, no logic affected — the removed code generated mappings like `QsXVXtQ0zE.com` that could never match any resource URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
