### PR TITLE
fix: sync FactBase facts to PG on push to prevent /people net-worth stat fluctuation

### DIFF
--- a/.github/workflows/sync-entities-facts.yml
+++ b/.github/workflows/sync-entities-facts.yml
@@ -1,15 +1,22 @@
-name: Sync Entities
-run-name: "Sync Entities${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
+name: Sync Entities and Facts
+run-name: "Sync Entities and Facts${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
 
 on:
   push:
     branches: [main, production]
     paths:
       - "data/entities/**"
+      # FactBase YAML facts — sync-facts must run when these change so the
+      # wiki-server DB stays in sync with YAML. Without this, the /people page
+      # "With Net Worth" stat fluctuates: API path returns stale DB count while
+      # local fallback returns correct YAML count. See issue where count was 3 vs 4.
+      - "packages/factbase/data/things/**"
       # Also trigger when the sync/prune pipeline or workflow config changes,
       # so that new prune logic is exercised immediately after merge. See #2796.
       - "crux/wiki-server/sync-entities.ts"
+      - "crux/wiki-server/sync-facts.ts"
       - "apps/wiki-server/src/routes/tablebase/entities.ts"
+      - "apps/wiki-server/src/routes/factbase/facts.ts"
       - ".github/workflows/sync-entities-facts.yml"
 
   # Run weekly to catch stale entities that missed path-triggered syncs.
@@ -58,6 +65,15 @@ jobs:
 
       - name: Sync entities to wiki-server
         run: pnpm crux wiki-server sync-entities
+        env:
+          LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+
+      - name: Sync FactBase facts to wiki-server
+        # Syncs packages/factbase/data/things/*.yaml → facts table in PG.
+        # Must run after sync-entities so FK constraints (facts.entity_id →
+        # entities.stable_id) are satisfied for any newly added entities.
+        run: pnpm crux wiki-server sync-facts
         env:
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}


### PR DESCRIPTION
## Summary

- The `/people` page "With Net Worth" stat (showing 3 or 4) was non-deterministic because the page uses two data paths: the wiki-server API (reads PostgreSQL `facts` table) and a local YAML fallback (reads `packages/factbase/data/things/*.yaml` directly).
- The PostgreSQL `facts` table was missing Elon Musk's net-worth fact because there was no CI workflow that triggered `sync-facts` when FactBase YAML files changed. This caused the API path to return 3 while the local fallback returned 4.
- Added `packages/factbase/data/things/**` as a trigger path in `sync-entities-facts.yml` and added a `sync-facts` step (runs after `sync-entities` so FK constraints are satisfied).

## Root Cause Details

The `/people` page (`apps/web/src/app/people/page.tsx`) calls `loadFromApi()` which fetches `/api/entities/directory?entityType=person&measures=net-worth,...`. If the API fails, it falls back to `loadFromLocal()` which reads FactBase YAML directly via `getKBLatest()`.

- **Local path**: Always returns 4 people with net-worth (from YAML: Elon Musk, Dustin Moskovitz, Sam Altman, Jaan Tallinn).
- **API path**: Returns however many facts are in the `facts` table. Elon Musk's net-worth fact (`f_eM7kL8mN9o`) was added/updated in FactBase YAML but never synced to PG because `sync-entities-facts.yml` only watched `data/entities/**` — not `packages/factbase/data/things/**`.

The alternating 3/4 behavior happened because: when the wiki-server was reachable, the API returned 3 (no Elon Musk net-worth in DB); when it was unreachable or timed out, the fallback returned 4.

## Test Plan

- [x] `pnpm test` — all 200 test files pass (4318 tests)
- [x] `pnpm crux w validate gate --scope=content` — passes
- [ ] After merging: verify the workflow runs on the next push to `packages/factbase/data/things/` and that the `facts` table is updated
- [ ] After fact sync runs: verify `/people` page consistently shows 4 "With Net Worth"

## Files Changed

- `.github/workflows/sync-entities-facts.yml`: Added `packages/factbase/data/things/**` trigger path, `crux/wiki-server/sync-facts.ts` and `apps/wiki-server/src/routes/factbase/facts.ts` code change paths, and `sync-facts` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
