### PR TITLE
fix: handle string timestamps in /suggest content freshness check

### DIFF
--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -588,7 +588,7 @@ const resourcesApp = new Hono()
       id: string;
       url: string;
       title: string | null;
-      fetched_at: Date | null;
+      fetched_at: string | Date | null;
       has_content: boolean;
     }
     const existingRows: ResourceWithContent[] =
@@ -672,7 +672,7 @@ const resourcesApp = new Hono()
       let contentStatus: ContentStatus;
       if (!r.has_content) {
         contentStatus = "missing";
-      } else if (r.fetched_at && now - r.fetched_at.getTime() > maxAge) {
+      } else if (r.fetched_at && now - new Date(r.fetched_at).getTime() > maxAge) {
         contentStatus = "stale";
       } else {
         contentStatus = "fresh";


### PR DESCRIPTION
## Summary
- The `/api/resources/suggest` endpoint crashes with `r.fetched_at.getTime is not a function` when re-checking URLs that already have content in `citation_content`
- Root cause: raw SQL queries via postgres.js return timestamps as strings, not `Date` objects, but the code called `.getTime()` directly
- Fix: wrap `fetched_at` with `new Date()` before calling `.getTime()`

## How found
Discovered while testing the resource upload system post-PR #3504 deployment. Initial `/suggest` call works (creates resources with `contentStatus: "missing"`), but a second call after jobs complete crashes because `fetched_at` is now a non-null string.

## Test plan
- [x] Submitted 6 URLs via `/suggest` — all created successfully
- [x] Enqueued and verified `resource-verify` jobs — all 6 completed with `reachable` status
- [ ] After deploy: re-call `/suggest` with the same URLs — should return `contentStatus: "fresh"` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)