### PR TITLE
fix: reduce source-check false positives and fix stale verdict aggregation

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -298,18 +298,9 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
     return {};
   }
 
-  // Build a URL → best verdict map from all citation quotes across all pages.
-  // A URL may appear in multiple pages with different verdicts; prefer the
-  // MOST CAUTIOUS verdict (worst case wins) so flagged issues are never hidden.
-  const VERDICT_PRIORITY = {
-    inaccurate: 6,    // Most concerning → highest priority
-    unsupported: 5,
-    minor_issues: 4,
-    not_verifiable: 3,
-    accurate: 2,
-    verified: 1,
-  };
-
+  // Build a URL → verdict map from all citation quotes across all pages.
+  // When a URL has multiple verdicts, prefer the MOST RECENT one so that
+  // re-checks actually update the displayed verdict (fixes stale contradictions).
   const urlToVerdict = new Map();
 
   for (const quotes of Object.values(citationQuotesBundle)) {
@@ -320,10 +311,11 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
 
       const normalizedUrl = normalizeUrlForMatch(q.url);
       const existing = urlToVerdict.get(normalizedUrl);
-      const existingPriority = existing ? (VERDICT_PRIORITY[existing] ?? 0) : 0;
-      const newPriority = VERDICT_PRIORITY[verdict] ?? 0;
-      if (newPriority > existingPriority) {
-        urlToVerdict.set(normalizedUrl, verdict);
+      // Use most recent verdict (by checkedAt/updatedAt) or just overwrite
+      // since citation quotes are ordered by recency in the bundle.
+      // If no timestamp info, last-write-wins gives the most recent check.
+      if (!existing || (q.checkedAt && existing.checkedAt && q.checkedAt > existing.checkedAt) || !existing.checkedAt) {
+        urlToVerdict.set(normalizedUrl, { verdict, checkedAt: q.checkedAt ?? null });
       }
     }
   }
@@ -346,9 +338,9 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
       if (!url.startsWith('http://') && !url.startsWith('https://')) continue;
 
       const normalizedSource = normalizeUrlForMatch(url);
-      const verdict = urlToVerdict.get(normalizedSource);
-      if (verdict) {
-        verification[fact.id] = verdict;
+      const entry = urlToVerdict.get(normalizedSource);
+      if (entry) {
+        verification[fact.id] = entry.verdict;
         matchCount++;
       }
     }

--- a/crux/commands/factbase-source-check.ts
+++ b/crux/commands/factbase-source-check.ts
@@ -262,13 +262,20 @@ ${sourceText}
 
 Does the source text confirm, contradict, or not address this claim?
 
-Consider:
+IMPORTANT — avoid these common false-positive errors:
+- **Range vs. point**: If the source gives a range (e.g., "51-200 employees") and the claimed value falls within that range (e.g., 91), that is "confirmed", NOT contradicted.
+- **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
+- **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
+- **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
+
+Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
 - Dates may be approximate
-- The source may confirm the general fact but with a slightly different value
 - If the source discusses the topic but the specific data point isn't mentioned, that's "unverifiable"
 - If the source has a newer value that supersedes the claimed value, that's "outdated"
 - If the source partially confirms (e.g., confirms the ballpark but not the exact figure), that's "partial"
+
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {
@@ -384,7 +391,28 @@ async function storeVerificationResult(result: VerificationResult): Promise<void
   );
 
   if (!response.ok) {
-    console.warn(`[fb-source-check] Failed to store verification for ${result.factId}: ${response.error}`);
+    console.warn(`[fb-source-check] Failed to store evidence for ${result.factId}: ${response.error}`);
+  }
+
+  // Also store aggregate verdict so re-runs update the displayed verdict.
+  // Without this, stale contradictions persist even after re-checks confirm data.
+  const verdictBody = {
+    recordType: 'fact',
+    recordId: result.factId,
+    verdict: result.verdict,
+    confidence: result.confidence,
+    reasoning: result.reasoning,
+    sourcesChecked: 1,
+  };
+
+  const verdictResponse = await apiRequest<{ ok: boolean }>(
+    'POST',
+    '/api/verifications/verdicts',
+    verdictBody,
+  );
+
+  if (!verdictResponse.ok) {
+    console.warn(`[fb-source-check] Failed to store verdict for ${result.factId}: ${verdictResponse.error}`);
   }
 }
 

--- a/crux/commands/source-check-orchestrate.ts
+++ b/crux/commands/source-check-orchestrate.ts
@@ -755,12 +755,20 @@ ${sourceText.slice(0, 4000)}
 
 Does the source text confirm, contradict, or not address this claim?
 
-Consider:
+IMPORTANT — avoid these common false-positive errors:
+- **Range vs. point**: If the source gives a range (e.g., "51-200 employees") and the claimed value falls within that range (e.g., 91), that is "confirmed", NOT contradicted.
+- **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
+- **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
+- **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
+
+Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
 - Dates may be approximate
 - If the source discusses the topic but the specific data point isn't mentioned, that's "unverifiable"
 - If the source has a newer value that supersedes the claimed value, that's "outdated"
 - If the source partially confirms (e.g., confirms the ballpark but not the exact figure), that's "partial"
+
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {
@@ -795,13 +803,21 @@ ${sourceText.slice(0, 4000)}
 
 Does the source text confirm, contradict, or not address the claims in this record?
 
-Consider:
+IMPORTANT — avoid these common false-positive errors:
+- **Range vs. point**: If the source gives a range (e.g., "51-200 employees") and the claimed value falls within that range (e.g., 91), that is "confirmed", NOT contradicted.
+- **Temporal mismatch**: Only compare values from the same time period. If the claim is about 2024 but the source discusses 2025 (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
+- **Wrong source relevance**: The source must actually discuss the specific claim. A company's own page cannot contradict a person's prior employment at a different company — that's "unverifiable".
+- **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted".
+
+Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
 - Names may differ slightly (abbreviations, legal names vs common names)
 - Dates may be approximate
 - If the source discusses the topic but doesn't contain the specific data, that's "unverifiable"
 - If the source has newer data that supersedes the record, that's "outdated"
 - If the source partially confirms (e.g., confirms role but not dates), that's "partial"
+
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {
@@ -958,9 +974,11 @@ async function verifySingleItem(
 
 async function storeResult(item: VerifyItem, result: VerifyResult): Promise<void> {
   if (item.data.kind === 'fact') {
+    const factId = (item.data as FactItemData).fact.id;
+
     await storeSourceCheckEvidence({
       recordType: 'fact',
-      recordId: (item.data as FactItemData).fact.id,
+      recordId: factId,
       sourceUrl: result.sourceUrl,
       verdict: result.verdict,
       confidence: result.confidence,
@@ -968,6 +986,20 @@ async function storeResult(item: VerifyItem, result: VerifyResult): Promise<void
       reasoning: result.reasoning,
       isPrimarySource: true,
     }, '[source-check]');
+
+    // Store aggregate verdict for facts too — ensures the most recent
+    // check result is reflected in the verdicts table, fixing stale
+    // contradictions that persisted after re-checks confirmed data.
+    await storeAggregateVerdict({
+      recordType: 'fact',
+      recordId: factId,
+      verdict: result.verdict,
+      confidence: result.confidence,
+      reasoning: result.reasoning,
+      sourcesChecked: 1,
+    }, '[source-check]').catch((e: unknown) => {
+      console.warn(`[source-check] Failed to store fact verdict: ${e instanceof Error ? e.message : String(e)}`);
+    });
   } else if (item.data.kind === 'record') {
     const recordData = item.data as RecordItemData;
 

--- a/crux/lib/source-check/source-fetcher.test.ts
+++ b/crux/lib/source-check/source-fetcher.test.ts
@@ -105,4 +105,53 @@ describe('htmlToText', () => {
   it('handles plain text (no HTML)', () => {
     expect(htmlToText('Just plain text')).toBe('Just plain text');
   });
+
+  it('extracts main content area when present', () => {
+    const html = `
+      <header><nav><a href="/">Home</a><a href="/about">About</a></nav></header>
+      <main><h1>Article Title</h1><p>This is the real content of the page with important facts.</p></main>
+      <footer><p>Copyright 2024</p></footer>
+    `;
+    const text = htmlToText(html);
+    expect(text).toContain('Article Title');
+    expect(text).toContain('real content');
+    expect(text).not.toContain('Home');
+    expect(text).not.toContain('Copyright');
+  });
+
+  it('extracts article content when no main tag', () => {
+    const html = `
+      <nav><a href="/">Menu Item 1</a></nav>
+      <article><h1>Story</h1><p>The article body has more than two hundred characters of actual useful content that we want to extract for source checking purposes.</p></article>
+      <aside><p>Sidebar content</p></aside>
+    `;
+    const text = htmlToText(html);
+    expect(text).toContain('Story');
+    expect(text).toContain('article body');
+    expect(text).not.toContain('Menu Item');
+    expect(text).not.toContain('Sidebar');
+  });
+
+  it('strips nav, header, footer, aside tags from full HTML', () => {
+    const html = `
+      <nav><a href="/">Nav Link</a></nav>
+      <header><h1>Site Header</h1></header>
+      <div><p>The actual page content</p></div>
+      <footer><p>Footer text</p></footer>
+      <aside><p>Side panel</p></aside>
+    `;
+    const text = htmlToText(html);
+    expect(text).toContain('actual page content');
+    expect(text).not.toContain('Nav Link');
+    expect(text).not.toContain('Site Header');
+    expect(text).not.toContain('Footer text');
+    expect(text).not.toContain('Side panel');
+  });
+
+  it('falls back to full HTML when main/article too short', () => {
+    const html = '<main><p>Hi</p></main><div><p>Full body content is here with details</p></div>';
+    const text = htmlToText(html);
+    // <main> has < 200 chars, so falls back to full HTML
+    expect(text).toContain('Full body content');
+  });
 });

--- a/crux/lib/source-check/source-fetcher.ts
+++ b/crux/lib/source-check/source-fetcher.ts
@@ -40,11 +40,20 @@ export function isPrivateHost(host: string): boolean {
 
 /**
  * Strip HTML tags and entities from raw HTML, returning plain text.
+ * Prioritizes <main>, <article>, or role="main" content to avoid
+ * nav/header/footer pollution that causes false "unverifiable" verdicts.
  */
 export function htmlToText(html: string): string {
-  return html
+  // Try to extract the main content area first to avoid nav/menu noise
+  const bodyContent = extractMainContent(html) ?? html;
+
+  return bodyContent
     .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, '')
+    .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, '')
+    .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, '')
+    .replace(/<aside[^>]*>[\s\S]*?<\/aside>/gi, '')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')
@@ -54,6 +63,28 @@ export function htmlToText(html: string): string {
     .replace(/&#39;/g, "'")
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+/**
+ * Try to extract the main content from an HTML page.
+ * Returns the inner HTML of <main>, <article>, or role="main" element,
+ * or null if none found.
+ */
+function extractMainContent(html: string): string | null {
+  // Try <main> tag
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch && mainMatch[1].length > 200) return mainMatch[1];
+
+  // Try role="main"
+  const roleMainMatch = html.match(/<[^>]+role=["']main["'][^>]*>([\s\S]*?)<\/\w+>/i);
+  if (roleMainMatch && roleMainMatch[1].length > 200) return roleMainMatch[1];
+
+  // Try <article> tag
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  if (articleMatch && articleMatch[1].length > 200) return articleMatch[1];
+
+  // No main content area found — fall back to full HTML
+  return null;
 }
 
 /**

--- a/crux/lib/source-check/verdict-handler.ts
+++ b/crux/lib/source-check/verdict-handler.ts
@@ -56,7 +56,7 @@ export async function storeSourceCheckEvidence(params: {
  * @param logPrefix - Prefix for warning messages (default: '[source-check]')
  */
 export async function storeAggregateVerdict(params: {
-  recordType: RecordType;
+  recordType: RecordType | 'fact';
   recordId: string;
   verdict: SourceCheckVerdict | string;
   confidence: number;


### PR DESCRIPTION
## Summary

- **LLM prompt improvements**: Add explicit false-positive avoidance guidance for range-vs-point (source says "51-200 employees", wiki says 91 → confirmed not contradicted), temporal mismatch (different time periods → unverifiable not contradicted), and wrong-source-relevance (company page can't contradict prior employment elsewhere → unverifiable)
- **Verdict aggregation fix**: Both `factbase-source-check` and `source-check-orchestrate` now store aggregate verdicts for facts (previously only evidence was stored), so re-running checks actually updates the displayed verdict. Changed `build-data.mjs` from "worst verdict wins" to "most recent verdict wins"
- **Web scraper body extraction**: `htmlToText` now extracts `<main>`, `<article>`, or `role="main"` content first and strips `<nav>`, `<header>`, `<footer>`, `<aside>` tags to reduce false "unverifiable" verdicts from nav/menu HTML noise

Closes #3157
Closes #3158

## Test plan
- [x] All 102 source-check tests pass (5 test files)
- [x] 4 new tests for `htmlToText` body extraction
- [x] TypeScript type-check passes with no new errors
- [x] `build-data:content` succeeds
- [x] Pre-existing build failure (factbase/currencies) confirmed on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
