### PR TITLE
fix: legislation timeline tab shows blank when only undated resources exist

### DIFF
--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -671,15 +671,16 @@ export default async function LegislationDetailPage({
     timelineResources
   );
 
-  // Show Timeline tab if there's any timeline content
+  // Show Timeline tab if there's any dated timeline content.
+  // Exclude undatedResources — they don't render in the timeline view,
+  // so including them inflates the count and causes the tab to appear empty.
   const timelineItemCount =
     unifiedTimeline.milestones.length +
     unifiedTimeline.milestones.reduce(
       (sum, m) => sum + m.children.length,
       0
     ) +
-    unifiedTimeline.earlyCoverage.length +
-    unifiedTimeline.undatedResources.length;
+    unifiedTimeline.earlyCoverage.length;
 
   if (timelineItemCount > 0) {
     tabs.push({


### PR DESCRIPTION
## Summary

- Excluded `undatedResources.length` from `timelineItemCount` in the legislation detail page
- Previously, the Timeline tab appeared with a count badge when all resources were undated, but rendered blank because undated resources don't display in the timeline view
- Now the tab only shows when there are actual dated milestones or early coverage items

Closes #3478

## Test plan

- [ ] Visit a legislation page where all resources are undated — Timeline tab should not appear
- [ ] Visit a legislation page with dated events — Timeline tab should still appear with correct count
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)