### PR TITLE
feat: add tsvector search to directory page endpoints

### DIFF
--- a/apps/wiki-server/drizzle/0122_entities_search_vector.sql
+++ b/apps/wiki-server/drizzle/0122_entities_search_vector.sql
@@ -1,0 +1,17 @@
+-- Add tsvector search_vector column to entities table for full-text search.
+-- Uses the same generated-column pattern as the things table (migration 0086/0113).
+-- Title gets weight A, description gets weight B for relevance ranking.
+
+ALTER TABLE entities ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B')
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_entities_search ON entities USING GIN(search_vector);
+
+-- Also enable the pg_trgm extension for trigram fallback (idempotent).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Trigram index on title for typo-tolerant fallback search.
+CREATE INDEX IF NOT EXISTS idx_entities_title_trgm ON entities USING GIN(title gin_trgm_ops);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1780128000000,
       "tag": "0121_data_first_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1780214400000,
+      "tag": "0122_entities_search_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/query-helpers.test.ts
+++ b/apps/wiki-server/src/__tests__/query-helpers.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { parseSort, paginationMeta } from "../routes/shared/query-helpers.js";
+import { sql } from "drizzle-orm";
+import {
+  parseSort,
+  paginationMeta,
+  buildTsvectorSearchCondition,
+  buildTsvectorRankExpr,
+  buildTrigramFallbackCondition,
+  buildTrigramRankExpr,
+  TRIGRAM_FALLBACK_THRESHOLD,
+  TRIGRAM_SIMILARITY_THRESHOLD,
+} from "../routes/shared/query-helpers.js";
+import { entities } from "../schema.js";
 
 describe("parseSort", () => {
   const allowed = ["amount", "date", "name"] as const;
@@ -73,5 +84,91 @@ describe("paginationMeta", () => {
       pageSize: 20,
       pageCount: 1,
     });
+  });
+});
+
+describe("buildTsvectorSearchCondition", () => {
+  const searchVectorExpr = sql.raw("search_vector");
+  const columns = [entities.title, entities.description];
+
+  it("returns undefined for empty search term", () => {
+    expect(buildTsvectorSearchCondition(searchVectorExpr, "", columns)).toBeUndefined();
+    expect(buildTsvectorSearchCondition(searchVectorExpr, "   ", columns)).toBeUndefined();
+  });
+
+  it("returns a SQL object for a valid search term", () => {
+    const result = buildTsvectorSearchCondition(searchVectorExpr, "alignment", columns);
+    expect(result).toBeDefined();
+    // Should be a Drizzle SQL object (has queryChunks or similar structure)
+    expect(result).toHaveProperty("queryChunks");
+  });
+
+  it("falls back to ILIKE for all-punctuation input", () => {
+    // buildPrefixTsquery returns "" for "!@#" so buildTsvectorSearchCondition
+    // should fall back to buildSearchCondition (ILIKE)
+    const result = buildTsvectorSearchCondition(searchVectorExpr, "!@#$%", columns);
+    // All-punctuation produces empty tsquery AND empty ILIKE pattern after stripping
+    // The ILIKE fallback will still produce a condition for the raw input "%!@#$%%"
+    expect(result).toBeDefined();
+  });
+
+  it("normalizes letter/digit boundaries (sb1047 → sb 1047)", () => {
+    const result = buildTsvectorSearchCondition(searchVectorExpr, "sb1047", columns);
+    // Should produce a tsvector condition since "sb 1047" has valid words
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("queryChunks");
+  });
+});
+
+describe("buildTsvectorRankExpr", () => {
+  const searchVectorExpr = sql.raw("search_vector");
+
+  it("returns undefined for empty or all-punctuation input", () => {
+    expect(buildTsvectorRankExpr(searchVectorExpr, entities.title, "")).toBeUndefined();
+    expect(buildTsvectorRankExpr(searchVectorExpr, entities.title, "   ")).toBeUndefined();
+    expect(buildTsvectorRankExpr(searchVectorExpr, entities.title, "!@#")).toBeUndefined();
+  });
+
+  it("returns a SQL expression for valid input", () => {
+    const result = buildTsvectorRankExpr(searchVectorExpr, entities.title, "alignment");
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("queryChunks");
+  });
+
+  it("handles multi-word queries", () => {
+    const result = buildTsvectorRankExpr(searchVectorExpr, entities.title, "AI safety");
+    expect(result).toBeDefined();
+  });
+});
+
+describe("buildTrigramFallbackCondition", () => {
+  it("returns a SQL condition for any input", () => {
+    const result = buildTrigramFallbackCondition(entities.title, "anthropic");
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("queryChunks");
+  });
+
+  it("accepts a custom threshold", () => {
+    const result = buildTrigramFallbackCondition(entities.title, "test", 0.5);
+    expect(result).toBeDefined();
+  });
+});
+
+describe("buildTrigramRankExpr", () => {
+  it("returns a SQL expression", () => {
+    const result = buildTrigramRankExpr(entities.title, "anthropic");
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("queryChunks");
+  });
+});
+
+describe("tsvector search constants", () => {
+  it("exports TRIGRAM_FALLBACK_THRESHOLD", () => {
+    expect(TRIGRAM_FALLBACK_THRESHOLD).toBeGreaterThanOrEqual(1);
+  });
+
+  it("exports TRIGRAM_SIMILARITY_THRESHOLD", () => {
+    expect(TRIGRAM_SIMILARITY_THRESHOLD).toBeGreaterThan(0);
+    expect(TRIGRAM_SIMILARITY_THRESHOLD).toBeLessThan(1);
   });
 });

--- a/apps/wiki-server/src/routes/shared/query-helpers.ts
+++ b/apps/wiki-server/src/routes/shared/query-helpers.ts
@@ -12,6 +12,12 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { escapeIlike } from "./utils.js";
 import { entities } from "../../schema.js";
 import { STABLE_ID_PATTERN } from "./entity-ref.js";
+import {
+  buildPrefixTsquery,
+  normalizeSearchQuery,
+  TRIGRAM_SIMILARITY_THRESHOLD,
+  TRIGRAM_FALLBACK_THRESHOLD,
+} from "../../search-utils.js";
 
 /**
  * Build an ILIKE OR search condition across multiple columns.
@@ -29,6 +35,105 @@ export function buildSearchCondition(
   if (conditions.length === 1) return conditions[0];
   return sql`(${sql.join(conditions, sql` OR `)})`;
 }
+
+/**
+ * Build a tsvector full-text search condition using search_vector column.
+ *
+ * Uses prefix-matching tsquery (e.g. "AI align" → "AI:* & align:*") for
+ * search-as-you-type behavior. Falls back to ILIKE on specified columns
+ * when no valid tsquery can be built (e.g. all-punctuation input).
+ *
+ * @param searchVectorExpr - SQL expression for the tsvector column (e.g. `sql.raw("e.search_vector")`)
+ * @param searchTerm - User's raw search input
+ * @param ilikeFallbackColumns - Columns to ILIKE-search when tsquery is empty
+ * @returns SQL condition or undefined if searchTerm is empty
+ */
+export function buildTsvectorSearchCondition(
+  searchVectorExpr: SQL,
+  searchTerm: string,
+  ilikeFallbackColumns: PgColumn[],
+): SQL | undefined {
+  const trimmed = searchTerm.trim();
+  if (!trimmed) return undefined;
+
+  const normalized = normalizeSearchQuery(trimmed);
+  const tsquery = buildPrefixTsquery(normalized);
+
+  if (tsquery) {
+    return sql`${searchVectorExpr} @@ to_tsquery('english', ${tsquery})`;
+  }
+
+  // Fallback to ILIKE if tsquery could not be built
+  return buildSearchCondition(ilikeFallbackColumns, trimmed);
+}
+
+/**
+ * Build a tsvector relevance rank expression with title-match boosting.
+ *
+ * Returns a SQL expression that computes:
+ *   ts_rank_cd(search_vector, tsquery, 1) + title_boost
+ *
+ * The title boost uses exact match (+1000), starts-with (+100), and
+ * word-boundary (+10) bonuses to ensure exact title matches rank first.
+ *
+ * @param searchVectorColumn - SQL expression for the tsvector column (e.g. `sql.raw("e.search_vector")`)
+ * @param titleColumn - SQL expression for the title column (e.g. `entities.title` or `sql.raw("t.title")`)
+ * @param searchTerm - User's raw search input
+ * @returns SQL expression for relevance ranking, or undefined if no valid tsquery
+ */
+export function buildTsvectorRankExpr(
+  searchVectorColumn: SQL,
+  titleColumn: SQL | PgColumn,
+  searchTerm: string,
+): SQL | undefined {
+  const normalized = normalizeSearchQuery(searchTerm.trim());
+  const tsquery = buildPrefixTsquery(normalized);
+  if (!tsquery) return undefined;
+
+  // Title-match boost: exact match (+1000), starts-with (+100), word boundary (+10)
+  // This mirrors the logic in titleMatchBoostExpr() from search-utils.ts but
+  // is expressed as a Drizzle SQL template for type safety.
+  const titleBoost = sql`(
+    CASE
+      WHEN lower(${titleColumn}) = lower(${searchTerm}) THEN 1000
+      WHEN position('(' || upper(${searchTerm}) || ')' in ${titleColumn}) > 0 THEN 500
+      WHEN starts_with(lower(${titleColumn}), lower(${searchTerm}) || ' ') THEN 100
+      WHEN position(' ' || lower(${searchTerm}) in lower(${titleColumn})) > 0 THEN 10
+      ELSE 0
+    END
+  )`;
+
+  return sql`ts_rank_cd(${searchVectorColumn}, to_tsquery('english', ${tsquery}), 1) + ${titleBoost}`;
+}
+
+/**
+ * Build a trigram similarity fallback condition for when tsvector search
+ * returns too few results (typo tolerance).
+ *
+ * @param titleColumn - SQL expression or column for the title
+ * @param searchTerm - User's raw search input
+ * @param threshold - Minimum similarity score (default: TRIGRAM_SIMILARITY_THRESHOLD)
+ * @returns SQL condition
+ */
+export function buildTrigramFallbackCondition(
+  titleColumn: SQL | PgColumn,
+  searchTerm: string,
+  threshold: number = TRIGRAM_SIMILARITY_THRESHOLD,
+): SQL {
+  return sql`similarity(${titleColumn}, ${searchTerm}) > ${threshold}`;
+}
+
+/**
+ * Build a trigram similarity score expression for ORDER BY.
+ */
+export function buildTrigramRankExpr(
+  titleColumn: SQL | PgColumn,
+  searchTerm: string,
+): SQL {
+  return sql`similarity(${titleColumn}, ${searchTerm})`;
+}
+
+export { TRIGRAM_FALLBACK_THRESHOLD, TRIGRAM_SIMILARITY_THRESHOLD };
 
 /**
  * Parse a sort string like "amount:desc" into field and direction.

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -19,7 +19,15 @@ import {
   SyncEntitiesBatchSchema,
 } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
-import { buildSearchCondition, parseSort } from "../shared/query-helpers.js";
+import {
+  buildSearchCondition,
+  buildTsvectorSearchCondition,
+  buildTsvectorRankExpr,
+  buildTrigramFallbackCondition,
+  buildTrigramRankExpr,
+  parseSort,
+  TRIGRAM_FALLBACK_THRESHOLD,
+} from "../shared/query-helpers.js";
 
 // ---- Constants ----
 
@@ -204,20 +212,59 @@ const entitiesApp = new Hono()
   .get("/search", zv("query", SearchQuery), async (c) => {
     const { q, limit } = c.req.valid("query");
     const db = getDrizzleDb();
-    const pattern = `%${escapeIlike(q)}%`;
 
-    const rows = await db
-      .select()
-      .from(entities)
-      .where(
-        or(
-          ilike(entities.title, pattern),
-          ilike(entities.id, pattern),
-          ilike(entities.description, pattern)
+    const searchVectorExpr = sql.raw("search_vector");
+    const ftsCondition = buildTsvectorSearchCondition(
+      searchVectorExpr,
+      q,
+      [entities.title, entities.id, entities.description],
+    );
+
+    const rankExpr = buildTsvectorRankExpr(
+      searchVectorExpr,
+      entities.title,
+      q,
+    );
+
+    let rows;
+    if (ftsCondition && rankExpr) {
+      // Tsvector search with relevance ranking
+      rows = await db
+        .select()
+        .from(entities)
+        .where(ftsCondition)
+        .orderBy(sql`${rankExpr} DESC`, entities.id)
+        .limit(limit);
+
+      // Trigram fallback if too few results
+      if (rows.length < TRIGRAM_FALLBACK_THRESHOLD) {
+        const trigramCondition = buildTrigramFallbackCondition(entities.title, q);
+        const trigramRows = await db
+          .select()
+          .from(entities)
+          .where(trigramCondition)
+          .orderBy(sql`${buildTrigramRankExpr(entities.title, q)} DESC`, entities.id)
+          .limit(limit);
+        if (trigramRows.length > rows.length) {
+          rows = trigramRows;
+        }
+      }
+    } else {
+      // ILIKE fallback when tsquery cannot be built
+      const pattern = `%${escapeIlike(q)}%`;
+      rows = await db
+        .select()
+        .from(entities)
+        .where(
+          or(
+            ilike(entities.title, pattern),
+            ilike(entities.id, pattern),
+            ilike(entities.description, pattern)
+          )
         )
-      )
-      .orderBy(entities.id)
-      .limit(limit);
+        .orderBy(entities.id)
+        .limit(limit);
+    }
 
     return c.json({
       results: rows.map(formatEntity),
@@ -261,12 +308,26 @@ const entitiesApp = new Hono()
     // Build WHERE — always filter to organization entity type
     const conditions: SQL[] = [eq(entities.entityType, "organization")];
 
+    // Search: prefer tsvector full-text search, fall back to ILIKE + trigram
+    const searchVectorExpr = sql.raw("search_vector");
+    let searchRankExpr: SQL | undefined;
+    let searchMode: "fts" | "trigram" | null = null;
+
     if (q) {
-      const searchCond = buildSearchCondition(
-        [entities.title, entities.id, entities.description],
+      const ftsCondition = buildTsvectorSearchCondition(
+        searchVectorExpr,
         q,
+        [entities.title, entities.id, entities.description],
       );
-      if (searchCond) conditions.push(searchCond);
+      if (ftsCondition) {
+        conditions.push(ftsCondition);
+        searchRankExpr = buildTsvectorRankExpr(
+          searchVectorExpr,
+          entities.title,
+          q,
+        );
+        searchMode = "fts";
+      }
     }
 
     const where = conditions.length === 1 ? conditions[0] : and(...conditions)!;
@@ -319,11 +380,18 @@ const entitiesApp = new Hono()
         ? sql`${sortCol} DESC NULLS LAST`
         : sql`${sortCol} ASC NULLS LAST`;
 
+    // When searching with relevance, override sort with search rank
+    const effectiveOrder = (q && searchRankExpr && (sort === undefined || sort === ""))
+      ? sql`${searchRankExpr} DESC, ${entities.title} ASC`
+      : orderClause;
+
     // Filtered count
-    const [{ total }] = await db
+    const [{ total: ftsTotal }] = await db
       .select({ total: count() })
       .from(entities)
       .where(where);
+
+    let total = ftsTotal;
 
     // Data query with lateral fact subqueries
     interface OrgRow {
@@ -343,7 +411,7 @@ const entitiesApp = new Hono()
       foundedDate: string | null;
     }
 
-    const rows: OrgRow[] = await db
+    let rows: OrgRow[] = await db
       .select({
         id: entities.id,
         wikiId: entities.wikiId,
@@ -362,9 +430,52 @@ const entitiesApp = new Hono()
       })
       .from(entities)
       .where(where)
-      .orderBy(orderClause, entities.id)
+      .orderBy(effectiveOrder, entities.id)
       .limit(limit)
       .offset(offset);
+
+    // Trigram fallback: if FTS returned too few results and we have a search term,
+    // retry with trigram similarity on title for typo tolerance.
+    if (q && total < TRIGRAM_FALLBACK_THRESHOLD && searchMode === "fts") {
+      searchMode = "trigram";
+      const trigramConditions: SQL[] = [
+        eq(entities.entityType, "organization"),
+        buildTrigramFallbackCondition(entities.title, q),
+      ];
+      const trigramWhere = and(...trigramConditions)!;
+      const trigramRank = buildTrigramRankExpr(entities.title, q);
+
+      const [{ total: trigramTotal }] = await db
+        .select({ total: count() })
+        .from(entities)
+        .where(trigramWhere);
+
+      if (trigramTotal > total) {
+        total = trigramTotal;
+        rows = await db
+          .select({
+            id: entities.id,
+            wikiId: entities.wikiId,
+            stableId: entities.stableId,
+            title: entities.title,
+            description: entities.description,
+            website: entities.website,
+            revenueNum: sql<number | null>`${latestFact("revenue")}`,
+            revenueDate: sql<string | null>`${latestFactAsOf("revenue")}`,
+            valuationNum: sql<number | null>`${latestFact("valuation")}`,
+            valuationDate: sql<string | null>`${latestFactAsOf("valuation")}`,
+            headcount: sql<number | null>`${latestFact("headcount")}`,
+            headcountDate: sql<string | null>`${latestFactAsOf("headcount")}`,
+            totalFundingNum: sql<number | null>`${latestFact("total-funding")}`,
+            foundedDate: sql<string | null>`${latestFactText("founded-date")}`,
+          })
+          .from(entities)
+          .where(trigramWhere)
+          .orderBy(sql`${trigramRank} DESC`, entities.id)
+          .limit(limit)
+          .offset(offset);
+      }
+    }
 
     return c.json({
       organizations: rows.map((r) => ({
@@ -386,6 +497,7 @@ const entitiesApp = new Hono()
       total,
       limit,
       offset,
+      searchMode,
     });
   })
 

--- a/apps/wiki-server/src/routes/tablebase/people.ts
+++ b/apps/wiki-server/src/routes/tablebase/people.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import { sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { zv, escapeIlike } from "../shared/utils.js";
-import { parseSort } from "../shared/query-helpers.js";
+import { parseSort, TRIGRAM_FALLBACK_THRESHOLD } from "../shared/query-helpers.js";
+import {
+  buildPrefixTsquery,
+  normalizeSearchQuery,
+  TRIGRAM_SIMILARITY_THRESHOLD,
+} from "../../search-utils.js";
 
 // ---- Constants ----
 
@@ -80,32 +85,68 @@ const peopleApp = new Hono()
 
     // Build dynamic WHERE fragments
     const extraConditions: ReturnType<typeof sql>[] = [];
+    let searchMode: "fts" | "trigram" | "ilike" | null = null;
 
     if (q) {
-      const pattern = `%${escapeIlike(q.trim())}%`;
-      extraConditions.push(sql`(
-        t.title ILIKE ${pattern}
-        OR t.description ILIKE ${pattern}
-        OR EXISTS (
-          SELECT 1 FROM facts f_s
-          WHERE f_s.entity_id = t.id
-          AND f_s.measure = 'role'
-          AND f_s.value ILIKE ${pattern}
-        )
-        OR EXISTS (
-          SELECT 1 FROM facts f_s2
-          WHERE f_s2.entity_id = t.id
-          AND f_s2.measure = 'employed-by'
-          AND (
-            f_s2.value ILIKE ${pattern}
-            OR EXISTS (
-              SELECT 1 FROM entities e_s
-              WHERE e_s.stable_id = f_s2.value
-              AND e_s.title ILIKE ${pattern}
+      const trimmedQ = q.trim();
+      const normalized = normalizeSearchQuery(trimmedQ);
+      const tsquery = buildPrefixTsquery(normalized);
+
+      if (tsquery) {
+        // Primary: tsvector full-text search on things.search_vector
+        // Also search role and employer facts via ILIKE for completeness
+        const pattern = `%${escapeIlike(trimmedQ)}%`;
+        extraConditions.push(sql`(
+          t.search_vector @@ to_tsquery('english', ${tsquery})
+          OR EXISTS (
+            SELECT 1 FROM facts f_s
+            WHERE f_s.entity_id = t.id
+            AND f_s.measure = 'role'
+            AND f_s.value ILIKE ${pattern}
+          )
+          OR EXISTS (
+            SELECT 1 FROM facts f_s2
+            WHERE f_s2.entity_id = t.id
+            AND f_s2.measure = 'employed-by'
+            AND (
+              f_s2.value ILIKE ${pattern}
+              OR EXISTS (
+                SELECT 1 FROM entities e_s
+                WHERE e_s.stable_id = f_s2.value
+                AND e_s.title ILIKE ${pattern}
+              )
             )
           )
-        )
-      )`);
+        )`);
+        searchMode = "fts";
+      } else {
+        // Fallback to ILIKE when tsquery cannot be built (all-punctuation input)
+        const pattern = `%${escapeIlike(trimmedQ)}%`;
+        extraConditions.push(sql`(
+          t.title ILIKE ${pattern}
+          OR t.description ILIKE ${pattern}
+          OR EXISTS (
+            SELECT 1 FROM facts f_s
+            WHERE f_s.entity_id = t.id
+            AND f_s.measure = 'role'
+            AND f_s.value ILIKE ${pattern}
+          )
+          OR EXISTS (
+            SELECT 1 FROM facts f_s2
+            WHERE f_s2.entity_id = t.id
+            AND f_s2.measure = 'employed-by'
+            AND (
+              f_s2.value ILIKE ${pattern}
+              OR EXISTS (
+                SELECT 1 FROM entities e_s
+                WHERE e_s.stable_id = f_s2.value
+                AND e_s.title ILIKE ${pattern}
+              )
+            )
+          )
+        )`);
+        searchMode = "ilike";
+      }
     }
 
     if (affiliation) {
@@ -147,10 +188,31 @@ const peopleApp = new Hono()
       netWorth: netWorthSubquery,
     };
     const sortExpr = sortExprMap[field] ?? sql`t.title`;
-    const orderClause =
+    const defaultOrderClause =
       dir === "desc"
         ? sql`${sortExpr} DESC NULLS LAST`
         : sql`${sortExpr} ASC NULLS LAST`;
+
+    // When searching via FTS with no explicit sort, order by search relevance
+    let orderClause = defaultOrderClause;
+    if (q && searchMode === "fts" && (sort === undefined || sort === "")) {
+      const trimmedQ = q.trim();
+      const normalized = normalizeSearchQuery(trimmedQ);
+      const tsquery = buildPrefixTsquery(normalized);
+      if (tsquery) {
+        // Title-match boost: exact (+1000), acronym-in-parens (+500), starts-with (+100), word-boundary (+10)
+        orderClause = sql`(
+          ts_rank_cd(t.search_vector, to_tsquery('english', ${tsquery}), 1)
+          + CASE
+              WHEN lower(t.title) = lower(${trimmedQ}) THEN 1000
+              WHEN position('(' || upper(${trimmedQ}) || ')' in t.title) > 0 THEN 500
+              WHEN starts_with(lower(t.title), lower(${trimmedQ}) || ' ') THEN 100
+              WHEN position(' ' || lower(${trimmedQ}) in lower(t.title)) > 0 THEN 10
+              ELSE 0
+            END
+        ) DESC`;
+      }
+    }
 
     // Count query
     const countResult = (await db.execute(sql`
@@ -160,10 +222,10 @@ const peopleApp = new Hono()
         AND t.entity_type = 'person'
         ${extraWhere}
     `)) as CountRow[];
-    const total = countResult[0]?.total ?? 0;
+    let total = countResult[0]?.total ?? 0;
 
     // Data query with fact subqueries for person attributes
-    const rows = (await db.execute(sql`
+    let rows = (await db.execute(sql`
       SELECT
         t.id,
         t.source_id AS slug,
@@ -184,11 +246,78 @@ const peopleApp = new Hono()
       OFFSET ${offset}
     `)) as PersonRawRow[];
 
+    // Trigram fallback: if FTS returned too few results, retry with trigram similarity
+    if (q && total < TRIGRAM_FALLBACK_THRESHOLD && searchMode === "fts") {
+      searchMode = "trigram";
+      const trimmedQ = q.trim();
+
+      // Build trigram conditions: keep affiliation filter if present, replace search with trigram
+      const trigramConditions: ReturnType<typeof sql>[] = [];
+      trigramConditions.push(
+        sql`similarity(t.title, ${trimmedQ}) > ${TRIGRAM_SIMILARITY_THRESHOLD}`,
+      );
+
+      if (affiliation) {
+        trigramConditions.push(sql`EXISTS (
+          SELECT 1 FROM facts f_aff
+          WHERE f_aff.entity_id = t.id
+          AND f_aff.measure = 'employed-by'
+          AND (
+            f_aff.value = ${affiliation}
+            OR EXISTS (
+              SELECT 1 FROM entities e_aff
+              WHERE e_aff.stable_id = f_aff.value
+              AND (e_aff.id = ${affiliation} OR e_aff.title = ${affiliation})
+            )
+          )
+        )`);
+      }
+
+      const trigramExtraWhere =
+        trigramConditions.length > 0
+          ? sql`AND ${trigramConditions.reduce((acc, cond, i) => (i === 0 ? cond : sql`${acc} AND ${cond}`))}`
+          : sql``;
+
+      const trigramCountResult = (await db.execute(sql`
+        SELECT COUNT(*)::int AS total
+        FROM things t
+        WHERE t.thing_type = 'entity'
+          AND t.entity_type = 'person'
+          ${trigramExtraWhere}
+      `)) as CountRow[];
+      const trigramTotal = trigramCountResult[0]?.total ?? 0;
+
+      if (trigramTotal > total) {
+        total = trigramTotal;
+        rows = (await db.execute(sql`
+          SELECT
+            t.id,
+            t.source_id AS slug,
+            t.title AS name,
+            t.wiki_id AS "wikiId",
+            t.description,
+            ${roleSubquery} AS role,
+            (SELECT f_e.value FROM facts f_e WHERE f_e.entity_id = t.id AND f_e.measure = 'employed-by' LIMIT 1) AS "employerId",
+            ${employerSubquery} AS "employerName",
+            ${bornYearSubquery} AS "bornYear",
+            ${netWorthSubquery} AS "netWorth"
+          FROM things t
+          WHERE t.thing_type = 'entity'
+            AND t.entity_type = 'person'
+            ${trigramExtraWhere}
+          ORDER BY similarity(t.title, ${trimmedQ}) DESC, t.id
+          LIMIT ${limit}
+          OFFSET ${offset}
+        `)) as PersonRawRow[];
+      }
+    }
+
     return c.json({
       items: rows.map(formatPersonRow),
       total,
       limit,
       offset,
+      searchMode,
     });
   })
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -809,11 +809,14 @@ export const entities = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    // search_vector tsvector column is managed via raw SQL migration 0120
+    // (Drizzle doesn't have native tsvector support)
   },
   (table) => [
     index("idx_ent_wiki_id").on(table.wikiId),
     index("idx_ent_entity_type").on(table.entityType),
     index("idx_ent_title").on(table.title),
+    // GIN index on search_vector + trigram index on title created in migration SQL
   ]
 );
 


### PR DESCRIPTION
## Summary
- Add PostgreSQL tsvector full-text search to directory page API endpoints (organizations, people, entity search), replacing ILIKE-based search
- Add `search_vector` generated column + GIN index to the `entities` table via migration 0120, with a trigram index on title for fallback
- Create shared tsvector search utilities (`buildTsvectorSearchCondition`, `buildTsvectorRankExpr`, `buildTrigramFallbackCondition`, `buildTrigramRankExpr`) in `query-helpers.ts`
- Upgrade `/api/entities/organizations` endpoint to use tsvector search with relevance ranking (ts_rank_cd + title-match boosting) and trigram fallback when FTS returns too few results
- Upgrade `/api/entities/search` endpoint to use tsvector search with relevance ranking
- Upgrade `/api/people` endpoint to use `things.search_vector` (which already exists) with relevance ranking and trigram fallback
- Add `searchMode` field to organization and people API responses indicating whether results came from FTS, trigram fallback, or ILIKE
- Add unit tests for all new query helper functions

## Endpoints upgraded
| Endpoint | Table | Before | After |
|----------|-------|--------|-------|
| `GET /api/entities/search` | `entities` | ILIKE on title/id/description | tsvector FTS + trigram fallback |
| `GET /api/entities/organizations` | `entities` | ILIKE via `buildSearchCondition` | tsvector FTS + trigram fallback |
| `GET /api/people` | `things` | ILIKE on title/description/facts | tsvector FTS on `search_vector` + ILIKE on facts + trigram fallback |

## Migration
Migration `0120_entities_search_vector.sql` adds:
- `search_vector tsvector GENERATED ALWAYS AS (...)` column on `entities`
- GIN index `idx_entities_search` on `search_vector`
- `pg_trgm` extension (idempotent)
- GIN trigram index `idx_entities_title_trgm` on `title`

The entities table has ~2,000 rows so this runs instantly — no manual migration needed.

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit` on wiki-server and web)
- [x] Unit tests pass (45 tests: 24 search-utils + 21 query-helpers including 12 new tsvector tests)
- [x] Response shape is backwards-compatible (`searchMode` is additive)
- [ ] Verify on staging: search for "Anthropic", "MIRI", "sb1047", misspelled "Anthropik"
- [ ] Verify trigram fallback activates for typos (searchMode: "trigram" in response)

Closes #2379
