### PR TITLE
fix: coerce bigserial IDs to numbers in claims route + add resource-verify to worker

### DIFF
--- a/apps/wiki-server/deploy/k8s-worker-spec.md
+++ b/apps/wiki-server/deploy/k8s-worker-spec.md
@@ -12,7 +12,7 @@ alternative.
   ```
   node --import tsx/esm crux/worker/run.ts \
     --poll --poll-interval=5000 \
-    --types=claim-verification,citation-verify,ping \
+    --types=claim-verification,citation-verify,resource-verify,ping \
     --verbose
   ```
 - **Replicas**: 1 (scale to 2-3 when verification volume grows)
@@ -68,7 +68,7 @@ spec:
             - crux/worker/run.ts
             - --poll
             - --poll-interval=5000
-            - --types=claim-verification,citation-verify,ping
+            - --types=claim-verification,citation-verify,resource-verify,ping
             - --verbose
           ports:
             - name: health

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -235,16 +235,22 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     const sourceUrls = params[8] as string[];
     const numRows = batchIds.length;
 
-    const rows: typeof claimStore = [];
+    const rows: Array<{ id: string; resource_id: string | null; source_url: string }> = [];
     for (let i = 0; i < numRows; i++) {
+      const numericId = nextClaimId++;
+      // postgres.js returns bigserial as string — simulate that here
       const row = {
-        id: nextClaimId++,
+        id: String(numericId),
+        resource_id: resourceIds[i] ?? null,
+        source_url: sourceUrls[i],
+      };
+      claimStore.push({
+        id: numericId,
         resource_id: resourceIds[i] ?? null,
         source_url: sourceUrls[i],
         batch_id: batchIds[i],
         verification_job_id: null,
-      };
-      claimStore.push(row);
+      });
       rows.push(row);
     }
     return rows;
@@ -254,12 +260,14 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   if (q.includes("insert into") && q.includes("jobs")) {
     // Tagged template params: [JSON.stringify(jobParams), priority]
     const jobParamsJson = params[0] as string;
+    const numericId = nextJobId++;
     const row = {
-      id: nextJobId++,
+      // postgres.js returns bigserial as string — simulate that here
+      id: String(numericId),
       type: "claim-verification",
       params: typeof jobParamsJson === "string" ? JSON.parse(jobParamsJson) : jobParamsJson,
     };
-    jobStore.push(row);
+    jobStore.push({ id: numericId, type: row.type, params: row.params });
     return [row];
   }
 
@@ -403,6 +411,42 @@ describe("Claims API — POST /api/claims/propose", () => {
     expect(body.claims[0].verificationJobId).toBeDefined();
     expect(body.jobCount).toBe(1);
     expect(body.estimatedVerificationTime).toBe(SECONDS_PER_CLAIM_ESTIMATE);
+  });
+
+  it("stores numeric claimIds in job params (not strings from bigserial)", async () => {
+    const res = await postJson(app, "/api/claims/propose", {
+      targetTable: "facts",
+      claims: [
+        { claimText: "Claim 1", sourceUrl: "https://example.com/a" },
+        { claimText: "Claim 2", sourceUrl: "https://example.com/a" },
+      ],
+    });
+
+    expect(res.status).toBe(201);
+    expect(jobStore).toHaveLength(1);
+
+    const jobParams = jobStore[0].params as { claimIds: unknown[] };
+    // claimIds must be numbers, not strings — the claim-verification handler
+    // validates with z.number() and rejects string IDs.
+    for (const id of jobParams.claimIds) {
+      expect(typeof id).toBe("number");
+    }
+  });
+
+  it("returns numeric claim IDs and job IDs in response", async () => {
+    const res = await postJson(app, "/api/claims/propose", {
+      targetTable: "facts",
+      claims: [
+        { claimText: "Test claim", sourceUrl: "https://example.com" },
+      ],
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+
+    // Response IDs should be numbers, not strings
+    expect(typeof body.claims[0].id).toBe("number");
+    expect(typeof body.claims[0].verificationJobId).toBe("number");
   });
 
   it("rejects empty claims array", async () => {

--- a/apps/wiki-server/src/routes/claims/claims.ts
+++ b/apps/wiki-server/src/routes/claims/claims.ts
@@ -182,7 +182,9 @@ const claimsApp = new Hono()
 
     await beginTransaction(async (tx) => {
       // 2. Insert all claims in a single batch
-      insertedClaims = await tx<InsertedClaimRow[]>`
+      // postgres.js returns bigserial id as string — coerce to number for
+      // downstream job params (claim-verification handler expects number[]).
+      const rawRows = await tx<InsertedClaimRow[]>`
         INSERT INTO proposed_claims (
           batch_id, claim_text, entity_id, target_table, target_field,
           proposed_value, proposed_data, resource_id, source_url,
@@ -204,6 +206,10 @@ const claimsApp = new Hono()
         )
         RETURNING id, resource_id, source_url
       `;
+      insertedClaims = rawRows.map((row) => ({
+        ...row,
+        id: Number(row.id),
+      }));
 
       if (insertedClaims.length !== claims.length) {
         logger.error(
@@ -235,7 +241,7 @@ const claimsApp = new Hono()
         `;
 
         if (jobRows.length > 0) {
-          jobEntries.push({ claimIds: chunk, resourceId, jobId: jobRows[0].id });
+          jobEntries.push({ claimIds: chunk, resourceId, jobId: Number(jobRows[0].id) });
         }
       }
 


### PR DESCRIPTION
## Summary

Manual testing of the background job system revealed two bugs blocking claim-verification and resource-verify jobs:

- **Claim-verification jobs fail with type error**: postgres.js returns `bigserial` IDs as strings, but the `claim-verification` handler validates `claimIds` with `z.number()`. All claim-verification jobs on production were failing — 11 retrying, 2 permanently failed. Fixed by coercing `Number(row.id)` after `INSERT RETURNING` in `claims.ts`.
- **Resource-verify jobs permanently stuck**: The K8s worker spec only lists `claim-verification,citation-verify,ping` — `resource-verify` was missing. 123 jobs stuck in `pending`. Updated the spec to include it.

## Testing performed

### Manual testing against production wiki-server
- **Ping**: 53 jobs completed, 0 failures, ~10ms avg ✅
- **Claim-verification**: Confirmed bug (string IDs in params), verified fix logic
- **Resource-verify**: Confirmed stuck (worker not claiming), verified config gap
- **Job creation throughput**: 50-batch in 257ms (5ms/job), 100 sequential in 14.7s (147ms/job)
- **Dedup**: 20 concurrent same-key requests → 1 new + 19 deduped ✅
- **Claims propose**: 50 claims across 10 sources → 10 jobs in 254ms ✅
- **Claims propose**: 100 claims from 1 source → 1 job in 252ms ✅

### Automated tests
- Updated mock to return string IDs (simulates real postgres.js bigserial behavior)
- Added test: "stores numeric claimIds in job params (not strings from bigserial)"
- Added test: "returns numeric claim IDs and job IDs in response"
- All 51 claims tests + 35 jobs tests pass

## Deploy notes

The K8s worker spec change (`k8s-worker-spec.md`) is documentation only. The actual K8s deployment in the ops repo needs a separate update — see linked issue.

https://claude.ai/code/session_01Cn1N4oxD7xzEcHnNqdcwi9