### PR TITLE
feat: add source-check verdict context to improve pipeline

### DIFF
--- a/crux/authoring/page-improver/build-context.ts
+++ b/crux/authoring/page-improver/build-context.ts
@@ -10,6 +10,7 @@
 
 import { buildEntityLookupForContent } from '../../lib/entity-lookup.ts';
 import { buildKbContextForPage } from '../../lib/factbase-context.ts';
+import { buildSourceCheckContext } from '../../lib/source-check-context.ts';
 import { resolveTemplate, formatTemplateForPrompt } from '../../lib/content/page-templates.ts';
 import { getPageType } from '../../lib/page-analysis.ts';
 import { IMPROVE_PROMPT } from './phases/prompts.ts';
@@ -27,6 +28,8 @@ export interface ImproveContext {
   templateContext: string | null;
   /** Objectivity context (alerts + issues) from analysis. */
   objectivityContext: string;
+  /** Source-check verdict context (contradicted/outdated claims), or null if unavailable. */
+  sourceCheckContext: string | null;
 }
 
 export interface BuildImproveContextOptions {
@@ -93,6 +96,22 @@ export async function buildImproveContext(
     log('improve', `  Using template: ${template.name}`);
   }
 
+  // Fetch source-check verdicts (contradicted/outdated) for this entity
+  log('improve', 'Loading source-check verdicts...');
+  let sourceCheckContext: string | null = null;
+  try {
+    sourceCheckContext = await buildSourceCheckContext(page.id);
+    if (sourceCheckContext) {
+      const lineCount = sourceCheckContext.split('\n').filter(Boolean).length;
+      log('improve', `  Found ${lineCount} source-check warnings for this entity`);
+    } else {
+      log('improve', '  No actionable source-check verdicts found');
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log('improve', `  Source-check context load failed: ${error.message} — continuing without`);
+  }
+
   const prompt = IMPROVE_PROMPT({
     page, filePath, importPath, directions,
     analysis, research, objectivityContext,
@@ -100,6 +119,7 @@ export async function buildImproveContext(
     claimsContext: null,
     gapAnalysisContext: null,
     kbContext, tier, templateContext,
+    sourceCheckContext,
   });
 
   return {
@@ -108,5 +128,6 @@ export async function buildImproveContext(
     kbContext,
     templateContext,
     objectivityContext,
+    sourceCheckContext,
   };
 }

--- a/crux/authoring/page-improver/phases/prompts.ts
+++ b/crux/authoring/page-improver/phases/prompts.ts
@@ -145,10 +145,12 @@ interface ImprovePromptArgs {
   tier: string;
   /** Formatted template requirements (from resolveTemplate + formatTemplateForPrompt). */
   templateContext: string | null;
+  /** Source-check verdicts (contradicted/outdated) for the page's entity. */
+  sourceCheckContext: string | null;
 }
 
 export function IMPROVE_PROMPT(args: ImprovePromptArgs): string {
-  const { page, filePath, importPath, directions, analysis, research, objectivityContext, currentContent, entityLookup, claimsContext, gapAnalysisContext, kbContext, tier, templateContext } = args;
+  const { page, filePath, importPath, directions, analysis, research, objectivityContext, currentContent, entityLookup, claimsContext, gapAnalysisContext, kbContext, tier, templateContext, sourceCheckContext } = args;
 
   const isPolish = tier === 'polish';
   const pageType = getPageType(page);
@@ -255,6 +257,16 @@ and contradictions where the page disagrees with verified claims. These are high
 Each missing fact has a source URL -- add it with a footnote citation.
 
 ${gapAnalysisContext}
+` : ''}${sourceCheckContext ? `
+### Source-Check Warnings (PRIORITY -- flagged claims to fix)
+
+The following claims about this entity have been flagged by automated source-checking against primary sources.
+**Contradicted** claims have evidence that they are wrong. **Outdated** claims have newer data available.
+
+**IMPORTANT: Verify and correct these claims during improvement.** If you cannot find a corrected value in
+the research sources, flag the claim with {/* NEEDS CITATION */} rather than leaving the incorrect value.
+
+${sourceCheckContext}
 ` : ''}
 ### Quality Standards (Extended)
 - Replace vague claims with specific numbers; use \`<KBF>\` for canonical KB facts and \`<Calc>\` for derived values

--- a/crux/lib/source-check-context.test.ts
+++ b/crux/lib/source-check-context.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildSourceCheckContext } from './source-check-context.ts';
+
+// Mock the wiki-server client
+vi.mock('./wiki-server/client.ts', () => ({
+  apiRequest: vi.fn(),
+}));
+
+// Mock loadDatabase
+vi.mock('./content-types.ts', () => ({
+  loadDatabase: vi.fn(() => ({
+    typedEntities: [
+      { id: 'anthropic', stableId: 'ent_abc123', wikiId: 'E22', title: 'Anthropic' },
+      { id: 'miri', stableId: 'ent_def456', wikiId: 'E44', title: 'MIRI' },
+    ],
+  })),
+}));
+
+import { apiRequest } from './wiki-server/client.ts';
+const mockApiRequest = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildSourceCheckContext', () => {
+  it('returns null when no actionable verdicts exist', async () => {
+    mockApiRequest.mockResolvedValue({ ok: true, data: { verdicts: [], total: 0 } });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).toBeNull();
+  });
+
+  it('returns formatted context for contradicted verdicts', async () => {
+    mockApiRequest.mockImplementation(async (_method, path) => {
+      if (typeof path === 'string' && path.includes('verdict=contradicted')) {
+        return {
+          ok: true as const,
+          data: {
+            verdicts: [
+              {
+                recordType: 'fact',
+                recordId: 'f_revenue_2025',
+                fieldName: null,
+                entityId: 'ent_abc123',
+                verdict: 'contradicted',
+                confidence: 0.92,
+                reasoning: 'Source says $9B revenue, page claims $4B',
+                sourcesChecked: 2,
+                needsRecheck: false,
+                nextCheckDue: null,
+                lastComputedAt: '2025-01-15T00:00:00Z',
+                createdAt: '2025-01-15T00:00:00Z',
+                updatedAt: '2025-01-15T00:00:00Z',
+              },
+            ],
+            total: 1,
+          },
+        };
+      }
+      return { ok: true as const, data: { verdicts: [], total: 0 } };
+    });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).not.toBeNull();
+    expect(result).toContain('CONTRADICTED (1)');
+    expect(result).toContain('[contradicted]');
+    expect(result).toContain('fact/f_revenue_2025');
+    expect(result).toContain('Source says $9B revenue');
+    expect(result).toContain('confidence: 92%');
+  });
+
+  it('returns formatted context for outdated verdicts', async () => {
+    mockApiRequest.mockImplementation(async (_method, path) => {
+      if (typeof path === 'string' && path.includes('verdict=outdated')) {
+        return {
+          ok: true as const,
+          data: {
+            verdicts: [
+              {
+                recordType: 'personnel',
+                recordId: 'p_ceo_role',
+                fieldName: 'headcount',
+                entityId: 'ent_abc123',
+                verdict: 'outdated',
+                confidence: 0.85,
+                reasoning: 'Headcount was 500, now 1,035 per Sep 2024 report',
+                sourcesChecked: 1,
+                needsRecheck: false,
+                nextCheckDue: null,
+                lastComputedAt: '2025-01-15T00:00:00Z',
+                createdAt: '2025-01-15T00:00:00Z',
+                updatedAt: '2025-01-15T00:00:00Z',
+              },
+            ],
+            total: 1,
+          },
+        };
+      }
+      return { ok: true as const, data: { verdicts: [], total: 0 } };
+    });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).not.toBeNull();
+    expect(result).toContain('OUTDATED (1)');
+    expect(result).toContain('[outdated]');
+    expect(result).toContain('[field: headcount]');
+    expect(result).toContain('personnel/p_ceo_role');
+  });
+
+  it('includes both contradicted and outdated verdicts', async () => {
+    mockApiRequest.mockImplementation(async (_method, path) => {
+      if (typeof path === 'string' && path.includes('verdict=contradicted')) {
+        return {
+          ok: true as const,
+          data: {
+            verdicts: [
+              {
+                recordType: 'fact',
+                recordId: 'f1',
+                fieldName: null,
+                entityId: 'ent_abc123',
+                verdict: 'contradicted',
+                confidence: 0.9,
+                reasoning: 'Wrong value',
+                sourcesChecked: 1,
+                needsRecheck: false,
+                nextCheckDue: null,
+                lastComputedAt: null,
+                createdAt: null,
+                updatedAt: null,
+              },
+            ],
+            total: 1,
+          },
+        };
+      }
+      if (typeof path === 'string' && path.includes('verdict=outdated')) {
+        return {
+          ok: true as const,
+          data: {
+            verdicts: [
+              {
+                recordType: 'fact',
+                recordId: 'f2',
+                fieldName: null,
+                entityId: 'ent_abc123',
+                verdict: 'outdated',
+                confidence: 0.8,
+                reasoning: 'Old data',
+                sourcesChecked: 1,
+                needsRecheck: false,
+                nextCheckDue: null,
+                lastComputedAt: null,
+                createdAt: null,
+                updatedAt: null,
+              },
+            ],
+            total: 1,
+          },
+        };
+      }
+      return { ok: true as const, data: { verdicts: [], total: 0 } };
+    });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).not.toBeNull();
+    expect(result).toContain('2 issues');
+    expect(result).toContain('CONTRADICTED (1)');
+    expect(result).toContain('OUTDATED (1)');
+  });
+
+  it('returns null when wiki-server is unavailable', async () => {
+    mockApiRequest.mockResolvedValue({
+      ok: false as const,
+      error: 'unavailable' as const,
+      message: 'LONGTERMWIKI_SERVER_URL not set',
+    });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on unexpected errors without throwing', async () => {
+    mockApiRequest.mockRejectedValue(new Error('network error'));
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).toBeNull();
+  });
+
+  it('deduplicates verdicts found under multiple entity IDs', async () => {
+    // The same verdict returned under both slug and stableId queries
+    const sharedVerdict = {
+      recordType: 'fact',
+      recordId: 'f_revenue',
+      fieldName: null,
+      entityId: 'ent_abc123',
+      verdict: 'contradicted',
+      confidence: 0.9,
+      reasoning: 'Revenue mismatch',
+      sourcesChecked: 1,
+      needsRecheck: false,
+      nextCheckDue: null,
+      lastComputedAt: null,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    mockApiRequest.mockImplementation(async (_method, path) => {
+      if (typeof path === 'string' && path.includes('verdict=contradicted')) {
+        return {
+          ok: true as const,
+          data: { verdicts: [sharedVerdict], total: 1 },
+        };
+      }
+      return { ok: true as const, data: { verdicts: [], total: 0 } };
+    });
+
+    const result = await buildSourceCheckContext('anthropic');
+    expect(result).not.toBeNull();
+    // Should have exactly 1 issue despite being returned for multiple entity ID queries
+    expect(result).toContain('1 issue');
+    // Count occurrences of the verdict — should appear only once
+    const matches = result!.match(/fact\/f_revenue/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('queries both slug and stableId', async () => {
+    mockApiRequest.mockResolvedValue({ ok: true, data: { verdicts: [], total: 0 } });
+
+    await buildSourceCheckContext('anthropic');
+
+    // Should have queried for both 'anthropic', 'ent_abc123', and 'E22'
+    const calls = mockApiRequest.mock.calls.map(c => c[1]);
+    const entityIdsQueried = calls.map(path =>
+      typeof path === 'string' ? decodeURIComponent(path.match(/entity_id=([^&]+)/)?.[1] ?? '') : '',
+    ).filter(Boolean);
+
+    expect(entityIdsQueried).toContain('anthropic');
+    expect(entityIdsQueried).toContain('ent_abc123');
+    expect(entityIdsQueried).toContain('E22');
+  });
+});

--- a/crux/lib/source-check-context.ts
+++ b/crux/lib/source-check-context.ts
@@ -1,0 +1,173 @@
+/**
+ * Source-Check Verdict Context for Improve Pipeline
+ *
+ * Fetches source-check verdicts for an entity from the wiki-server and formats
+ * them as concise LLM context. Only includes actionable verdicts (contradicted,
+ * outdated) so the improve LLM knows which claims need correction.
+ *
+ * Best-effort: if the wiki-server is unavailable, returns null and the improve
+ * pipeline proceeds without this context.
+ */
+
+import { apiRequest } from './wiki-server/client.ts';
+import { loadDatabase } from './content-types.ts';
+
+/** Shape of a single verdict from the wiki-server API. */
+interface SourceCheckVerdict {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  entityId: string | null;
+  verdict: string;
+  confidence: number | null;
+  reasoning: string | null;
+  sourcesChecked: number | null;
+  needsRecheck: boolean;
+  nextCheckDue: string | null;
+  lastComputedAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+/** Response shape from GET /api/source-checks/verdicts. */
+interface VerdictsResponse {
+  verdicts: SourceCheckVerdict[];
+  total: number;
+}
+
+/** Verdicts that are actionable for the improve pipeline. */
+const ACTIONABLE_VERDICTS = ['contradicted', 'outdated'] as const;
+
+/**
+ * Resolve a page ID (slug like "anthropic") to its stableId for API queries.
+ *
+ * Returns the slug itself if no stableId is found (the verdict API also stores
+ * entity_id as a slug in some cases).
+ */
+function resolveStableId(pageId: string): string[] {
+  try {
+    const db = loadDatabase();
+    const entities = db.typedEntities ?? db.entities ?? [];
+    const entity = entities.find(
+      (e) =>
+        e.id === pageId ||
+        e.wikiId === pageId,
+    );
+    if (!entity) return [pageId];
+
+    // database.json entities have runtime fields (stableId) not present in
+    // the static Entity interface. Use runtime property access.
+    const rec = entity as { id: string; wikiId?: string; stableId?: string };
+    const ids = new Set<string>();
+    ids.add(pageId);
+    if (rec.stableId) ids.add(rec.stableId);
+    if (rec.wikiId) ids.add(rec.wikiId);
+    return Array.from(ids);
+  } catch {
+    return [pageId];
+  }
+}
+
+/**
+ * Fetch actionable source-check verdicts for a page's entity.
+ *
+ * Queries the wiki-server for contradicted and outdated verdicts associated
+ * with the entity. Returns null if no actionable verdicts are found or if
+ * the server is unavailable.
+ */
+async function fetchActionableVerdicts(
+  pageId: string,
+): Promise<SourceCheckVerdict[] | null> {
+  const entityIds = resolveStableId(pageId);
+  const allVerdicts: SourceCheckVerdict[] = [];
+
+  for (const entityId of entityIds) {
+    for (const verdict of ACTIONABLE_VERDICTS) {
+      const result = await apiRequest<VerdictsResponse>(
+        'GET',
+        `/api/source-checks/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
+      );
+      if (result.ok) {
+        allVerdicts.push(...result.data.verdicts);
+      }
+    }
+  }
+
+  if (allVerdicts.length === 0) return null;
+
+  // Deduplicate by (recordType, recordId, fieldName) in case multiple entity IDs matched
+  const seen = new Set<string>();
+  const deduped: SourceCheckVerdict[] = [];
+  for (const v of allVerdicts) {
+    const key = `${v.recordType}:${v.recordId}:${v.fieldName ?? ''}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(v);
+    }
+  }
+
+  return deduped.length > 0 ? deduped : null;
+}
+
+/**
+ * Format a single verdict as a concise bullet point for the LLM.
+ */
+function formatVerdict(v: SourceCheckVerdict): string {
+  const confidence = v.confidence != null ? ` (confidence: ${(v.confidence * 100).toFixed(0)}%)` : '';
+  const field = v.fieldName ? ` [field: ${v.fieldName}]` : '';
+  const reasoning = v.reasoning
+    ? ` — ${v.reasoning.slice(0, 300)}`
+    : '';
+  return `- [${v.verdict}]${field}${confidence} ${v.recordType}/${v.recordId}${reasoning}`;
+}
+
+/**
+ * Build source-check verdict context for a wiki page.
+ *
+ * Fetches contradicted and outdated verdicts from the wiki-server and formats
+ * them as a compact block for injection into the improve LLM prompt.
+ *
+ * Returns null if:
+ * - The wiki-server is unavailable
+ * - No actionable verdicts exist for this entity
+ * - An error occurs (best-effort, never throws)
+ *
+ * @param pageId - The wiki page slug (e.g. "anthropic")
+ */
+export async function buildSourceCheckContext(
+  pageId: string,
+): Promise<string | null> {
+  try {
+    const verdicts = await fetchActionableVerdicts(pageId);
+    if (!verdicts || verdicts.length === 0) return null;
+
+    const lines: string[] = [];
+    lines.push(`Source-check warnings for this entity (${verdicts.length} issue${verdicts.length === 1 ? '' : 's'}):`);
+    lines.push('');
+
+    const contradicted = verdicts.filter(v => v.verdict === 'contradicted');
+    const outdated = verdicts.filter(v => v.verdict === 'outdated');
+
+    if (contradicted.length > 0) {
+      lines.push(`CONTRADICTED (${contradicted.length}):`);
+      for (const v of contradicted) {
+        lines.push(formatVerdict(v));
+      }
+      lines.push('');
+    }
+
+    if (outdated.length > 0) {
+      lines.push(`OUTDATED (${outdated.length}):`);
+      for (const v of outdated) {
+        lines.push(formatVerdict(v));
+      }
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[source-check-context] Failed to fetch verdicts for "${pageId}": ${msg} — skipping`);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- When the improve pipeline runs for a page, it now fetches contradicted and outdated source-check verdicts from the wiki-server and includes them as priority context in the LLM prompt
- The LLM is instructed to verify and correct these flagged claims during improvement
- The fetch is best-effort: if the wiki-server is unavailable or no actionable verdicts exist, the pipeline proceeds normally

## Changes
- **New file: `crux/lib/source-check-context.ts`** — Fetches verdicts from `/api/source-checks/verdicts` filtered by entity_id and verdict type (contradicted/outdated), resolves page slugs to stableId/wikiId for comprehensive matching, deduplicates results, and formats them as concise LLM context
- **New file: `crux/lib/source-check-context.test.ts`** — 8 tests covering: empty results, contradicted verdicts, outdated verdicts, both types, server unavailable, error handling, deduplication, and entity ID resolution
- **Modified: `crux/authoring/page-improver/build-context.ts`** — Calls `buildSourceCheckContext()` and passes the result to the IMPROVE_PROMPT
- **Modified: `crux/authoring/page-improver/phases/prompts.ts`** — Adds `sourceCheckContext` field to prompt args and injects a "Source-Check Warnings" section when verdicts are present

## Test plan
- [x] All 8 new tests pass (`npx vitest run crux/lib/source-check-context.test.ts`)
- [x] No type errors in modified files (`tsc --noEmit`)
- [x] Existing test suite unaffected (pre-existing failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)