### PR TITLE
fix: enrich division detail pages with funding programs and sibling navigation

### DIFF
--- a/apps/web/src/app/divisions/[slug]/division-data.ts
+++ b/apps/web/src/app/divisions/[slug]/division-data.ts
@@ -341,6 +341,14 @@ export const PROGRAM_TYPE_COLORS: Record<string, string> = {
 
 // ── Main data loader ─────────────────────────────────────────────────
 
+export interface SiblingDivision {
+  key: string;
+  name: string;
+  divisionType: string;
+  status: string | null;
+  href: string | null;
+}
+
 export interface DivisionPageData {
   division: ParsedDivision;
   parent: { name: string; href: string | null };
@@ -351,6 +359,7 @@ export interface DivisionPageData {
   divisionPrograms: ParsedFundingProgram[];
   grants: ParsedDivisionGrant[];
   recipients: DivisionRecipient[];
+  siblingDivisions: SiblingDivision[];
 }
 
 export function loadDivisionPageData(record: import("@/data/factbase").KBRecordEntry): DivisionPageData {
@@ -448,6 +457,27 @@ export function loadDivisionPageData(record: import("@/data/factbase").KBRecordE
   const recipients = [...recipientMap.values()]
     .sort((a, b) => b.totalAmount - a.totalAmount);
 
+  // Find sibling divisions (other divisions in the same org, excluding current)
+  const allDivisions = getAllKBRecords("divisions");
+  const currentName = division.name;
+  const seenNames = new Set<string>([currentName]);
+  const siblingDivisions: SiblingDivision[] = [];
+  for (const d of allDivisions) {
+    if (d.ownerEntityId !== division.ownerEntityId) continue;
+    const name = (d.fields.name as string) ?? d.key;
+    if (seenNames.has(name)) continue;
+    seenNames.add(name);
+    const parsed = parseDivision(d);
+    siblingDivisions.push({
+      key: d.key,
+      name: parsed.name,
+      divisionType: parsed.divisionType,
+      status: parsed.status,
+      href: getDivisionHref(parsed),
+    });
+  }
+  siblingDivisions.sort((a, b) => a.name.localeCompare(b.name));
+
   return {
     division,
     parent,
@@ -458,5 +488,6 @@ export function loadDivisionPageData(record: import("@/data/factbase").KBRecordE
     divisionPrograms,
     grants,
     recipients,
+    siblingDivisions,
   };
 }

--- a/apps/web/src/app/divisions/[slug]/division-sections.tsx
+++ b/apps/web/src/app/divisions/[slug]/division-sections.tsx
@@ -3,7 +3,15 @@
  */
 import Link from "next/link";
 
-import type { ParsedDivisionPersonnel } from "./division-data";
+import type { ParsedDivisionPersonnel, ParsedFundingProgram, SiblingDivision } from "./division-data";
+import {
+  DIVISION_TYPE_LABELS,
+  DIVISION_TYPE_COLORS,
+} from "../division-constants";
+import {
+  titleCase,
+} from "@/components/wiki/factbase/format";
+import { formatCompactCurrency } from "@/lib/format-compact";
 
 // ── Team Members Section ─────────────────────────────────────────────
 
@@ -64,6 +72,131 @@ export function TeamMembersSection({
             ))}
           </tbody>
         </table>
+      </div>
+    </section>
+  );
+}
+
+// ── Funding Programs Section ─────────────────────────────────────
+
+export function FundingProgramsSection({
+  programs,
+}: {
+  programs: ParsedFundingProgram[];
+}) {
+  if (programs.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold tracking-tight">Funding Programs</h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          {programs.length}
+        </span>
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+      </div>
+      <div className="border border-border/60 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th scope="col" className="text-left py-2 px-3 font-medium">Program</th>
+              <th scope="col" className="text-left py-2 px-3 font-medium">Type</th>
+              <th scope="col" className="text-right py-2 px-3 font-medium">Budget</th>
+              <th scope="col" className="text-center py-2 px-3 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {programs.map((p) => (
+              <tr key={p.key} className="hover:bg-muted/20 transition-colors">
+                <td className="py-2 px-3">
+                  <span className="font-medium text-foreground text-xs">
+                    {p.name}
+                  </span>
+                  {p.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                      {p.description}
+                    </p>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-xs text-muted-foreground whitespace-nowrap">
+                  {titleCase(p.programType)}
+                </td>
+                <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                  {p.totalBudget != null && (
+                    <span className="font-semibold">
+                      {formatCompactCurrency(p.totalBudget)}
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-center text-xs">
+                  {p.status && (
+                    <span className="text-muted-foreground">
+                      {titleCase(p.status)}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ── Sibling Divisions Section ────────────────────────────────────
+
+export function SiblingDivisionsSection({
+  siblings,
+  parentName,
+}: {
+  siblings: SiblingDivision[];
+  parentName: string;
+}) {
+  if (siblings.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h2 className="text-base font-bold tracking-tight">
+          Other {parentName} Divisions
+        </h2>
+        <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+          {siblings.length}
+        </span>
+        <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {siblings.map((s) => (
+          <div key={s.key} className="inline-flex items-center gap-1.5">
+            {s.href ? (
+              <Link
+                href={s.href}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 text-xs font-medium text-foreground hover:bg-muted/50 transition-colors"
+              >
+                <span>{s.name}</span>
+                <span
+                  className={`px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
+                    DIVISION_TYPE_COLORS[s.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                  }`}
+                >
+                  {DIVISION_TYPE_LABELS[s.divisionType] ?? titleCase(s.divisionType)}
+                </span>
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 text-xs font-medium text-muted-foreground">
+                <span>{s.name}</span>
+                <span
+                  className={`px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
+                    DIVISION_TYPE_COLORS[s.divisionType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                  }`}
+                >
+                  {DIVISION_TYPE_LABELS[s.divisionType] ?? titleCase(s.divisionType)}
+                </span>
+              </span>
+            )}
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/organizations/[slug]/divisions/[divSlug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions/[divSlug]/page.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/app/divisions/[slug]/division-data";
 import {
   TeamMembersSection,
+  FundingProgramsSection,
+  SiblingDivisionsSection,
   BackToParentLink,
 } from "@/app/divisions/[slug]/division-sections";
 import {
@@ -56,6 +58,15 @@ function DivisionTabs({ data }: { data: import("@/app/divisions/[slug]/division-
       label: "Recipients",
       count: data.recipients.length,
       content: <PaginatedRecipientsTable recipients={data.recipients} />,
+    });
+  }
+
+  if (data.divisionPrograms.length > 0) {
+    tabs.push({
+      id: "programs",
+      label: "Funding Programs",
+      count: data.divisionPrograms.length,
+      content: <FundingProgramsSection programs={data.divisionPrograms} />,
     });
   }
 
@@ -204,16 +215,13 @@ export default async function DivisionDetailPage({ params }: PageProps) {
 
       {/* Tabbed content */}
       <DivisionTabs data={data} />
-      {data.personnel.length === 0 && data.grants.length === 0 && data.recipients.length === 0 && (
-        <div className="rounded-lg border border-border/60 bg-muted/30 px-6 py-8 text-center">
-          <p className="text-sm text-muted-foreground mb-1">
-            No detailed data available for this division yet.
-          </p>
-          <p className="text-xs text-muted-foreground/60">
-            People, grants, and funding programs for this division will be added
-            as the wiki grows.
-          </p>
-        </div>
+
+      {/* Sibling divisions for navigation */}
+      {data.siblingDivisions.length > 0 && (
+        <SiblingDivisionsSection
+          siblings={data.siblingDivisions}
+          parentName={data.parent.name}
+        />
       )}
 
       {/* Back to parent org */}


### PR DESCRIPTION
## Summary

- **Add Funding Programs tab**: `divisionPrograms` was already loaded in `loadDivisionPageData` but never displayed. Now shows as a tab with program name, type, budget, and status.
- **Add sibling divisions section**: Shows other divisions in the same parent org with type badges and links, giving users navigation context even when no tabular data exists.
- **Remove misleading empty state**: The "No detailed data available" message appeared even when the header showed notes, lead, dates, and website. Replaced with the sibling divisions section which provides useful navigation.

## Details

The root issue is that division detail pages only showed tabs for People (0 division-personnel records exist), Grants (only 34 of 112 divisions have linked grants), and Recipients (subset of Grants). The `divisionPrograms` data was fetched but never wired to the UI.

For the ~78 divisions with no grants, the page now shows:
- Header metadata (already present: name, type, status, parent org, lead, dates, website, notes)
- Funding programs tab (if linked programs exist -- ~31 divisions)
- Sibling divisions navigation (links to other divisions in the same org)
- Back to parent link

Closes #3370

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Division pages with grants still show Grants/Recipients tabs
- [ ] Division pages with funding programs show the new Funding Programs tab
- [ ] Sibling divisions section appears with correct links to other org divisions
- [ ] Pages without any tabular data no longer show "No detailed data available"

Generated with [Claude Code](https://claude.com/claude-code)