### PR TITLE
fix: entity sync timeout — increase to 120s + reduce batch size to 50

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -828,6 +828,7 @@ const entitiesApp = new Hono()
     const { entities: items } = c.req.valid("json");
     const db = getDrizzleDb();
 
+
     // Validate relatedEntries references: strip out references to entities
     // that don't exist (either in this batch or in PG). This allows the sync
     // to proceed even when entities reference each other across batches.
@@ -862,6 +863,9 @@ const entitiesApp = new Hono()
 
     try {
       await db.transaction(async (tx) => {
+        // Increase statement_timeout for bulk sync — default 30s is too tight
+        // for batches of 100 entities with FK cascade checks on referencing tables.
+        await tx.execute(sql`SET LOCAL statement_timeout = '120000'`); // 2 min
         const allVals = items.map((e) => ({
           id: e.id,
           wikiId: e.wikiId ?? null,

--- a/crux/wiki-server/sync-entities.ts
+++ b/crux/wiki-server/sync-entities.ts
@@ -32,7 +32,9 @@ const EXPERTS_FILE = join(PROJECT_ROOT, "data/experts.yaml");
 const PEOPLE_RESOURCES_FILE = join(PROJECT_ROOT, "data/people-resources.yaml");
 
 // --- Configuration ---
-const DEFAULT_BATCH_SIZE = 100;
+// Reduced from 100 to 50 — batches of 100 can exceed the 30s statement_timeout
+// when entities have many FK cascade checks (facts, claims, personnel tables).
+const DEFAULT_BATCH_SIZE = 50;
 
 // --- Types ---
 


### PR DESCRIPTION
## Summary

Entity sync fails on ~50% of batches (400/1028 entities). Investigation found:

1. **Statement timeout (30s) likely exceeded**: Batches of 100 entities with FK cascade checks on referencing tables (facts, claims, personnel) can exceed the 30s `statement_timeout`.

2. **Detail field never appeared because production branch lacks our fixes**: The deploy workflow builds from `production` branch, but all our dbError fixes were merged to `main` only.

Fix:
- `SET LOCAL statement_timeout = '120000'` inside the sync transaction (2 minutes)
- Reduce default batch size from 100 to 50

## Test plan
- [ ] Entity sync passes with 0 errors after deploy
- [ ] Verify sync completes within reasonable time (~2 min total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)