### PR TITLE
fix: add path aliases to crux tsconfig for transitive import resolution

### DIFF
--- a/crux/tsconfig.json
+++ b/crux/tsconfig.json
@@ -10,7 +10,28 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "checkJs": false
+    "checkJs": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../apps/web/src/*"],
+      "@lib/*": ["../apps/web/src/lib/*"],
+      "@data": ["../apps/web/src/data/index.ts"],
+      "@data/*": ["../apps/web/src/data/*"],
+      "@components/*": ["../apps/web/src/components/*"],
+      "@wiki-server/api-types": ["../apps/wiki-server/src/api-types.ts"],
+      "@wiki-server/api-response-types": ["../apps/wiki-server/src/api-response-types.ts"],
+      "@wiki-server/facts-route": ["../apps/wiki-server/src/routes/factbase/facts.ts"],
+      "@wiki-server/source-checks-route": ["../apps/wiki-server/src/routes/source-check/source-checks.ts"],
+      "@wiki-server/grants-route": ["../apps/wiki-server/src/routes/tablebase/grants.ts"],
+      "@wiki-server/divisions-route": ["../apps/wiki-server/src/routes/tablebase/divisions.ts"],
+      "@wiki-server/funding-programs-route": ["../apps/wiki-server/src/routes/tablebase/funding-programs.ts"],
+      "@wiki-server/personnel-route": ["../apps/wiki-server/src/routes/tablebase/personnel.ts"],
+      "@wiki-server/prediction-markets-route": ["../apps/wiki-server/src/routes/tablebase/prediction-markets.ts"],
+      "@wiki-server/secondary-market-prices-route": ["../apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts"],
+      "@wiki-server/data-quality-route": ["../apps/wiki-server/src/routes/operational/data-quality.ts"],
+      "@wiki-server/talent-flows-route": ["../apps/wiki-server/src/routes/tablebase/talent-flows.ts"],
+      "@wiki-server/jobs-route": ["../apps/wiki-server/src/routes/operational/jobs.ts"]
+    }
   },
   "include": [
     "lib/**/*.ts",


### PR DESCRIPTION
## Summary

- Adds `baseUrl` and `paths` to `crux/tsconfig.json` mirroring `apps/web/tsconfig.json` aliases
- Fixes TS2307 errors (`Cannot find module '@lib/yaml'`, `@lib/wiki-server`, `@/lib/stable-id`) that occur when the crux typecheck (`validate-crux-tsc.ts`) transitively resolves `apps/web/src/data/tablebase.ts`
- The transitive import chain: `crux/lib/grant-import/entity-matcher.ts` -> `apps/web/src/data/tablebase.ts` -> `@lib/yaml` (unresolved)

## Test plan

- [ ] CI passes — specifically the `validate` step's crux typecheck should now report 0 errors instead of 17+
- [ ] `tsc --noEmit -p crux/tsconfig.json` exits cleanly

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module resolution configuration to support import path aliases, enhancing code organization and development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->