### PR TITLE
fix: org profile grants fetch exceeds server MAX_PAGE_SIZE (400 error)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -177,7 +177,7 @@ export default async function OrgProfilePage({
     fetchPgPersonnel(entityStableId),
     fetchMarketData(entity.id),
     fetchFromWikiServer<RpcGrantsByEntityResult>(
-      `/api/grants/by-entity/${encodeURIComponent(entityStableId)}?limit=500&offset=0`,
+      `/api/grants/by-entity/${encodeURIComponent(entityStableId)}?limit=200&offset=0`,
       { revalidate: 3600, timeoutMs: 10_000 },
     ),
   ]);


### PR DESCRIPTION
## Summary
- The ISR grants fetch on org profile pages used `limit=500`, but the wiki-server `/api/grants/by-entity/` endpoint validates `max=200` (`MAX_PAGE_SIZE`), returning a **400 validation error**
- This silently broke the Funding tab on all funder org pages (Coefficient Giving, LTFF, etc.) — `pgGrantCount` fell to 0 so the tab never rendered
- Fix: `limit=500` → `limit=200`. The `total` field still reflects the true count (e.g., 2626 for Coefficient Giving), and the interactive grants table uses server-side pagination at `PAGE_SIZE=50`

## Test plan
- [ ] After deploy, check https://www.longtermwiki.com/organizations/coefficient-giving has a Funding tab with ~2626 grants
- [ ] Check https://www.longtermwiki.com/organizations/ltff has a Funding tab with ~545 grants
- [ ] Check https://www.longtermwiki.com/organizations/sff still works (468 grants)

🤖 Generated with [Claude Code](https://claude.ai/code)