### PR TITLE
fix: add redirects for intuitive research area and benchmark slugs

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -235,6 +235,12 @@ const nextConfig: NextConfig = {
         destination: "/organizations/cea",
         permanent: true,
       },
+      // Research area intuitive-slug redirects (#3486)
+      {
+        source: "/research-areas/agentic-ai",
+        destination: "/research-areas/agentic-ai-research",
+        permanent: true,
+      },
       // AI model and benchmark alternate-name redirects
       {
         source: "/ai-models/gemini-ultra",
@@ -249,6 +255,11 @@ const nextConfig: NextConfig = {
       {
         source: "/benchmarks/hle",
         destination: "/benchmarks/humanitys-last-exam",
+        permanent: true,
+      },
+      {
+        source: "/benchmarks/browse-comp",
+        destination: "/benchmarks/browsecomp",
         permanent: true,
       },
     ];


### PR DESCRIPTION
## Summary

- Add redirect `/research-areas/agentic-ai` -> `/research-areas/agentic-ai-research` (slug mismatch from display name "Agentic AI")
- Add redirect `/benchmarks/browse-comp` -> `/benchmarks/browsecomp` (hyphenated variant of BrowseComp)
- Two other redirects from #3486 (`ai-evaluations` -> `evals`, `mechanistic-interpretability` -> `mech-interp`) already existed in `next.config.ts`

Closes #3486

## Test plan

- [ ] Verify `/research-areas/agentic-ai` redirects to `/research-areas/agentic-ai-research`
- [ ] Verify `/benchmarks/browse-comp` redirects to `/benchmarks/browsecomp`
- [ ] Verify existing redirects (`ai-evaluations`, `mechanistic-interpretability`) still work
- [ ] Build passes (TypeScript check confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)