### PR TITLE
fix: verdict upsert — use Drizzle ORM instead of raw SQL

### DIFF
--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -437,11 +437,13 @@ const sourceChecksApp = new Hono()
           await db
             .update(verificationVerdicts)
             .set({
+              entityId: entityIdVal,
               verdict: body.verdict,
               confidence: confidenceVal,
               reasoning: reasoningVal,
               sourcesChecked: sourcesCheckedVal,
               needsRecheck: false,
+              nextCheckDue: nextCheckDueVal,
               lastComputedAt: now,
               updatedAt: now,
             })


### PR DESCRIPTION
Raw sql template was failing. Switch to Drizzle .update()/.insert() which handle params correctly.

## Test plan
- [ ] After deploy: POST /api/verifications/verdicts returns {ok: true}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated verification verdict processing logic to use Drizzle ORM, replacing raw SQL database operations for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->