### PR TITLE
Add secondary_market_prices PG table for tracking private company valuations

### DIFF
--- a/apps/wiki-server/drizzle/0133_create_secondary_market_prices.sql
+++ b/apps/wiki-server/drizzle/0133_create_secondary_market_prices.sql
@@ -1,0 +1,31 @@
+-- Secondary market prices: tracks private company valuations across platforms over time
+CREATE TABLE IF NOT EXISTS secondary_market_prices (
+    id VARCHAR(10) PRIMARY KEY,
+    company_id TEXT NOT NULL,
+    company_entity_id TEXT REFERENCES entities(stable_id) ON DELETE SET NULL,
+    company_display_name TEXT,
+    platform TEXT NOT NULL,
+    date TEXT NOT NULL,
+    price_per_share NUMERIC,
+    implied_valuation NUMERIC,
+    implied_valuation_low NUMERIC,
+    implied_valuation_high NUMERIC,
+    volume NUMERIC,
+    open_interest NUMERIC,
+    bid_price NUMERIC,
+    ask_price NUMERIC,
+    spread_percent NUMERIC,
+    price_type TEXT NOT NULL DEFAULT 'last_trade',
+    source TEXT,
+    notes TEXT,
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_smp_company ON secondary_market_prices(company_id);
+CREATE INDEX IF NOT EXISTS idx_smp_company_entity ON secondary_market_prices(company_entity_id);
+CREATE INDEX IF NOT EXISTS idx_smp_platform ON secondary_market_prices(platform);
+CREATE INDEX IF NOT EXISTS idx_smp_date ON secondary_market_prices(date);
+CREATE INDEX IF NOT EXISTS idx_smp_company_date ON secondary_market_prices(company_entity_id, date);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_smp_unique ON secondary_market_prices(company_id, platform, date, price_type);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -930,7 +930,14 @@
       "idx": 132,
       "version": "7",
       "when": 1781078400000,
-      "tag": "0132_research_area_evaluations",
+      "tag": "0132_create_secondary_market_prices",
+      "breakpoints": true
+    },
+    {
+      "idx": 133,
+      "version": "7",
+      "when": 1781164800000,
+      "tag": "0133_create_secondary_market_prices",
       "breakpoints": true
     }
   ]

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -21,6 +21,7 @@ import { fundingProgramsRoute } from "./routes/tablebase/funding-programs.js";
 import { benchmarksRoute } from "./routes/tablebase/benchmarks.js";
 import { benchmarkResultsRoute } from "./routes/tablebase/benchmark-results.js";
 import { thingsRoute } from "./routes/tablebase/things.js";
+import { secondaryMarketPricesRoute } from "./routes/tablebase/secondary-market-prices.js";
 
 // Unified source-check system (replaces factbase-verifications + record-verifications)
 import { sourceChecksRoute } from "./routes/source-check/source-checks.js";
@@ -188,6 +189,7 @@ export function createApp() {
   app.route("/api/funding-rounds", fundingRoundsRoute);
   app.route("/api/investments", investmentsRoute);
   app.route("/api/equity-positions", equityPositionsRoute);
+  app.route("/api/secondary-market-prices", secondaryMarketPricesRoute);
   app.route("/api/divisions", divisionsRoute);
   app.route("/api/division-personnel", divisionPersonnelRoute);
   app.route("/api/funding-programs", fundingProgramsRoute);

--- a/apps/wiki-server/src/routes/tablebase/index.ts
+++ b/apps/wiki-server/src/routes/tablebase/index.ts
@@ -25,3 +25,4 @@ export { entityEventsRoute, type EntityEventsRoute } from "./entity-events.js";
 export { entityAssessmentsRoute, type EntityAssessmentsRoute } from "./entity-assessments.js";
 export { publicationsRoute, type PublicationsRoute } from "./publications.js";
 export { websiteSourcesRoute, type WebsiteSourcesRoute } from "./website-sources.js";
+export { secondaryMarketPricesRoute, type SecondaryMarketPricesRoute } from "./secondary-market-prices.js";

--- a/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
+++ b/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
@@ -1,0 +1,400 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, and, count, desc, asc, sql, gte, lte } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { getDrizzleDb } from "../../db.js";
+import { secondaryMarketPrices, entities } from "../../schema.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+  zv,
+} from "../shared/utils.js";
+import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
+import { formatEntityRef } from "../shared/entity-ref.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 500;
+
+const VALID_PLATFORMS = [
+  "ventuals",
+  "forge",
+  "hiive",
+  "upmarket",
+  "premier-alternatives",
+  "notice",
+] as const;
+
+const VALID_PRICE_TYPES = [
+  "mark",
+  "oracle",
+  "last_trade",
+  "indicative",
+  "bid",
+  "ask",
+  "mid",
+] as const;
+
+// ---- Query schemas ----
+
+const AllQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  offset: z.coerce.number().int().min(0).default(0),
+  platform: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+
+const ByEntityQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  offset: z.coerce.number().int().min(0).default(0),
+  platform: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+
+const TimeseriesQuery = z.object({
+  platform: z.string().optional(),
+  priceType: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(500),
+});
+
+// ---- Sync schema ----
+
+const SyncSecondaryMarketPriceItemSchema = z.object({
+  id: z.string().length(10),
+  companyId: z.string().min(1).max(200),
+  platform: z.enum(VALID_PLATFORMS),
+  date: z.string().min(4).max(20),
+  pricePerShare: z.number().nullable().optional(),
+  impliedValuation: z.number().nullable().optional(),
+  impliedValuationLow: z.number().nullable().optional(),
+  impliedValuationHigh: z.number().nullable().optional(),
+  volume: z.number().nullable().optional(),
+  openInterest: z.number().nullable().optional(),
+  bidPrice: z.number().nullable().optional(),
+  askPrice: z.number().nullable().optional(),
+  spreadPercent: z.number().nullable().optional(),
+  priceType: z.enum(VALID_PRICE_TYPES).default("last_trade"),
+  source: z.string().max(2000).nullable().optional(),
+  notes: z.string().max(5000).nullable().optional(),
+});
+
+const SyncBatchSchema = z.object({
+  items: z.array(SyncSecondaryMarketPriceItemSchema).min(1).max(500),
+});
+
+// ---- Helpers ----
+
+const companyEntity = alias(entities, "company_entity");
+
+const joinedSelect = {
+  price: secondaryMarketPrices,
+  companyTitle: companyEntity.title,
+  companySlug: companyEntity.id,
+};
+
+interface JoinedRow {
+  price: typeof secondaryMarketPrices.$inferSelect;
+  companyTitle: string | null;
+  companySlug: string | null;
+}
+
+function formatRow(r: JoinedRow) {
+  const p = r.price;
+  const companyRef = formatEntityRef(
+    p.companyEntityId,
+    r.companySlug,
+    r.companyTitle,
+    p.companyDisplayName,
+    p.companyId
+  );
+  return {
+    id: p.id,
+    companyId: p.companyId,
+    platform: p.platform,
+    date: p.date,
+    pricePerShare: p.pricePerShare != null ? Number(p.pricePerShare) : null,
+    impliedValuation: p.impliedValuation != null ? Number(p.impliedValuation) : null,
+    impliedValuationLow: p.impliedValuationLow != null ? Number(p.impliedValuationLow) : null,
+    impliedValuationHigh: p.impliedValuationHigh != null ? Number(p.impliedValuationHigh) : null,
+    volume: p.volume != null ? Number(p.volume) : null,
+    openInterest: p.openInterest != null ? Number(p.openInterest) : null,
+    bidPrice: p.bidPrice != null ? Number(p.bidPrice) : null,
+    askPrice: p.askPrice != null ? Number(p.askPrice) : null,
+    spreadPercent: p.spreadPercent != null ? Number(p.spreadPercent) : null,
+    priceType: p.priceType,
+    source: p.source,
+    notes: p.notes,
+    company: companyRef,
+    // Legacy flat fields
+    companyEntityId: p.companyEntityId,
+    companyDisplayName: p.companyDisplayName,
+    companyResolvedName: companyRef.name,
+    syncedAt: p.syncedAt,
+    createdAt: p.createdAt,
+    updatedAt: p.updatedAt,
+  };
+}
+
+function toNum(v: number | null | undefined): string | null {
+  return v != null ? String(v) : null;
+}
+
+// ---- Route definition (method-chained for Hono RPC type inference) ----
+
+const secondaryMarketPricesApp = new Hono<{ Variables: ResolvedEntityVars }>()
+
+  // ---- GET /stats ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const [statsRow] = await db
+      .select({
+        total: count(),
+        uniqueCompanies: sql<number>`count(distinct ${secondaryMarketPrices.companyId})`,
+        uniquePlatforms: sql<number>`count(distinct ${secondaryMarketPrices.platform})`,
+        latestDate: sql<string>`max(${secondaryMarketPrices.date})`,
+        earliestDate: sql<string>`min(${secondaryMarketPrices.date})`,
+      })
+      .from(secondaryMarketPrices);
+
+    return c.json({
+      total: statsRow.total,
+      uniqueCompanies: Number(statsRow.uniqueCompanies),
+      uniquePlatforms: Number(statsRow.uniquePlatforms),
+      latestDate: statsRow.latestDate,
+      earliestDate: statsRow.earliestDate,
+    });
+  })
+
+  // ---- GET /all ----
+  .get("/all", zv("query", AllQuery), async (c) => {
+    const { limit, offset, platform, dateFrom, dateTo } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (platform) conditions.push(eq(secondaryMarketPrices.platform, platform));
+    if (dateFrom) conditions.push(gte(secondaryMarketPrices.date, dateFrom));
+    if (dateTo) conditions.push(lte(secondaryMarketPrices.date, dateTo));
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const rows = await db
+      .select(joinedSelect)
+      .from(secondaryMarketPrices)
+      .leftJoin(companyEntity, eq(secondaryMarketPrices.companyEntityId, companyEntity.stableId))
+      .where(whereClause)
+      .orderBy(desc(secondaryMarketPrices.date), secondaryMarketPrices.platform)
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(secondaryMarketPrices)
+      .where(whereClause);
+    const total = countResult[0].count;
+
+    return c.json({
+      prices: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /by-entity/:entityId ----
+  .get("/by-entity/:entityId", resolveEntityId(), zv("query", ByEntityQuery), async (c) => {
+    const resolvedId = c.get("resolvedEntityId");
+    const { limit, offset, platform, dateFrom, dateTo } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [eq(secondaryMarketPrices.companyId, resolvedId)];
+    if (platform) conditions.push(eq(secondaryMarketPrices.platform, platform));
+    if (dateFrom) conditions.push(gte(secondaryMarketPrices.date, dateFrom));
+    if (dateTo) conditions.push(lte(secondaryMarketPrices.date, dateTo));
+
+    const whereClause = and(...conditions);
+
+    const rows = await db
+      .select(joinedSelect)
+      .from(secondaryMarketPrices)
+      .leftJoin(companyEntity, eq(secondaryMarketPrices.companyEntityId, companyEntity.stableId))
+      .where(whereClause)
+      .orderBy(desc(secondaryMarketPrices.date), secondaryMarketPrices.platform)
+      .limit(limit)
+      .offset(offset);
+
+    const countResult = await db
+      .select({ count: count() })
+      .from(secondaryMarketPrices)
+      .where(whereClause);
+    const total = countResult[0].count;
+
+    return c.json({
+      entityId: resolvedId,
+      prices: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // ---- GET /latest/:entityId ----
+  .get("/latest/:entityId", resolveEntityId(), async (c) => {
+    const resolvedId = c.get("resolvedEntityId");
+    const db = getDrizzleDb();
+
+    // Get the most recent price from each platform for this company
+    const rows = await db
+      .select(joinedSelect)
+      .from(secondaryMarketPrices)
+      .leftJoin(companyEntity, eq(secondaryMarketPrices.companyEntityId, companyEntity.stableId))
+      .where(eq(secondaryMarketPrices.companyId, resolvedId))
+      .orderBy(desc(secondaryMarketPrices.date), secondaryMarketPrices.platform)
+      .limit(50);
+
+    // Deduplicate: keep only the latest per platform+priceType
+    const seen = new Set<string>();
+    const latest = rows.filter((r) => {
+      const key = `${r.price.platform}:${r.price.priceType}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    // Compute summary stats
+    const valuations = latest
+      .map((r) => r.price.impliedValuation)
+      .filter((v): v is string => v != null)
+      .map(Number);
+    const median = valuations.length > 0
+      ? valuations.sort((a, b) => a - b)[Math.floor(valuations.length / 2)]
+      : null;
+    const min = valuations.length > 0 ? Math.min(...valuations) : null;
+    const max = valuations.length > 0 ? Math.max(...valuations) : null;
+
+    return c.json({
+      entityId: resolvedId,
+      prices: latest.map(formatRow),
+      summary: {
+        platformCount: latest.length,
+        medianValuation: median,
+        minValuation: min,
+        maxValuation: max,
+        dispersionPercent: median && min && max
+          ? Math.round(((max - min) / median) * 100)
+          : null,
+      },
+    });
+  })
+
+  // ---- GET /timeseries/:entityId ----
+  .get("/timeseries/:entityId", resolveEntityId(), zv("query", TimeseriesQuery), async (c) => {
+    const resolvedId = c.get("resolvedEntityId");
+    const { platform, priceType, limit } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [eq(secondaryMarketPrices.companyId, resolvedId)];
+    if (platform) conditions.push(eq(secondaryMarketPrices.platform, platform));
+    if (priceType) conditions.push(eq(secondaryMarketPrices.priceType, priceType));
+
+    const rows = await db
+      .select({
+        date: secondaryMarketPrices.date,
+        platform: secondaryMarketPrices.platform,
+        priceType: secondaryMarketPrices.priceType,
+        pricePerShare: secondaryMarketPrices.pricePerShare,
+        impliedValuation: secondaryMarketPrices.impliedValuation,
+        volume: secondaryMarketPrices.volume,
+      })
+      .from(secondaryMarketPrices)
+      .where(and(...conditions))
+      .orderBy(asc(secondaryMarketPrices.date), secondaryMarketPrices.platform)
+      .limit(limit);
+
+    return c.json({
+      entityId: resolvedId,
+      points: rows.map((r) => ({
+        date: r.date,
+        platform: r.platform,
+        priceType: r.priceType,
+        pricePerShare: r.pricePerShare != null ? Number(r.pricePerShare) : null,
+        impliedValuation: r.impliedValuation != null ? Number(r.impliedValuation) : null,
+        volume: r.volume != null ? Number(r.volume) : null,
+      })),
+      total: rows.length,
+    });
+  })
+
+  // ---- POST /sync ----
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = SyncBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { items } = parsed.data;
+    const db = getDrizzleDb();
+
+    let upserted = 0;
+
+    await db.transaction(async (tx) => {
+      const allVals = items.map((item) => ({
+        id: item.id,
+        companyId: item.companyId,
+        platform: item.platform,
+        date: item.date,
+        pricePerShare: toNum(item.pricePerShare),
+        impliedValuation: toNum(item.impliedValuation),
+        impliedValuationLow: toNum(item.impliedValuationLow),
+        impliedValuationHigh: toNum(item.impliedValuationHigh),
+        volume: toNum(item.volume),
+        openInterest: toNum(item.openInterest),
+        bidPrice: toNum(item.bidPrice),
+        askPrice: toNum(item.askPrice),
+        spreadPercent: toNum(item.spreadPercent),
+        priceType: item.priceType,
+        source: item.source ?? null,
+        notes: item.notes ?? null,
+      }));
+
+      await tx
+        .insert(secondaryMarketPrices)
+        .values(allVals)
+        .onConflictDoUpdate({
+          target: [
+            secondaryMarketPrices.companyId,
+            secondaryMarketPrices.platform,
+            secondaryMarketPrices.date,
+            secondaryMarketPrices.priceType,
+          ],
+          set: {
+            pricePerShare: sql`excluded.price_per_share`,
+            impliedValuation: sql`excluded.implied_valuation`,
+            impliedValuationLow: sql`excluded.implied_valuation_low`,
+            impliedValuationHigh: sql`excluded.implied_valuation_high`,
+            volume: sql`excluded.volume`,
+            openInterest: sql`excluded.open_interest`,
+            bidPrice: sql`excluded.bid_price`,
+            askPrice: sql`excluded.ask_price`,
+            spreadPercent: sql`excluded.spread_percent`,
+            source: sql`excluded.source`,
+            notes: sql`excluded.notes`,
+            syncedAt: sql`now()`,
+            updatedAt: sql`now()`,
+          },
+        });
+
+      upserted = allVals.length;
+    });
+
+    return c.json({ upserted });
+  });
+
+// ---- Exports ----
+
+export const secondaryMarketPricesRoute = secondaryMarketPricesApp;
+export type SecondaryMarketPricesRoute = typeof secondaryMarketPricesApp;

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1878,6 +1878,78 @@ export const equityPositions = pgTable(
 );
 
 /**
+ * Secondary Market Prices — tracks private company valuations across
+ * secondary/derivatives market platforms over time.
+ *
+ * Each row is one observation: a platform's price for a company on a given date.
+ * Multiple platforms may have different prices on the same date.
+ */
+export const secondaryMarketPrices = pgTable(
+  "secondary_market_prices",
+  {
+    id: varchar("id", { length: 10 }).primaryKey(),
+    /** Legacy company ID (entity slug). Kept for migration compat. */
+    companyId: text("company_id").notNull(),
+    /** FK to entities.stable_id for the company. Null when unresolved. */
+    companyEntityId: text("company_entity_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" }
+    ),
+    /** Display name fallback when company doesn't have an entity. */
+    companyDisplayName: text("company_display_name"),
+    /** Platform identifier: ventuals, forge, hiive, upmarket, premier-alternatives, notice */
+    platform: text("platform").notNull(),
+    /** Observation date: YYYY-MM-DD or YYYY-MM */
+    date: text("date").notNull(),
+    /** Per-share price in USD (nullable; not all platforms report this) */
+    pricePerShare: numeric("price_per_share"),
+    /** Implied company valuation in USD */
+    impliedValuation: numeric("implied_valuation"),
+    /** Lower bound of implied valuation if range */
+    impliedValuationLow: numeric("implied_valuation_low"),
+    /** Upper bound of implied valuation if range */
+    impliedValuationHigh: numeric("implied_valuation_high"),
+    /** Trading volume in USD (nullable) */
+    volume: numeric("volume"),
+    /** Open interest for derivatives platforms (nullable) */
+    openInterest: numeric("open_interest"),
+    /** Best bid per share (nullable) */
+    bidPrice: numeric("bid_price"),
+    /** Best ask per share (nullable) */
+    askPrice: numeric("ask_price"),
+    /** Bid-ask spread as percentage (nullable) */
+    spreadPercent: numeric("spread_percent"),
+    /** Price type: mark, oracle, last_trade, indicative, bid, ask, mid */
+    priceType: text("price_type").notNull().default("last_trade"),
+    /** URL to the platform page */
+    source: text("source"),
+    notes: text("notes"),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_smp_company").on(table.companyId),
+    index("idx_smp_company_entity").on(table.companyEntityId),
+    index("idx_smp_platform").on(table.platform),
+    index("idx_smp_date").on(table.date),
+    index("idx_smp_company_date").on(table.companyEntityId, table.date),
+    uniqueIndex("idx_smp_unique").on(
+      table.companyId,
+      table.platform,
+      table.date,
+      table.priceType
+    ),
+  ]
+);
+
+/**
  * Divisions — organizational sub-units (funds, teams, departments, labs, program areas).
  */
 export const divisions = pgTable(


### PR DESCRIPTION
## Summary

New PG-primary TableBase table for tracking private company valuations across secondary/derivatives market platforms over time. This addresses #3002 (Phase 1: Schema + CRUD routes).

### What's included

**Schema** (`schema.ts` + migration `0132`):
- `secondary_market_prices` table with: company FK, platform, date, price_per_share, implied_valuation (with low/high range), volume, open_interest, bid/ask, spread_percent, price_type
- Unique constraint on `(company_id, platform, date, price_type)` prevents duplicates
- Indexes on company, platform, date, and compound company+date

**API Routes** (Hono RPC, method-chained):
- `GET /api/secondary-market-prices/stats` — aggregate stats (total records, unique companies/platforms, date range)
- `GET /api/secondary-market-prices/all` — paginated list with platform/date filters
- `GET /api/secondary-market-prices/by-entity/:entityId` — prices for one company
- `GET /api/secondary-market-prices/latest/:entityId` — latest price per platform with summary (median, min, max valuation, dispersion %)
- `GET /api/secondary-market-prices/timeseries/:entityId` — time-series for charting, filterable by platform/priceType
- `POST /api/secondary-market-prices/sync` — batch upsert (up to 500 items)

**Supported platforms**: ventuals, forge, hiive, upmarket, premier-alternatives, notice

**Also fixes**: `~\$` → `≈\$` across 7 MDX files (tilde-dollar validation test was failing)

### What's NOT included (future phases per #3002)

- CLI command for manual data entry (Phase 2)
- Data seeding/backfill (Phase 2)
- Dashboard page (Phase 3)
- MDX components for live data in wiki pages (Phase 4)

Closes #3002

## Test plan

- [x] Schema imports correctly (`node --import tsx/esm` test)
- [x] Route imports correctly
- [x] `validate-content.test.ts` passes (7/7) — tilde-dollar fix
- [x] All content tests pass (964/964)
- [ ] Migration runs on wiki-server startup (requires deploy)
- [ ] API endpoints respond correctly (requires running wiki-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secondary market pricing data management system with new API endpoints for querying market prices by company and entity.
  * Supports filtering by platform, date ranges, and price types.
  * Includes ability to retrieve the latest pricing information across multiple market platforms and sync new pricing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->