### PR TITLE
feat: add display-names and display-formatting gate validators

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -196,6 +196,16 @@ const SCRIPTS = {
     description: 'Validate resource authorEntityIds and publicationId references (advisory)',
     passthrough: ['ci', 'verbose'],
   },
+  'display-names': {
+    script: 'validate/validate-display-names.ts',
+    description: 'Detect raw machine IDs in entity display fields (titles)',
+    passthrough: ['ci'],
+  },
+  'display-formatting': {
+    script: 'validate/validate-display-formatting.ts',
+    description: 'Detect serialization bugs and unescaped MDX in entity data',
+    passthrough: ['ci'],
+  },
   'to-rdjsonl': {
     script: 'validate/to-rdjsonl.ts',
     description: 'Convert unified --ci JSON to Reviewdog rdjsonl (reads stdin)',

--- a/crux/validate/validate-display-formatting.test.ts
+++ b/crux/validate/validate-display-formatting.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the display formatting validator.
+ *
+ * Tests the exported detection functions directly (unit tests) and
+ * runs the validator against the current codebase (integration test).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import {
+  containsObjectObject,
+  hasUnescapedMdxInTitle,
+  isStringifiedNullish,
+  isStringifiedNaN,
+} from './validate-display-formatting.ts';
+
+const REPO_ROOT = `${__dirname}/../..`;
+
+function run(cmd: string): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(cmd, {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: (e.stdout || '') + (e.stderr || ''), exitCode: e.status ?? 1 };
+  }
+}
+
+describe('containsObjectObject', () => {
+  it('detects [object Object]', () => {
+    expect(containsObjectObject('[object Object]')).toBe(true);
+    expect(containsObjectObject('Name: [object Object]')).toBe(true);
+    expect(containsObjectObject('Data is [object Object] here')).toBe(true);
+  });
+
+  it('rejects normal strings', () => {
+    expect(containsObjectObject('Anthropic')).toBe(false);
+    expect(containsObjectObject('An object in the room')).toBe(false);
+    expect(containsObjectObject('')).toBe(false);
+  });
+});
+
+describe('hasUnescapedMdxInTitle', () => {
+  it('detects bare angle brackets not part of HTML tags', () => {
+    // Bare < not followed by a tag name
+    expect(hasUnescapedMdxInTitle('Revenue < $1M')).toBe(true);
+    expect(hasUnescapedMdxInTitle('Score <100')).toBe(true);
+    expect(hasUnescapedMdxInTitle('x < y')).toBe(true);
+  });
+
+  it('allows HTML-like tags', () => {
+    // These look like valid HTML tags — the MDX compiler handles them
+    expect(hasUnescapedMdxInTitle('<em>emphasis</em>')).toBe(false);
+    expect(hasUnescapedMdxInTitle('<strong>bold</strong>')).toBe(false);
+    expect(hasUnescapedMdxInTitle('</div>')).toBe(false);
+  });
+
+  it('detects bare curly braces', () => {
+    expect(hasUnescapedMdxInTitle('Value {computed}')).toBe(true);
+    expect(hasUnescapedMdxInTitle('Count: {}')).toBe(true);
+    expect(hasUnescapedMdxInTitle('Result }')).toBe(true);
+  });
+
+  it('allows normal titles', () => {
+    expect(hasUnescapedMdxInTitle('Anthropic')).toBe(false);
+    expect(hasUnescapedMdxInTitle('AI Safety Research Overview')).toBe(false);
+    expect(hasUnescapedMdxInTitle('OpenAI - GPT-4 Launch')).toBe(false);
+    expect(hasUnescapedMdxInTitle('$100M Funding Round')).toBe(false);
+  });
+});
+
+describe('isStringifiedNullish', () => {
+  it('detects "undefined" and "null"', () => {
+    expect(isStringifiedNullish('undefined')).toBe(true);
+    expect(isStringifiedNullish('null')).toBe(true);
+    expect(isStringifiedNullish(' undefined ')).toBe(true);
+    expect(isStringifiedNullish(' null ')).toBe(true);
+  });
+
+  it('rejects normal strings containing these words', () => {
+    expect(isStringifiedNullish('null hypothesis')).toBe(false);
+    expect(isStringifiedNullish('undefined behavior')).toBe(false);
+    expect(isStringifiedNullish('Anthropic')).toBe(false);
+    expect(isStringifiedNullish('')).toBe(false);
+  });
+});
+
+describe('isStringifiedNaN', () => {
+  it('detects "NaN"', () => {
+    expect(isStringifiedNaN('NaN')).toBe(true);
+    expect(isStringifiedNaN(' NaN ')).toBe(true);
+  });
+
+  it('rejects normal strings', () => {
+    expect(isStringifiedNaN('Nanjing')).toBe(false);
+    expect(isStringifiedNaN('Banana')).toBe(false);
+    expect(isStringifiedNaN('')).toBe(false);
+  });
+});
+
+describe('validate-display-formatting integration', () => {
+  it('passes on the current codebase', () => {
+    const result = run('npx tsx crux/validate/validate-display-formatting.ts');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No display formatting issues found');
+  }, 30_000);
+});

--- a/crux/validate/validate-display-formatting.ts
+++ b/crux/validate/validate-display-formatting.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+/**
+ * Display Formatting Validator — Detect common rendering bugs in entity data
+ *
+ * Scans entity YAML files for:
+ *   - `[object Object]` in any string field (serialization bug)
+ *   - Unescaped MDX characters in title/description fields (`<`, `{`, `}`)
+ *     that would break rendering
+ *   - `undefined` or `null` as literal strings in display fields
+ *   - `NaN` as a literal string in display fields
+ *
+ * These indicate data pipeline bugs where objects are stringified incorrectly
+ * or special characters leak into display fields.
+ *
+ * Usage: npx tsx crux/validate/validate-display-formatting.ts
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import { getColors } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+const ENTITIES_DIR = join(PROJECT_ROOT, 'data/entities');
+
+export interface DisplayFormattingViolation {
+  file: string;
+  entityId: string;
+  field: string;
+  value: string;
+  reason: string;
+}
+
+/**
+ * Check if a string contains `[object Object]` — a sign of accidental
+ * toString() on a JS object.
+ */
+export function containsObjectObject(value: string): boolean {
+  return value.includes('[object Object]');
+}
+
+/**
+ * Check if a title/description contains unescaped MDX-breaking characters.
+ * In MDX, bare `<` (not part of a known HTML tag) and bare `{`/`}` will
+ * break compilation. This catches cases where these leak into entity titles
+ * or descriptions from data sources.
+ *
+ * We only flag obvious cases:
+ *   - `<` not followed by a common HTML tag name or `/` (closing tag)
+ *   - Bare `{` or `}` not inside a code fence
+ *
+ * The title field should never contain MDX syntax — it's always rendered
+ * as plain text in headings, meta tags, and directory tables.
+ */
+export function hasUnescapedMdxInTitle(value: string): boolean {
+  // Check for bare < that isn't an HTML tag or escaped
+  // Common HTML tags that are fine: <br>, <em>, <strong>, <a>, <code>, <span>, <div>
+  const bareAngleBracket = /<(?![a-z/!])/i;
+  if (bareAngleBracket.test(value)) return true;
+
+  // Check for bare { or } (JSX expression syntax)
+  if (/[{}]/.test(value)) return true;
+
+  return false;
+}
+
+/**
+ * Check if a string is the literal "undefined" or "null" — signs of
+ * accidental stringification of JS undefined/null values.
+ */
+export function isStringifiedNullish(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed === 'undefined' || trimmed === 'null';
+}
+
+/**
+ * Check if a string is the literal "NaN".
+ */
+export function isStringifiedNaN(value: string): boolean {
+  return value.trim() === 'NaN';
+}
+
+interface YamlEntity {
+  id?: string;
+  stableId?: string;
+  title?: string;
+  description?: string;
+  customFields?: Array<{ label?: string; value?: string }>;
+  sources?: Array<{ title?: string; url?: string }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Recursively scan all string values in an object for [object Object].
+ * Returns field paths where violations are found.
+ */
+function findObjectObjectInValue(
+  value: unknown,
+  path: string,
+): Array<{ field: string; value: string }> {
+  const results: Array<{ field: string; value: string }> = [];
+
+  if (typeof value === 'string') {
+    if (containsObjectObject(value)) {
+      results.push({ field: path, value });
+    }
+  } else if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      results.push(...findObjectObjectInValue(value[i], `${path}[${i}]`));
+    }
+  } else if (value !== null && typeof value === 'object') {
+    for (const [key, val] of Object.entries(value)) {
+      results.push(...findObjectObjectInValue(val, path ? `${path}.${key}` : key));
+    }
+  }
+
+  return results;
+}
+
+function checkEntity(entity: YamlEntity, file: string): DisplayFormattingViolation[] {
+  const violations: DisplayFormattingViolation[] = [];
+  const entityId = entity.id || entity.stableId || '(no id)';
+
+  // 1. Check for [object Object] anywhere in the entity
+  const objectObjectHits = findObjectObjectInValue(entity, '');
+  for (const hit of objectObjectHits) {
+    violations.push({
+      file,
+      entityId,
+      field: hit.field,
+      value: hit.value.length > 80 ? hit.value.slice(0, 80) + '...' : hit.value,
+      reason: 'Contains "[object Object]" (serialization bug)',
+    });
+  }
+
+  // 2. Check title for unescaped MDX characters
+  if (typeof entity.title === 'string') {
+    if (hasUnescapedMdxInTitle(entity.title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: entity.title,
+        reason: 'Title contains unescaped MDX characters (< or {/}) that may break rendering',
+      });
+    }
+
+    if (isStringifiedNullish(entity.title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: entity.title,
+        reason: 'Title is the literal string "undefined" or "null"',
+      });
+    }
+
+    if (isStringifiedNaN(entity.title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: entity.title,
+        reason: 'Title is the literal string "NaN"',
+      });
+    }
+  }
+
+  // 3. Check description for stringified nullish/NaN
+  if (typeof entity.description === 'string') {
+    if (isStringifiedNullish(entity.description)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'description',
+        value: entity.description,
+        reason: 'Description is the literal string "undefined" or "null"',
+      });
+    }
+
+    if (isStringifiedNaN(entity.description)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'description',
+        value: entity.description,
+        reason: 'Description is the literal string "NaN"',
+      });
+    }
+  }
+
+  // 4. Check customField values
+  if (Array.isArray(entity.customFields)) {
+    for (const cf of entity.customFields) {
+      if (typeof cf.value === 'string') {
+        if (isStringifiedNullish(cf.value)) {
+          violations.push({
+            file,
+            entityId,
+            field: `customFields[label="${cf.label || '?'}"].value`,
+            value: cf.value,
+            reason: 'Custom field value is the literal string "undefined" or "null"',
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: DisplayFormattingViolation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking for display formatting issues in entity data...${c.reset}\n`);
+
+  let yamlFiles: string[];
+  try {
+    yamlFiles = readdirSync(ENTITIES_DIR).filter(f => f.endsWith('.yaml'));
+  } catch {
+    console.log(`${c.dim}Skipping: could not read entities directory at ${ENTITIES_DIR}${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: DisplayFormattingViolation[] = [];
+  let totalEntities = 0;
+
+  for (const file of yamlFiles) {
+    const filePath = join(ENTITIES_DIR, file);
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue; // Skip unreadable files
+    }
+
+    let entities: YamlEntity[];
+    try {
+      const parsed = parseYaml(content);
+      if (!Array.isArray(parsed)) continue;
+      entities = parsed as YamlEntity[];
+    } catch {
+      continue; // Skip malformed YAML
+    }
+
+    for (const entity of entities) {
+      totalEntities++;
+      const violations = checkEntity(entity, file);
+      allViolations.push(...violations);
+    }
+  }
+
+  if (allViolations.length === 0) {
+    console.log(`${c.green}No display formatting issues found (${totalEntities} entities checked)${c.reset}`);
+  } else {
+    console.log(`${c.red}Found ${allViolations.length} display formatting issue(s):${c.reset}\n`);
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file} → ${v.entityId}${c.reset}`);
+      console.log(`    ${c.dim}${v.field}: "${v.value}"${c.reset}`);
+      console.log(`    ${c.dim}Reason: ${v.reason}${c.reset}\n`);
+    }
+    console.log(`${c.dim}Fix: correct the serialization issue or escape MDX characters in entity YAML files.${c.reset}`);
+  }
+
+  return { passed: allViolations.length === 0, errors: allViolations.length, violations: allViolations };
+}
+
+if (process.argv[1]?.includes('validate-display-formatting')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-display-names.test.ts
+++ b/crux/validate/validate-display-names.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the display names validator.
+ *
+ * Tests the exported detection functions directly (unit tests) and
+ * runs the validator against the current codebase (integration test).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import {
+  looksLikeStableId,
+  looksLikeHashId,
+  isPureNumericId,
+  isUnknownPlaceholder,
+} from './validate-display-names.ts';
+
+const REPO_ROOT = `${__dirname}/../..`;
+
+function run(cmd: string): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(cmd, {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: (e.stdout || '') + (e.stderr || ''), exitCode: e.status ?? 1 };
+  }
+}
+
+describe('looksLikeStableId', () => {
+  it('detects typical stableIds', () => {
+    expect(looksLikeStableId('mK9pX3rQ7n')).toBe(true);
+    expect(looksLikeStableId('Tw_Eo226h3')).toBe(true);
+    expect(looksLikeStableId('A4XoubikkQ')).toBe(true); // has digits, mixed case
+    expect(looksLikeStableId('Z62bQynY4g')).toBe(true);
+    expect(looksLikeStableId('0u4J70VqFY')).toBe(true);
+  });
+
+  it('rejects real names that happen to be 10 chars', () => {
+    // Real words/names should not be flagged
+    expect(looksLikeStableId('Washington')).toBe(false); // no digits
+    expect(looksLikeStableId('Regulation')).toBe(false); // no digits
+    expect(looksLikeStableId('abcdefghij')).toBe(false); // all lowercase
+    expect(looksLikeStableId('ABCDEFGHIJ')).toBe(false); // all uppercase
+  });
+
+  it('rejects strings of wrong length', () => {
+    expect(looksLikeStableId('abc')).toBe(false);
+    expect(looksLikeStableId('mK9pX3rQ7nX')).toBe(false); // 11 chars
+    expect(looksLikeStableId('')).toBe(false);
+  });
+
+  it('rejects strings with special characters', () => {
+    expect(looksLikeStableId('mK9pX3r.7n')).toBe(false);
+    expect(looksLikeStableId('mK9 X3rQ7n')).toBe(false);
+  });
+});
+
+describe('looksLikeHashId', () => {
+  it('detects hash-like strings', () => {
+    expect(looksLikeHashId('aB3cD4eF5gH6')).toBe(true); // 12 chars, pure alphanumeric, mixed case + digits
+    expect(looksLikeHashId('xY9kL2mN0pQr')).toBe(true); // 12 chars
+  });
+
+  it('rejects hyphenated product names', () => {
+    // These should NOT be flagged — they're real product/model names
+    expect(looksLikeHashId('GPT-4o-mini')).toBe(false);
+    expect(looksLikeHashId('Llama-3-70B')).toBe(false);
+    expect(looksLikeHashId('Claude-3-Opus')).toBe(false);
+  });
+
+  it('rejects strings with underscores', () => {
+    // Conservative: underscores excluded to avoid false positives
+    expect(looksLikeHashId('person_xY9kL2mN0p')).toBe(false);
+  });
+
+  it('rejects real names', () => {
+    expect(looksLikeHashId('Anthropic')).toBe(false); // too short, no digits
+    expect(looksLikeHashId('John Smith')).toBe(false); // has space
+    expect(looksLikeHashId('Buck Shlegeris')).toBe(false); // has space
+    expect(looksLikeHashId('OpenAI')).toBe(false); // too short
+  });
+
+  it('rejects strings that are too short or too long', () => {
+    expect(looksLikeHashId('aB3c')).toBe(false); // too short
+    expect(looksLikeHashId('aB3cD4eF5g')).toBe(false); // 10 chars — too short (caught by stableId check)
+    expect(looksLikeHashId('a'.repeat(31))).toBe(false); // too long
+  });
+
+  it('rejects strings with spaces', () => {
+    expect(looksLikeHashId('aB3 cD4 eF5g')).toBe(false);
+  });
+});
+
+describe('isPureNumericId', () => {
+  it('detects pure numbers', () => {
+    expect(isPureNumericId('12345')).toBe(true);
+    expect(isPureNumericId('0')).toBe(true);
+    expect(isPureNumericId('999999')).toBe(true);
+    expect(isPureNumericId(' 123 ')).toBe(true); // trims whitespace
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(isPureNumericId('abc')).toBe(false);
+    expect(isPureNumericId('123abc')).toBe(false);
+    expect(isPureNumericId('$100')).toBe(false);
+    expect(isPureNumericId('')).toBe(false);
+  });
+});
+
+describe('isUnknownPlaceholder', () => {
+  it('detects "Unknown" in various cases', () => {
+    expect(isUnknownPlaceholder('Unknown')).toBe(true);
+    expect(isUnknownPlaceholder('unknown')).toBe(true);
+    expect(isUnknownPlaceholder('UNKNOWN')).toBe(true);
+    expect(isUnknownPlaceholder(' Unknown ')).toBe(true); // trims whitespace
+  });
+
+  it('rejects non-placeholder strings', () => {
+    expect(isUnknownPlaceholder('Unknown Person')).toBe(false);
+    expect(isUnknownPlaceholder('The Unknown')).toBe(false);
+    expect(isUnknownPlaceholder('Anthropic')).toBe(false);
+    expect(isUnknownPlaceholder('')).toBe(false);
+  });
+});
+
+describe('validate-display-names integration', () => {
+  it('passes on the current codebase', () => {
+    const result = run('npx tsx crux/validate/validate-display-names.ts');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No raw machine IDs found');
+  }, 30_000);
+});

--- a/crux/validate/validate-display-names.ts
+++ b/crux/validate/validate-display-names.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+/**
+ * Display Names Validator — Detect raw machine IDs in display fields
+ *
+ * Scans entity YAML files for:
+ *   - StableIds appearing as entity `title` fields (10-char alphanumeric with mixed case)
+ *   - Hash-like strings (generateId output) in title fields
+ *   - Pure numeric IDs used as titles
+ *   - The literal string "Unknown" as a title
+ *
+ * These indicate data pipeline bugs where machine-readable identifiers
+ * leak into user-facing display fields.
+ *
+ * Usage: npx tsx crux/validate/validate-display-names.ts
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import { getColors } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+const ENTITIES_DIR = join(PROJECT_ROOT, 'data/entities');
+
+export interface DisplayNameViolation {
+  file: string;
+  entityId: string;
+  field: string;
+  value: string;
+  reason: string;
+}
+
+/**
+ * StableId pattern: exactly 10 alphanumeric characters with at least one
+ * uppercase and at least one lowercase letter. This matches the canonical
+ * stableId format (e.g., "mK9pX3rQ7n", "Tw_Eo226h3").
+ *
+ * We also allow underscores since some stableIds contain them.
+ */
+const STABLE_ID_PATTERN = /^[A-Za-z0-9_]{10}$/;
+
+/**
+ * Check if a string looks like a stableId (machine-generated 10-char ID).
+ * Requires mixed case to avoid false positives on short real names.
+ */
+export function looksLikeStableId(value: string): boolean {
+  if (!STABLE_ID_PATTERN.test(value)) return false;
+  // Must contain at least one uppercase AND one lowercase letter
+  // to distinguish from real words like "Washington" or "Pythonista"
+  const hasUpper = /[A-Z]/.test(value);
+  const hasLower = /[a-z]/.test(value);
+  const hasDigit = /[0-9]/.test(value);
+  // A stableId typically has digits mixed in; pure alphabetic 10-char strings
+  // are more likely to be real words (e.g., "Regulation")
+  return hasUpper && hasLower && hasDigit;
+}
+
+/**
+ * Check if a string looks like a hash-based ID from generateId().
+ * These are typically longer alphanumeric strings that are clearly not names.
+ *
+ * Conservative: only flags strings that are purely alphanumeric (no hyphens,
+ * no underscores) to avoid false positives on real product names like
+ * "GPT-4o-mini" or "Llama-3.1-405B". Hash IDs from generateId() are
+ * pure alphanumeric.
+ */
+export function looksLikeHashId(value: string): boolean {
+  // Only flag pure alphanumeric strings (no hyphens, no underscores)
+  // to avoid false positives on hyphenated product/model names
+  if (value.length < 11 || value.length > 30) return false;
+  if (/\s/.test(value)) return false; // Real names have spaces
+  if (!/^[A-Za-z0-9]+$/.test(value)) return false; // Pure alphanumeric only
+  const hasUpper = /[A-Z]/.test(value);
+  const hasLower = /[a-z]/.test(value);
+  const hasDigit = /[0-9]/.test(value);
+  // Must have all three character classes — unlikely for a real name
+  return hasUpper && hasLower && hasDigit;
+}
+
+/**
+ * Check if a string is purely numeric (a raw database ID).
+ */
+export function isPureNumericId(value: string): boolean {
+  return /^\d+$/.test(value.trim());
+}
+
+/**
+ * Check if a title is the literal "Unknown" (case-insensitive).
+ */
+export function isUnknownPlaceholder(value: string): boolean {
+  return value.trim().toLowerCase() === 'unknown';
+}
+
+interface YamlEntity {
+  id?: string;
+  stableId?: string;
+  title?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+function checkEntity(entity: YamlEntity, file: string): DisplayNameViolation[] {
+  const violations: DisplayNameViolation[] = [];
+  const entityId = entity.id || entity.stableId || '(no id)';
+
+  // Check title field
+  if (typeof entity.title === 'string') {
+    const title = entity.title.trim();
+
+    if (looksLikeStableId(title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: title,
+        reason: 'Title looks like a raw stableId (10-char machine-generated ID)',
+      });
+    } else if (looksLikeHashId(title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: title,
+        reason: 'Title looks like a hash-based machine ID',
+      });
+    } else if (isPureNumericId(title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: title,
+        reason: 'Title is a pure numeric ID',
+      });
+    } else if (isUnknownPlaceholder(title)) {
+      violations.push({
+        file,
+        entityId,
+        field: 'title',
+        value: title,
+        reason: 'Title is the placeholder "Unknown"',
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: DisplayNameViolation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking for raw machine IDs in entity display fields...${c.reset}\n`);
+
+  let yamlFiles: string[];
+  try {
+    yamlFiles = readdirSync(ENTITIES_DIR).filter(f => f.endsWith('.yaml'));
+  } catch {
+    console.log(`${c.dim}Skipping: could not read entities directory at ${ENTITIES_DIR}${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: DisplayNameViolation[] = [];
+  let totalEntities = 0;
+
+  for (const file of yamlFiles) {
+    const filePath = join(ENTITIES_DIR, file);
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue; // Skip unreadable files
+    }
+
+    let entities: YamlEntity[];
+    try {
+      const parsed = parseYaml(content);
+      if (!Array.isArray(parsed)) continue;
+      entities = parsed as YamlEntity[];
+    } catch {
+      continue; // Skip malformed YAML
+    }
+
+    for (const entity of entities) {
+      totalEntities++;
+      const violations = checkEntity(entity, file);
+      allViolations.push(...violations);
+    }
+  }
+
+  if (allViolations.length === 0) {
+    console.log(`${c.green}No raw machine IDs found in display fields (${totalEntities} entities checked)${c.reset}`);
+  } else {
+    console.log(`${c.red}Found ${allViolations.length} display name issue(s):${c.reset}\n`);
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file} → ${v.entityId}${c.reset}`);
+      console.log(`    ${c.dim}${v.field}: "${v.value}"${c.reset}`);
+      console.log(`    ${c.dim}Reason: ${v.reason}${c.reset}\n`);
+    }
+    console.log(`${c.dim}Fix: replace machine IDs with human-readable names in entity YAML files.${c.reset}`);
+  }
+
+  return { passed: allViolations.length === 0, errors: allViolations.length, violations: allViolations };
+}
+
+if (process.argv[1]?.includes('validate-display-names')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -563,6 +563,26 @@ const PARALLEL_STEPS: Step[] = [
     advisory: true,
     emitOutputInCi: true,
   },
+  {
+    id: 'display-names',
+    name: 'Display name quality (no raw machine IDs in titles)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-display-names.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: raw stableIds or "Unknown" in entity titles produce broken
+    // display on organization pages, people pages, and directory listings.
+    // These indicate data pipeline bugs that should be caught immediately.
+  },
+  {
+    id: 'display-formatting',
+    name: 'Display formatting quality (no [object Object], no unescaped MDX in titles)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-display-formatting.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: [object Object] in any field and unescaped MDX characters in
+    // titles indicate serialization bugs or data contamination that produce
+    // broken rendering.
+  },
 ];
 
 // Phase 4 (--full only): Runs after all validations pass


### PR DESCRIPTION
## Summary
- Add `display-names` validator: detects raw stableIds (10-char machine IDs like `Tw_Eo226h3`), hash-based IDs, pure numeric IDs, and "Unknown" placeholders in entity title fields
- Add `display-formatting` validator: detects `[object Object]` serialization bugs in any string field, unescaped MDX characters (`<`, `{`, `}`) in titles, and stringified `null`/`undefined`/`NaN` values
- Both validators registered as **CI-blocking** steps in the gate pipeline and as standalone `pnpm crux validate display-names` / `display-formatting` commands
- 26 unit and integration tests covering detection functions, edge cases (hyphenated model names like `GPT-4o-mini` are not false positives), and clean runs against the current codebase

## Context
Organization pages were showing "Unknown" names and raw stableIds like `Tw_Eo226h3` due to data pipeline bugs (PR #3257 fixes the root cause). These gate validators prevent similar regressions by catching display-quality issues at build time before they reach production.

## Test plan
- [x] Both validators pass on current codebase (1631 entities scanned, 0 violations)
- [x] 26 unit tests pass: stableId detection, hash ID detection, numeric ID detection, Unknown placeholder, [object Object], unescaped MDX, stringified nullish/NaN
- [x] False positive testing: real names ("Washington"), model names ("GPT-4o-mini"), hyphenated titles are not flagged
- [x] TypeScript compiles cleanly (no errors in new files)
- [x] Validators execute in <1s each (well under 5s target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
