### PR TITLE
Fix contradicted verdicts: correct wrong data + tune checker prompts

### DIFF
--- a/crux/commands/factbase-source-check.ts
+++ b/crux/commands/factbase-source-check.ts
@@ -267,6 +267,12 @@ IMPORTANT — avoid these common false-positive errors:
 - **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
 - **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
 - **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
+- **URL format**: "example.com", "https://www.example.com", and "http://example.com" all refer to the same website. Differences in protocol (http/https), "www" prefix, or trailing slashes are NOT contradictions — use "confirmed".
+- **Date precision**: "2016-08" and "30 August 2016" are equivalent. Month-level vs day-level dates for the same month are NOT contradictions — use "confirmed".
+- **Archive URLs**: A web.archive.org URL for a defunct/dissolved organization is intentional — not a contradiction with the original URL. Use "confirmed".
+- **Opaque identifiers**: If a field contains an opaque ID (e.g., "sid_xxxx", "pjaXzBneWf") you cannot resolve, that is "unverifiable" — never "contradicted".
+- **Partial listings**: Listing one founder/member when the source lists multiple is "partial", not "contradicted". The claim is incomplete, not wrong.
+- **NaN/null values**: If the claimed value is "$NaN", "NaN", null, or undefined, that is a data bug — mark "unverifiable", not "contradicted".
 
 Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
@@ -275,7 +281,7 @@ Other considerations:
 - If the source has a newer value that supersedes the claimed value, that's "outdated"
 - If the source partially confirms (e.g., confirms the ballpark but not the exact figure), that's "partial"
 
-Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is genuinely incompatible with the claim for the same time period — not just formatted differently or incomplete.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {

--- a/crux/commands/source-check-orchestrate.ts
+++ b/crux/commands/source-check-orchestrate.ts
@@ -770,6 +770,12 @@ IMPORTANT — avoid these common false-positive errors:
 - **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
 - **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
 - **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
+- **URL format**: "example.com", "https://www.example.com", and "http://example.com" all refer to the same website. Differences in protocol, "www" prefix, or trailing slashes are NOT contradictions — use "confirmed".
+- **Date precision**: "2016-08" and "30 August 2016" are equivalent. Month-level vs day-level dates for the same month are NOT contradictions — use "confirmed".
+- **Archive URLs**: A web.archive.org URL for a defunct organization is intentional — not a contradiction with the original URL.
+- **Opaque identifiers**: If a field contains an opaque ID (e.g., "sid_xxxx") you cannot resolve, that is "unverifiable" — never "contradicted".
+- **Partial listings**: Listing one founder/member when the source lists multiple is "partial", not "contradicted".
+- **NaN/null values**: If the claimed value is "$NaN", "NaN", null, or undefined, that is a data bug — mark "unverifiable", not "contradicted".
 
 Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
@@ -778,7 +784,7 @@ Other considerations:
 - If the source has a newer value that supersedes the claimed value, that's "outdated"
 - If the source partially confirms (e.g., confirms the ballpark but not the exact figure), that's "partial"
 
-Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is genuinely incompatible with the claim — not just formatted differently or incomplete.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {
@@ -818,6 +824,11 @@ IMPORTANT — avoid these common false-positive errors:
 - **Temporal mismatch**: Only compare values from the same time period. If the claim is about 2024 but the source discusses 2025 (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
 - **Wrong source relevance**: The source must actually discuss the specific claim. A company's own page cannot contradict a person's prior employment at a different company — that's "unverifiable".
 - **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted".
+- **URL format**: "example.com", "https://www.example.com", and "http://example.com" refer to the same website. Protocol/prefix differences are NOT contradictions.
+- **Date precision**: "2016-08" and "30 August 2016" are equivalent — NOT a contradiction.
+- **Opaque identifiers**: If a person field contains an opaque ID (e.g., "sid_xxxx", "pjaXzBneWf") you cannot resolve to a name, that is "unverifiable" — never "contradicted". The ID may correctly map to the named person but you cannot verify this.
+- **Partial listings**: Listing one founder/member when there are multiple is "partial", not "contradicted".
+- **NaN/null values**: If a value is "$NaN", "NaN", null, or undefined, that is a data bug — mark "unverifiable".
 
 Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
@@ -827,7 +838,7 @@ Other considerations:
 - If the source has newer data that supersedes the record, that's "outdated"
 - If the source partially confirms (e.g., confirms role but not dates), that's "partial"
 
-Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is incompatible with the claim for the same time period.
+Reserve "contradicted" ONLY for cases where the source clearly and directly states a value that is genuinely incompatible with the claim — not just formatted differently or incomplete.
 
 Respond with ONLY a JSON object (no markdown code fences):
 {

--- a/crux/commands/source-check-wiki-pages.ts
+++ b/crux/commands/source-check-wiki-pages.ts
@@ -232,7 +232,16 @@ ${item.sourceContext.slice(0, 500)}
 
 Does the source text confirm, contradict, or not address this claim?
 
-Consider:
+IMPORTANT — avoid these common false-positive errors:
+- **Approximate values**: Within 10% is "partial" or "confirmed", not "contradicted"
+- **URL format**: "example.com" and "https://www.example.com" are the same website — NOT a contradiction
+- **Date precision**: "2016-08" and "30 August 2016" are equivalent — NOT a contradiction
+- **Partial listings**: Listing one founder when there are multiple is "partial", not "contradicted"
+- **Opaque identifiers**: If a field has an opaque ID you can't resolve, that's "unverifiable" — never "contradicted"
+- **NaN/null values**: "$NaN" or null claimed values are data bugs — mark "unverifiable"
+- Reserve "contradicted" ONLY for direct, clear incompatibility where the source states a genuinely different value
+
+Other considerations:
 - Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
 - Dates may be approximate
 - If the source discusses the topic but the specific data point isn't mentioned, that's "unverifiable"

--- a/crux/lib/job-handlers/claim-verification.ts
+++ b/crux/lib/job-handlers/claim-verification.ts
@@ -22,7 +22,6 @@ import { escapeXml } from '../prompt-utils.ts';
 import { getCitationContentByUrl } from '../wiki-server/citations.ts';
 import { storeSourceCheckEvidence } from '../source-check/verdict-handler.ts';
 import { apiRequest } from '../wiki-server/client.ts';
-import { escapeXml } from '../prompt-utils.ts';
 import type { JobHandlerResult, JobHandlerContext } from './types.ts';
 import { z } from 'zod';
 
@@ -121,7 +120,13 @@ IMPORTANT — avoid common false-positive errors:
 - Range vs. point: if source says "51-200" and claim is 91, that's "confirmed" (within range)
 - Temporal mismatch: only compare the same time period
 - Approximate values: within 10% is "confirmed" or "partial"
-- Reserve "contradicted" ONLY for direct, clear incompatibility
+- URL format: "example.com", "https://www.example.com", and "http://example.com" all refer to the same website — differences in protocol (http/https), "www" prefix, or trailing slashes are NOT contradictions. Use "confirmed".
+- Date precision: "2016-08" and "30 August 2016" are equivalent. A month-level date vs a day-level date for the same month is NOT a contradiction. Use "confirmed".
+- Archive URLs: If the claim uses a web.archive.org URL for a defunct/dissolved organization, that is intentional — not a contradiction with the original URL.
+- Opaque identifiers: If a record field contains an opaque ID (e.g., "sid_xxxx", "pjaXzBneWf") that you cannot resolve to a name, that is "unverifiable" — you cannot determine if the ID maps to the correct person. Never mark these as "contradicted".
+- Partial listings: If the claim lists ONE founder/member but the source lists MULTIPLE (or vice versa), that is "partial" — not "contradicted". The claim is incomplete, not wrong.
+- NaN/null values: If the claimed value is literally "$NaN", "NaN", null, or undefined, that indicates a data bug — mark as "unverifiable", not "contradicted".
+- Reserve "contradicted" ONLY for direct, clear incompatibility where the source states a value that is genuinely wrong, not just formatted differently or incomplete
 
 Respond with a JSON array (one object per claim):
 [

--- a/packages/factbase/data/things/anthropic.yaml
+++ b/packages/factbase/data/things/anthropic.yaml
@@ -183,11 +183,11 @@ facts:
   - id: f_Z7oaVivRvE
     property: headcount
     value:
+      - 200
       - 300
-      - 400
     asOf: 2023-06
     source: https://seo.ai/blog/how-many-people-work-at-anthropic
-    notes: "Approximate headcount mid-2023 from multiple sources"
+    notes: "Approximate headcount mid-2023; seo.ai reports ~240 for 2023, other sources suggest up to 300"
 
   - id: f_0PxEBZyv45
     property: headcount

--- a/packages/factbase/data/things/asml.yaml
+++ b/packages/factbase/data/things/asml.yaml
@@ -93,10 +93,10 @@ facts:
   # ── Market cap ──────────────────────────────────────────────────
   - id: f_asml_mcap_2026
     property: market-cap
-    value: 2.7e+11
+    value: 5.11e+11
     asOf: 2026-03
     source: https://stockanalysis.com/stocks/asml/market-cap/
-    notes: "Market cap ~$270B as of March 2026"
+    notes: "Market cap ~$511B as of late March 2026"
 
   # ── Export control events ───────────────────────────────────────
   - id: f_asml_export_2023

--- a/packages/factbase/data/things/cset.yaml
+++ b/packages/factbase/data/things/cset.yaml
@@ -62,7 +62,7 @@ facts:
 
   - id: f_6hiba4OWK7
     property: program
-    value: "CyberAI Project — $5M Hewlett Foundation-funded program examining the intersection of AI, cybersecurity, and geopolitics"
+    value: "CyberAI Project — Hewlett Foundation-funded program examining the intersection of AI, cybersecurity, and geopolitics ($2M initial 2019, $3M renewal 2022, $5M total)"
     source: https://cset.georgetown.edu/article/cset-receives-2-million-grant-to-fund-new-cyberai-project/
 
   - id: f_RtJB5XxjsA

--- a/packages/factbase/data/things/deepseek.yaml
+++ b/packages/factbase/data/things/deepseek.yaml
@@ -47,10 +47,10 @@ facts:
   # ── Headcount ───────────────────────────────────────────────────
   - id: f_VX3CZVjbug
     property: headcount
-    value: 160
+    value: 200
     asOf: 2025-01
     source: https://seo.ai/blog/how-many-employees-does-deepseek-ai-have
-    notes: "Approximately 150-200 employees; LinkedIn lists 51-200 range. Relatively
+    notes: "Approximately 200 employees as of January 2025; LinkedIn lists 51-200 range. Relatively
       small team for a frontier lab."
 
   # ── Funding ─────────────────────────────────────────────────────

--- a/packages/factbase/data/things/democracy-forward.yaml
+++ b/packages/factbase/data/things/democracy-forward.yaml
@@ -2,9 +2,9 @@ entity: sid_yTlRworV1V
 facts:
   - id: f_tjK3GJTnOA
     property: founded-date
-    value: "2017"
+    value: "2016"
     source: https://democracyforward.org/about/
-    notes: "Founded in 2017"
+    notes: "Founded in 2016 in the wake of the 2016 election; publicly launched 2017"
 
   - id: f_ixLgM3sWwA
     property: headquarters

--- a/packages/factbase/data/things/govai.yaml
+++ b/packages/factbase/data/things/govai.yaml
@@ -135,7 +135,7 @@ facts:
     property: publication
     value: "Risk Thresholds for Frontier AI — proposes framework for when frontier AI capabilities warrant regulatory intervention"
     asOf: 2024
-    source: https://arxiv.org/abs/2311.14368
+    source: https://arxiv.org/abs/2406.14713
 
   - id: f_4BkaaQZD2q
     property: legal-identifier

--- a/packages/factbase/data/things/macarthur-foundation.yaml
+++ b/packages/factbase/data/things/macarthur-foundation.yaml
@@ -26,9 +26,9 @@ facts:
     notes: From Wikidata Q1424691
   - id: s2svxs5ctw
     property: founded-date
-    value: 1970-01
+    value: 1978-01-06
     source: https://www.wikidata.org/wiki/Q1424691
-    notes: From Wikidata Q1424691
+    notes: "From Wikidata Q1424691; January 6, 1978 per official history. Wikidata also has 1970 from ROR but 1978 is authoritative."
   - id: yWgyL14yNw
     property: headquarters
     value: Illinois

--- a/packages/factbase/data/things/partnership-on-ai.yaml
+++ b/packages/factbase/data/things/partnership-on-ai.yaml
@@ -36,7 +36,7 @@ facts:
     property: description
     value: "Multi-stakeholder organization bringing together academics, civil
       society, industry, and media to advance understanding of AI technologies.
-      Founded by six major tech companies, PAI now has over 100 partner
+      Founded by six major tech companies, PAI now has 138 partner
       organizations and focuses on responsible AI practices and guidelines."
     asOf: 2026-03
     source: https://partnershiponai.org/about/
@@ -58,10 +58,10 @@ facts:
 
   - id: f_vfOPhOwJQP
     property: partner-count
-    value: "100"
-    asOf: 2025
+    value: "138"
+    asOf: 2026-03
     source: https://partnershiponai.org/partners/
-    notes: "100+ partner organizations including tech companies, civil society, academia, and media"
+    notes: "138 partner organizations across tech companies, civil society, academia, and media"
 
   - id: f_7cjV8ehCYn
     property: country

--- a/packages/factbase/data/things/protect-democracy.yaml
+++ b/packages/factbase/data/things/protect-democracy.yaml
@@ -2,9 +2,9 @@ entity: sid_xxHyEDGp4Y
 facts:
   - id: f_fNjFtPQSuQ
     property: founded-date
-    value: "2017"
+    value: "2016-11"
     source: https://en.wikipedia.org/wiki/Protect_Democracy
-    notes: "Founded in early 2017"
+    notes: "Formed November 2016; incorporated and launched publicly in early 2017"
 
   - id: f_1Mqq9p4LHQ
     property: employee-count

--- a/packages/factbase/data/things/tsmc.yaml
+++ b/packages/factbase/data/things/tsmc.yaml
@@ -97,10 +97,10 @@ facts:
   # ── Market cap ──────────────────────────────────────────────────
   - id: f_tsmc_mcap_2026
     property: market-cap
-    value: 8.8e+11
+    value: 1.75e+12
     asOf: 2026-03
     source: https://stockanalysis.com/stocks/tsm/market-cap/
-    notes: "Market cap ~$880B as of March 2026"
+    notes: "Market cap ~$1.75T as of late March 2026"
 
   # ── Arizona fab investment ──────────────────────────────────────
   - id: f_tsmc_arizona


### PR DESCRIPTION
## Summary

Addresses the 68 contradicted verdicts on the [Entity Verifications dashboard (E2200)](https://www.longtermwiki.com/wiki/E2200). Two-track approach:

**Track 1 — Tune source-check prompts** (reduces ~30 false positives):
- Added guidance for URL format normalization (`example.com` = `https://www.example.com`)
- Added date precision tolerance (`2016-08` = `30 August 2016`)
- Added opaque ID handling (`sid_xxx` → unverifiable, not contradicted)
- Added partial listing rule (listing one of multiple founders → partial)
- Added NaN/null value handling (data bugs → unverifiable)
- Added archive URL guidance for defunct orgs
- Fixed pre-existing duplicate `escapeXml` import in `claim-verification.ts`
- Applied to all 5 verification prompt builders across 4 files

**Track 2 — Fix genuinely wrong facts** (10 corrections):

| Entity | Field | Old Value | New Value | Why |
|--------|-------|-----------|-----------|-----|
| Protect Democracy | founded | 2017 | 2016-11 | Wikipedia says Nov 2016 |
| Democracy Forward | founded | 2017 | 2016 | Source says "wake of 2016 election" |
| MacArthur Foundation | founded | 1970-01 | 1978-01-06 | Official history says 1978 |
| TSMC | market cap | $880B | $1.75T | Was stale |
| ASML | market cap | $270B | $511B | Was stale |
| DeepSeek | headcount | 160 | 200 | Source says ~200 |
| Anthropic | headcount (mid-2023) | 300-400 | 200-300 | Source reports ~240 |
| Partnership on AI | partners | 100 | 138 | Current count is 138 |
| CSET CyberAI | description | "$5M" | "$2M initial + $3M renewal" | Clarify breakdown |
| GovAI | publication URL | arXiv:2311.14368 | arXiv:2406.14713 | Old URL was a physics paper |

## Expected impact

- ~30 false positives should resolve on next re-check (prompt tuning)
- ~10 genuinely contradicted verdicts resolved (data fixes)
- ~25 remaining contradictions need individual review (stale time-sensitive data, borderline cases)

## Test plan

- [x] `pnpm build-data:content` — YAML parsing clean
- [x] `pnpm crux w validate gate --fix --scope=content` — all checks pass
- [x] Gate failures on push are pre-existing (KB schema validation, YAML entity reference integrity — unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification accuracy by refining verdict classification to reduce false positives caused by formatting differences, URL variations, date format equivalences, partial listings, and opaque identifiers.

* **Chores**
  * Updated factbase with corrected organizational information including headcounts, market capitalizations, founding dates, and partner counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->