### PR TITLE
fix: remove stale verify-records import (crashes all crux commands)

### DIFF
--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -163,7 +163,6 @@ const domains = {
   'backfill-pr-outcomes': backfillPrOutcomesCommands,
   'factbase-migrate-entities': factbaseMigrateEntitiesCommands,
   verify: verifyEntityCommands,
-  'verify-records': recordsVerifyCommands,
   'verify-orchestrate': verifyOrchestrateCommands,
   'qa-sweep': qaSweepCommands,
   'qa-checks': qaChecksCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -77,7 +77,6 @@ export const GROUPS: Record<string, GroupDef> = {
       'orgs',
       'research-areas',
       'verify',
-      'verify-records',
       'verify-orchestrate',
       'legislation',
     ],


### PR DESCRIPTION
records-verify.ts was deleted but crux.mjs still referenced it. All crux commands crashed.