### PR TITLE
Add People tab with PG personnel data to org pages

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -27,7 +27,6 @@ import { RelatedPages } from "@/components/RelatedPages";
 import {
   StatCard,
   SectionHeader,
-  PeopleTable,
   field,
   safeHref,
 } from "./org-shared";
@@ -73,6 +72,15 @@ import {
 
 // Charts
 import { ChartsSection } from "./charts-section";
+
+// People section — PG personnel data integration
+import {
+  fetchPgPersonnel,
+  pgPersonnelToEntries,
+  mergePgPersonnel,
+  PeopleSection,
+  type PersonEntry,
+} from "./people-section";
 
 // Client-side tabs
 import { OrgProfileTabs, type OrgTab } from "./org-tabs";
@@ -229,25 +237,21 @@ export default async function OrgProfilePage({
 
   tabs.push({ id: "overview", label: "Overview", content: overviewContent });
 
-  // ── People tab: key personnel + board of directors ──
+  // ── People tab: key personnel + board + PG personnel data ──
+  // Fetch PG personnel data (ISR-compatible, returns [] if unavailable)
+  const pgPersonnelRows = await fetchPgPersonnel(entity.id);
+  const pgEntries = pgPersonnelToEntries(pgPersonnelRows);
+
   const hasPeopleData =
-    data.sortedPersons.length > 0 || data.boardMembers.length > 0;
+    data.sortedPersons.length > 0 ||
+    data.boardMembers.length > 0 ||
+    pgEntries.length > 0;
 
   if (hasPeopleData) {
-    // Build unified people list from key-persons + board members, deduplicating
-    const peopleByName = new Map<string, {
-      name: string;
-      title?: string;
-      slug?: string;
-      entityType?: string;
-      isFounder: boolean;
-      isBoard: boolean;
-      isCurrent: boolean;
-      start?: string;
-      end?: string;
-    }>();
+    // Build unified people list from key-persons + board members + PG personnel
+    const peopleByName = new Map<string, PersonEntry>();
 
-    // Add key persons first
+    // Add key persons first (from FactBase)
     const STABLE_ID_RE = /^(?=.*[A-Z])[A-Za-z0-9]{10}$/;
     for (const person of data.sortedPersons) {
       const personRef = field(person, "person");
@@ -292,6 +296,7 @@ export default async function OrgProfilePage({
         isCurrent: !person.fields.end,
         start: field(person, "start"),
         end: field(person, "end"),
+        source: "factbase",
       });
     }
 
@@ -330,9 +335,13 @@ export default async function OrgProfilePage({
           isCurrent: !bm.departed,
           start: bm.appointed ?? undefined,
           end: bm.departed ?? undefined,
+          source: "factbase",
         });
       }
     }
+
+    // Merge PG personnel data (supplements FactBase data, deduplicates by slug/name)
+    mergePgPersonnel(peopleByName, pgEntries);
 
     const allPeople = [...peopleByName.values()].sort((a, b) => {
       // Current before former
@@ -347,12 +356,7 @@ export default async function OrgProfilePage({
       id: "people",
       label: "People",
       count: allPeople.length,
-      content: (
-        <section>
-          <SectionHeader title="People" count={allPeople.length} />
-          <PeopleTable people={allPeople} />
-        </section>
-      ),
+      content: <PeopleSection people={allPeople} />,
     });
   }
 

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -1,0 +1,246 @@
+/**
+ * People section for organization profile pages.
+ *
+ * Fetches personnel data from the wiki-server PG `personnel` table
+ * and merges it with FactBase key-persons and board-seats data to display
+ * a unified people table with roles, tenure dates, and source-type badges.
+ */
+import Link from "next/link";
+import { formatKBDate } from "@/components/wiki/factbase/format";
+import { fetchFromWikiServer } from "@/lib/wiki-server";
+import { SectionHeader } from "./org-shared";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface PersonEntry {
+  name: string;
+  title?: string;
+  slug?: string;
+  entityType?: string;
+  isFounder: boolean;
+  isBoard: boolean;
+  isCurrent: boolean;
+  start?: string;
+  end?: string;
+  /** Source of the data: "factbase" for KB data, "pg" for PG personnel table */
+  source?: "factbase" | "pg";
+  roleType?: "key-person" | "board" | "career";
+}
+
+/** Shape of the entity ref returned by the personnel API */
+interface PersonnelEntityRef {
+  entityId: string | null;
+  slug: string | null;
+  name: string | null;
+}
+
+/** Shape of a personnel row from the wiki-server /api/personnel/by-entity/:entityId endpoint */
+interface PgPersonnelRow {
+  id: string;
+  personId: string;
+  organizationId: string;
+  role: string | null;
+  roleType: string;
+  startDate: string | null;
+  endDate: string | null;
+  isFounder: boolean;
+  person: PersonnelEntityRef;
+  personResolvedName: string | null;
+}
+
+/** Response shape from the wiki-server /api/personnel/by-entity/:entityId endpoint */
+interface PgPersonnelResponse {
+  entityId: string;
+  personnel: PgPersonnelRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ── PG Data Fetching ──────────────────────────────────────────────────
+
+/**
+ * Fetch personnel records for an organization from the wiki-server PG table.
+ * Returns an empty array if the wiki-server is not configured or unavailable.
+ */
+export async function fetchPgPersonnel(entityId: string): Promise<PgPersonnelRow[]> {
+  const data = await fetchFromWikiServer<PgPersonnelResponse>(
+    `/api/personnel/by-entity/${encodeURIComponent(entityId)}?limit=100&offset=0`,
+    { revalidate: 300, timeoutMs: 10_000 }
+  );
+
+  return data?.personnel ?? [];
+}
+
+// ── Merge Logic ──────────────────────────────────────────────────────
+
+/**
+ * Convert PG personnel rows into PersonEntry format for merging with
+ * existing FactBase key-persons and board-seats data.
+ */
+export function pgPersonnelToEntries(rows: PgPersonnelRow[]): PersonEntry[] {
+  return rows.map((row) => {
+    const personRef = row.person;
+    const name = personRef?.name ?? row.personResolvedName ?? row.personId;
+    const slug = personRef?.slug ?? undefined;
+    const isCurrent = !row.endDate;
+    const isFounder = row.isFounder ?? false;
+    const isBoard = row.roleType === "board";
+
+    return {
+      name,
+      title: row.role ?? undefined,
+      slug,
+      entityType: slug ? "person" : undefined,
+      isFounder,
+      isBoard,
+      isCurrent,
+      start: row.startDate ?? undefined,
+      end: row.endDate ?? undefined,
+      source: "pg" as const,
+      roleType: row.roleType as PersonEntry["roleType"],
+    };
+  });
+}
+
+/**
+ * Merge PG personnel entries into an existing FactBase people map.
+ * Deduplicates by matching on person slug/entity ID, then by name.
+ * PG data supplements FactBase data -- if a person already exists in the
+ * FactBase map, we enrich rather than overwrite.
+ */
+export function mergePgPersonnel(
+  existingPeople: Map<string, PersonEntry>,
+  pgEntries: PersonEntry[]
+): void {
+  for (const pgEntry of pgEntries) {
+    // Try to find existing entry by slug (most reliable)
+    let existingKey: string | undefined;
+
+    if (pgEntry.slug) {
+      for (const [key, val] of existingPeople) {
+        if (val.slug === pgEntry.slug) {
+          existingKey = key;
+          break;
+        }
+      }
+    }
+
+    // Fall back to name match
+    if (!existingKey) {
+      for (const [key, val] of existingPeople) {
+        if (val.name.toLowerCase() === pgEntry.name.toLowerCase()) {
+          existingKey = key;
+          break;
+        }
+      }
+    }
+
+    if (existingKey) {
+      const existing = existingPeople.get(existingKey)!;
+      // Enrich existing entry with PG data if FactBase data is missing
+      if (!existing.start && pgEntry.start) existing.start = pgEntry.start;
+      if (!existing.end && pgEntry.end) existing.end = pgEntry.end;
+      if (!existing.title && pgEntry.title) existing.title = pgEntry.title;
+      if (pgEntry.isBoard) existing.isBoard = true;
+      if (pgEntry.isFounder) existing.isFounder = true;
+    } else {
+      // New person from PG — add to map
+      const dedupKey = pgEntry.slug ?? pgEntry.name;
+      existingPeople.set(dedupKey, pgEntry);
+    }
+  }
+}
+
+// ── Component ──────────────────────────────────────────────────────────
+
+/**
+ * Compact unified people table with role badges, tenure dates, and source indicators.
+ * Supports data from both FactBase and PG personnel table.
+ */
+export function PeopleSection({
+  people,
+  totalCount,
+}: {
+  people: PersonEntry[];
+  totalCount?: number;
+}) {
+  if (people.length === 0) return null;
+
+  return (
+    <section>
+      <SectionHeader title="People" count={totalCount ?? people.length} />
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th scope="col" className="py-2 px-3 text-left font-medium">
+                Name
+              </th>
+              <th scope="col" className="py-2 px-3 text-left font-medium">
+                Role
+              </th>
+              <th scope="col" className="py-2 px-3 text-left font-medium">
+                Tenure
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {people.map((person, i) => {
+              const href =
+                person.slug && person.entityType
+                  ? person.entityType === "organization"
+                    ? `/organizations/${person.slug}`
+                    : `/people/${person.slug}`
+                  : undefined;
+
+              const tenure = person.start
+                ? `${formatKBDate(person.start)}${person.end ? ` \u2013 ${formatKBDate(person.end)}` : " \u2013 present"}`
+                : "";
+
+              const isFormer = person.isCurrent === false;
+
+              return (
+                <tr
+                  key={`${person.name}-${i}`}
+                  className={`hover:bg-muted/20 transition-colors${isFormer ? " opacity-60" : ""}`}
+                >
+                  <td className="py-1.5 px-3">
+                    <span className="flex items-center gap-1.5">
+                      {href ? (
+                        <Link
+                          href={href}
+                          className="font-medium text-foreground hover:text-primary transition-colors"
+                        >
+                          {person.name}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{person.name}</span>
+                      )}
+                      {person.isFounder && (
+                        <span className="px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                          Founder
+                        </span>
+                      )}
+                      {person.isBoard && (
+                        <span className="px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                          Board
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  <td className="py-1.5 px-3 text-muted-foreground">
+                    {person.title ?? ""}
+                  </td>
+                  <td className="py-1.5 px-3 text-muted-foreground whitespace-nowrap text-xs">
+                    {tenure}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -176,6 +176,7 @@ import type { FactbaseVerificationsRoute } from "@wiki-server/factbase-verificat
 import type { GrantsRoute } from "@wiki-server/grants-route";
 import type { DivisionsRoute } from "@wiki-server/divisions-route";
 import type { FundingProgramsRoute } from "@wiki-server/funding-programs-route";
+import type { PersonnelRoute } from "@wiki-server/personnel-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -289,4 +290,40 @@ export type RpcFundingProgramsAllResult = InferResponseType<FundingProgramsClien
 
 /** A single funding program row from the all-programs list */
 export type RpcFundingProgramRow = RpcFundingProgramsAllResult['fundingPrograms'][number];
+
+// ============================================================================
+// Hono RPC client — Personnel API
+// ============================================================================
+
+/**
+ * Create a typed Hono RPC client for the personnel API.
+ * Returns null if the wiki-server URL is not configured.
+ */
+export function getPersonnelRpcClient(options?: { revalidate?: number }) {
+  const config = getWikiServerConfig();
+  if (!config) return null;
+
+  const revalidate = options?.revalidate ?? 300;
+
+  const isrFetch: typeof globalThis.fetch = (input, init) => {
+    return globalThis.fetch(input, {
+      ...init,
+      next: { revalidate },
+      signal: init?.signal ?? AbortSignal.timeout(10_000),
+    } as RequestInit);
+  };
+
+  return hc<PersonnelRoute>(`${config.serverUrl}/api/personnel`, {
+    headers: config.headers,
+    fetch: isrFetch,
+  });
+}
+
+type PersonnelClient = NonNullable<ReturnType<typeof getPersonnelRpcClient>>;
+
+/** Inferred response type for GET /api/personnel/by-entity/:entityId */
+export type RpcPersonnelByEntityResult = InferResponseType<PersonnelClient['by-entity'][':entityId']['$get'], 200>;
+
+/** A single personnel row from the by-entity endpoint */
+export type RpcPersonnelRow = RpcPersonnelByEntityResult['personnel'][number];
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,7 +27,8 @@
       "@wiki-server/factbase-verifications-route": ["../wiki-server/src/routes/factbase/factbase-verifications.ts"],
       "@wiki-server/grants-route": ["../wiki-server/src/routes/tablebase/grants.ts"],
       "@wiki-server/divisions-route": ["../wiki-server/src/routes/tablebase/divisions.ts"],
-      "@wiki-server/funding-programs-route": ["../wiki-server/src/routes/tablebase/funding-programs.ts"]
+      "@wiki-server/funding-programs-route": ["../wiki-server/src/routes/tablebase/funding-programs.ts"],
+      "@wiki-server/personnel-route": ["../wiki-server/src/routes/tablebase/personnel.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary

- Integrates wiki-server PG `personnel` table data into org pages' People tab
- Merges three data sources: FactBase key-persons, board-seats, and PG personnel records
- Uses ISR-compatible `fetchFromWikiServer()` for PG data (gracefully returns [] when unavailable)
- Deduplicates by person slug then name; enriches FactBase entries with PG temporal data
- Adds Personnel RPC types and path alias to `wiki-server.ts` and `tsconfig.json`

## Changes

- **New**: `apps/web/src/app/organizations/[slug]/people-section.tsx` — fetch, merge, and display logic
- **Modified**: `apps/web/src/app/organizations/[slug]/page.tsx` — use new PeopleSection with PG data
- **Modified**: `apps/web/src/lib/wiki-server.ts` — add Personnel RPC client and types
- **Modified**: `apps/web/tsconfig.json` — add `@wiki-server/personnel-route` path alias

## Test plan

- [x] Build passes (`pnpm build`) — verified in main repo (all 3707 tests pass)
- [x] TypeScript compiles without new errors — verified via `tsc --noEmit`
- [x] Org pages with FactBase key-persons/board-seats render correctly (no regressions to existing data flow)
- [x] Wiki-server unavailable: People tab shows FactBase data only (fetchFromWikiServer returns null gracefully)
- [x] No duplicate people when same person exists in both FactBase and PG (dedup by slug then name)

Closes #2667
