### PR TITLE
refactor: remove legacy ID detection code after sid_ migration

### DIFF
--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -15,32 +15,15 @@ import { createHash } from 'node:crypto';
 // Shared ID detection helpers
 // ---------------------------------------------------------------------------
 
-/** Matches stableIds: exactly 10 alphanumeric chars with at least one uppercase letter.
- * Canonical definition: apps/web/src/lib/stable-id.ts */
-const STABLE_ID_RE = /^(?=.*[A-Z])[A-Za-z0-9]{10}$/;
-/** Matches pure numeric IDs (legacy DB PKs). */
-const NUMERIC_ID_RE = /^\d+$/;
+/** The prefix for all entity stableIds. */
+const SID_PREFIX = 'sid_';
 
 /**
- * Detect contaminated stableIds: machine-generated IDs with hyphens/underscores
- * from a legacy import bug. Examples: "D-BpcrbThn", "Tw_Eo226h3".
- * Real slugs are all-lowercase; contaminated IDs have uppercase letters.
- */
-function isContaminatedStableId(s) {
-  if (!s.includes('-') && !s.includes('_')) return false;
-  if (!/[A-Z]/.test(s)) return false;
-  const stripped = s.replace(/[-_]/g, '');
-  if (stripped.length < 8 || stripped.length > 12) return false;
-  if (!/^[A-Za-z0-9]+$/.test(stripped)) return false;
-  return true;
-}
-
-/**
- * Check if a string is a bare machine ID (stableId, numeric PK, or contaminated
- * stableId) that should never be displayed as a human-readable name.
+ * Check if a string is a sid_-prefixed stableId that should never be
+ * displayed as a human-readable name.
  */
 function isBareMachineId(s) {
-  return STABLE_ID_RE.test(s) || NUMERIC_ID_RE.test(s) || isContaminatedStableId(s);
+  return typeof s === 'string' && s.startsWith(SID_PREFIX);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -10,7 +10,7 @@ import {
   formatKBDate,
   titleCase,
 } from "@/components/wiki/factbase/format";
-import { STABLE_ID_PATTERN, NUMERIC_ID_PATTERN } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 export const metadata: Metadata = {
   title: "Funding Rounds",
@@ -20,11 +20,11 @@ export const metadata: Metadata = {
 
 /**
  * Filter out raw IDs that aren't human-readable names.
- * Returns null for stableIds and numeric PKs so the resolver can handle them.
+ * Returns null for stableIds so the resolver can handle them.
  */
 function filterRawId(name: string | null): string | null {
   if (!name) return null;
-  if (STABLE_ID_PATTERN.test(name) || NUMERIC_ID_PATTERN.test(name)) return null;
+  if (isSid(name)) return null;
   return name;
 }
 

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { resolveOrgBySlug, getOrgSlugs } from "@/app/organizations/org-utils";
 import { resolveSlugAlias } from "@/data/factbase";
 import { getTypedEntityById, getTypedEntityByStableId, getTypedEntities, isOrganization, isProject } from "@/data";
-import { STABLE_ID_PATTERN, NUMERIC_ID_PATTERN } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 import {
   getKBLatest,
   getKBProperty,
@@ -304,9 +304,8 @@ export default async function OrgProfilePage({
       }
       // Build display name: prefer explicit display_name, then resolved title,
       // then humanized slug. Never display raw stableIds or numeric IDs.
-      const isStableIdVal = STABLE_ID_PATTERN.test(personRef ?? "");
-      const isNumericId = NUMERIC_ID_PATTERN.test(personRef ?? "");
-      const fallbackName = (isStableIdVal || isNumericId)
+      const isMachineId = isSid(personRef ?? "");
+      const fallbackName = isMachineId
         ? "Unknown"
         : titleCase(personRef ?? person.key);
       const name =

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -12,7 +12,7 @@ import {
   type RpcPersonnelByEntityResult,
   type RpcPersonnelRow,
 } from "@/lib/wiki-server";
-import { isBareMachineId } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 import { SectionHeader } from "./org-shared";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -64,23 +64,10 @@ export async function fetchPgPersonnel(entityId: string): Promise<RpcPersonnelRo
  */
 /**
  * Check if a string is a displayable person name (not a machine-generated ID).
- * Rejects stableIds (both sid_-prefixed and legacy bare 10-char), numeric PKs,
- * contaminated IDs with hyphens/underscores, and short digit+uppercase strings
- * that look like legacy IDs.
+ * Rejects sid_-prefixed stableIds.
  */
 function isDisplayablePersonName(name: string): boolean {
-  if (isBareMachineId(name)) return false;
-  // Legacy IDs with hyphens from a fixed bug in id.ts (e.g., "8-JZq4lrlD").
-  // Real person names at this length always contain spaces or start with a letter
-  // followed by lowercase — IDs mix digits and uppercase without spaces.
-  if (
-    name.length <= 15 &&
-    !name.includes(" ") &&
-    /\d/.test(name) &&
-    /[A-Z]/.test(name)
-  )
-    return false;
-  return true;
+  return !isSid(name);
 }
 
 /**
@@ -89,16 +76,13 @@ function isDisplayablePersonName(name: string): boolean {
  * Strips "new:" prefix and converts slug-format IDs to title case.
  */
 function humanizePersonId(raw: string): string | null {
-  if (isBareMachineId(raw)) return null;
+  if (isSid(raw)) return null;
   const cleaned = raw.startsWith("new:") ? raw.slice(4).trim() : raw;
   if (!cleaned) return null;
-  if (isBareMachineId(cleaned)) return null;
+  if (isSid(cleaned)) return null;
   // If it looks like a slug (contains hyphens/underscores), humanize it
   if (cleaned.includes("-") || cleaned.includes("_")) {
-    const humanized = titleCase(cleaned);
-    // Reject if the result still looks like a machine ID
-    if (!isDisplayablePersonName(humanized)) return null;
-    return humanized;
+    return titleCase(cleaned);
   }
   if (!isDisplayablePersonName(cleaned)) return null;
   return cleaned;

--- a/apps/web/src/components/wiki/EntityLink.tsx
+++ b/apps/web/src/components/wiki/EntityLink.tsx
@@ -5,7 +5,7 @@ import { getEntityTypeIcon } from "./EntityTypeIcon";
 import { cn } from "@lib/utils";
 import styles from "./tooltip.module.css";
 import { stripMdxEscapes } from "@lib/inline-markdown";
-import { isAnySid } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 interface EntityLinkProps {
   id: string;
@@ -32,10 +32,10 @@ function formatEntityType(type: string): string {
 }
 
 function formatIdAsTitle(id: string): string {
-  // Detect stableIds (both sid_-prefixed and legacy 10-char alphanumeric)
-  // and wiki IDs (E<number>). These should not be shown as titles since
-  // they are opaque identifiers, not human-readable slugs.
-  if (isAnySid(id) || /^E\d+$/.test(id)) {
+  // Detect stableIds (sid_-prefixed) and wiki IDs (E<number>).
+  // These should not be shown as titles since they are opaque identifiers,
+  // not human-readable slugs.
+  if (isSid(id) || /^E\d+$/.test(id)) {
     return id;
   }
   return id

--- a/apps/web/src/data/entity-nav.ts
+++ b/apps/web/src/data/entity-nav.ts
@@ -4,7 +4,7 @@
 
 import { getTableBase, getIdRegistry, resolveId, getTypedEntityById, getEntityBundle, type BacklinkEntry } from "./tablebase";
 import type { WithSource } from "./tablebase";
-import { isAnySid } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 // ============================================================================
 // DIRECTORY URL RESOLUTION
@@ -61,8 +61,8 @@ export function getEntityHref(id: string, _type?: string): string {
   if (/^E\d+$/.test(id) && registry.byWikiId[id]) {
     return `/wiki/${id}`;
   }
-  // If it's a stableId (sid_-prefixed or legacy 10-char), resolve to slug first, then get wikiId
-  if (isAnySid(id) && registry.byStableId?.[id]) {
+  // If it's a stableId (sid_-prefixed), resolve to slug first, then get wikiId
+  if (isSid(id) && registry.byStableId?.[id]) {
     const slug = registry.byStableId[id];
     const wikiId = registry.bySlug[slug];
     return wikiId ? `/wiki/${wikiId}` : `/wiki/${slug}`;

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -33,7 +33,7 @@ import {
   isPolicy,
 } from "./entity-schemas";
 import type { ValidSubcategory } from "./valid-subcategories";
-import { isAnySid } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 // Re-export for consumers
 export type { WithSource };
@@ -502,8 +502,8 @@ function resolveIdWithoutRegistry(id: string): string {
     const registry = getIdRegistry();
     return registry.byWikiId[id] || id;
   }
-  // StableId: sid_-prefixed or legacy 10-char alphanumeric → slug
-  if (isAnySid(id)) {
+  // StableId: sid_-prefixed → slug
+  if (isSid(id)) {
     const registry = getIdRegistry();
     return registry.byStableId?.[id] || id;
   }
@@ -598,8 +598,8 @@ export function resolveId(id: string): string {
     const registry = getIdRegistry();
     return registry.byWikiId[id] || id;
   }
-  // StableId: sid_-prefixed or legacy 10-char alphanumeric → slug
-  if (isAnySid(id)) {
+  // StableId: sid_-prefixed → slug
+  if (isSid(id)) {
     const registry = getIdRegistry();
     return registry.byStableId?.[id] || id;
   }

--- a/apps/web/src/lib/__tests__/stable-id.test.ts
+++ b/apps/web/src/lib/__tests__/stable-id.test.ts
@@ -1,127 +1,32 @@
 import { describe, it, expect } from "vitest";
-import {
-  isStableId,
-  isAlphanumeric10,
-  isBareMachineId,
-  isContaminatedStableId,
-} from "../stable-id";
+import { isSid, isDisplayableName, SID_PREFIX } from "../stable-id";
 
-describe("isContaminatedStableId", () => {
-  // Positive cases — contaminated stableIds from the legacy bug
-  it("detects hyphen-contaminated stableId: D-BpcrbThn", () => {
-    expect(isContaminatedStableId("D-BpcrbThn")).toBe(true);
+describe("isSid (re-exported from id-utils)", () => {
+  it("detects sid_-prefixed IDs", () => {
+    expect(isSid("sid_1LcLlMGLbw")).toBe(true);
+    expect(isSid("sid_AbCdEfG12H")).toBe(true);
   });
 
-  it("detects underscore-contaminated stableId: Tw_Eo226h3", () => {
-    expect(isContaminatedStableId("Tw_Eo226h3")).toBe(true);
-  });
-
-  it("detects hyphen-contaminated stableId: V-55MuswUh", () => {
-    expect(isContaminatedStableId("V-55MuswUh")).toBe(true);
-  });
-
-  // Negative cases — real slugs should NOT be detected
-  it("does not match all-lowercase slug: tom-brown", () => {
-    expect(isContaminatedStableId("tom-brown")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: employee-equity-pool", () => {
-    expect(isContaminatedStableId("employee-equity-pool")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: jan-leike", () => {
-    expect(isContaminatedStableId("jan-leike")).toBe(false);
-  });
-
-  it("does not match all-lowercase slug: series-g-institutional", () => {
-    expect(isContaminatedStableId("series-g-institutional")).toBe(false);
-  });
-
-  it("does not match string without hyphens or underscores", () => {
-    expect(isContaminatedStableId("AbCdEfG12H")).toBe(false);
-  });
-
-  it("does not match very long strings", () => {
-    expect(isContaminatedStableId("A-very-long-mixed-Case-string")).toBe(false);
-  });
-
-  it("does not match very short strings", () => {
-    expect(isContaminatedStableId("A-b")).toBe(false);
-  });
-
-  it("does not match pure lowercase with numbers", () => {
-    expect(isContaminatedStableId("abc-12345")).toBe(false);
+  it("rejects non-prefixed strings", () => {
+    expect(isSid("1LcLlMGLbw")).toBe(false);
+    expect(isSid("openai")).toBe(false);
+    expect(isSid("AbCdEfG12H")).toBe(false);
   });
 });
 
-describe("isBareMachineId", () => {
-  it("catches clean stableIds", () => {
-    expect(isBareMachineId("AbCdEfG12H")).toBe(true);
-    expect(isBareMachineId("3KjUCZCV8w")).toBe(true);
+describe("isDisplayableName (re-exported from id-utils)", () => {
+  it("accepts human-readable names", () => {
+    expect(isDisplayableName("John Smith")).toBe(true);
+    expect(isDisplayableName("anthropic")).toBe(true);
   });
 
-  it("catches numeric PKs", () => {
-    expect(isBareMachineId("335")).toBe(true);
-    expect(isBareMachineId("0")).toBe(true);
-  });
-
-  it("catches contaminated stableIds", () => {
-    expect(isBareMachineId("D-BpcrbThn")).toBe(true);
-    expect(isBareMachineId("Tw_Eo226h3")).toBe(true);
-    expect(isBareMachineId("V-55MuswUh")).toBe(true);
-  });
-
-  it("does not catch valid slugs", () => {
-    expect(isBareMachineId("tom-brown")).toBe(false);
-    expect(isBareMachineId("anthropic")).toBe(false);
-    expect(isBareMachineId("employee-equity-pool")).toBe(false);
-  });
-
-  it("does NOT catch all-lowercase 10-char words (not machine IDs)", () => {
-    // isBareMachineId uses isStableId (strict: requires uppercase) so that
-    // all-lowercase words like "bioweapons" and "conjecture" are humanized
-    // rather than hidden as Unknown. StableIds always have at least one uppercase letter.
-    expect(isBareMachineId("bioweapons")).toBe(false);
-    expect(isBareMachineId("conjecture")).toBe(false);
-  });
-
-  it("does not catch real slugs with hyphens", () => {
-    expect(isBareMachineId("tom-brown")).toBe(false);
-    expect(isBareMachineId("jan-leike")).toBe(false);
-    expect(isBareMachineId("employee-equity-pool")).toBe(false);
-    expect(isBareMachineId("series-g-institutional")).toBe(false);
+  it("rejects sid_-prefixed IDs", () => {
+    expect(isDisplayableName("sid_1LcLlMGLbw")).toBe(false);
   });
 });
 
-describe("isStableId", () => {
-  it("matches standard stableIds", () => {
-    expect(isStableId("AbCdEfG12H")).toBe(true);
-    expect(isStableId("3KjUCZCV8w")).toBe(true);
-  });
-
-  it("does not match all-lowercase 10-char strings", () => {
-    expect(isStableId("bioweapons")).toBe(false);
-    expect(isStableId("conjecture")).toBe(false);
-  });
-
-  it("does not match strings with hyphens", () => {
-    expect(isStableId("D-BpcrbThn")).toBe(false);
-  });
-});
-
-describe("isAlphanumeric10", () => {
-  it("matches 10-char alphanumeric strings regardless of case", () => {
-    expect(isAlphanumeric10("AbCdEfG12H")).toBe(true);
-    expect(isAlphanumeric10("bioweapons")).toBe(true);
-    expect(isAlphanumeric10("1234567890")).toBe(true);
-  });
-
-  it("does not match strings with special characters", () => {
-    expect(isAlphanumeric10("D-BpcrbThn")).toBe(false);
-  });
-
-  it("does not match strings of wrong length", () => {
-    expect(isAlphanumeric10("short")).toBe(false);
-    expect(isAlphanumeric10("toolongstring")).toBe(false);
+describe("SID_PREFIX", () => {
+  it("is sid_", () => {
+    expect(SID_PREFIX).toBe("sid_");
   });
 });

--- a/apps/web/src/lib/resolve-entity-name.ts
+++ b/apps/web/src/lib/resolve-entity-name.ts
@@ -17,7 +17,7 @@ import {
 import { getTypedEntityById } from "@/data/tablebase";
 import { getEntityHref } from "@/data/entity-nav";
 import { titleCase } from "@/components/wiki/factbase/format";
-import { isBareMachineId } from "@/lib/stable-id";
+import { isSid } from "@/lib/stable-id";
 
 /** Build the canonical href for an entity, falling back to /factbase/entity/{id}. */
 function buildEntityHref(slug: string | undefined, entityId: string): string | null {
@@ -57,10 +57,9 @@ export function resolveEntityName(
   displayName?: string | null,
 ): { name: string; href: string | null } {
   // 1. Use embedded displayName if available (from API JOIN)
-  //    But reject bare stableIds, numeric PKs, contaminated IDs, and raw slugs
-  //    that leaked through — these are not human-readable names and should be
-  //    resolved via the full pipeline below (FactBase/TableBase lookups, then
-  //    humanization as a last resort).
+  //    But reject stableIds and raw slugs that leaked through — these are not
+  //    human-readable names and should be resolved via the full pipeline below
+  //    (FactBase/TableBase lookups, then humanization as a last resort).
   //
   //    Also reject displayNames that exactly match the entityId — this indicates
   //    the API couldn't resolve the entity and just echoed the raw ID/slug back.
@@ -73,7 +72,7 @@ export function resolveEntityName(
 
   if (
     trimmedDisplayName &&
-    !isBareMachineId(trimmedDisplayName) &&
+    !isSid(trimmedDisplayName) &&
     !looksLikeSlug(trimmedDisplayName) &&
     !displayNameIsJustEchoedId
   ) {
@@ -120,8 +119,8 @@ export function resolveEntityName(
     };
   }
 
-  // 5. Detect unresolvable machine IDs (stableIds, contaminated stableIds, numeric PKs)
-  if (isBareMachineId(cleanId)) {
+  // 5. Detect unresolvable machine IDs (sid_-prefixed stableIds)
+  if (isSid(cleanId)) {
     return { name: "Unknown", href: null };
   }
 

--- a/apps/web/src/lib/stable-id.ts
+++ b/apps/web/src/lib/stable-id.ts
@@ -1,57 +1,8 @@
 /**
  * Canonical stableId detection — thin re-export from @longterm-wiki/id-utils.
  *
- * This module re-exports the shared ID utilities and adds app-specific helpers
- * (isContaminatedStableId, isBareMachineId) that aren't needed in the core package.
+ * All entity stableIds now use the `sid_` prefix. Legacy bare 10-char IDs,
+ * contaminated IDs, and numeric PKs are no longer in use.
  */
 
-export {
-  isSid,
-  isDisplayableName,
-  isAnySid,
-  isLegacyStableId,
-  STABLE_ID_PATTERN,
-  NUMERIC_ID_PATTERN,
-} from "@longterm-wiki/id-utils";
-
-import { NUMERIC_ID_PATTERN } from "@longterm-wiki/id-utils";
-
-/** Check if a string looks like a stableId (strict: requires uppercase). */
-export function isStableId(s: string): boolean {
-  // Delegates to the legacy pattern which requires uppercase
-  return /^(?=.*[A-Z])[A-Za-z0-9]{10}$/.test(s);
-}
-
-/**
- * Check if a string is any 10-char alphanumeric ID (relaxed: no uppercase requirement).
- * Use this for ID lookup/routing contexts where all-lowercase stableIds must also match.
- * Use `isStableId()` for display contexts where you need to distinguish IDs from slugs.
- */
-export function isAlphanumeric10(s: string): boolean {
-  return /^[A-Za-z0-9]{10}$/.test(s);
-}
-
-/** Check if a string is a bare machine ID (stableId or numeric PK) that should never be displayed. */
-export function isBareMachineId(s: string): boolean {
-  return isStableId(s) || NUMERIC_ID_PATTERN.test(s) || isContaminatedStableId(s);
-}
-
-/**
- * Detect "contaminated" stableIds — machine-generated IDs that contain
- * hyphens or underscores due to a legacy bug in crux/lib/grant-import/id.ts
- * (fixed 2026-03-26). Examples: "D-BpcrbThn", "Tw_Eo226h3", "V-55MuswUh".
- *
- * Heuristic: if the string contains at least one uppercase letter and, after
- * stripping hyphens/underscores, is 8-12 alphanumeric chars, it's likely a
- * contaminated stableId rather than a meaningful slug like "tom-brown".
- * Real slugs are all-lowercase by convention.
- */
-export function isContaminatedStableId(s: string): boolean {
-  if (!s.includes("-") && !s.includes("_")) return false;
-  if (!/[A-Z]/.test(s)) return false;
-  const stripped = s.replace(/[-_]/g, "");
-  // 8-12 chars: stableIds are 10 chars, so 10 +/- 2 tolerates one separator being stripped
-  if (stripped.length < 8 || stripped.length > 12) return false;
-  if (!/^[A-Za-z0-9]+$/.test(stripped)) return false;
-  return true;
-}
+export { isSid, isDisplayableName, SID_PREFIX } from "@longterm-wiki/id-utils";

--- a/apps/wiki-server/src/__tests__/entity-ref.test.ts
+++ b/apps/wiki-server/src/__tests__/entity-ref.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { formatEntityRef, STABLE_ID_PATTERN } from "../routes/shared/entity-ref.js";
+import { formatEntityRef } from "../routes/shared/entity-ref.js";
 
 describe("formatEntityRef", () => {
   it("returns entity title when available", () => {
-    const ref = formatEntityRef("abc123ABCD", "anthropic", "Anthropic", null, "anthropic");
-    expect(ref).toEqual({ entityId: "abc123ABCD", slug: "anthropic", name: "Anthropic" });
+    const ref = formatEntityRef("sid_abc123ABCD", "anthropic", "Anthropic", null, "anthropic");
+    expect(ref).toEqual({ entityId: "sid_abc123ABCD", slug: "anthropic", name: "Anthropic" });
   });
 
   it("falls back to displayName when no entity title", () => {
-    const ref = formatEntityRef("abc123ABCD", "anthropic", null, "Anthropic PBC", "anthropic");
+    const ref = formatEntityRef("sid_abc123ABCD", "anthropic", null, "Anthropic PBC", "anthropic");
     expect(ref.name).toBe("Anthropic PBC");
   });
 
@@ -17,77 +17,28 @@ describe("formatEntityRef", () => {
     expect(ref.name).toBe("anthropic");
   });
 
-  it("returns null name for stableId-shaped rawId", () => {
-    const ref = formatEntityRef(null, null, null, null, "abc123ABCD");
+  it("returns null name for sid_-prefixed rawId", () => {
+    const ref = formatEntityRef(null, null, null, null, "sid_abc123ABCD");
     expect(ref.name).toBeNull();
   });
 
-  it("returns null name for pure numeric rawId (legacy DB IDs)", () => {
-    const ref = formatEntityRef(null, null, null, null, "175");
-    expect(ref.name).toBeNull();
-  });
-
-  it("returns null name for other numeric IDs", () => {
-    expect(formatEntityRef(null, null, null, null, "265").name).toBeNull();
-    expect(formatEntityRef(null, null, null, null, "335").name).toBeNull();
-    expect(formatEntityRef(null, null, null, null, "0").name).toBeNull();
-    expect(formatEntityRef(null, null, null, null, "999999").name).toBeNull();
-  });
-
-  it("allows alphanumeric rawId that is not a stableId or numeric", () => {
+  it("allows non-sid rawId", () => {
     const ref = formatEntityRef(null, null, null, null, "openai-2024");
     expect(ref.name).toBe("openai-2024");
   });
 
-  it("rejects legacy base64url IDs with hyphens/underscores as names", () => {
-    // These legacy IDs (from a fixed bug in id.ts) should not leak through
-    // as display names. Migration 0141 normalized most, but personnel records
-    // may still contain them as personDisplayName values.
-    expect(formatEntityRef(null, null, null, null, "Tw_Eo226h3").name).toBeNull();
-    expect(formatEntityRef(null, null, null, null, "V-55MuswUh").name).toBeNull();
-  });
-
-  it("rejects stableId in displayName and falls back to rawId", () => {
-    const ref = formatEntityRef(null, null, null, "AbCdEfG12H", "some-org");
+  it("rejects sid_-prefixed displayName and falls back to rawId", () => {
+    const ref = formatEntityRef(null, null, null, "sid_AbCdEfG12H", "some-org");
     expect(ref.name).toBe("some-org");
   });
 
-  it("rejects legacy ID in displayName and returns null when no fallback", () => {
-    const ref = formatEntityRef(null, null, null, "8-JZq4lrlD", null);
+  it("rejects sid_-prefixed displayName and returns null when no fallback", () => {
+    const ref = formatEntityRef(null, null, null, "sid_8JZq4lrlDA", null);
     expect(ref.name).toBeNull();
   });
 
   it("returns all null for no inputs", () => {
     const ref = formatEntityRef(null, null, null, null, null);
     expect(ref).toEqual({ entityId: null, slug: null, name: null });
-  });
-});
-
-describe("STABLE_ID_PATTERN", () => {
-  it("matches 10-char alphanumeric with uppercase", () => {
-    expect(STABLE_ID_PATTERN.test("abc123ABCD")).toBe(true);
-    expect(STABLE_ID_PATTERN.test("AbCdEfGhIj")).toBe(true);
-  });
-
-  it("rejects strings without uppercase", () => {
-    expect(STABLE_ID_PATTERN.test("abcdefghij")).toBe(false);
-  });
-
-  it("rejects wrong length", () => {
-    expect(STABLE_ID_PATTERN.test("abc123ABC")).toBe(false);
-    expect(STABLE_ID_PATTERN.test("abc123ABCDE")).toBe(false);
-  });
-
-  it("rejects numeric-only strings", () => {
-    expect(STABLE_ID_PATTERN.test("1234567890")).toBe(false);
-  });
-
-  it("rejects base64url chars (- and _) in stableIds", () => {
-    // These were produced by a now-fixed bug in crux/lib/grant-import/id.ts.
-    // Migration 0141 normalized all existing contaminated IDs.
-    expect(STABLE_ID_PATTERN.test("Tw_Eo226h3")).toBe(false);
-    expect(STABLE_ID_PATTERN.test("V-55MuswUh")).toBe(false);
-    expect(STABLE_ID_PATTERN.test("FqdVIQLb-I")).toBe(false);
-    expect(STABLE_ID_PATTERN.test("09_v0xRGgS")).toBe(false);
   });
 });

--- a/apps/wiki-server/src/routes/shared/entity-ref.ts
+++ b/apps/wiki-server/src/routes/shared/entity-ref.ts
@@ -5,18 +5,11 @@
  * so the frontend always has slug (for URLs) and name (for display) — never bare stableIds.
  */
 
-import {
-  isAnySid,
-  STABLE_ID_PATTERN,
-  NUMERIC_ID_PATTERN,
-} from "@longterm-wiki/id-utils";
-
-// Re-export for consumers that import STABLE_ID_PATTERN from this module
-export { STABLE_ID_PATTERN };
+import { isSid } from "@longterm-wiki/id-utils";
 
 /** Structured entity reference in API responses. */
 export interface EntityRef {
-  /** Entity stableId (10-char alphanumeric), null if unresolved */
+  /** Entity stableId (sid_-prefixed), null if unresolved */
   entityId: string | null;
   /** Entity slug (URL-friendly), null if entity not found in DB */
   slug: string | null;
@@ -41,17 +34,11 @@ export function formatEntityRef(
   rawId: string | null,
 ): EntityRef {
   // Name priority: entity title > display name > raw ID (if not a bare machine ID)
-  // Skip bare stableIds (both new sid_ and legacy), numeric database PKs, and legacy IDs with hyphens
-  const isId = (s: string) => {
-    if (isAnySid(s) || NUMERIC_ID_PATTERN.test(s)) return true;
-    // Legacy IDs with hyphens/underscores (e.g., "8-JZq4lrlD", "Tw_Eo226h3")
-    if (s.length >= 8 && s.length <= 12 && /[_-]/.test(s) && /\d/.test(s) && /[A-Z]/.test(s) && !s.includes(" ")) return true;
-    return false;
-  };
+  // Skip sid_-prefixed stableIds
   const name =
     entityTitle ??
-    (displayName && !isId(displayName) ? displayName : null) ??
-    (rawId && !isId(rawId) ? rawId : null);
+    (displayName && !isSid(displayName) ? displayName : null) ??
+    (rawId && !isSid(rawId) ? rawId : null);
 
   return {
     entityId: entityId ?? null,

--- a/apps/wiki-server/src/routes/shared/query-helpers.ts
+++ b/apps/wiki-server/src/routes/shared/query-helpers.ts
@@ -11,7 +11,7 @@ import type { PgColumn } from "drizzle-orm/pg-core";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { escapeIlike } from "./utils.js";
 import { entities } from "../../schema.js";
-import { STABLE_ID_PATTERN } from "./entity-ref.js";
+import { isSid } from "@longterm-wiki/id-utils";
 import {
   buildPrefixTsquery,
   normalizeSearchQuery,
@@ -192,8 +192,8 @@ export async function resolveEntityStableId(
   db: PostgresJsDatabase<any>,
   entityId: string,
 ): Promise<string> {
-  // StableIds are exactly 10 alphanumeric chars with at least one uppercase
-  if (STABLE_ID_PATTERN.test(entityId)) return entityId;
+  // StableIds have the sid_ prefix
+  if (isSid(entityId)) return entityId;
   // Looks like a slug — try to resolve
   const [entity] = await db
     .select({ stableId: entities.stableId })

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -28,7 +28,7 @@ import { sqlInList } from "../shared/query-helpers.js";
 const MAX_PAGE_SIZE = 200;
 const VALID_ROLE_TYPES = ["key-person", "board", "career"] as const;
 
-import { STABLE_ID_PATTERN } from "../shared/entity-ref.js";
+import { isSid } from "@longterm-wiki/id-utils";
 
 // ---- Query schemas ----
 
@@ -81,7 +81,7 @@ const SyncPersonnelBatchSchema = z.object({
 /** Clean a raw personId for display: strip "new:" prefix, hide bare stableIds. */
 function cleanPersonId(pid: string): string | null {
   if (pid.startsWith("new:")) return pid.slice(4).trim();
-  if (STABLE_ID_PATTERN.test(pid)) return null;
+  if (isSid(pid)) return null;
   return pid;
 }
 
@@ -288,7 +288,7 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
       let issueType: string;
       if (p.personId.startsWith("new:")) {
         issueType = "new-prefix";
-      } else if (STABLE_ID_PATTERN.test(p.personId)) {
+      } else if (isSid(p.personId)) {
         issueType = "unresolved-stableId";
       } else if (!p.personEntityId) {
         issueType = "no-entity-match";

--- a/crux/scripts/cleanup-personnel.ts
+++ b/crux/scripts/cleanup-personnel.ts
@@ -12,12 +12,10 @@
  */
 
 import { apiRequest } from '../lib/wiki-server/client.ts';
-import { isAnySid, NUMERIC_ID_PATTERN } from '../../packages/id-utils/src/index.ts';
-
-const LEGACY_ID_RE = /^[A-Za-z0-9][_-][A-Za-z0-9_-]{7,10}$/;
+import { isSid } from '../../packages/id-utils/src/index.ts';
 
 function isMachineId(s: string): boolean {
-  return isAnySid(s) || NUMERIC_ID_PATTERN.test(s) || LEGACY_ID_RE.test(s);
+  return isSid(s);
 }
 
 interface PersonnelRecord {

--- a/crux/validate/validate-display-names.ts
+++ b/crux/validate/validate-display-names.ts
@@ -20,7 +20,7 @@ import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
 import { getColors } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
-import { isLegacyStableId } from '../../packages/id-utils/src/index.ts';
+import { isSid } from '../../packages/id-utils/src/index.ts';
 
 const ENTITIES_DIR = join(PROJECT_ROOT, 'data/entities');
 
@@ -33,21 +33,11 @@ export interface DisplayNameViolation {
 }
 
 /**
- * Check if a string looks like a stableId (machine-generated 10-char ID).
- * Uses isLegacyStableId from id-utils for the base 10-char pattern check,
- * then adds heuristics requiring mixed case + digits to avoid false positives
- * on short real names like "Washington" or "Regulation".
+ * Check if a string looks like a stableId (sid_-prefixed machine-generated ID).
+ * All stableIds now use the sid_ prefix, so this is a simple prefix check.
  */
 export function looksLikeStableId(value: string): boolean {
-  if (!isLegacyStableId(value)) return false;
-  // Must contain at least one uppercase AND one lowercase letter
-  // to distinguish from real words like "Washington" or "Pythonista"
-  const hasUpper = /[A-Z]/.test(value);
-  const hasLower = /[a-z]/.test(value);
-  const hasDigit = /[0-9]/.test(value);
-  // A stableId typically has digits mixed in; pure alphabetic 10-char strings
-  // are more likely to be real words (e.g., "Regulation")
-  return hasUpper && hasLower && hasDigit;
+  return isSid(value);
 }
 
 /**

--- a/crux/validate/validate-soft-fks.ts
+++ b/crux/validate/validate-soft-fks.ts
@@ -23,7 +23,7 @@ import {
   apiRequest,
   type ApiResult,
 } from "../lib/wiki-server/client.ts";
-import { STABLE_ID_PATTERN } from '../../packages/id-utils/src/index.ts';
+import { isSid } from '../../packages/id-utils/src/index.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -378,7 +378,7 @@ export async function validateTable(
 
       // If it looks like a stableId pattern but didn't resolve, it's dangling
       // If it looks like a display name, it's a softer issue but still unresolved
-      const isStableIdLike = STABLE_ID_PATTERN.test(strValue);
+      const isStableIdLike = isSid(strValue);
       const isDisplayNameVal = isDisplayName(strValue);
 
       // Count as unresolved if:
@@ -556,13 +556,13 @@ export async function runValidation(opts: {
     // Print unresolved details
     const allUnresolved = allStats.flatMap((s) => s.unresolvedList);
     const danglingFks = allUnresolved.filter(
-      (u) => STABLE_ID_PATTERN.test(u.value)
+      (u) => isSid(u.value)
     );
     const displayNames = allUnresolved.filter(
-      (u) => isDisplayName(u.value) && !STABLE_ID_PATTERN.test(u.value)
+      (u) => isDisplayName(u.value) && !isSid(u.value)
     );
     const slugLike = allUnresolved.filter(
-      (u) => !STABLE_ID_PATTERN.test(u.value) && !isDisplayName(u.value)
+      (u) => !isSid(u.value) && !isDisplayName(u.value)
     );
 
     if (danglingFks.length > 0) {

--- a/packages/id-utils/src/index.ts
+++ b/packages/id-utils/src/index.ts
@@ -5,13 +5,9 @@
  * This makes them trivially distinguishable from slugs, names, and other strings.
  *
  * The entire ID detection API is:
- *   isSid(s)           — is this a sid_-prefixed entity stableId?
+ *   isSid(s)             — is this a sid_-prefixed entity stableId?
  *   isDisplayableName(s) — is this safe to show to users? (inverse of isSid)
- *   generateSid()      — create a new sid_-prefixed stableId
- *
- * Legacy support (for migration period only):
- *   isLegacyStableId(s) — detects old bare 10-char IDs without sid_ prefix
- *   isAnySid(s)         — detects both new (sid_) and legacy (bare) formats
+ *   generateSid()        — create a new sid_-prefixed stableId
  */
 
 import { randomBytes } from "crypto";
@@ -41,38 +37,6 @@ export function isDisplayableName(s: string | null | undefined): boolean {
 export function generateSid(): string {
   return SID_PREFIX + randomAlphanumeric10();
 }
-
-// ── Legacy Support (migration period) ──────────────────────────────────
-
-/**
- * Detects old-format bare 10-char alphanumeric stableIds (without sid_ prefix).
- * Requires at least one uppercase letter to avoid false positives on 10-char
- * lowercase slugs like "bioweapons" or "conjecture".
- * Use during migration period only. After migration completes, this can be removed.
- */
-export function isLegacyStableId(s: string | null | undefined): boolean {
-  return typeof s === "string" && /^(?=.*[A-Z])[A-Za-z0-9]{10}$/.test(s);
-}
-
-/**
- * Detects stableIds in either new (sid_) or legacy (bare 10-char) format.
- * Use during migration period for code that needs to handle both.
- */
-export function isAnySid(s: string | null | undefined): boolean {
-  return isSid(s) || isLegacyStableId(s);
-}
-
-/**
- * Legacy patterns — exported for backward compatibility during migration.
- * Prefer isSid() for new code.
- * @deprecated Use isSid() instead
- */
-export const STABLE_ID_PATTERN = /^(?=.*[A-Z])[A-Za-z0-9]{10}$/;
-
-/**
- * @deprecated Use isSid() instead — numeric PKs will be migrated away
- */
-export const NUMERIC_ID_PATTERN = /^\d+$/;
 
 // ── Internal ───────────────────────────────────────────────────────────
 

--- a/packages/id-utils/tests/index.test.ts
+++ b/packages/id-utils/tests/index.test.ts
@@ -4,8 +4,6 @@ import {
   isSid,
   isDisplayableName,
   generateSid,
-  isLegacyStableId,
-  isAnySid,
 } from "../src/index.js";
 
 describe("isSid", () => {
@@ -88,53 +86,6 @@ describe("generateSid", () => {
   });
 });
 
-describe("isLegacyStableId", () => {
-  it("detects bare 10-char alphanumeric IDs with uppercase", () => {
-    expect(isLegacyStableId("1LcLlMGLbw")).toBe(true);
-    expect(isLegacyStableId("AbCdEfG12H")).toBe(true);
-  });
-
-  it("rejects all-lowercase 10-char strings (could be slugs)", () => {
-    expect(isLegacyStableId("bioweapons")).toBe(false);
-    expect(isLegacyStableId("conjecture")).toBe(false);
-    expect(isLegacyStableId("abcdefghij")).toBe(false);
-  });
-
-  it("rejects all-numeric 10-char strings", () => {
-    expect(isLegacyStableId("0123456789")).toBe(false);
-  });
-
-  it("rejects wrong lengths", () => {
-    expect(isLegacyStableId("abc123ABC")).toBe(false);
-    expect(isLegacyStableId("abc123ABCDE")).toBe(false);
-  });
-
-  it("rejects non-alphanumeric", () => {
-    expect(isLegacyStableId("abc-123ABC")).toBe(false);
-    expect(isLegacyStableId("abc_123ABC")).toBe(false);
-  });
-
-  it("rejects sid_-prefixed (those are new format)", () => {
-    expect(isLegacyStableId("sid_1LcLlM")).toBe(false);
-  });
-});
-
-describe("isAnySid", () => {
-  it("detects new format", () => {
-    expect(isAnySid("sid_1LcLlMGLbw")).toBe(true);
-  });
-
-  it("detects legacy format", () => {
-    expect(isAnySid("1LcLlMGLbw")).toBe(true);
-  });
-
-  it("rejects non-IDs", () => {
-    expect(isAnySid("openai")).toBe(false);
-    expect(isAnySid("John Smith")).toBe(false);
-    expect(isAnySid("openai-2024")).toBe(false);
-  });
-});
-
 describe("null/undefined safety", () => {
   it("isSid returns false for non-string values", () => {
     expect(isSid(undefined)).toBe(false);
@@ -144,10 +95,5 @@ describe("null/undefined safety", () => {
   it("isDisplayableName returns false for non-string values", () => {
     expect(isDisplayableName(undefined)).toBe(false);
     expect(isDisplayableName(null)).toBe(false);
-  });
-
-  it("isAnySid returns false for non-string values", () => {
-    expect(isAnySid(undefined)).toBe(false);
-    expect(isAnySid(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Remove all legacy ID detection functions from `packages/id-utils` (`isLegacyStableId`, `isAnySid`, `STABLE_ID_PATTERN`, `NUMERIC_ID_PATTERN`) — the `sid_` prefix migration is complete and these are no longer needed
- Simplify `apps/web/src/lib/stable-id.ts` to only re-export `isSid`, `isDisplayableName`, `SID_PREFIX` — removed `isStableId`, `isAlphanumeric10`, `isBareMachineId`, `isContaminatedStableId`
- Update 15 consumer files across `apps/web/`, `apps/wiki-server/`, and `crux/` to use `isSid()` instead of the removed functions

Net change: -343 lines across 19 files.

## Test plan

- [x] `packages/id-utils` tests pass (15 tests)
- [x] `apps/web/src/lib/__tests__/stable-id.test.ts` passes (5 tests)
- [x] `apps/wiki-server/src/__tests__/entity-ref.test.ts` passes (8 tests)
- [x] `apps/web` TypeScript check passes (`npx tsc --noEmit`)
- [x] `apps/wiki-server` TypeScript check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)