### PR TITLE
fix: remove mismatched EntityLink IDs in LTBT page (unbreak main)

### DIFF
--- a/content/docs/knowledge-base/organizations/long-term-benefit-trust.mdx
+++ b/content/docs/knowledge-base/organizations/long-term-benefit-trust.mdx
@@ -63,7 +63,7 @@ At the close of Anthropic's Series C funding round, the company amended its corp
 - **November 2024**: Trust representation scheduled to increase to three of five board members[^rc-7132]
 - **December 2023**: <EntityLink id="jason-matheny" name="jason-matheny">Jason Matheny</EntityLink> stepped down to avoid conflicts with <EntityLink id="E1185" name="rand-corporation">RAND Corporation</EntityLink> policy work[^rc-7132]
 - **April 2024**: <EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink> stepped down to become Head of AI Safety at U.S. AI Safety Institute[^rc-7132][^rc-3786]
-- **2025**: <EntityLink id="E3233" name="richard-fontaine">Richard Fontaine</EntityLink> appointed as trustee; <EntityLink id="E3234" name="mariano-florentino-cuellar">Mariano-Florentino Cuéllar</EntityLink> appointed[^rc-3786][^rc-b61b]
+- **2025**: Richard Fontaine appointed as trustee; Mariano-Florentino Cuéllar appointed[^rc-3786][^rc-b61b]
 
 ## Governance Structure and Powers
 
@@ -77,8 +77,8 @@ Initial trustees were appointed by Anthropic's board, but subsequent trustees ar
 
 | Name | Role/Expertise | Status | Notes |
 |------|----------------|--------|-------|
-| <EntityLink id="E3232" name="neil-buddy-shah">Neil Buddy Shah</EntityLink> | CEO, Clinton Health Access Initiative | Current (Chair) | Initial trustee, still serving as of early 2026[^rc-d567][^rc-82cc] |
-| <EntityLink id="E3235" name="kanika-bahl">Kanika Bahl</EntityLink> | CEO & President, <EntityLink id="E1229" name="evidence-action">Evidence Action</EntityLink> | Current | Initial trustee; CEO of <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> top charity[^rc-d567][^rc-3786] |
+| Neil Buddy Shah | CEO, Clinton Health Access Initiative | Current (Chair) | Initial trustee, still serving as of early 2026[^rc-d567][^rc-82cc] |
+| Kanika Bahl | CEO & President, <EntityLink id="E1229" name="evidence-action">Evidence Action</EntityLink> | Current | Initial trustee; CEO of <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> top charity[^rc-d567][^rc-3786] |
 | <EntityLink id="zach-robinson" name="zach-robinson">Zach Robinson</EntityLink> | CEO, <EntityLink id="E517" name="cea">Centre for Effective Altruism</EntityLink> | Current | Initial trustee[^rc-d567][^rc-3786] |
 | Richard Fontaine | CEO, <EntityLink id="E1189" name="cnas">Center for a New American Security</EntityLink> | Appointed 2025 | National security expert[^rc-3786] |
 | Mariano-Florentino Cuéllar | Former California Supreme Court Justice | Appointed Jan 2026 | Global AI governance expert[^rc-3786][^rc-b61b] |


### PR DESCRIPTION
## Summary
- E3232-E3235 were allocated to different entities (stuart-armstrong, ramana-kumar, etc.) but used in the LTBT page for trustees (Neil Buddy Shah, Kanika Bahl, etc.)
- This causes `entitylink-ids` validation to fail, breaking the gate check on main and all PRs

## Test plan
- [x] `pnpm crux w validate gate --scope=content` — all 3 checks pass