### PR TITLE
fix: resource-ingest DNS/timeout persistence, Twitter soft-404, cookie consent

### DIFF
--- a/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
+++ b/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
@@ -671,4 +671,20 @@ describe('handleResourceIngest — cookie consent detection (#3522)', () => {
     expect(result.success).toBe(true);
     expect(result.data.status).toBe('cookie_blocked');
   });
+
+  it('does NOT false-positive on domains containing "cookie" (e.g. cookieconsent.org)', async () => {
+    const body = '<html><body><h1>CookieConsent library docs</h1><p>How to add consent banners.</p></body></html>';
+    mockFetchSource.mockResolvedValue(mockFetchResult({
+      content: body,
+      url: 'https://cookieconsent.org/docs/getting-started',
+    }));
+
+    const result = await handleResourceIngest(
+      { resourceId: 'res-domain', url: 'https://cookieconsent.org/docs/getting-started' },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.status).toBe('reachable');
+  });
 });

--- a/crux/lib/job-handlers/resource-ingest.ts
+++ b/crux/lib/job-handlers/resource-ingest.ts
@@ -102,12 +102,12 @@ function detectTwitterSoft404(text: string, contentLength: number, finalUrl: str
  */
 const COOKIE_CONSENT_URL_PATTERNS = [
   /[?&]error=cookies/i,
-  /cookie.consent/i,
-  /cookie.policy/i,
-  /cookie.notice/i,
-  /gdpr.consent/i,
-  /consent.manager/i,
-  /cookie.wall/i,
+  /\/cookie[-_.]?consent/i,
+  /\/cookie[-_.]?policy/i,
+  /\/cookie[-_.]?notice/i,
+  /\/gdpr[-_.]?consent/i,
+  /\/consent[-_.]?manager/i,
+  /\/cookie[-_.]?wall/i,
 ];
 
 const COOKIE_CONSENT_CONTENT_PATTERNS = [
@@ -126,10 +126,18 @@ const COOKIE_CONSENT_CONTENT_PATTERNS = [
  * that mention cookies in their privacy notice footer.
  */
 function detectCookieConsent(text: string, contentLength: number, finalUrl: string): boolean {
-  // URL-based detection — redirect to a consent page
-  if (COOKIE_CONSENT_URL_PATTERNS.some((p) => p.test(finalUrl))) return true;
-  // Content-based detection — only on short pages
+  // Only check short pages (<10KB) — long pages with cookie mentions are real content
   if (contentLength > 10_000) return false;
+  // URL-based detection — check path + query only (not domain) to avoid
+  // false positives on domains like cookieconsent.org
+  try {
+    const { pathname, search } = new URL(finalUrl);
+    const pathAndQuery = pathname + search;
+    if (COOKIE_CONSENT_URL_PATTERNS.some((p) => p.test(pathAndQuery))) return true;
+  } catch {
+    // Malformed URL — skip URL-based detection, fall through to content check
+  }
+  // Content-based detection
   return COOKIE_CONSENT_CONTENT_PATTERNS.some((p) => p.test(text));
 }
 
@@ -319,6 +327,8 @@ export async function handleResourceIngest(
     });
   } catch (err: unknown) {
     const error = err instanceof Error ? err.message : String(err);
+    // Persist error status even for unexpected failures
+    await persistFetchStatus(resourceId, 'error', ctx);
     return {
       success: false,
       data: { resourceId, url, durationMs: Date.now() - startTime },


### PR DESCRIPTION
## Summary
- **#3520**: `buildResult()` now calls `updateResourceFetchStatus()` (fire-and-forget) to persist fetchStatus to the resource record for ALL code paths — DNS failures (`dead`), timeouts (`error`), blocked hosts (`error`), invalid URLs (`dead`), and successful checks (`ok`/`paywall`). Previously the handler returned results but never updated the resource record.
- **#3521**: Adds `detectTwitterSoft404()` — Twitter/X returns HTTP 200 with ~493 chars for nonexistent profiles. Detected by checking host (twitter.com/x.com) + short content (<1500 chars) + absence of `og:description` meta tag. Real profiles include og:description and are not flagged.
- **#3522**: Adds `detectCookieConsent()` — sites like nature.com redirect to cookie consent pages instead of serving articles. Detected via URL patterns (`?error=cookies`, `cookie-consent`, etc.) and content patterns ("we use cookies", "this site requires cookies", etc.) on short pages (<10KB). Sets status to `cookie_blocked` → persisted as `error`.

## Test plan
- [x] 14 new tests covering all three fixes (5 persistence, 4 Twitter, 5 cookie consent)
- [x] All 48 tests pass (`npx vitest run crux/lib/job-handlers/__tests__/resource-verify.test.ts`)
- [x] No type errors in changed files
- [x] Pre-existing gate failures are unrelated (KB schema validation, YAML entity refs)

Closes #3520
Closes #3521
Closes #3522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for resource verification including DNS failures, timeouts, invalid URLs, SSRF-blocked hosts, and reachability confirmation.

* **New Features**
  * Enhanced soft-404 detection with improved platform-specific heuristics for better accuracy
  * Added detection for cookie consent walls and related redirect patterns
  * Improved resource fetch status tracking and persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->