### PR TITLE
fix: align cited-by count in sources overview with resources page

### DIFF
--- a/apps/web/src/app/sources/sources-overview-content.tsx
+++ b/apps/web/src/app/sources/sources-overview-content.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getAllPublications, getAllResources } from "@/data";
+import { getAllPublications, getAllResources, getPagesForResource } from "@/data";
 
 export function SourcesOverviewContent() {
   const publications = getAllPublications();
@@ -8,7 +8,7 @@ export function SourcesOverviewContent() {
   const peerReviewed = publications.filter((p) => p.peer_reviewed).length;
   const withSummary = resources.filter((r) => r.summary).length;
   const citedResources = resources.filter(
-    (r) => r.cited_by && r.cited_by.length > 0,
+    (r) => getPagesForResource(r.id).length > 0,
   ).length;
 
   const stats = [


### PR DESCRIPTION
## Summary

Fixes a count discrepancy where the Sources overview component (`SourcesOverviewContent`) showed 4,526 resources "Cited by Pages" while the `/sources` App Router page showed 4,317.

**Root cause:** `SourcesOverviewContent` counted `r.cited_by && r.cited_by.length > 0` directly from the resource snapshot, while `page.tsx` used `getPagesForResource(r.id)` which resolves against the actual page index. The snapshot's `cited_by` array can contain stale page references.

**Fix:** Align `SourcesOverviewContent` to use `getPagesForResource()` — the same method used everywhere else.

## Test plan
- [x] Build passes
- [x] Both pages now show consistent counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)