### PR TITLE
fix: entity sync 500 errors — things upsert PK conflict

### DIFF
--- a/apps/wiki-server/src/routes/shared/thing-sync.ts
+++ b/apps/wiki-server/src/routes/shared/thing-sync.ts
@@ -164,10 +164,17 @@ export async function upsertThingsInTx(
     .insert(things)
     .values(allVals)
     .onConflictDoUpdate({
-      target: [things.sourceTable, things.sourceId],
+      // Use PK (id) as conflict target, not (source_table, source_id).
+      // When an entity's stableId already exists in things from a different
+      // source (e.g., grants), the PK conflict fires before the composite
+      // unique constraint, causing the insert to fail. Using the PK ensures
+      // the upsert always works regardless of source_table.
+      target: things.id,
       set: {
         title: sql`excluded.title`,
         thingType: sql`excluded.thing_type`,
+        sourceTable: sql`excluded.source_table`,
+        sourceId: sql`excluded.source_id`,
         entityType: sql`excluded.entity_type`,
         description: sql`excluded.description`,
         sourceUrl: sql`excluded.source_url`,


### PR DESCRIPTION
## Summary

Entity sync fails on ~50% of batches (400/1028 entities) with `database_error: entities sync failed`. 

**Root cause**: `upsertThingsInTx()` uses `ON CONFLICT (source_table, source_id)` but some entities' `stableId` values already exist in the `things` table from other sources (e.g., grants). The PK constraint on `things.id` fires before the composite unique constraint, causing an unresolvable conflict.

**Fix**: Change conflict target to `things.id` (the PK). Also update `source_table` and `source_id` in the SET clause so the latest source wins.

**Impact**: Unblocks entity sync on main and all release PRs.

## Test plan
- [ ] Entity sync passes with 0 errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization to correctly handle conflicts by ensuring all relevant source information is updated during concurrent operations, maintaining data consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->