### PR TITLE
fix: QURI FactBase — remove redundant funding, split legal structure, fix founder name

### DIFF
--- a/packages/factbase/data/things/quri.yaml
+++ b/packages/factbase/data/things/quri.yaml
@@ -33,35 +33,27 @@ facts:
       1 full-time staff (Ozzie Gooen); plus research collaborators
       (Nuño Sempere, Eli Lifland) and past contributors
 
-  - id: f_zwFMLRENMB
-    property: funding-received
-    value: 650000
-    asOf: !date 2022
-    source: https://survivalandflourishing.fund
-    notes: Survival and Flourishing Fund (SFF) grants 2019-2022
-    grantor: !ref pvJ50HupEQ
-
-  - id: f_AyrcCzn5aW
-    property: funding-received
-    value: 200000
-    asOf: !date 2022
-    source: https://web.archive.org/web/20221212115231/https://ftxfuturefund.org/
-    notes: Future Fund grant 2022 (pre-FTX collapse)
-
-  - id: f_qduycirTr5
-    property: funding-received
-    value: 100000
-    asOf: !date 2024
-    notes: Long-Term Future Fund (LTFF) ongoing support (estimated annual; not a sourced exact figure)
-    grantor: !ref yA12C1KcjQ
-
   - id: f_QR8legal01
     property: legal-structure
-    value: "501(c)(3) nonprofit; fiscally sponsored by Rethink Priorities"
+    value: "501(c)(3) nonprofit"
     asOf: !date 2026-03
+    source: https://quantifieduncertainty.org/about/
+
+  - id: f_QR8fiscal01
+    property: fiscal-sponsor
+    value: !ref t0p43V5oLA
+    asOf: !date 2023
+    source: https://quantifieduncertainty.org/about/
+    notes: Fiscally sponsored under Rethink Priorities Special Projects Program since 2023
 
   - id: f_QR9fndby01
     property: founded-by
     value:
       - !ref 24aX2Ru7Dg
     notes: Founded by Ozzie Gooen in 2019
+
+  - id: f_QR9fndby02
+    property: founded-by-name
+    value: Ozzie Gooen
+    source: https://quantifieduncertainty.org/about/
+    notes: Text fallback for display when entity ref doesn't resolve


### PR DESCRIPTION
## Summary

Fixes several data quality issues on the QURI organization page (`/organizations/quri`):

- **Remove funding-received facts** — this data is already in TableBase grants (Funding tab shows 8 records with funder details). The FactBase version was a worse duplicate showing only $100K (latest fact) instead of the full picture
- **Split legal structure** — "501(c)(3) nonprofit; fiscally sponsored by Rethink Priorities" split into:
  - `legal-structure`: "501(c)(3) nonprofit" 
  - `fiscal-sponsor`: entity ref to Rethink Priorities (relational, goes both ways)
- **Add founded-by-name** — text fallback "Ozzie Gooen" since the `!ref` entity ID "24aX2Ru7Dg" was displaying as raw stableId
- **Personnel sync** — ran `import-quri-personnel sync` to add 9 records (Ozzie, Nuño, Sam Nolan, Slava, etc.) with historical start/end dates

Note: The "Unknown" name on the People tab (issue #3194) is a separate frontend bug where personnel records' personId stableIds aren't resolved to names.

## Test Plan
- [x] `pnpm crux fb show quri` — no funding-received, correct legal structure, founded-by-name present
- [x] Facts synced to prod wiki-server (1883 facts upserted)
- [x] Personnel synced to prod wiki-server (9 records)
- [ ] After deploy: verify /organizations/quri Overview shows no "$0 funding" card
