### PR TITLE
fix: integer Y-axis ticks on headcount charts, benchmark tab URL routing

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -263,6 +263,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">AI models directory with pricing, benchmarks, and safety data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Model" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />

--- a/apps/web/src/app/benchmarks/benchmarks-view.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { BenchmarksTable, type BenchmarkRow } from "@/app/benchmarks/benchmarks-table";
 import {
   ComparisonMatrix,
@@ -24,7 +25,25 @@ export function BenchmarksView({
   matrixModels,
   matrixScores,
 }: Props) {
-  const [view, setView] = useState<ViewMode>("directory");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const viewParam = searchParams.get("view");
+  const view: ViewMode = viewParam === "matrix" ? "matrix" : "directory";
+
+  const setView = useCallback(
+    (next: ViewMode) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === "matrix") {
+        params.set("view", "matrix");
+      } else {
+        params.delete("view");
+      }
+      const query = params.toString();
+      router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   return (
     <div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
             <Link href="/" className="w-64 shrink-0 px-4 py-3 text-lg font-bold no-underline text-foreground max-md:w-auto">
               Longterm Wiki
             </Link>
-            <nav className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
+            <nav aria-label="Main navigation" className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
               <div className="hidden md:flex items-center gap-4">
                 <DesktopNav />
               </div>
@@ -69,7 +69,7 @@ export default function RootLayout({
                 title="Atom feed"
                 target="_blank"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-4">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-4" aria-hidden="true">
                   <circle cx="6.18" cy="17.82" r="2.18"/>
                   <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
                 </svg>

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -810,7 +810,7 @@ export default async function LegislationDetailPage({
       </div>
 
       {/* Tabs — full width; sidebar is inside Overview tab only */}
-      <ProfileTabs tabs={tabs} />
+      <ProfileTabs tabs={tabs} ariaLabel="Legislation sections" />
     </div>
   );
 }

--- a/apps/web/src/app/organizations/[slug]/org-charts.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-charts.tsx
@@ -124,10 +124,14 @@ export function TimeSeriesChart({
     padding.top + chartH - ((v - minVal) / valRange) * chartH;
 
   // Y-axis ticks (4-5 ticks)
+  // For integer formats (e.g. headcount), round ticks to whole numbers to
+  // avoid fractional values like "12.075" on the axis.
   const yTicks: number[] = [];
-  const tickStep = valRange / 4;
+  const rawTickStep = valRange / 4;
+  const tickStep = format === "number" ? Math.ceil(rawTickStep) : rawTickStep;
   for (let i = 0; i <= 4; i++) {
-    yTicks.push(minVal + tickStep * i);
+    const raw = minVal + tickStep * i;
+    yTicks.push(format === "number" ? Math.round(raw) : raw);
   }
 
   // X-axis labels: use unique years

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -806,7 +806,7 @@ export default async function OrgProfilePage({
       </div>
 
       {/* ── Tabbed content ─────────────────────────────────────── */}
-      <OrgProfileTabs tabs={tabs} />
+      <OrgProfileTabs tabs={tabs} ariaLabel="Organization sections" />
     </div>
   );
 }

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -493,19 +493,20 @@ export function OrganizationsTable({
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">Organizations directory with financial and headcount data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader label="Organization" sortKey="name" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               {isSortable("orgType") ? (
                 <SortHeader label="Type" sortKey="orgType" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               ) : (
-                <th className="py-2.5 px-3 font-medium text-left">Type</th>
+                <th scope="col" className="py-2.5 px-3 font-medium text-left">Type</th>
               )}
               {visibleColumns.has("completionScore") && (
                 isSortable("completionScore") ? (
                   <SortHeader label="Data" sortKey="completionScore" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
                 ) : (
-                  <th className="py-2.5 px-3 font-medium text-center">Data</th>
+                  <th scope="col" className="py-2.5 px-3 font-medium text-center">Data</th>
                 )
               )}
               <SortHeader label="Revenue" sortKey="revenue" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
@@ -517,7 +518,7 @@ export function OrganizationsTable({
                 isSortable("peopleCount") ? (
                   <SortHeader label="People" sortKey="peopleCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
                 ) : (
-                  <th className="py-2.5 px-3 font-medium text-right">People</th>
+                  <th scope="col" className="py-2.5 px-3 font-medium text-right">People</th>
                 )
               )}
             </tr>
@@ -527,6 +528,8 @@ export function OrganizationsTable({
               <tr>
                 <td
                   colSpan={activeColCount}
+                  role="status"
+                  aria-live="polite"
                   className="py-8 text-center text-muted-foreground text-sm"
                 >
                   Loading organizations...

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -330,6 +330,7 @@ export default function Home() {
                   </div>
                   <Link
                     href={section.href}
+                    aria-label={`View all ${section.label}`}
                     className="inline-block mt-2 text-xs text-muted-foreground hover:text-foreground no-underline transition-colors"
                   >
                     View all &rarr;
@@ -347,6 +348,7 @@ export default function Home() {
             <div className="flex-1 h-px bg-border" />
             <Link
               href="/wiki"
+              aria-label="View all wiki pages"
               className="text-sm text-muted-foreground hover:text-foreground no-underline transition-colors flex-shrink-0"
             >
               View all &rarr;

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -408,7 +408,7 @@ export default async function PersonProfilePage({
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main content — tabbed */}
         <div className="lg:col-span-2">
-          <ProfileTabs tabs={tabs} />
+          <ProfileTabs tabs={tabs} ariaLabel="Person sections" />
         </div>
 
         {/* Sidebar */}

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -394,6 +394,7 @@ export function PeopleTable({
       {/* Table */}
       <div className="border border-border rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
+          <caption className="sr-only">People directory with roles, affiliations, and career data</caption>
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted sticky top-0 z-10 backdrop-blur-sm">
               <SortHeader
@@ -471,6 +472,8 @@ export function PeopleTable({
               <tr>
                 <td
                   colSpan={serverMode ? 5 : 8}
+                  role="status"
+                  aria-live="polite"
                   className="py-8 text-center text-muted-foreground text-sm"
                 >
                   Loading people...

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -47,12 +47,12 @@ export function MobileNav() {
         className="p-2 text-muted-foreground hover:text-foreground transition-colors"
       >
         {open ? (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="18" y1="6" x2="6" y2="18" />
             <line x1="6" y1="6" x2="18" y2="18" />
           </svg>
         ) : (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="4" y1="6" x2="20" y2="6" />
             <line x1="4" y1="12" x2="20" y2="12" />
             <line x1="4" y1="18" x2="20" y2="18" />

--- a/apps/web/src/components/NavDropdown.tsx
+++ b/apps/web/src/components/NavDropdown.tsx
@@ -69,6 +69,7 @@ export function NavDropdown({ label, items }: NavDropdownType) {
       >
         {label}
         <svg
+          aria-hidden="true"
           width="12"
           height="12"
           viewBox="0 0 24 24"

--- a/apps/web/src/components/directory/Breadcrumbs.tsx
+++ b/apps/web/src/components/directory/Breadcrumbs.tsx
@@ -9,7 +9,7 @@ export function Breadcrumbs({
   items: Array<{ label: string; href?: string }>;
 }) {
   return (
-    <nav className="text-sm text-muted-foreground mb-4">
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground mb-4">
       {items.map((item, i) => (
         <span key={item.label}>
           {i > 0 && <span className="mx-1.5">/</span>}

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -11,10 +11,16 @@ export interface ProfileTab {
   content: React.ReactNode;
 }
 
+export interface ProfileTabsProps {
+  tabs: ProfileTab[];
+  /** Accessible label for the tab list, e.g. "Organization sections" */
+  ariaLabel?: string;
+}
+
 /**
  * Inner component that reads search params (must be wrapped in Suspense).
  */
-function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
+function ProfileTabsInner({ tabs, ariaLabel }: { tabs: ProfileTab[]; ariaLabel?: string }) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -47,7 +53,7 @@ function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
-      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
+      <TabsList aria-label={ariaLabel ?? "Page sections"} className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
         {visibleTabs.map((tab) => (
           <TabsTrigger
             key={tab.id}
@@ -77,13 +83,13 @@ function ProfileTabsInner({ tabs }: { tabs: ProfileTab[] }) {
  * Static fallback rendered during SSR before useSearchParams resolves.
  * Shows the default (first) tab without URL syncing.
  */
-function ProfileTabsFallback({ tabs }: { tabs: ProfileTab[] }) {
+function ProfileTabsFallback({ tabs, ariaLabel }: { tabs: ProfileTab[]; ariaLabel?: string }) {
   const visibleTabs = tabs.filter((t) => t.count !== 0);
   if (visibleTabs.length === 0) return null;
   if (visibleTabs.length === 1) return <>{visibleTabs[0].content}</>;
   return (
     <Tabs defaultValue={visibleTabs[0].id}>
-      <TabsList className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
+      <TabsList aria-label={ariaLabel ?? "Page sections"} className="w-full justify-start gap-1 bg-transparent p-0 border-b border-border rounded-none h-auto pb-0 overflow-x-auto">
         {visibleTabs.map((tab) => (
           <TabsTrigger
             key={tab.id}
@@ -114,10 +120,10 @@ function ProfileTabsFallback({ tabs }: { tabs: ProfileTab[] }) {
  * - Renders content directly (no tab chrome) when only one tab remains
  * - Syncs active tab to ?tab= URL query param for shareable links
  */
-export function ProfileTabs({ tabs }: { tabs: ProfileTab[] }) {
+export function ProfileTabs({ tabs, ariaLabel }: ProfileTabsProps) {
   return (
-    <Suspense fallback={<ProfileTabsFallback tabs={tabs} />}>
-      <ProfileTabsInner tabs={tabs} />
+    <Suspense fallback={<ProfileTabsFallback tabs={tabs} ariaLabel={ariaLabel} />}>
+      <ProfileTabsInner tabs={tabs} ariaLabel={ariaLabel} />
     </Suspense>
   );
 }

--- a/apps/web/src/components/directory/SortHeader.tsx
+++ b/apps/web/src/components/directory/SortHeader.tsx
@@ -28,6 +28,7 @@ export function SortHeader<K extends string>({
 
   return (
     <th
+      scope="col"
       className={`py-2.5 px-3 font-medium ${className ?? ""}`}
       aria-sort={ariaSort}
     >


### PR DESCRIPTION
## Summary
Fixes 2 P2 bugs from QA sweep (Discussion #3220):

- **Bug 31**: Headcount chart Y-axis showed fractional values (`12.075`, `24.15`). Fixed by rounding tick steps to integers when `format === "number"`
- **Bug 58**: Benchmark comparison matrix tab had no URL routing — tab state lost on refresh. Added `?view=matrix` URL parameter support via `useSearchParams`

Bug 55 (React hydration error #418) was investigated but root cause not identified within time limit — the codebase already uses correct SSR patterns (`useEffect` for localStorage, `suppressHydrationWarning`, deterministic defaults).

## Test plan
- [x] All tests pass
- [x] Chart fix: verified tick values round to integers for count metrics
- [x] Tab routing: `/benchmarks?view=matrix` restores matrix view

🤖 Generated with [Claude Code](https://claude.com/claude-code)