### PR TITLE
refactor: extract shared wayback and forum config utilities

### DIFF
--- a/crux/lib/forum-api.ts
+++ b/crux/lib/forum-api.ts
@@ -35,7 +35,13 @@ export const LESSWRONG: Forum = {
   baseUrl: 'https://www.lesswrong.com',
 };
 
-export const ALL_FORUMS: Forum[] = [EA_FORUM, LESSWRONG];
+export const ALIGNMENT_FORUM: Forum = {
+  name: 'Alignment Forum',
+  graphqlUrl: 'https://www.alignmentforum.org/graphql',
+  baseUrl: 'https://www.alignmentforum.org',
+};
+
+export const ALL_FORUMS: Forum[] = [EA_FORUM, LESSWRONG, ALIGNMENT_FORUM];
 
 /** Execute a GraphQL query against a forum API. Throws on HTTP or GraphQL errors. */
 export async function forumGraphql(

--- a/crux/lib/search/fetch-strategies.test.ts
+++ b/crux/lib/search/fetch-strategies.test.ts
@@ -18,12 +18,27 @@ import {
 } from './fetch-strategies.ts';
 
 // Mock the forum API module
-vi.mock('../forum-api.ts', () => ({
-  forumGraphql: vi.fn(),
+vi.mock('../forum-api.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../forum-api.ts')>();
+  return {
+    ...actual,
+    forumGraphql: vi.fn(),
+  };
+});
+
+// Mock the shared wayback module
+vi.mock('../wayback.ts', () => ({
+  fetchWaybackPageContent: vi.fn(),
+  lookupWaybackSnapshot: vi.fn(),
+  extractTitleFromHtml: vi.fn(),
+  htmlToPlainText: vi.fn(),
 }));
 
 import { forumGraphql } from '../forum-api.ts';
 const mockForumGraphql = vi.mocked(forumGraphql);
+
+import { fetchWaybackPageContent } from '../wayback.ts';
+const mockFetchWaybackPageContent = vi.mocked(fetchWaybackPageContent);
 
 // ---------------------------------------------------------------------------
 // Domain Classification Tests
@@ -295,33 +310,13 @@ describe('fetchWaybackContent', () => {
     vi.resetAllMocks();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('fetches content from Wayback Machine', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-
-    // Mock Wayback availability API
-    fetchSpy.mockResolvedValueOnce(
-      new Response(JSON.stringify({
-        archived_snapshots: {
-          closest: {
-            url: 'https://web.archive.org/web/20230101/https://www.fhi.ox.ac.uk/report',
-            timestamp: '20230101120000',
-            available: true,
-          },
-        },
-      }), { status: 200 }),
-    );
-
-    // Mock archive content fetch
-    fetchSpy.mockResolvedValueOnce(
-      new Response(
-        '<html><head><title>FHI Report</title></head><body><p>This is an important report about existential risk from the Future of Humanity Institute. It covers various topics related to AI safety and global catastrophic risks.</p></body></html>',
-        { status: 200, headers: { 'content-type': 'text/html' } },
-      ),
-    );
+  it('wraps fetchWaybackPageContent result into StrategyResult', async () => {
+    mockFetchWaybackPageContent.mockResolvedValueOnce({
+      title: 'FHI Report',
+      content: 'This is an important report about existential risk.',
+      contentType: 'text/html',
+      archiveUrl: 'https://web.archive.org/web/20230101/https://www.fhi.ox.ac.uk/report',
+    });
 
     const result = await fetchWaybackContent('https://www.fhi.ox.ac.uk/report');
 
@@ -330,44 +325,13 @@ describe('fetchWaybackContent', () => {
     expect(result!.content).toContain('existential risk');
     expect(result!.fetchMethod).toBe('wayback');
     expect(result!.archiveUrl).toContain('web.archive.org');
+    expect(result!.httpStatus).toBe(200);
   });
 
-  it('returns null when no snapshot is available', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-
-    // Availability API: no snapshot
-    fetchSpy.mockResolvedValueOnce(
-      new Response(JSON.stringify({ archived_snapshots: {} }), { status: 200 }),
-    );
-
-    // Direct URL: 404
-    fetchSpy.mockResolvedValueOnce(
-      new Response('Not Found', { status: 404 }),
-    );
+  it('returns null when fetchWaybackPageContent returns null', async () => {
+    mockFetchWaybackPageContent.mockResolvedValueOnce(null);
 
     const result = await fetchWaybackContent('https://nonexistent-site.example.com/page');
-    expect(result).toBeNull();
-  });
-
-  it('returns null when archived content is too short', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-
-    fetchSpy.mockResolvedValueOnce(
-      new Response(JSON.stringify({
-        archived_snapshots: {
-          closest: { url: 'https://web.archive.org/web/2023/test', timestamp: '20230101', available: true },
-        },
-      }), { status: 200 }),
-    );
-
-    fetchSpy.mockResolvedValueOnce(
-      new Response('<html><body>Too short</body></html>', {
-        status: 200,
-        headers: { 'content-type': 'text/html' },
-      }),
-    );
-
-    const result = await fetchWaybackContent('https://example.com/short');
     expect(result).toBeNull();
   });
 });

--- a/crux/lib/search/fetch-strategies.ts
+++ b/crux/lib/search/fetch-strategies.ts
@@ -15,8 +15,14 @@
  * See: https://github.com/quantified-uncertainty/longterm-wiki/issues/3457
  */
 
-import { forumGraphql, type Forum } from '../forum-api.ts';
+import {
+  forumGraphql,
+  LESSWRONG, EA_FORUM, ALIGNMENT_FORUM,
+  ALL_FORUMS,
+  type Forum,
+} from '../forum-api.ts';
 import { extractDOI as extractDOIFromUtils } from '../../resource-utils.ts';
+import { fetchWaybackPageContent } from '../wayback.ts';
 
 // ---------------------------------------------------------------------------
 // Strategy Types
@@ -150,13 +156,19 @@ export function isFirecrawlPriorityDomain(url: string): boolean {
 // Forum GraphQL Content Fetching
 // ---------------------------------------------------------------------------
 
-const FORUM_CONFIGS: Record<string, Forum> = {
-  'www.lesswrong.com': { name: 'LessWrong', graphqlUrl: 'https://www.lesswrong.com/graphql', baseUrl: 'https://www.lesswrong.com' },
-  'lesswrong.com': { name: 'LessWrong', graphqlUrl: 'https://www.lesswrong.com/graphql', baseUrl: 'https://www.lesswrong.com' },
-  'www.alignmentforum.org': { name: 'Alignment Forum', graphqlUrl: 'https://www.alignmentforum.org/graphql', baseUrl: 'https://www.alignmentforum.org' },
-  'alignmentforum.org': { name: 'Alignment Forum', graphqlUrl: 'https://www.alignmentforum.org/graphql', baseUrl: 'https://www.alignmentforum.org' },
-  'forum.effectivealtruism.org': { name: 'EA Forum', graphqlUrl: 'https://forum.effectivealtruism.org/graphql', baseUrl: 'https://forum.effectivealtruism.org' },
-};
+// Built from the canonical ALL_FORUMS list in forum-api.ts.
+// Keyed by hostname (with and without www.) for direct lookup.
+const FORUM_CONFIGS: Record<string, Forum> = Object.fromEntries(
+  ALL_FORUMS.flatMap((forum) => {
+    const hostname = new URL(forum.baseUrl).hostname;
+    const entries: [string, Forum][] = [[hostname, forum]];
+    // Also map www. variant if the canonical hostname doesn't have it
+    if (!hostname.startsWith('www.')) {
+      entries.push([`www.${hostname}`, forum]);
+    }
+    return entries;
+  }),
+);
 
 /**
  * Extract post ID from a forum URL.
@@ -357,131 +369,22 @@ export async function fetchDoiContent(url: string): Promise<StrategyResult | nul
 }
 
 // ---------------------------------------------------------------------------
-// Wayback Machine Content Fetching
+// Wayback Machine Content Fetching (delegates to shared crux/lib/wayback.ts)
 // ---------------------------------------------------------------------------
 
 /**
- * Look up a Wayback Machine snapshot URL.
- */
-async function lookupWaybackSnapshot(url: string): Promise<{ archiveUrl: string; timestamp: string } | null> {
-  // Strategy 1: Availability API
-  try {
-    const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
-    const response = await fetch(apiUrl, {
-      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
-      signal: AbortSignal.timeout(8_000),
-    });
-
-    if (response.ok) {
-      const data = await response.json() as {
-        archived_snapshots?: { closest?: { url: string; timestamp: string; available: boolean } };
-      };
-      const snapshot = data?.archived_snapshots?.closest;
-      if (snapshot?.available && snapshot.url) {
-        return { archiveUrl: snapshot.url, timestamp: snapshot.timestamp };
-      }
-    }
-  } catch {
-    // Fall through to direct URL approach
-  }
-
-  // Strategy 2: Direct Wayback URL — follows redirect to closest snapshot
-  try {
-    const directUrl = `https://web.archive.org/web/2024/${url}`;
-    const response = await fetch(directUrl, {
-      redirect: 'manual',
-      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (response.status === 302 || response.status === 301) {
-      const location = response.headers.get('location');
-      if (location?.includes('web.archive.org/web/')) {
-        const tsMatch = location.match(/\/web\/(\d{14})\//);
-        return { archiveUrl: location, timestamp: tsMatch?.[1] ?? 'unknown' };
-      }
-    }
-    if (response.ok) {
-      return { archiveUrl: directUrl, timestamp: 'unknown' };
-    }
-  } catch {
-    // Both strategies failed
-  }
-
-  return null;
-}
-
-/**
- * Extract text content from a Wayback Machine archived HTML page.
- */
-function extractWaybackText(html: string): { title: string | null; content: string } {
-  // Extract title
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  const title = titleMatch
-    ? titleMatch[1].replace(/\s+/g, ' ').trim()
-    : null;
-
-  // Convert HTML to plain text
-  const content = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    // Remove Wayback Machine toolbar
-    .replace(/<!-- BEGIN WAYBACK TOOLBAR[\s\S]*?END WAYBACK TOOLBAR -->/gi, '')
-    .replace(/<div id="wm-ipp-base"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/gi, '')
-    .replace(/<\/?(p|div|br|h[1-6]|li|tr|blockquote|section|article)[^>]*>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/[ \t]+/g, ' ')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-
-  return { title, content };
-}
-
-/**
  * Fetch content from the Wayback Machine for a dead or unreachable URL.
+ * Wraps the shared fetchWaybackPageContent into a StrategyResult.
  */
 export async function fetchWaybackContent(url: string): Promise<StrategyResult | null> {
-  const snapshot = await lookupWaybackSnapshot(url);
-  if (!snapshot) return null;
+  const result = await fetchWaybackPageContent(url);
+  if (!result) return null;
 
-  try {
-    const response = await fetch(snapshot.archiveUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; LongtermWikiBot/1.0; +https://www.longtermwiki.com)',
-        Accept: 'text/html,application/xhtml+xml,*/*',
-      },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (!response.ok) return null;
-
-    const ct = response.headers.get('content-type') ?? '';
-    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) {
-      return null; // Skip non-HTML (PDFs etc.)
-    }
-
-    const html = await response.text();
-    const { title, content } = extractWaybackText(html);
-
-    if (content.length < 100) return null; // Too little content
-
-    return {
-      title: title ?? '',
-      content: content.slice(0, 100_000),
-      httpStatus: 200,
-      fetchMethod: 'wayback',
-      archiveUrl: snapshot.archiveUrl,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[fetch-strategies] Wayback fetch failed for ${url}: ${msg.slice(0, 200)}`);
-    return null;
-  }
+  return {
+    title: result.title ?? '',
+    content: result.content,
+    httpStatus: 200,
+    fetchMethod: 'wayback',
+    archiveUrl: result.archiveUrl,
+  };
 }

--- a/crux/lib/wayback.ts
+++ b/crux/lib/wayback.ts
@@ -1,0 +1,181 @@
+/**
+ * Wayback Machine — shared lookup and content extraction utilities.
+ *
+ * Used by:
+ *   - crux/lib/search/fetch-strategies.ts (source-fetcher domain routing)
+ *   - crux/resource-enrichment/fetch-wayback.ts (CLI batch fetcher)
+ *   - crux/link-checker/archive.ts (link-checker archive lookup)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WaybackSnapshot {
+  /** The Wayback Machine archive URL */
+  archiveUrl: string;
+  /** Timestamp string from Wayback (14-digit or 'unknown') */
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot Lookup
+// ---------------------------------------------------------------------------
+
+const USER_AGENT = 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)';
+
+/**
+ * Look up a Wayback Machine snapshot using two strategies:
+ *   1. Availability API (fast but sometimes unreliable)
+ *   2. Direct web URL redirect probe (more reliable fallback)
+ *
+ * Returns null if no snapshot is available.
+ */
+export async function lookupWaybackSnapshot(url: string): Promise<WaybackSnapshot | null> {
+  // Strategy 1: Availability API
+  try {
+    const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
+    const response = await fetch(apiUrl, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (response.ok) {
+      const data = await response.json() as {
+        archived_snapshots?: { closest?: { url: string; timestamp: string; available: boolean } };
+      };
+      const snapshot = data?.archived_snapshots?.closest;
+      if (snapshot?.available && snapshot.url) {
+        return { archiveUrl: snapshot.url, timestamp: snapshot.timestamp };
+      }
+    }
+  } catch {
+    // Availability API may be down — fall through to direct URL approach
+  }
+
+  // Strategy 2: Direct Wayback URL — follows redirect to closest snapshot
+  try {
+    const directUrl = `https://web.archive.org/web/2024/${url}`;
+    const response = await fetch(directUrl, {
+      redirect: 'manual',
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (response.status === 302 || response.status === 301) {
+      const location = response.headers.get('location');
+      if (location?.includes('web.archive.org/web/')) {
+        const tsMatch = location.match(/\/web\/(\d{14})\//);
+        return { archiveUrl: location, timestamp: tsMatch?.[1] ?? 'unknown' };
+      }
+    }
+    if (response.ok) {
+      return { archiveUrl: directUrl, timestamp: 'unknown' };
+    }
+  } catch {
+    // Both strategies failed — return null
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// HTML-to-Text Extraction (Wayback-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract title from an HTML string.
+ */
+export function extractTitleFromHtml(html: string): string | null {
+  const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (!m) return null;
+  const raw = m[1].replace(/\s+/g, ' ').trim();
+  if (!raw || raw.length < 2) return null;
+  return raw;
+}
+
+/**
+ * Convert HTML to plain text, stripping tags and decoding entities.
+ * Optionally strips the Wayback Machine toolbar injected into archived pages.
+ */
+export function htmlToPlainText(html: string, options?: { stripWaybackToolbar?: boolean }): string {
+  let result = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
+
+  if (options?.stripWaybackToolbar) {
+    result = result
+      .replace(/<!-- BEGIN WAYBACK TOOLBAR[\s\S]*?END WAYBACK TOOLBAR -->/gi, '')
+      .replace(/<div id="wm-ipp-base"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/gi, '');
+  }
+
+  return result
+    .replace(/<\/?(p|div|br|h[1-6]|li|tr|blockquote|section|article)[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Content Fetching
+// ---------------------------------------------------------------------------
+
+export interface WaybackContent {
+  title: string | null;
+  content: string;
+  contentType: string;
+  archiveUrl: string;
+}
+
+/**
+ * Fetch and extract text content from a Wayback Machine archived page.
+ * Combines snapshot lookup + HTTP fetch + HTML extraction.
+ *
+ * Returns null if no snapshot exists, content is non-HTML, or content is too short.
+ */
+export async function fetchWaybackPageContent(url: string): Promise<WaybackContent | null> {
+  const snapshot = await lookupWaybackSnapshot(url);
+  if (!snapshot) return null;
+
+  try {
+    const response = await fetch(snapshot.archiveUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; LongtermWikiBot/1.0; +https://www.longtermwiki.com)',
+        Accept: 'text/html,application/xhtml+xml,*/*',
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) return null;
+
+    const ct = response.headers.get('content-type') ?? '';
+    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) {
+      return null;
+    }
+
+    const html = await response.text();
+    const title = extractTitleFromHtml(html);
+    const content = htmlToPlainText(html, { stripWaybackToolbar: true });
+
+    if (content.length < 100) return null;
+
+    return {
+      title,
+      content: content.slice(0, 100_000),
+      contentType: 'text/html',
+      archiveUrl: snapshot.archiveUrl,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[wayback] Fetch failed for ${url}: ${msg.slice(0, 200)}`);
+    return null;
+  }
+}

--- a/crux/link-checker/archive.ts
+++ b/crux/link-checker/archive.ts
@@ -1,44 +1,12 @@
 /**
  * Archive.org lookup — find Wayback Machine snapshots for broken URLs.
  *
- * Queries the Wayback Machine availability API to find archived
- * versions of URLs that returned broken or error status.
+ * Delegates to the shared crux/lib/wayback.ts for the actual API call.
  */
 
 import { sleep } from '../resource-utils.ts';
-import type { CheckResult, ArchiveResult } from './types.ts';
-
-// ── Archive.org Lookup ───────────────────────────────────────────────────────
-
-/** Query Wayback Machine for an archived snapshot of a URL. */
-async function lookupArchive(url: string): Promise<ArchiveResult> {
-  try {
-    const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
-    const response = await fetch(apiUrl, {
-      headers: { 'User-Agent': 'LongtermWikiLinkChecker/1.0' },
-      signal: AbortSignal.timeout(10000),
-    });
-
-    if (!response.ok) {
-      return { url, archiveUrl: null };
-    }
-
-    const data = await response.json() as {
-      archived_snapshots?: {
-        closest?: { url: string; timestamp: string; available: boolean };
-      };
-    };
-
-    const snapshot = data?.archived_snapshots?.closest;
-    if (snapshot?.available && snapshot.url) {
-      return { url, archiveUrl: snapshot.url, timestamp: snapshot.timestamp };
-    }
-
-    return { url, archiveUrl: null };
-  } catch {
-    return { url, archiveUrl: null };
-  }
-}
+import { lookupWaybackSnapshot } from '../lib/wayback.ts';
+import type { CheckResult } from './types.ts';
 
 /** Look up archive.org snapshots for broken URLs. */
 export async function lookupArchiveForBroken(results: CheckResult[]): Promise<void> {
@@ -56,10 +24,10 @@ export async function lookupArchiveForBroken(results: CheckResult[]): Promise<vo
   let found = 0;
   for (let i = 0; i < broken.length; i++) {
     const result = broken[i];
-    const archive = await lookupArchive(result.url);
+    const snapshot = await lookupWaybackSnapshot(result.url);
 
-    if (archive.archiveUrl) {
-      result.archiveUrl = archive.archiveUrl;
+    if (snapshot) {
+      result.archiveUrl = snapshot.archiveUrl;
       found++;
     }
 

--- a/crux/resource-enrichment/fetch-wayback.ts
+++ b/crux/resource-enrichment/fetch-wayback.ts
@@ -5,6 +5,8 @@
  * the Wayback Machine (web.archive.org). Stores content in citation_content
  * with fetchMethod='wayback'.
  *
+ * Uses shared Wayback utilities from crux/lib/wayback.ts.
+ *
  * Usage:
  *   pnpm crux resources fetch-wayback --dry-run        # Preview
  *   pnpm crux resources fetch-wayback --limit=50       # Fetch up to 50
@@ -15,143 +17,12 @@ import { loadResourcesPGFirst } from '../resource-io.ts';
 import { upsertCitationContent } from '../lib/wiki-server/citations.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { sleep } from '../resource-utils.ts';
-import type { Resource } from '../resource-types.ts';
 import type { CommandResult } from '../lib/cli.ts';
-
-// ── Wayback Machine lookup ────────────────────────────────────────────────────
-
-interface WaybackSnapshot {
-  url: string;
-  timestamp: string;
-}
-
-/**
- * Look up a Wayback Machine snapshot using multiple strategies:
- * 1. Availability API (fast but often unreliable)
- * 2. Direct web URL (follows redirect to closest snapshot — more reliable)
- */
-async function lookupWayback(url: string): Promise<WaybackSnapshot | null> {
-  // Strategy 1: Availability API (fast when it works)
-  try {
-    const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
-    const response = await fetch(apiUrl, {
-      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
-      signal: AbortSignal.timeout(8_000),
-    });
-
-    if (response.ok) {
-      const data = await response.json() as {
-        archived_snapshots?: { closest?: { url: string; timestamp: string; available: boolean } };
-      };
-      const snapshot = data?.archived_snapshots?.closest;
-      if (snapshot?.available && snapshot.url) {
-        return { url: snapshot.url, timestamp: snapshot.timestamp };
-      }
-    }
-  } catch {
-    // API may be down — fall through to direct URL approach
-  }
-
-  // Strategy 2: Direct web URL — Wayback redirects to closest snapshot
-  // GET https://web.archive.org/web/2024/https://example.com → 302 → actual snapshot
-  try {
-    const directUrl = `https://web.archive.org/web/2024/${url}`;
-    const response = await fetch(directUrl, {
-      redirect: 'manual', // Don't follow — we want the redirect URL
-      headers: { 'User-Agent': 'LongtermWikiBot/1.0 (+https://www.longtermwiki.com)' },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (response.status === 302 || response.status === 301) {
-      const location = response.headers.get('location');
-      if (location && location.includes('web.archive.org/web/')) {
-        // Extract timestamp from URL like /web/20240315123456/https://...
-        const tsMatch = location.match(/\/web\/(\d{14})\//);
-        return {
-          url: location,
-          timestamp: tsMatch?.[1] || 'unknown',
-        };
-      }
-    }
-
-    // 200 means we got the page directly (no redirect)
-    if (response.ok) {
-      return { url: directUrl, timestamp: 'unknown' };
-    }
-  } catch {
-    // Direct URL also failed
-  }
-
-  return null;
-}
-
-// ── Content extraction ───────────────────────────────────────────────────────
-
-function extractTitleFromHtml(html: string): string | null {
-  const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  if (!m) return null;
-  const raw = m[1].replace(/\s+/g, ' ').trim();
-  if (!raw || raw.length < 2) return null;
-  return raw;
-}
-
-function htmlToPlainText(html: string): string {
-  return html
-    // Remove script/style blocks
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    // Remove Wayback Machine toolbar
-    .replace(/<!-- BEGIN WAYBACK TOOLBAR[\s\S]*?END WAYBACK TOOLBAR -->/gi, '')
-    .replace(/<div id="wm-ipp-base"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/gi, '')
-    // Convert block elements to newlines
-    .replace(/<\/?(p|div|br|h[1-6]|li|tr|blockquote|section|article)[^>]*>/gi, '\n')
-    // Remove remaining tags
-    .replace(/<[^>]+>/g, '')
-    // Decode common entities
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    // Collapse whitespace
-    .replace(/[ \t]+/g, ' ')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-async function fetchWaybackContent(
-  archiveUrl: string,
-): Promise<{ title: string | null; content: string; contentType: string } | null> {
-  try {
-    const response = await fetch(archiveUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; LongtermWikiBot/1.0; +https://www.longtermwiki.com)',
-        Accept: 'text/html,application/xhtml+xml,*/*',
-      },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (!response.ok) return null;
-
-    const ct = response.headers.get('content-type') || '';
-    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) {
-      // PDF or other binary — skip for now
-      return null;
-    }
-
-    const html = await response.text();
-    const title = extractTitleFromHtml(html);
-    const content = htmlToPlainText(html);
-
-    if (content.length < 100) return null; // Too little content
-
-    return { title, content, contentType: 'text/html' };
-  } catch {
-    return null;
-  }
-}
+import {
+  lookupWaybackSnapshot,
+  extractTitleFromHtml,
+  htmlToPlainText,
+} from '../lib/wayback.ts';
 
 // ── Main command ─────────────────────────────────────────────────────────────
 
@@ -232,7 +103,7 @@ export async function fetchWaybackCommand(
       const r = toProcess[i];
 
       // Step 1: Look up Wayback snapshot
-      const snapshot = await lookupWayback(r.url);
+      const snapshot = await lookupWaybackSnapshot(r.url);
       if (!snapshot) {
         noSnapshot++;
         if (verbose) console.log(`  ✗ No snapshot: ${r.title || r.url}`);
@@ -249,7 +120,7 @@ export async function fetchWaybackCommand(
       }
 
       // Step 2: Fetch content from Wayback
-      const result = await fetchWaybackContent(snapshot.url);
+      const result = await fetchArchiveContent(snapshot.archiveUrl);
       if (!result || result.content.length < 100) {
         fetchFailed++;
         if (verbose) console.log(`  ✗ Fetch failed: ${r.title || r.url}`);
@@ -307,4 +178,38 @@ export async function fetchWaybackCommand(
   console.log(`    Fetch failed:    ${fetchFailed}`);
 
   return { exitCode: 0, output: `Fetched ${fetched} resources from Wayback Machine` };
+}
+
+// ── Content fetch helper (archive URL → extracted text) ─────────────────────
+
+async function fetchArchiveContent(
+  archiveUrl: string,
+): Promise<{ title: string | null; content: string; contentType: string } | null> {
+  try {
+    const response = await fetch(archiveUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; LongtermWikiBot/1.0; +https://www.longtermwiki.com)',
+        Accept: 'text/html,application/xhtml+xml,*/*',
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) return null;
+
+    const ct = response.headers.get('content-type') || '';
+    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) {
+      return null;
+    }
+
+    const html = await response.text();
+    const title = extractTitleFromHtml(html);
+    const content = htmlToPlainText(html, { stripWaybackToolbar: true });
+
+    if (content.length < 100) return null;
+
+    return { title, content, contentType: 'text/html' };
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- Extract three duplicate Wayback Machine implementations into `crux/lib/wayback.ts`: snapshot lookup, HTML title extraction, HTML-to-plaintext conversion (with optional Wayback toolbar stripping), and full page content fetching
- Updated all three consumers to use the shared module: `fetch-strategies.ts`, `resource-enrichment/fetch-wayback.ts`, `link-checker/archive.ts`
- Add `ALIGNMENT_FORUM` constant to `crux/lib/forum-api.ts` and include it in `ALL_FORUMS`
- Build `FORUM_CONFIGS` dynamically from `ALL_FORUMS` instead of hardcoding 5 duplicate hostname-to-Forum entries

Net -73 lines. Stacks on #3466.

## Test plan

- [x] 93 tests pass in fetch-strategies + source-fetcher test files
- [x] Full test suite: 4409 tests pass
- [x] `pnpm build` succeeds

Generated with [Claude Code](https://claude.ai/code)