### PR TITLE
fix: review fixes for legislation pages

### DIFF
--- a/content/docs/knowledge-base/responses/take-it-down-act.mdx
+++ b/content/docs/knowledge-base/responses/take-it-down-act.mdx
@@ -6,13 +6,13 @@ subcategory: legislation
 update_frequency: 30
 createdAt: "2026-03-23"
 lastEdited: "2026-03-23"
-summary: "The TAKE IT DOWN Act (signed May 2025) is the first U.S. federal law explicitly targeting harmful AI-generated imagery, criminalizing non-consensual deepfakes and mandating 48-hour platform takedowns; the article is well-structured with a genuine criticisms section but relies on a single aggregated footnote for all citations."
+summary: "The TAKE IT DOWN Act (signed May 2025) is the first U.S. federal law explicitly targeting harmful AI-generated imagery, criminalizing non-consensual deepfakes and mandating 48-hour platform takedowns."
 sidebar:
   order: 50
 ---
 import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
 
-The **TAKE IT DOWN Act** (Tools to Address Known Exploitation by Immobilizing Technological Deepfakes on Websites and Networks Act) is a U.S. federal law signed by President Donald Trump on May 19, 2025, that criminalizes the knowing publication or threatened publication of non-consensual intimate imagery (NCII)—including both authentic photographs and AI-generated deepfakes—and requires covered online platforms to remove such content within 48 hours of a verified victim request. It is the first federal law specifically targeting harmful AI use in intimate imagery.
+The **TAKE IT DOWN Act** (Tools to Address Known Exploitation by Immobilizing Technological Deepfakes on Websites and Networks Act) is a U.S. federal law signed by President Donald Trump on May 19, 2025, that criminalizes the knowing publication or threatened publication of non-consensual intimate imagery (NCII)—including both authentic photographs and AI-generated deepfakes—and requires covered online platforms to remove such content within 48 hours of a verified victim request.[^rc-bill] It is the first federal law specifically targeting harmful AI use in intimate imagery.[^rc-iapp]
 
 ## Quick Assessment
 
@@ -33,52 +33,53 @@ The **TAKE IT DOWN Act** (Tools to Address Known Exploitation by Immobilizing Te
 | Source | Link |
 |--------|------|
 | Official Text | [govinfo.gov](https://www.govinfo.gov/content/pkg/COMPS-18158/pdf/COMPS-18158.pdf) |
+| Congress.gov | [S.146](https://www.congress.gov/bill/119th-congress/senate-bill/146) |
 
 ## Overview
 
-The TAKE IT DOWN Act addresses one of the more direct and immediate harms arising from AI-generated imagery: the production and distribution of sexualized deepfakes depicting real, identifiable individuals without their consent. The law closes a significant gap in prior federal law, which lacked a nationwide prohibition specifically covering digitally fabricated intimate imagery. All 50 states had enacted some form of NCII protection prior to the Act, but many of those statutes did not cover AI-generated content or "digital forgeries," leaving victims of deepfake abuse without federal recourse.
+The TAKE IT DOWN Act addresses one of the more direct and immediate harms arising from AI-generated imagery: the production and distribution of sexualized deepfakes depicting real, identifiable individuals without their consent. The law closes a significant gap in prior federal law, which lacked a nationwide prohibition specifically covering digitally fabricated intimate imagery. All 50 states had enacted some form of NCII protection prior to the Act, but many of those statutes did not cover AI-generated content or "digital forgeries," leaving victims of deepfake abuse without federal recourse.[^rc-crs]
 
-The Act operates on two main tracks. First, it creates a federal criminal offense: anyone who knowingly publishes or threatens to publish NCII—whether real or AI-generated—faces up to two years imprisonment, with harsher penalties when the victim is a minor. The law clarifies that consent to the creation of an image does not constitute consent to its distribution, a provision aimed squarely at sextortion scenarios. Second, it imposes affirmative platform obligations: covered services (websites, social media applications, and apps hosting user-generated content, excluding ISPs and email providers) must establish notice-and-takedown processes by May 19, 2026, and must act on verified victim requests within 48 hours, including making reasonable efforts to remove duplicate copies and reposts.
+The Act operates on two main tracks. First, it creates a federal criminal offense: anyone who knowingly publishes or threatens to publish NCII—whether real or AI-generated—faces up to two years imprisonment, with harsher penalties when the victim is a minor. The law clarifies that consent to the creation of an image does not constitute consent to its distribution, a provision aimed squarely at sextortion scenarios.[^rc-bill] Second, it imposes affirmative platform obligations: covered services (websites, social media applications, and apps hosting user-generated content, excluding ISPs and email providers) must establish notice-and-takedown processes by May 19, 2026, and must act on verified victim requests within 48 hours, including making reasonable efforts to remove duplicate copies and reposts.[^rc-bill]
 
-Enforcement of the platform obligations falls to the Federal Trade Commission under existing Federal Trade Commission Act authority. Platforms acting in good faith receive safe harbor protections from liability. The law also includes carve-outs shielding medical professionals, law enforcement, journalists, and artistic works from prosecution, and explicitly preserves First Amendment protections for speech on matters of public concern.
+Enforcement of the platform obligations falls to the Federal Trade Commission under existing Federal Trade Commission Act authority. Platforms acting in good faith receive safe harbor protections from liability. The law also includes carve-outs shielding medical professionals, law enforcement, journalists, and artistic works from prosecution, and explicitly preserves First Amendment protections for speech on matters of public concern.[^rc-crs]
 
 ## History
 
 ### Triggering Incident
 
-The Act's origins trace to a 2023 incident in Aledo, Texas, in which a high school student used AI software to manipulate innocent photographs of female classmates into nude images, which were then distributed anonymously via Snapchat. The incident drew significant public attention to the inadequacy of existing law in addressing AI-facilitated sexual abuse imagery targeting minors, and directly motivated Senator Ted Cruz to pursue federal legislation.[^1]
+The Act's origins trace to a 2023 incident in Aledo, Texas, in which a high school student used AI software to manipulate innocent photographs of female classmates into nude images, which were then distributed anonymously via Snapchat. The incident drew significant public attention to the inadequacy of existing law in addressing AI-facilitated sexual abuse imagery targeting minors, and directly motivated Senator Ted Cruz to pursue federal legislation.[^rc-wiki]
 
 ### Legislative Progression
 
-Senator Cruz introduced the Senate bill (S. 4569) in April/June 2024, with Senator Amy Klobuchar of Minnesota as a leading bipartisan co-sponsor. A companion House bill (H.R. 8989) was introduced in June 2024. The bill attracted support from eleven additional senators across both parties, as well as endorsements from over 100 organizations including Microsoft, the NCAA, SAG-AFTRA, the National Organization for Women, IBM, the National Center for Missing and Exploited Children, and RAINN.[^1]
+Senator Cruz introduced the Senate bill (S. 4569) in April/June 2024, with Senator Amy Klobuchar of Minnesota as a leading bipartisan co-sponsor. A companion House bill (H.R. 8989) was introduced in June 2024. The bill attracted support from eleven additional senators across both parties, as well as endorsements from over 100 organizations including Microsoft, the NCAA, SAG-AFTRA, the National Organization for Women, IBM, the National Center for Missing and Exploited Children, and RAINN.[^rc-klob]
 
-The Senate passed the bill unanimously. The bill encountered delays in the House during the 118th Congress due to packaging complications with budget legislation, but the House ultimately passed it 409–2 in April 2025. President Trump signed the Act into law on May 19, 2025, at a ceremony attended by survivors and advocates including representatives from RAINN. First Lady Melania Trump was a prominent advocate for the legislation, hosting a White House roundtable on March 3, 2025, with victim Elliston Berry, a 14-year-old whose case of AI-generated nude images had drawn national attention.[^1]
+The Senate passed the bill unanimously. The bill encountered delays in the House during the 118th Congress due to packaging complications with budget legislation, but the House ultimately passed it 409–2 in April 2025. President Trump signed the Act into law on May 19, 2025, at a ceremony attended by survivors and advocates including representatives from RAINN.[^rc-klob] First Lady Melania Trump was a prominent advocate for the legislation, hosting a White House roundtable on March 3, 2025, with victim Elliston Berry, a 14-year-old whose case of AI-generated nude images had drawn national attention.[^rc-wiki]
 
 ### Implementation Timeline
 
-Criminal provisions took effect immediately upon the Act's signing. Covered platforms have until May 19, 2026—one year post-enactment—to implement compliant notice-and-takedown systems. The FTC has not yet announced a detailed enforcement strategy as of early 2026, though legal advisors have urged platforms to document good-faith compliance efforts during the implementation period.[^1]
+Criminal provisions took effect immediately upon the Act's signing. Covered platforms have until May 19, 2026—one year post-enactment—to implement compliant notice-and-takedown systems. The FTC has not yet announced a detailed enforcement strategy as of early 2026, though legal advisors have urged platforms to document good-faith compliance efforts during the implementation period.[^rc-iapp]
 
 ## Core Provisions
 
 ### Criminal Liability
 
-The Act makes it a federal crime to knowingly publish or threaten to publish NCII—defined to include both authentic images obtained without a reasonable expectation of privacy and AI-generated deepfakes depicting identifiable individuals in sexually explicit contexts—with the intent to harm, harass, humiliate, degrade, or arouse. The offense carries up to two years imprisonment for imagery involving adult victims, with heightened penalties when the victim is a minor. The law covers threats as well as actual publication, directly targeting sextortion schemes. It applies across interstate commerce, encompassing social media platforms, websites, and applications.[^1]
+The Act makes it a federal crime to knowingly publish or threaten to publish NCII—defined to include both authentic images obtained without a reasonable expectation of privacy and AI-generated deepfakes depicting identifiable individuals in sexually explicit contexts—with the intent to harm, harass, humiliate, degrade, or arouse. The offense carries up to two years imprisonment for imagery involving adult victims, with heightened penalties when the victim is a minor. The law covers threats as well as actual publication, directly targeting sextortion schemes. It applies across interstate commerce, encompassing social media platforms, websites, and applications.[^rc-bill]
 
 ### Platform Takedown Obligations
 
-Covered platforms—broadly defined to include websites, social media services, and apps that host user-generated content—must establish processes allowing victims to submit verified removal requests, typically requiring an electronic signature and location details sufficient to identify the content. Upon receiving a valid request, platforms have 48 hours to remove the reported content and must make reasonable efforts to identify and delete copies and reposts. Internet service providers and email services are excluded from coverage.[^1]
+Covered platforms—broadly defined to include websites, social media services, and apps that host user-generated content—must establish processes allowing victims to submit verified removal requests, typically requiring an electronic signature and location details sufficient to identify the content. Upon receiving a valid request, platforms have 48 hours to remove the reported content and must make reasonable efforts to identify and delete copies and reposts. Internet service providers and email services are excluded from coverage.[^rc-bill]
 
-The FTC enforces platform compliance as a matter of unfair or deceptive trade practices under the FTC Act, with jurisdiction extended to include nonprofit organizations. Platforms that document good-faith compliance efforts receive safe harbor protection against liability for both mistaken removals and for content they fail to identify.[^1]
+The FTC enforces platform compliance as a matter of unfair or deceptive trade practices under the FTC Act, with jurisdiction extended to include nonprofit organizations. Platforms that document good-faith compliance efforts receive safe harbor protection against liability for both mistaken removals and for content they fail to identify.[^rc-crs]
 
 ### Protections and Carve-Outs
 
-The Act includes explicit protections for good-faith disclosures by medical professionals, law enforcement, and related actors. It preserves First Amendment protections for journalism, artistic expression, and matters of public concern. It does not preempt existing state NCII laws, meaning that state and federal regimes continue to operate in parallel. The Act also does not create a private right of action for victims against platforms, limiting direct civil remedies to the FTC enforcement track.[^1]
+The Act includes explicit protections for good-faith disclosures by medical professionals, law enforcement, and related actors. It preserves First Amendment protections for journalism, artistic expression, and matters of public concern. It does not preempt existing state NCII laws, meaning that state and federal regimes continue to operate in parallel. The Act also does not create a private right of action for victims against platforms, limiting direct civil remedies to the FTC enforcement track.[^rc-crs]
 
 ## Relationship to AI Governance
 
 The TAKE IT DOWN Act is notable as the first U.S. federal law explicitly restricting a specific harmful application of AI—the generation of non-consensual intimate imagery—rather than addressing AI governance in broad structural terms. In this sense it represents a narrowly targeted, harm-specific approach to AI regulation, distinct from comprehensive AI governance frameworks such as the <EntityLink id="E127">EU AI Act</EntityLink> or proposed U.S. bills like the <EntityLink id="E48">Safe and Secure Innovation for Frontier Artificial Intelligence Models Act</EntityLink>.
 
-The Act is also related to the DEFIANCE Act, which addresses civil remedies for victims of AI-generated NCII, and complements but does not supersede state-level legislation. Advocates described the Act as a targeted fix for a specific class of AI-enabled harm, rather than as comprehensive AI governance. Some commentators, including Nathan Leamer of the Digital First Project, characterized it as a potential template for balanced AI policy that addresses concrete harms without broadly restricting AI development.[^1]
+The Act is also related to the DEFIANCE Act, which addresses civil remedies for victims of AI-generated NCII, and complements but does not supersede state-level legislation. Advocates described the Act as a targeted fix for a specific class of AI-enabled harm, rather than as comprehensive AI governance.[^rc-iapp]
 
 ## Criticisms and Concerns
 
@@ -86,23 +87,23 @@ Despite near-unanimous congressional support, the Act has drawn criticism from c
 
 ### Censorship and Overreach Risks
 
-The Electronic Frontier Foundation (EFF), the Cyber Civil Rights Initiative (CCRI), the Cato Institute, and Public Knowledge have raised concerns about the Act's potential for misuse. Critics argue that the 48-hour removal deadline creates strong pressure for platforms—especially smaller ones—to over-remove content rather than risk FTC enforcement, without adequate verification that reported content actually constitutes NCII. Unlike the Digital Millennium Copyright Act (DMCA), the Act lacks counternotice procedures, anti-abuse provisions, or restoration mechanisms for wrongly removed content.[^1]
+The Electronic Frontier Foundation (EFF), the Cyber Civil Rights Initiative (CCRI), the Cato Institute, and Public Knowledge have raised concerns about the Act's potential for misuse. Critics argue that the 48-hour removal deadline creates strong pressure for platforms—especially smaller ones—to over-remove content rather than risk FTC enforcement, without adequate verification that reported content actually constitutes NCII. Unlike the Digital Millennium Copyright Act (DMCA), the Act lacks counternotice procedures, anti-abuse provisions, or restoration mechanisms for wrongly removed content.[^rc-eff]
 
-EFF and others warned that the broad definition of covered content, applicable across all user-generated content forums including private messaging applications, could be exploited to suppress satire, journalism, political speech, or commercial content unrelated to NCII. Critics also noted that FTC jurisdiction extended to nonprofits raises concerns about the potential politicization of enforcement.[^1]
+EFF and others warned that the broad definition of covered content, applicable across all user-generated content forums including private messaging applications, could be exploited to suppress satire, journalism, political speech, or commercial content unrelated to NCII. Critics also noted that FTC jurisdiction extended to nonprofits raises concerns about the potential politicization of enforcement.[^rc-eff]
 
-The CCRI, which otherwise supports the criminalization of NCII, specifically opposed the notice-and-takedown framework on constitutional grounds, arguing that it could suppress lawful speech and was drafted more broadly than necessary to address the targeted harm. Some experts characterized the takedown provisions as a potential "poison pill" that could ultimately harm victims by creating a regime susceptible to abuse.[^1]
+The CCRI, which otherwise supports the criminalization of NCII, specifically opposed the notice-and-takedown framework on constitutional grounds, arguing that it could suppress lawful speech and was drafted more broadly than necessary to address the targeted harm.[^rc-eff]
 
 ### Encryption and Privacy Concerns
 
-Requirements that platforms make "reasonable efforts" to identify and remove copies of reported content have prompted concerns that compliance could require scanning private communications, potentially undermining end-to-end encryption in messaging applications. Critics argue this could expose platforms to a dilemma between complying with the Act and maintaining user privacy protections.[^1]
+Requirements that platforms make "reasonable efforts" to identify and remove copies of reported content have prompted concerns that compliance could require scanning private communications, potentially undermining end-to-end encryption in messaging applications.[^rc-eff]
 
 ### Enforcement Gaps
 
-The Act does not preempt state laws, creating potential inconsistencies for national platforms operating across multiple jurisdictions, each with distinct NCII frameworks. The lack of a private right of action against non-compliant platforms also limits victim recourse outside the FTC enforcement channel. Compliance burdens on small platforms may be substantial given the requirement to document good-faith efforts and implement robust reporting systems within one year of enactment.[^1]
+The Act does not preempt state laws, creating potential inconsistencies for national platforms operating across multiple jurisdictions, each with distinct NCII frameworks. The lack of a private right of action against non-compliant platforms also limits victim recourse outside the FTC enforcement channel. Compliance burdens on small platforms may be substantial given the requirement to document good-faith efforts and implement robust reporting systems within one year of enactment.[^rc-crs]
 
 ### Counterarguments
 
-Proponents respond that the Act's explicit First Amendment carve-outs, its focus on knowing and intentional conduct, and the good-faith safe harbor for platforms provide meaningful protections against the most significant overreach risks. The near-unanimous congressional votes suggest broad consensus that the Act appropriately balances victim protection against free speech concerns, even if critics maintain the balance is imperfect. Advocates including RAINN and the National Center for Missing and Exploited Children characterized the Act as a long-overdue response to documented, severe harms, particularly to minors.[^1]
+Proponents respond that the Act's explicit First Amendment carve-outs, its focus on knowing and intentional conduct, and the good-faith safe harbor for platforms provide meaningful protections against the most significant overreach risks. The near-unanimous congressional votes suggest broad consensus that the Act appropriately balances victim protection against free speech concerns, even if critics maintain the balance is imperfect. Advocates including RAINN and the National Center for Missing and Exploited Children characterized the Act as a long-overdue response to documented, severe harms, particularly to minors.[^rc-rainn]
 
 ## Key Uncertainties
 
@@ -114,4 +115,10 @@ Proponents respond that the Act's explicit First Amendment carve-outs, its focus
 
 ## Sources
 
-[^1]: Research compiled from public reporting on the TAKE IT DOWN Act, S. 146, including legislative history, congressional records, advocacy organization statements (EFF, CCRI, Cato Institute, RAINN, National Center for Missing and Exploited Children), and legal analysis published through mid-2025. Full text available at [govinfo.gov](https://www.govinfo.gov/content/pkg/COMPS-18158/pdf/COMPS-18158.pdf).
+[^rc-bill]: TAKE IT DOWN Act, S. 146, 119th Congress. [Full text](https://www.govinfo.gov/content/pkg/COMPS-18158/pdf/COMPS-18158.pdf).
+[^rc-crs]: Congressional Research Service. "The TAKE IT DOWN Act: A Federal Law Prohibiting the Nonconsensual Publication of Intimate Images." [LSB11314](https://www.congress.gov/crs-product/LSB11314).
+[^rc-eff]: Electronic Frontier Foundation. "Politicians Rushed Through An Online Speech 'Solution.' Victims Deserve Better." [EFF](https://www.eff.org/deeplinks/2025/12/politicians-rushed-through-online-speech-solution-victims-deserve-better).
+[^rc-klob]: Senator Amy Klobuchar. "Klobuchar's Bipartisan TAKE IT DOWN Act Signed into Law." [Press Release](https://www.klobuchar.senate.gov/public/index.cfm/2025/5/klobuchar-s-bipartisan-take-it-down-act-signed-into-law).
+[^rc-rainn]: RAINN. "Take It Down Act." [RAINN](https://rainn.org/federal-legislation/take-it-down-act/).
+[^rc-iapp]: IAPP. "TAKE IT DOWN Act: The next bipartisan US federal privacy, AI law." [IAPP](https://iapp.org/news/a/take-it-down-act-the-next-bipartisan-us-federal-privacy-ai-law).
+[^rc-wiki]: "TAKE IT DOWN Act." Wikipedia. [Wikipedia](https://en.wikipedia.org/wiki/TAKE_IT_DOWN_Act).

--- a/content/docs/knowledge-base/responses/trump-ai-framework-2026.mdx
+++ b/content/docs/knowledge-base/responses/trump-ai-framework-2026.mdx
@@ -54,7 +54,7 @@ The document's release was understood by legal and policy analysts as the openin
 
 ## Seven Pillars
 
-The framework is organized into seven thematic sections, though sources vary slightly in their enumeration (some characterizing the document as covering six key objectives). The pillars and their core recommendations are as follows:
+The framework is organized into seven thematic sections. The pillars and their core recommendations are as follows:
 
 **1. Protecting Children and Empowering Parents.** The framework calls for targeted federal standards to protect minors online, including safeguards against AI-enabled child sexual abuse material (CSAM) and online exploitation. This pillar is among the least contested in the document.
 

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -5671,7 +5671,7 @@
       importance: high
       reason: Senate rejected AI preemption moratorium in One Big Beautiful Bill Act due to bipartisan concerns about eroding state consumer protection authority
   relatedEntries:
-    - id: pz3KSt33AA
+    - id: us-executive-order
       type: policy
   description: >-
     First major AI executive order of the Trump second term, signed January 23, 2025. Revokes


### PR DESCRIPTION
## Summary

Follow-up fixes from paranoid review of PR #3083:

- **take-it-down-act.mdx**: Replace single aggregated `[^1]` footnote with 7 specific citations (bill text, CRS report, EFF analysis, Klobuchar press release, RAINN, IAPP, Wikipedia)
- **trump-ai-framework-2026.mdx**: Remove hedging about "six vs seven" pillars — the document clearly has seven sections
- **responses.yaml**: Use slug `us-executive-order` instead of stableId `pz3KSt33AA` in `relatedEntries` for `trump-eo-14179` to match codebase convention

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass
- [x] `pnpm test` — 4187/4187 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced "Take It Down Act" article with detailed source citations and added Congress.gov external resource link.
  * Improved clarity in "Trump AI Framework" section for consistency.
  * Refined references and knowledge base content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->