### PR TITLE
Fix review issues on org people tab (PR #2864)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-shared.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-shared.tsx
@@ -2,10 +2,8 @@
  * Shared components and helpers used across organization profile sections.
  * Extracted from page.tsx as a pure refactor — no visual changes.
  */
-import Link from "next/link";
 import type { KBRecordEntry } from "@/data/factbase";
 import {
-  formatKBDate,
   shortDomain,
   isUrl,
 } from "@/components/wiki/factbase/format";
@@ -97,87 +95,6 @@ export function SourceLink({ source }: { source: string | undefined }) {
     );
   }
   return <span className="text-[11px] text-muted-foreground">{source}</span>;
-}
-
-/** Compact unified people table with tags inline next to name. */
-export function PeopleTable({
-  people,
-}: {
-  people: Array<{
-    name: string;
-    title?: string;
-    slug?: string;
-    entityType?: string;
-    isFounder?: boolean;
-    isBoard?: boolean;
-    isCurrent?: boolean;
-    start?: string;
-    end?: string;
-  }>;
-}) {
-  if (people.length === 0) return null;
-
-  return (
-    <div className="border border-border rounded-xl overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-            <th scope="col" className="py-2 px-3 text-left font-medium">Name</th>
-            <th scope="col" className="py-2 px-3 text-left font-medium">Role</th>
-            <th scope="col" className="py-2 px-3 text-left font-medium">Tenure</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border/50">
-          {people.map((person, i) => {
-            const href = person.slug && person.entityType
-              ? person.entityType === "organization"
-                ? `/organizations/${person.slug}`
-                : `/people/${person.slug}`
-              : undefined;
-
-            const tenure = person.start
-              ? `${formatKBDate(person.start)}${person.end ? ` \u2013 ${formatKBDate(person.end)}` : " \u2013 present"}`
-              : "";
-
-            const isFormer = person.isCurrent === false;
-            const hasTags = person.isFounder || person.isBoard;
-
-            return (
-              <tr key={`${person.name}-${i}`} className={`hover:bg-muted/20 transition-colors${isFormer ? " opacity-60" : ""}`}>
-                <td className="py-1.5 px-3">
-                  <span className="flex items-center gap-1.5">
-                    {href ? (
-                      <Link href={href} className="font-medium text-foreground hover:text-primary transition-colors">
-                        {person.name}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{person.name}</span>
-                    )}
-                    {hasTags && (
-                      <>
-                        {person.isFounder && (
-                          <span className="px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-                            Founder
-                          </span>
-                        )}
-                        {person.isBoard && (
-                          <span className="px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
-                            Board
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </span>
-                </td>
-                <td className="py-1.5 px-3 text-muted-foreground">{person.title ?? ""}</td>
-                <td className="py-1.5 px-3 text-muted-foreground whitespace-nowrap text-xs">{tenure}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
 }
 
 export function Badge({ children, color }: { children: React.ReactNode; color?: string }) {

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -85,6 +85,9 @@ import {
 // Client-side tabs
 import { OrgProfileTabs, type OrgTab } from "./org-tabs";
 
+// ISR revalidation: refresh PG personnel data every hour (matches divisions/grants pages)
+export const revalidate = 3600;
+
 export function generateStaticParams() {
   return getOrgSlugs().map((slug) => ({ slug }));
 }
@@ -296,7 +299,6 @@ export default async function OrgProfilePage({
         isCurrent: !person.fields.end,
         start: field(person, "start"),
         end: field(person, "end"),
-        source: "factbase",
       });
     }
 
@@ -335,7 +337,6 @@ export default async function OrgProfilePage({
           isCurrent: !bm.departed,
           start: bm.appointed ?? undefined,
           end: bm.departed ?? undefined,
-          source: "factbase",
         });
       }
     }

--- a/apps/web/src/app/organizations/[slug]/people-section.test.ts
+++ b/apps/web/src/app/organizations/[slug]/people-section.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+import {
+  pgPersonnelToEntries,
+  mergePgPersonnel,
+  type PersonEntry,
+} from "./people-section";
+import type { RpcPersonnelRow } from "@/lib/wiki-server";
+
+// ── Test helpers ──────────────────────────────────────────────────────
+
+/** Build a minimal RpcPersonnelRow for testing. */
+function makeRow(overrides: Partial<RpcPersonnelRow> = {}): RpcPersonnelRow {
+  return {
+    id: "row-1",
+    personId: "person-1",
+    organizationId: "org-1",
+    role: "Engineer",
+    roleType: "key-person",
+    startDate: "2020-01-01",
+    endDate: null,
+    isFounder: false,
+    appointedBy: null,
+    background: null,
+    source: null,
+    notes: null,
+    person: { entityId: null, slug: null, name: null },
+    organization: { entityId: null, slug: null, name: null },
+    personEntityId: null,
+    personDisplayName: null,
+    personResolvedName: null,
+    orgEntityId: null,
+    orgDisplayName: null,
+    orgResolvedName: null,
+    syncedAt: "2024-01-01T00:00:00Z",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  } as RpcPersonnelRow;
+}
+
+function makeEntry(overrides: Partial<PersonEntry> = {}): PersonEntry {
+  return {
+    name: "Test Person",
+    isFounder: false,
+    isBoard: false,
+    isCurrent: true,
+    ...overrides,
+  };
+}
+
+// ── pgPersonnelToEntries ──────────────────────────────────────────────
+
+describe("pgPersonnelToEntries", () => {
+  it("converts a basic row to a PersonEntry", () => {
+    const row = makeRow({
+      personId: "alice",
+      role: "CEO",
+      roleType: "key-person",
+      startDate: "2020-01-01",
+      endDate: null,
+      isFounder: true,
+      person: { entityId: "e1", slug: "alice-smith", name: "Alice Smith" },
+    });
+
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      name: "Alice Smith",
+      title: "CEO",
+      slug: "alice-smith",
+      entityType: "person",
+      isFounder: true,
+      isBoard: false,
+      isCurrent: true,
+      start: "2020-01-01",
+      end: undefined,
+      roleType: "key-person",
+    });
+  });
+
+  it("uses personResolvedName as fallback when person.name is null", () => {
+    const row = makeRow({
+      person: { entityId: null, slug: null, name: null },
+      personResolvedName: "Resolved Name",
+    });
+
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries[0].name).toBe("Resolved Name");
+  });
+
+  it("uses personId as last-resort fallback name", () => {
+    const row = makeRow({
+      personId: "fallback-id",
+      person: { entityId: null, slug: null, name: null },
+      personResolvedName: null,
+    });
+
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries[0].name).toBe("fallback-id");
+  });
+
+  it("sets isCurrent=false when endDate is present", () => {
+    const row = makeRow({ endDate: "2023-12-31" });
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries[0].isCurrent).toBe(false);
+    expect(entries[0].end).toBe("2023-12-31");
+  });
+
+  it("marks board members correctly", () => {
+    const row = makeRow({ roleType: "board" });
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries[0].isBoard).toBe(true);
+    expect(entries[0].roleType).toBe("board");
+  });
+
+  it("sets roleType to undefined for invalid roleType values", () => {
+    const row = makeRow({ roleType: "unknown-type" as string });
+    const entries = pgPersonnelToEntries([row]);
+    expect(entries[0].roleType).toBeUndefined();
+  });
+
+  it("handles empty array input", () => {
+    const entries = pgPersonnelToEntries([]);
+    expect(entries).toEqual([]);
+  });
+
+  it("sets entityType only when slug is present", () => {
+    const withSlug = makeRow({
+      person: { entityId: "e1", slug: "alice", name: "Alice" },
+    });
+    const withoutSlug = makeRow({
+      person: { entityId: null, slug: null, name: "Bob" },
+    });
+
+    const entries = pgPersonnelToEntries([withSlug, withoutSlug]);
+    expect(entries[0].entityType).toBe("person");
+    expect(entries[1].entityType).toBeUndefined();
+  });
+});
+
+// ── mergePgPersonnel ──────────────────────────────────────────────────
+
+describe("mergePgPersonnel", () => {
+  it("adds new entries when no overlap exists", () => {
+    const existing = new Map<string, PersonEntry>();
+    existing.set("alice", makeEntry({ name: "Alice", slug: "alice" }));
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({ name: "Bob", slug: "bob", title: "Engineer" }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    expect(existing.size).toBe(2);
+    expect(existing.get("bob")).toBeDefined();
+    expect(existing.get("bob")!.name).toBe("Bob");
+  });
+
+  it("deduplicates by slug match", () => {
+    const existing = new Map<string, PersonEntry>();
+    existing.set("key-1", makeEntry({ name: "Alice A.", slug: "alice" }));
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({
+        name: "Alice Anderson",
+        slug: "alice",
+        title: "CEO",
+        start: "2020-01-01",
+      }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    // Should not add duplicate
+    expect(existing.size).toBe(1);
+    // Should enrich the existing entry
+    const alice = existing.get("key-1")!;
+    expect(alice.name).toBe("Alice A."); // Keeps original name
+    expect(alice.title).toBe("CEO"); // Enriched from PG
+    expect(alice.start).toBe("2020-01-01"); // Enriched from PG
+  });
+
+  it("deduplicates by case-insensitive name match", () => {
+    const existing = new Map<string, PersonEntry>();
+    existing.set("person-1", makeEntry({ name: "John Smith" }));
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({ name: "john smith", title: "Director", start: "2019-06-15" }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    expect(existing.size).toBe(1);
+    const john = existing.get("person-1")!;
+    expect(john.title).toBe("Director");
+    expect(john.start).toBe("2019-06-15");
+  });
+
+  it("enriches existing entry without overwriting present fields", () => {
+    const existing = new Map<string, PersonEntry>();
+    existing.set("key-1", makeEntry({
+      name: "Alice",
+      slug: "alice",
+      title: "Existing Title",
+      start: "2018-01-01",
+      isBoard: false,
+      isFounder: false,
+    }));
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({
+        name: "Alice",
+        slug: "alice",
+        title: "New Title",       // Should NOT overwrite
+        start: "2020-01-01",      // Should NOT overwrite
+        end: "2023-12-31",        // Should fill in (was missing)
+        isBoard: true,            // Should set to true
+        isFounder: true,          // Should set to true
+      }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    const alice = existing.get("key-1")!;
+    expect(alice.title).toBe("Existing Title"); // Not overwritten
+    expect(alice.start).toBe("2018-01-01");     // Not overwritten
+    expect(alice.end).toBe("2023-12-31");       // Filled in
+    expect(alice.isBoard).toBe(true);           // Set to true
+    expect(alice.isFounder).toBe(true);         // Set to true
+  });
+
+  it("handles empty PG entries", () => {
+    const existing = new Map<string, PersonEntry>();
+    existing.set("alice", makeEntry({ name: "Alice" }));
+
+    mergePgPersonnel(existing, []);
+
+    expect(existing.size).toBe(1);
+  });
+
+  it("handles empty existing map", () => {
+    const existing = new Map<string, PersonEntry>();
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({ name: "Alice", slug: "alice" }),
+      makeEntry({ name: "Bob" }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    expect(existing.size).toBe(2);
+    expect(existing.has("alice")).toBe(true);
+    expect(existing.has("Bob")).toBe(true);
+  });
+
+  it("uses name as dedup key when slug is absent", () => {
+    const existing = new Map<string, PersonEntry>();
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({ name: "Alice No-Slug" }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    expect(existing.has("Alice No-Slug")).toBe(true);
+  });
+
+  it("prefers slug match over name match", () => {
+    const existing = new Map<string, PersonEntry>();
+    // Person exists with slug "alice" but different display name
+    existing.set("key-1", makeEntry({ name: "Dr. Alice Smith", slug: "alice" }));
+    // Another person with name "Alice Smith" but different slug
+    existing.set("key-2", makeEntry({ name: "Alice Smith", slug: "alice-other" }));
+
+    const pgEntries: PersonEntry[] = [
+      makeEntry({
+        name: "Alice Smith",
+        slug: "alice",
+        title: "CEO",
+      }),
+    ];
+
+    mergePgPersonnel(existing, pgEntries);
+
+    // Should match by slug to key-1, not by name to key-2
+    expect(existing.size).toBe(2);
+    expect(existing.get("key-1")!.title).toBe("CEO");
+    expect(existing.get("key-2")!.title).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -7,7 +7,11 @@
  */
 import Link from "next/link";
 import { formatKBDate } from "@/components/wiki/factbase/format";
-import { fetchFromWikiServer } from "@/lib/wiki-server";
+import {
+  fetchFromWikiServer,
+  type RpcPersonnelByEntityResult,
+  type RpcPersonnelRow,
+} from "@/lib/wiki-server";
 import { SectionHeader } from "./org-shared";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -22,40 +26,13 @@ export interface PersonEntry {
   isCurrent: boolean;
   start?: string;
   end?: string;
-  /** Source of the data: "factbase" for KB data, "pg" for PG personnel table */
-  source?: "factbase" | "pg";
   roleType?: "key-person" | "board" | "career";
 }
 
-/** Shape of the entity ref returned by the personnel API */
-interface PersonnelEntityRef {
-  entityId: string | null;
-  slug: string | null;
-  name: string | null;
-}
+/** Max page size accepted by the wiki-server personnel endpoint */
+const MAX_PERSONNEL_LIMIT = 200;
 
-/** Shape of a personnel row from the wiki-server /api/personnel/by-entity/:entityId endpoint */
-interface PgPersonnelRow {
-  id: string;
-  personId: string;
-  organizationId: string;
-  role: string | null;
-  roleType: string;
-  startDate: string | null;
-  endDate: string | null;
-  isFounder: boolean;
-  person: PersonnelEntityRef;
-  personResolvedName: string | null;
-}
-
-/** Response shape from the wiki-server /api/personnel/by-entity/:entityId endpoint */
-interface PgPersonnelResponse {
-  entityId: string;
-  personnel: PgPersonnelRow[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+const VALID_ROLE_TYPES = new Set<string>(["key-person", "board", "career"]);
 
 // ── PG Data Fetching ──────────────────────────────────────────────────
 
@@ -63,11 +40,17 @@ interface PgPersonnelResponse {
  * Fetch personnel records for an organization from the wiki-server PG table.
  * Returns an empty array if the wiki-server is not configured or unavailable.
  */
-export async function fetchPgPersonnel(entityId: string): Promise<PgPersonnelRow[]> {
-  const data = await fetchFromWikiServer<PgPersonnelResponse>(
-    `/api/personnel/by-entity/${encodeURIComponent(entityId)}?limit=100&offset=0`,
+export async function fetchPgPersonnel(entityId: string): Promise<RpcPersonnelRow[]> {
+  const data = await fetchFromWikiServer<RpcPersonnelByEntityResult>(
+    `/api/personnel/by-entity/${encodeURIComponent(entityId)}?limit=${MAX_PERSONNEL_LIMIT}&offset=0`,
     { revalidate: 300, timeoutMs: 10_000 }
   );
+
+  if (data && data.total > data.personnel.length) {
+    console.warn(
+      `[people-section] Personnel data truncated for entity ${entityId}: showing ${data.personnel.length} of ${data.total} records`
+    );
+  }
 
   return data?.personnel ?? [];
 }
@@ -78,7 +61,7 @@ export async function fetchPgPersonnel(entityId: string): Promise<PgPersonnelRow
  * Convert PG personnel rows into PersonEntry format for merging with
  * existing FactBase key-persons and board-seats data.
  */
-export function pgPersonnelToEntries(rows: PgPersonnelRow[]): PersonEntry[] {
+export function pgPersonnelToEntries(rows: RpcPersonnelRow[]): PersonEntry[] {
   return rows.map((row) => {
     const personRef = row.person;
     const name = personRef?.name ?? row.personResolvedName ?? row.personId;
@@ -97,8 +80,9 @@ export function pgPersonnelToEntries(rows: PgPersonnelRow[]): PersonEntry[] {
       isCurrent,
       start: row.startDate ?? undefined,
       end: row.endDate ?? undefined,
-      source: "pg" as const,
-      roleType: row.roleType as PersonEntry["roleType"],
+      roleType: VALID_ROLE_TYPES.has(row.roleType)
+        ? (row.roleType as PersonEntry["roleType"])
+        : undefined,
     };
   });
 }
@@ -160,16 +144,14 @@ export function mergePgPersonnel(
  */
 export function PeopleSection({
   people,
-  totalCount,
 }: {
   people: PersonEntry[];
-  totalCount?: number;
 }) {
   if (people.length === 0) return null;
 
   return (
     <section>
-      <SectionHeader title="People" count={totalCount ?? people.length} />
+      <SectionHeader title="People" count={people.length} />
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead>

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -33,6 +33,12 @@ export default defineConfig({
       "@lib": path.resolve(__dirname, "./src/lib"),
       "@wiki-server/api-response-types": path.resolve(__dirname, "../wiki-server/src/api-response-types.ts"),
       "@wiki-server/api-types": path.resolve(__dirname, "../wiki-server/src/api-types.ts"),
+      "@wiki-server/facts-route": path.resolve(__dirname, "../wiki-server/src/routes/factbase/facts.ts"),
+      "@wiki-server/factbase-verifications-route": path.resolve(__dirname, "../wiki-server/src/routes/factbase/factbase-verifications.ts"),
+      "@wiki-server/grants-route": path.resolve(__dirname, "../wiki-server/src/routes/tablebase/grants.ts"),
+      "@wiki-server/divisions-route": path.resolve(__dirname, "../wiki-server/src/routes/tablebase/divisions.ts"),
+      "@wiki-server/funding-programs-route": path.resolve(__dirname, "../wiki-server/src/routes/tablebase/funding-programs.ts"),
+      "@wiki-server/personnel-route": path.resolve(__dirname, "../wiki-server/src/routes/tablebase/personnel.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary

Fixes 7 review issues found on PR #2864 (Org pages People tab with PG personnel data).

**Critical/Bug fixes:**
- Replace hand-written `PgPersonnelRow`/`PgPersonnelResponse` with RPC-inferred types from `wiki-server.ts`, eliminating type duplication that can silently drift
- Add `export const revalidate = 3600` to org page for ISR -- without this, PG personnel data was baked at build time and never refreshed
- Increase personnel fetch limit from 100 to 200 (server MAX_PAGE_SIZE) and add `console.warn` when results are truncated

**Style/cleanup:**
- Remove orphaned `PeopleTable` component from `org-shared.tsx` (no longer imported after the PR moved to `PeopleSection`)
- Remove unused `source` field from `PersonEntry` and unused `totalCount` prop from `PeopleSection`
- Add runtime validation for `roleType` (was doing unsafe `as` cast)
- Add 16 unit tests for `pgPersonnelToEntries` and `mergePgPersonnel` covering: basic conversion, fallback names, dedup by slug, dedup by case-insensitive name, enrichment without overwrite, empty inputs, slug preference over name
- Add missing `@wiki-server/*` route aliases to `vitest.config.ts` so test files that transitively import from `wiki-server.ts` can resolve Hono route types

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit` exits 0)
- [x] All 16 new tests pass (`vitest run people-section.test.ts`)
- [x] Full test suite passes (`pnpm test` -- 173 files, 3734 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)