### PR TITLE
fix: resolve Unknown company names and add OpenAI funding rounds

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, sql, desc } from "drizzle-orm";
+import { eq, count, sql, desc, inArray, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { getDrizzleDb } from "../../db.js";
 import { fundingRounds, entities } from "../../schema.js";
@@ -209,6 +209,24 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
     ]);
     if (refError) return refError;
 
+    // Resolve companyId values (slugs or stableIds) to proper stableIds for the FK column.
+    // This ensures companyEntityId is populated so the JOIN on GET /all works correctly.
+    const uniqueCompanyIds = [...new Set(items.map((i) => i.companyId).filter(Boolean))];
+    const entityRows = uniqueCompanyIds.length > 0
+      ? await db
+          .select({ id: entities.id, stableId: entities.stableId })
+          .from(entities)
+          .where(or(inArray(entities.id, uniqueCompanyIds), inArray(entities.stableId, uniqueCompanyIds)))
+      : [];
+
+    const companyStableIdMap = new Map<string, string>();
+    for (const row of entityRows) {
+      if (row.stableId) {
+        companyStableIdMap.set(row.id, row.stableId);
+        companyStableIdMap.set(row.stableId, row.stableId);
+      }
+    }
+
     let upserted = 0;
     let verdictsResult = { written: 0 };
 
@@ -219,6 +237,7 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
         return {
           id: item.id,
           companyId: item.companyId,
+          companyEntityId: companyStableIdMap.get(item.companyId) ?? null,
           name: item.name,
           date: item.date ?? null,
           raised: item.raised != null ? String(item.raised) : null,
@@ -241,6 +260,7 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
           target: fundingRounds.id,
           set: {
             companyId: sql`excluded.company_id`,
+            companyEntityId: sql`COALESCE(excluded.company_entity_id, ${fundingRounds.companyEntityId})`,
             name: sql`excluded.name`,
             date: sql`excluded.date`,
             raised: sql`excluded.raised`,


### PR DESCRIPTION
## Summary

Fixes three P2 funding data issues:

- **Bug 20 (done in prior session)**: Deleted duplicate "Technical AI Safety RFP (2025)" funding program (ID `a2NsC7Lk0g`). Only the canonical ID `Kb9uB1Zp1E` remains.

- **Bug 21**: The `POST /api/funding-rounds/sync` route never populated the `company_entity_id` column. This caused the JOIN used for company name resolution to fail, making all company names display as "Unknown" in `/funding-rounds`. Fixed by batch-resolving `companyId` values to stableIds before the transaction and including `companyEntityId` in all insert values (using `COALESCE` on conflict to preserve existing values). Also ran a SQL backfill on prod to set `company_entity_id` for all 83 existing rows.

- **Bug 49**: OpenAI had 3 funding rounds in the DB but showed "Unknown" as the company name (covered by Bug 21 fix). Additionally added 4 historical OpenAI rounds that were missing: 2015 seed ($1B pledge), 2019 Microsoft strategic ($1B), 2021 equity ($1B), and 2023 Microsoft strategic (~$10B). OpenAI now has 7 documented funding rounds totaling ~$60B.

## Code change

The only code change is in `apps/wiki-server/src/routes/tablebase/funding-rounds.ts`:
- Added `inArray, or` to drizzle-orm imports
- Before the sync transaction, batch-lookup all `companyId` values against `entities.id` and `entities.stableId` to build a stableId map
- Pass `companyEntityId` in each insert row; use `COALESCE` on conflict to avoid overwriting existing values

## Prod data changes (already applied)
- SQL backfill: all 87 funding rounds now have `company_entity_id` set
- Added 4 OpenAI historical funding rounds via the sync API

## Test plan
- [x] TypeScript: `apps/wiki-server/node_modules/.bin/tsc --noEmit` exits 0
- [x] API: `/api/funding-rounds/all` returns 0 rounds with missing `companyRef.entityId` (verified: was 75, now 0)
- [x] API: OpenAI has 7 funding rounds with correct `company_entity_id = 1LcLlMGLbw` (verified in prod DB)
- [x] API: No duplicate "Technical AI Safety RFP (2025)" in funding programs (verified: 1 entry with ID `Kb9uB1Zp1E`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened company entity resolution in data synchronization to improve mapping reliability and preserve existing company relationships during record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->