### PR TITLE
fix: bounded export query, SQL min_priority filter, bulk benchmark inserts, structured logger

### DIFF
--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -14,10 +14,12 @@ import {
 } from "../shared/utils.js";
 import { SyncFactsBatchSchema } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
+import { logger } from "../../logger.js";
 
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
+const EXPORT_MAX_LIMIT = 50000;
 
 // ---- Query schemas ----
 
@@ -264,20 +266,55 @@ const factsApp = new Hono()
   // Returns all facts grouped by entityId, reconstructed into the KB Fact shape
   // (FactValue discriminated union). Used by build-data.mjs to read facts from
   // PG instead of YAML.
-  .get("/export", async (c) => {
-    const db = getDrizzleDb();
+  //
+  // Supports optional pagination via `limit` (max 50000) and `offset`.
+  // Callers that need the full dataset should paginate using offset until the
+  // returned `total` is exhausted.
+  .get(
+    "/export",
+    zv(
+      "query",
+      z.object({
+        limit: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(EXPORT_MAX_LIMIT)
+          .default(EXPORT_MAX_LIMIT),
+        offset: z.coerce.number().int().min(0).default(0),
+      })
+    ),
+    async (c) => {
+      const { limit, offset } = c.req.valid("query");
+      const db = getDrizzleDb();
 
-    const rows = await db.select().from(facts).orderBy(asc(facts.entityId), asc(facts.factId));
+      const rows = await db
+        .select()
+        .from(facts)
+        .orderBy(asc(facts.entityId), asc(facts.factId))
+        .limit(limit)
+        .offset(offset);
 
-    const grouped: Record<string, object[]> = {};
-    for (const row of rows) {
-      const fact = pgRowToFact(row);
-      if (!grouped[row.entityId]) grouped[row.entityId] = [];
-      grouped[row.entityId].push(fact);
+      const countResult = await db.select({ count: count() }).from(facts);
+      const total = countResult[0].count;
+
+      const grouped: Record<string, object[]> = {};
+      for (const row of rows) {
+        const fact = pgRowToFact(row);
+        if (!grouped[row.entityId]) grouped[row.entityId] = [];
+        grouped[row.entityId].push(fact);
+      }
+
+      return c.json({
+        facts: grouped,
+        total,
+        returned: rows.length,
+        limit,
+        offset,
+        entities: Object.keys(grouped).length,
+      });
     }
-
-    return c.json({ facts: grouped, total: rows.length, entities: Object.keys(grouped).length });
-  })
+  )
 
   // ---- POST /sync ----
   // Uses manual JSON parsing to preserve the "invalid_json" error code
@@ -301,7 +338,7 @@ const factsApp = new Hono()
       const missingSet = new Set(missingEntities);
       const skipped = items.filter((f) => missingSet.has(f.entityId));
       items = items.filter((f) => !missingSet.has(f.entityId));
-      console.warn(
+      logger.warn(
         `[facts/sync] Skipping ${skipped.length} facts for ${missingEntities.length} missing entities: ${missingEntities.slice(0, 10).join(", ")}${missingEntities.length > 10 ? ` ... (+${missingEntities.length - 10} more)` : ""}`
       );
       if (items.length === 0) {
@@ -320,7 +357,7 @@ const factsApp = new Hono()
     if (subjectIds.length > 0) {
       missingSubjects = await checkRefsExist(db, entities, entities.stableId, subjectIds);
       if (missingSubjects.length > 0) {
-        console.warn(
+        logger.warn(
           `Facts sync: nulling out ${missingSubjects.length} unresolved subject(s): ${missingSubjects.join(", ")}`
         );
         const missingSet = new Set(missingSubjects);

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -8,6 +8,7 @@ import {
   sql,
   desc,
   lte,
+  gte,
   ne,
   isNull,
   inArray,
@@ -1099,6 +1100,11 @@ const sourceChecksApp = new Hono()
     if (record_type) {
       conditions.push(eq(sourceCheckVerdicts.recordType, record_type));
     }
+    // Push min_priority into SQL so the total count and pagination are correct.
+    // The CASE expression is wrapped in a subquery to avoid repeating it.
+    if (min_priority !== undefined) {
+      conditions.push(gte(priorityExpr, min_priority));
+    }
 
     const whereClause = and(...conditions);
 
@@ -1126,13 +1132,7 @@ const sourceChecksApp = new Hono()
       .limit(limit)
       .offset(offset);
 
-    // Apply min_priority filter in-app (simpler than adding it to the SQL WHERE
-    // since the CASE expression would need to be repeated)
-    const filtered = min_priority !== undefined
-      ? rows.filter((r) => r.priority >= min_priority)
-      : rows;
-
-    // Count total matching rows
+    // Count total matching rows (includes min_priority filter)
     const countResult = await db
       .select({ count: count() })
       .from(sourceCheckVerdicts)
@@ -1140,7 +1140,7 @@ const sourceChecksApp = new Hono()
     const total = countResult[0].count;
 
     return c.json({
-      items: filtered.map((r) => ({
+      items: rows.map((r) => ({
         recordType: r.recordType,
         recordId: r.recordId,
         fieldName: r.fieldName,

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -194,37 +194,37 @@ const benchmarkResultsApp = new Hono()
     let verdictsResult = { written: 0 };
 
     await db.transaction(async (tx) => {
-      for (const item of parsed.data.items) {
-        await tx
-          .insert(benchmarkResults)
-          .values({
-            id: item.id,
-            benchmarkId: item.benchmarkId,
-            modelId: item.modelId,
-            score: item.score,
-            unit: item.unit ?? null,
-            date: item.date ?? null,
-            sourceUrl: item.sourceUrl ?? null,
-            notes: item.notes ?? null,
-            syncedAt: now,
-            updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: benchmarkResults.id,
-            set: {
-              benchmarkId: item.benchmarkId,
-              modelId: item.modelId,
-              score: item.score,
-              unit: item.unit ?? null,
-              date: item.date ?? null,
-              sourceUrl: item.sourceUrl ?? null,
-              notes: item.notes ?? null,
-              syncedAt: now,
-              updatedAt: now,
-            },
-          });
-        upserted++;
-      }
+      const allVals = parsed.data.items.map((item) => ({
+        id: item.id,
+        benchmarkId: item.benchmarkId,
+        modelId: item.modelId,
+        score: item.score,
+        unit: item.unit ?? null,
+        date: item.date ?? null,
+        sourceUrl: item.sourceUrl ?? null,
+        notes: item.notes ?? null,
+        syncedAt: now,
+        updatedAt: now,
+      }));
+
+      await tx
+        .insert(benchmarkResults)
+        .values(allVals)
+        .onConflictDoUpdate({
+          target: benchmarkResults.id,
+          set: {
+            benchmarkId: sql`excluded.benchmark_id`,
+            modelId: sql`excluded.model_id`,
+            score: sql`excluded.score`,
+            unit: sql`excluded.unit`,
+            date: sql`excluded.date`,
+            sourceUrl: sql`excluded.source_url`,
+            notes: sql`excluded.notes`,
+            syncedAt: sql`excluded.synced_at`,
+            updatedAt: sql`excluded.updated_at`,
+          },
+        });
+      upserted = allVals.length;
 
       // Dual-write to things table
       await upsertThingsInTx(

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -892,7 +892,7 @@ const entitiesApp = new Hono()
             );
           }
         }
-        console.warn(
+        logger.warn(
           `[entities/sync] Stripped ${missing.length} unresolved relatedEntries refs: ${missing.slice(0, 10).join(", ")}${missing.length > 10 ? ` ... (+${missing.length - 10} more)` : ""}`
         );
       }


### PR DESCRIPTION
## Summary
Fixes 4 P2 server-side code issues from QA sweep (Discussion #3220):

- **Bug 16**: Added LIMIT/OFFSET pagination to `GET /export` in facts.ts (was unbounded full table dump). Max 50,000 rows per request. Response now includes `total`, `returned`, `limit`, `offset`.
- **Bug 61**: Moved `min_priority` filter from post-fetch JS `.filter()` into SQL WHERE clause in `/due-for-recheck`. Fixes misleading `total` count and broken pagination.
- **Bug 62**: Replaced sequential per-row inserts in benchmark-results `/sync` with single bulk `insert().values(allVals).onConflictDoUpdate()`.
- **Bug 64**: Replaced 3 `console.warn()` calls with structured `logger.warn()` in facts.ts and entities.ts.

## Test plan
- [x] TypeScript compiles cleanly
- [x] No behavioral changes to existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)