### PR TITLE
fix: replace 184 empty relatedEntries with [] (unbreak main)

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -476,7 +476,7 @@
   type: person
   title: Neel Nanda
   website: https://www.neelnanda.io
-  relatedEntries:
+  relatedEntries: []
 - id: nick-bostrom
   stableId: IQvWHA3OiF
   wikiId: E215
@@ -896,7 +896,7 @@
     and critical perspectives on EA institutions.
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: vidur-kapur
   stableId: XqvdX3YisQ
   wikiId: E580
@@ -971,7 +971,7 @@
   type: person
   title: Nick Beckstead
   website: https://www.nickbeckstead.com/
-  relatedEntries:
+  relatedEntries: []
 - id: will-macaskill
   stableId: p1P9oQwB6w
   wikiId: E862
@@ -1517,7 +1517,7 @@
     - community-building
   clusters:
     - community
-  relatedEntries:
+  relatedEntries: []
 - id: richard-mallah
   stableId: mK2KLknYGg
   type: person
@@ -1575,7 +1575,7 @@
   clusters:
     - ai-safety
     - community
-  relatedEntries:
+  relatedEntries: []
 - id: scott-wiener
   stableId: HLc6VrCh5w
   wikiId: E1471
@@ -1617,7 +1617,7 @@
       value: "Governor of California"
     - label: Known For
       value: "SB 1047 veto, signing 18 AI bills, SB 53"
-  relatedEntries:
+  relatedEntries: []
 - id: josue-estrada
   stableId: FeHrdAUKpQ
   type: person
@@ -2091,7 +2091,7 @@
     consumption of $169 (95% CI: $131-$1,185).
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: quinn-dougherty
   stableId: YtooTZ0ORg
   type: person
@@ -2103,7 +2103,7 @@
   website: https://quinnd.net
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: elizabeth-van-nostrand
   stableId: rF8popeiHw
   type: person
@@ -2115,7 +2115,7 @@
   website: https://acesounderglass.com
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: umur-ozkul
   stableId: y9XSIBClAw
   type: person
@@ -2126,7 +2126,7 @@
     language design.
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: jacob-lagerros
   stableId: JUWVFemrYQ
   type: person
@@ -2136,7 +2136,7 @@
     Future of Humanity Institute. Subsequently worked at LessWrong.
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: andrew-critch
   stableId: ckKaHtKC5g
   type: person
@@ -2153,7 +2153,7 @@
   clusters:
     - ai-safety
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: peter-wildeford
   stableId: mIbKwQ4ZwQ
   type: person
@@ -2181,7 +2181,7 @@
     Nuño at an FHI Summer Fellowship.
   clusters:
     - epistemics
-  relatedEntries:
+  relatedEntries: []
 - id: tom-brown
   stableId: 4CY8YJCrM7
   wikiId: E1258
@@ -2392,17 +2392,17 @@
   stableId: 1nsWegMiR3
   type: person
   title: Markus Anderljung
-  relatedEntries:
+  relatedEntries: []
 - id: emma-bluemke
   stableId: wKx_yCn-EJ
   type: person
   title: Emma Bluemke
-  relatedEntries:
+  relatedEntries: []
 - id: anton-korinek
   stableId: evoWfReU6W
   type: person
   title: Anton Korinek
-  relatedEntries:
+  relatedEntries: []
 - id: amba-kak
   stableId: xTqcQVprIH
   type: person
@@ -2429,37 +2429,37 @@
   stableId: lCvbYl5SE0
   type: person
   title: Sarah Myers West
-  relatedEntries:
+  relatedEntries: []
 - id: kate-crawford
   stableId: 77SnPuPnk8
   type: person
   title: Kate Crawford
-  relatedEntries:
+  relatedEntries: []
 - id: meredith-whittaker
   stableId: 3R1I5JCrP4
   type: person
   title: Meredith Whittaker
-  relatedEntries:
+  relatedEntries: []
 - id: heidy-khlaaf
   stableId: npfho6p1QL
   type: person
   title: Heidy Khlaaf
-  relatedEntries:
+  relatedEntries: []
 - id: thomas-woodside
   stableId: KfgopYXMo8
   type: person
   title: Thomas Woodside
-  relatedEntries:
+  relatedEntries: []
 - id: andy-zou
   stableId: SIfbuDzvcU
   type: person
   title: Andy Zou
-  relatedEntries:
+  relatedEntries: []
 - id: mantas-mazeika
   stableId: j4eeIGYdY2
   type: person
   title: Mantas Mazeika
-  relatedEntries:
+  relatedEntries: []
 - id: esben-kran
   stableId: HwM6OF6Ewg
   type: person
@@ -2497,7 +2497,7 @@
   description: >-
     CEO of Apart Research. Leads the organization's operations, research sprints,
     and fellowship programs.
-  relatedEntries:
+  relatedEntries: []
 - id: jason-hoelscher-obermaier
   stableId: 2kfQ41S__Y
   type: person
@@ -2506,49 +2506,49 @@
     Director of Research at Apart Research. Runs Apart Lab and Apart Sprints
     research programs. Has a PhD and co-authored publications including
     "Detecting Edit Failures In Large Language Models" (ACL 2023).
-  relatedEntries:
+  relatedEntries: []
 - id: natalia-perez-campanero-antolin
   stableId: i78bV5zHTe
   type: person
   title: Natalia Perez-Campanero Antolin
   description: >-
     Research Lead at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: jacob-haimes
   stableId: Bq7bnwVybe
   type: person
   title: Jacob Haimes
   description: >-
     Research Manager at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: al-hussein-saqr
   stableId: vxQxyoROkq
   type: person
   title: Al-Hussein Saqr
   description: >-
     Operations Coordinator at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: clement-neo
   stableId: BkIIdAqW_U
   type: person
   title: Clement Neo
   description: >-
     Lab Advisor at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: christian-schroeder-de-witt
   stableId: Uyu-64zinm
   type: person
   title: Christian Schroeder de Witt
   description: >-
     Research Advisor at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: nick-fitz
   stableId: g2nElvI1Hj
   type: person
   title: Nick Fitz
   description: >-
     Strategy Advisor at Apart Research.
-  relatedEntries:
+  relatedEntries: []
 - id: jeremie-harris
   stableId: aJOiUj35UA
   type: person
@@ -3599,7 +3599,7 @@
     Co-founder and Projects Director of Foresight Institute. Nanotechnology
     advocate credited with coining the term "open-source software" in its
     modern software community sense (1998).
-  relatedEntries:
+  relatedEntries: []
 - id: k-eric-drexler
   stableId: jExOzigU4B
   type: person
@@ -3608,7 +3608,7 @@
     Co-founder of Foresight Institute. Pioneer in nanotechnology and
     molecular manufacturing. Author of foundational works on molecular
     machine systems.
-  relatedEntries:
+  relatedEntries: []
 - id: james-c-bennett
   stableId: 8Mk8-7uSm6
   type: person
@@ -3616,7 +3616,7 @@
   description: >-
     Co-founder and Director of Foresight Institute. Co-founder of commercial
     space launch companies and consultant in space and technology.
-  relatedEntries:
+  relatedEntries: []
 - id: brandon-goldman
   stableId: 04ESS5IDzn
   type: person
@@ -3624,7 +3624,7 @@
   description: >-
     Treasurer of Foresight Institute. Investor focused on AI safety and
     existential risk.
-  relatedEntries:
+  relatedEntries: []
 - id: sonia-arrison
   stableId: JkPfxLKrTR
   type: person
@@ -3632,7 +3632,7 @@
   description: >-
     Director of Foresight Institute. Author of '100 Plus'. Founder of 100
     Plus Capital. Board member at Thiel Foundation.
-  relatedEntries:
+  relatedEntries: []
 - id: chip-morningstar
   stableId: uPDPgwTvaz
   type: person
@@ -3640,7 +3640,7 @@
   description: >-
     Director of Foresight Institute. Software architect focused on online
     entertainment and communication.
-  relatedEntries:
+  relatedEntries: []
 - id: peter-diamandis
   stableId: tVhfitccVu
   type: person
@@ -3649,602 +3649,602 @@
     Advisor to Foresight Institute. Founder of X-Prize Foundation. Chaired
     Feynman Grand Prize committee (2004). Entrepreneur and author focused
     on exponential technologies.
-  relatedEntries:
+  relatedEntries: []
 - id: michael-skuhersky
   stableId: WF63mO4uXf
   type: person
   title: Michael Skuhersky
   description: >-
     Researcher in synthetic neurobiology and mind uploading at MIT Media Lab. Foresight Fellow (2017).
-  relatedEntries:
+  relatedEntries: []
 - id: berhane-temelso
   stableId: E4_x-Cc9Nb
   type: person
   title: Berhane Temelso
   description: >-
     Computational chemist at Furman University. Foresight Fellow (2017).
-  relatedEntries:
+  relatedEntries: []
 - id: christopher-wilmer
   stableId: gc2ul9ESdY
   type: person
   title: Christopher Wilmer
   description: >-
     Chemical engineering researcher focused on molecular machines at University of Pittsburgh. Foresight Fellow (2017).
-  relatedEntries:
+  relatedEntries: []
 - id: chuyang-cheng
   stableId: 0NB15aKxPM
   type: person
   title: Chuyang Cheng
   description: >-
     Researcher in molecular machines at Northwestern University (Stoddart group). Foresight Fellow (2017).
-  relatedEntries:
+  relatedEntries: []
 - id: eva-maria-strauch
   stableId: k3aEQarjFs
   type: person
   title: Eva-Maria Strauch
   description: >-
     Protein design researcher at University of Washington. Foresight Fellow (2017).
-  relatedEntries:
+  relatedEntries: []
 - id: roman-yampolskiy
   stableId: LH_b3YDCyA
   type: person
   title: Roman V. Yampolskiy
   description: >-
     AI safety and security researcher at University of Louisville. Known for work on AI containment and the AI control problem. Foresight Fellow (2018).
-  relatedEntries:
+  relatedEntries: []
 - id: grigory-tikhomirov
   stableId: _OzCsPWWG2
   type: person
   title: Grigory Tikhomirov
   description: >-
     DNA nanotechnology researcher at Caltech. Foresight Fellow (2018).
-  relatedEntries:
+  relatedEntries: []
 - id: jane-lippencott
   stableId: mEMBu1OgGM
   type: person
   title: Jane Lippencott
   description: >-
     Blockchain governance researcher. Associated with ZenCash and Eden. Foresight Fellow (2018).
-  relatedEntries:
+  relatedEntries: []
 - id: peter-scheyer
   stableId: -IegqWaP_8
   type: person
   title: Peter Scheyer
   description: >-
     Researcher in corporate AGI and computer security. Foresight Fellow (2018).
-  relatedEntries:
+  relatedEntries: []
 - id: patrick-mellor
   stableId: xckZ8811MM
   type: person
   title: Patrick Mellor
   description: >-
     Clean energy and CO2 drawdown researcher at San Francisco State University. Foresight Fellow (2019).
-  relatedEntries:
+  relatedEntries: []
 - id: tj-brunette
   stableId: BXUtJUR2Mk
   type: person
   title: TJ Brunette
   description: >-
     Protein design and molecular machines researcher at University of Washington (Baker lab). Foresight Fellow (2019).
-  relatedEntries:
+  relatedEntries: []
 - id: caroline-jeanmaire
   stableId: VZOcEjZnoz
   type: person
   title: Caroline Jeanmaire
   description: >-
     AI governance researcher at UC Berkeley Center for Human-Compatible AI (CHAI). Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: felix-andreas-faber
   stableId: jc3mO3Nbd5
   type: person
   title: Felix Andreas Faber
   description: >-
     Machine learning researcher focused on drug and materials discovery. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: matthew-ryder
   stableId: f3iZsZaJL7
   type: person
   title: Matthew R. Ryder
   description: >-
     Molecular-scale engineering researcher at Oak Ridge National Laboratory. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: alevtina-evgrafova
   stableId: iClhSDzfCb
   type: person
   title: Alevtina Evgrafova
   description: >-
     Researcher in sustainable agriculture. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: tony-lai
   stableId: bZ-9Klhvc-
   type: person
   title: Tony Lai
   description: >-
     Legal engineering researcher at Stanford CodeX focused on biosphere governance. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: giuliana-rotola
   stableId: 3Nvj6hnumO
   type: person
   title: Giuliana Rotola
   description: >-
     Space studies and space law researcher. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: jeffrey-ladish
   stableId: WVV_8_T-oo
   type: person
   title: Jeffrey Ladish
   description: >-
     Biosecurity researcher and advocate. Foresight Fellow (2020). Works on reducing catastrophic biological risks.
-  relatedEntries:
+  relatedEntries: []
 - id: tessa-alexanian
   stableId: NRW6ZB83dF
   type: person
   title: Tessa Alexanian
   description: >-
     Responsible biotechnology researcher and advocate. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: daniel-elton
   stableId: Cz6cISzH1W
   type: person
   title: Daniel Elton
   description: >-
     AI for medical imaging researcher at NIH Clinical Center. Foresight Fellow (2020).
-  relatedEntries:
+  relatedEntries: []
 - id: liang-feng
   stableId: 0SMuMn2uP1
   type: person
   title: Liang Feng
   description: >-
     Researcher in metal-organic frameworks and molecular machines. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: maxim-ziatdinov
   stableId: jF16YrGGt9
   type: person
   title: Maxim Ziatdinov
   description: >-
     Machine learning for materials science researcher. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: yunyan-qiu
   stableId: pIg7IUR6ZK
   type: person
   title: Yunyan Qiu
   description: >-
     Molecular machines researcher at Northwestern University (Stoddart group). Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: xiaohu-neil-zhu
   stableId: DIubf1q8c4
   type: person
   title: Xiaohu (Neil) Zhu
   description: >-
     AI education researcher at University AI (China). Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: joscha-bach
   stableId: _LXq6c8vXY
   type: person
   title: Joscha Bach
   description: >-
     AI researcher affiliated with AI Foundation, MIT Media Lab, and Harvard. Known for work on cognitive architectures and artificial general intelligence. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: jazear-brooks
   stableId: 1CMuMbNe1q
   type: person
   title: Jazear Brooks
   description: >-
     Computer science and fintech researcher. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: yip-fai-tse
   stableId: h7l352tthg
   type: person
   title: Yip Fai Tse
   description: >-
     AI ethics researcher focused on nonhuman animals at Princeton University (under Peter Singer). Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: stephen-malina
   stableId: PG8MZrQT6v
   type: person
   title: Stephen Malina
   description: >-
     Machine learning researcher focused on virus and protein design at Dyno Therapeutics. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: jj-ben-joseph
   stableId: MPO_wgUUDj
   type: person
   title: JJ Ben-Joseph
   description: >-
     Biosecurity and AI researcher at In-Q-Tel. Foresight Fellow (2021).
-  relatedEntries:
+  relatedEntries: []
 - id: delphine-larrieu
   stableId: ovkNsXhA41
   type: person
   title: Delphine Larrieu
   description: >-
     Researcher on premature aging syndromes at Cambridge Institute for Medical Research. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: simon-krause
   stableId: dLjBtrUfhw
   type: person
   title: Simon Krause
   description: >-
     Researcher on framework-embedded molecular machines at Max Planck Institute. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: alexander-fedintsev
   stableId: B-2DIwLZOb
   type: person
   title: Alexander Fedintsev
   description: >-
     Bioinformatics and machine learning researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: tatyana-dobreva
   stableId: bQv1tYrfRd
   type: person
   title: Tatyana Dobreva
   description: >-
     Signal processing and neuroprosthetics researcher at NASA JPL. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: victor-garcia-lopez
   stableId: 551B3lJTX0
   type: person
   title: Victor Garcia Lopez
   description: >-
     Researcher in molecular devices. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: david-august
   stableId: nuD8_FJ7ne
   type: person
   title: David August
   description: >-
     Molecular weaving researcher at University of Edinburgh. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: matthew-mcateer
   stableId: 0xBcCmkVM4
   type: person
   title: Matthew McAteer
   description: >-
     Biotech and machine learning researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: jamie-joyce
   stableId: PEyP8A7QXX
   type: person
   title: Jamie Joyce
   description: >-
     Structured knowledge and argument mapping researcher. Founder of Society Library. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: nikola-markov
   stableId: 30kVfhriPv
   type: person
   title: Nikola T. Markov
   description: >-
     Bioinformatics and aging researcher at Buck Institute. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: zvonimir-vrselja
   stableId: j_tiaJYbZf
   type: person
   title: Zvonimir Vrselja
   description: >-
     Neuroscience researcher at Yale School of Medicine. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: bradley-english
   stableId: U1OfRySCHR
   type: person
   title: Bradley English
   description: >-
     Aging biomarkers researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: tushant-jha
   stableId: _OcY1kmurG
   type: person
   title: Tushant Jha
   description: >-
     AI ethics and value alignment researcher at Future of Humanity Institute (FHI). Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: tinka-vidovic
   stableId: Mo3dSTEDNV
   type: person
   title: Tinka Vidovic
   description: >-
     Molecular medicine and anti-aging researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: maryna-polyakova
   stableId: WwfLP95_oA
   type: person
   title: Maryna Polyakova
   description: >-
     Neuroimaging and depression researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: yuri-deigin
   stableId: 8bh_v5LzgL
   type: person
   title: Yuri Deigin
   description: >-
     Biotech entrepreneur focused on drug discovery and longevity. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: yanguang-zhou
   stableId: 1KA0JCfjE4
   type: person
   title: Yanguang Zhou
   description: >-
     Mechanical engineering and thermal science researcher at HKUST. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: georgios-kaissis
   stableId: jxL-vV2Li1
   type: person
   title: Georgios Kaissis
   description: >-
     Radiology and privacy-preserving machine learning researcher at TU Munich. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: yuanning-feng
   stableId: 0Z1dC0PS2b
   type: person
   title: Yuanning Feng
   description: >-
     Researcher in dynamic functional molecules. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: giulio-ragazzon
   stableId: Wj8Gmei1lA
   type: person
   title: Giulio Ragazzon
   description: >-
     Molecular machines and photochemistry researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: kai-micah-mills
   stableId: v80f8wYPXB
   type: person
   title: Kai Micah Mills
   description: >-
     Serial entrepreneur and technologist. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: philipp-koellinger
   stableId: z1et4GySMo
   type: person
   title: Philipp Koellinger
   description: >-
     Social science genetics researcher at University of Wisconsin-Madison. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: joshua-tan
   stableId: ekENYOG2FU
   type: person
   title: Joshua Tan
   description: >-
     AI governance and metagovernance researcher affiliated with Oxford and Stanford. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: mac-davis
   stableId: Kj61v4mfdi
   type: person
   title: Mac Davis
   description: >-
     Gene therapy and biohacking researcher. Foresight Fellow (2022).
-  relatedEntries:
+  relatedEntries: []
 - id: matthew-allcock
   stableId: BP5q62cTTr
   type: person
   title: Matthew Allcock
   description: >-
     Space weather and infrastructure resilience researcher. Foresight Fellow (2022, 2025).
-  relatedEntries:
+  relatedEntries: []
 - id: shady-el-damaty
   stableId: mKcC7QBEQe
   type: person
   title: Shady El Damaty
   description: >-
     Intelligent cooperation and neurotech researcher at Holonym and OpSci. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: aaron-mayer
   stableId: HewWunPEsp
   type: person
   title: Aaron Mayer
   description: >-
     Effective altruism and investing researcher. Founder of Open Heart Capital. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: danielle-fong
   stableId: 0CnCl3sc0f
   type: person
   title: Danielle Fong
   description: >-
     Energy and science entrepreneur. Co-founder of LightSail Energy. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: ala-shaabana
   stableId: VVMNSO3e-Z
   type: person
   title: Ala Shaabana
   description: >-
     Machine learning and distributed systems researcher at McMaster University. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: ghada-almashaqbeh
   stableId: x-zXBr_BdK
   type: person
   title: Ghada Almashaqbeh
   description: >-
     Computer science and cryptography researcher at UConn. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: kelvin-yu
   stableId: 52Ahct1S5P
   type: person
   title: Kelvin Yu
   description: >-
     Tech policy researcher focused on US-China geopolitics. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: mikayla-maki
   stableId: j6eTa7sKMl
   type: person
   title: Mikayla Maki
   description: >-
     Distributed web and P2P software researcher at Portland State University and Zed. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: stacy-copp
   stableId: NzAxfm9CE9
   type: person
   title: Stacy Copp
   description: >-
     Photonic nanomaterials researcher at UC Irvine. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: ekaterina-ilin
   stableId: PYdGMjfM5p
   type: person
   title: Ekaterina Ilin
   description: >-
     Stellar magnetism and exoplanet habitability researcher. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: laura-minquini
   stableId: 9TxPq16hyW
   type: person
   title: Laura Minquini
   description: >-
     Branding and business development professional. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: mariam-elgabry
   stableId: BoLCyyyEm8
   type: person
   title: Mariam Elgabry
   description: >-
     Cyber-biosecurity researcher at Bronic. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: logan-thrasher-collins
   stableId: Qcjn1NUW9M
   type: person
   title: Logan Thrasher Collins
   description: >-
     Neurotech, connectomics, and synthetic biology researcher. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: andy-matuschak
   stableId: SJNMsyBonF
   type: person
   title: Andy Matuschak
   description: >-
     Tools for thought and learning technology researcher. Known for work on spaced repetition and evergreen notes. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: rico-meinl
   stableId: UBIyBMiwKy
   type: person
   title: Rico Meinl
   description: >-
     Computational biology researcher at retro.bio. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: raiany-romanni
   stableId: WAANMEujqf
   type: person
   title: Raiany Romanni
   description: >-
     Bioethics and longevity researcher. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: jonathan-passerat-palmbach
   stableId: Z_T7HrdQBj
   type: person
   title: Jonathan Passerat-Palmbach
   description: >-
     Privacy-enhancing technology researcher at Flashbots. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: guido-putignano
   stableId: VdhYJjQ4J3
   type: person
   title: Guido Putignano
   description: >-
     Synthetic biology therapeutics researcher. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: anastasia-ershova
   stableId: S9a6WggxO5
   type: person
   title: Anastasia Ershova
   description: >-
     DNA research scientist. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: david-boyer
   stableId: -cudJYVqrX
   type: person
   title: David Boyer
   description: >-
     Neurodegeneration researcher. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: marco-ovalle
   stableId: 53vPdbF2jq
   type: person
   title: Marco Ovalle
   description: >-
     Molecular machines researcher in the Feringa group. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: theo-knopfer
   stableId: NNYy055wJx
   type: person
   title: Theo Knopfer
   description: >-
     Researcher on emerging technology terrorism risk. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: stephane-redon
   stableId: ORyNColiWM
   type: person
   title: Stephane Redon
   description: >-
     Molecular simulation researcher. Founder of OneAngstrom. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: elena-meirzadeh
   stableId: uG_sGCLVzX
   type: person
   title: Elena Meirzadeh
   description: >-
     Solid-state chemistry researcher at Columbia University. Foresight Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: alia-abbas
   stableId: oKmVk_aaZG
   type: person
   title: Alia Abbas
   description: >-
     Physics and materials engineering researcher. Foresight Prodigy Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: natasha-asmi
   stableId: Lar4TaohoD
   type: person
   title: Natasha Asmi
   description: >-
     Scientific ecosystem infrastructure researcher at Halogen. Foresight Prodigy Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: akash-patel
   stableId: 6bkO20mLYD
   type: person
   title: Akash Patel
   description: >-
     Medicine and nanotech researcher at BandX. Foresight Prodigy Fellow (2023).
-  relatedEntries:
+  relatedEntries: []
 - id: pavi-dhiman
   stableId: L727R6bnP2
   type: person
   title: Pavi Dhiman
   description: >-
     Young researcher and Foresight Prodigy Fellow (2023). One of the youngest fellows at 16 years old at time of selection.
-  relatedEntries:
+  relatedEntries: []
 - id: aj-kourabi
   stableId: aqSu5pvw4Q
   type: person
   title: AJ Kourabi
   description: >-
     Engineering researcher at McMaster University. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: hooman-reza-nezhad
   stableId: bQcUONnc08
   type: person
   title: Hooman Reza Nezhad
   description: >-
     STEM and Mars resource utilization researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: lisa-thiergart
   stableId: hBqW4ONQOf
   type: person
   title: Lisa Thiergart
   description: >-
     AI safety and neurotech researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: michael-florea
   stableId: SIvlDx1NDX
   type: person
   title: Michael Florea
   description: >-
     Genetic engineering and longevity researcher at Olden Labs. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: chris-wintersinger
   stableId: CYWc9anaJp
   type: person
   title: Chris Wintersinger
   description: >-
     Biological engineering researcher and biotech startup founder. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: ethan-caballero
   stableId: xg5tg6bSyL
   type: person
@@ -4875,385 +4875,385 @@
   title: Scott Emmons
   description: >-
     AI safety and alignment researcher at Google DeepMind. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: ariel-zeleznikow-johnston
   stableId: EOr3GHi0mq
   type: person
   title: Ariel Zeleznikow-Johnston
   description: >-
     Neuroscience and consciousness researcher at Monash University. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: niccolo-zanichelli
   stableId: yloXSksP3p
   type: person
   title: Niccolo Zanichelli
   description: >-
     AI and biology researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: jason-hausenloy
   stableId: anJm4-_QW0
   type: person
   title: Jason Hausenloy
   description: >-
     AI policy researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: nora-ammann
   stableId: 9OYg0A2u9v
   type: person
   title: Nora Ammann
   description: >-
     Guaranteed Safe AI researcher at PIBBSS. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: zan-huang
   stableId: zT8gF0s15B
   type: person
   title: Zan Huang
   description: >-
     AI, cognition, and music composition researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: claire-short
   stableId: cIKKyepSlX
   type: person
   title: Claire Short
   description: >-
     AI and neuroscience researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: amanda-ngo
   stableId: Rnlp94clBB
   type: person
   title: Amanda Ngo
   description: >-
     AI for wellbeing researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: samuel-nellessen
   stableId: i9FJ8vh36r
   type: person
   title: Samuel Nellessen
   description: >-
     AI researcher at Radboud University. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: bogdan-ionut-cirstea
   stableId: mpkV-n2lMm
   type: person
   title: Bogdan-Ionut Cirstea
   description: >-
     AI existential safety researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: bear-haon
   stableId: hOfDebmkcY
   type: person
   title: Bear Haon
   description: >-
     Robotics and trustworthy autonomous systems researcher at UC Berkeley. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: sruthi-sivakumar
   stableId: cREFraM1QC
   type: person
   title: Sruthi Sivakumar
   description: >-
     Computational biology and longevity researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: roman-bauer
   stableId: -lMQMNfhSu
   type: person
   title: Roman Bauer
   description: >-
     Computational biology and brain modeling researcher at University of Surrey. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: simeon-campos
   stableId: 4V7_qVznQK
   type: person
   title: Simeon Campos
   description: >-
     AI governance and AI auditing researcher at SaferAI. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: dmitrii-usynin
   stableId: iuLi9NNEtt
   type: person
   title: Dmitrii Usynin
   description: >-
     Machine learning under privacy constraints researcher at Imperial College London and TU Munich. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: ekaterina-seltikova
   stableId: wc-8Sekkqt
   type: person
   title: Ekaterina Seltikova
   description: >-
     Lunar exploration and space researcher. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: shuntaro-amano
   stableId: pbOuMCEkuP
   type: person
   title: Shuntaro Amano
   description: >-
     Autonomous molecular motors researcher at University of Strasbourg. Foresight Fellow (2024).
-  relatedEntries:
+  relatedEntries: []
 - id: dean-thomas
   stableId: 3-3k_iIEBt
   type: person
   title: Dean Thomas
   description: >-
     Digital chemistry and molecular machines researcher at University of Glasgow. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: felix-sosa
   stableId: UmkwKHQIo5
   type: person
   title: Felix Sosa
   description: >-
     Computational cognitive science and AGI researcher at Harvard/MIT. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: jasper-gotting
   stableId: U8w-x24QoY
   type: person
   title: Jasper Gotting
   description: >-
     AI and biotech risks researcher at SecureBio. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: yasmeen-hmaidan
   stableId: JlRea3-OEV
   type: person
   title: Yasmeen Hmaidan
   description: >-
     Neurotechnology and e-textiles researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: guanyu-lu
   stableId: OF4YTvRCbi
   type: person
   title: Guanyu Lu
   description: >-
     Nanoscale light-matter interactions researcher at Northwestern University. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: nirosha-murugan
   stableId: 69uPZKxSDe
   type: person
   title: Nirosha Murugan
   description: >-
     Biophysics and cellular communication researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: abhinav-singh
   stableId: GuvDN-3G9F
   type: person
   title: Abhinav Singh
   description: >-
     Cybersecurity researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: zihao-ou
   stableId: YDyJQcs6xr
   type: person
   title: Zihao Ou
   description: >-
     Biomedical science and tissue transparency researcher at UT Dallas. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: moritz-von-knebel
   stableId: 2hbTrdTLY_
   type: person
   title: Moritz von Knebel
   description: >-
     Tech geopolitics and semiconductor security researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: akash-kulgod
   stableId: Cv-tq9lK1G
   type: person
   title: Akash Kulgod
   description: >-
     Brain-computer interfaces and disease detection researcher at Dognosis. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: penghao-li
   stableId: fVwZd8qbAg
   type: person
   title: Penghao Li
   description: >-
     Chemistry researcher at University of Mississippi. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: aydin-gokce
   stableId: bEefY866Md
   type: person
   title: Aydin Gokce
   description: >-
     Cybernetics researcher at General Cybernetics. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: raghav-sehgal
   stableId: on2sSLp8Ak
   type: person
   title: Raghav Sehgal
   description: >-
     Computational biology researcher at Yale. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: maxx-yung
   stableId: siyU8twAWy
   type: person
   title: Maxx Yung
   description: >-
     Materials engineering researcher at University of Pennsylvania. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: gustavs-zilgalvis
   stableId: OTY4pxUlg2
   type: person
   title: Gustavs Zilgalvis
   description: >-
     International policy researcher at Stanford. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: chiara-herzog
   stableId: aVyDpkdJyI
   type: person
   title: Chiara Herzog
   description: >-
     Ageing and biomarkers researcher at King's College London. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: ruairidh-battleday
   stableId: 0uoTCLKHAV
   type: person
   title: Ruairidh Battleday
   description: >-
     Cognitive science and AI researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: peggy-yin
   stableId: T55A96uz_3
   type: person
   title: Peggy Yin
   description: >-
     Psychology and cognitive security researcher at Stanford. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: ninon-lize-masclef
   stableId: EtUZ3PP2KP
   type: person
   title: Ninon Lize Masclef
   description: >-
     AI, neuroscience, and 3D visual perception researcher at MIT Media Lab. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: mahlaqua-mila-noor
   stableId: 0nZmkTd3Ug
   type: person
   title: Mahlaqua Mila Noor
   description: >-
     Researcher at University of Cambridge. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: fin-moorhouse
   stableId: XQm8l8LuOs
   type: person
   title: Fin Moorhouse
   description: >-
     Existential Hope researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: abigail-olvera
   stableId: Ek1Ki4LnFH
   type: person
   title: Abigail Olvera
   description: >-
     Existential Hope researcher. Foresight Fellow (2025).
-  relatedEntries:
+  relatedEntries: []
 - id: alberto-privitera
   stableId: 7V2LqaTShW
   type: person
   title: Alberto Privitera
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: alex-plesa
   stableId: OSe82Ax4gm
   type: person
   title: Alex Plesa
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: avery-krieger
   stableId: koF-u4YPz5
   type: person
   title: Avery Krieger
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: constanze-albrecht
   stableId: hHyQAK9htk
   type: person
   title: Constanze Albrecht
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: donnacha-fitzgerald
   stableId: aZQXutz76s
   type: person
   title: Donnacha Fitzgerald
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: elisa-kallioniemi
   stableId: UQKSKdPyiQ
   type: person
   title: Elisa Kallioniemi
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: gianluca-cidonio
   stableId: phMYtz3rfV
   type: person
   title: Gianluca Cidonio
   description: >-
     Foresight Fellow (2026).
-  relatedEntries:
+  relatedEntries: []
 - id: creon-levit
   stableId: trv0r0CAA9
   type: person
   title: Creon Levit
   description: >-
     Space technology researcher at Planet Labs. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: anders-sandberg
   stableId: 7ojZDBA9wb
   type: person
   title: Anders Sandberg
   description: >-
     Existential risk and long-range futures researcher. Previously at Future of Humanity Institute (FHI) at University of Oxford. Known for work on global catastrophic risks, whole brain emulation, and human enhancement. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: mark-s-miller
   stableId: PmKAZl2vJK
   type: person
   title: Mark S. Miller
   description: >-
     Pioneer of agoric computing and smart contracts. Chief Scientist at Agoric. Known for object-capability security model and the E programming language. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: martin-edelstein
   stableId: CiN_-IiD1U
   type: person
   title: Martin Edelstein
   description: >-
     Bottom-up nanotechnology researcher at Covalent Industrial Technologies. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: brad-templeton
   stableId: fdyIzTzN0R
   type: person
   title: Brad Templeton
   description: >-
     Computing pioneer and EFF board member. Faculty at Singularity University. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: zooko-wilcox
   stableId: F2KOlrJHwv
   type: person
   title: Zooko Wilcox
   description: >-
     Cryptocurrency and privacy researcher. Founder of Electric Coin Company (Zcash). Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: samo-burja
   stableId: RZt-Ryen4Q
   type: person
   title: Samo Burja
   description: >-
     Political risk and institutional analysis researcher. Founder of Bismarck Analysis. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: adam-brown
   stableId: ZZ63lzP4Gp
   type: person
   title: Adam Brown
   description: >-
     Theoretical physics and cosmology researcher at Stanford. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: chiara-marletto
   stableId: tzd-uHhq6m
   type: person
   title: Chiara Marletto
   description: >-
     Quantum theory of computation researcher at Oxford. Known for constructor theory. Foresight Institute Senior Fellow.
-  relatedEntries:
+  relatedEntries: []
 - id: david-manheim
   stableId: 4auxbz6oS9
   type: person
@@ -6063,7 +6063,7 @@
   customFields:
     - label: Role
       value: "Co-founder and CEO, GiveWell"
-  relatedEntries:
+  relatedEntries: []
 - id: bill-gates
   stableId: kzPpqPCdnw
   wikiId: E1910
@@ -6100,7 +6100,7 @@
   customFields:
     - label: Role
       value: "Founder, Pivotal Ventures; Former Co-chair, Gates Foundation"
-  relatedEntries:
+  relatedEntries: []
 - id: peter-singer
   stableId: TDUEAFxz2w
   wikiId: E1912
@@ -6180,7 +6180,7 @@
   customFields:
     - label: Role
       value: "President and CEO, Bezos Earth Fund"
-  relatedEntries:
+  relatedEntries: []
 - id: pierre-omidyar
   stableId: Ol0uNxO0gg
   wikiId: E1916
@@ -6258,7 +6258,7 @@
   customFields:
     - label: Role
       value: "Co-founder and Co-chair, Arnold Ventures"
-  relatedEntries:
+  relatedEntries: []
 - id: darren-walker
   stableId: Be7G95qQ1Q
   wikiId: E1920
@@ -6356,7 +6356,7 @@
   customFields:
     - label: Role
       value: "Co-founder, Omidyar Network; Founder, Humanity United"
-  relatedEntries:
+  relatedEntries: []
 - id: leah-edgerton
   stableId: Xq2bq3EJZQ
   wikiId: E1925
@@ -6392,7 +6392,7 @@
   customFields:
     - label: Role
       value: "Executive Director, The Life You Can Save"
-  relatedEntries:
+  relatedEntries: []
 - id: john-arne-rottingen
   stableId: QkTjuStGuw
   wikiId: E1927


### PR DESCRIPTION
## Summary
- 184 entities had `relatedEntries:` with no value (YAML null), failing schema validation
- These came from recently-added entities missing the `[]` default
- Fixes the `sync-entities > Validate schemas` CI step that's blocking main

## Test plan
- [x] `pnpm crux validate schema` — all 1863 items pass
- [x] `pnpm build-data:content` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized data structure format across multiple entries in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->