### PR TITLE
fix: post-merge ARIA improvements — personnel, qa-checks, davidad page

### DIFF
--- a/content/docs/knowledge-base/people/david-dalrymple.mdx
+++ b/content/docs/knowledge-base/people/david-dalrymple.mdx
@@ -2,12 +2,12 @@
 wikiId: E1998
 title: David Dalrymple
 description: AI safety researcher and Programme Director at ARIA, leading a £59M Safeguarded AI programme focused on formal verification and mathematical guarantees for safe AI deployment.
-subcategory: safety-researchers
 sidebar:
   order: 50
+subcategory: safety-researchers
 lastEdited: 2026-03-22
 createdAt: 2026-03-22
-summary: David "davidad" Dalrymple is Programme Director at ARIA, leading the £59M Safeguarded AI programme. Lead author of "Towards Guaranteed Safe AI" (2024) with Bengio, Russell, Tegmark, and Seshia.
+summary: A comprehensive biographical profile of David Dalrymple covering his role directing ARIA's £59M Safeguarded AI programme, his technical approach to formal verification for safety-critical AI, and his views on AI timelines. Content is well-organized and concrete but has significant citation gaps—footnotes are vague research notes rather than verifiable primary sources, and several key biographical and economic claims lack proper sourcing.
 ---
 import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
 
@@ -16,12 +16,12 @@ import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@compone
 | Attribute | Details |
 |-----------|---------|
 | **Full Name** | David A. Dalrymple ("davidad") |
-| **Current Role** | Programme Director, UK Advanced Research and Invention Agency (ARIA) |
-| **Programme** | Safeguarded AI (£59M R&D programme) |
-| **Previous Role** | Research Fellow, Oxford University Future of Humanity Institute (2021–2023) |
+| **Current Role** | Programme Director, <EntityLink id="E1997" name="aria-uk">Advanced Research and Invention Agency (ARIA)</EntityLink> |
+| **Programme** | Safeguarded AI (\£59M R&D programme) |
+| **Previous Role** | Research Fellow, Oxford University <EntityLink id="E140" name="fhi">Future of Humanity Institute</EntityLink> (2021–2023) |
 | **Key Focus** | Formal verification, provably safe AI, mathematical guarantees for critical infrastructure |
 | **Notable Work** | Safeguarded AI framework, flexHEG, *C. elegans* nervous system simulation, Filecoin co-invention |
-| **Community Standing** | Well-regarded in AI safety community; cited positively on LessWrong and EA Forum |
+| **Key Collaborators** | <EntityLink id="E380" name="yoshua-bengio">Yoshua Bengio</EntityLink>, <EntityLink id="E290" name="stuart-russell">Stuart Russell</EntityLink>, <EntityLink id="E433" name="max-tegmark">Max Tegmark</EntityLink>, Sanjit Seshia (co-authors); <EntityLink id="E129" name="evan-hubinger">Evan Hubinger</EntityLink> (MATS co-mentor) |
 
 ## Key Links
 
@@ -32,82 +32,82 @@ import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@compone
 
 ## Overview
 
-<EntityLink id="E1998">David Dalrymple</EntityLink>, widely known online as "davidad," is a researcher and programme director whose work sits at the intersection of formal verification, AI safety, and applied mathematics. Since 2023 he has served as Programme Director at the UK's Advanced Research and Invention Agency (ARIA), where he directs a £59 million R&D programme on Safeguarded AI and the broader Mathematics for Safe AI initiative. His core thesis is that AI systems deployed in safety-critical domains — such as electricity grids, climate modeling, and critical infrastructure — require formal mathematical guarantees rather than empirical reliability assessments alone.
+<EntityLink id="E1998" name="david-dalrymple">David Dalrymple</EntityLink>, widely known online as "davidad," is a researcher and programme director whose work sits at the intersection of formal verification, AI safety, and applied mathematics. Since 2023 he has served as Programme Director at the UK's <EntityLink id="E1997" name="aria-uk">Advanced Research and Invention Agency (ARIA)</EntityLink>, where he directs a \£59 million R&D programme on Safeguarded AI and the broader Mathematics for Safe AI initiative. His core thesis is that AI systems deployed in safety-critical domains — such as electricity grids, climate modeling, and critical infrastructure — require formal mathematical guarantees as a complement to empirical reliability assessments.
 
-Before joining ARIA, Dalrymple was a Research Fellow at Oxford University's <EntityLink id="E140">Future of Humanity Institute</EntityLink> (2021–2023), where he worked on metaethics for AI alignment and sociotechnical safety engineering. His background spans an unusually wide range of fields: he studied computer architecture and programming languages at MIT, then biophysics and neuroinformatics at Harvard, and has published on topics ranging from *Caenorhabditis elegans* nervous system simulation to applied category theory and compositional machine learning semantics. He is also a co-inventor of Filecoin, a blockchain-based decentralized storage protocol.
+Before joining ARIA, Dalrymple was a Research Fellow at Oxford University's <EntityLink id="E140" name="fhi">Future of Humanity Institute</EntityLink> (2021–2023), where he worked on metaethics for AI alignment and sociotechnical safety engineering. His background spans a wide range of fields: he studied computer architecture and programming languages at MIT, then biophysics and neuroinformatics at Harvard, and has published on topics ranging from *Caenorhabditis elegans* nervous system simulation to applied category theory and compositional machine learning semantics. He is also a co-inventor of Filecoin, a blockchain-based decentralized storage protocol.
 
-Within the AI safety community, Dalrymple's approach — sometimes called <EntityLink id="E484">Provably Safe AI</EntityLink> — has been received positively, with his Open Agency Architecture cited as among the more comprehensive technical statements of what AI safety requires. He has also expressed public concern that rapid AI capability progress may outpace the development of adequate safety measures, particularly for systems that could come to control critical infrastructure.
+Within the AI safety community, Dalrymple's approach — sometimes called <EntityLink id="E484" name="provably-safe">Provably Safe AI</EntityLink> — has been cited in technical discussions, with his Open Agency Architecture discussed on <EntityLink id="E538" name="lesswrong">LessWrong</EntityLink> as a detailed technical framework for AI safety requirements. He has also expressed public concern that rapid AI capability progress may outpace the development of adequate safety measures, particularly for systems that could come to control critical infrastructure.
 
 ## Background and Early Career
 
-Dalrymple's educational path was unconventional. According to available biographical sources, he completed a B.S. in Computer Science at the University of Maryland, Baltimore County (2000–2005), with a focus on algorithms and data structures, before studying computer architecture and programming languages at MIT's Media Lab and subsequently pursuing doctoral work in biophysics and neuroinformatics at Harvard — though he did not complete a PhD at either institution.[^1]
+Dalrymple's educational path was unconventional. According to available biographical sources, he completed a B.S. in Computer Science at the <EntityLink id="E1128" name="university-of-maryland">University of Maryland</EntityLink>, Baltimore County (2000–2005), with a focus on algorithms and data structures, before studying computer architecture and programming languages at MIT's Media Lab and subsequently pursuing doctoral work in biophysics and neuroinformatics at Harvard — though he did not complete a PhD at either institution.[^rc-5af7]
 
-An early significant research contribution was leading an international collaboration on imaging and simulation of the nervous system of *C. elegans*, the smallest known nervous system. This work, funded by personal grants from Google co-founder Larry Page and PayPal co-founder Peter Thiel, was published in *Nature Methods*.[^1] The project combined advanced microscopy with biophysical simulation techniques and represented a foundational contribution to neuroinformatics.
+An early significant research contribution was leading an international collaboration on imaging and simulation of the nervous system of *C. elegans*, the smallest known nervous system. This work, funded by personal grants from <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink> co-founder Larry Page and PayPal co-founder Peter Thiel, was published in *Nature Methods*.[^rc-5af7] The project combined advanced microscopy with biophysical simulation techniques and produced a detailed nervous system simulation.
 
-Dalrymple also received a Thiel Foundation research grant in 2012 for work on brain analysis. His tech industry experience includes a senior software engineering role at Twitter, where he worked on cache systems, and research and co-invention work at Protocol Labs, where he co-invented Filecoin and contributed to research on public goods funding and distributed storage. During this period he also worked on dioptics — a mathematical framework unifying open games from game theory and gradient-based learners from machine learning — presenting this work at SYCO 5.[^2]
+Dalrymple also received a Thiel Foundation research grant in 2012 for work on brain analysis. His tech industry experience includes a senior software engineering role at Twitter, where he worked on cache systems, and research and co-invention work at Protocol Labs, where he co-invented Filecoin and contributed to research on public goods funding and distributed storage. During this period he also worked on dioptics — a mathematical framework unifying open games from game theory and gradient-based learners from machine learning — presenting this work at SYCO 5.[^rc-ee14]
 
-He has held advisory roles including membership on the Industrial Advisory Board of the University of Birmingham School of Computer Science and participation in a joint China–U.S.–Australia AI governance panel, including as an invited delegate to a Meeting of Eminent Thinkers on AI Governance at Tsinghua University in 2019.[^1]
+He has held advisory roles including membership on the Industrial Advisory Board of the University of Birmingham School of Computer Science and participation in a joint China–U.S.–Australia AI governance panel, including as an invited delegate to a Meeting of Eminent Thinkers on AI Governance at Tsinghua University in 2019.[^rc-5af7]
 
 ## AI Safety Work
 
 ### The Safeguarded AI Framework
 
-The central thrust of Dalrymple's current work is what he calls Safeguarded AI — an approach that distinguishes between different phases of AI capability development and tailors safety strategies accordingly. Rather than attempting to guarantee safety across open-ended or unbounded contexts — which he regards as extremely difficult given the current state of the science — Safeguarded AI focuses on generating formal safety guarantees within well-defined, scoped contexts of use, drawing on methods from safety-critical engineering.[^3]
+The central thrust of Dalrymple's current work is what he calls Safeguarded AI — an approach that distinguishes between different phases of AI capability development and tailors safety strategies accordingly. Rather than attempting to guarantee safety across open-ended or unbounded contexts — which he regards as extremely difficult given the current state of the science — Safeguarded AI focuses on generating formal safety guarantees within well-defined, scoped contexts of use, drawing on methods from safety-critical engineering.[^rc-a5c5]
 
-The framework incorporates multiple layers: formal verification of algorithmic behavior, containment measures, and hardware-level security protections. A key output of this work is **flexHEG** (flexible hardware-enabled guarantees), which addresses how safety properties can be embedded into computing hardware itself — ensuring confidentiality, integrity, and availability without creating surveillance vulnerabilities. This work was published in 2025 as "Flexible Hardware-Enabled Guarantees for AI Compute," co-authored with J. Petrie, O. Aarne, and N. Ammann.[^4]
+The framework incorporates multiple layers: formal verification of algorithmic behavior, containment measures, and hardware-level security protections. A key output of this work is **flexHEG** (flexible hardware-enabled guarantees), which addresses how safety properties can be embedded into computing hardware itself — ensuring confidentiality, integrity, and availability without creating surveillance vulnerabilities. This work was published in 2025 as "Flexible Hardware-Enabled Guarantees for AI Compute," co-authored with J. Petrie, O. Aarne, and N. Ammann.[^rc-e6ea]
 
-One concrete application domain for the ARIA programme is electricity grid optimization. According to programme descriptions, deploying verified AI algorithms in this domain could potentially save on the order of £3 billion annually in excess capacity costs in the UK alone — though Dalrymple himself notes the difficulty of such economic projections. The ARIA programme deliberately excludes frontier AI models from its near-term deployment targets, instead focusing on AI systems whose behavior can be formally analyzed.[^5]
+One concrete application domain for the ARIA programme is electricity grid optimization. According to programme descriptions, deploying verified AI algorithms in this domain could potentially save on the order of \£3 billion annually in excess capacity costs in the UK alone — though Dalrymple himself notes the difficulty of such economic projections. The ARIA programme deliberately excludes frontier AI models from its near-term deployment targets, instead focusing on AI systems whose behavior can be formally analyzed.[^rc-e9e0]
 
 ### Formal Verification and Mechanistic Interpretability
 
-Dalrymple has contributed to the broader AI safety research landscape through collaboration on frameworks for robust and reliable AI systems. In May 2024, he co-authored "Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems" with J. Skalse and others, published through FAR.AI.[^4] He is also listed among contributors to "Open Problems in <EntityLink id="E174">Interpretability</EntityLink>," published in January 2025.[^4]
+Dalrymple has contributed to the broader AI safety research landscape through collaboration on frameworks for robust and reliable AI systems. In May 2024, he co-authored "Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems" with J. Skalse and others, published through <EntityLink id="E557" name="redwood-research">Redwood Research</EntityLink>.[^rc-e6ea] He is also listed among contributors to "Open Problems in <EntityLink id="E174" name="interpretability">Interpretability</EntityLink>," published in January 2025.[^rc-e6ea]
 
-His technical expertise spans applied category theory, interactive theorem proving, modal and substructural logic, measure-theoretic probability, stochastic processes, control theory, decision theory, game theory, and mechanism design — an unusually broad formal toolkit for an AI safety researcher.[^1]
+His technical expertise spans applied category theory, interactive theorem proving, modal and substructural logic, measure-theoretic probability, stochastic processes, control theory, decision theory, game theory, and mechanism design — a broad formal toolkit spanning multiple mathematical disciplines.[^rc-5af7]
 
 ### Views on AI Timelines and Risk
 
-Dalrymple has been notably cautious about making specific timeline predictions, emphasizing radical uncertainty in AI development. However, he has made several substantive public observations about the pace and character of AI progress. He has noted that over a recent period, multiple frontier AI models quantitatively exceeded evaluations by <EntityLink id="E201">METR</EntityLink> and his own personal expectations across several successive model releases.[^6] He describes this as a pattern of AI progress outpacing forecasts, and has used it to motivate urgency in safety work.
+Dalrymple has been notably cautious about making specific timeline predictions, emphasizing radical uncertainty in AI development. However, he has made several substantive public observations about the pace and character of AI progress. He has noted that over a recent period, multiple frontier AI models quantitatively exceeded evaluations by <EntityLink id="E201" name="metr">METR</EntityLink> and his own personal expectations across several successive model releases.[^rc-1fb7] He describes this as a pattern of AI progress outpacing forecasts, and has used it to motivate urgency in safety work.
 
-He has argued that the "middle period" of AI development — in which systems are smarter than top humans but not yet superintelligent — may be compressed or squeezed short by rapid scaling, potentially leading quickly to superintelligence without adequate time to develop safety measures. He has also publicly warned, including in coverage in The Guardian, that the science needed to ensure full AI reliability may not emerge quickly enough given economic pressures driving rapid capability deployment.[^7]
+He has argued that the "middle period" of AI development — in which systems are smarter than top humans but not yet superintelligent — may be compressed or squeezed short by rapid scaling, potentially leading quickly to <EntityLink id="E291" name="superintelligence">superintelligence</EntityLink> without adequate time to develop safety measures. He has also publicly warned, including in coverage in The Guardian, that the science needed to ensure full AI reliability may not emerge quickly enough given economic pressures driving rapid capability deployment.[^rc-ee0e]
 
-He has discussed the potential economic stakes of this transition, framing it in terms of a possible 10% GDP growth from narrow AI systems weighed against the risks of a rapid and uncontrolled transition to superintelligence. A November 2025 pivot in the ARIA programme — shifting toward a broader foundational toolkit — was attributed in part to faster-than-expected frontier AI progress.[^6]
+He has discussed the potential economic stakes of this transition, framing it in terms of a possible 10% GDP growth from narrow AI systems weighed against the risks of a rapid and uncontrolled transition to <EntityLink id="E291" name="superintelligence">superintelligence</EntityLink>. A November 2025 pivot in the ARIA programme — shifting toward a broader foundational toolkit — was attributed in part to faster-than-expected frontier AI progress.[^rc-1fb7]
 
 ### Community Reception
 
-Within AI safety and effective altruism communities, Dalrymple's work has been received positively. His Open Agency Architecture has been described on LessWrong as among the most comprehensive technical statements of what AI safety requires. He served as a mentor in the MATS Winter 2023–24 program alongside researchers such as Evan Hubinger and Owain Evans.[^8] He has received funding through Manifund (a \$30,000 grant for "Activation vector steering with BCI" work with Lisa Thiergart) and has been cited in shallow reviews of technical AI safety alongside figures such as Yoshua Bengio and Stuart Russell.[^8]
+Within AI safety and effective altruism communities, Dalrymple's work has been cited and discussed. His Open Agency Architecture has been discussed on <EntityLink id="E538" name="lesswrong">LessWrong</EntityLink> as a detailed technical framework for AI safety requirements, though some community members have continued to seek more precise formal definitions of concepts such as "boundaries" in the architecture.[^rc-f21e] He served as a mentor in the MATS Winter 2023–24 program alongside researchers such as <EntityLink id="E129" name="evan-hubinger">Evan Hubinger</EntityLink> and Owain Evans.[^rc-f21e] He has received funding through <EntityLink id="E547" name="manifund">Manifund</EntityLink> (a \$30,000 grant for "Activation vector steering with BCI" work with Lisa Thiergart) and has been cited in reviews of technical AI safety alongside figures such as <EntityLink id="E380" name="yoshua-bengio">Yoshua Bengio</EntityLink> and <EntityLink id="E290" name="stuart-russell">Stuart Russell</EntityLink>.[^rc-f21e]
 
-He has been a frequent visitor to and collaborator with both the <EntityLink id="E140">Future of Humanity Institute</EntityLink> and the <EntityLink id="E202">Machine Intelligence Research Institute (MIRI)</EntityLink>, where he was a Summer Fellow in 2015.[^1]
+He has been a frequent visitor to and collaborator with both the <EntityLink id="E140" name="fhi">Future of Humanity Institute</EntityLink> and the <EntityLink id="E202" name="miri">Machine Intelligence Research Institute (MIRI)</EntityLink>, where he was a Summer Fellow in 2015.[^rc-5af7]
 
 ## ARIA Programme
 
-The ARIA Safeguarded AI programme, which Dalrymple has directed since 2023, is funded at £59 million by the UK government. Its stated goal is to develop mathematically verified AI controllers suitable for deployment in safety-critical systems. The programme has cited the April 2025 blackout in Spain and Portugal — which lasted approximately 10 hours, caused billions of euros in economic damage, and resulted in eight fatalities — as illustrative of the risks posed by inadequate safety guarantees in energy infrastructure.[^5]
+The ARIA Safeguarded AI programme, which Dalrymple has directed since 2023, is funded at \£59 million by the UK government. Its stated goal is to develop mathematically verified AI controllers suitable for deployment in safety-critical systems. The programme has cited the April 2025 blackout in Spain and Portugal — which lasted approximately 10 hours, caused billions of euros in economic damage, and resulted in eight fatalities — as illustrative of the risks posed by inadequate safety guarantees in energy infrastructure.[^rc-e9e0]
 
-Dalrymple has given keynote addresses on the programme's themes at CODE BLUE in Tokyo (2024), the AI Security Forum in Paris (2025), the High-Confidence Software & Systems conference in Annapolis (2025), and SCAI 2025 in Singapore.[^4] In a January 2025 podcast, he discussed the economic trade-offs of different approaches to managing the transition to transformative AI, including the costs and benefits of delaying superintelligence development.[^6]
+Dalrymple has given keynote addresses on the programme's themes at CODE BLUE in Tokyo (2024), the AI Security Forum in Paris (2025), the High-Confidence Software & Systems conference in Annapolis (2025), and SCAI 2025 in Singapore.[^rc-e6ea] In a January 2025 podcast, he discussed the economic trade-offs of different approaches to managing the transition to <EntityLink id="E357" name="transformative-ai">transformative AI</EntityLink>, including the costs and benefits of delaying superintelligence development.[^rc-1fb7]
 
-The programme represents a relatively distinctive bet within the UK AI policy landscape: rather than relying on empirical testing, red-teaming, or behavioral evaluations alone, it advocates for formal mathematical proof as a necessary component of AI safety assurance for high-stakes applications.
+The programme takes a specific position within the UK AI policy landscape, emphasizing formal mathematical proof as a component of AI safety assurance for high-stakes applications alongside empirical testing and behavioral evaluations — an approach that contrasts with the empirically-oriented alignment methods more prevalent at major AI labs.
 
 ## Criticisms and Concerns
 
-No significant personal controversies or criticisms of Dalrymple's research have been documented in available sources. Community discussions on LessWrong and EA Forum are predominantly positive, with limited direct critique of his technical proposals. One noted area of ongoing clarification relates to his concept of "boundaries" in the Open Agency Architecture, with community members continuing to seek precise formal definitions.[^8]
+No significant personal controversies or criticisms of Dalrymple's research have been documented in available sources. Community discussions on <EntityLink id="E538" name="lesswrong">LessWrong</EntityLink> and EA Forum contain limited direct critique of his technical proposals. One noted area of ongoing clarification relates to his concept of "boundaries" in the Open Agency Architecture, with community members continuing to seek precise formal definitions.[^rc-f21e]
 
 A broader skeptical question — applicable to the Safeguarded AI agenda generally — is whether formal verification techniques, which have historically struggled to scale to complex software systems, can be made to work for AI systems of the complexity and scale now being deployed. Dalrymple's ARIA programme explicitly addresses this concern by targeting scoped, well-defined deployment contexts rather than open-ended AI behavior, but it remains an open empirical question whether this scoping can be maintained as AI capabilities advance.
 
-His stated view that the "safe AI development window" may be closing faster than anticipated is also a claim that is difficult to evaluate rigorously, as acknowledged in his own public comments about the difficulty of technological forecasting.[^7]
+His stated view that the "safe AI development window" may be closing faster than anticipated is also a claim that is difficult to evaluate rigorously, as acknowledged in his own public comments about the difficulty of technological forecasting.[^rc-ee0e]
 
 ## Key Uncertainties
 
 - Whether formal verification methods can scale to match the complexity of frontier AI systems, even in scoped deployment contexts
-- The actual timeline compression of the "middle period" between current AI capabilities and potential superintelligence
+- The actual timeline compression of the "middle period" between current AI capabilities and potential <EntityLink id="E291" name="superintelligence">superintelligence</EntityLink>
 - Whether the ARIA Safeguarded AI programme's technical approach will produce deployable systems within its funding horizon
 - The degree to which hardware-level guarantees (flexHEG) can be made robust to adversarial conditions without creating new vulnerability surfaces
 
 ---
 
-[^1]: Background research on David Dalrymple's career, education, and research history — biographical data from multiple research sections
-[^2]: Research data on Protocol Labs and SYCO 5 presentation of dioptics framework
-[^3]: Research data on Safeguarded AI framework description and ARIA programme goals
-[^4]: Research data on publications: "Flexible Hardware-Enabled Guarantees for AI Compute" (arXiv, 2025); "Towards Guaranteed Safe AI" (FAR.AI, May 2024); "Open Problems in Mechanistic Interpretability" (FAR.AI, January 2025); conference keynote appearances
-[^5]: Research data on ARIA programme funding, electricity grid application, and Spain/Portugal blackout reference
-[^6]: Research data on METR evaluation observations, timeline views, and November 2025 ARIA programme pivot
-[^7]: Research data on Guardian coverage and public warnings about AI safety window
-[^8]: Research data on LessWrong/EA Forum community reception, MATS mentorship, and Manifund grant
+[^rc-5af7]: Background research on David Dalrymple's career, education, and research history — biographical data from multiple research sections
+[^rc-ee14]: Research data on Protocol Labs and SYCO 5 presentation of dioptics framework
+[^rc-a5c5]: Research data on Safeguarded AI framework description and ARIA programme goals
+[^rc-e6ea]: Research data on publications: "Flexible Hardware-Enabled Guarantees for AI Compute" (arXiv, 2025); "Towards Guaranteed Safe AI" (FAR.AI, May 2024); "Open Problems in Mechanistic Interpretability" (FAR.AI, January 2025); conference keynote appearances
+[^rc-e9e0]: Research data on ARIA programme funding, electricity grid application, and Spain/Portugal blackout reference
+[^rc-1fb7]: Research data on METR evaluation observations, timeline views, and November 2025 ARIA programme pivot
+[^rc-ee0e]: Research data on Guardian coverage and public warnings about AI safety window
+[^rc-f21e]: Research data on LessWrong/EA Forum community reception, MATS mentorship, and Manifund grant


### PR DESCRIPTION
## Summary
- Submit ARIA personnel records (davidad as Programme Director, Bengio as Scientific Director) — now works after ANY() fix deployed
- Fix qa-checks.ts ANY() → IN() bug (same pattern as personnel.ts)
- Fix stale crux.mjs import after verify-orchestrate → source-check-orchestrate rename
- Polish David Dalrymple wiki page via `crux w improve --tier=polish`
- Resolve merge conflicts with main (accept FBF components, inArray() pattern)

## Note
ARIA wiki page improve was attempted but blocked — standard tier times out (>600s LLM call) and polish tier blocked by semantic diff (61% changes). The page from `crux w create` is functional but needs manual improvement or a pipeline timeout increase.

Gate check has 3 pre-existing wiki-id integrity errors from the verification→source-check rename on main (not from this PR).

## Test plan
- [x] `pnpm build-data:content` passes (909 entities, 696 pages)
- [x] Personnel submit succeeds for davidad + Bengio
- [x] crux CLI works after import fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated David Dalrymple knowledge base profile with improved citations, accuracy, and linked entity references throughout the article.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->