### PR TITLE
fix: add AGENT_RESET=1 escape hatch to branch-switch hook

### DIFF
--- a/.claude/hooks/block-branch-switch.sh
+++ b/.claude/hooks/block-branch-switch.sh
@@ -30,6 +30,12 @@ fi
 
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
+# Allow branch switching when AGENT_RESET=1 is set in the command
+# (used by /agent-reset to intentionally return to main)
+if echo "$COMMAND" | grep -qE 'AGENT_RESET=1'; then
+  exit 0
+fi
+
 # Strip heredocs and quoted strings to avoid false positives
 STRIPPED=$(echo "$COMMAND" | sed -E "s/<<'?[A-Za-z_]+'?//" | sed '/^EOF$/,$d' | sed -E 's/-m "[^"]*"//g' | sed -E "s/-m '[^']*'//g")
 

--- a/.claude/skills/agent-reset/SKILL.md
+++ b/.claude/skills/agent-reset/SKILL.md
@@ -33,10 +33,10 @@ This command handles the full session transition: DB close + git reset + local c
    git clean -fd --exclude=.agent-slot --exclude=.envrc --exclude=.env
    ```
 
-5. **Switch to main and pull latest**:
+5. **Switch to main and pull latest** (prefix with `AGENT_RESET=1` to bypass the branch-switch hook):
    ```bash
    BRANCH=$(git branch --show-current)
-   git checkout main
+   AGENT_RESET=1 git checkout main
    git pull --ff-only origin main
    ```
 


### PR DESCRIPTION
The block-branch-switch hook prevents accidental mid-session branch switches, but it also blocks /agent-reset which intentionally needs to return to main. Add an env var check so the reset skill can bypass.