### PR TITLE
fix: rename Publication Venues to Publications for URL consistency

### DIFF
--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -42,9 +42,9 @@ export async function generateMetadata({
   if (!pub) return { title: "Publication Not Found" };
 
   return {
-    title: `${pub.name} | Publication Venues`,
+    title: `${pub.name} | Publications`,
     description:
-      pub.description || `${pub.name} — publication venue tracked in the wiki.`,
+      pub.description || `${pub.name} — publication tracked in the wiki.`,
   };
 }
 
@@ -99,7 +99,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
       >
         <ArrowLeft className="w-3.5 h-3.5" />
-        All Publication Venues
+        All Publications
       </Link>
 
       {/* Header */}

--- a/apps/web/src/app/publications/page.tsx
+++ b/apps/web/src/app/publications/page.tsx
@@ -8,9 +8,9 @@ import { ProfileStatCard } from "@/components/directory";
 import { PublicationsTable, type PublicationRow } from "./publications-table";
 
 export const metadata: Metadata = {
-  title: "Publication Venues",
+  title: "Publications",
   description:
-    "Directory of publication venues tracked in the wiki, with credibility ratings, peer-review status, and resource counts.",
+    "Directory of publications tracked in the wiki, with credibility ratings, peer-review status, and resource counts.",
 };
 
 export default function PublicationsPage() {
@@ -59,10 +59,10 @@ export default function PublicationsPage() {
     <div className="max-w-[90rem] mx-auto px-6 py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold tracking-tight mb-2">
-          Publication Venues
+          Publications
         </h1>
         <p className="text-muted-foreground text-sm max-w-2xl">
-          Publication venues tracked in the wiki, with credibility ratings and
+          Publications tracked in the wiki, with credibility ratings and
           resource counts. Covers academic journals, preprint servers, company
           blogs, think tanks, and more.
         </p>

--- a/apps/web/src/app/sources/sources-overview-content.tsx
+++ b/apps/web/src/app/sources/sources-overview-content.tsx
@@ -13,7 +13,7 @@ export function SourcesOverviewContent() {
 
   const stats = [
     { label: "Resources", value: resources.length, href: "/resources" },
-    { label: "Publication Venues", value: publications.length, href: "/publications" },
+    { label: "Publications", value: publications.length, href: "/publications" },
     { label: "Peer-Reviewed Venues", value: peerReviewed },
     { label: "With Summaries", value: withSummary },
     { label: "Cited by Pages", value: citedResources },
@@ -72,7 +72,7 @@ export function SourcesOverviewContent() {
           className="group block rounded-xl border border-border/60 bg-card p-6 no-underline transition-all hover:shadow-md hover:border-border"
         >
           <h3 className="text-lg font-bold mb-2 group-hover:text-primary transition-colors">
-            Publication Venues
+            Publications
           </h3>
           <p className="text-sm text-muted-foreground leading-relaxed">
             {publications.length} publication venues with credibility ratings

--- a/apps/web/src/app/sources/sources-tabs.tsx
+++ b/apps/web/src/app/sources/sources-tabs.tsx
@@ -28,7 +28,7 @@ export function SourcesTabs({
         },
         {
           id: "publications",
-          label: "Publication Venues",
+          label: "Publications",
           count: publicationCount,
           content: <PublicationsTable publications={publicationRows} />,
         },


### PR DESCRIPTION
## Summary
- Renamed "Publication Venues" to "Publications" across the publications directory page title, metadata, h1, detail page breadcrumb/metadata, and sources overview references
- Fixes mismatch where URL said `/publications` but page title said "Publication Venues"

Closes #3235

## Test plan
- [x] Text-only change — verified by grep that all "Publication Venues" references in affected files are updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated terminology across publication-related pages and sections from "Publication Venues" to "Publications" for consistent language throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->