### PR TITLE
fix: update trivy-action to v0.35.0 (unblocks wiki-server deploys)

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -435,7 +435,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/quantified-uncertainty/longterm-wiki-server:sha-${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Summary
- `aquasecurity/trivy-action@0.30.0` does not exist — version tags jump from 0.29.x to 0.32.0
- This has been blocking ALL wiki-server deploys (security scan step fails immediately)
- Updated to latest stable v0.35.0

## Impact
This unblocks wiki-server deployment, which is needed for several pending migrations (policy stakeholder things, importance column, etc.)

## Test plan
- [x] One-line change to workflow file
- [x] v0.35.0 confirmed to exist via GitHub tags page


🤖 Generated with [Claude Code](https://claude.com/claude-code)