### PR TITLE
fix: resource suggestion — ON CONFLICT url, dedup guard, type safety

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -585,6 +585,8 @@ const resourcesApp = new Hono()
   // ---- POST /suggest (register URLs as resources + check content freshness) ----
 
   .post("/suggest", zv("json", SuggestResourcesSchema), async (c) => {
+    // Note: entityId and agentSessionId are accepted by the schema but not yet used.
+    // They are reserved for Phase 2 (linking suggestions to entities/sessions). See #3253.
     const { urls, maxContentAgeMs } = c.req.valid("json");
     const maxAge = maxContentAgeMs ?? SUGGEST_RESOURCES_DEFAULT_MAX_AGE_MS;
     const now = Date.now();
@@ -597,7 +599,11 @@ const resourcesApp = new Hono()
     const urlToOriginal = new Map<string, string>();
     for (const url of uniqueUrls) {
       for (const variant of urlVariants(url)) {
-        urlToOriginal.set(variant, url);
+        // First URL wins — skip if variant already mapped (prevents lossy overwrites
+        // when different input URLs produce overlapping variants)
+        if (!urlToOriginal.has(variant)) {
+          urlToOriginal.set(variant, url);
+        }
       }
     }
     const allVariants = [...urlToOriginal.keys()];
@@ -640,7 +646,7 @@ const resourcesApp = new Hono()
         SELECT * FROM unnest(${ids}::text[], ${toCreate}::text[])
           AS t(id, url),
           LATERAL (SELECT 'web'::text AS type, now() AS created_at, now() AS updated_at) defaults
-        ON CONFLICT (id) DO UPDATE SET updated_at = now()
+        ON CONFLICT (url) DO UPDATE SET updated_at = now()
         RETURNING id, url, title, null::timestamptz AS fetched_at, false AS has_content
       `;
       for (const row of created) {

--- a/crux/lib/search/suggest-resources.ts
+++ b/crux/lib/search/suggest-resources.ts
@@ -30,7 +30,7 @@ export interface SuggestedResource {
   url: string;
   resourceId: string;
   status: 'ok' | 'error' | 'paywall' | 'dead';
-  contentLength: number;
+  contentLength: number | null;
   title: string | null;
 }
 
@@ -105,7 +105,7 @@ export async function suggestResources(
         url: r.url,
         resourceId: r.resourceId,
         status: 'ok' as const,
-        contentLength: 0, // fresh content exists but we didn't re-fetch, so length unknown
+        contentLength: null, // fresh content exists but we didn't re-fetch, so length unknown
         title: r.title,
       };
     }


### PR DESCRIPTION
## Summary
Follow-up fixes from code review of #3263 (already merged):
- **P1**: Changed `ON CONFLICT (id)` to `ON CONFLICT (url)` in bulk resource INSERT — prevents crashes on URL unique constraint violations
- **P1**: Added dedup guard to `urlToOriginal` Map — first URL wins when variants overlap
- **P2**: Documented `entityId`/`agentSessionId` as reserved for Phase 2
- **P2**: Changed `contentLength: 0` → `null` for fresh content (type: `number | null`)

## Test plan
- [x] TypeScript compiles
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search suggestion handling to prevent URL variant mappings from being overwritten when multiple URLs map to the same resource.

* **Refactor**
  * Updated content length representation in resource suggestions to better distinguish between unknown and zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->