### PR TITLE
fix: recover NOT EXISTS integrity SQL from lost QA sweep commits

### DIFF
--- a/apps/wiki-server/src/routes/operational/integrity.ts
+++ b/apps/wiki-server/src/routes/operational/integrity.ts
@@ -43,7 +43,7 @@ const integrityApp = new Hono()
       // 1. facts.entity_id → entities.stable_id
       checkDangling(
         db,
-        sql`SELECT DISTINCT entity_id AS ref FROM facts WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL)`,
+        sql`SELECT DISTINCT f.entity_id AS ref FROM facts f WHERE NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = f.entity_id)`,
         "facts",
         "entity_id",
         "entities"
@@ -51,16 +51,16 @@ const integrityApp = new Hono()
       // 2. summaries.entity_id → entities.stable_id
       checkDangling(
         db,
-        sql`SELECT DISTINCT entity_id AS ref FROM summaries WHERE entity_id NOT IN (SELECT stable_id FROM entities WHERE stable_id IS NOT NULL)`,
+        sql`SELECT DISTINCT s.entity_id AS ref FROM summaries s WHERE NOT EXISTS (SELECT 1 FROM entities e WHERE e.stable_id = s.entity_id)`,
         "summaries",
         "entity_id",
         "entities"
       ),
       // 4. citation_quotes.page_id → wiki_pages
-      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
+      // Catches both NULL page_id (unresolved) and non-NULL values with no matching wiki_page
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id::text AS ref FROM citation_quotes WHERE (page_id IS NULL OR page_id NOT IN (SELECT id FROM wiki_pages))`,
+        sql`SELECT DISTINCT cq.page_id::text AS ref FROM citation_quotes cq WHERE cq.page_id IS NULL OR NOT EXISTS (SELECT 1 FROM wiki_pages wp WHERE wp.id = cq.page_id)`,
         "citation_quotes",
         "page_id",
         "wiki_pages"
@@ -68,16 +68,16 @@ const integrityApp = new Hono()
       // 5. citation_quotes.resource_id → resources
       checkDangling(
         db,
-        sql`SELECT DISTINCT resource_id AS ref FROM citation_quotes WHERE resource_id IS NOT NULL AND resource_id NOT IN (SELECT id FROM resources)`,
+        sql`SELECT DISTINCT cq.resource_id AS ref FROM citation_quotes cq WHERE cq.resource_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.id = cq.resource_id)`,
         "citation_quotes",
         "resource_id",
         "resources"
       ),
       // 6. edit_logs.page_id → wiki_pages
-      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
+      // Catches both NULL page_id (unresolved) and non-NULL values with no matching wiki_page
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id::text AS ref FROM edit_logs WHERE (page_id IS NULL OR page_id NOT IN (SELECT id FROM wiki_pages))`,
+        sql`SELECT DISTINCT el.page_id::text AS ref FROM edit_logs el WHERE el.page_id IS NULL OR NOT EXISTS (SELECT 1 FROM wiki_pages wp WHERE wp.id = el.page_id)`,
         "edit_logs",
         "page_id",
         "wiki_pages"
@@ -85,16 +85,16 @@ const integrityApp = new Hono()
       // 7. entities.relatedEntries JSONB → entities
       checkDangling(
         db,
-        sql`SELECT DISTINCT elem->>'id' AS ref FROM entities, jsonb_array_elements(related_entries) AS elem WHERE related_entries IS NOT NULL AND (elem->>'id') NOT IN (SELECT id FROM entities)`,
+        sql`SELECT DISTINCT elem->>'id' AS ref FROM entities ent, jsonb_array_elements(ent.related_entries) AS elem WHERE ent.related_entries IS NOT NULL AND NOT EXISTS (SELECT 1 FROM entities e2 WHERE e2.id = elem->>'id')`,
         "entities",
         "related_entries[].id",
         "entities"
       ),
       // 8. resource_citations.page_id → wiki_pages
-      // NULL-safe: NULL NOT IN (...) = NULL in SQL, so include IS NULL to catch unresolved rows
+      // Catches both NULL page_id (unresolved) and non-NULL values with no matching wiki_page
       checkDangling(
         db,
-        sql`SELECT DISTINCT page_id::text AS ref FROM resource_citations WHERE (page_id IS NULL OR page_id NOT IN (SELECT id FROM wiki_pages))`,
+        sql`SELECT DISTINCT rc.page_id::text AS ref FROM resource_citations rc WHERE rc.page_id IS NULL OR NOT EXISTS (SELECT 1 FROM wiki_pages wp WHERE wp.id = rc.page_id)`,
         "resource_citations",
         "page_id",
         "wiki_pages"


### PR DESCRIPTION
## Summary
- Recovers the one remaining fix from 4 lost post-merge commits on `claude/qa-sweep-deep-fixes` (PR #2604, merged Mar 17)
- Replaces `NOT IN (SELECT ...)` with `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` in all 7 integrity check SQL queries
- Adds table aliases (f, s, cq, el, ent, rc) for clarity

## Context

PR #2604 was squash-merged on Mar 17, but 4 commits were pushed after the merge point and never made it to main. After auditing all 4 commits against current main:

| Commit | Description | Status |
|--------|-------------|--------|
| 45663d4 | FLI/CG data fixes (parent-org property, wikiId null, headcount) | Already on main |
| b35cd98 | Stale open-philanthropy entity references → coefficient-giving | Already on main |
| c2b69fe | P1 QA sweep (dbError wrapping, entity-transform fields, links.ts double-cast, resources HARD_LIMIT, coefficient-giving MDX) | Already on main |
| ee251d4 | **NOT EXISTS for integrity SQL** + shared PaginationControls | PaginationControls already on main; **SQL fix still needed** |

Only the integrity SQL fix (`NOT IN` → `NOT EXISTS`) was missing from main.

## Why NOT EXISTS is better

`NOT IN` has a subtle NULL-safety issue: `WHERE x NOT IN (SELECT y FROM t)` returns NULL (not TRUE) when any `y` is NULL, which can cause rows to silently disappear from results. `NOT EXISTS` avoids this and is typically more performant with correlated subqueries.

## Test plan
- [x] Verified all 7 integrity SQL queries updated
- [x] Confirmed test failures are pre-existing worktree issues (identical on main)
- [x] Build-data step passes
- [x] Change is SQL-only inside template literals — no TypeScript logic changed

Closes #3207

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal database integrity check queries to improve efficiency. SQL predicates for validating data consistency have been restructured without affecting the overall behavior or results of integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->