### PR TITLE
refactor: extract shared fetchSourceContent utility

### DIFF
--- a/crux/commands/factbase-source-check.ts
+++ b/crux/commands/factbase-source-check.ts
@@ -19,23 +19,11 @@ import type { Graph } from '../../packages/factbase/src/graph.ts';
 import type { Entity, Fact, Property } from '../../packages/factbase/src/types.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { parseJsonResponse } from '../lib/anthropic.ts';
-import { getCitationContentByUrl } from '../lib/wiki-server/citations.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
-import {
-  detectPaywall,
-  isUnverifiableDomain,
-  classifyFetchError,
-  type SourceFetchErrorType,
-} from '../lib/search/paywall-detection.ts';
+import type { SourceFetchErrorType } from '../lib/search/paywall-detection.ts';
 import { loadGraphFull, resolveEntity } from '../lib/factbase-loader.ts';
 import type { LoadedKB } from '../lib/factbase-loader.ts';
-
-// ── Constants ─────────────────────────────────────────────────────────
-
-/** Max characters of source content to send to the LLM */
-const MAX_CONTENT_LENGTH = 8000;
-/** HTTP fetch timeout in milliseconds */
-const FETCH_TIMEOUT_MS = 15_000;
+import { fetchSourceContent } from '../lib/source-check/fetch-source.ts';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -92,148 +80,6 @@ interface SourceCheckSummary {
 // ── Helpers ────────────────────────────────────────────────────────────
 
 // LoadedKB, loadGraphFull, resolveEntity imported from ../lib/kb-loader.ts
-
-/** Result of fetching source content, with structured error info */
-interface FetchSourceResult {
-  content: string | null;
-  errorType?: SourceFetchErrorType;
-  errorMessage?: string;
-}
-
-/**
- * Fetch source content for a URL.
- *
- * Resolution order:
- *   1. Check for unverifiable domains (social media etc.)
- *   2. Try wiki-server citation_content cache (fullText field)
- *   3. Direct HTTP fetch with HTML tag stripping
- *   4. Detect paywall signals in fetched content
- *
- * Returns structured error types for machine-readable classification.
- */
-async function fetchSourceContent(url: string): Promise<FetchSourceResult> {
-  // SSRF protection: only allow https:// URLs (no http://, file://, ftp://, etc.)
-  if (!url.startsWith('https://')) {
-    console.warn(`[kb-source-check] Skipping non-HTTPS URL: ${url}`);
-    return { content: null, errorType: 'fetch_error', errorMessage: 'Non-HTTPS URL' };
-  }
-
-  // SSRF protection: block private/internal hosts
-  try {
-    const parsed = new URL(url);
-    const host = parsed.hostname.toLowerCase();
-    if (
-      host === 'localhost' ||
-      host === '127.0.0.1' ||
-      host === '[::1]' ||
-      host === '::1' ||
-      host === '0.0.0.0' ||
-      host === '[::]' ||
-      host === '::' ||
-      host.endsWith('.local') ||
-      host.endsWith('.internal') ||
-      // IPv4 private ranges
-      /^10\./.test(host) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-      /^192\.168\./.test(host) ||
-      /^169\.254\./.test(host) ||
-      // IPv6 private/reserved ranges
-      /^fe80:/i.test(host) ||          // link-local
-      /^f[cd][0-9a-f]{2}:/i.test(host) || // unique local (fc00::/7)
-      /^::ffff:127\./i.test(host) ||   // IPv4-mapped loopback
-      /^::ffff:10\./i.test(host) ||    // IPv4-mapped private
-      /^::ffff:192\.168\./i.test(host) || // IPv4-mapped private
-      /^::ffff:172\.(1[6-9]|2\d|3[01])\./i.test(host) || // IPv4-mapped private
-      /^::ffff:169\.254\./i.test(host) // IPv4-mapped link-local
-    ) {
-      console.warn(`[kb-source-check] Blocking private/internal URL: ${url}`);
-      return { content: null, errorType: 'access_denied', errorMessage: 'Private/internal host blocked' };
-    }
-  } catch {
-    return { content: null, errorType: 'fetch_error', errorMessage: 'Invalid URL' };
-  }
-
-  // Check for unverifiable domains (social media, etc.)
-  if (isUnverifiableDomain(url)) {
-    console.warn(`[kb-source-check] Unverifiable domain: ${url}`);
-    return { content: null, errorType: 'unverifiable_domain', errorMessage: 'Domain blocks automated access' };
-  }
-
-  // Try wiki-server citation_content cache first
-  try {
-    const result = await getCitationContentByUrl(url);
-    if (result.ok && result.data) {
-      // RPC type inference resolves to `never` because the route can return 400/404.
-      // The actual shape includes fullText from the citation_content table row.
-      const cached = result.data as Record<string, unknown>;
-      const content = cached.fullText as string | null;
-      if (content && content.length > 0) {
-        // Check for paywall signals even in cached content
-        if (detectPaywall(content)) {
-          console.warn(`[kb-source-check] Cached content for ${url} appears paywalled`);
-          return { content: content.slice(0, MAX_CONTENT_LENGTH), errorType: 'paywall', errorMessage: 'Cached content appears paywalled' };
-        }
-        return { content: content.slice(0, MAX_CONTENT_LENGTH) };
-      }
-    }
-  } catch (e: unknown) {
-    // Wiki-server unavailable — fall back to direct fetch
-    console.warn(`[kb-source-check] Wiki-server cache miss for ${url}: ${e instanceof Error ? e.message : String(e)}`);
-  }
-
-  // Direct fetch with timeout
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'LongtermWiki-FactChecker/1.0',
-        'Accept': 'text/html,application/xhtml+xml,text/plain',
-      },
-    });
-    clearTimeout(timer);
-
-    if (!response.ok) {
-      const errorType = classifyFetchError(response.status, null, null, url);
-      console.warn(`[kb-source-check] HTTP ${response.status} for ${url}`);
-      return { content: null, errorType: errorType ?? 'fetch_error', errorMessage: `HTTP ${response.status}` };
-    }
-
-    const html = await response.text();
-    // Strip HTML tags for a basic text extraction
-    const text = html
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replace(/<[^>]+>/g, ' ')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/\s+/g, ' ')
-      .trim();
-
-    const content = text.slice(0, MAX_CONTENT_LENGTH);
-
-    // Detect paywall in fetched content
-    if (detectPaywall(content)) {
-      console.warn(`[kb-source-check] Paywall detected for ${url}`);
-      return { content, errorType: 'paywall', errorMessage: 'Content appears paywalled' };
-    }
-
-    return { content };
-  } catch (e: unknown) {
-    if (e instanceof DOMException && e.name === 'AbortError') {
-      console.warn(`[kb-source-check] Timeout fetching ${url}`);
-      return { content: null, errorType: 'timeout', errorMessage: 'Request timed out' };
-    }
-    const msg = e instanceof Error ? e.message : String(e);
-    console.warn(`[kb-source-check] Failed to fetch ${url}: ${msg}`);
-    return { content: null, errorType: 'fetch_error', errorMessage: msg };
-  }
-}
 
 /**
  * Build the LLM verification prompt for a single fact.
@@ -293,7 +139,10 @@ async function verifySingleFact(
   const sourceUrl = fact.source!;
 
   // Fetch source content
-  const fetchResult = await fetchSourceContent(sourceUrl);
+  const fetchResult = await fetchSourceContent(sourceUrl, {
+    userAgent: 'LongtermWiki-FactChecker/1.0',
+    logPrefix: '[kb-source-check]',
+  });
   if (!fetchResult.content) {
     return {
       factId: fact.id,

--- a/crux/commands/records-source-check.ts
+++ b/crux/commands/records-source-check.ts
@@ -18,24 +18,14 @@ import type { CommandOptions as BaseOptions, CommandResult } from '../lib/comman
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { parseJsonResponse } from '../lib/anthropic.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
-import {
-  detectPaywall,
-  isUnverifiableDomain,
-  classifyFetchError,
-  type SourceFetchErrorType,
-} from '../lib/search/paywall-detection.ts';
-import { getCitationContentByUrl } from '../lib/wiki-server/citations.ts';
+import type { SourceFetchErrorType } from '../lib/search/paywall-detection.ts';
 import {
   VALID_RECORD_TYPES,
   VALID_SOURCE_CHECK_VERDICTS,
   type RecordType,
   type SourceCheckVerdict,
 } from '../../apps/wiki-server/src/api-types.ts';
-
-// ── Constants ────────────────────────────────────────────────────────
-
-const MAX_CONTENT_LENGTH = 8000;
-const FETCH_TIMEOUT_MS = 15_000;
+import { fetchSourceContent } from '../lib/source-check/fetch-source.ts';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -254,102 +244,6 @@ function buildRecordToVerify(recordType: RecordType, item: Record<string, unknow
   }
 }
 
-// ── Source fetching ──────────────────────────────────────────────────
-
-interface FetchSourceResult {
-  content: string | null;
-  errorType?: SourceFetchErrorType;
-  errorMessage?: string;
-}
-
-async function fetchSourceContent(url: string): Promise<FetchSourceResult> {
-  if (!url.startsWith('https://')) {
-    return { content: null, errorType: 'fetch_error', errorMessage: 'Non-HTTPS URL' };
-  }
-
-  // SSRF protection
-  try {
-    const parsed = new URL(url);
-    const host = parsed.hostname.toLowerCase();
-    if (
-      host === 'localhost' || host === '127.0.0.1' || host === '[::1]' ||
-      host === '0.0.0.0' || host.endsWith('.local') || host.endsWith('.internal') ||
-      /^10\./.test(host) || /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-      /^192\.168\./.test(host) || /^169\.254\./.test(host)
-    ) {
-      return { content: null, errorType: 'access_denied', errorMessage: 'Private host blocked' };
-    }
-  } catch {
-    return { content: null, errorType: 'fetch_error', errorMessage: 'Invalid URL' };
-  }
-
-  if (isUnverifiableDomain(url)) {
-    return { content: null, errorType: 'unverifiable_domain', errorMessage: 'Domain blocks automated access' };
-  }
-
-  // Try wiki-server citation_content cache
-  try {
-    const result = await getCitationContentByUrl(url);
-    if (result.ok && result.data) {
-      const cached = result.data as Record<string, unknown>;
-      const content = cached.fullText as string | null;
-      if (content && content.length > 0) {
-        if (detectPaywall(content)) {
-          return { content: content.slice(0, MAX_CONTENT_LENGTH), errorType: 'paywall', errorMessage: 'Cached content appears paywalled' };
-        }
-        return { content: content.slice(0, MAX_CONTENT_LENGTH) };
-      }
-    }
-  } catch {
-    // Fall through to direct fetch
-  }
-
-  // Direct fetch
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'LongtermWiki-RecordVerifier/1.0',
-        'Accept': 'text/html,application/xhtml+xml,text/plain',
-      },
-    });
-    clearTimeout(timer);
-
-    if (!response.ok) {
-      const errorType = classifyFetchError(response.status, null, null, url);
-      return { content: null, errorType: errorType ?? 'fetch_error', errorMessage: `HTTP ${response.status}` };
-    }
-
-    const html = await response.text();
-    const text = html
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replace(/<[^>]+>/g, ' ')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, MAX_CONTENT_LENGTH);
-
-    if (detectPaywall(text)) {
-      return { content: text, errorType: 'paywall', errorMessage: 'Content appears paywalled' };
-    }
-
-    return { content: text };
-  } catch (e: unknown) {
-    if (e instanceof DOMException && e.name === 'AbortError') {
-      return { content: null, errorType: 'timeout', errorMessage: 'Request timed out' };
-    }
-    return { content: null, errorType: 'fetch_error', errorMessage: e instanceof Error ? e.message : String(e) };
-  }
-}
-
 // ── LLM verification ────────────────────────────────────────────────
 
 function buildPrompt(record: RecordToVerify, sourceText: string): string {
@@ -395,7 +289,10 @@ async function verifySingleRecord(
   record: RecordToVerify,
   client: ReturnType<typeof createLlmClient>,
 ): Promise<SourceCheckResult | SourceCheckError> {
-  const fetchResult = await fetchSourceContent(record.sourceUrl);
+  const fetchResult = await fetchSourceContent(record.sourceUrl, {
+    userAgent: 'LongtermWiki-RecordVerifier/1.0',
+    logPrefix: '[record-source-check]',
+  });
   if (!fetchResult.content) {
     return {
       recordType: record.recordType,

--- a/crux/lib/source-check/fetch-source.test.ts
+++ b/crux/lib/source-check/fetch-source.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { isPrivateHost, htmlToPlainText, fetchSourceContent } from './fetch-source.ts';
+
+// ── isPrivateHost ─────────────────────────────────────────────────────
+
+describe('isPrivateHost', () => {
+  it('blocks localhost variants', () => {
+    expect(isPrivateHost('localhost')).toBe(true);
+    expect(isPrivateHost('127.0.0.1')).toBe(true);
+    expect(isPrivateHost('[::1]')).toBe(true);
+    expect(isPrivateHost('::1')).toBe(true);
+    expect(isPrivateHost('0.0.0.0')).toBe(true);
+  });
+
+  it('blocks IPv4 private ranges', () => {
+    expect(isPrivateHost('10.0.0.1')).toBe(true);
+    expect(isPrivateHost('172.16.0.1')).toBe(true);
+    expect(isPrivateHost('172.31.255.255')).toBe(true);
+    expect(isPrivateHost('192.168.1.1')).toBe(true);
+    expect(isPrivateHost('169.254.0.1')).toBe(true);
+  });
+
+  it('blocks IPv6 private/reserved ranges', () => {
+    expect(isPrivateHost('fe80::1')).toBe(true);
+    expect(isPrivateHost('fc00::1')).toBe(true);
+    expect(isPrivateHost('fd12::1')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 addresses for private hosts', () => {
+    expect(isPrivateHost('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateHost('::ffff:10.0.0.1')).toBe(true);
+    expect(isPrivateHost('::ffff:192.168.1.1')).toBe(true);
+    expect(isPrivateHost('::ffff:172.16.0.1')).toBe(true);
+    expect(isPrivateHost('::ffff:169.254.0.1')).toBe(true);
+  });
+
+  it('blocks .local and .internal TLDs', () => {
+    expect(isPrivateHost('myserver.local')).toBe(true);
+    expect(isPrivateHost('db.internal')).toBe(true);
+  });
+
+  it('allows public hostnames', () => {
+    expect(isPrivateHost('google.com')).toBe(false);
+    expect(isPrivateHost('8.8.8.8')).toBe(false);
+    expect(isPrivateHost('example.org')).toBe(false);
+    expect(isPrivateHost('2001:db8::1')).toBe(false);
+  });
+});
+
+// ── htmlToPlainText ───────────────────────────────────────────────────
+
+describe('htmlToPlainText', () => {
+  it('removes script tags and their content', () => {
+    const html = '<p>Hello</p><script>alert("xss")</script><p>World</p>';
+    const text = htmlToPlainText(html);
+    expect(text).not.toContain('alert');
+    expect(text).toContain('Hello');
+    expect(text).toContain('World');
+  });
+
+  it('removes style tags and their content', () => {
+    const html = '<style>.foo { color: red; }</style><p>Content</p>';
+    const text = htmlToPlainText(html);
+    expect(text).not.toContain('color');
+    expect(text).toContain('Content');
+  });
+
+  it('unescapes HTML entities', () => {
+    const html = '&amp; &lt;tag&gt; &quot;quoted&quot; &#39;single&#39; &nbsp;space';
+    const text = htmlToPlainText(html);
+    expect(text).toContain('& <tag> "quoted" \'single\'');
+  });
+
+  it('collapses whitespace', () => {
+    const html = '<p>Hello</p>   \n\n   <p>World</p>';
+    const text = htmlToPlainText(html);
+    // Should not have multiple consecutive spaces
+    expect(text).not.toMatch(/\s{2,}/);
+    expect(text).toContain('Hello');
+    expect(text).toContain('World');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    const html = '  <p>Hello</p>  ';
+    const text = htmlToPlainText(html);
+    expect(text).toBe('Hello');
+  });
+
+  it('handles empty input', () => {
+    expect(htmlToPlainText('')).toBe('');
+  });
+});
+
+// ── fetchSourceContent ────────────────────────────────────────────────
+
+describe('fetchSourceContent', () => {
+  it('rejects non-HTTPS URLs', async () => {
+    const result = await fetchSourceContent('http://example.com/page');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('fetch_error');
+    expect(result.errorMessage).toBe('Non-HTTPS URL');
+  });
+
+  it('rejects file:// URLs', async () => {
+    const result = await fetchSourceContent('file:///etc/passwd');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('fetch_error');
+    expect(result.errorMessage).toBe('Non-HTTPS URL');
+  });
+
+  it('blocks private hosts', async () => {
+    const result = await fetchSourceContent('https://127.0.0.1/secret');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('access_denied');
+    expect(result.errorMessage).toBe('Private/internal host blocked');
+  });
+
+  it('blocks IPv6 private hosts', async () => {
+    const result = await fetchSourceContent('https://[::1]/secret');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('access_denied');
+  });
+
+  it('blocks unverifiable domains', async () => {
+    const result = await fetchSourceContent('https://twitter.com/user/status/123');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('unverifiable_domain');
+    expect(result.errorMessage).toBe('Domain blocks automated access');
+  });
+
+  it('returns error for invalid URL', async () => {
+    const result = await fetchSourceContent('https://');
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('fetch_error');
+  });
+
+  it('passes custom options through', async () => {
+    // Verify that custom user agent and log prefix don't cause errors
+    const result = await fetchSourceContent('http://example.com', {
+      userAgent: 'TestAgent/1.0',
+      logPrefix: '[test]',
+      maxContentLength: 100,
+      fetchTimeoutMs: 5000,
+    });
+    // Should still reject non-HTTPS
+    expect(result.content).toBeNull();
+    expect(result.errorType).toBe('fetch_error');
+  });
+});

--- a/crux/lib/source-check/fetch-source.ts
+++ b/crux/lib/source-check/fetch-source.ts
@@ -1,0 +1,215 @@
+/**
+ * Shared source-content fetching utility for source-check commands.
+ *
+ * Consolidates the duplicated fetchSourceContent() logic from
+ * factbase-source-check.ts and records-source-check.ts into a single
+ * implementation with comprehensive SSRF protection, caching, paywall
+ * detection, and error logging.
+ */
+
+import {
+  detectPaywall,
+  isUnverifiableDomain,
+  classifyFetchError,
+  type SourceFetchErrorType,
+} from '../search/paywall-detection.ts';
+import { getCitationContentByUrl } from '../wiki-server/citations.ts';
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/** Max characters of source content to send to the LLM */
+export const MAX_CONTENT_LENGTH = 8000;
+
+/** Default HTTP fetch timeout in milliseconds */
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+/** Default User-Agent header */
+const DEFAULT_USER_AGENT = 'LongtermWiki/1.0';
+
+/** Default log prefix for console messages */
+const DEFAULT_LOG_PREFIX = '[source-check]';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/** Result of fetching source content, with structured error info */
+export interface FetchSourceResult {
+  content: string | null;
+  errorType?: SourceFetchErrorType;
+  errorMessage?: string;
+}
+
+/** Options for fetchSourceContent */
+export interface FetchSourceOptions {
+  /** User-Agent header for direct HTTP requests */
+  userAgent?: string;
+  /** Prefix for log messages (e.g., '[kb-source-check]') */
+  logPrefix?: string;
+  /** Max characters of content to return (default: 8000) */
+  maxContentLength?: number;
+  /** HTTP fetch timeout in milliseconds (default: 15000) */
+  fetchTimeoutMs?: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Check if a hostname is a private/internal host that should be blocked
+ * for SSRF protection. Covers IPv4 private ranges, IPv6 private/reserved
+ * ranges, and IPv4-mapped IPv6 addresses.
+ */
+export function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '[::1]' ||
+    host === '::1' ||
+    host === '0.0.0.0' ||
+    host === '[::]' ||
+    host === '::' ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    // IPv4 private ranges
+    /^10\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    // IPv6 private/reserved ranges
+    /^fe80:/i.test(host) ||          // link-local
+    /^f[cd][0-9a-f]{2}:/i.test(host) || // unique local (fc00::/7)
+    /^::ffff:127\./i.test(host) ||   // IPv4-mapped loopback
+    /^::ffff:10\./i.test(host) ||    // IPv4-mapped private
+    /^::ffff:192\.168\./i.test(host) || // IPv4-mapped private
+    /^::ffff:172\.(1[6-9]|2\d|3[01])\./i.test(host) || // IPv4-mapped private
+    /^::ffff:169\.254\./i.test(host) // IPv4-mapped link-local
+  );
+}
+
+/**
+ * Convert HTML to plain text by stripping tags and unescaping entities.
+ * Uses a 9-replace chain for basic but reliable HTML-to-text conversion.
+ */
+export function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// ── Main fetch function ───────────────────────────────────────────────
+
+/**
+ * Fetch source content for a URL.
+ *
+ * Resolution order:
+ *   1. Reject non-HTTPS URLs (SSRF protection)
+ *   2. Block private/internal hosts (SSRF protection)
+ *   3. Check for unverifiable domains (social media etc.)
+ *   4. Try wiki-server citation_content cache (fullText field)
+ *   5. Direct HTTP fetch with HTML tag stripping
+ *   6. Detect paywall signals in fetched content
+ *
+ * Returns structured error types for machine-readable classification.
+ */
+export async function fetchSourceContent(
+  url: string,
+  options?: FetchSourceOptions,
+): Promise<FetchSourceResult> {
+  const prefix = options?.logPrefix ?? DEFAULT_LOG_PREFIX;
+  const maxLen = options?.maxContentLength ?? MAX_CONTENT_LENGTH;
+  const timeoutMs = options?.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const userAgent = options?.userAgent ?? DEFAULT_USER_AGENT;
+
+  // SSRF protection: only allow https:// URLs (no http://, file://, ftp://, etc.)
+  if (!url.startsWith('https://')) {
+    console.warn(`${prefix} Skipping non-HTTPS URL: ${url}`);
+    return { content: null, errorType: 'fetch_error', errorMessage: 'Non-HTTPS URL' };
+  }
+
+  // SSRF protection: block private/internal hosts
+  try {
+    const parsed = new URL(url);
+    if (isPrivateHost(parsed.hostname)) {
+      console.warn(`${prefix} Blocking private/internal URL: ${url}`);
+      return { content: null, errorType: 'access_denied', errorMessage: 'Private/internal host blocked' };
+    }
+  } catch {
+    return { content: null, errorType: 'fetch_error', errorMessage: 'Invalid URL' };
+  }
+
+  // Check for unverifiable domains (social media, etc.)
+  if (isUnverifiableDomain(url)) {
+    console.warn(`${prefix} Unverifiable domain: ${url}`);
+    return { content: null, errorType: 'unverifiable_domain', errorMessage: 'Domain blocks automated access' };
+  }
+
+  // Try wiki-server citation_content cache first
+  try {
+    const result = await getCitationContentByUrl(url);
+    if (result.ok && result.data) {
+      // RPC type inference resolves to `never` because the route can return 400/404.
+      // The actual shape includes fullText from the citation_content table row.
+      const cached = result.data as Record<string, unknown>;
+      const content = cached.fullText as string | null;
+      if (content && content.length > 0) {
+        // Check for paywall signals even in cached content
+        if (detectPaywall(content)) {
+          console.warn(`${prefix} Cached content for ${url} appears paywalled`);
+          return { content: content.slice(0, maxLen), errorType: 'paywall', errorMessage: 'Cached content appears paywalled' };
+        }
+        return { content: content.slice(0, maxLen) };
+      }
+    }
+  } catch (e: unknown) {
+    // Wiki-server unavailable — fall back to direct fetch
+    console.warn(`${prefix} Wiki-server cache miss for ${url}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  // Direct fetch with timeout
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': userAgent,
+        'Accept': 'text/html,application/xhtml+xml,text/plain',
+      },
+    });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const errorType = classifyFetchError(response.status, null, null, url);
+      console.warn(`${prefix} HTTP ${response.status} for ${url}`);
+      return { content: null, errorType: errorType ?? 'fetch_error', errorMessage: `HTTP ${response.status}` };
+    }
+
+    const html = await response.text();
+    const text = htmlToPlainText(html);
+    const content = text.slice(0, maxLen);
+
+    // Detect paywall in fetched content
+    if (detectPaywall(content)) {
+      console.warn(`${prefix} Paywall detected for ${url}`);
+      return { content, errorType: 'paywall', errorMessage: 'Content appears paywalled' };
+    }
+
+    return { content };
+  } catch (e: unknown) {
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      console.warn(`${prefix} Timeout fetching ${url}`);
+      return { content: null, errorType: 'timeout', errorMessage: 'Request timed out' };
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`${prefix} Failed to fetch ${url}: ${msg}`);
+    return { content: null, errorType: 'fetch_error', errorMessage: msg };
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated `fetchSourceContent()` logic (~200 lines total) from `factbase-source-check.ts` and `records-source-check.ts` into a shared utility at `crux/lib/source-check/fetch-source.ts`
- The records version gains IPv6 SSRF protection and error logging that was previously only in the factbase version
- Exports `isPrivateHost()`, `htmlToPlainText()`, and `fetchSourceContent()` with configurable options (userAgent, logPrefix, maxContentLength, fetchTimeoutMs)
- Both consumers now call the shared function with their specific user-agent and log prefix

## Test plan
- [x] 19 new tests for `isPrivateHost()` (localhost, IPv4 private, IPv6 private, IPv4-mapped, public hosts), `htmlToPlainText()` (script/style removal, entity unescaping, whitespace collapsing), and `fetchSourceContent()` (non-HTTPS rejection, SSRF blocking, unverifiable domains)
- [x] All existing crux tests still pass
- [x] Pure extraction — no behavior changes except records gaining IPv6 SSRF protection and logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)