### PR TITLE
fix: restore apiRequest import in source-check-orchestrate.ts

### DIFF
--- a/crux/commands/source-check-orchestrate.ts
+++ b/crux/commands/source-check-orchestrate.ts
@@ -23,6 +23,7 @@ import type { LoadedKB } from '../lib/factbase-loader.ts';
 import type { Fact, Entity as FBEntity } from '../../packages/factbase/src/types.ts';
 import { formatFactValue } from '../../packages/factbase/src/format.ts';
 import { createLlmClient } from '../lib/llm.ts';
+import { apiRequest } from '../lib/wiki-server/client.ts';
 import { listVerdicts, getVerificationStats } from '../lib/wiki-server/verifications.ts';
 import type { SourceFetchErrorType } from '../lib/search/paywall-detection.ts';
 import {


### PR DESCRIPTION
## Summary

- Restores the missing `apiRequest` import in `crux/commands/source-check-orchestrate.ts` that was removed during the typed client migration in PR #3691
- The `collectRecordItems` function calls `apiRequest()` to paginate through all record types, but the import was dropped, causing a runtime error

## Context

This addresses CodeRabbit review comment #1 from PR #3691. The other two comments were either already fixed (bluesky RPC keys, commit 07968f2) or false positives (benchmark-results uses `benchmarkResults` key, not `items`, matching the actual server route).

Closes #3691 review items.

## Test plan

- [ ] `pnpm build` passes (TypeScript compilation catches the missing import)
- [ ] `pnpm crux fb source-check` runs without `apiRequest is not defined` errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>