### PR TITLE
fix: strip null bytes from snapshot content (gates-foundation)

### DIFF
--- a/crux/lib/grant-import/snapshot-capture.ts
+++ b/crux/lib/grant-import/snapshot-capture.ts
@@ -42,8 +42,12 @@ export async function captureSourceSnapshot(sourceId: string): Promise<{ ok: boo
   }
 
   try {
-    // Read raw content, strip BOM if present (gates-foundation CSV has one)
-    const rawContent = readFileSync(manifest.cachePath, 'utf8').replace(/^\uFEFF/, '');
+    // Read raw content, clean up common issues:
+    // - Strip BOM (gates-foundation CSV has one)
+    // - Strip null bytes (gates-foundation CSV has 5MB of null padding — Postgres rejects \0 in text)
+    const rawContent = readFileSync(manifest.cachePath, 'utf8')
+      .replace(/^\uFEFF/, '')
+      .replace(/\0/g, '');
     if (!rawContent || rawContent.length === 0) {
       console.log(`  [snapshot] Empty cache file for ${sourceId}, skipping`);
       return { ok: false, error: 'empty cache file' };


### PR DESCRIPTION
## Summary
Strip null bytes (`\0`) from raw content before uploading snapshots. The gates-foundation CSV has ~5MB of null byte padding (30% of the 16MB file) — PostgreSQL text columns reject null bytes, causing the persistent 500 error on INSERT.

## Root cause
The gates-foundation CSV download from their website is partially corrupted: actual CSV data ends at ~11.8MB, and the remaining ~5MB is null-filled padding. This is likely a server-side issue on gatesfoundation.org.

## Test plan
- [ ] After merge + deploy, run `WIKI_SERVER_ENV=prod pnpm crux tb data-sources-snapshot gates-foundation`
- [ ] Should succeed — this is the last of 14 sources

🤖 Generated with [Claude Code](https://claude.ai/code)