### PR TITLE
fix: skip CI summary job on label events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,12 @@ jobs:
   # ---------------------------------------------------------------------------
   ci:
     needs: [build-data, validate, build-nextjs, test]
-    if: always()
+    # Skip on label events — dependent jobs skip too, so "skipped != success" would
+    # cause a false failure on every label add/remove (e.g. agent:working).
+    if: >-
+      always() &&
+      github.event.action != 'labeled' &&
+      github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed


### PR DESCRIPTION
## Summary
- Fix false CI failures caused by label events (e.g. adding `agent:working`)
- The `ci` gate job had `if: always()` but its deps (build-data, validate, build-nextjs, test) skip on label events
- When a label was added/removed, deps were skipped and `ci` failed because `"skipped" != "success"`
- This caused every PR that received a label change to show as UNSTABLE

## Fix
Add the same label-event filter to the `ci` summary job that all other jobs already have:
```yaml
if: >-
  always() &&
  github.event.action != 'labeled' &&
  github.event.action != 'unlabeled'
```

## Test plan
- [x] Verified the change is consistent with existing label filters on all other CI jobs
- [x] `actionlint` passes (validated by gate check)
- [x] Gate check failures are pre-existing on main (Crux TS check, KB schema validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow stability by preventing false failure reports when handling pull request label changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->