### PR TITLE
fix: defend against Claude Code worktree CWD corruption bug

### DIFF
--- a/.claude/hooks/cleanup-worktrees.sh
+++ b/.claude/hooks/cleanup-worktrees.sh
@@ -152,6 +152,18 @@ for i in "${!PATHS[@]}"; do
   fi
 
   if [ "$SHOULD_REMOVE" = true ]; then
+    # Safety: check if any process has its CWD inside this worktree.
+    # This prevents removing a worktree that a concurrent Claude session
+    # is still using (addresses CWD corruption bug — see .claude/rules/worktree-isolation-bug.md).
+    if command -v lsof >/dev/null 2>&1; then
+      # lsof -d cwd lists only CWD file descriptors — fast and targeted
+      if lsof -d cwd 2>/dev/null | grep -qF "$WT_PATH"; then
+        log "Skipping worktree (CWD in use by active process): $WT_PATH"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+      fi
+    fi
+
     log "Removing stale worktree: $WT_PATH (branch: ${WT_BRANCH:-detached})"
     # Try without --force first to respect locks; fall back to --force only if needed
     if git worktree remove "$WT_PATH" 2>/dev/null || git worktree remove "$WT_PATH" --force 2>/dev/null; then

--- a/.claude/hooks/recover-cwd.sh
+++ b/.claude/hooks/recover-cwd.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# PostToolUse hook (Agent) — recover working directory after subagent returns.
+#
+# Claude Code has a known bug where spawning a subagent with
+# isolation: "worktree" contaminates the parent session's Bash CWD,
+# leaving it pointing at the worktree path. When the worktree is
+# cleaned up, ALL subsequent Bash commands fail permanently.
+#
+# This hook runs after every Agent tool call and checks whether the
+# CWD is still valid. If it has drifted into a .claude/worktrees/
+# path (or the path no longer exists), it attempts to restore the
+# CWD to $CLAUDE_PROJECT_DIR.
+#
+# Known issues tracked at:
+#   https://github.com/anthropics/claude-code/issues/42282
+#   https://github.com/anthropics/claude-code/issues/18236
+#   https://github.com/anthropics/claude-code/issues/41010
+#
+# NOTE: This is a best-effort mitigation. The Bash tool validates CWD
+# existence *before* executing commands, so if the CWD is already
+# deleted by the time this hook runs, the hook itself may fail.
+# The primary defense is to avoid isolation: "worktree" entirely.
+
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
+  exit 0
+fi
+
+# Check if the current working directory exists and is valid
+if ! cd "." 2>/dev/null; then
+  # CWD is gone — try to recover
+  cd "$PROJECT_DIR" 2>/dev/null || exit 0
+  echo "WARNING: Working directory was deleted (likely a cleaned-up worktree). Recovered to $PROJECT_DIR" >&2
+  exit 0
+fi
+
+# Check if we've drifted into a worktree path
+CURRENT_DIR="$(pwd 2>/dev/null || true)"
+if [[ "$CURRENT_DIR" == */.claude/worktrees/* ]]; then
+  cd "$PROJECT_DIR" 2>/dev/null || exit 0
+  echo "WARNING: CWD drifted into worktree ($CURRENT_DIR). Recovered to $PROJECT_DIR" >&2
+  exit 0
+fi
+
+exit 0

--- a/.claude/rules/worktree-isolation-bug.md
+++ b/.claude/rules/worktree-isolation-bug.md
@@ -1,0 +1,35 @@
+# Worktree Isolation Bug — DO NOT USE `isolation: "worktree"`
+
+## The bug
+
+Claude Code has a confirmed, unpatched bug where `Agent(isolation: "worktree")` corrupts the parent session's Bash working directory. After the subagent finishes and the worktree is cleaned up, **all Bash commands in the parent session fail permanently** with "Working directory no longer exists." The session is unrecoverable — restart is the only option.
+
+Tracked in multiple open issues (no official fix):
+- [#42282](https://github.com/anthropics/claude-code/issues/42282) — CWD drift after subagent worktree
+- [#18236](https://github.com/anthropics/claude-code/issues/18236) — Bash tool permanently broken after CWD deleted
+- [#41010](https://github.com/anthropics/claude-code/issues/41010) — Worktree cleanup deletes parent session CWD
+- [#27881](https://github.com/anthropics/claude-code/issues/27881) — Context compaction causes CWD drift into worktrees
+- [#28363](https://github.com/anthropics/claude-code/issues/28363) — WorktreeRemove hook never fires for subagent worktrees
+
+## Rule
+
+**Never use `isolation: "worktree"` in Agent tool calls.** This applies to all sessions — coordinator, slot agents, and skills.
+
+For branch isolation, use the agent workspace slots (`lw/a1`–`lw/a15`) which are full independent clones and do not trigger this bug.
+
+## What happens without `isolation: "worktree"`
+
+Agents spawned without worktree isolation run in the **same directory** as the parent session. This is fine for:
+- Read-only research (searching, reading files, web fetches)
+- Code analysis and review
+- Running commands that don't modify the working tree
+
+If you need an agent to modify files on a different branch, dispatch it to a different slot via `./ws open <N> --claude` rather than using worktree isolation.
+
+## Defenses in place
+
+Even though the rule is "don't use it," we have layered defenses in case it happens accidentally:
+
+1. **PostToolUse hook** (`.claude/hooks/recover-cwd.sh`): Attempts to restore CWD to `$CLAUDE_PROJECT_DIR` after Agent calls if drift is detected. Best-effort — may not catch all cases.
+2. **Safer cleanup hook** (`.claude/hooks/cleanup-worktrees.sh`): Checks for processes with CWD inside a worktree before removing it. Skips removal if active.
+3. **This rule file**: Loaded automatically into Claude Code sessions as a reminder.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/recover-cwd.sh\"",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 
 ## Key Conventions
 
-- **Branch discipline**: Never switch branches mid-session — PreToolUse hooks block `git checkout <branch>`, `git switch`, and `git stash`. To work on another branch, use the Agent tool with `isolation: "worktree"`. To create a new branch from the current one, `git checkout -b claude/<description>` is allowed. Never edit files on `main` — a PreToolUse hook blocks Edit/Write on main. If a dev server was running, restart it after switching branches (Next.js serves from the current working directory, not the branch the server was started from).
+- **Branch discipline**: Never switch branches mid-session — PreToolUse hooks block `git checkout <branch>`, `git switch`, and `git stash`. **Do NOT use `isolation: "worktree"` in Agent calls** — it has a [confirmed Claude Code bug](https://github.com/anthropics/claude-code/issues/42282) that corrupts the parent session's working directory and bricks the session. For branch isolation, use agent workspace slots (`lw/a1`–`lw/a15`). See `.claude/rules/worktree-isolation-bug.md`. To create a new branch from the current one, `git checkout -b claude/<description>` is allowed. Never edit files on `main` — a PreToolUse hook blocks Edit/Write on main. If a dev server was running, restart it after switching branches (Next.js serves from the current working directory, not the branch the server was started from).
 - **Path aliases**: `@/`, `@components/`, `@data/`, `@lib/` in app code
 - **Entity types**: Canonical list in `apps/web/src/data/entity-type-names.ts`
 - **MDX escaping**: `\$100` not `$100`, `\<100ms` not `<100ms`
@@ -178,3 +178,4 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/internal-dashboards.md` — Dashboard creation pattern
 - `.claude/rules/implementation-quality.md` — Thoroughness, testing depth, self-review
 - `.claude/rules/auto-update-system.md` — Auto-update system
+- `.claude/rules/worktree-isolation-bug.md` — Known Claude Code worktree CWD bug (DO NOT USE `isolation: "worktree"`)


### PR DESCRIPTION
## Summary

Claude Code has a confirmed, unpatched platform bug where `Agent(isolation: "worktree")` corrupts the parent session's Bash working directory. After the subagent finishes and the worktree is cleaned up, **all Bash commands in the parent session fail permanently** — the session is bricked with no recovery.

This has been causing recurring session crashes in our agent workflows. Multiple GitHub issues document the same bug with no official fix:
- [anthropics/claude-code#42282](https://github.com/anthropics/claude-code/issues/42282) — CWD drift after subagent worktree
- [anthropics/claude-code#18236](https://github.com/anthropics/claude-code/issues/18236) — Bash tool permanently broken after CWD deleted
- [anthropics/claude-code#41010](https://github.com/anthropics/claude-code/issues/41010) — Worktree cleanup deletes parent session CWD

## Changes — defense in depth

1. **CLAUDE.md** — warns against `isolation: "worktree"`, recommends agent slots instead
2. **PostToolUse hook** (`recover-cwd.sh`) — attempts CWD recovery after Agent calls if drift detected
3. **Safer cleanup** (`cleanup-worktrees.sh`) — checks for active process CWDs via `lsof` before removing worktrees
4. **Rule doc** (`worktree-isolation-bug.md`) — documents the bug with links and mitigation strategy

## Test plan

- [ ] Verify the PostToolUse hook fires after Agent tool calls
- [ ] Verify `cleanup-worktrees.sh` skips worktrees with active CWDs
- [ ] Verify sessions no longer crash from worktree CWD corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)