### PR TITLE
fix: E2100 wikiId collision — move deprecated dashboard to E2500

### DIFF
--- a/apps/web/src/app/internal/entity-source-checks/entity-source-checks-content.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/entity-source-checks-content.tsx
@@ -10,7 +10,7 @@ import { SourceCheckTabs } from "./source-check-tabs";
  * Combines three previously separate dashboards into tabbed sections:
  * - Verdicts (E2200): all source-check verdicts with expandable evidence
  * - FactBase (E1045): FactBase-specific source-check stats and table
- * - Coverage (E2100): entity type coverage analysis and priority queue
+ * - Coverage (E2500): entity type coverage analysis and priority queue
  *
  * Each tab renders the original content component — no logic was duplicated.
  */

--- a/content/docs/internal/source-check-coverage-dashboard.mdx
+++ b/content/docs/internal/source-check-coverage-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-wikiId: E2100
+wikiId: E2500
 title: "Source-Check Coverage (Deprecated)"
 description: "Merged into the consolidated Source Checks dashboard (E2200). This page redirects."
 subcategory: dashboards


### PR DESCRIPTION
## Summary

Entity auto-ID assignment expanded past E2100, causing `gabriel-alfour` to collide with the deprecated source-check-coverage dashboard. Move dashboard to E2500.

This is the same pattern as E2050 (#2948). We should allocate dashboard IDs from a reserved high range (E2000+) to avoid recurring collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)