### PR TITLE
fix: coerce bigserial claim IDs to number in claim-verification handler

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1355,7 +1355,7 @@ export const ProposeClaimsSchema = z.object({
 export type ProposeClaims = z.infer<typeof ProposeClaimsSchema>;
 
 export const ClaimVerdictSchema = z.object({
-  claimId: z.number().int().positive(),
+  claimId: z.coerce.number().int().positive(),
   status: z.enum(["verified", "contradicted", "unverifiable"]),
   confidence: z.number().min(0).max(1),
   reasoning: z.string().max(5000),

--- a/apps/wiki-server/src/routes/claims/claims.ts
+++ b/apps/wiki-server/src/routes/claims/claims.ts
@@ -347,7 +347,7 @@ const claimsApp = new Hono()
     }
 
     const claims = await sql<ClaimDetailRow[]>`
-      SELECT id, claim_text, source_url, target_table, target_field,
+      SELECT id::int, claim_text, source_url, target_table, target_field,
              proposed_value, agent_evidence, resource_id
       FROM proposed_claims
       WHERE id = ANY(${ids})
@@ -366,7 +366,7 @@ const claimsApp = new Hono()
     logger.debug({ batchId }, "polling claim status");
 
     const claims = await sql<ProposedClaimRow[]>`
-      SELECT id, batch_id, claim_text, status, verdict_confidence, verdict_reasoning, extracted_value
+      SELECT id::int, batch_id, claim_text, status, verdict_confidence, verdict_reasoning, extracted_value
       FROM proposed_claims
       WHERE batch_id = ${batchId}
       ORDER BY id ASC

--- a/crux/lib/job-handlers/claim-verification.ts
+++ b/crux/lib/job-handlers/claim-verification.ts
@@ -274,7 +274,7 @@ export async function handleClaimVerification(
       const parsed = MultiClaimResultSchema.safeParse(raw);
 
       if (parsed.success) {
-        const expectedIds = new Set(batch.map((cl) => cl.id));
+        const expectedIds = new Set(batch.map((cl) => Number(cl.id)));
         const seenIds = new Set<number>();
 
         for (const r of parsed.data) {
@@ -298,7 +298,7 @@ export async function handleClaimVerification(
 
         // Treat omitted claims as errors so they get unverifiable status
         for (const cl of batch) {
-          if (!seenIds.has(cl.id)) {
+          if (!seenIds.has(Number(cl.id))) {
             console.warn(`[claim-verification] LLM omitted claimId ${cl.id} — marking unverifiable`);
             errors.push({ claimId: cl.id, error: 'LLM omitted this claim from verification response' });
           }
@@ -322,7 +322,7 @@ export async function handleClaimVerification(
 
   // 4. Store evidence for each verified claim
   for (const r of allResults) {
-    const claim = claims.find((cl) => cl.id === r.claimId);
+    const claim = claims.find((cl) => Number(cl.id) === r.claimId);
     if (!claim) continue;
 
     await storeSourceCheckEvidence({


### PR DESCRIPTION
## Summary

One-line fix: coerce `claim.id` from string to number after fetching from `/api/claims/by-ids`.

postgres.js returns bigserial columns as strings. The handler compared these string IDs against Zod-parsed number IDs from the LLM response, causing all claims to be marked "unknown". Then the string IDs were rejected by the verdicts endpoint's Zod schema.

Closes #3442

## Test plan

- [ ] Deploy and re-create claim-verification jobs
- [ ] Verify verdicts POST succeeds (no type mismatch)
- [ ] Verify claims are matched correctly (no "unknown claimId" warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed claim ID formatting to properly convert to numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->