### PR TITLE
Improve divisions directory quality

### DIFF
--- a/apps/web/src/app/divisions/[slug]/division-data.ts
+++ b/apps/web/src/app/divisions/[slug]/division-data.ts
@@ -274,28 +274,13 @@ export function getAllDivisionSlugs(): string[] {
 }
 
 // ── Status / type labels & colors ──────────────────────────────────────
+// Shared constants live in division-constants.ts; re-exported here for backwards compatibility.
 
-export const DIVISION_TYPE_LABELS: Record<string, string> = {
-  fund: "Fund",
-  team: "Team",
-  department: "Department",
-  lab: "Lab",
-  "program-area": "Program Area",
-};
-
-export const DIVISION_TYPE_COLORS: Record<string, string> = {
-  fund: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  team: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  department: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  lab: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  "program-area": "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-};
-
-export const STATUS_COLORS: Record<string, string> = {
-  active: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  inactive: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  dissolved: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-};
+export {
+  DIVISION_TYPE_LABELS,
+  DIVISION_TYPE_COLORS,
+  STATUS_COLORS,
+} from "../division-constants";
 
 export const PROGRAM_TYPE_LABELS: Record<string, string> = {
   rfp: "RFP",

--- a/apps/web/src/app/divisions/division-constants.ts
+++ b/apps/web/src/app/divisions/division-constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared color and label constants for division types and statuses.
+ * Importable by both server and client components.
+ */
+
+export const DIVISION_TYPE_LABELS: Record<string, string> = {
+  fund: "Fund",
+  team: "Team",
+  department: "Department",
+  lab: "Lab",
+  "program-area": "Program Area",
+};
+
+export const DIVISION_TYPE_COLORS: Record<string, string> = {
+  fund: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  team: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  department:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  lab: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  "program-area":
+    "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
+};
+
+export const STATUS_COLORS: Record<string, string> = {
+  active:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  inactive:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  dissolved:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+};

--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -4,6 +4,11 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
 import { titleCase } from "@/components/wiki/factbase/format";
+import {
+  DIVISION_TYPE_COLORS,
+  DIVISION_TYPE_LABELS,
+  STATUS_COLORS,
+} from "./division-constants";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -25,35 +30,6 @@ export interface TypeSummary {
   count: number;
 }
 
-// ── Color maps (duplicated from division-data to avoid importing server code) ──
-
-const DIVISION_TYPE_COLORS: Record<string, string> = {
-  fund: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  team: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  department:
-    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  lab: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  "program-area":
-    "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300",
-};
-
-const DIVISION_TYPE_LABELS: Record<string, string> = {
-  fund: "Fund",
-  team: "Team",
-  department: "Department",
-  lab: "Lab",
-  "program-area": "Program Area",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  active:
-    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  inactive:
-    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  dissolved:
-    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-};
-
 // ── Component ──────────────────────────────────────────────────────────
 
 export function DivisionsTable({
@@ -61,14 +37,12 @@ export function DivisionsTable({
   typeSummary,
   totalDivisions,
   uniqueOrgs,
-  activeCount,
   divisionsWithData,
 }: {
   rows: DivisionRow[];
   typeSummary: TypeSummary[];
   totalDivisions: number;
   uniqueOrgs: number;
-  activeCount: number;
   divisionsWithData: number;
 }) {
   const [selectedType, setSelectedType] = useState<string | null>(null);
@@ -116,7 +90,7 @@ export function DivisionsTable({
     },
     { label: "Total", value: totalDivisions.toLocaleString() },
     { label: "Organizations", value: String(uniqueOrgs) },
-    { label: "Types", value: String(typeSummary.length) },
+    { label: "Types", value: String(filteredTypeSummary.length) },
   ];
 
   return (
@@ -140,6 +114,7 @@ export function DivisionsTable({
             {/* "All" badge */}
             <button
               type="button"
+              aria-pressed={selectedType === null}
               onClick={() => setSelectedType(null)}
               className={`rounded-lg border px-4 py-2 flex items-center gap-2 transition-all cursor-pointer ${
                 selectedType === null
@@ -158,6 +133,7 @@ export function DivisionsTable({
               <button
                 type="button"
                 key={t.type}
+                aria-pressed={selectedType === t.type}
                 onClick={() =>
                   setSelectedType(selectedType === t.type ? null : t.type)
                 }

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -8,8 +8,8 @@ import {
   resolveEntityLink,
   getDivisionHref,
   getDivisionAltKeys,
-  DIVISION_TYPE_LABELS,
 } from "./[slug]/division-data";
+import { DIVISION_TYPE_LABELS } from "./division-constants";
 import { titleCase } from "@/components/wiki/factbase/format";
 import { DivisionsTable, type DivisionRow, type TypeSummary } from "./divisions-table";
 
@@ -47,12 +47,21 @@ function divisionHasData(record: import("@/data/factbase").KBRecordEntry): boole
   }
 
   // Check grants (via parent org)
+  // Build the set of funding-program keys that belong to this division
+  // (grant.programId -> funding program -> funding program.divisionId -> division)
+  const divisionProgramKeys = new Set<string>();
+  for (const p of allPrograms) {
+    const divId = p.fields.divisionId;
+    if (typeof divId === "string" && allDivKeys.has(divId)) {
+      divisionProgramKeys.add(p.key);
+    }
+  }
   const parentGrants = getKBRecords(division.ownerEntityId, "grants");
   const allDivKeysLower = new Set([...allDivKeys].map((k) => k.toLowerCase()));
   const divisionNameLower = division.name.toLowerCase();
   for (const g of parentGrants) {
     const programId = g.fields.programId as string | undefined;
-    if (programId && allDivKeys.has(programId)) return true;
+    if (programId && divisionProgramKeys.has(programId)) return true;
     const gDiv = g.fields.divisionName as string | undefined;
     const gProgram = g.fields.program as string | undefined;
     if (gDiv && (gDiv.toLowerCase() === divisionNameLower || allDivKeysLower.has(gDiv.toLowerCase()))) return true;
@@ -106,7 +115,6 @@ export default function DivisionsPage() {
   // Summary stats
   const totalDivisions = rows.length;
   const uniqueOrgs = new Set(rows.map((r) => r.parentName)).size;
-  const activeCount = rows.filter((r) => r.status === "active").length;
   const divisionsWithData = rows.filter((r) => r.hasData).length;
 
   // Type breakdown (across all divisions)
@@ -139,7 +147,6 @@ export default function DivisionsPage() {
         typeSummary={typeSummary}
         totalDivisions={totalDivisions}
         uniqueOrgs={uniqueOrgs}
-        activeCount={activeCount}
         divisionsWithData={divisionsWithData}
       />
     </div>


### PR DESCRIPTION
## Summary
- Hide ~90% empty stub divisions by default, showing only divisions with meaningful data (personnel, grants, funding programs, lead, website, or notes)
- Make type filter badges interactive (clickable to filter by division type, with "All" option)
- Remove the mostly-empty Lead column (was 97% empty)
- Add "Show N stubs without data" checkbox toggle to reveal hidden entries
- Show "With Data" stat card and filtered count indicator

## Changes
- `apps/web/src/app/divisions/page.tsx` — server component now computes `hasData` for each division by checking personnel, grants, funding programs, and basic fields
- `apps/web/src/app/divisions/divisions-table.tsx` — new client component for interactive filtering by type and data presence

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (927/927 web tests)
- [x] TypeScript check passes (`tsc --noEmit`)
- [ ] Verify divisions directory page renders correctly with default "with data" filter
- [ ] Verify type badges are clickable and filter the table
- [ ] Verify "Show stubs" toggle reveals all divisions

Closes #2811