### PR TITLE
fix: QA sweep P0+P1 fixes — frontend, wiki-server, CLI, data

### DIFF
--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -8,13 +8,18 @@ let resourceStore: Map<string, Record<string, unknown>>;
 let citationStore: Array<{ resource_id: string; page_slug: string; page_id: number; created_at: Date }>;
 
 // Helper: derive the simplified suggest shape from a full resource row.
+// In production, has_content is derived via LEFT JOIN citation_content:
+//   (cc.full_text IS NOT NULL AND length(cc.full_text) > 0) AS has_content
+// Since the mock doesn't model citation_content, we check:
+//   1. An explicit has_content field (set directly by suggest tests), OR
+//   2. content_hash being non-null (proxy for content having been fetched)
 function toSuggestShape(row: Record<string, unknown>): { id: string; url: string; title: string | null; fetched_at: Date | null; has_content: boolean } {
   return {
     id: row.id as string,
     url: row.url as string,
     title: (row.title as string | null) ?? null,
     fetched_at: (row.fetched_at as Date | null) ?? null,
-    has_content: row.has_content === true,
+    has_content: row.has_content === true || (row.content_hash != null && row.content_hash !== ""),
   };
 }
 

--- a/crux/lib/job-handlers/__tests__/claim-verification-redteam.test.ts
+++ b/crux/lib/job-handlers/__tests__/claim-verification-redteam.test.ts
@@ -147,19 +147,13 @@ describe("handleClaimVerification — adversarial inputs", () => {
       baseCtx,
     );
 
-    // The handler should succeed — long strings are passed through to the verdicts endpoint
-    // which validates/truncates via Zod schema
-    expect(result).toBeDefined();
-    if (result.success && result.data.results) {
-      // If verdicts were posted, verify the API was called with the long values
-      const verdictsCall = mockApiRequest.mock.calls.find(
-        (call) => call[1] === '/api/claims/verdicts'
-      );
-      if (verdictsCall) {
-        const postedVerdicts = (verdictsCall[2] as { verdicts: Array<{ reasoning: string }> }).verdicts;
-        expect(postedVerdicts.length).toBeGreaterThan(0);
-      }
-    }
+    // The handler succeeds overall, but the oversized strings (50k chars)
+    // exceed the Zod schema's max(5000) constraint on extracted_value/reasoning,
+    // so the LLM result fails parsing and the claim is marked as an error.
+    expect(result.success).toBe(true);
+    expect(result.data.confirmed).toBe(0);
+    expect(result.data.errors).toBe(1);
+    expect(result.data.totalClaims).toBe(1);
   });
 
   it("handles LLM returning NaN confidence", async () => {


### PR DESCRIPTION
## Summary

Fixes 13 P0/P1 issues identified in the exhaustive QA sweep (2026-03-29). 18 files changed across frontend, wiki-server, CLI, and data layers.

**Frontend (5 fixes):**
- Use `entityStableId` instead of slug for `fetchPgPersonnel` — latent breakage risk (#3363)
- Add `relative` positioning to org-charts "Other" bar segment (#3373)
- Fix legislation stakeholder bar denominator — excluded positions no longer counted
- Add redirect `/benchmarks/humanity-s-last-exam` → `humanitys-last-exam` (#3359)
- Display correct currency symbol (£/€) for non-USD funding programs (#3362)

**Wiki-server (3 fixes):**
- Convert N+1 sync loops to bulk inserts in political-races, website-sources, claims (#3364)
- Add LIMIT 500 to unbounded queries in personnel `/broken` and grants `/by-org-summary` (#3372)
- Remove unused `entityTitleMap` wasted DB query in political-races sync

**CLI (3 fixes):**
- Replace macOS-only `stat -f %m` / `ls` with Node.js `statSync` / `readdirSync` in pr-patrol (#3365)
- Fix validate-review-marker to be fail-closed (`Infinity` fallback instead of `0`) (#3366)
- Add error logging + truncation warnings to all dedup fetch functions (#3367)

**Data (2 fixes):**
- Unquote FLI grant-given YAML values for proper numeric formatting (#3356)
- Remove 4 stale relatedEntry IDs from LTBT and OpenAI Foundation entities
- Add correct `employed-by`/`role` FactBase facts for Daniela Amodei, Jan Leike, Ilya Sutskever, Paul Christiano (#3350)

**Deploy note:** After merge, run `pnpm crux wiki-server sync-facts` against production to push new FactBase facts to PG.

Closes #3350
Closes #3356
Closes #3359
Closes #3362
Closes #3363
Closes #3364
Closes #3365
Closes #3366
Closes #3367
Closes #3372
Closes #3373

## Test plan

- [x] `pnpm build` passes (full Next.js production build)
- [x] `pnpm test` passes (206 tests, 1 pre-existing failure in career-import unrelated to changes)
- [x] New `formatCompactCurrency` tests added for GBP/EUR/unknown currencies
- [ ] Verify ARIA programs show £ on /funding-programs after deploy
- [ ] Verify /benchmarks/humanity-s-last-exam redirects correctly
- [ ] Run `sync-facts` post-deploy and verify /api/people returns updated roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-currency support with correct symbol display across the site.

* **Bug Fixes**
  * Consistent currency formatting in funding program pages and budget tables.
  * Fixed legislation position-summary rendering and improved organization chart segment positioning.
  * Corrected organization market-data lookup and added a permanent redirect for an encoded-apostrophe benchmark URL.

* **Performance**
  * Bulk upserts and capped query results for large sync/endpoints; various backend optimizations.

* **Tests**
  * Added currency-formatting tests and strengthened founder-detection test.

* **Data Updates**
  * Added/adjusted biographical and grant facts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->