### PR TITLE
fix: update Ian Hogarth from current to former Chair of UK AISI

### DIFF
--- a/.tablebase-org-notes.yaml
+++ b/.tablebase-org-notes.yaml
@@ -346,7 +346,7 @@ us-ai-safety-institute:
 uk-ai-safety-institute:
   entityId: "361"
   notes: |
-    Renamed to AI Security Institute February 2025. Ian Hogarth (chair, June 2023),
+    Renamed to AI Security Institute February 2025. Ian Hogarth (former chair, June 2023 – Feb 2025),
     Jade Leung (CTO, 2023), Adam Beaumont (director). aisi.gov.uk is the current URL.
 
 cset:

--- a/content/docs/knowledge-base/organizations/uk-aisi.mdx
+++ b/content/docs/knowledge-base/organizations/uk-aisi.mdx
@@ -5,7 +5,7 @@ description: The UK AI Safety Institute (renamed AI Security Institute in Februa
 sidebar:
   order: 18
 subcategory: government
-lastEdited: 2025-12-28
+lastEdited: 2026-03-26
 update_frequency: 21
 summary: The UK AI Safety Institute (renamed AI Security Institute in Feb 2025) operates with ~30 technical staff and 50M GBP annual budget, conducting frontier model evaluations using its open-source Inspect AI framework and coordinating the 10+ country International Network of AI Safety Institutes. April 2024 evaluations found frontier models capable of intermediate cybersecurity tasks and PhD-level biology knowledge, with safeguards vulnerable to basic jailbreaks.
 clusters:
@@ -23,7 +23,7 @@ The UK AI Safety Institute (UK AISI) is a government organization established in
 
 As one of the first government bodies specifically dedicated to advanced AI safety (alongside the US AISI), the UK AISI plays a pioneering role in translating AI safety research into government policy and practice. The organization conducts technical research on AI risks, evaluates frontier models for dangerous capabilities, develops safety standards, and coordinates international efforts through the International Network of <EntityLink id="E13" name="ai-safety-institutes">AI Safety Institutes</EntityLink>, which now includes 10+ member countries.
 
-The UK AISI's strategic positioning reflects the UK government's ambition: to be a global hub for AI safety, bridging technical research communities, frontier AI labs, and international policymakers. Chair <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> has described AISI as a "startup inside the government" that combines technical rigor with policy influence.
+The UK AISI's strategic positioning reflects the UK government's ambition: to be a global hub for AI safety, bridging technical research communities, frontier AI labs, and international policymakers. Former Chair <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> (2023-2025) described AISI as a "startup inside the government" that combines technical rigor with policy influence.
 
 ### Organization at a Glance
 
@@ -32,7 +32,7 @@ The UK AISI's strategic positioning reflects the UK government's ambition: to be
 | **Founded** | November 2023 (following AI Safety Summit) |
 | **Renamed** | February 2025 (to AI Security Institute) |
 | **Parent Department** | Department for Science, Innovation and Technology (DSIT) |
-| **Leadership** | <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> (Chair) |
+| **Leadership** | <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> (former Chair, 2023-2025) |
 | **Technical Staff** | 30+ researchers (as of mid-2024) |
 | **Annual Budget** | Approximately 50 million GBP |
 | **Locations** | London (HQ), San Francisco (opened 2024) |
@@ -228,12 +228,12 @@ flowchart TD
 
 <Section title="Leadership">
   <KeyPeople people={[
-    { name: "Ian Hogarth", role: "Chair" },
+    { name: "Ian Hogarth", role: "Former Chair (2023-2025)" },
     { name: "Various senior researchers", role: "Technical leadership and research" },
   ]} />
 </Section>
 
-### Ian Hogarth (Chair)
+### Ian Hogarth (Former Chair, 2023-2025)
 
 **Background:**
 - Technology entrepreneur and investor


### PR DESCRIPTION
## Summary

- Updated Ian Hogarth's role from current "Chair" to "Former Chair (2023-2025)" across the UK AISI wiki page (overview text, organization table, KeyPeople component, and section heading)
- Updated both personnel records in the PG database (career and key-person role types) to set `endDate: 2025-02` via the production wiki-server API
- Updated `.tablebase-org-notes.yaml` to reflect former status

Ian Hogarth stepped down as Chair when UK AISI was reorganized and renamed to the AI Security Institute in February 2025.

Closes #3178

## Test plan

- [x] Personnel API verified: both records (sHzf5wCER0, pBnOC0Pe1m) now show endDate: 2025-02
- [x] Wiki page changes reviewed in diff: 5 references updated from Chair to Former Chair

🤖 Generated with [Claude Code](https://claude.com/claude-code)