### PR TITLE
feat: add dedicated /source-checks routes with server-side pagination

### DIFF
--- a/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
@@ -1,0 +1,317 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import {
+  fetchDetailed,
+} from "@/lib/wiki-server";
+import type {
+  RpcSourceCheckDetailResult,
+  RpcSourceChecksResolveNamesResult,
+} from "@/lib/wiki-server";
+import {
+  VerdictBadge,
+  formatRecordType,
+} from "../../source-checks-shared";
+import { cn } from "@/lib/utils";
+
+export const revalidate = 3600;
+export const dynamicParams = true;
+
+interface PageProps {
+  params: Promise<{ recordType: string; recordId: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { recordType, recordId } = await params;
+
+  // Try to resolve a human-readable name
+  const namesResult = await fetchDetailed<RpcSourceChecksResolveNamesResult>(
+    `/api/source-checks/resolve-names?record_type=${encodeURIComponent(recordType)}&record_ids=${encodeURIComponent(recordId)}`,
+    { revalidate: 3600 }
+  );
+  const name = namesResult.ok ? namesResult.data.names[recordId] : null;
+  const title = name
+    ? `Source Check: ${name}`
+    : `Source Check: ${formatRecordType(recordType)} ${recordId}`;
+
+  return {
+    title: `${title} | Longterm Wiki`,
+    description: `Source verification details for ${name ?? recordId} (${formatRecordType(recordType)}).`,
+  };
+}
+
+export default async function SourceCheckDetailPage({ params }: PageProps) {
+  const { recordType, recordId } = await params;
+
+  // Fetch detail (verdicts + evidence) and names in parallel
+  const [detailResult, namesResult] = await Promise.all([
+    fetchDetailed<RpcSourceCheckDetailResult>(
+      `/api/source-checks/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
+      { revalidate: 3600 }
+    ),
+    fetchDetailed<RpcSourceChecksResolveNamesResult>(
+      `/api/source-checks/resolve-names?record_type=${encodeURIComponent(recordType)}&record_ids=${encodeURIComponent(recordId)}`,
+      { revalidate: 3600 }
+    ),
+  ]);
+
+  if (!detailResult.ok) {
+    if (
+      detailResult.error.type === "server-error" &&
+      detailResult.error.status === 404
+    ) {
+      notFound();
+    }
+    return (
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        <Link
+          href="/source-checks"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          All Source Checks
+        </Link>
+        <h1 className="text-2xl font-bold mb-4">Source Check Detail</h1>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6 text-sm text-red-600">
+          <p className="font-medium mb-1">Unable to load source check data</p>
+          <p className="text-red-500/80">
+            The wiki-server may be temporarily unavailable. Please try again
+            later.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const { verdicts, evidence } = detailResult.data;
+  const resolvedName = namesResult.ok
+    ? namesResult.data.names[recordId]
+    : null;
+  const displayName =
+    resolvedName ?? `${formatRecordType(recordType)} ${recordId}`;
+
+  // Use the first verdict for the primary summary (may have multiple per field)
+  const primaryVerdict = verdicts[0] ?? null;
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-8">
+      {/* Breadcrumbs */}
+      <Link
+        href="/source-checks"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+      >
+        <ArrowLeft className="w-3.5 h-3.5" />
+        All Source Checks
+      </Link>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
+          <span className="capitalize">{formatRecordType(recordType)}</span>
+          <span>/</span>
+          <span className="font-mono">{recordId}</span>
+        </div>
+        <h1 className="text-2xl font-bold mb-2">{displayName}</h1>
+      </div>
+
+      {/* Verdict summary cards */}
+      {verdicts.length > 0 ? (
+        <div className="space-y-4 mb-8">
+          {verdicts.map((v, i) => (
+            <div
+              key={`${v.fieldName ?? "overall"}-${i}`}
+              className="rounded-lg border border-border/60 p-5"
+            >
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div>
+                  {v.fieldName && (
+                    <p className="text-xs text-muted-foreground mb-1">
+                      Field:{" "}
+                      <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                        {v.fieldName}
+                      </code>
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3">
+                    <VerdictBadge verdict={v.verdict} />
+                    {v.confidence != null && (
+                      <span className="text-sm tabular-nums font-medium">
+                        {Math.round(v.confidence * 100)}% confidence
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right text-xs text-muted-foreground">
+                  {v.sourcesChecked > 0 && (
+                    <p>
+                      {v.sourcesChecked} source
+                      {v.sourcesChecked !== 1 ? "s" : ""} checked
+                    </p>
+                  )}
+                  {v.lastComputedAt && (
+                    <p>
+                      Last checked:{" "}
+                      {new Date(v.lastComputedAt).toLocaleDateString()}
+                    </p>
+                  )}
+                  {v.needsRecheck && (
+                    <p className="text-amber-500 font-medium mt-0.5">
+                      Needs recheck
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Confidence bar */}
+              {v.confidence != null && (
+                <div className="w-full bg-muted rounded-full h-2 mb-3">
+                  <div
+                    className={cn(
+                      "h-2 rounded-full transition-all",
+                      v.verdict === "confirmed"
+                        ? "bg-emerald-500"
+                        : v.verdict === "contradicted"
+                          ? "bg-red-500"
+                          : v.verdict === "outdated"
+                            ? "bg-amber-500"
+                            : "bg-gray-400"
+                    )}
+                    style={{ width: `${Math.round(v.confidence * 100)}%` }}
+                  />
+                </div>
+              )}
+
+              {v.reasoning && (
+                <p className="text-sm text-muted-foreground">{v.reasoning}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border/60 p-6 text-center text-muted-foreground mb-8">
+          <p>No verdict records found for this item.</p>
+        </div>
+      )}
+
+      {/* Evidence table */}
+      {evidence.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            Evidence ({evidence.length} source
+            {evidence.length !== 1 ? "s" : ""})
+          </h2>
+          <div className="overflow-x-auto rounded-lg border border-border/60">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-muted/50 text-left text-muted-foreground">
+                  <th className="py-2 pl-4 pr-3 font-medium">Source</th>
+                  <th className="py-2 pr-3 font-medium">Verdict</th>
+                  <th className="py-2 pr-3 font-medium">Confidence</th>
+                  <th className="py-2 pr-3 font-medium">Expected</th>
+                  <th className="py-2 pr-3 font-medium">Found</th>
+                  <th className="py-2 pr-3 font-medium">Quote</th>
+                  <th className="py-2 pr-3 font-medium">Model</th>
+                  <th className="py-2 pr-4 font-medium">Checked</th>
+                </tr>
+              </thead>
+              <tbody>
+                {evidence.map((e) => (
+                  <tr
+                    key={e.id}
+                    className="border-b border-border/30 last:border-0"
+                  >
+                    <td className="py-2 pl-4 pr-3 max-w-[200px]">
+                      {e.sourceUrl ? (
+                        <a
+                          href={e.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:underline flex items-center gap-1 dark:text-blue-400"
+                        >
+                          <ExternalLink className="h-3 w-3 shrink-0" />
+                          <span className="truncate">
+                            {(() => {
+                              try {
+                                return new URL(e.sourceUrl).hostname;
+                              } catch {
+                                return e.sourceUrl;
+                              }
+                            })()}
+                          </span>
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-3">
+                      <VerdictBadge verdict={e.verdict} />
+                    </td>
+                    <td className="py-2 pr-3 tabular-nums">
+                      {e.confidence != null
+                        ? `${Math.round(e.confidence * 100)}%`
+                        : "-"}
+                    </td>
+                    <td
+                      className="py-2 pr-3 max-w-[150px] truncate"
+                      title={e.expectedValue ?? undefined}
+                    >
+                      {e.expectedValue || "-"}
+                    </td>
+                    <td
+                      className="py-2 pr-3 max-w-[150px] truncate"
+                      title={e.extractedValue ?? undefined}
+                    >
+                      {e.extractedValue || "-"}
+                    </td>
+                    <td className="py-2 pr-3 max-w-[200px]">
+                      {e.extractedQuote ? (
+                        <span
+                          className="text-muted-foreground line-clamp-2"
+                          title={e.extractedQuote}
+                        >
+                          &ldquo;{e.extractedQuote}&rdquo;
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-3 text-muted-foreground">
+                      {e.checkerModel || "-"}
+                    </td>
+                    <td className="py-2 pr-4 tabular-nums text-muted-foreground">
+                      {e.checkedAt
+                        ? new Date(e.checkedAt).toLocaleDateString()
+                        : "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {evidence.length === 0 && (
+        <section className="mb-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            Evidence
+          </h2>
+          <div className="rounded-lg border border-border/60 p-6 text-center text-muted-foreground">
+            <p>No evidence records found for this item.</p>
+          </div>
+        </section>
+      )}
+
+      {/* Footer */}
+      <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
+        Record Type:{" "}
+        <code className="px-1 py-0.5 bg-muted rounded">{recordType}</code>{" "}
+        &middot; Record ID:{" "}
+        <code className="px-1 py-0.5 bg-muted rounded">{recordId}</code>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/source-checks/page.tsx
+++ b/apps/web/src/app/source-checks/page.tsx
@@ -1,0 +1,339 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  fetchDetailed,
+} from "@/lib/wiki-server";
+import type {
+  RpcSourceChecksStatsResult,
+  RpcSourceChecksVerdictsResult,
+  RpcSourceChecksResolveNamesResult,
+} from "@/lib/wiki-server";
+import { SourceChecksTable } from "./source-checks-table";
+import { SourceChecksSearch } from "./source-checks-filter";
+import {
+  VERDICT_STYLES,
+  PAGE_SIZE,
+  buildFilterUrl,
+  formatRecordType,
+} from "./source-checks-shared";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Source Checks | Longterm Wiki",
+  description:
+    "Directory of source verification checks across wiki data, including personnel records, grants, divisions, and more.",
+};
+
+// Revalidate every 5 minutes
+export const revalidate = 300;
+
+interface PageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+function getParam(
+  searchParams: Record<string, string | string[] | undefined>,
+  key: string
+): string | undefined {
+  const val = searchParams[key];
+  return typeof val === "string" ? val : undefined;
+}
+
+export default async function SourceChecksPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const filterType = getParam(sp, "type") ?? "all";
+  const filterVerdict = getParam(sp, "verdict") ?? "all";
+  const searchQuery = getParam(sp, "q") ?? "";
+  const pageNum = Math.max(1, parseInt(getParam(sp, "page") ?? "1", 10) || 1);
+  const offset = (pageNum - 1) * PAGE_SIZE;
+
+  // Build API query params for verdicts
+  const verdictParams = new URLSearchParams();
+  if (filterType !== "all") verdictParams.set("record_type", filterType);
+  if (filterVerdict !== "all") verdictParams.set("verdict", filterVerdict);
+  verdictParams.set("limit", String(PAGE_SIZE));
+  verdictParams.set("offset", String(offset));
+
+  // Fetch stats and verdicts in parallel
+  const [statsResult, verdictsResult] = await Promise.all([
+    fetchDetailed<RpcSourceChecksStatsResult>("/api/source-checks/stats", {
+      revalidate: 300,
+    }),
+    fetchDetailed<RpcSourceChecksVerdictsResult>(
+      `/api/source-checks/verdicts?${verdictParams.toString()}`,
+      { revalidate: 300 }
+    ),
+  ]);
+
+  // Handle error state
+  if (!statsResult.ok || !verdictsResult.ok) {
+    return (
+      <div className="max-w-[90rem] mx-auto px-6 py-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-4">
+          Source Checks
+        </h1>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6 text-sm text-red-600">
+          <p className="font-medium mb-1">Unable to load source check data</p>
+          <p className="text-red-500/80">
+            The wiki-server may be temporarily unavailable. Please try again
+            later.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const stats = statsResult.data;
+  const { verdicts, total } = verdictsResult.data;
+
+  // Resolve names for the current page of verdicts
+  let names: Record<string, string> = {};
+  if (verdicts.length > 0) {
+    // Group by record type for batch resolution
+    const byType = new Map<string, Set<string>>();
+    for (const v of verdicts) {
+      const existing = byType.get(v.recordType);
+      if (existing) {
+        existing.add(v.recordId);
+      } else {
+        byType.set(v.recordType, new Set([v.recordId]));
+      }
+    }
+
+    const nameResults = await Promise.all(
+      [...byType.entries()].map(async ([recordType, ids]) => {
+        const idList = [...ids].join(",");
+        const result = await fetchDetailed<RpcSourceChecksResolveNamesResult>(
+          `/api/source-checks/resolve-names?record_type=${encodeURIComponent(recordType)}&record_ids=${encodeURIComponent(idList)}`,
+          { revalidate: 300 }
+        );
+        return result.ok ? result.data.names : {};
+      })
+    );
+    for (const nameMap of nameResults) {
+      names = { ...names, ...nameMap };
+    }
+  }
+
+  // Client-side search filtering (server already filtered by type/verdict)
+  const filteredVerdicts = searchQuery
+    ? verdicts.filter((v) => {
+        const name = names[v.recordId] ?? "";
+        const searchLower = searchQuery.toLowerCase();
+        return (
+          v.recordId.toLowerCase().includes(searchLower) ||
+          v.recordType.toLowerCase().includes(searchLower) ||
+          name.toLowerCase().includes(searchLower) ||
+          (v.reasoning?.toLowerCase().includes(searchLower) ?? false)
+        );
+      })
+    : verdicts;
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  // Stats
+  const avgConfidence =
+    stats.avg_confidence > 0
+      ? `${Math.round(stats.avg_confidence * 100)}%`
+      : "N/A";
+
+  // Build sorted type/verdict entries for filter tabs
+  const typeEntries = Object.entries(stats.by_type).sort(
+    ([, a], [, b]) => b - a
+  );
+  const verdictEntries = Object.entries(stats.by_verdict).sort(
+    ([, a], [, b]) => b - a
+  );
+
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
+          Source Checks
+        </h1>
+        <p className="text-muted-foreground text-sm max-w-2xl">
+          Automated verification of wiki data against original sources. Each
+          record is checked against one or more external sources to confirm
+          accuracy.
+        </p>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <div className="rounded-lg border border-border/60 p-4">
+          <p className="text-xs text-muted-foreground mb-1">Total Verdicts</p>
+          <p className="text-2xl font-bold tabular-nums">{stats.total}</p>
+        </div>
+        <div className="rounded-lg border border-border/60 p-4">
+          <p className="text-xs text-muted-foreground mb-1">Avg Confidence</p>
+          <p className="text-2xl font-bold tabular-nums">{avgConfidence}</p>
+        </div>
+        <div className="rounded-lg border border-border/60 p-4">
+          <p className="text-xs text-muted-foreground mb-1">Needs Recheck</p>
+          <p
+            className={cn(
+              "text-2xl font-bold tabular-nums",
+              stats.needs_recheck > 0 && "text-amber-600"
+            )}
+          >
+            {stats.needs_recheck}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border/60 p-4">
+          <p className="text-xs text-muted-foreground mb-1">Record Types</p>
+          <p className="text-2xl font-bold tabular-nums">
+            {Object.keys(stats.by_type).length}
+          </p>
+        </div>
+      </div>
+
+      {/* Filter tabs — record type */}
+      <div className="space-y-3 mb-4">
+        <div className="flex gap-1.5 flex-wrap">
+          <Link
+            href={buildFilterUrl("/source-checks", {
+              type: "all",
+              verdict: filterVerdict,
+              q: searchQuery,
+            })}
+            className={cn(
+              "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+              filterType === "all"
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            )}
+          >
+            All types ({stats.total})
+          </Link>
+          {typeEntries.map(([type, count]) => (
+            <Link
+              key={type}
+              href={buildFilterUrl("/source-checks", {
+                type,
+                verdict: filterVerdict,
+                q: searchQuery,
+              })}
+              className={cn(
+                "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                filterType === type
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              )}
+            >
+              {formatRecordType(type)} ({count})
+            </Link>
+          ))}
+        </div>
+
+        {/* Filter tabs — verdict */}
+        <div className="flex gap-1.5 flex-wrap">
+          <Link
+            href={buildFilterUrl("/source-checks", {
+              type: filterType,
+              verdict: "all",
+              q: searchQuery,
+            })}
+            className={cn(
+              "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+              filterVerdict === "all"
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            )}
+          >
+            All verdicts
+          </Link>
+          {verdictEntries.map(([v, count]) => {
+            const style = VERDICT_STYLES[v] || VERDICT_STYLES.unchecked;
+            return (
+              <Link
+                key={v}
+                href={buildFilterUrl("/source-checks", {
+                  type: filterType,
+                  verdict: v,
+                  q: searchQuery,
+                })}
+                className={cn(
+                  "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                  filterVerdict === v
+                    ? `${style.bg} ${style.text}`
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+                )}
+              >
+                {v} ({count})
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Search + results count */}
+      <div className="flex items-center gap-4 mb-4">
+        <SourceChecksSearch />
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
+          {searchQuery
+            ? `${filteredVerdicts.length} of ${total} results`
+            : `${total} results`}
+        </span>
+      </div>
+
+      {/* Table */}
+      <SourceChecksTable verdicts={filteredVerdicts} names={names} />
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-1 mt-4">
+          <span className="text-sm text-muted-foreground">
+            Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of{" "}
+            {total}
+          </span>
+          <div className="flex items-center gap-1">
+            {pageNum > 1 ? (
+              <Link
+                href={buildFilterUrl("/source-checks", {
+                  type: filterType,
+                  verdict: filterVerdict,
+                  q: searchQuery,
+                  page: pageNum - 1,
+                })}
+                className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 transition-colors"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" /> Prev
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground opacity-40 cursor-not-allowed">
+                <ChevronLeft className="h-3.5 w-3.5" /> Prev
+              </span>
+            )}
+            <span className="px-2 text-xs text-muted-foreground tabular-nums">
+              {pageNum} / {totalPages}
+            </span>
+            {pageNum < totalPages ? (
+              <Link
+                href={buildFilterUrl("/source-checks", {
+                  type: filterType,
+                  verdict: filterVerdict,
+                  q: searchQuery,
+                  page: pageNum + 1,
+                })}
+                className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 transition-colors"
+              >
+                Next <ChevronRight className="h-3.5 w-3.5" />
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground opacity-40 cursor-not-allowed">
+                Next <ChevronRight className="h-3.5 w-3.5" />
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground mt-4">
+        Data from <code className="text-[11px]">source_check_verdicts</code>{" "}
+        table. Click a row to view detailed evidence.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/source-checks/source-checks-filter.tsx
+++ b/apps/web/src/app/source-checks/source-checks-filter.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useRef, useCallback } from "react";
+import { Search } from "lucide-react";
+
+export function SourceChecksSearch() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const currentQ = searchParams.get("q") ?? "";
+
+  const handleChange = useCallback(
+    (value: string) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        const sp = new URLSearchParams(searchParams.toString());
+        if (value) {
+          sp.set("q", value);
+        } else {
+          sp.delete("q");
+        }
+        // Reset to page 1 on search change
+        sp.delete("page");
+        const qs = sp.toString();
+        router.push(qs ? `/source-checks?${qs}` : "/source-checks");
+      }, 300);
+    },
+    [router, searchParams]
+  );
+
+  return (
+    <div className="relative flex-1 max-w-md">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        placeholder="Search source checks..."
+        defaultValue={currentQ}
+        onChange={(e) => handleChange(e.target.value)}
+        className="h-10 w-full rounded-lg border border-border bg-background pl-10 pr-4 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/source-checks/source-checks-shared.tsx
+++ b/apps/web/src/app/source-checks/source-checks-shared.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+
+// ── Verdict styling ─────────────────────────────────────────────────────
+
+export const VERDICT_STYLES: Record<string, { bg: string; text: string }> = {
+  confirmed: { bg: "bg-emerald-500/15", text: "text-emerald-600" },
+  contradicted: { bg: "bg-red-500/15", text: "text-red-600" },
+  outdated: { bg: "bg-amber-500/15", text: "text-amber-600" },
+  partial: { bg: "bg-amber-400/15", text: "text-amber-500" },
+  unverifiable: { bg: "bg-gray-500/15", text: "text-gray-500" },
+  unchecked: { bg: "bg-gray-400/15", text: "text-gray-400" },
+};
+
+export function VerdictBadge({ verdict, className }: { verdict: string; className?: string }) {
+  const style = VERDICT_STYLES[verdict] || VERDICT_STYLES.unchecked;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold",
+        style.bg,
+        style.text,
+        className
+      )}
+    >
+      {verdict}
+    </span>
+  );
+}
+
+// ── Pagination helpers ──────────────────────────────────────────────────
+
+export const PAGE_SIZE = 50;
+
+/** Build a URL search string preserving existing filters and updating page. */
+export function buildFilterUrl(
+  base: string,
+  params: { type?: string; verdict?: string; page?: number; q?: string }
+): string {
+  const sp = new URLSearchParams();
+  if (params.type && params.type !== "all") sp.set("type", params.type);
+  if (params.verdict && params.verdict !== "all") sp.set("verdict", params.verdict);
+  if (params.q) sp.set("q", params.q);
+  if (params.page && params.page > 1) sp.set("page", String(params.page));
+  const qs = sp.toString();
+  return qs ? `${base}?${qs}` : base;
+}
+
+/** Format a record type for display (capitalize). */
+export function formatRecordType(type: string): string {
+  return type
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/apps/web/src/app/source-checks/source-checks-table.tsx
+++ b/apps/web/src/app/source-checks/source-checks-table.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import type { RpcSourceCheckVerdictRow } from "@/lib/wiki-server";
+import { VerdictBadge, formatRecordType } from "./source-checks-shared";
+
+interface SourceChecksTableProps {
+  verdicts: RpcSourceCheckVerdictRow[];
+  names: Record<string, string>;
+}
+
+export function SourceChecksTable({ verdicts, names }: SourceChecksTableProps) {
+  if (verdicts.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+        <p className="text-lg font-medium mb-2">No source checks found</p>
+        <p className="text-sm">Try adjusting your filters.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/60">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/50 text-left text-xs text-muted-foreground">
+            <th className="py-2.5 pl-4 pr-3 font-medium">Type</th>
+            <th className="py-2.5 pr-3 font-medium">Record</th>
+            <th className="py-2.5 pr-3 font-medium">Verdict</th>
+            <th className="py-2.5 pr-3 font-medium">Confidence</th>
+            <th className="py-2.5 pr-3 font-medium">Sources</th>
+            <th className="py-2.5 pr-3 font-medium">Last Checked</th>
+            <th className="py-2.5 pr-4 font-medium w-8"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {verdicts.map((v) => {
+            const detailHref = `/source-checks/${encodeURIComponent(v.recordType)}/${encodeURIComponent(v.recordId)}`;
+            const displayName = names[v.recordId];
+
+            return (
+              <tr
+                key={`${v.recordType}:${v.recordId}:${v.fieldName ?? ""}`}
+                className="border-b border-border/30 last:border-0 hover:bg-muted/30 transition-colors"
+              >
+                <td className="py-2.5 pl-4 pr-3">
+                  <span className="text-xs font-medium capitalize">
+                    {formatRecordType(v.recordType)}
+                  </span>
+                </td>
+                <td className="py-2.5 pr-3">
+                  {displayName ? (
+                    <div className="flex flex-col gap-0.5">
+                      <Link
+                        href={detailHref}
+                        className="text-xs font-medium text-foreground hover:underline"
+                        title={displayName}
+                      >
+                        {displayName.length > 40
+                          ? displayName.slice(0, 38) + "..."
+                          : displayName}
+                      </Link>
+                      <span className="text-[10px] font-mono text-muted-foreground">
+                        {v.recordId.length > 15
+                          ? v.recordId.slice(0, 12) + "..."
+                          : v.recordId}
+                      </span>
+                    </div>
+                  ) : (
+                    <Link
+                      href={detailHref}
+                      className="text-xs font-mono text-muted-foreground hover:underline"
+                      title={v.recordId}
+                    >
+                      {v.recordId.length > 20
+                        ? v.recordId.slice(0, 18) + "..."
+                        : v.recordId}
+                    </Link>
+                  )}
+                </td>
+                <td className="py-2.5 pr-3">
+                  <VerdictBadge verdict={v.verdict} />
+                </td>
+                <td className="py-2.5 pr-3">
+                  {v.confidence != null ? (
+                    <span className="text-sm tabular-nums font-medium">
+                      {Math.round(v.confidence * 100)}%
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">-</span>
+                  )}
+                </td>
+                <td className="py-2.5 pr-3">
+                  <span className="text-sm tabular-nums">
+                    {v.sourcesChecked}
+                  </span>
+                </td>
+                <td className="py-2.5 pr-3">
+                  {v.lastComputedAt ? (
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {new Date(v.lastComputedAt).toLocaleDateString()}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">-</span>
+                  )}
+                </td>
+                <td className="py-2.5 pr-4">
+                  <Link
+                    href={detailHref}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="View details"
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -47,6 +47,7 @@ export const NAV_ITEMS: NavItem[] = [
     items: [
       { href: "/sources", label: "Sources" },
       { href: "/factbase", label: "FactBase" },
+      { href: "/source-checks", label: "Source Checks" },
     ],
   },
   { href: "/wiki/E755", label: "About" },

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -233,6 +233,12 @@ export type RpcSourceChecksVerdictsResult = InferResponseType<SourceChecksClient
 /** A single verdict row from the verdicts list */
 export type RpcSourceCheckVerdictRow = RpcSourceChecksVerdictsResult['verdicts'][number];
 
+/** Inferred response type for GET /api/source-checks/verdicts/:recordType/:recordId */
+export type RpcSourceCheckDetailResult = InferResponseType<SourceChecksClient['verdicts'][':recordType'][':recordId']['$get'], 200>;
+
+/** Inferred response type for GET /api/source-checks/resolve-names */
+export type RpcSourceChecksResolveNamesResult = InferResponseType<SourceChecksClient['resolve-names']['$get'], 200>;
+
 // ============================================================================
 // Hono RPC client — Grants API
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `/source-checks` list page with server-side pagination, type/verdict filter tabs as `<Link>` components, and debounced search
- Add `/source-checks/[recordType]/[recordId]` detail page with verdict summary, confidence bar, and per-source evidence table (ISR with 1hr revalidation)
- Add RPC types (`RpcSourceCheckDetailResult`, `RpcSourceChecksResolveNamesResult`) inferred from wiki-server route
- Add "Source Checks" entry to Data nav dropdown
- E2200 internal dashboard left completely unchanged

## Test plan

- [x] `pnpm build` passes — new routes compile without TypeScript errors
- [x] `pnpm test` passes (pre-existing `snapshot-resources` failures only)
- [x] E2200 dashboard files unchanged (confirmed via `git diff`)
- [ ] Navigate to `/source-checks` — verify stats cards, filter tabs, pagination, and search
- [ ] Click a row — verify `/source-checks/{recordType}/{recordId}` detail page renders
- [ ] Verify `/wiki/E2200` still works independently
- [ ] Verify nav dropdown includes "Source Checks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3082
