### PR TITLE
Add reverse mapping from slug to wiki ID in build-data script

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -724,6 +724,7 @@ async function main() {
         }
       } else {
         wikiIdToSlug[page.wikiId] = page.id;
+        slugToWikiId[page.id] = page.wikiId;
       }
     }
   }


### PR DESCRIPTION
## Summary
This change adds a reverse mapping in the build-data script to enable lookups from page slug to wiki ID, complementing the existing forward mapping.

## Key Changes
- Added `slugToWikiId[page.id] = page.wikiId;` to populate the reverse mapping when processing pages
- This allows the script to efficiently look up a wiki ID given a page slug, which was previously only possible in the forward direction

## Implementation Details
The new line is added in the same conditional block where `wikiIdToSlug` is populated, ensuring both mappings stay synchronized during the data build process. This bidirectional mapping pattern is useful for scenarios where the script or downstream consumers need to resolve wiki IDs from slug identifiers.

https://claude.ai/code/session_01JQTvDw1nnZr69zPzGcbV3P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed page reference resolution during the build process to ensure entity links are properly tracked and resolved across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->