### PR TITLE
fix: retry 429 on resource scan in enqueue commands

### DIFF
--- a/crux/commands/jobs.ts
+++ b/crux/commands/jobs.ts
@@ -618,14 +618,25 @@ async function enqueueResourceIngest(_args: string[], options: CommandOptions): 
   output += `${c.dim}Scanning resources...${c.reset}\n`;
 
   while (true) {
-    const result = await apiRequest<{
-      resources: Array<{ id: string; url: string; lastFetchedAt: string | null }>;
-      total: number;
-      limit: number;
-      offset: number;
-    }>('GET', `/api/resources/all?limit=${PAGE_SIZE}&offset=${offset}`);
+    let result;
+    for (let retry = 0; retry < 10; retry++) {
+      result = await apiRequest<{
+        resources: Array<{ id: string; url: string; lastFetchedAt: string | null }>;
+        total: number;
+        limit: number;
+        offset: number;
+      }>('GET', `/api/resources/all?limit=${PAGE_SIZE}&offset=${offset}`);
 
-    if (!result.ok) return handleApiError(result, c);
+      if (result.ok) break;
+      if (result.message.includes('429')) {
+        const waitSec = Math.min(30, 2 ** retry);
+        process.stderr.write(`  ${c.yellow}Rate limited on scan, waiting ${waitSec}s...${c.reset}\n`);
+        await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+        continue;
+      }
+      return handleApiError(result, c);
+    }
+    if (!result?.ok) return handleApiError(result!, c);
 
     total = result.data.total;
     for (const r of result.data.resources) {
@@ -830,20 +841,31 @@ async function enqueueResourceReingest(_args: string[], options: CommandOptions)
   output += `${c.dim}Scanning resources...${c.reset}\n`;
 
   while (true) {
-    const result = await apiRequest<{
-      resources: Array<{
-        id: string;
-        url: string;
-        lastFetchedAt: string | null;
-        contentLifecycle: string | null;
-        contentHash: string | null;
-      }>;
-      total: number;
-      limit: number;
-      offset: number;
-    }>('GET', `/api/resources/all?limit=${PAGE_SIZE}&offset=${pageOffset}`);
+    let result;
+    for (let retry = 0; retry < 10; retry++) {
+      result = await apiRequest<{
+        resources: Array<{
+          id: string;
+          url: string;
+          lastFetchedAt: string | null;
+          contentLifecycle: string | null;
+          contentHash: string | null;
+        }>;
+        total: number;
+        limit: number;
+        offset: number;
+      }>('GET', `/api/resources/all?limit=${PAGE_SIZE}&offset=${pageOffset}`);
 
-    if (!result.ok) return handleApiError(result, c);
+      if (result.ok) break;
+      if (result.message.includes('429')) {
+        const waitSec = Math.min(30, 2 ** retry);
+        process.stderr.write(`  ${c.yellow}Rate limited on scan, waiting ${waitSec}s...${c.reset}\n`);
+        await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+        continue;
+      }
+      return handleApiError(result, c);
+    }
+    if (!result?.ok) return handleApiError(result!, c);
 
     total = result.data.total;
     for (const r of result.data.resources) {


### PR DESCRIPTION
## Summary

Both `enqueue-resource-ingest` and `enqueue-resource-reingest` failed immediately on 429 during the initial resource scan (`GET /api/resources/all`), unlike job creation which already had retry logic. This caused bulk enqueue of 5,330 resources to fail entirely — the process got stuck in a rate-limit loop creating hundreds of retries on job creation while the initial scan couldn't even start.

Adds exponential backoff retry (up to 10 attempts, max 30s wait) on the scan phase.

## Found during

Attempting to run `pnpm crux sys jobs enqueue-resource-ingest` against production to populate citation_content (#3508). The process hammered the rate limiter for several minutes before being killed.

## Test plan

- [x] Tests pass
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)