### PR TITLE
feat: register sid-display validator as CI-blocking gate check

### DIFF
--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -464,6 +464,18 @@ const PARALLEL_STEPS: Step[] = [
     emitOutputInCi: true,
   },
   {
+    id: 'sid-display',
+    name: 'No sid_ values in display name columns',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-sid-display.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: display name columns must never contain sid_-prefixed stableIds.
+    // The sid_ prefix makes detection trivial. If any display column has a sid_
+    // value, it means the enrichment pipeline wrote a stableId where a human-
+    // readable name should be. Requires wiki-server for API queries.
+    requiresServer: true,
+  },
+  {
     id: 'soft-fks',
     name: 'Soft FK entity reference validation (advisory)',
     command: 'npx',

--- a/crux/validate/validate-sid-display.ts
+++ b/crux/validate/validate-sid-display.ts
@@ -9,17 +9,18 @@
  * or be NULL. This validator catches cases where the enrichment pipeline
  * incorrectly stores a stableId as a display name.
  *
- * Checks all 5 tables with display name columns:
+ * Checks all 6 tables with display name columns:
  * - personnel: person_display_name, org_display_name
  * - grants: grantee_display_name, org_display_name
  * - funding_rounds: company_display_name, lead_investor_display_name
  * - investments: company_display_name, investor_display_name
  * - equity_positions: company_display_name, holder_display_name
+ * - entity_events: entity_display_name
  *
  * Also checks that raw ID fields (person_id, grantee_id, etc.) that contain
  * sid_-prefixed values have a resolved entity FK.
  *
- * Requires wiki-server to be running (queries the API). Advisory — not CI-blocking.
+ * Requires wiki-server to be running (queries the API). CI-blocking.
  *
  * Usage:
  *   npx tsx crux/validate/validate-sid-display.ts              # advisory mode
@@ -160,6 +161,16 @@ export const TABLE_DISPLAY_SPECS: TableDisplaySpec[] = [
       { idField: "companyId", entityFkField: "companyEntityId" },
       { idField: "holderId", entityFkField: "holderEntityId" },
     ],
+    maxLimit: 200,
+  },
+  {
+    apiPath: "/api/entity-events/all",
+    responseKey: "events",
+    displayFields: [
+      { displayField: "entityDisplayName" },
+    ],
+    // entityId is a hard FK (NOT NULL) — no separate raw ID vs resolved FK pattern
+    idFields: [],
     maxLimit: 200,
   },
 ];


### PR DESCRIPTION
## Summary

- Registers `validate-sid-display` as a **blocking** gate check (`requiresServer: true`) in the pre-push gate
- Adds entity_events table coverage (entityDisplayName field) to the validator
- Updates doc comment to reflect CI-blocking status

The validator itself already existed with comprehensive tests (11 tests) — this PR promotes it from an unregistered standalone script to a proper gate check that prevents `sid_`-prefixed stableIds from appearing in display name columns.

Closes #3460

## Also closed as already-implemented

- **#3461** (Centralized `resolveEntityFKs()`) — already exists at `apps/wiki-server/src/routes/shared/resolve-entity-fks.ts`, wired into all 5 sync endpoints
- **#3462** (Enrichment pipeline guard) — already exists in `crux/tablebase/tools.ts` lines 386-438, validates all entity refs and rejects fabricated IDs

## Test plan

- [x] All 11 existing validator tests pass (`pnpm vitest run crux/validate/validate-sid-display.test.ts`)
- [x] Gate file loads and runs without errors
- [x] Validator correctly skips when wiki-server is unavailable (requiresServer: true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)