### PR TITLE
fix: P0 batch — grants URL filter + sqlInList consolidation

### DIFF
--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { PaginationControls } from "@/components/directory/PaginationControls";
@@ -55,12 +56,35 @@ export function GrantsTable({
   rows: GrantRow[];
   funders: FunderSummary[];
 }) {
-  const [search, setSearch] = useState("");
-  const [funderFilter, setFunderFilter] = useState<string>("all");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
-  const [sortKey, setSortKey] = useState<SortKey>("amount");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [page, setPage] = useState(0);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [search, setSearch] = useState(() => searchParams.get("search") ?? "");
+  const [funderFilter, setFunderFilter] = useState<string>(() => searchParams.get("funder") ?? "all");
+  const [statusFilter, setStatusFilter] = useState<string>(() => searchParams.get("status") ?? "all");
+  const [sortKey, setSortKey] = useState<SortKey>(() => (searchParams.get("sort") as SortKey) || "amount");
+  const [sortDir, setSortDir] = useState<SortDir>(() => (searchParams.get("dir") as SortDir) || "desc");
+  const [page, setPage] = useState(() => {
+    const p = parseInt(searchParams.get("page") ?? "0", 10);
+    return Number.isFinite(p) && p >= 0 ? p : 0;
+  });
+
+  const updateUrl = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === "" || value === "all" || (key === "sort" && value === "amount") || (key === "dir" && value === "desc") || (key === "page" && value === "0")) {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      }
+      const query = params.toString();
+      router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   // Dynamically detect whether status data exists in the dataset.
   // The grant import pipeline currently sets status to null for all PG-sourced
@@ -88,13 +112,17 @@ export function GrantsTable({
   }, [rows]);
 
   const handleSort = (key: SortKey) => {
+    let newDir: SortDir;
     if (sortKey === key) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      newDir = sortDir === "asc" ? "desc" : "asc";
+      setSortDir(newDir);
     } else {
+      newDir = key === "name" || key === "organization" || key === "recipient" || key === "program" ? "asc" : "desc";
       setSortKey(key);
-      setSortDir(key === "name" || key === "organization" || key === "recipient" || key === "program" ? "asc" : "desc");
+      setSortDir(newDir);
     }
     setPage(0);
+    updateUrl({ sort: key, dir: newDir, page: null });
   };
 
   const filtered = useMemo(() => {
@@ -141,6 +169,7 @@ export function GrantsTable({
             onChange={(e) => {
               setSearch(e.target.value);
               setPage(0);
+              updateUrl({ search: e.target.value, page: null });
             }}
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
           />
@@ -152,6 +181,7 @@ export function GrantsTable({
                 onClick={() => {
                   setStatusFilter("all");
                   setPage(0);
+                  updateUrl({ status: null, page: null });
                 }}
                 aria-pressed={statusFilter === "all"}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
@@ -170,8 +200,10 @@ export function GrantsTable({
                   type="button"
                   key={s}
                   onClick={() => {
-                    setStatusFilter(statusFilter === s ? "all" : s);
+                    const next = statusFilter === s ? "all" : s;
+                    setStatusFilter(next);
                     setPage(0);
+                    updateUrl({ status: next, page: null });
                   }}
                   aria-pressed={statusFilter === s}
                   className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
@@ -199,6 +231,7 @@ export function GrantsTable({
               onClick={() => {
                 setFunderFilter("all");
                 setPage(0);
+                updateUrl({ funder: null, page: null });
               }}
               aria-pressed={funderFilter === "all"}
               className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
@@ -217,8 +250,10 @@ export function GrantsTable({
                 type="button"
                 key={f.id}
                 onClick={() => {
-                  setFunderFilter(funderFilter === f.id ? "all" : f.id);
+                  const next = funderFilter === f.id ? "all" : f.id;
+                  setFunderFilter(next);
                   setPage(0);
+                  updateUrl({ funder: next, page: null });
                 }}
                 aria-pressed={funderFilter === f.id}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
@@ -247,7 +282,7 @@ export function GrantsTable({
           pageCount={totalPages}
           totalItems={filtered.length}
           pageSize={PAGE_SIZE}
-          onPageChange={setPage}
+          onPageChange={(p) => { setPage(p); updateUrl({ page: String(p) }); }}
         />
       </div>
 
@@ -400,7 +435,7 @@ export function GrantsTable({
           pageCount={totalPages}
           totalItems={filtered.length}
           pageSize={PAGE_SIZE}
-          onPageChange={setPage}
+          onPageChange={(p) => { setPage(p); updateUrl({ page: String(p) }); }}
         />
       </div>
     </div>

--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllKBRecords, getKBEntity, getKBEntitySlug } from "@/data/factbase";
@@ -211,7 +212,9 @@ export default function GrantsPage() {
 
       {/* Grants table */}
       {totalGrants > 0 ? (
-        <GrantsTable rows={rows} funders={funderSummaries} />
+        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading grants table...</div>}>
+          <GrantsTable rows={rows} funders={funderSummaries} />
+        </Suspense>
       ) : (
         <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
           <p className="text-lg font-medium mb-2">No grants data available</p>

--- a/apps/wiki-server/src/routes/operational/qa-checks.ts
+++ b/apps/wiki-server/src/routes/operational/qa-checks.ts
@@ -8,6 +8,7 @@
 import { Hono } from "hono";
 import { eq, desc, and, sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
+import { sqlInList } from "../shared/query-helpers.js";
 import { qaPageChecks } from "../../schema.js";
 import {
   parseJsonBody,
@@ -54,13 +55,6 @@ const ENTITY_TYPE_TO_DIRECTORY: Record<string, string> = {
   event: "events",
   "research-area": "research-areas",
 };
-
-function sqlInList(values: string[]) {
-  return sql.join(
-    values.map((v) => sql`${v}`),
-    sql`, `,
-  );
-}
 
 const qaChecksApp = new Hono()
   // ---- POST / (record a single check) ----

--- a/apps/wiki-server/src/routes/shared/query-helpers.ts
+++ b/apps/wiki-server/src/routes/shared/query-helpers.ts
@@ -156,6 +156,24 @@ export function parseSort(
   };
 }
 
+/**
+ * Build a parameterized SQL value list for use with `IN (...)`.
+ *
+ * Drizzle's `sql` tag expands JS arrays as row constructors `($1,$2,...)` which
+ * is valid for `IN` but **not** for PostgreSQL `ANY()` (which expects an array
+ * type). Use `IN (${sqlInList(arr)})` instead of `= ANY(${arr})` in raw
+ * `db.execute()` / tagged-template queries.
+ *
+ * Supports string and number arrays. Caller must guard against empty arrays
+ * before calling this function.
+ */
+export function sqlInList(values: (string | number)[]) {
+  return sql.join(
+    values.map((v) => sql`${v}`),
+    sql`, `,
+  );
+}
+
 /** Standard paginated response metadata. */
 export interface PaginationMeta {
   total: number;

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -26,6 +26,7 @@ import {
   buildTrigramFallbackCondition,
   buildTrigramRankExpr,
   parseSort,
+  sqlInList,
   TRIGRAM_FALLBACK_THRESHOLD,
 } from "../shared/query-helpers.js";
 
@@ -126,21 +127,6 @@ const DirectoryQuery = z.object({
 });
 
 // ---- Helpers ----
-
-/**
- * Build a parameterized SQL value list for use with `IN (...)`.
- *
- * Drizzle's `sql` tag expands JS arrays as value-lists `($1,$2,...)` which is
- * a row constructor — valid for `IN` but **not** for PostgreSQL `ANY()` (which
- * expects an array type). Use `IN (${sqlInList(arr)})` instead of
- * `= ANY(${arr})` in raw `db.execute()` queries.
- */
-function sqlInList(values: string[]) {
-  return sql.join(
-    values.map((v) => sql`${v}`),
-    sql`, `,
-  );
-}
 
 /**
  * Auto-clear the `stub` flag from entity metadata when the entity has been

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -19,19 +19,7 @@ import { logAuditEntries } from "./audit-log.js";
 import { InlineVerificationSchema } from "./verification-schema.js";
 import { writeInlineVerdicts, logVerificationCoverage } from "./write-inline-verdicts.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
-
-// ---- Helpers: SQL ----
-
-/**
- * Build a parameterized SQL value list for use with `IN (...)`.
- * See entities.ts for full docs on why ANY() doesn't work with Drizzle sql tag.
- */
-function sqlInList(values: string[]) {
-  return sql.join(
-    values.map((v) => sql`${v}`),
-    sql`, `,
-  );
-}
+import { sqlInList } from "../shared/query-helpers.js";
 
 // ---- Constants ----
 


### PR DESCRIPTION
## Summary
- **#3352 Grants URL funder filter**: All filter state (funder, status, search, sort, pagination) now syncs to URL parameters via `useSearchParams`. Filtered views are shareable and bookmarkable. Added `<Suspense>` wrapper for SSR compatibility.
- **#3007 Drizzle ANY() audit**: Extracted duplicated `sqlInList` helpers from `entities.ts`, `personnel.ts`, and `qa-checks.ts` into shared `query-helpers.ts`. Audited all remaining `= ANY()` patterns — they all use raw postgres.js (not drizzle `sql` tag) and are safe.
- **#3351** was already fixed in a prior commit.

Closes #3352
Closes #3007

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (4485 tests, 0 failures)
- [x] Gate check passes
- [ ] Visit `/grants?funder=<id>` and verify filter is pre-selected
- [ ] Click funder buttons and verify URL updates
- [ ] Share filtered URL and verify it loads with correct filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)