### PR TITLE
fix: P0/P1 quick wins — security, display, and formatting bugs

### DIFF
--- a/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const org = resolveOrgBySlug(slug);
   const orgName = org?.title ?? slug;
   const parts = [grant.name];
-  if (grant.amount) parts.push(formatCompactCurrency(grant.amount, grant.currency ?? undefined));
+  if (grant.amount) parts.push(formatCompactCurrency(grant.amount));
 
   return {
     title: `${grant.name} | ${orgName} | Grants`,
@@ -135,7 +135,12 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
         {/* Amount hero */}
         {grant.amount != null && (
           <div className="text-3xl font-bold tabular-nums tracking-tight text-primary mb-1">
-            {formatCompactCurrency(grant.amount, grant.currency ?? undefined)}
+            {formatCompactCurrency(grant.amount)}
+            {grant.currency && grant.currency !== "USD" && (
+              <span className="text-base font-medium text-muted-foreground ml-2">
+                {grant.currency}
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -215,8 +220,8 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
 
           {grant.notes && (
             <DetailSection title="Notes">
-              <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line">
-                {grant.notes}
+              <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                {grant.notes.replace(/\\n/g, "\n")}
               </p>
             </DetailSection>
           )}

--- a/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
+++ b/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
@@ -747,8 +747,8 @@ function CellContent({
       ) : null;
     case "notes":
       return grant.notes ? (
-        <span className="text-muted-foreground text-xs line-clamp-2">
-          {grant.notes}
+        <span className="text-muted-foreground text-xs line-clamp-2 whitespace-pre-wrap">
+          {grant.notes.replace(/\\n/g, "\n")}
         </span>
       ) : null;
     case "verified":

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -17,6 +17,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { getDrizzleDb } from "../../db.js";
+import { escapeIlike } from "../shared/utils.js";
 import {
   sourceCheckEvidence,
   sourceCheckVerdicts,


### PR DESCRIPTION
## Summary
Batch fix for 5 P0/P1 issues identified in triage:

- **#3623 (P0 security)**: ILIKE wildcard injection in source-checks search — added `escapeIlike()` sanitization (the utility already existed and was used everywhere else)
- **#3631**: Literal `\n` strings in grant notes — convert to actual newlines with `whitespace-pre-wrap`
- **#3633**: FactBase entity pages with underscores in URL return 404 — normalize `_` → `-` before lookup
- **#3636**: Politicians table name and district run together — put jurisdiction on its own line
- **#3626**: Grant amounts rounded too aggressively ($6.6M → $7M) — show one decimal for non-round millions

Closes #3623
Closes #3631
Closes #3633
Closes #3636
Closes #3626

## Test plan
- [x] `pnpm build` passes (after `pnpm install` to re-link workspace packages)
- [ ] Verify source-checks search with `%` and `_` characters no longer produces unexpected results
- [ ] Verify grant detail pages render newlines properly in notes
- [ ] Verify `/factbase/entity/some_entity` redirects correctly
- [ ] Verify politicians table has name and jurisdiction on separate lines
- [ ] Verify grant amounts like $6.6M display correctly (not rounded to $7M)

**Note:** Pre-push gate fails on pre-existing "Resource data quality" check (not related to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grant notes to properly display newlines
  * Improved free-text search to handle special characters in queries

* **Style**
  * Updated grant amount and currency display formatting
  * Modified jurisdiction field layout in politicians table
<!-- end of auto-generated comment: release notes by coderabbit.ai -->