### PR TITLE
feat: add importance/weight indicator to policy stakeholders

### DIFF
--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -68,6 +68,33 @@ const POSITION_COLORS: Record<string, string> = {
   mixed: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
 };
 
+/** Compact circle indicator for stakeholder importance. */
+function ImportanceIndicator({ importance }: { importance: "high" | "medium" | "low" }) {
+  // high = filled circle, medium = half-filled circle, low = empty circle
+  const size = 10;
+  if (importance === "high") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 10 10" aria-label="High importance">
+        <circle cx="5" cy="5" r="4" className="fill-foreground/70" />
+      </svg>
+    );
+  }
+  if (importance === "medium") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 10 10" aria-label="Medium importance">
+        <circle cx="5" cy="5" r="4" className="fill-none stroke-foreground/60" strokeWidth="1.2" />
+        <path d="M5,1 A4,4 0 0,0 5,9 Z" className="fill-foreground/60" />
+      </svg>
+    );
+  }
+  // low
+  return (
+    <svg width={size} height={size} viewBox="0 0 10 10" aria-label="Low importance">
+      <circle cx="5" cy="5" r="4" className="fill-none stroke-foreground/40" strokeWidth="1.2" />
+    </svg>
+  );
+}
+
 /** Status pipeline stages for the visual timeline. */
 const PIPELINE_STAGES = [
   { key: "introduced", label: "Introduced" },
@@ -124,9 +151,13 @@ export default async function LegislationDetailPage({
 
   const wikiHref = getPolicyWikiHref(entity);
 
-  const supporters = entity.stakeholders.filter((s) => s.position === "support");
-  const opponents = entity.stakeholders.filter((s) => s.position === "oppose");
-  const mixed = entity.stakeholders.filter((s) => s.position === "mixed" || s.position === "neutral");
+  const importanceOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  const byImportance = <T extends { importance?: string }>(a: T, b: T) =>
+    (importanceOrder[a.importance ?? ""] ?? 3) - (importanceOrder[b.importance ?? ""] ?? 3);
+
+  const supporters = entity.stakeholders.filter((s) => s.position === "support").sort(byImportance);
+  const opponents = entity.stakeholders.filter((s) => s.position === "oppose").sort(byImportance);
+  const mixed = entity.stakeholders.filter((s) => s.position === "mixed" || s.position === "neutral").sort(byImportance);
 
   const provisionsByCategory = new Map<string, typeof entity.provisions>();
   for (const p of entity.provisions) {
@@ -465,11 +496,21 @@ export default async function LegislationDetailPage({
                   return (
                     <tr key={i} className="hover:bg-muted/20 align-top">
                       <td className="py-1.5 px-3">
-                        {href ? (
-                          <Link href={href} className="text-primary hover:underline font-medium text-sm">{stakeholder.name}</Link>
-                        ) : (
-                          <span className="font-medium text-sm">{stakeholder.name}</span>
-                        )}
+                        <span className="inline-flex items-center gap-1.5">
+                          {stakeholder.importance && (
+                            <span
+                              className="inline-block flex-shrink-0"
+                              title={`${stakeholder.importance} importance`}
+                            >
+                              <ImportanceIndicator importance={stakeholder.importance} />
+                            </span>
+                          )}
+                          {href ? (
+                            <Link href={href} className="text-primary hover:underline font-medium text-sm">{stakeholder.name}</Link>
+                          ) : (
+                            <span className="font-medium text-sm">{stakeholder.name}</span>
+                          )}
+                        </span>
                       </td>
                       <td className="py-1.5 px-3">
                         <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${POSITION_COLORS[stakeholder.position] ?? "bg-gray-100 text-gray-600"}`}>

--- a/apps/web/src/data/entity-schemas.ts
+++ b/apps/web/src/data/entity-schemas.ts
@@ -146,6 +146,7 @@ const PolicyStakeholder = z.object({
   name: z.string(),
   entityId: z.string().optional(),
   position: z.enum(["support", "oppose", "neutral", "mixed"]),
+  importance: z.enum(["high", "medium", "low"]).optional(),
   reason: z.string().optional(),
   source: z.string().optional(),
   /** Short notes on funding, affiliations, and connections to other stakeholders */

--- a/apps/wiki-server/drizzle/0117_policy_stakeholder_importance.sql
+++ b/apps/wiki-server/drizzle/0117_policy_stakeholder_importance.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "policy_stakeholders" ADD COLUMN "importance" text;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -820,6 +820,13 @@
       "when": 1779696000000,
       "tag": "0116_resource_sub_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "7",
+      "when": 1779782400000,
+      "tag": "0117_policy_stakeholder_importance",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+++ b/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
@@ -17,12 +17,15 @@ const VALID_POSITIONS = ["support", "oppose", "neutral", "mixed"] as const;
 
 // ---- Schemas ----
 
+const VALID_IMPORTANCE = ["high", "medium", "low"] as const;
+
 const SyncStakeholderItemSchema = z.object({
   id: z.string().length(10),
   policyEntityId: z.string().min(1).max(200),
   stakeholderEntityId: z.string().max(200).nullable().optional(),
   stakeholderDisplayName: z.string().min(1).max(500),
   position: z.enum(VALID_POSITIONS),
+  importance: z.enum(VALID_IMPORTANCE).nullable().optional(),
   reason: z.string().max(5000).nullable().optional(),
   source: z.string().max(2000).nullable().optional(),
   context: z.array(z.string()).nullable().optional(),
@@ -108,6 +111,7 @@ const policyStakeholdersApp = new Hono()
             stakeholderEntityId: item.stakeholderEntityId ?? null,
             stakeholderDisplayName: item.stakeholderDisplayName,
             position: item.position,
+            importance: item.importance ?? null,
             reason: item.reason ?? null,
             source: item.source ?? null,
             context: item.context ?? null,
@@ -121,6 +125,7 @@ const policyStakeholdersApp = new Hono()
               stakeholderEntityId: item.stakeholderEntityId ?? null,
               stakeholderDisplayName: item.stakeholderDisplayName,
               position: item.position,
+              importance: item.importance ?? null,
               reason: item.reason ?? null,
               source: item.source ?? null,
               context: item.context ?? null,

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2548,6 +2548,8 @@ export const policyStakeholders = pgTable(
     stakeholderDisplayName: text("stakeholder_display_name").notNull(),
     /** Position: support | oppose | neutral | mixed */
     position: text("position").notNull(),
+    /** Importance/weight: high | medium | low */
+    importance: text("importance"),
     /** Reason for the position */
     reason: text("reason"),
     /** Source URL */


### PR DESCRIPTION
## Summary
- Adds an optional `importance` field (`high` | `medium` | `low`) to the `PolicyStakeholder` Zod schema in `entity-schemas.ts`
- Adds `importance` text column to the `policy_stakeholders` PG table (schema + Drizzle migration 0117)
- Updates the sync route to accept and persist the `importance` field
- Displays a small SVG circle indicator next to stakeholder names in the legislation detail page (filled = high, half-filled = medium, empty = low)
- Sorts stakeholders by importance within each position group (high first)

## Files changed
- `apps/web/src/data/entity-schemas.ts` — schema field
- `apps/wiki-server/src/schema.ts` — PG column
- `apps/wiki-server/drizzle/0117_policy_stakeholder_importance.sql` — migration
- `apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts` — sync route
- `apps/web/src/app/legislation/[slug]/page.tsx` — UI indicator + sorting

## Test plan
- [x] TypeScript compiles (`tsc --noEmit` passes for both web and wiki-server)
- [ ] Verify importance indicators render on a legislation page with populated data
- [ ] Verify migration applies cleanly on wiki-server startup

Generated with [Claude Code](https://claude.com/claude-code)