### PR TITLE
feat: add auto-verify-stakeholders command

### DIFF
--- a/crux/commands/legislation/auto-verify-stakeholders.test.ts
+++ b/crux/commands/legislation/auto-verify-stakeholders.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the auto-verify-stakeholders CLI command.
+ *
+ * Tests dry-run mode with real YAML data (no LLM or API calls needed).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { commands } from './auto-verify-stakeholders.ts';
+
+describe('crux w auto-verify-stakeholders --dry-run', () => {
+  it('lists stakeholders to verify across all policies', async () => {
+    const result = await commands.verify([], { dryRun: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Stakeholders to verify');
+    expect(result.output).toContain('Position:');
+    expect(result.output).toContain('Source:');
+    expect(result.output).toContain('Thing ID:');
+  });
+
+  it('filters by policy ID', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      policy: 'california-sb1047',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('california-sb1047');
+    // Should NOT contain other policies
+    expect(result.output).not.toContain('colorado-ai-act');
+    expect(result.output).not.toContain('eu-ai-act');
+  });
+
+  it('returns error for nonexistent policy', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      policy: 'nonexistent-policy-xyz',
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('No policy entity found');
+  });
+
+  it('returns JSON in json mode', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      policy: 'colorado-ai-act',
+      json: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+    expect(data[0]).toHaveProperty('policyId');
+    expect(data[0]).toHaveProperty('stakeholderName');
+    expect(data[0]).toHaveProperty('position');
+    expect(data[0]).toHaveProperty('sourceUrl');
+    expect(data[0]).toHaveProperty('thingId');
+  });
+
+  it('respects budget limit in dry-run', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      budget: '3',
+      json: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output);
+    expect(data.length).toBe(3);
+  });
+
+  it('generates correct thing IDs', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      policy: 'california-sb1047',
+      json: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output) as Array<{ thingId: string; stakeholderName: string }>;
+
+    // Check specific thing ID formats
+    const elonEntry = data.find((d) => d.stakeholderName === 'Elon Musk');
+    expect(elonEntry).toBeDefined();
+    expect(elonEntry!.thingId).toBe('policy-stakeholder:california-sb1047:elon-musk');
+
+    const openaiEntry = data.find((d) => d.stakeholderName === 'OpenAI');
+    expect(openaiEntry).toBeDefined();
+    expect(openaiEntry!.thingId).toBe('policy-stakeholder:california-sb1047:openai');
+  });
+
+  it('only includes stakeholders with source URLs', async () => {
+    const result = await commands.verify([], {
+      dryRun: true,
+      policy: 'california-sb1047',
+      json: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output) as Array<{ sourceUrl: string }>;
+
+    // All entries should have source URLs
+    for (const entry of data) {
+      expect(entry.sourceUrl).toBeTruthy();
+      expect(entry.sourceUrl).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it('default command is verify', async () => {
+    // The default export should be the same as verify
+    const defaultResult = await commands.default([], { dryRun: true, policy: 'colorado-ai-act', json: true });
+    const verifyResult = await commands.verify([], { dryRun: true, policy: 'colorado-ai-act', json: true });
+    expect(defaultResult.output).toBe(verifyResult.output);
+  });
+});

--- a/crux/commands/legislation/auto-verify-stakeholders.ts
+++ b/crux/commands/legislation/auto-verify-stakeholders.ts
@@ -1,0 +1,646 @@
+/**
+ * Auto-Verify Stakeholder Positions
+ *
+ * Fetches source URLs for stakeholder positions on policy entities,
+ * sends the content to an LLM for verification, and records results
+ * via the wiki-server API.
+ *
+ * Subcommands:
+ *   verify    Verify stakeholder positions against their source URLs
+ *
+ * Flags:
+ *   --policy=<id>     Only verify stakeholders for one policy entity
+ *   --dry-run         Show what would be verified without API calls
+ *   --budget=<N>      Maximum number of LLM calls to make (default: unlimited)
+ *   --json            Output results as JSON
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import { PROJECT_ROOT } from '../../lib/content-types.ts';
+import { createLlmClient, callLlm, MODELS } from '../../lib/llm.ts';
+import { CostTracker } from '../../lib/cost-tracker.ts';
+import { fetchSource } from '../../lib/search/source-fetcher.ts';
+import { apiRequest } from '../../lib/wiki-server/client.ts';
+import { createLogger } from '../../lib/output.ts';
+import { parseIntOpt, type CommandResult } from '../../lib/cli.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Stakeholder {
+  name: string;
+  entityId?: string;
+  position: 'support' | 'oppose' | 'neutral' | 'mixed';
+  reason?: string;
+  source?: string;
+  context?: string[];
+}
+
+interface PolicyEntity {
+  id: string;
+  stableId: string;
+  wikiId?: string;
+  type: string;
+  title: string;
+  stakeholders?: Stakeholder[];
+}
+
+type VerificationVerdict = 'confirmed' | 'contradicted' | 'partial' | 'unverifiable';
+
+interface VerificationResult {
+  policyId: string;
+  policyTitle: string;
+  stakeholderName: string;
+  position: string;
+  reason?: string;
+  sourceUrl: string;
+  verdict: VerificationVerdict;
+  confidence: number;
+  extractedEvidence: string;
+  notes: string;
+  sourceStatus: string;
+  skipped: boolean;
+  skipReason?: string;
+}
+
+interface ExistingVerdict {
+  thingId: string;
+  verdict: string;
+  confidence: number | null;
+  needsRecheck: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Data loading
+// ---------------------------------------------------------------------------
+
+function loadPolicyEntities(): PolicyEntity[] {
+  const yamlPath = join(PROJECT_ROOT, 'data/entities/responses.yaml');
+  const raw = readFileSync(yamlPath, 'utf-8');
+  const entities = parseYaml(raw) as PolicyEntity[];
+
+  return entities.filter(
+    (e) => e.type === 'policy' && Array.isArray(e.stakeholders) && e.stakeholders.length > 0,
+  );
+}
+
+/**
+ * Build a thing ID for a stakeholder position.
+ * Uses the format: policy-stakeholder:<policyId>:<stakeholderName>
+ * This must match the thing ID convention used by the things sync system.
+ */
+function buildStakeholderThingId(policyId: string, stakeholderName: string): string {
+  const slug = stakeholderName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `policy-stakeholder:${policyId}:${slug}`;
+}
+
+// ---------------------------------------------------------------------------
+// Existing verdict check
+// ---------------------------------------------------------------------------
+
+async function getExistingVerdict(thingId: string): Promise<ExistingVerdict | null> {
+  const result = await apiRequest<ExistingVerdict>('GET', `/api/things/verdicts/${encodeURIComponent(thingId)}`);
+
+  if (result.ok) {
+    return result.data;
+  }
+
+  // 404 = no verdict yet, which is fine
+  if (!result.ok && result.message.startsWith('404')) {
+    return null;
+  }
+
+  // For other errors (unavailable, timeout), log and return null
+  if (!result.ok) {
+    console.warn(`[auto-verify] Could not check existing verdict for ${thingId}: ${result.message}`);
+    return null;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// LLM verification
+// ---------------------------------------------------------------------------
+
+interface LlmVerificationResult {
+  verdict: VerificationVerdict;
+  confidence: number;
+  extractedEvidence: string;
+  notes: string;
+}
+
+async function verifyStakeholderPosition(
+  client: ReturnType<typeof createLlmClient>,
+  tracker: CostTracker,
+  stakeholder: Stakeholder,
+  policyTitle: string,
+  sourceContent: string,
+): Promise<LlmVerificationResult> {
+  const prompt = `You are verifying a stakeholder position claim against a source document.
+
+CLAIM TO VERIFY:
+- Stakeholder: ${stakeholder.name}
+- Policy: ${policyTitle}
+- Stated position: ${stakeholder.position}
+- Stated reason: ${stakeholder.reason || '(none provided)'}
+
+SOURCE CONTENT (from ${stakeholder.source}):
+${sourceContent.slice(0, 50_000)}
+
+INSTRUCTIONS:
+Based on the source content above, verify whether it supports the claimed position.
+Respond in exactly this JSON format (no markdown fencing):
+
+{
+  "verdict": "<one of: confirmed, contradicted, partial, unverifiable>",
+  "confidence": <number between 0.0 and 1.0>,
+  "extractedEvidence": "<specific text from the source that supports or contradicts the claim, max 500 chars>",
+  "notes": "<brief explanation of your verdict, max 300 chars>"
+}
+
+VERDICT DEFINITIONS:
+- "confirmed": The source clearly confirms the stakeholder's position and reason
+- "contradicted": The source contradicts the claimed position or reason
+- "partial": The source partially confirms the position but some details differ
+- "unverifiable": The source does not contain enough information to verify the claim
+
+Be conservative: if the source is ambiguous or doesn't mention the stakeholder, use "unverifiable".
+If the source mentions the stakeholder but with a different position, use "contradicted".
+If the position matches but the reason is different, use "partial".`;
+
+  const result = await callLlm(client, prompt, {
+    model: MODELS.haiku,
+    maxTokens: 1000,
+    temperature: 0,
+    tracker,
+    label: 'verify-stakeholder',
+    retryLabel: 'verify-stakeholder',
+  });
+
+  try {
+    // Try to parse the JSON response, handling possible markdown code blocks
+    let text = result.text.trim();
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+    }
+    const parsed = JSON.parse(text) as {
+      verdict?: string;
+      confidence?: number;
+      extractedEvidence?: string;
+      notes?: string;
+    };
+
+    const validVerdicts: VerificationVerdict[] = ['confirmed', 'contradicted', 'partial', 'unverifiable'];
+    const verdict = validVerdicts.includes(parsed.verdict as VerificationVerdict)
+      ? (parsed.verdict as VerificationVerdict)
+      : 'unverifiable';
+
+    const confidence = typeof parsed.confidence === 'number'
+      ? Math.max(0, Math.min(1, parsed.confidence))
+      : 0.5;
+
+    return {
+      verdict,
+      confidence,
+      extractedEvidence: (parsed.extractedEvidence || '').slice(0, 500),
+      notes: (parsed.notes || '').slice(0, 300),
+    };
+  } catch (parseErr: unknown) {
+    const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+    console.warn(`[auto-verify] Failed to parse LLM response: ${msg}`);
+    return {
+      verdict: 'unverifiable',
+      confidence: 0.0,
+      extractedEvidence: '',
+      notes: `LLM response parsing failed: ${msg.slice(0, 200)}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recording results to wiki-server
+// ---------------------------------------------------------------------------
+
+interface PostVerificationBody {
+  thingId: string;
+  sourceUrl: string;
+  fieldName: string;
+  expectedValue: string;
+  verdict: VerificationVerdict;
+  confidence: number;
+  extractedValue: string;
+  checkerModel: string;
+  isPrimarySource: boolean;
+  notes: string;
+}
+
+interface PostVerdictBody {
+  thingId: string;
+  verdict: VerificationVerdict | 'unchecked';
+  confidence: number;
+  reasoning: string;
+  sourcesChecked: number;
+  needsRecheck: boolean;
+}
+
+async function recordVerification(verification: PostVerificationBody): Promise<boolean> {
+  const result = await apiRequest<unknown>('POST', '/api/things/verifications', verification);
+  if (!result.ok) {
+    console.warn(`[auto-verify] Failed to record verification: ${result.message}`);
+    return false;
+  }
+  return true;
+}
+
+async function recordVerdict(verdict: PostVerdictBody): Promise<boolean> {
+  const result = await apiRequest<unknown>('POST', '/api/things/verdicts', verdict);
+  if (!result.ok) {
+    console.warn(`[auto-verify] Failed to record verdict: ${result.message}`);
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Main verification pipeline
+// ---------------------------------------------------------------------------
+
+interface VerifyOptions {
+  policy?: string;
+  dryRun?: boolean;
+  budget?: string | number;
+  json?: boolean;
+  ci?: boolean;
+  [key: string]: unknown;
+}
+
+async function verify(_args: string[], options: VerifyOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+  const dryRun = Boolean(options.dryRun);
+  const budgetLimit = parseIntOpt(options.budget, 0); // 0 = unlimited
+  const policyFilter = options.policy as string | undefined;
+
+  // 1. Load policy entities
+  const policyEntities = loadPolicyEntities();
+  const filtered = policyFilter
+    ? policyEntities.filter((p) => p.id === policyFilter)
+    : policyEntities;
+
+  if (filtered.length === 0) {
+    const msg = policyFilter
+      ? `No policy entity found with id "${policyFilter}"`
+      : 'No policy entities with stakeholders found in responses.yaml';
+    return { output: msg, exitCode: 1 };
+  }
+
+  // 2. Collect all stakeholders with source URLs
+  interface StakeholderWithPolicy {
+    policy: PolicyEntity;
+    stakeholder: Stakeholder;
+    thingId: string;
+  }
+
+  const allStakeholders: StakeholderWithPolicy[] = [];
+  for (const policy of filtered) {
+    for (const stakeholder of policy.stakeholders || []) {
+      if (!stakeholder.source) continue;
+      const thingId = buildStakeholderThingId(policy.id, stakeholder.name);
+      allStakeholders.push({ policy, stakeholder, thingId });
+    }
+  }
+
+  if (allStakeholders.length === 0) {
+    return { output: 'No stakeholders with source URLs found.', exitCode: 0 };
+  }
+
+  console.log(`${c.bold}Auto-Verify Stakeholder Positions${c.reset}`);
+  console.log(`${c.dim}Found ${allStakeholders.length} stakeholders with source URLs across ${filtered.length} policies${c.reset}`);
+
+  if (dryRun) {
+    console.log(`\n${c.yellow}DRY RUN — no API calls will be made${c.reset}\n`);
+  }
+
+  // 3. Filter out already-verified stakeholders
+  const toVerify: StakeholderWithPolicy[] = [];
+  const skippedAlreadyVerified: VerificationResult[] = [];
+
+  for (const item of allStakeholders) {
+    if (dryRun) {
+      // In dry-run mode, include everything
+      toVerify.push(item);
+      continue;
+    }
+
+    const existingVerdict = await getExistingVerdict(item.thingId);
+    if (existingVerdict && !existingVerdict.needsRecheck) {
+      skippedAlreadyVerified.push({
+        policyId: item.policy.id,
+        policyTitle: item.policy.title,
+        stakeholderName: item.stakeholder.name,
+        position: item.stakeholder.position,
+        reason: item.stakeholder.reason,
+        sourceUrl: item.stakeholder.source!,
+        verdict: existingVerdict.verdict as VerificationVerdict,
+        confidence: existingVerdict.confidence ?? 0,
+        extractedEvidence: '',
+        notes: 'Already verified — skipped',
+        sourceStatus: 'cached',
+        skipped: true,
+        skipReason: 'already-verified',
+      });
+      continue;
+    }
+    toVerify.push(item);
+  }
+
+  if (skippedAlreadyVerified.length > 0) {
+    console.log(`${c.dim}Skipping ${skippedAlreadyVerified.length} already-verified stakeholders${c.reset}`);
+  }
+
+  // 4. Apply budget limit
+  const effectiveBudget = budgetLimit > 0 ? budgetLimit : toVerify.length;
+  const limited = toVerify.slice(0, effectiveBudget);
+
+  if (budgetLimit > 0 && toVerify.length > budgetLimit) {
+    console.log(`${c.yellow}Budget limit: processing ${budgetLimit} of ${toVerify.length} remaining stakeholders${c.reset}`);
+  }
+
+  console.log(`\n${c.bold}Processing ${limited.length} stakeholders...${c.reset}\n`);
+
+  // 5. Dry run output
+  if (dryRun) {
+    let output = `\n${c.bold}Stakeholders to verify:${c.reset}\n\n`;
+    for (const item of limited) {
+      output += `  ${c.cyan}${item.policy.id}${c.reset} / ${item.stakeholder.name}\n`;
+      output += `    Position: ${item.stakeholder.position}\n`;
+      output += `    Source: ${item.stakeholder.source}\n`;
+      output += `    Thing ID: ${item.thingId}\n\n`;
+    }
+    output += `\n${c.dim}Total: ${limited.length} stakeholders would be verified${c.reset}\n`;
+
+    if (options.json) {
+      return {
+        output: JSON.stringify(
+          limited.map((i) => ({
+            policyId: i.policy.id,
+            stakeholderName: i.stakeholder.name,
+            position: i.stakeholder.position,
+            sourceUrl: i.stakeholder.source,
+            thingId: i.thingId,
+          })),
+          null,
+          2,
+        ),
+        exitCode: 0,
+      };
+    }
+
+    return { output, exitCode: 0 };
+  }
+
+  // 6. Create LLM client and cost tracker
+  let client: ReturnType<typeof createLlmClient>;
+  try {
+    client = createLlmClient();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { output: `Failed to create LLM client: ${msg}`, exitCode: 1 };
+  }
+  const tracker = new CostTracker();
+
+  // 7. Process each stakeholder
+  const results: VerificationResult[] = [...skippedAlreadyVerified];
+  let verified = 0;
+  let failed = 0;
+
+  for (const item of limited) {
+    const { policy, stakeholder, thingId } = item;
+    const sourceUrl = stakeholder.source!;
+
+    console.log(`  ${c.dim}[${verified + failed + 1}/${limited.length}]${c.reset} ${policy.id} / ${stakeholder.name}...`);
+
+    // 7a. Fetch source content
+    let sourceContent: string;
+    let sourceStatus: string;
+    try {
+      const fetched = await fetchSource({
+        url: sourceUrl,
+        extractMode: 'full',
+      });
+
+      sourceStatus = fetched.status;
+
+      if (fetched.status !== 'ok' || !fetched.content || fetched.content.length < 50) {
+        const reason = fetched.status === 'dead'
+          ? 'Source URL is dead'
+          : fetched.status === 'paywall'
+            ? 'Source is behind a paywall'
+            : fetched.content.length < 50
+              ? 'Source content too short to verify'
+              : `Source fetch status: ${fetched.status}`;
+
+        results.push({
+          policyId: policy.id,
+          policyTitle: policy.title,
+          stakeholderName: stakeholder.name,
+          position: stakeholder.position,
+          reason: stakeholder.reason,
+          sourceUrl,
+          verdict: 'unverifiable',
+          confidence: 0,
+          extractedEvidence: '',
+          notes: reason,
+          sourceStatus,
+          skipped: true,
+          skipReason: 'fetch-failed',
+        });
+        console.log(`    ${c.yellow}skipped (${reason})${c.reset}`);
+        failed++;
+        continue;
+      }
+
+      sourceContent = fetched.content;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.push({
+        policyId: policy.id,
+        policyTitle: policy.title,
+        stakeholderName: stakeholder.name,
+        position: stakeholder.position,
+        reason: stakeholder.reason,
+        sourceUrl,
+        verdict: 'unverifiable',
+        confidence: 0,
+        extractedEvidence: '',
+        notes: `Fetch error: ${msg.slice(0, 200)}`,
+        sourceStatus: 'error',
+        skipped: true,
+        skipReason: 'fetch-error',
+      });
+      console.log(`    ${c.red}fetch error: ${msg.slice(0, 100)}${c.reset}`);
+      failed++;
+      continue;
+    }
+
+    // 7b. LLM verification
+    let llmResult: LlmVerificationResult;
+    try {
+      llmResult = await verifyStakeholderPosition(
+        client,
+        tracker,
+        stakeholder,
+        policy.title,
+        sourceContent,
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.push({
+        policyId: policy.id,
+        policyTitle: policy.title,
+        stakeholderName: stakeholder.name,
+        position: stakeholder.position,
+        reason: stakeholder.reason,
+        sourceUrl,
+        verdict: 'unverifiable',
+        confidence: 0,
+        extractedEvidence: '',
+        notes: `LLM error: ${msg.slice(0, 200)}`,
+        sourceStatus,
+        skipped: true,
+        skipReason: 'llm-error',
+      });
+      console.log(`    ${c.red}LLM error: ${msg.slice(0, 100)}${c.reset}`);
+      failed++;
+      continue;
+    }
+
+    // 7c. Record verification to wiki-server
+    const recordedVerification = await recordVerification({
+      thingId,
+      sourceUrl,
+      fieldName: 'position',
+      expectedValue: `${stakeholder.position}: ${stakeholder.reason || ''}`.slice(0, 5000),
+      verdict: llmResult.verdict,
+      confidence: llmResult.confidence,
+      extractedValue: llmResult.extractedEvidence.slice(0, 5000),
+      checkerModel: MODELS.haiku,
+      isPrimarySource: true,
+      notes: llmResult.notes.slice(0, 10000),
+    });
+
+    if (!recordedVerification) {
+      console.log(`    ${c.yellow}warning: failed to record verification to wiki-server${c.reset}`);
+    }
+
+    // 7d. Update aggregate verdict
+    const recordedVerdict = await recordVerdict({
+      thingId,
+      verdict: llmResult.verdict,
+      confidence: llmResult.confidence,
+      reasoning: llmResult.notes,
+      sourcesChecked: 1,
+      needsRecheck: false,
+    });
+
+    if (!recordedVerdict) {
+      console.log(`    ${c.yellow}warning: failed to record verdict to wiki-server${c.reset}`);
+    }
+
+    const verdictColor = llmResult.verdict === 'confirmed'
+      ? c.green
+      : llmResult.verdict === 'contradicted'
+        ? c.red
+        : llmResult.verdict === 'partial'
+          ? c.yellow
+          : c.dim;
+
+    console.log(`    ${verdictColor}${llmResult.verdict}${c.reset} (${(llmResult.confidence * 100).toFixed(0)}% confidence)`);
+
+    results.push({
+      policyId: policy.id,
+      policyTitle: policy.title,
+      stakeholderName: stakeholder.name,
+      position: stakeholder.position,
+      reason: stakeholder.reason,
+      sourceUrl,
+      verdict: llmResult.verdict,
+      confidence: llmResult.confidence,
+      extractedEvidence: llmResult.extractedEvidence,
+      notes: llmResult.notes,
+      sourceStatus,
+      skipped: false,
+    });
+
+    verified++;
+  }
+
+  // 8. Summary output
+  const activeResults = results.filter((r) => !r.skipped);
+  const confirmed = activeResults.filter((r) => r.verdict === 'confirmed').length;
+  const contradicted = activeResults.filter((r) => r.verdict === 'contradicted').length;
+  const partial = activeResults.filter((r) => r.verdict === 'partial').length;
+  const unverifiable = activeResults.filter((r) => r.verdict === 'unverifiable').length;
+
+  let output = `\n${c.bold}Verification Summary${c.reset}\n`;
+  output += `${c.dim}${'─'.repeat(50)}${c.reset}\n`;
+  output += `  ${c.green}Confirmed:${c.reset}    ${confirmed}\n`;
+  output += `  ${c.red}Contradicted:${c.reset} ${contradicted}\n`;
+  output += `  ${c.yellow}Partial:${c.reset}      ${partial}\n`;
+  output += `  ${c.dim}Unverifiable:${c.reset} ${unverifiable}\n`;
+  output += `  Skipped:       ${results.filter((r) => r.skipped).length}\n`;
+  output += `  Failed:        ${failed}\n`;
+  output += `\n  Cost: $${tracker.totalCost.toFixed(4)}\n`;
+  output += `  Tokens: ${tracker.totalTokens.input} in / ${tracker.totalTokens.output} out\n`;
+
+  if (options.json) {
+    return {
+      output: JSON.stringify(
+        {
+          results,
+          summary: { confirmed, contradicted, partial, unverifiable, skipped: skippedAlreadyVerified.length, failed },
+          cost: tracker.toJSON(),
+        },
+        null,
+        2,
+      ),
+      exitCode: contradicted > 0 ? 1 : 0,
+    };
+  }
+
+  return { output, exitCode: contradicted > 0 ? 1 : 0 };
+}
+
+// ── Command Registry ────────────────────────────────────────────────────────
+
+export const commands = {
+  default: verify,
+  verify,
+};
+
+export function getHelp(): string {
+  return `
+Auto-Verify Stakeholder Positions
+
+Verifies stakeholder position claims in policy entities against their source URLs.
+Fetches source content, uses an LLM to check claims, and records results via wiki-server.
+
+Commands:
+  verify (default)   Verify stakeholder positions against source URLs
+
+Options:
+  --policy=<id>      Only verify stakeholders for one policy (e.g., --policy=california-sb1047)
+  --dry-run          Show what would be verified without making any API calls
+  --budget=<N>       Maximum number of LLM verification calls (default: unlimited)
+  --json             Output results as JSON
+
+Examples:
+  pnpm crux w auto-verify-stakeholders --dry-run
+  pnpm crux w auto-verify-stakeholders --policy=california-sb1047 --budget=5
+  pnpm crux w auto-verify-stakeholders --json
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -87,6 +87,7 @@ import * as importFundingProgramsCommands from './commands/import-funding-progra
 import * as peopleCommands from './commands/people.ts';
 import * as orgsCommands from './commands/orgs.ts';
 import * as researchAreasCommands from './commands/research-areas.ts';
+import * as autoVerifyStakeholdersCommands from './commands/legislation/auto-verify-stakeholders.ts';
 import * as backfillStableIdsCommand from './commands/backfill-stable-ids.ts';
 import * as backfillYamlStableIdsCommand from './commands/backfill-yaml-stable-ids.ts';
 import * as factbaseMigrateEntitiesCommands from './commands/factbase-migrate-entities.ts';
@@ -147,6 +148,7 @@ const domains = {
   people: peopleCommands,
   orgs: orgsCommands,
   'research-areas': researchAreasCommands,
+  'auto-verify-stakeholders': autoVerifyStakeholdersCommands,
   'backfill-stable-ids': backfillStableIdsCommand,
   'backfill-yaml-stable-ids': backfillYamlStableIdsCommand,
   'factbase-migrate-entities': factbaseMigrateEntitiesCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -51,6 +51,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'evals',
       'research',
       'grokipedia',
+      'auto-verify-stakeholders',
     ],
     flattened: ['content'],
   },


### PR DESCRIPTION
## Summary

- Add `crux/commands/legislation/auto-verify-stakeholders.ts` — a new CLI command that verifies stakeholder position claims against their source URLs
- Uses the existing `source-fetcher` to fetch URL content, `callLlm` (Haiku) to verify claims, and `apiRequest` to record results to the wiki-server Things verification/verdict API
- Registered in the wiki group: `pnpm crux w auto-verify-stakeholders`
- Includes 8 tests covering dry-run mode, policy filtering, budget limiting, JSON output, and thing ID generation

## Key design decisions

- **Haiku model** for cost efficiency (each verification is a straightforward text comparison)
- **Idempotent**: skips stakeholders that already have a verdict (unless `needsRecheck` is true)
- **Budget control**: `--budget=N` limits number of LLM calls per run
- **Graceful degradation**: handles dead URLs, paywalls, LLM parse failures, and wiki-server unavailability without crashing
- **Thing ID convention**: `policy-stakeholder:<policyId>:<slug>` for verification records

## Test plan

- [x] `pnpm crux w auto-verify-stakeholders --help` shows usage
- [x] `pnpm crux w auto-verify-stakeholders --dry-run` lists 49 stakeholders across 10 policies
- [x] `--policy=california-sb1047` filters correctly
- [x] `--budget=3 --dry-run` limits output
- [x] `--json --dry-run` returns valid JSON
- [x] All 8 vitest tests pass
- [x] Existing tests unaffected (170/171 pass, 1 pre-existing timeout in rules.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
