### PR TITLE
Fix stale references and restore tests from pruning PRs

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -50,7 +50,7 @@ audits:
       git branch -r --list 'origin/claude/*' 2>/dev/null | wc -l | tr -d ' '
     how_to_verify: |
       Compare the number of recent claude/* branches (from check_command output)
-      with session count in the Agent Sessions dashboard (E912).
+      with session count in the Agent Activity dashboard (E1281).
       A large gap means agents are completing work without logging sessions.
     frequency: weekly
     added: "2026-03-04"
@@ -124,12 +124,12 @@ audits:
 
   - id: active-agents-dashboard-adoption
     category: feature-health
-    description: "Active Agents dashboard (E925) is populated with data and referenced by maintenance or agent sessions"
+    description: "Agent Activity dashboard (E1281) is populated with data and referenced by maintenance or agent sessions"
     check_type: manual
     how_to_verify: |
-      1. Visit the Active Agents dashboard to confirm it shows recent data.
+      1. Visit the Agent Activity dashboard (E1281) to confirm it shows recent data.
       2. Search session logs and maintenance reports for references to
-         "active-agents" or "E925".
+         "agent-activity" or "E1281".
       3. If the dashboard shows no data or is never referenced, consider
          whether to promote its use, simplify it, or remove it.
     frequency: monthly
@@ -210,6 +210,18 @@ audits:
       - date: "2026-03-31"
         result: pass
         checked_by: "manual"
+  - id: model-freshness
+    category: infrastructure
+    description: "Claude model IDs in crux/lib/anthropic.ts are still the latest available versions"
+    check_type: manual
+    how_to_verify: |
+      1. Check the Anthropic API docs or release notes for the latest Claude model IDs.
+      2. Compare with MODELS in crux/lib/anthropic.ts and MODEL_ALIASES.
+      3. If new models are available, update MODELS, MODEL_ALIASES, and MODELS_LAST_VERIFIED.
+      4. Also check crux/lib/llm.ts for any hardcoded model references.
+    frequency: monthly
+    added: "2026-03-30"
+
   - id: audits-system-adoption
     category: process
     description: "This audits system itself is being used — items are checked on schedule, not abandoned"

--- a/apps/web/src/app/internal/__tests__/active-agents-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/active-agents-content.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Render smoke tests for the Active Agents dashboard content component.
+ *
+ * Active Agents makes two parallel API calls (agents + open PRs) and enriches
+ * agent rows with PR numbers from branch matching. These tests verify the
+ * component renders without throwing for all key data scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  fetchFromWikiServer: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+vi.mock("@/app/internal/agent-activity/active-agents-table", () => ({
+  ActiveAgentsTable: () => null,
+}));
+
+vi.mock("@/app/internal/agent-activity/agent-events-panel", () => ({
+  AgentEventsPanel: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@lib/wiki-server";
+import { ActiveAgentsContent } from "@/app/internal/agent-activity/active-agents-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockAgents = [
+  {
+    id: 1,
+    sessionId: "sess-abc123",
+    sessionName: "Fix auth session",
+    branch: "claude/fix-123",
+    task: "Fix authentication vulnerability",
+    status: "active",
+    currentStep: "Writing tests",
+    issueNumber: 123,
+    prNumber: null,
+    filesTouched: ["src/auth.ts", "src/middleware.ts"],
+    model: "claude-opus-4-6",
+    worktree: "/tmp/worktree-abc",
+    heartbeatAt: "2025-01-01T11:55:00Z",
+    startedAt: "2025-01-01T10:00:00Z",
+    completedAt: null,
+  },
+  {
+    id: 2,
+    sessionId: "sess-def456",
+    sessionName: null,
+    branch: "claude/feature-789",
+    task: "Add dashboard feature",
+    status: "completed",
+    currentStep: null,
+    issueNumber: 789,
+    prNumber: 456,
+    filesTouched: null,
+    model: null,
+    worktree: null,
+    heartbeatAt: "2025-01-01T09:30:00Z",
+    startedAt: "2025-01-01T09:00:00Z",
+    completedAt: "2025-01-01T09:30:00Z",
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ActiveAgentsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with active agents", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: {
+        agents: mockAgents.map((a) => ({ ...a })),
+        conflicts: [],
+        directoryConflicts: [],
+      },
+      source: "api" as const,
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with no agents", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { agents: [], conflicts: [], directoryConflicts: [] },
+      source: "api" as const,
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API is not configured", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { agents: [], conflicts: [], directoryConflicts: [] },
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with issue conflicts", async () => {
+    const conflictData = {
+      agents: [
+        { ...mockAgents[0], issueNumber: 100 },
+        {
+          id: 3,
+          sessionId: "sess-ghi789",
+          sessionName: null,
+          branch: "claude/another-fix-100",
+          task: "Also fixing issue 100",
+          status: "active",
+          currentStep: "Analyzing code",
+          issueNumber: 100,
+          prNumber: null,
+          filesTouched: null,
+          model: null,
+          worktree: null,
+          heartbeatAt: "2025-01-01T11:50:00Z",
+          startedAt: "2025-01-01T11:00:00Z",
+          completedAt: null,
+        },
+      ],
+      conflicts: [
+        { issueNumber: 100, sessionIds: ["sess-abc123", "sess-ghi789"] },
+      ],
+      directoryConflicts: [],
+    };
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: conflictData,
+      source: "api" as const,
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with directory conflicts", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: {
+        agents: mockAgents.map((a) => ({ ...a })),
+        conflicts: [],
+        directoryConflicts: [
+          {
+            directory: "/Users/user/Documents/GitHub.nosync/longterm-wiki",
+            sessionIds: ["sess-abc123", "sess-def456"],
+          },
+        ],
+      },
+      source: "api" as const,
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with mixed agent statuses", async () => {
+    const mixedAgents = [
+      { ...mockAgents[0], status: "active" },
+      { ...mockAgents[1], id: 3, status: "stale", sessionId: "sess-stale" },
+      {
+        ...mockAgents[1],
+        id: 4,
+        status: "completed",
+        sessionId: "sess-completed",
+      },
+    ];
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { agents: mixedAgents, conflicts: [], directoryConflicts: [] },
+      source: "api" as const,
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { agents: [], conflicts: [], directoryConflicts: [] },
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "connect ECONNREFUSED 127.0.0.1:3100",
+      },
+    });
+
+    const element = await ActiveAgentsContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/agent-sessions-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/agent-sessions-content.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Render smoke tests for the Agent Sessions dashboard content component.
+ *
+ * These tests call the async server component directly with mocked API data
+ * to verify the component renders without throwing. They catch data shape
+ * mismatches (e.g. renamed fields, missing required props) before they
+ * reach production.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+// Table is a "use client" component — stub it so the node env can import it.
+vi.mock("@/app/internal/agent-activity/sessions-table", () => ({
+  AgentSessionsTable: () => null,
+}));
+
+vi.mock("@components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import {
+  withApiFallback,
+  fetchDetailed,
+} from "@lib/wiki-server";
+import { AgentSessionsContent } from "@/app/internal/agent-activity/agent-sessions-content";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockAgentSessions = [
+  {
+    id: 1,
+    branch: "claude/fix-123",
+    task: "Fix authentication bug",
+    sessionType: "bugfix",
+    issueNumber: 123,
+    worktree: null,
+    status: "completed",
+    startedAt: "2025-01-01T10:00:00Z",
+    completedAt: "2025-01-01T12:00:00Z",
+    prUrl: "https://github.com/org/repo/pull/456",
+    prOutcome: "merged",
+    fixesPrUrl: null,
+  },
+  {
+    id: 2,
+    branch: "claude/feature-789",
+    task: "Add new dashboard",
+    sessionType: "infrastructure",
+    issueNumber: 789,
+    worktree: null,
+    status: "active",
+    startedAt: "2025-01-02T09:00:00Z",
+    completedAt: null,
+    prUrl: null,
+    prOutcome: null,
+    fixesPrUrl: null,
+  },
+];
+
+const mockSessionLogs = [
+  {
+    id: 1,
+    branch: "claude/fix-123",
+    title: "Fix auth bug session",
+    model: "claude-opus-4-6",
+    cost: "2.50",
+    costCents: 250,
+    durationMinutes: 120,
+    prUrl: "https://github.com/org/repo/pull/456",
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AgentSessionsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing when API returns session data", async () => {
+    vi.mocked(fetchDetailed)
+      .mockResolvedValueOnce({ ok: true, data: { sessions: mockAgentSessions } })
+      .mockResolvedValueOnce({ ok: true, data: { sessions: mockSessionLogs } });
+
+    vi.mocked(withApiFallback).mockImplementation(async (apiLoader) => {
+      const result = await apiLoader();
+      if (result && typeof result === "object" && "ok" in result && result.ok) {
+        return { data: (result as { ok: true; data: unknown }).data, source: "api" as const };
+      }
+      return { data: [], source: "local" as const };
+    });
+
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API returns empty sessions", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "api" as const,
+    });
+
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API fails (fallback to local data)", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API has connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: [],
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders enrichment scenario without throwing (smoke test with session log data)", async () => {
+    vi.mocked(fetchDetailed)
+      .mockResolvedValueOnce({ ok: true, data: { sessions: mockAgentSessions } })
+      .mockResolvedValueOnce({ ok: true, data: { sessions: mockSessionLogs } });
+
+    // Use the real withApiFallback to test the data transformation
+    const { withApiFallback: realWithApiFallback } = await vi.importActual<
+      typeof import("@lib/wiki-server")
+    >("@lib/wiki-server");
+    vi.mocked(withApiFallback).mockImplementation(realWithApiFallback);
+
+    // Verify the component doesn't crash with enriched data.
+    // The actual enrichment logic (merging cost/durationMinutes/prUrl from session
+    // logs into agent sessions) is exercised by the real withApiFallback path here,
+    // but since AgentSessionsTable is mocked to () => null we cannot assert on the
+    // props it receives. This test guards against crashes; data-shape assertions
+    // belong in a unit test of the enrichment helper directly.
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("handles sessions with fix-chain data (fixesPrUrl)", async () => {
+    const sessionsWithFixes = [
+      ...mockAgentSessions,
+      {
+        id: 3,
+        branch: "claude/fix-of-fix",
+        task: "Fix regression from PR 456",
+        sessionType: "bugfix",
+        issueNumber: null,
+        worktree: null,
+        status: "completed",
+        startedAt: "2025-01-03T10:00:00Z",
+        completedAt: "2025-01-03T11:00:00Z",
+        prUrl: "https://github.com/org/repo/pull/500",
+        prOutcome: "merged",
+        fixesPrUrl: "https://github.com/org/repo/pull/456",
+      },
+    ];
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: sessionsWithFixes.map((s) => ({
+        ...s,
+        model: null,
+        cost: null,
+        costCents: null,
+        durationMinutes: null,
+        title: null,
+      })),
+      source: "api" as const,
+    });
+
+    const element = await AgentSessionsContent();
+    expect(element).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/internal/__tests__/session-insights-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/session-insights-content.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Render smoke tests for the Session Insights dashboard content component.
+ *
+ * SessionInsightsContent fetches learnings and recommendations from the
+ * wiki-server API. These tests verify the component renders without
+ * throwing for the key data scenarios including empty state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type React from "react";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+vi.mock("@/lib/wiki-server", () => ({
+  fetchDetailed: vi.fn(),
+  withApiFallback: vi.fn(),
+}));
+
+vi.mock("@/app/internal/agent-activity/insights-table", () => ({
+  InsightsTable: () => null,
+}));
+
+vi.mock("@/components/internal/DataSourceBanner", () => ({
+  DataSourceBanner: () => null,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { withApiFallback } from "@/lib/wiki-server";
+import { SessionInsightsContent } from "@/app/internal/agent-activity/session-insights-content";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockInsights = {
+  insights: [
+    {
+      date: "2025-01-01",
+      branch: "claude/fix-auth",
+      title: "Fix auth session",
+      type: "learning" as const,
+      text: "The auth middleware needs to check token expiry before validation",
+    },
+    {
+      date: "2025-01-02",
+      branch: "claude/add-dashboard",
+      title: "Add dashboard",
+      type: "recommendation" as const,
+      text: "Consider adding caching for dashboard API calls",
+    },
+    {
+      date: null,
+      branch: null,
+      title: null,
+      type: "learning" as const,
+      text: "Some insight without session metadata",
+    },
+  ],
+  summary: {
+    total: 3,
+    byType: { learning: 2, recommendation: 1 },
+  },
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SessionInsightsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without throwing with insights data", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: mockInsights,
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+
+  it("renders without throwing with empty insights", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: { insights: [], summary: { total: 0, byType: {} } },
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when API returns null (no local fallback)", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: null,
+      source: "local" as const,
+      apiError: { type: "not-configured" as const },
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing with connection error", async () => {
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: null,
+      source: "local" as const,
+      apiError: {
+        type: "connection-error" as const,
+        message: "ECONNREFUSED",
+      },
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+  });
+
+  it("renders without throwing when summary has many types", async () => {
+    const manyTypes = {
+      insights: mockInsights.insights,
+      summary: {
+        total: 10,
+        byType: { learning: 5, recommendation: 3, observation: 2 },
+      },
+    };
+
+    vi.mocked(withApiFallback).mockResolvedValue({
+      data: manyTypes,
+      source: "api" as const,
+    });
+
+    const element = await SessionInsightsContent();
+    expect(element).toBeTruthy();
+    if (element) {
+      const markup = renderToStaticMarkup(element as React.ReactElement);
+      expect(markup).not.toMatch(/undefined|NaN/);
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/wiki-nav.test.ts
+++ b/apps/web/src/lib/__tests__/wiki-nav.test.ts
@@ -102,7 +102,7 @@ describe("detectSidebarType", () => {
   it("returns 'internal' for /internal/ paths", () => {
     expect(detectSidebarType("/internal/")).toBe("internal");
     expect(detectSidebarType("/internal/architecture")).toBe("internal");
-    expect(detectSidebarType("/internal/facts")).toBe("internal");
+    expect(detectSidebarType("/internal/entities")).toBe("internal");
   });
 
   it("returns 'about' for About page paths", () => {

--- a/crux/commands/agents.ts
+++ b/crux/commands/agents.ts
@@ -450,34 +450,34 @@ async function sweepCommand(
   const timeout = Number(options.timeout || 30);
   let output = '';
 
-  // Sweep E925 active agents (stale after timeout minutes)
+  // Sweep active agents (stale after timeout minutes)
   const agentResult = await sweepStaleAgents(timeout);
   if (agentResult.ok) {
     if (agentResult.data.swept > 0) {
-      output += `Active agents (E925): swept ${agentResult.data.swept} stale agent(s):\n`;
+      output += `Active agents (E1281): swept ${agentResult.data.swept} stale agent(s):\n`;
       for (const a of agentResult.data.agents) {
         output += `  #${a.id} (${a.sessionId})\n`;
       }
     } else {
-      output += 'Active agents (E925): no stale agents.\n';
+      output += 'Active agents (E1281): no stale agents.\n';
     }
   } else {
-    output += `Active agents (E925): Error: ${agentResult.message}\n`;
+    output += `Active agents (E1281): Error: ${agentResult.message}\n`;
   }
 
-  // Sweep E912 agent sessions (stale after 2 hours)
+  // Sweep agent sessions (stale after 2 hours)
   const sessionResult = await sweepStaleSessions(2);
   if (sessionResult.ok) {
     if (sessionResult.data.swept > 0) {
-      output += `Agent sessions (E912): swept ${sessionResult.data.swept} stale session(s):\n`;
+      output += `Agent sessions (E1281): swept ${sessionResult.data.swept} stale session(s):\n`;
       for (const s of sessionResult.data.sessions) {
         output += `  #${s.id} (${s.branch})\n`;
       }
     } else {
-      output += 'Agent sessions (E912): no stale sessions.\n';
+      output += 'Agent sessions (E1281): no stale sessions.\n';
     }
   } else {
-    output += `Agent sessions (E912): Error: ${sessionResult.message}\n`;
+    output += `Agent sessions (E1281): Error: ${sessionResult.message}\n`;
   }
 
   return { exitCode: 0, output };

--- a/crux/lib/anthropic.ts
+++ b/crux/lib/anthropic.ts
@@ -26,6 +26,8 @@ config({ path: '.env.local' });
 /**
  * Date when MODELS were last verified as current.
  * Update this date after confirming models are still the latest versions.
+ * Model freshness is tracked via the `model-freshness` maintenance audit
+ * in `.claude/audits.yaml` — not an automated validator.
  */
 export const MODELS_LAST_VERIFIED = '2026-02-18';
 

--- a/crux/lib/page-coverage.ts
+++ b/crux/lib/page-coverage.ts
@@ -9,7 +9,7 @@
  * Used by:
  *   - Build-time pipeline (build-data.mjs) → stored in database.json per page
  *   - PageStatus component (reads pre-computed coverage, overrides live citation data)
- *   - Page Coverage dashboard (/internal/page-coverage)
+ *   - Page Coverage dashboard (E899)
  */
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #3544 (dashboard pruning) and #3538 (validator pruning) review findings that were merged before fix commits could land.

- **Stale entity IDs**: Updated E912 (Agent Sessions) and E925 (Active Agents) references to E1281 (Agent Activity) in `.claude/audits.yaml` and `crux/commands/agents.ts`
- **Stale path references**: Fixed `/internal/page-coverage` comment in `page-coverage.ts`, `/internal/facts` test reference in `wiki-nav.test.ts`
- **Restored 3 deleted test files** (`active-agents-content.test.tsx`, `agent-sessions-content.test.tsx`, `session-insights-content.test.tsx`) with updated import paths pointing to `agent-activity/`
- **Model freshness audit**: Added `model-freshness` audit entry to `audits.yaml` and a note in `crux/lib/anthropic.ts` explaining that model freshness is tracked via maintenance audits

## Test plan

- [x] All 3 restored test files pass (18 tests total)
- [x] wiki-nav.test.ts passes (27 tests)
- [x] No stale E912/E925 references remain in modified files

Generated with [Claude Code](https://claude.com/claude-code)