### PR TITLE
fix: resolve benchmark slugs to IDs in benchmark-results sync

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -170,16 +170,27 @@ const benchmarkResultsApp = new Hono()
     if (benchmarkIds.length > 0) {
       const placeholders = benchmarkIds.map((id) => sql`${id}`);
       const inList = sql.join(placeholders, sql`, `);
-      const found = await db.execute<{ id: string }>(sql`
-        SELECT id FROM benchmarks WHERE id IN (${inList})
+      // Check both id (10-char hash) and slug (e.g., "mmlu") since the enrichment
+      // agent may submit either format.
+      const found = await db.execute<{ id: string; slug: string }>(sql`
+        SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
       `);
-      const foundSet = new Set(found.map((r) => r.id));
-      const missing = benchmarkIds.filter((id) => !foundSet.has(id));
+      const foundIdSet = new Set(found.map((r) => r.id));
+      const foundSlugSet = new Set(found.map((r) => r.slug));
+      // Build slug→id mapping for auto-resolution
+      const slugToId = new Map(found.map((r) => [r.slug, r.id]));
+      const missing = benchmarkIds.filter((id) => !foundIdSet.has(id) && !foundSlugSet.has(id));
       if (missing.length > 0) {
         return validationError(
           c,
           `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first (pnpm crux wiki-server sync-benchmarks).`,
         );
+      }
+      // Auto-resolve slugs to IDs so the upsert uses the correct FK
+      for (const item of parsed.data.items) {
+        if (slugToId.has(item.benchmarkId)) {
+          item.benchmarkId = slugToId.get(item.benchmarkId)!;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- The benchmark-results sync endpoint validates `benchmarkId` against `benchmarks.id` (a 10-char hash), but the enrichment agent submits slugs like `"mmlu"` instead
- Now also checks `benchmarks.slug` and auto-resolves slugs to their 10-char IDs before the upsert
- Unblocks benchmark result enrichment via `crux tb tablebase loop --task-type=benchmark-result-fill`

## Test plan
- [ ] Submit benchmark results with slug `benchmarkId` (e.g., "mmlu") — should resolve and succeed
- [ ] Submit with 10-char hash `benchmarkId` — should still work as before
- [ ] Submit with nonexistent slug — should still return validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)