### PR TITLE
feat: add --concurrency flag to source-check orchestrator

### DIFF
--- a/crux/commands/source-check-orchestrate.ts
+++ b/crux/commands/source-check-orchestrate.ts
@@ -75,6 +75,7 @@ interface OrchestrateOptions extends BaseOptions {
   'dry-run'?: boolean;
   dryRun?: boolean;
   ci?: boolean;
+  concurrency?: string;
 }
 
 type VerifyItemKind = 'fact' | 'record' | 'entity';
@@ -1149,6 +1150,7 @@ export async function orchestrateCommand(
   }
 
   // ── Live execution ──
+  const concurrency = options.concurrency ? parseInt(String(options.concurrency), 10) : 5;
   const client = createLlmClient();
   const summary: OrchestrationSummary = {
     total: itemsToVerify.length,
@@ -1174,19 +1176,25 @@ export async function orchestrateCommand(
     summary.byKind[item.kind].total++;
   }
 
-  console.log(`\n\x1b[1mVerifying ${itemsToVerify.length} items (est. \$${estimatedCost.toFixed(2)})...\x1b[0m\n`);
+  const concurrencyLabel = concurrency > 1 ? `, concurrency=${concurrency}` : '';
+  console.log(`\n\x1b[1mVerifying ${itemsToVerify.length} items (est. \$${estimatedCost.toFixed(2)}${concurrencyLabel})...\x1b[0m\n`);
 
-  for (let i = 0; i < itemsToVerify.length; i++) {
-    const item = itemsToVerify[i];
+  let completedCount = 0;
+
+  async function processItem(item: VerifyItem, index: number): Promise<void> {
     const kindLabel = item.kind.toUpperCase().padEnd(7);
-    console.log(`  [${i + 1}/${itemsToVerify.length}] ${kindLabel} ${item.description.slice(0, 80)}`);
 
     const result = await verifySingleItem(item, client, useWebSearch);
+
+    // Synchronize output and summary updates
+    completedCount++;
+    const progress = `[${completedCount}/${itemsToVerify.length}]`;
 
     if ('error' in result) {
       summary.errors++;
       summary.failures.push(result);
       const typeTag = result.errorType ? ` [${result.errorType}]` : '';
+      console.log(`  ${progress} ${kindLabel} ${item.description.slice(0, 80)}`);
       console.log(`    \x1b[31mERROR${typeTag}: ${result.error}\x1b[0m`);
     } else {
       summary[result.verdict]++;
@@ -1199,6 +1207,7 @@ export async function orchestrateCommand(
         : result.verdict === 'contradicted'
           ? '\x1b[31m'
           : '\x1b[33m';
+      console.log(`  ${progress} ${kindLabel} ${item.description.slice(0, 80)}`);
       console.log(`    ${color}${result.verdict}\x1b[0m (confidence: ${(result.confidence * 100).toFixed(0)}%)`);
 
       if (result.verdict === 'contradicted' || result.verdict === 'outdated') {
@@ -1210,6 +1219,23 @@ export async function orchestrateCommand(
         console.warn(`    \x1b[33mStorage failed: ${e instanceof Error ? e.message : String(e)}\x1b[0m`);
       });
     }
+  }
+
+  // Run with concurrency-limited pool
+  if (concurrency <= 1) {
+    for (let i = 0; i < itemsToVerify.length; i++) {
+      await processItem(itemsToVerify[i], i);
+    }
+  } else {
+    const executing = new Set<Promise<void>>();
+    for (let i = 0; i < itemsToVerify.length; i++) {
+      const p = processItem(itemsToVerify[i], i).finally(() => executing.delete(p));
+      executing.add(p);
+      if (executing.size >= concurrency) {
+        await Promise.race(executing);
+      }
+    }
+    await Promise.all(executing);
   }
 
   // ── Build summary output ──
@@ -1540,6 +1566,7 @@ Options:
   --entity-type=X        Filter by entity type (organization, person, ai-model, ...)
   --entity=X             Filter by entity (org or person stableId)
   --source=X             Source mode: existing | web-search | all (default: existing)
+  --concurrency=N        Number of parallel verifications (default: 5)
   --dry-run              Show what would be verified without calling LLM
   --ci                   JSON output
 


### PR DESCRIPTION
## Summary
- Add `--concurrency=N` flag to `verify-orchestrate` command (default: 5)
- Replaces sequential for-loop with a concurrency-limited promise pool
- Each verification item is independent (separate URL fetch + LLM call + DB write), so parallelism is safe
- `--concurrency=1` falls back to original sequential behavior

## Motivation
A 1,377-item FactBase source-check run took ~30 minutes sequentially. With concurrency=5, this drops to ~6 minutes.

## Test plan
- [x] Tested with `--limit=10 --concurrency=5` — items process in parallel, summary is correct
- [x] Tested with `--concurrency=1` — sequential fallback works, no concurrency label in output
- [x] Tested dry-run mode — unaffected by change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
