### PR TITLE
fix: maintenance sweep — QA fixes, duplicate entities, audits cleanup

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -164,59 +164,16 @@ audits:
 #
 # Status: pending | verified | failed | wontfix
 
-post_merge:
-  - id: vercel-production-only-post-merge
-    pr: 1630
-    merged: "2026-03-04"
-    claim: "Vercel ignoreCommand restricts builds to ONLY the production branch (not main, not claude/*)"
-    how_to_verify: "Check Vercel deployments for any non-production deploys since PR #1630 merged"
-    status: verified
-    deadline: "2026-03-18"
-    checked_date: "2026-03-05"
-    notes: "Verified: ignoreCommand in apps/web/vercel.json correctly builds only production branch. Site is live at longtermwiki.com (671 pages). Config: [[  == production ]] && exit 1; exit 0"
+post_merge: []
 
-  - id: audits-system-post-merge
-    pr: 1637
-    merged: "2026-03-04"
-    claim: "The crux sys audits system works end-to-end after merge"
-    how_to_verify: "Run each crux sys audits subcommand on main branch and verify output is correct"
-    status: verified
-    deadline: "2026-03-18"
-    checked_date: "2026-03-05"
-    notes: "Verified: all audits subcommands work (list, report, run-auto, check). YAML schema valid. 7 audits + 2 post-merge items tracked correctly. run-auto executes hybrid check_commands."
-
-  - id: groundskeeper-fixes-post-merge
-    pr: 1813
-    merged: "2026-03-06"
-    claim: "Staggered wellness cron schedules prevent duplicate issue creation; auto-update env vars enable session log writing; groundskeeper API key migration works"
-    how_to_verify: "After next 8AM/PM UTC wellness run, check that only 1 wellness issue is created (not duplicates). Check next auto-update run for no LONGTERMWIKI_SERVER_URL warnings. Check groundskeeper logs for no API key errors."
-    status: verified
-    deadline: "2026-03-20"
-    checked_date: "2026-03-08"
-    notes: "Verified: Wellness issues #1796, #1819, #1841, #1857, #1892 show no simultaneous duplicates. Each opens after prior closes. Staggered cron scheduling working correctly."
-
-  - id: reviewdog-ci-annotations
-    pr: 1787
-    merged: "2026-03-05"
-    claim: "Reviewdog posts inline annotations on PR diffs for crux validation findings and actionlint errors"
-    how_to_verify: "Open a PR with a known validation issue (e.g. unescaped $) and check that inline annotations appear in the Files Changed tab"
-    status: verified
-    deadline: "2026-03-19"
-
-  - id: workflow-fixes-maintenance-sweep
-    pr: 2094
-    merged: "2026-03-10"
-    claim: "server-health-monitor jq fix, auto-update push --force fix, and scheduled-deploy removal from health checks all work correctly in CI"
-    how_to_verify: "After next scheduled runs, check: (1) server-health-monitor succeeds, (2) auto-update push succeeds (if pages modified), (3) ci-pr-health no longer flags scheduled-deploy as missing"
-    status: verified
-    deadline: "2026-03-17"
-    checked_date: "2026-03-13"
-    notes: "Verified: (1) server-health-monitor manual dispatch succeeded 2026-03-11, jq fix works. (2) auto-update push can't be verified — pipeline fails on LLM content quality before reaching push step. (3) ci-pr-health confirmed: no scheduled-deploy references. Marking as verified since the specific fixes work; auto-update issues are unrelated content quality problems."
-
-  - id: robots-txt-crawler-blocking
-    pr: TBD
-    merged: "2026-03-21"
-    claim: "robots.txt Disallow rules for /factbase/ and /organizations/*/grants/ reduce bot traffic to near-zero on those routes, cutting Vercel function costs"
-    how_to_verify: "Check Vercel observability for /factbase/record/[recordId] route — requests should drop from 202K/day to near-zero within 1-2 weeks as crawlers honor robots.txt. Check billing to confirm cost reduction."
-    status: verified
-    deadline: "2026-04-04"
+# ---------------------------------------------------------------------------
+# Archived post-merge items (all verified — kept for historical record)
+# ---------------------------------------------------------------------------
+# Archived 2026-03-28 during maintenance sweep.
+#
+#   vercel-production-only-post-merge (PR #1630, verified 2026-03-05)
+#   audits-system-post-merge (PR #1637, verified 2026-03-05)
+#   groundskeeper-fixes-post-merge (PR #1813, verified 2026-03-08)
+#   reviewdog-ci-annotations (PR #1787, verified 2026-03-05)
+#   workflow-fixes-maintenance-sweep (PR #2094, verified 2026-03-13)
+#   robots-txt-crawler-blocking (merged 2026-03-21, verified)

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({
 }
 
 function formatPrice(price: number): string {
-  return `\$${price}`;
+  return `\$${price.toFixed(2)}`;
 }
 
 export default async function AiModelDetailPage({

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -68,11 +68,52 @@ export async function generateMetadata({
  * Derive a human-readable source name from a URL.
  * Tries the publication database first, then falls back to a cleaned domain name.
  */
+/** Common domain → display name fallbacks for sources not in the publication DB. */
+const DOMAIN_DISPLAY_NAMES: Record<string, string> = {
+  "github.com": "GitHub",
+  "nytimes.com": "The New York Times",
+  "washingtonpost.com": "The Washington Post",
+  "reuters.com": "Reuters",
+  "apnews.com": "AP News",
+  "bbc.co.uk": "BBC",
+  "bbc.com": "BBC",
+  "theguardian.com": "The Guardian",
+  "bloomberg.com": "Bloomberg",
+  "ft.com": "Financial Times",
+  "wsj.com": "The Wall Street Journal",
+  "politico.com": "Politico",
+  "thehill.com": "The Hill",
+  "congress.gov": "Congress.gov",
+  "whitehouse.gov": "White House",
+  "arxiv.org": "arXiv",
+  "twitter.com": "Twitter/X",
+  "x.com": "X",
+  "medium.com": "Medium",
+  "substack.com": "Substack",
+  "techcrunch.com": "TechCrunch",
+  "theverge.com": "The Verge",
+  "wired.com": "Wired",
+  "arstechnica.com": "Ars Technica",
+  "cnbc.com": "CNBC",
+  "cnn.com": "CNN",
+  "npr.org": "NPR",
+  "pbs.org": "PBS",
+  "nature.com": "Nature",
+  "science.org": "Science",
+};
+
 function getSourceDisplayName(url: string): string | undefined {
   const domain = extractDomain(url);
   if (!domain) return undefined;
   const pub = getPublicationByDomain(domain);
   if (pub) return pub.name;
+  // Check hardcoded fallbacks for common sources
+  const fallback = DOMAIN_DISPLAY_NAMES[domain];
+  if (fallback) return fallback;
+  // Check subdomain match (e.g., news.bbc.co.uk → BBC)
+  for (const [d, name] of Object.entries(DOMAIN_DISPLAY_NAMES)) {
+    if (domain.endsWith(`.${d}`)) return name;
+  }
   const cleaned = domain
     .replace(/\.(com|org|net|io|co|gov|edu|us|uk|ca|au)$/i, "")
     .replace(/\./g, " ");

--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -1204,7 +1204,7 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
         : { name: "", href: null };
       return {
         ...parsed,
-        holderName: resolved.name || titleCase(parsed.holderId ?? "") || "Unknown Holder",
+        holderName: resolved.name || "Unknown Holder",
         holderHref: resolved.href,
       };
     })

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -270,9 +270,12 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       .map(quoteToSqlRow);
   }
 
-  // --- citation_quotes: SELECT WHERE (no ORDER BY, no COUNT, no GROUP BY, no LIMIT) ---
-  if (q.includes("citation_quotes") && q.includes("where") && !q.includes("count(*)") && !q.includes("group by") && !q.includes("order by") && !q.includes("limit")) {
-    if (params.length === 1) {
+  // --- citation_quotes: SELECT WHERE (no ORDER BY, no COUNT, no GROUP BY) ---
+  // Handles health endpoint (with or without LIMIT). First param is always pageId.
+  if (q.includes("citation_quotes") && q.includes("where") && !q.includes("count(*)") && !q.includes("group by") && !q.includes("order by")) {
+    // Health query: params[0] = pageId, optionally params[1] = limit value
+    // Single-quote query: params[0] = pageId, params[1] = footnote (handled below if 2 non-limit params)
+    if (params.length === 1 || (params.length === 2 && q.includes("limit"))) {
       const intId = params[0] as number;
       return Array.from(quotesStore.values())
         .filter((r) => r.pageId === intId)

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -17,45 +17,7 @@ import {
 } from "../../api-types.js";
 import { z } from "zod";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
-
-// ---- Parsers ----
-
-/**
- * Parse a cost string like "~$0.50", "$1.23", "~$10" into integer cents.
- */
-export function parseCostCents(cost: string | null | undefined): number | null {
-  if (!cost) return null;
-  const match = cost.match(/\$\s*([\d.]+)/);
-  if (!match) return null;
-  const dollars = parseFloat(match[1]);
-  if (isNaN(dollars)) return null;
-  return Math.round(dollars * 100);
-}
-
-/**
- * Parse a duration string like "~20 minutes", "~1.5 hours", "30min", "1h 15m" into minutes.
- */
-export function parseDurationMinutes(duration: string | null | undefined): number | null {
-  if (!duration) return null;
-  const lower = duration.toLowerCase();
-  const hoursAndMinutes = lower.match(/([\d.]+)\s*h(?:ours?)?\s+([\d.]+)\s*m(?:in(?:utes?)?)?/);
-  if (hoursAndMinutes) {
-    const h = parseFloat(hoursAndMinutes[1]);
-    const m = parseFloat(hoursAndMinutes[2]);
-    if (!isNaN(h) && !isNaN(m)) return h * 60 + m;
-  }
-  const hoursMatch = lower.match(/([\d.]+)\s*h(?:ours?|r)?(?!\s*[\d.])/);
-  if (hoursMatch) {
-    const h = parseFloat(hoursMatch[1]);
-    if (!isNaN(h)) return h * 60;
-  }
-  const minutesMatch = lower.match(/([\d.]+)\s*m(?:in(?:utes?)?)?/);
-  if (minutesMatch) {
-    const m = parseFloat(minutesMatch[1]);
-    if (!isNaN(m)) return m;
-  }
-  return null;
-}
+import { parseCostCents, parseDurationMinutes } from "./sessions.js";
 
 // ---- Query schemas ----
 

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -486,7 +486,7 @@ const thingsApp = new Hono()
 
     const SyncThingSchema = z.object({
       id: z.string().min(1).max(200),
-      thingType: z.enum(VALID_THING_TYPES as unknown as [string, ...string[]]),
+      thingType: z.enum(VALID_THING_TYPES),
       title: z.string().min(1).max(2000),
       parentThingId: z.string().max(200).optional(),
       sourceTable: z.string().min(1).max(100),

--- a/apps/wiki-server/src/routes/tablebase/website-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/website-sources.ts
@@ -209,7 +209,8 @@ const websiteSourcesApp = new Hono()
       .select()
       .from(websiteSourcePages)
       .where(eq(websiteSourcePages.sourceId, sourceId))
-      .orderBy(websiteSourcePages.path);
+      .orderBy(websiteSourcePages.path)
+      .limit(5000);
 
     return c.json({ sourceId, pages });
   })

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -199,7 +199,8 @@ const citationsApp = new Hono()
         accuracyScore: citationQuotes.accuracyScore,
       })
       .from(citationQuotes)
-      .where(eq(citationQuotes.pageId, intId));
+      .where(eq(citationQuotes.pageId, intId))
+      .limit(1000);
 
     return c.json(computePageHealth(pageId, rows));
   })

--- a/crux/commands/audits.ts
+++ b/crux/commands/audits.ts
@@ -581,6 +581,9 @@ async function runAutoCommand(
     lines.push('');
 
     try {
+      // Note: check_command is from version-controlled audits.yaml.
+      // Commands require shell features (pipes, loops, gh api) so
+      // they run through execSync. YAML changes are reviewed via PR.
       const output = execSync(item.check_command!, {
         cwd: PROJECT_ROOT,
         timeout: 30_000,

--- a/crux/resource-enrichment/fetch-wayback.ts
+++ b/crux/resource-enrichment/fetch-wayback.ts
@@ -282,9 +282,13 @@ export async function fetchWaybackCommand(
       }
 
       // Update enrichment status
+      // Fire-and-forget: enrichment status update is best-effort; failure
+      // should not block wayback batch processing.
       await apiRequest('POST', '/api/resources/batch', {
         items: [{ id: r.id, url: r.url, enrichmentStatus: 'fetched' }],
-      }).catch(() => {});
+      }).catch((e: unknown) => {
+        console.warn(`Failed to update enrichment status for ${r.id}: ${e instanceof Error ? e.message : String(e)}`);
+      });
 
       if ((fetched + fetchFailed) % 20 === 0) {
         process.stdout.write(`\r  Progress: ${i + 1}/${toProcess.length} checked, ${fetched} fetched, ${found} snapshots found`);

--- a/crux/validate/validate-factbase-entity-ids.ts
+++ b/crux/validate/validate-factbase-entity-ids.ts
@@ -231,6 +231,8 @@ export function runCheck(): ValidatorResult {
   return { passed: errors === 0, errors, warnings };
 }
 
-// Direct invocation
-const result = runCheck();
-process.exit(result.passed ? 0 : 1);
+// Only run when invoked directly (not when imported as a module)
+if (process.argv[1]?.endsWith('validate-factbase-entity-ids.ts')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/data/entities/coordination-ecosystem.yaml
+++ b/data/entities/coordination-ecosystem.yaml
@@ -291,28 +291,6 @@
     - title: Centre for the Governance of AI
       url: https://www.governance.ai
 
-- id: forethought-foundation
-  stableId: Pd-y8jBVN0
-  type: organization
-  orgType: generic
-  title: Forethought Foundation
-  description: >-
-    Research organization that published "Design Sketches for Collective Epistemics" (2025),
-    proposing five technologies for shifting society toward high-honesty equilibria:
-    Community Notes for Everything, Rhetoric Highlighting, Reliability Tracking,
-    Epistemic Virtue Evals, and Provenance Tracing.
-  website: https://www.forethought.org
-  tags:
-    - collective-epistemics
-    - information-integrity
-    - governance
-  clusters:
-    - governance
-    - epistemics
-  sources:
-    - title: Forethought Foundation
-      url: https://www.forethought.org
-
 - id: newdemocracy-foundation
   stableId: 7bmpbkSWVn
   type: organization

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -3664,8 +3664,10 @@
   orgType: academic
   title: University of Pennsylvania
   website: https://www.upenn.edu
+  slugAliases:
+    - upenn
   description: >-
-    Private Ivy League research university in Philadelphia.
+    Private Ivy League research university in Philadelphia. Home to Philip Tetlock and the Good Judgment Project.
   relatedEntries:
     - id: philip-tetlock
       type: person
@@ -6658,7 +6660,7 @@
   title: Forethought Foundation
   website: https://www.forethought.org
   description: >-
-    Research foundation co-founded by Will MacAskill, focused on longtermism and improving long-run outcomes for humanity. Produces research on AI and existential risk.
+    Research foundation co-founded by Will MacAskill, focused on longtermism and improving long-run outcomes for humanity. Produces research on AI and existential risk. Published "Design Sketches for Collective Epistemics" (2025).
   relatedEntries:
     - id: will-macaskill
       type: person
@@ -6666,6 +6668,11 @@
     - ea-community
     - longtermism
     - existential-risk
+    - collective-epistemics
+    - governance
+  sources:
+    - title: Forethought Foundation
+      url: https://www.forethought.org
   lastUpdated: 2026-03
 
 - id: ada-lovelace-institute
@@ -8519,16 +8526,6 @@
   description: >-
     University of California campus. Home to Anthony Aguirre (FLI co-founder,
     Metaculus co-founder).
-  lastUpdated: 2026-03
-
-- id: upenn
-  stableId: fwWLWc3zlo
-  type: organization
-  orgType: academic
-  title: University of Pennsylvania
-  website: https://www.upenn.edu
-  description: >-
-    Ivy League university. Home to Philip Tetlock and the Good Judgment Project.
   lastUpdated: 2026-03
 
 - id: uva


### PR DESCRIPTION
## Summary

Maintenance sweep: fixes multiple bugs and code quality issues identified during exhaustive codebase review.

- **Audits cleanup** (#3284): Archive 6 verified post_merge entries, keeping comments for historical record
- **Duplicate entity removal** (#3312): Merge forethought-foundation/forethought and upenn/university-of-pennsylvania duplicates
- **QA code quality fixes** (#3319): Add LIMIT to unbounded queries, fix formatPrice trailing zeros, remove double-cast, deduplicate parsers, add warn logging to silent catch, add import-time guard
- **Legislation stakeholder display** (#3314): Add 30 common domain→display name fallbacks for source column
- **Equity position naming** (#3309): Remove dead titleCase fallback in holder name resolution

## Test plan

- [x] TypeScript type-check clean (web + wiki-server)
- [x] All 4424 tests pass (including updated citations.test.ts mock)
- [x] Production build succeeds
- [x] Gate check: KB schema failure is pre-existing (248 errors on main)
- [x] Paranoid diff review completed — no actionable findings

Closes #3284
