### PR TITLE
feat: add proposed_claims and claim_record_links tables

### DIFF
--- a/apps/wiki-server/drizzle/0141_create_proposed_claims.sql
+++ b/apps/wiki-server/drizzle/0141_create_proposed_claims.sql
@@ -1,0 +1,58 @@
+-- Claims-first verification tables (issue #3253, Component 1)
+-- Research agents propose structured claims; a worker verifies them before applying.
+
+CREATE TABLE IF NOT EXISTS proposed_claims (
+  id BIGSERIAL PRIMARY KEY,
+  batch_id TEXT NOT NULL,
+
+  -- What's being claimed
+  claim_text TEXT NOT NULL,
+  entity_id TEXT,
+  target_table TEXT NOT NULL,
+  target_field TEXT,
+  proposed_value TEXT,
+  proposed_data JSONB,
+
+  -- Source evidence (from research agent)
+  resource_id TEXT REFERENCES resources(id),
+  source_url TEXT NOT NULL,
+  agent_evidence TEXT,
+
+  -- Verification state (updated by worker)
+  status TEXT NOT NULL DEFAULT 'pending',
+  verdict_confidence REAL,
+  verdict_reasoning TEXT,
+  extracted_value TEXT,
+  checker_model TEXT,
+  verified_at TIMESTAMPTZ,
+  evidence_id BIGINT,
+
+  -- Job tracking
+  verification_job_id BIGINT,
+
+  -- Audit
+  submitted_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS claim_record_links (
+  id BIGSERIAL PRIMARY KEY,
+  claim_id BIGINT NOT NULL REFERENCES proposed_claims(id),
+  record_type TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  match_verdict TEXT,
+  match_confidence REAL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for proposed_claims
+CREATE INDEX idx_pc_batch ON proposed_claims(batch_id);
+CREATE INDEX idx_pc_status ON proposed_claims(status);
+CREATE INDEX idx_pc_entity ON proposed_claims(entity_id);
+CREATE INDEX idx_pc_resource ON proposed_claims(resource_id);
+CREATE INDEX idx_pc_target ON proposed_claims(target_table, entity_id);
+
+-- Indexes for claim_record_links
+CREATE INDEX idx_crl_claim ON claim_record_links(claim_id);
+CREATE INDEX idx_crl_record ON claim_record_links(record_type, record_id);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -988,6 +988,13 @@
       "when": 1781769600000,
       "tag": "0140_tablebase_audit_log",
       "breakpoints": true
+    },
+    {
+      "idx": 141,
+      "version": "7",
+      "when": 1781856000000,
+      "tag": "0141_create_proposed_claims",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1293,3 +1293,38 @@ export const RecordQaCheckSchema = z.object({
 export const RecordQaCheckBatchSchema = z.object({
   items: z.array(RecordQaCheckSchema).min(1).max(200),
 });
+
+// ---------------------------------------------------------------------------
+// Claims: Proposed Claims schemas (issue #3253)
+// ---------------------------------------------------------------------------
+
+export const VALID_CLAIM_STATUSES = [
+  "pending",
+  "verifying",
+  "verified",
+  "contradicted",
+  "unverifiable",
+  "expired",
+] as const;
+export type ClaimStatus = (typeof VALID_CLAIM_STATUSES)[number];
+
+export const ProposeClaimsSchema = z.object({
+  entityId: z.string().max(200),
+  targetTable: z.string().max(100),
+  agentSessionId: z.string().max(200).optional(),
+  claims: z
+    .array(
+      z.object({
+        claimText: z.string().min(1).max(5000),
+        targetField: z.string().max(200).optional(),
+        proposedValue: z.string().max(5000).optional(),
+        proposedData: z.record(z.unknown()).optional(),
+        resourceId: z.string().max(200),
+        sourceUrl: z.string().url().max(2000),
+        agentEvidence: z.string().max(5000),
+      })
+    )
+    .min(1)
+    .max(100),
+});
+export type ProposeClaims = z.infer<typeof ProposeClaimsSchema>;

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3306,3 +3306,91 @@ export const raceCandidates = pgTable(
     index("idx_rc_ai_stance").on(table.aiStance),
   ]
 );
+
+// ============================================================================
+// Claims-first verification — proposed_claims + claim_record_links
+//
+// Research agents propose structured claims about entities. A verification
+// worker checks each claim against source evidence and records a verdict.
+// claim_record_links connects approved claims to the records they affected.
+//
+// See: https://github.com/quantified-uncertainty/longterm-wiki/issues/3253
+// ============================================================================
+
+/**
+ * Proposed claims — structured assertions submitted by research agents
+ * for verification before being applied to TableBase records.
+ */
+export const proposedClaims = pgTable(
+  "proposed_claims",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    batchId: text("batch_id").notNull(),
+
+    // What's being claimed
+    claimText: text("claim_text").notNull(),
+    entityId: text("entity_id"),
+    targetTable: text("target_table").notNull(),
+    targetField: text("target_field"),
+    proposedValue: text("proposed_value"),
+    proposedData: jsonb("proposed_data"),
+
+    // Source evidence (from research agent)
+    resourceId: text("resource_id").references(() => resources.id),
+    sourceUrl: text("source_url").notNull(),
+    agentEvidence: text("agent_evidence"),
+
+    // Verification state (updated by worker)
+    status: text("status").notNull().default("pending"),
+    verdictConfidence: real("verdict_confidence"),
+    verdictReasoning: text("verdict_reasoning"),
+    extractedValue: text("extracted_value"),
+    checkerModel: text("checker_model"),
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    evidenceId: bigint("evidence_id", { mode: "number" }),
+
+    // Job tracking
+    verificationJobId: bigint("verification_job_id", { mode: "number" }),
+
+    // Audit
+    submittedBy: text("submitted_by"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_pc_batch").on(table.batchId),
+    index("idx_pc_status").on(table.status),
+    index("idx_pc_entity").on(table.entityId),
+    index("idx_pc_resource").on(table.resourceId),
+    index("idx_pc_target").on(table.targetTable, table.entityId),
+  ]
+);
+
+/**
+ * Claim-record links — connects verified claims to the domain records
+ * they were applied to (personnel, grants, funding_rounds, etc.).
+ */
+export const claimRecordLinks = pgTable(
+  "claim_record_links",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    claimId: bigint("claim_id", { mode: "number" })
+      .notNull()
+      .references(() => proposedClaims.id),
+    recordType: text("record_type").notNull(),
+    recordId: text("record_id").notNull(),
+    matchVerdict: text("match_verdict"),
+    matchConfidence: real("match_confidence"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_crl_claim").on(table.claimId),
+    index("idx_crl_record").on(table.recordType, table.recordId),
+  ]
+);


### PR DESCRIPTION
## Summary
- Adds `proposed_claims` and `claim_record_links` database tables (Drizzle schema + migration 0141)
- Adds Zod validation schemas (`VALID_CLAIM_STATUSES`, `ProposeClaimsSchema`) to `api-types.ts`
- This is Component 1 of the claims-first verification architecture

These tables support a workflow where research agents propose structured claims about entities, which are then independently verified before being applied to TableBase records.

## Test plan
- [x] TypeScript compiles without new errors (pre-existing baseline only)
- [x] Migration SQL is syntactically valid and uses IF NOT EXISTS for safety
- [x] Schema matches migration SQL (column names, types, indexes)
- [x] Zod schemas have proper validation constraints

Closes #3253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
