### PR TITLE
feat: make citation audit gate default-on for improve --apply

### DIFF
--- a/crux/authoring/page-improver/index.ts
+++ b/crux/authoring/page-improver/index.ts
@@ -116,7 +116,7 @@ Options:
   --skip-session-log              Skip auto-posting session log to wiki-server after apply
   --skip-enrich                   Skip post-improve enrichment (entity-links, fact-refs)
   --section-level                 Use per-## section rewriting instead of single-pass improve (#671)
-  --citation-gate                 Block --apply when citation audit pass rate is below threshold
+  --skip-citation-gate            Allow --apply even when citation audit fails (default: gate ON)
   --skip-citation-audit           Skip the post-improve citation audit phase
   --citation-audit-model <model>  Override LLM model for per-citation verification
   --no-save-artifacts             Skip saving intermediate artifacts to wiki-server DB
@@ -299,7 +299,7 @@ Examples:
       skipSessionLog: opts['skip-session-log'] === true ? true : undefined,
       skipEnrich: opts['skip-enrich'] === true ? true : undefined,
       sectionLevel: opts['section-level'] === true ? true : undefined,
-      citationGate: opts['citation-gate'] === true ? true : undefined,
+      citationGate: opts['skip-citation-gate'] === true ? false : true,
       skipCitationAudit: opts['skip-citation-audit'] === true ? true : undefined,
       citationAuditModel: (opts['citation-audit-model'] as string) || undefined,
       saveArtifacts: opts['no-save-artifacts'] === true ? false : undefined,

--- a/crux/authoring/page-improver/phases/citation-audit.test.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.test.ts
@@ -200,32 +200,32 @@ describe('citationAuditPhase', () => {
     expect(getLogMessages().some(msg => msg.includes('Citation audit passed'))).toBe(true);
   });
 
-  it('logs [WARNING] in advisory mode when audit fails', async () => {
+  it('logs [GATE] by default when audit fails (gate is default-on)', async () => {
     vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
       summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
       pass: false,
     }));
 
-    const options: PipelineOptions = {};  // no citationGate → advisory mode
-    await citationAuditPhase(mockPage, 'content', undefined, options);
-
-    const messages = getLogMessages();
-    expect(messages.some(msg => msg.includes('[WARNING]'))).toBe(true);
-    expect(messages.some(msg => msg.includes('[GATE]'))).toBe(false);
-  });
-
-  it('logs [GATE] in gate mode when audit fails', async () => {
-    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
-      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
-      pass: false,
-    }));
-
-    const options: PipelineOptions = { citationGate: true };
+    const options: PipelineOptions = {};  // default → gate mode
     await citationAuditPhase(mockPage, 'content', undefined, options);
 
     const messages = getLogMessages();
     expect(messages.some(msg => msg.includes('[GATE]'))).toBe(true);
     expect(messages.some(msg => msg.includes('[WARNING]'))).toBe(false);
+  });
+
+  it('logs [WARNING] in advisory mode when audit fails (--skip-citation-gate)', async () => {
+    vi.mocked(auditCitations).mockResolvedValueOnce(makeAuditResult({
+      summary: { total: 2, verified: 1, failed: 1, misattributed: 0, unchecked: 0, unsourcedTableCells: 0 },
+      pass: false,
+    }));
+
+    const options: PipelineOptions = { citationGate: false };  // --skip-citation-gate
+    await citationAuditPhase(mockPage, 'content', undefined, options);
+
+    const messages = getLogMessages();
+    expect(messages.some(msg => msg.includes('[WARNING]'))).toBe(true);
+    expect(messages.some(msg => msg.includes('[GATE]'))).toBe(false);
   });
 
   it('passes source cache to auditCitations when research includes sourceCache', async () => {

--- a/crux/authoring/page-improver/phases/citation-audit.ts
+++ b/crux/authoring/page-improver/phases/citation-audit.ts
@@ -1,13 +1,14 @@
 /**
  * Citation Audit Phase
  *
- * Post-improve advisory check that verifies each citation in the improved
- * content against its source URL using the citation-auditor module.
+ * Post-improve citation verification gate.
  *
- * Runs after the enrich phase. In advisory mode (default), warnings are
- * logged but --apply is never blocked. In gate mode (--citation-gate), the
- * pipeline aborts --apply when the verified fraction falls below the
- * passThreshold.
+ * Verifies each citation in the improved content against its source URL
+ * using the citation-auditor module.
+ *
+ * Runs after the enrich phase. In gate mode (default), --apply is blocked
+ * when the verified fraction falls below the passThreshold. Use
+ * --skip-citation-gate to run in advisory mode (warnings only).
  *
  * Source cache integration:
  *   When the research phase built a SourceCacheEntry[], it is converted into
@@ -142,7 +143,7 @@ export async function citationAuditPhase(
   } else if (result.pass) {
     log('citation-audit', `\u2713 Citation audit passed`);
   } else {
-    const mode = options.citationGate ? 'GATE' : 'WARNING';
+    const mode = options.citationGate !== false ? 'GATE' : 'WARNING';
     log(
       'citation-audit',
       `\u26A0 [${mode}] Citation audit failed: pass rate below threshold (${verified}/${verified + failed} verified)`,

--- a/crux/authoring/page-improver/pipeline.ts
+++ b/crux/authoring/page-improver/pipeline.ts
@@ -274,10 +274,10 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
             r.auditResult = await citationAuditPhase(page, r.improvedContent!, r.research, options);
           } catch (err: unknown) {
             const error = err instanceof Error ? err : new Error(String(err));
-            if (options.citationGate) {
-              throw new Error(`Citation audit failed with --citation-gate: ${error.message}`);
+            if (options.citationGate !== false) {
+              throw new Error(`Citation audit error (use --skip-citation-gate to bypass): ${error.message}`);
             }
-            log('citation-audit', `⚠ Citation audit failed: ${error.message} — continuing without audit`);
+            log('citation-audit', `⚠ Citation audit failed: ${error.message} — continuing (--skip-citation-gate)`);
           }
         }
         break;
@@ -363,21 +363,22 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
       console.log(`Unsourced table cells: ${unsourcedTableCells} (numeric claims without citations)`);
     }
     if (!r.auditResult.pass) {
-      if (options.citationGate && dryRun) {
-        console.log(`⚠ Citation audit FAILED (--citation-gate inactive in dry-run; would block --apply)`);
-      } else if (options.citationGate && !dryRun) {
-        console.log(`⚠ Citation audit FAILED — blocking apply (--citation-gate)`);
+      const gateActive = options.citationGate !== false;
+      if (gateActive && dryRun) {
+        console.log(`⚠ Citation audit FAILED (would block --apply; use --skip-citation-gate to bypass)`);
+      } else if (gateActive && !dryRun) {
+        console.log(`⚠ Citation audit FAILED — blocking apply`);
       } else {
-        console.log(`⚠ Citation audit FAILED (advisory)`);
+        console.log(`⚠ Citation audit FAILED (gate disabled via --skip-citation-gate)`);
       }
     }
   }
 
-  // Gate mode: abort --apply when citation audit fails
-  if (options.citationGate && !dryRun && r.auditResult && !r.auditResult.pass) {
+  // Gate mode (default): abort --apply when citation audit fails
+  if (options.citationGate !== false && !dryRun && r.auditResult && !r.auditResult.pass) {
     const auditPath = path.join(TEMP_DIR, page.id, 'citation-audit.json');
-    console.error('\nApply blocked: citation audit failed and --citation-gate is set.');
-    console.error(`Review ${auditPath} for per-citation details.`);
+    console.error('\nApply blocked: citation audit failed.');
+    console.error(`Use --skip-citation-gate to apply anyway, or review ${auditPath} for per-citation details.`);
     process.exit(1);
   }
 

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -127,7 +127,8 @@ export interface PipelineOptions {
   /**
    * When true, the citation audit phase blocks --apply when the verified
    * fraction falls below the passThreshold (gate mode).
-   * Default: false (advisory mode — warnings logged, apply not blocked).
+   * Default: true (gate mode — apply blocked on audit failure).
+   * Use --skip-citation-gate to disable.
    */
   citationGate?: boolean;
   /**

--- a/crux/commands/cli-flag-forwarding.test.ts
+++ b/crux/commands/cli-flag-forwarding.test.ts
@@ -336,7 +336,7 @@ const CONTENT_SCRIPTS: Record<string, Pick<ScriptConfig, 'passthrough' | 'positi
     passthrough: [
       'ci', 'tier', 'directions', 'dryRun', 'dry-run', 'apply', 'grade', 'no-grade',
       'triage', 'skip-session-log', 'skip-enrich', 'section-level', 'engine',
-      'citation-gate', 'skip-citation-audit', 'citation-audit-model',
+      'citation-gate', 'skip-citation-gate', 'skip-citation-audit', 'citation-audit-model',
       'batch', 'batch-file', 'batch-budget', 'page-timeout', 'resume',
       'report-file', 'no-save-artifacts', 'output', 'limit',
     ],
@@ -433,8 +433,8 @@ describe('structural guard — test configs stay in sync with source', () => {
     expect(VALIDATE_SCRIPTS.gate.passthrough).toHaveLength(7);
   });
 
-  it('content improve passthrough has exactly 25 entries', () => {
-    expect(CONTENT_SCRIPTS.improve.passthrough).toHaveLength(25);
+  it('content improve passthrough has exactly 26 entries', () => {
+    expect(CONTENT_SCRIPTS.improve.passthrough).toHaveLength(26);
   });
 
   it('citations verify passthrough has exactly 6 entries', () => {

--- a/crux/commands/content.ts
+++ b/crux/commands/content.ts
@@ -14,7 +14,7 @@ const SCRIPTS: Record<string, ScriptConfig> = {
   improve: {
     script: 'authoring/page-improver/index.ts',
     description: 'Improve an existing page with AI assistance',
-    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'dry-run', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log', 'skip-enrich', 'section-level', 'engine', 'citation-gate', 'skip-citation-audit', 'citation-audit-model', 'batch', 'batch-file', 'batch-budget', 'page-timeout', 'resume', 'report-file', 'no-save-artifacts', 'output', 'limit', 'openrouter', 'gap-analysis', 'api-direct'],
+    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'dry-run', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log', 'skip-enrich', 'section-level', 'engine', 'citation-gate', 'skip-citation-gate', 'skip-citation-audit', 'citation-audit-model', 'batch', 'batch-file', 'batch-budget', 'page-timeout', 'resume', 'report-file', 'no-save-artifacts', 'output', 'limit', 'openrouter', 'gap-analysis', 'api-direct'],
     positional: true,
   },
   iterate: {
@@ -101,7 +101,7 @@ Options:
   --dry-run         Preview without changes
   --apply           Apply changes (suggest-links, improve)
   --skip-session-log  Skip auto-posting session log to wiki-server after improve --apply
-  --citation-gate     Block --apply if citation audit pass rate < 80% (improve)
+  --skip-citation-gate  Allow --apply even if citation audit fails (default: gate ON) (improve)
   --skip-citation-audit  Skip citation audit phase (improve)
   --citation-audit-model Override LLM model for citation verification (improve)
   --batch=id1,id2     Batch mode: comma-separated page IDs (improve, requires --engine=v2)


### PR DESCRIPTION
## Summary

The citation audit phase now **blocks `--apply` by default** when the verified fraction falls below 80%. Previously this was opt-in via `--citation-gate`.

This prevents the improve pipeline from introducing uncited or misattributed claims faster than they can be fixed manually.

### Behavior change
| Before | After |
|--------|-------|
| `improve --apply` → advisory warnings only | `improve --apply` → **blocked if audit fails** |
| `improve --apply --citation-gate` → blocked | `improve --apply` → blocked (same, now default) |
| N/A | `improve --apply --skip-citation-gate` → advisory only |

### Files changed
- `types.ts`: Updated `citationGate` default documentation
- `index.ts`: Added `--skip-citation-gate` flag, flipped default
- `pipeline.ts`: Gate logic uses `!== false` instead of truthy check
- `citation-audit.ts`: Updated phase documentation
- `content.ts`: Updated CLI help text and passthrough list
- Tests updated to match new default behavior

## Test plan
- [x] citation-audit tests: 22/22 pass (gate/advisory mode tests updated)
- [x] CLI flag forwarding tests: 62/62 pass
- [x] No TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
