### PR TITLE
fix: backport skip_post_deploy_smoke_test from production hotfix

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -18,6 +18,14 @@ on:
         required: false
         type: boolean
         default: false
+      skip_post_deploy_smoke_test:
+        description: >
+          Skip the post-deploy smoke test and automatic rollback. Use during
+          incident recovery when the server is already down and the smoke test
+          would just trigger another rollback cycle.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wiki-server-docker-${{ github.ref }}
@@ -251,6 +259,7 @@ jobs:
           echo "Health status: ${HEALTH_STATUS}"
 
       - name: Post-deploy smoke test
+        if: inputs.skip_post_deploy_smoke_test != true
         id: post-deploy-smoke
         env:
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}


### PR DESCRIPTION
## Summary
Backports the `skip_post_deploy_smoke_test` workflow input from production hotfix #3323 to main. Without this, the next release (main → production) would overwrite the hotfix, removing the ability to skip post-deploy smoke tests during incident recovery.

This must merge before release PR #3337.

## Test plan
- [x] Only adds workflow input + `if` condition — no code changes
- [x] Matches production's version exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)