### PR TITLE
fix: resource pipeline robustness — persist timeout status, fix stats, escape prompts

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -963,8 +963,8 @@ const resourcesApp = new Hono()
       `,
       rawDb<{ with_full_text: string; with_metadata_only: string }[]>`
         SELECT
-          (SELECT count(*) FROM citation_content WHERE full_text IS NOT NULL) AS with_full_text,
-          (SELECT count(*) FROM citation_content WHERE full_text IS NULL AND page_title IS NOT NULL) AS with_metadata_only
+          (SELECT count(*) FROM citation_content WHERE resource_id IS NOT NULL AND full_text IS NOT NULL) AS with_full_text,
+          (SELECT count(*) FROM citation_content WHERE resource_id IS NOT NULL AND full_text IS NULL AND page_title IS NOT NULL) AS with_metadata_only
       `,
     ]);
 

--- a/crux/resource-enrichment/prompts.ts
+++ b/crux/resource-enrichment/prompts.ts
@@ -17,10 +17,10 @@ export function classificationPrompt(resource: {
 }): string {
   return `Classify this resource:
 
-URL: ${resource.url}
-Title: ${resource.title || '(none)'}
-Current type: ${resource.type || '(none)'}
-Content preview: ${resource.content_snippet || '(none)'}
+URL: ${escapeXml(resource.url)}
+Title: ${escapeXml(resource.title || '(none)')}
+Current type: ${escapeXml(resource.type || '(none)')}
+Content preview: ${escapeXml(resource.content_snippet || '(none)')}
 
 Return JSON with these fields:
 {
@@ -46,12 +46,12 @@ export function enrichmentPrompt(resource: {
 }): string {
   return `Analyze this resource and provide enriched metadata:
 
-URL: ${resource.url}
-Title: ${resource.title || '(none)'}
-Type: ${resource.type || '(none)'}
-Current summary: ${resource.summary || '(none)'}
-Content (first 4000 chars): ${resource.content?.slice(0, 4000) || '(none)'}
-Current tags: ${resource.existing_tags?.join(', ') || '(none)'}
+URL: ${escapeXml(resource.url)}
+Title: ${escapeXml(resource.title || '(none)')}
+Type: ${escapeXml(resource.type || '(none)')}
+Current summary: ${escapeXml(resource.summary || '(none)')}
+Content (first 4000 chars): ${escapeXml(resource.content?.slice(0, 4000) || '(none)')}
+Current tags: ${escapeXml(resource.existing_tags?.join(', ') || '(none)')}
 
 Return JSON:
 {


### PR DESCRIPTION
## Summary

Four targeted fixes for the resource verification and enrichment pipeline:

- **Persist fetch_status for timeout/unreachable**: When `fetch()` throws (DNS failure, connection refused, timeout), the handler previously returned early without calling `persistResults()`. Now these cases correctly persist `dead` status to the resources table, matching the behavior for HTTP errors and large responses.
- **Fix contentCacheStats inflation**: The stats endpoint counted ALL `citation_content` rows, including URLs without matching resources. Now filters by `resource_id IS NOT NULL` to only count resource-linked rows.
- **Add escapeXml to legacy enrichment prompts**: The new `combinedEnrichmentPrompt()` correctly used `escapeXml()`, but the older `classificationPrompt()` and `enrichmentPrompt()` did not. Added `escapeXml()` wrapping to all user-controlled data in these legacy functions.
- **Large-body resources now chain to enrichment**: Resources with Content-Length > 10MB were persisted as reachable but skipped the enrichment chaining code. The enrich handler already handles the no-content fallback (enriches from URL+title only), so these should be chained. Extracted `enqueueEnrichment()` helper to DRY the chaining logic.

Related to discussion #3499.

## Test plan

- [x] New tests: `persists dead status on timeout`, `persists dead status on unreachable (DNS failure)`, `enqueues resource-enrich job for large-body reachable resources`
- [x] All 45 resource-verify tests pass
- [x] All 19 resource-enrich tests pass
- [x] `pnpm build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and tracking of unreachable and dead resources during verification
  * Resource enrichment now applies to resources with large content bodies
  * Enhanced error tracking for network timeouts and connection failures
  * Strengthened input sanitization in resource enrichment prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->