### PR TITLE
fix: trigger entity sync on pipeline changes to prune ghost entries

### DIFF
--- a/.github/workflows/sync-entities-facts.yml
+++ b/.github/workflows/sync-entities-facts.yml
@@ -6,6 +6,11 @@ on:
     branches: [main, production]
     paths:
       - "data/entities/**"
+      # Also trigger when the sync/prune pipeline or workflow config changes,
+      # so that new prune logic is exercised immediately after merge. See #2796.
+      - "crux/wiki-server/sync-entities.ts"
+      - "apps/wiki-server/src/routes/tablebase/entities.ts"
+      - ".github/workflows/sync-entities-facts.yml"
 
   # Run weekly to catch stale entities that missed path-triggered syncs.
   # Ghost entries can persist if entity YAML is deleted but the sync workflow


### PR DESCRIPTION
## Summary

- Adds trigger paths to the sync-entities workflow so it runs when the sync/prune pipeline code changes (not just entity YAML)
- This ensures merging this PR will automatically trigger a sync+prune run against production, cleaning up the 7 ghost duplicate person entries
- The prune infrastructure (endpoint, sync-entities prune step, orphan validator, one-time scripts) already exists and works correctly — the gap was that deploying the prune code didn't trigger the workflow that runs it

## Root Cause Analysis

The ghost entries (`askell-amanda`, `bowman-samuel-r`, `andrew-y-ng`, `andreas-stuhlm-ller`, `alex-kaskasoli`, `buck`, `algon`) were created by personnel enrichment tasks with garbled/inverted slugs. They persist in PG because:

1. The entities were deleted from `data/entities/people.yaml` (correct canonical entries exist)
2. The sync-entities workflow now includes a prune step (added in recent PRs)
3. **But** the workflow only triggered on changes to `data/entities/**` — deploying new prune logic to `crux/wiki-server/sync-entities.ts` or `apps/wiki-server/src/routes/tablebase/entities.ts` didn't trigger a sync
4. The weekly Monday cron would eventually clean these up, but this PR makes it happen immediately on merge

## Changes

Added three trigger paths to `.github/workflows/sync-entities-facts.yml`:
- `crux/wiki-server/sync-entities.ts` — the sync/prune pipeline implementation
- `apps/wiki-server/src/routes/tablebase/entities.ts` — the prune endpoint
- `.github/workflows/sync-entities-facts.yml` — the workflow file itself (self-trigger on config changes)

## Test plan

- [x] Workflow YAML validated with Python yaml.safe_load — no syntax errors
- [x] Existing entity prune tests pass (entities.test.ts, sync-entities.test.ts, validate-orphan-entities.test.ts)
- [x] Pre-existing scope-flag test failure unrelated to this change (confirmed fails on main)
- [ ] Post-merge: confirm sync-entities workflow triggers automatically and ghost entries are cleaned

Closes #2796
