### PR TITLE
fix: correct 127 relatedEntries type mismatches across entity YAML

### DIFF
--- a/crux/validate/validate-related-entry-types.test.ts
+++ b/crux/validate/validate-related-entry-types.test.ts
@@ -109,6 +109,33 @@ describe('findTypeMismatches', () => {
     expect(mismatches).toHaveLength(0);
   });
 
+    it('detects mismatches when relatedEntries reference by stableId', () => {
+    const entities = [
+      {
+        id: 'some-entity',
+        type: 'concept',
+        _sourceFile: 'concepts.yaml',
+        relatedEntries: [
+          { id: 'aBcDeFgHiJ', type: 'safety-agenda' }, // Wrong! Actually 'research-area'
+        ],
+      },
+    ];
+    // typeMap includes both slug and stableId for the referenced entity
+    const typeMap = new Map([
+      ['some-entity', 'concept'],
+      ['interpretability', 'research-area'],
+      ['aBcDeFgHiJ', 'research-area'], // stableId mapping
+    ]);
+
+    const mismatches = findTypeMismatches(entities, typeMap);
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0]).toMatchObject({
+      referencedEntityId: 'aBcDeFgHiJ',
+      declaredType: 'safety-agenda',
+      actualType: 'research-area',
+    });
+  });
+
   it('reports correct source file', () => {
     const entities = [
       {

--- a/crux/validate/validate-related-entry-types.ts
+++ b/crux/validate/validate-related-entry-types.ts
@@ -67,7 +67,9 @@ export interface TypeMismatch {
 const ENTITIES_DIR = join(PROJECT_ROOT, 'data', 'entities');
 
 /**
- * Load all entities from YAML files and build an id→type map.
+ * Load all entities from YAML files and build an id->type map.
+ * Maps both slug ids and stableIds so relatedEntries references
+ * (which may use either form) can be resolved.
  */
 function loadEntities(): {
   entities: Array<EntityRecord & { _sourceFile: string }>;
@@ -95,6 +97,10 @@ function loadEntities(): {
         if (entity && typeof entity === 'object' && entity.id && entity.type) {
           entities.push({ ...entity, _sourceFile: filename });
           typeMap.set(entity.id, entity.type);
+          // relatedEntries often reference by stableId, not slug id
+          if (entity.stableId) {
+            typeMap.set(entity.stableId, entity.type);
+          }
         }
       }
     } else if (parsed && typeof parsed === 'object') {
@@ -102,6 +108,9 @@ function loadEntities(): {
       if (e.id && e.type) {
         entities.push({ ...e, _sourceFile: filename as string });
         typeMap.set(e.id, e.type);
+        if ((e as Record<string, unknown>).stableId) {
+          typeMap.set((e as Record<string, unknown>).stableId as string, e.type);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixed the `validate-related-entry-types` validator to resolve entity references by `stableId` in addition to slug `id`. Previously, 86% of typed relatedEntries references (1510/1756) were silently skipped because they use stableIds, not slugs.
- Corrected 127 type mismatches across 9 entity YAML files (ai-models, capabilities, concepts, misc, models, organizations, people, responses, risks). Common patterns: `safety-agenda` -> `research-area`, `policy` -> `concept`, `concept` -> `approach`.
- Added a test covering the stableId lookup path.

Closes #3172

## Test plan
- [x] `npx tsx crux/validate/validate-related-entry-types.ts` reports 0 mismatches
- [x] `npx vitest run crux/validate/validate-related-entry-types.test.ts` passes (7 tests)
- [x] YAML changes are targeted text replacements (no YAML re-serialization), preserving comments and formatting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation for related entries using alternate identifier formats.

* **Refactor**
  * Improved entity type validation to resolve references using multiple identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->