### PR TITLE
refactor: extract shared post-processing and prompt-building for improve pipeline

### DIFF
--- a/crux/authoring/page-improver/build-context.ts
+++ b/crux/authoring/page-improver/build-context.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared prompt-building context for the improve pipeline.
+ *
+ * Assembles the entity lookup, KB facts, template context, and objectivity
+ * context needed to construct the IMPROVE_PROMPT. Used by both the interactive
+ * improve pipeline (improvePhase) and the batch-improve path (auto-update).
+ *
+ * Extracted from duplicated logic in improve.ts and batch-improve.ts — see #2924.
+ */
+
+import { buildEntityLookupForContent } from '../../lib/entity-lookup.ts';
+import { buildKbContextForPage } from '../../lib/factbase-context.ts';
+import { resolveTemplate, formatTemplateForPrompt } from '../../lib/content/page-templates.ts';
+import { getPageType } from '../../lib/page-analysis.ts';
+import { IMPROVE_PROMPT } from './phases/prompts.ts';
+import type { PageData, AnalysisResult, ResearchResult } from './types.ts';
+import { ROOT, buildObjectivityContext } from './utils.ts';
+
+export interface ImproveContext {
+  /** The assembled prompt string for the IMPROVE_PROMPT. */
+  prompt: string;
+  /** Entity lookup table for content-referenced entities. */
+  entityLookup: string;
+  /** KB context (structured facts) for the page entity, or null if unavailable. */
+  kbContext: string | null;
+  /** Template context string for the page type, or null if no template. */
+  templateContext: string | null;
+  /** Objectivity context (alerts + issues) from analysis. */
+  objectivityContext: string;
+}
+
+export interface BuildImproveContextOptions {
+  page: PageData;
+  currentContent: string;
+  filePath: string;
+  importPath: string;
+  directions: string;
+  analysis: AnalysisResult;
+  research: ResearchResult;
+  tier: string;
+  /** Optional: pass a custom log function. Defaults to no-op. */
+  log?: (phase: string, msg: string) => void;
+}
+
+/**
+ * Build the full improve context (entity lookup, KB facts, template, prompt).
+ *
+ * This is the shared logic that both improve.ts and batch-improve.ts use to
+ * assemble the IMPROVE_PROMPT. Callers provide page data, analysis, research,
+ * and directions; this function handles the rest.
+ */
+export async function buildImproveContext(
+  options: BuildImproveContextOptions,
+): Promise<ImproveContext> {
+  const {
+    page, currentContent, filePath, importPath,
+    directions, analysis, research, tier,
+  } = options;
+  const log = options.log ?? (() => {});
+
+  const objectivityContext = buildObjectivityContext(page, analysis);
+
+  log('improve', 'Building entity lookup table...');
+  const entityLookup = buildEntityLookupForContent(currentContent, ROOT);
+  const entityLookupCount = entityLookup.split('\n').filter(Boolean).length;
+  log('improve', `  Found ${entityLookupCount} relevant entities for lookup`);
+
+  // Load KB facts for the entity associated with this page
+  log('improve', 'Loading KB facts for entity...');
+  let kbContext: string | null = null;
+  try {
+    kbContext = await buildKbContextForPage(page.id, page.path);
+    if (kbContext) {
+      const lineCount = kbContext.split('\n').length;
+      log('improve', `  Found KB entity with ${lineCount} lines of structured facts`);
+    } else {
+      log('improve', '  No KB entity found for this page (or entity has no facts)');
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log('improve', `  KB context load failed: ${error.message} — continuing without KB context`);
+  }
+
+  // Resolve template for this page (explicit frontmatter > entity type inference)
+  const pageType = getPageType(page);
+  const fmMatch = currentContent.match(/^---\n([\s\S]*?)\n---/);
+  const pageTemplateMatch = fmMatch?.[1]?.match(/^pageTemplate:\s*(.+)$/m);
+  const pageTemplateValue = pageTemplateMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
+  const template = resolveTemplate(pageTemplateValue, pageType);
+  let templateContext: string | null = null;
+  if (template) {
+    templateContext = formatTemplateForPrompt(template);
+    log('improve', `  Using template: ${template.name}`);
+  }
+
+  const prompt = IMPROVE_PROMPT({
+    page, filePath, importPath, directions,
+    analysis, research, objectivityContext,
+    currentContent, entityLookup,
+    claimsContext: null,
+    gapAnalysisContext: null,
+    kbContext, tier, templateContext,
+  });
+
+  return {
+    prompt,
+    entityLookup,
+    kbContext,
+    templateContext,
+    objectivityContext,
+  };
+}

--- a/crux/authoring/page-improver/phases/improve.ts
+++ b/crux/authoring/page-improver/phases/improve.ts
@@ -2,25 +2,18 @@
  * Improve Phase
  *
  * Generates improved content using analysis, research, and LLM synthesis.
- * Handles entity lookup, frontmatter repair, and related-pages stripping.
+ * Delegates prompt-building to buildImproveContext() and post-processing to
+ * postProcessImproveResult() — shared with the batch-improve path.
  */
 
 import fs from 'fs';
 import { MODELS } from '../../../lib/anthropic.ts';
-import { buildEntityLookupForContent } from '../../../lib/entity-lookup.ts';
-import { buildKbContextForPage } from '../../../lib/factbase-context.ts';
-import { resolveTemplate, formatTemplateForPrompt } from '../../../lib/content/page-templates.ts';
-import { getPageType } from '../../../lib/page-analysis.ts';
-import { convertSlugsToWikiIds } from '../../creator/deployment.ts';
-import { convertNewFootnotes } from '../../../lib/convert-new-footnotes.ts';
 import { buildCachedSystemPrompt, STATIC_IMPROVE_GUIDELINES } from '../../../lib/prompt-cache.ts';
 import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '../types.ts';
-import {
-  ROOT, log, getFilePath, getImportPath, writeTemp,
-  repairFrontmatter, ensureFrontmatterFields, stripRelatedPagesSections, cleanEntityLinks, buildObjectivityContext,
-} from '../utils.ts';
+import { ROOT, log, getFilePath, getImportPath, writeTemp } from '../utils.ts';
 import { runAgent } from '../api.ts';
-import { IMPROVE_PROMPT } from './prompts.ts';
+import { buildImproveContext } from '../build-context.ts';
+import { postProcessImproveResult } from '../post-process.ts';
 
 export async function improvePhase(page: PageData, analysis: AnalysisResult, research: ResearchResult, directions: string, options: PipelineOptions, contentOverride?: string): Promise<string> {
   log('improve', 'Starting improvements');
@@ -31,48 +24,11 @@ export async function improvePhase(page: PageData, analysis: AnalysisResult, res
   const currentContent = contentOverride ?? fs.readFileSync(filePath, 'utf-8');
   const importPath = getImportPath();
 
-  const objectivityContext = buildObjectivityContext(page, analysis);
-
-  log('improve', 'Building entity lookup table...');
-  const entityLookup = buildEntityLookupForContent(currentContent, ROOT);
-  const entityLookupCount = entityLookup.split('\n').filter(Boolean).length;
-  log('improve', `  Found ${entityLookupCount} relevant entities for lookup`);
-
-  // Load KB facts for the entity associated with this page
-  log('improve', 'Loading KB facts for entity...');
-  let kbContext: string | null = null;
-  try {
-    kbContext = await buildKbContextForPage(page.id, page.path);
-    if (kbContext) {
-      const lineCount = kbContext.split('\n').length;
-      log('improve', `  Found KB entity with ${lineCount} lines of structured facts`);
-    } else {
-      log('improve', '  No KB entity found for this page (or entity has no facts)');
-    }
-  } catch (err: unknown) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    log('improve', `  KB context load failed: ${error.message} — continuing without KB context`);
-  }
-
-  // Resolve template for this page (explicit frontmatter > entity type inference)
-  const pageType = getPageType(page);
-  // Extract pageTemplate from frontmatter in the content
-  const fmMatch = currentContent.match(/^---\n([\s\S]*?)\n---/);
-  const pageTemplateMatch = fmMatch?.[1]?.match(/^pageTemplate:\s*(.+)$/m);
-  const pageTemplateValue = pageTemplateMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
-  const template = resolveTemplate(pageTemplateValue, pageType);
-  let templateContext: string | null = null;
-  if (template) {
-    templateContext = formatTemplateForPrompt(template);
-    log('improve', `  Using template: ${template.name}`);
-  }
-
   const tier = options.tier || 'standard';
-  const prompt = IMPROVE_PROMPT({
-    page, filePath, importPath, directions,
-    analysis, research, objectivityContext,
-    currentContent, entityLookup, claimsContext: null,
-    gapAnalysisContext: null, kbContext, tier, templateContext,
+  const { prompt } = await buildImproveContext({
+    page, currentContent, filePath, importPath,
+    directions, analysis, research, tier,
+    log,
   });
 
   // Use prompt caching: pass static guidelines as a cached system prompt.
@@ -86,130 +42,16 @@ export async function improvePhase(page: PageData, analysis: AnalysisResult, res
     systemPrompt: cachedSystem,
   });
 
-  let improvedContent: string = result;
-
-  // Strategy 1: If the response starts with frontmatter, use it directly.
-  // Strategy 2: Extract content from markdown code fences (```mdx, ```markdown, ```json, or bare ```)
-  // Strategy 3: Detect JSON-wrapped responses with "content" field and extract the markdown.
-  // Strategy 4: Fall back to original content if nothing looks like valid MDX.
-  if (!improvedContent.startsWith('---')) {
-    // Scan all code blocks and prefer the one whose content is valid MDX (starts with ---).
-    // The non-greedy single-match regex previously picked the *first* code block, which
-    // could be a JSON analysis blob preceding the actual MDX output — causing silent
-    // corruption of the page file. See: fix-footer-rendering-ttIYJ.
-    const codeBlocks = [...result.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)];
-    const mdxBlock = codeBlocks.find(m => m[1].trimStart().startsWith('---'));
-    if (mdxBlock) {
-      improvedContent = mdxBlock[1];
-    } else if (codeBlocks.length > 0) {
-      // Fallback: use the largest code block (most likely to be the full MDX)
-      const largest = codeBlocks.reduce((a, b) => a[1].length >= b[1].length ? a : b);
-      improvedContent = largest[1];
-    }
-
-    // Detect JSON-wrapped responses: {"content": "...", "claimMap": [...]}
-    // The LLM sometimes returns structured JSON instead of raw MDX.
-    const contentFieldMatch = improvedContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/s);
-    if (contentFieldMatch) {
-      log('improve', '⚠ Detected JSON-wrapped response — extracting "content" field');
-      try {
-        // Unescape JSON string: \n → newline, \" → ", \\ → \, \t → tab
-        const extracted = JSON.parse(`"${contentFieldMatch[1]}"`);
-        if (typeof extracted === 'string' && extracted.length > 100) {
-          improvedContent = extracted;
-        }
-      } catch {
-        // JSON.parse may fail on truncated strings — try manual unescaping
-        let raw = contentFieldMatch[1];
-        let manual = '';
-        for (let i = 0; i < raw.length; i++) {
-          if (raw[i] === '\\' && i + 1 < raw.length) {
-            const next = raw[i + 1];
-            if (next === 'n') { manual += '\n'; i++; }
-            else if (next === '"') { manual += '"'; i++; }
-            else if (next === '\\') { manual += '\\'; i++; }
-            else if (next === 't') { manual += '\t'; i++; }
-            else { manual += raw[i]; }
-          } else {
-            manual += raw[i];
-          }
-        }
-        if (manual.length > 100) {
-          log('improve', '  Used manual unescaping for truncated JSON content string');
-          improvedContent = manual;
-        }
-      }
-    }
-  }
-
-  // Validate: improved content should look like MDX (start with frontmatter or heading).
-  // If it looks like raw JSON or garbage, fall back to original content.
-  const trimmed = improvedContent.trim();
-  if (
-    !trimmed.startsWith('---') &&
-    !trimmed.startsWith('#') &&
-    !trimmed.startsWith('import ') &&
-    !trimmed.startsWith('<')
-  ) {
-    log('improve', `⚠ Response does not look like MDX (starts with "${trimmed.substring(0, 40)}...") — keeping original`);
-    return currentContent;
-  }
-
-  // Guard against LLM truncation: if output is significantly shorter than input,
-  // the LLM likely hit maxTokens and returned incomplete content.
-  const inputWords = currentContent.split(/\s+/).length;
-  const outputWords = improvedContent.split(/\s+/).length;
-  if (outputWords < inputWords * 0.5 && inputWords > 200) {
-    log('improve', `⚠ Truncation detected: output (${outputWords} words) < 50% of input (${inputWords} words) — keeping original`);
-    return currentContent;
-  }
-
-  // Update lastEdited in frontmatter
-  const today = new Date().toISOString().split('T')[0];
-  improvedContent = improvedContent.replace(
-    /lastEdited:\s*["']?\d{4}-\d{2}-\d{2}["']?/,
-    `lastEdited: "${today}"`
+  const postProcessed = await postProcessImproveResult(
+    result, currentContent, page.id, filePath, ROOT, log,
   );
 
-  improvedContent = repairFrontmatter(improvedContent);
-  improvedContent = ensureFrontmatterFields(currentContent, improvedContent);
-  improvedContent = cleanEntityLinks(improvedContent);
-  improvedContent = stripRelatedPagesSections(improvedContent);
-
-  const { content: convertedContent, converted: slugsConverted } = convertSlugsToWikiIds(improvedContent, ROOT);
-  if (slugsConverted > 0) {
-    log('improve', `  Converted ${slugsConverted} remaining slug-based EntityLink ID(s) to E## format`);
-    improvedContent = convertedContent;
+  if (postProcessed.failed) {
+    log('improve', `Post-processing failed: ${postProcessed.failureReason} — keeping original`);
+    return currentContent;
   }
 
-  // Convert numbered footnotes [^N] to [^kb-factId] or [^rc-XXXX] references.
-  // KB fact matching is attempted first when the page has a corresponding KB entity.
-  // DB entries are NOT created here (dry-run semantics) — they are created
-  // when the pipeline applies changes via --apply. This step only rewrites
-  // the footnote format in the content string.
-  try {
-    const fnResult = await convertNewFootnotes(improvedContent, page.id, {
-      createDbEntries: false,
-      entityId: page.id,
-    });
-    if (fnResult.convertedCount > 0) {
-      const parts: string[] = [];
-      if (fnResult.kbMatchCount > 0) {
-        parts.push(`${fnResult.kbMatchCount} to [^kb-...] (KB fact match)`);
-      }
-      const rcCount = fnResult.convertedCount - fnResult.kbMatchCount;
-      if (rcCount > 0) {
-        parts.push(`${rcCount} to [^rc-XXXX]`);
-      }
-      log('improve', `  Converted ${fnResult.convertedCount} numbered footnote(s): ${parts.join(', ')}`);
-      improvedContent = fnResult.content;
-    }
-  } catch (err: unknown) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    log('improve', `  Footnote conversion failed: ${error.message} — continuing with numbered footnotes`);
-  }
-
-  writeTemp(page.id, 'improved.mdx', improvedContent);
+  writeTemp(page.id, 'improved.mdx', postProcessed.content);
   log('improve', 'Complete');
-  return improvedContent;
+  return postProcessed.content;
 }

--- a/crux/authoring/page-improver/post-process.ts
+++ b/crux/authoring/page-improver/post-process.ts
@@ -1,0 +1,170 @@
+/**
+ * Post-processing for LLM improve results.
+ *
+ * Shared between the interactive improve pipeline (improvePhase) and the
+ * batch-improve path (auto-update). Extracts MDX from code fences, validates
+ * the output, repairs frontmatter, converts footnotes, etc.
+ *
+ * Extracted from duplicated logic in improve.ts and batch-improve.ts — see #2924.
+ */
+
+import { convertSlugsToWikiIds } from '../creator/deployment.ts';
+import { convertNewFootnotes } from '../../lib/convert-new-footnotes.ts';
+import {
+  repairFrontmatter,
+  ensureFrontmatterFields,
+  stripRelatedPagesSections,
+  cleanEntityLinks,
+} from './utils.ts';
+
+export interface PostProcessResult {
+  content: string;
+  failed: boolean;
+  failureReason?: string;
+}
+
+/**
+ * Post-process a raw LLM improve result into valid MDX content.
+ *
+ * Steps:
+ * 1. Extract MDX from code fences (if wrapped)
+ * 2. Detect and extract JSON-wrapped responses
+ * 3. Validate that the result looks like MDX
+ * 4. Guard against LLM truncation
+ * 5. Update lastEdited date
+ * 6. Repair frontmatter, ensure fields, clean entity links, strip related pages
+ * 7. Convert slug-based EntityLink IDs to E## format
+ * 8. Convert numbered footnotes to [^kb-...] / [^rc-XXXX] format
+ */
+export async function postProcessImproveResult(
+  rawResult: string,
+  currentContent: string,
+  pageId: string,
+  _filePath: string,
+  root: string,
+  log: (phase: string, msg: string) => void,
+): Promise<PostProcessResult> {
+  let improvedContent: string = rawResult;
+
+  // ── Step 1–2: Extract MDX from code blocks or JSON wrapper ───────────
+  if (!improvedContent.startsWith('---')) {
+    // Scan all code blocks and prefer the one whose content is valid MDX (starts with ---).
+    // The non-greedy single-match regex previously picked the *first* code block, which
+    // could be a JSON analysis blob preceding the actual MDX output — causing silent
+    // corruption of the page file. See: fix-footer-rendering-ttIYJ.
+    const codeBlocks = [...rawResult.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)];
+    const mdxBlock = codeBlocks.find(m => m[1].trimStart().startsWith('---'));
+    if (mdxBlock) {
+      improvedContent = mdxBlock[1];
+    } else if (codeBlocks.length > 0) {
+      // Fallback: use the largest code block (most likely to be the full MDX)
+      const largest = codeBlocks.reduce((a, b) => a[1].length >= b[1].length ? a : b);
+      improvedContent = largest[1];
+    }
+
+    // Detect JSON-wrapped responses: {"content": "...", "claimMap": [...]}
+    // The LLM sometimes returns structured JSON instead of raw MDX.
+    const contentFieldMatch = improvedContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/s);
+    if (contentFieldMatch) {
+      log('post-process', 'Detected JSON-wrapped response — extracting "content" field');
+      try {
+        // Unescape JSON string: \n → newline, \" → ", \\ → \, \t → tab
+        const extracted = JSON.parse(`"${contentFieldMatch[1]}"`);
+        if (typeof extracted === 'string' && extracted.length > 100) {
+          improvedContent = extracted;
+        }
+      } catch {
+        // JSON.parse may fail on truncated strings — try manual unescaping
+        const raw = contentFieldMatch[1];
+        let manual = '';
+        for (let i = 0; i < raw.length; i++) {
+          if (raw[i] === '\\' && i + 1 < raw.length) {
+            const next = raw[i + 1];
+            if (next === 'n') { manual += '\n'; i++; }
+            else if (next === '"') { manual += '"'; i++; }
+            else if (next === '\\') { manual += '\\'; i++; }
+            else if (next === 't') { manual += '\t'; i++; }
+            else { manual += raw[i]; }
+          } else {
+            manual += raw[i];
+          }
+        }
+        if (manual.length > 100) {
+          log('post-process', 'Used manual unescaping for truncated JSON content string');
+          improvedContent = manual;
+        }
+      }
+    }
+  }
+
+  // ── Step 3: Validate that the result looks like MDX ──────────────────
+  const trimmed = improvedContent.trim();
+  if (
+    !trimmed.startsWith('---') &&
+    !trimmed.startsWith('#') &&
+    !trimmed.startsWith('import ') &&
+    !trimmed.startsWith('<')
+  ) {
+    return {
+      content: currentContent,
+      failed: true,
+      failureReason: `Response does not look like MDX (starts with "${trimmed.substring(0, 40)}...")`,
+    };
+  }
+
+  // ── Step 4: Guard against LLM truncation ─────────────────────────────
+  const inputWords = currentContent.split(/\s+/).length;
+  const outputWords = improvedContent.split(/\s+/).length;
+  if (outputWords < inputWords * 0.5 && inputWords > 200) {
+    return {
+      content: currentContent,
+      failed: true,
+      failureReason: `Truncation detected: output (${outputWords} words) < 50% of input (${inputWords} words)`,
+    };
+  }
+
+  // ── Step 5: Update lastEdited in frontmatter ─────────────────────────
+  const today = new Date().toISOString().split('T')[0];
+  improvedContent = improvedContent.replace(
+    /lastEdited:\s*["']?\d{4}-\d{2}-\d{2}["']?/,
+    `lastEdited: "${today}"`,
+  );
+
+  // ── Step 6: Repair frontmatter, ensure fields, clean entity links ────
+  improvedContent = repairFrontmatter(improvedContent);
+  improvedContent = ensureFrontmatterFields(currentContent, improvedContent);
+  improvedContent = cleanEntityLinks(improvedContent);
+  improvedContent = stripRelatedPagesSections(improvedContent);
+
+  // ── Step 7: Convert slug-based EntityLink IDs to E## format ──────────
+  const { content: convertedContent, converted: slugsConverted } = convertSlugsToWikiIds(improvedContent, root);
+  if (slugsConverted > 0) {
+    log('post-process', `Converted ${slugsConverted} remaining slug-based EntityLink ID(s) to E## format`);
+    improvedContent = convertedContent;
+  }
+
+  // ── Step 8: Convert numbered footnotes ───────────────────────────────
+  try {
+    const fnResult = await convertNewFootnotes(improvedContent, pageId, {
+      createDbEntries: false,
+      entityId: pageId,
+    });
+    if (fnResult.convertedCount > 0) {
+      const parts: string[] = [];
+      if (fnResult.kbMatchCount > 0) {
+        parts.push(`${fnResult.kbMatchCount} to [^kb-...] (KB fact match)`);
+      }
+      const rcCount = fnResult.convertedCount - fnResult.kbMatchCount;
+      if (rcCount > 0) {
+        parts.push(`${rcCount} to [^rc-XXXX]`);
+      }
+      log('post-process', `Converted ${fnResult.convertedCount} numbered footnote(s): ${parts.join(', ')}`);
+      improvedContent = fnResult.content;
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log('post-process', `Footnote conversion failed: ${error.message} — continuing with numbered footnotes`);
+  }
+
+  return { content: improvedContent, failed: false };
+}

--- a/crux/auto-update/batch-improve.ts
+++ b/crux/auto-update/batch-improve.ts
@@ -19,7 +19,6 @@
  */
 
 import fs from 'fs';
-import Anthropic from '@anthropic-ai/sdk';
 import { createLlmClient } from '../lib/llm.ts';
 import { MODELS } from '../lib/anthropic.ts';
 import { buildCachedSystemPrompt, STATIC_IMPROVE_GUIDELINES } from '../lib/prompt-cache.ts';
@@ -27,20 +26,14 @@ import { runBatch, extractBatchResultText, type BatchRequest } from '../lib/anth
 import type { PageUpdate, RunResult } from './types.ts';
 import { analyzePhase } from '../authoring/page-improver/phases/analyze.ts';
 import { researchPhase } from '../authoring/page-improver/phases/research.ts';
-import { IMPROVE_PROMPT } from '../authoring/page-improver/phases/prompts.ts';
 import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '../authoring/page-improver/types.ts';
 import {
-  ROOT, getFilePath, getImportPath, repairFrontmatter, ensureFrontmatterFields,
-  stripRelatedPagesSections, cleanEntityLinks, buildObjectivityContext, loadPages, findPage,
+  ROOT, getFilePath, getImportPath, loadPages, findPage,
 } from '../authoring/page-improver/utils.ts';
 import { setApiDirectMode } from '../authoring/page-improver/api.ts';
-import { buildEntityLookupForContent } from '../lib/entity-lookup.ts';
-import { buildKbContextForPage } from '../lib/factbase-context.ts';
-import { resolveTemplate, formatTemplateForPrompt } from '../lib/content/page-templates.ts';
-import { getPageType } from '../lib/page-analysis.ts';
-import { convertSlugsToWikiIds } from '../authoring/creator/deployment.ts';
-import { convertNewFootnotes } from '../lib/convert-new-footnotes.ts';
 import { resolveModel } from '../lib/anthropic.ts';
+import { buildImproveContext } from '../authoring/page-improver/build-context.ts';
+import { postProcessImproveResult } from '../authoring/page-improver/post-process.ts';
 
 interface PreparedPage {
   update: PageUpdate;
@@ -110,41 +103,20 @@ export async function executeBatchImprove(
         research = await researchPhase(page, analysis, { ...options, deep: false });
       }
 
-      // Build the improve prompt (same as improvePhase does)
+      // Build the improve prompt using shared context builder
       const filePath = getFilePath(page.path);
       const currentContent = fs.readFileSync(filePath, 'utf-8');
       const importPath = getImportPath();
-      const objectivityContext = buildObjectivityContext(page, analysis);
-      const entityLookup = buildEntityLookupForContent(currentContent, ROOT);
 
-      let kbContext: string | null = null;
-      try {
-        kbContext = await buildKbContextForPage(page.id, page.path);
-      } catch (err: unknown) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        if (verbose) console.log(`    ${update.pageTitle}: KB context failed: ${error.message}`);
-      }
+      const verboseLog = verbose
+        ? (phase: string, msg: string) => console.log(`    ${update.pageTitle}: [${phase}] ${msg}`)
+        : undefined;
 
-      const pageType = getPageType(page);
-      const fmMatch = currentContent.match(/^---\n([\s\S]*?)\n---/);
-      const pageTemplateMatch = fmMatch?.[1]?.match(/^pageTemplate:\s*(.+)$/m);
-      const pageTemplateValue = pageTemplateMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
-      const template = resolveTemplate(pageTemplateValue, pageType);
-      let templateContext: string | null = null;
-      if (template) {
-        templateContext = formatTemplateForPrompt(template);
-      }
-
-      const prompt = IMPROVE_PROMPT({
-        page, filePath, importPath,
+      const { prompt } = await buildImproveContext({
+        page, currentContent, filePath, importPath,
         directions: update.directions,
-        analysis, research, objectivityContext,
-        currentContent, entityLookup,
-        claimsContext: null,
-        gapAnalysisContext: null,
-        kbContext,
-        tier: update.suggestedTier,
-        templateContext,
+        analysis, research, tier: update.suggestedTier,
+        log: verboseLog,
       });
 
       prepared.push({
@@ -281,7 +253,7 @@ export async function executeBatchImprove(
 
 /**
  * Apply a batch API result to a page file.
- * Mirrors the post-processing logic from improvePhase.
+ * Uses shared postProcessImproveResult for all post-processing.
  */
 async function applyBatchResult(
   p: PreparedPage,
@@ -290,117 +262,26 @@ async function applyBatchResult(
 ): Promise<RunResult> {
   const start = Date.now();
 
-  let improvedContent = rawResult;
+  const verboseLog = verbose
+    ? (phase: string, msg: string) => console.log(`    ${p.update.pageTitle}: [${phase}] ${msg}`)
+    : (_phase: string, _msg: string) => {};
 
-  // Extract MDX from code blocks if wrapped
-  if (!improvedContent.startsWith('---')) {
-    const codeBlocks = [...rawResult.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)];
-    const mdxBlock = codeBlocks.find(m => m[1].trimStart().startsWith('---'));
-    if (mdxBlock) {
-      improvedContent = mdxBlock[1];
-    } else if (codeBlocks.length > 0) {
-      const largest = codeBlocks.reduce((a, b) => a[1].length >= b[1].length ? a : b);
-      improvedContent = largest[1];
-    }
-
-    // Detect JSON-wrapped responses: {"content": "...", "claimMap": [...]}
-    // The LLM sometimes returns structured JSON instead of raw MDX.
-    const contentFieldMatch = improvedContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/s);
-    if (contentFieldMatch) {
-      if (verbose) console.log(`    ${p.update.pageTitle}: detected JSON-wrapped response — extracting "content" field`);
-      try {
-        // Unescape JSON string: \n → newline, \" → ", \\ → \, \t → tab
-        const extracted = JSON.parse(`"${contentFieldMatch[1]}"`);
-        if (typeof extracted === 'string' && extracted.length > 100) {
-          improvedContent = extracted;
-        }
-      } catch {
-        // JSON.parse may fail on truncated strings — try manual unescaping
-        const raw = contentFieldMatch[1];
-        let manual = '';
-        for (let i = 0; i < raw.length; i++) {
-          if (raw[i] === '\\' && i + 1 < raw.length) {
-            const next = raw[i + 1];
-            if (next === 'n') { manual += '\n'; i++; }
-            else if (next === '"') { manual += '"'; i++; }
-            else if (next === '\\') { manual += '\\'; i++; }
-            else if (next === 't') { manual += '\t'; i++; }
-            else { manual += raw[i]; }
-          } else {
-            manual += raw[i];
-          }
-        }
-        if (manual.length > 100) {
-          if (verbose) console.log(`    ${p.update.pageTitle}: used manual unescaping for truncated JSON content string`);
-          improvedContent = manual;
-        }
-      }
-    }
-  }
-
-  // Validate: looks like MDX?
-  const trimmed = improvedContent.trim();
-  if (
-    !trimmed.startsWith('---') &&
-    !trimmed.startsWith('#') &&
-    !trimmed.startsWith('import ') &&
-    !trimmed.startsWith('<')
-  ) {
-    return {
-      pageId: p.update.pageId,
-      status: 'failed',
-      tier: p.update.suggestedTier,
-      error: `Response does not look like MDX (starts with "${trimmed.substring(0, 40)}...")`,
-      durationMs: Date.now() - start,
-    };
-  }
-
-  // Guard against truncation
-  const inputWords = p.currentContent.split(/\s+/).length;
-  const outputWords = improvedContent.split(/\s+/).length;
-  if (outputWords < inputWords * 0.5 && inputWords > 200) {
-    return {
-      pageId: p.update.pageId,
-      status: 'failed',
-      tier: p.update.suggestedTier,
-      error: `Truncation detected: output (${outputWords} words) < 50% of input (${inputWords} words)`,
-      durationMs: Date.now() - start,
-    };
-  }
-
-  // Update lastEdited
-  const today = new Date().toISOString().split('T')[0];
-  improvedContent = improvedContent.replace(
-    /lastEdited:\s*["']?\d{4}-\d{2}-\d{2}["']?/,
-    `lastEdited: "${today}"`,
+  const postProcessed = await postProcessImproveResult(
+    rawResult, p.currentContent, p.page.id, p.filePath, ROOT, verboseLog,
   );
 
-  // Post-processing (same as improvePhase)
-  improvedContent = repairFrontmatter(improvedContent);
-  improvedContent = ensureFrontmatterFields(p.currentContent, improvedContent);
-  improvedContent = cleanEntityLinks(improvedContent);
-  improvedContent = stripRelatedPagesSections(improvedContent);
-
-  const { content: convertedContent, converted: slugsConverted } = convertSlugsToWikiIds(improvedContent, ROOT);
-  if (slugsConverted > 0) {
-    improvedContent = convertedContent;
-  }
-
-  // Convert footnotes
-  try {
-    const fnResult = await convertNewFootnotes(improvedContent, p.page.id, {
-      createDbEntries: false,
-      entityId: p.page.id,
-    });
-    if (fnResult.convertedCount > 0) {
-      improvedContent = fnResult.content;
-    }
-  } catch (e: unknown) {
-    console.warn(`Footnote conversion failed: ${e instanceof Error ? e.message : String(e)}`);
+  if (postProcessed.failed) {
+    return {
+      pageId: p.update.pageId,
+      status: 'failed',
+      tier: p.update.suggestedTier,
+      error: postProcessed.failureReason,
+      durationMs: Date.now() - start,
+    };
   }
 
   // Write the result
-  fs.writeFileSync(p.filePath, improvedContent);
+  fs.writeFileSync(p.filePath, postProcessed.content);
   if (verbose) console.log(`    ${p.update.pageTitle}: applied`);
 
   return {

--- a/crux/auto-update/orchestrator.ts
+++ b/crux/auto-update/orchestrator.ts
@@ -14,7 +14,7 @@ import { stringify as stringifyYaml } from 'yaml';
 import { PROJECT_ROOT, loadPages } from '../lib/content-types.ts';
 import { fetchAllSources, loadSeenItems, saveSeenItems } from './feed-fetcher.ts';
 import { buildDigest, normalizeTitle } from './digest.ts';
-import { routeDigest } from './page-router.ts';
+import { routeDigest, COST_MAP, BATCH_COST_MAP } from './page-router.ts';
 import { getDueWatchlistUpdates, markWatchlistUpdated } from './watchlist.ts';
 import { recordAutoUpdateRun, insertAutoUpdateNewsItems } from '../lib/wiki-server/auto-update.ts';
 import type { AutoUpdateOptions, RunReport, RunResult, NewsDigest, UpdatePlan } from './types.ts';
@@ -416,10 +416,7 @@ export async function runPipeline(options: AutoUpdateOptions = {}): Promise<Pipe
   console.log(`\n── Stage 4: Executing updates${useBatch ? ' (Batch API — 50% cost reduction)' : ''} ──`);
   const results: RunResult[] = [];
   let spent = 0;
-  // Batch API provides 50% discount on all token costs
-  const costMap: Record<string, number> = useBatch
-    ? { polish: 1.25, standard: 3.25, deep: 6.25 }
-    : { polish: 2.5, standard: 6.5, deep: 12.5 };
+  const costMap = useBatch ? BATCH_COST_MAP : COST_MAP;
 
   if (useBatch) {
     // ── Batch execution path ──────────────────────────────────────────────

--- a/crux/auto-update/page-router.ts
+++ b/crux/auto-update/page-router.ts
@@ -200,12 +200,21 @@ Output ONLY a JSON object with this structure:
  * With Batch API (--batch flag): 50% discount on all token costs.
  * Batch costs: polish ~$1.25, standard ~$3.25, deep ~$6.25, budget ~$1.50
  */
-const COST_MAP: Record<string, number> = {
+export const COST_MAP: Record<string, number> = {
   polish: 2.5,
   standard: 6.5,
   deep: 12.5,
   budget: 3,
   premium: 10,
+};
+
+/** Batch API costs: 50% discount on all token costs. */
+export const BATCH_COST_MAP: Record<string, number> = {
+  polish: 1.25,
+  standard: 3.25,
+  deep: 6.25,
+  budget: 1.5,
+  premium: 5,
 };
 
 // ── Routing Helpers (exported for testing) ───────────────────────────────────


### PR DESCRIPTION
## Summary

- Extract `postProcessImproveResult()` into `crux/authoring/page-improver/post-process.ts` — shared between `improve.ts` and `batch-improve.ts` for MDX extraction, validation, frontmatter repair, footnote conversion
- Extract `buildImproveContext()` into `crux/authoring/page-improver/build-context.ts` — shared prompt-building logic (entity lookup, KB facts, template resolution, IMPROVE_PROMPT assembly)
- Export `COST_MAP` and `BATCH_COST_MAP` from `page-router.ts` and import in `orchestrator.ts` instead of hardcoding

Follow-up to #2924 which identified these DRY issues during code review.

## Test plan

- [x] `vitest run --config crux/vitest.config.ts` passes (185/186 pass, 1 pre-existing timeout)
- [x] TypeScript compilation has no new errors in changed files
- [x] No behavioral changes — pure refactoring of existing logic into shared modules

Generated with [Claude Code](https://claude.com/claude-code)