### PR TITLE
fix: remove duplicate employee-tender-offer property (unbreak main)

### DIFF
--- a/packages/factbase/data/properties.yaml
+++ b/packages/factbase/data/properties.yaml
@@ -713,19 +713,6 @@ properties:
 
   # ── Additional Monetary ───────────────────────────────────────────
 
-  employee-tender-offer:
-    name: Employee Tender Offer
-    description: "Dollar value of an employee share sale or tender offer program"
-    dataType: number
-    unit: USD
-    category: financial
-    temporal: true
-    appliesTo: [organization]
-    display:
-      divisor: 1e9
-      prefix: "$"
-      suffix: "B"
-
   market-cap:
     name: Market Cap
     description: "Market capitalization (publicly traded) or implied valuation for private companies"


### PR DESCRIPTION
## Summary
- `employee-tender-offer` was defined twice in `properties.yaml` (lines 572 and 702)
- This causes `YAMLParseError: Map keys must be unique` which breaks `build-data` on main
- Removed the duplicate, keeping the first definition

## Test plan
- [x] `pnpm build-data:content` passes (0 YAML parse errors)