### PR TITLE
fix: remove duplicate entities and deduplicate directory listings

### DIFF
--- a/apps/web/src/app/investments/page.tsx
+++ b/apps/web/src/app/investments/page.tsx
@@ -31,7 +31,7 @@ interface InvestmentRow {
 export default function InvestmentsPage() {
   const allRecords = getAllKBRecords("investments");
 
-  const rows: InvestmentRow[] = allRecords.map((record) => {
+  const allRows: InvestmentRow[] = allRecords.map((record) => {
     const f = record.fields;
     const company = resolveEntityLink(record.ownerEntityId);
     const investorId =
@@ -53,6 +53,43 @@ export default function InvestmentsPage() {
       role: typeof f.role === "string" ? f.role : null,
     };
   });
+
+  // Deduplicate investment rows. The PG data can contain near-duplicate rows
+  // (e.g., a "YC round" record with a resolved investor entity link and a
+  // "YC batch" record without one). Group by company + investor name
+  // (case-insensitive) + round name, keeping the record with the most data
+  // (prefer linked investor, then higher amount, then more fields).
+  const dedupMap = new Map<string, InvestmentRow>();
+  for (const row of allRows) {
+    const fp = [
+      row.companyName.toLowerCase().trim(),
+      row.investorName.toLowerCase().trim(),
+      (row.roundName ?? "").toLowerCase().trim(),
+    ].join("|");
+
+    const existing = dedupMap.get(fp);
+    if (!existing) {
+      dedupMap.set(fp, row);
+      continue;
+    }
+
+    // Prefer the row with an investor link, then higher amount, then more
+    // non-null fields as a tiebreaker.
+    const score = (r: InvestmentRow) => {
+      let s = 0;
+      if (r.investorHref) s += 100;
+      if (r.companyHref) s += 100;
+      if (r.amount != null) s += 10;
+      if (r.date) s += 1;
+      if (r.instrument) s += 1;
+      if (r.role) s += 1;
+      return s;
+    };
+    if (score(row) > score(existing)) {
+      dedupMap.set(fp, row);
+    }
+  }
+  const rows = Array.from(dedupMap.values());
 
   // Sort by amount descending, then date descending
   rows.sort((a, b) => {

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -117,7 +117,31 @@ async function loadFromApi(): Promise<FetchResult<ProjectsPageData>> {
 
   if (!result.ok) return result;
 
-  const rows = result.data.entities.map(apiEntityToRow);
+  // Deduplicate entities by title. The PG entities table can contain stale
+  // rows where the slug was reassigned — the old row's id is set to its
+  // stableId (a hash-like string) and both the old and new rows appear.
+  // Keep the row with a slug-style id (contains hyphens) over hash-style ids,
+  // or the one with a wikiId, or the first one seen.
+  const seen = new Map<string, DirectoryEntity>();
+  for (const e of result.data.entities) {
+    const key = e.title.toLowerCase().trim();
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, e);
+      continue;
+    }
+    // Prefer slug-style ids (contain hyphens) over hash-style ids
+    const hasSlugId = (ent: DirectoryEntity) => ent.id.includes("-");
+    const hasWikiId = (ent: DirectoryEntity) => ent.wikiId != null;
+    if (
+      (!hasSlugId(existing) && hasSlugId(e)) ||
+      (!hasWikiId(existing) && hasWikiId(e))
+    ) {
+      seen.set(key, e);
+    }
+  }
+
+  const rows = Array.from(seen.values()).map(apiEntityToRow);
   const stats = buildStats(rows);
 
   return { ok: true, data: { rows, stats } };


### PR DESCRIPTION
## Summary

- **#3310 (Projects)**: Add client-side deduplication in the projects directory page API path to filter out stale PG entity entries with hash-style IDs. The entity YAML changes in this PR will trigger the `sync-entities-facts` workflow on merge, which runs the prune step to permanently remove stale entries from PG.
- **#3311 (Investments)**: Add client-side deduplication in the investments page, grouping by company + investor name + round name (case-insensitive) and keeping the record with the most data (linked entity refs, amount, etc.).
- **#3312 (Org duplicates)**: Remove `forethought-foundation` from `coordination-ecosystem.yaml` (duplicate of `forethought` in `organizations.yaml`) and `upenn` from `organizations.yaml` (duplicate of `university-of-pennsylvania` with wikiId E1116). Merge useful tags/description from removed entries into canonical entries.

Closes #3310
Closes #3311
Closes #3312

## Test plan

- [x] `pnpm build` passes (1797 entities, down from 1799)
- [x] `pnpm test` passes (1003 web + 4383 crux tests)
- [x] No broken EntityLink references
- [x] No remaining references to removed entity slugs (`forethought-foundation`, `upenn`)
- [x] Dedup logic in projects page filters by title match, prefers slug-style IDs
- [x] Dedup logic in investments page filters by company+investor+round, prefers linked records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
