### PR TITLE
Add verification system for stakeholder positions

### DIFF
--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -41,6 +41,7 @@ import {
   type RawResource,
 } from "@/app/legislation/[slug]/timeline-utils";
 import { parseDisplayDateToISO } from "@/app/legislation/[slug]/date-utils";
+import { StakeholderVerificationBadge } from "@/app/legislation/[slug]/stakeholder-verification-badge";
 
 export function generateStaticParams() {
   return getPolicySlugs().map((slug) => ({ slug }));
@@ -472,8 +473,14 @@ export default async function LegislationDetailPage({
                         )}
                       </td>
                       <td className="py-1.5 px-3">
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${POSITION_COLORS[stakeholder.position] ?? "bg-gray-100 text-gray-600"}`}>
-                          {stakeholder.position}
+                        <span className="inline-flex items-center gap-1.5">
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${POSITION_COLORS[stakeholder.position] ?? "bg-gray-100 text-gray-600"}`}>
+                            {stakeholder.position}
+                          </span>
+                          <StakeholderVerificationBadge
+                            verification={stakeholder.verification}
+                            stakeholderName={stakeholder.name}
+                          />
                         </span>
                       </td>
                       <td className="py-1.5 px-3 text-foreground/70 text-sm">

--- a/apps/web/src/app/legislation/[slug]/stakeholder-verification-badge.tsx
+++ b/apps/web/src/app/legislation/[slug]/stakeholder-verification-badge.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import * as HoverCard from "@radix-ui/react-hover-card";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  ShieldQuestion,
+  ShieldX,
+  FileText,
+  Newspaper,
+  MessageSquare,
+  Megaphone,
+  Lightbulb,
+  ExternalLink,
+} from "lucide-react";
+import type {
+  StakeholderVerificationType,
+  StakeholderEvidenceType,
+} from "@/data/entity-schemas";
+
+// ── Verification status configuration ──────────────────────────
+
+interface StatusConfig {
+  icon: typeof ShieldCheck;
+  label: string;
+  color: string;
+  iconColor: string;
+  bgColor: string;
+}
+
+const STATUS_CONFIG: Record<string, StatusConfig> = {
+  verified: {
+    icon: ShieldCheck,
+    label: "Verified",
+    color: "text-emerald-700 dark:text-emerald-400",
+    iconColor: "text-emerald-600 dark:text-emerald-400",
+    bgColor: "bg-emerald-500/10",
+  },
+  "partially-verified": {
+    icon: ShieldAlert,
+    label: "Partially Verified",
+    color: "text-amber-700 dark:text-amber-400",
+    iconColor: "text-amber-500 dark:text-amber-400",
+    bgColor: "bg-amber-500/10",
+  },
+  unverified: {
+    icon: ShieldQuestion,
+    label: "Unverified",
+    color: "text-muted-foreground",
+    iconColor: "text-muted-foreground",
+    bgColor: "bg-muted/50",
+  },
+  disputed: {
+    icon: ShieldX,
+    label: "Disputed",
+    color: "text-red-700 dark:text-red-400",
+    iconColor: "text-red-500 dark:text-red-400",
+    bgColor: "bg-red-500/10",
+  },
+};
+
+// ── Evidence type icons ──────────────────────────────────────
+
+const EVIDENCE_TYPE_CONFIG: Record<
+  string,
+  { icon: typeof FileText; label: string }
+> = {
+  "primary-source": { icon: FileText, label: "Primary Source" },
+  "news-report": { icon: Newspaper, label: "News Report" },
+  "social-media": { icon: MessageSquare, label: "Social Media" },
+  "official-statement": { icon: Megaphone, label: "Official Statement" },
+  inference: { icon: Lightbulb, label: "Inference" },
+};
+
+// ── Date formatting ──────────────────────────────────────────
+
+function formatDate(dateStr: string): string {
+  try {
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+// ── Evidence item ──────────────────────────────────────────
+
+function EvidenceItem({ evidence }: { evidence: StakeholderEvidenceType }) {
+  const config = EVIDENCE_TYPE_CONFIG[evidence.type] ?? {
+    icon: FileText,
+    label: evidence.type,
+  };
+  const Icon = config.icon;
+
+  return (
+    <div className="flex gap-2 py-1.5 first:pt-0 last:pb-0">
+      <Icon className="w-3.5 h-3.5 text-muted-foreground shrink-0 mt-0.5" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-semibold">
+            {config.label}
+          </span>
+          {evidence.date && (
+            <span className="text-[10px] text-muted-foreground">
+              {formatDate(evidence.date)}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-foreground/80 leading-snug mt-0.5">
+          {evidence.description}
+        </p>
+        {evidence.url && (
+          <a
+            href={evidence.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline mt-1"
+          >
+            <ExternalLink className="w-3 h-3" />
+            View source
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ──────────────────────────────────────────
+
+interface StakeholderVerificationBadgeProps {
+  verification: StakeholderVerificationType | undefined;
+  stakeholderName: string;
+}
+
+export function StakeholderVerificationBadge({
+  verification,
+  stakeholderName,
+}: StakeholderVerificationBadgeProps) {
+  // When there is no verification data at all, don't render anything
+  if (!verification?.status) {
+    return null;
+  }
+
+  const config = STATUS_CONFIG[verification.status];
+  if (!config) return null;
+
+  const Icon = config.icon;
+  const hasDetails =
+    (verification.evidence && verification.evidence.length > 0) ||
+    verification.notes ||
+    verification.verifiedDate;
+
+  // If there are no details to show in a hover card, render a static icon
+  if (!hasDetails) {
+    return (
+      <span
+        className="inline-flex items-center"
+        title={`${config.label} position`}
+      >
+        <Icon className={`w-3.5 h-3.5 ${config.iconColor}`} />
+      </span>
+    );
+  }
+
+  return (
+    <HoverCard.Root openDelay={200} closeDelay={150}>
+      <HoverCard.Trigger asChild>
+        <button
+          type="button"
+          className={`inline-flex items-center rounded-full p-0.5 ${config.bgColor} cursor-pointer transition-opacity hover:opacity-80`}
+          aria-label={`Verification status for ${stakeholderName}: ${config.label}`}
+        >
+          <Icon className={`w-3.5 h-3.5 ${config.iconColor}`} />
+        </button>
+      </HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          className="z-50 w-80 rounded-lg border border-border bg-popover p-4 shadow-lg animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2"
+          side="bottom"
+          align="start"
+          sideOffset={6}
+        >
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-2">
+            <Icon className={`w-4 h-4 ${config.iconColor} shrink-0`} />
+            <span className={`text-sm font-semibold ${config.color}`}>
+              {config.label}
+            </span>
+            {verification.verifiedDate && (
+              <span className="text-xs text-muted-foreground ml-auto">
+                {formatDate(verification.verifiedDate)}
+              </span>
+            )}
+          </div>
+
+          {/* Stakeholder name */}
+          <p className="text-xs font-medium text-foreground mb-2">
+            {stakeholderName}
+          </p>
+
+          {/* Notes */}
+          {verification.notes && (
+            <p className="text-xs text-muted-foreground leading-relaxed mb-3">
+              {verification.notes}
+            </p>
+          )}
+
+          {/* Evidence chain */}
+          {verification.evidence && verification.evidence.length > 0 && (
+            <div className="border-t border-border pt-2">
+              <h4 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-semibold mb-2">
+                Evidence
+              </h4>
+              <div className="space-y-2 divide-y divide-border/50">
+                {verification.evidence.map((ev, idx) => (
+                  <EvidenceItem key={idx} evidence={ev} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          <HoverCard.Arrow className="fill-border" />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  );
+}

--- a/apps/web/src/data/entity-schemas-verification.test.ts
+++ b/apps/web/src/data/entity-schemas-verification.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { TypedEntitySchema } from "@/data/entity-schemas";
+
+/**
+ * Tests for the PolicyStakeholder verification schema extension.
+ * Validates that the new verification field is properly optional and
+ * correctly validates when present.
+ */
+
+function makePolicyEntity(stakeholderOverrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-policy",
+    title: "Test Policy Act",
+    entityType: "policy" as const,
+    stakeholders: [
+      {
+        name: "Test Org",
+        position: "support",
+        reason: "Test reason",
+        ...stakeholderOverrides,
+      },
+    ],
+  };
+}
+
+describe("PolicyStakeholder verification schema", () => {
+  it("accepts stakeholders without verification (backward compatible)", () => {
+    const result = TypedEntitySchema.safeParse(makePolicyEntity());
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts stakeholders with undefined verification", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({ verification: undefined })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts stakeholders with empty verification object", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({ verification: {} })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts stakeholders with full verification data", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: {
+          status: "verified",
+          verifiedDate: "2026-03-15",
+          notes: "Confirmed via official testimony.",
+          evidence: [
+            {
+              type: "primary-source",
+              url: "https://example.com/testimony.pdf",
+              description: "Written testimony submitted to committee",
+              date: "2025-09-01",
+            },
+            {
+              type: "news-report",
+              description: "Reported by AP News",
+            },
+          ],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const entity = result.data;
+      if (entity.entityType === "policy") {
+        const stakeholder = entity.stakeholders[0];
+        expect(stakeholder.verification?.status).toBe("verified");
+        expect(stakeholder.verification?.evidence).toHaveLength(2);
+        expect(stakeholder.verification?.evidence?.[0].type).toBe(
+          "primary-source"
+        );
+      }
+    }
+  });
+
+  it("accepts all valid verification statuses", () => {
+    for (const status of [
+      "verified",
+      "partially-verified",
+      "unverified",
+      "disputed",
+    ]) {
+      const result = TypedEntitySchema.safeParse(
+        makePolicyEntity({
+          verification: { status },
+        })
+      );
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid verification status", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: { status: "unknown-status" },
+      })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid evidence types", () => {
+    for (const type of [
+      "primary-source",
+      "news-report",
+      "social-media",
+      "official-statement",
+      "inference",
+    ]) {
+      const result = TypedEntitySchema.safeParse(
+        makePolicyEntity({
+          verification: {
+            status: "verified",
+            evidence: [{ type, description: "Test evidence" }],
+          },
+        })
+      );
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid evidence type", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: {
+          status: "verified",
+          evidence: [{ type: "blog-post", description: "Some blog" }],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects evidence without required description field", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: {
+          status: "verified",
+          evidence: [{ type: "primary-source", url: "https://example.com" }],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts verification with only status (minimal)", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: { status: "unverified" },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts verification with notes but no evidence", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: {
+          status: "partially-verified",
+          notes: "Position inferred from public statements",
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts evidence without optional url and date", () => {
+    const result = TypedEntitySchema.safeParse(
+      makePolicyEntity({
+        verification: {
+          status: "verified",
+          evidence: [
+            {
+              type: "inference",
+              description: "Based on organizational mission statement",
+            },
+          ],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const entity = result.data;
+      if (entity.entityType === "policy") {
+        const ev = entity.stakeholders[0].verification?.evidence?.[0];
+        expect(ev?.url).toBeUndefined();
+        expect(ev?.date).toBeUndefined();
+      }
+    }
+  });
+});

--- a/apps/web/src/data/entity-schemas.ts
+++ b/apps/web/src/data/entity-schemas.ts
@@ -142,6 +142,20 @@ const OrganizationEntitySchema = BaseEntity.extend({
   parentOrg: z.string().optional(),
 });
 
+const StakeholderEvidence = z.object({
+  type: z.enum(["primary-source", "news-report", "social-media", "official-statement", "inference"]),
+  url: z.string().optional(),
+  description: z.string(),
+  date: z.string().optional(),
+});
+
+const StakeholderVerification = z.object({
+  status: z.enum(["verified", "partially-verified", "unverified", "disputed"]).optional(),
+  verifiedDate: z.string().optional(),
+  evidence: z.array(StakeholderEvidence).optional(),
+  notes: z.string().optional(),
+});
+
 const PolicyStakeholder = z.object({
   name: z.string(),
   entityId: z.string().optional(),
@@ -150,6 +164,8 @@ const PolicyStakeholder = z.object({
   source: z.string().optional(),
   /** Short notes on funding, affiliations, and connections to other stakeholders */
   context: z.array(z.string()).optional(),
+  /** Verification status and evidence chain for this stakeholder's claimed position */
+  verification: StakeholderVerification.optional(),
 });
 
 const PolicyProvision = z.object({
@@ -412,6 +428,9 @@ export type ResearchAreaEntity = z.infer<typeof ResearchAreaEntitySchema>;
 export type ApproachEntity = z.infer<typeof ApproachEntitySchema>;
 export type EventEntity = z.infer<typeof EventEntitySchema>;
 export type GenericEntity = z.infer<typeof GenericEntitySchema>;
+export type PolicyStakeholderType = z.infer<typeof PolicyStakeholder>;
+export type StakeholderVerificationType = z.infer<typeof StakeholderVerification>;
+export type StakeholderEvidenceType = z.infer<typeof StakeholderEvidence>;
 
 // ============================================================================
 // TYPE GUARDS


### PR DESCRIPTION
## Summary

- Add `verification` field to `PolicyStakeholder` Zod schema with `status` (verified/partially-verified/unverified/disputed), `evidence` chain (typed as primary-source, news-report, social-media, official-statement, inference), `verifiedDate`, and `notes`
- Create `StakeholderVerificationBadge` client component using `@radix-ui/react-hover-card` (already installed) with color-coded shield icons (green=verified, yellow=partially-verified, gray=unverified, red=disputed)
- Integrate badge inline with position pills in the legislation stakeholders table
- Add 12 Vitest tests for schema validation covering all valid/invalid inputs
- Schema is fully backward-compatible: no verification data = no badge rendered

## Test plan

- [x] All 12 new schema validation tests pass (`pnpm test -- --run src/data/entity-schemas-verification.test.ts`)
- [x] Existing tests unaffected (622 passing, pre-existing failures unrelated)
- [x] TypeScript compilation clean (only pre-existing worktree environment errors)
- [x] Schema accepts stakeholders without verification field (backward compat)
- [x] Schema rejects invalid status values and evidence types
- [ ] Manual: Add sample verification data to a stakeholder in responses.yaml and verify badge renders on legislation page

Generated with [Claude Code](https://claude.com/claude-code)
