### PR TITLE
fix: wrong migration journal tag at idx 132 — breaks main CI + release

### DIFF
--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -930,7 +930,7 @@
       "idx": 132,
       "version": "7",
       "when": 1781078400000,
-      "tag": "0132_create_secondary_market_prices",
+      "tag": "0132_research_area_evaluations",
       "breakpoints": true
     },
     {


### PR DESCRIPTION
## Summary

Journal entry idx 132 has tag `0132_create_secondary_market_prices` but the actual SQL file is `0132_research_area_evaluations.sql`. The secondary market prices migration is correctly at idx 133.

This breaks:
- Test DB migrations (file not found)
- Migration integrity check (tag/file mismatch)
- Release PR #3028

**Main CI is red. Release is blocked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)