### PR TITLE
fix: politician name spacing, citation hydration error, dead code cleanup

### DIFF
--- a/apps/web/src/app/api/verification-names-proxy/route.ts
+++ b/apps/web/src/app/api/verification-names-proxy/route.ts
@@ -81,25 +81,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ names, hrefs });
   }
 
-  // Fact resolution: use local FactBase data (property name as label)
-  if (recordType === "fact") {
-    const ids = recordIds.split(",").filter(Boolean);
-    const names: Record<string, string> = {};
-
-    for (const factId of ids) {
-      const fact = getKBFactById(factId);
-      if (fact) {
-        const property = getKBProperty(fact.propertyId);
-        const entity = getKBEntity(fact.subjectId);
-        const propertyName = property?.name ?? fact.propertyId;
-        const entityName = entity?.name ?? fact.subjectId;
-        names[factId] = `${entityName} — ${propertyName}`;
-      }
-    }
-
-    return NextResponse.json({ names });
-  }
-
   // All other types: proxy to wiki-server
   const config = getWikiServerConfig();
   if (!config) {

--- a/apps/web/src/app/politicians/politicians-table.tsx
+++ b/apps/web/src/app/politicians/politicians-table.tsx
@@ -180,17 +180,19 @@ export function PoliticiansTable({ rows }: { rows: PoliticianRow[] }) {
               <tr key={row.id} className="hover:bg-muted/20 transition-colors">
                 {/* Name */}
                 <td className="py-2.5 px-3 max-w-xs">
-                  <Link
-                    href={`/people/${row.id}`}
-                    className="font-medium hover:text-primary transition-colors line-clamp-1"
-                  >
-                    {row.title}
-                  </Link>
-                  {row.jurisdiction && (
-                    <span className="text-[10px] text-muted-foreground/60 ml-1">
-                      {row.jurisdiction}
-                    </span>
-                  )}
+                  <div className="flex flex-col">
+                    <Link
+                      href={`/people/${row.id}`}
+                      className="font-medium hover:text-primary transition-colors line-clamp-1"
+                    >
+                      {row.title}
+                    </Link>
+                    {row.jurisdiction && (
+                      <span className="text-[10px] text-muted-foreground/60 leading-tight">
+                        {row.jurisdiction}
+                      </span>
+                    )}
+                  </div>
                 </td>
 
                 {/* Office */}

--- a/apps/web/src/components/wiki/CitationOverlay.tsx
+++ b/apps/web/src/components/wiki/CitationOverlay.tsx
@@ -93,13 +93,25 @@ function getVerdictConfig(quote: CitationQuote): VerdictConfig | null {
   return null;
 }
 
+const MONTH_ABBR = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/** Format an ISO date string deterministically (no locale/timezone variance). */
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
+    const parts = iso.split(/[-T]/);
+    const year = parts[0];
+    const month = parts[1] ? parseInt(parts[1], 10) : 0;
+    const day = parts[2] ? parseInt(parts[2], 10) : 0;
+    if (month >= 1 && month <= 12 && day >= 1) {
+      return `${MONTH_ABBR[month - 1]} ${day}, ${year}`;
+    }
+    if (month >= 1 && month <= 12) {
+      return `${MONTH_ABBR[month - 1]} ${year}`;
+    }
+    return year || iso;
   } catch {
     return iso;
   }


### PR DESCRIPTION
## Summary

Fixes from Playwright production testing (7 parallel agents, ~230 checks):

- **Politicians table (#3636)**: Name and district text concatenated without spacing ("Alex BoresNY-12"). Now renders jurisdiction on its own line below the name using flex-col layout.
- **Citation hydration error**: `CitationOverlay.formatDate()` used `toLocaleDateString()` which produces different output server vs client (locale/timezone variance). Replaced with deterministic string parsing. Fixes React hydration error #418 on E91, E100.
- **Dead code**: Removed duplicate unreachable `recordType === "fact"` branch in verification-names-proxy.

Note: The FBCompareTable raw integer issue (#3637) was already fixed in the current codebase — confirmed zero raw integers in local build. Production will be fixed on next deploy.

Closes #3636

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 1121 tests pass
- [x] Local Playwright verification: 0 raw integers on E640
- [ ] Verify politician names have district on separate line after deploy
- [ ] Verify no hydration errors on E91, E100 after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized the politicians table layout to display politician names and associated jurisdiction information in a vertical stacked arrangement for enhanced visual clarity and readability.

* **Improvements**
  * Citation dates now display in a standardized, deterministic format that remains consistent across all platforms and regional settings, eliminating locale-dependent date formatting variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->