### PR TITLE
fix: E2200 coverage tab and action queue improvements

### DIFF
--- a/apps/web/src/app/internal/entity-source-checks/action-queue.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/action-queue.tsx
@@ -265,21 +265,38 @@ function ActionGroup({
 // ── Single action item ─────────────────────────────────────────────────────
 
 function ActionItem({ item, names }: { item: VerdictRow; names: NameMap }) {
-  const displayName = names[item.recordId]
-    ?? names[item.entityId ?? ""]
-    ?? item.recordId;
+  // Resolve the record-level name (e.g., fact label "Headquarters", personnel name)
+  const recordName = names[item.recordId] ?? null;
+  // Resolve the parent entity name (e.g., "Anthropic", "Elon Musk")
+  const entityName = item.entityId ? (names[item.entityId] ?? null) : null;
 
-  const truncatedName = displayName.length > 50
-    ? displayName.slice(0, 48) + "..."
+  // Build display name: prefer "Entity: Record" when both are available
+  // so users can distinguish multiple entries for the same entity.
+  let displayName: string;
+  if (recordName && entityName && recordName !== entityName) {
+    displayName = `${entityName}: ${recordName}`;
+  } else {
+    displayName = recordName ?? entityName ?? item.recordId;
+  }
+
+  // Strip "new:" prefix from resolved display names
+  if (displayName.startsWith("new:")) {
+    displayName = displayName.slice(4);
+  }
+
+  const truncatedName = displayName.length > 60
+    ? displayName.slice(0, 58) + "..."
     : displayName;
 
+  const href = `/source-checks/${encodeURIComponent(item.recordType)}/${encodeURIComponent(item.recordId)}`;
+
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors">
+    <a href={href} className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors group">
       <div className="flex items-center gap-3 min-w-0">
         <span className="shrink-0 inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
           {item.recordType}
         </span>
-        <span className="text-sm font-medium truncate" title={displayName}>
+        <span className="text-sm font-medium truncate group-hover:text-blue-600 dark:group-hover:text-blue-400" title={displayName}>
           {truncatedName}
         </span>
         {item.fieldName && (
@@ -298,6 +315,6 @@ function ActionItem({ item, names }: { item: VerdictRow; names: NameMap }) {
           {formatTimeSince(item.lastComputedAt)}
         </span>
       </div>
-    </div>
+    </a>
   );
 }

--- a/apps/web/src/app/internal/entity-source-checks/coverage-bars.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/coverage-bars.tsx
@@ -59,8 +59,11 @@ export function CoverageBars() {
     );
   }
 
+  // Filter out rows with neither total records nor verdicts (phantom record types)
+  const meaningful = coverage.filter((r) => r.total > 0 || r.verified > 0);
+
   // Sort by percentage descending, then by total descending for ties
-  const sorted = [...coverage].sort((a, b) => {
+  const sorted = [...meaningful].sort((a, b) => {
     if (b.percentage !== a.percentage) return b.percentage - a.percentage;
     return b.total - a.total;
   });

--- a/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
@@ -577,9 +577,10 @@ export function EntitySourceChecksViewer() {
   const contradictedCount = verdicts.filter((v) => v.verdict === "contradicted").length;
   const needsRecheckCount = verdicts.filter((v) => v.needsRecheck).length;
 
-  // Coverage stats
-  const totalRecords = coverageData.reduce((sum, r) => sum + r.total, 0);
-  const totalVerified = coverageData.reduce((sum, r) => sum + r.verified, 0);
+  // Coverage stats — filter out rows with neither records nor verdicts
+  const meaningfulCoverage = coverageData.filter((r) => r.total > 0 || r.verified > 0);
+  const totalRecords = meaningfulCoverage.reduce((sum, r) => sum + r.total, 0);
+  const totalVerified = meaningfulCoverage.reduce((sum, r) => sum + r.verified, 0);
   const overallCoveragePct = totalRecords > 0
     ? Math.round((totalVerified / totalRecords) * 100)
     : 0;
@@ -608,7 +609,7 @@ export function EntitySourceChecksViewer() {
           <div className="rounded-lg border border-border/60 p-4">
             <p className="text-xs text-muted-foreground mb-1">Total Records</p>
             <p className="text-2xl font-bold tabular-nums">{totalRecords.toLocaleString()}</p>
-            <p className="text-xs text-muted-foreground mt-1">{coverageData.length} record types</p>
+            <p className="text-xs text-muted-foreground mt-1">{meaningfulCoverage.length} record types</p>
           </div>
         )}
         {totalRecords > 0 && (

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -748,6 +748,8 @@ const sourceChecksApp = new Hono()
       SELECT 'citation', count(*)::int FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
       UNION ALL
       SELECT 'wiki-page', count(*)::int FROM wiki_pages
+      UNION ALL
+      SELECT 'fact', count(DISTINCT fact_id)::int FROM facts
     `);
 
     const totalsByType: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- **Coverage tab**: Add `fact` record type to the coverage SQL query so fact verdicts show the correct total count instead of "477 / 0 (0%)"
- **Coverage tab**: Filter out phantom rows where both total and verified are 0 (e.g., entity-assessment, entity-event) from coverage bars and viewer stats
- **Action Queue**: Show combined "Entity: Claim" names (e.g., "Anthropic: Headquarters") so users can distinguish multiple entries for the same entity
- **Action Queue**: Strip "new:" prefix from display names, make items clickable links to source-check detail pages

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit` passes for both web and wiki-server)

Generated with [Claude Code](https://claude.com/claude-code)
