### PR TITLE
fix: filter out unnamed personnel from org People tabs

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -274,12 +274,12 @@ export default async function OrgProfilePage({
   tabs.push({ id: "overview", label: "Overview", content: overviewContent });
 
   // ── People tab: key personnel + board + PG personnel data ──
-  const pgEntries = pgPersonnelToEntries(pgPersonnelRows);
+  const pgResult = pgPersonnelToEntries(pgPersonnelRows);
 
   const hasPeopleData =
     data.sortedPersons.length > 0 ||
     data.boardMembers.length > 0 ||
-    pgEntries.length > 0;
+    pgResult.entries.length > 0;
 
   if (hasPeopleData) {
     // Build unified people list from key-persons + board members + PG personnel
@@ -373,7 +373,7 @@ export default async function OrgProfilePage({
     }
 
     // Merge PG personnel data (supplements FactBase data, deduplicates by slug/name)
-    mergePgPersonnel(peopleByName, pgEntries);
+    mergePgPersonnel(peopleByName, pgResult.entries);
 
     const allPeople = [...peopleByName.values()].sort((a, b) => {
       // Current before former
@@ -388,7 +388,7 @@ export default async function OrgProfilePage({
       id: "people",
       label: "People",
       count: allPeople.length,
-      content: <PeopleSection people={allPeople} />,
+      content: <PeopleSection people={allPeople} unresolvedCount={pgResult.unresolvedCount} />,
     });
   }
 

--- a/apps/web/src/app/organizations/[slug]/people-section.test.ts
+++ b/apps/web/src/app/organizations/[slug]/people-section.test.ts
@@ -62,9 +62,10 @@ describe("pgPersonnelToEntries", () => {
       person: { entityId: "e1", slug: "alice-smith", name: "Alice Smith" },
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries).toHaveLength(1);
-    expect(entries[0]).toEqual({
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.unresolvedCount).toBe(0);
+    expect(result.entries[0]).toEqual({
       name: "Alice Smith",
       title: "CEO",
       slug: "alice-smith",
@@ -84,8 +85,8 @@ describe("pgPersonnelToEntries", () => {
       personResolvedName: "Resolved Name",
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].name).toBe("Resolved Name");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].name).toBe("Resolved Name");
   });
 
   it("humanizes slug-format personId as last-resort fallback name", () => {
@@ -95,30 +96,32 @@ describe("pgPersonnelToEntries", () => {
       personResolvedName: null,
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].name).toBe("Fallback Id");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].name).toBe("Fallback Id");
   });
 
-  it("returns 'Unknown' for bare stableId personId", () => {
+  it("excludes bare stableId personId and counts as unresolved", () => {
     const row = makeRow({
       personId: "AbCdEfG12H",
       person: { entityId: null, slug: null, name: null },
       personResolvedName: null,
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].name).toBe("Unknown");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries).toHaveLength(0);
+    expect(result.unresolvedCount).toBe(1);
   });
 
-  it("returns 'Unknown' for numeric PK personId", () => {
+  it("excludes numeric PK personId and counts as unresolved", () => {
     const row = makeRow({
       personId: "12345",
       person: { entityId: null, slug: null, name: null },
       personResolvedName: null,
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].name).toBe("Unknown");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries).toHaveLength(0);
+    expect(result.unresolvedCount).toBe(1);
   });
 
   it("strips 'new:' prefix from personId fallback", () => {
@@ -128,33 +131,34 @@ describe("pgPersonnelToEntries", () => {
       personResolvedName: null,
     });
 
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].name).toBe("Jane Smith");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].name).toBe("Jane Smith");
   });
 
   it("sets isCurrent=false when endDate is present", () => {
     const row = makeRow({ endDate: "2023-12-31" });
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].isCurrent).toBe(false);
-    expect(entries[0].end).toBe("2023-12-31");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].isCurrent).toBe(false);
+    expect(result.entries[0].end).toBe("2023-12-31");
   });
 
   it("marks board members correctly", () => {
     const row = makeRow({ roleType: "board" });
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].isBoard).toBe(true);
-    expect(entries[0].roleType).toBe("board");
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].isBoard).toBe(true);
+    expect(result.entries[0].roleType).toBe("board");
   });
 
   it("sets roleType to undefined for invalid roleType values", () => {
     const row = makeRow({ roleType: "unknown-type" as string });
-    const entries = pgPersonnelToEntries([row]);
-    expect(entries[0].roleType).toBeUndefined();
+    const result = pgPersonnelToEntries([row]);
+    expect(result.entries[0].roleType).toBeUndefined();
   });
 
   it("handles empty array input", () => {
-    const entries = pgPersonnelToEntries([]);
-    expect(entries).toEqual([]);
+    const result = pgPersonnelToEntries([]);
+    expect(result.entries).toEqual([]);
+    expect(result.unresolvedCount).toBe(0);
   });
 
   it("sets entityType only when slug is present", () => {
@@ -165,9 +169,24 @@ describe("pgPersonnelToEntries", () => {
       person: { entityId: null, slug: null, name: "Bob" },
     });
 
-    const entries = pgPersonnelToEntries([withSlug, withoutSlug]);
-    expect(entries[0].entityType).toBe("person");
-    expect(entries[1].entityType).toBeUndefined();
+    const result = pgPersonnelToEntries([withSlug, withoutSlug]);
+    expect(result.entries[0].entityType).toBe("person");
+    expect(result.entries[1].entityType).toBeUndefined();
+  });
+
+  it("correctly partitions mixed named and unnamed records", () => {
+    const rows = [
+      makeRow({ personId: "alice", person: { entityId: "e1", slug: "alice", name: "Alice" } }),
+      makeRow({ personId: "AbCdEfG12H", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
+      makeRow({ personId: "bob-jones", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
+      makeRow({ personId: "XyZaBcDe99", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
+    ];
+
+    const result = pgPersonnelToEntries(rows);
+    expect(result.entries).toHaveLength(2); // Alice + Bob Jones (humanized)
+    expect(result.unresolvedCount).toBe(2); // 2 stableIds
+    expect(result.entries[0].name).toBe("Alice");
+    expect(result.entries[1].name).toBe("Bob Jones");
   });
 });
 

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -83,25 +83,39 @@ function humanizePersonId(raw: string): string | null {
   return cleaned;
 }
 
-export function pgPersonnelToEntries(rows: RpcPersonnelRow[]): PersonEntry[] {
-  return rows.map((row) => {
+export interface PgPersonnelResult {
+  entries: PersonEntry[];
+  /** Number of records excluded because the person name could not be resolved */
+  unresolvedCount: number;
+}
+
+export function pgPersonnelToEntries(rows: RpcPersonnelRow[]): PgPersonnelResult {
+  const entries: PersonEntry[] = [];
+  let unresolvedCount = 0;
+
+  for (const row of rows) {
     const personRef = row.person;
     // Name resolution priority:
     // 1. Structured ref name (from entity JOIN)
     // 2. Pre-resolved name from API (personResolvedName)
     // 3. Humanized raw personId (strips new:, converts slug to title case)
-    // 4. "Unknown" for bare stableIds and numeric PKs
+    // 4. Skip — bare stableIds and numeric PKs are not displayable
     const name =
       personRef?.name ??
       row.personResolvedName ??
-      humanizePersonId(row.personId) ??
-      "Unknown";
+      humanizePersonId(row.personId);
+
+    if (!name) {
+      unresolvedCount++;
+      continue;
+    }
+
     const slug = personRef?.slug ?? undefined;
     const isCurrent = !row.endDate;
     const isFounder = row.isFounder ?? false;
     const isBoard = row.roleType === "board";
 
-    return {
+    entries.push({
       name,
       title: row.role ?? undefined,
       slug,
@@ -114,8 +128,10 @@ export function pgPersonnelToEntries(rows: RpcPersonnelRow[]): PersonEntry[] {
       roleType: VALID_ROLE_TYPES.has(row.roleType)
         ? (row.roleType as PersonEntry["roleType"])
         : undefined,
-    };
-  });
+    });
+  }
+
+  return { entries, unresolvedCount };
 }
 
 /**
@@ -175,10 +191,12 @@ export function mergePgPersonnel(
  */
 export function PeopleSection({
   people,
+  unresolvedCount = 0,
 }: {
   people: PersonEntry[];
+  unresolvedCount?: number;
 }) {
-  if (people.length === 0) return null;
+  if (people.length === 0 && unresolvedCount === 0) return null;
 
   return (
     <section>
@@ -254,6 +272,11 @@ export function PeopleSection({
           </tbody>
         </table>
       </div>
+      {unresolvedCount > 0 && (
+        <p className="text-xs text-muted-foreground mt-2 px-1">
+          {unresolvedCount} additional personnel {unresolvedCount === 1 ? "record" : "records"} pending name resolution
+        </p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **P1 bug**: 73% of personnel records (1,133 of 1,551) showed "Unknown" on org People tabs because their stableID `personId` has no matching entity in PG
- **Root cause**: LLM enrichment sessions generated stableIDs via `generateId()` but never created the corresponding entity records in PG. The names are unrecoverable from the stableIDs alone.
- **Fix**: Instead of rendering "Unknown" entries, `pgPersonnelToEntries()` now filters them out and returns an `unresolvedCount`. The `PeopleSection` component shows a subtle note: "N additional personnel records pending name resolution"
- **Result**: Org People tabs now show only named personnel (clean data), with transparency about how many records are pending

### Before
```
D-BpcrbThn  | Researcher | 2021–present
Tw_Eo226h3  | Researcher | 2022–present
Unknown     | Researcher | 2023–present
```

### After
```
Alice Smith | CEO        | 2020–present
Bob Jones   | Engineer   | 2021–present

13 additional personnel records pending name resolution
```

## Test plan
- [x] Updated 12 existing tests for new return type `{entries, unresolvedCount}`
- [x] Added 1 new test for mixed named/unnamed partition
- [x] All 683 tests pass

Found by exhaustive QA sweep (Discussion #3220, bug #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a summary indicator showing the count of personnel entries pending name resolution.

* **Bug Fixes**
  * Personnel with unresolved names are now excluded from the main list and tracked separately, improving data accuracy and clarity in team rosters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->