### PR TITLE
fix: publication authors, benchmark grammar, Claude safety levels

### DIFF
--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -220,7 +220,7 @@ export default async function BenchmarkDetailPage({
           <h2 className="text-lg font-bold tracking-tight mb-4">
             Leaderboard
             <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {sorted.length} models
+              {sorted.length} {sorted.length === 1 ? "model" : "models"}
             </span>
           </h2>
           <div className="border border-border rounded-xl overflow-x-auto">

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -479,11 +479,12 @@ export default async function LegislationDetailPage({
   }
 
   // History tab (amendments + key figures)
-  if (entity.amendments.length > 0 || entity.keyPoliticians.length > 0 || entity.keyFigures.length > 0) {
+  const historyItemCount = entity.amendments.length + entity.keyPoliticians.length + entity.keyFigures.length;
+  if (historyItemCount > 0) {
     tabs.push({
       id: "history",
       label: "History",
-      count: entity.amendments.length,
+      count: historyItemCount,
       content: (
         <div className="space-y-8">
           {/* Key Politicians */}

--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -85,6 +85,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
       id: r.id,
       title: r.title,
       type: r.type,
+      authors: r.authors ?? [],
       publishedDate: r.published_date ?? null,
       hasSummary: !!r.summary,
       citingPageCount: citingPages.length,

--- a/apps/web/src/app/publications/[id]/publication-resources-table.tsx
+++ b/apps/web/src/app/publications/[id]/publication-resources-table.tsx
@@ -37,6 +37,7 @@ export interface PublicationResourceRow {
   id: string;
   title: string;
   type: string;
+  authors: string[];
   publishedDate: string | null;
   hasSummary: boolean;
   citingPageCount: number;
@@ -73,6 +74,33 @@ function makeColumns(): ColumnDef<PublicationResourceRow>[] {
         const color = RESOURCE_TYPE_COLORS[t] || DEFAULT_RESOURCE_TYPE_COLOR;
         return (
           <span className={`text-xs px-1.5 py-0.5 rounded ${color}`}>{t}</span>
+        );
+      },
+    },
+    {
+      accessorKey: "authors",
+      header: "Authors",
+      cell: ({ row }) => {
+        const authors = row.original.authors;
+        if (!authors.length)
+          return (
+            <span className="text-muted-foreground/40 text-xs">{"\u2014"}</span>
+          );
+        const display = authors.slice(0, 2);
+        const remaining = authors.length - display.length;
+        return (
+          <span
+            className="text-xs text-muted-foreground max-w-[180px] truncate block"
+            title={authors.join(", ")}
+          >
+            {display.join(", ")}
+            {remaining > 0 && ` +${remaining}`}
+          </span>
+        );
+      },
+      filterFn: (row, _columnId, filterValue: string) => {
+        return row.original.authors.some((a) =>
+          a.toLowerCase().includes(filterValue.toLowerCase()),
         );
       },
     },

--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -551,7 +551,7 @@
   inputPrice: 15
   outputPrice: 75
   contextWindow: 200000
-  safetyLevel: ASL-2
+  safetyLevel: ASL-3
   openWeight: false
   modality:
     - text
@@ -609,7 +609,7 @@
   inputPrice: 15
   outputPrice: 75
   contextWindow: 200000
-  safetyLevel: ASL-2
+  safetyLevel: ASL-3
   openWeight: false
   modality:
     - text
@@ -650,7 +650,7 @@
   inputPrice: 3
   outputPrice: 15
   contextWindow: 200000
-  safetyLevel: ASL-2
+  safetyLevel: ASL-3
   openWeight: false
   modality:
     - text
@@ -742,7 +742,7 @@
   inputPrice: 5
   outputPrice: 25
   contextWindow: 200000
-  safetyLevel: ASL-2
+  safetyLevel: ASL-3
   openWeight: false
   modality:
     - text


### PR DESCRIPTION
## Summary

Fixes multiple content/data gaps reported in #3494:

- **Publication author column**: Added an "Authors" column to publication resource tables, showing the first 2 author names with a "+N" overflow indicator. Authors are sourced from the existing `authors` field on the `Resource` type.
- **Benchmark pluralization**: Fixed "1 models" grammar bug on single-model benchmark detail pages — now correctly shows "1 model".
- **Legislation History tab count**: The History tab's badge count now reflects all content (amendments + key politicians + key figures), not just amendments. Previously, a legislation with 0 amendments but key politicians would show `count: 0`, causing ProfileTabs to hide the tab.
- **Claude ASL-3 safety levels**: Updated Claude Opus 4, Opus 4.1, Sonnet 4.5, and Opus 4.5 from ASL-2 to ASL-3, matching Anthropic's official announcements. Claude Haiku 4.5 correctly remains ASL-2.

Closes #3494

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified — no new errors)
- [ ] Publication detail pages show author names in the resource table
- [ ] Benchmark pages with 1 model show "1 model" (not "1 models")
- [ ] Legislation pages with key politicians but no amendments still show the History tab
- [ ] AI model directory shows ASL-3 for Claude Opus 4/4.1/4.5 and Sonnet 4.5

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Authors column to publication resources, displaying up to two author names with additional count indicators and search filtering support.

* **Bug Fixes**
  * Fixed grammar for singular/plural model count labels.
  * Updated History tab to reflect combined count from amendments, key politicians, and key figures.

* **Chores**
  * Updated safety levels for Claude AI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->