### PR TITLE
refactor: migrate citation imports to unified citation-service

### DIFF
--- a/crux/authoring/orchestrator/tools/audit-citations.ts
+++ b/crux/authoring/orchestrator/tools/audit-citations.ts
@@ -5,7 +5,7 @@
  * Cost: ~$0.20.
  */
 
-import { auditCitations, type AuditRequest } from '../../../lib/citation/citation-auditor.ts';
+import { auditCitations, type AuditRequest } from '../../../lib/citation/citation-service.ts';
 import type { ToolRegistration } from './types.ts';
 
 export const tool: ToolRegistration = {

--- a/crux/authoring/orchestrator/tools/deep-citation-check.ts
+++ b/crux/authoring/orchestrator/tools/deep-citation-check.ts
@@ -8,7 +8,7 @@
  * Cost: $0 (local parsing).
  */
 
-import { extractCitationsFromContent } from '../../../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../../../lib/citation/citation-service.ts';
 import { stripFrontmatter } from '../../../lib/patterns.ts';
 import type { ToolRegistration } from './types.ts';
 

--- a/crux/authoring/orchestrator/types.ts
+++ b/crux/authoring/orchestrator/types.ts
@@ -8,7 +8,7 @@
 
 import type { SourceCacheEntry } from '../../lib/content/section-writer.ts';
 import type { ParsedSection, SplitPage } from '../../lib/content/section-splitter.ts';
-import type { CitationAudit } from '../../lib/citation/citation-auditor.ts';
+import type { CitationAudit } from '../../lib/citation/citation-service.ts';
 import type { CostTracker } from '../../lib/cost-tracker.ts';
 
 // ---------------------------------------------------------------------------

--- a/crux/authoring/page-improver/phases/citation-audit.test.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.test.ts
@@ -11,8 +11,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildAuditorSourceCache, citationAuditPhase } from './citation-audit.ts';
-import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation/citation-auditor.ts';
-import type { AuditResult } from '../../../lib/citation/citation-auditor.ts';
+import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation/citation-service.ts';
+import type { AuditResult } from '../../../lib/citation/citation-service.ts';
 import type { SourceCacheEntry } from '../../../lib/content/section-writer.ts';
 import type { ResearchResult, PipelineOptions, PageData } from '../types.ts';
 

--- a/crux/authoring/page-improver/phases/citation-audit.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.ts
@@ -18,7 +18,7 @@
  * See issue #670.
  */
 
-import { auditCitations, MIN_SOURCE_CONTENT_LENGTH, type AuditResult, type SourceCache } from '../../../lib/citation/citation-auditor.ts';
+import { auditCitations, MIN_SOURCE_CONTENT_LENGTH, type AuditResult, type SourceCache } from '../../../lib/citation/citation-service.ts';
 import type { SourceCacheEntry } from '../../../lib/content/section-writer.ts';
 import type { FetchedSource } from '../../../lib/search/source-fetcher.ts';
 import type { PageData, ResearchResult, PipelineOptions } from '../types.ts';

--- a/crux/authoring/page-improver/phases/research.ts
+++ b/crux/authoring/page-improver/phases/research.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 import { MODELS } from '../../../lib/anthropic.ts';
 import { fetchSources, type FetchRequest, type FetchedSource } from '../../../lib/search/source-fetcher.ts';
-import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation/citation-auditor.ts';
+import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation/citation-service.ts';
 import type { SourceCacheEntry } from '../../../lib/content/section-writer.ts';
 import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '../types.ts';
 import { log, writeTemp } from '../utils.ts';

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { SourceCacheEntry } from '../../lib/content/section-writer.ts';
-import type { AuditResult } from '../../lib/citation/citation-auditor.ts';
+import type { AuditResult } from '../../lib/citation/citation-service.ts';
 
 export interface TierConfig {
   name: string;

--- a/crux/auto-update/ci-audit.ts
+++ b/crux/auto-update/ci-audit.ts
@@ -28,7 +28,7 @@ import { getColors } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
-import { extractCitationsFromContent } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import { checkAccuracyForPage } from '../citations/check-accuracy.ts';
 import { exportDashboardData } from '../citations/export-dashboard.ts';
 import type { AccuracyResult } from '../citations/check-accuracy.ts';

--- a/crux/auto-update/ci-verify-citations.ts
+++ b/crux/auto-update/ci-verify-citations.ts
@@ -21,10 +21,8 @@ import { parse as parseYaml } from 'yaml';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
-import {
-  verifyCitationsForPage,
-  extractCitationsFromContent,
-} from '../lib/citation/citation-archive.ts';
+import { verifyCitationsForPage } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/crux/citations/audit-check.ts
+++ b/crux/citations/audit-check.ts
@@ -31,8 +31,7 @@ import { fileURLToPath } from 'url';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
-import { auditCitations } from '../lib/citation/citation-auditor.ts';
-import type { CitationAudit } from '../lib/citation/citation-auditor.ts';
+import { auditCitations, type CitationAudit } from '../lib/citation/citation-service.ts';
 
 const DEFAULT_THRESHOLD = 0.8;
 const DEFAULT_DELAY_MS = 300;

--- a/crux/citations/audit.ts
+++ b/crux/citations/audit.ts
@@ -19,7 +19,7 @@ import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
-import { extractCitationsFromContent } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import { DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
 import { extractQuotesForPage } from './extract-quotes.ts';
 import { checkAccuracyForPage } from './check-accuracy.ts';

--- a/crux/citations/extract-quotes.ts
+++ b/crux/citations/extract-quotes.ts
@@ -19,10 +19,8 @@ import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
 import { getColors } from '../lib/output.ts';
 import { parseCliArgs } from '../lib/cli.ts';
-import {
-  extractCitationsFromContent,
-  extractClaimSentence,
-} from '../lib/citation/citation-archive.ts';
+import { extractClaimSentence } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import { fetchSource } from '../lib/search/source-fetcher.ts';
 import {
   getQuote,

--- a/crux/citations/shared.ts
+++ b/crux/citations/shared.ts
@@ -10,7 +10,7 @@ import { basename } from 'path';
 import { CONTENT_DIR_ABS } from '../lib/content-types.ts';
 import { findMdxFiles } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
-import { extractCitationsFromContent } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import type { Colors } from '../lib/output.ts';
 
 // ---------------------------------------------------------------------------

--- a/crux/citations/verify-citations.ts
+++ b/crux/citations/verify-citations.ts
@@ -21,10 +21,10 @@ import { getColors } from '../lib/output.ts';
 import { parseCliArgs } from '../lib/cli.ts';
 import {
   verifyCitationsForPage,
-  extractCitationsFromContent,
   readCitationArchive,
   type CitationArchiveFile,
 } from '../lib/citation/citation-archive.ts';
+import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import { fetchAndVerifyClaim } from '../lib/search/source-fetcher.ts';
 import { findPagesWithCitations } from './shared.ts';
 import { getResourceByUrl } from '../lib/search/resource-lookup.ts';

--- a/crux/lib/citation/citation-archive.ts
+++ b/crux/lib/citation/citation-archive.ts
@@ -377,7 +377,7 @@ export function extractClaimSentence(body: string, footnoteNum: number): string 
 // Content fetching — delegates to source-fetcher.ts (single fetch layer)
 // ---------------------------------------------------------------------------
 
-export interface FetchResult {
+interface FetchResult {
   httpStatus: number;
   pageTitle: string | null;
   contentSnippet: string | null;
@@ -428,7 +428,7 @@ function sourceToFetchResult(source: FetchedSource): FetchResult {
  * Returns a FetchResult for backward compatibility with callers that
  * use the legacy interface.
  */
-export async function fetchCitationUrl(url: string): Promise<FetchResult> {
+async function fetchCitationUrl(url: string): Promise<FetchResult> {
   const source = await fetchSource({ url, extractMode: 'full' });
   return sourceToFetchResult(source);
 }

--- a/crux/lib/citation/citation-service.ts
+++ b/crux/lib/citation/citation-service.ts
@@ -266,6 +266,7 @@ export {
 } from './citation-archive.ts';
 
 export {
+  auditCitations,
   type AuditResult,
   type AuditVerdict,
   type CitationAudit,


### PR DESCRIPTION
## Summary

Sub-PR C of #1479. Migrates 16 files to import from `citation-service.ts` instead of directly from `citation-archive.ts` and `citation-auditor.ts`.

### Changes

- **14 consumer files** migrated to import `extractCitationsFromContent`, `auditCitations`, and types from `citation-service.ts`
- **citation-archive.ts**: Made `fetchCitationUrl` and `FetchResult` non-exported (only used internally)
- **citation-service.ts**: Added `auditCitations` to re-exports

### Files migrated
`crux/citations/audit.ts`, `audit-check.ts`, `shared.ts`, `extract-quotes.ts`, `verify-citations.ts`
`crux/auto-update/ci-verify-citations.ts`, `ci-audit.ts`
`crux/authoring/page-improver/phases/citation-audit.ts`, `research.ts`, `types.ts`
`crux/authoring/orchestrator/tools/audit-citations.ts`, `deep-citation-check.ts`, `types.ts`

Net: -4 lines. Pure import migration — no behavior changes.

Depends on: #2898 (Sub-PR B)
Closes #1479

## Test plan
- [x] All citation tests pass (45/45)
- [x] TypeScript errors match baseline (12 pre-existing, 0 new)
- [x] No behavior changes — import paths only

🤖 Generated with [Claude Code](https://claude.com/claude-code)