### PR TITLE
fix: maintenance sweep — MDX build error, stale constants, slug aliases, title mismatch

### DIFF
--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -42,9 +42,9 @@ export async function generateMetadata({
   if (!pub) return { title: "Publication Not Found" };
 
   return {
-    title: `${pub.name} | Publication Venues`,
+    title: `${pub.name} | Publications`,
     description:
-      pub.description || `${pub.name} — publication venue tracked in the wiki.`,
+      pub.description || `${pub.name} — publication tracked in the wiki.`,
   };
 }
 
@@ -99,7 +99,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
       >
         <ArrowLeft className="w-3.5 h-3.5" />
-        All Publication Venues
+        All Publications
       </Link>
 
       {/* Header */}

--- a/apps/web/src/app/publications/page.tsx
+++ b/apps/web/src/app/publications/page.tsx
@@ -8,9 +8,9 @@ import { ProfileStatCard } from "@/components/directory";
 import { PublicationsTable, type PublicationRow } from "./publications-table";
 
 export const metadata: Metadata = {
-  title: "Publication Venues",
+  title: "Publications",
   description:
-    "Directory of publication venues tracked in the wiki, with credibility ratings, peer-review status, and resource counts.",
+    "Directory of publications tracked in the wiki, with credibility ratings, peer-review status, and resource counts.",
 };
 
 export default function PublicationsPage() {
@@ -59,10 +59,10 @@ export default function PublicationsPage() {
     <div className="max-w-[90rem] mx-auto px-6 py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold tracking-tight mb-2">
-          Publication Venues
+          Publications
         </h1>
         <p className="text-muted-foreground text-sm max-w-2xl">
-          Publication venues tracked in the wiki, with credibility ratings and
+          Publications tracked in the wiki, with credibility ratings and
           resource counts. Covers academic journals, preprint servers, company
           blogs, think tanks, and more.
         </p>

--- a/apps/web/src/app/sources/sources-overview-content.tsx
+++ b/apps/web/src/app/sources/sources-overview-content.tsx
@@ -13,7 +13,7 @@ export function SourcesOverviewContent() {
 
   const stats = [
     { label: "Resources", value: resources.length, href: "/resources" },
-    { label: "Publication Venues", value: publications.length, href: "/publications" },
+    { label: "Publications", value: publications.length, href: "/publications" },
     { label: "Peer-Reviewed Venues", value: peerReviewed },
     { label: "With Summaries", value: withSummary },
     { label: "Cited by Pages", value: citedResources },
@@ -72,10 +72,10 @@ export function SourcesOverviewContent() {
           className="group block rounded-xl border border-border/60 bg-card p-6 no-underline transition-all hover:shadow-md hover:border-border"
         >
           <h3 className="text-lg font-bold mb-2 group-hover:text-primary transition-colors">
-            Publication Venues
+            Publications
           </h3>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            {publications.length} publication venues with credibility ratings
+            {publications.length} publications with credibility ratings
             (1-5 scale). Maps domains to venues for automatic resource
             credibility assignment.
           </p>

--- a/apps/web/src/app/sources/sources-tabs.tsx
+++ b/apps/web/src/app/sources/sources-tabs.tsx
@@ -28,7 +28,7 @@ export function SourcesTabs({
         },
         {
           id: "publications",
-          label: "Publication Venues",
+          label: "Publications",
           count: publicationCount,
           content: <PublicationsTable publications={publicationRows} />,
         },

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -619,6 +619,10 @@ const STATIC_SLUG_ALIASES: Record<string, string> = {
   "math": "math-benchmark",
   "mistral-large": "mistral-large-2",
   "alignment-research-center": "arc",
+  "gemini-2-0": "gemini-2-0-flash",
+  "william-macaskill": "will-macaskill",
+  "executive-order-14110": "us-executive-order",
+  "sb-1047": "california-sb1047",
 };
 
 /**

--- a/apps/wiki-server/src/routes/operational/monitoring.ts
+++ b/apps/wiki-server/src/routes/operational/monitoring.ts
@@ -33,7 +33,7 @@ const SERVICES = [
 
 // Expected migration count — update this when adding new drizzle migrations.
 // Read from apps/wiki-server/drizzle/meta/_journal.json entries length.
-const EXPECTED_MIGRATION_COUNT = 108;
+const EXPECTED_MIGRATION_COUNT = 142;
 
 // ── Typed row interfaces for raw SQL results ────────────────────────────
 interface DbCountsRow {

--- a/content/docs/knowledge-base/debates/case-for-xrisk.mdx
+++ b/content/docs/knowledge-base/debates/case-for-xrisk.mdx
@@ -773,10 +773,10 @@ This 9-minute advance in one year reflects increasing expert concern about the p
   spectrum={{ low: "Negligible (under 1%)", high: "Very High (>50%)" }}
   positions={[
     { actor: "Roman Yampolskiy", position: "Very high", estimate: "99%", confidence: "high" },
-    { actor: "<EntityLink id="E114" name="eliezer-yudkowsky">Eliezer Yudkowsky</EntityLink> (MIRI)", position: "Very high", estimate: "~90%", confidence: "high" },
-    { actor: "<EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink>", position: "Moderate-high", estimate: "~20-50%", confidence: "medium" },
+    { actor: "Eliezer Yudkowsky (MIRI)", position: "Very high", estimate: "~90%", confidence: "high" },
+    { actor: "Paul Christiano", position: "Moderate-high", estimate: "~20-50%", confidence: "medium" },
     { actor: "AI Impacts Survey 2023 (mean)", position: "Moderate", estimate: "14.4%", confidence: "medium" },
-    { actor: "<EntityLink id="E355" name="toby-ord">Toby Ord</EntityLink> (The Precipice)", position: "Moderate", estimate: "~10%", confidence: "medium" },
+    { actor: "Toby Ord (The Precipice)", position: "Moderate", estimate: "~10%", confidence: "medium" },
     { actor: "AI Impacts Survey 2023 (median)", position: "Low-moderate", estimate: "5%", confidence: "medium" },
     { actor: "Superforecasters (XPT 2022)", position: "Very low", estimate: "0.38%", confidence: "high" },
   ]}

--- a/crux/validate/validate-display-names.test.ts
+++ b/crux/validate/validate-display-names.test.ts
@@ -32,7 +32,6 @@ function run(cmd: string): { stdout: string; exitCode: number } {
 describe('looksLikeStableId', () => {
   it('detects typical stableIds', () => {
     expect(looksLikeStableId('mK9pX3rQ7n')).toBe(true);
-    expect(looksLikeStableId('Tw_Eo226h3')).toBe(true);
     expect(looksLikeStableId('A4XoubikkQ')).toBe(true); // has digits, mixed case
     expect(looksLikeStableId('Z62bQynY4g')).toBe(true);
     expect(looksLikeStableId('0u4J70VqFY')).toBe(true);

--- a/crux/validate/validate-display-names.ts
+++ b/crux/validate/validate-display-names.ts
@@ -32,13 +32,11 @@ export interface DisplayNameViolation {
 }
 
 /**
- * StableId pattern: exactly 10 alphanumeric characters with at least one
- * uppercase and at least one lowercase letter. This matches the canonical
- * stableId format (e.g., "mK9pX3rQ7n", "Tw_Eo226h3").
- *
- * We also allow underscores since some stableIds contain them.
+ * StableId pattern: exactly 10 alphanumeric characters [A-Za-z0-9].
+ * StableIds never contain `-` or `_` (migration 0141 normalized all legacy ones).
+ * Canonical definition: apps/web/src/lib/stable-id.ts
  */
-const STABLE_ID_PATTERN = /^[A-Za-z0-9_]{10}$/;
+const STABLE_ID_PATTERN = /^[A-Za-z0-9]{10}$/;
 
 /**
  * Check if a string looks like a stableId (machine-generated 10-char ID).


### PR DESCRIPTION
## Summary

Maintenance sweep fixing 5 issues across the codebase:

- **P0 build fix**: Remove EntityLink components from JSX string attributes in `case-for-xrisk.mdx` that broke MDX/acorn parsing and prevented `pnpm build` from completing
- **Stale constant**: Update `EXPECTED_MIGRATION_COUNT` from 108 → 142 to match actual migration file count
- **Pattern divergence**: Align `STABLE_ID_PATTERN` in `validate-display-names.ts` with canonical `stable-id.ts` (remove underscore allowance invalidated by migration 0141)
- **404 fixes**: Add 4 slug aliases (`gemini-2-0`, `william-macaskill`, `executive-order-14110`, `sb-1047`) to resolve missing redirects
- **Title mismatch**: Rename "Publication Venues" → "Publications" across all page titles, metadata, tabs, and links to match `/publications` URL

Also cleaned up stale `agent:working` label on #3022 and closed #3315 (already fixed by #3285).

Closes #3307
Closes #3316
Closes #3317
Closes #3313
Closes #3235

## Test plan

- [x] `pnpm test` — 4383 tests pass
- [x] `pnpm build` — exits 0, all 1968 wiki pages compile (MDX fix verified)
- [x] `pnpm crux w validate gate --fix` — 5/5 gate checks pass
- [x] `validate-display-names.test.ts` — 15 tests pass (underscore rejection verified)
- [x] Integration test "passes on the current codebase" — confirms no false positives from tighter regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
