### PR TITLE
fix: research area entity lists + deduplicate escapeXml

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -51,6 +51,7 @@ import {
   fetchAssessments,
   fetchBenchmarkResults,
   fetchResearchAreas,
+  fetchResearchAreaDetails,
   fetchRecordVerdicts,
   // fetchFactBaseFromServer — available but not yet wired as default (PG-primary prep)
   fetchPolicyStakeholderIds,
@@ -666,6 +667,10 @@ async function main() {
     database.researchAreas = researchAreasData;
     database.recordVerdicts = recordVerdicts;
     assessmentMap = assessments;
+
+    // Fetch detail data (orgs, papers, grants) for each research area
+    const areaIds = researchAreasData.map(a => a.id);
+    database.researchAreaDetails = await fetchResearchAreaDetails(areaIds);
   }
 
   // Build URL → resource map for unconverted link detection

--- a/apps/web/scripts/lib/output-writer.mjs
+++ b/apps/web/scripts/lib/output-writer.mjs
@@ -41,6 +41,7 @@ export function writeMainOutputFiles({ database, outputFile }) {
     recordVerdicts: _recordVerdicts,
     kbFactVerification: _kbFactVerification,
     researchAreas: _researchAreas,
+    researchAreaDetails: _researchAreaDetails,
     pageReferenceIndex: _pageReferenceIndex,
     // Phase 2: Operational/internal-only data (dashboards use wiki-server API)
     prItems: _prItems,
@@ -82,7 +83,7 @@ export function writeMainOutputFiles({ database, outputFile }) {
   writeFileSync(outputFile, JSON.stringify(databaseForOutput, null, 2));
   const strippedKeys = [
     'benchmarkResults', 'citationQuotes', 'recordVerdicts', 'kbFactVerification',
-    'researchAreas', 'pageReferenceIndex', 'prItems', 'updateSchedule',
+    'researchAreas', 'researchAreaDetails', 'pageReferenceIndex', 'prItems', 'updateSchedule',
     'redundancyPairs', 'backlinks', 'relatedGraph', 'resources',
   ];
   console.log(`\n✓ Written: ${outputFile} (stripped: entities, KB, experts, ${strippedKeys.join(', ')})`);
@@ -102,6 +103,7 @@ export function writeMainOutputFiles({ database, outputFile }) {
   const LAZY_FILES = [
     { key: '_benchmarkResults', varRef: _benchmarkResults, name: 'benchmark-results.json', label: 'benchmark results' },
     { key: '_researchAreas', varRef: _researchAreas, name: 'research-areas.json', label: 'research areas' },
+    { key: '_researchAreaDetails', varRef: _researchAreaDetails, name: 'research-area-details.json', label: 'research area details' },
     { key: '_recordVerdicts', varRef: _recordVerdicts, name: 'record-verdicts.json', label: 'record verdicts' },
     { key: '_kbFactVerification', varRef: _kbFactVerification, name: 'kb-fact-verification.json', label: 'KB fact verifications' },
   ];

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -495,6 +495,58 @@ export async function fetchResearchAreas() {
 }
 
 /**
+ * Fetch detail data (organizations, papers, grants, fundingByOrg) for each
+ * research area. Returns a map keyed by area ID.
+ *
+ * This replaces the ISR-based per-page fetch that was unreliable during builds.
+ */
+export async function fetchResearchAreaDetails(areaIds) {
+  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  if (!serverUrl || areaIds.length === 0) {
+    console.log('  research-area-details: skipped (no server or no areas)');
+    return {};
+  }
+
+  const headers = buildHeaders();
+  const details = {};
+  let fetched = 0;
+  let failed = 0;
+
+  // Fetch in parallel with a concurrency limit of 10
+  const CONCURRENCY = 10;
+  for (let i = 0; i < areaIds.length; i += CONCURRENCY) {
+    const batch = areaIds.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(async (id) => {
+        const resp = await fetch(`${serverUrl}/api/research-areas/${id}`, {
+          headers,
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        return { id, data: await resp.json() };
+      })
+    );
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        const { id, data } = result.value;
+        details[id] = {
+          organizations: data.organizations ?? [],
+          papers: data.papers ?? [],
+          grants: data.grants ?? [],
+          fundingByOrg: data.fundingByOrg ?? [],
+        };
+        fetched++;
+      } else {
+        failed++;
+      }
+    }
+  }
+
+  console.log(`  research-area-details: ${fetched} fetched, ${failed} failed`);
+  return details;
+}
+
+/**
  * Fetch verification verdicts from wiki-server (unified verification system).
  * Returns a map keyed by "recordType:recordId" -> verdict info.
  */

--- a/apps/web/src/app/research-areas/[slug]/page.tsx
+++ b/apps/web/src/app/research-areas/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getResearchAreasFromPG, getTypedEntityById } from "@/data/tablebase";
+import { getResearchAreasFromPG, getTypedEntityById, getResearchAreaDetail } from "@/data/tablebase";
 import { getEntityHref } from "@/data/entity-nav";
 import {
   CLUSTER_COLORS,
@@ -9,53 +9,6 @@ import {
   formatCluster,
   formatFunding,
 } from "../research-area-constants";
-import { fetchFromWikiServer } from "@/lib/wiki-server";
-
-// ---------------------------------------------------------------------------
-// Types for the enriched detail response from wiki-server
-// ---------------------------------------------------------------------------
-
-interface AreaDetailGrant {
-  id: string;
-  name: string;
-  amount: number | null;
-  date: string | null;
-  organizationId: string;
-  granteeId: string | null;
-  confidence: number | null;
-}
-
-interface AreaDetailFundingByOrg {
-  organizationId: string;
-  grantCount: number;
-  totalAmount: string;
-}
-
-interface AreaDetailPaper {
-  id: number;
-  resourceId: string | null;
-  title: string;
-  url: string | null;
-  authors: string | null;
-  publishedDate: string | null;
-  citationCount: number | null;
-  isSeminal: boolean;
-  sortOrder: number;
-  notes: string | null;
-}
-
-interface AreaDetailOrg {
-  organizationId: string;
-  role: string;
-  notes: string | null;
-}
-
-interface AreaDetailResponse {
-  grants: AreaDetailGrant[];
-  fundingByOrg: AreaDetailFundingByOrg[];
-  papers: AreaDetailPaper[];
-  organizations: AreaDetailOrg[];
-}
 
 // ---------------------------------------------------------------------------
 // Data helpers
@@ -125,11 +78,8 @@ export default async function ResearchAreaDetailPage({
     ? allAreas.find((a) => a.id === area.parentAreaId)
     : null;
 
-  // Fetch rich detail from wiki-server (ISR, 5 min revalidation)
-  const detail = await fetchFromWikiServer<AreaDetailResponse>(
-    `/api/research-areas/${slug}`,
-    { revalidate: 300 }
-  );
+  // Load detail data from build-time JSON (fetched from wiki-server during build-data)
+  const detail = getResearchAreaDetail(slug);
 
   const grants = detail?.grants ?? [];
   const fundingByOrg = detail?.fundingByOrg ?? [];

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1022,6 +1022,73 @@ export function getResearchAreasFromPG(
 }
 
 // ============================================================================
+// RESEARCH AREA DETAILS
+// Entity lists (orgs, papers, grants) for research area detail pages.
+// Loaded from research-area-details.json (built from wiki-server at build time).
+// ============================================================================
+
+export interface ResearchAreaDetailOrg {
+  organizationId: string;
+  role: string;
+  notes: string | null;
+}
+
+export interface ResearchAreaDetailPaper {
+  id: number;
+  resourceId: string | null;
+  title: string;
+  url: string | null;
+  authors: string | null;
+  publishedDate: string | null;
+  citationCount: number | null;
+  isSeminal: boolean;
+  sortOrder: number;
+  notes: string | null;
+}
+
+export interface ResearchAreaDetailGrant {
+  id: string;
+  name: string;
+  amount: number | null;
+  date: string | null;
+  organizationId: string;
+  granteeId: string | null;
+  confidence: number | null;
+}
+
+export interface ResearchAreaDetailFundingByOrg {
+  organizationId: string;
+  grantCount: number;
+  totalAmount: string;
+}
+
+export interface ResearchAreaDetail {
+  organizations: ResearchAreaDetailOrg[];
+  papers: ResearchAreaDetailPaper[];
+  grants: ResearchAreaDetailGrant[];
+  fundingByOrg: ResearchAreaDetailFundingByOrg[];
+}
+
+let _researchAreaDetails: Record<string, ResearchAreaDetail> | null = null;
+
+function loadResearchAreaDetails(): Record<string, ResearchAreaDetail> {
+  if (_researchAreaDetails) return _researchAreaDetails;
+  const filePath = path.join(LOCAL_DATA_DIR, "research-area-details.json");
+  try {
+    _researchAreaDetails = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return _researchAreaDetails!;
+  } catch {
+    _researchAreaDetails = {};
+    return _researchAreaDetails;
+  }
+}
+
+/** Get detail data (orgs, papers, grants) for a research area by ID. */
+export function getResearchAreaDetail(areaId: string): ResearchAreaDetail | null {
+  return loadResearchAreaDetails()[areaId] ?? null;
+}
+
+// ============================================================================
 // RECORD VERDICTS
 // Used by VerificationBadge on organization, grant, and funding-round detail pages.
 // ============================================================================

--- a/crux/lib/job-handlers/claim-verification.ts
+++ b/crux/lib/job-handlers/claim-verification.ts
@@ -18,6 +18,7 @@
 import { createLlmClient, MODELS } from '../llm.ts';
 import { callLlm } from '../llm.ts';
 import { parseJsonResponse } from '../anthropic.ts';
+import { escapeXml } from '../prompt-utils.ts';
 import { getCitationContentByUrl } from '../wiki-server/citations.ts';
 import { storeSourceCheckEvidence } from '../source-check/verdict-handler.ts';
 import { apiRequest } from '../wiki-server/client.ts';
@@ -79,17 +80,6 @@ const SingleClaimResultSchema = z.object({
 });
 
 const MultiClaimResultSchema = z.array(SingleClaimResultSchema);
-
-// ---------------------------------------------------------------------------
-// XML escaping — prevent prompt injection via user-supplied claim fields
-// ---------------------------------------------------------------------------
-
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
 
 // ---------------------------------------------------------------------------
 // Prompt builder


### PR DESCRIPTION
## Summary
- **#3371 Research area entity lists**: Pages showed counts (e.g., "Organizations: 3") but no entity lists because they depended on a runtime wiki-server fetch that failed during SSG builds. Fixed by fetching detail data (orgs, papers, grants, funding breakdown) during the `build-data` pipeline and reading from `research-area-details.json` at render time — same pattern as other directory pages.
- **#3381 Deduplicate escapeXml**: Removed the duplicate `escapeXml()` from `claim-verification.ts` and replaced with import from the shared `prompt-utils.ts`. Gate check confirms no unescaped prompt interpolations exist.

**Note:** Local gate check fails on pre-existing `@longterm-wiki/id-utils` module resolution error (affects `stable-id.ts` and `entity-ref.ts`). This is not caused by these changes — same failure on main.

Closes #3371
Closes #3381

## Test plan
- [x] TypeScript check passes (only pre-existing id-utils errors)
- [x] App tests pass (1063/1063)
- [x] Crux tests pass (4485/4485)
- [ ] After deploy: verify `/research-areas/interpretability` shows organization and grant tables
- [ ] After deploy: verify `/research-areas/rlhf` still shows entity lists (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)