### PR TITLE
fix: correct stableId mismatches for 2 entities

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2423,7 +2423,7 @@
     - alignment
 
 - id: jaime-sevilla
-  stableId: G7Hg6qBW6A
+  stableId: g7Hg6qBW6A
   type: person
   title: Jaime Sevilla
   description: >-
@@ -2501,7 +2501,7 @@
     - effective-altruism
 
 - id: ketan-ramakrishnan
-  stableId: Ma5lO6r5Fw
+  stableId: u7QD93Xjug
   type: person
   title: Ketan Ramakrishnan
   description: >-


### PR DESCRIPTION
## Summary

Fixes entity sync failures caused by stableId mismatches between YAML and PG:

- **ketan-ramakrishnan**: Ma5lO6r5Fw → u7QD93Xjug (old value belongs to avital-balwit)
- **jaime-sevilla**: G7Hg6qBW6A → g7Hg6qBW6A (case mismatch)

## Test plan
- [x] Verified PG canonical stableIds via API
- [ ] After merge: re-run entity sync