### PR TITLE
fix: pre-push hook blocks pushes to branches with merged PRs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,6 +8,30 @@
 
 set -euo pipefail
 
+# ── Check for pushes to branches with already-merged PRs ──
+# Prevents orphaned commits when an agent pushes after merge.
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && command -v gh &>/dev/null; then
+  PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null || true)
+  if [ "$PR_STATE" = "MERGED" ]; then
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║  BLOCKED: PR for branch '$BRANCH' is already MERGED.       ║"
+    echo "║                                                            ║"
+    echo "║  These commits will be orphaned — they won't reach main.   ║"
+    echo "║  Create a new branch and cherry-pick your commits instead. ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    exit 1
+  fi
+  if [ "$PR_STATE" = "CLOSED" ]; then
+    echo ""
+    echo "⚠  WARNING: PR for branch '$BRANCH' is CLOSED."
+    echo "   Commits pushed here won't reach main unless a new PR is opened."
+    echo ""
+  fi
+fi
+
 echo ""
 echo "Running pre-push gate checks..."
 echo ""


### PR DESCRIPTION
## Summary

Adds a guard at the start of `.githooks/pre-push` that checks whether the current branch's PR has already been merged. If so, the push is blocked with a clear error message explaining that commits will be orphaned.

**Motivated by:** An incident where a FactBase fix was pushed to `claude/fix-quri-page` after PR #3186 was already merged. The commit never reached main and had to be cherry-picked into a separate PR (#3196).

## Behavior

- **PR merged** → push blocked with error
- **PR closed** → push allowed with warning  
- **PR open / no PR / no gh CLI** → push proceeds normally
- **main branch** → check skipped

## Test Plan
- [x] Hook correctly detects merged PR state via `gh pr view`
- [x] Falls through gracefully when `gh` CLI unavailable
- [x] Doesn't affect pushes to main or branches without PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-push git hook to detect PR state and block pushes for merged PRs, with warnings for closed PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->