### PR TITLE
fix: snapshot capture — FLI path, Manifund script, error messages

### DIFF
--- a/crux/lib/grant-import/manifests/index.ts
+++ b/crux/lib/grant-import/manifests/index.ts
@@ -178,7 +178,7 @@ const fli: DataSourceManifest = {
   accessMethod: 'web_scrape',
   publisherEntityId: 'sid_d9sWZtyVwg',
   updateFrequency: 'annual',
-  cachePath: '/tmp/fli-grants.csv',
+  cachePath: '/tmp/fli-grants.sql',
   schema: {
     fields: [
       { sourceName: 'title', internalField: 'name', type: 'string' },

--- a/crux/lib/grant-import/snapshot-capture.ts
+++ b/crux/lib/grant-import/snapshot-capture.ts
@@ -71,7 +71,8 @@ export async function captureSourceSnapshot(sourceId: string): Promise<{ ok: boo
     });
 
     if (!dsResult.ok) {
-      const msg = `Failed to sync data source ${sourceId}: ${dsResult.error}`;
+      const detail = !dsResult.ok ? dsResult.message : '';
+      const msg = `Failed to sync data source ${sourceId}: ${dsResult.error}${detail ? ` — ${detail}` : ''}`;
       console.warn(`  [snapshot] ${msg}`);
       return { ok: false, error: msg };
     }
@@ -93,7 +94,9 @@ export async function captureSourceSnapshot(sourceId: string): Promise<{ ok: boo
       }
       return { ok: true };
     } else {
-      const msg = `Failed to store snapshot for ${sourceId}: ${snapResult.error}`;
+      const sizeMB = (rawContent.length / (1024 * 1024)).toFixed(1);
+      const detail = !snapResult.ok ? snapResult.message : '';
+      const msg = `Failed to store snapshot for ${sourceId} (${sizeMB}MB): ${snapResult.error}${detail ? ` — ${detail}` : ''}`;
       console.warn(`  [snapshot] ${msg}`);
       return { ok: false, error: msg };
     }

--- a/crux/lib/grant-import/sources/manifund.ts
+++ b/crux/lib/grant-import/sources/manifund.ts
@@ -46,49 +46,53 @@ async function fetchManifundProjects(): Promise<ManifundProject[]> {
   console.log("  (Manifund uses Vercel security checkpoint — requires headless browser)");
 
   const script = `
-    const { chromium } = require('playwright');
-    (async () => {
-      const browser = await chromium.launch({ headless: true });
-      const context = await browser.newContext();
-      const page = await context.newPage();
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
 
-      await page.goto('https://manifund.org/', { waitUntil: 'domcontentloaded', timeout: 20000 });
-      await page.waitForTimeout(5000);
+  await page.goto('https://manifund.org/', { waitUntil: 'domcontentloaded', timeout: 20000 });
+  await page.waitForTimeout(5000);
 
-      let allProjects = [];
-      let before = null;
-      let pageNum = 0;
+  let allProjects = [];
+  let before = null;
+  let pageNum = 0;
 
-      while (true) {
-        pageNum++;
-        const url = before
-          ? '/api/v0/projects?before=' + encodeURIComponent(before)
-          : '/api/v0/projects';
+  while (true) {
+    pageNum++;
+    const url = before
+      ? '/api/v0/projects?before=' + encodeURIComponent(before)
+      : '/api/v0/projects';
 
-        const text = await page.evaluate(async (u) => {
-          const resp = await fetch(u);
-          if (!resp.ok) throw new Error('HTTP ' + resp.status);
-          return resp.text();
-        }, url);
+    const text = await page.evaluate(async (u) => {
+      const resp = await fetch(u);
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.text();
+    }, url);
 
-        const data = JSON.parse(text);
-        process.stderr.write('  Page ' + pageNum + ': ' + data.length + ' projects\\n');
+    const data = JSON.parse(text);
+    process.stderr.write('  Page ' + pageNum + ': ' + data.length + ' projects\\n');
 
-        if (data.length === 0) break;
-        allProjects = allProjects.concat(data);
+    if (data.length === 0) break;
+    allProjects = allProjects.concat(data);
 
-        before = data[data.length - 1].created_at;
-        if (data.length < 100) break;
-      }
+    before = data[data.length - 1].created_at;
+    if (data.length < 100) break;
+  }
 
-      process.stdout.write(JSON.stringify(allProjects));
-      await browser.close();
-    })().catch(e => { process.stderr.write('ERROR: ' + e.message + '\\n'); process.exit(1); });
-  `;
+  process.stdout.write(JSON.stringify(allProjects));
+  await browser.close();
+})().catch(e => { process.stderr.write('ERROR: ' + e.message + '\\n'); process.exit(1); });
+`;
+
+  // Write script to temp file to avoid shell quoting issues with node -e
+  const scriptPath = '/tmp/manifund-fetch.cjs';
+  writeFileSync(scriptPath, script);
 
   try {
     const result = execSync(
-      `node -e ${JSON.stringify(script)}`,
+      `node ${scriptPath}`,
       { maxBuffer: 50 * 1024 * 1024, timeout: 120_000, encoding: "utf8", stdio: ["pipe", "pipe", "inherit"] }
     );
 


### PR DESCRIPTION
## Summary
- Fix FLI manifest `cachePath` from `.csv` to `.sql` — download produces SQL but manifest expected CSV, so snapshots were always skipped
- Fix Manifund Playwright script — `node -e` with multiline string caused SyntaxError; now writes to temp `.cjs` file
- Improve snapshot error messages to include HTTP status, response body, and file size — makes nginx 413 errors immediately obvious instead of opaque "bad_request"

## Context
Found during post-deploy verification of release 2026-04-02. Only 2/14 data source snapshots succeeded. Root causes:
- **4 sources**: blocked by nginx ingress 1MB body limit (fix: quantified-uncertainty/ops#57)
- **1 source** (FLI): wrong cachePath in manifest (this PR)
- **1 source** (Manifund): Playwright script broken by shell quoting (this PR)
- **1 source** (GiveWell): requires manual Airtable export (can't automate)
- **5 sources**: empty cachePath, no download automation (acx-grants, ftx-future-fund, aria, vipulnaik, foresight-prizes)

## Test plan
- [ ] After ops#57 merges (nginx body limit), re-run `WIKI_SERVER_ENV=prod pnpm crux tb data-sources-snapshot --all`
- [ ] Verify FLI snapshot succeeds (was always skipped before)
- [ ] Verify error messages for any remaining failures show HTTP status + file size

🤖 Generated with [Claude Code](https://claude.com/claude-code)