### PR TITLE
fix: correct content accuracy issues across 6 wiki pages

### DIFF
--- a/content/docs/knowledge-base/organizations/govai.mdx
+++ b/content/docs/knowledge-base/organizations/govai.mdx
@@ -7,7 +7,7 @@ sidebar:
 subcategory: safety-orgs
 lastEdited: 2025-12-28
 update_frequency: 21
-summary: "GovAI is an AI policy research organization with ~15-20 staff, funded primarily by Coefficient Giving (\\$1.8M+ in 2023-2024), that has trained 100+ governance researchers through fellowships and currently holds Vice-Chair position in EU GPAI Code drafting. Their compute governance research has influenced regulatory thresholds across US, UK, and EU, with alumni now occupying key positions in frontier labs, think tanks, and government."
+summary: "GovAI is an AI policy research organization with ~40-45 staff, funded primarily by Coefficient Giving (\\$1.8M+ in 2023-2024), that has trained 100+ governance researchers through fellowships and currently holds Vice-Chair position in EU GPAI Code drafting. Their compute governance research has influenced regulatory thresholds across US, UK, and EU, with alumni now occupying key positions in frontier labs, think tanks, and government."
 clusters:
   - ai-safety
   - governance
@@ -32,7 +32,7 @@ The organization's influence extends beyond research: GovAI alumni now occupy ke
 | Founded | 2018 (as part of FHI); Independent 2023 |
 | Location | London, UK (moved from Oxford in 2024) |
 | Structure | Independent nonprofit |
-| Staff Size | ≈15-20 researchers and staff |
+| Staff Size | ≈40-45 researchers and staff |
 | Annual Budget | ≈\$1-4M (estimated from grants) |
 | Primary Funder | <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> (\$1.8M+ in 2023-2024) |
 | Affiliations | <EntityLink id="E365" name="us-aisi">US AI Safety Institute</EntityLink> Consortium member |
@@ -221,7 +221,7 @@ GovAI's conceptual frameworks have shaped regulatory thinking:
 
 | Organization | Focus | Size | Budget | Policy Access |
 |--------------|-------|------|--------|---------------|
-| GovAI | AI governance research + field building | ≈20 | ≈\$1M | High (EU, UK, US) |
+| GovAI | AI governance research + field building | ≈40-45 | ≈\$1M | High (EU, UK, US) |
 | CSET (Georgetown) | Security + emerging tech | ≈50 | ≈\$10M+ | High (US focus) |
 | RAND AI | Broad AI policy | ≈30 | ≈\$1M+ | High (US focus) |
 | Oxford AI Governance | Academic research | ≈10 | ≈\$1M | Medium |

--- a/content/docs/knowledge-base/organizations/uk-aisi.mdx
+++ b/content/docs/knowledge-base/organizations/uk-aisi.mdx
@@ -23,7 +23,7 @@ The UK AI Safety Institute (UK AISI) is a government organization established in
 
 As one of the first government bodies specifically dedicated to advanced AI safety (alongside the US AISI), the UK AISI plays a pioneering role in translating AI safety research into government policy and practice. The organization conducts technical research on AI risks, evaluates frontier models for dangerous capabilities, develops safety standards, and coordinates international efforts through the International Network of <EntityLink id="E13" name="ai-safety-institutes">AI Safety Institutes</EntityLink>, which now includes 10+ member countries.
 
-The UK AISI's strategic positioning reflects the UK government's ambition: to be a global hub for AI safety, bridging technical research communities, frontier AI labs, and international policymakers. Chair <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> has described AISI as a "startup inside the government" that combines technical rigor with policy influence.
+The UK AISI's strategic positioning reflects the UK government's ambition: to be a global hub for AI safety, bridging technical research communities, frontier AI labs, and international policymakers. Former Chair <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> described AISI as a "startup inside the government" that combines technical rigor with policy influence.
 
 ### Organization at a Glance
 
@@ -32,7 +32,7 @@ The UK AISI's strategic positioning reflects the UK government's ambition: to be
 | **Founded** | November 2023 (following AI Safety Summit) |
 | **Renamed** | February 2025 (to AI Security Institute) |
 | **Parent Department** | Department for Science, Innovation and Technology (DSIT) |
-| **Leadership** | <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> (Chair) |
+| **Leadership** | <EntityLink id="E162" name="ian-hogarth">Ian Hogarth</EntityLink> (former Chair, 2023-2025) |
 | **Technical Staff** | 30+ researchers (as of mid-2024) |
 | **Annual Budget** | Approximately 50 million GBP |
 | **Locations** | London (HQ), San Francisco (opened 2024) |
@@ -86,7 +86,7 @@ The UK AISI's strategic positioning reflects the UK government's ambition: to be
 
 ### Early Development (2023-2024)
 
-**2023 activities:** The Institute rapidly hired technical staff, recruiting senior alumni from <EntityLink id="E218" name="openai">OpenAI</EntityLink>, <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink>, and the University of Oxford. Ian Hogarth was appointed as permanent Chair in June 2023. By the end of 2023, the organization had established its organizational structure, built relationships with AI labs for model access, and begun coordination with the US AISI.
+**2023 activities:** The Institute rapidly hired technical staff, recruiting senior alumni from <EntityLink id="E218" name="openai">OpenAI</EntityLink>, <EntityLink id="E98" name="deepmind">Google DeepMind</EntityLink>, and the University of Oxford. Ian Hogarth was appointed as Chair in June 2023 and served until 2025. By the end of 2023, the organization had established its organizational structure, built relationships with AI labs for model access, and begun coordination with the US AISI.
 
 **2024 milestones:**
 
@@ -228,12 +228,12 @@ flowchart TD
 
 <Section title="Leadership">
   <KeyPeople people={[
-    { name: "Ian Hogarth", role: "Chair" },
+    { name: "Ian Hogarth", role: "Former Chair (2023-2025)" },
     { name: "Various senior researchers", role: "Technical leadership and research" },
   ]} />
 </Section>
 
-### Ian Hogarth (Chair)
+### Ian Hogarth (Former Chair, 2023-2025)
 
 **Background:**
 - Technology entrepreneur and investor

--- a/content/docs/knowledge-base/people/daniela-amodei.mdx
+++ b/content/docs/knowledge-base/people/daniela-amodei.mdx
@@ -76,7 +76,7 @@ As President, Amodei oversees Anthropic's commercial and operational side, which
 | Round | Date | Amount | Lead Investor(s) | Post-Money Valuation |
 |-------|------|--------|-----------------|---------------------|
 | Series A | May 2021 | \$124M | Dustin Moscovitz, <EntityLink id="E577" name="jaan-tallinn">Jaan Tallinn</EntityLink> | ≈\$550M |
-| Series B | Apr 2022 | \$580M | <EntityLink id="E857" name="sam-bankman-fried">Sam Bankman-Fried</EntityLink> / FTX | ≈\$4B |
+| Series B | Apr 2022 | \$580M | Spark Capital | ≈\$4B |
 | Series C | May 2023 | \$450M | Spark Capital; Google first invested | — |
 | Amazon (initial) | Sep 2023 | \$4B | Amazon | — |
 | Amazon (follow-on) | Mar 2024 | \$2.75B | Amazon | — |

--- a/content/docs/knowledge-base/people/dario-amodei.mdx
+++ b/content/docs/knowledge-base/people/dario-amodei.mdx
@@ -52,10 +52,10 @@ His approach emphasizes empirical alignment research on frontier models, <Entity
 | Organization | Role | Period | Key Contributions |
 |--------------|------|--------|-------------------|
 | Google Brain | Research Scientist | 2015–2016 | Language modeling research |
-| <EntityLink id="E218" name="openai">OpenAI</EntityLink> | VP of Research | 2016–2021 | Led GPT-2 and GPT-3 development |
+| <EntityLink id="E218" name="openai">OpenAI</EntityLink> | VP of Research | 2016–2020 | Led GPT-2 and GPT-3 development |
 | <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> | CEO & Co-founder | 2021–present | Constitutional AI, Claude development |
 
-Amodei left <EntityLink id="E218" name="openai">OpenAI</EntityLink> in 2021 alongside his sister <EntityLink id="E90" name="daniela-amodei">Daniela Amodei</EntityLink> and other researchers due to disagreements over commercialization direction and safety governance approaches.
+Amodei left <EntityLink id="E218" name="openai">OpenAI</EntityLink> in December 2020 alongside his sister <EntityLink id="E90" name="daniela-amodei">Daniela Amodei</EntityLink> and other researchers due to disagreements over commercialization direction and safety governance approaches.
 
 ## Core Philosophy: Competitive Safety Development
 
@@ -244,7 +244,7 @@ Anthropic's interpretability team describes its mission as understanding how lar
 
 | Period | Key Developments | View Changes |
 |--------|------------------|--------------|
-| OpenAI Era (2016–2021) | Scaling laws discovery, GPT development | Increased urgency on timelines |
+| OpenAI Era (2016–2020) | Scaling laws discovery, GPT development | Increased urgency on timelines |
 | Early Anthropic (2021–2022) | Constitutional AI development | Greater alignment optimism |
 | Recent (2023–2024) | Claude-3 capabilities, policy engagement | More explicit public risk communication |
 

--- a/content/docs/knowledge-base/people/holden-karnofsky.mdx
+++ b/content/docs/knowledge-base/people/holden-karnofsky.mdx
@@ -19,7 +19,7 @@ import {DataInfoBox, R, EntityLink} from '@components/wiki';
 
 ## Overview
 
-<EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> was co-CEO of <R id="MWExMWE0YT"><EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink></R> (formerly <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink>), the most influential grantmaker in AI safety and existential risk. Through Coefficient, he directed over \$300 million toward AI safety research and governance, fundamentally transforming it from a fringe academic interest into a well-funded field with hundreds of researchers. In 2025, he joined Anthropic.
+<EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> was co-CEO of <R id="MWExMWE0YT"><EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink></R> (formerly Open Philanthropy), the most influential grantmaker in AI safety and existential risk. Through Coefficient, he directed over \$300 million toward AI safety research and governance, fundamentally transforming it from a fringe academic interest into a well-funded field with hundreds of researchers. In 2025, he joined Anthropic.
 
 His strategic thinking has shaped how the effective altruism community prioritizes AI risk through frameworks like the <R id="Zjk2NzY2OT">"Most Important Century"</R> thesis. This argues we may live in the century that determines humanity's entire future trajectory due to transformative AI development.
 
@@ -51,7 +51,7 @@ His strategic thinking has shaped how the effective altruism community prioritiz
 ### Transition to AI Focus (2014-2018)
 
 **Initial AI engagement:**
-- 2014: First significant AI safety grants through Coefficient Giving (now Coefficient Giving)
+- 2014: First significant AI safety grants through Open Philanthropy (now Coefficient Giving)
 - 2016: Major funding to <EntityLink id="E57" name="chai">Center for Human-Compatible AI (CHAI)</EntityLink>
 - 2017: Early <EntityLink id="E218" name="openai">OpenAI</EntityLink> funding (before pivot to for-profit)
 - 2018: Increased conviction leading to AI as top priority

--- a/content/docs/knowledge-base/responses/export-controls.mdx
+++ b/content/docs/knowledge-base/responses/export-controls.mdx
@@ -37,7 +37,7 @@ This page covers **export controls**—one approach within the broader Compute G
 
 ## Overview
 
-The United States has implemented unprecedented export controls on advanced semiconductors and semiconductor manufacturing equipment, primarily targeting China's access to AI-enabling hardware. These controls represent the most significant attempt to constrain AI development through hardware governance, with the Biden administration treating semiconductor exports as a national security priority comparable to nuclear technology controls during the Cold War.
+The United States has implemented unprecedented export controls on advanced semiconductors and semiconductor manufacturing equipment, primarily targeting China's access to AI-enabling hardware. These controls represent the most significant attempt to constrain AI development through hardware governance, with the Biden administration having treated semiconductor exports as a national security priority comparable to nuclear technology controls during the Cold War.
 
 The fundamental logic is straightforward: control access to advanced chips, thereby constraining compute availability, which in turn limits the ability to train and deploy frontier AI systems. Unlike other compute governance approaches that focus on monitoring or triggering regulatory requirements, export controls are inherently restrictive—they aim to completely deny access to certain actors rather than regulate usage. This makes them a blunt but potentially powerful instrument for shaping the global AI landscape.
 
@@ -235,7 +235,7 @@ As CSIS notes, "BIS's limited in-region capacity—there is only a single export
 
 ### Near-Term Outlook (1-2 Years)
 
-Export controls are likely to become more comprehensive and stringent as the Biden administration and Congress view them as a successful policy tool. Additional countries may be added to restrictions, performance thresholds may be lowered further, and new categories of dual-use technology may be controlled. The December 2024 expansion suggests this trajectory will continue regardless of specific Chinese responses.
+Export controls have been trending toward greater comprehensiveness and stringency, with Congress viewing them as a useful policy tool. Additional countries may be added to restrictions, performance thresholds may be lowered further, and new categories of dual-use technology may be controlled. The December 2024 expansion suggests this trajectory will continue regardless of specific Chinese responses.
 
 Chinese circumvention efforts will likely become more sophisticated, with increased use of third-country intermediaries, cloud workarounds, and alternative supply chains. However, the scale of circumvention is unlikely to fully offset the restrictions given the concentrated nature of advanced semiconductor production and US supply chain integration.
 


### PR DESCRIPTION
## Summary

- **govai.mdx**: Reconciled headcount discrepancy — narrative said 15-20 staff but FactBase structured data says 40-45. Updated all three occurrences (summary, organization profile table, comparison table) to match FactBase.
- **export-controls.mdx**: Fixed Biden administration framing from present tense to past tense (Biden left office January 2025). Updated two passages in overview and near-term outlook sections.
- **dario-amodei.mdx**: Fixed OpenAI departure date from "2021" to "December 2020", consistent with daniela-amodei.mdx (which already says December 2020) and Anthropic's founding timeline. Updated career table, narrative text, and timeline table.
- **holden-karnofsky.mdx**: Fixed "formerly Coefficient Giving" to "formerly Open Philanthropy" — Open Philanthropy was the organization's prior name, Coefficient Giving is the current name. Also fixed a 2014 reference that incorrectly used the current name for a historical period.
- **daniela-amodei.mdx**: Fixed Series B lead investor from "Sam Bankman-Fried / FTX" to "Spark Capital" — per the official Anthropic press release (cited in FactBase) and FactBase valuation data. FTX's ~$500M investment was a separate transaction, not the Series B lead.
- **uk-aisi.mdx**: Updated all references to Ian Hogarth from current Chair to former Chair (2023-2025), consistent with entity YAML description and FactBase data. Updated 5 locations: overview narrative, organization table, 2023 activities section, KeyPeople component, and section heading.

## Cross-references verified
- GovAI headcount: FactBase shows 40-45 employees (2025)
- Dario departure: daniela-amodei.mdx says December 2020; Anthropic FactBase shows founded 2021-01 (consistent with late-2020 departure)
- Series B lead: Anthropic FactBase cites official press release showing Spark Capital as lead
- Ian Hogarth: Entity YAML and FactBase both say "former Chair (2023-2025)"

## Note on Ian Hogarth PG data (#3178)
The entity YAML and FactBase data were already correct. The MDX content has been updated. The PostgreSQL personnel table (which drives the /people directory page) still needs its end_date updated — this requires a wiki-server API call or direct DB update, which is outside the scope of this content-only PR.

Closes #3318
Closes #3178

## Test plan
- [x] `pnpm crux w fix escaping` — no issues
- [x] `pnpm crux w fix markdown` — no issues
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
