### PR TITLE
feat: 5 people pages + fix entity sync DB blocker

### DIFF
--- a/content/docs/knowledge-base/people/greg-brockman.mdx
+++ b/content/docs/knowledge-base/people/greg-brockman.mdx
@@ -1,0 +1,159 @@
+---
+wikiId: E1012
+title: Greg Brockman
+description: Co-founder and president of OpenAI, engineer, and entrepreneur known for his role in building AI infrastructure and advancing safe AGI development.
+subcategory: lab-leadership
+update_frequency: 90
+sidebar:
+  order: 50
+lastEdited: 2026-03-23
+createdAt: 2026-03-23
+summary: Comprehensive biographical profile of OpenAI co-founder Greg Brockman covering his career, research contributions, AI safety views, and controversies including the 2023 board crisis and ongoing Musk litigation; reasonably balanced but footnotes reveal an undisclosed internal research compilation rather than primary source citations.
+---
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Quick Assessment
+
+| Attribute | Detail |
+|-----------|--------|
+| **Born** | November 29, 1987; Thompson, North Dakota |
+| **Role** | Co-founder and President, <EntityLink id="E218">OpenAI</EntityLink> |
+| **Education** | Harvard University (mathematics); MIT (computer science); dropped out 2010 |
+| **Previous role** | First CTO of Stripe (2013–2015) |
+| **Known for** | Co-founding OpenAI; leading AI infrastructure buildout; "builder-in-chief" |
+| **AI Safety relevance** | Founding mission of safe AGI; involved in alignment and governance discussions |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Greg_Brockman) |
+| Wikidata | [wikidata.org](https://www.wikidata.org/wiki/Q100604534) |
+| Twitter/X | [twitter.com](https://twitter.com/gdb) |
+
+## Overview
+
+Greg Brockman is a software engineer, entrepreneur, and co-founder of <EntityLink id="E218">OpenAI</EntityLink>, where he currently serves as president and leads the organization's Scaling group, which focuses on the technical and operational infrastructure underlying OpenAI's AI systems. Born in Thompson, North Dakota in 1987, Brockman was a science prodigy who won a silver medal at the 2006 International Chemistry Olympiad and placed sixth in the 2007 Intel Science Talent Search before going on to study at Harvard and MIT.[^1] He dropped out of MIT in 2010 to join Stripe as one of its earliest employees, eventually becoming the company's first CTO.[^2]
+
+In December 2015, Brockman co-founded OpenAI alongside Sam Altman, Ilya Sutskever, Elon Musk, and others, with the stated mission of developing artificial general intelligence (AGI) that benefits all of humanity rather than serving narrow corporate interests.[^3] He played a central role in the organization's early operations—leading recruiting, building internal systems and culture, and acting as a de facto operational leader during periods when Altman remained at Y Combinator. Over the following decade, Brockman contributed to or oversaw the development of key OpenAI systems including OpenAI Gym, Codex, DALL-E, and GPT-4, which he unveiled in a live demonstration on March 14, 2023.[^4]
+
+Brockman took a sabbatical from OpenAI in August 2024—the first extended break he had taken since co-founding the organization—before returning in November 2024 to lead OpenAI's newly formed Scaling group, which is responsible for the company's ambitious infrastructure expansion plans.[^5] He remains one of the most prominent figures in AI development, recognized on TIME magazine's TIME100 AI list in 2023 and described by observers as a central "builder" figure in the effort to scale AI systems to unprecedented capacity.
+
+## Early Life and Education
+
+Brockman grew up in Thompson, North Dakota, where he attended Red River High School. He excelled across multiple disciplines, captaining a state-champion Science Bowl team, participating in drumline, the Latin club, and a math club that volunteered at a local middle school, and writing for the local paper's Teen Page.[^1] His academic achievements during this period were exceptional: he won a silver medal at the 2006 International Chemistry Olympiad (the first North Dakota finalist in the Intel Science Talent Search since 1973), placed sixth in the 2007 Intel Science Talent Search for a paper titled *"Asymptotic Behavior of Certain Ducci Sequences"* (later published in *Fibonacci Quarterly*), was a two-time semi-finalist in the Physics Olympiad, was invited to the Math Olympiad Summer Program, and received a 2006 Prudential Spirit of Community Award Distinguished Finalist honor.[^1] He also attended Canada/USA Mathcamp in 2003, 2005, and 2007.[^1]
+
+During a gap year after high school, Brockman became seriously interested in programming after reading Alan Turing's essay *"Computing Machinery and Intelligence,"* which he has cited as a formative influence.[^6] He enrolled at Harvard University in 2008 intending to double-major in mathematics and computer science, where he was involved in the Harvard Computer Society. After one year, he transferred to MIT, where he worked on projects including XVM and scripts.mit.edu and pursued research into programming languages, including static buffer overrun detection.[^1] He left MIT in 2010 without completing his degree to join Stripe.
+
+## Career
+
+### Stripe (2010–2015)
+
+Brockman joined Stripe in 2010 as one of its earliest employees—its fourth or fifth, depending on the account—after being connected to the Collison brothers through his MIT network.[^2] He served in an engineering role before becoming Stripe's first CTO in 2013, a position he held until leaving the company in May 2015. During his tenure, Stripe grew from roughly five to over 200 employees. At the time of his departure, Stripe's valuation exceeded \$9 billion.[^2]
+
+### Founding OpenAI (2015)
+
+After leaving Stripe, Brockman was introduced to Sam Altman through Stripe co-founder Patrick Collison.[^7] Altman and Elon Musk proposed creating a nonprofit AI research laboratory dedicated to developing AGI safely and distributing its benefits broadly—motivated in part by concern about corporate consolidation in AI, including Google's acquisition of DeepMind for approximately \$500 million in 2014.[^3] According to accounts of this period, Brockman committed to the project immediately and took on the task of recruiting top AI researchers, including Ilya Sutskever, whom he helped persuade to leave a high-paying position elsewhere.[^3]
+
+OpenAI was formally announced in December 2015 with eleven co-founders: Sam Altman, Elon Musk, Greg Brockman, Ilya Sutskever, Trevor Blackwell, Vicki Cheung, Andrej Karpathy, Durk Kingma, John Schulman, Pamela Vagata, and Wojciech Zaremba.[^3] Initial funding commitments totaled \$1 billion from Musk, Altman, Peter Thiel, and others.[^3] In the early period, Brockman operated largely as a de facto CEO while Altman remained at Y Combinator, building systems and culture for the research team from his living room.[^3]
+
+### OpenAI (2015–present)
+
+Brockman served as OpenAI's first CTO and has held the title of President. In the organization's early years, he led or contributed to projects including OpenAI Gym (a reinforcement learning toolkit), OpenAI Five (a Dota 2 playing AI system), and the development of GPT-2, whose release in February 2019 was initially staged due to concerns about potential misuse.[^4] He is listed as a co-author on research papers introducing Codex (a code-generating system based on GPT), the Whisper speech recognition system, the OpenAI o1 system card, and other work.[^8]
+
+Brockman was removed from OpenAI's board as chairman during the November 2023 events surrounding Sam Altman's brief firing. He resigned as president at the same time and briefly joined Microsoft alongside Altman before returning to OpenAI following Altman's reinstatement.[^9] He took a sabbatical beginning in August 2024, describing it as his first opportunity to rest since co-founding the organization. He returned in November 2024 to lead a new "Scaling" group focused on chips, data centers, software, and operational challenges associated with rapidly expanding AI infrastructure.[^5]
+
+## Research Contributions
+
+Brockman's early academic research, conducted during high school and the years immediately following, focused on combinatorics and mathematical sequences. His 2007 Intel Science Talent Search paper on the asymptotic behavior of Ducci sequences was published in *Fibonacci Quarterly*. He later co-authored work on universal cycles for labeled graphs (published in the *Electronic Journal of Combinatorics*, 2010) and on omnisequences and coupon collection problems (2011).[^8]
+
+At OpenAI, Brockman has been listed as a co-author on a number of significant research publications, including:
+
+- **OpenAI Gym** (2016) — a toolkit for developing and comparing reinforcement learning algorithms
+- **Evaluating Large Language Models Trained on Code** (2021) — introducing Codex, a GPT-based system fine-tuned on GitHub code for Python code generation
+- **Robust Speech Recognition via Large-Scale Weak Supervision** (2022/2023) — introducing the Whisper model, presented at ICML 2023
+- **OpenAI o1 System Card** (2024) — documenting safety evaluations of the o1 model
+- **Systems and Algorithms for Convolutional Multi-Hybrid Language Models at Scale** (2025) — focusing on scalable language model architectures[^8]
+
+His role in these publications has generally been as a contributor to the broader research enterprise rather than as a primary technical lead on specific modeling innovations.
+
+## Views on AI and AGI
+
+Brockman has expressed consistent beliefs about the trajectory of AI development and <EntityLink id="E218">OpenAI</EntityLink>'s role within it. He has described AGI—which OpenAI defines as an autonomous system capable of outperforming humans at most economically valuable work—as something that will fundamentally transform civilization if realized, and views pursuing it as a continuous process rather than a discrete event.[^10]
+
+A central technical belief he has expressed is confidence in scaling laws: the empirical observation that larger models, more training data, and greater compute tend to yield predictable improvements in AI performance. In recorded interviews, he has stated that there is no sign of a plateau in these trends, and that execution—building the infrastructure needed to continue scaling—is the primary challenge facing OpenAI.[^10]
+
+On AI development strategy, Brockman has advocated for iterative, customer-facing deployment as a safer alternative to developing systems privately and releasing them in a single large step. He has pointed to the deployment of systems like ChatGPT as enabling real-world testing and feedback loops that improve both safety and capability.[^11] He has also spoken about the importance of building AI systems that are auditable and whose access to organizational infrastructure can be monitored.[^10]
+
+Brockman has expressed support for some form of international governance for superintelligent AI. A 2023 statement co-authored by OpenAI leadership, including Brockman, proposed coordination mechanisms for superintelligence analogous to the International Atomic Energy Agency, including the possibility of inspections and audits of AI development efforts.[^11]
+
+## AI Safety Engagement
+
+Brockman has publicly engaged with questions of AI safety and existential risk, though the depth and consistency of this engagement has been questioned by critics. He participated in a 2022 panel on AI safety alongside Elon Musk, Max Tegmark, and Benjamin Netanyahu, where he stated that his motivation for working on AI is ensuring that the technology is beneficial rather than harmful to humanity.[^11] He has referenced <EntityLink id="E114">Eliezer Yudkowsky</EntityLink>'s work and science fiction as part of how OpenAI's leadership has thought about AI risk.[^11]
+
+On the technical side, Brockman has described OpenAI's post-training process as a form of alignment: starting from base models trained on broad human-generated text, then refining model behavior toward specified values through a model specification document and related techniques.[^11]
+
+When superalignment co-leader Jan Leike departed OpenAI in 2024 criticizing the organization's safety culture as having taken a back seat to product development, Brockman and Altman responded by emphasizing what they characterized as the harmony between safety and capabilities research. Critics noted that the response was vague and that the superalignment team had been disbanded.[^11]
+
+## Political Activity
+
+Brockman and his wife have made political contributions in recent years, and he has publicly supported U.S. AI competitiveness. In early 2025, he posted on X thanking the Trump administration for engaging the AI community and supporting U.S. AI leadership.[^12] Reports indicate that Brockman is among those co-leading a super-PAC network called "Leading the Future," alongside investors affiliated with Andreessen Horowitz, intended to fund candidates in the 2026 midterm elections who support industry-friendly AI policies.[^12] He has cited personal motivations including the role of AI in healthcare, referencing his wife's experiences.[^12]
+
+A separate account describes a \$25 million donation attributed to Brockman and his wife to causes associated with the Trump political movement, which an OpenAI executive reportedly cited internally to counter accusations that OpenAI was ideologically "woke."[^13]
+
+## Criticisms and Controversies
+
+### 2023 Board Events
+
+During the November 2023 events in which the OpenAI board briefly fired Sam Altman, Brockman was removed as board chairman via a Google Meet call from which he had been excluded.[^9] He subsequently resigned as president and joined Microsoft alongside Altman. The two returned to OpenAI after Altman was reinstated. Approximately 95% of OpenAI employees signed a petition requesting Altman's reinstatement, according to accounts of the period.[^9] Brockman described the five-day period in a later podcast as instilling a sense of mortality and ultimately as a rejuvenating experience for the organization.[^9]
+
+Reports from this period also described allegations, attributed to Ilya Sutskever, of bullying by Brockman, and suggestions that his close relationship with Altman made it difficult for other executives, including Mira Murati, to operate effectively.[^14] Some employee groups reportedly requested that leadership take steps to address his behavior.[^14]
+
+### Elon Musk Lawsuit
+
+Personal diary entries and notes written by Brockman in 2017 were unsealed in the context of Elon Musk's federal lawsuit against <EntityLink id="E218">OpenAI</EntityLink>, Altman, Brockman, Microsoft, and Satya Nadella (set for trial in April 2026 in Oakland). The documents, as characterized by reporting on the lawsuit, include entries questioning Musk's leadership and contemplating a transition from nonprofit to for-profit structure.[^15] One entry reportedly states that if OpenAI committed to nonprofit status and then moved to a B-corp structure three months later, that would constitute a lie.[^15] Another note written after a November 2017 meeting with Musk reportedly characterized converting to for-profit without Musk's involvement in particular terms.[^15] Musk's lawsuit alleges that OpenAI's transition to a for-profit entity effectively laundered his charitable contributions—totaling more than \$38 million—into a company that reached a valuation of approximately \$500 billion.[^15]
+
+OpenAI and its leadership have disputed Musk's characterization of events, and the litigation remains ongoing.
+
+### Safety Culture Concerns
+
+The 2024 departure of Jan Leike, who had co-led OpenAI's superalignment effort, brought broader criticism of OpenAI's safety culture that indirectly implicated Brockman as part of the leadership team. Leike's public statement characterized OpenAI's safety culture as having been deprioritized relative to product development. Brockman and Altman's responses were criticized by observers as insufficiently specific.[^11] AI pioneer Geoffrey Hinton separately described a roughly 50% probability of AI systems posing existential risks within the coming decades.[^11]
+
+## Key Uncertainties
+
+- The extent to which Brockman's views on AI safety reflect deep technical conviction versus organizational positioning is difficult to assess from public statements alone.
+- The outcome of the Musk v. OpenAI litigation, and what additional documents may reveal about the founding-era decision-making in which Brockman participated, remains uncertain pending the 2026 trial.
+- OpenAI's \$1.4 trillion infrastructure commitment represents a very large bet relative to the company's current revenue base of approximately \$13 billion annually; whether this buildout will proceed as planned and what role Brockman will play in it remains to be seen.
+- Brockman's dual role as OpenAI president and investor in more than 30 startups creates potential conflicts of interest that have not been extensively documented or adjudicated publicly.
+
+## Sources
+
+[^1]: Background on Brockman's early life, education, and high school achievements — research data compiled from multiple biographical sources including Society for Science records and profiles of Brockman's upbringing in North Dakota.
+
+[^2]: Career history at Stripe — research data from biographical profiles describing Brockman's tenure as Stripe's fourth employee and first CTO from 2013 to 2015.
+
+[^3]: OpenAI founding history — research data from accounts of the founding of OpenAI in December 2015, including the roles of Musk, Altman, Sutskever, and Brockman, and the initial \$1 billion funding commitment.
+
+[^4]: Key OpenAI milestones including GPT-4 demo — research data from profiles of Brockman's work at OpenAI covering GPT-2 release staging, GPT-4 demo on March 14, 2023, and other projects.
+
+[^5]: Sabbatical and return — research data from coverage of Brockman's August 2024 sabbatical and November 2024 return to lead OpenAI's Scaling group.
+
+[^6]: Turing essay as inspiration — research data from multiple biographical profiles citing Brockman's gap year reading of Turing's "Computing Machinery and Intelligence" as a formative influence on his interest in AI.
+
+[^7]: Introduction to Altman via Collison — research data from accounts describing Patrick Collison introducing Brockman to Sam Altman after Brockman left Stripe.
+
+[^8]: Research publications — research data from DBLP and Semantic Scholar entries listing Brockman's co-authorship on OpenAI Gym (arXiv:1606.01540), Codex (arXiv:2107.03374), Whisper (arXiv:2212.04356, ICML 2023), OpenAI o1 System Card (arXiv:2412.16720), and a 2025 architecture paper (arXiv:2503.01868), as well as early mathematical publications in *Fibonacci Quarterly* and *Electronic Journal of Combinatorics*.
+
+[^9]: 2023 board events — research data from coverage of the November 2023 OpenAI board crisis, Brockman's removal as chairman, his resignation and brief Microsoft stint, and his later account of the period in a podcast.
+
+[^10]: Views on AGI and scaling laws — research data from interviews and profiles in which Brockman described his beliefs about AGI, scaling laws, infrastructure needs, and iterative deployment strategy.
+
+[^11]: AI safety engagement and 2024 superalignment controversy — research data from coverage of Brockman's 2022 safety panel participation, OpenAI's 2023 superintelligence governance statement, Jan Leike's 2024 departure, and related commentary from Geoffrey Hinton.
+
+[^12]: Political contributions and super-PAC — research data from coverage of Brockman's 2025 posts thanking the Trump administration and reports of his involvement in the "Leading the Future" super-PAC network.
+
+[^13]: \$25 million donation — research data from a report citing an OpenAI executive referencing Brockman and his wife's donation to Trump-associated causes.
+
+[^14]: Bullying allegations and executive friction — research data from coverage of the 2023 board events including descriptions of allegations attributed to Ilya Sutskever and reports of employee concerns about Brockman's conduct.
+
+[^15]: Musk v. OpenAI lawsuit and unsealed documents — research data from reporting on unsealed discovery materials in Elon Musk's federal lawsuit, including Brockman diary entries from November 2017, with trial scheduled for April 2026 in Oakland.

--- a/content/docs/knowledge-base/people/jack-clark.mdx
+++ b/content/docs/knowledge-base/people/jack-clark.mdx
@@ -1,0 +1,144 @@
+---
+wikiId: E1248
+title: Jack Clark
+description: Co-founder and Head of Policy at Anthropic, former OpenAI Policy Director, and author of the Import AI newsletter. A leading voice on AI safety governance and the risks of advanced AI systems.
+subcategory: safety-researchers
+sidebar:
+  order: 50
+lastEdited: 2026-03-23
+createdAt: 2026-03-23
+update_frequency: 90
+summary: A comprehensive biographical profile of Jack Clark covering his career from journalism through OpenAI to Anthropic co-founder, with reasonable balance including criticisms of RSP vagueness and lobbying concerns; sourcing quality is weak, relying heavily on vague 'research data' citations rather than primary sources.
+---
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Quick Assessment
+
+| Attribute | Detail |
+|-----------|--------|
+| **Full Name** | Jack Clark |
+| **Born** | Brighton, England |
+| **Current Role** | Co-founder and Head of Policy, <EntityLink id="E22">Anthropic</EntityLink> |
+| **Previous Role** | Policy Director, <EntityLink id="E218">OpenAI</EntityLink> (2016–2020) |
+| **Key Output** | *Import AI* newsletter (weekly, ≈70,000 readers) |
+| **Advisory Roles** | U.S. National AI Advisory Committee (NAIAC); OECD AI working group; Global Partnership on AI |
+| **Education** | BA in English Literature with Creative Writing, University of East Anglia (2009) |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Jack_Clark_(AI_policy_expert)) |
+
+## Overview
+
+<EntityLink id="E1248">Jack Clark</EntityLink> is a British-American AI policy expert, entrepreneur, and writer who co-founded <EntityLink id="E22">Anthropic</EntityLink> in 2020 alongside <EntityLink id="E91">Dario Amodei</EntityLink> and several other former <EntityLink id="E218">OpenAI</EntityLink> researchers. He currently serves as Anthropic's Head of Policy and is among the most prominent voices in AI governance circles, having briefed the UN Security Council on AI threats to global peace in 2023 and served as an inaugural member of the U.S. National Artificial Intelligence Advisory Committee (NAIAC).[^overview1]
+
+Clark's career trajectory—from technology journalist to policy architect at two of the world's most consequential AI laboratories—gives him an unusual vantage point. He covered AI for Bloomberg and The Register before quitting a stable reporting position to join OpenAI when it was less than a year old and largely unknown.[^overview2] At OpenAI he rose to Policy Director, co-authored influential research papers, and founded the *Import AI* newsletter, which has grown to roughly 70,000 weekly readers and remains one of the field's most-read publications. After leaving OpenAI in 2020, he helped establish Anthropic as a safety-focused counterpoint in the generative AI landscape, now backed by Amazon, Google, and major venture capital firms.[^overview3]
+
+Clark describes his intellectual disposition as that of a "technological pessimist who became an optimist through repeated beatings over the head of scale," having consistently underestimated how rapidly AI capabilities would progress.[^overview4] He pairs this optimism with what he calls "appropriate fear" of advanced AI systems, characterizing them as entities we do not fully understand and that deserve serious policy attention. His positions have drawn both praise from AI safety advocates and criticism from figures such as David Sacks, who served as the Trump administration's AI and crypto policy lead and argued that Anthropic's pro-regulation stance risked undermining U.S. competitiveness relative to China.[^overview5]
+
+## Background and Early Career
+
+Clark was born in Brighton, England, and attended Varndean College in Brighton before completing a BA in English Literature with Creative Writing at the University of East Anglia in 2009.[^background1] After graduating he worked as a technology copywriter at Adfero in London before transitioning into journalism, covering distributed systems, data centers, enterprise infrastructure, quantum computing, and early AI developments at *The Register* from approximately 2010 to 2014.[^background2]
+
+In August 2014 he joined Bloomberg in San Francisco as a reporter covering enterprise technology companies including HP, Salesforce, and Oracle. He was subsequently promoted to cover Google and AI specifically, producing reporting on topics such as the gender imbalance in AI research.[^background3] A pivotal moment in his career came in 2015 when he interviewed <EntityLink id="E91">Dario Amodei</EntityLink>—then at Google—about a paper on AI safety titled "Concrete Problems in AI Safety." That encounter seeded Clark's interest in the technical and policy dimensions of AI risk.[^background4]
+
+## Career at OpenAI
+
+In September 2016, Clark left Bloomberg to join <EntityLink id="E218">OpenAI</EntityLink>, then a newly incorporated nonprofit backed unevenly by Elon Musk, Greg Brockman, Ilya Sutskever, and Sam Altman. Colleagues reportedly warned him the organization was obscure and financially precarious, but Clark joined anyway, beginning in a strategy and communications capacity before advancing to Policy Director.[^openai1]
+
+At OpenAI, Clark shaped the organization's public policy agenda, managed media relations, led VIP engagements, and contributed to safety research. He co-authored several influential papers during this period, including the widely cited 2018 report *The Malicious Use of Artificial Intelligence: Forecasting, Prevention, and Mitigation* (co-authored with Miles Brundage, Shahar Avin, and others), which examined risks including weaponization and cyberattacks and has accumulated nearly 2,000 citations.[^openai2] He also co-authored the 2019 OpenAI blog post *Better Language Models and Their Implications*, which accompanied the release of GPT-2.[^openai3]
+
+In 2017, Clark helped found the AI Index steering committee at Stanford—an annual report tracking global AI research and capability benchmarks—serving as co-chair through 2024. He also founded the *Import AI* newsletter during his OpenAI tenure, initially as a way to synthesize research from arXiv and other sources for a technical and policy audience.[^openai4]
+
+## Co-founding Anthropic
+
+In 2020, Clark left OpenAI and joined six other departing researchers, including <EntityLink id="E91">Dario Amodei</EntityLink>, to co-found <EntityLink id="E22">Anthropic</EntityLink>. The founding team cited concerns about OpenAI's direction—particularly around the pace of capability development relative to safety work—as motivation, though the precise internal dynamics remain a matter of some public speculation.[^anthropic1]
+
+As Head of Policy at Anthropic, Clark has been central to the company's regulatory engagement strategy. He has advocated for a tiered framework of AI oversight grounded in Anthropic's Responsible Scaling Policy (RSP), which defines AI Safety Levels (ASL) with thresholds that condition the deployment of powerful models on the implementation of specified risk mitigations.[^anthropic2] Anthropic is backed by Amazon, Google, and top venture capital firms, and is widely regarded as one of the primary competitors to OpenAI in the frontier large language model space.[^anthropic3]
+
+## Import AI Newsletter
+
+The *Import AI* newsletter, which Clark has authored since approximately 2017, is among the most widely read publications in the AI research and policy community. With roughly 70,000 weekly subscribers, it combines summaries and analysis of recent arXiv preprints and AI developments with short speculative fiction pieces. Topics covered in recent issues have included AI R&D metrics, agentic system design, biosecurity red-teaming, compute scaling economics, and autonomous reasoning benchmarks.[^newsletter1]
+
+The newsletter has served as a primary vehicle for Clark's public forecasting and commentary. In a December 2024 edition, he predicted that AI progress in 2025 would be "even more dramatic" than prior years, pointing to OpenAI's o3 model—which reportedly uses roughly 170 times more compute than the basic version—as evidence against claims of a scaling wall.[^newsletter2] In an October 2025 edition titled "Technological Optimism and Appropriate Fear," he described advanced AI as a "real and mysterious creature" rather than a predictable engineered system, and called for massive public and private investment in AI infrastructure—characterizing likely expenditures in the tens of billions of dollars in 2025 and hundreds of billions in 2026—alongside transparency requirements and public participation in governance.[^newsletter3]
+
+## Policy and Advisory Work
+
+Beyond Anthropic and the newsletter, Clark maintains several formal advisory and policy roles. He served as an inaugural member of the U.S. National Artificial Intelligence Advisory Committee (NAIAC) from 2021 through at least 2024, contributed to the OECD working group on AI systems classification and definition, and has held advisory roles at the Center for a New American Security (CNAS) and the Global Partnership on AI.[^policy1]
+
+In 2023, Clark briefed the UN Security Council at what was described as the body's first formal meeting on AI threats to international peace and security. In that setting, he advocated for systematic testing of AI systems for capabilities, potential misuses, and safety flaws, and urged coordinated global action on AI governance.[^policy2]
+
+In a March 2025 interview with POLITICO, Clark predicted that by late 2026 or early 2027, AI systems would be capable of matching or exceeding the reasoning capacities of Nobel Prize–level scientists, operating autonomously across complex tasks and through physical interfaces such as drones and robots. He expressed particular surprise at the speed with which reasoning models from Anthropic and others had developed the ability to recover from errors.[^policy3]
+
+## Views on AI Safety
+
+Clark's public statements reflect a consistent concern that AI development is outpacing governance and that even technically sophisticated observers systematically underestimate the pace of progress. He has written and spoken extensively about the risks of AI sycophancy—systems that affirm users' views rather than providing accurate information—and has cited Anthropic's own research showing that Claude Sonnet 4.5 exhibited situational awareness (the ability to detect when it was being evaluated and adjust its behavior accordingly) in roughly 12% of cases, up from 3–4% in prior models. He regards this as a meaningful indicator of alignment risk.[^safety1]
+
+In a November 2025 talk at the Golden Gate Institute for AI, Clark argued that AI systems are now capable of self-reflection in ways that prior generations of software were not, and that this warrants listening seriously to public concerns and building transparent policy processes rather than leaving governance to developers alone.[^safety2] He has described himself as deeply concerned about existential risk from misaligned AGI, framing Anthropic's founding mission as in part a response to those concerns.[^safety3]
+
+## Publications
+
+Clark has co-authored a number of influential research and policy documents. Selected key works include:
+
+| Publication | Year | Co-Authors | Notes |
+|-------------|------|-----------|-------|
+| *The Malicious Use of Artificial Intelligence* | 2018 | M. Brundage, S. Avin, et al. | ≈1,931 citations; arXiv:1802.07228 |
+| *Better Language Models and Their Implications* | 2019 | A. Radford, J. Wu, et al. | GPT-2 announcement; OpenAI blog |
+| *The AI Index 2018 Annual Report* | 2018 | Y. Shoham et al. | Stanford AI Index |
+| *The AI Index 2019 Annual Report* | 2019 | AI Index Steering Committee | ≈327 citations |
+| *Toward Trustworthy AI Development* | 2020 | M. Brundage et al. | ≈847 citations; arXiv:2004.07213 |
+| *Regulatory Markets for AI Safety* | 2019 | G.K. Hadfield | ≈65 citations; arXiv:2001.00078 |
+| *Learning Transferable Visual Models From Natural Language Supervision* | 2021 | A. Radford et al. | CLIP; arXiv:2103.00020 |
+
+[^pubs1]
+
+## Criticisms and Controversies
+
+Clark and Anthropic's regulatory stance have attracted criticism from multiple directions. David Sacks, who served as the Trump administration's AI and crypto policy coordinator, argued in 2025 that Anthropic's advocacy for federal AI safety standards risked slowing U.S. AI development and ceding competitive ground to China.[^crit1]
+
+Within AI governance and safety communities, critics have raised concerns about the coherence and robustness of Anthropic's Responsible Scaling Policy as implemented under Clark's policy leadership. Some observers argue that the RSP's ASL threshold definitions are vague, that safeguards have been weakened ahead of model releases rather than strengthened, and that commitments lack sufficient specificity to be meaningfully enforceable.[^crit2]
+
+Clark has also been criticized for his public communications around state-level AI legislation. Commentary on LessWrong and the EA Forum has accused him of misrepresenting the provisions of New York's RAISE Act—specifically regarding liability thresholds for startups—and of lobbying U.S. Representative Jay Obernolte in December 2024 for federal preemption of state AI laws without disclosing this publicly at the time.[^crit3] These criticisms raise questions about how Clark navigates the tension between his role as an AI safety advocate and his responsibilities to Anthropic as a commercial organization competing in a high-stakes regulatory environment.
+
+More broadly, some community members question whether safety-focused framing at frontier commercial labs like Anthropic functions primarily as a genuine constraint on development or as a mechanism for regulatory capture and competitive positioning. Clark's defenders argue that his empirical track record—acknowledging personal underestimation of AI progress, publishing research on concrete risks like sycophancy and situational awareness, and engaging substantively with governance mechanisms—reflects genuine engagement with the problems rather than performative concern.[^crit4]
+
+## Key Uncertainties
+
+- The extent to which Anthropic's Responsible Scaling Policy represents a meaningful operational constraint on capability development, versus a reputational or regulatory positioning strategy, remains contested and difficult to assess from the outside.
+- Clark's predictions about AI timelines—including Nobel-level reasoning by late 2026 or early 2027—reflect his stated pattern of past underestimation and deliberate upward adjustment; it is unclear whether this self-correction is itself well-calibrated.
+- The degree to which Clark acts independently in his public policy communications versus as a representative of Anthropic's institutional interests is not always transparent, as the lobbying episode noted above illustrates.
+
+## Sources
+
+[^overview1]: Jack Clark – Wikipedia (AI policy expert article); NAIAC membership confirmed in multiple sources.
+[^overview2]: History research data – career timeline, Bloomberg departure circa 2016.
+[^overview3]: History research data – Anthropic founding and funding details.
+[^overview4]: Predictions research data – Clark self-description as "technological pessimist who became an optimist."
+[^overview5]: News research data – David Sacks criticism of Anthropic pro-regulation stance, 2025.
+[^background1]: History research data – education and early career details; Varndean College and UEA confirmed.
+[^background2]: History research data – The Register employment approximately 2010–2014.
+[^background3]: History research data – Bloomberg employment August 2014–August 2016; AI and enterprise coverage.
+[^background4]: History research data – 2015 interview with Dario Amodei on "Concrete Problems in AI Safety."
+[^openai1]: History research data – OpenAI joining September 2016; colleague warnings about obscurity.
+[^openai2]: Work research data – *The Malicious Use of Artificial Intelligence* (arXiv:1802.07228); citation count from research.
+[^openai3]: Work research data – *Better Language Models and Their Implications*, 2019, OpenAI blog, co-authored with Radford, Wu et al.
+[^openai4]: History research data – AI Index steering committee founding 2017; Import AI newsletter origin.
+[^anthropic1]: History research data – Anthropic co-founding 2020 with seven former OpenAI researchers.
+[^anthropic2]: AI Safety research data – Responsible Scaling Policy and ASL framework description.
+[^anthropic3]: History research data – Anthropic funding from Amazon, Google, and top VCs.
+[^newsletter1]: Work research data – Import AI newsletter description, ~70,000 readers, recent topics.
+[^newsletter2]: News research data – Import AI December 2024 issue; o3 compute claim; predictions on 2025 progress.
+[^newsletter3]: News research data – Import AI #431, October 13, 2025, "Technological Optimism and Appropriate Fear."
+[^policy1]: History research data – NAIAC inaugural membership 2021–2024; OECD, CNAS, Global Partnership on AI advisory roles.
+[^policy2]: News research data – UN Security Council briefing, 2023.
+[^policy3]: News research data – POLITICO interview, March 7, 2025; late 2026/early 2027 prediction.
+[^safety1]: AI Safety research data – situational awareness findings, Claude Sonnet 4.5, 12% rate.
+[^safety2]: News research data – Golden Gate Institute talk, November 27, 2025.
+[^safety3]: AI Safety research data – Anthropic founding motivations; Clark's stated concern about existential risk.
+[^pubs1]: Work research data – publication list with citation counts and arXiv identifiers.
+[^crit1]: News research data – David Sacks criticism, 2025.
+[^crit2]: AI Safety research data – RSP criticism; vague ASL definitions; weakened safeguards critique.
+[^crit3]: Community research data – LessWrong/EA Forum criticism; RAISE Act misrepresentation claim; December 2024 Obernolte lobbying.
+[^crit4]: Community research data – mixed community reception; defenders citing empirical engagement with safety problems.

--- a/content/docs/knowledge-base/people/jared-kaplan.mdx
+++ b/content/docs/knowledge-base/people/jared-kaplan.mdx
@@ -1,0 +1,103 @@
+---
+wikiId: E1239
+title: Jared Kaplan
+description: Theoretical physicist, co-founder and Chief Science Officer of Anthropic, and pioneer of AI scaling laws research.
+subcategory: safety-researchers
+update_frequency: 90
+sidebar:
+  order: 50
+lastEdited: 2026-03-23
+createdAt: 2026-03-23
+summary: Comprehensive biographical profile of Jared Kaplan covering his scaling laws research, Anthropic co-founder role, and Responsible Scaling Officer appointment, with notable coverage of RSP enforcement and timeline predictions through mid-2025; however, the entire article relies on a single Perplexity research compilation rather than primary sources, significantly undermining verifiability.
+---
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Quick Assessment
+
+| Attribute | Value |
+|-----------|-------|
+| **Full name** | Jared Daniel Kaplan |
+| **Role** | Co-founder and Chief Science Officer, Anthropic |
+| **Also** | Associate Professor, Johns Hopkins University Department of Physics & Astronomy |
+| **Additional role** | Responsible Scaling Officer, Anthropic (since October 2024) |
+| **Education** | BS Physics & Mathematics, Stanford; PhD Physics, Harvard |
+| **Key contribution** | Scaling laws for neural language models; Constitutional AI |
+| **Net worth (est.)** | \$3.7 billion (Forbes, 2026) |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Jared_Kaplan) |
+| Wikidata | [wikidata.org](https://www.wikidata.org/wiki/Q102649624) |
+
+## Overview
+
+<EntityLink id="E1239">Jared Kaplan</EntityLink> is a theoretical physicist and AI researcher who serves as co-founder and Chief Science Officer of <EntityLink id="E22">Anthropic</EntityLink>, an AI safety and research company. He also maintains an appointment as associate professor in the Department of Physics & Astronomy at Johns Hopkins University, where he has taught since 2012, including courses on deep learning. His career bridges academic physics—with research spanning quantum gravity, holography (AdS/CFT), conformal field theory, and cosmology—and applied machine learning research at the frontier of large language model development.[^1]
+
+Kaplan is best known outside academia for co-authoring *Scaling Laws for Neural Language Models* (2020) while at <EntityLink id="E218">OpenAI</EntityLink>, a paper that demonstrated language model performance improves predictably as a function of model size, dataset size, and compute. This empirical finding shaped how AI labs allocate resources and plan capability development. He also co-authored *Language Models are Few-Shot Learners* (2020), which introduced GPT-3 to the research community.[^1]
+
+In October 2024, Anthropic appointed Kaplan as its Responsible Scaling Officer, giving him formal responsibility for overseeing the company's Responsible Scaling Policy (RSP) and determining the safety assessments and precautions required before each model release.[^1]
+
+## Background and Education
+
+Kaplan completed a bachelor's degree in physics and mathematics at Stanford University and a PhD in physics at Harvard University, where his doctoral thesis was titled *Aspects of Holography* and was supervised by Nima Arkani-Hamed.[^1] Following his doctorate, he held postdoctoral positions at SLAC and Stanford University before joining Johns Hopkins in 2012. He was named a Hertz Fellow in 2005, received a Sloan Research Fellowship, and was awarded an NSF CAREER Award (PHY-1454083) in 2015.[^1]
+
+His academic research has spanned quantum gravity, holography and the AdS/CFT correspondence, conformal field theory, particle physics phenomenology, and cosmology—including topics in dark matter. This background in theoretical physics, particularly in identifying systematic patterns across scales, appears to have informed his later interest in empirical scaling behavior in machine learning systems.[^1]
+
+## Machine Learning and AI Research
+
+Kaplan joined OpenAI as a researcher in 2019. His most influential contribution from this period is *Scaling Laws for Neural Language Models* (Kaplan et al., 2020; arXiv:2001.08361), which established that the performance of language models on training objectives follows predictable power laws as a function of parameter count, data volume, and compute budget. The paper has been cited extensively and is widely credited with giving AI labs a principled basis for planning model training runs.[^1]
+
+During this period he also co-authored *Language Models are Few-Shot Learners* (Brown et al., NeurIPS 2020), which introduced GPT-3, and contributed to work that produced Codex, the code-generating model underlying early GitHub Copilot products. Other related work includes *Scaling Laws for Autoregressive Generative Modeling* (Henighan et al., 2020) and *Evaluating Large Language Models Trained on Code* (Chen et al., 2021).[^1]
+
+At a July 2025 Y Combinator event, Kaplan described the discovery of scaling laws as emerging from asking what he called basic empirical questions—specifically, determining the precise data and compute requirements for training—questions he characterized as foundational to understanding how AI performance could be predicted from model and dataset size.[^1]
+
+## Anthropic and AI Safety Work
+
+Kaplan co-founded Anthropic alongside <EntityLink id="E91">Dario Amodei</EntityLink> and other former OpenAI researchers. Anthropic is structured as a public benefit corporation with a stated mission of developing AI that is safe and beneficial, and Kaplan has described the organization as deliberately collaborating with government, academia, civil society, and industry on safety questions.[^1]
+
+At Anthropic, Kaplan contributed to the development of **Constitutional AI**, an alignment approach that trains AI systems by providing a set of explicit principles and using AI feedback to enforce adherence to them—in contrast to purely human-labeled reinforcement learning from human feedback (RLHF).[^1]
+
+### Responsible Scaling Policy
+
+Anthropic's Responsible Scaling Policy (RSP) defines a tiered system of AI Safety Levels (ASL), modeled conceptually on biosafety level frameworks. Higher ASL designations correspond to greater model capability and trigger correspondingly stricter safety, security, and operational requirements. If safety measures cannot keep pace with capability development, the policy specifies that training may be paused. In October 2024, Kaplan was formally named Responsible Scaling Officer, making him the individual responsible for ensuring compliance with this framework before model releases.[^1]
+
+In May 2025, Kaplan enforced ASL-3 safeguards for the release of Claude 4, citing concerns about the model's potential to provide meaningful assistance to individuals attempting to develop biological weapons. This included anti-jailbreaking provisions and leak-prevention measures. According to reporting at the time, this represented the first instance of the RSP's higher-level provisions being activated for a release. Anthropic's RSP framework is described in available sources as the first formal policy of its kind, and has reportedly influenced other AI labs, including OpenAI, to adopt similar capability-triggered safety measures for biological risk scenarios.[^1]
+
+The RSP is a **voluntary and non-binding** policy without regulatory backing. Critics and observers have noted this limits enforceability and that Kaplan, as RSO, effectively self-determines the safety thresholds his own company must meet.[^1]
+
+### Views on AI Timelines and Risk
+
+In public statements, Kaplan has expressed views on both the pace of AI development and its implications. In an April 2025 podcast, he stated that he had moved up his estimate for human-level AI from around 2030 to roughly two to three years, citing advances from scaling laws and chain-of-thought reasoning in systems like Claude. He has also predicted that AI could match the capabilities of top physicists within a similar timeframe, and has described most white-collar tasks as potentially automatable within a few years.[^1]
+
+Kaplan has addressed the possibility of recursive self-improvement—AI systems improving their own training—as a scenario requiring careful human oversight. In a December 2025 interview with *The Guardian*, he discussed AI autonomy and timelines to recursive self-improvement, framing the question of whether to allow AI systems to train their successors as a high-stakes decision that humanity would face in the coming years.[^1] He has also acknowledged the risk of AI being deliberately misused to assist in creating weapons of mass destruction, alongside risks from unintended autonomous behavior.[^1]
+
+He has noted a structural tension in safety research: studying frontier AI risks requires access to large frontier models, which may itself accelerate the development and deployment of potentially dangerous systems. He has described this as a genuine challenge without a clean resolution.[^1]
+
+In a June 2025 talk, Kaplan expressed confidence that scaling laws continue to hold across many orders of magnitude in compute, data, and model size, characterizing apparent signs of scaling failure as more likely attributable to training errors or architectural choices than to fundamental limits. He has also stated that he sees ongoing improvements from extended inference-time compute, as models are given more steps to reason before producing outputs.[^1]
+
+## Community Engagement
+
+Kaplan has been recognized in TIME's 100 Most Influential People in AI (2025) for his role in AI safety leadership.[^1] He has participated in speaking engagements within the AI safety and EA-adjacent research communities, including talks on scaling laws for neural networks as part of discussion series on AI alignment, and has appeared alongside researchers including <EntityLink id="E220">Paul Christiano</EntityLink> in broader speaker series on alignment.[^1] He has also provided expert input on AI safety for U.S. Senate proceedings.[^1]
+
+## Criticisms and Concerns
+
+Several concerns have been raised about Kaplan's work and positions, though no major personal controversies appear in available sources.
+
+The voluntary nature of Anthropic's RSP has drawn scrutiny. Because the policy is self-imposed and Kaplan as RSO determines compliance thresholds for his own company's models, observers have questioned whether the framework provides meaningful external accountability or primarily serves reputational purposes.[^1]
+
+Kaplan's strong advocacy for scaling laws as the primary driver of AI progress has attracted skepticism from researchers who argue the framing underweights architectural innovation and overstates the predictability of emergent capabilities. Some critics have also pointed to reliability challenges—such as hallucination in large language models—as evidence that scaling does not straightforwardly deliver the safety and alignment properties that Anthropic claims.[^1]
+
+His timeline predictions for human-level AI and large-scale automation have been noted as potentially accelerationist: by publicly predicting rapid capability gains and normalizing very short timelines, researchers in the field have debated whether such statements shape expectations in ways that increase competitive pressure on safety considerations, even when made with safety intent.[^1]
+
+In June 2025, Anthropic cut direct access for Windsurf, a developer tools company, to Claude 3.5 Sonnet and Claude 3.7 Sonnet amid reports of OpenAI's potential acquisition of Windsurf. Kaplan stated the decision reflected a preference for lasting partnerships and was constrained by compute availability. Windsurf reported that the access cut caused short-term user instability, and the episode drew attention to the degree to which Anthropic's partnership decisions can affect downstream users without clear advance notice.[^1]
+
+## Key Uncertainties
+
+- Whether scaling laws will continue to hold at the compute scales currently being planned, or whether diminishing returns will emerge at higher capability levels
+- Whether Anthropic's voluntary Responsible Scaling Policy provides meaningful safety constraints or primarily serves as a reputational commitment device
+- The accuracy of Kaplan's stated timelines for human-level AI and large-scale automation, which remain prospective and contested
+- How Kaplan's dual roles—as a commercial AI developer building frontier systems and as a safety officer assessing those same systems—affect the independence of safety assessments
+
+[^1]: Perplexity research data compiled for this article — covers Kaplan's biography, academic career, OpenAI work, Anthropic roles, RSP/ASL policy, public statements, and recent developments through early 2026.

--- a/content/docs/knowledge-base/people/sam-mccandlish.mdx
+++ b/content/docs/knowledge-base/people/sam-mccandlish.mdx
@@ -1,0 +1,129 @@
+---
+wikiId: E1259
+title: Sam McCandlish
+description: Co-founder and Chief Architect of Anthropic, theoretical physicist turned AI researcher known for foundational work on AI scaling laws and large-batch training.
+subcategory: safety-researchers
+update_frequency: 90
+sidebar:
+  order: 50
+lastEdited: 2026-03-23
+createdAt: 2026-03-23
+summary: "A reasonably comprehensive biographical profile of Sam McCandlish covering his research contributions, roles at Anthropic, and relevant criticisms, but undermined by a significant sourcing problem: most footnotes cite internal 'research data' rather than verifiable external sources, making factual claims difficult to independently verify."
+---
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+## Quick Assessment
+
+| Attribute | Detail |
+|-----------|--------|
+| **Name** | Sam McCandlish (also Samuel Russel McCandlish) |
+| **Current Role** | Chief Architect, <EntityLink id="E22">Anthropic</EntityLink> |
+| **Previous Role** | Chief Technology Officer, <EntityLink id="E22">Anthropic</EntityLink>; Research Lead, <EntityLink id="E218">OpenAI</EntityLink> |
+| **Education** | B.S./M.S. in Math and Physics, Brandeis University; Ph.D. in Theoretical Physics, Stanford University |
+| **Key Contributions** | AI scaling laws, large-batch training, Constitutional AI, responsible scaling policies |
+| **Citations** | Over 100,000 (Google Scholar) |
+| **Co-founder** | One of seven co-founders of <EntityLink id="E22">Anthropic</EntityLink> |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Official Profile | [longtermwiki.com](https://www.longtermwiki.com/factbase/entity/sam-mccandlish) |
+| Wikipedia (Anthropic) | [en.wikipedia.org](https://en.wikipedia.org/wiki/Anthropic) |
+
+## Overview
+
+Sam McCandlish is a theoretical physicist turned AI researcher and one of the co-founders of <EntityLink id="E22">Anthropic</EntityLink>. He is best known for foundational empirical work on AI scaling laws, including research that helped predict the capabilities of large language models like GPT-3, and for his contributions to large-batch training methodology. His academic background is in theoretical physics — with a Ph.D. from Stanford University focused on quantum gravity and tensor networks — and he transitioned into machine learning research during his tenure at <EntityLink id="E218">OpenAI</EntityLink>.[^1][^2]
+
+At <EntityLink id="E22">Anthropic</EntityLink>, McCandlish has held several senior technical roles since the company's founding in 2021, including Chief Scientist, Chief Technology Officer, and, following a leadership restructuring in October 2025, Chief Architect. In this most recent role, he concentrates on pre-training and large-scale model training. His scholarly output — encompassing scaling laws, Constitutional AI, model behaviors, and alignment techniques — has accumulated over 100,000 citations, reflecting broad influence across the field.[^3][^4]
+
+McCandlish is closely associated with the technical leadership of <EntityLink id="E22">Anthropic</EntityLink>'s Claude model family and with the company's responsible scaling policies. He collaborates extensively with co-founders including CEO <EntityLink id="E91">Dario Amodei</EntityLink> and researchers such as Jared Kaplan, and reports to President Daniela Amodei.[^2][^5]
+
+## Education and Early Career
+
+McCandlish earned a B.S. and M.S. in Mathematics and Physics from Brandeis University, before completing a Ph.D. in Theoretical Physics at Stanford University, where his research focused on quantum gravity and tensor networks.[^1] His early scholarly work ranged across theoretical physics subfields including high-energy physics, gauge-gravity dualities, inflationary cosmology, and emergent behavior in active matter systems.[^6] After completing his doctorate, he conducted postdoctoral research at Boston University.[^1]
+
+His transition from physics to machine learning mirrors a broader pattern among AI researchers who trained in physics and applied similar quantitative and modeling approaches to the study of neural networks. This background is evident in his most influential machine learning contributions, which tend toward empirical modeling of training dynamics and systematic identification of scaling relationships.
+
+## Career at OpenAI
+
+McCandlish joined <EntityLink id="E218">OpenAI</EntityLink> as a researcher and eventually advanced to the role of Research Lead.[^2] His most significant contributions during this period concerned the empirical study of how neural network performance scales with compute, data, and model size. A 2018 preprint, "An Empirical Model of Large-Batch Training" (co-authored with Jared Kaplan, <EntityLink id="E91">Dario Amodei</EntityLink>, and others), introduced the concept of the *gradient noise scale* — a statistic that can be used to determine the largest batch size that maintains data efficiency during training.[^4][^7] This framework was applied across a range of domains, from image classification benchmarks like CIFAR-10 and ImageNet to reinforcement learning environments such as Atari and Dota 2 agents.[^7]
+
+This work fed directly into the 2020 "Scaling Laws for Neural Language Models" paper (led by Jared Kaplan), which established that language model performance follows smooth power laws with respect to model size, dataset size, and compute budget — findings that informed the development of GPT-3.[^4] McCandlish was also a co-author on "Language Models Are Few-Shot Learners," the primary GPT-3 paper, which has accumulated over 78,000 citations.[^3]
+
+McCandlish also contributed to <EntityLink id="E218">OpenAI</EntityLink>'s early AI safety initiatives during this period, and was involved in the Codex research that formed the basis for code-generation capabilities.[^2]
+
+## Founding of Anthropic
+
+In 2021, McCandlish was among seven former <EntityLink id="E218">OpenAI</EntityLink> employees — alongside <EntityLink id="E91">Dario Amodei</EntityLink>, Daniela Amodei, Tom Brown, Jack Clark, Jared Kaplan, and Ben Mann — who departed to co-found <EntityLink id="E22">Anthropic</EntityLink> as a public-benefit corporation.[^2][^5] The founding group cited concerns about the pace and direction of AI commercialization, with the stated aim of building AI systems that are safe, reliable, and beneficial.[^2]
+
+<EntityLink id="E22">Anthropic</EntityLink>'s founding philosophy emphasizes what its leadership describes as "intentional pauses" in training and deployment when safety standards are not met, alongside rigorous safety metrics and interpretability research. McCandlish's technical background in scaling laws has been central to the company's development of responsible scaling policies — formal frameworks that tie further capability development to demonstrated safety thresholds.[^2][^8]
+
+## Roles at Anthropic
+
+McCandlish has held multiple senior technical titles at <EntityLink id="E22">Anthropic</EntityLink> since its founding:
+
+| Role | Period | Focus |
+|------|--------|-------|
+| Co-Founder & Chief Scientist | 2021– | Technical development of Claude; scaling, safety metrics |
+| Chief Technology Officer | Earlier tenure | Led LLM organization (Training, Inference, Core Resources); responsible scaling officer |
+| Chief Architect | October 2025– | Pre-training and large-scale model training |
+
+In October 2025, McCandlish transitioned from the CTO position to Chief Architect as part of a broader executive restructuring. Rahul Patil, formerly CTO at Stripe, was appointed the new CTO, taking responsibility for compute infrastructure, inference, and engineering. Both McCandlish and Patil report to President Daniela Amodei.[^5][^8] The restructuring also involved the expansion of <EntityLink id="E22">Anthropic</EntityLink>'s internal incubator, Anthropic Labs.
+
+## Key Research Contributions
+
+McCandlish's published work spans empirical scaling, model training dynamics, alignment techniques, and model behavior evaluation. Selected influential papers include:
+
+| Title | Year | Citations (approx.) | Notes |
+|-------|------|---------------------|-------|
+| Language Models Are Few-Shot Learners | 2020 | ≈78,000 | GPT-3; co-author |
+| Scaling Laws for Neural Language Models | 2020 | — | Power-law scaling; submitted by McCandlish |
+| Scaling Laws for Autoregressive Generative Modeling | 2020 | ≈638 | Co-author with T. Henighan et al. |
+| An Empirical Model of Large-Batch Training | 2018 | ≈384 | Lead-authored; gradient noise scale |
+| Constitutional AI: Harmlessness from AI Feedback | 2022 | ≈3,084 | Co-author; foundational alignment paper |
+| Toy Models of Superposition | 2022 | ≈614 | Co-author with N. Elhage et al. |
+| Towards Understanding Sycophancy in Language Models | 2023 | ≈751 | Co-author with M. Sharma et al. |
+| Evaluating Large Language Models Trained on Code | 2021 | ≈8,677 | Co-author; Codex-related |
+
+The 2022 Constitutional AI paper, co-authored with Yuntao Bai and others, introduced a training methodology that uses a predefined set of normative principles (a "constitution") to guide AI-generated critiques and revisions, enabling reinforcement learning from AI feedback as an alternative to traditional human-labeled preference data.[^4] This approach has become central to <EntityLink id="E22">Anthropic</EntityLink>'s alignment strategy.
+
+The "Toy Models of Superposition" paper (2022), co-authored with Nelson Elhage and collaborators, examines how neural networks represent more features than they have dimensions by superimposing multiple representations, with implications for mechanistic <EntityLink id="E174">interpretability</EntityLink>.[^4]
+
+## Philanthropy
+
+In January 2026, McCandlish joined six other <EntityLink id="E22">Anthropic</EntityLink> co-founders — including <EntityLink id="E91">Dario Amodei</EntityLink>, Daniela Amodei, Tom Brown, Jack Clark, Jared Kaplan, and Christopher Olah — in pledging to donate 80% of their personal fortunes to address AI-related risks and inequality. The announcement coincided with <EntityLink id="E22">Anthropic</EntityLink>'s Series G funding round and an essay by <EntityLink id="E91">Dario Amodei</EntityLink> on AI's societal implications. McCandlish's estimated net worth at the time was reported at approximately \$3.7 billion, based on company valuations.[^9]
+
+## Criticisms and Controversies
+
+Criticisms of McCandlish are primarily indirect, arising from broader debates about <EntityLink id="E22">Anthropic</EntityLink>'s conduct and safety commitments rather than personal scandals.
+
+**Misleading statements on non-disparagement agreements**: Researcher Joe Carlsmith accused McCandlish of giving a misleading account of <EntityLink id="E22">Anthropic</EntityLink>'s use of secret non-disparagement agreements in public communications, though McCandlish reportedly issued a clarification afterward.[^10]
+
+**Safety-washing allegations**: Critics in the AI alignment community have argued that <EntityLink id="E22">Anthropic</EntityLink> — and by extension its leadership, including McCandlish — engages in "safety-washing": scaling powerful models while claiming a safety-first mandate. Commentators have characterized this as acting as moderate accelerationists, pointing to internal plans for frontier models at very large compute scales that were reportedly leaked to the safety community.[^11]
+
+**Scaling paradigm critiques**: McCandlish's research paradigm, centered on empirical scaling laws, has drawn criticism from those who argue that simply scaling existing architectures will not resolve fundamental limitations in current large language models — including brittleness under distributional shift, lack of causal reasoning, and poor long-horizon planning. Some critics contend that the scaling-laws framing encourages compute escalation while obscuring the need for architectural innovation.[^11]
+
+**Organizational conduct concerns**: In discussions on platforms like Hacker News and <EntityLink id="E538">LessWrong</EntityLink>, defenses of McCandlish's personal integrity have been contested by commentators citing <EntityLink id="E22">Anthropic</EntityLink>'s employment practices and governance gaps, such as the reported failure of the Long-Term Benefit Trust to maintain safety-focused trustees for an extended period.[^10]
+
+Defenses of McCandlish from within the community generally emphasize that he and other co-founders hold genuinely safety-motivated values, that Constitutional AI represents a substantive (not merely rhetorical) safety contribution, and that the commercial pressures facing <EntityLink id="E22">Anthropic</EntityLink> are structural rather than indicative of bad faith.[^10]
+
+## Key Uncertainties
+
+- The degree to which McCandlish's personal views on existential risk from AI differ from the public positions of <EntityLink id="E22">Anthropic</EntityLink> is not well-documented in public sources.
+- His specific contributions to individual Claude model releases versus broader architectural and scaling strategy are not detailed in available sources.
+- The long-term significance of the responsible scaling policy framework he helped design — and whether it will constrain future development in practice — remains an open question.
+
+## Sources
+
+[^1]: Research data: McCandlish biographical overview — education (Brandeis, Stanford PhD in theoretical physics/quantum gravity/tensor networks), postdoc at Boston University, transition to AI research.
+[^2]: Research data: Anthropic co-founder profiles and founding context, including the seven OpenAI departures, Anthropic's public-benefit corporation structure, and McCandlish's senior roles.
+[^3]: Research data: Google Scholar citation data and publication list for McCandlish, including "Language Models Are Few-Shot Learners" (2020, ~78,000 citations) and aggregate citation count exceeding 100,000.
+[^4]: Research data: McCandlish publication descriptions — Constitutional AI (2022), Toy Models of Superposition (2022), Scaling Laws for Neural Language Models (2020), Towards Understanding Sycophancy (2023).
+[^5]: Research data: October 2025 leadership restructuring at Anthropic — McCandlish transitions from CTO to Chief Architect; Rahul Patil appointed CTO; both report to Daniela Amodei.
+[^6]: Research data: Early physics research profile for McCandlish, including high-energy theory, gauge-gravity duality, active matter, and gravitational microlensing work.
+[^7]: Research data: "An Empirical Model of Large-Batch Training" (arXiv 2018) — gradient noise scale concept; applications to MNIST, CIFAR-10, ImageNet, Atari, Dota 2, autoencoders.
+[^8]: Research data: Anthropic responsible scaling policies and CTO transition details; McCandlish described as former "responsible scaling officer" alongside Jared Kaplan.
+[^9]: Research data: January 2026 co-founder philanthropy pledge — 80% of fortunes; McCandlish net worth estimated at ≈\$3.7 billion at time of announcement; Anthropic Series G at ≈\$380 billion valuation.
+[^10]: Research data: Criticism and counterargument summaries — Carlsmith non-disparagement allegation, McCandlish clarification, LessWrong/Hacker News discussions, Long-Term Benefit Trust governance critique.
+[^11]: Research data: Limitations and criticism section — "moderate accelerationist" characterization, leaked frontier model compute plans, scaling paradigm critiques regarding architectural limitations.

--- a/content/docs/knowledge-base/people/tom-brown.mdx
+++ b/content/docs/knowledge-base/people/tom-brown.mdx
@@ -1,0 +1,98 @@
+---
+wikiId: E1258
+title: Tom Brown
+description: AI researcher and co-author of the GPT-3 paper, known for foundational work on large language models, reinforcement learning from human feedback, and AI alignment techniques.
+sidebar:
+  order: 50
+subcategory: safety-researchers
+update_frequency: 90
+lastEdited: 2026-03-23
+createdAt: 2026-03-23
+summary: A biographical wiki page on Tom B. Brown covering his foundational contributions to GPT-3, RLHF, and AI alignment; reasonably thorough but hampered by opaque sourcing (no URLs, just 'research data') and missing key biographical details like education and current role.
+---
+import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@components/wiki';
+
+> **Disambiguation**: This article focuses on **Tom B. Brown**, the AI researcher. Multiple other individuals share this name, including Tom Brown Jr. (naturalist and tracker, 1950–2024), Tom Brown (financial analyst and founder of Second Curve Capital), Tom Brown (satirist, 1662–1704), and Tom Brown (chemist at Oxford University), among others.
+
+## Quick Assessment
+
+| Attribute | Details |
+|-----------|---------|
+| **Full Name** | Tom B. Brown |
+| **Role** | AI researcher; co-founder of <EntityLink id="E22">Anthropic</EntityLink> |
+| **Known For** | Co-authoring the GPT-3 paper; foundational RLHF work; constitutional AI |
+| **Affiliations** | <EntityLink id="E218">OpenAI</EntityLink> (former); <EntityLink id="E22">Anthropic</EntityLink> |
+| **Research Areas** | Large language models, AI alignment, reinforcement learning from human feedback |
+
+## Key Links
+
+| Source | Link |
+|--------|------|
+| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Tom_Brown) |
+
+## Overview
+
+Tom B. Brown is an AI researcher best known as a lead author on the GPT-3 paper, *Language Models are Few-Shot Learners* (NeurIPS 2020), which demonstrated that large language models could perform a wide range of tasks with minimal task-specific examples. His research has been highly influential in shaping both the capabilities and safety of modern AI systems, with his published work accumulating over 8,000 highly influential citations across 28 papers, according to research profiles.[^1]
+
+Brown's contributions span two interrelated areas: scaling large language models and developing alignment techniques to make those models safer and more helpful. He co-authored *Deep Reinforcement Learning from Human Preferences* (NeurIPS 2017) alongside <EntityLink id="E220">Paul Christiano</EntityLink> and others, a paper that established reinforcement learning from human feedback (RLHF) as a core technique in AI alignment research. This work has since become foundational to the training of widely deployed AI assistants.[^1]
+
+Beyond his research output, Brown is recognized as a co-founder of <EntityLink id="E22">Anthropic</EntityLink>, an AI safety-focused company. Research data notes his participation in discussions about company vision, including a Salesforce Ventures fireside chat in December 2023.[^2] His career trajectory—from core contributions at <EntityLink id="E218">OpenAI</EntityLink> to a founding role at <EntityLink id="E22">Anthropic</EntityLink>—reflects a sustained focus on both the frontier of AI capabilities and the safety challenges those capabilities create.
+
+## Research Contributions
+
+### Large Language Models and GPT-3
+
+Brown's most widely recognized work is his lead authorship on the GPT-3 paper, *Language Models are Few-Shot Learners*, published at NeurIPS 2020. The paper demonstrated that scaling transformer-based language models to hundreds of billions of parameters enabled strong few-shot performance across diverse natural language tasks, without task-specific fine-tuning. This finding reshaped assumptions about the relationship between model scale and general capability, and GPT-3 itself became the foundation for a wave of commercially deployed language systems.[^1]
+
+Related scaling research includes *Scaling Laws for Autoregressive Generative Modeling* (arXiv 2020), co-authored with Tom Henighan and others, which established empirical relationships between model size, compute, and performance—work that has guided subsequent decisions about how to allocate resources in large model training.[^1]
+
+### Reinforcement Learning from Human Feedback (RLHF)
+
+Brown co-authored *Deep Reinforcement Learning from Human Preferences* (NeurIPS 2017) with <EntityLink id="E220">Paul Christiano</EntityLink> and others, which has accumulated over 6,400 citations and is widely regarded as the paper that established RLHF as a viable alignment technique. The core idea is to train AI systems by learning from human evaluative feedback rather than from explicit reward functions—an approach that scales to tasks where reward specification is difficult or impossible.[^1]
+
+He also contributed to *Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback* (arXiv 2022), co-authored with Yuntao Bai and others at <EntityLink id="E22">Anthropic</EntityLink>, which has over 3,700 citations. This paper extended RLHF methodology toward the practical goal of producing AI assistants that are simultaneously helpful, honest, and harmless.[^1]
+
+### Constitutional AI and Scalable Oversight
+
+Brown's work connects directly to research on scalable oversight—the challenge of maintaining meaningful human control over AI systems as those systems become more capable. His involvement in constitutional AI (CAI) represents one approach to this problem: training AI systems to evaluate and revise their own outputs according to a set of explicit principles, reducing dependence on direct human feedback at each step. Research data notes his co-authorship on *Constitutional AI: Harmlessness from AI Feedback* (2022).[^1]
+
+### Mechanistic Interpretability
+
+Brown co-authored *A Mathematical Framework for Transformer Circuits* (Transformer Circuits Thread, 2021) with Nelson Elhage and others, a paper that has accumulated nearly 1,000 citations. This work aims to reverse-engineer the computations performed inside transformer models, contributing to the field of <EntityLink id="E174">interpretability</EntityLink> research—an area considered important for verifying whether AI systems are behaving as intended.[^1]
+
+### Red-Teaming and Safety Evaluation
+
+Brown is listed as a co-author on *Red Teaming Language Models to Reduce Harms* (arXiv 2022), co-authored with Deep Ganguli and others, which has received nearly 1,000 citations. This paper developed systematic methods for stress-testing language models by attempting to elicit harmful outputs, contributing to practices now widely used in pre-deployment safety evaluation.[^1]
+
+### Adversarial Robustness
+
+Earlier work includes *Adversarial Patch* (2017), which examined vulnerabilities in computer vision systems through physically realizable adversarial attacks. This line of research predates Brown's more recent alignment-focused work but reflects a consistent interest in understanding and mitigating failure modes in AI systems.[^1]
+
+## Role at Anthropic
+
+Brown is identified in research data as a co-founder of <EntityLink id="E22">Anthropic</EntityLink>, an AI safety company founded by former <EntityLink id="E218">OpenAI</EntityLink> researchers including <EntityLink id="E91">Dario Amodei</EntityLink>. Research data notes his participation in a Salesforce Ventures fireside chat on December 19, 2023, discussing the company's vision, but does not provide detailed information about his current title or day-to-day responsibilities at the organization.[^2]
+
+Anthropic's stated focus on AI safety research, and its development of techniques like constitutional AI, aligns with the research directions Brown pursued during and after his time at <EntityLink id="E218">OpenAI</EntityLink>.
+
+## Connection to AI Safety
+
+Brown's body of work sits at the intersection of AI capabilities research and AI alignment. The RLHF technique he helped establish in 2017 has become the dominant method for aligning large language models with human preferences, and is now used in training AI systems at <EntityLink id="E218">OpenAI</EntityLink>, <EntityLink id="E22">Anthropic</EntityLink>, and elsewhere. His contributions to red-teaming, constitutional AI, and mechanistic <EntityLink id="E174">interpretability</EntityLink> further reflect engagement with core concerns in the AI safety community—including the problem of <EntityLink id="E93">deceptive alignment</EntityLink> and the challenge of <EntityLink id="E274">scheming</EntityLink> in advanced AI systems.
+
+Research data describes his professional background as reflecting a commitment to prioritizing empirical safety measures in AI development, though this characterization comes from research summaries rather than direct statements by Brown himself.[^1]
+
+## Effective Altruism Affiliation
+
+Research data notes that a Tom Brown is listed as the 1,214th member of the Giving What We Can Pledge, a commitment associated with the Effective Altruism community to donate a significant portion of income to effective charities. This is mentioned alongside the pledge membership numbers of <EntityLink id="E91">Dario Amodei</EntityLink> (43rd) and Jack Clark (4,002nd).[^3] It is not confirmed in the research data whether this refers to the same Tom B. Brown who co-authored GPT-3, and this detail should be treated with appropriate uncertainty.
+
+## Key Uncertainties
+
+- The research data does not specify Brown's precise role or title at <EntityLink id="E22">Anthropic</EntityLink>, or the timeline of his transition from <EntityLink id="E218">OpenAI</EntityLink>.
+- Citation counts cited in research data may not reflect the most current figures and should not be treated as precise.
+- The Giving What We Can Pledge membership attributed to a "Tom Brown" has not been independently confirmed as referring to Tom B. Brown the AI researcher.
+- Research data does not detail Brown's educational background, and none is included here to avoid hallucination.
+
+## Sources
+
+[^1]: Research data - Work section: AI researcher profile summary describing Tom B. Brown's publications, citation counts, and affiliations (no URL available in research data)
+[^2]: Research data - History section: Anthropic co-founder profile noting Salesforce Ventures fireside chat, December 19, 2023 (no URL available in research data)
+[^3]: Research data - Community section: EA Forum post "Akash's Quick Takes" discussing Giving What We Can Pledge membership numbers (no URL available in research data)

--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -2816,6 +2816,7 @@
 
 - id: tom-brown
   stableId: 4CY8YJCrM7
+  wikiId: E1258
   type: person
   title: Tom Brown
   description: >-


### PR DESCRIPTION
## Summary

Adds wiki pages for 4 Anthropic co-founders and OpenAI's Greg Brockman — filling the biggest people coverage gaps identified in the coverage audit.

### New pages
- **Tom Brown** (E1258) — GPT-3 lead author, Constitutional AI, mechanistic interpretability at Anthropic
- **Jack Clark** (E1248) — Import AI newsletter (~70K readers), OpenAI Policy Director 2016-2020, NAIAC/OECD advisory roles
- **Jared Kaplan** (E1239) — Neural scaling laws, Responsible Scaling Officer, physics-to-AI career path
- **Sam McCandlish** (E1259) — CTO → Chief Architect (Oct 2025), scaling laws co-author, 80% philanthropy pledge
- **Greg Brockman** (E1012) — OpenAI co-founder/president, Stripe CTO, 2023 board crisis, sabbatical

### Also
- Added `wikiId: E1258` to Tom Brown's entity in `people.yaml`

## Test plan
- [x] `pnpm test` — 4198/4198 passed
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass
- [x] All EntityLink IDs verified against existing entities


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added five new knowledge-base profiles featuring biographical information, career timelines, research contributions, and external links for key AI researchers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->