### PR TITLE
feat: bulk-enqueue resource-verify jobs for unfetched resources

### DIFF
--- a/crux/commands/jobs.ts
+++ b/crux/commands/jobs.ts
@@ -671,10 +671,11 @@ async function enqueueResourceVerify(_args: string[], options: CommandOptions): 
 
   for (let i = 0; i < toEnqueue.length; i++) {
     const r = toEnqueue[i];
-    let attempts = 0;
-    const MAX_ATTEMPTS = 3;
+    let rateLimitRetries = 0;
+    const MAX_RATE_LIMIT_RETRIES = 10; // Rate limits always resolve — retry generously
 
-    while (attempts < MAX_ATTEMPTS) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       const result = await createJob({
         type: 'resource-verify',
         params: { resourceId: r.id, url: r.url },
@@ -684,13 +685,20 @@ async function enqueueResourceVerify(_args: string[], options: CommandOptions): 
       });
 
       if (!result.ok && result.message.includes('429')) {
+        if (rateLimitRetries >= MAX_RATE_LIMIT_RETRIES) {
+          failed++;
+          if (failed <= 3) {
+            process.stderr.write(`  ${c.red}Error: rate limit exhausted after ${MAX_RATE_LIMIT_RETRIES} retries for ${r.id}${c.reset}\n`);
+          }
+          break;
+        }
         // Rate limited — extract retry-after and wait
         const retryMatch = result.message.match(/retryAfter[":]+\s*(\d+)/i);
         const waitSec = retryMatch ? parseInt(retryMatch[1], 10) : 30;
         rateLimitPauses++;
+        rateLimitRetries++;
         process.stderr.write(`  ${c.yellow}Rate limited, waiting ${waitSec}s...${c.reset}\n`);
         await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
-        attempts++;
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Adds `crux sys jobs enqueue-resource-verify` command to bulk-create `resource-verify` jobs for all resources with `lastFetchedAt === null`
- Pages through `/api/resources/all`, filters unfetched, creates jobs with dedup keys to safely re-run
- Handles server rate-limiting (429) with automatic retry using `retryAfter` header
- Supports `--dry-run` to preview and `--limit=N` to cap enqueue count

## Context
5,326 resources have never been fetched. The worker has only completed 123. Source-checking can't verify claims against unfetched sources, so this bottlenecks all verification backfill.

Related issues:
- #3449 — Scale resource-verify worker replicas
- #3452 — Add dedupKey support to batch job creation

## Test plan
- [x] Dry run shows correct unfetched count
- [x] Small batch (20) creates jobs successfully  
- [x] Dedup verified: re-running same batch dedupes correctly
- [x] Rate-limit retry works (429 → wait → retry → success)
- [x] Full enqueue running in background with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)