### PR TITLE
fix: add ISR caching to uncached dynamic routes and noindex to factbase entity

### DIFF
--- a/apps/web/src/app/factbase/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/factbase/entity/[entityId]/page.tsx
@@ -110,6 +110,7 @@ export async function generateMetadata({
   const entity = getKBEntity(entityId);
   return {
     title: entity ? `KB: ${entity.name}` : `KB: ${entityId}`,
+    robots: { index: false },
   };
 }
 

--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -25,6 +25,9 @@ import {
   ArrowLeft,
 } from "lucide-react";
 
+// Cache for 1 hour — on-demand rendered to reduce build size.
+export const revalidate = 3600;
+
 interface PageProps {
   params: Promise<{ id: string }>;
 }

--- a/apps/web/src/app/resources/[id]/page.tsx
+++ b/apps/web/src/app/resources/[id]/page.tsx
@@ -33,6 +33,9 @@ import {
 import { cn } from "@lib/utils";
 import { safeHref } from "@/lib/directory-utils";
 
+// Cache for 1 hour — these on-demand pages get heavy bot traffic with 0% cache hits.
+export const revalidate = 3600;
+
 interface PageProps {
   params: Promise<{ id: string }>;
 }

--- a/apps/web/src/app/wiki/[id]/data/page.tsx
+++ b/apps/web/src/app/wiki/[id]/data/page.tsx
@@ -23,6 +23,8 @@ function isWikiId(id: string): boolean {
 
 // Opt out of static generation — these pages are debug/internal tools.
 export const dynamicParams = true;
+// Cache for 1 hour to reduce serverless function invocations from bots.
+export const revalidate = 3600;
 
 function Section({
   title,

--- a/apps/web/src/app/wiki/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/wiki/[id]/opengraph-image.tsx
@@ -4,6 +4,7 @@ import { wikiIdToSlug } from "@/lib/mdx";
 import { stripMdxEscapes } from "@/lib/inline-markdown";
 
 export const runtime = "nodejs";
+export const revalidate = 3600;
 export const alt = "Longterm Wiki";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";


### PR DESCRIPTION
## Summary

- Add `revalidate = 3600` (1-hour ISR cache) to 4 more dynamic routes that had 0% cache hit rate:
  - `/resources/[id]` — 86 req/day, 40% bot traffic
  - `/wiki/[id]/data` — 31 req/day, 97% bot traffic
  - `/wiki/[id]/opengraph-image` — 39 req/day, 95% bot traffic
  - `/publications/[id]` — 18 req/day, uncached
- Add `robots: { index: false }` to `/factbase/entity/[entityId]` metadata for consistency with the other 3 factbase detail pages

Follow-up to #2874 which blocked crawlers in robots.txt and added caching to factbase pages.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (3743 tests)
- [x] TypeScript compiles clean

Closes #2871

🤖 Generated with [Claude Code](https://claude.com/claude-code)
