### PR TITLE
Add wikiId E1012 to Greg Brockman entity

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2530,6 +2530,7 @@
 
 - id: greg-brockman
   stableId: Yq4s2cI7ng
+  wikiId: E1012
   type: person
   title: Greg Brockman
   description: >-


### PR DESCRIPTION
## Summary
- Add missing `wikiId: E1012` to Greg Brockman's entity in `data/entities/people.yaml`
- The ID was already allocated by the wiki-server but the YAML field was missing (discovered during #2340 page creation when wiki-server was unavailable)

## Test plan
- [x] One-line YAML change, no logic
- [x] wikiId E1012 confirmed allocated via `pnpm crux tb ids allocate greg-brockman`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
