### PR TITLE
release: 2026-03-29 #7

### DIFF
--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -8,12 +8,14 @@ WORKDIR /repo
 # Copy workspace manifests and lockfile first for layer caching
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
+COPY packages/id-utils/package.json ./packages/id-utils/
 
-# Install only wiki-server dependencies
-RUN pnpm install --frozen-lockfile --filter wiki-server
+# Install wiki-server and its workspace dependencies
+RUN pnpm install --frozen-lockfile --filter wiki-server...
 
-# Copy server source
+# Copy server source and workspace packages it depends on
 COPY apps/wiki-server/ ./apps/wiki-server/
+COPY packages/id-utils/ ./packages/id-utils/
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Release 2026-03-29

**2 commits** since last release.

> [!WARNING]
> Production has **12 commits** not on main (hotfixes or merge commits).
> Review carefully to ensure these won't be overwritten.

### Fixes
- fix: include @longterm-wiki/id-utils in wiki-server Docker image

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->

---
[Full diff](https://github.com/quantified-uncertainty/longterm-wiki/compare/production...main)