### PR TITLE
fix: make gate advisory for infra-dependent checks + dedup funding programs

### DIFF
--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -1330,7 +1330,72 @@ async function cmdSync(dryRun: boolean) {
     );
   }
 
+  // Pre-sync duplicate check: detect (orgId, name) collisions within the batch.
+  // Different idSeeds can generate different IDs for the same program, which
+  // would bypass the server's ON CONFLICT (id) upsert and create duplicates.
+  // The DB has a unique index on (org_id, name) as a safety net, but catching
+  // duplicates here gives a clear error message. See incident #3326.
+  const seen = new Map<string, string>(); // "orgId|name" -> first id
+  const dupes: Array<{ key: string; id1: string; id2: string }> = [];
+  for (const item of items) {
+    const key = `${item.orgId}|${item.name.toLowerCase().trim()}`;
+    const existing = seen.get(key);
+    if (existing) {
+      dupes.push({ key, id1: existing, id2: item.id });
+    } else {
+      seen.set(key, item.id);
+    }
+  }
+  if (dupes.length > 0) {
+    console.error("\nDuplicate (orgId, name) pairs detected in funding programs batch:");
+    for (const d of dupes) {
+      console.error(`  ${d.key}: ids ${d.id1} vs ${d.id2}`);
+    }
+    throw new Error(
+      `${dupes.length} duplicate funding program(s) in batch — fix idSeeds to avoid collisions`
+    );
+  }
+
   console.log(`\nSyncing ${items.length} funding programs to ${serverUrl}...`);
+
+  // Cross-check against existing server records: warn if any item would
+  // create a duplicate (orgId, name) pair with a different ID. The DB
+  // unique index blocks this, but a clear warning prevents confusion.
+  const orgIds = [...new Set(items.map(i => i.orgId))];
+  const existingByKey = new Map<string, string>(); // "orgId|name" -> existing id
+  for (const orgId of orgIds) {
+    const existing = await apiRequest<{ fundingPrograms: Array<{ id: string; orgId: string; name: string }> }>(
+      'GET',
+      `/api/funding-programs/by-org/${encodeURIComponent(orgId)}?limit=500`,
+    ).catch((e: unknown) => {
+      // Non-critical: server-side dedup check is best-effort.
+      // The DB unique index is the authoritative enforcement.
+      console.warn(`  (skipping server dedup check for org ${orgId}: ${e instanceof Error ? e.message : String(e)})`);
+      return null;
+    });
+    if (existing?.ok) {
+      for (const fp of existing.data.fundingPrograms) {
+        existingByKey.set(`${fp.orgId}|${fp.name.toLowerCase().trim()}`, fp.id);
+      }
+    }
+  }
+  if (existingByKey.size > 0) {
+    const conflicts: Array<{ name: string; newId: string; existingId: string }> = [];
+    for (const item of items) {
+      const key = `${item.orgId}|${item.name.toLowerCase().trim()}`;
+      const existingId = existingByKey.get(key);
+      if (existingId && existingId !== item.id) {
+        conflicts.push({ name: item.name, newId: item.id, existingId });
+      }
+    }
+    if (conflicts.length > 0) {
+      console.warn("\n  Warning: funding programs with matching (orgId, name) but different IDs:");
+      for (const c of conflicts) {
+        console.warn(`    "${c.name}": sync id=${c.newId}, existing id=${c.existingId}`);
+      }
+      console.warn("  These will be rejected by the DB unique constraint. Fix the idSeed or delete the old record.\n");
+    }
+  }
 
   if (dryRun) {
     console.log("  (dry run -- no data written)");

--- a/crux/tablebase/dedup.test.ts
+++ b/crux/tablebase/dedup.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the wiki-server client before importing the module under test
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe('dedup', () => {
+  let apiRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const client = await import('../lib/wiki-server/client.ts');
+    apiRequest = vi.mocked(client.apiRequest);
+    apiRequest.mockReset();
+  });
+
+  describe('dedupFundingPrograms', () => {
+    it('filters out candidates that match existing records by orgId + name', async () => {
+      // Mock server response with existing programs
+      apiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          fundingPrograms: [
+            { orgId: 'org1', name: 'AI Safety RFP 2025' },
+            { orgId: 'org1', name: 'Technical Fellowship' },
+          ],
+        },
+      });
+
+      const { dedupFundingPrograms } = await import('./dedup.ts');
+
+      const candidates = [
+        { orgId: 'org1', name: 'AI Safety RFP 2025', programType: 'rfp' },  // duplicate
+        { orgId: 'org1', name: 'New Grant Round', programType: 'grant-round' },  // new
+        { orgId: 'org1', name: 'Technical Fellowship', programType: 'fellowship' },  // duplicate
+      ];
+
+      const result = await dedupFundingPrograms('org1', candidates);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: 'New Grant Round' });
+    });
+
+    it('is case-insensitive for name matching', async () => {
+      apiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          fundingPrograms: [
+            { orgId: 'org1', name: 'AI Safety RFP' },
+          ],
+        },
+      });
+
+      const { dedupFundingPrograms } = await import('./dedup.ts');
+
+      const candidates = [
+        { orgId: 'org1', name: 'ai safety rfp', programType: 'rfp' },  // case-insensitive duplicate
+        { orgId: 'org1', name: 'Different Program', programType: 'grant-round' },
+      ];
+
+      const result = await dedupFundingPrograms('org1', candidates);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: 'Different Program' });
+    });
+
+    it('returns all candidates when server returns no existing records', async () => {
+      apiRequest.mockResolvedValue({
+        ok: true,
+        data: { fundingPrograms: [] },
+      });
+
+      const { dedupFundingPrograms } = await import('./dedup.ts');
+
+      const candidates = [
+        { orgId: 'org1', name: 'New Program 1' },
+        { orgId: 'org1', name: 'New Program 2' },
+      ];
+
+      const result = await dedupFundingPrograms('org1', candidates);
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns all candidates when server is unreachable', async () => {
+      apiRequest.mockResolvedValue({
+        ok: false,
+        message: 'Server unreachable',
+      });
+
+      const { dedupFundingPrograms } = await import('./dedup.ts');
+
+      const candidates = [
+        { orgId: 'org1', name: 'Program A' },
+      ];
+
+      const result = await dedupFundingPrograms('org1', candidates);
+      expect(result).toHaveLength(1);
+    });
+
+    it('trims whitespace in name comparison', async () => {
+      apiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          fundingPrograms: [
+            { orgId: 'org1', name: '  AI Safety RFP  ' },
+          ],
+        },
+      });
+
+      const { dedupFundingPrograms } = await import('./dedup.ts');
+
+      const candidates = [
+        { orgId: 'org1', name: 'AI Safety RFP' },  // matches after trim
+      ];
+
+      const result = await dedupFundingPrograms('org1', candidates);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/crux/tablebase/dedup.ts
+++ b/crux/tablebase/dedup.ts
@@ -33,6 +33,12 @@ interface BenchmarkResultRecord {
   [key: string]: unknown;
 }
 
+interface FundingProgramRecord {
+  orgId: string;
+  name: string;
+  [key: string]: unknown;
+}
+
 interface GrantRecord {
   id: string;
   granteeId?: string | null;
@@ -73,6 +79,14 @@ async function fetchExistingBenchmarkResults(modelId: string): Promise<Benchmark
     `/api/benchmark-results/by-model/${encodeURIComponent(modelId)}?limit=200`,
   );
   return result.ok ? result.data.benchmarkResults : [];
+}
+
+async function fetchExistingFundingPrograms(orgId: string): Promise<FundingProgramRecord[]> {
+  const result = await apiRequest<{ fundingPrograms: FundingProgramRecord[] }>(
+    'GET',
+    `/api/funding-programs/by-org/${encodeURIComponent(orgId)}?limit=500`,
+  );
+  return result.ok ? result.data.fundingPrograms : [];
 }
 
 async function fetchExistingGrantsForOrg(entityId: string): Promise<GrantRecord[]> {
@@ -144,6 +158,20 @@ export async function dedupBenchmarkResults(
   );
   return candidates.filter(
     c => !keys.has(`${normalize(c.benchmarkId)}|${normalize(c.modelId)}`),
+  );
+}
+
+/** Dedup funding programs. Match on orgId + name (case-insensitive). */
+export async function dedupFundingPrograms(
+  orgId: string,
+  candidates: Array<Record<string, unknown>>,
+): Promise<Array<Record<string, unknown>>> {
+  const existing = await fetchExistingFundingPrograms(orgId);
+  const keys = new Set(
+    existing.map(r => `${normalize(r.orgId)}|${normalize(r.name)}`),
+  );
+  return candidates.filter(
+    c => !keys.has(`${normalize(c.orgId)}|${normalize(c.name)}`),
   );
 }
 

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -40,6 +40,7 @@ import { join } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
 import { categorizeFiles, canSkipBuildData, triageGateChecks, type TriageResult } from './gate-triage.ts';
+import { isServerAvailable } from '../lib/wiki-server/client.ts';
 
 /**
  * Find the tsc binary. Prefers the local copy in apps/web/node_modules
@@ -159,6 +160,7 @@ interface Step {
   cwd: string;
   advisory?: boolean; // if true, failure is reported but doesn't block
   emitOutputInCi?: boolean; // print captured output in CI even on success
+  requiresServer?: boolean; // if true, auto-advisory when wiki-server is unreachable
 }
 
 const APP_DIR = `${PROJECT_ROOT}/apps/web`;
@@ -335,19 +337,27 @@ const PARALLEL_STEPS: Step[] = [
   },
   {
     id: 'review-marker',
-    name: 'PR review status',
+    name: 'PR review status (advisory)',
     command: 'npx',
     args: ['tsx', 'crux/validate/validate-review-marker.ts'],
     cwd: PROJECT_ROOT,
-    // Blocking: large PRs (>5 files or >300 lines) must be reviewed via
-    // /agent-review-pr. The check passes immediately for small PRs.
+    // Advisory: the pre-push gate runs before a PR exists, so review status
+    // is not applicable at push time. The /agent-session-ready-PR workflow
+    // enforces /review-pr before shipping — that is the enforcement point.
+    // Making this blocking in the gate caused agents to use --no-verify (#3301).
+    advisory: true,
   },
   {
     id: 'typecheck-crux-baseline',
-    name: 'Crux TypeScript check',
+    name: 'Crux TypeScript check (advisory)',
     command: 'npx',
     args: ['tsx', 'crux/validate/validate-crux-tsc.ts'],
     cwd: PROJECT_ROOT,
+    // Advisory: CI runs this with continue-on-error:true, so the gate
+    // should match. The crux/ codebase has pre-existing type errors from
+    // rapid iteration. Making this blocking locally while advisory in CI
+    // creates a discrepancy that causes agents to use --no-verify (#3301).
+    advisory: true,
   },
   {
     id: 'kb-schema',
@@ -434,6 +444,7 @@ const PARALLEL_STEPS: Step[] = [
     // gracefully when the server is unavailable (fail-open). Promotes to
     // blocking once orphan entities are consistently zero.
     advisory: true,
+    requiresServer: true,
     emitOutputInCi: true,
   },
   {
@@ -446,6 +457,7 @@ const PARALLEL_STEPS: Step[] = [
     // in PG tables (personnel, grants, investments, etc.) that don't resolve
     // to known entities. Informational for now.
     advisory: true,
+    requiresServer: true,
     emitOutputInCi: true,
   },
   {
@@ -457,6 +469,7 @@ const PARALLEL_STEPS: Step[] = [
     // Advisory: depends on wiki-server being reachable. The check skips
     // gracefully when the server is unavailable (fail-open).
     advisory: true,
+    requiresServer: true,
     emitOutputInCi: true,
   },
   {
@@ -480,6 +493,7 @@ const PARALLEL_STEPS: Step[] = [
     // Advisory: depends on wiki-server being reachable. The check skips
     // gracefully when the server is unavailable (fail-open).
     advisory: true,
+    requiresServer: true,
     emitOutputInCi: true,
   },
   {
@@ -492,6 +506,7 @@ const PARALLEL_STEPS: Step[] = [
     // and publicationId fields in the resources table reference valid entities
     // and publications. Informational for now.
     advisory: true,
+    requiresServer: true,
     emitOutputInCi: true,
   },
   {
@@ -802,6 +817,23 @@ async function main(): Promise<void> {
     return;
   }
 
+  // ── Pre-triage: Check wiki-server availability for server-dependent checks ──
+  const hasServerDependentSteps = PARALLEL_STEPS.some(s => s.requiresServer);
+  let serverAvailable = true;
+  if (hasServerDependentSteps && !CI_MODE) {
+    // In CI, the wiki-server is always expected to be available.
+    // Locally, check and skip server-dependent checks if unreachable.
+    try {
+      serverAvailable = await isServerAvailable();
+    } catch {
+      serverAvailable = false;
+    }
+    if (!serverAvailable && !CI_MODE) {
+      const serverSteps = PARALLEL_STEPS.filter(s => s.requiresServer);
+      console.log(`${c.dim}  Wiki-server unreachable — ${serverSteps.length} server-dependent check(s) will be skipped${c.reset}`);
+    }
+  }
+
   // ── Phase 0: Triage — decide which checks to skip ─────────────────────────
   if (!NO_TRIAGE && changedFiles.length > 0) {
     const categories = categorizeFiles(changedFiles);
@@ -816,9 +848,14 @@ async function main(): Promise<void> {
     triageResult = await triageGateChecks(changedFiles, allStepIds, categories);
   }
 
-  // Filter parallel steps based on triage
+  // Filter parallel steps based on triage + server availability
   const skippedStepIds = new Set(triageResult ? Object.keys(triageResult.skip) : []);
-  const activeParallelSteps = PARALLEL_STEPS.filter(s => !skippedStepIds.has(s.id));
+  const activeParallelSteps = PARALLEL_STEPS.filter(s => {
+    if (skippedStepIds.has(s.id)) return false;
+    // Skip server-dependent checks when wiki-server is unreachable (local only)
+    if (s.requiresServer && !serverAvailable && !CI_MODE) return false;
+    return true;
+  });
   const skippedCount = PARALLEL_STEPS.length - activeParallelSteps.length + (skippedBuildData ? 1 : 0);
 
   const totalSteps = (skippedBuildData ? 0 : 1) + (FIX_MODE ? FIX_STEPS.length : 0) + activeParallelSteps.length + (FULL_MODE ? 1 : 0);


### PR DESCRIPTION
## Summary

- **Gate fixes (#3301)**: Made `review-marker` and `typecheck-crux-baseline` advisory (not blocking) in the pre-push gate. `review-marker` blocks pre-push but no PR exists yet at push time; `typecheck-crux-baseline` was blocking locally but advisory in CI (`continue-on-error: true`). Also added `requiresServer` flag to auto-skip wiki-server-dependent checks when the server is unreachable locally.
- **Migration 0142 (#3326 P1)**: Created `0142_dedup_funding_program_unique.sql` handling all 3 duplicate funding_program pairs (the original migration only handled 1). Adds `UNIQUE INDEX ON (org_id, name)` to prevent recurrence. Cosmetic — prod was already fixed manually.
- **Sync pipeline dedup (#3326 P2)**: Added pre-sync duplicate detection to `import-funding-programs sync` (both within-batch collision check and cross-check against existing server records). Added `dedupFundingPrograms` to `crux/tablebase/dedup.ts` with 5 passing tests.

Closes #3301

Also addresses P1/P2 action items from incident #3326.

## Test plan

- [x] 5 new tests for `dedupFundingPrograms` (case-insensitive matching, empty results, server unreachable, whitespace trimming)
- [x] Drizzle journal integrity check passes (143 migrations registered)
- [x] TypeScript compilation clean for all changed files
- [x] Pre-existing test suite unchanged (2 pre-existing failures in scope-flag and rules timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
