### PR TITLE
Source check dashboard: resource linking, better stats, claims display

### DIFF
--- a/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
+++ b/apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx
@@ -130,7 +130,7 @@ function buildColumns(names: NameMap, hrefs: HrefMap): ColumnDef<VerdictRow>[] {
     },
     {
       accessorKey: "recordId",
-      header: ({ column }) => <SortableHeader column={column}>Field</SortableHeader>,
+      header: ({ column }) => <SortableHeader column={column}>Claim</SortableHeader>,
       cell: ({ row }) => {
         const resolvedName = names[row.original.recordId];
         const recordId = row.original.recordId;
@@ -194,7 +194,7 @@ function buildColumns(names: NameMap, hrefs: HrefMap): ColumnDef<VerdictRow>[] {
         const r = row.original.reasoning;
         if (!r) return <span className="text-xs text-muted-foreground">-</span>;
         return (
-          <span className="text-xs text-muted-foreground line-clamp-2" title={r}>
+          <span className="text-xs text-muted-foreground line-clamp-1" title={r}>
             {r}
           </span>
         );
@@ -362,6 +362,17 @@ function ExpandedDetail({
               ) : (
                 <span className="text-xs text-muted-foreground italic">{sourceUrl}</span>
               )}
+              {(() => {
+                const withResource = items.find(e => e.resourceId);
+                if (!withResource) return null;
+                return (
+                  <a href={`/resources/${withResource.resourceId}`}
+                    className="text-xs text-emerald-600 hover:underline flex items-center gap-1 dark:text-emerald-400 shrink-0 ml-2"
+                    title="View resource details">
+                    Resource
+                  </a>
+                );
+              })()}
               <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
                 {items.length} check{items.length !== 1 ? "s" : ""}
               </span>
@@ -756,11 +767,7 @@ export function EntitySourceChecksViewer() {
   const rangeEnd = Math.min((pageIndex + 1) * ps, filteredCount);
 
   // Stats — computed from filtered data so they update with active filters
-  const withConfidence = filtered.filter((v) => v.confidence != null);
-  const avgConfidence = withConfidence.length > 0
-    ? withConfidence.reduce((s, v) => s + v.confidence!, 0) / withConfidence.length : 0;
   const contradictedCount = filtered.filter((v) => v.verdict === "contradicted").length;
-  const needsRecheckCount = filtered.filter((v) => v.needsRecheck).length;
 
   // Coverage stats — filter out rows with neither records nor verdicts
   const meaningfulCoverage = coverageData.filter((r) => r.total > 0 || r.verified > 0);
@@ -790,36 +797,54 @@ export function EntitySourceChecksViewer() {
     <div className="not-prose">
       {/* Stats cards */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
-        {totalRecords > 0 && (
-          <div className="rounded-lg border border-border/60 p-4">
-            <p className="text-xs text-muted-foreground mb-1">Total Records</p>
-            <p className="text-2xl font-bold tabular-nums">{totalRecords.toLocaleString()}</p>
-            <p className="text-xs text-muted-foreground mt-1">{meaningfulCoverage.length} record types</p>
-          </div>
-        )}
-        {totalRecords > 0 && (
-          <div className="rounded-lg border border-border/60 p-4">
-            <p className="text-xs text-muted-foreground mb-1">Checked</p>
-            <p className={cn("text-2xl font-bold tabular-nums", overallCoveragePct < 50 ? "text-amber-600" : "text-emerald-600")}>{overallCoveragePct}%</p>
-            <p className="text-xs text-muted-foreground mt-1">{totalVerified.toLocaleString()} / {totalRecords.toLocaleString()}</p>
-          </div>
-        )}
-        <div className="rounded-lg border border-border/60 p-4">
-          <p className="text-xs text-muted-foreground mb-1">Total Verdicts</p>
-          <p className="text-2xl font-bold tabular-nums">{filtered.length}</p>
-        </div>
-        <div className="rounded-lg border border-border/60 p-4">
-          <p className="text-xs text-muted-foreground mb-1">Avg Confidence</p>
-          <p className="text-2xl font-bold tabular-nums">{avgConfidence > 0 ? `${Math.round(avgConfidence * 100)}%` : "N/A"}</p>
-        </div>
-        <div className="rounded-lg border border-border/60 p-4">
-          <p className="text-xs text-muted-foreground mb-1">Contradicted</p>
-          <p className={cn("text-2xl font-bold tabular-nums", contradictedCount > 0 ? "text-red-600" : "")}>{contradictedCount}</p>
-        </div>
-        <div className="rounded-lg border border-border/60 p-4">
-          <p className="text-xs text-muted-foreground mb-1">Needs Recheck</p>
-          <p className={cn("text-2xl font-bold tabular-nums", needsRecheckCount > 0 ? "text-amber-600" : "")}>{needsRecheckCount}</p>
-        </div>
+        {(() => {
+          const confirmedCount = filtered.filter((v) => v.verdict === "confirmed").length;
+          const hasIssuesCount = filtered.filter((v) => v.verdict === "contradicted" || v.verdict === "outdated" || v.verdict === "partial").length;
+          const unverifiableCount = filtered.filter((v) => v.verdict === "unverifiable").length;
+          const accuracyDenom = confirmedCount + contradictedCount + filtered.filter((v) => v.verdict === "outdated").length;
+          const accuracyPct = accuracyDenom > 0 ? Math.round((confirmedCount / accuracyDenom) * 100) : null;
+          const checkedTotal = filtered.length;
+          const pctOf = (n: number) => checkedTotal > 0 ? `${Math.round((n / checkedTotal) * 100)}% of checked` : "0% of checked";
+
+          return (
+            <>
+              <div className="rounded-lg border border-border/60 p-4">
+                <p className="text-xs text-muted-foreground mb-1">Verified Correct</p>
+                <p className="text-2xl font-bold tabular-nums text-emerald-600">{confirmedCount}</p>
+                <p className="text-xs text-muted-foreground mt-1">{pctOf(confirmedCount)}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 p-4">
+                <p className="text-xs text-muted-foreground mb-1">Has Issues</p>
+                <p className="text-2xl font-bold tabular-nums text-amber-600">{hasIssuesCount}</p>
+                <p className="text-xs text-muted-foreground mt-1">{pctOf(hasIssuesCount)}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 p-4">
+                <p className="text-xs text-muted-foreground mb-1">Unverifiable</p>
+                <p className="text-2xl font-bold tabular-nums">{unverifiableCount}</p>
+                <p className="text-xs text-muted-foreground mt-1">{pctOf(unverifiableCount)}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 p-4">
+                <p className="text-xs text-muted-foreground mb-1">Contradicted</p>
+                <p className={cn("text-2xl font-bold tabular-nums", contradictedCount > 0 ? "text-red-600" : "")}>{contradictedCount}</p>
+                <p className="text-xs text-muted-foreground mt-1">Review and correct</p>
+              </div>
+              <div className="rounded-lg border border-border/60 p-4">
+                <p className="text-xs text-muted-foreground mb-1">Accuracy Rate</p>
+                <p className={cn("text-2xl font-bold tabular-nums", accuracyPct === null ? "" : accuracyPct >= 90 ? "text-emerald-600" : accuracyPct >= 75 ? "text-amber-600" : "text-red-600")}>
+                  {accuracyPct !== null ? `${accuracyPct}%` : "N/A"}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">Excludes unverifiable</p>
+              </div>
+              {totalRecords > 0 && (
+                <div className="rounded-lg border border-border/60 p-4">
+                  <p className="text-xs text-muted-foreground mb-1">Coverage</p>
+                  <p className={cn("text-2xl font-bold tabular-nums", overallCoveragePct < 50 ? "text-amber-600" : "text-emerald-600")}>{overallCoveragePct}%</p>
+                  <p className="text-xs text-muted-foreground mt-1">{totalVerified.toLocaleString()} / {totalRecords.toLocaleString()}</p>
+                </div>
+              )}
+            </>
+          );
+        })()}
       </div>
 
       {/* Contradictions alert section */}

--- a/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
+++ b/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
@@ -119,39 +119,78 @@ export async function SourceCheckCoverageContent() {
       <DataSourceBanner source={source} apiError={apiError} />
 
       <p className="text-muted-foreground text-sm leading-relaxed mb-6">
-        Source-check coverage across all record types. Data from the unified{" "}
-        <code className="text-[11px]">source_check_verdicts</code> and{" "}
-        <code className="text-[11px]">source_check_evidence</code> tables.
+        Data quality and coverage across all record types.
       </p>
 
       {/* ── (a) Summary cards ──────────────────────────────────────────── */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 not-prose mb-8">
-        <StatCard
-          label="Total Entities"
-          value={totalEntities.toLocaleString()}
-          sub={`${entityTypes.length} entity types`}
-        />
-        <StatCard
-          label="Total Verdicts"
-          value={vStats.total.toLocaleString()}
-          sub={Object.entries(vStats.by_type ?? {}).map(([t, c]) => `${t}: ${c}`).join(", ") || "None yet"}
-        />
-        <StatCard
-          label="Avg Confidence"
-          value={
-            vStats.avg_confidence > 0
-              ? `${Math.round(vStats.avg_confidence * 100)}%`
-              : "N/A"
-          }
-          sub={`Across ${vStats.total.toLocaleString()} verdicts`}
-        />
-        <StatCard
-          label="Needs Recheck"
-          value={vStats.needs_recheck.toLocaleString()}
-          color={vStats.needs_recheck > 0 ? "text-amber-600" : ""}
-          sub={vStats.needs_recheck > 0 ? "Verdicts flagged for recheck" : "All up to date"}
-        />
-      </div>
+      {(() => {
+        const bv = vStats.by_verdict ?? {};
+        const confirmed = bv["confirmed"] ?? 0;
+        const contradicted = bv["contradicted"] ?? 0;
+        const outdated = bv["outdated"] ?? 0;
+        const partial = bv["partial"] ?? 0;
+        const unverifiable = bv["unverifiable"] ?? 0;
+        const unchecked = bv["unchecked"] ?? 0;
+        const totalChecked = vStats.total - unchecked;
+        const hasIssues = contradicted + outdated + partial;
+        const accuracyDenom = confirmed + contradicted + outdated;
+        const accuracyRate = accuracyDenom > 0 ? (confirmed / accuracyDenom) * 100 : 0;
+        const pct = (n: number) =>
+          totalChecked > 0 ? `${Math.round((n / totalChecked) * 100)}%` : "—";
+
+        return (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 not-prose mb-8">
+            <StatCard
+              label="Verified Correct"
+              value={confirmed.toLocaleString()}
+              color="text-emerald-600"
+              sub={`${pct(confirmed)} of checked verdicts`}
+            />
+            <StatCard
+              label="Has Issues"
+              value={hasIssues.toLocaleString()}
+              color={hasIssues > 0 ? "text-amber-600" : ""}
+              sub={`${pct(hasIssues)} of checked verdicts`}
+            />
+            <StatCard
+              label="Unverifiable"
+              value={unverifiable.toLocaleString()}
+              color="text-muted-foreground"
+              sub={`${pct(unverifiable)} of checked verdicts`}
+            />
+            <StatCard
+              label="Contradicted"
+              value={contradicted.toLocaleString()}
+              color={contradicted > 0 ? "text-red-600" : ""}
+              sub={contradicted > 0 ? "Action required — data may be wrong" : "None found"}
+            />
+            <StatCard
+              label="Accuracy Rate"
+              value={
+                accuracyDenom > 0
+                  ? `${Math.round(accuracyRate)}%`
+                  : "N/A"
+              }
+              color={
+                accuracyDenom === 0
+                  ? ""
+                  : accuracyRate >= 90
+                    ? "text-emerald-600"
+                    : accuracyRate >= 75
+                      ? "text-amber-600"
+                      : "text-red-600"
+              }
+              sub="Confirmed / (Confirmed + Wrong + Outdated)"
+            />
+            <StatCard
+              label="Needs Recheck"
+              value={vStats.needs_recheck.toLocaleString()}
+              color={vStats.needs_recheck > 0 ? "text-amber-600" : ""}
+              sub={vStats.needs_recheck > 0 ? "Verdicts flagged for recheck" : "All up to date"}
+            />
+          </div>
+        );
+      })()}
 
       {/* ── (b) Entities by Type ────────────────────────────────── */}
       <div className="not-prose mb-8">

--- a/crux/lib/source-check/verdict-handler.ts
+++ b/crux/lib/source-check/verdict-handler.ts
@@ -7,6 +7,7 @@
  */
 
 import { apiRequest } from '../wiki-server/client.ts';
+import { lookupResourceByUrl } from '../wiki-server/resources.ts';
 import { MODELS } from '../llm.ts';
 import type { SourceCheckVerdict, RecordType } from '../../../apps/wiki-server/src/api-types.ts';
 
@@ -27,7 +28,20 @@ export async function storeSourceCheckEvidence(params: {
   isPrimarySource?: boolean;
   /** Entity ID to associate with this evidence (e.g., org stableId for personnel/division records) */
   entityId?: string | null;
+  resourceId?: string | null;
 }, logPrefix = '[source-check]'): Promise<void> {
+  let resolvedResourceId = params.resourceId ?? null;
+  if (!resolvedResourceId && params.sourceUrl) {
+    try {
+      const resource = await lookupResourceByUrl(params.sourceUrl);
+      if (resource.ok) {
+        resolvedResourceId = resource.data.id;
+      }
+    } catch {
+      // Best-effort: resource lookup failure should not block evidence storage
+    }
+  }
+
   const body = {
     recordType: params.recordType,
     recordId: params.recordId,
@@ -39,6 +53,7 @@ export async function storeSourceCheckEvidence(params: {
     notes: params.reasoning,
     ...(params.isPrimarySource !== undefined ? { isPrimarySource: params.isPrimarySource } : {}),
     ...(params.entityId ? { entityId: params.entityId } : {}),
+    resourceId: resolvedResourceId,
   };
 
   const response = await apiRequest<{ id: number; verdictFlagged: boolean }>(


### PR DESCRIPTION
## Summary

Addresses three of the six issues identified in the source check audit ([Discussion #3558](https://github.com/quantified-uncertainty/longterm-wiki/discussions/3558)).

- **Fix 1 — Resource linking**: Auto-resolve `resourceId` in `storeSourceCheckEvidence()` by calling `lookupResourceByUrl()`. The DB column, API field, and frontend rendering all existed already — just needed the lookup call. Evidence records will now link to Resource pages when a matching resource exists.

- **Fix 2 — Headline stats redesign**: Replace misleading "Avg Confidence" (which measured LLM self-certainty, not data quality) with actionable metrics on both the Verdicts tab and Coverage tab: Verified Correct, Has Issues, Unverifiable, Contradicted, Accuracy Rate (confirmed / (confirmed + contradicted + outdated), excluding unverifiable).

- **Fix 3 — Claims display**: Rename "Field" column to "Claim" for clarity, tighten reasoning to 1 line, and add "Resource" links in expanded evidence sections when `resourceId` is available.

## Files changed

- `crux/lib/source-check/verdict-handler.ts` — resource lookup + `resourceId` param
- `apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx` — coverage tab stats
- `apps/web/src/app/internal/entity-source-checks/entity-source-checks-viewer.tsx` — verdicts tab stats + column rename + resource links

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit` on `apps/web`)
- [x] All 4577 tests pass
- [ ] Verify dashboard renders correctly on deployed preview
- [ ] Verify resource links appear for evidence with known resource URLs

Note: `pnpm build` has a pre-existing failure in organization entity pages (`(0, ah.R) is not a function`) unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
