### PR TITLE
Fix CZI headcount, Open Phil redirect, and $0B display bug

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,6 +36,12 @@ const nextConfig: NextConfig = {
         destination: "/resources",
         permanent: true,
       },
+      // Open Philanthropy rebranded to Coefficient Giving (E521)
+      {
+        source: "/wiki/E552",
+        destination: "/wiki/E521",
+        permanent: true,
+      },
       // Deprecated stub E8 redirects to the canonical full page E366 (#2688)
       {
         source: "/legislation/ai-executive-order",

--- a/packages/factbase/data/things/chan-zuckerberg-initiative.yaml
+++ b/packages/factbase/data/things/chan-zuckerberg-initiative.yaml
@@ -37,11 +37,10 @@ facts:
 
   - id: f_60fN0AilQQ
     property: headcount
-    value: 70
+    value: 805
     asOf: "2026"
     source: https://fortune.com/2026/02/01/chan-zuckerberg-initiative-layoffs-all-in-on-ai-biomedical-research/
-    notes: "Approximately 70 jobs cut (~8% of workforce) to refocus on AI-biomedical
-      research"
+    notes: "Approximately 805 employees after laying off ~70 (~8% of ~875 workforce) to refocus on AI-biomedical research"
   - id: m7Lq9YLiqw
     property: founded-date
     value: "2015"

--- a/packages/factbase/src/format.ts
+++ b/packages/factbase/src/format.ts
@@ -34,6 +34,58 @@ export function formatMoney(value: number, currencyCode: string = "USD"): string
   return `${sign}${cur.symbol}${num}`;
 }
 
+// ── Adaptive divisor helpers ─────────────────────────────────────────
+
+/** Scale steps: each entry is [divisor, suffix]. Order: largest first. */
+const SCALE_STEPS: [number, string][] = [
+  [1e12, "T"],
+  [1e9, "B"],
+  [1e6, "M"],
+  [1e3, "K"],
+];
+
+/**
+ * When the configured divisor produces a value that rounds to 0,
+ * step down to a smaller scale that produces a meaningful number.
+ *
+ * Only steps down through standard scales (T/B/M/K). If the suffix
+ * isn't a recognized scale suffix, returns the original values unchanged
+ * (non-standard display configs should not be silently rewritten).
+ */
+function adaptiveDivisor(
+  value: number,
+  originalDivisor: number,
+  originalSuffix: string,
+): { divided: number; suffix: string } {
+  const trimmedSuffix = originalSuffix.trim();
+
+  // Only adapt for recognized scale suffixes
+  const isScaleSuffix = SCALE_STEPS.some(([, s]) => s === trimmedSuffix);
+  if (!isScaleSuffix) {
+    return { divided: value / originalDivisor, suffix: originalSuffix };
+  }
+
+  // Find the first scale that produces a non-zero formatted value
+  for (const [div, suf] of SCALE_STEPS) {
+    if (div >= originalDivisor) continue; // skip same or larger scales
+    const divided = value / div;
+    if (Math.abs(divided) >= 0.1) {
+      return { divided, suffix: suf };
+    }
+  }
+
+  // No scale worked — return raw value with no suffix
+  return { divided: value, suffix: "" };
+}
+
+/** Format a divided numeric value with appropriate decimal places. */
+function formatDivided(divided: number): string {
+  if (Math.abs(divided) >= 100) {
+    return divided.toLocaleString("en-US", { maximumFractionDigits: 0 });
+  }
+  return divided.toLocaleString("en-US", { maximumFractionDigits: 1 });
+}
+
 // ── Value formatting ────────────────────────────────────────────────
 
 /**
@@ -57,23 +109,26 @@ export function formatValue(value: unknown, property?: Property, currency?: stri
     }
 
     let formatted: string;
+    let effectiveSuffix = suffix ?? "";
     if (divisor && Number.isFinite(divisor)) {
       const divided = value / divisor;
-      if (divided >= 100) {
-        formatted = divided.toLocaleString("en-US", {
-          maximumFractionDigits: 0,
-        });
+      // If the divided value is too small to display meaningfully, fall back
+      // to a smaller scale. Threshold 0.1 catches both the "$0B" bug (values
+      // that round to zero) and marginal "$0.1B" cases that read better as "$50M".
+      const wouldBeZero = Math.abs(divided) > 0 && Math.abs(divided) < 0.1;
+      if (wouldBeZero) {
+        const result = adaptiveDivisor(value, divisor, effectiveSuffix);
+        formatted = formatDivided(result.divided);
+        effectiveSuffix = result.suffix;
       } else {
-        formatted = divided.toLocaleString("en-US", {
-          maximumFractionDigits: 1,
-        });
+        formatted = formatDivided(divided);
       }
     } else {
       // No divisor: use raw number without locale grouping separators.
       // This handles cases like "born-year: 1983" where commas would be wrong.
       formatted = String(value);
     }
-    return `${effectivePrefix}${formatted}${suffix ?? ""}`;
+    return `${effectivePrefix}${formatted}${effectiveSuffix}`;
   }
 
   if (typeof value === "number") {

--- a/packages/factbase/tests/currencies.test.ts
+++ b/packages/factbase/tests/currencies.test.ts
@@ -137,3 +137,71 @@ describe("formatValue with currency override", () => {
     expect(result).toBe("40%");
   });
 });
+
+describe("formatValue adaptive divisor ($0B bug fix)", () => {
+  const revenueProperty: Property = {
+    id: "revenue",
+    name: "Revenue",
+    dataType: "number",
+    unit: "USD",
+    display: { divisor: 1e9, prefix: "$", suffix: "B" },
+  };
+
+  it("falls back to M for values under $50M (would round to $0B)", () => {
+    expect(formatValue(50_000_000, revenueProperty)).toBe("$50M");
+    expect(formatValue(10_000_000, revenueProperty)).toBe("$10M");
+    expect(formatValue(1_000_000, revenueProperty)).toBe("$1M");
+  });
+
+  it("falls back to K for very small values", () => {
+    // 500K / 1e6 = 0.5 → "$0.5M" (M is sufficient)
+    expect(formatValue(500_000, revenueProperty)).toBe("$0.5M");
+    // 50K / 1e6 = 0.05 < 0.1 → falls through to K: 50K / 1e3 = 50 → "$50K"
+    expect(formatValue(50_000, revenueProperty)).toBe("$50K");
+  });
+
+  it("falls back to raw value when all scales too large", () => {
+    // 5 / 1e3 = 0.005 < 0.1 → all scales exhausted → raw value
+    expect(formatValue(5, revenueProperty)).toBe("$5");
+  });
+
+  it("still uses B for values that display correctly", () => {
+    expect(formatValue(1_000_000_000, revenueProperty)).toBe("$1B");
+    expect(formatValue(10_000_000_000, revenueProperty)).toBe("$10B");
+    expect(formatValue(500_000_000, revenueProperty)).toBe("$0.5B");
+  });
+
+  it("handles the boundary correctly (values < 0.1 after division fall back)", () => {
+    // 49M / 1e9 = 0.049 < 0.1 → falls back to M
+    expect(formatValue(49_000_000, revenueProperty)).toBe("$49M");
+    // 50M / 1e9 = 0.05 < 0.1 → falls back to M
+    expect(formatValue(50_000_000, revenueProperty)).toBe("$50M");
+    // 99M / 1e9 = 0.099 < 0.1 → falls back to M
+    expect(formatValue(99_000_000, revenueProperty)).toBe("$99M");
+    // 100M / 1e9 = 0.1 → displays as $0.1B (at the threshold)
+    expect(formatValue(100_000_000, revenueProperty)).toBe("$0.1B");
+  });
+
+  it("handles negative values with adaptive fallback", () => {
+    expect(formatValue(-10_000_000, revenueProperty)).toBe("$-10M");
+  });
+
+  it("handles zero correctly (no fallback needed)", () => {
+    expect(formatValue(0, revenueProperty)).toBe("$0B");
+  });
+
+  it("preserves currency override with adaptive fallback", () => {
+    expect(formatValue(50_000_000, revenueProperty, "GBP")).toBe("£50M");
+  });
+
+  it("does not adapt non-scale suffixes", () => {
+    const customProperty: Property = {
+      id: "custom",
+      name: "Custom",
+      dataType: "number",
+      display: { divisor: 1e9, prefix: "", suffix: " widgets" },
+    };
+    // Non-scale suffix: should NOT adapt, just display the divided value
+    expect(formatValue(10_000_000, customProperty)).toBe("0 widgets");
+  });
+});


### PR DESCRIPTION
## Summary
- **CZI headcount fix**: Corrected FactBase value from 70 (number of layoffs) to 805 (actual headcount after layoffs: 875 - 70)
- **Open Philanthropy redirect**: Added permanent Next.js redirect from `/wiki/E552` to `/wiki/E521` (Coefficient Giving) since Open Philanthropy rebranded in November 2025
- **$0B display bug fix**: `formatValue()` with `divisor: 1e9` was displaying values under ~$100M as "$0B". Added adaptive divisor fallback that steps down through B/M/K scales when the configured divisor produces a value too small to display meaningfully (e.g., $50M now shows as "$50M" instead of "$0B")

## Test plan
- [x] 9 new test cases for adaptive divisor behavior (boundary values, fallback chains, currency overrides, non-scale suffixes)
- [x] All 52 existing format/currency tests pass
- [x] No regressions in factbase test suite (pre-existing stress test failures unrelated)

Generated with [Claude Code](https://claude.com/claude-code)