### PR TITLE
fix: groundskeeper task failures — time-windowed stats, elevated timeouts

### DIFF
--- a/apps/groundskeeper/src/tasks/job-worker-health.ts
+++ b/apps/groundskeeper/src/tasks/job-worker-health.ts
@@ -9,13 +9,16 @@ const HEARTBEAT_WARN_MS = 5 * 60 * 1000;
 const HEARTBEAT_CRITICAL_MS = 15 * 60 * 1000;
 
 /** Maximum pending jobs per type before warning. */
-const BACKLOG_THRESHOLD = 20;
+const BACKLOG_THRESHOLD = 50;
 
 /** Failure rate above which a warning is emitted. */
 const FAILURE_RATE_THRESHOLD = 0.3;
 
 /** Minimum completed+failed jobs to compute a meaningful failure rate. */
 const FAILURE_RATE_MIN_SAMPLE = 10;
+
+/** Time window for failure rate and backlog checks (24 hours). */
+const STATS_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 interface ActiveAgent {
   sessionId: string;
@@ -89,11 +92,13 @@ export async function jobWorkerHealth(
     );
   }
 
-  // 2. Check job backlog and failure rate via /api/jobs/stats
+  // 2. Check job backlog and failure rate via /api/jobs/stats (time-windowed)
+  // Use a 24h window so historical failures don't permanently poison the check.
+  const since = new Date(Date.now() - STATS_WINDOW_MS).toISOString();
   const statsResult = await apiRequest<JobStatsResponse>(
     config,
     "GET",
-    "/api/jobs/stats",
+    `/api/jobs/stats?since=${encodeURIComponent(since)}`,
   );
   if (statsResult.ok && statsResult.data) {
     checksPerformed++;

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -94,6 +94,7 @@ describe("snapshotRetention", () => {
         })
         .mockResolvedValueOnce({
           ok: false,
+          status: 500,
           text: async () => "Internal Server Error",
         })
     );
@@ -102,7 +103,7 @@ describe("snapshotRetention", () => {
 
     expect(result.success).toBe(false);
     expect(result.summary).toContain("hallucination_risk: deleted 100");
-    expect(result.summary).toContain("citation_accuracy: FAILED");
+    expect(result.summary).toContain("citation_accuracy: FAILED (HTTP 500)");
   });
 
   it("returns success (skipped) when no API key is set", async () => {
@@ -128,7 +129,7 @@ describe("snapshotRetention", () => {
     const result = await snapshotRetention(config);
 
     expect(result.success).toBe(false);
-    expect(result.summary).toContain("hallucination_risk: FAILED");
+    expect(result.summary).toContain("hallucination_risk: FAILED (Connection refused)");
     expect(result.summary).toContain("citation_accuracy: deleted 10");
     expect(fetch).toHaveBeenCalledTimes(2);
   });

--- a/apps/groundskeeper/src/tasks/snapshot-retention.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.ts
@@ -8,6 +8,20 @@ interface CleanupResult {
   keep: number;
 }
 
+interface CleanupError {
+  status?: number;
+  body?: string;
+  error?: string;
+}
+
+function formatCleanupError(err?: CleanupError): string {
+  if (!err) return "unknown";
+  if (err.status) return `HTTP ${err.status}`;
+  if (err.error) return err.error;
+  if (err.body) return err.body.slice(0, 50);
+  return "unknown";
+}
+
 function getWikiServerApiKey(): string | undefined {
   const prefix = process.env["WIKI_SERVER_ENV"] === "prod" ? "PROD_" : "";
   return process.env[`${prefix}LONGTERMWIKI_SERVER_API_KEY`];
@@ -21,13 +35,13 @@ async function callCleanupEndpoint(
   config: Config,
   path: string,
   keep: number,
-): Promise<CleanupResult | null> {
+): Promise<{ result: CleanupResult | null; error?: CleanupError }> {
   const url = `${config.wikiServerUrl}${path}?keep=${keep}`;
   const apiKey = getWikiServerApiKey();
 
   if (!apiKey) {
     logger.warn("LONGTERMWIKI_SERVER_API_KEY is not set — skipping cleanup.");
-    return null;
+    return { result: null, error: { error: "no API key" } };
   }
 
   try {
@@ -42,16 +56,17 @@ async function callCleanupEndpoint(
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       logger.error({ status: res.status, body: text.slice(0, 200), path }, "Cleanup endpoint failed");
-      return null;
+      return { result: null, error: { status: res.status, body: text.slice(0, 100) } };
     }
 
-    return (await res.json()) as CleanupResult;
+    return { result: (await res.json()) as CleanupResult };
   } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
     logger.error(
-      { error: err instanceof Error ? err.message : String(err), path },
+      { error: errorMsg, path },
       "Cleanup request failed",
     );
-    return null;
+    return { result: null, error: { error: errorMsg } };
   }
 }
 
@@ -78,30 +93,32 @@ export async function snapshotRetention(
   let anyFailed = false;
 
   // 1. Hallucination risk snapshots
-  const hrResult = await callCleanupEndpoint(
+  const hr = await callCleanupEndpoint(
     config,
     "/api/hallucination-risk/cleanup",
     keep,
   );
-  if (hrResult) {
-    results.push(`hallucination_risk: deleted ${hrResult.deleted}`);
-    logger.info({ table: "hallucination_risk_snapshots", deleted: hrResult.deleted, keep }, "Cleanup complete");
+  if (hr.result) {
+    results.push(`hallucination_risk: deleted ${hr.result.deleted}`);
+    logger.info({ table: "hallucination_risk_snapshots", deleted: hr.result.deleted, keep }, "Cleanup complete");
   } else {
-    results.push("hallucination_risk: FAILED");
+    const detail = formatCleanupError(hr.error);
+    results.push(`hallucination_risk: FAILED (${detail})`);
     anyFailed = true;
   }
 
   // 2. Citation accuracy snapshots
-  const caResult = await callCleanupEndpoint(
+  const ca = await callCleanupEndpoint(
     config,
     "/api/citations/accuracy-snapshots/cleanup",
     keep,
   );
-  if (caResult) {
-    results.push(`citation_accuracy: deleted ${caResult.deleted}`);
-    logger.info({ table: "citation_accuracy_snapshots", deleted: caResult.deleted, keep }, "Cleanup complete");
+  if (ca.result) {
+    results.push(`citation_accuracy: deleted ${ca.result.deleted}`);
+    logger.info({ table: "citation_accuracy_snapshots", deleted: ca.result.deleted, keep }, "Cleanup complete");
   } else {
-    results.push("citation_accuracy: FAILED");
+    const detail = formatCleanupError(ca.error);
+    results.push(`citation_accuracy: FAILED (${detail})`);
     anyFailed = true;
   }
 

--- a/apps/wiki-server/src/routes/operational/jobs.ts
+++ b/apps/wiki-server/src/routes/operational/jobs.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, count, sql, desc } from "drizzle-orm";
+import { eq, and, count, sql, desc, gte } from "drizzle-orm";
 import { getDb, getDrizzleDb } from "../../db.js";
 import { jobs } from "../../schema.js";
 import {
@@ -558,9 +558,18 @@ const jobsApp = new Hono()
   })
 
   // ---- GET /stats (aggregate counts by type and status) ----
+  // Supports optional `since` query parameter (ISO 8601 timestamp) to filter
+  // jobs created after that time. Without `since`, returns all-time stats.
 
   .get("/stats", async (c) => {
     const db = getDrizzleDb();
+
+    // Parse optional time window
+    const sinceParam = c.req.query("since");
+    const sinceDate = sinceParam ? new Date(sinceParam) : null;
+    const timeFilter = sinceDate && !isNaN(sinceDate.getTime())
+      ? gte(jobs.createdAt, sinceDate)
+      : undefined;
 
     const byTypeStatus = await db
       .select({
@@ -569,6 +578,7 @@ const jobsApp = new Hono()
         count: count(),
       })
       .from(jobs)
+      .where(timeFilter)
       .groupBy(jobs.type, jobs.status);
 
     // Compute average duration for completed jobs
@@ -582,7 +592,8 @@ const jobsApp = new Hono()
         and(
           eq(jobs.status, "completed"),
           sql`${jobs.startedAt} IS NOT NULL`,
-          sql`${jobs.completedAt} IS NOT NULL`
+          sql`${jobs.completedAt} IS NOT NULL`,
+          timeFilter,
         )
       )
       .groupBy(jobs.type);
@@ -595,7 +606,10 @@ const jobsApp = new Hono()
         failed: sql<number>`sum(case when ${jobs.status} = 'failed' then 1 else 0 end)`,
       })
       .from(jobs)
-      .where(sql`${jobs.status} IN ('completed', 'failed')`)
+      .where(and(
+        sql`${jobs.status} IN ('completed', 'failed')`,
+        timeFilter,
+      ))
       .groupBy(jobs.type);
 
     // Build summary
@@ -623,11 +637,15 @@ const jobsApp = new Hono()
       }
     }
 
-    const totalResult = await db.select({ count: count() }).from(jobs);
+    const totalResult = await db
+      .select({ count: count() })
+      .from(jobs)
+      .where(timeFilter);
 
     return c.json({
       totalJobs: totalResult[0].count,
       byType: typeSummary,
+      ...(sinceDate ? { since: sinceDate.toISOString() } : {}),
     });
   })
 

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, count, avg, sql, asc, desc, isNotNull, lt } from "drizzle-orm";
-import { getDrizzleDb, getDb } from "../../db.js";
+import { getDrizzleDb, getDb, beginTransaction } from "../../db.js";
 import { citationQuotes, citationContent, citationAccuracySnapshots, wikiPages, resources } from "../../schema.js";
 import { checkRefsExist } from "../shared/ref-check.js";
 import {
@@ -1236,22 +1236,29 @@ const citationsApp = new Hono()
       });
     }
 
+    // Use a transaction with elevated statement_timeout (2 minutes) since the
+    // default 30s pool timeout can be exceeded on large tables.
     logger.info({ keep }, "Deleting old citation accuracy snapshots");
-    const result = await rawDb`
-      DELETE FROM citation_accuracy_snapshots
-      WHERE id NOT IN (
-        SELECT id FROM (
-          SELECT id, ROW_NUMBER() OVER (
-            -- COALESCE to -1 so NULL page_id rows don't all collapse into one partition
-            PARTITION BY COALESCE(page_id, -1) ORDER BY snapshot_at DESC
-          ) AS rn
-          FROM citation_accuracy_snapshots
-        ) ranked
-        WHERE rn <= ${keep}
-      )
-    `;
+    let deleted = 0;
+    await beginTransaction(async (tx) => {
+      await tx`SET LOCAL statement_timeout = '120000'`;
+      const result = await tx`
+        DELETE FROM citation_accuracy_snapshots
+        WHERE id NOT IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              -- COALESCE to -1 so NULL page_id rows don't all collapse into one partition
+              PARTITION BY COALESCE(page_id, -1) ORDER BY snapshot_at DESC
+            ) AS rn
+            FROM citation_accuracy_snapshots
+          ) ranked
+          WHERE rn <= ${keep}
+        )
+      `;
+      deleted = result.count;
+    });
 
-    return c.json({ deleted: result.count, keep });
+    return c.json({ deleted, keep });
   });
 
 export const citationsRoute = citationsApp;

--- a/apps/wiki-server/src/routes/wikibase/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/wikibase/hallucination-risk.ts
@@ -489,23 +489,28 @@ const hallucinationRiskApp = new Hono()
       });
     }
 
-    // Actually delete old snapshots, keeping latest `keep` per page
+    // Actually delete old snapshots, keeping latest `keep` per page.
+    // Use a transaction with elevated statement_timeout (2 minutes) since the
+    // default 30s pool timeout can be exceeded on large tables.
     logger.info({ keep }, "Deleting old hallucination risk snapshots");
-    const result = await rawDb`
-      DELETE FROM hallucination_risk_snapshots
-      WHERE id NOT IN (
-        SELECT id FROM (
-          SELECT id, ROW_NUMBER() OVER (
-            -- COALESCE to -1 so NULL page_id rows don't all collapse into one partition
-            PARTITION BY COALESCE(page_id, -1) ORDER BY computed_at DESC
-          ) AS rn
-          FROM hallucination_risk_snapshots
-        ) ranked
-        WHERE rn <= ${keep}
-      )
-    `;
-
-    const deleted = result.count;
+    let deleted = 0;
+    await beginTransaction(async (tx) => {
+      await tx`SET LOCAL statement_timeout = '120000'`;
+      const result = await tx`
+        DELETE FROM hallucination_risk_snapshots
+        WHERE id NOT IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              -- COALESCE to -1 so NULL page_id rows don't all collapse into one partition
+              PARTITION BY COALESCE(page_id, -1) ORDER BY computed_at DESC
+            ) AS rn
+            FROM hallucination_risk_snapshots
+          ) ranked
+          WHERE rn <= ${keep}
+        )
+      `;
+      deleted = result.count;
+    });
 
     // Refresh materialized view after cleanup
     try {

--- a/crux/health/checks/job-queue.ts
+++ b/crux/health/checks/job-queue.ts
@@ -2,11 +2,17 @@
  * Job Queue Health Check
  *
  * Fetches /api/jobs/stats from wiki-server and checks for:
- *   - High failure rates (>50% with >5 total jobs of that type)
+ *   - High failure rates (>50% with >5 total jobs of that type) in the last 24h
  *   - Large pending backlogs (>100 pending for any single type)
+ *
+ * Uses a 24-hour time window for failure rate calculations to avoid
+ * historical failures permanently poisoning the health check.
  */
 
 import type { CheckResult } from '../health-check.ts';
+
+/** Time window for stats (24 hours). */
+const STATS_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 interface JobTypeStats {
   byStatus: Record<string, number>;
@@ -34,9 +40,10 @@ export async function checkJobQueue(): Promise<CheckResult> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
 
+  const since = new Date(Date.now() - STATS_WINDOW_MS).toISOString();
   let data: JobStatsResponse;
   try {
-    const res = await fetch(`${serverUrl}/api/jobs/stats`, {
+    const res = await fetch(`${serverUrl}/api/jobs/stats?since=${encodeURIComponent(since)}`, {
       headers,
       signal: AbortSignal.timeout(15_000),
     });
@@ -61,7 +68,7 @@ export async function checkJobQueue(): Promise<CheckResult> {
   }
 
   const totalJobs = data.totalJobs ?? 0;
-  detail.push(`Total jobs: ${totalJobs}`);
+  detail.push(`Total jobs (last 24h): ${totalJobs}`);
 
   const byType = data.byType ?? {};
 


### PR DESCRIPTION
## Summary

Fixes three root causes for the `job-worker-health` (0% success, 84/84 failed) and `snapshot-retention` (0% success, 2/2 failed) groundskeeper task failures:

- **job-worker-health — all-time stats poisoning**: The `/api/jobs/stats` endpoint returned all-time data, so 1,506 historical `resource-verify` failures permanently kept the failure rate above the 30% threshold. Added optional `since` query parameter to the endpoint. Updated both the groundskeeper task and the `crux health` wellness check to use a 24-hour window. Also raised `BACKLOG_THRESHOLD` from 20 to 50 (normal batch ingestion easily exceeds 20).

- **snapshot-retention — 30s statement_timeout exceeded**: The cleanup DELETE queries use `ROW_NUMBER()` window functions that scan the entire table. On large snapshot tables, this exceeds the 30-second pool `statement_timeout`. Wrapped both cleanup queries in `beginTransaction()` with `SET LOCAL statement_timeout = '120000'` (2 minutes), matching the pattern already used by `refreshMaterializedView()` in the same file.

- **snapshot-retention — opaque failure summaries**: Failure summaries just said `"FAILED"` with no HTTP status or error message. Now includes diagnostic detail (e.g., `"FAILED (HTTP 500)"` or `"FAILED (Connection refused)"`) in the summary recorded to `groundskeeper_runs`, making future debugging much easier.

Closes #3595

## Changed files

| File | Change |
|------|--------|
| `apps/wiki-server/src/routes/operational/jobs.ts` | Add optional `since` query param to `/api/jobs/stats` |
| `apps/groundskeeper/src/tasks/job-worker-health.ts` | Use 24h time window, raise backlog threshold to 50 |
| `crux/health/checks/job-queue.ts` | Use 24h time window for wellness check |
| `apps/wiki-server/src/routes/wikibase/hallucination-risk.ts` | Wrap cleanup DELETE in transaction with 120s timeout |
| `apps/wiki-server/src/routes/wikibase/citations.ts` | Wrap cleanup DELETE in transaction with 120s timeout |
| `apps/groundskeeper/src/tasks/snapshot-retention.ts` | Include error details in failure summaries |
| `apps/groundskeeper/src/tasks/snapshot-retention.test.ts` | Update test expectations for new summary format |

## Test plan

- [x] `pnpm exec tsc --noEmit` passes in `apps/wiki-server/`
- [x] `npx vitest run src/tasks/snapshot-retention.test.ts` — all 6 tests pass
- [x] `/api/jobs/stats` is backward-compatible (no `since` param = all-time, same as before)
- [ ] After deploy: verify `job-worker-health` starts succeeding (check groundskeeper-runs dashboard)
- [ ] After deploy: verify `snapshot-retention` completes within the 120s timeout
- [ ] Monitor system health dashboard for task success rates returning above 0%

Generated with [Claude Code](https://claude.com/claude-code)