### PR TITLE
fix: resolve person displayName instead of raw stableId

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -310,6 +310,7 @@ export default async function OrgProfilePage({
         ? "Unknown"
         : titleCase(personRef ?? person.key);
       const name =
+        person.displayName ??
         field(person, "display_name") ??
         typedPerson?.title ??
         fallbackName;

--- a/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
+++ b/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
@@ -337,7 +337,7 @@ function StatCard({
 function PersonCard({ item }: { item: FactBaseRecordEntry }) {
   const personId = field(item, "person");
   const personEntity = personId ? getKBEntity(personId) : null;
-  const name = personEntity?.name ?? field(item, "display_name") ?? titleCase(item.key);
+  const name = personEntity?.name ?? item.displayName ?? field(item, "display_name") ?? titleCase(item.key);
   const title = field(item, "title");
   const start = field(item, "start");
   const end = field(item, "end");
@@ -360,7 +360,7 @@ function PersonCard({ item }: { item: FactBaseRecordEntry }) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 flex-wrap">
             {personId ? (
-              <FBRefLink id={personId} className="font-semibold text-sm leading-tight text-foreground group-hover:text-primary transition-colors" />
+              <FBRefLink id={personId} label={item.displayName} className="font-semibold text-sm leading-tight text-foreground group-hover:text-primary transition-colors" />
             ) : (
               <span className="font-semibold text-sm leading-tight">{name}</span>
             )}


### PR DESCRIPTION
## Summary
- Fix Key People section on organization detail pages showing raw stableIds (e.g., "K5ykAghIr6") instead of person names
- Add `item.displayName` (set by the build script from `personResolvedName`) to the name resolution fallback chain in three locations:
  - `FBAutoFacts.tsx` PersonCard name computation
  - `FBAutoFacts.tsx` PersonCard FBRefLink label prop (so even unresolved entities show correct names)
  - Organizations `page.tsx` key-persons name computation

## Root cause
The build script (`personnelRowToRecordEntry`) sets `displayName` as a top-level property on the record entry, but the PersonCard components were only checking `item.fields.display_name` (which doesn't exist) or falling back to `titleCase(item.key)` (the PG row ID).

## Test plan
- [x] TypeScript type check confirms no new errors from the changes
- [x] Changes are type-safe: displayName is string | undefined on FactBaseRecordEntry, compatible with nullish coalescing chain and FBRefLink label prop

Closes #3194