### PR TITLE
Filter publication-only stubs from people directory

### DIFF
--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -303,7 +303,6 @@ export default async function PeoplePage() {
   const withBornYear = rows.filter((r) => r.bornYear != null).length;
   const withNetWorth = rows.filter((r) => r.netWorthNum != null).length;
   const withPositions = rows.filter((r) => r.positionCount > 0).length;
-  const withPublications = rows.filter((r) => r.publicationCount > 0).length;
   const totalCareerEntries = rows.reduce((s, r) => s + r.careerHistoryCount, 0);
   const uniqueTopics = new Set(rows.flatMap((r) => r.topics)).size;
 

--- a/apps/web/src/app/people/people-filter.test.ts
+++ b/apps/web/src/app/people/people-filter.test.ts
@@ -76,8 +76,8 @@ describe("isPersonMeaningful", () => {
     ).toBe(false);
   });
 
-  it("returns false for person with only netWorth", () => {
-    expect(isPersonMeaningful(makeRow({ netWorthNum: 1e9 }))).toBe(false);
+  it("returns true for person with only netWorth", () => {
+    expect(isPersonMeaningful(makeRow({ netWorthNum: 1e9 }))).toBe(true);
   });
 });
 

--- a/apps/web/src/app/people/people-filter.ts
+++ b/apps/web/src/app/people/people-filter.ts
@@ -4,13 +4,13 @@ import type { PersonRow } from "./people-table";
  * Determines whether a person entry has enough meaningful data to display
  * by default in the people directory.
  *
- * A person is considered "meaningful" (not a publication-only stub) if they have
- * at least one of:
+ * A person is considered "meaningful" (not a stub) if they have at least one of:
  * - A role recorded
  * - An employer/affiliation recorded
  * - A wiki page
  * - Career history entries
  * - Expert positions
+ * - A net worth value (only recorded for notable people)
  *
  * People who only have publications (or nothing at all) are considered stubs
  * and hidden by default, with a toggle to show them.
@@ -21,6 +21,7 @@ export function isPersonMeaningful(row: PersonRow): boolean {
   if (row.wikiPageId != null) return true;
   if (row.careerHistoryCount > 0) return true;
   if (row.positionCount > 0) return true;
+  if (row.netWorthNum != null) return true;
   return false;
 }
 

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -140,12 +140,18 @@ export function PeopleTable({
 
   const allRows = staticRows ?? EMPTY_ROWS;
 
+  // When stubs are hidden, chip counts should reflect the meaningful subset
+  const chipSourceRows = useMemo(() => {
+    if (serverMode) return EMPTY_ROWS;
+    if (showAll) return allRows;
+    return allRows.filter(isPersonMeaningful);
+  }, [serverMode, showAll, allRows]);
+
   // Collect top affiliations for filter (only those with 2+ people)
   // In server mode, affiliations will be empty (server filter uses text).
   const affiliationChips = useMemo(() => {
-    const dataSource = serverMode ? EMPTY_ROWS : allRows;
     const counts = new Map<string, number>();
-    for (const r of dataSource) {
+    for (const r of chipSourceRows) {
       if (r.employerName) {
         counts.set(r.employerName, (counts.get(r.employerName) ?? 0) + 1);
       }
@@ -155,13 +161,13 @@ export function PeopleTable({
       .sort((a, b) => b[1] - a[1])
       .slice(0, 10)
       .map(([name, count]) => ({ key: name, label: name, count }));
-  }, [allRows, serverMode]);
+  }, [chipSourceRows]);
 
   // Collect all topics (static mode only — topics not available from server)
   const topicChips = useMemo(() => {
     if (serverMode) return [];
     const counts = new Map<string, number>();
-    for (const r of allRows) {
+    for (const r of chipSourceRows) {
       for (const t of r.topics) {
         counts.set(t, (counts.get(t) ?? 0) + 1);
       }
@@ -169,7 +175,7 @@ export function PeopleTable({
     return [...counts.entries()]
       .sort((a, b) => b[1] - a[1])
       .map(([slug, count]) => ({ key: slug, label: topicLabel(slug), count }));
-  }, [allRows, serverMode]);
+  }, [chipSourceRows, serverMode]);
 
   // ── Unified search handler ──
   const search = serverMode ? server.search : urlSearch;
@@ -313,7 +319,7 @@ export function PeopleTable({
       const base = filteredTotal === (allRows.length - stubCount)
         ? `${filteredTotal} people with detailed data`
         : `${filteredTotal} of ${allRows.length - stubCount} people with detailed data`;
-      return `Showing ${base}. ${stubCount} publication-only entries hidden.`;
+      return `Showing ${base}. ${stubCount} stub entries hidden.`;
     }
     const filterCount =
       filteredTotal === allRows.length
@@ -349,7 +355,7 @@ export function PeopleTable({
               items={affiliationChips}
               selected={activeAffiliation}
               onSelect={handleAffiliationFilter}
-              allCount={allRows.length}
+              allCount={chipSourceRows.length}
             />
           )}
         </div>
@@ -380,7 +386,7 @@ export function PeopleTable({
             onClick={() => urlSetFilter("showAll", showAll ? "all" : "true")}
             className="text-xs text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
           >
-            {showAll ? "Hide publication-only entries" : "Show all"}
+            {showAll ? "Hide stub entries" : "Show all"}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Hide publication-only stub entries from the people directory by default — only show people with roles, affiliations, wiki pages, career history, or expert positions
- Add a URL-persisted "Show all" toggle so users can still see the complete list
- Show informative status text: "Showing X people with detailed data. Y publication-only entries hidden."
- Update stat cards to prominently display "With Detailed Data" count alongside "Total People"
- Add `isPersonMeaningful()` utility with 14 unit tests covering all criteria and edge cases

## Details
Previously, ~80% of people in the directory (429 of 534) were publication-only stubs showing mostly empty dashes across all columns. This made the directory look sparse and unhelpful. Now the directory defaults to showing only the ~105 people with meaningful structured data, while a toggle reveals the full list.

The filtering criteria (`isPersonMeaningful`) considers a person meaningful if they have at least one of:
- A role recorded
- An employer/affiliation
- A wiki page (wikiPageId)
- Career history entries
- Expert positions

The toggle state persists in the URL (`?showAll=true`) so it's shareable.

## Test plan
- [x] 14 new unit tests for `isPersonMeaningful()` and `partitionPersonRows()` — all pass
- [x] Existing 25 tests in `people-utils.test.ts` still pass
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Full `pnpm build` succeeds
- [ ] Visual verification: directory shows filtered list by default, toggle works, stat cards correct

Closes #2808

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to show/hide publication-only entries in the people directory.
  * Updated summary stats to show "With Detailed Data" alongside a separate "Total People" count.
  * Added a toggle control to switch between filtered and full entry lists.

* **Tests**
  * Added tests covering the logic that classifies entries as meaningful vs. publication-only and the partitioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->