### PR TITLE
fix: raise authenticated rate limits to prevent dashboard 429s

### DIFF
--- a/apps/wiki-server/src/rate-limit.ts
+++ b/apps/wiki-server/src/rate-limit.ts
@@ -382,15 +382,22 @@ export const DEFAULT_WRITE_LIMIT: RateLimitConfig = {
   windowMs: 60_000,
 };
 
-/** Authenticated rate limit: 1000 GET requests per minute per IP. */
+/**
+ * Authenticated rate limit: 5000 GET requests per minute per IP.
+ * Vercel ISR, CI sync, crux CLI, and snapshot capture all share this pool.
+ * 1000 was too low — snapshot runs + concurrent ISR exhausted it.
+ */
 export const DEFAULT_AUTH_READ_LIMIT: RateLimitConfig = {
-  maxRequests: 1000,
+  maxRequests: 5000,
   windowMs: 60_000,
 };
 
-/** Authenticated rate limit: 200 write requests per minute per IP. */
+/**
+ * Authenticated rate limit: 500 write requests per minute per IP.
+ * Snapshot --all fires sync + create for each of 14 sources.
+ */
 export const DEFAULT_AUTH_WRITE_LIMIT: RateLimitConfig = {
-  maxRequests: 200,
+  maxRequests: 500,
   windowMs: 60_000,
 };
 


### PR DESCRIPTION
## Summary
Raise authenticated rate limits from 1000→5000 reads/min and 200→500 writes/min.

## Problem
Running `snapshot --all` (14 sources) exhausted the authenticated read pool (1000/min), causing 429 errors on the production System Health dashboard (E927) and all other ISR-backed pages. The `X-RateLimit-Remaining: 0` header confirmed the pool was drained.

Authenticated traffic (Vercel ISR, CI sync, crux CLI, snapshot capture) all shares one pool per IP. With snapshot runs doing dozens of sync + snapshot + dedup-check calls, 1000/min is too tight.

## Fix
- Read: 1000 → 5000/min (handles concurrent ISR + CLI without contention)
- Write: 200 → 500/min (14 sources × ~3 writes = ~42, but with retry/backoff can spike higher)
- Unauthenticated limits unchanged (100 read, 20 write)

## Test plan
- [ ] After deploy, run `snapshot --all` and verify dashboard loads without 429s
- [ ] Check `X-RateLimit-Remaining` header on authenticated requests stays well above 0

🤖 Generated with [Claude Code](https://claude.ai/code)