### PR TITLE
fix: agent activity metrics query wrong table

### DIFF
--- a/apps/wiki-server/src/routes/operational/monitoring.ts
+++ b/apps/wiki-server/src/routes/operational/monitoring.ts
@@ -706,13 +706,16 @@ async function fetchDeployHistory() {
 // ---- Agent activity summary ----
 
 async function fetchAgentActivity(rawDb: ReturnType<typeof getDb>) {
+  // active_agents is a transient state table for currently-running agents.
+  // agent_sessions is the permanent session history — use it for weekly metrics.
   const result = await rawDb`
     SELECT
-      count(*) FILTER (WHERE status = 'active' AND heartbeat_at >= now() - interval '15 minutes')::int AS active_now,
+      (SELECT count(*)::int FROM active_agents
+        WHERE status = 'active' AND heartbeat_at >= now() - interval '15 minutes') AS active_now,
       count(*) FILTER (WHERE started_at >= now() - interval '7 days')::int AS sessions_this_week,
-      count(*) FILTER (WHERE started_at >= now() - interval '7 days' AND pr_number IS NOT NULL)::int AS prs_this_week,
+      count(*) FILTER (WHERE started_at >= now() - interval '7 days' AND pr_url IS NOT NULL)::int AS prs_this_week,
       count(*) FILTER (WHERE started_at >= now() - interval '7 days' AND status = 'completed')::int AS completed_this_week
-    FROM active_agents
+    FROM agent_sessions
   `;
 
   const row = result[0] as AgentActivityRow;


### PR DESCRIPTION
## Summary
- The health dashboard's "Agent Activity (7d)" section was querying `active_agents` (transient state table) instead of `agent_sessions` (permanent history), causing sessions/PRs/completion metrics to be wrong
- `active_now` still correctly reads from `active_agents` (its intended purpose)
- `sessions_this_week`, `prs_this_week`, `completed_this_week` now read from `agent_sessions` where the data actually lives
- `pr_url IS NOT NULL` replaces `pr_number IS NOT NULL` (pr_number was never populated; PR URLs are stored in `agent_sessions.pr_url`)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (193 files, 4140 tests)
- [ ] After deploy, verify E927 dashboard shows non-zero PRs Created and Completion Rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
