### PR TITLE
fix: prevent duplicate tmux windows and clean agent worktrees

### DIFF
--- a/.claude/hooks/cleanup-worktrees.sh
+++ b/.claude/hooks/cleanup-worktrees.sh
@@ -110,16 +110,30 @@ for i in "${!PATHS[@]}"; do
     continue
   fi
 
-  # Safety: skip worktrees with uncommitted changes
+  # Auto-generated worktree-agent-* branches are ephemeral subagent sessions.
+  # They never have PRs and should always be cleaned up, even with untracked files.
+  IS_AGENT_WORKTREE=false
+  if [[ "$WT_BRANCH" == worktree-agent-* ]] || [[ "$WT_PATH" == */.claude/worktrees/agent-* ]]; then
+    IS_AGENT_WORKTREE=true
+  fi
+
+  # Safety: skip worktrees with uncommitted changes (but not agent worktrees)
   if [ -n "$(git -C "$WT_PATH" status --porcelain 2>/dev/null | head -1)" ]; then
-    SKIPPED=$((SKIPPED + 1))
-    continue
+    if [ "$IS_AGENT_WORKTREE" = false ]; then
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+    # Agent worktrees with untracked files are still cleaned — they're ephemeral
+    log "  Agent worktree has uncommitted changes, cleaning anyway: $WT_PATH"
   fi
 
   # Determine if the branch is stale
   SHOULD_REMOVE=false
 
-  if [ "$WT_BRANCH" = "__detached__" ]; then
+  # Agent worktrees are always stale once the session ends
+  if [ "$IS_AGENT_WORKTREE" = true ]; then
+    SHOULD_REMOVE=true
+  elif [ "$WT_BRANCH" = "__detached__" ]; then
     # Detached HEAD with clean working tree — safe to remove
     SHOULD_REMOVE=true
   elif [ -n "$WT_BRANCH" ]; then

--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -418,6 +418,17 @@ async function open(args: string[], _options: CommandOptions): Promise<CommandRe
   const withClaude = args.includes('--claude');
   const windowName = `A${slot}`;
 
+  // Check if a window with this name already exists — reuse it instead of creating a duplicate
+  try {
+    const existing = execSync(`tmux list-windows -F '#{window_name}' 2>/dev/null`, { encoding: 'utf8' });
+    if (existing.split('\n').includes(windowName)) {
+      execSync(`tmux select-window -t "${windowName}"`, { stdio: 'inherit' });
+      return { exitCode: 0, output: `Switched to existing tmux window ${windowName}` };
+    }
+  } catch {
+    // tmux query failed — fall through to create a new window
+  }
+
   try {
     if (withClaude) {
       execSync(`tmux new-window -n "${windowName}" -c "${slotDir}" "claude"`, { stdio: 'inherit' });


### PR DESCRIPTION
## Summary

Two systemic fixes for recurring stale tmux/worktree accumulation:

- **`ws open` deduplication**: Before creating a new tmux window, checks if one with the same name already exists. If so, switches to it instead of creating a duplicate. Prevents the "10 A8 windows" problem that keeps recurring.

- **Agent worktree cleanup**: `cleanup-worktrees.sh` (SessionEnd hook) now always removes `worktree-agent-*` branches and `.claude/worktrees/agent-*` paths, even when they have untracked files. These are ephemeral subagent sessions created by `Agent isolation: "worktree"` — they never have PRs, so the conservative "skip if dirty or no PR" check was preventing their cleanup indefinitely.

## Root cause

1. `ws open <N>` called `tmux new-window` without checking for existing windows with the same name — each call created a duplicate
2. `cleanup-worktrees.sh` skipped any worktree with uncommitted changes (line 114) and any branch without a merged/closed PR (line 132-137). Auto-generated `worktree-agent-*` branches have neither PRs nor clean trees, so they were never cleaned

## Test plan

- [x] `pnpm build` passes
- [x] Verified `ws open` logic: `tmux list-windows` check correctly identifies existing windows
- [x] Verified cleanup logic: agent worktrees detected by both branch name pattern and path pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)