### PR TITLE
fix: resolve FactBase ref-type values to entity names on detail pages

### DIFF
--- a/apps/web/src/app/factbase/fact/[factId]/page.tsx
+++ b/apps/web/src/app/factbase/fact/[factId]/page.tsx
@@ -76,6 +76,56 @@ function getRawValue(fact: Fact): string {
   }
 }
 
+/** Render a single ref entity ID as a resolved name link. */
+function RefLink({ entityId }: { entityId: string }) {
+  const refEntity = getKBEntity(entityId);
+  return (
+    <Link
+      href={`/factbase/entity/${entityId}`}
+      className="text-primary hover:underline"
+    >
+      {refEntity?.name ?? entityId}
+    </Link>
+  );
+}
+
+/**
+ * Render a fact value with entity resolution for ref/refs types.
+ * For ref-type values, resolves the entity ID to a human-readable name
+ * and renders it as a clickable link. For other types, returns the
+ * formatted string value.
+ */
+function FactValueDisplay({
+  fact,
+  unit,
+  display,
+}: {
+  fact: Fact;
+  unit?: string;
+  display?: Property["display"];
+}) {
+  const v = fact.value;
+
+  if (v.type === "ref") {
+    return <RefLink entityId={v.value} />;
+  }
+
+  if (v.type === "refs") {
+    return (
+      <>
+        {v.value.map((refId: string, i: number) => (
+          <span key={refId}>
+            {i > 0 && ", "}
+            <RefLink entityId={refId} />
+          </span>
+        ))}
+      </>
+    );
+  }
+
+  return <>{formatKBFactValue(fact, unit, display)}</>;
+}
+
 function getValueType(fact: Fact): string {
   return fact.value.type;
 }
@@ -99,7 +149,6 @@ export default async function FactDetailPage({ params }: PageProps) {
   const entityName = entity?.name ?? fact.subjectId;
   const propertyName = property?.name ?? fact.propertyId;
 
-  const formattedValue = formatKBFactValue(fact, property?.unit, property?.display);
   const rawValue = getRawValue(fact);
   const valueType = getValueType(fact);
   const unit = getUnit(fact, property);
@@ -137,7 +186,9 @@ export default async function FactDetailPage({ params }: PageProps) {
       </nav>
 
       {/* Header */}
-      <h1 className="text-2xl font-bold mb-1">{formattedValue}</h1>
+      <h1 className="text-2xl font-bold mb-1">
+        <FactValueDisplay fact={fact} unit={property?.unit} display={property?.display} />
+      </h1>
       <p className="text-sm text-muted-foreground mb-6">
         <FactLink href={`/factbase/entity/${fact.subjectId}`}>{entityName}</FactLink>
         {" \u203A "}
@@ -153,7 +204,9 @@ export default async function FactDetailPage({ params }: PageProps) {
         <KVRow label="Property">
           <FactLink href={`/factbase/property/${fact.propertyId}`}>{propertyName}</FactLink>
         </KVRow>
-        <KVRow label="Formatted Value">{formattedValue}</KVRow>
+        <KVRow label="Formatted Value">
+          <FactValueDisplay fact={fact} unit={property?.unit} display={property?.display} />
+        </KVRow>
         <KVRow label="Raw Value">
           <span className="font-mono">{rawValue}</span>
         </KVRow>
@@ -266,14 +319,15 @@ export default async function FactDetailPage({ params }: PageProps) {
               <tbody>
                 {timeSeriesFacts.map((f) => {
                   const isCurrent = f.id === factId;
-                  const fValue = formatKBFactValue(f, property?.unit, property?.display);
                   return (
                     <tr
                       key={f.id}
                       className={`border-t border-border ${isCurrent ? "bg-primary/5" : "[&:nth-child(even)]:bg-muted/30"}`}
                     >
                       <td className="px-3 py-1.5">{formatKBDate(f.asOf)}</td>
-                      <td className="px-3 py-1.5 font-mono">{fValue}</td>
+                      <td className="px-3 py-1.5 font-mono">
+                        <FactValueDisplay fact={f} unit={property?.unit} display={property?.display} />
+                      </td>
                       <td className="px-3 py-1.5">
                         {f.source && isUrl(f.source) ? (
                           <a

--- a/apps/web/src/app/factbase/record/[recordId]/page.tsx
+++ b/apps/web/src/app/factbase/record/[recordId]/page.tsx
@@ -20,6 +20,20 @@ import {
 } from "@/components/wiki/factbase/format";
 import { KVRow, KVTable } from "@/components/wiki/factbase/factbase-detail-shared";
 
+/** FactBase entity IDs are exactly 10 alphanumeric characters. */
+const ENTITY_ID_RE = /^[A-Za-z0-9]{10}$/;
+
+/**
+ * Try to resolve a string value as a FactBase entity reference.
+ * Returns the entity if the value matches the 10-char alphanumeric ID format
+ * and corresponds to a known entity. This is used as a heuristic fallback when
+ * schema field definitions are unavailable.
+ */
+function tryResolveRef(value: unknown) {
+  if (typeof value !== "string" || !ENTITY_ID_RE.test(value)) return undefined;
+  return getFactBaseEntity(value);
+}
+
 // ── Rendering mode ───────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~351 pages saved).
 // These are internal KB record detail pages with low traffic.
@@ -210,6 +224,24 @@ export default async function RecordDetailPage({ params }: PageProps) {
             );
           }
 
+          // Heuristic ref detection: if schema is unavailable, check if the
+          // value looks like a FactBase entity ID and resolves to a known entity
+          if (!fieldDef) {
+            const resolvedEntity = tryResolveRef(fieldValue);
+            if (resolvedEntity) {
+              return (
+                <KVRow key={fieldName} label={titleCase(fieldName)}>
+                  <Link
+                    href={`/factbase/entity/${fieldValue}`}
+                    className="text-primary hover:underline"
+                  >
+                    {resolvedEntity.name}
+                  </Link>
+                </KVRow>
+              );
+            }
+          }
+
           // Everything else
           return (
             <KVRow key={fieldName} label={titleCase(fieldName)}>
@@ -277,6 +309,20 @@ export default async function RecordDetailPage({ params }: PageProps) {
                                 </Link>
                               </td>
                             );
+                          }
+
+                          // Heuristic ref fallback for missing schemas
+                          if (!colDef) {
+                            const resolvedEnt = tryResolveRef(cellVal);
+                            if (resolvedEnt) {
+                              return (
+                                <td key={col} className="px-3 py-1.5">
+                                  <Link href={`/factbase/entity/${cellVal}`} className="text-primary hover:underline">
+                                    {resolvedEnt.name}
+                                  </Link>
+                                </td>
+                              );
+                            }
                           }
 
                           return (


### PR DESCRIPTION
## Summary
- Fact detail pages (`/factbase/fact/[factId]`) now show resolved entity names as clickable links for ref-type fact values, instead of raw 10-character entity IDs
- Record detail pages (`/factbase/record/[recordId]`) now use heuristic entity ID detection to resolve ref values when schema field definitions are unavailable
- Both the main display and time series table on fact pages are fixed

## Changes
- Added `RefLink` and `FactValueDisplay` components to the fact detail page for ref/refs value rendering
- Added `tryResolveRef()` heuristic to the record detail page that matches 10-char alphanumeric strings against known FactBase entities
- Applied heuristic ref resolution to both the fields section and sibling records table on record pages

Closes #3062

## Test plan
- [x] Code review: ref-type values use `getKBEntity()` / `getFactBaseEntity()` to resolve names, consistent with entity page behavior
- [x] TypeScript types verified (explicit `string` and `number` annotations on map callbacks)
- [x] Non-ref fact values still use `formatKBFactValue()` unchanged