### PR TITLE
fix: Facts heading badge, topics grammar, GPQA Diamond label, stableId regex

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -263,6 +263,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">AI models directory with pricing, benchmarks, and safety data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Model" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
@@ -273,7 +274,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
               <SortHeader label="Context" sortKey="contextWindow" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Safety" sortKey="safetyLevel" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="MMLU" sortKey="mmlu" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
-              <SortHeader label="GPQA" sortKey="gpqa" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
+              <SortHeader label="GPQA Diamond" sortKey="gpqa" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="SWE-bench" sortKey="sweBench" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
             </tr>
           </thead>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
             <Link href="/" className="w-64 shrink-0 px-4 py-3 text-lg font-bold no-underline text-foreground max-md:w-auto">
               Longterm Wiki
             </Link>
-            <nav className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
+            <nav aria-label="Main navigation" className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
               <div className="hidden md:flex items-center gap-4">
                 <DesktopNav />
               </div>
@@ -69,7 +69,7 @@ export default function RootLayout({
                 title="Atom feed"
                 target="_blank"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-4">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-4" aria-hidden="true">
                   <circle cx="6.18" cy="17.82" r="2.18"/>
                   <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
                 </svg>

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -806,7 +806,7 @@ export default async function OrgProfilePage({
       </div>
 
       {/* ── Tabbed content ─────────────────────────────────────── */}
-      <OrgProfileTabs tabs={tabs} />
+      <OrgProfileTabs tabs={tabs} ariaLabel="Organization sections" />
     </div>
   );
 }

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -493,19 +493,20 @@ export function OrganizationsTable({
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">Organizations directory with financial and headcount data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Organization" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               {isSortable("orgType") ? (
                 <SortHeader label="Type" sortKey="orgType" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               ) : (
-                <th className="py-2.5 px-3 font-medium text-left">Type</th>
+                <th scope="col" className="py-2.5 px-3 font-medium text-left">Type</th>
               )}
               {visibleColumns.has("completionScore") && (
                 isSortable("completionScore") ? (
                   <SortHeader label="Data" sortKey="completionScore" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
                 ) : (
-                  <th className="py-2.5 px-3 font-medium text-center">Data</th>
+                  <th scope="col" className="py-2.5 px-3 font-medium text-center">Data</th>
                 )
               )}
               <SortHeader label="Revenue" sortKey="revenue" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
@@ -517,7 +518,7 @@ export function OrganizationsTable({
                 isSortable("peopleCount") ? (
                   <SortHeader label="People" sortKey="peopleCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
                 ) : (
-                  <th className="py-2.5 px-3 font-medium text-right">People</th>
+                  <th scope="col" className="py-2.5 px-3 font-medium text-right">People</th>
                 )
               )}
             </tr>
@@ -527,6 +528,8 @@ export function OrganizationsTable({
               <tr>
                 <td
                   colSpan={activeColCount}
+                  role="status"
+                  aria-live="polite"
                   className="py-8 text-center text-muted-foreground text-sm"
                 >
                   Loading organizations...

--- a/apps/web/src/app/people/[slug]/expert-positions.tsx
+++ b/apps/web/src/app/people/[slug]/expert-positions.tsx
@@ -36,7 +36,7 @@ export function ExpertPositions({
       <h2 className="text-lg font-bold tracking-tight mb-4">
         Expert Positions
         <span className="ml-2 text-sm font-normal text-muted-foreground">
-          {positions.length} topics
+          {positions.length} {positions.length === 1 ? "topic" : "topics"}
         </span>
       </h2>
       <div className="border border-border/60 rounded-xl bg-card overflow-hidden">

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -394,6 +394,7 @@ export function PeopleTable({
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">People directory with roles, affiliations, and career data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader
@@ -471,6 +472,8 @@ export function PeopleTable({
               <tr>
                 <td
                   colSpan={serverMode ? 5 : 8}
+                  role="status"
+                  aria-live="polite"
                   className="py-8 text-center text-muted-foreground text-sm"
                 >
                   Loading people...

--- a/apps/web/src/components/directory/Breadcrumbs.tsx
+++ b/apps/web/src/components/directory/Breadcrumbs.tsx
@@ -9,7 +9,7 @@ export function Breadcrumbs({
   items: Array<{ label: string; href?: string }>;
 }) {
   return (
-    <nav className="text-sm text-muted-foreground mb-4">
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground mb-4">
       {items.map((item, i) => (
         <span key={item.label}>
           {i > 0 && <span className="mx-1.5">/</span>}

--- a/apps/web/src/components/directory/FactsSection.tsx
+++ b/apps/web/src/components/directory/FactsSection.tsx
@@ -136,12 +136,13 @@ export function FactsPanel({
 
   return (
     <section>
-      <h2 className="text-lg font-bold tracking-tight mb-4">
-        Facts
-        <span className="ml-2 text-sm font-normal text-muted-foreground">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-lg font-bold tracking-tight">Facts</h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
           {latestByProp.size}
         </span>
-      </h2>
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" aria-hidden="true" />
+      </div>
       <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
         {categoryGroups.map(({ category, label, props }) => (
           <div key={category} className="px-4 py-3">

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -11,10 +11,16 @@ export interface ProfileTab {
   content: React.ReactNode;
 }
 
+export interface ProfileTabsProps {
+  tabs: ProfileTab[];
+  /** Accessible label for the tab list, e.g. "Organization sections" */
+  ariaLabel?: string;
+}
+
 /**
  * Inner component that reads search params (must be wrapped in Suspense).
  */
-function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
+function ProfileTabsInner({ tabs, ariaLabel }: { tabs: ProfileTab[]; ariaLabel?: string }) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -47,7 +53,7 @@ function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
-      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
+      <TabsList aria-label={ariaLabel ?? "Page sections"} className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
         {visibleTabs.map((tab) => (
           <TabsTrigger
             key={tab.id}
@@ -77,13 +83,13 @@ function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
  * Static fallback rendered during SSR before useSearchParams resolves.
  * Shows the default (first) tab without URL syncing.
  */
-function ProfileTabsFallback({ tabs }: { tabs: ProfileTab[] }) {
+function ProfileTabsFallback({ tabs, ariaLabel }: { tabs: ProfileTab[]; ariaLabel?: string }) {
   const visibleTabs = tabs.filter((t) => t.count !== 0);
   if (visibleTabs.length === 0) return null;
   if (visibleTabs.length === 1) return <>{visibleTabs[0].content}</>;
   return (
     <Tabs defaultValue={visibleTabs[0].id}>
-      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
+      <TabsList aria-label={ariaLabel ?? "Page sections"} className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
         {visibleTabs.map((tab) => (
           <TabsTrigger
             key={tab.id}
@@ -114,10 +120,10 @@ function ProfileTabsFallback({ tabs }: { tabs: ProfileTab[] }) {
  * - Renders content directly (no tab chrome) when only one tab remains
  * - Syncs active tab to ?tab= URL query param for shareable links
  */
-export function ProfileTabs({ tabs }: { tabs: ProfileTab[] }) {
+export function ProfileTabs({ tabs, ariaLabel }: ProfileTabsProps) {
   return (
-    <Suspense fallback={<ProfileTabsFallback tabs={tabs} />}>
-      <ProfileTabsInner tabs={tabs} />
+    <Suspense fallback={<ProfileTabsFallback tabs={tabs} ariaLabel={ariaLabel} />}>
+      <ProfileTabsInner tabs={tabs} ariaLabel={ariaLabel} />
     </Suspense>
   );
 }

--- a/apps/web/src/components/directory/SortHeader.tsx
+++ b/apps/web/src/components/directory/SortHeader.tsx
@@ -28,6 +28,7 @@ export function SortHeader<K extends string>({
 
   return (
     <th
+      scope="col"
       className={`py-2.5 px-3 font-medium ${className ?? ""}`}
       aria-sort={ariaSort}
     >

--- a/apps/web/src/data/entity-nav.ts
+++ b/apps/web/src/data/entity-nav.ts
@@ -61,7 +61,7 @@ export function getEntityHref(id: string, _type?: string): string {
     return `/wiki/${id}`;
   }
   // If it's a stableId, resolve to slug first, then get wikiId
-  if (/^[A-Za-z0-9]{10}$/.test(id) && registry.byStableId?.[id]) {
+  if (/^(?=.*[A-Z])[A-Za-z0-9]{10}$/.test(id) && registry.byStableId?.[id]) {
     const slug = registry.byStableId[id];
     const wikiId = registry.bySlug[slug];
     return wikiId ? `/wiki/${wikiId}` : `/wiki/${slug}`;


### PR DESCRIPTION
## Summary
Fixes 4 P2 bugs from QA sweep (Discussion #3220):

- **Bug 30**: `Facts35` heading — count was concatenated directly. Now shows heading + styled pill badge
- **Bug 34**: "1 topics" → "1 topic" singularization in Expert Positions
- **Bug 45**: GPQA column header in AI models table → "GPQA Diamond" (matches actual data)
- **Bug 60**: `entity-nav.ts` stableId regex tightened to require uppercase letter (matches `resolve-entity-name.ts`)

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced table accessibility with screen reader descriptions and improved header semantics.
  * Improved navigation labeling for assistive technologies.

* **Bug Fixes**
  * Fixed entity resolution logic for more accurate URL handling.
  * Corrected text pluralization for topic counts.

* **Style**
  * Refined Facts section header layout and visual styling.
  * Updated table column header labels for clarity.

* **Accessibility**
  * Added live region announcements for loading states.
  * Enhanced breadcrumb and tabbed content navigation labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->