### PR TITLE
Unify source-check UI: inline dots + summary banner

### DIFF
--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import type { RecordVerdict } from "@/data/tablebase";
 import { titleCase } from "@/components/wiki/factbase/format";
 import {
@@ -194,7 +194,6 @@ export function DivisionsTable({
                 </th>
                 <th className="text-left py-2.5 px-3 font-medium">Type</th>
                 <th className="text-left py-2.5 px-3 font-medium">Status</th>
-                <th className="text-center py-2.5 px-3 font-medium">Verified</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -204,18 +203,21 @@ export function DivisionsTable({
                   className="hover:bg-muted/20 transition-colors"
                 >
                   <td className="py-2 px-3">
-                    {row.href ? (
-                      <Link
-                        href={row.href}
-                        className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                      >
-                        {row.name}
-                      </Link>
-                    ) : (
-                      <span className="font-medium text-foreground text-xs">
-                        {row.name}
-                      </span>
-                    )}
+                    <span className="flex items-center gap-1.5">
+                      <RecordVerificationDot verdict={row.verdict?.verdict} />
+                      {row.href ? (
+                        <Link
+                          href={row.href}
+                          className="font-medium text-foreground text-xs hover:text-primary transition-colors"
+                        >
+                          {row.name}
+                        </Link>
+                      ) : (
+                        <span className="font-medium text-foreground text-xs">
+                          {row.name}
+                        </span>
+                      )}
+                    </span>
                   </td>
                   <td className="py-2 px-3 text-xs">
                     {row.parentHref ? (
@@ -251,9 +253,6 @@ export function DivisionsTable({
                         {titleCase(row.status)}
                       </span>
                     )}
-                  </td>
-                  <td className="py-2 px-3 text-center">
-                    <SourceCheckBadge verdict={row.verdict} />
                   </td>
                 </tr>
               ))}

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -13,6 +13,7 @@ import {
 import { DIVISION_TYPE_LABELS } from "./division-constants";
 import { titleCase } from "@/components/wiki/factbase/format";
 import { DivisionsTable, type DivisionRow, type TypeSummary } from "./divisions-table";
+import { VerificationSummaryBanner } from "@/components/directory/VerificationSummaryBanner";
 
 export const metadata: Metadata = {
   title: "Divisions",
@@ -143,6 +144,8 @@ export default function DivisionsPage() {
           areas tracked in the knowledge base.
         </p>
       </div>
+
+      <VerificationSummaryBanner recordType="division" totalOverride={totalDivisions} />
 
       <DivisionsTable
         rows={rows}

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import type { RecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { compareFPRows, type SortDir } from "./funding-programs-sort";
@@ -341,7 +341,6 @@ export function FundingProgramsListTable({
                 onSort={handleSort}
                 className="text-center"
               />
-              <th className="text-center py-2.5 px-3 font-medium">Verified</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -352,12 +351,15 @@ export function FundingProgramsListTable({
               >
                 {/* Name */}
                 <td className="py-2.5 px-3">
-                  <Link
-                    href={`/funding-programs/${row.id}`}
-                    className="font-medium text-foreground hover:text-primary transition-colors"
-                  >
-                    {row.name}
-                  </Link>
+                  <span className="flex items-center gap-1.5">
+                    <RecordVerificationDot verdict={row.verdict?.verdict} />
+                    <Link
+                      href={`/funding-programs/${row.id}`}
+                      className="font-medium text-foreground hover:text-primary transition-colors"
+                    >
+                      {row.name}
+                    </Link>
+                  </span>
                   {row.applicationUrl && (
                     <a
                       href={row.applicationUrl}
@@ -426,10 +428,6 @@ export function FundingProgramsListTable({
                   )}
                 </td>
 
-                {/* Verified */}
-                <td className="py-2.5 px-3 text-center">
-                  <SourceCheckBadge verdict={row.verdict} />
-                </td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -10,7 +10,7 @@ import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -195,7 +195,7 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
               {titleCase(round.instrument)}
             </span>
           )}
-          <SourceCheckBadge verdict={roundVerdict} />
+          <RecordVerificationDot verdict={roundVerdict?.verdict} showLabel />
         </div>
 
         {/* Amount hero */}

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { getAllKBRecords } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { resolveEntityLink, INSTRUMENT_COLORS } from "@/lib/record-detail-ui";
 import {
@@ -139,7 +139,6 @@ export default function FundingRoundsPage() {
                   Lead Investor
                 </th>
                 <th className="text-center py-2.5 px-3 font-medium">Date</th>
-                <th className="text-center py-2.5 px-3 font-medium">Verified</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -151,12 +150,15 @@ export default function FundingRoundsPage() {
                   className="hover:bg-muted/20 transition-colors"
                 >
                   <td className="py-2 px-3">
-                    <Link
-                      href={`/funding-rounds/${row.key}`}
-                      className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                    >
-                      {row.name}
-                    </Link>
+                    <span className="flex items-center gap-1.5">
+                      <RecordVerificationDot verdict={verdict?.verdict} />
+                      <Link
+                        href={`/funding-rounds/${row.key}`}
+                        className="font-medium text-foreground text-xs hover:text-primary transition-colors"
+                      >
+                        {row.name}
+                      </Link>
+                    </span>
                   </td>
                   <td className="py-2 px-3 text-xs">
                     {row.companyHref ? (
@@ -209,9 +211,6 @@ export default function FundingRoundsPage() {
                   </td>
                   <td className="py-2 px-3 text-center text-muted-foreground text-xs whitespace-nowrap">
                     {row.date ? formatKBDate(row.date) : ""}
-                  </td>
-                  <td className="py-2 px-3 text-center">
-                    <SourceCheckBadge verdict={verdict} />
                   </td>
                 </tr>
                 );

--- a/apps/web/src/app/investments/[id]/page.tsx
+++ b/apps/web/src/app/investments/[id]/page.tsx
@@ -10,7 +10,7 @@ import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -197,7 +197,7 @@ export default async function InvestmentDetailPage({ params }: PageProps) {
                 {titleCase(investment.instrument)}
               </span>
             )}
-            <SourceCheckBadge verdict={investmentVerdict} />
+            <RecordVerificationDot verdict={investmentVerdict?.verdict} showLabel />
           </div>
         </div>
 

--- a/apps/web/src/app/organizations/[slug]/divisions-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions-section.tsx
@@ -8,6 +8,8 @@ import { formatCompactCurrency } from "@/lib/format-compact";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedDivisionRecord } from "./org-data";
 import { getDivisionHref } from "@/app/divisions/[slug]/division-data";
+import { getRecordVerdict } from "@/data/tablebase";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 
 type LeadMap = Map<string, { name: string; href: string | null }>;
 type MembersMap = Map<string, Array<{ name: string; href: string | null; role: string | null }>>;
@@ -228,10 +230,12 @@ export function DivisionsSection({
               const resolvedLead = leadResolved?.get(d.key);
               const stats = spending?.get(d.key);
               const divMembers = members?.get(d.key) ?? [];
+              const verdict = getRecordVerdict("division", String(d.key));
               return (
                 <tr key={d.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-2.5 px-3">
-                    <span className="font-medium text-foreground text-xs">
+                    <span className="font-medium text-foreground text-xs flex items-center gap-1.5">
+                      <RecordVerificationDot verdict={verdict?.verdict} />
                       {(() => {
                         const href = getDivisionHref(d);
                         return href ? (

--- a/apps/web/src/app/organizations/[slug]/equity-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/equity-section.tsx
@@ -6,7 +6,7 @@
  */
 import Link from "next/link";
 import { getRecordVerdict } from "@data/tablebase";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedEquityPositionRecord, ParsedInvestmentRecord, ParsedCharitablePledgeRecord, NumericOrRange } from "./org-data";
@@ -164,7 +164,7 @@ export function EquityPositionsSection({
                           source
                         </a>
                       )}
-                      <SourceCheckBadge verdict={verdict} />
+                      <RecordVerificationDot verdict={verdict?.verdict} />
                     </div>
                     {pos.notes && (
                       <div className="text-[11px] text-muted-foreground/70 leading-tight mt-0.5">

--- a/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
@@ -8,7 +8,7 @@ import {
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { Breadcrumbs } from "@/components/directory";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { safeHref } from "@/lib/directory-utils";
 import {
   formatKBDate,
@@ -129,7 +129,7 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
               {titleCase(grant.status)}
             </span>
           )}
-          <SourceCheckBadge verdict={grantVerdict} />
+          <RecordVerificationDot verdict={grantVerdict?.verdict} showLabel />
         </div>
 
         {/* Amount hero */}

--- a/apps/web/src/app/organizations/[slug]/programs-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/programs-section.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { titleCase } from "@/components/wiki/factbase/format";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { getRecordVerdict } from "@data/tablebase";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import { PROGRAM_TYPE_LABELS, PROGRAM_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR } from "@/app/organizations/org-constants";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedFundingProgramRecord } from "./org-data";
@@ -64,7 +64,7 @@ export function FundingProgramsSection({
                         source
                       </a>
                     )}
-                    <SourceCheckBadge verdict={verdict} />
+                    <RecordVerificationDot verdict={verdict?.verdict} />
                     {p.description && (
                       <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
                         {p.description}

--- a/apps/web/src/app/people/[slug]/career-history.tsx
+++ b/apps/web/src/app/people/[slug]/career-history.tsx
@@ -3,7 +3,7 @@ import { resolveEntityRef, formatDateRange } from "@/lib/directory-utils";
 import { getKBEntitySlug } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
 import { CurrentBadge, FounderBadge } from "@/components/directory";
-import { SourceCheckBadge } from "@/components/directory/SourceCheckBadge";
+import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
 import type { CareerHistoryEntry } from "../people-utils";
 
 export function CareerHistory({
@@ -35,7 +35,7 @@ export function CareerHistory({
                 <span className="font-semibold text-sm">{entry.title}</span>
                 {isFounder && <FounderBadge />}
                 {isCurrent && <CurrentBadge />}
-                <SourceCheckBadge verdict={verdict} />
+                <RecordVerificationDot verdict={verdict?.verdict} />
               </div>
               <div className="text-sm text-muted-foreground mt-0.5">
                 {orgSlug ? (

--- a/apps/web/src/components/directory/SourceCheckBadge.tsx
+++ b/apps/web/src/components/directory/SourceCheckBadge.tsx
@@ -100,6 +100,11 @@ export function collectionToRecordType(
     investments: "investment",
     "equity-positions": "equity-position",
     "policy-stakeholders": "policy-stakeholder",
+    publications: "publication",
+    "benchmark-results": "benchmark-result",
+    "entity-events": "entity-event",
+    "entity-assessments": "entity-assessment",
+    "secondary-market-prices": "secondary-market-price",
   };
   return MAP[collection] ?? null;
 }
@@ -120,6 +125,12 @@ export function schemaToRecordType(schema: string): string | null {
     investment: "investment",
     "equity-position": "equity-position",
     "division-personnel": "personnel",
+    publication: "publication",
+    "benchmark-result": "benchmark-result",
+    "policy-stakeholder": "policy-stakeholder",
+    "entity-event": "entity-event",
+    "entity-assessment": "entity-assessment",
+    "secondary-market-price": "secondary-market-price",
   };
   return MAP[schema] ?? null;
 }

--- a/apps/web/src/components/directory/VerificationSummaryBanner.tsx
+++ b/apps/web/src/components/directory/VerificationSummaryBanner.tsx
@@ -1,0 +1,57 @@
+/**
+ * Section-level verification coverage summary.
+ *
+ * Shows "12 of 47 records source-checked" above a table, with a breakdown
+ * of verdict counts. Only renders when at least one record has been checked.
+ * Server component — calls getRecordVerdictStats() directly.
+ */
+import { getRecordVerdictStats } from "@data/tablebase";
+
+export function VerificationSummaryBanner({
+  recordType,
+  totalOverride,
+}: {
+  recordType: string;
+  /** Override the total count (useful when the table filters records). */
+  totalOverride?: number;
+}) {
+  const stats = getRecordVerdictStats(recordType);
+  const checked = stats.confirmed + stats.contradicted + stats.outdated + stats.partial + stats.unverifiable;
+  const total = totalOverride ?? checked + stats.unchecked;
+
+  if (checked === 0) return null;
+
+  const parts: string[] = [];
+  if (stats.confirmed > 0) parts.push(`${stats.confirmed} confirmed`);
+  if (stats.contradicted > 0) parts.push(`${stats.contradicted} disputed`);
+  if (stats.outdated > 0) parts.push(`${stats.outdated} outdated`);
+  if (stats.partial > 0) parts.push(`${stats.partial} partial`);
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/30 border border-border/50 rounded-lg px-3 py-1.5 mb-2">
+      <svg
+        className="w-3.5 h-3.5 shrink-0 text-muted-foreground/70"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+      <span>
+        <span className="font-medium text-foreground/80">{checked}</span>
+        {" of "}
+        <span className="font-medium text-foreground/80">{total}</span>
+        {" records source-checked"}
+        {parts.length > 0 && (
+          <span className="text-muted-foreground/80">
+            {" \u00b7 "}
+            {parts.join(" \u00b7 ")}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1137,6 +1137,17 @@ export function getRecordVerdict(recordType: string, recordId: string): RecordVe
   return getRecordVerdicts()[`${recordType}:${recordId}`] ?? null;
 }
 
+/** Batch-enrich an array of rows with their source-check verdicts. */
+export function enrichWithVerdicts<T extends { key: string | number }>(
+  rows: T[],
+  recordType: string,
+): (T & { verdict: RecordVerdict | null })[] {
+  return rows.map((r) => ({
+    ...r,
+    verdict: getRecordVerdict(recordType, String(r.key)),
+  }));
+}
+
 /** Get verification stats for a specific record type */
 export function getRecordVerdictStats(recordType: string): {
   total: number;


### PR DESCRIPTION
## Summary

Unify source-check verification display across all TableBase tables. Replaces the pill-style `SourceCheckBadge` with compact inline `RecordVerificationDot` dots, removes misleading empty "Verified" columns from tables with 0% coverage, and adds a section-level coverage summary banner.

- **Convert all 9 `SourceCheckBadge` usages to `RecordVerificationDot`** — consistent inline dot pattern everywhere
- **Remove dedicated "Verified" columns** from divisions, funding-programs, and funding-rounds directory tables (these had 0-81% coverage; empty columns are misleading)
- **Add `VerificationSummaryBanner`** — shows "12 of 47 records source-checked" above tables. Added to divisions directory page (81% coverage). Uses `getRecordVerdictStats()` which existed but had zero consumers.
- **Add `enrichWithVerdicts()` utility** to `tablebase.ts` for batch verdict lookups
- **Reconcile record type mappings** — add 5 missing types (publication, benchmark-result, entity-event, entity-assessment, secondary-market-price) to `collectionToRecordType` and `schemaToRecordType`
- **Add inline dots to org divisions section** — new source-check integration for org page divisions tab

See discussion: #3586

## Test plan
- [x] `pnpm build` passes (clean build after .next removal)
- [x] `pnpm test` — all 323 tests pass (64 crux + 5 web + 36 wiki-server + 218 other)
- [x] `npx tsc --noEmit` — no new type errors (only pre-existing id-utils resolution)
- [x] No remaining imports of `SourceCheckBadge` outside its definition file
- [x] `RecordVerificationDot` renders nothing for null/undefined verdicts (same as before)
- [ ] Visual check: divisions directory shows summary banner + inline dots
- [ ] Visual check: funding-rounds directory no longer has empty "Verified" column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
