### PR TITLE
fix: QA sweep fixes — numeric ID display + entity-ref tests

### DIFF
--- a/apps/wiki-server/src/__tests__/entity-ref.test.ts
+++ b/apps/wiki-server/src/__tests__/entity-ref.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { formatEntityRef, STABLE_ID_PATTERN } from "../routes/shared/entity-ref.js";
+
+describe("formatEntityRef", () => {
+  it("returns entity title when available", () => {
+    const ref = formatEntityRef("abc123ABCD", "anthropic", "Anthropic", null, "anthropic");
+    expect(ref).toEqual({ entityId: "abc123ABCD", slug: "anthropic", name: "Anthropic" });
+  });
+
+  it("falls back to displayName when no entity title", () => {
+    const ref = formatEntityRef("abc123ABCD", "anthropic", null, "Anthropic PBC", "anthropic");
+    expect(ref.name).toBe("Anthropic PBC");
+  });
+
+  it("falls back to rawId when no title or displayName", () => {
+    const ref = formatEntityRef(null, null, null, null, "anthropic");
+    expect(ref.name).toBe("anthropic");
+  });
+
+  it("returns null name for stableId-shaped rawId", () => {
+    const ref = formatEntityRef(null, null, null, null, "abc123ABCD");
+    expect(ref.name).toBeNull();
+  });
+
+  it("returns null name for pure numeric rawId (legacy DB IDs)", () => {
+    const ref = formatEntityRef(null, null, null, null, "175");
+    expect(ref.name).toBeNull();
+  });
+
+  it("returns null name for other numeric IDs", () => {
+    expect(formatEntityRef(null, null, null, null, "265").name).toBeNull();
+    expect(formatEntityRef(null, null, null, null, "335").name).toBeNull();
+    expect(formatEntityRef(null, null, null, null, "0").name).toBeNull();
+    expect(formatEntityRef(null, null, null, null, "999999").name).toBeNull();
+  });
+
+  it("allows alphanumeric rawId that is not a stableId or numeric", () => {
+    const ref = formatEntityRef(null, null, null, null, "openai-2024");
+    expect(ref.name).toBe("openai-2024");
+  });
+
+  it("returns all null for no inputs", () => {
+    const ref = formatEntityRef(null, null, null, null, null);
+    expect(ref).toEqual({ entityId: null, slug: null, name: null });
+  });
+});
+
+describe("STABLE_ID_PATTERN", () => {
+  it("matches 10-char alphanumeric with uppercase", () => {
+    expect(STABLE_ID_PATTERN.test("abc123ABCD")).toBe(true);
+    expect(STABLE_ID_PATTERN.test("AbCdEfGhIj")).toBe(true);
+  });
+
+  it("rejects strings without uppercase", () => {
+    expect(STABLE_ID_PATTERN.test("abcdefghij")).toBe(false);
+  });
+
+  it("rejects wrong length", () => {
+    expect(STABLE_ID_PATTERN.test("abc123ABC")).toBe(false);
+    expect(STABLE_ID_PATTERN.test("abc123ABCDE")).toBe(false);
+  });
+
+  it("rejects numeric-only strings", () => {
+    expect(STABLE_ID_PATTERN.test("1234567890")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes from the deep QA sweep (2026-03-23). Addresses the P0 bug where funding rounds showed raw numeric IDs instead of company names.

## Changes

### Fix: Funding rounds show raw numeric IDs instead of company names

`formatEntityRef()` in `entity-ref.ts` used `rawId` as a last-resort display name, filtering out stableId patterns but not pure numeric strings. Legacy funding round rows in PG have `companyId` values like "175", "265", "335" with null `companyEntityId`. These numbers were displayed as company names.

**Fix:** Added `/^\d+$/` check so numeric IDs return `name: null` (shows "Unknown" on frontend) instead of the raw number.

### Test: Unit tests for formatEntityRef

12 tests covering name priority chain, stableId filtering, numeric ID filtering, and edge cases.

## Test plan

- [x] `pnpm test` passes (wiki-nav test now passes after local database.json rebuild)
- [x] New entity-ref unit tests pass (12/12)
- [x] `pnpm build` succeeds
- [x] Verified numeric IDs ("175", "265", "335", "0", "999999") return null name
- [x] Verified non-numeric slugs ("openai-2024") still return as name

## QA Sweep Context

This PR is part of the deep QA sweep that found 53 findings across ~120+ pages. 19 GitHub issues were filed (#3035-#3062). Full report posted to [Discussion #2650](https://github.com/quantified-uncertainty/longterm-wiki/discussions/2650).
