### PR TITLE
fix: [object Object] in FactBase fact display — flatten nested value format

### DIFF
--- a/apps/web/src/components/wiki/factbase/format.ts
+++ b/apps/web/src/components/wiki/factbase/format.ts
@@ -129,8 +129,34 @@ export function formatKBFactValue(
     }
     case "min":
       return `\u2265${formatKBNumber(v.value, unit, display)}`;
-    case "json":
+    case "json": {
+      // Guard: if the JSON value is a nested FactValue object (e.g., malformed YAML
+      // `value: {type: number, value: X, unit: USD}`), format it properly instead of
+      // showing raw JSON. This prevents "[object Object]" or ugly JSON strings.
+      const jv = v.value;
+      if (
+        jv !== null &&
+        typeof jv === "object" &&
+        !Array.isArray(jv) &&
+        "type" in jv &&
+        "value" in jv
+      ) {
+        const nested = jv as { type: string; value: unknown; unit?: string };
+        if (nested.type === "number" && typeof nested.value === "number") {
+          return formatKBNumber(nested.value, unit ?? nested.unit, display, fact.currency);
+        }
+        if (nested.type === "text" && typeof nested.value === "string") {
+          return nested.value;
+        }
+        if (nested.type === "date" && typeof nested.value === "string") {
+          return formatKBDate(nested.value);
+        }
+        if (nested.type === "boolean") {
+          return nested.value ? "Yes" : "No";
+        }
+      }
       return JSON.stringify(v.value);
+    }
     default: {
       // Safety: guard against value being an object (e.g., malformed FactValue
       // or nested object not caught by a specific case). String({}) produces

--- a/packages/factbase/data/things/fli.yaml
+++ b/packages/factbase/data/things/fli.yaml
@@ -21,28 +21,22 @@ facts:
     notes: From Wikidata Q18356657
   - id: zmHy23FJeA
     property: grant-given
-    value:
-      type: number
-      value: 25025000
-      unit: USD
+    value: "25025000"
+    unit: USD
     asOf: !date 2022-12
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Initial capitalization of Future of Life Foundation (FLF)
   - id: 6kND9gRtUg
     property: grant-given
-    value:
-      type: number
-      value: 15700000
-      unit: USD
+    value: "15700000"
+    unit: USD
     asOf: !date 2023
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional grant to FLF in 2023
   - id: 4p6lNgGXTw
     property: grant-given
-    value:
-      type: number
-      value: 18100000
-      unit: USD
+    value: "18100000"
+    unit: USD
     asOf: !date 2024
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional grant to FLF in 2024

--- a/packages/factbase/data/things/future-of-life-foundation.yaml
+++ b/packages/factbase/data/things/future-of-life-foundation.yaml
@@ -19,30 +19,24 @@ facts:
 
   - id: jcWxrJcFHA
     property: funding-received
-    value:
-      type: number
-      value: 25025000
-      unit: USD
+    value: "25025000"
+    unit: USD
     asOf: !date 2022
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Initial capitalization from FLI in December 2022
 
   - id: kkD8QJ7GnQ
     property: funding-received
-    value:
-      type: number
-      value: 15700000
-      unit: USD
+    value: "15700000"
+    unit: USD
     asOf: !date 2023
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional FLI grant in 2023
 
   - id: c4n53UgmJQ
     property: funding-received
-    value:
-      type: number
-      value: 18100000
-      unit: USD
+    value: "18100000"
+    unit: USD
     asOf: !date 2024
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional FLI grant in 2024
@@ -66,20 +60,16 @@ facts:
 
   - id: oVR358oLnw
     property: grant-given
-    value:
-      type: number
-      value: 800000
-      unit: USD
+    value: "800000"
+    unit: USD
     asOf: !date 2025-04
     source: https://www.wiseancestors.org/discover/wise-ancestors-receives-grant-from-future-of-life-foundation-supporting-the-growth-of-its-highly-collaborative-decentralized-conservation-genomics-platform
     notes: Grant to Wise Ancestors for conservation genomics platform growth
 
   - id: XoYyHGrQXw
     property: grant-given
-    value:
-      type: number
-      value: 1275000
-      unit: USD
+    value: "1275000"
+    unit: USD
     asOf: !date 2025-07
     notes: >-
       Estimated cost of AI for Human Reasoning Fellowship: 30 fellows x


### PR DESCRIPTION
## Summary
- **P0 bug**: `[object Object]` rendered on org pages (Anthropic Total Funding, Customer Count; OpenAI Valuation) and Sam Altman's Quick Assessment
- **Root cause**: 2 FactBase YAML files (`fli.yaml`, `future-of-life-foundation.yaml`) used nested value format `{type: number, value: X, unit: USD}` instead of flat scalars, creating doubly-nested FactValues
- **Fix**: Flattened 8 facts in the 2 YAML files + added defensive handling in `format.ts` to detect and format nested FactValue objects as a guard against future YAML authoring mistakes

Found by exhaustive QA sweep (Discussion #3220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)