### PR TITLE
revert: remove TLS bypass workaround (root cause was Xfinity Advanced Security)

### DIFF
--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -27,7 +27,6 @@
 
 import { getColors } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
-import { serverFetch, getServerUrl, getApiKey } from '../lib/wiki-server/client.ts';
 import { checkJobQueue } from './checks/job-queue.ts';
 import { checkPrQuality } from './checks/pr-quality.ts';
 import { checkCiMainHealth } from './checks/ci-main-health.ts';
@@ -44,8 +43,8 @@ const REPORT_MODE = args.includes('--report');
 const AUTO_ISSUE = args.includes('--auto-issue');
 const CLEANUP_LABELS = args.includes('--cleanup-labels');
 
-const SERVER_URL = getServerUrl();
-const API_KEY = getApiKey();
+const SERVER_URL = process.env.LONGTERMWIKI_SERVER_URL ?? '';
+const API_KEY = process.env.LONGTERMWIKI_SERVER_API_KEY ?? '';
 const WIKI_PUBLIC_URL = process.env.WIKI_PUBLIC_URL ?? '';
 
 // Count lower bounds — alert if DB drops significantly below these baselines
@@ -86,7 +85,7 @@ async function fetchJson(url: string, authHeader?: string): Promise<{ ok: boolea
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (authHeader) headers['Authorization'] = authHeader;
 
-    const res = await serverFetch(url, { headers, timeoutMs: 15_000 });
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(15_000) });
     let data: unknown = null;
     try { data = await res.json(); } catch { /* body may not be JSON */ }
     return { ok: res.ok, status: res.status, data };

--- a/crux/lib/wiki-server/client.test.ts
+++ b/crux/lib/wiki-server/client.test.ts
@@ -6,7 +6,6 @@ const origKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
 const origWikiServer = process.env.WIKI_SERVER_ENV;
 const origProdUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
 const origProdKey = process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
-const origTlsBypass = process.env.WIKI_SERVER_TLS_BYPASS;
 
 describe('wiki-server/client', () => {
   let client: typeof import('./client.ts');
@@ -27,8 +26,6 @@ describe('wiki-server/client', () => {
     else delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
     if (origProdKey !== undefined) process.env.PROD_LONGTERMWIKI_SERVER_API_KEY = origProdKey;
     else delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
-    if (origTlsBypass !== undefined) process.env.WIKI_SERVER_TLS_BYPASS = origTlsBypass;
-    else delete process.env.WIKI_SERVER_TLS_BYPASS;
   });
 
   describe('getServerUrl', () => {
@@ -211,39 +208,6 @@ describe('wiki-server/client', () => {
       process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
       const result = await client.isServerAvailable();
       expect(result).toBe(false);
-    });
-  });
-
-  describe('TLS bypass (WIKI_SERVER_TLS_BYPASS)', () => {
-    it('uses standard fetch for HTTP URLs even when bypass is enabled', async () => {
-      process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:19999';
-      process.env.WIKI_SERVER_TLS_BYPASS = 'true';
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true }), { status: 200 }),
-      );
-      await client.apiRequest('GET', '/api/test');
-      expect(fetchSpy).toHaveBeenCalled();
-    });
-
-    it('does not use standard fetch for HTTPS URLs when bypass is enabled', async () => {
-      process.env.LONGTERMWIKI_SERVER_URL = 'https://example.com';
-      process.env.WIKI_SERVER_TLS_BYPASS = 'true';
-      // tlsBypassFetch uses node:https, not global fetch
-      const fetchSpy = vi.spyOn(globalThis, 'fetch');
-      // This will fail to connect but should NOT call global fetch
-      const result = await client.apiRequest('GET', '/api/test', undefined, 1000);
-      expect(fetchSpy).not.toHaveBeenCalled();
-      expect(result.ok).toBe(false);
-    });
-
-    it('uses standard fetch when bypass is not enabled', async () => {
-      process.env.LONGTERMWIKI_SERVER_URL = 'https://example.com';
-      delete process.env.WIKI_SERVER_TLS_BYPASS;
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true }), { status: 200 }),
-      );
-      await client.apiRequest('GET', '/api/test');
-      expect(fetchSpy).toHaveBeenCalled();
     });
   });
 });

--- a/crux/lib/wiki-server/client.ts
+++ b/crux/lib/wiki-server/client.ts
@@ -7,15 +7,11 @@
  *   - `batchedRequest()` — batched fetch with configurable timeout
  *   - Configuration helpers (URL, API key, headers)
  *   - Health check
- *   - TLS bypass for ISP-level SNI filtering (WIKI_SERVER_TLS_BYPASS)
  */
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
-
-import * as https from 'node:https';
-import * as dns from 'node:dns/promises';
 
 import {
   WIKI_SERVER_TIMEOUT_MS as TIMEOUT_MS,
@@ -97,103 +93,6 @@ function classifyStatus(status: number): ApiError {
 }
 
 // ---------------------------------------------------------------------------
-// TLS bypass for ISP SNI filtering
-// ---------------------------------------------------------------------------
-
-/**
- * Whether TLS bypass is enabled. When set, HTTPS requests to the wiki-server
- * connect directly to the resolved IP with a dummy TLS servername, bypassing
- * ISP-level SNI filtering (e.g., Comcast/Xfinity safebrowse.io interception).
- *
- * The real hostname is sent via the Host header so K8s nginx ingress routes
- * correctly. Certificate verification is disabled since the K8s ingress
- * serves a default cert that won't match the hostname.
- */
-function isTlsBypassEnabled(): boolean {
-  return process.env.WIKI_SERVER_TLS_BYPASS === 'true';
-}
-
-/** DNS resolution cache to avoid repeated lookups. */
-let resolvedIpCache: { hostname: string; ip: string; expiry: number } | null = null;
-
-async function resolveHostnameToIp(hostname: string): Promise<string> {
-  const now = Date.now();
-  if (resolvedIpCache && resolvedIpCache.hostname === hostname && now < resolvedIpCache.expiry) {
-    return resolvedIpCache.ip;
-  }
-  const { address } = await dns.lookup(hostname);
-  resolvedIpCache = { hostname, ip: address, expiry: now + 5 * 60 * 1000 }; // 5-min TTL
-  return address;
-}
-
-/**
- * Fetch via node:https with TLS bypass — connects to the resolved IP with
- * a dummy SNI to avoid ISP-level domain blocking.
- */
-async function tlsBypassFetch(
-  url: string,
-  init: {
-    method: string;
-    headers: Record<string, string>;
-    body?: string;
-    timeoutMs: number;
-  },
-): Promise<{ ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> }> {
-  const parsed = new URL(url);
-  const hostname = parsed.hostname;
-  const ip = await resolveHostnameToIp(hostname);
-  const port = parsed.port ? parseInt(parsed.port, 10) : 443;
-
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const settle = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      fn();
-    };
-
-    const timer = setTimeout(() => {
-      req.destroy();
-      settle(() =>
-        reject(new DOMException('The operation was aborted', 'AbortError')),
-      );
-    }, init.timeoutMs);
-
-    const req = https.request(
-      {
-        hostname: ip,
-        port,
-        path: parsed.pathname + parsed.search,
-        method: init.method,
-        rejectUnauthorized: false,
-        servername: 'internal', // Dummy SNI to bypass ISP filtering
-        headers: { ...init.headers, Host: hostname },
-      },
-      (res) => {
-        let body = '';
-        res.on('data', (chunk: Buffer) => (body += chunk.toString()));
-        res.on('error', (err) => settle(() => reject(err)));
-        res.on('end', () => {
-          const status = res.statusCode ?? 500;
-          settle(() =>
-            resolve({
-              ok: status >= 200 && status < 300,
-              status,
-              text: async () => body,
-              json: async () => JSON.parse(body),
-            }),
-          );
-        });
-      },
-    );
-    req.on('error', (err) => settle(() => reject(err)));
-    if (init.body) req.write(init.body);
-    req.end();
-  });
-}
-
-// ---------------------------------------------------------------------------
 // Core request function
 // ---------------------------------------------------------------------------
 
@@ -213,34 +112,22 @@ export async function apiRequest<T>(
     return apiErr('unavailable', `${prefix}LONGTERMWIKI_SERVER_URL not set`);
   }
 
-  const fullUrl = `${serverUrl}${path}`;
-  const useTlsBypass = isTlsBypassEnabled() && serverUrl.startsWith('https://');
-
   try {
-    const headers = buildHeaders();
-    const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-    let res: { ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> };
+    const options: RequestInit = {
+      method,
+      headers: buildHeaders(),
+      signal: controller.signal,
+    };
 
-    if (useTlsBypass) {
-      res = await tlsBypassFetch(fullUrl, {
-        method,
-        headers,
-        body: bodyStr,
-        timeoutMs,
-      });
-    } else {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      const fetchRes = await fetch(fullUrl, {
-        method,
-        headers,
-        body: bodyStr,
-        signal: controller.signal,
-      });
-      clearTimeout(timer);
-      res = fetchRes;
+    if (body !== undefined) {
+      options.body = JSON.stringify(body);
     }
+
+    const res = await fetch(`${serverUrl}${path}`, options);
+    clearTimeout(timer);
 
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -274,40 +161,6 @@ export async function batchedRequest<T>(
 }
 
 // ---------------------------------------------------------------------------
-// Shared server fetch — exported for health-check.ts and other callers
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch a URL from the wiki-server, using TLS bypass when enabled.
- * TLS bypass only applies when the URL matches the configured wiki-server URL
- * — other HTTPS URLs (e.g., public frontend) use standard fetch.
- */
-export async function serverFetch(
-  url: string,
-  init?: { method?: string; headers?: Record<string, string>; body?: string; timeoutMs?: number },
-): Promise<{ ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> }> {
-  const method = init?.method ?? 'GET';
-  const headers = init?.headers ?? {};
-  const timeoutMs = init?.timeoutMs ?? TIMEOUT_MS;
-
-  const serverUrl = getServerUrl();
-  if (isTlsBypassEnabled() && url.startsWith('https://') && serverUrl && url.startsWith(serverUrl)) {
-    return tlsBypassFetch(url, { method, headers, body: init?.body, timeoutMs });
-  }
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const res = await fetch(url, {
-    method,
-    headers,
-    body: init?.body,
-    signal: controller.signal,
-  });
-  clearTimeout(timer);
-  return res;
-}
-
-// ---------------------------------------------------------------------------
 // Health check
 // ---------------------------------------------------------------------------
 
@@ -319,10 +172,17 @@ export async function isServerAvailable(): Promise<boolean> {
   if (!serverUrl) return false;
 
   try {
-    const res = await serverFetch(`${serverUrl}/health`, { timeoutMs: TIMEOUT_MS });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const res = await fetch(`${serverUrl}/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
     if (!res.ok) return false;
 
-    const body = (await res.json()) as { status?: string };
+    const body = await res.json();
     return body.status === 'healthy';
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Reverts the TLS bypass code from #2834. Investigation found the actual root cause:

- **Xfinity's "Advanced Security" feature** (enabled by default on Xfinity gateways) performs SNI inspection on TLS connections
- It was blocking all `*.k8s.quantifieduncertainty.org` hostnames specifically — responding with 256 bytes of `0xFF` garbage to kill TLS handshakes
- The K8s infrastructure was working correctly the entire time — valid Let's Encrypt certs, proper ingress config, no ssl-passthrough issues
- The block was confirmed to be SNI-pattern-specific: `*.k8s.quantifieduncertainty.org` → blocked, `*.quantifieduncertainty.org` (without k8s) → passes through fine
- Fix: disable Advanced Security in the Xfinity app, or use your own router in bridge mode

The bypass code added ~160 lines of custom HTTP client (`tlsBypassFetch`) with `rejectUnauthorized: false`, DNS caching, and a second code path for every server request. This is unnecessary now that the root cause is understood and resolved at the network level.

## Test plan

- [ ] `pnpm build` exits 0
- [ ] `pnpm test` passes
- [ ] Wiki-server health check works without `WIKI_SERVER_TLS_BYPASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed TLS bypass feature for server connections

* **Refactor**
  * Simplified request handling to use standard fetch API with timeout support
  * Server configuration now retrieves values directly from environment variables
  * Updated request timeout implementation to use `AbortSignal`-based mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->