### PR TITLE
Add source-check verdict columns to directory tables

### DIFF
--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
+import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import type { RecordVerdict } from "@/data/tablebase";
 import { titleCase } from "@/components/wiki/factbase/format";
 import {
   DIVISION_TYPE_COLORS,
@@ -22,6 +24,8 @@ export interface DivisionRow {
   href: string | null;
   /** Whether this division has meaningful data (personnel, grants, programs, lead, etc.) */
   hasData: boolean;
+  /** Source-check verification verdict, if available */
+  verdict: RecordVerdict | null;
 }
 
 export interface TypeSummary {
@@ -190,6 +194,7 @@ export function DivisionsTable({
                 </th>
                 <th className="text-left py-2.5 px-3 font-medium">Type</th>
                 <th className="text-left py-2.5 px-3 font-medium">Status</th>
+                <th className="text-center py-2.5 px-3 font-medium">Verified</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -246,6 +251,9 @@ export function DivisionsTable({
                         {titleCase(row.status)}
                       </span>
                     )}
+                  </td>
+                  <td className="py-2 px-3 text-center">
+                    <SourceCheckBadge verdict={row.verdict} />
                   </td>
                 </tr>
               ))}

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -3,6 +3,7 @@ import {
   getAllKBRecords,
   getKBRecords,
 } from "@/data/factbase";
+import { getRecordVerdict } from "@/data/tablebase";
 import {
   parseDivision,
   resolveEntityLink,
@@ -94,6 +95,7 @@ export default function DivisionsPage() {
         status: division.status,
         href,
         hasData: false, // computed below
+        verdict: getRecordVerdict("division", String(division.key)),
       },
       record,
     });

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import type { RecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { compareFPRows, type SortDir } from "./funding-programs-sort";
 import { FP_STATUS_COLORS, PROGRAM_TYPE_LABELS } from "./funding-programs-constants";
@@ -23,6 +25,8 @@ export interface FundingProgramListRow {
   status: string | null;
   source: string | null;
   description: string | null;
+  /** Source-check verification verdict, if available */
+  verdict: RecordVerdict | null;
 }
 
 type SortKey = "name" | "organization" | "type" | "budget" | "status" | "deadline";
@@ -337,6 +341,7 @@ export function FundingProgramsListTable({
                 onSort={handleSort}
                 className="text-center"
               />
+              <th className="text-center py-2.5 px-3 font-medium">Verified</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -419,6 +424,11 @@ export function FundingProgramsListTable({
                   ) : (
                     <span className="text-muted-foreground/40">{"\u2014"}</span>
                   )}
+                </td>
+
+                {/* Verified */}
+                <td className="py-2.5 px-3 text-center">
+                  <SourceCheckBadge verdict={row.verdict} />
                 </td>
               </tr>
             ))}

--- a/apps/web/src/app/funding-programs/page.tsx
+++ b/apps/web/src/app/funding-programs/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllKBRecords } from "@/data/factbase";
-import { getTypedEntityById } from "@/data/tablebase";
+import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { parseFundingProgram } from "./[id]/program-data";
@@ -55,6 +55,7 @@ export default function FundingProgramsPage() {
       status: p.status,
       source: p.source,
       description: p.description,
+      verdict: getRecordVerdict("funding-program", String(p.key)),
     };
   });
 

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllKBRecords } from "@/data/factbase";
+import { getRecordVerdict } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
+import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { resolveEntityLink, INSTRUMENT_COLORS } from "@/lib/record-detail-ui";
 import {
@@ -119,10 +121,13 @@ export default function FundingRoundsPage() {
                   Lead Investor
                 </th>
                 <th className="text-center py-2.5 px-3 font-medium">Date</th>
+                <th className="text-center py-2.5 px-3 font-medium">Verified</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
-              {rows.map((row) => (
+              {rows.map((row) => {
+                const verdict = getRecordVerdict("funding-round", String(row.key));
+                return (
                 <tr
                   key={row.key}
                   className="hover:bg-muted/20 transition-colors"
@@ -187,8 +192,12 @@ export default function FundingRoundsPage() {
                   <td className="py-2 px-3 text-center text-muted-foreground text-xs whitespace-nowrap">
                     {row.date ? formatKBDate(row.date) : ""}
                   </td>
+                  <td className="py-2 px-3 text-center">
+                    <SourceCheckBadge verdict={verdict} />
+                  </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- Add "Verified" column (SourceCheckBadge) to the **divisions**, **funding-programs**, and **funding-rounds** directory table pages
- These three directories were the only ones missing verdict columns that other directory pages (equity-positions, personnel/career-history) already display
- For client-component tables (divisions, funding-programs), verdict data is looked up server-side via `getRecordVerdict()` and passed through the row props
- For the server-component table (funding-rounds), verdict is computed inline in the render loop

## Test plan
- [x] Type check passes (no new errors introduced)
- [x] Changes follow existing pattern from equity-section.tsx and career-history.tsx
- [x] SourceCheckBadge component unchanged
- [ ] Build passes (`pnpm build`) — to be verified in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Verified" columns to divisions, funding programs, and funding rounds tables to display source verification status for each record, helping users identify verified data at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->