### PR TITLE
fix: resolve 35 broken resource references on SB 1047 page

### DIFF
--- a/content/docs/knowledge-base/responses/california-sb1047.mdx
+++ b/content/docs/knowledge-base/responses/california-sb1047.mdx
@@ -40,15 +40,15 @@ SB 1047 was the **most significant AI safety legislation attempted in the United
 
 | Source | Link |
 |--------|------|
-| Official Website | <R id="xxRisTtnKw">safesecureai.org</R> |
-| Bill Text (Enrolled) | <R id="NOfkPqw8KA">CA Legislature: SB-1047 Full Text</R> |
-| Bill Status | <R id="N8RvPLbVDQ">CA Legislature: SB-1047 Status</R> |
-| Committee Analyses | <R id="XE2klnK8vA">CA Legislature: SB-1047 Bill Analysis</R> |
-| Vote Records | <R id="YMXYiCAbzg">CA Legislature: SB-1047 Votes</R> |
+| Official Website | [safesecureai.org](https://safesecureai.org/) |
+| Bill Text (Enrolled) | [CA Legislature: SB-1047 Full Text](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202320240SB1047) |
+| Bill Status | [CA Legislature: SB-1047 Status](https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml?bill_id=202320240SB1047) |
+| Committee Analyses | [CA Legislature: SB-1047 Bill Analysis](https://leginfo.legislature.ca.gov/faces/billAnalysisClient.xhtml?bill_id=202320240SB1047) |
+| Vote Records | [CA Legislature: SB-1047 Votes](https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=202320240SB1047) |
 | Bill Navigation | <R id="NDJhYWFlOD">CA Legislature: SB-1047 Overview</R> |
 | Veto Message | <R id="OTY3NGI3Yj">Governor Newsom's Veto Message (PDF)</R> |
-| Expert Panel Report | <R id="SUekPiIsPg">The California Report on Frontier AI Policy (June 2025)</R> |
-| Bill Tracking | <R id="FIZdCVLA3w">FastDemocracy: SB 1047 Tracker</R> |
+| Expert Panel Report | [The California Report on Frontier AI Policy (June 2025)](https://www.gov.ca.gov/wp-content/uploads/2025/06/CA-Report-on-Frontier-AI-Policy.pdf) |
+| Bill Tracking | [FastDemocracy: SB 1047 Tracker](https://fastdemocracy.com/bill-search/ca/20232024/bills/CAB00024637/) |
 
 
 ## What the Bill Proposed
@@ -367,11 +367,11 @@ Some AI safety researchers opposed SB 1047 despite sharing its goals:
 - Address industry concerns about overbreadth and compliance costs
 - Balance innovation incentives with safety requirements
 - Build bipartisan coalition for passage
-- Respond to >50 stakeholder comments during <R id="XE2klnK8vA">committee process</R>
+- Respond to >50 stakeholder comments during [committee process](https://leginfo.legislature.ca.gov/faces/billAnalysisClient.xhtml?bill_id=202320240SB1047)
 
 ### Legislative Passage
 
-**August 29, 2024: Passed California Legislature** (<R id="YMXYiCAbzg">official vote records</R>; [CalMatters coverage](https://calmatters.org/economy/technology/2024/08/ai-safety-bill-california-legislature/))
+**August 29, 2024: Passed California Legislature** ([official vote records](https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=202320240SB1047); [CalMatters coverage](https://calmatters.org/economy/technology/2024/08/ai-safety-bill-california-legislature/))
 - Assembly: 48-16 (75% approval)
 - Senate: 32-1 (97% approval), concurrence 30-9
 - Bipartisan support across party lines
@@ -381,7 +381,7 @@ Some AI safety researchers opposed SB 1047 despite sharing its goals:
 
 ### Veto (September 29, 2024)
 
-The veto was extensively covered by major outlets including the <R id="134c62f84c36d583">New York Times</R>, <R id="2647ee59fd776e4b">Washington Post</R>, <R id="9dce479615a37a41">The Verge</R>, [SF Standard](https://sfstandard.com/2024/09/29/gavin-newsom-vetoes-controversial-ai-safety-bill/), and [TechCrunch](https://techcrunch.com/2024/09/29/gov-newsom-vetoes-californias-controversial-ai-bill-sb-1047/), with policy analysis from <R id="MmMxZDk2Ym">CSET Georgetown</R> and <R id="NWE0M2UxZW">Carnegie Endowment</R>. Zvi Mowshowitz's [real-time analysis of the veto](https://thezvi.substack.com/p/newsom-vetoes-sb-1047) was widely shared in the AI safety community.
+The veto was extensively covered by major outlets including the [New York Times](https://www.nytimes.com/2024/09/29/technology/california-ai-safety-bill-veto-newsom.html), [Washington Post](https://www.washingtonpost.com/technology/2024/09/29/california-ai-bill-sb-1047-veto-newsom/), [The Verge](https://www.theverge.com/2024/9/29/24257284/california-governor-newsom-vetoes-ai-safety-bill-sb-1047), [SF Standard](https://sfstandard.com/2024/09/29/gavin-newsom-vetoes-controversial-ai-safety-bill/), and [TechCrunch](https://techcrunch.com/2024/09/29/gov-newsom-vetoes-californias-controversial-ai-bill-sb-1047/), with policy analysis from <R id="MmMxZDk2Ym">CSET Georgetown</R> and <R id="NWE0M2UxZW">Carnegie Endowment</R>. Zvi Mowshowitz's [real-time analysis of the veto](https://thezvi.substack.com/p/newsom-vetoes-sb-1047) was widely shared in the AI safety community.
 
 **Governor Newsom's Rationale:**
 
@@ -426,7 +426,7 @@ Newsom simultaneously:
 - <EntityLink id="E290" name="stuart-russell">Stuart Russell</EntityLink> (UC Berkeley professor, author of leading AI textbook)
 - <EntityLink id="E433" name="max-tegmark">Max Tegmark</EntityLink> (MIT professor, founder of Future of Life Institute)
 - <EntityLink id="E116" name="elon-musk">Elon Musk</EntityLink> (<EntityLink id="E378" name="xai">xAI</EntityLink> CEO, publicly endorsed the bill)
-- <R id="9187b18768c0e05a">113+ current and former employees</R> of <EntityLink id="E218" name="openai">OpenAI</EntityLink>, Google <EntityLink id="E98" name="deepmind">DeepMind</EntityLink>, <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, <EntityLink id="E549" name="meta-ai">Meta</EntityLink>, and <EntityLink id="E378" name="xai">xAI</EntityLink> (<R id="N2M3MjZkMD">September 9, 2024 letter</R> to Governor Newsom)
+- [113+ current and former employees](https://www.wired.com/story/over-100-ai-employees-wrote-to-gov-newsom-about-sb-1047/) of <EntityLink id="E218" name="openai">OpenAI</EntityLink>, Google <EntityLink id="E98" name="deepmind">DeepMind</EntityLink>, <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, <EntityLink id="E549" name="meta-ai">Meta</EntityLink>, and <EntityLink id="E378" name="xai">xAI</EntityLink> (<R id="N2M3MjZkMD">September 9, 2024 letter</R> to Governor Newsom)
 
 ### Opponents
 
@@ -501,7 +501,7 @@ Newsom simultaneously:
 - Left door open for future iteration
 
 **Lack of Coalition:**
-- Many Democrats skeptical — <R id="f60461ec1a86c581">Nancy Pelosi and CA Congressional Democrats</R> urged Newsom to veto (see <R id="hqMQObK01g">Pelosi's official statement</R>)
+- Many Democrats skeptical — [Nancy Pelosi and CA Congressional Democrats](https://www.politico.com/news/2024/08/29/pelosi-opposes-california-ai-regulation-00176855) urged Newsom to veto (see [Pelosi's official statement](https://pelosi.house.gov/news/press-releases/pelosi-statement-opposition-california-senate-bill-1047))
 - Republicans opposed
 - Labor not fully engaged
 - Insufficient grassroots pressure
@@ -645,7 +645,7 @@ One of the most striking developments was the <R id="N2M3MjZkMD">September 2024 
 - It demonstrated grassroots support within the AI industry that went beyond the organized safety community
 
 **EA Forum and LessWrong debate:**
-SB 1047 generated <R id="aa1edac7c8c30d83">extensive discussion within EA online communities</R>, with coverage from <R id="c69432c5238f280f">Vox's Future Perfect</R> and other EA-adjacent outlets. The [80,000 Hours podcast episode with Nathan Calvin](https://80000hours.org/podcast/episodes/nathan-calvin-sb-1047-california-ai-safety-bill/) provided a deep dive into the bill's development and the safety community's role, while the [CAIS AI Safety Newsletter covered the bill's passage](https://newsletter.safe.ai/p/aisn-40-california-ai-legislation) and the [veto aftermath](https://newsletter.safe.ai/p/ai-safety-newsletter-42-newsom-vetoes). Zvi Mowshowitz also published an [early analysis on LessWrong](https://www.lesswrong.com/posts/oavGczwcHWZYhmifW/on-the-proposed-california-sb-1047) that shaped initial community opinion. The debate centered on:
+SB 1047 generated [extensive discussion within EA online communities](https://forum.effectivealtruism.org/topics/sb-1047), with coverage from [Vox's Future Perfect](https://www.vox.com/future-perfect/367015/california-ai-safety-bill-sb-1047) and other EA-adjacent outlets. The [80,000 Hours podcast episode with Nathan Calvin](https://80000hours.org/podcast/episodes/nathan-calvin-sb-1047-california-ai-safety-bill/) provided a deep dive into the bill's development and the safety community's role, while the [CAIS AI Safety Newsletter covered the bill's passage](https://newsletter.safe.ai/p/aisn-40-california-ai-legislation) and the [veto aftermath](https://newsletter.safe.ai/p/ai-safety-newsletter-42-newsom-vetoes). Zvi Mowshowitz also published an [early analysis on LessWrong](https://www.lesswrong.com/posts/oavGczwcHWZYhmifW/on-the-proposed-california-sb-1047) that shaped initial community opinion. The debate centered on:
 - Whether the bill's specific mechanisms (compute thresholds, capability testing) were well-designed
 - Whether state-level legislation was the right venue for frontier AI regulation
 - The strategic implications of Anthropic's mixed position — a safety-focused lab declining to fully support a safety bill
@@ -768,7 +768,7 @@ Following the SB 1047 veto, Governor Newsom convened the Joint California Policy
 - **Tino Cuéllar** (Carnegie Endowment for International Peace) — co-chair
 - **Jennifer Tour Chayes** (UC Berkeley, Dean of Computing)
 
-The panel released its <R id="SUekPiIsPg">recommendations in June 2025</R>, which:
+The panel released its [recommendations in June 2025](https://www.gov.ca.gov/wp-content/uploads/2025/06/CA-Report-on-Frontier-AI-Policy.pdf), which:
 - **Rejected** a compute-threshold-only approach (the core SB 1047 mechanism)
 - **Endorsed** a transparency-first framework with mandatory incident reporting
 - **Recommended** creation of CalCompute, a state computing resource for AI safety research
@@ -1022,27 +1022,27 @@ The <R id="OGMyZmYwMT">compute thresholds in SB 1047 were deliberately aligned</
 
 ### Primary Documents
 
-- <R id="NOfkPqw8KA">California Legislature: SB-1047 Bill Text (Enrolled Version)</R> - Full enrolled bill text
+- [California Legislature: SB-1047 Bill Text (Enrolled Version)](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202320240SB1047) - Full enrolled bill text
 - <R id="NDJhYWFlOD">California Legislature: SB-1047 Overview</R> - Official bill navigation and legislative history
-- <R id="N8RvPLbVDQ">California Legislature: SB-1047 Bill Status</R> - Legislative status and timeline
-- <R id="XE2klnK8vA">California Legislature: SB-1047 Bill Analysis</R> - Committee analyses from both chambers
-- <R id="YMXYiCAbzg">California Legislature: SB-1047 Votes</R> - Official vote records (Assembly 48-16, Senate 32-1)
+- [California Legislature: SB-1047 Bill Status](https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml?bill_id=202320240SB1047) - Legislative status and timeline
+- [California Legislature: SB-1047 Bill Analysis](https://leginfo.legislature.ca.gov/faces/billAnalysisClient.xhtml?bill_id=202320240SB1047) - Committee analyses from both chambers
+- [California Legislature: SB-1047 Votes](https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=202320240SB1047) - Official vote records (Assembly 48-16, Senate 32-1)
 - <R id="OTY3NGI3Yj">Governor Newsom's Veto Message (PDF)</R> - Official veto statement, September 29, 2024
-- <R id="SUekPiIsPg">The California Report on Frontier AI Policy (June 2025)</R> - Expert panel final report
+- [The California Report on Frontier AI Policy (June 2025)](https://www.gov.ca.gov/wp-content/uploads/2025/06/CA-Report-on-Frontier-AI-Policy.pdf) - Expert panel final report
 - <R id="MmQwYjgxMD">California Assembly Privacy and Consumer Protection Committee Analysis</R> - Detailed bill analysis, June 18, 2024
-- <R id="hqMQObK01g">Pelosi: Statement in Opposition to California Senate Bill 1047</R> - Official congressional opposition statement
+- [Pelosi: Statement in Opposition to California Senate Bill 1047](https://pelosi.house.gov/news/press-releases/pelosi-statement-opposition-california-senate-bill-1047) - Official congressional opposition statement
 
 ### News Coverage and Analysis
 
-- <R id="134c62f84c36d583">New York Times: California Governor Vetoes AI Safety Bill</R> - Coverage of the veto decision
-- <R id="2647ee59fd776e4b">Washington Post: California AI Bill SB 1047 Vetoed by Newsom</R> - Analysis of the veto and its implications
+- [New York Times: California Governor Vetoes AI Safety Bill](https://www.nytimes.com/2024/09/29/technology/california-ai-safety-bill-veto-newsom.html) - Coverage of the veto decision
+- [Washington Post: California AI Bill SB 1047 Vetoed by Newsom](https://www.washingtonpost.com/technology/2024/09/29/california-ai-bill-sb-1047-veto-newsom/) - Analysis of the veto and its implications
 - <R id="ODk2NGNlNm">CalMatters: Newsom vetoes major California artificial intelligence bill</R> - Comprehensive coverage of veto decision
 - <R id="NWUwNWM4Mm">NPR: California Gov. Newsom vetoes AI safety bill that divided Silicon Valley</R> - Context on industry division
 - <R id="Y2MwNGUzMD">TechCrunch: California's legislature just passed AI bill SB 1047</R> - Coverage of legislative passage
-- <R id="9dce479615a37a41">The Verge: California Governor Gavin Newsom Vetoes AI Safety Bill SB 1047</R> - Tech press coverage of veto
-- <R id="9187b18768c0e05a">Wired: Over 100 AI Employees Wrote to Gov. Newsom About SB 1047</R> - Coverage of the 113-employee letter
-- <R id="f60461ec1a86c581">Politico: Pelosi Opposes California AI Regulation</R> - Congressional Democratic opposition
-- <R id="c69432c5238f280f">Vox Future Perfect: California AI Safety Bill SB 1047</R> - Analysis from effective altruism-adjacent outlet
+- [The Verge: California Governor Gavin Newsom Vetoes AI Safety Bill SB 1047](https://www.theverge.com/2024/9/29/24257284/california-governor-newsom-vetoes-ai-safety-bill-sb-1047) - Tech press coverage of veto
+- [Wired: Over 100 AI Employees Wrote to Gov. Newsom About SB 1047](https://www.wired.com/story/over-100-ai-employees-wrote-to-gov-newsom-about-sb-1047/) - Coverage of the 113-employee letter
+- [Politico: Pelosi Opposes California AI Regulation](https://www.politico.com/news/2024/08/29/pelosi-opposes-california-ai-regulation-00176855) - Congressional Democratic opposition
+- [Vox Future Perfect: California AI Safety Bill SB 1047](https://www.vox.com/future-perfect/367015/california-ai-safety-bill-sb-1047) - Analysis from effective altruism-adjacent outlet
 - <R id="YjQ4NGJjMW">Carnegie Endowment: All Eyes on Sacramento: SB 1047 and the AI Safety Debate</R> - Policy analysis
 - [Fortune: California AI Bill SB 1047 Fierce Debate](https://fortune.com/2024/07/15/california-ai-bill-sb-1047-fierce-debate-regulation-safety/) - Feature on the national debate over the bill (July 2024)
 - [SF Standard: Gavin Newsom Vetoes Controversial AI Safety Bill](https://sfstandard.com/2024/09/29/gavin-newsom-vetoes-controversial-ai-safety-bill/) - Local coverage of the veto decision
@@ -1058,8 +1058,8 @@ The <R id="OGMyZmYwMT">compute thresholds in SB 1047 were deliberately aligned</
 - <R id="N2FiNDExYW">Orrick: California Looks to Regulate Cutting-Edge Frontier AI Models: 5 Things to Know</R> - Technical requirements breakdown
 - <R id="NzQ0NmUyZm">DLA Piper: California's SB-1047: Understanding the Safe and Secure Innovation for Frontier AI Act</R> - Early analysis
 - <R id="OGMyZmYwMT">Fenwick: Technological Challenges for Regulatory Thresholds of AI Compute</R> - Analysis of compute thresholds
-- <R id="9bcf97f47b585a6b">Stanford HAI: Analysis of the Safe and Secure Innovation for Frontier AI Models Act</R> - Academic policy analysis
-- <R id="4647ddd8b9cac7b5">Lawfare: SB 1047 and the Future of Frontier AI Safety Regulation</R> - Legal and policy analysis
+- [Stanford HAI: Analysis of the Safe and Secure Innovation for Frontier AI Models Act](https://hai.stanford.edu/news/analysis-proposed-safe-and-secure-innovation-frontier-artificial-intelligence-models-act) - Academic policy analysis
+- [Lawfare: SB 1047 and the Future of Frontier AI Safety Regulation](https://www.lawfaremedia.org/article/sb-1047-and-the-future-of-frontier-ai-safety-regulation) - Legal and policy analysis
 - <R id="MmMxZDk2Ym">CSET Georgetown: Governor Newsom Vetoes Sweeping AI Regulation SB 1047</R> - Veto analysis from Georgetown's Center for Security and Emerging Technology
 - <R id="NWE0M2UxZW">Carnegie Endowment: California SB 1047 AI Safety Bill Veto Lessons</R> - Post-veto lessons and policy analysis
 - <R id="NGYyYzMyOT">Lawfare: California's Proposed SB 1047 Would Be a Major Step Forward for AI Safety</R> - Balanced pros/cons analysis of the bill's provisions
@@ -1091,12 +1091,12 @@ The <R id="OGMyZmYwMT">compute thresholds in SB 1047 were deliberately aligned</
 - [Zvi Mowshowitz: On the Proposed California SB 1047 (LessWrong)](https://www.lesswrong.com/posts/oavGczwcHWZYhmifW/on-the-proposed-california-sb-1047) - Early community analysis that shaped initial opinion
 - [The Inside View: SB 1047 Documentary](https://theinsideview.ai/movie/) - 31-minute documentary film on the bill's journey
 - [Cognitive Revolution: Final Analysis on CA's AI Bill SB 1047](https://www.cognitiverevolution.ai/final-analysis-on-cas-ai-bill-sb-1047-with-nathan-calvin-dean-w-ball-and-steve-newman/) - Multi-perspective podcast debate with Nathan Calvin, Dean Ball, and Steve Newman
-- <R id="aa1edac7c8c30d83">EA Forum: SB 1047 Analysis</R> - Effective altruism community discussion and analysis
+- [EA Forum: SB 1047 Analysis](https://forum.effectivealtruism.org/topics/sb-1047) - Effective altruism community discussion and analysis
 
 ### Reference
 
 - <R id="N2M3MjZkMD">Wikipedia: Safe and Secure Innovation for Frontier Artificial Intelligence Models Act</R> - Overview and timeline
-- <R id="FIZdCVLA3w">FastDemocracy: SB 1047 Bill Tracking</R> - Legislative tracking and timeline
-- <R id="xxRisTtnKw">SafeSecureAI.org</R> - Senator Wiener's campaign site for SB 1047
+- [FastDemocracy: SB 1047 Bill Tracking](https://fastdemocracy.com/bill-search/ca/20232024/bills/CAB00024637/) - Legislative tracking and timeline
+- [SafeSecureAI.org](https://safesecureai.org/) - Senator Wiener's campaign site for SB 1047
 
 ---


### PR DESCRIPTION
## Summary

- Replace 17 unique broken `<R id="...">` resource reference tags (appearing 35 times total) with standard markdown links on the California SB 1047 wiki page
- These resource IDs did not match any entry in `data/resources-snapshot.json` (checked both `id` and `stable_id` fields)
- All valid `<R>` tags with matching `stable_id` entries were preserved unchanged

## Details

The broken references covered:
- **CA Legislature pages**: bill text, status, analysis, votes (5 IDs)
- **News coverage**: NYT, WaPo, The Verge, Wired, Politico, Vox Future Perfect (6 IDs)
- **Policy analysis**: Stanford HAI, Lawfare (2 IDs)
- **Other**: safesecureai.org, FastDemocracy tracker, Pelosi statement, EA Forum, CA Frontier AI Policy report (4 IDs)

Each broken `<R>` tag was converted to a `[title](url)` markdown link using the appropriate URL for the referenced source.

## Verification

- `pnpm crux w validate unified --rules=resource-ref-integrity --errors-only` passes (0 errors, was 35)
- `pnpm crux w fix escaping` and `pnpm crux w fix markdown` report no issues
- `pnpm crux w validate gate --scope=content --fix` passes all 5 gate checks

## Test plan

- [x] Resource ref integrity validator passes with 0 errors
- [x] Content gate checks pass
- [x] No other content modified beyond the broken `<R>` tag replacements