### PR TITLE
Switch database.json to compact JSON format

### DIFF
--- a/apps/web/scripts/lib/output-writer.mjs
+++ b/apps/web/scripts/lib/output-writer.mjs
@@ -51,7 +51,7 @@ export function writeMainOutputFiles({ database, outputFile }) {
     relatedGraph: _relatedGraph,
     ...databaseForOutput
   } = database;
-  writeFileSync(outputFile, JSON.stringify(databaseForOutput, null, 2));
+  writeFileSync(outputFile, JSON.stringify(databaseForOutput));
   const strippedKeys = [
     'benchmarkResults', 'citationQuotes', 'recordVerdicts', 'kbFactVerification',
     'researchAreas', 'pageReferenceIndex', 'prItems', 'updateSchedule',
@@ -62,7 +62,7 @@ export function writeMainOutputFiles({ database, outputFile }) {
   // Write FactBase data to a separate file (loaded independently by factbase.ts)
   const FACTBASE_OUTPUT_FILE = join(OUTPUT_DIR, 'factbase-data.json');
   if (_kbData) {
-    writeFileSync(FACTBASE_OUTPUT_FILE, JSON.stringify(_kbData, null, 2));
+    writeFileSync(FACTBASE_OUTPUT_FILE, JSON.stringify(_kbData));
     console.log(`✓ Written: ${FACTBASE_OUTPUT_FILE} (FactBase facts, records, schemas — entities owned by TableBase)`);
   } else {
     console.warn('⚠ FactBase data not available — factbase-data.json not written');


### PR DESCRIPTION
## Summary
- Remove pretty-printing (`null, 2`) from `database.json` and `factbase-data.json` output in `writeMainOutputFiles()`
- Saves ~30-40% file size with no functional change — both files are gitignored and consumed only by the Next.js build

## Test plan
- [x] `pnpm build-data:content` succeeds and produces valid JSON
- [x] Pre-existing test failures confirmed identical on parent branch (not introduced by this change)
- [x] TypeScript errors are pre-existing wiki-server schema issues, unrelated to `.mjs` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
