### PR TITLE
fix: remove duplicate div tags in ai-models and legislation tables (unbreak main)

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -147,8 +147,6 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
   return (
     <div>
       {/* Filters */}
-      <div role="search" className="flex flex-col gap-3 mb-5">
-
       <div className="flex flex-col gap-3 mb-5" role="search">
         <div className="flex flex-col sm:flex-row gap-3">
           <input

--- a/apps/web/src/app/legislation/legislation-table.tsx
+++ b/apps/web/src/app/legislation/legislation-table.tsx
@@ -325,8 +325,6 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
   return (
     <div>
       {/* Filters */}
-      <div role="search" className="flex flex-col gap-3 mb-5">
-
       <div className="flex flex-col gap-3 mb-5" role="search">
         <div className="flex flex-col sm:flex-row gap-3">
           <input


### PR DESCRIPTION
## Summary
- Same bug as #3280 — accessibility PR #3261 merge left duplicate `<div role="search">` tags
- Fixes `ai-models-table.tsx` and `legislation-table.tsx`
- Both had an unclosed div causing webpack build failures

## Test plan
- [x] `tsc --noEmit` clean (0 errors)