### PR TITLE
feat: domain-aware fetch strategies for resource verification

### DIFF
--- a/crux/lib/search/fetch-strategies.test.ts
+++ b/crux/lib/search/fetch-strategies.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for fetch-strategies.ts
+ *
+ * Covers: domain classification, forum content fetching, DOI resolution,
+ * Wayback Machine content fetching.
+ *
+ * Network calls are mocked via vitest's built-in fetch mock.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  getContentFetchStrategy,
+  isDeadDomain,
+  isFirecrawlPriorityDomain,
+  fetchForumContent,
+  fetchDoiContent,
+  fetchWaybackContent,
+} from './fetch-strategies.ts';
+
+// Mock the forum API module
+vi.mock('../forum-api.ts', () => ({
+  forumGraphql: vi.fn(),
+}));
+
+import { forumGraphql } from '../forum-api.ts';
+const mockForumGraphql = vi.mocked(forumGraphql);
+
+// ---------------------------------------------------------------------------
+// Domain Classification Tests
+// ---------------------------------------------------------------------------
+
+describe('getContentFetchStrategy', () => {
+  it('returns forum-api for LessWrong URLs', () => {
+    expect(getContentFetchStrategy('https://www.lesswrong.com/posts/abc123/some-post')).toBe('forum-api');
+    expect(getContentFetchStrategy('https://lesswrong.com/posts/abc123/some-post')).toBe('forum-api');
+  });
+
+  it('returns forum-api for Alignment Forum URLs', () => {
+    expect(getContentFetchStrategy('https://www.alignmentforum.org/posts/xyz789/alignment-post')).toBe('forum-api');
+    expect(getContentFetchStrategy('https://alignmentforum.org/posts/xyz789/alignment-post')).toBe('forum-api');
+  });
+
+  it('returns forum-api for EA Forum URLs', () => {
+    expect(getContentFetchStrategy('https://forum.effectivealtruism.org/posts/abc/test')).toBe('forum-api');
+  });
+
+  it('returns wayback-only for known dead domains', () => {
+    expect(getContentFetchStrategy('https://www.fhi.ox.ac.uk/paper.pdf')).toBe('wayback-only');
+    expect(getContentFetchStrategy('https://fhi.ox.ac.uk/about')).toBe('wayback-only');
+    expect(getContentFetchStrategy('https://ftxfuturefund.org/grants')).toBe('wayback-only');
+  });
+
+  it('returns doi for academic publisher domains', () => {
+    expect(getContentFetchStrategy('https://www.nature.com/articles/s41586-021-03819-2')).toBe('doi');
+    expect(getContentFetchStrategy('https://www.science.org/doi/10.1126/science.abc1234')).toBe('doi');
+    expect(getContentFetchStrategy('https://www.sciencedirect.com/science/article/pii/S0123456789')).toBe('doi');
+    expect(getContentFetchStrategy('https://pnas.org/doi/10.1073/pnas.123')).toBe('doi');
+  });
+
+  it('returns firecrawl-priority for bot-blocked domains', () => {
+    expect(getContentFetchStrategy('https://openai.com/blog/some-post')).toBe('firecrawl-priority');
+    expect(getContentFetchStrategy('https://www.rand.org/pubs/research-reports/RR1234.html')).toBe('firecrawl-priority');
+    expect(getContentFetchStrategy('https://www.reuters.com/technology/ai-article')).toBe('firecrawl-priority');
+    expect(getContentFetchStrategy('https://www.bloomberg.com/news/articles/ai')).toBe('firecrawl-priority');
+    expect(getContentFetchStrategy('https://medium.com/some-article')).toBe('firecrawl-priority');
+  });
+
+  it('returns default for normal domains', () => {
+    expect(getContentFetchStrategy('https://arxiv.org/abs/2301.12345')).toBe('default');
+    expect(getContentFetchStrategy('https://en.wikipedia.org/wiki/AI')).toBe('default');
+    expect(getContentFetchStrategy('https://example.com/page')).toBe('default');
+    expect(getContentFetchStrategy('https://github.com/some/repo')).toBe('default');
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    expect(getContentFetchStrategy('')).toBe('default');
+    expect(getContentFetchStrategy('not a url')).toBe('default');
+  });
+});
+
+describe('isDeadDomain', () => {
+  it('detects dead domains', () => {
+    expect(isDeadDomain('https://www.fhi.ox.ac.uk/report')).toBe(true);
+    expect(isDeadDomain('https://ftxfuturefund.org/grants')).toBe(true);
+  });
+
+  it('returns false for live domains', () => {
+    expect(isDeadDomain('https://www.anthropic.com')).toBe(false);
+    expect(isDeadDomain('https://openai.com')).toBe(false);
+  });
+});
+
+describe('isFirecrawlPriorityDomain', () => {
+  it('detects Firecrawl-priority domains', () => {
+    expect(isFirecrawlPriorityDomain('https://openai.com/blog/gpt-4')).toBe(true);
+    expect(isFirecrawlPriorityDomain('https://www.rand.org/pubs/report.html')).toBe(true);
+  });
+
+  it('returns false for normal domains', () => {
+    expect(isFirecrawlPriorityDomain('https://arxiv.org/abs/1234')).toBe(false);
+    expect(isFirecrawlPriorityDomain('https://en.wikipedia.org')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forum Content Fetching
+// ---------------------------------------------------------------------------
+
+describe('fetchForumContent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('fetches post content via GraphQL API', async () => {
+    mockForumGraphql.mockResolvedValueOnce({
+      data: {
+        post: {
+          result: {
+            title: 'AI Alignment Research',
+            contents: { markdown: 'This is the full post content about alignment.' },
+            user: { displayName: 'John Doe' },
+            coauthors: [{ displayName: 'Jane Smith' }],
+            postedAt: '2025-01-15T12:00:00Z',
+          },
+        },
+      },
+    });
+
+    const result = await fetchForumContent('https://www.lesswrong.com/posts/abc123/ai-alignment-research');
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('AI Alignment Research');
+    expect(result!.content).toContain('AI Alignment Research');
+    expect(result!.content).toContain('John Doe, Jane Smith');
+    expect(result!.content).toContain('This is the full post content about alignment.');
+    expect(result!.fetchMethod).toBe('forum-api');
+    expect(result!.httpStatus).toBe(200);
+  });
+
+  it('returns null for non-forum URLs', async () => {
+    const result = await fetchForumContent('https://example.com/page');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when post has no content', async () => {
+    mockForumGraphql.mockResolvedValueOnce({
+      data: {
+        post: {
+          result: {
+            title: 'Empty Post',
+            contents: { markdown: '' },
+            user: { displayName: 'Test' },
+          },
+        },
+      },
+    });
+
+    const result = await fetchForumContent('https://www.lesswrong.com/posts/abc123/empty');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when post is not found', async () => {
+    mockForumGraphql.mockResolvedValueOnce({
+      data: { post: { result: null } },
+    });
+
+    const result = await fetchForumContent('https://www.lesswrong.com/posts/notfound/missing');
+    expect(result).toBeNull();
+  });
+
+  it('handles GraphQL errors gracefully', async () => {
+    mockForumGraphql.mockRejectedValueOnce(new Error('GraphQL HTTP error: 500'));
+
+    const result = await fetchForumContent('https://www.lesswrong.com/posts/abc/test');
+    expect(result).toBeNull();
+  });
+
+  it('extracts post ID from sequence URLs', async () => {
+    mockForumGraphql.mockResolvedValueOnce({
+      data: {
+        post: {
+          result: {
+            title: 'Sequence Post',
+            contents: { markdown: 'Content from a sequence.' },
+            user: { displayName: 'Author' },
+          },
+        },
+      },
+    });
+
+    const result = await fetchForumContent('https://www.lesswrong.com/s/seqABC/p/postXYZ');
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Sequence Post');
+    // Verify the correct post ID was passed to the GraphQL query
+    expect(mockForumGraphql).toHaveBeenCalledWith(
+      'https://www.lesswrong.com/graphql',
+      expect.any(String),
+      { id: 'postXYZ' },
+    );
+  });
+
+  it('returns null for URLs without post ID', async () => {
+    const result = await fetchForumContent('https://www.lesswrong.com/users/someuser');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DOI Resolution
+// ---------------------------------------------------------------------------
+
+describe('fetchDoiContent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('resolves DOI and returns structured metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        status: 'ok',
+        message: {
+          DOI: '10.1038/s41586-021-03819-2',
+          title: ['Superhuman AI for protein structure prediction'],
+          author: [
+            { given: 'John', family: 'Jumper' },
+            { given: 'Richard', family: 'Evans' },
+          ],
+          abstract: '<p>Proteins are essential to life.</p>',
+          'container-title': ['Nature'],
+          'published-print': { 'date-parts': [[2021, 7, 15]] },
+          'is-referenced-by-count': 12345,
+        },
+      }), { status: 200 }),
+    );
+
+    // URL must contain an actual DOI pattern (10.XXXX/...) for extraction to work
+    const result = await fetchDoiContent('https://doi.org/10.1038/s41586-021-03819-2');
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Superhuman AI for protein structure prediction');
+    expect(result!.content).toContain('John Jumper, Richard Evans');
+    expect(result!.content).toContain('Nature');
+    expect(result!.content).toContain('Proteins are essential to life.');
+    expect(result!.fetchMethod).toBe('doi-crossref');
+    expect(result!.resolvedUrl).toBe('https://doi.org/10.1038/s41586-021-03819-2');
+  });
+
+  it('returns null for URLs without a DOI', async () => {
+    const result = await fetchDoiContent('https://example.com/no-doi-here');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when CrossRef API returns non-ok status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Not Found', { status: 404 }),
+    );
+
+    const result = await fetchDoiContent('https://doi.org/10.1234/nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('timeout'));
+
+    const result = await fetchDoiContent('https://doi.org/10.1234/test');
+    expect(result).toBeNull();
+  });
+
+  it('extracts DOI from publisher URL paths', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        status: 'ok',
+        message: {
+          DOI: '10.1073/pnas.2012345678',
+          title: ['A PNAS Paper'],
+          abstract: 'Test abstract content here.',
+          'is-referenced-by-count': 100,
+        },
+      }), { status: 200 }),
+    );
+
+    const result = await fetchDoiContent('https://www.pnas.org/doi/full/10.1073/pnas.2012345678');
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('A PNAS Paper');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wayback Machine Content Fetching
+// ---------------------------------------------------------------------------
+
+describe('fetchWaybackContent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches content from Wayback Machine', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    // Mock Wayback availability API
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        archived_snapshots: {
+          closest: {
+            url: 'https://web.archive.org/web/20230101/https://www.fhi.ox.ac.uk/report',
+            timestamp: '20230101120000',
+            available: true,
+          },
+        },
+      }), { status: 200 }),
+    );
+
+    // Mock archive content fetch
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        '<html><head><title>FHI Report</title></head><body><p>This is an important report about existential risk from the Future of Humanity Institute. It covers various topics related to AI safety and global catastrophic risks.</p></body></html>',
+        { status: 200, headers: { 'content-type': 'text/html' } },
+      ),
+    );
+
+    const result = await fetchWaybackContent('https://www.fhi.ox.ac.uk/report');
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('FHI Report');
+    expect(result!.content).toContain('existential risk');
+    expect(result!.fetchMethod).toBe('wayback');
+    expect(result!.archiveUrl).toContain('web.archive.org');
+  });
+
+  it('returns null when no snapshot is available', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    // Availability API: no snapshot
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ archived_snapshots: {} }), { status: 200 }),
+    );
+
+    // Direct URL: 404
+    fetchSpy.mockResolvedValueOnce(
+      new Response('Not Found', { status: 404 }),
+    );
+
+    const result = await fetchWaybackContent('https://nonexistent-site.example.com/page');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when archived content is too short', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        archived_snapshots: {
+          closest: { url: 'https://web.archive.org/web/2023/test', timestamp: '20230101', available: true },
+        },
+      }), { status: 200 }),
+    );
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<html><body>Too short</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      }),
+    );
+
+    const result = await fetchWaybackContent('https://example.com/short');
+    expect(result).toBeNull();
+  });
+});

--- a/crux/lib/search/fetch-strategies.ts
+++ b/crux/lib/search/fetch-strategies.ts
@@ -1,0 +1,509 @@
+/**
+ * Domain-Aware Content Fetch Strategies
+ *
+ * Routes URLs to specialized fetching strategies based on domain.
+ * Used by source-fetcher.ts to improve fetch success rates for domains
+ * that block generic HTTP requests (403), require API access, or are dead (404).
+ *
+ * Strategies:
+ *   - forum-api: LessWrong, Alignment Forum, EA Forum → GraphQL API
+ *   - doi: Academic publishers (Nature, Science, etc.) → CrossRef DOI resolution
+ *   - firecrawl-priority: Bot-blocked domains (OpenAI, Reuters, etc.) → Firecrawl first
+ *   - wayback: Dead domains / 404s → Wayback Machine archived content
+ *   - default: Standard Firecrawl → built-in fetch
+ *
+ * See: https://github.com/quantified-uncertainty/longterm-wiki/issues/3457
+ */
+
+import { forumGraphql, type Forum } from '../forum-api.ts';
+
+// ---------------------------------------------------------------------------
+// Strategy Types
+// ---------------------------------------------------------------------------
+
+export type ContentFetchStrategy =
+  | 'forum-api'
+  | 'doi'
+  | 'firecrawl-priority'
+  | 'wayback-only'
+  | 'default';
+
+export interface StrategyResult {
+  title: string;
+  content: string;
+  httpStatus: number;
+  fetchMethod: string;
+  /** If DOI was resolved, the resolved URL */
+  resolvedUrl?: string;
+  /** If Wayback was used, the archive URL */
+  archiveUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Domain Lists
+// ---------------------------------------------------------------------------
+
+/** Domains where Firecrawl should be tried first (known to block bots). */
+const FIRECRAWL_PRIORITY_DOMAINS = [
+  'openai.com',
+  'www.rand.org',
+  'www.reuters.com',
+  'reuters.com',
+  'www.bloomberg.com',
+  'bloomberg.com',
+  'www.cnas.org',
+  'cnas.org',
+  'medium.com',
+  'www.wired.com',
+  'wired.com',
+  'www.nytimes.com',
+  'nytimes.com',
+  'www.washingtonpost.com',
+  'washingtonpost.com',
+  'www.theguardian.com',
+  'theguardian.com',
+  'www.bbc.com',
+  'bbc.com',
+  'techcrunch.com',
+  'www.techcrunch.com',
+  'www.cnbc.com',
+  'cnbc.com',
+  'arstechnica.com',
+  'www.technologyreview.com',
+  'technologyreview.com',
+  'time.com',
+  'www.ft.com',
+  'ft.com',
+];
+
+/** Academic publisher domains where DOI resolution works better than HTTP. */
+const DOI_DOMAINS = [
+  'nature.com',
+  'science.org',
+  'springer.com',
+  'wiley.com',
+  'sciencedirect.com',
+  'tandfonline.com',
+  'pnas.org',
+  'cell.com',
+  'journals.sagepub.com',
+  'link.springer.com',
+  'academic.oup.com',
+  'www.science.org',
+];
+
+/** Forum domains that support GraphQL content fetching. */
+const FORUM_DOMAINS = [
+  'www.lesswrong.com',
+  'lesswrong.com',
+  'www.alignmentforum.org',
+  'alignmentforum.org',
+  'forum.effectivealtruism.org',
+  'www.effectivealtruism.org',
+];
+
+/** Domains known to be permanently dead (site shut down). */
+const DEAD_DOMAINS = [
+  'www.fhi.ox.ac.uk',
+  'fhi.ox.ac.uk',
+  'ftxfuturefund.org',
+  'www.ftxfuturefund.org',
+  'safesecureai.org',
+  'www.safesecureai.org',
+  'maliciousaireport.com',
+  'www.maliciousaireport.com',
+  'www.thefilterbubble.com',
+  'www.redqueenbio.com',
+  'saferai.uk',
+  'www.saferai.uk',
+  'www.apollo-research.ai',
+  'www.sparprogram.org',
+  'www.deepfakedetectionchallenge.com',
+];
+
+// ---------------------------------------------------------------------------
+// Domain Classification
+// ---------------------------------------------------------------------------
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '';
+  }
+}
+
+function matchesDomainList(hostname: string, domains: string[]): boolean {
+  return domains.some(d => hostname === d || hostname.endsWith('.' + d));
+}
+
+/**
+ * Determine the best content-fetch strategy for a URL.
+ */
+export function getContentFetchStrategy(url: string): ContentFetchStrategy {
+  const hostname = getHostname(url);
+  if (!hostname) return 'default';
+
+  if (matchesDomainList(hostname, FORUM_DOMAINS)) return 'forum-api';
+  if (matchesDomainList(hostname, DEAD_DOMAINS)) return 'wayback-only';
+  if (matchesDomainList(hostname, DOI_DOMAINS)) return 'doi';
+  if (matchesDomainList(hostname, FIRECRAWL_PRIORITY_DOMAINS)) return 'firecrawl-priority';
+
+  return 'default';
+}
+
+/**
+ * Check if a domain is known to be permanently dead (for Wayback-only routing).
+ */
+export function isDeadDomain(url: string): boolean {
+  return matchesDomainList(getHostname(url), DEAD_DOMAINS);
+}
+
+/**
+ * Check if a domain should prioritize Firecrawl over built-in HTTP.
+ */
+export function isFirecrawlPriorityDomain(url: string): boolean {
+  return matchesDomainList(getHostname(url), FIRECRAWL_PRIORITY_DOMAINS);
+}
+
+// ---------------------------------------------------------------------------
+// Forum GraphQL Content Fetching
+// ---------------------------------------------------------------------------
+
+const FORUM_CONFIGS: Record<string, Forum> = {
+  'www.lesswrong.com': { name: 'LessWrong', graphqlUrl: 'https://www.lesswrong.com/graphql', baseUrl: 'https://www.lesswrong.com' },
+  'lesswrong.com': { name: 'LessWrong', graphqlUrl: 'https://www.lesswrong.com/graphql', baseUrl: 'https://www.lesswrong.com' },
+  'www.alignmentforum.org': { name: 'Alignment Forum', graphqlUrl: 'https://www.alignmentforum.org/graphql', baseUrl: 'https://www.alignmentforum.org' },
+  'alignmentforum.org': { name: 'Alignment Forum', graphqlUrl: 'https://www.alignmentforum.org/graphql', baseUrl: 'https://www.alignmentforum.org' },
+  'forum.effectivealtruism.org': { name: 'EA Forum', graphqlUrl: 'https://forum.effectivealtruism.org/graphql', baseUrl: 'https://forum.effectivealtruism.org' },
+  'www.effectivealtruism.org': { name: 'EA Forum', graphqlUrl: 'https://forum.effectivealtruism.org/graphql', baseUrl: 'https://forum.effectivealtruism.org' },
+};
+
+/**
+ * Extract post ID from a forum URL.
+ * Handles: /posts/{id}/{slug}, /posts/{id}, /s/{id}/p/{id}
+ */
+function extractForumPostId(url: string): string | null {
+  // Standard post URL: /posts/{postId}/{slug}
+  const postMatch = url.match(/\/posts\/([a-zA-Z0-9]+)/);
+  if (postMatch) return postMatch[1];
+
+  // Sequence post URL: /s/{seqId}/p/{postId}
+  const seqMatch = url.match(/\/s\/[a-zA-Z0-9]+\/p\/([a-zA-Z0-9]+)/);
+  if (seqMatch) return seqMatch[1];
+
+  return null;
+}
+
+/**
+ * Fetch forum post content via GraphQL API.
+ * Returns markdown content directly from the forum's API.
+ */
+export async function fetchForumContent(url: string): Promise<StrategyResult | null> {
+  const hostname = getHostname(url);
+  const forum = FORUM_CONFIGS[hostname];
+  if (!forum) return null;
+
+  const postId = extractForumPostId(url);
+  if (!postId) return null;
+
+  try {
+    const data = await forumGraphql(forum.graphqlUrl, `
+      query GetPostContent($id: String!) {
+        post(input: { selector: { _id: $id } }) {
+          result {
+            title
+            contents {
+              markdown
+            }
+            user { displayName }
+            coauthors { displayName }
+            postedAt
+          }
+        }
+      }
+    `, { id: postId }) as {
+      data?: {
+        post?: {
+          result?: {
+            title: string;
+            contents?: { markdown?: string };
+            user?: { displayName: string };
+            coauthors?: { displayName: string }[];
+            postedAt?: string;
+          };
+        };
+      };
+    };
+
+    const post = data?.data?.post?.result;
+    if (!post) return null;
+
+    const markdown = post.contents?.markdown;
+    if (!markdown || markdown.length === 0) return null;
+
+    // Build a content string with metadata header
+    const authors = [
+      post.user?.displayName,
+      ...(post.coauthors?.map(c => c.displayName) ?? []),
+    ].filter(Boolean).join(', ');
+
+    const header = [
+      `# ${post.title}`,
+      authors ? `By ${authors}` : '',
+      post.postedAt ? `Published: ${post.postedAt.split('T')[0]}` : '',
+      '',
+    ].filter(Boolean).join('\n');
+
+    const content = (header + '\n' + markdown).slice(0, 100_000);
+
+    return {
+      title: post.title,
+      content,
+      httpStatus: 200,
+      fetchMethod: 'forum-api',
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[fetch-strategies] Forum API failed for ${url}: ${msg.slice(0, 200)}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DOI Resolution Content Fetching
+// ---------------------------------------------------------------------------
+
+const CROSSREF_BASE = 'https://api.crossref.org';
+const CROSSREF_USER_AGENT = 'LongtermWiki/1.0 (mailto:contact@longtermwiki.com)';
+
+/**
+ * Extract DOI from a URL. Handles direct doi.org links and publisher URLs
+ * with DOI patterns embedded in the path.
+ */
+function extractDoi(url: string): string | null {
+  // Direct doi.org link
+  const doiOrgMatch = url.match(/doi\.org\/(10\.\d{4,}\/[^\s?#]+)/);
+  if (doiOrgMatch) return doiOrgMatch[1];
+
+  // DOI embedded in publisher URL path
+  const pathMatch = url.match(/(10\.\d{4,}\/[^\s?#]+)/);
+  if (pathMatch) return pathMatch[1];
+
+  return null;
+}
+
+interface CrossrefWork {
+  DOI: string;
+  title?: string[];
+  author?: { given?: string; family?: string; name?: string }[];
+  abstract?: string;
+  'container-title'?: string[];
+  'published-print'?: { 'date-parts': number[][] };
+  'published-online'?: { 'date-parts': number[][] };
+  issued?: { 'date-parts': number[][] };
+}
+
+/**
+ * Fetch content via DOI resolution through CrossRef.
+ * Gets structured metadata (title, abstract, authors) which is more
+ * reliable than scraping publisher pages that block bots.
+ */
+export async function fetchDoiContent(url: string): Promise<StrategyResult | null> {
+  const doi = extractDoi(url);
+  if (!doi) return null;
+
+  try {
+    const apiUrl = `${CROSSREF_BASE}/works/${encodeURIComponent(doi)}`;
+    const response = await fetch(apiUrl, {
+      headers: { 'User-Agent': CROSSREF_USER_AGENT },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) return null;
+
+    const data = await response.json() as { status: string; message: CrossrefWork };
+    if (data.status !== 'ok') return null;
+
+    const work = data.message;
+    const title = work.title?.[0] ?? '';
+    const journal = work['container-title']?.[0] ?? '';
+
+    // Clean abstract (strip JATS/HTML tags)
+    const abstractRaw = work.abstract ?? '';
+    const abstract = abstractRaw
+      .replace(/<[^>]+>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    // Format authors
+    const authors = (work.author ?? [])
+      .map(a => a.name ?? [a.given, a.family].filter(Boolean).join(' '))
+      .filter(Boolean);
+
+    // Extract publication date
+    const dateParts = (
+      work['published-print'] ?? work['published-online'] ?? work.issued
+    )?.['date-parts']?.[0];
+    const pubDate = dateParts
+      ? dateParts.map(p => String(p).padStart(2, '0')).join('-')
+      : '';
+
+    // Build structured content
+    const contentParts = [
+      `# ${title}`,
+      authors.length > 0 ? `Authors: ${authors.join(', ')}` : '',
+      journal ? `Journal: ${journal}` : '',
+      pubDate ? `Published: ${pubDate}` : '',
+      `DOI: ${work.DOI}`,
+      '',
+      abstract ? `## Abstract\n\n${abstract}` : '',
+    ].filter(Boolean);
+
+    const content = contentParts.join('\n');
+
+    if (content.length < 50) return null; // Not enough content
+
+    return {
+      title,
+      content,
+      httpStatus: 200,
+      fetchMethod: 'doi-crossref',
+      resolvedUrl: `https://doi.org/${work.DOI}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[fetch-strategies] DOI resolution failed for ${url}: ${msg.slice(0, 200)}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wayback Machine Content Fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a Wayback Machine snapshot URL.
+ */
+async function lookupWaybackSnapshot(url: string): Promise<{ archiveUrl: string; timestamp: string } | null> {
+  // Strategy 1: Availability API
+  try {
+    const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
+    const response = await fetch(apiUrl, {
+      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (response.ok) {
+      const data = await response.json() as {
+        archived_snapshots?: { closest?: { url: string; timestamp: string; available: boolean } };
+      };
+      const snapshot = data?.archived_snapshots?.closest;
+      if (snapshot?.available && snapshot.url) {
+        return { archiveUrl: snapshot.url, timestamp: snapshot.timestamp };
+      }
+    }
+  } catch {
+    // Fall through to direct URL approach
+  }
+
+  // Strategy 2: Direct Wayback URL — follows redirect to closest snapshot
+  try {
+    const directUrl = `https://web.archive.org/web/2024/${url}`;
+    const response = await fetch(directUrl, {
+      redirect: 'manual',
+      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (response.status === 302 || response.status === 301) {
+      const location = response.headers.get('location');
+      if (location?.includes('web.archive.org/web/')) {
+        const tsMatch = location.match(/\/web\/(\d{14})\//);
+        return { archiveUrl: location, timestamp: tsMatch?.[1] ?? 'unknown' };
+      }
+    }
+    if (response.ok) {
+      return { archiveUrl: directUrl, timestamp: 'unknown' };
+    }
+  } catch {
+    // Both strategies failed
+  }
+
+  return null;
+}
+
+/**
+ * Extract text content from a Wayback Machine archived HTML page.
+ */
+function extractWaybackText(html: string): { title: string | null; content: string } {
+  // Extract title
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch
+    ? titleMatch[1].replace(/\s+/g, ' ').trim()
+    : null;
+
+  // Convert HTML to plain text
+  const content = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    // Remove Wayback Machine toolbar
+    .replace(/<!-- BEGIN WAYBACK TOOLBAR[\s\S]*?END WAYBACK TOOLBAR -->/gi, '')
+    .replace(/<div id="wm-ipp-base"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/gi, '')
+    .replace(/<\/?(p|div|br|h[1-6]|li|tr|blockquote|section|article)[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return { title, content };
+}
+
+/**
+ * Fetch content from the Wayback Machine for a dead or unreachable URL.
+ */
+export async function fetchWaybackContent(url: string): Promise<StrategyResult | null> {
+  const snapshot = await lookupWaybackSnapshot(url);
+  if (!snapshot) return null;
+
+  try {
+    const response = await fetch(snapshot.archiveUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; LongtermWikiBot/1.0; +https://www.longtermwiki.com)',
+        Accept: 'text/html,application/xhtml+xml,*/*',
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) return null;
+
+    const ct = response.headers.get('content-type') ?? '';
+    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) {
+      return null; // Skip non-HTML (PDFs etc.)
+    }
+
+    const html = await response.text();
+    const { title, content } = extractWaybackText(html);
+
+    if (content.length < 100) return null; // Too little content
+
+    return {
+      title: title ?? '',
+      content: content.slice(0, 100_000),
+      httpStatus: 200,
+      fetchMethod: 'wayback',
+      archiveUrl: snapshot.archiveUrl,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[fetch-strategies] Wayback fetch failed for ${url}: ${msg.slice(0, 200)}`);
+    return null;
+  }
+}

--- a/crux/lib/search/resource-lookup.ts
+++ b/crux/lib/search/resource-lookup.ts
@@ -173,3 +173,28 @@ export function updateResourceFetchStatus(
       );
     });
 }
+
+/**
+ * Update a resource's archive_url by calling the wiki-server batch endpoint.
+ *
+ * Fire-and-forget: errors are logged but do not propagate to the caller.
+ */
+export function updateResourceArchiveUrl(
+  resourceId: string,
+  archiveUrl: string,
+): void {
+  import('../wiki-server/resources.ts')
+    .then((mod) => mod.updateResourceArchiveUrl(resourceId, archiveUrl))
+    .then((result) => {
+      if (!result.ok) {
+        console.warn(
+          `[resource-lookup] Failed to update archive URL for ${resourceId}: ${result.error}`,
+        );
+      }
+    })
+    .catch((e: unknown) => {
+      console.warn(
+        `[resource-lookup] Failed to update archive URL for ${resourceId}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    });
+}

--- a/crux/lib/search/source-fetcher.test.ts
+++ b/crux/lib/search/source-fetcher.test.ts
@@ -66,6 +66,7 @@ vi.mock('./resource-lookup.ts', () => ({
     return null;
   }),
   updateResourceFetchStatus: vi.fn(),
+  updateResourceArchiveUrl: vi.fn(),
 }));
 
 // Mock pdf-extractor (the module source-fetcher actually imports) instead of
@@ -84,6 +85,15 @@ vi.mock('youtube-transcript', () => ({
 // Mock api-keys to ensure Firecrawl is never activated in tests.
 vi.mock('../api-keys.ts', () => ({
   getApiKey: vi.fn(() => undefined),
+}));
+
+// Mock fetch-strategies so domain-aware routing doesn't interfere with existing tests.
+// All strategies return null (no match), falling through to standard fetch path.
+vi.mock('./fetch-strategies.ts', () => ({
+  getContentFetchStrategy: vi.fn(() => 'default'),
+  fetchForumContent: vi.fn().mockResolvedValue(null),
+  fetchDoiContent: vi.fn().mockResolvedValue(null),
+  fetchWaybackContent: vi.fn().mockResolvedValue(null),
 }));
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/search/source-fetcher.ts
+++ b/crux/lib/search/source-fetcher.ts
@@ -40,6 +40,7 @@ import {
   getResourceById,
   getResourceByUrl,
   updateResourceFetchStatus,
+  updateResourceArchiveUrl,
   type ResourceEntry,
 } from './resource-lookup.ts';
 import { isYoutubeUrl } from '../../resource-utils.ts';
@@ -47,6 +48,13 @@ import {
   detectPaywall,
   isUnverifiableDomain,
 } from './paywall-detection.ts';
+import {
+  getContentFetchStrategy,
+  fetchForumContent,
+  fetchDoiContent,
+  fetchWaybackContent,
+  type StrategyResult,
+} from './fetch-strategies.ts';
 
 // ---------------------------------------------------------------------------
 // Public interfaces (spec from issue #633)
@@ -676,11 +684,9 @@ async function _fetchSourceCore(
     return result;
   }
 
-  // ---- 5. Network fetch (Firecrawl → built-in fallback) ----
-  // arXiv: rewrite to Ar5iv HTML for clean full-text extraction.
-  // If Ar5iv fails (404 — paper not converted yet), fall back to original arxiv.org URL.
-  const ar5ivUrl = rewriteArxivUrl(url);
-  const fetchUrl = ar5ivUrl ?? url;
+  // ---- 5. Network fetch (domain-aware strategies → Firecrawl → built-in) ----
+  // Domain-aware routing (#3457): specialized strategies run first for domains
+  // where they recover content that generic HTTP can't (403s, dead sites, paywalls).
 
   let title = '';
   let content = '';
@@ -688,26 +694,82 @@ async function _fetchSourceCore(
   let fetchError: string | null = null;
   let fetchedContentType: FetchedSourceContentType = 'html';
   let fetchMethod: string = 'built-in';
+  let archiveUrl: string | undefined;
 
-  const firecrawlResult = await fetchWithFirecrawl(fetchUrl);
-  if (firecrawlResult) {
-    title = firecrawlResult.title;
-    content = firecrawlResult.content;
-    httpStatus = 200;
-    // Firecrawl returns markdown — treat as HTML-equivalent
-    fetchedContentType = 'html';
-    fetchMethod = 'firecrawl';
+  const strategy = getContentFetchStrategy(url);
+
+  let strategyResult: StrategyResult | null = null;
+
+  // Try domain-specific strategy first
+  switch (strategy) {
+    case 'forum-api':
+      strategyResult = await fetchForumContent(url);
+      break;
+    case 'doi':
+      strategyResult = await fetchDoiContent(url);
+      break;
+    case 'wayback-only':
+      strategyResult = await fetchWaybackContent(url);
+      break;
+    case 'firecrawl-priority':
+      // For bot-blocked domains, try Firecrawl first and skip built-in if it fails
+      // (built-in would just get a 403 anyway).
+      {
+        const fcResult = await fetchWithFirecrawl(url);
+        if (fcResult) {
+          strategyResult = {
+            title: fcResult.title,
+            content: fcResult.content,
+            httpStatus: 200,
+            fetchMethod: 'firecrawl',
+          };
+        }
+        // If Firecrawl failed, fall through to built-in as a last resort
+      }
+      break;
+    default:
+      // 'default' — handled below in the standard fetch path
+      break;
+  }
+
+  if (strategyResult && strategyResult.content.length > 0) {
+    title = strategyResult.title;
+    content = strategyResult.content;
+    httpStatus = strategyResult.httpStatus;
+    fetchMethod = strategyResult.fetchMethod;
+    archiveUrl = strategyResult.archiveUrl;
   } else {
-    const builtinResult = await fetchWithBuiltin(fetchUrl);
-    // If Ar5iv failed with a 4xx error, retry with the original arxiv.org URL
-    if (ar5ivUrl && builtinResult.httpStatus >= 400 && fetchUrl !== url) {
-      const fallbackResult = await fetchWithBuiltin(url);
-      if (fallbackResult.httpStatus < 400 && fallbackResult.content.length > 0) {
-        title = fallbackResult.title;
-        content = fallbackResult.content;
-        httpStatus = fallbackResult.httpStatus;
-        fetchError = fallbackResult.error;
-        fetchedContentType = fallbackResult.contentType;
+    // Standard fetch path: arXiv rewrite → Firecrawl → built-in
+    const ar5ivUrl = rewriteArxivUrl(url);
+    const fetchUrl = ar5ivUrl ?? url;
+
+    const firecrawlResult = strategy !== 'firecrawl-priority'
+      ? await fetchWithFirecrawl(fetchUrl)
+      : null; // Already tried above for firecrawl-priority
+    if (firecrawlResult) {
+      title = firecrawlResult.title;
+      content = firecrawlResult.content;
+      httpStatus = 200;
+      fetchedContentType = 'html';
+      fetchMethod = 'firecrawl';
+    } else {
+      const builtinResult = await fetchWithBuiltin(fetchUrl);
+      // If Ar5iv failed with a 4xx error, retry with the original arxiv.org URL
+      if (ar5ivUrl && builtinResult.httpStatus >= 400 && fetchUrl !== url) {
+        const fallbackResult = await fetchWithBuiltin(url);
+        if (fallbackResult.httpStatus < 400 && fallbackResult.content.length > 0) {
+          title = fallbackResult.title;
+          content = fallbackResult.content;
+          httpStatus = fallbackResult.httpStatus;
+          fetchError = fallbackResult.error;
+          fetchedContentType = fallbackResult.contentType;
+        } else {
+          title = builtinResult.title;
+          content = builtinResult.content;
+          httpStatus = builtinResult.httpStatus;
+          fetchError = builtinResult.error;
+          fetchedContentType = builtinResult.contentType;
+        }
       } else {
         title = builtinResult.title;
         content = builtinResult.content;
@@ -715,16 +777,26 @@ async function _fetchSourceCore(
         fetchError = builtinResult.error;
         fetchedContentType = builtinResult.contentType;
       }
-    } else {
-      title = builtinResult.title;
-      content = builtinResult.content;
-      httpStatus = builtinResult.httpStatus;
-      fetchError = builtinResult.error;
-      fetchedContentType = builtinResult.contentType;
     }
   }
 
-  // ---- 5b. Determine status ----
+  // ---- 5b. Wayback fallback for 404/dead URLs ----
+  // If the standard fetch got a 404/410 and we didn't already try Wayback,
+  // attempt Wayback as a last resort (#3457 P2).
+  if ((httpStatus === 404 || httpStatus === 410 || (httpStatus === 0 && fetchError)) &&
+      content.length === 0 && strategy !== 'wayback-only') {
+    const waybackResult = await fetchWaybackContent(url);
+    if (waybackResult && waybackResult.content.length > 0) {
+      title = waybackResult.title;
+      content = waybackResult.content;
+      httpStatus = waybackResult.httpStatus;
+      fetchMethod = waybackResult.fetchMethod;
+      archiveUrl = waybackResult.archiveUrl;
+      fetchError = null;
+    }
+  }
+
+  // ---- 5c. Determine status ----
   let status: FetchedSourceStatus;
   if (fetchError && httpStatus === 0) {
     status = 'error';
@@ -744,6 +816,11 @@ async function _fetchSourceCore(
   if (content.length > 0) {
     saveToMemoryCache(url, title, content, httpStatus, fetchedContentType);
     saveToPostgres(url, title, content, httpStatus, fetchedContentType, fetchMethod);
+  }
+
+  // ---- 6b. Update archive URL on resource (fire-and-forget) ----
+  if (archiveUrl && resource) {
+    updateResourceArchiveUrl(resource.id, archiveUrl);
   }
 
   // ---- 7. Extract excerpts ----

--- a/crux/lib/wiki-server/resources.ts
+++ b/crux/lib/wiki-server/resources.ts
@@ -112,3 +112,16 @@ export async function suggestResourcesApi(
 ): Promise<ApiResult<SuggestResourcesResult>> {
   return apiRequest<SuggestResourcesResult>('POST', '/api/resources/suggest', input);
 }
+
+/**
+ * Update a resource's archive_url via the batch endpoint.
+ * Used by source-fetcher when Wayback Machine content is found for a dead link.
+ */
+export async function updateResourceArchiveUrl(
+  id: string,
+  archiveUrl: string,
+): Promise<ApiResult<{ upserted: number; results: Array<{ id: string; url: string }> }>> {
+  return apiRequest('POST', '/api/resources/batch', {
+    items: [{ id, archiveUrl }],
+  });
+}


### PR DESCRIPTION
## Summary

- Adds domain-aware content-fetching strategies to `source-fetcher.ts` that route URLs to specialized fetch methods based on domain type
- **Forum API**: LessWrong, Alignment Forum, EA Forum URLs use GraphQL API for clean markdown content instead of HTTP scraping (fixes 10+ `alignmentforum.org` 403s)
- **DOI resolution**: Academic publisher URLs (Nature, Science, PNAS, etc.) resolved via CrossRef API for structured metadata
- **Firecrawl priority**: Bot-blocked domains (OpenAI, RAND, Reuters, Bloomberg, Medium) try Firecrawl first since built-in HTTP gets 403
- **Wayback Machine**: Dead domains (FHI, FTX Future Fund, etc.) automatically fetch from web.archive.org; any URL returning 404/410 gets automatic Wayback fallback
- **Archive URL persistence**: When Wayback content is found, `resources.archive_url` is populated via the batch API

New file: `crux/lib/search/fetch-strategies.ts` — strategy router + domain-specific fetch implementations
Modified: `crux/lib/search/source-fetcher.ts` — integrates strategy routing before standard fetch path

Addresses P0 (Firecrawl for bot-blocked), P1 (domain-aware routing), P2 (auto-archive dead links) from the issue.

Closes #3457

## Test plan

- [x] 27 new tests in `fetch-strategies.test.ts` covering domain classification, forum fetching, DOI resolution, and Wayback fetching
- [x] All 67 existing `source-fetcher.test.ts` tests still pass (strategy module mocked to return `default`)
- [x] Full test suite: 4410 tests pass
- [x] `pnpm build` succeeds
- [x] No TypeScript errors in changed files (pre-existing crux TS errors unrelated to this PR)

Generated with [Claude Code](https://claude.com/claude-code)