### PR TITLE
fix: resolve FactBase ref links to proper directory URLs

### DIFF
--- a/apps/web/src/components/directory/FactsSection.tsx
+++ b/apps/web/src/components/directory/FactsSection.tsx
@@ -9,6 +9,7 @@ import {
   getKBEntitySlug,
   isFactExpired,
 } from "@/data/factbase";
+import { getEntityHref } from "@/data/entity-nav";
 import {
   formatKBFactValue,
   titleCase,
@@ -67,18 +68,26 @@ export function groupByCategory(
 
 // ── Components ───────────────────────────────────────────────────────
 
+/**
+ * Resolve a FactBase ref value to its canonical URL.
+ * Uses getKBEntitySlug to get the slug (handles both stableIds and slugs),
+ * then getEntityHref for proper directory routing (all entity types).
+ * Falls back to /factbase/entity/{id} only if the entity has no wiki presence.
+ */
+function resolveRefHref(refId: string): string {
+  const refSlug = getKBEntitySlug(refId);
+  if (refSlug) return getEntityHref(refSlug);
+  return `/factbase/entity/${refId}`;
+}
+
 /** Render a fact value, resolving ref/refs to entity name links. */
 export function FactValueDisplay({ fact, property }: { fact: Fact; property?: Property }) {
   const v = fact.value;
   if (v.type === "ref") {
     const refEntity = getKBEntity(v.value);
     if (refEntity) {
-      const refSlug = getKBEntitySlug(v.value);
-      const href = refSlug && refEntity.type === "organization" ? `/organizations/${refSlug}`
-        : refSlug && refEntity.type === "person" ? `/people/${refSlug}`
-        : `/factbase/entity/${v.value}`;
       return (
-        <Link href={href} className="text-primary hover:underline">
+        <Link href={resolveRefHref(v.value)} className="text-primary hover:underline">
           {refEntity.name}
         </Link>
       );
@@ -91,14 +100,10 @@ export function FactValueDisplay({ fact, property }: { fact: Fact; property?: Pr
         {v.value.map((refId, i) => {
           const refEntity = getKBEntity(refId);
           if (refEntity) {
-            const refSlug = getKBEntitySlug(refId);
-            const href = refSlug && refEntity.type === "organization" ? `/organizations/${refSlug}`
-              : refSlug && refEntity.type === "person" ? `/people/${refSlug}`
-              : `/factbase/entity/${refId}`;
             return (
               <span key={refId}>
                 {i > 0 && ", "}
-                <Link href={href} className="text-primary hover:underline">
+                <Link href={resolveRefHref(refId)} className="text-primary hover:underline">
                   {refEntity.name}
                 </Link>
               </span>

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -645,6 +645,10 @@ export function getFactBaseEntitySlug(entityId: string): string | undefined {
     const registry = getIdRegistry();
     const slug = registry.stableIdToSlug?.[entityId] ?? registry.byStableId?.[entityId];
     if (slug) return slug;
+
+    // Check if the input is already a known slug (e.g. "us-aisi" passed
+    // from a FactBase ref value that happens to be a slug, not a stableId)
+    if (registry.stableIdBySlug?.[entityId]) return entityId;
   } catch {
     // database.json not available yet — fall through
   }

--- a/apps/web/src/lib/__tests__/resolve-entity-name.test.ts
+++ b/apps/web/src/lib/__tests__/resolve-entity-name.test.ts
@@ -11,13 +11,20 @@ vi.mock("@/data/tablebase", () => ({
   getTypedEntityById: vi.fn(),
 }));
 
+// Mock entity-nav — getEntityHref builds directory URLs from slugs
+vi.mock("@/data/entity-nav", () => ({
+  getEntityHref: vi.fn(),
+}));
+
 import { resolveEntityName } from "../resolve-entity-name";
 import { getKBEntity, getKBEntitySlug } from "@/data/factbase";
 import { getTypedEntityById } from "@/data/tablebase";
+import { getEntityHref } from "@/data/entity-nav";
 
 const mockGetKBEntity = vi.mocked(getKBEntity);
 const mockGetKBEntitySlug = vi.mocked(getKBEntitySlug);
 const mockGetTypedEntityById = vi.mocked(getTypedEntityById);
+const mockGetEntityHref = vi.mocked(getEntityHref);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -36,6 +43,7 @@ describe("resolveEntityName", () => {
       type: "person",
     } as ReturnType<typeof getKBEntity>);
     mockGetKBEntitySlug.mockReturnValue("dario-amodei");
+    mockGetEntityHref.mockReturnValue("/people/dario-amodei");
 
     const result = resolveEntityName("3KjUCZCV8w", "Dario Amodei");
     expect(result).toEqual({
@@ -51,6 +59,7 @@ describe("resolveEntityName", () => {
       type: "organization",
     } as ReturnType<typeof getKBEntity>);
     mockGetKBEntitySlug.mockReturnValue("anthropic");
+    mockGetEntityHref.mockReturnValue("/organizations/anthropic");
 
     const result = resolveEntityName("3KjUCZCV8w");
     expect(result).toEqual({
@@ -66,6 +75,7 @@ describe("resolveEntityName", () => {
       type: "organization",
     } as ReturnType<typeof getKBEntity>);
     mockGetKBEntitySlug.mockReturnValue("miri");
+    mockGetEntityHref.mockReturnValue("/organizations/miri");
 
     const result = resolveEntityName("miri");
     expect(result).toEqual({
@@ -131,10 +141,11 @@ describe("resolveEntityName", () => {
       type: "person",
     } as ReturnType<typeof getKBEntity>);
     mockGetKBEntitySlug.mockReturnValue("some-entity");
+    mockGetEntityHref.mockReturnValue("/people/some-entity");
 
     const result = resolveEntityName("some-entity", "Override Name");
     expect(result.name).toBe("Override Name");
-    // Still gets href from FactBase
+    // Still gets href from FactBase via getEntityHref
     expect(result.href).toBe("/people/some-entity");
   });
 
@@ -152,19 +163,21 @@ describe("resolveEntityName", () => {
     expect(result.name).toBe("Empty Name");
   });
 
-  it("returns factbase entity path for non-org/person types", () => {
+  it("uses getEntityHref for all entity types with slugs (including non-directory types)", () => {
     mockGetKBEntity.mockReturnValue({
       id: "some-concept",
       name: "Some Concept",
       type: "concept",
     } as ReturnType<typeof getKBEntity>);
     mockGetKBEntitySlug.mockReturnValue("some-concept");
+    mockGetEntityHref.mockReturnValue("/wiki/E42");
 
     const result = resolveEntityName("some-concept");
     expect(result).toEqual({
       name: "Some Concept",
-      href: "/factbase/entity/some-concept",
+      href: "/wiki/E42",
     });
+    expect(mockGetEntityHref).toHaveBeenCalledWith("some-concept");
   });
 
   it("trims whitespace from displayName", () => {
@@ -196,6 +209,7 @@ describe("resolveEntityName", () => {
       customFields: [],
       relatedTopics: [],
     });
+    mockGetEntityHref.mockReturnValue("/organizations/some-org");
 
     const result = resolveEntityName("some-org");
     expect(result).toEqual({
@@ -218,6 +232,7 @@ describe("resolveEntityName", () => {
       customFields: [],
       relatedTopics: [],
     });
+    mockGetEntityHref.mockReturnValue("/people/tom-brown");
 
     const result = resolveEntityName("tom-brown");
     expect(result).toEqual({

--- a/apps/web/src/lib/resolve-entity-name.ts
+++ b/apps/web/src/lib/resolve-entity-name.ts
@@ -15,6 +15,7 @@ import {
   getKBEntitySlug,
 } from "@/data/factbase";
 import { getTypedEntityById } from "@/data/tablebase";
+import { getEntityHref } from "@/data/entity-nav";
 import { titleCase } from "@/components/wiki/factbase/format";
 
 /**
@@ -29,14 +30,18 @@ const STABLE_ID_PATTERN = /^(?=.*[A-Z])[A-Za-z0-9]{10}$/;
  */
 const NUMERIC_ID_PATTERN = /^\d+$/;
 
+/**
+ * Build the canonical href for an entity.
+ * Uses getEntityHref which handles all entity types with directory pages
+ * (organizations, people, ai-models, benchmarks, policies, projects, etc.).
+ * Falls back to /factbase/entity/{id} only for entities without wiki slugs.
+ */
 function buildEntityHref(
-  entityType: string,
+  _entityType: string,
   slug: string | undefined,
   entityId: string,
 ): string | null {
-  if (!slug) return `/factbase/entity/${entityId}`;
-  if (entityType === "organization") return `/organizations/${slug}`;
-  if (entityType === "person") return `/people/${slug}`;
+  if (slug) return getEntityHref(slug);
   return `/factbase/entity/${entityId}`;
 }
 


### PR DESCRIPTION
## Summary
- Fix `getFactBaseEntitySlug()` to handle inputs that are already slugs (e.g. "us-aisi"), not just stableIds
- Refactor `FactValueDisplay` in `FactsSection.tsx` to use `getEntityHref` for all entity types (previously only handled organization and person types, falling back to `/factbase/entity/` for everything else)
- Update `buildEntityHref` in `resolve-entity-name.ts` to use `getEntityHref` for canonical URL resolution across all entity types
- Update tests to mock the new `getEntityHref` dependency

## Test plan
- [x] `resolve-entity-name.test.ts` passes (19 tests)
- [x] Verified the fix handles slug inputs ("us-aisi") and stableId inputs ("fYyAxYlHDQ") correctly
- [x] All existing test expectations preserved for org/person types; non-directory types now route through `getEntityHref` instead of falling back to `/factbase/entity/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
