### PR TITLE
fix: replace N+1 query patterns with bulk SQL in 3 batch endpoints

### DIFF
--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -69,44 +69,54 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // ---- INSERT INTO resources ... ON CONFLICT ----
+  // ---- INSERT INTO resources ... ON CONFLICT (supports multi-row) ----
   if (q.includes("insert into") && q.includes('"resources"') && !q.includes("resource_citations")) {
     const now = new Date();
-    const id = params[0] as string;
-    const existing = resourceStore.get(id);
+    const COLS = 27; // Number of columns in resourceValues()
+    const numRows = Math.max(1, Math.floor(params.length / COLS));
+    const results: Record<string, unknown>[] = [];
 
-    const row: Record<string, unknown> = {
-      id,
-      url: params[1],
-      // COALESCE(incoming, existing): non-null incoming overwrites; null preserves existing.
-      // Mirrors the server-side ON CONFLICT SET COALESCE() for enrichable fields.
-      title: params[2] ?? existing?.title ?? null,
-      type: params[3] ?? existing?.type ?? null,
-      summary: params[4] ?? existing?.summary ?? null,
-      review: params[5] ?? existing?.review ?? null,
-      abstract: params[6] ?? existing?.abstract ?? null,
-      key_points: params[7] ?? existing?.key_points ?? null,
-      publication_id: params[8] ?? existing?.publication_id ?? null,
-      authors: params[9] ?? existing?.authors ?? null,
-      published_date: params[10] ?? existing?.published_date ?? null,
-      tags: params[11] ?? existing?.tags ?? null,
-      local_filename: params[12] ?? existing?.local_filename ?? null,
-      credibility_override: params[13] ?? existing?.credibility_override ?? null,
-      fetched_at: params[14] ?? existing?.fetched_at ?? null,
-      content_hash: params[15] ?? existing?.content_hash ?? null,
-      // stableId is generate-once: preserve existing, only set if row didn't have one
-      stable_id: existing?.stable_id ?? params[16] ?? null,
-      created_at: existing?.created_at ?? now,
-      updated_at: now,
-    };
-    resourceStore.set(id, row);
-    return [row];
+    for (let r = 0; r < numRows; r++) {
+      const o = r * COLS;
+      const id = params[o] as string;
+      const existing = resourceStore.get(id);
+
+      const row: Record<string, unknown> = {
+        id,
+        url: params[o + 1],
+        // COALESCE(incoming, existing): non-null incoming overwrites; null preserves existing.
+        title: params[o + 2] ?? existing?.title ?? null,
+        type: params[o + 3] ?? existing?.type ?? null,
+        summary: params[o + 4] ?? existing?.summary ?? null,
+        review: params[o + 5] ?? existing?.review ?? null,
+        abstract: params[o + 6] ?? existing?.abstract ?? null,
+        key_points: params[o + 7] ?? existing?.key_points ?? null,
+        publication_id: params[o + 8] ?? existing?.publication_id ?? null,
+        authors: params[o + 9] ?? existing?.authors ?? null,
+        published_date: params[o + 10] ?? existing?.published_date ?? null,
+        tags: params[o + 11] ?? existing?.tags ?? null,
+        local_filename: params[o + 12] ?? existing?.local_filename ?? null,
+        credibility_override: params[o + 13] ?? existing?.credibility_override ?? null,
+        fetched_at: params[o + 14] ?? existing?.fetched_at ?? null,
+        content_hash: params[o + 15] ?? existing?.content_hash ?? null,
+        // stableId is generate-once: preserve existing, only set if row didn't have one
+        stable_id: existing?.stable_id ?? params[o + 16] ?? null,
+        created_at: existing?.created_at ?? now,
+        updated_at: now,
+      };
+      resourceStore.set(id, row);
+      results.push(row);
+    }
+    return results;
   }
 
-  // ---- DELETE FROM resource_citations WHERE resource_id = $1 ----
+  // ---- DELETE FROM resource_citations WHERE resource_id ... ----
   if (q.includes("delete") && q.includes("resource_citations") && q.includes("where")) {
-    const resourceId = params[0] as string;
-    citationStore = citationStore.filter((c) => c.resource_id !== resourceId);
+    // Supports both single-row (= $1) and bulk (IN ($1, $2, ...)) deletes
+    for (const p of params) {
+      const resourceId = p as string;
+      citationStore = citationStore.filter((c) => c.resource_id !== resourceId);
+    }
     return [];
   }
 

--- a/apps/wiki-server/src/__tests__/sessions.test.ts
+++ b/apps/wiki-server/src/__tests__/sessions.test.ts
@@ -153,65 +153,73 @@ vi.mock("../db.js", async () => {
       return [];
     }
 
-    // ---- INSERT INTO sessions (upsert — ON CONFLICT DO UPDATE) ----
+    // ---- INSERT INTO sessions (upsert — ON CONFLICT DO UPDATE, supports multi-row) ----
     if (q.includes("insert into") && q.includes('"sessions"') && !q.includes("session_pages")) {
-      const incoming = {
-        date: String(params[0]),
-        branch: params[1] as string | null,
-        title: params[2] as string,
-        summary: params[3] as string | null,
-        model: params[4] as string | null,
-        duration: params[5] as string | null,
-        cost: params[6] as string | null,
-        cost_cents: params[7] as number | null,
-        duration_minutes: params[8] as number | null,
-        pr_url: params[9] as string | null,
-        checks_yaml: params[10] as string | null,
-        issues_json: params[11] ?? null,
-        learnings_json: params[12] ?? null,
-        recommendations_json: params[13] ?? null,
-        reviewed: params[14] as boolean | null,
-      };
+      const COLS = 15; // Number of columns in sessionValues()
+      const numRows = Math.max(1, Math.floor(params.length / COLS));
+      const results: typeof sessionStore = [];
 
-      // Check for conflict on (date, title)
-      const existing = sessionStore.find(
-        (s) => s.date === incoming.date && s.title === incoming.title
-      );
+      for (let r = 0; r < numRows; r++) {
+        const o = r * COLS;
+        const incoming = {
+          date: String(params[o]),
+          branch: params[o + 1] as string | null,
+          title: params[o + 2] as string,
+          summary: params[o + 3] as string | null,
+          model: params[o + 4] as string | null,
+          duration: params[o + 5] as string | null,
+          cost: params[o + 6] as string | null,
+          cost_cents: params[o + 7] as number | null,
+          duration_minutes: params[o + 8] as number | null,
+          pr_url: params[o + 9] as string | null,
+          checks_yaml: params[o + 10] as string | null,
+          issues_json: params[o + 11] ?? null,
+          learnings_json: params[o + 12] ?? null,
+          recommendations_json: params[o + 13] ?? null,
+          reviewed: params[o + 14] as boolean | null,
+        };
 
-      if (existing && q.includes("on conflict")) {
-        // Update existing row
-        Object.assign(existing, {
-          branch: incoming.branch,
-          summary: incoming.summary,
-          model: incoming.model,
-          duration: incoming.duration,
-          cost: incoming.cost,
-          cost_cents: incoming.cost_cents,
-          duration_minutes: incoming.duration_minutes,
-          pr_url: incoming.pr_url,
-          checks_yaml: incoming.checks_yaml,
-          issues_json: incoming.issues_json,
-          learnings_json: incoming.learnings_json,
-          recommendations_json: incoming.recommendations_json,
-          reviewed: incoming.reviewed,
-        });
-        return [existing];
+        // Check for conflict on (date, title)
+        const existing = sessionStore.find(
+          (s) => s.date === incoming.date && s.title === incoming.title
+        );
+
+        if (existing && q.includes("on conflict")) {
+          Object.assign(existing, {
+            branch: incoming.branch,
+            summary: incoming.summary,
+            model: incoming.model,
+            duration: incoming.duration,
+            cost: incoming.cost,
+            cost_cents: incoming.cost_cents,
+            duration_minutes: incoming.duration_minutes,
+            pr_url: incoming.pr_url,
+            checks_yaml: incoming.checks_yaml,
+            issues_json: incoming.issues_json,
+            learnings_json: incoming.learnings_json,
+            recommendations_json: incoming.recommendations_json,
+            reviewed: incoming.reviewed,
+          });
+          results.push(existing);
+        } else {
+          const row = {
+            ...incoming,
+            id: nextSessionId++,
+            created_at: new Date(),
+          };
+          sessionStore.push(row);
+          results.push(row);
+        }
       }
-
-      const row = {
-        ...incoming,
-        id: nextSessionId++,
-        created_at: new Date(),
-      };
-      sessionStore.push(row);
-      return [row];
+      return results;
     }
 
-    // ---- DELETE FROM session_pages WHERE session_id = $1 ----
+    // ---- DELETE FROM session_pages WHERE session_id ... ----
     if (q.includes("delete") && q.includes("session_pages")) {
-      const sessionId = params[0] as number;
+      // Supports both single-row (= $1) and bulk (IN ($1, $2, ...)) deletes
+      const sessionIds = params.map(Number);
       sessionPageStore = sessionPageStore.filter(
-        (r) => r.session_id !== sessionId
+        (r) => !sessionIds.includes(r.session_id)
       );
       return [];
     }

--- a/apps/wiki-server/src/routes/operational/sessions.ts
+++ b/apps/wiki-server/src/routes/operational/sessions.ts
@@ -232,43 +232,54 @@ const sessionsApp = new Hono()
           ? await resolvePageIntIds(tx, allPageIds)
           : new Map<string, number>();
 
-        const created: Array<{ id: number; title: string; pageCount: number }> = [];
+        // Bulk upsert all sessions in one query
+        const allVals = items.map((d) => sessionValues(d));
+        const upsertedRows = await tx
+          .insert(sessions)
+          .values(allVals)
+          .onConflictDoUpdate({
+            target: [sessions.date, sessions.title],
+            set: sessionConflictSet,
+          })
+          .returning({ id: sessions.id, title: sessions.title });
 
-        for (const d of items) {
-          const rows = await tx
-            .insert(sessions)
-            .values(sessionValues(d))
-            .onConflictDoUpdate({
-              target: [sessions.date, sessions.title],
-              set: sessionConflictSet,
-            })
-            .returning({ id: sessions.id, title: sessions.title });
+        const sessionIds = upsertedRows.map((r) => r.id);
 
-          const session = firstOrThrow(rows, `session batch upsert "${d.title}"`);
-
-          // Replace page associations: delete old, insert new
+        // Bulk delete old page associations for all affected sessions
+        if (sessionIds.length > 0) {
           await tx
             .delete(sessionPages)
-            .where(eq(sessionPages.sessionId, session.id));
-
-          if (d.pages.length > 0) {
-            await tx
-              .insert(sessionPages)
-              .values(d.pages.map((pageId) => ({
-                sessionId: session.id,
-                pageId,
-                pageIdInt: intIdMap.get(pageId) ?? null, // Phase 4a dual-write
-              })));
-          }
-
-          created.push({
-            id: session.id,
-            title: session.title,
-            pageCount: d.pages.length,
-          });
+            .where(inArray(sessionPages.sessionId, sessionIds));
         }
 
-        return created;
+        // Bulk insert all new page associations
+        const allPageAssociations: Array<{
+          sessionId: number;
+          pageId: string;
+          pageIdInt: number | null;
+        }> = [];
+        for (let i = 0; i < items.length; i++) {
+          const d = items[i];
+          const sessionId = upsertedRows[i].id;
+          for (const pageId of d.pages) {
+            allPageAssociations.push({
+              sessionId,
+              pageId,
+              pageIdInt: intIdMap.get(pageId) ?? null, // Phase 4a dual-write
+            });
+          }
+        }
+        if (allPageAssociations.length > 0) {
+          await tx
+            .insert(sessionPages)
+            .values(allPageAssociations);
+        }
+
+        return upsertedRows.map((row, i) => ({
+          id: row.id,
+          title: row.title,
+          pageCount: items[i].pages.length,
+        }));
       });
     } catch (err) {
       return dbError(c, "session batch", err, { itemCount: items.length });

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -7,6 +7,7 @@ import {
   count,
   sql,
   desc,
+  inArray,
   type SQL,
 } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -433,7 +434,7 @@ const resourcesApp = new Hono()
       }
     }
 
-    const results: Array<{ id: string; url: string }> = [];
+    let results: Array<{ id: string; url: string }> = [];
     try {
       await db.transaction(async (tx) => {
         // Phase 4a: pre-resolve all citedBy page IDs in one batch query
@@ -442,13 +443,83 @@ const resourcesApp = new Hono()
           ? await resolvePageIntIds(tx, allCitedByIds)
           : new Map<string, number>();
 
-        for (const item of items) {
-          // Skip per-row search_vector update; handled in bulk below
-          const result = await upsertResource(tx, item, {
-            skipSearchVector: true,
-            intIdMap,
+        // Bulk upsert all resources in one query
+        const allVals = items.map((d) => resourceValues(d));
+        const upsertedRows = await tx
+          .insert(resources)
+          .values(allVals)
+          .onConflictDoUpdate({
+            target: resources.id,
+            set: {
+              url: sql`excluded.url`,
+              title: sql`COALESCE(excluded.title, ${resources.title})`,
+              type: sql`COALESCE(excluded.type, ${resources.type})`,
+              summary: sql`COALESCE(excluded.summary, ${resources.summary})`,
+              review: sql`COALESCE(excluded.review, ${resources.review})`,
+              abstract: sql`COALESCE(excluded.abstract, ${resources.abstract})`,
+              keyPoints: sql`COALESCE(excluded.key_points, ${resources.keyPoints})`,
+              publicationId: sql`COALESCE(excluded.publication_id, ${resources.publicationId})`,
+              authors: sql`COALESCE(excluded.authors, ${resources.authors})`,
+              publishedDate: sql`COALESCE(excluded.published_date, ${resources.publishedDate})`,
+              tags: sql`COALESCE(excluded.tags, ${resources.tags})`,
+              localFilename: sql`COALESCE(excluded.local_filename, ${resources.localFilename})`,
+              credibilityOverride: sql`COALESCE(excluded.credibility_override, ${resources.credibilityOverride})`,
+              fetchedAt: sql`COALESCE(excluded.fetched_at, ${resources.fetchedAt})`,
+              contentHash: sql`COALESCE(excluded.content_hash, ${resources.contentHash})`,
+              stableId: sql`COALESCE(${resources.stableId}, excluded.stable_id)`,
+              archiveUrl: sql`COALESCE(excluded.archive_url, ${resources.archiveUrl})`,
+              stance: sql`COALESCE(excluded.stance, ${resources.stance})`,
+              contextNote: sql`COALESCE(excluded.context_note, ${resources.contextNote})`,
+              resourcePurpose: sql`COALESCE(excluded.resource_purpose, ${resources.resourcePurpose})`,
+              resourceSubtype: sql`COALESCE(excluded.resource_subtype, ${resources.resourceSubtype})`,
+              typeMetadata: sql`COALESCE(excluded.type_metadata, ${resources.typeMetadata})`,
+              publisherEntityId: sql`COALESCE(excluded.publisher_entity_id, ${resources.publisherEntityId})`,
+              relatedEntityIds: sql`COALESCE(excluded.related_entity_ids, ${resources.relatedEntityIds})`,
+              enrichmentStatus: sql`COALESCE(excluded.enrichment_status, ${resources.enrichmentStatus})`,
+              enrichmentDate: sql`CASE WHEN excluded.enrichment_status IS NOT NULL THEN now() ELSE COALESCE(null::timestamptz, ${resources.enrichmentDate}) END`,
+              importanceScore: sql`COALESCE(excluded.importance_score, ${resources.importanceScore})`,
+              updatedAt: sql`now()`,
+            },
+          })
+          .returning({
+            id: resources.id,
+            url: resources.url,
+            title: resources.title,
           });
-          results.push({ id: result.id, url: result.url });
+
+        results = upsertedRows.map((r) => ({ id: r.id, url: r.url }));
+
+        // Bulk replace citations: delete all old citations for batch resources, then insert new ones
+        const resourceIdsWithCitations = items
+          .filter((d) => d.citedBy && d.citedBy.length > 0)
+          .map((d) => d.id);
+        if (resourceIdsWithCitations.length > 0) {
+          await tx
+            .delete(resourceCitations)
+            .where(inArray(resourceCitations.resourceId, resourceIdsWithCitations));
+
+          const allCitations: Array<{
+            resourceId: string;
+            pageId: string;
+            pageIdInt: number | null;
+          }> = [];
+          for (const item of items) {
+            if (item.citedBy && item.citedBy.length > 0) {
+              for (const pageId of item.citedBy) {
+                allCitations.push({
+                  resourceId: item.id,
+                  pageId,
+                  pageIdInt: intIdMap.get(pageId) ?? null,
+                });
+              }
+            }
+          }
+          if (allCitations.length > 0) {
+            await tx
+              .insert(resourceCitations)
+              .values(allCitations)
+              .onConflictDoNothing();
+          }
         }
 
         // Bulk search_vector update for all upserted resources (one query)
@@ -1038,86 +1109,112 @@ const resourcesApp = new Hono()
 
     try {
       await db.transaction(async (tx) => {
-        // Batch upsert papers
-        if (batchData.papers) {
-          for (const item of batchData.papers) {
-            const { resourceId, ...data } = item;
-            await tx
-              .insert(resourcePapers)
-              .values({ resourceId, ...data, categories: data.categories ?? null, updatedAt: new Date() })
-              .onConflictDoUpdate({
-                target: resourcePapers.resourceId,
-                set: {
-                  arxivId: sql`COALESCE(${data.arxivId ?? null}, ${resourcePapers.arxivId})`,
-                  doi: sql`COALESCE(${data.doi ?? null}, ${resourcePapers.doi})`,
-                  semanticScholarId: sql`COALESCE(${data.semanticScholarId ?? null}, ${resourcePapers.semanticScholarId})`,
-                  abstract: sql`COALESCE(${data.abstract ?? null}, ${resourcePapers.abstract})`,
-                  citationCount: sql`COALESCE(${data.citationCount ?? null}, ${resourcePapers.citationCount})`,
-                  influentialCitationCount: sql`COALESCE(${data.influentialCitationCount ?? null}, ${resourcePapers.influentialCitationCount})`,
-                  categories: data.categories
-                    ? sql`COALESCE(${JSON.stringify(data.categories)}::jsonb, ${resourcePapers.categories})`
-                    : sql`COALESCE(null::jsonb, ${resourcePapers.categories})`,
-                  methodology: sql`COALESCE(${data.methodology ?? null}, ${resourcePapers.methodology})`,
-                  year: sql`COALESCE(${data.year ?? null}, ${resourcePapers.year})`,
-                  updatedAt: sql`now()`,
-                },
-              });
-            results.papers++;
-          }
+        // Bulk upsert papers in one query
+        if (batchData.papers && batchData.papers.length > 0) {
+          const paperVals = batchData.papers.map((item) => ({
+            resourceId: item.resourceId,
+            arxivId: item.arxivId ?? null,
+            doi: item.doi ?? null,
+            semanticScholarId: item.semanticScholarId ?? null,
+            abstract: item.abstract ?? null,
+            citationCount: item.citationCount ?? null,
+            influentialCitationCount: item.influentialCitationCount ?? null,
+            categories: item.categories ?? null,
+            methodology: item.methodology ?? null,
+            year: item.year ?? null,
+            updatedAt: new Date(),
+          }));
+          await tx
+            .insert(resourcePapers)
+            .values(paperVals)
+            .onConflictDoUpdate({
+              target: resourcePapers.resourceId,
+              set: {
+                arxivId: sql`COALESCE(excluded.arxiv_id, ${resourcePapers.arxivId})`,
+                doi: sql`COALESCE(excluded.doi, ${resourcePapers.doi})`,
+                semanticScholarId: sql`COALESCE(excluded.semantic_scholar_id, ${resourcePapers.semanticScholarId})`,
+                abstract: sql`COALESCE(excluded.abstract, ${resourcePapers.abstract})`,
+                citationCount: sql`COALESCE(excluded.citation_count, ${resourcePapers.citationCount})`,
+                influentialCitationCount: sql`COALESCE(excluded.influential_citation_count, ${resourcePapers.influentialCitationCount})`,
+                categories: sql`COALESCE(excluded.categories, ${resourcePapers.categories})`,
+                methodology: sql`COALESCE(excluded.methodology, ${resourcePapers.methodology})`,
+                year: sql`COALESCE(excluded.year, ${resourcePapers.year})`,
+                updatedAt: sql`now()`,
+              },
+            });
+          results.papers = batchData.papers.length;
         }
 
-        // Batch upsert forum posts
-        if (batchData.forumPosts) {
-          for (const item of batchData.forumPosts) {
-            const { resourceId, ...data } = item;
-            await tx
-              .insert(resourceForumPosts)
-              .values({ resourceId, ...data, forumTags: data.forumTags ?? null, updatedAt: new Date() })
-              .onConflictDoUpdate({
-                target: resourceForumPosts.resourceId,
-                set: {
-                  forum: data.forum,
-                  forumPostId: sql`COALESCE(${data.forumPostId ?? null}, ${resourceForumPosts.forumPostId})`,
-                  forumSlug: sql`COALESCE(${data.forumSlug ?? null}, ${resourceForumPosts.forumSlug})`,
-                  karma: sql`COALESCE(${data.karma ?? null}, ${resourceForumPosts.karma})`,
-                  commentCount: sql`COALESCE(${data.commentCount ?? null}, ${resourceForumPosts.commentCount})`,
-                  authorUsername: sql`COALESCE(${data.authorUsername ?? null}, ${resourceForumPosts.authorUsername})`,
-                  forumTags: data.forumTags
-                    ? sql`COALESCE(${JSON.stringify(data.forumTags)}::jsonb, ${resourceForumPosts.forumTags})`
-                    : sql`COALESCE(null::jsonb, ${resourceForumPosts.forumTags})`,
-                  sequenceTitle: sql`COALESCE(${data.sequenceTitle ?? null}, ${resourceForumPosts.sequenceTitle})`,
-                  curated: data.curated != null ? data.curated : sql`${resourceForumPosts.curated}`,
-                  crossPostedFrom: sql`COALESCE(${data.crossPostedFrom ?? null}, ${resourceForumPosts.crossPostedFrom})`,
-                  canonicalForum: sql`COALESCE(${data.canonicalForum ?? null}, ${resourceForumPosts.canonicalForum})`,
-                  updatedAt: sql`now()`,
-                },
-              });
-            results.forumPosts++;
-          }
+        // Bulk upsert forum posts in one query
+        if (batchData.forumPosts && batchData.forumPosts.length > 0) {
+          const forumVals = batchData.forumPosts.map((item) => ({
+            resourceId: item.resourceId,
+            forum: item.forum,
+            forumPostId: item.forumPostId ?? null,
+            forumSlug: item.forumSlug ?? null,
+            karma: item.karma ?? null,
+            commentCount: item.commentCount ?? null,
+            authorUsername: item.authorUsername ?? null,
+            forumTags: item.forumTags ?? null,
+            sequenceTitle: item.sequenceTitle ?? null,
+            curated: item.curated ?? null,
+            crossPostedFrom: item.crossPostedFrom ?? null,
+            canonicalForum: item.canonicalForum ?? null,
+            updatedAt: new Date(),
+          }));
+          await tx
+            .insert(resourceForumPosts)
+            .values(forumVals)
+            .onConflictDoUpdate({
+              target: resourceForumPosts.resourceId,
+              set: {
+                forum: sql`excluded.forum`,
+                forumPostId: sql`COALESCE(excluded.forum_post_id, ${resourceForumPosts.forumPostId})`,
+                forumSlug: sql`COALESCE(excluded.forum_slug, ${resourceForumPosts.forumSlug})`,
+                karma: sql`COALESCE(excluded.karma, ${resourceForumPosts.karma})`,
+                commentCount: sql`COALESCE(excluded.comment_count, ${resourceForumPosts.commentCount})`,
+                authorUsername: sql`COALESCE(excluded.author_username, ${resourceForumPosts.authorUsername})`,
+                forumTags: sql`COALESCE(excluded.forum_tags, ${resourceForumPosts.forumTags})`,
+                sequenceTitle: sql`COALESCE(excluded.sequence_title, ${resourceForumPosts.sequenceTitle})`,
+                curated: sql`COALESCE(excluded.curated, ${resourceForumPosts.curated})`,
+                crossPostedFrom: sql`COALESCE(excluded.cross_posted_from, ${resourceForumPosts.crossPostedFrom})`,
+                canonicalForum: sql`COALESCE(excluded.canonical_forum, ${resourceForumPosts.canonicalForum})`,
+                updatedAt: sql`now()`,
+              },
+            });
+          results.forumPosts = batchData.forumPosts.length;
         }
 
-        // Batch upsert policy docs
-        if (batchData.policyDocs) {
-          for (const item of batchData.policyDocs) {
-            const { resourceId, ...data } = item;
-            await tx
-              .insert(resourcePolicyDocs)
-              .values({ resourceId, ...data, updatedAt: new Date() })
-              .onConflictDoUpdate({
-                target: resourcePolicyDocs.resourceId,
-                set: {
-                  documentType: sql`COALESCE(${data.documentType ?? null}, ${resourcePolicyDocs.documentType})`,
-                  jurisdictionEntityId: sql`COALESCE(${data.jurisdictionEntityId ?? null}, ${resourcePolicyDocs.jurisdictionEntityId})`,
-                  agencyEntityId: sql`COALESCE(${data.agencyEntityId ?? null}, ${resourcePolicyDocs.agencyEntityId})`,
-                  policyEntityId: sql`COALESCE(${data.policyEntityId ?? null}, ${resourcePolicyDocs.policyEntityId})`,
-                  effectiveDate: sql`COALESCE(${data.effectiveDate ?? null}, ${resourcePolicyDocs.effectiveDate})`,
-                  documentStatus: sql`COALESCE(${data.documentStatus ?? null}, ${resourcePolicyDocs.documentStatus})`,
-                  referenceNumber: sql`COALESCE(${data.referenceNumber ?? null}, ${resourcePolicyDocs.referenceNumber})`,
-                  updatedAt: sql`now()`,
-                },
-              });
-            results.policyDocs++;
-          }
+        // Bulk upsert policy docs in one query
+        if (batchData.policyDocs && batchData.policyDocs.length > 0) {
+          const policyVals = batchData.policyDocs.map((item) => ({
+            resourceId: item.resourceId,
+            documentType: item.documentType ?? null,
+            jurisdictionEntityId: item.jurisdictionEntityId ?? null,
+            agencyEntityId: item.agencyEntityId ?? null,
+            policyEntityId: item.policyEntityId ?? null,
+            effectiveDate: item.effectiveDate ?? null,
+            documentStatus: item.documentStatus ?? null,
+            referenceNumber: item.referenceNumber ?? null,
+            updatedAt: new Date(),
+          }));
+          await tx
+            .insert(resourcePolicyDocs)
+            .values(policyVals)
+            .onConflictDoUpdate({
+              target: resourcePolicyDocs.resourceId,
+              set: {
+                documentType: sql`COALESCE(excluded.document_type, ${resourcePolicyDocs.documentType})`,
+                jurisdictionEntityId: sql`COALESCE(excluded.jurisdiction_entity_id, ${resourcePolicyDocs.jurisdictionEntityId})`,
+                agencyEntityId: sql`COALESCE(excluded.agency_entity_id, ${resourcePolicyDocs.agencyEntityId})`,
+                policyEntityId: sql`COALESCE(excluded.policy_entity_id, ${resourcePolicyDocs.policyEntityId})`,
+                effectiveDate: sql`COALESCE(excluded.effective_date, ${resourcePolicyDocs.effectiveDate})`,
+                documentStatus: sql`COALESCE(excluded.document_status, ${resourcePolicyDocs.documentStatus})`,
+                referenceNumber: sql`COALESCE(excluded.reference_number, ${resourcePolicyDocs.referenceNumber})`,
+                updatedAt: sql`now()`,
+              },
+            });
+          results.policyDocs = batchData.policyDocs.length;
         }
       });
 


### PR DESCRIPTION
## Summary

Fixes N+1 query patterns in three wiki-server batch endpoints by replacing sequential per-row SQL loops with bulk operations:

- **POST /resources/batch**: Per-row `upsertResource()` loop replaced with single bulk `INSERT ... ON CONFLICT DO UPDATE` using `excluded.*` references. Citations are now bulk-deleted with `inArray()` and bulk-inserted in one query.
- **POST /sessions/batch**: Per-row session insert + per-row page delete/insert replaced with bulk session INSERT, bulk page DELETE via `inArray()`, and bulk page INSERT.
- **POST /resources/batch-details**: Per-row loops for papers, forumPosts, and policyDocs replaced with single bulk `INSERT ... ON CONFLICT` per sub-table using `excluded.*` COALESCE patterns.

### Query count reduction (200-item batch)

| Endpoint | Before | After |
|----------|--------|-------|
| `/resources/batch` | ~600 queries | ~6 queries |
| `/sessions/batch` | ~600 queries | ~4 queries |
| `/resources/batch-details` | ~N per type | 1 per type |

The `pages/sync` endpoint was already using bulk operations and did not need changes.

Closes #2623

## Test plan

- [x] All 684 wiki-server tests pass (33 test files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Full `pnpm build` succeeds
- [x] Test mocks updated to handle multi-row INSERT patterns
- [x] Existing batch/upsert/COALESCE behavior preserved
- [x] Single-resource POST endpoint unchanged (still uses per-row `upsertResource()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
