### PR TITLE
fix: wikiId E2050 collision breaks main CI build

### DIFF
--- a/apps/web/src/app/internal/verification-coverage/page.tsx
+++ b/apps/web/src/app/internal/verification-coverage/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function VerificationCoveragePage() {
-  redirect("/wiki/E2050");
+  redirect("/wiki/E2100");
 }

--- a/content/docs/internal/verification-coverage-dashboard.mdx
+++ b/content/docs/internal/verification-coverage-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-wikiId: E2050
+wikiId: E2100
 title: "Verification Coverage"
 description: "Dashboard showing verification status across all TableBase data"
 subcategory: dashboards


### PR DESCRIPTION
## Summary

Main CI is red because entity auto-ID assignment (E1991-E2060 for entities without wikiIds) collides with the verification dashboard's manually assigned E2050.

Move the dashboard to E2100 (above the auto range).

**Urgent — main is broken.**

## Test plan

- [ ] Main CI build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)