### PR TITLE
fix: incorrect firecrawl EntityLink breaks main CI

### DIFF
--- a/content/docs/internal/automation-tools.mdx
+++ b/content/docs/internal/automation-tools.mdx
@@ -319,7 +319,7 @@ pnpm crux scan-content
 When verifying citations, the system fetches source URLs through a multi-layer cache:
 1. **In-memory LRU cache** (500 entries, session-scoped; implementation-defined in `crux/lib/source-cache.ts`)
 2. **PostgreSQL `citation_content`** (durable, cross-machine)
-3. **Network fetch** via <EntityLink id="E2014" name="firecrawl">Firecrawl</EntityLink> API[^rc-f762] or built-in fallback
+3. **Network fetch** via [Firecrawl](https://www.firecrawl.dev) API[^rc-f762] or built-in fallback
 
 Fetched content is cached in `.cache/sources/` locally and persisted to PostgreSQL for future sessions.
 


### PR DESCRIPTION
## Summary

`EntityLink id="E2014" name="firecrawl"` in automation-tools.mdx — E2014 is actually "rootly", not "firecrawl". Firecrawl has no wikiId so use a regular markdown link. This fixes the entitylink-ids validation error that breaks the scope-flag test and main CI.

**Main is red.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)