### PR TITLE
fix: extract Drizzle error cause chain in sync error responses

### DIFF
--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -68,12 +68,21 @@ export function dbError(
   err: unknown,
   context?: Record<string, unknown>
 ) {
+  // Extract the deepest error message — Drizzle wraps PG errors in cause chains
+  const extractMessage = (e: unknown): string => {
+    if (e instanceof Error) {
+      if (e.cause) return `${e.message} | cause: ${extractMessage(e.cause)}`;
+      return e.message;
+    }
+    return String(e);
+  };
+  const detail = extractMessage(err);
   logger.error({
     operation,
     ...(context ?? {}),
-    err: err instanceof Error ? err.message : String(err),
+    err: detail,
+    stack: err instanceof Error ? err.stack : undefined,
   }, `${operation} failed`);
-  const detail = err instanceof Error ? err.message : String(err);
   return c.json({ error: "database_error", message: `${operation} failed`, detail }, 500);
 }
 

--- a/crux/wiki-server/sync-common.ts
+++ b/crux/wiki-server/sync-common.ts
@@ -175,7 +175,7 @@ export async function fetchWithRetry(
 
       // 5xx — retry
       const body = await res.text().catch(() => "");
-      lastError = new Error(`HTTP ${res.status}: ${body.slice(0, 200)}`);
+      lastError = new Error(`HTTP ${res.status}: ${body.slice(0, 1000)}`);
     } catch (err) {
       lastError = err;
     }


### PR DESCRIPTION
## Summary

The sync-entities workflow fails with `{"error":"database_error","message":"entities sync failed"}` but no detail about the actual Postgres error. Two issues:

1. Drizzle wraps PG errors in a cause chain (`DrizzleQueryError` → `PostgresError`). The `err.message` only shows the wrapper. Added recursive cause extraction.
2. `fetchWithRetry` truncated response bodies to 200 chars, cutting off the detail field. Increased to 1000.

After merge + deploy, re-running sync will show the actual PG error causing 500 failures on ~50% of entity batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)