### PR TITLE
fix: verdict upsert fails with COALESCE ON CONFLICT

### DIFF
--- a/apps/wiki-server/src/routes/verification/verifications.ts
+++ b/apps/wiki-server/src/routes/verification/verifications.ts
@@ -379,8 +379,9 @@ const verificationsApp = new Hono()
     const fieldNameVal = body.fieldName ?? null;
     const entityIdVal = body.entityId ?? null;
 
-    const updateResult = await db.execute(sql`
+    const doUpdate = () => db.execute(sql`
       UPDATE verification_verdicts SET
+        entity_id = COALESCE(${entityIdVal}, entity_id),
         verdict = ${body.verdict},
         confidence = ${body.confidence ?? null},
         reasoning = ${body.reasoning ?? null},
@@ -394,22 +395,34 @@ const verificationsApp = new Hono()
         AND COALESCE(field_name, '') = COALESCE(${fieldNameVal}, '')
     `);
 
+    const updateResult = await doUpdate();
     const rowsUpdated = (updateResult as unknown as { count?: number })?.count ?? 0;
 
     if (rowsUpdated === 0) {
-      await db.execute(sql`
-        INSERT INTO verification_verdicts (
-          record_type, record_id, field_name, entity_id,
-          verdict, confidence, reasoning, sources_checked,
-          needs_recheck, next_check_due, last_computed_at,
-          created_at, updated_at
-        ) VALUES (
-          ${body.recordType}, ${body.recordId}, ${fieldNameVal}, ${entityIdVal},
-          ${body.verdict}, ${body.confidence ?? null}, ${body.reasoning ?? null}, ${body.sourcesChecked ?? 0},
-          false, ${body.nextCheckDue ? new Date(body.nextCheckDue) : null}, ${now},
-          ${now}, ${now}
-        )
-      `);
+      try {
+        await db.execute(sql`
+          INSERT INTO verification_verdicts (
+            record_type, record_id, field_name, entity_id,
+            verdict, confidence, reasoning, sources_checked,
+            needs_recheck, next_check_due, last_computed_at,
+            created_at, updated_at
+          ) VALUES (
+            ${body.recordType}, ${body.recordId}, ${fieldNameVal}, ${entityIdVal},
+            ${body.verdict}, ${body.confidence ?? null}, ${body.reasoning ?? null}, ${body.sourcesChecked ?? 0},
+            false, ${body.nextCheckDue ? new Date(body.nextCheckDue) : null}, ${now},
+            ${now}, ${now}
+          )
+        `);
+      } catch (insertErr: unknown) {
+        // Race condition: another request inserted between our UPDATE and INSERT.
+        // Retry the UPDATE which should now find the row.
+        const msg = insertErr instanceof Error ? insertErr.message : String(insertErr);
+        if (msg.includes("unique") || msg.includes("duplicate") || msg.includes("23505")) {
+          await doUpdate();
+        } else {
+          throw insertErr;
+        }
+      }
     }
 
     return c.json({ ok: true }, 200);


### PR DESCRIPTION
The ON CONFLICT with COALESCE expression fails with the postgres.js driver. Replace with UPDATE-then-INSERT pattern.

## Test plan
- [ ] After deploy: `crux verify anthropic --limit=3` — verdict storage should succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced verification check scheduling logic to ensure more reliable tracking of verification verdicts and accurate timing for next scheduled checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->