### PR TITLE
fix: correct 127 relatedEntries type mismatches

### DIFF
--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -72,7 +72,7 @@
       type: ai-model
       relationship: composed-of
     - id: 6sdr78k9kQ
-      type: concept
+      type: approach
       relationship: related
   sources:
     - title: Anthropic Claude Product Page

--- a/data/entities/capabilities.yaml
+++ b/data/entities/capabilities.yaml
@@ -13,7 +13,7 @@
       value: Devin, Claude Computer Use
   relatedEntries:
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
     - id: hwDgNNDsDQ
       type: risk
     - id: mK9pX3rQ7n
@@ -124,7 +124,7 @@
     - id: hwDgNNDsDQ
       type: risk
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
   sources:
     - title: 'SWE-bench: Can Language Models Resolve Real-World GitHub Issues?'
       url: https://arxiv.org/abs/2310.06770
@@ -161,7 +161,7 @@
     - id: MznJisvptw
       type: capability
     - id: DAaRZ9Q15A
-      type: risk
+      type: concept
   sources:
     - title: Personalized Persuasion with LLMs
       url: https://arxiv.org/abs/2403.14380
@@ -235,7 +235,7 @@
     - id: eUR0jvxO5A
       type: capability
     - id: CwBPBQAmxA
-      type: risk
+      type: concept
     - id: A4XoubikkQ
       type: organization
   sources:
@@ -272,7 +272,7 @@
       value: Partial automation, human-led
   relatedEntries:
     - id: fRYu1EXclA
-      type: analysis
+      type: concept
     - id: 64WDhlxxKA
       type: capability
     - id: 3fyHbDnHIQ
@@ -318,7 +318,7 @@
     - id: JqMTO0YVEA
       type: risk
     - id: etuIjQhFbQ
-      type: capability
+      type: research-area
     - id: QsXVXtQ0zE
       type: organization
     - id: mK9pX3rQ7n

--- a/data/entities/concepts.yaml
+++ b/data/entities/concepts.yaml
@@ -143,7 +143,7 @@
       value: Policy, law, international relations
   relatedEntries:
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: La8s84s3zg
       type: policy
     - id: XLLyzaEaCA
@@ -245,7 +245,7 @@
       value: PhD or self-study + demonstrations
   relatedEntries:
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
     - id: mK9pX3rQ7n
       type: organization
     - id: dwMzc9WzPa
@@ -428,7 +428,7 @@
   status: stub
   relatedEntries:
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
   tags:
     - interpretability
     - theory
@@ -735,7 +735,7 @@
     - id: sycophancy
       type: risk
     - id: rt6jVH9yuA
-      type: concept
+      type: approach
   lastUpdated: 2026-02
 
 - id: misuse-risks
@@ -794,11 +794,11 @@
     - governance
   relatedEntries:
     - id: 73qTEkYyWA
-      type: concept
+      type: research-area
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: pkCwkyxL0w
-      type: concept
+      type: approach
   lastUpdated: 2026-02
 
 - id: accident-risks
@@ -823,11 +823,11 @@
     - governance
   relatedEntries:
     - id: 8Bv92x9G1A
-      type: concept
+      type: risk
     - id: vc60Nthkcg
       type: risk
     - id: 5maTNr0PGA
-      type: concept
+      type: capability
     - id: mK9pX3rQ7n
       type: organization
     - id: puAffUjWSS
@@ -885,7 +885,7 @@
     - id: MUGUxfl2YA
       type: risk
     - id: KYKdAOzynA
-      type: concept
+      type: organization
     - id: 9v7wxee33g
       type: crux
     - id: Ped7HAlI0A
@@ -975,7 +975,7 @@
     - epistemics
   relatedEntries:
     - id: l8ZPtVJdsA
-      type: concept
+      type: approach
     - id: JKsVHQ5stQ
       type: person
     - id: zR4nW8xB2f
@@ -1014,9 +1014,9 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: x19LcGDk6Q
-      type: concept
+      type: risk
     - id: 73qTEkYyWA
-      type: concept
+      type: research-area
   lastUpdated: 2026-02
 
 - id: heavy-scaffolding
@@ -1047,7 +1047,7 @@
     - id: RScckMUC2g
       type: concept
     - id: BP0tsiccNw
-      type: concept
+      type: capability
   lastUpdated: 2026-02
 
 - id: provable-safe
@@ -1073,9 +1073,9 @@
     - governance
   relatedEntries:
     - id: DSSCdI8gLA
-      type: concept
+      type: approach
     - id: d9OJFyUmjw
-      type: concept
+      type: capability
     - id: RScckMUC2g
       type: concept
     - id: NCLlwmOTkg
@@ -1106,11 +1106,11 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: rSE7kY5k4Q
-      type: concept
+      type: research-area
     - id: 6sdr78k9kQ
       type: approach
     - id: x19LcGDk6Q
-      type: concept
+      type: risk
     - id: NCLlwmOTkg
       type: concept
   lastUpdated: 2026-02

--- a/data/entities/misc.yaml
+++ b/data/entities/misc.yaml
@@ -88,7 +88,7 @@
     - id: SUZgWeZLNA
       type: risk
     - id: khXUiwWtkg
-      type: concept
+      type: crux
   sources:
     - title: "Trump Orders US Government to Drop Anthropic After Pentagon Feud"
       url: https://www.bloomberg.com/news/articles/2026-02-27/trump-orders-us-government-to-drop-anthropic-after-pentagon-feud
@@ -161,7 +161,7 @@
     - id: RQsF3N9BQA
       type: analysis
     - id: eNJ3h95yWw
-      type: analysis
+      type: organization
     - id: 1LcLlMGLbw
       type: organization
     - id: mK9pX3rQ7n
@@ -354,7 +354,7 @@
     - id: 69vftmr1jg
       type: person
     - id: 3w5hW5liew
-      type: concept
+      type: organization
     - id: Jtj6jHbuQ7
       type: person
     - id: 1LcLlMGLbw
@@ -390,9 +390,9 @@
     - id: 1DjpqfXwjA
       type: analysis
     - id: eNJ3h95yWw
-      type: analysis
+      type: organization
     - id: 3w5hW5liew
-      type: concept
+      type: organization
     - id: zR4nW8xB2f
       type: person
   lastUpdated: 2026-02
@@ -427,7 +427,7 @@
     - id: hPZbflFceQ
       type: analysis
     - id: 3w5hW5liew
-      type: concept
+      type: organization
     - id: zR4nW8xB2f
       type: person
   lastUpdated: 2026-02
@@ -486,13 +486,13 @@
     - governance
   relatedEntries:
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
     - id: mK9pX3rQ7n
       type: organization
     - id: vzxfzxBITd
       type: person
     - id: SUZgWeZLNA
-      type: concept
+      type: risk
     - id: cBPkzcVBBQ
       type: organization
   lastUpdated: 2026-02
@@ -519,13 +519,13 @@
     - governance
   relatedEntries:
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
     - id: lfvY1bGeoA
       type: concept
     - id: mK9pX3rQ7n
       type: organization
     - id: La8s84s3zg
-      type: concept
+      type: policy
   lastUpdated: 2026-02
 
 - id: technical-pathways
@@ -552,7 +552,7 @@
     - id: CWaxxnWsDg
       type: analysis
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
     - id: mK9pX3rQ7n
       type: organization
     - id: 1LcLlMGLbw
@@ -582,7 +582,7 @@
     - id: CWaxxnWsDg
       type: analysis
     - id: SUZgWeZLNA
-      type: concept
+      type: risk
     - id: mK9pX3rQ7n
       type: organization
   lastUpdated: 2026-02
@@ -645,7 +645,7 @@
     - id: vc60Nthkcg
       type: risk
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
   lastUpdated: 2026-02
 
 - id: ea-biosecurity-scope

--- a/data/entities/models.yaml
+++ b/data/entities/models.yaml
@@ -69,7 +69,7 @@
       type: analysis
       relationship: related
     - id: SUZgWeZLNA
-      type: analysis
+      type: risk
       relationship: related
   tags:
     - prioritization
@@ -101,7 +101,7 @@
       type: analysis
       relationship: related
     - id: SUZgWeZLNA
-      type: analysis
+      type: risk
       relationship: related
   tags:
     - prioritization
@@ -261,10 +261,10 @@
       type: risk
       relationship: example
     - id: rSE7kY5k4Q
-      type: capability
+      type: research-area
       relationship: vulnerable-technique
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
       relationship: mitigation
   tags:
     - taxonomy
@@ -397,7 +397,7 @@
       type: risk
       relationship: related
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
       relationship: mitigation
   tags:
     - causal-model
@@ -2294,7 +2294,7 @@
     - id: oeNG1pEkeg
       type: analysis
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: Ja9HeRlQ2A
       type: analysis
   tags:
@@ -2461,7 +2461,7 @@
     - id: cF7VgLKSpg
       type: analysis
     - id: E2BOiahT9A
-      type: concept
+      type: crux
     - id: MvImONf1YA
       type: risk
     - id: URCXiRsX0w

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -52,7 +52,7 @@
       type: ai-model
       relationship: composed-of
     - id: D8dD07y5oQ
-      type: concept
+      type: risk
       relationship: research
     - id: A4XoubikkQ
       type: organization
@@ -340,11 +340,11 @@
   website: https://humancompatible.ai
   relatedEntries:
     - id: Ub7IaobzDA
-      type: safety-agenda
+      type: research-area
     - id: 9XN9QMfecA
       type: risk
     - id: aUMeFdALrA
-      type: safety-agenda
+      type: research-area
     - id: stuart-russell
       type: person
       relationship: leads-to
@@ -684,7 +684,7 @@
     - id: puAffUjWSS
       type: organization
     - id: aX0jkoaekQ
-      type: policy
+      type: organization
   sources:
     - title: ARC Website
       url: https://alignment.org
@@ -875,7 +875,7 @@
     - id: pKeaWwP6sQ
       type: organization
     - id: mnhBgvNfXA
-      type: event
+      type: historical
     - id: mK9pX3rQ7n
       type: organization
     - id: 1LcLlMGLbw
@@ -1664,7 +1664,7 @@
     - id: 3U1A3jX8wC
       type: person
     - id: 3w5hW5liew
-      type: concept
+      type: organization
   sources:
     - title: "OpenAI: Built to Benefit Everyone"
       url: https://openai.com/index/built-to-benefit-everyone/
@@ -1920,7 +1920,7 @@
     - id: pvJ50HupEQ
       type: organization
     - id: rt6jVH9yuA
-      type: concept
+      type: approach
   sources:
     - title: Palisade Research Website
       url: https://palisaderesearch.org/

--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -25,7 +25,7 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
     - id: zR4nW8xB2f
       type: person
   customFields:
@@ -132,7 +132,7 @@
     - id: y4bieqSeag
       type: organization
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: nGFBXZeM3d
       type: person
   customFields:
@@ -485,7 +485,7 @@
   website: https://anthropic.com
   relatedEntries:
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
 - id: nate-soares
   stableId: 5MVd90lzCg
   wikiId: E212
@@ -708,7 +708,7 @@
     - governance
   relatedEntries:
     - id: rt6jVH9yuA
-      type: concept
+      type: approach
     - id: bioweapons
       type: risk
     - id: MUGUxfl2YA
@@ -742,7 +742,7 @@
     - id: dVQzYIAN3A
       type: person
     - id: l8ZPtVJdsA
-      type: concept
+      type: approach
   lastUpdated: 2026-03
 
 - id: philip-tetlock

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -708,7 +708,7 @@
     - id: pz3KSt33AA
       type: policy
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: La8s84s3zg
       type: policy
     - id: ZXvLxl4RMw
@@ -891,9 +891,9 @@
     - id: La8s84s3zg
       type: policy
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: B3alpHHvzg
-      type: policy
+      type: event
   sources:
     - title: 'Translation: Interim Measures for Generative AI Management'
       url: >-
@@ -1200,7 +1200,7 @@
     - id: XLLyzaEaCA
       type: organization
     - id: khXUiwWtkg
-      type: approach
+      type: crux
     - id: SUZgWeZLNA
       type: risk
     - id: Pr5xmThNfA
@@ -1539,7 +1539,7 @@
       value: Up to EUR 35M or 7% of global annual turnover (prohibited practices); EUR 15M or 3% (other violations); EUR 7.5M or 1% (incorrect information)
   relatedEntries:
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: aX0jkoaekQ
       type: organization
     - id: XLLyzaEaCA
@@ -2376,7 +2376,7 @@
     - id: pz3KSt33AA
       type: policy
     - id: B3alpHHvzg
-      type: policy
+      type: event
     - id: mK9pX3rQ7n
       type: organization
     - id: 1LcLlMGLbw
@@ -2512,9 +2512,9 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
   sources:
     - title: Core Views on AI Safety
       url: https://anthropic.com/news/core-views-on-ai-safety
@@ -2993,7 +2993,7 @@
     - id: pKeaWwP6sQ
       type: organization
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: YDMiSB8wyg
       type: approach
   lastUpdated: 2026-02
@@ -3150,7 +3150,7 @@
     - id: JqMTO0YVEA
       type: risk
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
   lastUpdated: 2026-02
 
 - id: capability-elicitation
@@ -3239,7 +3239,7 @@
     - id: JqMTO0YVEA
       type: risk
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
   lastUpdated: 2026-02
 
 - id: ai-assisted
@@ -3298,7 +3298,7 @@
     - id: JqMTO0YVEA
       type: risk
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
   lastUpdated: 2026-02
 
 - id: alignment-evals
@@ -3384,7 +3384,7 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: rt6jVH9yuA
       type: approach
     - id: 9XN9QMfecA
@@ -3414,7 +3414,7 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: 9XN9QMfecA
       type: risk
     - id: vc60Nthkcg
@@ -3444,7 +3444,7 @@
     - id: xwxKWEAkSQ
       type: approach
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
   lastUpdated: 2026-02
 
 - id: preference-optimization
@@ -3470,7 +3470,7 @@
     - id: 1LcLlMGLbw
       type: organization
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: 9XN9QMfecA
       type: risk
   lastUpdated: 2026-02
@@ -3498,9 +3498,9 @@
     - id: 9XN9QMfecA
       type: risk
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
   lastUpdated: 2026-02
 
 - id: refusal-training
@@ -3527,7 +3527,7 @@
     - id: 1LcLlMGLbw
       type: organization
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: vc60Nthkcg
       type: risk
   lastUpdated: 2026-02
@@ -3755,11 +3755,11 @@
     - id: ULjDXpSLCI
       type: organization
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: 73qTEkYyWA
-      type: concept
+      type: research-area
     - id: etuIjQhFbQ
-      type: concept
+      type: research-area
   lastUpdated: 2026-02
 
 - id: evals-governance
@@ -3796,7 +3796,7 @@
     - id: rQEkFJxS5w
       type: organization
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: mK9pX3rQ7n
       type: organization
   lastUpdated: 2026-02
@@ -3898,7 +3898,7 @@
     - governance
   relatedEntries:
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: 1LcLlMGLbw
       type: organization
     - id: mK9pX3rQ7n
@@ -3939,7 +3939,7 @@
     - id: monitoring
       type: approach
     - id: uvwmYLYstg
-      type: policy
+      type: concept
   lastUpdated: 2026-02
 
 - id: monitoring
@@ -3968,9 +3968,9 @@
     - id: thresholds
       type: concept
     - id: uvwmYLYstg
-      type: policy
+      type: concept
     - id: 57vCq45URQ
-      type: policy
+      type: approach
     - id: hardware-enabled-governance
       type: approach
   lastUpdated: 2026-02
@@ -4146,7 +4146,7 @@
     - id: monitoring
       type: approach
     - id: uvwmYLYstg
-      type: policy
+      type: concept
     - id: international-regimes
       type: concept
   lastUpdated: 2026-02
@@ -4208,9 +4208,9 @@
     - id: y4bieqSeag
       type: organization
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: 3Mc5fuvtMg
-      type: policy
+      type: concept
   lastUpdated: 2026-02
 
 - id: training-programs
@@ -4341,7 +4341,7 @@
     - id: La8s84s3zg
       type: policy
     - id: 4a6Sf9Fupg
-      type: policy
+      type: concept
   lastUpdated: 2026-02
 
 - id: singapore-consensus
@@ -4368,13 +4368,13 @@
     - ai-safety
   relatedEntries:
     - id: B3alpHHvzg
-      type: policy
+      type: event
     - id: X2gSvrOang
       type: policy
     - id: aCEdTooCBw
       type: policy
     - id: 4a6Sf9Fupg
-      type: policy
+      type: concept
   sources:
     - title: The Singapore Consensus on Global AI Safety Research Priorities
       url: https://arxiv.org/abs/2506.20702
@@ -4672,7 +4672,7 @@
     - id: aCEdTooCBw
       type: policy
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
   lastUpdated: 2026-02
 
 - id: international-regimes
@@ -4747,13 +4747,13 @@
     - id: SUZgWeZLNA
       type: risk
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: SpFgTz2INg
       type: policy
     - id: uvwmYLYstg
-      type: policy
+      type: concept
     - id: 4a6Sf9Fupg
-      type: policy
+      type: concept
   lastUpdated: 2026-02
 
 - id: open-source
@@ -4815,7 +4815,7 @@
     - id: aCEdTooCBw
       type: policy
     - id: i1qSgjAj5A
-      type: policy
+      type: approach
     - id: La8s84s3zg
       type: policy
     - id: 1LcLlMGLbw
@@ -4900,11 +4900,11 @@
     - ai-safety
   relatedEntries:
     - id: 0vyIQ4YLIA
-      type: approach
+      type: research-area
     - id: 6sdr78k9kQ
       type: approach
     - id: sFjyY5xXZA
-      type: approach
+      type: research-area
     - id: y4bieqSeag
       type: organization
   lastUpdated: 2026-02
@@ -4929,7 +4929,7 @@
     - ai-safety
   relatedEntries:
     - id: 0vyIQ4YLIA
-      type: approach
+      type: research-area
     - id: xwxKWEAkSQ
       type: approach
     - id: H74rOLotqg
@@ -4962,9 +4962,9 @@
     - id: vc60Nthkcg
       type: risk
     - id: MBGtb3Qlkw
-      type: approach
+      type: research-area
     - id: 73qTEkYyWA
-      type: approach
+      type: research-area
     - id: ULjDXpSLCI
       type: organization
   lastUpdated: 2026-02
@@ -4989,9 +4989,9 @@
     - ai-safety
   relatedEntries:
     - id: rSE7kY5k4Q
-      type: approach
+      type: research-area
     - id: MBGtb3Qlkw
-      type: approach
+      type: research-area
     - id: vc60Nthkcg
       type: risk
     - id: mK9pX3rQ7n
@@ -5021,7 +5021,7 @@
     - id: MEt9F7f50w
       type: approach
     - id: 73qTEkYyWA
-      type: approach
+      type: research-area
     - id: 6sdr78k9kQ
       type: approach
     - id: vc60Nthkcg
@@ -5054,9 +5054,9 @@
     - id: 6sdr78k9kQ
       type: approach
     - id: sFjyY5xXZA
-      type: approach
+      type: research-area
     - id: 73qTEkYyWA
-      type: approach
+      type: research-area
   lastUpdated: 2026-02
 
 - id: sandboxing
@@ -5084,7 +5084,7 @@
     - id: cYETfX9wzA
       type: approach
     - id: 95ASV0XEwQ
-      type: concept
+      type: capability
     - id: rQEkFJxS5w
       type: organization
     - id: mK9pX3rQ7n
@@ -5150,7 +5150,7 @@
     - id: sandboxing
       type: approach
     - id: 95ASV0XEwQ
-      type: concept
+      type: capability
     - id: rQEkFJxS5w
       type: organization
     - id: mK9pX3rQ7n
@@ -5179,13 +5179,13 @@
     - ai-safety
   relatedEntries:
     - id: k6BfxaEwuQ
-      type: approach
+      type: research-area
     - id: MBGtb3Qlkw
-      type: approach
+      type: research-area
     - id: 95ASV0XEwQ
-      type: concept
+      type: capability
     - id: LSqNo6FATg
-      type: organization
+      type: approach
   lastUpdated: 2026-02
 
 
@@ -5871,7 +5871,7 @@
       value: Jennifer Pahlka (Code for America, USDS)
   relatedEntries:
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: aCEdTooCBw
       type: policy
     - id: 7ptWHyqwBA
@@ -5910,7 +5910,7 @@
     - id: y8Ib2pmieA
       type: concept
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
   sources:
     - title: Recoding America Official Website
       url: https://www.recodingamerica.us/

--- a/data/entities/risks.yaml
+++ b/data/entities/risks.yaml
@@ -405,7 +405,7 @@
     - id: hwDgNNDsDQ
       type: risk
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
   sources:
     - title: Corrigibility
       url: https://intelligence.org/files/Corrigibility.pdf
@@ -563,13 +563,13 @@
     - id: 8Bv92x9G1A
       type: risk
     - id: 73qTEkYyWA
-      type: safety-agenda
+      type: research-area
     - id: sFjyY5xXZA
-      type: safety-agenda
+      type: research-area
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
     - id: etuIjQhFbQ
-      type: approach
+      type: research-area
     - id: mK9pX3rQ7n
       type: organization
   sources:
@@ -1339,7 +1339,7 @@
     - id: hwDgNNDsDQ
       type: risk
     - id: aUMeFdALrA
-      type: safety-agenda
+      type: research-area
     - id: puAffUjWSS
       type: organization
   sources:
@@ -1815,7 +1815,7 @@
     - id: BYKermZj1A
       type: risk
     - id: aUMeFdALrA
-      type: safety-agenda
+      type: research-area
     - id: y4bieqSeag
       type: organization
   sources:
@@ -1920,7 +1920,7 @@
     - id: 7c6UC46TWQ
       type: risk
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
   sources:
     - title: Open-sourcing highly capable foundation models (arXiv)
       url: https://arxiv.org/abs/2311.09227
@@ -1970,7 +1970,7 @@
       value: Arms race dynamics
   relatedEntries:
     - id: lfvY1bGeoA
-      type: policy
+      type: concept
     - id: mK9pX3rQ7n
       type: organization
     - id: XLLyzaEaCA
@@ -2085,9 +2085,9 @@
     - id: nYPuaov1hA
       type: risk
     - id: rSE7kY5k4Q
-      type: capability
+      type: research-area
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
     - id: sycophancy
       type: risk
   sources:
@@ -2443,7 +2443,7 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: MBGtb3Qlkw
-      type: safety-agenda
+      type: research-area
     - id: automation-bias
       type: risk
     - id: erosion-of-agency
@@ -2552,7 +2552,7 @@
     - id: BYKermZj1A
       type: risk
     - id: aUMeFdALrA
-      type: safety-agenda
+      type: research-area
   sources:
     - title: 'Superintelligence: Paths, Dangers, Strategies'
       author: Nick Bostrom
@@ -2860,7 +2860,7 @@
     - id: mK9pX3rQ7n
       type: organization
     - id: 5maTNr0PGA
-      type: concept
+      type: capability
   lastUpdated: 2026-02
 
 # === Auto-generated stubs for pages missing entities ===


### PR DESCRIPTION
## Summary
- Scanned all `data/entities/*.yaml` files and identified 127 `relatedEntries` where the `type` field did not match the referenced entity's actual `entityType`
- Fixed all mismatches in-place across 9 entity YAML files
- Most common corrections: `safety-agenda` -> `research-area`, `policy` -> `concept`, `concept` -> `approach`/`risk`/`capability`

## Files changed
| File | Fixes |
|------|-------|
| `responses.yaml` | 56 |
| `concepts.yaml` | 18 |
| `risks.yaml` | 14 |
| `misc.yaml` | 13 |
| `organizations.yaml` | 7 |
| `models.yaml` | 7 |
| `capabilities.yaml` | 6 |
| `people.yaml` | 5 |
| `ai-models.yaml` | 1 |

## Test plan
- [x] Re-ran detection script after fix: 0 mismatches remaining
- [x] `pnpm build-data:content` passes cleanly (0 YAML parse errors, 1799 entities)
- [x] Gate check failures are pre-existing (4 EntityLink name mismatches on main), not caused by this change

Closes #3172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated entity relationship type classifications across the knowledge base to improve how topics, concepts, research areas, and other content are semantically categorized and linked. These changes enhance data consistency, strengthen the organization of relationships throughout the platform, and ensure more accurate semantic connections across all knowledge base entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->