### PR TITLE
fix: prevent infinite re-render loop on Source Checks dashboard

### DIFF
--- a/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
@@ -399,19 +399,29 @@ export function EntitySourceChecksViewer() {
     })();
   }, []);
 
-  // Compute filter options from data
-  const typeCounts = new Map<string, number>();
-  const verdictCounts = new Map<string, number>();
-  for (const v of verdicts) {
-    typeCounts.set(v.recordType, (typeCounts.get(v.recordType) ?? 0) + 1);
-    verdictCounts.set(v.verdict, (verdictCounts.get(v.verdict) ?? 0) + 1);
-  }
+  // Memoize filter options and filtered data to keep stable references.
+  // Without memoization, `filtered` is a new array every render, which
+  // TanStack Table treats as a data change — triggering autoResetPageIndex
+  // on every render and causing an infinite re-render loop that freezes the page.
+  const { typeCounts, verdictCounts } = useMemo(() => {
+    const tc = new Map<string, number>();
+    const vc = new Map<string, number>();
+    for (const v of verdicts) {
+      tc.set(v.recordType, (tc.get(v.recordType) ?? 0) + 1);
+      vc.set(v.verdict, (vc.get(v.verdict) ?? 0) + 1);
+    }
+    return { typeCounts: tc, verdictCounts: vc };
+  }, [verdicts]);
 
-  const filtered = verdicts.filter((v) => {
-    if (filterType !== "all" && v.recordType !== filterType) return false;
-    if (filterVerdict !== "all" && v.verdict !== filterVerdict) return false;
-    return true;
-  });
+  const filtered = useMemo(
+    () =>
+      verdicts.filter((v) => {
+        if (filterType !== "all" && v.recordType !== filterType) return false;
+        if (filterVerdict !== "all" && v.verdict !== filterVerdict) return false;
+        return true;
+      }),
+    [verdicts, filterType, filterVerdict]
+  );
 
   // Memoize columns so they update when record names are resolved
   const columns = useMemo(() => buildColumns(recordNames), [recordNames]);
@@ -441,6 +451,11 @@ export function EntitySourceChecksViewer() {
     onPaginationChange: setPagination,
     globalFilterFn: "includesString",
     state: { sorting, globalFilter, expanded, pagination },
+    // Disable auto-resets — this component manages pagination reset
+    // explicitly via its own useEffect. Without this, any state change
+    // could trigger auto-resets that fight with controlled state.
+    autoResetPageIndex: false,
+    autoResetExpanded: false,
   });
 
   const fetchDetail = useCallback(async (recordType: string, recordId: string) => {

--- a/apps/web/src/app/internal/factbase-source-checks/factbase-source-checks-table.tsx
+++ b/apps/web/src/app/internal/factbase-source-checks/factbase-source-checks-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import type { ColumnDef, ExpandedState } from "@tanstack/react-table";
 import {
   useReactTable,
@@ -356,17 +356,23 @@ export function FactBaseSourceChecksTable({ data }: { data: VerdictRow[] }) {
   const [filterVerdict, setFilterVerdict] = useState<string>("all");
   const [detailCache, setDetailCache] = useState<DetailCache>({});
 
-  // Compute unique verdicts for filter buttons
-  const verdictCounts = new Map<string, number>();
-  for (const row of data) {
-    verdictCounts.set(row.verdict, (verdictCounts.get(row.verdict) ?? 0) + 1);
-  }
-  const verdictTypes = [...verdictCounts.keys()].sort();
+  // Memoize to keep stable references — unstable `data` passed to useReactTable
+  // triggers autoResetPageIndex on every render, causing an infinite loop.
+  const { verdictCounts, verdictTypes } = useMemo(() => {
+    const vc = new Map<string, number>();
+    for (const row of data) {
+      vc.set(row.verdict, (vc.get(row.verdict) ?? 0) + 1);
+    }
+    return { verdictCounts: vc, verdictTypes: [...vc.keys()].sort() };
+  }, [data]);
 
-  const filtered =
-    filterVerdict === "all"
-      ? data
-      : data.filter((d) => d.verdict === filterVerdict);
+  const filtered = useMemo(
+    () =>
+      filterVerdict === "all"
+        ? data
+        : data.filter((d) => d.verdict === filterVerdict),
+    [data, filterVerdict]
+  );
 
   // Table state
   const [sorting, setSorting] = useState<SortingState>([
@@ -408,6 +414,8 @@ export function FactBaseSourceChecksTable({ data }: { data: VerdictRow[] }) {
       expanded,
       pagination,
     },
+    autoResetPageIndex: false,
+    autoResetExpanded: false,
   });
 
   const fetchDetail = useCallback(


### PR DESCRIPTION
## Summary

- **Root cause**: The `filtered` array passed as `data` to `useReactTable` was recreated on every render (new reference, same content). TanStack Table's `autoResetPageIndex` (default: `true`) detected the "changed" data on each re-render and triggered `setPagination`, which caused another render → another new array → another reset → infinite loop. This froze the page tab completely on any user interaction (pagination, row expand, filter click).
- **Fix**: Memoize `filtered` and derived counts with `useMemo` so the array reference is stable between renders. Also explicitly disable `autoResetPageIndex` and `autoResetExpanded` since both components already manage their own pagination reset via `useEffect`.
- Applied the same fix to the FactBase source checks table which had the identical bug.

## Test plan

- [x] Reproduced the freeze on production via Playwright (clicking Next caused page hang)
- [x] Verified fix on local dev server: pagination (Next/Prev), row expand, verdict filter, type filter all work without freezing
- [x] TypeScript type-check passes (`tsc --noEmit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved table performance in entity source checks and factbase checks interfaces through optimized internal computation and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->