### PR TITLE
fix: entity sync slug conflict — use Drizzle inArray (v2)

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -887,13 +887,18 @@ const entitiesApp = new Hono()
         // Clear stale rows where the slug (id) was reassigned to a different stableId.
         // Without this, the INSERT ON CONFLICT (stableId) can't handle the unique
         // constraint on id when a slug moved between entities.
+        // Note: Drizzle sql`` expands arrays as value-lists, not Pg arrays,
+        // so use inArray/notInArray instead of raw ANY/ALL.
         const batchSlugs = allVals.map((v) => v.id);
         const batchStableIds = allVals.map((v) => v.stableId);
-        await tx.execute(sql`
-          DELETE FROM entities
-          WHERE id = ANY(${batchSlugs})
-            AND stable_id != ALL(${batchStableIds})
-        `);
+        await tx
+          .delete(entities)
+          .where(
+            and(
+              inArray(entities.id, batchSlugs),
+              notInArray(entities.stableId, batchStableIds),
+            )
+          );
 
         await tx
           .insert(entities)


### PR DESCRIPTION
v2 fix: previous attempt used raw SQL ANY/ALL which doesn't work with Drizzle's array expansion. Use inArray/notInArray.