### PR TITLE
fix: move source-check search to server-side filtering

### DIFF
--- a/apps/web/src/app/source-checks/page.tsx
+++ b/apps/web/src/app/source-checks/page.tsx
@@ -55,6 +55,7 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
   const verdictParams = new URLSearchParams();
   if (filterType !== "all") verdictParams.set("record_type", filterType);
   if (filterVerdict !== "all") verdictParams.set("verdict", filterVerdict);
+  if (searchQuery) verdictParams.set("q", searchQuery);
   verdictParams.set("limit", String(PAGE_SIZE));
   verdictParams.set("offset", String(offset));
 
@@ -192,22 +193,6 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
       }
     }
   }
-
-  // Client-side search filtering (server already filtered by type/verdict)
-  const filteredVerdicts = searchQuery
-    ? verdicts.filter((v) => {
-        const recordName = names[v.recordId] ?? "";
-        const entityName = v.entityId ? (names[v.entityId] ?? "") : "";
-        const searchLower = searchQuery.toLowerCase();
-        return (
-          v.recordId.toLowerCase().includes(searchLower) ||
-          v.recordType.toLowerCase().includes(searchLower) ||
-          recordName.toLowerCase().includes(searchLower) ||
-          entityName.toLowerCase().includes(searchLower) ||
-          (v.reasoning?.toLowerCase().includes(searchLower) ?? false)
-        );
-      })
-    : verdicts;
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
@@ -369,14 +354,12 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
       <div className="flex items-center gap-4 mb-4">
         <SourceChecksSearch />
         <span className="text-sm text-muted-foreground whitespace-nowrap">
-          {searchQuery
-            ? `${filteredVerdicts.length} of ${total} results`
-            : `${total} results`}
+          {`${total} results`}
         </span>
       </div>
 
       {/* Table */}
-      <SourceChecksTable verdicts={filteredVerdicts} names={names} hrefs={hrefs} />
+      <SourceChecksTable verdicts={verdicts} names={names} hrefs={hrefs} />
 
       {/* Pagination */}
       {totalPages > 1 && (

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -12,6 +12,7 @@ import {
   ne,
   isNull,
   inArray,
+  ilike,
   countDistinct,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -101,6 +102,7 @@ const VerdictsQuery = z.object({
     .enum(["true", "false"])
     .transform((v) => v === "true")
     .optional(),
+  q: z.string().max(500).optional(),
   limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });
@@ -264,7 +266,7 @@ const sourceChecksApp = new Hono()
 
   // ---- GET /verdicts ----
   .get("/verdicts", zv("query", VerdictsQuery), async (c) => {
-    const { record_type, verdict, entity_id, needs_recheck, limit, offset } =
+    const { record_type, verdict, entity_id, needs_recheck, q, limit, offset } =
       c.req.valid("query");
     const db = getDrizzleDb();
 
@@ -280,6 +282,17 @@ const sourceChecksApp = new Hono()
     }
     if (entity_id) {
       conditions.push(eq(sourceCheckVerdicts.entityId, entity_id));
+    }
+    if (q) {
+      const pattern = `%${q}%`;
+      conditions.push(
+        or(
+          ilike(sourceCheckVerdicts.recordId, pattern),
+          ilike(sourceCheckVerdicts.recordType, pattern),
+          ilike(sourceCheckVerdicts.entityId, pattern),
+          ilike(sourceCheckVerdicts.reasoning, pattern),
+        )!
+      );
     }
 
     const whereClause =


### PR DESCRIPTION
## Summary
- Moves search/text filtering on `/source-checks` from client-side to server-side by adding a `q` query parameter to the wiki-server `GET /verdicts` endpoint
- The server now performs `ILIKE` search across `recordId`, `recordType`, `entityId`, and `reasoning` columns
- Removes the client-side `filteredVerdicts` filter that only searched within the current page of paginated results
- Pagination total now correctly reflects filtered results since the server count includes the search condition

## Problem
Search on the source-checks page was broken: the `q` parameter was applied as client-side filtering **after** server-side pagination returned a fixed page of results. This meant users could only search within the current page, not across all data. The result count also showed the wrong number.

## Changes
- `apps/wiki-server/src/routes/source-check/source-checks.ts`: Added `q` to `VerdictsQuery` schema and `ilike` OR condition across 4 columns
- `apps/web/src/app/source-checks/page.tsx`: Pass `q` to API request, remove client-side filtering

## Test plan
- [x] TypeScript compiles clean (wiki-server and web app)
- [x] Existing tests pass (4382/4382, 1 pre-existing failure unrelated)
- [x] Search query `q` is now passed to server API as query parameter
- [x] Client-side `filteredVerdicts` removed -- no more post-pagination filtering
- [x] Pagination `total` reflects server-side filtered count
- [x] Search resets to page 1 via existing `SourceChecksSearch` component

Closes #3169