### PR TITLE
fix: pass currency and unit to range/min formatters in FactBase rendering

### DIFF
--- a/apps/web/src/components/wiki/factbase/format.ts
+++ b/apps/web/src/components/wiki/factbase/format.ts
@@ -125,12 +125,13 @@ export function formatKBFactValue(
     case "refs":
       return v.value.join(", "); // Caller should render as EntityLinks
     case "range": {
-      const lowStr = formatKBNumber(v.low, unit, display);
-      const highStr = formatKBNumber(v.high, unit, display);
+      const rangeUnit = unit ?? v.unit;
+      const lowStr = formatKBNumber(v.low, rangeUnit, display, fact.currency);
+      const highStr = formatKBNumber(v.high, rangeUnit, display, fact.currency);
       return `${lowStr}\u2013${highStr}`;
     }
     case "min":
-      return `\u2265${formatKBNumber(v.value, unit, display)}`;
+      return `\u2265${formatKBNumber(v.value, unit ?? v.unit, display, fact.currency)}`;
     case "json": {
       // Guard: if the JSON value is a nested FactValue object (e.g., malformed YAML
       // `value: {type: number, value: X, unit: USD}`), format it properly instead of

--- a/apps/web/src/lib/__tests__/factbase-format.test.ts
+++ b/apps/web/src/lib/__tests__/factbase-format.test.ts
@@ -149,6 +149,74 @@ describe("formatKBFactValue", () => {
     });
   });
 
+  describe("Bug #3305: range and min values missing currency", () => {
+    it("passes currency to formatKBNumber for range values", () => {
+      const fact: Fact = {
+        id: "test", subjectId: "test", propertyId: "revenue",
+        value: { type: "range", low: 20_000_000_000, high: 26_000_000_000 },
+        currency: "GBP",
+      };
+      const result = formatKBFactValue(fact, "USD");
+      expect(result).toContain("£");
+      expect(result).not.toContain("$");
+    });
+
+    it("passes currency to formatKBNumber for min values", () => {
+      const fact: Fact = {
+        id: "test", subjectId: "test", propertyId: "revenue",
+        value: { type: "min", value: 5_000_000_000 },
+        currency: "GBP",
+      };
+      const result = formatKBFactValue(fact, "USD");
+      expect(result).toContain("£");
+      expect(result).not.toContain("$");
+    });
+
+    it("uses range value own unit when property unit is absent", () => {
+      const fact = makeFact("unknown-prop", { type: "range", low: 1_000_000_000, high: 2_000_000_000, unit: "USD" });
+      const result = formatKBFactValue(fact);
+      expect(result).toContain("$");
+    });
+
+    it("uses min value own unit when property unit is absent", () => {
+      const fact = makeFact("unknown-prop", { type: "min", value: 1_000_000_000, unit: "USD" });
+      const result = formatKBFactValue(fact);
+      expect(result).toContain("$");
+    });
+  });
+
+  describe("Bug #3305: JSON-wrapped nested FactValue objects", () => {
+    it("unwraps nested number from json format", () => {
+      const fact = makeFact("valuation", { type: "json", value: { type: "number", value: 500_000_000_000 } });
+      expect(formatKBFactValue(fact, "USD")).toBe("$500 billion");
+    });
+
+    it("unwraps nested number with unit from json format", () => {
+      const fact = makeFact("valuation", { type: "json", value: { type: "number", value: 500_000_000_000, unit: "USD" } });
+      expect(formatKBFactValue(fact)).toBe("$500 billion");
+    });
+
+    it("unwraps nested text from json format", () => {
+      const fact = makeFact("some-field", { type: "json", value: { type: "text", value: "Hello World" } });
+      expect(formatKBFactValue(fact)).toBe("Hello World");
+    });
+
+    it("unwraps nested boolean from json format", () => {
+      const fact = makeFact("some-bool", { type: "json", value: { type: "boolean", value: true } });
+      expect(formatKBFactValue(fact)).toBe("Yes");
+    });
+
+    it("unwraps nested date from json format", () => {
+      const fact = makeFact("some-date", { type: "json", value: { type: "date", value: "2025-06" } });
+      expect(formatKBFactValue(fact)).toBe("Jun 2025");
+    });
+
+    it("falls back to JSON.stringify for non-FactValue json objects", () => {
+      const fact = makeFact("some-json", { type: "json", value: { foo: "bar", baz: 42 } });
+      expect(formatKBFactValue(fact)).toBe('{"foo":"bar","baz":42}');
+    });
+  });
+
   describe("existing value types are unaffected", () => {
     it("formats boolean facts", () => {
       const fact = makeFact("some-bool", { type: "boolean", value: true });

--- a/content/docs/knowledge-base/people/sam-altman.mdx
+++ b/content/docs/knowledge-base/people/sam-altman.mdx
@@ -20,7 +20,7 @@ import {Mermaid, EntityLink, F} from '@components/wiki';
 | Dimension | Assessment | Evidence |
 |-----------|------------|----------|
 | **Role** | CEO of <EntityLink id="E218" name="openai">OpenAI</EntityLink> | Leading developer of GPT-4, ChatGPT, and frontier AI systems |
-| **Influence Level** | Very High | Oversees company valued at <FBF entity="1LcLlMGLbw" property="valuation" />; ChatGPT reached 100M users faster than any product in history |
+| **Influence Level** | Very High | Oversees company valued at <FBF entity="1LcLlMGLbw" property="valuation">\$500 billion</FBF>; ChatGPT reached 100M users faster than any product in history |
 | **AI Safety Stance** | Moderate/Pragmatic | Signed extinction risk statement; advocates gradual deployment; criticized by safety researchers for prioritizing capabilities |
 | **Timeline Views** | Near-term AGI | "AGI will probably get developed during this president's term" (2024); "superintelligence in a few thousand days" |
 | **Regulatory Position** | Pro-regulation | Called for licensing agency in Senate testimony; supports "thoughtful" government oversight |
@@ -52,7 +52,7 @@ import {Mermaid, EntityLink, F} from '@components/wiki';
 
 ## Overview
 
-<EntityLink id="E269" name="sam-altman">Sam Altman</EntityLink> is the CEO of <EntityLink id="E218" name="openai">OpenAI</EntityLink>, the artificial intelligence company behind ChatGPT, GPT-4, and DALL-E. He has become one of the most influential figures in AI development, navigating the company through its transformation from a nonprofit research lab to a commercial powerhouse valued at over <FBF entity="1LcLlMGLbw" property="valuation" />. His leadership has been marked by both remarkable commercial success and significant controversy, including his brief firing and rapid reinstatement in November 2023.
+<EntityLink id="E269" name="sam-altman">Sam Altman</EntityLink> is the CEO of <EntityLink id="E218" name="openai">OpenAI</EntityLink>, the artificial intelligence company behind ChatGPT, GPT-4, and DALL-E. He has become one of the most influential figures in AI development, navigating the company through its transformation from a nonprofit research lab to a commercial powerhouse valued at over <FBF entity="1LcLlMGLbw" property="valuation">\$500 billion</FBF>. His leadership has been marked by both remarkable commercial success and significant controversy, including his brief firing and rapid reinstatement in November 2023.
 
 Altman's career before OpenAI established him as a prominent Silicon Valley figure. He co-founded the location-based social network Loopt at age 19, became president of Y Combinator at 28, and helped fund hundreds of startups including Airbnb, Stripe, Reddit, and DoorDash. His transition to full-time OpenAI leadership in 2019 marked a pivot from startup investing to direct involvement in AI development.
 


### PR DESCRIPTION
## Summary
- Fix `formatKBFactValue` range case to pass `fact.currency` and fall back to `v.unit` when property unit is absent, preventing raw unformatted numbers like "20000000000-26000000000" on org facts panels
- Fix `formatKBFactValue` min case with the same currency/unit pass-through
- Add children fallback text (`\$500 billion`) to bare `<FBF>` components in `sam-altman.mdx` lines 23 and 55 to prevent potential `[object Object]` rendering
- Add 10 new tests covering range/min currency handling and JSON-wrapped nested FactValue unwrapping

## Test plan
- [x] All 38 factbase-format tests pass (28 existing + 10 new)
- [x] `pnpm build` passes cleanly
- [x] New tests verify GBP currency override renders `£` not `$` for range/min values
- [x] New tests verify range/min values use their own `unit` when property unit is absent
- [x] New tests verify JSON-wrapped nested FactValue objects are properly unwrapped

Closes #3305

🤖 Generated with [Claude Code](https://claude.com/claude-code)