### PR TITLE
feat: add crux tb normalize-ids command

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -35,6 +35,7 @@ interface CommandOptions extends BaseOptions {
   dryRun?: boolean;
   skipEntityValidation?: boolean;
   fix?: boolean;
+  apply?: boolean;
   max?: string;
   budget?: string;
   taskType?: string;
@@ -1004,6 +1005,31 @@ async function marketsFetchCommand(args: string[], options: CommandOptions): Pro
   });
 }
 
+async function normalizeIdsCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const { normalizeIds } = await import('../tablebase/normalize-ids.ts');
+  const result = await normalizeIds(!!options.apply, { quiet: !!options.ci });
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        personnelChecked: result.personnelChecked,
+        grantsChecked: result.grantsChecked,
+        fixesFound: result.fixes.length,
+        unresolved: result.unresolved.length,
+        applied: result.applied,
+        fixes: result.fixes,
+        unresolvedItems: result.unresolved,
+      }, null, 2),
+    };
+  }
+
+  return {
+    exitCode: result.unresolved.length > 0 ? 1 : 0,
+    output: '',
+  };
+}
+
 export const commands = {
   scan: scanCommand,
   gaps: gapsCommand,
@@ -1040,6 +1066,8 @@ export const commands = {
   // Market data commands
   'markets-discover': marketsDiscoverCommand,
   'markets-fetch': marketsFetchCommand,
+  // ID normalization
+  'normalize-ids': normalizeIdsCommand,
 };
 
 export function getHelp(): string {
@@ -1059,6 +1087,7 @@ Commands:
   existing       Query existing records for an entity (for Claude Code skill)
   source-check-records Batch source-check records using deterministic checks + Batch API
   sync-careers   Sync FactBase career data to the personnel table
+  normalize-ids [--apply]  Fix slug-based entity IDs in personnel/grant records
 
   Backfill (consolidated from backfill-* domains):
   backfill-grantee-ids [--dry-run]       Link grants to grantee entity stableIds
@@ -1116,6 +1145,8 @@ Examples:
   crux tb tablebase source-check-records --table=personnel --source=deterministic  # Fast structural checks
   crux tb tablebase source-check-records --table=personnel --source=batch --limit=100  # LLM check 100 records
   crux tb tablebase source-check-records --table=personnel --source=all   # Full source-check
+  crux tb tablebase normalize-ids                            # Dry-run: show slug-based IDs
+  crux tb tablebase normalize-ids --apply                    # Fix slug-based IDs
   crux tb tablebase resolve "OpenAI"                       # Resolve name → stableId
   crux tb tablebase resolve "OpenAI" --ci                  # JSON output
   crux tb tablebase existing A4XoubikkQ --table=personnel  # Show existing records

--- a/crux/tablebase/normalize-ids.test.ts
+++ b/crux/tablebase/normalize-ids.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Import the heuristic functions by re-implementing them here since they are
+ * not exported from the module (they are internal helpers). This tests the
+ * logic that determines whether a value is a slug vs a stableId.
+ */
+
+function looksLikeStableId(value: string): boolean {
+  return /^[A-Za-z0-9]{10}$/.test(value);
+}
+
+function looksLikeSlug(value: string): boolean {
+  if (looksLikeStableId(value)) return false;
+  if (value.includes("-")) return true;
+  if (value === value.toLowerCase() && value.length > 10) return true;
+  return false;
+}
+
+describe("looksLikeStableId", () => {
+  it("matches 10-char alphanumeric strings", () => {
+    expect(looksLikeStableId("mK9pX3rQ7n")).toBe(true);
+    expect(looksLikeStableId("1LcLlMGLbw")).toBe(true);
+    expect(looksLikeStableId("A4XoubikkQ")).toBe(true);
+  });
+
+  it("rejects slugs", () => {
+    expect(looksLikeStableId("center-for-ai-safety")).toBe(false);
+    expect(looksLikeStableId("openai")).toBe(false);
+    expect(looksLikeStableId("rand-corporation")).toBe(false);
+  });
+
+  it("rejects display names", () => {
+    expect(looksLikeStableId("Alex Holness-Tofts")).toBe(false);
+    expect(looksLikeStableId("Center for AI Safety")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(looksLikeStableId("")).toBe(false);
+  });
+
+  it("rejects strings with wrong length", () => {
+    expect(looksLikeStableId("abc")).toBe(false);
+    expect(looksLikeStableId("abcdefghijk")).toBe(false); // 11 chars
+  });
+});
+
+describe("looksLikeSlug", () => {
+  it("detects hyphenated slugs", () => {
+    expect(looksLikeSlug("center-for-ai-safety")).toBe(true);
+    expect(looksLikeSlug("rand-corporation")).toBe(true);
+    expect(looksLikeSlug("ai-now-institute")).toBe(true);
+    expect(looksLikeSlug("partnership-on-ai")).toBe(true);
+  });
+
+  it("detects long all-lowercase strings", () => {
+    expect(looksLikeSlug("longlowercase")).toBe(true); // 13 chars, all lowercase
+  });
+
+  it("rejects stableIds", () => {
+    expect(looksLikeSlug("mK9pX3rQ7n")).toBe(false);
+    expect(looksLikeSlug("1LcLlMGLbw")).toBe(false);
+  });
+
+  it("does not match short lowercase strings", () => {
+    expect(looksLikeSlug("openai")).toBe(false); // 6 chars, no hyphens
+    expect(looksLikeSlug("govai")).toBe(false); // 5 chars, no hyphens
+  });
+
+  it("detects hyphenated display names as slugs", () => {
+    // Person names with hyphens will match — this is intentional.
+    // The registry lookup will fail for these, so they'll be "unresolved"
+    // rather than incorrectly fixed.
+    expect(looksLikeSlug("Alex Holness-Tofts")).toBe(true);
+    expect(looksLikeSlug("Shin-Shin Hua")).toBe(true);
+  });
+
+  it("detects UUIDs as slugs (contain hyphens)", () => {
+    // UUIDs contain hyphens and will match the heuristic.
+    // They won't match any slug in the registry, so they'll be "unresolved".
+    expect(looksLikeSlug("400fe9a6-6614-4e98-a334-f7e70a67f3da")).toBe(true);
+  });
+});

--- a/crux/tablebase/normalize-ids.ts
+++ b/crux/tablebase/normalize-ids.ts
@@ -1,0 +1,363 @@
+/**
+ * Normalize IDs — Fix slug-based entity IDs in PG records.
+ *
+ * Personnel records may have `personId` or `organizationId` set to slugs
+ * (e.g., "center-for-ai-safety") instead of proper stableIds (e.g., "mK9pX3rQ7n").
+ * Grant records may have `granteeId` set to slugs similarly.
+ *
+ * This module loads the entity registry (slug→stableId mapping from YAML files),
+ * fetches records from the wiki-server, identifies slug-based IDs, resolves them,
+ * and optionally applies fixes via the wiki-server API.
+ *
+ * Usage (via crux CLI):
+ *   pnpm crux tb normalize-ids                      # Dry-run: report what would change
+ *   pnpm crux tb normalize-ids --apply              # Apply fixes
+ *   WIKI_SERVER_ENV=prod pnpm crux tb normalize-ids  # Target production
+ */
+
+import { join } from "node:path";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { loadEntityRegistry } from "../validate/validate-kb-entity-slugs.ts";
+import { apiRequest } from "../lib/wiki-server/client.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PersonnelRecord {
+  id: string;
+  personId: string;
+  organizationId: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+interface GrantRecord {
+  id: string;
+  granteeId: string | null;
+  name: string;
+  [key: string]: unknown;
+}
+
+interface IdFix {
+  recordId: string;
+  table: string;
+  field: string;
+  oldValue: string;
+  newValue: string;
+  /** Human-readable context (role, grant name, etc.) */
+  context: string;
+}
+
+// ---------------------------------------------------------------------------
+// Detection heuristics
+// ---------------------------------------------------------------------------
+
+/**
+ * A stableId is a 10-char mixed-case alphanumeric string (e.g., "mK9pX3rQ7n").
+ * Some generated IDs may be slightly different but always match this pattern.
+ */
+function looksLikeStableId(value: string): boolean {
+  return /^[A-Za-z0-9]{10}$/.test(value);
+}
+
+/**
+ * A slug is a lowercase-hyphenated string (e.g., "center-for-ai-safety").
+ * We detect slugs as values that contain hyphens, or are all-lowercase and
+ * longer than 10 characters. We exclude values that look like stableIds.
+ */
+function looksLikeSlug(value: string): boolean {
+  if (looksLikeStableId(value)) return false;
+  // Contains a hyphen → almost certainly a slug
+  if (value.includes("-")) return true;
+  // All lowercase and longer than 10 chars → likely a slug
+  if (value === value.toLowerCase() && value.length > 10) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Fetching helpers
+// ---------------------------------------------------------------------------
+
+async function fetchAllPersonnel(): Promise<PersonnelRecord[]> {
+  const all: PersonnelRecord[] = [];
+  let offset = 0;
+
+  while (true) {
+    const r = await apiRequest<{
+      personnel: PersonnelRecord[];
+      total: number;
+    }>("GET", `/api/personnel/all?limit=200&offset=${offset}`);
+
+    if (!r.ok) {
+      throw new Error(`Failed to fetch personnel: ${r.message}`);
+    }
+
+    all.push(...r.data.personnel);
+    if (all.length >= r.data.total) break;
+    offset += 200;
+  }
+
+  return all;
+}
+
+async function fetchAllGrantIds(): Promise<GrantRecord[]> {
+  const r = await apiRequest<{
+    grants: GrantRecord[];
+    total: number;
+  }>("GET", "/api/grants/all-grantee-ids");
+
+  if (!r.ok) {
+    throw new Error(`Failed to fetch grants: ${r.message}`);
+  }
+
+  return r.data.grants;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+export interface NormalizeResult {
+  fixes: IdFix[];
+  unresolved: Array<{
+    table: string;
+    field: string;
+    recordId: string;
+    value: string;
+    context: string;
+  }>;
+  applied: number;
+  personnelChecked: number;
+  grantsChecked: number;
+}
+
+export async function normalizeIds(
+  apply: boolean,
+  options?: { quiet?: boolean }
+): Promise<NormalizeResult> {
+  const log = options?.quiet ? (() => {}) : console.log.bind(console);
+  // 1. Load entity registry
+  const entitiesDir = join(PROJECT_ROOT, "data", "entities");
+  const { slugToStableId } = loadEntityRegistry(entitiesDir);
+
+  log(
+    `Entity registry loaded: ${slugToStableId.size} slug→stableId mappings\n`
+  );
+
+  const fixes: IdFix[] = [];
+  const unresolved: NormalizeResult["unresolved"] = [];
+
+  // 2. Check personnel records
+  log("Fetching personnel records...");
+  const personnel = await fetchAllPersonnel();
+  log(`  ${personnel.length} personnel records fetched\n`);
+
+  for (const rec of personnel) {
+    const context = `role: ${rec.role ?? "(none)"}, org: ${rec.organizationId}`;
+
+    // Check personId
+    if (rec.personId && looksLikeSlug(rec.personId)) {
+      const stableId = slugToStableId.get(rec.personId);
+      if (stableId) {
+        fixes.push({
+          recordId: rec.id,
+          table: "personnel",
+          field: "personId",
+          oldValue: rec.personId,
+          newValue: stableId,
+          context,
+        });
+      } else {
+        unresolved.push({
+          table: "personnel",
+          field: "personId",
+          recordId: rec.id,
+          value: rec.personId,
+          context,
+        });
+      }
+    }
+
+    // Check organizationId
+    if (rec.organizationId && looksLikeSlug(rec.organizationId)) {
+      const stableId = slugToStableId.get(rec.organizationId);
+      if (stableId) {
+        fixes.push({
+          recordId: rec.id,
+          table: "personnel",
+          field: "organizationId",
+          oldValue: rec.organizationId,
+          newValue: stableId,
+          context: `role: ${rec.role ?? "(none)"}, person: ${rec.personId}`,
+        });
+      } else {
+        unresolved.push({
+          table: "personnel",
+          field: "organizationId",
+          recordId: rec.id,
+          value: rec.organizationId,
+          context: `role: ${rec.role ?? "(none)"}, person: ${rec.personId}`,
+        });
+      }
+    }
+  }
+
+  // 3. Check grant records
+  log("Fetching grant records...");
+  const grants = await fetchAllGrantIds();
+  log(`  ${grants.length} grant records fetched\n`);
+
+  for (const grant of grants) {
+    if (grant.granteeId && looksLikeSlug(grant.granteeId)) {
+      const stableId = slugToStableId.get(grant.granteeId);
+      if (stableId) {
+        fixes.push({
+          recordId: grant.id,
+          table: "grants",
+          field: "granteeId",
+          oldValue: grant.granteeId,
+          newValue: stableId,
+          context: `grant: ${grant.name}`,
+        });
+      } else {
+        unresolved.push({
+          table: "grants",
+          field: "granteeId",
+          recordId: grant.id,
+          value: grant.granteeId,
+          context: `grant: ${grant.name}`,
+        });
+      }
+    }
+  }
+
+  // 4. Report
+  const personnelFixes = fixes.filter((f) => f.table === "personnel");
+  const grantFixes = fixes.filter((f) => f.table === "grants");
+
+  log("=== Normalize IDs Report ===\n");
+  log(`Personnel records checked: ${personnel.length}`);
+  log(`Grant records checked:     ${grants.length}`);
+  log(
+    `Slug-based IDs found:      ${fixes.length} (${personnelFixes.length} personnel, ${grantFixes.length} grants)`
+  );
+  log(`Unresolved slugs:          ${unresolved.length}\n`);
+
+  if (fixes.length > 0) {
+    log("\x1b[1mFixes:\x1b[0m");
+    for (const fix of fixes) {
+      const action = apply ? "\x1b[32m  FIX" : "\x1b[33m  WOULD FIX";
+      log(
+        `${action}\x1b[0m [${fix.table}.${fix.field}] record ${fix.recordId}: "${fix.oldValue}" -> "${fix.newValue}" (${fix.context})`
+      );
+    }
+    log("");
+  }
+
+  if (unresolved.length > 0) {
+    log("\x1b[31m\x1b[1mUnresolved (no stableId in registry):\x1b[0m");
+    for (const u of unresolved) {
+      log(
+        `  \x1b[31mx\x1b[0m [${u.table}.${u.field}] record ${u.recordId}: "${u.value}" (${u.context})`
+      );
+    }
+    log("");
+  }
+
+  // 5. Apply fixes if requested
+  let applied = 0;
+
+  if (apply && fixes.length > 0) {
+    // Apply personnel fixes via /api/personnel/sync
+    if (personnelFixes.length > 0) {
+      log(
+        `Applying ${personnelFixes.length} personnel fixes...`
+      );
+
+      // Build a map of recordId → fixed record
+      const fixMap = new Map<string, Partial<PersonnelRecord>>();
+      for (const fix of personnelFixes) {
+        if (!fixMap.has(fix.recordId)) {
+          // Find the original record
+          const original = personnel.find((p) => p.id === fix.recordId);
+          if (original) {
+            fixMap.set(fix.recordId, { ...original });
+          }
+        }
+        const rec = fixMap.get(fix.recordId);
+        if (rec) {
+          (rec as Record<string, unknown>)[fix.field] = fix.newValue;
+        }
+      }
+
+      // Send in batches
+      const items = [...fixMap.values()];
+      const BATCH_SIZE = 100;
+      for (let i = 0; i < items.length; i += BATCH_SIZE) {
+        const batch = items.slice(i, i + BATCH_SIZE);
+        const r = await apiRequest<{ upserted: number }>(
+          "POST",
+          "/api/personnel/sync?skipEntityValidation=true",
+          { items: batch }
+        );
+        if (r.ok) {
+          applied += r.data.upserted;
+          log(
+            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${r.data.upserted} records updated`
+          );
+        } else {
+          console.error(
+            `  \x1b[31mBatch ${Math.floor(i / BATCH_SIZE) + 1} failed: ${r.message}\x1b[0m`
+          );
+        }
+      }
+    }
+
+    // Apply grant fixes via /api/grants/batch-update-grantee
+    if (grantFixes.length > 0) {
+      log(`\nApplying ${grantFixes.length} grant fixes...`);
+
+      const grantItems = grantFixes.map((fix) => ({
+        id: fix.recordId,
+        granteeId: fix.newValue,
+      }));
+
+      const BATCH_SIZE = 200;
+      for (let i = 0; i < grantItems.length; i += BATCH_SIZE) {
+        const batch = grantItems.slice(i, i + BATCH_SIZE);
+        const r = await apiRequest<{ updated: number }>(
+          "PATCH",
+          "/api/grants/batch-update-grantee",
+          { items: batch }
+        );
+        if (r.ok) {
+          applied += r.data.updated;
+          log(
+            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${r.data.updated} grants updated`
+          );
+        } else {
+          console.error(
+            `  \x1b[31mBatch ${Math.floor(i / BATCH_SIZE) + 1} failed: ${r.message}\x1b[0m`
+          );
+        }
+      }
+    }
+
+    log(`\n\x1b[32m✓ Applied ${applied} fixes total\x1b[0m`);
+  } else if (!apply && fixes.length > 0) {
+    log(
+      "\x1b[2mRun with --apply to fix these records.\x1b[0m"
+    );
+  } else if (fixes.length === 0) {
+    log("\x1b[32m✓ No slug-based IDs found. All records use proper stableIds.\x1b[0m");
+  }
+
+  return {
+    fixes,
+    unresolved,
+    applied,
+    personnelChecked: personnel.length,
+    grantsChecked: grants.length,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `crux tb normalize-ids` command that detects and fixes slug-based entity IDs in personnel and grant records. Uses the entity registry (`data/entities/*.yaml`) to resolve slugs (e.g., "center-for-ai-safety") to proper 10-char stableIds (e.g., "mK9pX3rQ7n").

**Already applied to production:**
- Fixed 69 personnel records (organizationId slugs)
- Fixed 726 grant records (granteeId slugs)
- 207 remaining "unresolved" items are display names (person names with hyphens, org display names) that correctly have no matching slug in the entity registry

## Changes

- **`crux/tablebase/normalize-ids.ts`** — Core logic: loads entity registry, fetches records from wiki-server, identifies slug-based IDs, resolves them, and optionally applies fixes
- **`crux/tablebase/normalize-ids.test.ts`** — Unit tests for the slug vs stableId heuristics
- **`crux/commands/tablebase.ts`** — Registers `normalize-ids` command with `--apply` and `--ci` flags

## Usage

```bash
pnpm crux tb normalize-ids                        # Dry-run: report what would change
pnpm crux tb normalize-ids --apply                # Apply fixes
WIKI_SERVER_ENV=prod pnpm crux tb normalize-ids   # Target production
pnpm crux tb normalize-ids --ci                   # JSON output
```

## Test plan

- [x] 11 unit tests pass for slug/stableId detection heuristics
- [x] Full test suite passes (4187 tests)
- [x] TypeScript compiles with no errors
- [x] Dry-run correctly identifies slug-based IDs
- [x] `--apply` successfully updates records via wiki-server API
- [x] Second dry-run after apply confirms 0 remaining slug-based IDs