### PR TITLE
fix: enable snapshot capture for 6 remaining data sources

### DIFF
--- a/crux/lib/grant-import/manifests/index.ts
+++ b/crux/lib/grant-import/manifests/index.ts
@@ -199,11 +199,11 @@ const acxGrants: DataSourceManifest = {
   sourceId: 'acx-grants',
   name: 'Astral Codex Ten Grants',
   fetchUrl: null,
-  format: 'csv',
+  format: 'json_api',
   accessMethod: 'manual_export',
   publisherEntityId: 'sid_LBr3ocKKyQ',
   updateFrequency: 'annual',
-  cachePath: '',
+  cachePath: '/tmp/acx-grants.json',
   schema: { fields: [] },
   verification: { strategy: 'deterministic_row_match', matchFields: ['grantee', 'amount'] },
 };
@@ -215,7 +215,7 @@ const ftxFutureFund: DataSourceManifest = {
   format: 'csv',
   accessMethod: 'manual_export',
   updateFrequency: 'static',
-  cachePath: '',
+  cachePath: '/tmp/ftx-future-fund-combined.sql',
   schema: { fields: [] },
   verification: { strategy: 'deterministic_row_match', matchFields: ['grantee', 'amount'] },
 };
@@ -266,7 +266,7 @@ const vipulnaik: DataSourceManifest = {
   format: 'csv',
   accessMethod: 'direct_download',
   updateFrequency: 'monthly',
-  cachePath: '',
+  cachePath: '/tmp/vipulnaik-combined.sql',
   schema: { fields: [] },
   verification: { strategy: 'deterministic_row_match', matchFields: ['grantee', 'amount'] },
 };

--- a/crux/lib/grant-import/snapshot-capture.ts
+++ b/crux/lib/grant-import/snapshot-capture.ts
@@ -42,8 +42,8 @@ export async function captureSourceSnapshot(sourceId: string): Promise<{ ok: boo
   }
 
   try {
-    // Read raw content
-    const rawContent = readFileSync(manifest.cachePath, 'utf8');
+    // Read raw content, strip BOM if present (gates-foundation CSV has one)
+    const rawContent = readFileSync(manifest.cachePath, 'utf8').replace(/^\uFEFF/, '');
     if (!rawContent || rawContent.length === 0) {
       console.log(`  [snapshot] Empty cache file for ${sourceId}, skipping`);
       return { ok: false, error: 'empty cache file' };

--- a/crux/lib/grant-import/sources/acx-grants.ts
+++ b/crux/lib/grant-import/sources/acx-grants.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from "fs";
 import { matchGrantee } from "../entity-matcher.ts";
 import { matchProgram } from "../program-matcher.ts";
 import type { GrantSource, EntityMatcher, RawGrant } from "../types.ts";
@@ -176,7 +177,8 @@ export const source: GrantSource = {
   sourceUrl: "https://www.astralcodexten.com/p/acx-grants-results",
 
   ensureData() {
-    // Data is hardcoded — no download needed
+    // Data is hardcoded — serialize to cache file for snapshot capture
+    writeFileSync('/tmp/acx-grants.json', JSON.stringify(ACX_GRANTS_DATA));
   },
 
   parse(matcher: EntityMatcher): RawGrant[] {

--- a/crux/lib/grant-import/sources/ftx-future-fund.ts
+++ b/crux/lib/grant-import/sources/ftx-future-fund.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, writeFileSync } from "fs";
 import { execFileSync } from "child_process";
 import { truncateToMonth } from "../dates.ts";
 import { matchGrantee } from "../entity-matcher.ts";
@@ -122,6 +122,15 @@ export const source: GrantSource = {
       execFileSync("curl", ["-fsSL", "--retry", "3", "--connect-timeout", "10", "-o", path, url], {
         stdio: "inherit",
       });
+    }
+    // Write combined SQL file for snapshot capture
+    const combined = FTX_SQL_FILES
+      .map(f => `${FTX_SQL_DIR}/${f}`)
+      .filter(p => existsSync(p))
+      .map(p => readFileSync(p, 'utf8'))
+      .join('\n');
+    if (combined.length > 0) {
+      writeFileSync('/tmp/ftx-future-fund-combined.sql', combined);
     }
   },
 

--- a/crux/lib/grant-import/sources/manifund.ts
+++ b/crux/lib/grant-import/sources/manifund.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
-import { execSync } from "child_process";
 import { extractISODate } from "../dates.ts";
 import { matchGrantee } from "../entity-matcher.ts";
 import { matchProgram } from "../program-matcher.ts";
@@ -42,77 +41,16 @@ async function fetchManifundProjects(): Promise<ManifundProject[]> {
     }
   }
 
-  console.log("  Fetching from Manifund API via Playwright...");
-  console.log("  (Manifund uses Vercel security checkpoint — requires headless browser)");
-
-  const script = `
-const { chromium } = require('playwright');
-(async () => {
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext();
-  const page = await context.newPage();
-
-  await page.goto('https://manifund.org/', { waitUntil: 'domcontentloaded', timeout: 20000 });
-  await page.waitForTimeout(5000);
-
-  let allProjects = [];
-  let before = null;
-  let pageNum = 0;
-
-  while (true) {
-    pageNum++;
-    const url = before
-      ? '/api/v0/projects?before=' + encodeURIComponent(before)
-      : '/api/v0/projects';
-
-    const text = await page.evaluate(async (u) => {
-      const resp = await fetch(u);
-      if (!resp.ok) throw new Error('HTTP ' + resp.status);
-      return resp.text();
-    }, url);
-
-    const data = JSON.parse(text);
-    process.stderr.write('  Page ' + pageNum + ': ' + data.length + ' projects\\n');
-
-    if (data.length === 0) break;
-    allProjects = allProjects.concat(data);
-
-    before = data[data.length - 1].created_at;
-    if (data.length < 100) break;
-  }
-
-  process.stdout.write(JSON.stringify(allProjects));
-  await browser.close();
-})().catch(e => { process.stderr.write('ERROR: ' + e.message + '\\n'); process.exit(1); });
-`;
-
-  // Write script to temp file to avoid shell quoting issues with node -e
-  const scriptPath = '/tmp/manifund-fetch.cjs';
-  writeFileSync(scriptPath, script);
-
-  try {
-    const result = execSync(
-      `node ${scriptPath}`,
-      { maxBuffer: 50 * 1024 * 1024, timeout: 120_000, encoding: "utf8", stdio: ["pipe", "pipe", "inherit"] }
-    );
-
-    const projects: ManifundProject[] = JSON.parse(result);
-    console.log(`  Downloaded ${projects.length} projects`);
-
-    writeFileSync(MANIFUND_CACHE_PATH, JSON.stringify(projects));
-    return projects;
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.warn(`  Playwright fetch failed: ${msg}`);
-    console.log("  Trying direct fetch as fallback...");
-    return await fetchManifundDirect();
-  }
+  // Direct fetch — try with User-Agent and delays between pages to avoid 429
+  console.log("  Fetching from Manifund API...");
+  return await fetchManifundDirect();
 }
 
 async function fetchManifundDirect(): Promise<ManifundProject[]> {
   const allProjects: ManifundProject[] = [];
   let before: string | null = null;
   let pageNum = 0;
+  const MAX_RETRIES = 3;
 
   while (true) {
     pageNum++;
@@ -120,12 +58,25 @@ async function fetchManifundDirect(): Promise<ManifundProject[]> {
       ? `${MANIFUND_API_URL}?before=${encodeURIComponent(before)}`
       : MANIFUND_API_URL;
 
-    const response = await fetch(url, {
-      headers: { Accept: "application/json" },
-    });
+    let response: Response | null = null;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "longterm-wiki/1.0 (grant-import)",
+        },
+      });
+      if (response.status === 429) {
+        const retryAfter = parseInt(response.headers.get("retry-after") || "10", 10);
+        console.log(`  Rate limited, waiting ${retryAfter}s...`);
+        await new Promise(r => setTimeout(r, retryAfter * 1000));
+        continue;
+      }
+      break;
+    }
 
-    if (!response.ok) {
-      throw new Error(`Manifund API returned HTTP ${response.status}. Try again later or use cached data.`);
+    if (!response || !response.ok) {
+      throw new Error(`Manifund API returned HTTP ${response?.status ?? 'unknown'}. Try again later or use cached data.`);
     }
 
     const data: ManifundProject[] = await response.json();
@@ -136,6 +87,9 @@ async function fetchManifundDirect(): Promise<ManifundProject[]> {
 
     before = data[data.length - 1].created_at;
     if (data.length < 100) break;
+
+    // Delay between pages to avoid rate limiting
+    await new Promise(r => setTimeout(r, 1000));
   }
 
   console.log(`  Downloaded ${allProjects.length} projects`);

--- a/crux/lib/grant-import/sources/vipulnaik.ts
+++ b/crux/lib/grant-import/sources/vipulnaik.ts
@@ -9,7 +9,7 @@
  * manifund, givewell, acx-grants, gates-foundation, wellcome-trust, ford-foundation, aria).
  */
 
-import { readFileSync, existsSync, mkdirSync } from "fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { execFileSync } from "child_process";
 import { truncateToMonth } from "../dates.ts";
 import { matchGrantee } from "../entity-matcher.ts";
@@ -299,6 +299,15 @@ export const source: GrantSource = {
       }
     }
     console.log(`  Downloaded ${downloaded} files, ${skipped} cached`);
+    // Write combined SQL file for snapshot capture
+    const parts: string[] = [];
+    for (const donor of DONOR_CONFIGS) {
+      const localPath = `${LOCAL_DIR}/${donor.sqlPath.replace(/\//g, "_")}`;
+      if (existsSync(localPath)) parts.push(readFileSync(localPath, 'utf8'));
+    }
+    if (parts.length > 0) {
+      writeFileSync('/tmp/vipulnaik-combined.sql', parts.join('\n'));
+    }
   },
 
   parse(matcher: EntityMatcher): RawGrant[] {


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM from raw content before upload (fixes gates-foundation Postgres insert error)
- Add `cachePath` for ftx-future-fund, vipulnaik, acx-grants — each writes an aggregated cache file in `ensureData()`
- Simplify Manifund fetcher: drop broken Playwright dependency, use direct API with User-Agent, retry on 429, inter-page delay
- Update acx-grants manifest format to `json_api` (serialized JSON)

## Expected results after merge
With this PR + ops#58 (memory bump, already merged):

| Source | Before | After |
|---|---|---|
| gates-foundation (16MB) | 500 BOM error | Should succeed |
| ftx-future-fund | Skipped (empty cachePath) | Should succeed |
| vipulnaik | Skipped (empty cachePath) | Should succeed |
| acx-grants | Skipped (empty cachePath) | Should succeed |
| manifund | Playwright missing + 429 | Should succeed (direct fetch with retry) |
| aria | Skipped | Still skipped (needs scraper) |
| foresight-prizes | Skipped | Still skipped (needs scraper) |

Target: **11/14 sources** (up from 6/14 currently, 2/14 at start of day)

Closes #3604
Closes #3605

## Test plan
- [ ] Run `WIKI_SERVER_ENV=prod pnpm crux tb data-sources-snapshot --all` and verify 11+ sources succeed
- [ ] Verify gates-foundation no longer gets 500 error

🤖 Generated with [Claude Code](https://claude.ai/code)