### PR TITLE
fix: resource table column visibility and dead interface field

### DIFF
--- a/apps/web/src/app/resources/resources-table.tsx
+++ b/apps/web/src/app/resources/resources-table.tsx
@@ -327,6 +327,9 @@ const INITIAL_COLUMN_VISIBILITY: Record<string, boolean> = {
   id: false,
   tags: false,
   resourceSubtype: false,
+  citationCount: false, // 100% empty — sub-table data not in snapshot
+  publishedDate: false, // 91% empty
+  importanceScore: false, // 90% empty
 };
 
 export function ResourcesTable({ rows }: { rows: ResourceRow[] }) {

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -169,7 +169,6 @@ export interface Resource {
   published_date?: string;
   type: string;
   local_filename?: string;
-  importance?: number;
   abstract?: string;
   summary?: string;
   review?: string;
@@ -193,6 +192,7 @@ export interface Resource {
   related_entity_ids?: string[];
   enrichment_status?: string;
   importance_score?: number;
+  content_hash?: string;
   // Sub-table data
   paper?: ResourcePaper;
   forum_post?: ResourceForumPost;


### PR DESCRIPTION
## Summary

- Hide mostly-empty columns by default in the resources table: Cites (100% empty -- sub-table data not in snapshot), Published (91% empty), and Importance (90% empty). Users can still toggle them on via the column picker.
- Remove dead `importance` field from the `Resource` interface in `tablebase.ts` -- the actual field is `importance_score`, which already exists.
- Add missing `content_hash` field to the `Resource` interface.

## Test plan

- [x] `pnpm build` passes
- [x] Verified no code references the deleted `importance` field on Resource (only `importance_score` is used)
- [x] Column accessor keys match `makeColumns()` definitions (`citationCount`, `publishedDate`, `importanceScore`)

Generated with [Claude Code](https://claude.com/claude-code)