### PR TITLE
fix: remove duplicate escapeIlike import (blocks release CI)

### DIFF
--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -17,7 +17,6 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { getDrizzleDb } from "../../db.js";
-import { escapeIlike } from "../shared/utils.js";
 import {
   sourceCheckEvidence,
   sourceCheckVerdicts,


### PR DESCRIPTION
## Summary
Remove duplicate `escapeIlike` import in `source-checks.ts` — it was imported both standalone (line 20) and in the destructured block (line 42), causing `TS2300: Duplicate identifier` and blocking the release PR CI.

Introduced by #3641 merge.

## Test plan
- [x] `tsc --noEmit` passes in wiki-server
- [ ] Release PR #3674 CI should go green after this merges

🤖 Generated with [Claude Code](https://claude.ai/code)