### PR TITLE
feat: content_lifecycle field + website source registry (Discussion #2928)

### DIFF
--- a/apps/wiki-server/drizzle/0124_website_sources_and_content_lifecycle.sql
+++ b/apps/wiki-server/drizzle/0124_website_sources_and_content_lifecycle.sql
@@ -1,0 +1,66 @@
+-- WS1: Add content_lifecycle to resources
+-- WS2: Website source registry tables
+-- Part of Discussion #2928: Websites as Data Feeds
+
+-- ── Content Lifecycle ───────────────────────────────────────────────
+-- Classifies how resource content behaves over time, guiding
+-- verification scheduling and citation display.
+
+ALTER TABLE "resources" ADD COLUMN IF NOT EXISTS "content_lifecycle" TEXT;
+-- Values: 'immutable' | 'versioned' | 'evergreen' | 'ephemeral'
+
+CREATE INDEX IF NOT EXISTS "idx_res_content_lifecycle"
+  ON "resources" ("content_lifecycle");
+
+-- ── Website Sources ─────────────────────────────────────────────────
+-- Websites we actively track as structured data feeds.
+-- Each source is a domain linked to an entity (usually an organization).
+
+CREATE TABLE IF NOT EXISTS "website_sources" (
+  "id" VARCHAR(10) PRIMARY KEY,
+  "domain" TEXT NOT NULL,
+  "entity_id" TEXT REFERENCES "entities"("stable_id") ON DELETE SET NULL,
+  "entity_display_name" TEXT,
+  "reliability" TEXT NOT NULL DEFAULT 'medium',
+  "refresh_interval_days" INTEGER NOT NULL DEFAULT 30,
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "notes" TEXT,
+  "last_run_at" TIMESTAMP WITH TIME ZONE,
+  "last_error" TEXT,
+  "consecutive_failures" INTEGER NOT NULL DEFAULT 0,
+  "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_ws_domain"
+  ON "website_sources" ("domain");
+CREATE INDEX IF NOT EXISTS "idx_ws_entity"
+  ON "website_sources" ("entity_id");
+CREATE INDEX IF NOT EXISTS "idx_ws_enabled"
+  ON "website_sources" ("enabled");
+
+-- ── Website Source Pages ────────────────────────────────────────────
+-- Individual pages within a tracked website. Each page has its own
+-- fetch schedule, extraction targets, and snapshot tracking.
+
+CREATE TABLE IF NOT EXISTS "website_source_pages" (
+  "id" VARCHAR(10) PRIMARY KEY,
+  "source_id" VARCHAR(10) NOT NULL REFERENCES "website_sources"("id") ON DELETE CASCADE,
+  "path" TEXT NOT NULL,
+  "page_role" TEXT,
+  "extract_targets" JSONB,
+  "refresh_interval_days" INTEGER,
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "last_fetched_at" TIMESTAMP WITH TIME ZONE,
+  "last_content_hash" TEXT,
+  "last_snapshot_id" VARCHAR(10),
+  "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_wsp_source_path"
+  ON "website_source_pages" ("source_id", "path");
+CREATE INDEX IF NOT EXISTS "idx_wsp_role"
+  ON "website_source_pages" ("page_role");
+CREATE INDEX IF NOT EXISTS "idx_wsp_enabled"
+  ON "website_source_pages" ("enabled");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -869,6 +869,13 @@
       "when": 1780300800000,
       "tag": "0123_phase_d2b_drop_old_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 124,
+      "version": "7",
+      "when": 1780387200000,
+      "tag": "0124_website_sources_and_content_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -578,6 +578,8 @@ export const UpsertResourceSchema = z.object({
   relatedEntityIds: z.array(z.string().max(200)).max(50).nullable().optional(),
   enrichmentStatus: z.string().max(50).nullable().optional(),
   importanceScore: z.number().min(0).max(1).nullable().optional(),
+  /** How content behaves over time: immutable | versioned | evergreen | ephemeral */
+  contentLifecycle: z.enum(["immutable", "versioned", "evergreen", "ephemeral"]).nullable().optional(),
 });
 export type UpsertResource = z.infer<typeof UpsertResourceSchema>;
 

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -27,6 +27,7 @@ import { policyStakeholdersRoute } from "./routes/tablebase/policy-stakeholders.
 import { entityEventsRoute } from "./routes/tablebase/entity-events.js";
 import { entityAssessmentsRoute } from "./routes/tablebase/entity-assessments.js";
 import { publicationsRoute } from "./routes/tablebase/publications.js";
+import { websiteSourcesRoute } from "./routes/tablebase/website-sources.js";
 import { entityProfileRoute } from "./routes/tablebase/entity-profile.js";
 
 // FactBase routes — structured triples with temporal data
@@ -197,6 +198,7 @@ export function createApp() {
   app.route("/api/entity-events", entityEventsRoute);
   app.route("/api/entity-assessments", entityAssessmentsRoute);
   app.route("/api/publications", publicationsRoute);
+  app.route("/api/website-sources", websiteSourcesRoute);
 
   // Aggregated entity profile (reads from all TableBase tables)
   app.route("/api/entity-profile", entityProfileRoute);

--- a/apps/wiki-server/src/routes/tablebase/index.ts
+++ b/apps/wiki-server/src/routes/tablebase/index.ts
@@ -25,3 +25,4 @@ export { policyStakeholdersRoute, type PolicyStakeholdersRoute } from "./policy-
 export { entityEventsRoute, type EntityEventsRoute } from "./entity-events.js";
 export { entityAssessmentsRoute, type EntityAssessmentsRoute } from "./entity-assessments.js";
 export { publicationsRoute, type PublicationsRoute } from "./publications.js";
+export { websiteSourcesRoute, type WebsiteSourcesRoute } from "./website-sources.js";

--- a/apps/wiki-server/src/routes/tablebase/website-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/website-sources.ts
@@ -1,0 +1,310 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, count, desc, and, sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { websiteSources, websiteSourcePages, entities } from "../../schema.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+  zv,
+} from "../shared/utils.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 200;
+
+const VALID_RELIABILITY = ["high", "medium", "low"] as const;
+
+const VALID_PAGE_ROLES = [
+  "about",
+  "team",
+  "research",
+  "pricing",
+  "careers",
+  "docs",
+  "landing",
+  "blog-index",
+  "other",
+] as const;
+
+// ---- Schemas ----
+
+const AllQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  offset: z.coerce.number().int().min(0).default(0),
+  enabled: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+});
+
+const ByEntityQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const SyncSourceSchema = z.object({
+  id: z.string().length(10),
+  domain: z.string().min(1).max(500),
+  entityId: z.string().min(1).max(200).nullable().optional(),
+  entityDisplayName: z.string().max(500).nullable().optional(),
+  reliability: z.enum(VALID_RELIABILITY).default("medium"),
+  refreshIntervalDays: z.coerce.number().int().min(1).max(365).default(30),
+  enabled: z.boolean().default(true),
+  notes: z.string().max(5000).nullable().optional(),
+});
+
+const SyncSourceBatchSchema = z.object({
+  items: z.array(SyncSourceSchema).min(1).max(200),
+});
+
+const SyncPageSchema = z.object({
+  id: z.string().length(10),
+  sourceId: z.string().length(10),
+  path: z.string().min(1).max(2000),
+  pageRole: z.enum(VALID_PAGE_ROLES).nullable().optional(),
+  extractTargets: z.array(z.string().max(200)).max(50).nullable().optional(),
+  refreshIntervalDays: z.coerce.number().int().min(1).max(365).nullable().optional(),
+  enabled: z.boolean().default(true),
+});
+
+const SyncPageBatchSchema = z.object({
+  items: z.array(SyncPageSchema).min(1).max(500),
+});
+
+// ---- Typed row interfaces for raw SQL ----
+
+interface SourceWithPageCount {
+  id: string;
+  domain: string;
+  entity_id: string | null;
+  entity_display_name: string | null;
+  reliability: string;
+  refresh_interval_days: number;
+  enabled: boolean;
+  notes: string | null;
+  last_run_at: string | null;
+  last_error: string | null;
+  consecutive_failures: number;
+  created_at: string;
+  updated_at: string;
+  page_count: number;
+}
+
+// ---- Route ----
+
+const websiteSourcesApp = new Hono()
+
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+    const [sourcesCount] = await db
+      .select({ total: count() })
+      .from(websiteSources);
+    const [pagesCount] = await db
+      .select({ total: count() })
+      .from(websiteSourcePages);
+    const [enabledSources] = await db
+      .select({ total: count() })
+      .from(websiteSources)
+      .where(eq(websiteSources.enabled, true));
+    const [enabledPages] = await db
+      .select({ total: count() })
+      .from(websiteSourcePages)
+      .where(eq(websiteSourcePages.enabled, true));
+
+    return c.json({
+      sources: { total: sourcesCount.total, enabled: enabledSources.total },
+      pages: { total: pagesCount.total, enabled: enabledPages.total },
+    });
+  })
+
+  .get("/all", zv("query", AllQuery), async (c) => {
+    const { limit, offset, enabled } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = enabled !== undefined
+      ? eq(websiteSources.enabled, enabled)
+      : undefined;
+
+    const rows = await db
+      .select()
+      .from(websiteSources)
+      .where(conditions)
+      .orderBy(desc(websiteSources.updatedAt), websiteSources.id)
+      .limit(limit)
+      .offset(offset);
+
+    const [{ count: total }] = await db
+      .select({ count: count() })
+      .from(websiteSources)
+      .where(conditions);
+
+    // Fetch page counts per source
+    const pageCountRows = rows.length > 0
+      ? await db
+          .select({
+            sourceId: websiteSourcePages.sourceId,
+            pageCount: count(),
+          })
+          .from(websiteSourcePages)
+          .where(
+            sql`${websiteSourcePages.sourceId} IN (${sql.join(
+              rows.map((r) => sql`${r.id}`),
+              sql`, `
+            )})`
+          )
+          .groupBy(websiteSourcePages.sourceId)
+      : [];
+
+    const pageCountMap = new Map(
+      pageCountRows.map((r) => [r.sourceId, r.pageCount])
+    );
+
+    const sourcesWithPages = rows.map((r) => ({
+      ...r,
+      pageCount: pageCountMap.get(r.id) ?? 0,
+    }));
+
+    return c.json({ sources: sourcesWithPages, total, limit, offset });
+  })
+
+  .get("/by-entity/:entityId", zv("query", ByEntityQuery), async (c) => {
+    const entityId = c.req.param("entityId");
+    const { limit, offset } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    // Resolve entity — try stableId first, fall back to slug
+    let resolvedId = entityId;
+    const [byStable] = await db
+      .select({ stableId: entities.stableId })
+      .from(entities)
+      .where(eq(entities.stableId, entityId))
+      .limit(1);
+    if (!byStable) {
+      const [bySlug] = await db
+        .select({ stableId: entities.stableId })
+        .from(entities)
+        .where(eq(entities.id, entityId))
+        .limit(1);
+      if (bySlug) resolvedId = bySlug.stableId;
+    }
+
+    const rows = await db
+      .select()
+      .from(websiteSources)
+      .where(eq(websiteSources.entityId, resolvedId))
+      .orderBy(websiteSources.domain)
+      .limit(limit)
+      .offset(offset);
+
+    return c.json({ entityId: resolvedId, sources: rows, limit, offset });
+  })
+
+  .get("/:sourceId/pages", async (c) => {
+    const sourceId = c.req.param("sourceId");
+    const db = getDrizzleDb();
+
+    const pages = await db
+      .select()
+      .from(websiteSourcePages)
+      .where(eq(websiteSourcePages.sourceId, sourceId))
+      .orderBy(websiteSourcePages.path);
+
+    return c.json({ sourceId, pages });
+  })
+
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SyncSourceBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+    const now = new Date();
+    let upserted = 0;
+
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        await tx
+          .insert(websiteSources)
+          .values({
+            id: item.id,
+            domain: item.domain,
+            entityId: item.entityId ?? null,
+            entityDisplayName: item.entityDisplayName ?? null,
+            reliability: item.reliability,
+            refreshIntervalDays: item.refreshIntervalDays,
+            enabled: item.enabled,
+            notes: item.notes ?? null,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: websiteSources.id,
+            set: {
+              domain: item.domain,
+              entityId: item.entityId ?? null,
+              entityDisplayName: item.entityDisplayName ?? null,
+              reliability: item.reliability,
+              refreshIntervalDays: item.refreshIntervalDays,
+              enabled: item.enabled,
+              notes: item.notes ?? null,
+              updatedAt: now,
+            },
+          });
+        upserted++;
+      }
+    });
+
+    return c.json({ upserted });
+  })
+
+  .post("/sync-pages", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SyncPageBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+    const now = new Date();
+    let upserted = 0;
+
+    await db.transaction(async (tx) => {
+      for (const item of items) {
+        await tx
+          .insert(websiteSourcePages)
+          .values({
+            id: item.id,
+            sourceId: item.sourceId,
+            path: item.path,
+            pageRole: item.pageRole ?? null,
+            extractTargets: item.extractTargets ?? null,
+            refreshIntervalDays: item.refreshIntervalDays ?? null,
+            enabled: item.enabled,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: websiteSourcePages.id,
+            set: {
+              sourceId: item.sourceId,
+              path: item.path,
+              pageRole: item.pageRole ?? null,
+              extractTargets: item.extractTargets ?? null,
+              refreshIntervalDays: item.refreshIntervalDays ?? null,
+              enabled: item.enabled,
+              updatedAt: now,
+            },
+          });
+        upserted++;
+      }
+    });
+
+    return c.json({ upserted });
+  });
+
+export const websiteSourcesRoute = websiteSourcesApp;
+export type WebsiteSourcesRoute = typeof websiteSourcesApp;

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -77,6 +77,7 @@ interface ResourceSearchRow {
   enrichment_status: string | null;
   enrichment_date: string | null;
   importance_score: number | null;
+  content_lifecycle: string | null;
   created_at: string;
   updated_at: string;
   rank: number;
@@ -187,6 +188,7 @@ function resourceValues(d: ResourceInput) {
     relatedEntityIds: d.relatedEntityIds ?? null,
     enrichmentStatus: d.enrichmentStatus ?? null,
     importanceScore: d.importanceScore ?? null,
+    contentLifecycle: d.contentLifecycle ?? null,
   };
 }
 
@@ -256,6 +258,7 @@ async function upsertResource(
           ? sql`now()`
           : sql`COALESCE(null::timestamptz, ${resources.enrichmentDate})`,
         importanceScore: sql`COALESCE(${vals.importanceScore}, ${resources.importanceScore})`,
+        contentLifecycle: sql`COALESCE(${vals.contentLifecycle}, ${resources.contentLifecycle})`,
         updatedAt: sql`now()`,
       },
     })
@@ -339,6 +342,7 @@ function formatResource(r: typeof resources.$inferSelect) {
     enrichmentStatus: r.enrichmentStatus,
     enrichmentDate: r.enrichmentDate,
     importanceScore: r.importanceScore,
+    contentLifecycle: r.contentLifecycle,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   };
@@ -484,6 +488,7 @@ const resourcesApp = new Hono()
               enrichmentStatus: sql`COALESCE(excluded.enrichment_status, ${resources.enrichmentStatus})`,
               enrichmentDate: sql`CASE WHEN excluded.enrichment_status IS NOT NULL THEN now() ELSE COALESCE(null::timestamptz, ${resources.enrichmentDate}) END`,
               importanceScore: sql`COALESCE(excluded.importance_score, ${resources.importanceScore})`,
+              contentLifecycle: sql`COALESCE(excluded.content_lifecycle, ${resources.contentLifecycle})`,
               updatedAt: sql`now()`,
             },
           })
@@ -587,7 +592,7 @@ const resourcesApp = new Hono()
           fetch_status, last_fetched_at, archive_url, stance,
           context_note, resource_purpose, resource_subtype,
           type_metadata, publisher_entity_id, related_entity_ids,
-          enrichment_status, enrichment_date, importance_score,
+          enrichment_status, enrichment_date, importance_score, content_lifecycle,
           created_at, updated_at,
           ts_rank_cd(search_vector, to_tsquery('english', ${prefixQuery}), 1) AS rank
         FROM resources
@@ -628,6 +633,7 @@ const resourcesApp = new Hono()
         enrichmentStatus: r.enrichment_status,
         enrichmentDate: r.enrichment_date,
         importanceScore: r.importance_score,
+        contentLifecycle: r.content_lifecycle,
         createdAt: r.created_at,
         updatedAt: r.updated_at,
       })),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -617,6 +617,8 @@ export const resources = pgTable(
     enrichmentDate: timestamp("enrichment_date", { withTimezone: true }),
     /** Computed composite importance score 0-1 */
     importanceScore: real("importance_score"),
+    /** How content behaves over time: immutable | versioned | evergreen | ephemeral */
+    contentLifecycle: text("content_lifecycle"),
     // search_vector tsvector column is managed via raw SQL migration
     // (Drizzle doesn't have native tsvector support)
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -636,6 +638,7 @@ export const resources = pgTable(
     index("idx_res_publisher_entity_id").on(table.publisherEntityId),
     index("idx_res_resource_purpose").on(table.resourcePurpose),
     index("idx_res_resource_subtype").on(table.resourceSubtype),
+    index("idx_res_content_lifecycle").on(table.contentLifecycle),
     // GIN indexes on tags, authors, related_entity_ids, and search_vector
     // are created in migration SQL (Drizzle doesn't support GIN index declarations)
   ]
@@ -2662,6 +2665,93 @@ export const wikibasePageAssessments = pgTable(
 // Cross-entity join table tracking organization/person positions on policy entities.
 // Enables queries like "which orgs oppose AI regulation?" and
 // "what policies has Anthropic taken positions on?"
+
+// ── Website Sources ──────────────────────────────────────────────────────
+//
+// Websites tracked as structured data feeds. Each source is a domain
+// linked to an entity (usually an org). A periodic pipeline fetches
+// tracked pages, extracts structured facts via LLM, and upserts them
+// into TableBase/FactBase. See Discussion #2928.
+
+export const websiteSources = pgTable(
+  "website_sources",
+  {
+    id: varchar("id", { length: 10 }).primaryKey(),
+    /** Canonical domain, e.g. "anthropic.com" */
+    domain: text("domain").notNull(),
+    /** FK to entities.stable_id — usually the org this website belongs to */
+    entityId: text("entity_id").references(() => entities.stableId, {
+      onDelete: "set null",
+    }),
+    /** Display name resolved from entity, cached for convenience */
+    entityDisplayName: text("entity_display_name"),
+    /** Source reliability: high | medium | low */
+    reliability: text("reliability").notNull().default("medium"),
+    /** Default days between re-fetches for pages under this source */
+    refreshIntervalDays: integer("refresh_interval_days")
+      .notNull()
+      .default(30),
+    enabled: boolean("enabled").notNull().default(true),
+    notes: text("notes"),
+    /** When the extraction pipeline last ran for this source */
+    lastRunAt: timestamp("last_run_at", { withTimezone: true }),
+    /** Error message from last failed run */
+    lastError: text("last_error"),
+    /** Consecutive pipeline failures (reset to 0 on success) */
+    consecutiveFailures: integer("consecutive_failures").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_ws_domain").on(table.domain),
+    index("idx_ws_entity").on(table.entityId),
+    index("idx_ws_enabled").on(table.enabled),
+  ]
+);
+
+/** Individual pages within a tracked website source. */
+export const websiteSourcePages = pgTable(
+  "website_source_pages",
+  {
+    id: varchar("id", { length: 10 }).primaryKey(),
+    /** FK to website_sources.id */
+    sourceId: varchar("source_id", { length: 10 })
+      .notNull()
+      .references(() => websiteSources.id, { onDelete: "cascade" }),
+    /** Page path relative to domain, e.g. "/about", "/team" */
+    path: text("path").notNull(),
+    /** Role of this page: about | team | research | pricing | careers | docs | other */
+    pageRole: text("page_role"),
+    /** JSON array of FactBase property IDs to extract, e.g. ["headcount", "headquarters"] */
+    extractTargets: jsonb("extract_targets").$type<string[]>(),
+    /** Override source-level refresh interval for this page */
+    refreshIntervalDays: integer("refresh_interval_days"),
+    enabled: boolean("enabled").notNull().default(true),
+    /** When this page was last fetched */
+    lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
+    /** Content hash from last fetch (for change detection) */
+    lastContentHash: text("last_content_hash"),
+    /** ID of the most recent page_snapshot record (future FK) */
+    lastSnapshotId: varchar("last_snapshot_id", { length: 10 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_wsp_source_path").on(table.sourceId, table.path),
+    index("idx_wsp_role").on(table.pageRole),
+    index("idx_wsp_enabled").on(table.enabled),
+  ]
+);
+
+// ── Policy Stakeholders ──────────────────────────────────────────────────
 
 export const policyStakeholders = pgTable(
   "policy_stakeholders",


### PR DESCRIPTION
## Summary

Schema foundation for treating org websites as structured data feeds (Discussion #2928). Adds infrastructure for periodic website fetching, fact extraction, and staleness detection.

**WS1 — Content Lifecycle on Resources:**
- New `content_lifecycle` column on `resources` table: `immutable | versioned | evergreen | ephemeral`
- Wired through upsert schema (single + batch), API response serialization, and indexed for filtering
- Guides verification scheduling: only `evergreen`/`versioned` resources need periodic re-checking

**WS2 — Website Source Registry (PG-first):**
- `website_sources` table — one row per tracked domain, linked to entity via FK, with reliability, refresh interval, and operational state (last_run_at, consecutive_failures, last_error)
- `website_source_pages` table — one row per tracked page path, with page_role (about/team/research/etc.), extract_targets (JSONB array of FactBase property IDs), and snapshot tracking (last_content_hash, last_snapshot_id)
- Hono RPC API route at `/api/website-sources` with: `/stats`, `/all`, `/by-entity/:entityId`, `/:sourceId/pages`, `/sync`, `/sync-pages`

**Context:** From Discussion #2928 — org websites are primary data sources. A pipeline will periodically fetch tracked pages, extract structured facts via LLM, and upsert into TableBase/FactBase with snapshot provenance. This PR creates the schema and API; extraction pipeline and snapshot storage are follow-up work (WS3-WS7).

Closes #2928 (partial — schema only)

## Test plan
- [x] wiki-server TypeScript compiles clean (`npx tsc --noEmit`)
- [x] web app TypeScript compiles clean
- [x] All tests pass (4 pre-existing failures in entities.test.ts from tsvector migration, unrelated)
- [x] Gate check passes (all CI-blocking checks green)
- [ ] Verify migration runs on staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
