### PR TITLE
Convert issue creation rate limit to soft warning

### DIFF
--- a/.claude/rules/proactive-github-filing.md
+++ b/.claude/rules/proactive-github-filing.md
@@ -64,7 +64,7 @@ For longer descriptions, use `--problem-file=/tmp/problem.md`. Run `crux gh issu
 ## Guardrails
 
 - **Evidence required**: `crux gh issues create` requires `--problem`, `--file`, or `--evidence`. You must have *observed* the problem in the current session — do not file speculative or hypothetical issues. Point to a specific file, error message, or behavior you encountered.
-- **Rate limited**: `crux gh issues create` enforces a daily cap (5/day). This is intentional — if you're hitting the limit, you're filing too many.
+- **Soft daily warning**: After 5 issues/day, `crux gh issues create` shows a warning suggesting you batch remaining items into an umbrella issue. There is no hard block.
 - **Agent-labeled**: All agent-filed issues are auto-labeled `agent:filed` for tracking.
 - **Volume target**: 0-2 issues per session is normal. If you're finding 10+ problems, file the top 2-3 and batch the rest into one umbrella issue.
 

--- a/crux/commands/issues.ts
+++ b/crux/commands/issues.ts
@@ -289,17 +289,13 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     };
   }
 
-  // Rate limit: max DAILY_CREATE_LIMIT issues per day (prevents tracker flood)
-  if (!options['no-limit'] && !options.noLimit) {
+  // Soft warning when creating many issues in a day
+  {
     const todayCount = getCreatesToday();
     if (todayCount >= DAILY_CREATE_LIMIT) {
-      return {
-        output:
-          `${c.red}Daily issue creation limit reached (${DAILY_CREATE_LIMIT}/day).${c.reset}\n` +
-          `${c.dim}You've created ${todayCount} issues today. This limit prevents tracker flood.\n` +
-          `If this is genuinely important, use --no-limit to override.${c.reset}\n`,
-        exitCode: 1,
-      };
+      process.stderr.write(
+        `${c.yellow}⚠ You've created ${todayCount} issues today. Consider batching remaining items into one umbrella issue.${c.reset}\n`
+      );
     }
   }
 
@@ -430,8 +426,8 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   let output = '';
   const todayCount = getCreatesToday();
   output += `${c.green}✓${c.reset} Created issue #${issue.number}: ${issue.title}\n`;
-  if (todayCount >= DAILY_CREATE_LIMIT - 1) {
-    output += `  ${c.yellow}⚠ ${todayCount}/${DAILY_CREATE_LIMIT} daily issue limit used${c.reset}\n`;
+  if (todayCount >= DAILY_CREATE_LIMIT) {
+    output += `  ${c.dim}(${todayCount} issues created today)${c.reset}\n`;
   }
   output += `  ${c.cyan}${issue.html_url}${c.reset}\n`;
   const appliedLabels = options.model ? [...labels, `${MODEL_LABEL_PREFIX}${(options.model as string).toLowerCase()}`] : labels;

--- a/crux/lib/issues/rate-limit.ts
+++ b/crux/lib/issues/rate-limit.ts
@@ -7,7 +7,8 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 
-export const DAILY_CREATE_LIMIT = 2;
+/** Threshold for soft warning — not a hard limit */
+export const DAILY_CREATE_LIMIT = 5;
 const RATE_LIMIT_FILE = join(dirname(new URL(import.meta.url).pathname), '../../../.claude/issue-creates.json');
 
 interface RateLimitRecord {


### PR DESCRIPTION
## Summary
- The 2/day hard limit on `crux gh issues create` trained agents to reflexively add `--no-limit`, defeating its purpose
- Converted to a soft warning (stderr) after 5 issues/day — never blocks creation
- Removed the `--no-limit` flag (no longer needed)
- Updated `.claude/rules/proactive-github-filing.md` to document the new behavior

## Test plan
- [ ] Run `crux gh issues create` — should succeed without limit errors
- [ ] After 5 creates in a day, confirm a yellow warning appears but issue is still created

🤖 Generated with [Claude Code](https://claude.com/claude-code)