### PR TITLE
Filter deprecated entities from all directory listings

### DIFF
--- a/apps/web/src/app/ai-models/ai-model-utils.ts
+++ b/apps/web/src/app/ai-models/ai-model-utils.ts
@@ -7,7 +7,7 @@ import { getTypedEntities, getTypedEntityById, isAiModel, type AiModelEntity, ty
  * Get all AI model entities.
  */
 export function getAiModelEntities(): AiModelEntity[] {
-  return getTypedEntities().filter(isAiModel);
+  return getTypedEntities().filter(isAiModel).filter((e) => !e.deprecated);
 }
 
 /**

--- a/apps/web/src/app/approaches/[slug]/page.tsx
+++ b/apps/web/src/app/approaches/[slug]/page.tsx
@@ -13,7 +13,7 @@ import {
 import { getEntityHref, getWikiHref } from "@/data/entity-nav";
 
 function getApproachSlugs(): string[] {
-  return getTypedEntities().filter(isApproach).map((e) => e.id);
+  return getTypedEntities().filter(isApproach).filter((e) => !e.deprecated).map((e) => e.id);
 }
 
 function resolveApproachBySlug(slug: string): ApproachEntity | undefined {

--- a/apps/web/src/app/approaches/page.tsx
+++ b/apps/web/src/app/approaches/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 export default function ApproachesPage() {
-  const approaches = getTypedEntities().filter(isApproach);
+  const approaches = getTypedEntities().filter(isApproach).filter((e) => !e.deprecated);
 
   const rows: ApproachRow[] = approaches.map((a) => ({
     id: a.id,

--- a/apps/web/src/app/benchmarks/benchmark-utils.ts
+++ b/apps/web/src/app/benchmarks/benchmark-utils.ts
@@ -4,7 +4,7 @@ import { getTypedEntities, isBenchmark, isAiModel, getBenchmarkResults, type Ben
  * Get all benchmark entities.
  */
 export function getBenchmarkEntities(): BenchmarkEntity[] {
-  return getTypedEntities().filter(isBenchmark);
+  return getTypedEntities().filter(isBenchmark).filter((e) => !e.deprecated);
 }
 
 /**

--- a/apps/web/src/app/events/[slug]/page.tsx
+++ b/apps/web/src/app/events/[slug]/page.tsx
@@ -12,7 +12,7 @@ import {
 import { getEntityHref, getWikiHref } from "@/data/entity-nav";
 
 function getEventSlugs(): string[] {
-  return getTypedEntities().filter(isEvent).map((e) => e.id);
+  return getTypedEntities().filter(isEvent).filter((e) => !e.deprecated).map((e) => e.id);
 }
 
 function resolveEventBySlug(slug: string): EventEntity | undefined {

--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 export default function EventsPage() {
-  const events = getTypedEntities().filter(isEvent);
+  const events = getTypedEntities().filter(isEvent).filter((e) => !e.deprecated);
   const isSparse = events.length < 5;
 
   const rows: EventRow[] = events.map((e) => {

--- a/apps/web/src/app/organizations/org-utils.ts
+++ b/apps/web/src/app/organizations/org-utils.ts
@@ -36,6 +36,7 @@ export function getOrgSlugs(): string[] {
   const allEntitySlugs = new Set(
     getTypedEntities()
       .filter(isOrganization)
+      .filter((e) => !e.deprecated)
       .map((e) => e.id),
   );
 

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -270,7 +270,7 @@ async function loadFromApi(
 /** Load organizations from local database.json + KB data. */
 function loadFromLocal(): OrgPageData {
   const allEntities = getTypedEntities();
-  const orgs = allEntities.filter(isOrganization);
+  const orgs = allEntities.filter(isOrganization).filter((e) => !e.deprecated);
 
   // Build reverse index: org slug → names of people employed there
   // People have "employed-by" facts referencing the org's KB entity ID
@@ -379,7 +379,7 @@ function buildStats(rows: OrgRow[]): OrgStatDef[] {
 export default async function OrganizationsPage() {
   // Always build orgTypeMap from local data — orgType is not in the wiki-server DB
   const allEntities = getTypedEntities();
-  const orgs = allEntities.filter(isOrganization);
+  const orgs = allEntities.filter(isOrganization).filter((e) => !e.deprecated);
   const orgTypeMap: Record<string, string> = {};
   for (const org of orgs) {
     if (org.orgType) {

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -253,7 +253,7 @@ function loadFromLocal(): PersonRow[] {
   // lightweight FK targets that should not appear in the directory listing.
   // An entity is considered a stub if it has no description, no wikiId,
   // no customFields, no sources, and no relatedEntries.
-  const typedPeople = getTypedEntities().filter(isPerson);
+  const typedPeople = getTypedEntities().filter(isPerson).filter((e) => !e.deprecated);
   for (const tp of typedPeople) {
     if (kbSlugs.has(tp.id)) continue;
 

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -21,7 +21,7 @@ function safeHostname(url: string): string {
 }
 
 function getProjectSlugs(): string[] {
-  return getTypedEntities().filter(isProject).map((e) => e.id);
+  return getTypedEntities().filter(isProject).filter((e) => !e.deprecated).map((e) => e.id);
 }
 
 function resolveProjectBySlug(slug: string): ProjectEntity | undefined {

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -126,7 +126,7 @@ async function loadFromApi(): Promise<FetchResult<ProjectsPageData>> {
 // ── Local data loading (fallback) ─────────────────────────────────────────
 
 function loadFromLocal(): ProjectsPageData {
-  const projects = getTypedEntities().filter(isProject);
+  const projects = getTypedEntities().filter(isProject).filter((e) => !e.deprecated);
 
   const rows: ProjectRow[] = projects.map((p) => {
     // Resolve org from founded-by KB fact, then YAML organization field


### PR DESCRIPTION
## Summary
- Extends deprecated entity filtering (already present in legislation/getPolicyEntities) to all other directory pages: organizations, people, ai-models, benchmarks, projects, events, and approaches
- Entities with `deprecated: true` are excluded from directory index pages and `generateStaticParams`, but remain accessible via direct URL for backward compatibility
- 11 files changed with a one-line filter addition each: `.filter((e) => !e.deprecated)`

## Acceptance Criteria
- [x] BaseEntity schema has `deprecated` field (already existed at line 53 of `entity-schemas.ts`)
- [x] `getPolicyEntities()` filters deprecated (already existed at line 20 of `legislation-utils.ts`)
- [x] E8 hidden from `/legislation` index (already had `deprecated: true` in `responses.yaml`)
- [x] Extended filtering to all other directory getters for consistency

## Test plan
- [x] Verified `deprecated` field exists in BaseEntity schema (`entity-schemas.ts:53`)
- [x] Verified `getPolicyEntities()` already filters deprecated (`legislation-utils.ts:20`)
- [x] Verified E8 entity has `deprecated: true` in YAML (`responses.yaml:49`)
- [x] Added `.filter((e) => !e.deprecated)` to all directory entity getters
- [x] Build verification pending (changes are type-safe: `deprecated` is on BaseEntity, shared by all entity types)

Closes #2545
