### PR TITLE
hotfix: add skip_post_deploy_smoke_test to unblock recovery

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -18,6 +18,14 @@ on:
         required: false
         type: boolean
         default: false
+      skip_post_deploy_smoke_test:
+        description: >
+          Skip the post-deploy smoke test and automatic rollback. Use during
+          incident recovery when the server is already down and the smoke test
+          would just trigger another rollback cycle.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wiki-server-docker-${{ github.ref }}
@@ -251,6 +259,7 @@ jobs:
           echo "Health status: ${HEALTH_STATUS}"
 
       - name: Post-deploy smoke test
+        if: inputs.skip_post_deploy_smoke_test != true
         id: post-deploy-smoke
         env:
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}


### PR DESCRIPTION
## INCIDENT: Wiki server is down (503)

The deploy workflow's post-deploy smoke test is preventing recovery:
1. Server crashed during previous deploy's smoke test cleanup (DELETE got 502)
2. Server went 503 and never recovered
3. Re-deploying fails because the post-deploy smoke test can't reach the server
4. Smoke test failure triggers rollback, which doesn't fix anything
5. Circular failure loop

## Fix
Add `skip_post_deploy_smoke_test` workflow_dispatch input so we can deploy without the post-deploy check blocking recovery.

## Recovery steps after merge
1. Merge this PR to production
2. Run: `gh workflow run wiki-server-docker.yml --repo quantified-uncertainty/longterm-wiki --ref production -f skip_smoke_test=true -f skip_post_deploy_smoke_test=true`
3. Verify: `curl https://wiki-server.k8s.quantifieduncertainty.org/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)