### PR TITLE
fix: eliminate N+1 API calls in races page

### DIFF
--- a/apps/web/src/app/races/page.tsx
+++ b/apps/web/src/app/races/page.tsx
@@ -34,42 +34,46 @@ interface StatsApiResult {
 }
 
 export default async function RacesPage() {
-  // Fetch races (all, with ISR revalidation)
-  const racesData = await fetchFromWikiServer<{
-    races: RaceApiRow[];
-    total: number;
-  }>("/api/political-races/all?limit=200", { revalidate: 300 });
+  // Fetch races, stats, and all candidates in 3 parallel bulk calls (not per-race)
+  const [racesData, stats, candidatesData] = await Promise.all([
+    fetchFromWikiServer<{
+      races: RaceApiRow[];
+      total: number;
+    }>("/api/political-races/all?limit=200", { revalidate: 300 }),
+    fetchFromWikiServer<StatsApiResult>(
+      "/api/political-races/stats",
+      { revalidate: 300 },
+    ),
+    fetchFromWikiServer<{
+      candidates: (CandidateRow & { raceId: string })[];
+      total: number;
+    }>("/api/political-races/candidates/all?limit=1000", { revalidate: 300 }),
+  ]);
 
-  const stats = await fetchFromWikiServer<StatsApiResult>(
-    "/api/political-races/stats",
-    { revalidate: 300 },
-  );
+  // Group candidates by raceId for O(1) lookup
+  const candidatesByRace = new Map<string, CandidateRow[]>();
+  for (const c of candidatesData?.candidates ?? []) {
+    const list = candidatesByRace.get(c.raceId) ?? [];
+    list.push(c);
+    candidatesByRace.set(c.raceId, list);
+  }
 
-  // Fetch each race's candidates
   const races = racesData?.races ?? [];
-  const raceRows: RaceRow[] = await Promise.all(
-    races.map(async (race) => {
-      const detail = await fetchFromWikiServer<{
-        candidates: CandidateRow[];
-      }>(`/api/political-races/${race.id}`, { revalidate: 300 });
-
-      return {
-        id: race.id,
-        name: race.name,
-        raceType: race.raceType,
-        party: race.party,
-        level: race.level,
-        state: race.state,
-        district: race.district,
-        electionDate: race.electionDate,
-        status: race.status,
-        outcome: race.outcome,
-        outcomeDetails: race.outcomeDetails,
-        aiAngle: race.aiAngle,
-        candidates: detail?.candidates ?? [],
-      };
-    }),
-  );
+  const raceRows: RaceRow[] = races.map((race) => ({
+    id: race.id,
+    name: race.name,
+    raceType: race.raceType,
+    party: race.party,
+    level: race.level,
+    state: race.state,
+    district: race.district,
+    electionDate: race.electionDate,
+    status: race.status,
+    outcome: race.outcome,
+    outcomeDetails: race.outcomeDetails,
+    aiAngle: race.aiAngle,
+    candidates: candidatesByRace.get(race.id) ?? [],
+  }));
 
   const raceStats = stats?.races ?? { total: 0, upcoming: 0, active: 0, resolved: 0 };
   const candidateStats = stats?.candidates ?? { total: 0 };

--- a/apps/wiki-server/src/routes/tablebase/political-races.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-races.ts
@@ -69,6 +69,11 @@ const AllQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
+const CandidatesAllQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).default(1000),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 // ---- Sync schemas ----
 
 const SyncRaceItemSchema = z.object({
@@ -349,7 +354,7 @@ const politicalRacesApp = new Hono()
   })
 
   // ---- GET /candidates/all ----
-  .get("/candidates/all", zv("query", AllQuery), async (c) => {
+  .get("/candidates/all", zv("query", CandidatesAllQuery), async (c) => {
     const { limit, offset } = c.req.valid("query");
     const db = getDrizzleDb();
 


### PR DESCRIPTION
## Summary

- Replace ~200 per-race `fetchFromWikiServer` calls with a single bulk fetch to the existing `/candidates/all` endpoint
- Run all 3 data fetches (races, stats, candidates) in parallel via `Promise.all`
- Group candidates by `raceId` client-side using a `Map` for O(1) lookup
- Increase candidates/all endpoint limit from 200 to 1000 (candidates can significantly outnumber races)

**Before**: N+1 pattern — 1 call for races + ~200 calls for candidates (one per race) = ~202 wiki-server requests on ISR cache miss

**After**: 3 parallel bulk API calls regardless of race count

## Test plan

- [ ] Verify `/races` page renders correctly with candidates grouped under each race
- [ ] Verify expanded race rows still show candidate details
- [ ] Confirm build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized races page data loading through streamlined data retrieval.

* **API Updates**
  * Refined pagination parameters for the candidates endpoint with adjusted default and maximum limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->