### PR TITLE
fix: remove duplicate funding program and add unique constraint

### DIFF
--- a/apps/wiki-server/drizzle/0143_dedup_funding_program_unique.sql
+++ b/apps/wiki-server/drizzle/0143_dedup_funding_program_unique.sql
@@ -1,0 +1,20 @@
+-- Delete duplicate "Technical AI Safety RFP (2025)" funding program.
+-- Canonical ID Kb9uB1Zp1E (from import seed prog|coefficient-giving|technical-ai-safety-rfp-2025).
+-- Duplicate ID a2NsC7Lk0g was inserted by a prior sync with a different seed.
+-- Also reassign any grants pointing to the duplicate before deleting.
+
+-- Reassign grants that reference the duplicate to the canonical program
+UPDATE grants
+SET program_id = 'Kb9uB1Zp1E'
+WHERE program_id = 'a2NsC7Lk0g';
+
+-- Delete things entry for the duplicate
+DELETE FROM things
+WHERE source_table = 'funding_programs' AND source_id = 'a2NsC7Lk0g';
+
+-- Delete the duplicate funding program
+DELETE FROM funding_programs
+WHERE id = 'a2NsC7Lk0g';
+
+-- Add unique constraint on (org_id, name) to prevent future duplicates
+CREATE UNIQUE INDEX IF NOT EXISTS uq_fp_org_name ON funding_programs (org_id, name);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1002,6 +1002,13 @@
       "when": 1781856000000,
       "tag": "0142_create_proposed_claims",
       "breakpoints": true
+    },
+    {
+      "idx": 143,
+      "version": "7",
+      "when": 1781942400000,
+      "tag": "0143_dedup_funding_program_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2169,6 +2169,7 @@ export const fundingPrograms = pgTable(
     index("idx_fp_division").on(table.divisionId),
     index("idx_fp_status").on(table.status),
     index("idx_fp_type").on(table.programType),
+    uniqueIndex("uq_fp_org_name").on(table.orgId, table.name),
   ]
 );
 


### PR DESCRIPTION
## Summary
- Delete duplicate "Technical AI Safety RFP (2025)" funding program entry (`a2NsC7Lk0g`), keeping the canonical entry (`Kb9uB1Zp1E`) generated from the import seed
- Reassign any grants referencing the duplicate to the canonical entry
- Add unique index `uq_fp_org_name` on `(org_id, name)` to prevent future duplicates
- Update Drizzle schema to match

## Test plan
- [x] TypeScript compiles cleanly (wiki-server and web app)
- [x] Migration SQL reviewed: idempotent index creation, safe delete with grant reassignment
- [ ] Verify no duplicate programs at /funding-programs after deploy

Closes #3231

Generated with [Claude Code](https://claude.com/claude-code)