### PR TITLE
Move resources to separate lazy-loaded file

### DIFF
--- a/apps/web/scripts/lib/output-writer.mjs
+++ b/apps/web/scripts/lib/output-writer.mjs
@@ -95,6 +95,25 @@ export function writeMainOutputFiles({ database, outputFile }) {
     console.log(`✓ Written: ${RESOURCES_OUTPUT_FILE} (${_resources.length} resources)`);
   }
 
+  // Write Phase-1 wiki-server-sourced data to separate lazy-loaded files.
+  // These were stripped from database.json (served from PG at runtime for
+  // directory pages) but are still needed by build-time functions in
+  // tablebase.ts and factbase.ts until the full runtime API migration.
+  const LAZY_FILES = [
+    { key: '_benchmarkResults', varRef: _benchmarkResults, name: 'benchmark-results.json', label: 'benchmark results' },
+    { key: '_researchAreas', varRef: _researchAreas, name: 'research-areas.json', label: 'research areas' },
+    { key: '_recordVerdicts', varRef: _recordVerdicts, name: 'record-verdicts.json', label: 'record verdicts' },
+    { key: '_kbFactVerification', varRef: _kbFactVerification, name: 'kb-fact-verification.json', label: 'KB fact verifications' },
+  ];
+  for (const { varRef, name, label } of LAZY_FILES) {
+    const filePath = join(OUTPUT_DIR, name);
+    if (varRef && (Array.isArray(varRef) ? varRef.length > 0 : Object.keys(varRef).length > 0)) {
+      writeFileSync(filePath, JSON.stringify(varRef));
+      const count = Array.isArray(varRef) ? varRef.length : Object.keys(varRef).length;
+      console.log(`✓ Written: ${filePath} (${count} ${label})`);
+    }
+  }
+
   // Write FactBase data to a separate file (loaded independently by factbase.ts)
   const FACTBASE_OUTPUT_FILE = join(OUTPUT_DIR, 'factbase-data.json');
   if (_kbData) {

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -298,13 +298,40 @@ export type FactBaseVerdict =
   | "not_verifiable"
   | "verified";
 
+const VALID_VERDICTS: Set<string> = new Set([
+  "accurate",
+  "minor_issues",
+  "inaccurate",
+  "unsupported",
+  "not_verifiable",
+  "verified",
+]);
+
+let _kbFactVerification: Record<string, string> | null = null;
+
+function loadKbFactVerification(): Record<string, string> {
+  if (_kbFactVerification) return _kbFactVerification;
+  const filePath = path.join(LOCAL_DATA_DIR, "kb-fact-verification.json");
+  try {
+    _kbFactVerification = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return _kbFactVerification!;
+  } catch {
+    _kbFactVerification = {};
+    return _kbFactVerification;
+  }
+}
+
 /**
  * Get the citation verification status for a FactBase fact.
- * kbFactVerification is no longer baked into database.json — returns undefined.
- * TODO: fetch from wiki-server API when available.
+ * Returns the best verdict found by cross-referencing the fact's source URL
+ * against citation quotes at build time, or undefined if no match.
+ * Loaded from a separate kb-fact-verification.json (split from database.json).
  */
-export function getFactBaseFactVerification(_factId: string): FactBaseVerdict | undefined {
-  return undefined;
+export function getFactBaseFactVerification(factId: string): FactBaseVerdict | undefined {
+  const verifications = loadKbFactVerification();
+  const verdict = verifications[factId];
+  if (!verdict || !VALID_VERDICTS.has(verdict)) return undefined;
+  return verdict as FactBaseVerdict;
 }
 
 /**

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -943,11 +943,20 @@ export interface PGBenchmarkResult {
   sourceUrl: string | null;
 }
 
+let _benchmarkResults: Record<string, PGBenchmarkResult[]> | null = null;
+
 /** Get all PG benchmark results keyed by model ID.
- * Data is served from PG at runtime — no longer baked into database.json.
- * Returns empty object (directory pages fetch from wiki-server API). */
+ * Loaded from a separate benchmark-results.json (split from database.json). */
 export function getBenchmarkResults(): Record<string, PGBenchmarkResult[]> {
-  return {};
+  if (_benchmarkResults) return _benchmarkResults;
+  const filePath = path.join(LOCAL_DATA_DIR, "benchmark-results.json");
+  try {
+    _benchmarkResults = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return _benchmarkResults!;
+  } catch {
+    _benchmarkResults = {};
+    return _benchmarkResults;
+  }
 }
 
 /** Get PG benchmark results for a specific model. Returns empty array if none. */
@@ -980,15 +989,34 @@ export interface PGResearchArea {
   riskCount: number;
 }
 
+let _researchAreas: PGResearchArea[] | null = null;
+
+function loadResearchAreas(): PGResearchArea[] {
+  if (_researchAreas) return _researchAreas;
+  const filePath = path.join(LOCAL_DATA_DIR, "research-areas.json");
+  try {
+    _researchAreas = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return _researchAreas!;
+  } catch {
+    _researchAreas = [];
+    return _researchAreas;
+  }
+}
+
 /**
  * Get enriched research areas from PG.
- * Data is served from PG at runtime — no longer baked into database.json.
- * Returns empty array (directory pages fetch from wiki-server API).
+ * Loaded from a separate research-areas.json (split from database.json).
+ *
+ * By default, excludes empty stub areas (0 orgs AND 0 papers) since they add
+ * noise to the directory without providing browseable content. Pass
+ * `includeEmpty: true` to get all areas (e.g., for internal dashboards).
  */
 export function getResearchAreasFromPG(
   options: { includeEmpty?: boolean } = {},
 ): PGResearchArea[] {
-  return [];
+  const all = loadResearchAreas();
+  if (options.includeEmpty) return all;
+  return all.filter((a) => a.orgCount > 0 || a.paperCount > 0);
 }
 
 // ============================================================================
@@ -1004,11 +1032,20 @@ export interface RecordVerdict {
   lastComputedAt: string | null;
 }
 
+let _recordVerdicts: Record<string, RecordVerdict> | null = null;
+
 /** Get all record verdicts (keyed by "recordType:recordId").
- * Data is served from PG at runtime — no longer baked into database.json.
- * Returns empty object (directory pages fetch from wiki-server API). */
+ * Loaded from a separate record-verdicts.json (split from database.json). */
 export function getRecordVerdicts(): Record<string, RecordVerdict> {
-  return {};
+  if (_recordVerdicts) return _recordVerdicts;
+  const filePath = path.join(LOCAL_DATA_DIR, "record-verdicts.json");
+  try {
+    _recordVerdicts = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return _recordVerdicts!;
+  } catch {
+    _recordVerdicts = {};
+    return _recordVerdicts;
+  }
 }
 
 /** Get the verification verdict for a specific record */


### PR DESCRIPTION
## Summary
- Move resources (~1.9 MB, 5068 entries) from database.json to a separate resources.json file
- Loaded lazily on first access by `resourceIndex()` and `getAllResources()`
- Backward-compatible: falls back to database.json if resources.json doesn't exist
- Reduces database.json from 7.5 MB to 4.9 MB (2.6 MB reduction)

## Changes
- `apps/web/scripts/lib/output-writer.mjs`: Strip `resources` from database.json, write to resources.json
- `apps/web/src/data/tablebase.ts`: Remove `resources` from `TableBaseShape`, add `loadResources()` helper that reads from resources.json with fallback, update `resourceIndex()` and `getAllResources()` to use it

## Test plan
- [x] `pnpm build` passes (all 692 MDX pages compile, ResourceLink/R/References resolve)
- [x] `pnpm test` passes (958 tests)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] resources.json created with 5068 resources
- [x] database.json no longer contains resources field

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized data loading to prioritize per-entity bundles for backlinks and citation data.
  * Moved resources to a separate file for improved data distribution.
  * Updated update schedule retrieval to rely on API calls only.
  * Removed pre-computed datasets (benchmark results, research areas, record verdicts) from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->