### PR TITLE
Fix Coefficient Giving grants data contradictions

### DIFF
--- a/content/docs/knowledge-base/organizations/coefficient-giving.mdx
+++ b/content/docs/knowledge-base/organizations/coefficient-giving.mdx
@@ -5,7 +5,7 @@ description: "Coefficient Giving (formerly Open Philanthropy) is a major philant
 sidebar:
   order: 5
 subcategory: funders
-lastEdited: 2026-01-29
+lastEdited: 2026-03-20
 update_frequency: 45
 summary: "Coefficient Giving (formerly Open Philanthropy) has directed \\$4B+ in grants since 2014, including \\$336M to AI safety (~60% of external funding). The organization spent ~\\$50M on AI safety in 2024, with 68% going to evaluations/benchmarking, and launched a \\$40M Technical AI Safety RFP in 2025 covering 21 research areas with 2-week EOI response times."
 clusters:
@@ -163,20 +163,6 @@ The [Navigating Transformative AI Fund](https://coefficientgiving.org/funds/navi
 
 ## AI Safety Grantmaking
 
-### Major AI Safety Grantees (2024)
-
-Coefficient's largest 2024 AI safety grants reflect priorities across evaluations, interpretability, and theoretical alignment work:
-
-| Grantee | Amount | Focus | Notes |
-|---------|--------|-------|-------|
-| **Center for AI Safety** | \$8.5M | Field building, research | Training programs, compute grants, advocacy |
-| **Redwood Research** | \$6.2M | Alignment research | Interpretability, control research; \$26M+ total from Coefficient Giving |
-| **MIRI** | \$4.1M | Theoretical alignment | Agent foundations, deceptive alignment |
-| **Epoch AI** | ≈\$3M | AI forecasting | Compute trends, capability timelines |
-| **METR (formerly ARC Evals)** | ≈\$3M | Capability evaluations | Model evaluations used by labs and governments |
-| **AI Safety Camp** | ≈\$500K | Talent pipeline | Intensive research programs |
-| **Various Individuals** | ≈\$10M | Researchers, fellowships | PhDs, postdocs, independent researchers |
-
 ### 2024 Technical AI Safety Funding Breakdown
 
 An [analysis of Coefficient Giving's Technical AI Safety funding](https://www.lesswrong.com/posts/adzfKEW98TswZEA6T/brief-analysis-of-op-technical-ai-safety-funding) revealed the following distribution of the \$28M recorded in their database:
@@ -195,15 +181,18 @@ Note: The \$28M figure underestimates total 2024 spending as some approved grant
 
 ### Historical Major AI Safety Grants
 
+Totals from Coefficient Giving's public grants database (includes grants made when the organization was named Open Philanthropy):
+
 | Grantee | Total (All Years) | Period | Notable Impact |
 |---------|-------------------|--------|----------------|
-| **MIRI** | \$14.8M | 2014-2024 | Agent foundations, embedded agency |
-| **Redwood Research** | \$26M+ | 2021-2025 | Interpretability methods, control research |
-| **Center for AI Safety** | \$15M+ | 2022-2024 | Compute cluster, training programs |
-| **Future of Humanity Institute** | \$10M+ | 2015-2024 | Strategic analysis (closed 2024) |
-| **Center for Human-Compatible AI** | \$8M+ | 2016-2024 | <EntityLink id="E290" name="stuart-russell">Stuart Russell</EntityLink>'s CHAI lab |
+| **Redwood Research** | \$26.5M | 2021-2025 | Interpretability methods, control research (plus \$3M for Constellation coworking space) |
+| **Future of Humanity Institute** | \$20.4M | 2016-2021 | Strategic analysis (closed 2024) |
+| **EA Funds (LTFF + Infrastructure)** | \$19.3M | 2022-2023 | Regranting via Long-Term Future Fund and EA Infrastructure Fund |
+| **Center for Human-Compatible AI** | \$17.8M | 2016-2021 | <EntityLink id="E290" name="stuart-russell">Stuart Russell</EntityLink>'s CHAI lab (\$23M including BERI-CHAI collaborations) |
+| **MIRI** | \$14.8M | 2016-2020 | Agent foundations, embedded agency |
+| **Epoch AI** | \$13.3M | 2022-2025 | Compute trends, capability timelines |
+| **Center for AI Safety** | \$12.5M | 2022-2023 | Compute cluster, training programs |
 | **Anthropic** | \$0 directly | N/A | VC-funded; no grants in Coefficient Giving's database. GiveWell/Open Philanthropy co-founder <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> is married to Anthropic co-founder Daniela Amodei and joined Anthropic in 2025. |
-| **Long-Term Future Fund** | \$3.15M | 2019-2024 | Regranting to LTFF for distribution |
 
 ### 2025 Technical AI Safety RFP
 


### PR DESCRIPTION
## Summary
- Removed fabricated "Major AI Safety Grantees (2024)" table with per-grantee amounts that did not match any actual grants in the production database
- Replaced the Historical Major AI Safety Grants table with verified totals queried directly from the production grants DB
- Deleted 5 stale grants from the old `open-philanthropy` entity (NifCYhN75w) in production DB, including a spurious $250M Anthropic grant

## Data corrections (verified against production grants DB)

| Grantee | Old claim | Verified amount | Change |
|---------|-----------|----------------|--------|
| Redwood Research | $26M+ | $26.5M | Precise figure |
| FHI | $10M+ | $20.4M | Was significantly understated |
| EA Funds (LTFF) | $3.15M | $19.3M | Was showing one grant, not total |
| CHAI | $8M+ | $17.8M | Was significantly understated |
| MIRI | $14.8M | $14.8M | Correct; period fixed (2016-2020 not 2014-2024) |
| Epoch AI | Not listed | $13.3M | New addition |
| CAIS | $15M+ | $12.5M | Was overcounted |
| Anthropic | $0 | $0 | Confirmed correct |

## DB fix: Stale grants under old entity
Deleted 5 grants that were under the deprecated `open-philanthropy` entity (stableId: NifCYhN75w). These were manually-created aggregate records, not from the official Coefficient Giving CSV. Included a spurious $250M Anthropic grant and duplicated amounts for Redwood Research, CAIS, CHAI, and FAR AI.

MIRI grants ($14.8M across 5 grants) were already present in the DB under the correct Coefficient Giving entity -- the issue's report of missing MIRI grants was incorrect.

Closes #2807

## Test plan
- [x] Verified all grant amounts by querying production grants API directly
- [x] Confirmed MIRI grants (5 grants, $14.8M) present in DB under Coefficient Giving entity
- [x] Confirmed Anthropic has $0 grants in the Coefficient Giving CSV
- [x] Deleted 5 stale grants under old open-philanthropy entity
- [x] Verified old entity now has 0 grants
- [x] Content builds successfully (pnpm build-data:content)
- [x] MDX escaping and markdown fixers pass
- [x] File-level validation passes (comparison-operators, dollar-signs, entitylink-ids, frontmatter-schema, wiki-id-integrity, prefer-entitylink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
