### PR TITLE
feat: validate resource refs in improve/create pipeline before writing MDX

### DIFF
--- a/crux/authoring/orchestrator/index.ts
+++ b/crux/authoring/orchestrator/index.ts
@@ -28,6 +28,7 @@ import { deployToDestination, validateCrossLinks } from '../creator/deployment.t
 
 import { runOrchestrator, normalizeDollarEscaping } from './orchestrator.ts';
 import { generateCreateScaffold } from './scaffold.ts';
+import { validatePipelineResources } from '../../lib/validation/validate-resource-refs.ts';
 import { CREATE_TIER_BUDGETS, type OrchestratorOptions, type OrchestratorResult, type OrchestratorTier, type CreateTier } from './types.ts';
 
 export type { OrchestratorOptions, OrchestratorResult, OrchestratorTier };
@@ -203,6 +204,17 @@ export async function runOrchestratorPipeline(
   finalContent = repairFrontmatter(finalContent);
   finalContent = stripRelatedPagesSections(finalContent);
   finalContent = normalizeDollarEscaping(finalContent);
+
+  // ── Resource ref validation ─────────────────────────────────────────────
+  try {
+    const resourceValidation = await validatePipelineResources(finalContent, { log });
+    if (resourceValidation.refs.changed) {
+      finalContent = resourceValidation.refs.fixedContent;
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log('resource-validation', `Warning: resource ref validation failed (non-blocking): ${error.message}`);
+  }
 
   // ── Write output ───────────────────────────────────────────────────────
 
@@ -415,6 +427,17 @@ export async function runOrchestratorCreate(
   let finalContent = result.finalContent;
   finalContent = repairFrontmatter(finalContent);
   finalContent = stripRelatedPagesSections(finalContent);
+
+  // ── Resource ref validation ─────────────────────────────────────────────
+  try {
+    const resourceValidation = await validatePipelineResources(finalContent, { log });
+    if (resourceValidation.refs.changed) {
+      finalContent = resourceValidation.refs.fixedContent;
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log('resource-validation', `Warning: resource ref validation failed (non-blocking): ${error.message}`);
+  }
 
   // ── Write output ───────────────────────────────────────────────────────
 

--- a/crux/authoring/page-creator.ts
+++ b/crux/authoring/page-creator.ts
@@ -50,6 +50,7 @@ import { shouldUseApiDirect } from '../lib/claude-cli.ts';
 import { inferEntityType } from '../lib/category-entity-types.ts';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors, createPhaseLogger } from '../lib/output.ts';
+import { validatePipelineResources } from '../lib/validation/validate-resource-refs.ts';
 import type { CreatorContext } from './creator/types.ts';
 import { runOrchestratorCreate } from './orchestrator/index.ts';
 
@@ -547,6 +548,24 @@ async function main(): Promise<void> {
   }
 
   await runPipeline(topic, tier, directions, sourceFilePath, destPath, apiDirect);
+
+  // Resource ref validation on the generated content
+  const finalPath = path.join(getTopicDir(topic), 'final.mdx');
+  const draftPath = path.join(getTopicDir(topic), 'draft.mdx');
+  const contentPath = fs.existsSync(finalPath) ? finalPath : (fs.existsSync(draftPath) ? draftPath : null);
+  if (contentPath) {
+    try {
+      const generatedContent = fs.readFileSync(contentPath, 'utf-8');
+      const resourceValidation = await validatePipelineResources(generatedContent, { log });
+      if (resourceValidation.refs.changed) {
+        fs.writeFileSync(contentPath, resourceValidation.refs.fixedContent);
+        log('resource-validation', `Fixed content written to ${contentPath}`);
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      log('resource-validation', `Warning: resource ref validation failed (non-blocking): ${error.message}`);
+    }
+  }
 
   // Deploy to destination if --dest provided
   if (destPath) {

--- a/crux/authoring/page-improver/pipeline.ts
+++ b/crux/authoring/page-improver/pipeline.ts
@@ -22,6 +22,7 @@ import { FOOTNOTE_REF_RE } from '../../lib/patterns.ts';
 import { createDbEntriesForRcFootnotes } from '../../lib/convert-new-footnotes.ts';
 import { isBiographicalPage } from '../../lib/page-analysis.ts';
 import { validateMdxContent } from '../../lib/validation/validate-mdx-content.ts';
+import { validatePipelineResources } from '../../lib/validation/validate-resource-refs.ts';
 import { ValidationEngine } from '../../lib/validation/validation-engine.ts';
 import {
   analyzePhase, researchPhase, improvePhase, improveSectionsPhase,
@@ -383,6 +384,20 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
   }
 
   if (dryRun) {
+    // Resource ref validation in dry-run mode: report but don't modify temp file
+    try {
+      const resourceValidation = await validatePipelineResources(
+        fs.readFileSync(finalPath, 'utf-8'),
+        { log },
+      );
+      if (resourceValidation.refs.brokenRefs > 0) {
+        console.log(`Resource refs: ${resourceValidation.refs.brokenRefs} broken (would be auto-fixed on --apply)`);
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      log('resource-validation', `Warning: resource ref check failed: ${error.message}`);
+    }
+
     console.log('\nTo apply changes:');
     console.log(`  cp "${finalPath}" "${filePath}"`);
     console.log('\nOr review the diff:');
@@ -406,6 +421,18 @@ export async function runPipeline(pageId: string, options: PipelineOptions = {})
     // final write. The improve phase already calls ensureFrontmatterFields, but
     // later phases (enrich, validate auto-fixes, gap-fill) can re-modify content.
     contentToApply = ensureFrontmatterFields(originalContent, contentToApply);
+
+    // Resource reference validation: check <R id="..."> tags resolve to real resources.
+    // Runs BEFORE semantic diff so that broken-ref fixes are included in the diff analysis.
+    try {
+      const resourceValidation = await validatePipelineResources(contentToApply, { log });
+      if (resourceValidation.refs.changed) {
+        contentToApply = resourceValidation.refs.fixedContent;
+      }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      log('resource-validation', `Warning: resource ref validation failed (non-blocking): ${error.message}`);
+    }
 
     // Semantic diff: analyze factual claim changes for safety audit.
     // Runs BEFORE writing to disk so that 'block' assessments can prevent bad writes.

--- a/crux/lib/patterns.ts
+++ b/crux/lib/patterns.ts
@@ -37,6 +37,17 @@ export const COMPONENT_USAGE_RE = /<([A-Z][a-zA-Z0-9]*)/g;
 export const WIKI_IMPORT_RE = /import\s*\{([^}]+)\}\s*from\s*['"]@components\/wiki['"]/;
 
 // ---------------------------------------------------------------------------
+// Resource reference patterns
+// ---------------------------------------------------------------------------
+
+/** Match `<R id="...">` — captures the ID in group 1. Use with `g` flag. */
+export const RESOURCE_REF_RE = /<R\s+id=["']([^"']+)["'][^>]*>/g;
+
+/** Match full `<R id="...">text</R>` or self-closing `<R id="..." />`.
+ *  Groups: 1=id, 2=remaining attrs, 3=children text (if not self-closing). */
+export const RESOURCE_REF_FULL_RE = /<R\s+id=["']([^"']+)["']([^>]*?)(?:\/>|>([\s\S]*?)<\/R>)/g;
+
+// ---------------------------------------------------------------------------
 // Markdown patterns
 // ---------------------------------------------------------------------------
 

--- a/crux/lib/rules/resource-ref-integrity.ts
+++ b/crux/lib/rules/resource-ref-integrity.ts
@@ -6,6 +6,7 @@
  */
 
 import { createRule, Issue, Severity, type ContentFile, type ValidationEngine } from '../validation/validation-engine.ts';
+import { RESOURCE_REF_RE } from '../patterns.ts';
 import { loadResourceIdsPGFirst } from '../../resource-io.ts';
 
 // Cache to avoid re-fetching on every file check
@@ -22,9 +23,6 @@ async function getResourceIds(): Promise<Set<string> | null> {
   }
   return resourceIdCache;
 }
-
-/** Regex matching <R id="HEXID"> or <R id='HEXID'> */
-const RESOURCE_REF_RE = /<R\s+id=["']([^"']+)["'][^>]*>/g;
 
 export const resourceRefIntegrityRule = createRule({
   id: 'resource-ref-integrity',

--- a/crux/lib/validation/validate-resource-refs.test.ts
+++ b/crux/lib/validation/validate-resource-refs.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for resource reference validation (pre-write guard).
+ *
+ * Tests cover:
+ * - Extraction of <R> tags from MDX content
+ * - Validation against known resource IDs
+ * - Auto-fixing broken refs (strip or convert to links)
+ * - Title quality checking
+ * - Edge cases (code blocks, inline code, self-closing tags)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock resource-io BEFORE importing the module under test
+vi.mock('../../resource-io.ts', () => ({
+  loadResourceIdsPGFirst: vi.fn(async () =>
+    new Set(['valid-id-1', 'valid-id-2', 'aB1cD2eF3g']),
+  ),
+  loadResources: vi.fn(() => [
+    { id: 'valid-id-1', url: 'https://example.com/1', title: 'Resource 1' },
+    { id: 'valid-id-2', url: 'https://example.com/2', title: 'Resource 2', stable_id: 'aB1cD2eF3g' },
+  ]),
+}));
+
+import {
+  extractResourceRefs,
+  validateResourceRefs,
+  validateResourceTitles,
+  loadKnownResourceIdsSync,
+  validatePipelineResources,
+} from './validate-resource-refs.ts';
+
+// ---------------------------------------------------------------------------
+// extractResourceRefs
+// ---------------------------------------------------------------------------
+
+describe('extractResourceRefs', () => {
+  it('extracts a single <R> tag with children', () => {
+    const content = 'See <R id="abc123">this resource</R> for more.';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].id).toBe('abc123');
+    expect(refs[0].displayText).toBe('this resource');
+    expect(refs[0].line).toBe(1);
+  });
+
+  it('extracts multiple <R> tags', () => {
+    const content = [
+      'First <R id="id-1">Resource A</R>',
+      'Second <R id="id-2">Resource B</R>',
+      'Third <R id="id-3">Resource C</R>',
+    ].join('\n');
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(3);
+    expect(refs[0].id).toBe('id-1');
+    expect(refs[1].id).toBe('id-2');
+    expect(refs[2].id).toBe('id-3');
+  });
+
+  it('extracts self-closing <R> tags', () => {
+    const content = 'See <R id="abc123" /> for more.';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].id).toBe('abc123');
+    expect(refs[0].displayText).toBe('');
+  });
+
+  it('reports correct line numbers', () => {
+    const content = [
+      'Line 1',
+      'Line 2',
+      '<R id="abc">text</R>',
+      'Line 4',
+    ].join('\n');
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].line).toBe(3);
+  });
+
+  it('skips <R> tags inside fenced code blocks', () => {
+    const content = '```\n<R id="abc">text</R>\n```';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('skips <R> tags inside inline code spans', () => {
+    const content = 'Use `<R id="abc">text</R>` in your page.';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('handles <R> tags with additional attributes', () => {
+    const content = '<R id="abc" showType={true}>text</R>';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].id).toBe('abc');
+  });
+
+  it('handles single-quoted IDs', () => {
+    const content = "<R id='abc'>text</R>";
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].id).toBe('abc');
+  });
+
+  it('returns empty array for content with no <R> tags', () => {
+    const content = 'Just some plain text with no resource refs.';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('handles <R> tags on the same line', () => {
+    const content = '<R id="a">A</R> and <R id="b">B</R>';
+    const refs = extractResourceRefs(content);
+    expect(refs).toHaveLength(2);
+    expect(refs[0].id).toBe('a');
+    expect(refs[1].id).toBe('b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResourceRefs
+// ---------------------------------------------------------------------------
+
+describe('validateResourceRefs', () => {
+  const knownIds = new Set(['valid-id-1', 'valid-id-2', 'valid-id-3']);
+
+  it('passes content with all valid refs unchanged', () => {
+    const content = 'See <R id="valid-id-1">Resource A</R> and <R id="valid-id-2">Resource B</R>.';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.totalRefs).toBe(2);
+    expect(result.validRefs).toBe(2);
+    expect(result.brokenRefs).toBe(0);
+    expect(result.changed).toBe(false);
+    expect(result.fixedContent).toBe(content);
+  });
+
+  it('strips broken refs with no URL context', () => {
+    const content = 'See <R id="broken-id">Missing Resource</R> for details.';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.brokenRefs).toBe(1);
+    expect(result.broken[0].fix).toBe('stripped');
+    expect(result.fixedContent).toBe('See Missing Resource for details.');
+    expect(result.changed).toBe(true);
+  });
+
+  it('converts broken refs to markdown links when URL is on same line', () => {
+    const content = 'See <R id="broken-id">Missing Resource</R> at https://example.com/article';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.brokenRefs).toBe(1);
+    expect(result.broken[0].fix).toBe('converted-to-link');
+    expect(result.broken[0].url).toBe('https://example.com/article');
+    expect(result.fixedContent).toContain('[Missing Resource](https://example.com/article)');
+  });
+
+  it('uses the resource ID as display text when children are empty (self-closing)', () => {
+    const content = 'See <R id="broken-id" /> for details.';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.brokenRefs).toBe(1);
+    expect(result.broken[0].replacement).toBe('broken-id');
+  });
+
+  it('handles a mix of valid and broken refs', () => {
+    const content = [
+      '<R id="valid-id-1">Valid</R>',
+      '<R id="broken-id">Broken</R>',
+      '<R id="valid-id-2">Also Valid</R>',
+    ].join('\n');
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.totalRefs).toBe(3);
+    expect(result.validRefs).toBe(2);
+    expect(result.brokenRefs).toBe(1);
+  });
+
+  it('handles content with no <R> tags', () => {
+    const content = 'Plain text with no resource refs.';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.totalRefs).toBe(0);
+    expect(result.validRefs).toBe(0);
+    expect(result.brokenRefs).toBe(0);
+    expect(result.changed).toBe(false);
+  });
+
+  it('handles multiple broken refs', () => {
+    const content = [
+      '<R id="bad-1">Bad 1</R>',
+      '<R id="bad-2">Bad 2</R>',
+      '<R id="bad-3">Bad 3</R>',
+    ].join('\n');
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.brokenRefs).toBe(3);
+    expect(result.fixedContent).toBe('Bad 1\nBad 2\nBad 3');
+  });
+
+  it('preserves surrounding content when fixing refs', () => {
+    const content = 'Before <R id="broken">text</R> after.';
+    const result = validateResourceRefs(content, knownIds);
+    expect(result.fixedContent).toBe('Before text after.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResourceTitles
+// ---------------------------------------------------------------------------
+
+describe('validateResourceTitles', () => {
+  it('passes valid titles', () => {
+    const titles = [
+      { id: '1', title: 'Artificial Intelligence Safety Research' },
+      { id: '2', title: 'A Study of Alignment Techniques' },
+    ];
+    const result = validateResourceTitles(titles);
+    expect(result.checked).toBe(2);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('flags empty titles', () => {
+    const result = validateResourceTitles([{ id: '1', title: '' }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toContain('empty');
+  });
+
+  it('flags domain-only titles', () => {
+    const cases = [
+      'arxiv.org',
+      'www.nature.com',
+      'github.com',
+      'https://example.com/',
+    ];
+    for (const title of cases) {
+      const result = validateResourceTitles([{ id: '1', title }]);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].reason).toContain('domain name');
+    }
+  });
+
+  it('flags error/placeholder titles', () => {
+    const badTitles = ['Untitled', '404 Not Found', 'Error', 'Page Not Found', 'Access Denied'];
+    for (const title of badTitles) {
+      const result = validateResourceTitles([{ id: '1', title }]);
+      expect(result.issues.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('flags very short titles', () => {
+    const result = validateResourceTitles([{ id: '1', title: 'AI' }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toContain('too short');
+  });
+
+  it('flags very long titles', () => {
+    const longTitle = 'A'.repeat(301);
+    const result = validateResourceTitles([{ id: '1', title: longTitle }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toContain('too long');
+  });
+
+  it('flags Cloudflare challenge page titles', () => {
+    const result = validateResourceTitles([
+      { id: '1', title: 'Just a moment...' },
+      { id: '2', title: 'Attention Required! | Cloudflare' },
+    ]);
+    expect(result.issues).toHaveLength(2);
+  });
+
+  it('does not flag legitimate titles containing flagged words', () => {
+    const result = validateResourceTitles([
+      { id: '1', title: 'Understanding 404 Error Handling in Web Development' },
+    ]);
+    // "Understanding 404 Error Handling..." starts with "Understanding", not "404"
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('handles null and undefined titles', () => {
+    const result = validateResourceTitles([{ id: '1', title: 'null' }]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toContain('null');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadKnownResourceIdsSync
+// ---------------------------------------------------------------------------
+
+describe('loadKnownResourceIdsSync', () => {
+  it('returns a set of resource IDs from snapshot', () => {
+    const ids = loadKnownResourceIdsSync();
+    expect(ids).toBeInstanceOf(Set);
+    expect(ids.has('valid-id-1')).toBe(true);
+    expect(ids.has('valid-id-2')).toBe(true);
+  });
+
+  it('includes stable_ids in the set', () => {
+    const ids = loadKnownResourceIdsSync();
+    expect(ids.has('aB1cD2eF3g')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePipelineResources (integration)
+// ---------------------------------------------------------------------------
+
+describe('validatePipelineResources', () => {
+  it('validates refs against known IDs and returns fixed content', async () => {
+    const content = [
+      '---',
+      'title: Test',
+      '---',
+      '',
+      'See <R id="valid-id-1">Good Ref</R> for details.',
+      'Also <R id="nonexistent">Bad Ref</R> here.',
+    ].join('\n');
+
+    const logMessages: Array<{ phase: string; msg: string }> = [];
+    const result = await validatePipelineResources(content, {
+      log: (phase, msg) => logMessages.push({ phase, msg }),
+    });
+
+    expect(result.resourceIdsAvailable).toBe(true);
+    expect(result.refs.totalRefs).toBe(2);
+    expect(result.refs.validRefs).toBe(1);
+    expect(result.refs.brokenRefs).toBe(1);
+    expect(result.refs.fixedContent).toContain('Good Ref');
+    expect(result.refs.fixedContent).not.toContain('<R id="nonexistent">');
+    expect(logMessages.length).toBeGreaterThan(0);
+  });
+
+  it('validates resource titles when provided', async () => {
+    const content = 'Some content with no refs.';
+    const result = await validatePipelineResources(content, {
+      newResourceTitles: [
+        { id: '1', title: 'Good Title' },
+        { id: '2', title: 'Untitled' },
+      ],
+    });
+
+    expect(result.titles).toBeDefined();
+    expect(result.titles!.checked).toBe(2);
+    expect(result.titles!.issues).toHaveLength(1);
+  });
+
+  it('handles content with all valid refs', async () => {
+    const content = '<R id="valid-id-1">Valid</R>';
+    const logMessages: Array<{ phase: string; msg: string }> = [];
+    const result = await validatePipelineResources(content, {
+      log: (phase, msg) => logMessages.push({ phase, msg }),
+    });
+
+    expect(result.refs.brokenRefs).toBe(0);
+    expect(result.refs.changed).toBe(false);
+    // Should log a success message
+    expect(logMessages.some(m => m.msg.includes('all OK'))).toBe(true);
+  });
+});

--- a/crux/lib/validation/validate-resource-refs.ts
+++ b/crux/lib/validation/validate-resource-refs.ts
@@ -1,0 +1,468 @@
+/**
+ * Resource Reference Validation — Pre-Write Guard
+ *
+ * Validates <R id="..."> tags in generated MDX content before writing to disk.
+ * Catches broken resource references at the point of creation, not downstream.
+ *
+ * This runs AFTER LLM content generation and BEFORE the file is written.
+ * It logs warnings and auto-fixes what it can (strip broken tags, convert to
+ * markdown links when URL context is available). It never blocks the write.
+ *
+ * Also validates resource title quality for newly created resources.
+ */
+
+import { loadResourceIdsPGFirst, loadResources } from '../../resource-io.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ResourceRefMatch {
+  /** Full match string (e.g., `<R id="abc123">Label</R>`) */
+  fullMatch: string;
+  /** Resource ID from the id attribute */
+  id: string;
+  /** Display text/children of the <R> tag */
+  displayText: string;
+  /** 1-based line number */
+  line: number;
+  /** Character offset in the content string */
+  offset: number;
+}
+
+export interface BrokenRef {
+  /** The original match */
+  match: ResourceRefMatch;
+  /** How the reference was fixed */
+  fix: 'stripped' | 'converted-to-link';
+  /** The replacement string */
+  replacement: string;
+  /** URL used for conversion (if applicable) */
+  url?: string;
+}
+
+export interface ResourceRefValidationResult {
+  /** Total number of <R> refs found */
+  totalRefs: number;
+  /** Number of valid refs (ID exists in resource set) */
+  validRefs: number;
+  /** Number of broken refs found */
+  brokenRefs: number;
+  /** Details of each broken ref and its fix */
+  broken: BrokenRef[];
+  /** The fixed content (with broken refs repaired) */
+  fixedContent: string;
+  /** Whether any changes were made */
+  changed: boolean;
+}
+
+export interface TitleQualityIssue {
+  title: string;
+  reason: string;
+}
+
+export interface TitleQualityResult {
+  /** Number of titles checked */
+  checked: number;
+  /** Titles with quality issues */
+  issues: TitleQualityIssue[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex matching <R id="...">...</R> or self-closing <R id="..." />.
+ *
+ * Groups:
+ *   1 = id value
+ *   2 = remaining attributes + children (for non-self-closing)
+ *   3 = children text (inside the tag, before </R>)
+ *
+ * Handles both <R id="x">text</R> and <R id="x" /> forms.
+ */
+const R_TAG_FULL_RE = /<R\s+id=["']([^"']+)["']([^>]*?)(?:\/>|>([\s\S]*?)<\/R>)/g;
+
+/**
+ * Titles that indicate a failed fetch or placeholder.
+ * Case-insensitive match.
+ */
+const BAD_TITLE_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /^untitled$/i, reason: 'placeholder title "Untitled"' },
+  { pattern: /^404\b/i, reason: 'appears to be a 404 error page title' },
+  { pattern: /^error\b/i, reason: 'appears to be an error page title' },
+  { pattern: /^page not found$/i, reason: 'page not found error' },
+  { pattern: /^access denied$/i, reason: 'access denied error' },
+  { pattern: /^forbidden$/i, reason: 'forbidden error' },
+  { pattern: /^loading\.{0,3}$/i, reason: 'loading placeholder' },
+  { pattern: /^just a moment/i, reason: 'Cloudflare challenge page' },
+  { pattern: /^attention required/i, reason: 'Cloudflare challenge page' },
+  { pattern: /^please wait/i, reason: 'loading/challenge page' },
+  { pattern: /^sign in/i, reason: 'login page title' },
+  { pattern: /^log in/i, reason: 'login page title' },
+  { pattern: /^null$/i, reason: 'null value used as title' },
+  { pattern: /^undefined$/i, reason: 'undefined value used as title' },
+  { pattern: /^none$/i, reason: 'none value used as title' },
+  { pattern: /^N\/A$/i, reason: 'N/A used as title' },
+];
+
+/**
+ * Domain-only titles: just a hostname with no meaningful content.
+ * e.g., "arxiv.org", "www.nature.com", "github.com"
+ */
+const DOMAIN_ONLY_RE = /^(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+\.)+[a-z]{2,}[\/]?$/i;
+
+// ---------------------------------------------------------------------------
+// Core: Extract <R> refs from content
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all <R id="..."> tags from MDX content.
+ * Skips refs inside fenced code blocks and inline code spans.
+ */
+export function extractResourceRefs(content: string): ResourceRefMatch[] {
+  const matches: ResourceRefMatch[] = [];
+  const lines = content.split('\n');
+  let inFencedBlock = false;
+
+  // Build a line-offset map for efficient offset -> line lookup
+  const lineOffsets: number[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    lineOffsets.push(offset);
+    offset += line.length + 1; // +1 for newline
+  }
+
+  // Process line by line to handle code blocks
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx];
+
+    // Track fenced code blocks
+    if (/^[ \t]*(`{3,}|~{3,})/.test(line)) {
+      inFencedBlock = !inFencedBlock;
+      continue;
+    }
+    if (inFencedBlock) continue;
+
+    // Strip inline code spans before checking
+    const strippedLine = line.replace(/`[^`]*`/g, match => ' '.repeat(match.length));
+
+    R_TAG_FULL_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = R_TAG_FULL_RE.exec(strippedLine)) !== null) {
+      const id = match[1];
+      const children = match[3]?.trim() || '';
+
+      // Find the corresponding full match in the original line (not stripped)
+      // We need the actual original text for replacement
+      const originalMatch = findOriginalRTag(line, id);
+
+      matches.push({
+        fullMatch: originalMatch || match[0],
+        id,
+        displayText: children,
+        line: lineIdx + 1,
+        offset: lineOffsets[lineIdx] + match.index,
+      });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Find the full original <R> tag in a line, including children and closing tag.
+ * This handles multi-attribute tags where the stripped version may differ.
+ */
+function findOriginalRTag(line: string, id: string): string | null {
+  // Build a pattern that matches the specific R tag with this ID
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`<R\\s+id=["']${escaped}["']([^>]*?)(?:\\/>|>([\\s\\S]*?)<\\/R>)`);
+  const m = re.exec(line);
+  return m ? m[0] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Core: Validate and fix broken refs
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate all <R> tags in content against a set of known resource IDs.
+ * Returns validation results with the fixed content.
+ *
+ * For broken refs:
+ * - If a URL is nearby (in a footnote or the same line), converts to a markdown link
+ * - Otherwise, strips the <R> tag and leaves the display text
+ */
+export function validateResourceRefs(
+  content: string,
+  knownIds: Set<string>,
+): ResourceRefValidationResult {
+  const refs = extractResourceRefs(content);
+  const broken: BrokenRef[] = [];
+  let fixedContent = content;
+
+  for (const ref of refs) {
+    if (knownIds.has(ref.id)) continue;
+
+    // This ref is broken — try to find a URL context for conversion
+    const nearbyUrl = findNearbyUrl(content, ref);
+    const displayText = ref.displayText || ref.id;
+
+    let replacement: string;
+    let fix: 'stripped' | 'converted-to-link';
+    let url: string | undefined;
+
+    if (nearbyUrl) {
+      replacement = `[${displayText}](${nearbyUrl})`;
+      fix = 'converted-to-link';
+      url = nearbyUrl;
+    } else {
+      replacement = displayText;
+      fix = 'stripped';
+    }
+
+    broken.push({ match: ref, fix, replacement, url });
+
+    // Apply the fix to the content
+    fixedContent = fixedContent.replace(ref.fullMatch, replacement);
+  }
+
+  return {
+    totalRefs: refs.length,
+    validRefs: refs.length - broken.length,
+    brokenRefs: broken.length,
+    broken,
+    fixedContent,
+    changed: broken.length > 0,
+  };
+}
+
+/**
+ * Try to find a URL near a broken <R> tag that could be used as a fallback link.
+ *
+ * Searches:
+ * 1. The same line for a URL
+ * 2. Footnote definitions that reference the resource ID
+ * 3. Adjacent lines (within 2 lines)
+ */
+function findNearbyUrl(content: string, ref: ResourceRefMatch): string | null {
+  const lines = content.split('\n');
+  const lineIdx = ref.line - 1; // 0-based
+
+  // URL pattern for extraction
+  const urlRe = /https?:\/\/[^\s)"'\]>]+/g;
+
+  // 1. Check the same line (but not the R tag's own id)
+  const currentLine = lines[lineIdx] || '';
+  urlRe.lastIndex = 0;
+  let urlMatch: RegExpExecArray | null;
+  while ((urlMatch = urlRe.exec(currentLine)) !== null) {
+    return urlMatch[0];
+  }
+
+  // 2. Check footnote definitions referencing this resource
+  const footnoteRe = new RegExp(`^\\[\\^\\d+\\]:.*${escapeRegExp(ref.id)}`, 'gm');
+  const footnoteMatch = footnoteRe.exec(content);
+  if (footnoteMatch) {
+    urlRe.lastIndex = 0;
+    const fnUrlMatch = urlRe.exec(footnoteMatch[0]);
+    if (fnUrlMatch) return fnUrlMatch[0];
+  }
+
+  // 3. Check adjacent lines (1 line before and after)
+  for (const delta of [-1, 1]) {
+    const adjacentIdx = lineIdx + delta;
+    if (adjacentIdx >= 0 && adjacentIdx < lines.length) {
+      const adjacentLine = lines[adjacentIdx];
+      urlRe.lastIndex = 0;
+      const adjUrlMatch = urlRe.exec(adjacentLine);
+      if (adjUrlMatch) return adjUrlMatch[0];
+    }
+  }
+
+  return null;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ---------------------------------------------------------------------------
+// Title quality validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Check resource titles for quality issues.
+ *
+ * Flags:
+ * - Domain-only titles (e.g., "arxiv.org")
+ * - Error/placeholder titles (e.g., "404", "Untitled", "Page Not Found")
+ * - Very short titles (< 3 chars)
+ * - Very long titles (> 300 chars)
+ */
+export function validateResourceTitles(
+  titles: Array<{ id: string; title: string }>,
+): TitleQualityResult {
+  const issues: TitleQualityIssue[] = [];
+
+  for (const { title } of titles) {
+    if (!title || !title.trim()) {
+      issues.push({ title: title || '(empty)', reason: 'empty or blank title' });
+      continue;
+    }
+
+    const trimmed = title.trim();
+
+    // Check for domain-only titles
+    if (DOMAIN_ONLY_RE.test(trimmed)) {
+      issues.push({ title: trimmed, reason: 'title is just a domain name' });
+      continue;
+    }
+
+    // Check against bad title patterns
+    for (const { pattern, reason } of BAD_TITLE_PATTERNS) {
+      if (pattern.test(trimmed)) {
+        issues.push({ title: trimmed, reason });
+        break;
+      }
+    }
+
+    // Check length
+    if (trimmed.length < 3) {
+      issues.push({ title: trimmed, reason: `title too short (${trimmed.length} chars)` });
+    } else if (trimmed.length > 300) {
+      issues.push({
+        title: trimmed.slice(0, 60) + '...',
+        reason: `title too long (${trimmed.length} chars)`,
+      });
+    }
+  }
+
+  return { checked: titles.length, issues };
+}
+
+// ---------------------------------------------------------------------------
+// High-level pipeline integration
+// ---------------------------------------------------------------------------
+
+/**
+ * Load known resource IDs for validation.
+ *
+ * Tries PG first, falls back to snapshot. Returns an empty set with a warning
+ * if neither is available (never blocks the pipeline).
+ */
+export async function loadKnownResourceIds(): Promise<Set<string>> {
+  try {
+    return await loadResourceIdsPGFirst();
+  } catch {
+    // Neither PG nor snapshot available
+    return new Set();
+  }
+}
+
+/**
+ * Load known resource IDs synchronously from snapshot only.
+ * Faster than the async version — use when you know the wiki-server is unavailable.
+ */
+export function loadKnownResourceIdsSync(): Set<string> {
+  try {
+    const resources = loadResources();
+    const ids = new Set(resources.map(r => r.id));
+    for (const r of resources) {
+      if (r.stable_id) ids.add(r.stable_id);
+    }
+    return ids;
+  } catch {
+    return new Set();
+  }
+}
+
+export interface PipelineResourceValidationResult {
+  /** Resource ref validation result */
+  refs: ResourceRefValidationResult;
+  /** Title quality result (if titles were checked) */
+  titles?: TitleQualityResult;
+  /** Whether resource IDs were available for checking */
+  resourceIdsAvailable: boolean;
+}
+
+/**
+ * Run resource validation on generated MDX content.
+ *
+ * This is the main entry point for the improve/create pipeline.
+ * Call it after LLM generates content, before writing to disk.
+ *
+ * @param content - The generated MDX content
+ * @param options - Optional configuration
+ * @returns Validation result with fixed content
+ */
+export async function validatePipelineResources(
+  content: string,
+  options: {
+    /** New resource titles to check for quality (id + title pairs) */
+    newResourceTitles?: Array<{ id: string; title: string }>;
+    /** Logger function for output (defaults to console.log) */
+    log?: (phase: string, message: string) => void;
+  } = {},
+): Promise<PipelineResourceValidationResult> {
+  const { newResourceTitles, log: logFn } = options;
+
+  const logMsg = logFn || ((_phase: string, msg: string) => console.log(`  [resource-validation] ${msg}`));
+
+  // Load known resource IDs
+  const knownIds = await loadKnownResourceIds();
+  const resourceIdsAvailable = knownIds.size > 0;
+
+  if (!resourceIdsAvailable) {
+    logMsg('resource-validation', 'Warning: no resource IDs available — skipping ref validation');
+    return {
+      refs: {
+        totalRefs: 0,
+        validRefs: 0,
+        brokenRefs: 0,
+        broken: [],
+        fixedContent: content,
+        changed: false,
+      },
+      resourceIdsAvailable: false,
+    };
+  }
+
+  // Validate resource refs
+  const refs = validateResourceRefs(content, knownIds);
+
+  // Log results
+  if (refs.totalRefs > 0) {
+    if (refs.brokenRefs === 0) {
+      logMsg('resource-validation', `${refs.totalRefs} resource refs validated — all OK`);
+    } else {
+      logMsg('resource-validation',
+        `${refs.totalRefs} resource refs checked — ${refs.brokenRefs} broken refs fixed:`);
+      for (const broken of refs.broken) {
+        const fixLabel = broken.fix === 'converted-to-link'
+          ? `converted to markdown link (${broken.url})`
+          : 'stripped to plain text';
+        logMsg('resource-validation',
+          `  Line ${broken.match.line}: <R id="${broken.match.id}"> — ${fixLabel}`);
+      }
+    }
+  }
+
+  // Validate title quality if new resources provided
+  let titles: TitleQualityResult | undefined;
+  if (newResourceTitles && newResourceTitles.length > 0) {
+    titles = validateResourceTitles(newResourceTitles);
+    if (titles.issues.length > 0) {
+      logMsg('resource-validation',
+        `${titles.issues.length} resource title quality issues:`);
+      for (const issue of titles.issues) {
+        logMsg('resource-validation', `  "${issue.title}" — ${issue.reason}`);
+      }
+    }
+  }
+
+  return { refs, titles, resourceIdsAvailable };
+}


### PR DESCRIPTION
## Summary
- Adds a pre-write validation step that catches broken `<R id="...">` tags before they reach disk
- When the LLM generates content with resource references that don't exist in the database, the validator either converts them to markdown links (when a URL is nearby) or strips them to plain text (preserving the display text)
- Also adds title quality validation for new resources, catching domain-only titles, error page titles, and placeholder values
- Centralizes the `RESOURCE_REF_RE` pattern in `lib/patterns.ts` to avoid drift between the downstream validation rule and the pipeline guard

## Integration Points

The validation runs in all four pipeline paths:
1. **V1 improve pipeline** (`pipeline.ts`) — both dry-run (report only) and apply (fix + report) modes
2. **V2 orchestrator improve** (`orchestrator/index.ts`)
3. **V2 orchestrator create** (`orchestrator/index.ts`)
4. **V1 page creator** (`page-creator.ts`)

## Key Design Decisions
- **Non-blocking**: The validation never prevents a page from being written — it logs warnings and auto-fixes what it can
- **Fast**: Uses the in-memory resource ID set (from PG or snapshot), no HTTP calls per resource
- **Graceful degradation**: If neither PG nor snapshot is available, validation is skipped with a warning
- **URL fallback**: When a broken `<R>` tag has a URL on the same line or an adjacent line, it converts to a markdown link instead of stripping

## Test plan
- [x] 32 new unit tests covering extraction, validation, auto-fixing, title quality, and edge cases
- [x] Existing `resource-ref-integrity` rule tests still pass (11 tests)
- [x] `pnpm test` passes (pre-existing failures in `snapshot-resources.test.ts` and `scope-flag.test.ts` are unrelated)
- [x] TypeScript check passes (no new type errors)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated resource reference validation and auto-repair across orchestrator and page authoring pipelines. Broken references are automatically converted to Markdown links when context is available or removed; validation errors are logged as non-blocking warnings allowing pipelines to continue.

* **Tests**
  * Added comprehensive test suite for resource reference extraction, validation, repair, and title quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->