### PR TITLE
fix: restore content/ and data/ in Docker build context for discord-bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
 # Exclude heavy directories from Docker build context
 .git
 node_modules
-content
-data
+# NOTE: content/ and data/ are NOT ignored — the discord-bot Dockerfile
+# needs them for /ask command file tools. The worker and wiki-server
+# Dockerfiles don't COPY them, so they only add ~35MB to build context.
 apps/web/.next
 apps/web/node_modules
 apps/wiki-server/node_modules


### PR DESCRIPTION
## Summary

The `.dockerignore` was excluding `content/` and `data/`, which broke the discord-bot Docker build. The bot's Dockerfile COPYs these directories for the `/ask` command file tools.

The other Dockerfiles (worker, wiki-server) don't COPY these dirs, so including them only adds ~35MB to build context.

## Also done (production DB cleanup, not in this PR)

- Pruned 6.3M old hallucination_risk_snapshots rows (kept 7 days). DB: 2020 MB → 1290 MB
- Cleaned 168 stale active agents (status: active → completed)
- Cancelled 2 stuck test-integration pending jobs
- Deleted 73 test-integration + 2 monitoring-alert job rows

## Test plan

- [ ] Discord-bot Docker build succeeds after merge + production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include `content` and `data` directories in the build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->