### PR TITLE
feat: add Data Sources internal dashboard (E2131)

### DIFF
--- a/.claude/rules/internal-dashboards.md
+++ b/.claude/rules/internal-dashboards.md
@@ -40,6 +40,6 @@ Follow existing patterns in `apps/web/src/app/internal/entities/` (Pattern A ref
 
 All dashboards have entity IDs and use Pattern A (MDX stub + content component + redirect).
 
-**Dashboards:** System Health (E927), PR Dashboard (E1011), Entities & Pages (E908), Page Changes (E909), Update Schedule (E900), Suggested Pages (E910), Improve Runs (E911), Agent Activity (E1281), Auto-Update Runs (E914), Auto-Update News (E915), Groundskeeper Runs (E926), Grants (E1055), Divisions (E1058), Funding Programs (E1059), People Coverage (E1099), Entity Profile (E1929), Source Checks (E2200), Data Quality (E2600), Talent Flows (E2084), Jobs (E2120).
+**Dashboards:** System Health (E927), PR Dashboard (E1011), Entities & Pages (E908), Page Changes (E909), Update Schedule (E900), Suggested Pages (E910), Improve Runs (E911), Agent Activity (E1281), Auto-Update Runs (E914), Auto-Update News (E915), Groundskeeper Runs (E926), Grants (E1055), Divisions (E1058), Funding Programs (E1059), People Coverage (E1099), Entity Profile (E1929), Source Checks (E2200), Data Quality (E2600), Data Sources (E2131), Talent Flows (E2084), Jobs (E2120).
 
 **Citations:** Citation Accuracy (E917), Citation Content (E918), Hallucination Risk (E919).

--- a/apps/web/src/app/internal/data-sources/data-sources-content.tsx
+++ b/apps/web/src/app/internal/data-sources/data-sources-content.tsx
@@ -1,0 +1,163 @@
+import {
+  fetchDetailed,
+  type RpcDataSourceListResult,
+  type RpcDataSource,
+} from "@/lib/wiki-server";
+import { DataSourceBanner } from "@/components/internal/DataSourceBanner";
+import { resolveEntityName } from "@/lib/resolve-entity-name";
+import { DataSourcesTable, type DataSourceRow } from "./data-sources-table";
+import { computeFreshness } from "./freshness";
+
+// ---------------------------------------------------------------------------
+// Server-side enrichment
+// ---------------------------------------------------------------------------
+
+function enrichDataSources(sources: RpcDataSource[]): DataSourceRow[] {
+  return sources.map((s) => {
+    const publisher = s.publisherEntityId
+      ? resolveEntityName(s.publisherEntityId)
+      : null;
+    const freshness = computeFreshness(s.lastSnapshotAt, s.updateFrequency);
+    return {
+      id: s.id,
+      name: s.name,
+      dataFormat: s.dataFormat,
+      recordType: s.recordType,
+      publisherName: publisher?.name ?? null,
+      publisherHref: publisher?.href ?? null,
+      updateFrequency: s.updateFrequency,
+      lastSnapshotAt: s.lastSnapshotAt,
+      snapshotRecordCount: s.snapshotRecordCount,
+      sourceStatus: s.sourceStatus,
+      latestSnapshotHash: s.latestSnapshotHash,
+      freshness,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className={`text-2xl font-bold tabular-nums ${color ?? ""}`}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main content (server component)
+// ---------------------------------------------------------------------------
+
+export async function DataSourcesContent() {
+  const result = await fetchDetailed<RpcDataSourceListResult>(
+    "/api/data-sources",
+    { revalidate: 60 },
+  );
+
+  if (!result.ok) {
+    const errorMsg =
+      result.error.type === "not-configured"
+        ? "Wiki server not configured"
+        : result.error.type === "connection-error"
+          ? result.error.message
+          : `Server error: ${result.error.status}`;
+    return (
+      <div>
+        <DataSourceBanner source="api" apiError={result.error} />
+        <p className="text-destructive">
+          Failed to load data sources: {errorMsg}
+        </p>
+      </div>
+    );
+  }
+
+  const raw = result.data.dataSources;
+
+  if (raw.length === 0) {
+    return (
+      <div>
+        <DataSourceBanner source="api" />
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground my-6">
+          <p className="text-lg font-medium mb-2">No data sources registered</p>
+          <p className="text-sm">
+            Run{" "}
+            <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+              pnpm crux tb data-sources snapshot --all
+            </code>{" "}
+            to sync source metadata from manifests.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const rows = enrichDataSources(raw);
+
+  // Compute summary stats
+  const totalSources = rows.length;
+  const staleSources = rows.filter((r) => r.freshness === "overdue").length;
+  const totalRecords = rows.reduce(
+    (sum, r) => sum + (r.snapshotRecordCount ?? 0),
+    0,
+  );
+  const activeSources = rows.filter((r) => r.sourceStatus === "active").length;
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed mb-6">
+        Structured data sources for grants, personnel, and investments —
+        tracked with versioned snapshots and deterministic verification.
+      </p>
+
+      <DataSourceBanner source="api" />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 not-prose mb-8">
+        <StatCard
+          label="Active Sources"
+          value={activeSources}
+          sub={`${totalSources} total`}
+        />
+        <StatCard
+          label="Stale Sources"
+          value={staleSources}
+          color={staleSources > 0 ? "text-red-600" : "text-emerald-600"}
+          sub={staleSources > 0 ? "overdue for refresh" : "all on schedule"}
+        />
+        <StatCard
+          label="Records Tracked"
+          value={totalRecords.toLocaleString()}
+        />
+        <StatCard
+          label="Static Sources"
+          value={rows.filter((r) => r.freshness === "static").length}
+          sub="historical, not refreshed"
+        />
+      </div>
+
+      <DataSourcesTable rows={rows} />
+
+      <p className="text-xs text-muted-foreground mt-4">
+        Data from <code>data_sources</code> table via wiki-server API.
+        Freshness computed from <code>lastSnapshotAt</code> relative to{" "}
+        <code>updateFrequency</code>.
+      </p>
+    </>
+  );
+}

--- a/apps/web/src/app/internal/data-sources/data-sources-freshness.test.ts
+++ b/apps/web/src/app/internal/data-sources/data-sources-freshness.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeFreshness,
+  freshnessSortKey,
+  type Freshness,
+} from "./freshness";
+
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 86400000).toISOString();
+}
+
+describe("computeFreshness", () => {
+  it("returns 'static' for static update frequency", () => {
+    expect(computeFreshness(daysAgo(1000), "static")).toBe("static");
+    expect(computeFreshness(null, "static")).toBe("static");
+  });
+
+  it("returns 'unknown' when lastSnapshotAt is null", () => {
+    expect(computeFreshness(null, "quarterly")).toBe("unknown");
+  });
+
+  it("returns 'unknown' when updateFrequency is null", () => {
+    expect(computeFreshness(daysAgo(5), null)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for unrecognized frequency", () => {
+    expect(computeFreshness(daysAgo(5), "biweekly")).toBe("unknown");
+  });
+
+  describe("weekly (7 days)", () => {
+    it("returns 'fresh' within 80% of period (< 5.6d)", () => {
+      expect(computeFreshness(daysAgo(0), "weekly")).toBe("fresh");
+      expect(computeFreshness(daysAgo(3), "weekly")).toBe("fresh");
+      expect(computeFreshness(daysAgo(5), "weekly")).toBe("fresh");
+    });
+
+    it("returns 'due' between 80% and 120% of period (5.6d - 8.4d)", () => {
+      expect(computeFreshness(daysAgo(6), "weekly")).toBe("due");
+      expect(computeFreshness(daysAgo(7), "weekly")).toBe("due");
+      expect(computeFreshness(daysAgo(8), "weekly")).toBe("due");
+    });
+
+    it("returns 'overdue' beyond 120% of period (> 8.4d)", () => {
+      expect(computeFreshness(daysAgo(9), "weekly")).toBe("overdue");
+      expect(computeFreshness(daysAgo(30), "weekly")).toBe("overdue");
+    });
+  });
+
+  describe("quarterly (90 days)", () => {
+    it("returns 'fresh' within 80% of period (< 72d)", () => {
+      expect(computeFreshness(daysAgo(0), "quarterly")).toBe("fresh");
+      expect(computeFreshness(daysAgo(50), "quarterly")).toBe("fresh");
+      expect(computeFreshness(daysAgo(71), "quarterly")).toBe("fresh");
+    });
+
+    it("returns 'due' between 80% and 120% of period (72d - 108d)", () => {
+      expect(computeFreshness(daysAgo(72), "quarterly")).toBe("due");
+      expect(computeFreshness(daysAgo(90), "quarterly")).toBe("due");
+      expect(computeFreshness(daysAgo(107), "quarterly")).toBe("due");
+    });
+
+    it("returns 'overdue' beyond 120% of period (> 108d)", () => {
+      expect(computeFreshness(daysAgo(109), "quarterly")).toBe("overdue");
+      expect(computeFreshness(daysAgo(200), "quarterly")).toBe("overdue");
+    });
+  });
+
+  describe("annual (365 days)", () => {
+    it("returns 'fresh' within 292d", () => {
+      expect(computeFreshness(daysAgo(100), "annual")).toBe("fresh");
+      expect(computeFreshness(daysAgo(291), "annual")).toBe("fresh");
+    });
+
+    it("returns 'due' between 292d and 438d", () => {
+      expect(computeFreshness(daysAgo(300), "annual")).toBe("due");
+      expect(computeFreshness(daysAgo(365), "annual")).toBe("due");
+    });
+
+    it("returns 'overdue' beyond 438d", () => {
+      expect(computeFreshness(daysAgo(439), "annual")).toBe("overdue");
+    });
+  });
+});
+
+describe("freshnessSortKey", () => {
+  it("sorts overdue before due before unknown before static before fresh", () => {
+    const order: Freshness[] = ["overdue", "due", "unknown", "static", "fresh"];
+    const sorted = [...order].sort(
+      (a, b) => freshnessSortKey(a) - freshnessSortKey(b),
+    );
+    expect(sorted).toEqual(order);
+  });
+});

--- a/apps/web/src/app/internal/data-sources/data-sources-table.tsx
+++ b/apps/web/src/app/internal/data-sources/data-sources-table.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { freshnessSortKey, type Freshness } from "./freshness";
+import Link from "next/link";
+
+// ---------------------------------------------------------------------------
+// Row type (enriched server-side, passed as props)
+// ---------------------------------------------------------------------------
+
+export interface DataSourceRow {
+  id: string;
+  name: string;
+  dataFormat: string;
+  recordType: string;
+  publisherName: string | null;
+  publisherHref: string | null;
+  updateFrequency: string | null;
+  lastSnapshotAt: string | null;
+  snapshotRecordCount: number | null;
+  sourceStatus: string;
+  latestSnapshotHash: string | null;
+  freshness: Freshness;
+}
+
+// ---------------------------------------------------------------------------
+// Badge helpers
+// ---------------------------------------------------------------------------
+
+const FORMAT_STYLES: Record<string, { label: string; color: string }> = {
+  csv: { label: "CSV", color: "text-blue-600" },
+  html_table: { label: "HTML", color: "text-purple-600" },
+  json_api: { label: "JSON", color: "text-green-600" },
+  spreadsheet: { label: "Sheet", color: "text-orange-600" },
+};
+
+const RECORD_TYPE_STYLES: Record<string, { label: string; color: string }> = {
+  grant: { label: "Grant", color: "text-violet-600" },
+  personnel: { label: "Personnel", color: "text-sky-600" },
+  investment: { label: "Investment", color: "text-amber-600" },
+  publication: { label: "Publication", color: "text-teal-600" },
+  mixed: { label: "Mixed", color: "text-gray-600" },
+};
+
+const FRESHNESS_STYLES: Record<
+  Freshness,
+  { label: string; bg: string; text: string }
+> = {
+  fresh: {
+    label: "Fresh",
+    bg: "bg-emerald-100 dark:bg-emerald-900/40",
+    text: "text-emerald-700 dark:text-emerald-300",
+  },
+  due: {
+    label: "Due",
+    bg: "bg-amber-100 dark:bg-amber-900/40",
+    text: "text-amber-700 dark:text-amber-300",
+  },
+  overdue: {
+    label: "Overdue",
+    bg: "bg-red-100 dark:bg-red-900/40",
+    text: "text-red-700 dark:text-red-300",
+  },
+  static: {
+    label: "Static",
+    bg: "bg-gray-100 dark:bg-gray-900/40",
+    text: "text-gray-600 dark:text-gray-400",
+  },
+  unknown: {
+    label: "Unknown",
+    bg: "bg-gray-100 dark:bg-gray-900/40",
+    text: "text-gray-600 dark:text-gray-400",
+  },
+};
+
+const STATUS_STYLES: Record<string, { label: string; color: string }> = {
+  active: { label: "Active", color: "text-blue-600" },
+  archived: { label: "Archived", color: "text-muted-foreground" },
+  defunct: { label: "Defunct", color: "text-red-600" },
+};
+
+function Badge({ label, color }: { label: string; color: string }) {
+  return (
+    <span className={`text-xs font-medium ${color}`}>{label}</span>
+  );
+}
+
+function FreshnessBadge({ freshness }: { freshness: Freshness }) {
+  const style = FRESHNESS_STYLES[freshness];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style.bg} ${style.text}`}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (isNaN(ms) || ms < 0) return iso;
+  const days = Math.round(ms / 86400000);
+  if (days === 0) return "today";
+  if (days === 1) return "1d ago";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${(days / 365).toFixed(1)}y ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+const columns: ColumnDef<DataSourceRow>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Name</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-sm font-medium">{row.original.name}</span>
+    ),
+    filterFn: "includesString",
+    size: 240,
+  },
+  {
+    accessorKey: "dataFormat",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Format</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const style = FORMAT_STYLES[row.original.dataFormat];
+      return style ? (
+        <Badge label={style.label} color={style.color} />
+      ) : (
+        <span className="text-xs text-muted-foreground">
+          {row.original.dataFormat}
+        </span>
+      );
+    },
+    size: 80,
+  },
+  {
+    accessorKey: "recordType",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Type</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const style = RECORD_TYPE_STYLES[row.original.recordType];
+      return style ? (
+        <Badge label={style.label} color={style.color} />
+      ) : (
+        <span className="text-xs text-muted-foreground">
+          {row.original.recordType}
+        </span>
+      );
+    },
+    size: 90,
+  },
+  {
+    accessorKey: "publisherName",
+    header: "Publisher",
+    cell: ({ row }) => {
+      const { publisherName, publisherHref } = row.original;
+      if (!publisherName) {
+        return <span className="text-muted-foreground text-xs">—</span>;
+      }
+      if (publisherHref) {
+        return (
+          <Link
+            href={publisherHref}
+            className="text-xs hover:underline text-accent-foreground"
+          >
+            {publisherName}
+          </Link>
+        );
+      }
+      return <span className="text-xs">{publisherName}</span>;
+    },
+    size: 150,
+  },
+  {
+    accessorKey: "updateFrequency",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Frequency</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground capitalize">
+        {row.original.updateFrequency ?? "—"}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    accessorKey: "lastSnapshotAt",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Last Snapshot</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const d = row.original.lastSnapshotAt;
+      if (!d)
+        return <span className="text-xs text-muted-foreground">never</span>;
+      return (
+        <span
+          className="text-xs tabular-nums"
+          title={new Date(d).toISOString()}
+        >
+          {relativeTime(d)}
+        </span>
+      );
+    },
+    sortingFn: (a, b) => {
+      const aVal = a.original.lastSnapshotAt;
+      const bVal = b.original.lastSnapshotAt;
+      if (!aVal && !bVal) return 0;
+      if (!aVal) return 1;
+      if (!bVal) return -1;
+      return new Date(aVal).getTime() - new Date(bVal).getTime();
+    },
+    size: 110,
+  },
+  {
+    accessorKey: "snapshotRecordCount",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Records</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const count = row.original.snapshotRecordCount;
+      return (
+        <span className="text-xs tabular-nums">
+          {count != null ? count.toLocaleString() : "—"}
+        </span>
+      );
+    },
+    size: 80,
+  },
+  {
+    accessorKey: "freshness",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Freshness</SortableHeader>
+    ),
+    cell: ({ row }) => <FreshnessBadge freshness={row.original.freshness} />,
+    sortingFn: (a, b) =>
+      freshnessSortKey(a.original.freshness) -
+      freshnessSortKey(b.original.freshness),
+    size: 90,
+  },
+  {
+    accessorKey: "sourceStatus",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Status</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const style = STATUS_STYLES[row.original.sourceStatus];
+      return style ? (
+        <Badge label={style.label} color={style.color} />
+      ) : (
+        <span className="text-xs">{row.original.sourceStatus}</span>
+      );
+    },
+    size: 80,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Table component
+// ---------------------------------------------------------------------------
+
+export function DataSourcesTable({ rows }: { rows: DataSourceRow[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      searchPlaceholder="Search data sources..."
+      defaultSorting={[{ id: "freshness", desc: false }]}
+      pageSize={50}
+    />
+  );
+}

--- a/apps/web/src/app/internal/data-sources/freshness.ts
+++ b/apps/web/src/app/internal/data-sources/freshness.ts
@@ -1,0 +1,45 @@
+/**
+ * Freshness computation for data sources.
+ * Pure utility — no server-side imports, safe to test directly.
+ */
+
+export type Freshness = "fresh" | "due" | "overdue" | "static" | "unknown";
+
+const FREQ_DAYS: Record<string, number> = {
+  weekly: 7,
+  monthly: 30,
+  quarterly: 90,
+  annual: 365,
+};
+
+/**
+ * Compute the freshness status of a data source based on its last snapshot
+ * timestamp and expected update frequency.
+ */
+export function computeFreshness(
+  lastSnapshotAt: string | null,
+  updateFrequency: string | null,
+): Freshness {
+  if (updateFrequency === "static") return "static";
+  if (!lastSnapshotAt || !updateFrequency) return "unknown";
+  const expected = FREQ_DAYS[updateFrequency];
+  if (!expected) return "unknown";
+  const daysSince = Math.round(
+    (Date.now() - new Date(lastSnapshotAt).getTime()) / 86400000,
+  );
+  if (daysSince < expected * 0.8) return "fresh";
+  if (daysSince < expected * 1.2) return "due";
+  return "overdue";
+}
+
+/** Numeric sort key — surfaces problems first. */
+export function freshnessSortKey(f: Freshness): number {
+  const order: Record<Freshness, number> = {
+    overdue: 0,
+    due: 1,
+    unknown: 2,
+    static: 3,
+    fresh: 4,
+  };
+  return order[f];
+}

--- a/apps/web/src/app/internal/data-sources/page.tsx
+++ b/apps/web/src/app/internal/data-sources/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DataSourcesPage() {
+  redirect("/wiki/E2131");
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -83,6 +83,7 @@ import { EntitySourceChecksContent } from "@/app/internal/entity-source-checks/e
 import { DataQualityContent } from "@/app/internal/data-quality/data-quality-content";
 import { TalentFlowsContent } from "@/app/internal/talent-flows/talent-flows-content";
 import { JobsDashboardContent } from "@/app/internal/jobs/jobs-content";
+import { DataSourcesContent } from "@/app/internal/data-sources/data-sources-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -246,6 +247,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   DataQualityContent,
   TalentFlowsContent,
   JobsDashboardContent,
+  DataSourcesContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -267,6 +267,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Entity Profile", href: internalHref("entity-profile-dashboard") },
         { label: "Source Checks", href: internalHref("entity-source-checks-dashboard") },
         { label: "Data Quality", href: internalHref("data-quality-dashboard") },
+        { label: "Data Sources", href: internalHref("data-sources-dashboard") },
         { label: "Talent Flows", href: internalHref("talent-flows-dashboard") },
         { label: "Jobs", href: internalHref("jobs-dashboard") },
       ],

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -182,6 +182,7 @@ import type { SecondaryMarketPricesRoute } from "@wiki-server/secondary-market-p
 import type { DataQualityRoute } from "@wiki-server/data-quality-route";
 import type { TalentFlowsRoute } from "@wiki-server/talent-flows-route";
 import type { JobsRoute } from "@wiki-server/jobs-route";
+import type { DataSourcesRoute } from "@wiki-server/data-sources-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -430,4 +431,46 @@ export type RpcJobsListResult = InferResponseType<JobsClient['index']['$get'], 2
 
 /** A single job entry from the list endpoint */
 export type RpcJobEntry = RpcJobsListResult['entries'][number];
+
+// ============================================================================
+// Hono RPC client — Data Sources API
+// ============================================================================
+
+/**
+ * Create a typed Hono RPC client for the data sources API.
+ * Returns null if the wiki-server URL is not configured.
+ */
+export function getDataSourcesRpcClient(options?: { revalidate?: number }) {
+  const config = getWikiServerConfig();
+  if (!config) return null;
+
+  const revalidate = options?.revalidate ?? 60;
+
+  const isrFetch: typeof globalThis.fetch = (input, init) => {
+    return globalThis.fetch(input, {
+      ...init,
+      next: { revalidate },
+      signal: init?.signal ?? AbortSignal.timeout(10_000),
+    } as RequestInit);
+  };
+
+  return hc<DataSourcesRoute>(`${config.serverUrl}/api/data-sources`, {
+    headers: config.headers,
+    fetch: isrFetch,
+  });
+}
+
+type DataSourcesClient = NonNullable<ReturnType<typeof getDataSourcesRpcClient>>;
+
+/** Inferred response type for GET /api/data-sources/ (list all) */
+export type RpcDataSourceListResult = InferResponseType<DataSourcesClient['index']['$get'], 200>;
+
+/** A single data source from the list endpoint */
+export type RpcDataSource = RpcDataSourceListResult['dataSources'][number];
+
+/** Inferred response type for GET /api/data-sources/:id (used by detail page — PR 2) */
+export type RpcDataSourceDetailResult = InferResponseType<DataSourcesClient[':id']['$get'], 200>;
+
+/** Inferred response type for GET /api/data-sources/:id/snapshots (used by detail page — PR 2) */
+export type RpcSnapshotListResult = InferResponseType<DataSourcesClient[':id']['snapshots']['$get'], 200>;
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -33,7 +33,8 @@
       "@wiki-server/secondary-market-prices-route": ["../wiki-server/src/routes/tablebase/secondary-market-prices.ts"],
       "@wiki-server/data-quality-route": ["../wiki-server/src/routes/operational/data-quality.ts"],
       "@wiki-server/talent-flows-route": ["../wiki-server/src/routes/tablebase/talent-flows.ts"],
-      "@wiki-server/jobs-route": ["../wiki-server/src/routes/operational/jobs.ts"]
+      "@wiki-server/jobs-route": ["../wiki-server/src/routes/operational/jobs.ts"],
+      "@wiki-server/data-sources-route": ["../wiki-server/src/routes/tablebase/data-sources.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/content/docs/internal/data-sources-dashboard.mdx
+++ b/content/docs/internal/data-sources-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2131
+title: "Data Sources"
+description: "Structured data sources for grants, personnel, and investments — tracked with versioned snapshots and freshness monitoring"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-02"
+---
+
+<DataSourcesContent />


### PR DESCRIPTION
## Summary

New internal dashboard (Pattern A) at `/wiki/E2131` providing visibility into the 14 registered data sources that power grant imports and deterministic verification.

- **Stat cards**: Active sources, stale sources (overdue for refresh), records tracked, static sources
- **Sortable DataTable**: Name, format, record type, publisher, update frequency, last snapshot (relative time), record count, freshness badge, status
- **Freshness computation**: 5 states (fresh/due/overdue/static/unknown) with thresholds at 80%/120% of expected update interval
- **RPC client**: `getDataSourcesRpcClient()` with `InferResponseType` for type-safe API consumption
- **14 tests** for `computeFreshness()` and `freshnessSortKey()` covering all states and edge cases

Part of the Data Sources UI plan (Discussion #3589). This is PR 1 of 2 — the detail page + grants FK integration will follow as PR 2.

## Files

| File | Purpose |
|------|---------|
| `apps/web/src/app/internal/data-sources/page.tsx` | Redirect to `/wiki/E2131` |
| `apps/web/src/app/internal/data-sources/data-sources-content.tsx` | Server component — fetches API, enriches with publisher names, renders stat cards + table |
| `apps/web/src/app/internal/data-sources/data-sources-table.tsx` | `"use client"` DataTable with column defs, badges, sorting |
| `apps/web/src/app/internal/data-sources/freshness.ts` | Pure freshness computation utility (extracted for testability) |
| `content/docs/internal/data-sources-dashboard.mdx` | MDX stub with wikiId E2131 |
| `apps/web/tsconfig.json` | Added `@wiki-server/data-sources-route` path alias |
| `apps/web/src/lib/wiki-server.ts` | RPC client + inferred response types |

## Test plan

- [x] `computeFreshness()` — all 5 states, boundary values, null inputs, unrecognized frequency
- [x] `freshnessSortKey()` — correct ordering (overdue → due → unknown → static → fresh)
- [x] `pnpm build` — passes, E2131 page generated in `.next/server/app/wiki/E2131.html`
- [x] `pnpm test` — 4655 tests pass (65 files in apps/web, 218 total)
- [x] Gate check — all 39 checks pass
- [x] TypeScript — zero non-stale errors
- [x] Empty state handling — renders CLI instruction when no sources exist
- [x] Publisher null guard — 3 of 14 sources lack publisherEntityId, shows "—"
