### PR TITLE
fix: move extractDomain to module scope to resolve TS2304

### DIFF
--- a/crux/commands/resources/classify-stance.ts
+++ b/crux/commands/resources/classify-stance.ts
@@ -16,6 +16,14 @@ import { CostTracker } from '../../lib/cost-tracker.ts';
 import { getResourcesByPage, upsertResource } from '../../lib/wiki-server/resources.ts';
 import type { ResourceRow } from '../../lib/wiki-server/resources.ts';
 
+function extractDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
 const VALID_STANCES = ['support', 'oppose', 'neutral', 'mixed', 'analysis'] as const;
 type Stance = typeof VALID_STANCES[number];
 
@@ -81,15 +89,6 @@ export async function classifyStance(args: {
 
   let toClassify = unclassified;
   if (limit) toClassify = toClassify.slice(0, limit);
-
-  // Extract domain from URL for classification context
-  function extractDomain(url: string): string | null {
-    try {
-      return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
-    } catch {
-      return null;
-    }
-  }
 
   const items = toClassify.map((r: any) => ({
     id: r.id,


### PR DESCRIPTION
## Summary
- Fix pre-existing TypeScript error `TS2304: Cannot find name 'extractDomain'` in `crux/commands/resources/classify-stance.ts`
- The `extractDomain` function was defined inside `classifyStance()` but called from `buildUserPrompt()` at module scope, making it inaccessible
- Moved `extractDomain` to module scope and removed the duplicate definition inside `classifyStance()`

## Test plan
- [x] `tsc --noEmit -p crux/tsconfig.json` reports 0 errors for this file
- [x] No behavior change -- function logic is identical, only its scope changed
