### PR TITLE
feat: auto-retry CodeRabbit reviews after rate limit expires

### DIFF
--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -160,6 +160,46 @@ export function detectIssues(
   return { issues, botComments, failingChecks };
 }
 
+// ── CodeRabbit rate-limit detection ──────────────────────────────────────────
+
+/**
+ * Check if CodeRabbit's status context indicates the review was skipped
+ * due to rate limiting.
+ *
+ * CodeRabbit adds a StatusContext with `context: "CodeRabbit"`. When rate-limited,
+ * the `state` will be "PENDING" or "ERROR" rather than "SUCCESS".
+ * We also check review thread comments from coderabbitai for rate-limit keywords.
+ */
+export function detectCodeRabbitRateLimited(pr: GqlPrNode): boolean {
+  // Check StatusContext entries for CodeRabbit with non-success state
+  const contexts =
+    pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? [];
+  for (const ctx of contexts) {
+    if (
+      ctx.context?.toLowerCase() === 'coderabbit' &&
+      (ctx.state === 'PENDING' || ctx.state === 'ERROR' || ctx.state === 'FAILURE')
+    ) {
+      return true;
+    }
+  }
+
+  // Check review thread comments for rate-limit messages from coderabbitai
+  const threads = pr.reviewThreads?.nodes ?? [];
+  for (const thread of threads) {
+    if (thread.isResolved || thread.isOutdated) continue;
+    for (const comment of thread.comments.nodes) {
+      if (
+        comment.author?.login === 'coderabbitai' &&
+        /rate limit|review skipped/i.test(comment.body)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 // ── PR fetching ──────────────────────────────────────────────────────────────
 
 /** Fetch all open PRs via GraphQL. No logging — callers handle their own. */

--- a/crux/lib/pr-analysis/index.ts
+++ b/crux/lib/pr-analysis/index.ts
@@ -44,6 +44,7 @@ export { ADVISORY_ISSUES } from './types.ts';
 export {
   extractBotComments,
   detectIssues,
+  detectCodeRabbitRateLimited,
   fetchOpenPrs,
   fetchSinglePr,
   detectOverlaps,

--- a/crux/pr-patrol/detection.test.ts
+++ b/crux/pr-patrol/detection.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { detectIssues, extractBotComments, detectAllPrIssuesFromNodes } from './detection.ts';
+import { detectCodeRabbitRateLimited } from '../lib/pr-analysis/detection.ts';
 import type { GqlPrNode, PatrolConfig } from './types.ts';
 
 function makePrNode(overrides: Partial<GqlPrNode> = {}): GqlPrNode {
@@ -408,5 +409,192 @@ describe('detectAllPrIssuesFromNodes — bot/release PR skipping', () => {
     });
     const result = detectAllPrIssuesFromNodes([pr], verboseConfig);
     expect(result.find((r) => r.number === 41)).toBeUndefined();
+  });
+});
+
+// ── detectCodeRabbitRateLimited ──────────────────────────────────────────────
+
+describe('detectCodeRabbitRateLimited', () => {
+  it('returns true when CodeRabbit StatusContext is PENDING', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ context: 'CodeRabbit', state: 'PENDING' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
+  });
+
+  it('returns true when CodeRabbit StatusContext is ERROR', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ context: 'CodeRabbit', state: 'ERROR' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
+  });
+
+  it('returns true when CodeRabbit StatusContext is FAILURE', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ context: 'CodeRabbit', state: 'FAILURE' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
+  });
+
+  it('returns false when CodeRabbit StatusContext is SUCCESS', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ context: 'CodeRabbit', state: 'SUCCESS' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(false);
+  });
+
+  it('returns false when no CodeRabbit context exists', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ name: 'build', conclusion: 'SUCCESS' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(false);
+  });
+
+  it('returns true when coderabbitai comment mentions "rate limit"', () => {
+    const pr = makePrNode({
+      reviewThreads: {
+        nodes: [{
+          id: 'thread-rl',
+          isResolved: false,
+          isOutdated: false,
+          path: 'src/foo.ts',
+          line: 1,
+          startLine: null,
+          comments: {
+            nodes: [{ author: { login: 'coderabbitai' }, body: 'Rate limit exceeded. Please wait 30 minutes.' }],
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
+  });
+
+  it('returns true when coderabbitai comment mentions "Review skipped"', () => {
+    const pr = makePrNode({
+      reviewThreads: {
+        nodes: [{
+          id: 'thread-rs',
+          isResolved: false,
+          isOutdated: false,
+          path: 'src/bar.ts',
+          line: 5,
+          startLine: null,
+          comments: {
+            nodes: [{ author: { login: 'coderabbitai' }, body: 'Review skipped due to rate limiting.' }],
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
+  });
+
+  it('ignores resolved rate-limit threads', () => {
+    const pr = makePrNode({
+      reviewThreads: {
+        nodes: [{
+          id: 'thread-resolved',
+          isResolved: true,
+          isOutdated: false,
+          path: 'src/foo.ts',
+          line: 1,
+          startLine: null,
+          comments: {
+            nodes: [{ author: { login: 'coderabbitai' }, body: 'Rate limit exceeded.' }],
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(false);
+  });
+
+  it('ignores rate-limit comments from non-coderabbit authors', () => {
+    const pr = makePrNode({
+      reviewThreads: {
+        nodes: [{
+          id: 'thread-human',
+          isResolved: false,
+          isOutdated: false,
+          path: 'src/foo.ts',
+          line: 1,
+          startLine: null,
+          comments: {
+            nodes: [{ author: { login: 'humanuser' }, body: 'Rate limit exceeded on my local.' }],
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(false);
+  });
+
+  it('returns false for a clean PR with no rate-limit signals', () => {
+    const pr = makePrNode();
+    expect(detectCodeRabbitRateLimited(pr)).toBe(false);
+  });
+
+  it('is case-insensitive for CodeRabbit context name', () => {
+    const pr = makePrNode({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [{ context: 'coderabbit', state: 'PENDING' }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    expect(detectCodeRabbitRateLimited(pr)).toBe(true);
   });
 });

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -76,9 +76,12 @@ export { JSONL_FILE, REFLECTION_FILE, PARALLEL_STATE_FILE, getParallelState } fr
 import type { PatrolConfig } from './types.ts';
 import {
   appendJsonl,
+  clearCodeRabbitRetryTime,
   clearProcessed,
   clearTrackedMainFixPr,
+  CODERABBIT_DEFAULT_RETRY_DELAY_MS,
   ensureDirs,
+  getCodeRabbitRetryTime,
   getTrackedMainFixPr,
   isAbandoned,
   isCircuitOpen,
@@ -86,12 +89,14 @@ import {
   JSONL_FILE as JSONL_FILE_INTERNAL,
   log,
   logHeader,
+  setCodeRabbitRetryTime,
 } from './state.ts';
 import {
   detectAllPrIssuesFromNodes,
   detectPrOverlaps,
   fetchOpenPrs as daemonFetchOpenPrs,
 } from './detection.ts';
+import { detectCodeRabbitRateLimited } from '../lib/pr-analysis/detection.ts';
 import { rankPrs as daemonRankPrs } from './scoring.ts';
 import {
   findMergeCandidates as daemonFindMergeCandidates,
@@ -339,6 +344,70 @@ async function runCheckCycle(
     }
   }
 
+  // ── CodeRabbit review retry phase ────────────────────────────────────
+  // When CodeRabbit rate-limits a PR review, schedule a retry and post
+  // `@coderabbitai review` after the cooldown expires.
+
+  for (const pr of allPrs) {
+    const isRateLimited = detectCodeRabbitRateLimited(pr);
+
+    if (!isRateLimited) {
+      // Not rate-limited — clear any pending retry (review succeeded or not applicable)
+      clearCodeRabbitRetryTime(pr.number);
+      continue;
+    }
+
+    const existingRetry = getCodeRabbitRetryTime(pr.number);
+
+    if (!existingRetry) {
+      // First time seeing rate limit — schedule retry
+      const retryAt = new Date(Date.now() + CODERABBIT_DEFAULT_RETRY_DELAY_MS).toISOString();
+      setCodeRabbitRetryTime(pr.number, retryAt);
+      log(`  PR #${pr.number}: CodeRabbit rate-limited — scheduled retry at ${retryAt}`);
+      continue;
+    }
+
+    // Check if it's time to retry
+    const retryTime = new Date(existingRetry).getTime();
+    if (Date.now() < retryTime) {
+      const minutesLeft = Math.ceil((retryTime - Date.now()) / 60000);
+      if (config.verbose) {
+        log(`  ${cl.dim}PR #${pr.number}: CodeRabbit retry in ~${minutesLeft}min${cl.reset}`);
+      }
+      continue;
+    }
+
+    // Time to retry — post the review request comment
+    log(`  PR #${pr.number}: CodeRabbit retry time reached — requesting review`);
+    if (config.dryRun) {
+      log(`  ${cl.dim}[DRY RUN] Would post @coderabbitai review on PR #${pr.number}${cl.reset}`);
+    } else {
+      try {
+        await githubApi(`/repos/${config.repo}/issues/${pr.number}/comments`, {
+          method: 'POST',
+          body: { body: '@coderabbitai review' },
+        });
+        log(`  ${cl.green}Posted @coderabbitai review on PR #${pr.number}${cl.reset}`);
+        appendJsonl(JSONL_FILE_INTERNAL, {
+          type: 'coderabbit_retry',
+          pr_num: pr.number,
+          outcome: 'posted',
+        });
+      } catch (e) {
+        log(`  ${cl.yellow}Warning: could not post CodeRabbit retry on PR #${pr.number}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
+        appendJsonl(JSONL_FILE_INTERNAL, {
+          type: 'coderabbit_retry',
+          pr_num: pr.number,
+          outcome: 'error',
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+
+    // Clear the retry state — only retry once per rate-limit event
+    clearCodeRabbitRetryTime(pr.number);
+  }
+
   // ── Undraft phase ──────────────────────────────────────────────────
   // Auto-undraft draft PRs that are otherwise eligible for merge.
   // A PR is auto-undrafted when its only block reason is 'is-draft'.
@@ -512,6 +581,10 @@ export function readRecentLogs(count: number): string {
       } else if (entry.type === 'main_branch_result') {
         output.push(
           `  Main branch: ${entry.outcome} (${entry.elapsed_s}s) — run #${entry.run_id}`,
+        );
+      } else if (entry.type === 'coderabbit_retry') {
+        output.push(
+          `  PR #${entry.pr_num}: coderabbit-retry-${entry.outcome}${entry.error ? ` (${entry.error})` : ''}`,
         );
       } else if (entry.type === 'overlap_warning') {
         output.push(

--- a/crux/pr-patrol/state.test.ts
+++ b/crux/pr-patrol/state.test.ts
@@ -16,6 +16,10 @@ import {
   ensureDirs,
   markProcessed,
   isRecentlyProcessed,
+  getCodeRabbitRetryTime,
+  setCodeRabbitRetryTime,
+  clearCodeRabbitRetryTime,
+  CODERABBIT_DEFAULT_RETRY_DELAY_MS,
   STATE_DIR,
 } from './state.ts';
 
@@ -161,5 +165,42 @@ describe('clearProcessed', () => {
   it('is safe to call when no processed file exists', () => {
     // Should not throw
     clearProcessed(`nonexistent-key-${Date.now()}`);
+  });
+});
+
+// ── CodeRabbit retry tracking ────────────────────────────────────────────────
+
+describe('CodeRabbit retry state', () => {
+  const testPrNumber = 99990 + Math.floor(Math.random() * 1000);
+
+  afterEach(() => {
+    clearCodeRabbitRetryTime(testPrNumber);
+  });
+
+  it('returns null when no retry is scheduled', () => {
+    expect(getCodeRabbitRetryTime(testPrNumber)).toBeNull();
+  });
+
+  it('stores and retrieves a retry timestamp', () => {
+    const ts = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    setCodeRabbitRetryTime(testPrNumber, ts);
+    expect(getCodeRabbitRetryTime(testPrNumber)).toBe(ts);
+  });
+
+  it('clears the retry timestamp', () => {
+    const ts = new Date().toISOString();
+    setCodeRabbitRetryTime(testPrNumber, ts);
+    expect(getCodeRabbitRetryTime(testPrNumber)).not.toBeNull();
+    clearCodeRabbitRetryTime(testPrNumber);
+    expect(getCodeRabbitRetryTime(testPrNumber)).toBeNull();
+  });
+
+  it('clear is safe when no retry file exists', () => {
+    // Should not throw
+    clearCodeRabbitRetryTime(testPrNumber + 1);
+  });
+
+  it('has a 30-minute default retry delay', () => {
+    expect(CODERABBIT_DEFAULT_RETRY_DELAY_MS).toBe(30 * 60 * 1000);
   });
 });

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -329,6 +329,41 @@ export function clearPendingVerification(prNumber: number): void {
   }
 }
 
+// ── CodeRabbit review retry tracking ─────────────────────────────────────────
+// When CodeRabbit rate-limits a review, we schedule a retry after the cooldown.
+// Only retries once per rate-limit event to avoid spamming.
+
+/** Default wait time before retrying a CodeRabbit review (30 minutes). */
+export const CODERABBIT_DEFAULT_RETRY_DELAY_MS = 30 * 60 * 1000;
+
+/**
+ * Get the scheduled retry time for a CodeRabbit review on a PR.
+ * Returns the ISO timestamp when we should post `@coderabbitai review`, or null if not scheduled.
+ */
+export function getCodeRabbitRetryTime(prNumber: number): string | null {
+  const file = join(STATE_DIR, `coderabbit-retry-${prNumber}`);
+  if (!existsSync(file)) return null;
+  const content = readFileSync(file, 'utf-8').trim();
+  return content || null;
+}
+
+/**
+ * Schedule a CodeRabbit review retry at the given ISO timestamp.
+ */
+export function setCodeRabbitRetryTime(prNumber: number, isoTimestamp: string): void {
+  writeFileSync(join(STATE_DIR, `coderabbit-retry-${prNumber}`), isoTimestamp);
+}
+
+/**
+ * Clear the CodeRabbit retry state for a PR (after posting or if no longer needed).
+ */
+export function clearCodeRabbitRetryTime(prNumber: number): void {
+  const file = join(STATE_DIR, `coderabbit-retry-${prNumber}`);
+  if (existsSync(file)) {
+    try { unlinkSync(file); } catch { /* best-effort */ }
+  }
+}
+
 // ── Clear cooldown ──────────────────────────────────────────────────────────
 
 export function clearProcessed(key: number | string): void {


### PR DESCRIPTION
## Summary

When CodeRabbit rate-limits a PR review, PR Patrol now automatically posts `@coderabbitai review` after the cooldown expires (~30 min default).

- Detects rate-limited PRs via StatusContext state and review thread comments mentioning "rate limit" or "review skipped"
- Schedules a one-shot retry 30 minutes later using file-based state (same pattern as cooldowns)
- Posts the review request comment via GitHub API, logs the event
- Never spams — only one retry per rate-limit event, clears state after posting

## Files changed

- `crux/lib/pr-analysis/detection.ts` — `detectCodeRabbitRateLimited()` pure function
- `crux/pr-patrol/state.ts` — retry time state management
- `crux/pr-patrol/index.ts` — new phase in daemon loop between fix and undraft
- Tests for detection and state (16 new test cases, all passing)

## Test plan

- [x] 11 detection tests covering status context states, comment patterns, case sensitivity
- [x] 5 state management tests for get/set/clear retry time
- [ ] Manual: verify patrol posts `@coderabbitai review` after rate limit clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)