### PR TITLE
fix: remove trailing slash from talent-flows API URL

### DIFF
--- a/apps/web/src/app/internal/talent-flows/talent-flows-content.tsx
+++ b/apps/web/src/app/internal/talent-flows/talent-flows-content.tsx
@@ -17,7 +17,7 @@ import {
 
 async function loadFromApi(): Promise<FetchResult<RpcTalentFlowsResult>> {
   return fetchDetailed<RpcTalentFlowsResult>(
-    "/api/talent-flows/",
+    "/api/talent-flows",
     { revalidate: 3600 }
   );
 }


### PR DESCRIPTION
## Summary
- The talent-flows dashboard (E2084) was showing a 404 because the frontend fetched `/api/talent-flows/` (with trailing slash), but the Hono route only matches `/api/talent-flows` (no trailing slash)
- Fix: remove the trailing slash from the fetch URL in `talent-flows-content.tsx`

## Verification
- Confirmed `/api/talent-flows` returns 200 with 88 transitions, 70 people, 54 orgs
- Confirmed `/api/talent-flows/` returns 404
- `pnpm build` passes
- `pnpm test` passes (4305 tests)

## Test plan
- [ ] After merge + deploy, verify https://www.longtermwiki.com/wiki/E2084 shows data instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an API endpoint path issue in the talent flows feature to ensure proper data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->