### PR TITLE
fix: null title crashes /projects/squiggle on Vercel build

### DIFF
--- a/apps/web/src/data/infobox.ts
+++ b/apps/web/src/data/infobox.ts
@@ -43,7 +43,7 @@ export function getChildPagesForOverview(overviewId: string): ChildPageEntry[] {
   }
 
   // Sort alphabetically by title
-  children.sort((a, b) => a.title.localeCompare(b.title));
+  children.sort((a, b) => (a.title ?? "").localeCompare(b.title ?? ""));
   return children;
 }
 


### PR DESCRIPTION
## Summary

`children.sort((a, b) => a.title.localeCompare(b.title))` in `infobox.ts` crashes when an entity has a null title. This breaks the Vercel build at `/projects/squiggle`.

Fix: `(a.title ?? "").localeCompare(b.title ?? "")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)