### PR TITLE
fix: include @longterm-wiki/id-utils in wiki-server Docker image

### DIFF
--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -8,12 +8,14 @@ WORKDIR /repo
 # Copy workspace manifests and lockfile first for layer caching
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
+COPY packages/id-utils/package.json ./packages/id-utils/
 
-# Install only wiki-server dependencies
-RUN pnpm install --frozen-lockfile --filter wiki-server
+# Install wiki-server and its workspace dependencies
+RUN pnpm install --frozen-lockfile --filter wiki-server...
 
-# Copy server source
+# Copy server source and workspace packages it depends on
 COPY apps/wiki-server/ ./apps/wiki-server/
+COPY packages/id-utils/ ./packages/id-utils/
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary

- Adds `packages/id-utils/` to the wiki-server Dockerfile
- The sid_ prefix migration (#3402) added `@longterm-wiki/id-utils` as a wiki-server dependency, but the Dockerfile wasn't updated
- Pre-deploy smoke test fails with `Cannot find package '@longterm-wiki/id-utils'`, blocking the production deploy

## Urgency

This is blocking the production deploy of release PR #3409 (30 commits). The smoke test correctly caught this before the broken image reached production.

## Test plan

- [ ] Pre-deploy smoke test passes (wiki-server starts and responds healthy)
- [ ] Production deploy completes via ArgoCD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to optimize workspace dependency management and ensure proper inclusion of required packages in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->