### PR TITLE
refactor: simplify display name filtering after sid_ prefix migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,9 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - **Internal sidebar**: `apps/web/src/lib/wiki-nav.ts`
 - **GitHub API**: Use `crux gh issues/pr/ci/epic` commands — never raw `curl`
 - **Entity IDs — two tiers**:
-  - **Wiki entities** (orgs, concepts, important people with their own pages): Use `pnpm crux tb ids allocate <slug>` to get a `numericId` (E-number) + `stableId`. These get wiki pages at `/wiki/E<N>`. Only ~200-300 entities should have these.
-  - **TableBase reference records** (paper authors, personnel, minor people): Use `generateId("person:<slug>")` for a `stableId` only. NO `numericId`, no wiki page. Stored in the entities table for directory/personnel use but are lightweight. Use `crux tb ensure-entities` or `crux tb create-entity` for these.
+  - **Wiki entities** (orgs, concepts, important people with their own pages): Use `pnpm crux tb ids allocate <slug>` to get a `numericId` (E-number) + `stableId` (`sid_` prefix, e.g. `sid_1LcLlMGLbw`). These get wiki pages at `/wiki/E<N>`. Only ~200-300 entities should have these.
+  - **TableBase reference records** (paper authors, personnel, minor people): Use `generateId("person:<slug>")` for a `stableId` only (`sid_` prefix). NO `numericId`, no wiki page. Stored in the entities table for directory/personnel use but are lightweight. Use `crux tb ensure-entities` or `crux tb create-entity` for these.
+  - All stableIds use the `sid_` prefix format. Use `isSid()` from `@longterm-wiki/id-utils` to detect them.
   - **Never manually invent IDs** — use the functions above.
 - **Hono RPC**: Mandatory for new wiki-server routes. See `.claude/rules/wiki-server-rpc-migration.md`
 - **Content pages use local data**: Wiki pages read `database.json` — zero runtime API calls. Only internal dashboards make live wiki-server requests.

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -15,32 +15,12 @@ import { createHash } from 'node:crypto';
 // Shared ID detection helpers
 // ---------------------------------------------------------------------------
 
-/** Matches stableIds: exactly 10 alphanumeric chars with at least one uppercase letter.
- * Canonical definition: apps/web/src/lib/stable-id.ts */
-const STABLE_ID_RE = /^(?=.*[A-Z])[A-Za-z0-9]{10}$/;
-/** Matches pure numeric IDs (legacy DB PKs). */
-const NUMERIC_ID_RE = /^\d+$/;
+/** All stableIds use the sid_ prefix. */
+const SID_PREFIX = 'sid_';
 
-/**
- * Detect contaminated stableIds: machine-generated IDs with hyphens/underscores
- * from a legacy import bug. Examples: "D-BpcrbThn", "Tw_Eo226h3".
- * Real slugs are all-lowercase; contaminated IDs have uppercase letters.
- */
-function isContaminatedStableId(s) {
-  if (!s.includes('-') && !s.includes('_')) return false;
-  if (!/[A-Z]/.test(s)) return false;
-  const stripped = s.replace(/[-_]/g, '');
-  if (stripped.length < 8 || stripped.length > 12) return false;
-  if (!/^[A-Za-z0-9]+$/.test(stripped)) return false;
-  return true;
-}
-
-/**
- * Check if a string is a bare machine ID (stableId, numeric PK, or contaminated
- * stableId) that should never be displayed as a human-readable name.
- */
-function isBareMachineId(s) {
-  return STABLE_ID_RE.test(s) || NUMERIC_ID_RE.test(s) || isContaminatedStableId(s);
+/** Check if a string is a sid_-prefixed stableId that should never be displayed. */
+function isSid(s) {
+  return typeof s === 'string' && s.startsWith(SID_PREFIX);
 }
 
 // ---------------------------------------------------------------------------
@@ -786,7 +766,7 @@ function personnelRowToRecordEntry(row) {
   };
   // Embed resolved display name from API JOIN (personnel API returns personResolvedName).
   // Filter out bare stableIds and numeric PKs that aren't human-readable.
-  if (row.personResolvedName && !isBareMachineId(row.personResolvedName)) entry.displayName = row.personResolvedName;
+  if (row.personResolvedName && !isSid(row.personResolvedName)) entry.displayName = row.personResolvedName;
   return entry;
 }
 
@@ -817,7 +797,7 @@ function grantRowToRecordEntry(row) {
   };
   // Embed resolved grantee display name from entity ref.
   // Filter out bare machine IDs that aren't human-readable.
-  if (row.grantee?.name && !isBareMachineId(row.grantee.name)) entry.displayName = row.grantee.name;
+  if (row.grantee?.name && !isSid(row.grantee.name)) entry.displayName = row.grantee.name;
   return entry;
 }
 
@@ -839,8 +819,8 @@ function fundingRoundRowToRecordEntry(row) {
   // even when companyRef.entityId is null (legacy numeric companyId rows).
   // Filter out bare stableIds (10 alphanumeric chars with uppercase) and numeric PKs
   // that leak through as company names — these aren't human-readable.
-  if (row.companyRef?.name && !isBareMachineId(row.companyRef.name)) fields.company_name = row.companyRef.name;
-  else if (row.companyResolvedName && !isBareMachineId(row.companyResolvedName)) fields.company_name = row.companyResolvedName;
+  if (row.companyRef?.name && !isSid(row.companyRef.name)) fields.company_name = row.companyRef.name;
+  else if (row.companyResolvedName && !isSid(row.companyResolvedName)) fields.company_name = row.companyResolvedName;
 
   const entry = {
     key: row.id,
@@ -852,7 +832,7 @@ function fundingRoundRowToRecordEntry(row) {
   };
   // Embed resolved lead investor display name from entity ref.
   // Filter out bare machine IDs that aren't human-readable.
-  if (row.leadInvestorRef?.name && !isBareMachineId(row.leadInvestorRef.name)) entry.displayName = row.leadInvestorRef.name;
+  if (row.leadInvestorRef?.name && !isSid(row.leadInvestorRef.name)) entry.displayName = row.leadInvestorRef.name;
   return entry;
 }
 
@@ -893,7 +873,7 @@ function investmentRowToRecordEntry(row) {
   };
   // Embed resolved investor display name from entity ref.
   // Filter out bare machine IDs that aren't human-readable.
-  if (row.investor?.name && !isBareMachineId(row.investor.name)) entry.displayName = row.investor.name;
+  if (row.investor?.name && !isSid(row.investor.name)) entry.displayName = row.investor.name;
   return entry;
 }
 
@@ -930,7 +910,7 @@ function equityPositionRowToRecordEntry(row) {
   if (row.validEnd) entry.validEnd = row.validEnd;
   // Embed resolved holder display name from entity ref.
   // Filter out bare machine IDs that aren't human-readable.
-  if (row.holder?.name && !isBareMachineId(row.holder.name)) entry.displayName = row.holder.name;
+  if (row.holder?.name && !isSid(row.holder.name)) entry.displayName = row.holder.name;
   return entry;
 }
 

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -10,7 +10,7 @@ import {
   formatKBDate,
   titleCase,
 } from "@/components/wiki/factbase/format";
-import { STABLE_ID_PATTERN, NUMERIC_ID_PATTERN } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 export const metadata: Metadata = {
   title: "Funding Rounds",
@@ -20,11 +20,11 @@ export const metadata: Metadata = {
 
 /**
  * Filter out raw IDs that aren't human-readable names.
- * Returns null for stableIds and numeric PKs so the resolver can handle them.
+ * Returns null for stableIds so the resolver can handle them.
  */
 function filterRawId(name: string | null): string | null {
   if (!name) return null;
-  if (STABLE_ID_PATTERN.test(name) || NUMERIC_ID_PATTERN.test(name)) return null;
+  if (isSid(name)) return null;
   return name;
 }
 

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { resolveOrgBySlug, getOrgSlugs } from "@/app/organizations/org-utils";
 import { resolveSlugAlias } from "@/data/factbase";
 import { getTypedEntityById, getTypedEntityByStableId, getTypedEntities, isOrganization, isProject } from "@/data";
-import { STABLE_ID_PATTERN, NUMERIC_ID_PATTERN } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 import {
   getKBLatest,
   getKBProperty,
@@ -303,10 +303,8 @@ export default async function OrgProfilePage({
         typedPerson = getTypedEntityByStableId(personRef);
       }
       // Build display name: prefer explicit display_name, then resolved title,
-      // then humanized slug. Never display raw stableIds or numeric IDs.
-      const isStableIdVal = STABLE_ID_PATTERN.test(personRef ?? "");
-      const isNumericId = NUMERIC_ID_PATTERN.test(personRef ?? "");
-      const fallbackName = (isStableIdVal || isNumericId)
+      // then humanized slug. Never display raw stableIds.
+      const fallbackName = isSid(personRef)
         ? "Unknown"
         : titleCase(personRef ?? person.key);
       const name =

--- a/apps/web/src/app/organizations/[slug]/people-section.test.ts
+++ b/apps/web/src/app/organizations/[slug]/people-section.test.ts
@@ -100,45 +100,9 @@ describe("pgPersonnelToEntries", () => {
     expect(result.entries[0].name).toBe("Fallback Id");
   });
 
-  it("excludes bare stableId personId and counts as unresolved", () => {
+  it("excludes sid_-prefixed stableId personId and counts as unresolved", () => {
     const row = makeRow({
-      personId: "AbCdEfG12H",
-      person: { entityId: null, slug: null, name: null },
-      personResolvedName: null,
-    });
-
-    const result = pgPersonnelToEntries([row]);
-    expect(result.entries).toHaveLength(0);
-    expect(result.unresolvedCount).toBe(1);
-  });
-
-  it("excludes contaminated stableId personId (with hyphens) and counts as unresolved", () => {
-    const row = makeRow({
-      personId: "D-BpcrbThn",
-      person: { entityId: null, slug: null, name: null },
-      personResolvedName: null,
-    });
-
-    const result = pgPersonnelToEntries([row]);
-    expect(result.entries).toHaveLength(0);
-    expect(result.unresolvedCount).toBe(1);
-  });
-
-  it("excludes contaminated stableId personId (with underscores) and counts as unresolved", () => {
-    const row = makeRow({
-      personId: "Tw_Eo226h3",
-      person: { entityId: null, slug: null, name: null },
-      personResolvedName: null,
-    });
-
-    const result = pgPersonnelToEntries([row]);
-    expect(result.entries).toHaveLength(0);
-    expect(result.unresolvedCount).toBe(1);
-  });
-
-  it("excludes numeric PK personId and counts as unresolved", () => {
-    const row = makeRow({
-      personId: "12345",
+      personId: "sid_AbCdEfG12H",
       person: { entityId: null, slug: null, name: null },
       personResolvedName: null,
     });
@@ -201,24 +165,23 @@ describe("pgPersonnelToEntries", () => {
   it("correctly partitions mixed named and unnamed records", () => {
     const rows = [
       makeRow({ personId: "alice", person: { entityId: "e1", slug: "alice", name: "Alice" } }),
-      makeRow({ personId: "AbCdEfG12H", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
+      makeRow({ personId: "sid_AbCdEfG12H", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
       makeRow({ personId: "bob-jones", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
-      makeRow({ personId: "XyZaBcDe99", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
-      makeRow({ personId: "D-BpcrbThn", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
+      makeRow({ personId: "sid_XyZaBcDe99", person: { entityId: null, slug: null, name: null }, personResolvedName: null }),
     ];
 
     const result = pgPersonnelToEntries(rows);
     expect(result.entries).toHaveLength(2); // Alice + Bob Jones (humanized)
-    expect(result.unresolvedCount).toBe(3); // 2 clean stableIds + 1 contaminated
+    expect(result.unresolvedCount).toBe(2); // 2 stableIds
     expect(result.entries[0].name).toBe("Alice");
     expect(result.entries[1].name).toBe("Bob Jones");
   });
 
   it("rejects stableId in personResolvedName and counts as unresolved", () => {
     const row = makeRow({
-      personId: "AbCdEfG12H",
+      personId: "sid_AbCdEfG12H",
       person: { entityId: null, slug: null, name: null },
-      personResolvedName: "AbCdEfG12H", // stableId leaked into display name
+      personResolvedName: "sid_AbCdEfG12H", // stableId leaked into display name
     });
 
     const result = pgPersonnelToEntries([row]);
@@ -228,21 +191,9 @@ describe("pgPersonnelToEntries", () => {
 
   it("rejects stableId in person.name and counts as unresolved", () => {
     const row = makeRow({
-      personId: "XyZ1234abc",
-      person: { entityId: null, slug: null, name: "XyZ1234abc" }, // stableId as name
+      personId: "sid_XyZ1234abc",
+      person: { entityId: null, slug: null, name: "sid_XyZ1234abc" }, // stableId as name
       personResolvedName: null,
-    });
-
-    const result = pgPersonnelToEntries([row]);
-    expect(result.entries).toHaveLength(0);
-    expect(result.unresolvedCount).toBe(1);
-  });
-
-  it("rejects legacy hyphenated IDs like '8-JZq4lrlD'", () => {
-    const row = makeRow({
-      personId: "cEOljcVT3g",
-      person: { entityId: null, slug: null, name: null },
-      personResolvedName: "8-JZq4lrlD", // legacy bug ID with hyphen
     });
 
     const result = pgPersonnelToEntries([row]);

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -12,7 +12,7 @@ import {
   type RpcPersonnelByEntityResult,
   type RpcPersonnelRow,
 } from "@/lib/wiki-server";
-import { isBareMachineId } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 import { SectionHeader } from "./org-shared";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -62,45 +62,21 @@ export async function fetchPgPersonnel(entityId: string): Promise<RpcPersonnelRo
  * Convert PG personnel rows into PersonEntry format for merging with
  * existing FactBase key-persons and board-seats data.
  */
-/**
- * Check if a string is a displayable person name (not a machine-generated ID).
- * Rejects stableIds (both sid_-prefixed and legacy bare 10-char), numeric PKs,
- * contaminated IDs with hyphens/underscores, and short digit+uppercase strings
- * that look like legacy IDs.
- */
-function isDisplayablePersonName(name: string): boolean {
-  if (isBareMachineId(name)) return false;
-  // Legacy IDs with hyphens from a fixed bug in id.ts (e.g., "8-JZq4lrlD").
-  // Real person names at this length always contain spaces or start with a letter
-  // followed by lowercase — IDs mix digits and uppercase without spaces.
-  if (
-    name.length <= 15 &&
-    !name.includes(" ") &&
-    /\d/.test(name) &&
-    /[A-Z]/.test(name)
-  )
-    return false;
-  return true;
-}
 
 /**
  * Humanize a raw person identifier for display.
- * Returns null for bare stableIds and numeric PKs (not human-readable).
+ * Returns null for sid_-prefixed stableIds (not human-readable).
  * Strips "new:" prefix and converts slug-format IDs to title case.
  */
 function humanizePersonId(raw: string): string | null {
-  if (isBareMachineId(raw)) return null;
+  if (isSid(raw)) return null;
   const cleaned = raw.startsWith("new:") ? raw.slice(4).trim() : raw;
   if (!cleaned) return null;
-  if (isBareMachineId(cleaned)) return null;
+  if (isSid(cleaned)) return null;
   // If it looks like a slug (contains hyphens/underscores), humanize it
   if (cleaned.includes("-") || cleaned.includes("_")) {
-    const humanized = titleCase(cleaned);
-    // Reject if the result still looks like a machine ID
-    if (!isDisplayablePersonName(humanized)) return null;
-    return humanized;
+    return titleCase(cleaned);
   }
-  if (!isDisplayablePersonName(cleaned)) return null;
   return cleaned;
 }
 
@@ -117,19 +93,15 @@ export function pgPersonnelToEntries(rows: RpcPersonnelRow[]): PgPersonnelResult
   for (const row of rows) {
     const personRef = row.person;
     // Name resolution priority:
-    // 1. Structured ref name (from entity JOIN) — validated
-    // 2. Pre-resolved name from API (personResolvedName) — validated
+    // 1. Structured ref name (from entity JOIN) — skip if it's a stableId
+    // 2. Pre-resolved name from API (personResolvedName) — skip if it's a stableId
     // 3. Humanized raw personId (strips new:, converts slug to title case)
-    // 4. Skip — bare stableIds and numeric PKs are not displayable
-    //
-    // Every candidate is checked against isDisplayablePersonName() because
-    // the enrichment pipeline sometimes stores stableIds as personDisplayName,
-    // which then propagates through personResolvedName and personRef.name.
+    // 4. Skip — stableIds are not displayable
     const refName = personRef?.name;
     const resolvedName = row.personResolvedName;
     const name =
-      (refName && isDisplayablePersonName(refName) ? refName : null) ??
-      (resolvedName && isDisplayablePersonName(resolvedName) ? resolvedName : null) ??
+      (refName && !isSid(refName) ? refName : null) ??
+      (resolvedName && !isSid(resolvedName) ? resolvedName : null) ??
       humanizePersonId(row.personId);
 
     if (!name) {

--- a/apps/web/src/lib/__tests__/stable-id.test.ts
+++ b/apps/web/src/lib/__tests__/stable-id.test.ts
@@ -1,127 +1,58 @@
 import { describe, it, expect } from "vitest";
 import {
-  isStableId,
-  isAlphanumeric10,
-  isBareMachineId,
-  isContaminatedStableId,
+  isSid,
+  isAnySid,
+  isLegacyStableId,
 } from "../stable-id";
 
-describe("isContaminatedStableId", () => {
-  // Positive cases — contaminated stableIds from the legacy bug
-  it("detects hyphen-contaminated stableId: D-BpcrbThn", () => {
-    expect(isContaminatedStableId("D-BpcrbThn")).toBe(true);
+describe("isSid", () => {
+  it("detects sid_-prefixed stableIds", () => {
+    expect(isSid("sid_AbCdEfG12H")).toBe(true);
+    expect(isSid("sid_1LcLlMGLbw")).toBe(true);
   });
 
-  it("detects underscore-contaminated stableId: Tw_Eo226h3", () => {
-    expect(isContaminatedStableId("Tw_Eo226h3")).toBe(true);
+  it("rejects strings without sid_ prefix", () => {
+    expect(isSid("AbCdEfG12H")).toBe(false);
+    expect(isSid("tom-brown")).toBe(false);
+    expect(isSid("anthropic")).toBe(false);
+    expect(isSid("12345")).toBe(false);
   });
 
-  it("detects hyphen-contaminated stableId: V-55MuswUh", () => {
-    expect(isContaminatedStableId("V-55MuswUh")).toBe(true);
-  });
-
-  // Negative cases — real slugs should NOT be detected
-  it("does not match all-lowercase slug: tom-brown", () => {
-    expect(isContaminatedStableId("tom-brown")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: employee-equity-pool", () => {
-    expect(isContaminatedStableId("employee-equity-pool")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: jan-leike", () => {
-    expect(isContaminatedStableId("jan-leike")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: series-g-institutional", () => {
-    expect(isContaminatedStableId("series-g-institutional")).toBe(false);
-  });
-
-  it("does not match string without hyphens or underscores", () => {
-    expect(isContaminatedStableId("AbCdEfG12H")).toBe(false);
-  });
-
-  it("does not match very long strings", () => {
-    expect(isContaminatedStableId("A-very-long-mixed-Case-string")).toBe(false);
-  });
-
-  it("does not match very short strings", () => {
-    expect(isContaminatedStableId("A-b")).toBe(false);
-  });
-
-  it("does not match pure lowercase with numbers", () => {
-    expect(isContaminatedStableId("abc-12345")).toBe(false);
+  it("handles null and undefined", () => {
+    expect(isSid(null)).toBe(false);
+    expect(isSid(undefined)).toBe(false);
   });
 });
 
-describe("isBareMachineId", () => {
-  it("catches clean stableIds", () => {
-    expect(isBareMachineId("AbCdEfG12H")).toBe(true);
-    expect(isBareMachineId("3KjUCZCV8w")).toBe(true);
+describe("isAnySid", () => {
+  it("detects sid_-prefixed stableIds", () => {
+    expect(isAnySid("sid_AbCdEfG12H")).toBe(true);
   });
 
-  it("catches numeric PKs", () => {
-    expect(isBareMachineId("335")).toBe(true);
-    expect(isBareMachineId("0")).toBe(true);
+  it("detects legacy bare 10-char stableIds", () => {
+    expect(isAnySid("AbCdEfG12H")).toBe(true);
+    expect(isAnySid("3KjUCZCV8w")).toBe(true);
   });
 
-  it("catches contaminated stableIds", () => {
-    expect(isBareMachineId("D-BpcrbThn")).toBe(true);
-    expect(isBareMachineId("Tw_Eo226h3")).toBe(true);
-    expect(isBareMachineId("V-55MuswUh")).toBe(true);
-  });
-
-  it("does not catch valid slugs", () => {
-    expect(isBareMachineId("tom-brown")).toBe(false);
-    expect(isBareMachineId("anthropic")).toBe(false);
-    expect(isBareMachineId("employee-equity-pool")).toBe(false);
-  });
-
-  it("does NOT catch all-lowercase 10-char words (not machine IDs)", () => {
-    // isBareMachineId uses isStableId (strict: requires uppercase) so that
-    // all-lowercase words like "bioweapons" and "conjecture" are humanized
-    // rather than hidden as Unknown. StableIds always have at least one uppercase letter.
-    expect(isBareMachineId("bioweapons")).toBe(false);
-    expect(isBareMachineId("conjecture")).toBe(false);
-  });
-
-  it("does not catch real slugs with hyphens", () => {
-    expect(isBareMachineId("tom-brown")).toBe(false);
-    expect(isBareMachineId("jan-leike")).toBe(false);
-    expect(isBareMachineId("employee-equity-pool")).toBe(false);
-    expect(isBareMachineId("series-g-institutional")).toBe(false);
+  it("does not match slugs or names", () => {
+    expect(isAnySid("tom-brown")).toBe(false);
+    expect(isAnySid("anthropic")).toBe(false);
+    expect(isAnySid("bioweapons")).toBe(false); // all-lowercase 10-char, no uppercase
   });
 });
 
-describe("isStableId", () => {
-  it("matches standard stableIds", () => {
-    expect(isStableId("AbCdEfG12H")).toBe(true);
-    expect(isStableId("3KjUCZCV8w")).toBe(true);
+describe("isLegacyStableId", () => {
+  it("matches old 10-char alphanumeric IDs with uppercase", () => {
+    expect(isLegacyStableId("AbCdEfG12H")).toBe(true);
+    expect(isLegacyStableId("3KjUCZCV8w")).toBe(true);
   });
 
   it("does not match all-lowercase 10-char strings", () => {
-    expect(isStableId("bioweapons")).toBe(false);
-    expect(isStableId("conjecture")).toBe(false);
+    expect(isLegacyStableId("bioweapons")).toBe(false);
+    expect(isLegacyStableId("conjecture")).toBe(false);
   });
 
-  it("does not match strings with hyphens", () => {
-    expect(isStableId("D-BpcrbThn")).toBe(false);
-  });
-});
-
-describe("isAlphanumeric10", () => {
-  it("matches 10-char alphanumeric strings regardless of case", () => {
-    expect(isAlphanumeric10("AbCdEfG12H")).toBe(true);
-    expect(isAlphanumeric10("bioweapons")).toBe(true);
-    expect(isAlphanumeric10("1234567890")).toBe(true);
-  });
-
-  it("does not match strings with special characters", () => {
-    expect(isAlphanumeric10("D-BpcrbThn")).toBe(false);
-  });
-
-  it("does not match strings of wrong length", () => {
-    expect(isAlphanumeric10("short")).toBe(false);
-    expect(isAlphanumeric10("toolongstring")).toBe(false);
+  it("does not match sid_-prefixed strings", () => {
+    expect(isLegacyStableId("sid_AbCdEfG12H")).toBe(false);
   });
 });

--- a/apps/web/src/lib/resolve-entity-name.ts
+++ b/apps/web/src/lib/resolve-entity-name.ts
@@ -8,7 +8,7 @@
  * 3. TableBase entity lookup (direct slug match)
  * 4. Strip "new:" prefix
  * 5. Humanize slug-format IDs (hyphens/underscores → title case)
- * 6. "Unknown" for bare stableIds and numeric-only IDs
+ * 6. "Unknown" for sid_-prefixed stableIds
  */
 import {
   getKBEntity,
@@ -17,7 +17,7 @@ import {
 import { getTypedEntityById } from "@/data/tablebase";
 import { getEntityHref } from "@/data/entity-nav";
 import { titleCase } from "@/components/wiki/factbase/format";
-import { isBareMachineId } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 /** Build the canonical href for an entity, falling back to /factbase/entity/{id}. */
 function buildEntityHref(slug: string | undefined, entityId: string): string | null {
@@ -57,10 +57,9 @@ export function resolveEntityName(
   displayName?: string | null,
 ): { name: string; href: string | null } {
   // 1. Use embedded displayName if available (from API JOIN)
-  //    But reject bare stableIds, numeric PKs, contaminated IDs, and raw slugs
-  //    that leaked through — these are not human-readable names and should be
-  //    resolved via the full pipeline below (FactBase/TableBase lookups, then
-  //    humanization as a last resort).
+  //    But reject stableIds and raw slugs that leaked through — these are not
+  //    human-readable names and should be resolved via the full pipeline below
+  //    (FactBase/TableBase lookups, then humanization as a last resort).
   //
   //    Also reject displayNames that exactly match the entityId — this indicates
   //    the API couldn't resolve the entity and just echoed the raw ID/slug back.
@@ -73,7 +72,7 @@ export function resolveEntityName(
 
   if (
     trimmedDisplayName &&
-    !isBareMachineId(trimmedDisplayName) &&
+    !isSid(trimmedDisplayName) &&
     !looksLikeSlug(trimmedDisplayName) &&
     !displayNameIsJustEchoedId
   ) {
@@ -120,8 +119,8 @@ export function resolveEntityName(
     };
   }
 
-  // 5. Detect unresolvable machine IDs (stableIds, contaminated stableIds, numeric PKs)
-  if (isBareMachineId(cleanId)) {
+  // 5. Detect unresolvable stableIds
+  if (isSid(cleanId)) {
     return { name: "Unknown", href: null };
   }
 

--- a/apps/web/src/lib/stable-id.ts
+++ b/apps/web/src/lib/stable-id.ts
@@ -1,8 +1,7 @@
 /**
  * Canonical stableId detection — thin re-export from @longterm-wiki/id-utils.
  *
- * This module re-exports the shared ID utilities and adds app-specific helpers
- * (isContaminatedStableId, isBareMachineId) that aren't needed in the core package.
+ * All stableIds use the `sid_` prefix. Use `isSid()` to detect them.
  */
 
 export {
@@ -13,45 +12,3 @@ export {
   STABLE_ID_PATTERN,
   NUMERIC_ID_PATTERN,
 } from "@longterm-wiki/id-utils";
-
-import { NUMERIC_ID_PATTERN } from "@longterm-wiki/id-utils";
-
-/** Check if a string looks like a stableId (strict: requires uppercase). */
-export function isStableId(s: string): boolean {
-  // Delegates to the legacy pattern which requires uppercase
-  return /^(?=.*[A-Z])[A-Za-z0-9]{10}$/.test(s);
-}
-
-/**
- * Check if a string is any 10-char alphanumeric ID (relaxed: no uppercase requirement).
- * Use this for ID lookup/routing contexts where all-lowercase stableIds must also match.
- * Use `isStableId()` for display contexts where you need to distinguish IDs from slugs.
- */
-export function isAlphanumeric10(s: string): boolean {
-  return /^[A-Za-z0-9]{10}$/.test(s);
-}
-
-/** Check if a string is a bare machine ID (stableId or numeric PK) that should never be displayed. */
-export function isBareMachineId(s: string): boolean {
-  return isStableId(s) || NUMERIC_ID_PATTERN.test(s) || isContaminatedStableId(s);
-}
-
-/**
- * Detect "contaminated" stableIds — machine-generated IDs that contain
- * hyphens or underscores due to a legacy bug in crux/lib/grant-import/id.ts
- * (fixed 2026-03-26). Examples: "D-BpcrbThn", "Tw_Eo226h3", "V-55MuswUh".
- *
- * Heuristic: if the string contains at least one uppercase letter and, after
- * stripping hyphens/underscores, is 8-12 alphanumeric chars, it's likely a
- * contaminated stableId rather than a meaningful slug like "tom-brown".
- * Real slugs are all-lowercase by convention.
- */
-export function isContaminatedStableId(s: string): boolean {
-  if (!s.includes("-") && !s.includes("_")) return false;
-  if (!/[A-Z]/.test(s)) return false;
-  const stripped = s.replace(/[-_]/g, "");
-  // 8-12 chars: stableIds are 10 chars, so 10 +/- 2 tolerates one separator being stripped
-  if (stripped.length < 8 || stripped.length > 12) return false;
-  if (!/^[A-Za-z0-9]+$/.test(stripped)) return false;
-  return true;
-}


### PR DESCRIPTION
## Summary
- Replace complex regex-based ID detection (`isBareMachineId`, `isDisplayablePersonName`, `isContaminatedStableId`, `isStableId`, `isAlphanumeric10`) with simple `isSid()` checks now that all stableIds use the `sid_` prefix
- Simplify `people-section.tsx`, `resolve-entity-name.ts`, `page.tsx` (orgs), `funding-rounds/page.tsx`, `wiki-server-data.mjs`, and `stable-id.ts`
- Remove ~210 lines of legacy ID detection code and associated tests
- Update CLAUDE.md to document the `sid_` prefix format for entity IDs

## Test plan
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [x] stable-id.test.ts passes (9 tests)
- [x] people-section.test.ts has pre-existing path alias resolution failure unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)