### PR TITLE
feat: add frontmatter to all command definitions

### DIFF
--- a/.claude/commands/agent-init.md
+++ b/.claude/commands/agent-init.md
@@ -1,3 +1,8 @@
+---
+description: Initialize an agent checklist and establish working context. Run at session start.
+effort: low
+---
+
 # Agent Session Start
 
 Initialize an agent checklist and establish working context.

--- a/.claude/commands/agent-next-issue.md
+++ b/.claude/commands/agent-next-issue.md
@@ -1,3 +1,9 @@
+---
+description: Pick up the next highest-priority GitHub issue and start working on it.
+argument-hint: "[issue-number]"
+effort: medium
+---
+
 # Next Issue
 
 Pick up the next highest-priority GitHub issue and start working on it.

--- a/.claude/commands/agent-push-and-verify.md
+++ b/.claude/commands/agent-push-and-verify.md
@@ -1,3 +1,8 @@
+---
+description: Run CI checks locally, push to GitHub, and monitor until green. Fix and retry if anything fails.
+effort: medium
+---
+
 # Ship
 
 Run all CI checks locally, push to GitHub, and monitor until green. Fix and retry if anything fails.

--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -1,3 +1,8 @@
+---
+description: Comprehensive paranoid review of the current branch's changes. Combines diff review with execution-based verification.
+effort: high
+---
+
 # Review PR
 
 Comprehensive paranoid review of the current branch's changes. Combines diff review with execution-based verification.

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -1,3 +1,8 @@
+---
+description: Verify the agent checklist is complete, polish the PR, and ship.
+effort: medium
+---
+
 # Agent Session Ready PR
 
 Verify the agent checklist is complete, polish the PR, and ship.

--- a/.claude/commands/auto-update.md
+++ b/.claude/commands/auto-update.md
@@ -1,3 +1,8 @@
+---
+description: Run the daily wiki auto-update using subscription mode instead of API billing.
+effort: high
+---
+
 # Auto-Update (Subscription Mode)
 
 Run the daily wiki auto-update using Claude Code's subscription instead of API billing.

--- a/.claude/commands/maintain-audit.md
+++ b/.claude/commands/maintain-audit.md
@@ -1,3 +1,8 @@
+---
+description: Strategic review of codebase health, complexity trends, and simplification opportunities.
+effort: medium
+---
+
 # Codebase Audit
 
 Strategic review of codebase health, complexity trends, and simplification opportunities. Produces a written report with concrete recommendations.

--- a/.claude/commands/maintain-pr-patrol.md
+++ b/.claude/commands/maintain-pr-patrol.md
@@ -1,3 +1,8 @@
+---
+description: Scan all open PRs for issues and fix them in priority order.
+effort: medium
+---
+
 # PR Patrol
 
 Scan all open PRs for issues and fix them in priority order. One-shot version of the `pnpm crux gh pr-patrol` daemon.

--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -1,3 +1,9 @@
+---
+description: Systematic adversarial audit of the wiki — finds bugs, broken pages, regressions, data integrity issues.
+argument-hint: "[directories] [--depth=quick|standard|deep|exhaustive]"
+effort: medium
+---
+
 # Adversarial QA Sweep
 
 Systematic adversarial audit of the wiki. Finds bugs, broken pages, regressions, and data integrity issues. Produces a prioritized findings report and files GitHub issues for real bugs.

--- a/.claude/commands/maintain-retrospective.md
+++ b/.claude/commands/maintain-retrospective.md
@@ -1,3 +1,8 @@
+---
+description: Analyze recent PR patterns, session logs, and development process. Produces a process improvements report.
+effort: medium
+---
+
 # Retrospective
 
 Analyze recent PR patterns, session logs, and development process to identify what's working, what's not, and what to change. Produces a written report focused on process improvements.

--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -1,3 +1,8 @@
+---
+description: Prioritized maintenance — review PRs, analyze session logs, triage issues, detect cruft, take action.
+effort: medium
+---
+
 # Maintenance Sweep
 
 Run a prioritized maintenance session: review recent PRs, analyze session logs, triage GitHub issues, detect codebase cruft, and take action.

--- a/.claude/commands/review-entity-deep-dive.md
+++ b/.claude/commands/review-entity-deep-dive.md
@@ -1,3 +1,9 @@
+---
+description: Comprehensive review of a single entity — wiki page, facts, relationships, and overall quality.
+argument-hint: "<entity-slug>"
+effort: high
+---
+
 # Entity Deep Dive
 
 Comprehensive review of a single entity: its wiki page, statements, relationships, and overall quality. Identifies issues and makes improvements.

--- a/.claude/commands/review-knowledge-gap.md
+++ b/.claude/commands/review-knowledge-gap.md
@@ -1,3 +1,9 @@
+---
+description: Identify what's missing from the knowledge base — topics without entities, thin coverage, missing relationships.
+argument-hint: "[focus-area]"
+effort: medium
+---
+
 # Knowledge Gap Analysis
 
 Identify what's missing from the knowledge base: topics without entities, entities without statements, thin coverage areas, and important relationships that don't exist yet.

--- a/.claude/commands/review-ontology.md
+++ b/.claude/commands/review-ontology.md
@@ -1,3 +1,9 @@
+---
+description: Deep analysis of an entity's ontological structure — sub-entities, relationships, statement organization.
+argument-hint: "<entity-slug>"
+effort: medium
+---
+
 # Ontology Review
 
 Deep analysis of an entity's ontological structure: what sub-entities should exist, what relationships are missing, and how statements should be organized. Produces a structured report with actionable recommendations.

--- a/.claude/commands/review-tablebase-enrich.md
+++ b/.claude/commands/review-tablebase-enrich.md
@@ -1,3 +1,8 @@
+---
+description: Enrich structured data (personnel, funding, investments, benchmarks) using subscription mode.
+effort: medium
+---
+
 # TableBase Enrich (Subscription Mode)
 
 Enrich structured data (personnel, funding rounds, investments, benchmarks) using the subscription instead of API billing. Processes up to 5 tasks per invocation.


### PR DESCRIPTION
## Summary

- Adds YAML frontmatter (`effort`, `description`, `argument-hint`) to all 15 commands in `.claude/commands/`
- Uses Claude Code's skill frontmatter support (v2.1.72+) to control model effort per-command
- `effort: low` for mechanical tasks (agent-session-start), `effort: medium` for most commands, `effort: high` for thorough work (review-pr, entity-deep-dive, auto-update)
- Adds `argument-hint` for commands that take arguments (next-issue, qa-sweep, knowledge-gap, ontology-review, entity-deep-dive)

Related discussion: #3330 (RFC: Cloud Scheduled Tasks)

## Test plan

- [x] All 15 command files have valid YAML frontmatter
- [x] Gate check shows no new failures (pre-existing Crux TypeScript and KB schema failures also present on main)
- [x] Skills listing shows updated descriptions and argument hints



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added metadata (description and effort tracking) to internal command documentation files for improved organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->