### PR TITLE
fix: resolve entity/record names in source-checks pages

### DIFF
--- a/apps/web/src/app/source-checks/page.tsx
+++ b/apps/web/src/app/source-checks/page.tsx
@@ -111,15 +111,27 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
   let names: Record<string, string> = {};
   const hrefs: Record<string, string> = {};
   if (verdicts.length > 0) {
+    // Phase 0: Use persisted display names from verdicts (most reliable, survive record deletion)
+    for (const v of verdicts) {
+      if ("displayName" in v && v.displayName) {
+        names[v.recordId] = v.displayName as string;
+      }
+      if ("entityDisplayName" in v && v.entityDisplayName && v.entityId) {
+        names[v.entityId] = v.entityDisplayName as string;
+      }
+    }
+
     // Group record IDs by type for batch resolution via wiki-server
     const byType = new Map<string, Set<string>>();
     const entityIds = new Set<string>();
     for (const v of verdicts) {
-      const existing = byType.get(v.recordType);
-      if (existing) {
-        existing.add(v.recordId);
-      } else {
-        byType.set(v.recordType, new Set([v.recordId]));
+      if (!names[v.recordId]) {
+        const existing = byType.get(v.recordType);
+        if (existing) {
+          existing.add(v.recordId);
+        } else {
+          byType.set(v.recordType, new Set([v.recordId]));
+        }
       }
       if (v.entityId) {
         entityIds.add(v.entityId);

--- a/apps/web/src/data/entity-nav.ts
+++ b/apps/web/src/data/entity-nav.ts
@@ -4,7 +4,7 @@
 
 import { getTableBase, getIdRegistry, resolveId, getTypedEntityById, getEntityBundle, type BacklinkEntry } from "./tablebase";
 import type { WithSource } from "./tablebase";
-import { isSid } from "@/lib/stable-id";
+import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 
 // ============================================================================
 // DIRECTORY URL RESOLUTION
@@ -67,6 +67,16 @@ export function getEntityHref(id: string, _type?: string): string {
     const wikiId = registry.bySlug[slug];
     return wikiId ? `/wiki/${wikiId}` : `/wiki/${slug}`;
   }
+  // If it's a bare 10-char ID (no sid_ prefix), try with the prefix.
+  // source_check_verdicts.entityId often stores bare IDs.
+  if (!isSid(id) && isAnySid(id)) {
+    const prefixed = `${SID_PREFIX}${id}`;
+    if (registry.byStableId?.[prefixed]) {
+      const slug = registry.byStableId[prefixed];
+      const wikiId = registry.bySlug[slug];
+      return wikiId ? `/wiki/${wikiId}` : `/wiki/${slug}`;
+    }
+  }
   // Otherwise look up slug → wiki ID
   const wikiId = registry.bySlug[id];
   return wikiId ? `/wiki/${wikiId}` : `/wiki/${id}`;
@@ -83,7 +93,17 @@ export function getWikiHref(id: string): string {
     return `/wiki/${id}`;
   }
   const wikiId = registry.bySlug[slug];
-  return wikiId ? `/wiki/${wikiId}` : `/wiki/${slug}`;
+  if (wikiId) return `/wiki/${wikiId}`;
+  // Bare stableId fallback (e.g. "fVMqY7vpMA" → "sid_fVMqY7vpMA")
+  if (!isSid(id) && isAnySid(id)) {
+    const prefixed = `${SID_PREFIX}${id}`;
+    if (registry.byStableId?.[prefixed]) {
+      const pSlug = registry.byStableId[prefixed];
+      const pWikiId = registry.bySlug[pSlug];
+      return pWikiId ? `/wiki/${pWikiId}` : `/wiki/${pSlug}`;
+    }
+  }
+  return `/wiki/${slug}`;
 }
 
 // ============================================================================

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -33,7 +33,7 @@ import {
   isPolicy,
 } from "./entity-schemas";
 import type { ValidSubcategory } from "./valid-subcategories";
-import { isSid } from "@/lib/stable-id";
+import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 
 // Re-export for consumers
 export type { WithSource };
@@ -643,9 +643,9 @@ function entityStableIdIndex(): Map<string, AnyEntity> {
 }
 
 /**
- * Get a typed entity by stableId (10-char alphanumeric).
- * Resolves stableId → slug via idRegistry, then looks up the entity by slug.
- * Falls back to scanning the entity stableId index if the registry lookup fails.
+ * Get a typed entity by stableId.
+ * Handles both sid_-prefixed IDs (e.g. "sid_fVMqY7vpMA") and legacy bare IDs
+ * (e.g. "fVMqY7vpMA") — the latter appear in source_check_verdicts.entityId.
  */
 export function getTypedEntityByStableId(stableId: string): AnyEntity | undefined {
   const registry = getIdRegistry();
@@ -655,7 +655,22 @@ export function getTypedEntityByStableId(stableId: string): AnyEntity | undefine
     if (entity) return entity;
   }
   // Fallback: scan entities by their stableId field
-  return entityStableIdIndex().get(stableId);
+  const byIndex = entityStableIdIndex().get(stableId);
+  if (byIndex) return byIndex;
+
+  // If the ID is a bare 10-char ID (no sid_ prefix), try with the prefix.
+  // source_check_verdicts.entityId often stores bare IDs while entities use sid_ prefix.
+  if (!isSid(stableId) && isAnySid(stableId)) {
+    const prefixed = `${SID_PREFIX}${stableId}`;
+    const slugP = registry.byStableId?.[prefixed];
+    if (slugP) {
+      const entity = typedEntityIndex().get(slugP);
+      if (entity) return entity;
+    }
+    return entityStableIdIndex().get(prefixed);
+  }
+
+  return undefined;
 }
 
 function loadResources(): Resource[] {

--- a/apps/web/src/lib/stable-id.ts
+++ b/apps/web/src/lib/stable-id.ts
@@ -5,4 +5,4 @@
  * contaminated IDs, and numeric PKs are no longer in use.
  */
 
-export { isSid, isDisplayableName, SID_PREFIX } from "@longterm-wiki/id-utils";
+export { isSid, isAnySid, isDisplayableName, SID_PREFIX } from "@longterm-wiki/id-utils";

--- a/apps/wiki-server/drizzle/0150_source_check_display_names.sql
+++ b/apps/wiki-server/drizzle/0150_source_check_display_names.sql
@@ -1,0 +1,5 @@
+-- Add display name columns to source_check_verdicts.
+-- These persist the human-readable names at verdict write time so they
+-- survive record deletion/re-import (which orphans the original record ID).
+ALTER TABLE source_check_verdicts ADD COLUMN IF NOT EXISTS display_name text;
+ALTER TABLE source_check_verdicts ADD COLUMN IF NOT EXISTS entity_display_name text;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1051,6 +1051,13 @@
       "when": 1782288000000,
       "tag": "0149_add_content_hash_index",
       "breakpoints": true
+    },
+    {
+      "idx": 150,
+      "version": "7",
+      "when": 1782374400000,
+      "tag": "0150_source_check_display_names",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -87,6 +87,10 @@ const VerdictUpsertBody = z.object({
   recordId: z.string().min(1).max(MAX_ID_LENGTH),
   fieldName: z.string().max(200).nullable().optional(),
   entityId: z.string().max(200).nullable().optional(),
+  /** Human-readable record name, persisted at write time (survives record deletion). */
+  displayName: z.string().max(500).nullable().optional(),
+  /** Human-readable entity name, persisted at write time. */
+  entityDisplayName: z.string().max(500).nullable().optional(),
   verdict: z.enum(VALID_VERDICT_TYPES),
   confidence: z.number().min(0).max(1).optional(),
   reasoning: z.string().max(5000).optional(),
@@ -625,6 +629,8 @@ const sourceChecksApp = new Hono()
     // issues across PG versions with the postgres.js driver.
     const fieldNameVal = body.fieldName ?? null;
     const entityIdVal = body.entityId ?? null;
+    const displayNameVal = body.displayName ?? null;
+    const entityDisplayNameVal = body.entityDisplayName ?? null;
 
     // Use Drizzle ORM insert/update instead of raw SQL to avoid driver issues
     // with bare literals and COALESCE expressions.
@@ -639,6 +645,8 @@ const sourceChecksApp = new Hono()
       .update(sourceCheckVerdicts)
       .set({
         entityId: entityIdVal,
+        displayName: displayNameVal,
+        entityDisplayName: entityDisplayNameVal,
         verdict: body.verdict,
         confidence: confidenceVal,
         reasoning: reasoningVal,
@@ -666,6 +674,8 @@ const sourceChecksApp = new Hono()
             recordId: body.recordId,
             fieldName: fieldNameVal,
             entityId: entityIdVal,
+            displayName: displayNameVal,
+            entityDisplayName: entityDisplayNameVal,
             verdict: body.verdict,
             confidence: confidenceVal,
             reasoning: reasoningVal,
@@ -685,6 +695,8 @@ const sourceChecksApp = new Hono()
             .update(sourceCheckVerdicts)
             .set({
               entityId: entityIdVal,
+              displayName: displayNameVal,
+              entityDisplayName: entityDisplayNameVal,
               verdict: body.verdict,
               confidence: confidenceVal,
               reasoning: reasoningVal,
@@ -721,6 +733,36 @@ const sourceChecksApp = new Hono()
 
     const names: Record<string, string> = {};
 
+    // Phase 0: Check for persisted display names in source_check_verdicts.
+    // These survive record deletion and are the most reliable source.
+    const storedNames = await db
+      .select({
+        recordId: sourceCheckVerdicts.recordId,
+        displayName: sourceCheckVerdicts.displayName,
+      })
+      .from(sourceCheckVerdicts)
+      .where(
+        and(
+          eq(sourceCheckVerdicts.recordType, record_type),
+          inArray(sourceCheckVerdicts.recordId, record_ids),
+          isNull(sourceCheckVerdicts.fieldName),
+        )
+      );
+    for (const row of storedNames) {
+      if (row.displayName) {
+        names[row.recordId] = row.displayName;
+      }
+    }
+
+    // Only resolve IDs that don't have a stored display name
+    const remainingIds = record_ids.filter((id) => !names[id]);
+    // Replace record_ids with remainingIds for type-specific resolution below
+    const idsToResolve = remainingIds.length > 0 ? remainingIds : [];
+
+    if (idsToResolve.length === 0) {
+      return c.json({ names });
+    }
+
     if (record_type === "personnel") {
       // Personnel: join with entities to get person name + org name.
       // The join uses stableId, but some records have numeric IDs (e.g. "304")
@@ -745,7 +787,7 @@ const sourceChecksApp = new Hono()
           eq(personEntity.stableId, personnel.personEntityId)
         )
         .leftJoin(orgEntity, eq(orgEntity.stableId, personnel.orgEntityId))
-        .where(inArray(personnel.id, record_ids));
+        .where(inArray(personnel.id, idsToResolve));
 
       // Collect unresolved person/org entity IDs for secondary lookup
       const unresolvedPersonIds: string[] = [];
@@ -845,7 +887,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ id: divisions.id, name: divisions.name })
         .from(divisions)
-        .where(inArray(divisions.id, record_ids));
+        .where(inArray(divisions.id, idsToResolve));
 
       for (const row of rows) {
         names[row.id] = row.name;
@@ -855,7 +897,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ factId: facts.factId, label: facts.label })
         .from(facts)
-        .where(inArray(facts.factId, record_ids));
+        .where(inArray(facts.factId, idsToResolve));
 
       // Deduplicate: same factId may appear in multiple timeseries points
       for (const row of rows) {
@@ -868,7 +910,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ stableId: entities.stableId, title: entities.title })
         .from(entities)
-        .where(inArray(entities.stableId, record_ids));
+        .where(inArray(entities.stableId, idsToResolve));
 
       for (const row of rows) {
         if (row.stableId && row.title) {
@@ -879,7 +921,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ id: publications.id, title: publications.title })
         .from(publications)
-        .where(inArray(publications.id, record_ids));
+        .where(inArray(publications.id, idsToResolve));
 
       for (const row of rows) {
         names[row.id] = row.title;
@@ -894,7 +936,7 @@ const sourceChecksApp = new Hono()
         })
         .from(benchmarkResults)
         .leftJoin(benchmarks, eq(benchmarks.id, benchmarkResults.benchmarkId))
-        .where(inArray(benchmarkResults.id, record_ids));
+        .where(inArray(benchmarkResults.id, idsToResolve));
 
       for (const row of rows) {
         const bmName = row.benchmarkName ?? "Unknown benchmark";
@@ -905,7 +947,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ id: entityEvents.id, title: entityEvents.title })
         .from(entityEvents)
-        .where(inArray(entityEvents.id, record_ids));
+        .where(inArray(entityEvents.id, idsToResolve));
 
       for (const row of rows) {
         names[row.id] = row.title;
@@ -919,7 +961,7 @@ const sourceChecksApp = new Hono()
           rating: entityAssessments.rating,
         })
         .from(entityAssessments)
-        .where(inArray(entityAssessments.id, record_ids));
+        .where(inArray(entityAssessments.id, idsToResolve));
 
       for (const row of rows) {
         names[row.id] = `${row.dimension} (${row.entityId}): ${row.rating}`;
@@ -934,7 +976,7 @@ const sourceChecksApp = new Hono()
           platform: secondaryMarketPrices.platform,
         })
         .from(secondaryMarketPrices)
-        .where(inArray(secondaryMarketPrices.id, record_ids));
+        .where(inArray(secondaryMarketPrices.id, idsToResolve));
 
       for (const row of rows) {
         const company = row.companyDisplayName ?? row.companyId;
@@ -945,7 +987,7 @@ const sourceChecksApp = new Hono()
       // Resolve to "<page title> - Footnote N".
       const slugSet = new Set<string>();
       const parsed: Array<{ recordId: string; slug: string; footnote: string }> = [];
-      for (const rid of record_ids) {
+      for (const rid of idsToResolve) {
         const match = rid.match(/^page:(.+):fn(\d+)$/);
         if (match) {
           slugSet.add(match[1]);
@@ -978,7 +1020,7 @@ const sourceChecksApp = new Hono()
       const rows = await db
         .select({ slug: wikiPages.slug, title: wikiPages.title })
         .from(wikiPages)
-        .where(inArray(wikiPages.slug, record_ids));
+        .where(inArray(wikiPages.slug, idsToResolve));
 
       for (const row of rows) {
         names[row.slug] = row.title;
@@ -994,12 +1036,93 @@ const sourceChecksApp = new Hono()
         .where(
           and(
             eq(things.sourceTable, record_type),
-            inArray(things.sourceId, record_ids)
+            inArray(things.sourceId, idsToResolve)
           )
         );
 
       for (const row of rows) {
         names[row.sourceId] = row.title;
+      }
+    }
+
+    // ---- Fallback for orphaned records ----
+    // Records that were deleted/re-imported after source-checking won't be found
+    // by the type-specific queries above. For those, extract a display name from
+    // the verdict reasoning in source_check_verdicts + the linked entity title.
+    const unresolved = record_ids.filter((id) => !names[id]);
+    if (unresolved.length > 0) {
+      const fallbackRows = await db
+        .select({
+          recordId: sourceCheckVerdicts.recordId,
+          entityId: sourceCheckVerdicts.entityId,
+          reasoning: sourceCheckVerdicts.reasoning,
+          entityTitle: entities.title,
+        })
+        .from(sourceCheckVerdicts)
+        .leftJoin(entities, eq(entities.stableId, sourceCheckVerdicts.entityId))
+        .where(
+          and(
+            eq(sourceCheckVerdicts.recordType, record_type),
+            inArray(sourceCheckVerdicts.recordId, unresolved),
+            isNull(sourceCheckVerdicts.fieldName),
+          )
+        );
+
+      // If entity join failed (entityId stored without sid_ prefix), try with prefix
+      const stillMissing = new Map<string, typeof fallbackRows[number]>();
+      for (const row of fallbackRows) {
+        if (!row.entityTitle && row.entityId) {
+          stillMissing.set(row.entityId, row);
+        }
+      }
+      const prefixedLookup = new Map<string, string>();
+      if (stillMissing.size > 0) {
+        const prefixedIds = [...stillMissing.keys()].map((id) =>
+          id.startsWith("sid_") ? id : `sid_${id}`
+        );
+        const entityRows = await db
+          .select({ stableId: entities.stableId, title: entities.title })
+          .from(entities)
+          .where(inArray(entities.stableId, prefixedIds));
+        for (const row of entityRows) {
+          if (row.stableId && row.title) {
+            // Map bare ID → title
+            const bareId = row.stableId.startsWith("sid_")
+              ? row.stableId.slice(4)
+              : row.stableId;
+            prefixedLookup.set(bareId, row.title);
+            prefixedLookup.set(row.stableId, row.title);
+          }
+        }
+      }
+
+      for (const row of fallbackRows) {
+        if (names[row.recordId]) continue; // already resolved by dedup
+        const entityName =
+          row.entityTitle ??
+          (row.entityId ? prefixedLookup.get(row.entityId) : null) ??
+          null;
+
+        // Try to extract a person/item name from the reasoning text
+        // Common patterns: "confirms that [Name] joined..." / "The source confirms [Name]..."
+        let extractedName: string | null = null;
+        if (row.reasoning) {
+          const nameMatch = row.reasoning.match(
+            /(?:confirms?\s+(?:that\s+)?|identifies?\s+|mentions?\s+|states?\s+(?:that\s+)?)([A-Z][a-zA-Z.''-]+(?:\s+[A-Z][a-zA-Z.''-]+){0,4})/
+          );
+          if (nameMatch?.[1]) {
+            extractedName = nameMatch[1].trim();
+          }
+        }
+
+        if (extractedName && entityName) {
+          names[row.recordId] = `${extractedName} @ ${entityName}`;
+        } else if (extractedName) {
+          names[row.recordId] = extractedName;
+        } else if (entityName) {
+          names[row.recordId] = `${entityName} record`;
+        }
+        // If nothing resolves, the ID stays unresolved (shown as raw ID by frontend)
       }
     }
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1568,6 +1568,10 @@ export const sourceCheckVerdicts = pgTable(
     recordId: text("record_id").notNull(),
     fieldName: text("field_name"), // NULL = whole row verdict
     entityId: text("entity_id"), // for grouping/display
+    /** Human-readable name for this record, persisted at write time (survives record deletion). */
+    displayName: text("display_name"),
+    /** Human-readable name for the parent entity, persisted at write time. */
+    entityDisplayName: text("entity_display_name"),
     verdict: text("verdict").notNull(), // confirmed | contradicted | outdated | partial | unverifiable | unchecked
     confidence: real("confidence"),
     reasoning: text("reasoning"),

--- a/crux/commands/source-check-orchestrate.ts
+++ b/crux/commands/source-check-orchestrate.ts
@@ -38,7 +38,7 @@ import {
   SOURCE_CHECK_CONSTANTS,
   MODELS,
 } from '../lib/source-check/index.ts';
-import { str, strOrNull, numOrNull, resolveName, extractEntityId } from '../lib/source-check/record-fields.ts';
+import { str, strOrNull, numOrNull, resolveName, extractEntityId, extractEntityDisplayName } from '../lib/source-check/record-fields.ts';
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -121,6 +121,10 @@ interface RecordItemData {
   fields: Record<string, string | number | null>;
   /** Entity ID for the parent entity (org for personnel/divisions, company for funding-rounds, etc.) */
   entityId?: string | null;
+  /** Human-readable record description (persisted in verdict for name resolution) */
+  displayName?: string | null;
+  /** Human-readable entity name (persisted in verdict for name resolution) */
+  entityDisplayName?: string | null;
 }
 
 interface EntityItemData {
@@ -435,6 +439,7 @@ async function collectRecordItems(
         const priority = computeRecordPriority(recordType, existing);
 
         const entityId = extractEntityId(recordType, item);
+        const entityDisplayName = extractEntityDisplayName(recordType, item);
 
         items.push({
           kind: 'record',
@@ -452,6 +457,8 @@ async function collectRecordItems(
             recordId: id,
             fields,
             entityId,
+            displayName: description,
+            entityDisplayName,
           },
         });
       }
@@ -1045,6 +1052,8 @@ async function storeResult(item: VerifyItem, result: VerifyResult): Promise<void
       reasoning: result.reasoning,
       sourcesChecked: 1,
       entityId: recordData.entityId,
+      displayName: recordData.displayName,
+      entityDisplayName: recordData.entityDisplayName,
     }, '[source-check]').catch((e: unknown) => {
       console.warn(`[source-check] Failed to store record verdict: ${e instanceof Error ? e.message : String(e)}`);
     });

--- a/crux/lib/source-check/bare-id-resolution.test.ts
+++ b/crux/lib/source-check/bare-id-resolution.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests that bare stableId detection works correctly.
+ * Source-check verdicts store entity IDs without the sid_ prefix.
+ * The frontend must detect these and try the prefixed version.
+ *
+ * This is a CI-blocking test to prevent regression of the bug where
+ * entity names showed as raw IDs (e.g. "fVMqY7vpMA" instead of "Bezos Earth Fund").
+ */
+import { describe, it, expect } from 'vitest';
+import { isSid, isAnySid, SID_PREFIX, stripSid } from '../../../packages/id-utils/src/index.ts';
+
+describe('bare stableId detection for source-check entity resolution', () => {
+  describe('isAnySid detects both formats', () => {
+    it('detects sid_-prefixed IDs', () => {
+      expect(isAnySid('sid_fVMqY7vpMA')).toBe(true);
+      expect(isAnySid('sid_NPPTvNqRXA')).toBe(true);
+      expect(isAnySid('sid_wHfFIBrPcA')).toBe(true);
+    });
+
+    it('detects bare 10-char IDs with uppercase letters', () => {
+      expect(isAnySid('fVMqY7vpMA')).toBe(true);
+      expect(isAnySid('NPPTvNqRXA')).toBe(true);
+      expect(isAnySid('wHfFIBrPcA')).toBe(true);
+      expect(isAnySid('ULjDXpSLCI')).toBe(true);
+    });
+
+    it('rejects non-stableId strings', () => {
+      expect(isAnySid('hello-world')).toBe(false); // has hyphen
+      expect(isAnySid('E1470')).toBe(false); // too short
+      expect(isAnySid('my-entity-slug')).toBe(false); // not alphanumeric
+      expect(isAnySid('')).toBe(false);
+      expect(isAnySid(null)).toBe(false);
+      expect(isAnySid(undefined)).toBe(false);
+    });
+
+    it('rejects 10-char strings without uppercase (not stableId format)', () => {
+      expect(isAnySid('abcdefghij')).toBe(false); // all lowercase
+      expect(isAnySid('1234567890')).toBe(false); // all digits
+    });
+  });
+
+  describe('isSid only detects prefixed format', () => {
+    it('detects sid_-prefixed IDs', () => {
+      expect(isSid('sid_fVMqY7vpMA')).toBe(true);
+    });
+
+    it('rejects bare IDs', () => {
+      expect(isSid('fVMqY7vpMA')).toBe(false);
+    });
+  });
+
+  describe('sid_ prefix logic for entity resolution fallback', () => {
+    it('can construct prefixed ID from bare ID', () => {
+      const bareId = 'fVMqY7vpMA';
+      expect(isSid(bareId)).toBe(false);
+      expect(isAnySid(bareId)).toBe(true);
+
+      // This is the fallback logic used in getTypedEntityByStableId and getEntityHref
+      const prefixed = `${SID_PREFIX}${bareId}`;
+      expect(prefixed).toBe('sid_fVMqY7vpMA');
+      expect(isSid(prefixed)).toBe(true);
+    });
+
+    it('stripSid removes prefix correctly', () => {
+      expect(stripSid('sid_fVMqY7vpMA')).toBe('fVMqY7vpMA');
+      expect(stripSid('fVMqY7vpMA')).toBe('fVMqY7vpMA'); // no-op for bare IDs
+    });
+
+    it('real-world source-check entity IDs are detected as bare stableIds', () => {
+      // These are actual entity IDs found in production source_check_verdicts
+      const productionEntityIds = [
+        'fVMqY7vpMA', // Bezos Earth Fund
+        'NPPTvNqRXA', // Foresight Institute
+        'wHfFIBrPcA', // another org
+        'ULjDXpSLCI', // from grants
+      ];
+
+      for (const id of productionEntityIds) {
+        expect(isSid(id)).toBe(false); // not prefixed
+        expect(isAnySid(id)).toBe(true); // detected as bare stableId
+        expect(`${SID_PREFIX}${id}`).toMatch(/^sid_[A-Za-z0-9]{10}$/); // prefixed version is valid
+      }
+    });
+  });
+});

--- a/crux/lib/source-check/name-extraction.test.ts
+++ b/crux/lib/source-check/name-extraction.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the verdict reasoning name extraction regex.
+ * This regex is used in the resolve-names endpoint fallback to extract
+ * person/entity names from verdict reasoning when the original record
+ * has been deleted from its source table.
+ */
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Extracts a person/item name from verdict reasoning text.
+ * Matches patterns like "confirms that [Name]..." or "identifies [Name]..."
+ */
+function extractNameFromReasoning(reasoning: string): string | null {
+  const nameMatch = reasoning.match(
+    /(?:confirms?\s+(?:that\s+)?|identifies?\s+|mentions?\s+|states?\s+(?:that\s+)?)([A-Z][a-zA-Z.''-]+(?:\s+[A-Z][a-zA-Z.''-]+){0,4})/
+  );
+  return nameMatch?.[1]?.trim() ?? null;
+}
+
+describe('extractNameFromReasoning', () => {
+  it('extracts name from "confirms that [Name] joined..."', () => {
+    const reasoning =
+      'The source text explicitly confirms that Valerie Blain-Smith joined the Bezos Earth Fund as Chief People Officer in 2022.';
+    expect(extractNameFromReasoning(reasoning)).toBe('Valerie Blain-Smith');
+  });
+
+  it('extracts name from "confirms that [Name] joined..." with middle name', () => {
+    const reasoning =
+      'The source confirms that Leon Clarke joined the Bezos Earth Fund as Director of Decarbonization Pathways.';
+    expect(extractNameFromReasoning(reasoning)).toBe('Leon Clarke');
+  });
+
+  it('extracts name from "confirms [Name]..."', () => {
+    const reasoning =
+      "The source confirms Christine Peterson's role as co-founder of the Foresight Institute.";
+    expect(extractNameFromReasoning(reasoning)).toBe("Christine Peterson's");
+  });
+
+  it('extracts name from "identifies [Name]..."', () => {
+    const reasoning =
+      'The source identifies Peter Diamandis as a board member of the Foresight Institute.';
+    expect(extractNameFromReasoning(reasoning)).toBe('Peter Diamandis');
+  });
+
+  it('extracts name from "states that [Name]..."', () => {
+    const reasoning =
+      'The source states that K. Eric Drexler founded the Foresight Institute.';
+    expect(extractNameFromReasoning(reasoning)).toBe('K. Eric Drexler');
+  });
+
+  it('returns null when no name pattern is found', () => {
+    const reasoning = 'The data does not match any known source material.';
+    expect(extractNameFromReasoning(reasoning)).toBeNull();
+  });
+
+  it('returns null for empty reasoning', () => {
+    expect(extractNameFromReasoning('')).toBeNull();
+  });
+
+  it('extracts multi-word names', () => {
+    const reasoning =
+      'The source confirms that Brandon Goldman serves as Executive Director.';
+    expect(extractNameFromReasoning(reasoning)).toBe('Brandon Goldman');
+  });
+
+  it('handles names with hyphens', () => {
+    const reasoning =
+      'The source confirms that Valerie Blain-Smith joined the organization.';
+    expect(extractNameFromReasoning(reasoning)).toBe('Valerie Blain-Smith');
+  });
+});

--- a/crux/lib/source-check/record-fields.ts
+++ b/crux/lib/source-check/record-fields.ts
@@ -50,6 +50,33 @@ export function resolveName(item: Record<string, unknown>, ...keys: string[]): s
  *
  * Returns null if no entity ID is available.
  */
+/**
+ * Extract the display name for the parent entity (org, company, etc.).
+ * Used to persist a human-readable entity name alongside the entity ID in verdicts.
+ */
+export function extractEntityDisplayName(recordType: string, item: Record<string, unknown>): string | null {
+  switch (recordType) {
+    case 'personnel':
+      return strOrNull(item, 'orgResolvedName') ?? strOrNull(item, 'orgDisplayName') ?? null;
+    case 'division':
+      return strOrNull(item, 'parentOrgName') ?? strOrNull(item, 'name') ?? null;
+    case 'grant':
+      return strOrNull(item, 'orgResolvedName') ?? strOrNull(item, 'orgDisplayName') ?? null;
+    case 'funding-round':
+      return strOrNull(item, 'companyResolvedName') ?? strOrNull(item, 'companyDisplayName') ?? null;
+    case 'investment':
+      return strOrNull(item, 'investorResolvedName') ?? strOrNull(item, 'investorDisplayName') ?? null;
+    case 'equity-position':
+      return strOrNull(item, 'companyResolvedName') ?? strOrNull(item, 'companyDisplayName') ?? null;
+    case 'funding-program':
+      return strOrNull(item, 'orgResolvedName') ?? strOrNull(item, 'orgDisplayName') ?? null;
+    case 'policy-stakeholder':
+      return strOrNull(item, 'stakeholderResolvedName') ?? strOrNull(item, 'stakeholderDisplayName') ?? null;
+    default:
+      return null;
+  }
+}
+
 export function extractEntityId(recordType: string, item: Record<string, unknown>): string | null {
   switch (recordType) {
     case 'personnel':

--- a/crux/lib/source-check/verdict-handler.ts
+++ b/crux/lib/source-check/verdict-handler.ts
@@ -67,6 +67,10 @@ export async function storeAggregateVerdict(params: {
   sourcesChecked: number;
   /** Entity ID to associate with this verdict (e.g., org stableId for personnel/division records) */
   entityId?: string | null;
+  /** Human-readable record name (persisted in verdict, survives record deletion) */
+  displayName?: string | null;
+  /** Human-readable entity name (persisted in verdict, survives record deletion) */
+  entityDisplayName?: string | null;
 }, logPrefix = '[source-check]'): Promise<void> {
   const body = {
     recordType: params.recordType,
@@ -76,6 +80,8 @@ export async function storeAggregateVerdict(params: {
     reasoning: params.reasoning,
     sourcesChecked: params.sourcesChecked,
     ...(params.entityId ? { entityId: params.entityId } : {}),
+    ...(params.displayName ? { displayName: params.displayName } : {}),
+    ...(params.entityDisplayName ? { entityDisplayName: params.entityDisplayName } : {}),
   };
 
   const response = await apiRequest<{ ok: boolean }>(

--- a/crux/validate/validate-source-check-names.ts
+++ b/crux/validate/validate-source-check-names.ts
@@ -1,0 +1,162 @@
+/**
+ * Validate source-check name resolution quality.
+ *
+ * Checks that source-check verdicts resolve to human-readable names
+ * (not raw 10-char IDs). Catches regressions like the one where entity
+ * names showed as "fVMqY7vpMA" instead of "Bezos Earth Fund".
+ *
+ * Usage:
+ *   pnpm crux validate source-check-names              # Check against wiki-server
+ *   WIKI_SERVER_ENV=prod pnpm crux validate source-check-names  # Check production
+ *
+ * This validator checks:
+ * 1. Entity IDs in verdicts resolve to entity names (not raw IDs)
+ * 2. Record IDs in verdicts resolve to display names (not raw IDs)
+ * 3. Entity links resolve to valid wiki pages (not /wiki/<raw-id>)
+ */
+
+import { apiRequest } from '../lib/wiki-server/client.ts';
+import { isAnySid, isSid } from '../../packages/id-utils/src/index.ts';
+
+interface Verdict {
+  recordType: string;
+  recordId: string;
+  entityId: string | null;
+  verdict: string;
+}
+
+interface VerdictsResponse {
+  verdicts: Verdict[];
+  total: number;
+}
+
+interface ResolveNamesResponse {
+  names: Record<string, string>;
+}
+
+const RECORD_TYPES = ['personnel', 'grant', 'publication', 'division', 'investment', 'policy-stakeholder'];
+
+export async function validateSourceCheckNames(): Promise<{
+  pass: boolean;
+  totalChecked: number;
+  unresolvedEntities: number;
+  unresolvedRecords: number;
+  details: string[];
+}> {
+  const details: string[] = [];
+  let totalChecked = 0;
+  let unresolvedEntities = 0;
+  let unresolvedRecords = 0;
+
+  for (const recordType of RECORD_TYPES) {
+    // Fetch a sample of verdicts
+    const verdictsResult = await apiRequest<VerdictsResponse>(
+      'GET',
+      `/api/source-checks/verdicts?record_type=${recordType}&limit=20`
+    );
+
+    if (!verdictsResult.ok) {
+      details.push(`[SKIP] ${recordType}: failed to fetch verdicts`);
+      continue;
+    }
+
+    const { verdicts, total } = verdictsResult.data;
+    if (verdicts.length === 0) {
+      details.push(`[OK] ${recordType}: no verdicts`);
+      continue;
+    }
+
+    // Collect entity IDs and record IDs
+    const entityIds = new Set<string>();
+    const recordIds = new Set<string>();
+    for (const v of verdicts) {
+      if (v.entityId) entityIds.add(v.entityId);
+      recordIds.add(v.recordId);
+    }
+
+    // Check entity IDs — none should be bare stableIds without names
+    const entityIssues: string[] = [];
+    for (const eid of entityIds) {
+      if (isAnySid(eid) && !isSid(eid)) {
+        entityIssues.push(eid);
+      }
+    }
+    if (entityIssues.length > 0) {
+      // These are bare IDs that the frontend will need to resolve with sid_ prefix
+      details.push(
+        `[INFO] ${recordType}: ${entityIssues.length}/${entityIds.size} entity IDs stored without sid_ prefix`
+      );
+    }
+
+    // Resolve record names
+    const idList = [...recordIds].join(',');
+    const namesResult = await apiRequest<ResolveNamesResponse>(
+      'GET',
+      `/api/source-checks/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
+    );
+
+    if (!namesResult.ok) {
+      details.push(`[WARN] ${recordType}: resolve-names failed`);
+      continue;
+    }
+
+    const names = namesResult.data.names;
+    const unresolved: string[] = [];
+    for (const rid of recordIds) {
+      totalChecked++;
+      if (!names[rid]) {
+        unresolved.push(rid);
+        unresolvedRecords++;
+      }
+    }
+
+    // Count unresolved entities
+    unresolvedEntities += entityIssues.length;
+
+    const resolvedPct = Math.round(((recordIds.size - unresolved.length) / recordIds.size) * 100);
+    if (unresolved.length === 0) {
+      details.push(`[OK] ${recordType}: ${recordIds.size}/${total} sampled, 100% resolved`);
+    } else if (resolvedPct >= 50) {
+      details.push(
+        `[WARN] ${recordType}: ${unresolved.length}/${recordIds.size} unresolved (${resolvedPct}% resolved) — orphaned records`
+      );
+    } else {
+      details.push(
+        `[FAIL] ${recordType}: ${unresolved.length}/${recordIds.size} unresolved (${resolvedPct}% resolved) — likely broken resolution`
+      );
+    }
+  }
+
+  // Pass if >50% of records resolve (orphaned records are expected; broken resolution is not)
+  const resolvedPct = totalChecked > 0 ? Math.round(((totalChecked - unresolvedRecords) / totalChecked) * 100) : 100;
+  const pass = resolvedPct >= 50;
+
+  return {
+    pass,
+    totalChecked,
+    unresolvedEntities,
+    unresolvedRecords,
+    details,
+  };
+}
+
+// CLI entry point
+if (import.meta.url.endsWith(process.argv[1]) || process.argv[1]?.endsWith('validate-source-check-names.ts')) {
+  validateSourceCheckNames()
+    .then((result) => {
+      console.log('\n=== Source-Check Name Resolution Validation ===\n');
+      for (const line of result.details) {
+        console.log(`  ${line}`);
+      }
+      console.log();
+      console.log(`  Total records checked: ${result.totalChecked}`);
+      console.log(`  Unresolved records: ${result.unresolvedRecords}`);
+      console.log(`  Bare entity IDs (need sid_ prefix): ${result.unresolvedEntities}`);
+      console.log(`  Result: ${result.pass ? 'PASS' : 'FAIL'}\n`);
+      process.exit(result.pass ? 0 : 1);
+    })
+    .catch((e) => {
+      console.error('Validation failed:', e);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Fixes three bugs on the `/source-checks` pages where raw IDs were shown instead of human-readable names:

- **Entity column showed raw IDs** (e.g. `fVMqY7vpMA` instead of "Bezos Earth Fund") — `source_check_verdicts.entityId` stores bare IDs without `sid_` prefix, but entity lookup functions expected the prefix. Added `sid_` prefix fallback in `getTypedEntityByStableId()`, `getEntityHref()`, and `getWikiHref()`.

- **Personnel/grant record names showed raw IDs** — the personnel/grant records were deleted and re-imported with new IDs after source-checking, so `resolve-names` returned empty. Added server-side fallback that extracts names from verdict reasoning text + entity titles.

- **Detail page org links broken** (`/wiki/fVMqY7vpMA` → 404) — same bare ID issue in URL resolution.

Also adds **forward-looking fix**: `display_name` and `entity_display_name` columns in `source_check_verdicts` so names persist at write time and survive future record deletions. The orchestrator now passes display names when storing verdicts.

## Changes

| File | What |
|------|------|
| `apps/web/src/data/tablebase.ts` | `sid_` prefix fallback in `getTypedEntityByStableId()` |
| `apps/web/src/data/entity-nav.ts` | `sid_` prefix fallback in `getEntityHref()` and `getWikiHref()` |
| `apps/web/src/app/source-checks/page.tsx` | Use stored `displayName`/`entityDisplayName` from verdicts |
| `apps/wiki-server/src/routes/source-check/source-checks.ts` | Orphaned record fallback + stored displayName resolution + accept new fields |
| `apps/wiki-server/src/schema.ts` | Add `display_name`, `entity_display_name` columns |
| `apps/wiki-server/drizzle/0150_*` | Migration for new columns |
| `crux/lib/source-check/verdict-handler.ts` | Accept `displayName`/`entityDisplayName` params |
| `crux/commands/source-check-orchestrate.ts` | Pass display names to verdict storage |
| `crux/lib/source-check/record-fields.ts` | New `extractEntityDisplayName()` function |

## Deploy Checklist

- [ ] Migration `0150_source_check_display_names.sql` runs on startup (ADD COLUMN, fast)
- [ ] After deploy: verify `/source-checks?type=personnel` shows entity names

## Test plan

- [x] `pnpm test` — all 1050 web tests pass
- [x] `pnpm test -- crux/` — all 4595 crux tests pass  
- [x] `pnpm build` — production build succeeds
- [x] `tsc --noEmit` — no type errors in web or wiki-server
- [x] New tests: `bare-id-resolution.test.ts` (9 tests) and `name-extraction.test.ts` (9 tests)
- [ ] After deploy: manually verify entity names resolve on `/source-checks?type=personnel`
- [ ] After deploy: verify detail page org links go to correct wiki pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)