### PR TITLE
feat: unified source-check detail page links

### DIFF
--- a/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
@@ -19,6 +19,7 @@ import {
   ChevronLeft,
   ExternalLink,
   RotateCcw,
+  ArrowUpRight,
 } from "lucide-react";
 import { DataTable, SortableHeader } from "@/components/ui/data-table";
 import { cn } from "@/lib/utils";
@@ -230,6 +231,20 @@ function buildColumns(names: NameMap, hrefs: HrefMap): ColumnDef<VerdictRow>[] {
         if (!d) return <span className="text-xs text-muted-foreground">-</span>;
         return <span className="text-xs text-muted-foreground tabular-nums">{new Date(d).toLocaleDateString()}</span>;
       },
+    },
+    {
+      id: "detail",
+      size: 36,
+      header: () => null,
+      cell: ({ row }) => (
+        <a
+          href={`/source-checks/${encodeURIComponent(row.original.recordType)}/${encodeURIComponent(row.original.recordId)}`}
+          className="p-1 rounded hover:bg-muted transition-colors inline-flex"
+          title="View source check detail"
+        >
+          <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground" />
+        </a>
+      ),
     },
   ];
 }

--- a/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   VerdictBadge,
   formatRecordType,
+  getRecordHref,
 } from "../../source-checks-shared";
 import { cn } from "@/lib/utils";
 
@@ -40,6 +41,7 @@ export async function generateMetadata({
   return {
     title: `${title} | Longterm Wiki`,
     description: `Source verification details for ${name ?? recordId} (${formatRecordType(recordType)}).`,
+    robots: { index: false },
   };
 }
 
@@ -115,6 +117,17 @@ export default async function SourceCheckDetailPage({ params }: PageProps) {
           <span className="font-mono">{recordId}</span>
         </div>
         <h1 className="text-2xl font-bold mb-2">{displayName}</h1>
+        {(() => {
+          const recordHref = getRecordHref(recordType, recordId);
+          return recordHref ? (
+            <Link
+              href={recordHref}
+              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              View {formatRecordType(recordType).toLowerCase()} record &rarr;
+            </Link>
+          ) : null;
+        })()}
       </div>
 
       {/* Verdict summary cards */}

--- a/apps/web/src/app/source-checks/source-checks-shared.tsx
+++ b/apps/web/src/app/source-checks/source-checks-shared.tsx
@@ -52,3 +52,33 @@ export function formatRecordType(type: string): string {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
 }
+
+/**
+ * Get the URL for the source record's detail page.
+ * Returns null if no detail page exists for this record type.
+ */
+export function getRecordHref(recordType: string, recordId: string): string | null {
+  switch (recordType) {
+    case "fact":
+      return `/factbase/fact/${recordId}`;
+    case "wiki-page":
+      return `/wiki/${recordId}`;
+    case "grant":
+      return `/grants/${recordId}`;
+    case "publication":
+      return `/publications/${recordId}`;
+    case "investment":
+      return `/investments/${recordId}`;
+    case "funding-round":
+      return `/funding-rounds/${recordId}`;
+    case "division":
+      return `/divisions/${recordId}`;
+    default:
+      return null;
+  }
+}
+
+/** Get the URL for the source-check detail page. */
+export function getSourceCheckHref(recordType: string, recordId: string): string {
+  return `/source-checks/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`;
+}


### PR DESCRIPTION
## Summary

Connects the E2200 Source Checks dashboard to the existing `/source-checks/:recordType/:recordId` detail pages, and adds record back-links on those detail pages.

- **E2200 dashboard**: Each row now has an arrow icon (↗) linking to the full source-check detail page at `/source-checks/:type/:id`
- **Detail page**: Now links back to the source record (e.g., "View fact record →" links to `/factbase/fact/:id`)
- **Shared helpers**: `getRecordHref()` maps record types to their detail page URLs (fact, wiki-page, grant, publication, investment, funding-round, division); `getSourceCheckHref()` builds source-check detail URLs
- **SEO**: Detail pages now have `robots: { index: false }` metadata

## Context

The `/source-checks/:recordType/:recordId` detail pages already existed but were unreachable from the main E2200 dashboard. This PR connects the dots — from dashboard → detail page → source record → and back.

## Test plan

- [x] `pnpm build` passes
- [x] `tsc --noEmit` clean
- [x] Detail page shows "View fact record →" link for fact records
- [x] E2200 dashboard rows show arrow icon linking to detail pages
- [x] `getRecordHref` returns correct URLs for all supported record types

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detail link icons in the source checks table for navigation to individual check pages.
  * Added navigation links on check detail pages to access the corresponding original records.

* **Other Changes**
  * Disabled search engine indexing on source check detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->