### PR TITLE
refactor: resolve page IDs from wiki_pages instead of entity_ids

### DIFF
--- a/apps/wiki-server/src/__tests__/auto-update-news.test.ts
+++ b/apps/wiki-server/src/__tests__/auto-update-news.test.ts
@@ -185,11 +185,10 @@ const dispatch: SqlDispatcher = (query, params) => {
     return [{ last_value: 0, is_called: false }];
   }
 
-  // ---- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-    // Allocating on first use mirrors production where all page slugs have entity_ids.
-    // Phase C verified zero NULLs, so every slug encountered here will have an ID.
-    return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+  // ---- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug")) {
+    // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+    return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
   }
 
   // ---- TRUNCATE ----

--- a/apps/wiki-server/src/__tests__/auto-update-runs.test.ts
+++ b/apps/wiki-server/src/__tests__/auto-update-runs.test.ts
@@ -95,9 +95,9 @@ const dispatch: SqlDispatcher = (query, params) => {
     return [{ last_value: 0, is_called: false }];
   }
 
-  // ---- entity_ids: SELECT WHERE slug (for resolvePageIntIds) ----
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-    return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+  // ---- wiki_pages: SELECT WHERE slug (for resolvePageIntIds) ----
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug")) {
+    return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
   }
 
   // ---- TRUNCATE ----

--- a/apps/wiki-server/src/__tests__/build-metrics.test.ts
+++ b/apps/wiki-server/src/__tests__/build-metrics.test.ts
@@ -57,12 +57,12 @@ function resetStores() {
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
-  // ---- entity_ids slug resolution (Drizzle SELECT) ----
-  if (q.includes('"entity_ids"') && q.includes('"slug"') && q.includes('"wiki_id"')) {
-    const results: Array<{ slug: string; wiki_id: number }> = [];
+  // ---- wiki_pages slug resolution (Drizzle SELECT) ----
+  if (q.includes('from "wiki_pages"') && q.includes('"slug"') && q.includes('"id"')) {
+    const results: Array<{ slug: string; id: number }> = [];
     for (const p of params) {
       if (typeof p === "string" && slugIntIdMap.has(p)) {
-        results.push({ slug: p, wiki_id: slugIntIdMap.get(p)! });
+        results.push({ slug: p, id: slugIntIdMap.get(p)! });
       }
     }
     return results;

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -650,14 +650,14 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return row ? [contentToSqlRow(row)] : [];
   }
 
-  // --- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ---
-  // Allocating on first use mirrors production where all page slugs have entity_ids.
-  // Exception: "no-entity-id" slug returns no row, simulating a page absent from entity_ids
+  // --- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ---
+  // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+  // Exception: "no-entity-id" slug returns no row, simulating a page absent from wiki_pages
   // (used to test the null-intId early-return path in routes).
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug") && !q.includes("count(*)")) {
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && !q.includes("count(*)") && !q.includes("as id")) {
     return params
       .filter((p) => String(p) !== "no-entity-id")
-      .map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+      .map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
   }
 
   // --- entity_ids fallbacks (for health check count) ---

--- a/apps/wiki-server/src/__tests__/edit-logs.test.ts
+++ b/apps/wiki-server/src/__tests__/edit-logs.test.ts
@@ -128,11 +128,10 @@ function createMockSql() {
       return [{ last_value: 0, is_called: false }];
     }
 
-    // ---- entity_ids: SELECT for page-id-helpers resolvePageIntId(s) ----
-    if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-      // Allocating on first use mirrors production where all page slugs have entity_ids.
-      // Phase C verified zero NULLs, so every slug encountered here will have an ID.
-      return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+    // ---- wiki_pages: SELECT for page-id-helpers resolvePageIntId(s) ----
+    if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && !q.includes("as id")) {
+      // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+      return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
     }
 
     // ---- ref-check: SELECT id FROM wiki_pages WHERE id IN (...) ----

--- a/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
+++ b/apps/wiki-server/src/__tests__/hallucination-risk.test.ts
@@ -85,11 +85,10 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ last_value: 0, is_called: false }];
   }
 
-  // ---- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-    // Allocating on first use mirrors production where all page slugs have entity_ids.
-    // Phase C verified zero NULLs, so every slug encountered here will have an ID.
-    return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+  // ---- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug")) {
+    // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+    return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
   }
 
   // ---- INSERT INTO hallucination_risk_snapshots ----

--- a/apps/wiki-server/src/__tests__/links.test.ts
+++ b/apps/wiki-server/src/__tests__/links.test.ts
@@ -82,16 +82,15 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ wiki_id: getIntIdForSlug(slug), slug }];
   }
 
-  // --- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ---
-  // Must not match the page_links INSERT which contains entity_ids in a JOIN
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug") && !q.includes("count(*)") && !q.includes("page_links")) {
+  // --- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ---
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && !q.includes("count(*)") && !q.includes("page_links")) {
     return params
       .map((p) => {
         const slug = String(p);
-        const wiki_id = lookupIntIdForSlug(slug);
-        return wiki_id === undefined ? null : { wiki_id, slug };
+        const id = lookupIntIdForSlug(slug);
+        return id === undefined ? null : { id, slug };
       })
-      .filter((r): r is { wiki_id: number; slug: string } => r !== null);
+      .filter((r): r is { id: number; slug: string } => r !== null);
   }
 
   // --- page_links: DELETE all ---

--- a/apps/wiki-server/src/__tests__/page-id-helpers.test.ts
+++ b/apps/wiki-server/src/__tests__/page-id-helpers.test.ts
@@ -31,25 +31,25 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return rows;
   }
 
-  // --- entity_ids: SELECT single slug (for resolvePageIntId with LIMIT) ---
+  // --- wiki_pages: SELECT single slug (for resolvePageIntId with LIMIT) ---
   // Must come before the batch matcher below, since LIMIT queries also contain "where" and "slug".
-  if (q.includes('"entity_ids"') && q.includes("limit")) {
+  if (q.includes('from "wiki_pages"') && q.includes("limit")) {
     const slug = params[0] as string;
     const wikiId = entityIdsStore.get(slug);
     if (wikiId !== undefined) {
-      return [{ wiki_id: wikiId }];
+      return [{ id: wikiId }];
     }
     return [];
   }
 
-  // --- entity_ids: SELECT WHERE slug IN (...) ---
-  if (q.includes('"entity_ids"') && q.includes("where") && q.includes('"slug"')) {
-    const results: Array<{ slug: string; wiki_id: number }> = [];
+  // --- wiki_pages: SELECT WHERE slug IN (...) ---
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes('"slug"')) {
+    const results: Array<{ slug: string; id: number }> = [];
     for (const p of params) {
       const slug = p as string;
       const wikiId = entityIdsStore.get(slug);
       if (wikiId !== undefined) {
-        results.push({ slug, wiki_id: wikiId });
+        results.push({ slug, id: wikiId });
       }
     }
     return results;

--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -59,12 +59,13 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // --- entity_ids: SELECT WHERE slug IN (...) (batch resolve from page-id-helpers) ---
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug") && !q.includes("count(*)") && !q.includes("insert into")) {
+  // --- wiki_pages: SELECT WHERE slug IN (...) (batch resolve from page-id-helpers) ---
+  // Must exclude OR queries (get-by-slug-or-wikiId), search queries, and other wiki_pages handlers.
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && q.includes(" in ") && !q.includes("count(*)") && !q.includes("insert into") && !q.includes(" or ") && !q.includes("as id")) {
     const results: Record<string, unknown>[] = [];
     for (const [numId, entry] of entityIdsStore.entries()) {
       if (params.includes(entry.slug)) {
-        results.push({ wiki_id: numId, slug: entry.slug });
+        results.push({ id: numId, slug: entry.slug });
       }
     }
     return results;

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -49,11 +49,11 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ last_value: 0, is_called: false }];
   }
 
-  // ---- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
-  if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-    // Allocating on first use mirrors production where all page slugs have entity_ids.
-    // Phase C verified zero NULLs, so every slug encountered here will have an ID.
-    return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+  // ---- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
+  // Must use 'from "wiki_pages"' to avoid matching JOIN queries that also reference wiki_pages.
+  if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && !q.includes("as id")) {
+    // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+    return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
   }
 
   // ---- ref-check: SELECT id FROM wiki_pages WHERE id IN (...) ----

--- a/apps/wiki-server/src/__tests__/sessions.test.ts
+++ b/apps/wiki-server/src/__tests__/sessions.test.ts
@@ -146,11 +146,10 @@ vi.mock("../db.js", async () => {
       return [{ last_value: 0, is_called: false }];
     }
 
-    // ---- entity_ids: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
-    if (q.includes("entity_ids") && q.includes("where") && q.includes("slug")) {
-      // Allocating on first use mirrors production where all page slugs have entity_ids.
-      // Phase C verified zero NULLs, so every slug encountered here will have an ID.
-      return params.map((p) => ({ wiki_id: getIntIdForSlug(String(p)), slug: p }));
+    // ---- wiki_pages: SELECT WHERE slug (for resolvePageIntId/resolvePageIntIds) ----
+    if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug")) {
+      // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
+      return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
     }
 
     // ---- TRUNCATE ----

--- a/apps/wiki-server/src/routes/shared/page-id-helpers.ts
+++ b/apps/wiki-server/src/routes/shared/page-id-helpers.ts
@@ -1,33 +1,37 @@
 /**
  * Shared helpers for resolving page slugs to integer IDs
  * and auto-allocating entity IDs for new pages during sync.
+ *
+ * Read lookups (resolvePageIntId/resolvePageIntIds) query wiki_pages directly
+ * since wiki_pages.id is the integer PK and wiki_pages.slug is unique.
+ * Allocation (allocateAndResolvePageIntIds) still uses entity_ids for sequence-based ID generation.
  */
 
 import { eq, inArray, sql } from "drizzle-orm";
-import { entityIds } from "../../schema.js";
+import { entityIds, wikiPages } from "../../schema.js";
 import type { getDrizzleDb } from "../../db.js";
 
 type DrizzleDb = ReturnType<typeof getDrizzleDb>;
 
 /**
- * Resolve a single page slug to its integer ID via entity_ids table.
- * Returns null if the slug has no entity_id allocation.
+ * Resolve a single page slug to its integer ID via wiki_pages.
+ * Returns null if no page exists for the slug.
  */
 export async function resolvePageIntId(
   db: DrizzleDb,
   slug: string
 ): Promise<number | null> {
   const rows = await db
-    .select({ wikiId: entityIds.wikiId })
-    .from(entityIds)
-    .where(eq(entityIds.slug, slug))
+    .select({ id: wikiPages.id })
+    .from(wikiPages)
+    .where(eq(wikiPages.slug, slug))
     .limit(1);
-  return rows[0]?.wikiId ?? null;
+  return rows[0]?.id ?? null;
 }
 
 /**
  * Resolve multiple page slugs to their integer IDs in one query.
- * Returns a Map<slug, intId>. Slugs without an entity_id allocation are omitted.
+ * Returns a Map<slug, intId>. Slugs without a wiki_pages row are omitted.
  */
 export async function resolvePageIntIds(
   db: DrizzleDb,
@@ -37,13 +41,13 @@ export async function resolvePageIntIds(
 
   const uniqueSlugs = [...new Set(slugs)];
   const rows = await db
-    .select({ slug: entityIds.slug, wikiId: entityIds.wikiId })
-    .from(entityIds)
-    .where(inArray(entityIds.slug, uniqueSlugs));
+    .select({ slug: wikiPages.slug, id: wikiPages.id })
+    .from(wikiPages)
+    .where(inArray(wikiPages.slug, uniqueSlugs));
 
   const map = new Map<string, number>();
   for (const row of rows) {
-    map.set(row.slug, row.wikiId);
+    map.set(row.slug, row.id);
   }
   return map;
 }


### PR DESCRIPTION
## Summary

Post-migration optimization: `resolvePageIntId` and `resolvePageIntIds` now query `wiki_pages` directly instead of the `entity_ids` lookup table.

Now that `wiki_pages.id` is the integer PK and `wiki_pages.slug` is unique, there's no need to go through `entity_ids` for read lookups. This removes a table hop from every page-referencing write (~40 call sites across 16 route files).

`allocateAndResolvePageIntIds` still uses `entity_ids` for sequence-based ID generation — that role is unchanged.

## Test plan
- [x] TypeScript clean
- [x] 669 wiki-server tests pass
- [x] `page-id-helpers.test.ts` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal database query logic for page ID resolution while maintaining all existing functionality and user-facing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->