### PR TITLE
fix: correct wiki_pages join column in data-quality snapshot

### DIFF
--- a/apps/wiki-server/src/routes/operational/data-quality.ts
+++ b/apps/wiki-server/src/routes/operational/data-quality.ts
@@ -107,7 +107,7 @@ const dataQualityApp = new Hono()
       const entitiesTotal = entitiesTotalRows[0].count;
 
       const entitiesWithWikiPageRows = (await db.execute(
-        sql`SELECT COUNT(DISTINCT e.stable_id)::text AS cnt FROM entities e INNER JOIN wiki_pages wp ON wp.entity_id = e.stable_id`
+        sql`SELECT COUNT(DISTINCT e.stable_id)::text AS cnt FROM entities e INNER JOIN wiki_pages wp ON wp.wiki_id = e.wiki_id WHERE e.wiki_id IS NOT NULL`
       )) as Array<{ cnt: string }>;
       const entitiesWithWikiPage = parseInt(entitiesWithWikiPageRows[0]?.cnt ?? "0", 10);
 


### PR DESCRIPTION
## Summary
- The `POST /api/data-quality` snapshot endpoint was failing with 500 because the SQL query referenced `wp.entity_id`, a column that doesn't exist on `wiki_pages`
- Fixed to use the correct join: `wp.wiki_id = e.wiki_id`
- This is why the [quality dashboard (E2600)](https://www.longtermwiki.com/wiki/E2600) has shown "No snapshots yet" since it was created

## Test plan
- [x] Build passes (`pnpm build`)
- [ ] Post-deploy: run `crux sys quality snapshot` — should succeed and produce data
- [ ] Post-deploy: verify quality dashboard at E2600 renders the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected data quality metric calculation to accurately identify entities with wiki page associations by fixing the join condition and filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->