### PR TITLE
Remove deprecated ai-executive-order entity stub (E8)

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -35,28 +35,6 @@
       author: Summit Participants
   description: "Government-run institutions dedicated to evaluating frontier AI systems for dangerous capabilities and safety properties. Pioneered by the UK AISI in 2023, with analogues in the US (USAISI), EU, Japan, and others. Play a key role in pre-deployment evaluations and responsible scaling policy thresholds."
   lastUpdated: 2025-12
-# DEPRECATED: E8 ai-executive-order is a stub that duplicates E366 us-executive-order (the full page).
-# Kept for backward-compat link resolution; do not create new links to this entity.
-- id: ai-executive-order
-  stableId: Jn7939O5ls
-  wikiId: E8
-  type: policy
-  scope: Federal
-  jurisdiction: United States
-  summaryPage: governance-overview
-  title: AI Executive Order
-  policyStatus: revoked
-  deprecated: true
-  deprecatedInFavorOf: us-executive-order
-  description: >-
-    Deprecated stub. Use the us-executive-order entity (E366) instead.
-    US executive orders establishing AI safety requirements and oversight,
-    including EO 14110 (October 2023) on safe, secure, and trustworthy AI
-    development. Revoked by the Trump administration in January 2025.
-  clusters:
-    - ai-safety
-    - governance
-  lastUpdated: 2026-03
 - id: california-sb1047
   stableId: XcGTez1oFw
   wikiId: E48


### PR DESCRIPTION
## Summary
- Removes the deprecated `ai-executive-order` entity stub (E8, `Jn7939O5ls`) from `data/entities/responses.yaml`
- This entity was merged into `us-executive-order` (E366) in PR #2346 but the stub was left behind
- All remaining `ai-executive-order` string matches in the codebase are legitimate external URLs (Stanford HAI tracker, CSET analysis, etc.) — not entity ID references
- The redirect in `next.config.ts` (`/legislation/ai-executive-order` -> `/legislation/us-executive-order`) is kept for backward-compat URL resolution
- No FactBase file ever existed for `ai-executive-order`, confirming KB fact coverage

## Test plan
- [x] `pnpm build-data:content` — clean (882 entities, 0 errors)
- [x] `pnpm crux w validate gate --fix --scope=content` — all 5 checks pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Grep for `ai-executive-order` — no entity-level references remain (only external URLs)

Closes #2364


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated and revoked policy entity from the database to clean up outdated policy references and improve catalog accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->