### PR TITLE
feat: enrich Coefficient Giving FactBase entity

### DIFF
--- a/packages/factbase/data/things/coefficient-giving.yaml
+++ b/packages/factbase/data/things/coefficient-giving.yaml
@@ -78,7 +78,9 @@ facts:
     property: founded-date
     value: "2017-06"
     source: https://www.wikidata.org/wiki/Q25345685
-    notes: "Became independent LLC in June 2017 (previously operated as Open Philanthropy Project within GiveWell from 2014). Rebranded from Open Philanthropy to Coefficient Giving in November 2025."
+    notes: "Became independent LLC in June 2017 (previously operated as Open Philanthropy
+      Project within GiveWell from 2014). Rebranded from Open Philanthropy to Coefficient
+      Giving in November 2025."
   - id: Dyf2V67PFg
     property: headquarters
     value: San Francisco
@@ -89,19 +91,9 @@ facts:
     value: https://www.coefficientgiving.org
     source: https://www.coefficientgiving.org
     notes: Updated from openphilanthropy.org after Nov 2025 rebrand
-  - id: Qk5XmCiqzQ
-    property: founded-date
-    value: 2017-06
-    source: https://www.wikidata.org/wiki/Q25345685
-    notes: From Wikidata Q25345685
   - id: o7268a61Mg
     property: country
     value: United States
-    source: https://www.wikidata.org/wiki/Q25345685
-    notes: From Wikidata Q25345685
-  - id: BHfbCdt5UQ
-    property: website
-    value: https://coefficientgiving.org/
     source: https://www.wikidata.org/wiki/Q25345685
     notes: From Wikidata Q25345685
   - id: xrnLH5oqjg
@@ -114,3 +106,48 @@ facts:
     value: https://en.wikipedia.org/wiki/Coefficient_Giving
     source: https://www.wikidata.org/wiki/Q25345685
     notes: From Wikidata Q25345685
+
+  # ── Founders ─────────────────────────────────────────────────
+  - id: f_6C5bun09hg
+    property: founded-by
+    value:
+      - !ref Jtj6jHbuQ7
+      - !ref eQh3ZhWv8D
+    source: https://en.wikipedia.org/wiki/Coefficient_Giving
+    notes: "Dustin Moskovitz and Holden Karnofsky. Moskovitz co-founded Good Ventures
+      with Cari Tuna in 2011; Karnofsky co-founded GiveWell Labs (precursor) in 2014
+      and served as CEO/co-CEO until 2023."
+
+  - id: f_G1BnwqSzSg
+    property: founded-by-name
+    value: Cari Tuna
+    source: https://en.wikipedia.org/wiki/Cari_Tuna
+    notes: "Co-founder and Chair of Coefficient Giving; co-founded Good Ventures with
+      Dustin Moskovitz in 2011, which funded the Open Philanthropy Project."
+
+  - id: f_o7b7ts6XBg
+    property: founded-by-name
+    value: Elie Hassenfeld
+    source: https://coefficientgiving.org/governance/
+    notes: "Co-founded GiveWell with Holden Karnofsky in 2007; serves on Coefficient
+      Giving's Board of Managers. GiveWell Labs (2011) evolved into Open Philanthropy
+      Project (2014)."
+
+  # ── Legal Structure ──────────────────────────────────────────
+  - id: f_LUa4wxC8YQ
+    property: legal-structure
+    value: "Limited liability company (LLC)"
+    source: https://coefficientgiving.org/research/the-open-philanthropy-project-is-now-an-independent-organization/
+    notes: "Became independent LLC in June 2017 when separating from GiveWell. Structured
+      as LLC rather than nonprofit for operational flexibility; Board of Managers
+      includes Cari Tuna (Chair), Dustin Moskovitz, Elie Hassenfeld, and Alexander
+      Berger."
+
+  # ── Funding Received (non-Good Ventures donors) ─────────────
+  - id: f_NfLWUHRT2A
+    property: funding-received
+    value: 1e+8
+    asOf: "2024"
+    source: https://coefficientgiving.org/research/our-progress-in-2024-and-plans-for-2025/
+    notes: "Directed $100M+ to high-impact causes from donors besides Good Ventures
+      in 2024; more than doubled in 2025."


### PR DESCRIPTION
## Summary
- Add `founded-by` property with entity refs for Dustin Moskovitz and Holden Karnofsky
- Add `founded-by-name` entries for Cari Tuna and Elie Hassenfeld (no FactBase entities yet)
- Add `legal-structure` property: LLC (independent since June 2017)
- Add `funding-received` property: $100M+ from non-Good Ventures donors (2024)
- Remove duplicate `founded-date` and `website` entries from Wikidata import
- Coverage improved from 26% (10/39) to 33% (13/39)

## Test plan
- [x] `crux fb show coefficient-giving` loads correctly with all 22 facts
- [x] `founded-by` entity refs resolve to correct names (Dustin Moskovitz, Holden Karnofsky)
- [x] No duplicate facts remain
- [x] Coverage verified via `crux fb needs-update coefficient-giving`

Generated with [Claude Code](https://claude.com/claude-code)