### PR TITLE
fix: remove contradictory legal-structure fact, fix float precision in equity chart

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-charts.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-charts.tsx
@@ -421,7 +421,7 @@ export function EquityBreakdownChart({
     const holderSummaries = sorted.map((h) => {
       const stake =
         h.stakeLow != null && h.stakeHigh != null
-          ? `${h.stakeLow}–${h.stakeHigh}%`
+          ? `${parseFloat(h.stakeLow.toFixed(1))}–${parseFloat(h.stakeHigh.toFixed(1))}%`
           : `~${h.stakePercent.toFixed(1)}%`;
       const value =
         valuation != null
@@ -500,7 +500,7 @@ export function EquityBreakdownChart({
               </span>
               <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
                 {h.stakeLow != null && h.stakeHigh != null
-                  ? `${h.stakeLow}–${h.stakeHigh}%`
+                  ? `${parseFloat(h.stakeLow.toFixed(1))}–${parseFloat(h.stakeHigh.toFixed(1))}%`
                   : `~${h.stakePercent.toFixed(1)}%`}
               </span>
               {equityValue != null && (

--- a/packages/factbase/data/things/anthropic.yaml
+++ b/packages/factbase/data/things/anthropic.yaml
@@ -485,11 +485,6 @@ facts:
     value: Chris Olah
     source: https://www.wikidata.org/wiki/Q116758847
     notes: From Wikidata Q116758847; text value (not entity ref)
-  - id: wk9n4TXkdA
-    property: legal-structure
-    value: Delaware corporation
-    source: https://www.wikidata.org/wiki/Q116758847
-    notes: From Wikidata Q116758847
   - id: S4m9grsGAw
     property: wikipedia-url
     value: https://en.wikipedia.org/wiki/Anthropic


### PR DESCRIPTION
## Summary
- **Bug 19**: Removed stale Wikidata-imported `legal-structure: "Delaware corporation"` fact from Anthropic's FactBase YAML. The Harvard-sourced "Public benefit corporation" fact (with Long-Term Benefit Trust detail) remains as the canonical, more specific entry.
- **Bug 8**: Fixed float precision bug in equity breakdown chart (`org-charts.tsx`) where `0.017 * 100` produced `1.7000000000000002` in IEEE 754. Applied `.toFixed(1)` with `parseFloat` to round range values in both the aria label and legend table display.

## Test plan
- [x] YAML change reviewed: only the stale Wikidata legal-structure fact removed, Harvard PBC fact untouched
- [x] Float fix verified: `parseFloat((0.017 * 100).toFixed(1))` produces `1.7` (not `1.7000000000000002`)
- [x] Both display locations in org-charts.tsx updated (aria label and legend table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)