### PR TITLE
feat: wire page templates into synthesis and improve prompts

### DIFF
--- a/crux/authoring/creator/synthesis.ts
+++ b/crux/authoring/creator/synthesis.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { spawn } from 'child_process';
 import { inferEntityType } from '../../lib/category-entity-types.ts';
 import { buildEntityLookupForTopic } from '../../lib/entity-lookup.ts';
+import { resolveTemplate, formatTemplateForPrompt } from '../../lib/content/page-templates.ts';
 import type { SynthesisPhaseContext, CreatorContext } from './types.ts';
 
 type LoadResultContext = Pick<Required<CreatorContext>, 'loadResult'>;
@@ -152,6 +153,13 @@ ${citationWarning}
 ${directionsSection}
 
 ${canonicalLinksSection}
+${(() => {
+    const entityType = destPath ? inferEntityType(destPath) : null;
+    const tmpl = resolveTemplate(undefined, entityType || undefined);
+    return tmpl
+      ? `## Template Structure\nThis page should follow the **${tmpl.name}** template. Structure your article to include the required sections.\n\n${formatTemplateForPrompt(tmpl)}\n`
+      : '';
+  })()}
 ## Requirements
 
 1. **CRITICAL: Use ONLY real URLs from the research data**

--- a/crux/authoring/page-improver/phases/analyze.ts
+++ b/crux/authoring/page-improver/phases/analyze.ts
@@ -11,12 +11,24 @@ import type { PageData, AnalysisResult, PipelineOptions } from '../types.ts';
 import { log, getFilePath, writeTemp } from '../utils.ts';
 import { runAgent } from '../api.ts';
 import { parseJsonFromLlm } from './json-parsing.ts';
+import { resolveTemplate, formatTemplateForPrompt } from '../../../lib/content/page-templates.ts';
+import { getPageType } from '../../../lib/page-analysis.ts';
 
 export async function analyzePhase(page: PageData, directions: string, options: PipelineOptions): Promise<AnalysisResult> {
   log('analyze', 'Starting analysis');
 
   const filePath = getFilePath(page.path);
   const currentContent = fs.readFileSync(filePath, 'utf-8');
+
+  // Resolve template for gap analysis
+  const pageType = getPageType(page);
+  const fmMatch = currentContent.match(/^---\n([\s\S]*?)\n---/);
+  const pageTemplateMatch = fmMatch?.[1]?.match(/^pageTemplate:\s*(.+)$/m);
+  const pageTemplateValue = pageTemplateMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
+  const template = resolveTemplate(pageTemplateValue, pageType);
+  const templateSection = template
+    ? `\n## Template Requirements\nThis page should follow the **${template.name}** template. When analyzing gaps, check whether required sections are present.\n\n${formatTemplateForPrompt(template)}\n`
+    : '';
 
   const prompt = `Analyze this wiki page for improvement opportunities.
 
@@ -35,7 +47,7 @@ ${directions || 'No specific directions provided - do a general quality improvem
 ${currentContent}
 \`\`\`
 
-## Analysis Required
+${templateSection}## Analysis Required
 
 Analyze the page and output a JSON object with:
 

--- a/crux/authoring/page-improver/phases/improve.ts
+++ b/crux/authoring/page-improver/phases/improve.ts
@@ -9,6 +9,8 @@ import fs from 'fs';
 import { MODELS } from '../../../lib/anthropic.ts';
 import { buildEntityLookupForContent } from '../../../lib/entity-lookup.ts';
 import { buildKbContextForPage } from '../../../lib/factbase-context.ts';
+import { resolveTemplate, formatTemplateForPrompt } from '../../../lib/content/page-templates.ts';
+import { getPageType } from '../../../lib/page-analysis.ts';
 import { convertSlugsToWikiIds } from '../../creator/deployment.ts';
 import { convertNewFootnotes } from '../../../lib/convert-new-footnotes.ts';
 import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '../types.ts';
@@ -51,12 +53,25 @@ export async function improvePhase(page: PageData, analysis: AnalysisResult, res
     log('improve', `  KB context load failed: ${error.message} — continuing without KB context`);
   }
 
+  // Resolve template for this page (explicit frontmatter > entity type inference)
+  const pageType = getPageType(page);
+  // Extract pageTemplate from frontmatter in the content
+  const fmMatch = currentContent.match(/^---\n([\s\S]*?)\n---/);
+  const pageTemplateMatch = fmMatch?.[1]?.match(/^pageTemplate:\s*(.+)$/m);
+  const pageTemplateValue = pageTemplateMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
+  const template = resolveTemplate(pageTemplateValue, pageType);
+  let templateContext: string | null = null;
+  if (template) {
+    templateContext = formatTemplateForPrompt(template);
+    log('improve', `  Using template: ${template.name}`);
+  }
+
   const tier = options.tier || 'standard';
   const prompt = IMPROVE_PROMPT({
     page, filePath, importPath, directions,
     analysis, research, objectivityContext,
     currentContent, entityLookup, claimsContext: null,
-    gapAnalysisContext: null, kbContext, tier,
+    gapAnalysisContext: null, kbContext, tier, templateContext,
   });
 
   const result = await runAgent(prompt, {

--- a/crux/authoring/page-improver/phases/prompts.ts
+++ b/crux/authoring/page-improver/phases/prompts.ts
@@ -23,10 +23,12 @@ interface ImprovePromptArgs {
   /** Structured KB facts for the page's entity, if one exists in the KB. */
   kbContext: string | null;
   tier: string;
+  /** Formatted template requirements (from resolveTemplate + formatTemplateForPrompt). */
+  templateContext: string | null;
 }
 
 export function IMPROVE_PROMPT(args: ImprovePromptArgs): string {
-  const { page, filePath, importPath, directions, analysis, research, objectivityContext, currentContent, entityLookup, claimsContext, gapAnalysisContext, kbContext, tier } = args;
+  const { page, filePath, importPath, directions, analysis, research, objectivityContext, currentContent, entityLookup, claimsContext, gapAnalysisContext, kbContext, tier, templateContext } = args;
 
   const isPolish = tier === 'polish';
   const pageType = getPageType(page);
@@ -57,7 +59,13 @@ ${currentContent}
 \`\`\`
 
 ## Improvement Instructions
+${templateContext ? `
+### Template Requirements
+This page should follow the **${templateContext.split('\n')[0].replace('Template: ', '')}** template structure.
+${templateContext}
 
+Check that all required sections exist. If a required section is missing, add it with substantive content (not stubs). Do not add empty sections just to satisfy the template — only add sections where you have content from the research or existing page to fill them.
+` : ''}
 ### Content Preservation (CRITICAL)
 You are EDITING an existing page, not rewriting it from scratch. Your output must preserve:
 - **ALL existing sections** — do not drop, merge, or summarize away existing sections

--- a/crux/lib/content/page-templates.test.ts
+++ b/crux/lib/content/page-templates.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PAGE_TEMPLATES,
+  resolveTemplate,
+  formatTemplateForPrompt,
+} from './page-templates.ts';
+
+describe('resolveTemplate', () => {
+  it('resolves explicit pageTemplate from frontmatter', () => {
+    const t = resolveTemplate('knowledge-base-risk');
+    expect(t).not.toBeNull();
+    expect(t!.id).toBe('knowledge-base-risk');
+  });
+
+  it('resolves from entity type when pageTemplate is absent', () => {
+    const t = resolveTemplate(undefined, 'person');
+    expect(t).not.toBeNull();
+    expect(t!.id).toBe('knowledge-base-person');
+  });
+
+  it('explicit pageTemplate takes precedence over entityType', () => {
+    const t = resolveTemplate('knowledge-base-risk', 'person');
+    expect(t!.id).toBe('knowledge-base-risk');
+  });
+
+  it('returns null for unknown entity type', () => {
+    expect(resolveTemplate(undefined, 'unknown-type')).toBeNull();
+  });
+
+  it('returns null when both are absent', () => {
+    expect(resolveTemplate(undefined, undefined)).toBeNull();
+  });
+
+  it('maps all expected entity types to templates', () => {
+    const mappings: Record<string, string> = {
+      risk: 'knowledge-base-risk',
+      approach: 'knowledge-base-response',
+      response: 'knowledge-base-response',
+      model: 'knowledge-base-model',
+      analysis: 'knowledge-base-model',
+      concept: 'knowledge-base-concept',
+      person: 'knowledge-base-person',
+      organization: 'knowledge-base-organization',
+      overview: 'knowledge-base-overview',
+    };
+    for (const [entityType, templateId] of Object.entries(mappings)) {
+      const t = resolveTemplate(undefined, entityType);
+      expect(t, `${entityType} should resolve to ${templateId}`).not.toBeNull();
+      expect(t!.id).toBe(templateId);
+    }
+  });
+});
+
+describe('formatTemplateForPrompt', () => {
+  it('includes template name', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-risk'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Template: Knowledge Base - Risk');
+  });
+
+  it('includes minimum word count', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-risk'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Minimum word count: 800');
+  });
+
+  it('lists required sections', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-risk'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Required sections');
+    expect(output).toContain('Overview');
+    expect(output).toContain('Risk Assessment');
+    expect(output).toContain('How It Works');
+    expect(output).toContain('Responses');
+    expect(output).toContain('Key Uncertainties');
+  });
+
+  it('lists alternate labels for sections', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-risk'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('(or: Mechanisms');
+  });
+
+  it('lists optional sections separately', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-person'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Optional sections');
+    expect(output).toContain('Criticism');
+  });
+
+  it('lists quality criteria (excluding word-count)', () => {
+    const t = PAGE_TEMPLATES['knowledge-base-risk'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Quality criteria');
+    expect(output).toContain('Has Risk Assessment Table');
+    expect(output).toContain('Has Citations');
+    // word-count is excluded from display
+    expect(output).not.toContain('Sufficient Length');
+  });
+
+  it('handles templates with no sections', () => {
+    const t = PAGE_TEMPLATES['data-table'];
+    const output = formatTemplateForPrompt(t);
+    expect(output).toContain('Template: Interactive Data Table');
+    expect(output).not.toContain('Required sections');
+  });
+});

--- a/crux/lib/content/page-templates.ts
+++ b/crux/lib/content/page-templates.ts
@@ -44,6 +44,91 @@ export interface PageTemplate {
   qualityCriteria: QualityCriterion[];
 }
 
+/**
+ * Map from entity type (or page type) to template ID.
+ * Used to auto-resolve templates when `pageTemplate` frontmatter is absent.
+ */
+const ENTITY_TYPE_TO_TEMPLATE: Record<string, string> = {
+  risk: 'knowledge-base-risk',
+  approach: 'knowledge-base-response',
+  response: 'knowledge-base-response',
+  model: 'knowledge-base-model',
+  analysis: 'knowledge-base-model',
+  concept: 'knowledge-base-concept',
+  person: 'knowledge-base-person',
+  organization: 'knowledge-base-organization',
+  overview: 'knowledge-base-overview',
+};
+
+/**
+ * Resolve the best-matching template for a page.
+ * Priority: explicit `pageTemplate` frontmatter > entity type mapping.
+ * Returns null if no template matches.
+ */
+export function resolveTemplate(pageTemplate?: string, entityType?: string): PageTemplate | null {
+  if (pageTemplate && PAGE_TEMPLATES[pageTemplate]) {
+    return PAGE_TEMPLATES[pageTemplate];
+  }
+  if (entityType) {
+    const templateId = ENTITY_TYPE_TO_TEMPLATE[entityType];
+    if (templateId && PAGE_TEMPLATES[templateId]) {
+      return PAGE_TEMPLATES[templateId];
+    }
+  }
+  return null;
+}
+
+/**
+ * Format a template's requirements as a prompt-friendly string.
+ * Used to inject template structure into LLM synthesis/improve prompts.
+ */
+export function formatTemplateForPrompt(template: PageTemplate): string {
+  const lines: string[] = [];
+  lines.push(`Template: ${template.name}`);
+
+  if (template.minWordCount) {
+    lines.push(`Minimum word count: ${template.minWordCount}`);
+  }
+
+  const requiredSections = template.sections.filter(s => s.required);
+  const optionalSections = template.sections.filter(s => !s.required);
+
+  if (requiredSections.length > 0) {
+    lines.push('');
+    lines.push('Required sections (MUST be present as ## headings):');
+    for (const s of requiredSections) {
+      const alts = s.alternateLabels.length > 0
+        ? ` (or: ${s.alternateLabels.join(', ')})`
+        : '';
+      lines.push(`  - ${s.label}${alts}`);
+    }
+  }
+
+  if (optionalSections.length > 0) {
+    lines.push('');
+    lines.push('Optional sections (include if content supports them):');
+    for (const s of optionalSections) {
+      const alts = s.alternateLabels.length > 0
+        ? ` (or: ${s.alternateLabels.join(', ')})`
+        : '';
+      lines.push(`  - ${s.label}${alts}`);
+    }
+  }
+
+  const qualityCriteria = template.qualityCriteria.filter(
+    c => c.id !== 'word-count'
+  );
+  if (qualityCriteria.length > 0) {
+    lines.push('');
+    lines.push('Quality criteria (aim to satisfy these):');
+    for (const c of qualityCriteria) {
+      lines.push(`  - ${c.label}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 export const PAGE_TEMPLATES: Record<string, PageTemplate> = {
   'knowledge-base-risk': {
     id: 'knowledge-base-risk',


### PR DESCRIPTION
## Summary
- Add `resolveTemplate()` and `formatTemplateForPrompt()` to `page-templates.ts` — maps entity types to templates and renders requirements as prompt-friendly text
- Wire template requirements into the **improve** pipeline (`prompts.ts`, `improve.ts`) so the LLM knows about required sections and quality criteria
- Wire template context into the **analyze** pipeline (`analyze.ts`) so gap detection identifies missing template sections
- Wire template structure into the **create** pipeline (`synthesis.ts`) so new pages follow template structure from the start
- Add 13 tests covering `resolveTemplate()` and `formatTemplateForPrompt()`

Templates were defined but only used for post-hoc grading. Now they actively guide content generation.

Closes #128

## Test plan
- [x] 13 unit tests pass for `resolveTemplate()` and `formatTemplateForPrompt()`
- [x] `pnpm build` passes (full production build)
- [x] `pnpm test` passes (all 678 tests)
- [x] TypeScript check passes for all modified files (only pre-existing errors in unrelated citation files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
