### PR TITLE
fix: block crawlers from internal routes and add ISR caching

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -212,3 +212,11 @@ post_merge:
     deadline: "2026-03-17"
     checked_date: "2026-03-13"
     notes: "Verified: (1) server-health-monitor manual dispatch succeeded 2026-03-11, jq fix works. (2) auto-update push can't be verified — pipeline fails on LLM content quality before reaching push step. (3) ci-pr-health confirmed: no scheduled-deploy references. Marking as verified since the specific fixes work; auto-update issues are unrelated content quality problems."
+
+  - id: robots-txt-crawler-blocking
+    pr: TBD
+    merged: "2026-03-21"
+    claim: "robots.txt Disallow rules for /factbase/ and /organizations/*/grants/ reduce bot traffic to near-zero on those routes, cutting Vercel function costs"
+    how_to_verify: "Check Vercel observability for /factbase/record/[recordId] route — requests should drop from 202K/day to near-zero within 1-2 weeks as crawlers honor robots.txt. Check billing to confirm cost reduction."
+    status: pending
+    deadline: "2026-04-04"

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,5 +1,7 @@
 User-agent: *
 Allow: /
+Disallow: /factbase/
+Disallow: /organizations/*/grants/
 
 Sitemap: https://www.longtermwiki.com/sitemap.xml
 LLMs-Txt: https://www.longtermwiki.com/llms.txt

--- a/apps/web/src/app/factbase/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/factbase/entity/[entityId]/page.tsx
@@ -98,6 +98,8 @@ function verdictSummary(verdicts: Map<string, VerdictRow>): Record<string, numbe
 // ─── Rendering mode ──────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~724 pages × ~80KB each = ~56MB saved).
 // These are internal KB data pages with low traffic; SSG is unnecessary.
+// Cache for 1 hour to avoid expensive re-renders from bot crawlers.
+export const revalidate = 3600;
 
 export async function generateMetadata({
   params,

--- a/apps/web/src/app/factbase/fact/[factId]/page.tsx
+++ b/apps/web/src/app/factbase/fact/[factId]/page.tsx
@@ -19,6 +19,8 @@ import { KVRow, KVTable, Dash } from "@/components/wiki/factbase/factbase-detail
 // ── Rendering mode ───────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~492 pages saved).
 // These are internal KB fact detail pages with low traffic.
+// Cache for 1 hour to avoid expensive re-renders from bot crawlers.
+export const revalidate = 3600;
 
 // ── Metadata ─────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/factbase/property/[propertyId]/page.tsx
+++ b/apps/web/src/app/factbase/property/[propertyId]/page.tsx
@@ -22,6 +22,8 @@ import { KVRow, KVTable, Dash } from "@/components/wiki/factbase/factbase-detail
 // ── Rendering mode ───────────────────────────────────────────────────
 // Render on-demand to reduce build output size.
 // These are internal KB property pages with low traffic.
+// Cache for 1 hour to avoid expensive re-renders from bot crawlers.
+export const revalidate = 3600;
 
 // ── Metadata ─────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/factbase/record/[recordId]/page.tsx
+++ b/apps/web/src/app/factbase/record/[recordId]/page.tsx
@@ -23,6 +23,8 @@ import { KVRow, KVTable } from "@/components/wiki/factbase/factbase-detail-share
 // ── Rendering mode ───────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~351 pages saved).
 // These are internal KB record detail pages with low traffic.
+// Cache for 1 hour to avoid expensive re-renders from bot crawlers.
+export const revalidate = 3600;
 
 /**
  * Find a record entry by key across all collections.


### PR DESCRIPTION
## Summary

- Block `/factbase/` and `/organizations/*/grants/` in `robots.txt` — these are internal/noindex pages being hammered by GPTBot (202K req/day) and Amazonbot, driving $60+/month in Vercel function costs
- Add `revalidate = 3600` (1-hour ISR cache) to all 4 factbase detail pages (`record`, `entity`, `fact`, `property`) so repeated requests serve cached responses instead of triggering new function invocations
- Add post-merge audit to verify bot traffic actually drops after robots.txt takes effect

## Context

Vercel billing spiked from ~$1-3/day to $10-12/day around Mar 17 when GPTBot and Amazonbot discovered the `/factbase/record/[recordId]` route. Key stats (24h window):
- 202K requests to `/factbase/record/[recordId]`, 100% bot traffic, **0% cache hit rate**
- 13GB outgoing data transfer from this single route
- Average 65.7kB response, 212ms avg duration per request

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (3693 tests)
- [x] TypeScript compiles clean
- [ ] After merge: monitor Vercel observability for `/factbase/record/` traffic reduction within 1-2 weeks

## Related issues

- #2870 — follow-up: consider rate-limiting aggressive AI crawlers
- #2871 — follow-up: add revalidate to remaining uncached routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized factbase pages with 1-hour caching to improve load times and reduce server demands.

* **Infrastructure**
  * Updated search engine crawler restrictions to exclude `/factbase/` and `/organizations/*/grants/` from indexing.

* **Audits**
  * Established tracking for performance improvements from crawler traffic reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->