### PR TITLE
feat: add advisory source-check-verdicts gate rule

### DIFF
--- a/crux/lib/rules/index.ts
+++ b/crux/lib/rules/index.ts
@@ -95,6 +95,9 @@ import { noExecSyncRule } from './no-exec-sync.ts';
 import { resourceRefIntegrityRule } from './resource-ref-integrity.ts';
 import { kbfRefsRule } from './factbase-refs.ts';
 
+// Source-check verdict warnings (advisory)
+import { sourceCheckVerdictsRule } from './source-check-verdicts.ts';
+
 // Deprecated component detection
 import { noDeprecatedComponentsRule } from './no-deprecated-components.ts';
 
@@ -183,6 +186,7 @@ export {
   noExecSyncRule,
   resourceRefIntegrityRule,
   kbfRefsRule,
+  sourceCheckVerdictsRule,
   noDeprecatedComponentsRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,
@@ -250,6 +254,7 @@ export const allRules: Rule[] = [
   noExecSyncRule,
   resourceRefIntegrityRule,
   kbfRefsRule,
+  sourceCheckVerdictsRule,
   noDeprecatedComponentsRule,
   pipelineArtifactsRule,
   footnoteIntegrityRule,

--- a/crux/lib/rules/source-check-verdicts.test.ts
+++ b/crux/lib/rules/source-check-verdicts.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs before importing the rule
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+import { existsSync, readFileSync } from 'fs';
+import { sourceCheckVerdictsRule } from './source-check-verdicts.ts';
+import { ValidationEngine, Issue, type ContentFile } from '../validation/validation-engine.ts';
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+// Minimal engine stub — the rule doesn't use engine methods
+const stubEngine = {} as ValidationEngine;
+const emptyFiles: ContentFile[] = [];
+
+/** Helper: call the sync check function and return issues typed correctly */
+function runCheck(): Issue[] {
+  return sourceCheckVerdictsRule.check(emptyFiles, stubEngine) as Issue[];
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('sourceCheckVerdictsRule', () => {
+  it('has correct metadata', () => {
+    expect(sourceCheckVerdictsRule.id).toBe('source-check-verdicts');
+    expect(sourceCheckVerdictsRule.scope).toBe('global');
+  });
+
+  it('returns no issues when data files do not exist', () => {
+    mockedExistsSync.mockReturnValue(false);
+    const issues = runCheck();
+    expect(issues).toEqual([]);
+  });
+
+  it('returns no issues when all record verdicts are confirmed', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('record-verdicts.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'personnel:123': { verdict: 'confirmed', confidence: 0.95, sourcesChecked: 2, needsRecheck: false, lastComputedAt: '2026-01-01' },
+      'grant:456': { verdict: 'confirmed', confidence: 0.9, sourcesChecked: 1, needsRecheck: false, lastComputedAt: '2026-01-01' },
+    }));
+
+    const issues = runCheck();
+    expect(issues).toEqual([]);
+  });
+
+  it('warns on contradicted record verdicts', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('record-verdicts.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'personnel:abc': { verdict: 'contradicted', confidence: 0.8, sourcesChecked: 3, needsRecheck: true, lastComputedAt: '2026-01-01' },
+      'grant:xyz': { verdict: 'confirmed', confidence: 0.95, sourcesChecked: 2, needsRecheck: false, lastComputedAt: '2026-01-01' },
+    }));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].message).toContain('1 record(s) have contradicted');
+    expect(issues[0].message).toContain('personnel:abc');
+  });
+
+  it('warns on outdated record verdicts', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('record-verdicts.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'investment:100': { verdict: 'outdated', confidence: 0.7, sourcesChecked: 1, needsRecheck: true, lastComputedAt: '2025-06-01' },
+      'investment:200': { verdict: 'outdated', confidence: 0.6, sourcesChecked: 1, needsRecheck: true, lastComputedAt: '2025-06-01' },
+    }));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].message).toContain('2 record(s) have outdated');
+    expect(issues[0].message).toContain('investment:100');
+    expect(issues[0].message).toContain('investment:200');
+  });
+
+  it('reports both contradicted and outdated separately', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('record-verdicts.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'personnel:a': { verdict: 'contradicted', confidence: 0.8, sourcesChecked: 2, needsRecheck: true, lastComputedAt: '2026-01-01' },
+      'grant:b': { verdict: 'outdated', confidence: 0.5, sourcesChecked: 1, needsRecheck: true, lastComputedAt: '2025-01-01' },
+      'personnel:c': { verdict: 'confirmed', confidence: 0.95, sourcesChecked: 3, needsRecheck: false, lastComputedAt: '2026-01-01' },
+    }));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(2);
+    expect(issues[0].message).toContain('contradicted');
+    expect(issues[1].message).toContain('outdated');
+  });
+
+  it('warns on inaccurate KB fact verdicts', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('kb-fact-verification.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'f_anthropic_001': 'inaccurate',
+      'f_openai_002': 'accurate',
+      'f_deepmind_003': 'inaccurate',
+    }));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].message).toContain('2 FactBase fact(s) have inaccurate');
+    expect(issues[0].message).toContain('f_anthropic_001');
+    expect(issues[0].message).toContain('f_deepmind_003');
+  });
+
+  it('warns on unsupported KB fact verdicts', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('kb-fact-verification.json');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      'f_abc': 'unsupported',
+      'f_def': 'verified',
+    }));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].message).toContain('1 FactBase fact(s) have unsupported');
+    expect(issues[0].message).toContain('f_abc');
+  });
+
+  it('handles both data files present with mixed verdicts', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation((filePath) => {
+      const path = String(filePath);
+      if (path.includes('record-verdicts.json')) {
+        return JSON.stringify({
+          'personnel:a': { verdict: 'contradicted', confidence: 0.8, sourcesChecked: 2, needsRecheck: true, lastComputedAt: '2026-01-01' },
+        });
+      }
+      if (path.includes('kb-fact-verification.json')) {
+        return JSON.stringify({
+          'f_xyz': 'inaccurate',
+        });
+      }
+      return '{}';
+    });
+
+    const issues = runCheck();
+    // 1 contradicted record + 1 inaccurate fact = 2 issues
+    expect(issues).toHaveLength(2);
+    expect(issues.some((i: Issue) => i.message.includes('contradicted'))).toBe(true);
+    expect(issues.some((i: Issue) => i.message.includes('inaccurate'))).toBe(true);
+  });
+
+  it('truncates long lists to 10 items with a count suffix', () => {
+    mockedExistsSync.mockImplementation((path) => {
+      return String(path).includes('record-verdicts.json');
+    });
+
+    const verdicts: Record<string, unknown> = {};
+    for (let i = 0; i < 15; i++) {
+      verdicts[`personnel:${i}`] = { verdict: 'contradicted', confidence: 0.5, sourcesChecked: 1, needsRecheck: true, lastComputedAt: null };
+    }
+    mockedReadFileSync.mockReturnValue(JSON.stringify(verdicts));
+
+    const issues = runCheck();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('15 record(s)');
+    expect(issues[0].message).toContain('(and 5 more)');
+  });
+
+  it('handles malformed JSON gracefully', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue('not valid json{{{');
+
+    // Should not throw, just return empty (logs a warning internally)
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const issues = runCheck();
+    expect(issues).toEqual([]);
+    consoleSpy.mockRestore();
+  });
+
+  it('ignores non-problematic verdicts', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation((filePath) => {
+      const path = String(filePath);
+      if (path.includes('record-verdicts.json')) {
+        return JSON.stringify({
+          'personnel:a': { verdict: 'confirmed', confidence: 0.95, sourcesChecked: 3, needsRecheck: false, lastComputedAt: '2026-01-01' },
+          'grant:b': { verdict: 'partial', confidence: 0.6, sourcesChecked: 1, needsRecheck: false, lastComputedAt: '2026-01-01' },
+          'investment:c': { verdict: 'unverifiable', confidence: null, sourcesChecked: 0, needsRecheck: false, lastComputedAt: null },
+          'funding-round:d': { verdict: 'unchecked', confidence: null, sourcesChecked: 0, needsRecheck: false, lastComputedAt: null },
+        });
+      }
+      if (path.includes('kb-fact-verification.json')) {
+        return JSON.stringify({
+          'f_a': 'accurate',
+          'f_b': 'minor_issues',
+          'f_c': 'not_verifiable',
+          'f_d': 'verified',
+        });
+      }
+      return '{}';
+    });
+
+    const issues = runCheck();
+    expect(issues).toEqual([]);
+  });
+
+  it('handles empty verdict objects', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue('{}');
+
+    const issues = runCheck();
+    expect(issues).toEqual([]);
+  });
+});

--- a/crux/lib/rules/source-check-verdicts.ts
+++ b/crux/lib/rules/source-check-verdicts.ts
@@ -1,0 +1,157 @@
+/**
+ * Rule: Source-Check Verdicts
+ *
+ * Advisory (non-blocking) rule that warns when source-check verdicts indicate
+ * contradicted or outdated records. These verdicts come from the unified
+ * verification system and are cached locally in record-verdicts.json and
+ * kb-fact-verification.json after build-data runs with wiki-server access.
+ *
+ * Two data sources are checked:
+ *   1. Record verdicts (record-verdicts.json): Covers PG-primary records
+ *      like personnel, grants, investments, funding-rounds, etc.
+ *      Keys are "recordType:recordId", verdicts include: confirmed,
+ *      contradicted, outdated, partial, unverifiable, unchecked.
+ *
+ *   2. KB fact verdicts (kb-fact-verification.json): Covers FactBase facts
+ *      cross-referenced with citation quotes. Keys are fact IDs,
+ *      verdicts include: accurate, minor_issues, inaccurate, unsupported,
+ *      not_verifiable, verified.
+ *
+ * If the data files don't exist (e.g. wiki-server was unavailable during build),
+ * the rule skips silently.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { createRule, Issue, Severity } from '../validation/validation-engine.ts';
+import type { ContentFile, ValidationEngine } from '../validation/validation-engine.ts';
+import { PROJECT_ROOT } from '../content-types.ts';
+
+const DATA_DIR = join(PROJECT_ROOT, 'apps/web/src/data');
+const RECORD_VERDICTS_FILE = join(DATA_DIR, 'record-verdicts.json');
+const KB_FACT_VERIFICATION_FILE = join(DATA_DIR, 'kb-fact-verification.json');
+
+/** Record verdict shape from record-verdicts.json */
+interface RecordVerdict {
+  verdict: string;
+  confidence: number | null;
+  sourcesChecked: number;
+  needsRecheck: boolean;
+  lastComputedAt: string | null;
+}
+
+/**
+ * Safely load and parse a JSON file. Returns null if the file doesn't exist
+ * or can't be parsed — the rule should skip gracefully in either case.
+ */
+function loadJsonSafe<T>(filePath: string): T | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`source-check-verdicts: failed to parse ${filePath}: ${msg}`);
+    return null;
+  }
+}
+
+export const sourceCheckVerdictsRule = createRule({
+  id: 'source-check-verdicts',
+  name: 'Source-Check Verdicts',
+  description: 'Warn when records or facts have contradicted or outdated source-check verdicts',
+  scope: 'global',
+
+  check(_content: ContentFile[], _engine: ValidationEngine): Issue[] {
+    const issues: Issue[] = [];
+
+    // ── Record verdicts ──────────────────────────────────────────────────
+    const recordVerdicts = loadJsonSafe<Record<string, RecordVerdict>>(RECORD_VERDICTS_FILE);
+
+    if (recordVerdicts) {
+      // Group problematic verdicts by verdict type for a cleaner summary
+      const contradicted: string[] = [];
+      const outdated: string[] = [];
+
+      for (const [key, rv] of Object.entries(recordVerdicts)) {
+        if (rv.verdict === 'contradicted') {
+          contradicted.push(key);
+        } else if (rv.verdict === 'outdated') {
+          outdated.push(key);
+        }
+      }
+
+      if (contradicted.length > 0) {
+        // Cap the listed keys to avoid overwhelming output
+        const listed = contradicted.slice(0, 10).join(', ');
+        const suffix = contradicted.length > 10
+          ? ` (and ${contradicted.length - 10} more)`
+          : '';
+        issues.push(new Issue({
+          rule: 'source-check-verdicts',
+          file: RECORD_VERDICTS_FILE,
+          message: `${contradicted.length} record(s) have contradicted source-check verdicts: ${listed}${suffix}`,
+          severity: Severity.WARNING,
+        }));
+      }
+
+      if (outdated.length > 0) {
+        const listed = outdated.slice(0, 10).join(', ');
+        const suffix = outdated.length > 10
+          ? ` (and ${outdated.length - 10} more)`
+          : '';
+        issues.push(new Issue({
+          rule: 'source-check-verdicts',
+          file: RECORD_VERDICTS_FILE,
+          message: `${outdated.length} record(s) have outdated source-check verdicts: ${listed}${suffix}`,
+          severity: Severity.WARNING,
+        }));
+      }
+    }
+
+    // ── KB fact verdicts ─────────────────────────────────────────────────
+    const kbVerdicts = loadJsonSafe<Record<string, string>>(KB_FACT_VERIFICATION_FILE);
+
+    if (kbVerdicts) {
+      const inaccurate: string[] = [];
+      const unsupported: string[] = [];
+
+      for (const [factId, verdict] of Object.entries(kbVerdicts)) {
+        if (verdict === 'inaccurate') {
+          inaccurate.push(factId);
+        } else if (verdict === 'unsupported') {
+          unsupported.push(factId);
+        }
+      }
+
+      if (inaccurate.length > 0) {
+        const listed = inaccurate.slice(0, 10).join(', ');
+        const suffix = inaccurate.length > 10
+          ? ` (and ${inaccurate.length - 10} more)`
+          : '';
+        issues.push(new Issue({
+          rule: 'source-check-verdicts',
+          file: KB_FACT_VERIFICATION_FILE,
+          message: `${inaccurate.length} FactBase fact(s) have inaccurate citation verdicts: ${listed}${suffix}`,
+          severity: Severity.WARNING,
+        }));
+      }
+
+      if (unsupported.length > 0) {
+        const listed = unsupported.slice(0, 10).join(', ');
+        const suffix = unsupported.length > 10
+          ? ` (and ${unsupported.length - 10} more)`
+          : '';
+        issues.push(new Issue({
+          rule: 'source-check-verdicts',
+          file: KB_FACT_VERIFICATION_FILE,
+          message: `${unsupported.length} FactBase fact(s) have unsupported citation verdicts: ${listed}${suffix}`,
+          severity: Severity.WARNING,
+        }));
+      }
+    }
+
+    return issues;
+  },
+});
+
+export default sourceCheckVerdictsRule;


### PR DESCRIPTION
## Summary
- Adds a new `source-check-verdicts` validation rule to the unified gate system
- **Advisory only** (warnings, not errors) -- does not block CI
- Checks `record-verdicts.json` for contradicted/outdated record verdicts (personnel, grants, investments, funding-rounds, etc.)
- Checks `kb-fact-verification.json` for inaccurate/unsupported FactBase fact verdicts
- Skips silently when data files don't exist (common when wiki-server was unavailable during build)
- Truncates long lists to 10 items to keep output readable
- Includes 13 unit tests covering all verdict types, missing files, malformed JSON, and edge cases

## Test plan
- [x] All 13 new unit tests pass (`npx vitest run crux/lib/rules/source-check-verdicts.test.ts`)
- [x] Rule appears in `--list` output of unified validator
- [x] Rule runs without error when data files don't exist
- [x] Gate `--scope=content` still passes
- [x] No TypeScript errors in new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
