### PR TITLE
fix: restore LTBT trustee EntityLinks, remove Chris Olah from OpenAI 2024 departures

### DIFF
--- a/content/docs/knowledge-base/organizations/long-term-benefit-trust.mdx
+++ b/content/docs/knowledge-base/organizations/long-term-benefit-trust.mdx
@@ -63,7 +63,7 @@ At the close of Anthropic's Series C funding round, the company amended its corp
 - **November 2024**: Trust representation scheduled to increase to three of five board members[^rc-7132]
 - **December 2023**: <EntityLink id="jason-matheny" name="jason-matheny">Jason Matheny</EntityLink> stepped down to avoid conflicts with <EntityLink id="E1185" name="rand-corporation">RAND Corporation</EntityLink> policy work[^rc-7132]
 - **April 2024**: <EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink> stepped down to become Head of AI Safety at U.S. AI Safety Institute[^rc-7132][^rc-3786]
-- **2025**: Richard Fontaine appointed as trustee; Mariano-Florentino Cuéllar appointed[^rc-3786][^rc-b61b]
+- **2025**: <EntityLink id="richard-fontaine" name="richard-fontaine">Richard Fontaine</EntityLink> appointed as trustee; <EntityLink id="mariano-florentino-cuellar" name="mariano-florentino-cuellar">Mariano-Florentino Cuéllar</EntityLink> appointed[^rc-3786][^rc-b61b]
 
 ## Governance Structure and Powers
 
@@ -77,11 +77,11 @@ Initial trustees were appointed by Anthropic's board, but subsequent trustees ar
 
 | Name | Role/Expertise | Status | Notes |
 |------|----------------|--------|-------|
-| Neil Buddy Shah | CEO, Clinton Health Access Initiative | Current (Chair) | Initial trustee, still serving as of early 2026[^rc-d567][^rc-82cc] |
-| Kanika Bahl | CEO & President, <EntityLink id="E1229" name="evidence-action">Evidence Action</EntityLink> | Current | Initial trustee; CEO of <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> top charity[^rc-d567][^rc-3786] |
+| <EntityLink id="neil-buddy-shah" name="neil-buddy-shah">Neil Buddy Shah</EntityLink> | CEO, Clinton Health Access Initiative | Current (Chair) | Initial trustee, still serving as of early 2026[^rc-d567][^rc-82cc] |
+| <EntityLink id="kanika-bahl" name="kanika-bahl">Kanika Bahl</EntityLink> | CEO & President, <EntityLink id="E1229" name="evidence-action">Evidence Action</EntityLink> | Current | Initial trustee; CEO of <EntityLink id="E1056" name="givewell">GiveWell</EntityLink> top charity[^rc-d567][^rc-3786] |
 | <EntityLink id="zach-robinson" name="zach-robinson">Zach Robinson</EntityLink> | CEO, <EntityLink id="E517" name="cea">Centre for Effective Altruism</EntityLink> | Current | Initial trustee[^rc-d567][^rc-3786] |
-| Richard Fontaine | CEO, <EntityLink id="E1189" name="cnas">Center for a New American Security</EntityLink> | Appointed 2025 | National security expert[^rc-3786] |
-| Mariano-Florentino Cuéllar | Former California Supreme Court Justice | Appointed Jan 2026 | Global AI governance expert[^rc-3786][^rc-b61b] |
+| <EntityLink id="richard-fontaine" name="richard-fontaine">Richard Fontaine</EntityLink> | CEO, <EntityLink id="E1189" name="cnas">Center for a New American Security</EntityLink> | Appointed 2025 | National security expert[^rc-3786] |
+| <EntityLink id="mariano-florentino-cuellar" name="mariano-florentino-cuellar">Mariano-Florentino Cuéllar</EntityLink> | Former California Supreme Court Justice | Appointed Jan 2026 | Global AI governance expert[^rc-3786][^rc-b61b] |
 | <EntityLink id="E220" name="paul-christiano">Paul Christiano</EntityLink> | Founder, Alignment Research Center | Departed April 2024 | Left to join U.S. AI Safety Institute[^rc-d567][^rc-7132][^rc-3786] |
 | Jason Matheny | CEO, RAND Corporation | Departed December 2023 | Left to avoid conflicts with RAND policy work[^rc-d567][^rc-7132] |
 

--- a/content/docs/knowledge-base/organizations/openai.mdx
+++ b/content/docs/knowledge-base/organizations/openai.mdx
@@ -256,7 +256,6 @@ The following departures occurred in 2024. Stated reasons varied across individu
 |------------|------|----------------|---------------|-------------|
 | **<EntityLink id="E163" name="ilya-sutskever">Ilya Sutskever</EntityLink>** | Co-founder, Chief Scientist | May 2024 | "Personal project" (<EntityLink id="E291" name="superintelligence">SSI</EntityLink>) | Safe Superintelligence Inc |
 | **<EntityLink id="E182" name="jan-leike">Jan Leike</EntityLink>** | Superalignment Co-lead | May 2024 | "Safety culture backseat to products"[^rc-ef62] | <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> Head of Alignment |
-| **<EntityLink id="E59" name="chris-olah">Chris Olah</EntityLink>** | Interpretability team lead | 2024 | Led interpretability research before departure[^rc-45e1] | Not disclosed |
 | **<EntityLink id="john-schulman" name="john-schulman">John Schulman</EntityLink>** | Co-founder, PPO inventor | Aug 2024 | "Deepen <EntityLink id="E439" name="alignment">AI alignment</EntityLink> focus" | <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> |
 | **<EntityLink id="E1289" name="mira-murati">Mira Murati</EntityLink>** | Chief Technology Officer | Sept 2024 | "Personal exploration" | Not disclosed |
 


### PR DESCRIPTION
## Summary
- **LTBT page**: Restores EntityLinks for all four trustees (Neil Buddy Shah, Kanika Bahl, Richard Fontaine, Mariano-Florentino Cuéllar) using correct slug-based entity IDs. PR #3298 removed the wrong E-number EntityLinks but left plain text; this adds proper links to existing person entities.
- **OpenAI page**: Removes Chris Olah from the 2024 Key Leadership Departures table — he left OpenAI in 2020/2021 to co-found Anthropic, not in 2024. Also removes the dangling `[^rc-45e1]` footnote reference that was never defined.

## Test plan
- [x] `pnpm build` passes cleanly
- [x] `pnpm crux w fix escaping` and `pnpm crux w fix markdown` report no issues
- [x] All EntityLink IDs match existing entities in `data/entities/people.yaml`
- [x] No dangling footnote references remain

Closes #3308
Closes #3306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
