### PR TITLE
fix: align enrichment pipeline ID handling with sid_ prefix migration

### DIFF
--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -11,6 +11,7 @@ import { resolve } from 'path';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { proposeClaims, getClaimStatus } from '../lib/wiki-server/claims.ts';
 import { generateId } from '../lib/grant-import/id.ts';
+import { generateSid, isAnySid } from '../../packages/id-utils/src/index.ts';
 import { buildEntityMatcher, matchGrantee } from '../lib/grant-import/entity-matcher.ts';
 import { toSlug } from './types.ts';
 import { getTableConfig } from './table-registry.ts';
@@ -269,8 +270,8 @@ async function handleCreateEntity(input: Record<string, unknown>): Promise<strin
     return JSON.stringify({ created: false, existing: true, stableId: existing.stableId, name: existing.name });
   }
 
-  // Generate lightweight stableId (no wikiId — not a full wiki entity)
-  const stableId = generateId(`${entityType}:${slug}`);
+  // Generate sid_-prefixed stableId (no wikiId — not a full wiki entity)
+  const stableId = generateSid();
 
   // Sync entity to wiki-server (lightweight — no wikiId)
   const syncResult = await apiRequest<{ upserted: number }>('POST', '/api/entities/sync', {
@@ -287,8 +288,9 @@ async function handleCreateEntity(input: Record<string, unknown>): Promise<strin
     return `Error creating entity: ${syncResult.message}`;
   }
 
-  // Update the cached matcher so subsequent resolve calls find this entity
+  // Update caches so subsequent resolve/validate calls find this entity
   _entityMatcher = null; // Force re-build on next resolve
+  if (_knownStableIds) _knownStableIds.add(stableId); // Avoid stale-cache rejection in submit_records
 
   return JSON.stringify({
     created: true,
@@ -418,8 +420,8 @@ async function handleSubmitRecords(
         continue;
       }
 
-      // If it looks like a stableId (10-char alphanumeric), verify it exists
-      if (/^[A-Za-z0-9]{10}$/.test(val)) {
+      // If it looks like a stableId (sid_-prefixed or legacy 10-char), verify it exists
+      if (isAnySid(val)) {
         if (stableIdSet.has(val)) {
           continue; // Legitimate stableId from resolve_entity or create_entity
         }


### PR DESCRIPTION
## Summary

Three gaps in `crux/tablebase/tools.ts` after the `sid_` prefix migration (#3402) that could cause data inconsistency or validation bypass:

- **`create_entity` generated bare 10-char stableIds** — used `generateId()` which produces old-format IDs. Now uses `generateSid()` from `@longterm-wiki/id-utils` to produce `sid_`-prefixed IDs consistent with all post-migration entities.
- **Entity ref validation missed `sid_`-prefixed fabricated IDs** — the regex `/^[A-Za-z0-9]{10}$/` only catches bare 10-char IDs. A fabricated `sid_XYZ1234567` would bypass validation entirely. Now uses `isAnySid()` to catch both formats.
- **Stale `_knownStableIds` cache after `create_entity`** — newly created stableIds weren't added to the validation cache, so a subsequent `submit_records` in the same enrichment run could reject them as fabricated.

Found during cross-PR compatibility audit of #3347, #3392, #3396, #3402.

## Test plan
- [x] `pnpm build` passes (full production build with 1967+ static pages)
- [x] `pnpm test` passes (4496 tests, 212 test files)
- [x] Gate check failures are pre-existing on main (KB schema + YAML entity ref integrity from sid_ migration)
- [x] Verified `generateId` import retained for record IDs (varchar(10) PKs) which correctly don't use sid_ prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)