### PR TITLE
feat: sid_ guard in enrichment pipeline + entity-type issue gate + personnel cleanup

### DIFF
--- a/crux/commands/issues.ts
+++ b/crux/commands/issues.ts
@@ -45,7 +45,7 @@ import {
   formatIssueRow,
 } from '../lib/issues/formatting.ts';
 import { extractModel, applyModelLabel, isValidModel } from '../lib/issues/models.ts';
-import { DAILY_CREATE_LIMIT, getCreatesToday, recordCreate } from '../lib/issues/rate-limit.ts';
+import { DAILY_CREATE_LIMIT, ENTITY_TYPE_THRESHOLD, getCreatesToday, recordCreate, getOverrepresentedEntityTypes } from '../lib/issues/rate-limit.ts';
 
 /**
  * Read a text value from a `--*-file=<path>` flag.
@@ -379,6 +379,43 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     }
   }
 
+  // Entity-type duplicate gate: warn if >3 issues in this session reference the same entity type.
+  // This catches QA sweeps that file many symptom-level issues for one root cause (#3387).
+  const ENTITY_TYPE_PATTERNS: Array<[RegExp, string]> = [
+    [/\bperson(?:nel)?\b/, 'person'],
+    [/\bpeople\b/, 'person'],
+    [/\borganization\b/, 'organization'],
+    [/\binvestor\b/, 'investor'],
+    [/\binvestment\b/, 'investor'],
+    [/\bgrant(?:ee)?\b/, 'grant'],
+    [/\bbenchmark\b/, 'benchmark'],
+    [/\bai[- ]model\b/, 'ai-model'],  // "ai model" or "ai-model", not bare "model"
+    [/\bfunding\b/, 'funding'],
+  ];
+  // Strip the "## Recommended Model" section injected by buildIssueBody before scanning,
+  // so the --model flag doesn't cause false positives on every structured issue.
+  const textToScan = `${title} ${body}`.toLowerCase().replace(/## recommended model[\s\S]*?(?=##|$)/, '');
+  const normalizedTypes = [...new Set(
+    ENTITY_TYPE_PATTERNS
+      .filter(([re]) => re.test(textToScan))
+      .map(([, type]) => type),
+  )];
+
+  // Check existing counts before creating
+  const overrep = getOverrepresentedEntityTypes();
+  const overlapping = overrep.filter(([t]) => normalizedTypes.includes(t));
+  if (overlapping.length > 0 && !options.force) {
+    const details = overlapping.map(([t, n]) => `"${t}" (${n} issues today)`).join(', ');
+    return {
+      output:
+        `${c.yellow}⚠ Entity-type concentration warning:${c.reset} ${details}\n` +
+        `You've filed >${ENTITY_TYPE_THRESHOLD} issues today referencing the same entity type.\n` +
+        `These may be symptoms of a single root cause — consider filing one umbrella issue instead.\n` +
+        `${c.dim}Use --force to override this warning.${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
   // Evidence validation: advisory warning if issue body lacks concrete evidence
   let evidenceWarning = '';
   if (body && !options.draft) {
@@ -407,7 +444,7 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   });
 
   // Record creation for rate limiting (non-fatal)
-  try { recordCreate(); } catch { /* ignore — rate limiting is advisory */ }
+  try { recordCreate(normalizedTypes); } catch { /* ignore — rate limiting is advisory */ }
 
   // Apply model label if --model was specified
   if (options.model) {

--- a/crux/lib/issues/rate-limit.ts
+++ b/crux/lib/issues/rate-limit.ts
@@ -9,10 +9,16 @@ import { join, dirname } from 'path';
 
 /** Threshold for soft warning — not a hard limit */
 export const DAILY_CREATE_LIMIT = 5;
+
+/** Warn when >3 issues in one session reference the same entity type */
+export const ENTITY_TYPE_THRESHOLD = 3;
+
 const RATE_LIMIT_FILE = join(dirname(new URL(import.meta.url).pathname), '../../../.claude/issue-creates.json');
 
 interface RateLimitRecord {
   timestamps: string[]; // ISO date strings of issue creation times
+  /** Entity types mentioned in today's issues, keyed by type name → count */
+  entityTypeCounts?: Record<string, number>;
 }
 
 /**
@@ -30,10 +36,11 @@ export function getCreatesToday(): number {
 }
 
 /**
- * Record that an issue was just created.
+ * Record that an issue was just created, optionally with entity types it references.
  */
-export function recordCreate(): void {
+export function recordCreate(entityTypes?: string[]): void {
   const now = new Date().toISOString();
+  const today = now.slice(0, 10);
   let data: RateLimitRecord = { timestamps: [] };
   try {
     if (existsSync(RATE_LIMIT_FILE)) {
@@ -44,5 +51,37 @@ export function recordCreate(): void {
   const cutoff = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
   data.timestamps = data.timestamps.filter(t => t.slice(0, 10) >= cutoff);
   data.timestamps.push(now);
+
+  // Track entity types for today's session
+  if (!data.entityTypeCounts) data.entityTypeCounts = {};
+  // Reset counts if they're from a previous day (check first timestamp today)
+  const todayTimestamps = data.timestamps.filter(t => t.startsWith(today));
+  if (todayTimestamps.length <= 1) {
+    data.entityTypeCounts = {};
+  }
+  if (entityTypes) {
+    for (const t of entityTypes) {
+      const key = t.toLowerCase();
+      data.entityTypeCounts[key] = (data.entityTypeCounts[key] || 0) + 1;
+    }
+  }
+
   writeFileSync(RATE_LIMIT_FILE, JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Get entity types that have exceeded the threshold for today's session.
+ * Returns an array of [entityType, count] pairs that are over the limit.
+ */
+export function getOverrepresentedEntityTypes(): Array<[string, number]> {
+  try {
+    if (!existsSync(RATE_LIMIT_FILE)) return [];
+    const data: RateLimitRecord = JSON.parse(readFileSync(RATE_LIMIT_FILE, 'utf-8'));
+    if (!data.entityTypeCounts) return [];
+    return Object.entries(data.entityTypeCounts).filter(
+      ([, count]) => count > ENTITY_TYPE_THRESHOLD,
+    );
+  } catch {
+    return [];
+  }
 }

--- a/crux/scripts/cleanup-personnel.ts
+++ b/crux/scripts/cleanup-personnel.ts
@@ -77,9 +77,19 @@ async function main() {
   const all = await fetchAllPersonnel();
   console.log(`Total records: ${all.length}`);
 
-  // ── Category 1: No displayable name ──
-  const noName = all.filter((r) => !hasDisplayableName(r));
-  console.log(`\nRecords with no displayable name: ${noName.length}`);
+  // ── Category 1a: Fabricated stableId — personId looks like a stableId but doesn't
+  //    match any entity AND has no human-readable name from any source.
+  //    The !hasDisplayableName guard prevents deleting records that are merely
+  //    waiting for entity resolution (e.g., synced before their person entity).
+  const fabricatedId = all.filter(
+    (r) => STABLE_ID_RE.test(r.personId) && !r.personEntityId && !hasDisplayableName(r),
+  );
+  console.log(`\nRecords with fabricated personId (stableId, no entity, no name): ${fabricatedId.length}`);
+
+  // ── Category 1b: No displayable name (catches remaining junk) ──
+  const fabricatedIdSet = new Set(fabricatedId.map((r) => r.id));
+  const noName = all.filter((r) => !hasDisplayableName(r) && !fabricatedIdSet.has(r.id));
+  console.log(`Records with no displayable name (additional): ${noName.length}`);
 
   // ── Category 2: Duplicates (same person + same org) ──
   const seen = new Map<string, PersonnelRecord>();
@@ -112,12 +122,21 @@ async function main() {
   console.log(`Duplicate records: ${duplicates.length}`);
 
   // ── Summary ──
-  const toDelete = [...noName, ...duplicates];
+  const toDelete = [...fabricatedId, ...noName, ...duplicates];
   const toDeleteIds = [...new Set(toDelete.map((r) => r.id))];
   console.log(`\nTotal to delete: ${toDeleteIds.length}`);
+  console.log(`  - Fabricated stableIds: ${fabricatedId.length}`);
+  console.log(`  - No displayable name: ${noName.length}`);
+  console.log(`  - Duplicates: ${duplicates.length}`);
   console.log(`Will remain: ${all.length - toDeleteIds.length}`);
 
   // Show samples
+  console.log('\n── Sample deletions (fabricated stableId) ──');
+  for (const r of fabricatedId.slice(0, 10)) {
+    const org = r.organization?.name ?? r.organizationId;
+    console.log(`  ${r.id} | personId=${r.personId} | ${r.role} at ${org}`);
+  }
+
   console.log('\n── Sample deletions (no name) ──');
   for (const r of noName.slice(0, 10)) {
     const org = r.organization?.name ?? r.organizationId;

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -11,7 +11,7 @@ import { resolve } from 'path';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { proposeClaims, getClaimStatus } from '../lib/wiki-server/claims.ts';
 import { generateId } from '../lib/grant-import/id.ts';
-import { generateSid, isAnySid } from '../../packages/id-utils/src/index.ts';
+import { generateSid, isAnySid, isSid, stripSid, SID_PREFIX } from '../../packages/id-utils/src/index.ts';
 import { buildEntityMatcher, matchGrantee } from '../lib/grant-import/entity-matcher.ts';
 import { toSlug } from './types.ts';
 import { getTableConfig } from './table-registry.ts';
@@ -61,7 +61,7 @@ export function getToolDefinitions() {
       },
       {
         name: 'resolve_entity',
-        description: 'Resolve an entity name to its stable ID. Use this to find entity IDs for people, organizations, benchmarks, etc. before submitting records.',
+        description: 'Resolve an entity name to its stable ID (returned as sid_XXXX). You MUST use this tool to get IDs for people, organizations, benchmarks, etc. before submitting records. Never fabricate IDs — only use the sid_-prefixed values returned by this tool or create_entity.',
         input_schema: {
           type: 'object',
           properties: {
@@ -72,7 +72,7 @@ export function getToolDefinitions() {
       },
       {
         name: 'submit_records',
-        description: 'Submit new or updated records to a table. Records are validated and deduplicated before insertion.',
+        description: 'Submit new or updated records to a table. Records are validated and deduplicated before insertion. Entity reference fields (personId, organizationId, etc.) MUST use sid_-prefixed IDs from resolve_entity or create_entity.',
         input_schema: {
           type: 'object',
           properties: {
@@ -92,7 +92,7 @@ export function getToolDefinitions() {
       },
       {
         name: 'create_entity',
-        description: 'Create a new entity (person, organization, benchmark, etc.) in the database. Use this when resolve_entity returns NOT_FOUND for a person or org you need to reference. Returns the new entity\'s stableId.',
+        description: 'Create a new entity (person, organization, benchmark, etc.) in the database. Use this when resolve_entity returns NOT_FOUND for a person or org you need to reference. Returns the new entity\'s stableId as sid_XXXX — use this prefixed value in submit_records.',
         input_schema: {
           type: 'object',
           properties: {
@@ -209,7 +209,7 @@ async function handleQueryEntities(input: Record<string, unknown>): Promise<stri
 
   if (!result.ok) return `Error: ${result.message}`;
   return JSON.stringify(result.data.results.map(r => ({
-    id: r.stableId || r.id,
+    id: r.stableId ? SID_PREFIX + r.stableId : r.id,
     slug: r.id,
     title: r.title,
     entityType: r.entityType,
@@ -218,7 +218,7 @@ async function handleQueryEntities(input: Record<string, unknown>): Promise<stri
 
 async function handleQueryExistingRecords(input: Record<string, unknown>): Promise<string> {
   const table = input.table as string;
-  const entityId = input.entityId as string;
+  const entityId = stripSid(input.entityId as string);
 
   const config = getTableConfig(table);
   if (!config) return `Error: Unknown table "${table}"`;
@@ -236,7 +236,7 @@ function handleResolveEntity(input: Record<string, unknown>): string {
   // Try direct match first
   const match = matcher.match(name);
   if (match) {
-    return JSON.stringify({ found: true, stableId: match.stableId, slug: match.slug, name: match.name });
+    return JSON.stringify({ found: true, stableId: SID_PREFIX + match.stableId, slug: match.slug, name: match.name });
   }
 
   // Try matching with grantee normalization (strips Inc, LLC, etc.)
@@ -245,7 +245,7 @@ function handleResolveEntity(input: Record<string, unknown>): string {
     const m = matcher.match(granteeMatch);
     return JSON.stringify({
       found: true,
-      stableId: granteeMatch,
+      stableId: SID_PREFIX + granteeMatch,
       slug: m?.slug || '',
       name: m?.name || name,
       matchedVia: 'normalization',
@@ -267,7 +267,7 @@ async function handleCreateEntity(input: Record<string, unknown>): Promise<strin
   const matcher = getEntityMatcher();
   const existing = matcher.match(name);
   if (existing) {
-    return JSON.stringify({ created: false, existing: true, stableId: existing.stableId, name: existing.name });
+    return JSON.stringify({ created: false, existing: true, stableId: SID_PREFIX + existing.stableId, name: existing.name });
   }
 
   // Generate sid_-prefixed stableId (no wikiId — not a full wiki entity)
@@ -397,12 +397,12 @@ async function handleSubmitRecords(
   }
 
   // Validate and normalize entity reference fields.
-  // LLMs sometimes hallucinate plausible-looking 10-char stableIds instead of
-  // calling resolve_entity. We must verify ALL entity references exist — not
-  // just slug-formatted ones. See discussion #3387 for the full root cause.
+  // resolve_entity and create_entity return sid_-prefixed stableIds. We require
+  // the prefix (catches hallucinated IDs) AND verify the underlying ID exists in
+  // the known stableId set (catches fabricated sid_XXXX values). Belt + suspenders.
+  // See discussion #3387 for the full root cause.
   const entityFields = ['personId', 'organizationId', 'investorId', 'companyId', 'benchmarkId', 'modelId', 'granteeId'];
   const matcher = getEntityMatcher();
-  // Load idRegistry for stableId validation (matcher only indexes by name/slug/alias)
   const stableIdSet = getKnownStableIds();
   const invalidRefs: string[] = [];
   for (const record of records) {
@@ -413,6 +413,17 @@ async function handleSubmitRecords(
       // Skip "new:" prefixed values — these are unresolved names, handled downstream
       if (val.startsWith('new:')) continue;
 
+      // Best path: sid_-prefixed value from resolve_entity / create_entity
+      if (isSid(val)) {
+        const raw = stripSid(val);
+        if (stableIdSet.has(raw) || stableIdSet.has(val)) {
+          record[field] = raw;
+          continue;
+        }
+        invalidRefs.push(`${field}="${val}" — sid_-prefixed but ID not found in database. Use resolve_entity to get a valid ID.`);
+        continue;
+      }
+
       // Try to resolve via entity matcher (handles slugs, names, aliases)
       const match = matcher.match(val);
       if (match) {
@@ -420,12 +431,12 @@ async function handleSubmitRecords(
         continue;
       }
 
-      // If it looks like a stableId (sid_-prefixed or legacy 10-char), verify it exists
+      // Legacy bare stableId (10-char alphanumeric) — verify it exists
       if (isAnySid(val)) {
         if (stableIdSet.has(val)) {
-          continue; // Legitimate stableId from resolve_entity or create_entity
+          continue;
         }
-        invalidRefs.push(`${field}="${val}" in record for ${record.role || record.name || 'unknown'}`);
+        invalidRefs.push(`${field}="${val}" — looks like a fabricated stableId. Use resolve_entity to get a sid_-prefixed ID.`);
         continue;
       }
 

--- a/packages/id-utils/src/index.ts
+++ b/packages/id-utils/src/index.ts
@@ -24,9 +24,25 @@ export function isSid(s: string | null | undefined): boolean {
   return typeof s === "string" && s.startsWith(SID_PREFIX);
 }
 
+/**
+ * Is this any form of stableId? Matches both sid_-prefixed IDs and legacy
+ * 10-char alphanumeric IDs (with at least one uppercase letter).
+ */
+export function isAnySid(s: string | null | undefined): boolean {
+  if (typeof s !== "string") return false;
+  if (s.startsWith(SID_PREFIX)) return true;
+  // Legacy format: exactly 10 alphanumeric chars with at least one uppercase
+  return /^(?=.*[A-Z])[A-Za-z0-9]{10}$/.test(s);
+}
+
 /** Is this safe to show to users? (Not a machine-generated ID) */
 export function isDisplayableName(s: string | null | undefined): boolean {
   return typeof s === "string" && !isSid(s);
+}
+
+/** Strip sid_ prefix if present, returning the raw ID for storage/lookup. */
+export function stripSid(s: string): string {
+  return s.startsWith(SID_PREFIX) ? s.slice(SID_PREFIX.length) : s;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses the remaining work from [discussion #3387](https://github.com/quantified-uncertainty/longterm-wiki/discussions/3387):

- **sid_ prefix guard in enrichment pipeline** — `resolve_entity`, `create_entity`, and `query_entities` now return sid_-prefixed stableIds. `submit_records` requires the prefix AND verifies the underlying ID exists in the known stableId set (belt + suspenders — prefix alone is insufficient since the LLM can see and fabricate it). `query_existing_records` strips sid_ from entityId input. Tool descriptions updated to instruct the LLM about the convention.

- **id-utils: `isAnySid()` + `stripSid()`** — New exports that handle both sid_-prefixed and legacy 10-char stableIds. Fixes the broken `isAnySid` import on main.

- **Entity-type concentration gate on `crux gh issues create`** — When >3 issues in one day reference the same entity type (person, organization, grant, etc.), blocks creation with a warning suggesting an umbrella issue instead. Uses word-boundary regex to avoid substring false positives; strips the "Recommended Model" section before scanning so `--model` doesn't trigger on every issue. `--force` overrides.

- **Personnel cleanup script improvements** — Adds Category 1a for fabricated stableIds (personId matches stableId regex + no personEntityId + no displayable name). The `!hasDisplayableName` guard prevents deleting records that are merely waiting for entity resolution.

## Cleanup instructions

To clean up the 1,138 bad personnel records:
```bash
pnpm tsx crux/scripts/cleanup-personnel.ts --dry-run   # preview what would be deleted
pnpm tsx crux/scripts/cleanup-personnel.ts              # actually delete
```

## Test plan

- [ ] Run enrichment pipeline with a test entity — verify `resolve_entity` returns `sid_XXXX` format
- [ ] Submit records with bare 10-char stableId — verify rejection with clear error message
- [ ] Submit records with `sid_`-prefixed ID — verify acceptance and prefix stripped in stored data
- [ ] Submit records with fabricated `sid_XXXX` (not in DB) — verify rejection by existence check
- [ ] Run `crux gh issues create` 4+ times with "person" in title — verify gate triggers on 5th
- [ ] Run `crux gh issues create --force` — verify gate bypass
- [ ] Run cleanup script with `--dry-run` — verify output categories and sample records
- [ ] Verify pre-push gate failures are pre-existing (confirmed: main has 4 failures, this branch has 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)