### PR TITLE
fix: remove duplicate div tag in people-table (unbreak main)

### DIFF
--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -331,8 +331,6 @@ export function PeopleTable({
   return (
     <div>
       {/* Filters */}
-      <div role="search" className="flex flex-col gap-3 mb-5">
-
       <div className="flex flex-col gap-3 mb-5" role="search">
         <div className="flex flex-col sm:flex-row gap-3">
           <input


### PR DESCRIPTION
## Summary
- Bad merge from #3261 left a duplicate `<div role="search">` tag at line 334 with no closing tag
- This breaks the Next.js build on main (webpack error: unexpected token)

## Test plan
- [x] `tsc --noEmit` clean