### PR TITLE
Fix broken Coefficient Giving grant source URLs

### DIFF
--- a/apps/wiki-server/drizzle/0126_fix_coefficient_giving_source_urls.sql
+++ b/apps/wiki-server/drizzle/0126_fix_coefficient_giving_source_urls.sql
@@ -1,0 +1,14 @@
+-- Fix broken Coefficient Giving grant source URLs.
+-- The old /grants/ page returns 404 after the Open Philanthropy → Coefficient Giving rebrand.
+-- The grants are now listed per-fund at /funds/.
+-- Also updates the criminal justice program source URL which used a /grants/?q= query pattern.
+
+UPDATE grants
+SET source = 'https://coefficientgiving.org/funds/',
+    updated_at = now()
+WHERE source = 'https://coefficientgiving.org/grants/';
+
+UPDATE funding_programs
+SET source = 'https://coefficientgiving.org/grant-publishing-process/',
+    updated_at = now()
+WHERE source = 'https://coefficientgiving.org/grants/?q=&focus-area=criminal-justice-reform';

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -883,6 +883,13 @@
       "when": 1780473600000,
       "tag": "0125_create_entity_recommended_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 126,
+      "version": "7",
+      "when": 1780560000000,
+      "tag": "0126_fix_coefficient_giving_source_urls",
+      "breakpoints": true
     }
   ]
 }

--- a/content/docs/knowledge-base/organizations/coefficient-giving.mdx
+++ b/content/docs/knowledge-base/organizations/coefficient-giving.mdx
@@ -40,7 +40,7 @@ import { Mermaid, EntityLink } from '@components/wiki';
 | **Leadership** | Alexander Berger (CEO), <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> (Board) |
 | **Location** | San Francisco, California |
 | **Website** | [coefficientgiving.org](https://coefficientgiving.org/) |
-| **Grants Database** | [coefficientgiving.org/grants](https://coefficientgiving.org/grants/) |
+| **Grants Database** | [coefficientgiving.org/funds](https://coefficientgiving.org/funds/) |
 
 ## Overview
 
@@ -444,7 +444,7 @@ Key challenges to this transition include organizational inertia (Coefficient's 
 ## External Links
 
 - [Coefficient Giving Website](https://coefficientgiving.org/)
-- [Coefficient Giving Grants Database](https://coefficientgiving.org/grants/)
+- [Coefficient Giving Funds](https://coefficientgiving.org/funds/)
 - [Apply for Funding](https://coefficientgiving.org/apply-for-funding/)
 - [Navigating Transformative AI Fund](https://coefficientgiving.org/funds/navigating-transformative-ai/)
 - [EA Forum Topic: Coefficient Giving](https://forum.effectivealtruism.org/topics/coefficient-giving)

--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -167,7 +167,7 @@ const PROGRAMS: FundingProgramDef[] = [
       "Historical grantmaking for criminal justice reform. Program wound down in 2022.",
     programType: "grant-round",
     status: "closed",
-    source: "https://coefficientgiving.org/grants/?q=&focus-area=criminal-justice-reform",
+    source: "https://coefficientgiving.org/grant-publishing-process/",
     notes: "~$200M total grants. 398 grants. Focused on reducing incarceration.",
   },
   {

--- a/crux/lib/grant-import/__tests__/sync.test.ts
+++ b/crux/lib/grant-import/__tests__/sync.test.ts
@@ -67,8 +67,8 @@ describe("toSyncGrant", () => {
       focusArea: null,
       description: null,
     };
-    const sync = toSyncGrant(raw, "https://coefficientgiving.org/grants/");
-    expect(sync.source).toBe("https://coefficientgiving.org/grants/");
+    const sync = toSyncGrant(raw, "https://coefficientgiving.org/funds/");
+    expect(sync.source).toBe("https://coefficientgiving.org/funds/");
   });
 
   it("uses raw.sourceUrl when present (Manifund)", () => {
@@ -273,7 +273,7 @@ describe("toSyncGrant", () => {
       focusArea: null,
       description: null,
     };
-    const sync = toSyncGrant(raw, "https://coefficientgiving.org/grants/");
+    const sync = toSyncGrant(raw, "https://coefficientgiving.org/funds/");
     expect(sync.granteeId).toBeNull();
   });
 
@@ -289,7 +289,7 @@ describe("toSyncGrant", () => {
       focusArea: null,
       description: null,
     };
-    const sync = toSyncGrant(raw, "https://coefficientgiving.org/grants/");
+    const sync = toSyncGrant(raw, "https://coefficientgiving.org/funds/");
     expect(sync.granteeId).toBe("Some Real Organization");
   });
 
@@ -305,7 +305,7 @@ describe("toSyncGrant", () => {
       focusArea: null,
       description: null,
     };
-    const sync = toSyncGrant(raw, "https://coefficientgiving.org/grants/");
+    const sync = toSyncGrant(raw, "https://coefficientgiving.org/funds/");
     expect(sync.granteeId).toBe("aBcDeFgHiJ");
   });
 
@@ -322,7 +322,7 @@ describe("toSyncGrant", () => {
       focusArea: "Potential Risks from Advanced AI",
       description: "To support general research",
     };
-    const sync = toSyncGrant(raw, "https://coefficientgiving.org/grants/");
+    const sync = toSyncGrant(raw, "https://coefficientgiving.org/funds/");
     expect(sync.id).toBe("VvNfsbv6vA");
   });
 

--- a/crux/lib/grant-import/sources/coefficient-giving.ts
+++ b/crux/lib/grant-import/sources/coefficient-giving.ts
@@ -14,7 +14,7 @@ const CG_CSV_PATH = "/tmp/coefficient-giving-grants.csv";
 export const source: GrantSource = {
   id: "coefficient-giving",
   name: "Coefficient Giving",
-  sourceUrl: "https://coefficientgiving.org/grants/",
+  sourceUrl: "https://coefficientgiving.org/funds/",
 
   ensureData() {
     downloadIfMissing(CG_CSV_URL, CG_CSV_PATH, "Coefficient Giving CSV");


### PR DESCRIPTION
## Summary

- Fix all `coefficientgiving.org/grants/` URLs which return 404 after the Open Philanthropy rebrand
- The old centralized grants page no longer exists; grants are now listed per-fund at `/funds/`
- The old `openphilanthropy.org/grants/` correctly redirects to `coefficientgiving.org/funds/`, but the new domain never had a `/grants/` path

## Changes

- **Grant import source** (`crux/lib/grant-import/sources/coefficient-giving.ts`): Updated `sourceUrl` from `/grants/` to `/funds/`
- **Funding programs** (`crux/commands/import-funding-programs.ts`): Fixed criminal justice program source URL (`/grants/?q=...` was also 404) to point to the grant-publishing-process page
- **MDX content** (`coefficient-giving.mdx`): Updated two broken links in the info table and external links section
- **SQL migration** (`0123_fix_coefficient_giving_source_urls.sql`): Updates existing grant rows and funding program rows in PG
- **Tests**: Updated sync test assertions to use new URL

## Context

The CSV download URL (`coefficientgiving.org/wp-content/uploads/Coefficient-Giving-Grants-Archive.csv`) still works fine. Per-fund division/program source URLs (`coefficientgiving.org/funds/navigating-transformative-ai/` etc.) are all valid. Only the centralized `/grants/` path is broken.

Closes #2917

## Test plan

- [x] `pnpm test` passes (grant sync tests updated and green)
- [x] TypeScript check passes
- [ ] Verify migration runs on deploy (simple UPDATE, no DDL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)