### PR TITLE
feat: add verification query API endpoints

### DIFF
--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -144,6 +144,40 @@ const ResolveNamesQuery = z.object({
     ),
 });
 
+const ByEntityQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+  verdict: z.string().max(50).optional(),
+});
+
+const ByPageQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const VALID_ERROR_TYPES = [
+  "contradicted",
+  "outdated",
+  "unverifiable",
+  "partial",
+] as const;
+
+const FailuresQuery = z.object({
+  error_type: z.string().max(50).optional(),
+  record_type: z.string().max(50).optional(),
+  entity_id: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const StaleQuery = z.object({
+  days: z.coerce.number().int().min(1).max(3650).default(90),
+  record_type: z.string().max(50).optional(),
+  entity_id: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 // ---- Helpers ----
 
 /** Check if a checker model is stale (different from the current model). */
@@ -189,6 +223,95 @@ function mapEvidenceRow(e: {
     isStale: isStaleModel(e.checkerModel),
     notes: e.notes,
     checkedAt: e.checkedAt,
+  };
+}
+
+/** Map a verdict DB row to the API response shape. */
+function mapVerdictRow(r: {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  entityId: string | null;
+  displayName: string | null;
+  entityDisplayName: string | null;
+  verdict: string;
+  confidence: number | null;
+  reasoning: string | null;
+  sourcesChecked: number;
+  needsRecheck: boolean;
+  nextCheckDue: Date | null;
+  lastComputedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    recordType: r.recordType,
+    recordId: r.recordId,
+    fieldName: r.fieldName,
+    entityId: r.entityId,
+    displayName: r.displayName,
+    entityDisplayName: r.entityDisplayName,
+    verdict: r.verdict,
+    confidence: r.confidence,
+    reasoning: r.reasoning,
+    sourcesChecked: r.sourcesChecked,
+    needsRecheck: r.needsRecheck,
+    nextCheckDue: r.nextCheckDue,
+    lastComputedAt: r.lastComputedAt,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+/** Helper for /by-page endpoint: query verdicts by entity stableId and return the data. */
+async function queryVerdictsByEntity(
+  db: ReturnType<typeof getDrizzleDb>,
+  entityId: string,
+  pageTitle: string,
+  limit: number,
+  offset: number,
+) {
+  const rows = await db
+    .select()
+    .from(sourceCheckVerdicts)
+    .where(eq(sourceCheckVerdicts.entityId, entityId))
+    .orderBy(desc(sourceCheckVerdicts.lastComputedAt))
+    .limit(limit)
+    .offset(offset);
+
+  const countResult = await db
+    .select({ count: count() })
+    .from(sourceCheckVerdicts)
+    .where(eq(sourceCheckVerdicts.entityId, entityId));
+  const total = countResult[0].count;
+
+  const countsByVerdictRows = await db
+    .select({
+      verdict: sourceCheckVerdicts.verdict,
+      count: count(),
+    })
+    .from(sourceCheckVerdicts)
+    .where(eq(sourceCheckVerdicts.entityId, entityId))
+    .groupBy(sourceCheckVerdicts.verdict);
+
+  const counts: Record<string, number> = {
+    confirmed: 0,
+    contradicted: 0,
+    outdated: 0,
+    partial: 0,
+    unverifiable: 0,
+    unchecked: 0,
+  };
+  for (const row of countsByVerdictRows) {
+    counts[row.verdict] = row.count;
+  }
+
+  return {
+    verdicts: rows.map(mapVerdictRow),
+    total,
+    counts,
+    pageTitle,
+    entityId,
   };
 }
 
@@ -617,6 +740,258 @@ const sourceChecksApp = new Hono()
       currentCheckerModel: CURRENT_CHECKER_MODEL,
     });
   })
+
+  // ---- GET /by-entity/:entityId ----
+  // Returns all verdicts for a given entity with aggregate counts by verdict type.
+  .get(
+    "/by-entity/:entityId",
+    zv("query", ByEntityQuery),
+    async (c) => {
+      const entityId = c.req.param("entityId");
+      const { limit, offset, verdict } = c.req.valid("query");
+
+      if (entityId.length > MAX_ID_LENGTH) {
+        return c.json({
+          verdicts: [] as ReturnType<typeof mapVerdictRow>[],
+          total: 0,
+          counts: { confirmed: 0, contradicted: 0, outdated: 0, partial: 0, unverifiable: 0, unchecked: 0 },
+        });
+      }
+
+      const db = getDrizzleDb();
+
+      const conditions = [eq(sourceCheckVerdicts.entityId, entityId)];
+      if (verdict) {
+        conditions.push(eq(sourceCheckVerdicts.verdict, verdict));
+      }
+      const whereClause = and(...conditions);
+
+      const rows = await db
+        .select()
+        .from(sourceCheckVerdicts)
+        .where(whereClause)
+        .orderBy(desc(sourceCheckVerdicts.lastComputedAt))
+        .limit(limit)
+        .offset(offset);
+
+      const countResult = await db
+        .select({ count: count() })
+        .from(sourceCheckVerdicts)
+        .where(whereClause);
+      const total = countResult[0].count;
+
+      // Aggregate counts by verdict type (always unfiltered by verdict param)
+      const countsByVerdictRows = await db
+        .select({
+          verdict: sourceCheckVerdicts.verdict,
+          count: count(),
+        })
+        .from(sourceCheckVerdicts)
+        .where(eq(sourceCheckVerdicts.entityId, entityId))
+        .groupBy(sourceCheckVerdicts.verdict);
+
+      const counts: Record<string, number> = {
+        confirmed: 0,
+        contradicted: 0,
+        outdated: 0,
+        partial: 0,
+        unverifiable: 0,
+        unchecked: 0,
+      };
+      for (const row of countsByVerdictRows) {
+        counts[row.verdict] = row.count;
+      }
+
+      return c.json({
+        verdicts: rows.map(mapVerdictRow),
+        total,
+        counts,
+      });
+    }
+  )
+
+  // ---- GET /by-page/:pageSlug ----
+  // Returns all verdicts for records whose entityId matches the page's entity stableId.
+  .get(
+    "/by-page/:pageSlug",
+    zv("query", ByPageQuery),
+    async (c) => {
+      const pageSlug = c.req.param("pageSlug");
+      const { limit, offset } = c.req.valid("query");
+
+      if (pageSlug.length > MAX_ID_LENGTH) {
+        return c.json({
+          verdicts: [] as ReturnType<typeof mapVerdictRow>[],
+          total: 0,
+          counts: { confirmed: 0, contradicted: 0, outdated: 0, partial: 0, unverifiable: 0, unchecked: 0 },
+          pageTitle: null as string | null,
+          entityId: null as string | null,
+        });
+      }
+
+      const db = getDrizzleDb();
+
+      // Resolve page slug to entity stableId
+      const entityRows = await db
+        .select({ stableId: entities.stableId, title: entities.title })
+        .from(entities)
+        .where(eq(entities.id, pageSlug))
+        .limit(1);
+
+      if (entityRows.length === 0) {
+        // Try looking up by wikiId via wikiPages
+        const pageRows = await db
+          .select({ slug: wikiPages.slug, wikiId: wikiPages.wikiId, title: wikiPages.title })
+          .from(wikiPages)
+          .where(eq(wikiPages.slug, pageSlug))
+          .limit(1);
+
+        if (pageRows.length === 0) {
+          return c.json({
+            verdicts: [] as ReturnType<typeof mapVerdictRow>[],
+            total: 0,
+            counts: { confirmed: 0, contradicted: 0, outdated: 0, partial: 0, unverifiable: 0, unchecked: 0 },
+            pageTitle: null as string | null,
+            entityId: null as string | null,
+          });
+        }
+
+        const wikiId = pageRows[0].wikiId;
+        if (wikiId) {
+          const entityByWikiId = await db
+            .select({ stableId: entities.stableId, title: entities.title })
+            .from(entities)
+            .where(eq(entities.wikiId, wikiId))
+            .limit(1);
+
+          if (entityByWikiId.length > 0) {
+            const data = await queryVerdictsByEntity(db, entityByWikiId[0].stableId, pageRows[0].title, limit, offset);
+            return c.json(data);
+          }
+        }
+
+        return c.json({
+          verdicts: [] as ReturnType<typeof mapVerdictRow>[],
+          total: 0,
+          counts: { confirmed: 0, contradicted: 0, outdated: 0, partial: 0, unverifiable: 0, unchecked: 0 },
+          pageTitle: pageRows[0].title,
+          entityId: null as string | null,
+        });
+      }
+
+      const data = await queryVerdictsByEntity(db, entityRows[0].stableId, entityRows[0].title, limit, offset);
+      return c.json(data);
+    }
+  )
+
+  // ---- GET /failures ----
+  // Returns verdicts with non-confirmed verdicts (contradicted, outdated, partial, unverifiable).
+  .get(
+    "/failures",
+    zv("query", FailuresQuery),
+    async (c) => {
+      const { error_type, record_type, entity_id, limit, offset } = c.req.valid("query");
+      const db = getDrizzleDb();
+
+      const failureVerdicts = error_type ? [error_type] : [...VALID_ERROR_TYPES];
+
+      const conditions = [inArray(sourceCheckVerdicts.verdict, failureVerdicts)];
+      if (record_type) {
+        conditions.push(eq(sourceCheckVerdicts.recordType, record_type));
+      }
+      if (entity_id) {
+        conditions.push(eq(sourceCheckVerdicts.entityId, entity_id));
+      }
+
+      const whereClause = and(...conditions);
+
+      const rows = await db
+        .select()
+        .from(sourceCheckVerdicts)
+        .where(whereClause)
+        .orderBy(desc(sourceCheckVerdicts.lastComputedAt))
+        .limit(limit)
+        .offset(offset);
+
+      const countResult = await db
+        .select({ count: count() })
+        .from(sourceCheckVerdicts)
+        .where(whereClause);
+      const total = countResult[0].count;
+
+      // Breakdown by error type (always unfiltered by error_type param for the summary)
+      const byErrorTypeRows = await db
+        .select({
+          verdict: sourceCheckVerdicts.verdict,
+          count: count(),
+        })
+        .from(sourceCheckVerdicts)
+        .where(
+          and(
+            inArray(sourceCheckVerdicts.verdict, [...VALID_ERROR_TYPES]),
+            record_type ? eq(sourceCheckVerdicts.recordType, record_type) : undefined,
+            entity_id ? eq(sourceCheckVerdicts.entityId, entity_id) : undefined,
+          )
+        )
+        .groupBy(sourceCheckVerdicts.verdict);
+
+      const byErrorType: Record<string, number> = {};
+      for (const row of byErrorTypeRows) {
+        byErrorType[row.verdict] = row.count;
+      }
+
+      return c.json({
+        items: rows.map(mapVerdictRow),
+        total,
+        byErrorType,
+      });
+    }
+  )
+
+  // ---- GET /stale ----
+  // Returns verdicts that haven't been rechecked within N days.
+  .get(
+    "/stale",
+    zv("query", StaleQuery),
+    async (c) => {
+      const { days, record_type, entity_id, limit, offset } = c.req.valid("query");
+      const db = getDrizzleDb();
+
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - days);
+
+      const conditions = [lte(sourceCheckVerdicts.lastComputedAt, cutoffDate)];
+      if (record_type) {
+        conditions.push(eq(sourceCheckVerdicts.recordType, record_type));
+      }
+      if (entity_id) {
+        conditions.push(eq(sourceCheckVerdicts.entityId, entity_id));
+      }
+
+      const whereClause = and(...conditions);
+
+      const rows = await db
+        .select()
+        .from(sourceCheckVerdicts)
+        .where(whereClause)
+        .orderBy(sourceCheckVerdicts.lastComputedAt) // oldest first
+        .limit(limit)
+        .offset(offset);
+
+      const countResult = await db
+        .select({ count: count() })
+        .from(sourceCheckVerdicts)
+        .where(whereClause);
+      const total = countResult[0].count;
+
+      return c.json({
+        items: rows.map(mapVerdictRow),
+        total,
+        cutoffDate: cutoffDate.toISOString(),
+        days,
+      });
+    }
+  )
 
   // ---- POST /verdicts ----
   .post("/verdicts", async (c) => {

--- a/crux/lib/wiki-server/__tests__/source-checks.test.ts
+++ b/crux/lib/wiki-server/__tests__/source-checks.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for source-checks client functions.
+ *
+ * Mocks apiRequest to verify URL construction, parameter encoding,
+ * and response handling for the new query endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the client module's apiRequest before importing source-checks
+vi.mock('../client.ts', async () => {
+  const actual = await vi.importActual<typeof import('../client.ts')>('../client.ts');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+import { apiRequest } from '../client.ts';
+import {
+  getVerdictsByEntity,
+  getVerdictsByPage,
+  getFailures,
+  getStaleVerdicts,
+  getVerdictsByType,
+  getContradictedEntityIds,
+} from '../source-checks.ts';
+
+const mockApiRequest = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  mockApiRequest.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// getVerdictsByEntity
+// ---------------------------------------------------------------------------
+
+describe('getVerdictsByEntity', () => {
+  it('constructs correct URL with entityId path param', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0, counts: {} },
+    });
+
+    await getVerdictsByEntity('sid_abc123');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/by-entity/sid_abc123',
+    );
+  });
+
+  it('includes optional query params when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0, counts: {} },
+    });
+
+    await getVerdictsByEntity('sid_abc123', {
+      limit: 10,
+      offset: 20,
+      verdict: 'contradicted',
+    });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('/api/source-checks/by-entity/sid_abc123?');
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=20');
+    expect(url).toContain('verdict=contradicted');
+  });
+
+  it('encodes entityId with special characters', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0, counts: {} },
+    });
+
+    await getVerdictsByEntity('sid_with spaces/slash');
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('sid_with%20spaces%2Fslash');
+  });
+
+  it('omits query string when no options are provided', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0, counts: {} },
+    });
+
+    await getVerdictsByEntity('sid_abc123');
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toBe('/api/source-checks/by-entity/sid_abc123');
+    expect(url).not.toContain('?');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getVerdictsByPage
+// ---------------------------------------------------------------------------
+
+describe('getVerdictsByPage', () => {
+  it('constructs correct URL with page slug', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [],
+        total: 0,
+        counts: {},
+        pageTitle: 'Anthropic',
+        entityId: 'sid_abc',
+      },
+    });
+
+    await getVerdictsByPage('anthropic');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/by-page/anthropic',
+    );
+  });
+
+  it('includes pagination params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [],
+        total: 0,
+        counts: {},
+        pageTitle: null,
+        entityId: null,
+      },
+    });
+
+    await getVerdictsByPage('openai', { limit: 25, offset: 50 });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('limit=25');
+    expect(url).toContain('offset=50');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFailures
+// ---------------------------------------------------------------------------
+
+describe('getFailures', () => {
+  it('calls the failures endpoint with no params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, byErrorType: {} },
+    });
+
+    await getFailures();
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/failures',
+    );
+  });
+
+  it('includes error_type filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, byErrorType: {} },
+    });
+
+    await getFailures({ error_type: 'contradicted' });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('error_type=contradicted');
+  });
+
+  it('includes all filter params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, byErrorType: {} },
+    });
+
+    await getFailures({
+      error_type: 'outdated',
+      record_type: 'personnel',
+      entity_id: 'sid_xyz',
+      limit: 20,
+      offset: 5,
+    });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('error_type=outdated');
+    expect(url).toContain('record_type=personnel');
+    expect(url).toContain('entity_id=sid_xyz');
+    expect(url).toContain('limit=20');
+    expect(url).toContain('offset=5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStaleVerdicts
+// ---------------------------------------------------------------------------
+
+describe('getStaleVerdicts', () => {
+  it('calls the stale endpoint with no params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, cutoffDate: '2025-01-01T00:00:00.000Z', days: 90 },
+    });
+
+    await getStaleVerdicts();
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/stale',
+    );
+  });
+
+  it('includes days parameter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, cutoffDate: '2025-01-01T00:00:00.000Z', days: 30 },
+    });
+
+    await getStaleVerdicts({ days: 30 });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('days=30');
+  });
+
+  it('includes all optional params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { items: [], total: 0, cutoffDate: '2025-01-01T00:00:00.000Z', days: 60 },
+    });
+
+    await getStaleVerdicts({
+      days: 60,
+      record_type: 'fact',
+      entity_id: 'sid_test',
+      limit: 100,
+      offset: 10,
+    });
+
+    const url = mockApiRequest.mock.calls[0][1];
+    expect(url).toContain('days=60');
+    expect(url).toContain('record_type=fact');
+    expect(url).toContain('entity_id=sid_test');
+    expect(url).toContain('limit=100');
+    expect(url).toContain('offset=10');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getVerdictsByType (existing function — verify it still works)
+// ---------------------------------------------------------------------------
+
+describe('getVerdictsByType', () => {
+  it('constructs correct URL with verdict filter', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+
+    await getVerdictsByType('contradicted');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/verdicts?verdict=contradicted&limit=200',
+    );
+  });
+
+  it('respects custom limit', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+
+    await getVerdictsByType('confirmed', 50);
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/source-checks/verdicts?verdict=confirmed&limit=50',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getContradictedEntityIds (existing function — verify it still works)
+// ---------------------------------------------------------------------------
+
+describe('getContradictedEntityIds', () => {
+  it('returns entity IDs from contradicted verdicts', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          { entityId: 'sid_abc', verdict: 'contradicted' },
+          { entityId: 'sid_def', verdict: 'contradicted' },
+          { entityId: null, verdict: 'contradicted' },
+        ],
+        total: 3,
+      },
+    });
+
+    const result = await getContradictedEntityIds();
+
+    expect(result).toEqual(new Set(['sid_abc', 'sid_def']));
+  });
+
+  it('returns empty set when API is unavailable', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: 'unavailable',
+      message: 'not set',
+    });
+
+    const result = await getContradictedEntityIds();
+
+    expect(result).toEqual(new Set());
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('warns when total exceeds fetched count', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [{ entityId: 'sid_abc', verdict: 'contradicted' }],
+        total: 300,
+      },
+    });
+
+    const result = await getContradictedEntityIds();
+
+    expect(result).toEqual(new Set(['sid_abc']));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('1/300'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/crux/lib/wiki-server/index.ts
+++ b/crux/lib/wiki-server/index.ts
@@ -220,9 +220,20 @@ export type { AllocatedId, IdListResult } from './ids.ts';
 // Source Checks
 export {
   getVerdictsByType,
+  getVerdictsByEntity,
+  getVerdictsByPage,
+  getFailures,
+  getStaleVerdicts,
   getContradictedEntityIds,
 } from './source-checks.ts';
-export type { VerdictEntry, VerdictsResponse } from './source-checks.ts';
+export type {
+  VerdictEntry,
+  VerdictsResponse,
+  ByEntityResponse,
+  ByPageResponse,
+  FailuresResponse,
+  StaleResponse,
+} from './source-checks.ts';
 
 // Claims
 export { proposeClaims, getClaimStatus } from './claims.ts';

--- a/crux/lib/wiki-server/source-checks.ts
+++ b/crux/lib/wiki-server/source-checks.ts
@@ -1,8 +1,11 @@
 /**
- * Source-Check Verdicts API — wiki-server client module
+ * Source-Check Verdicts API -- wiki-server client module
  *
  * Provides functions to fetch source-check verdicts from the wiki-server.
- * Used by the auto-update pipeline to skip pages with contradicted verdicts.
+ * Used by the auto-update pipeline to skip pages with contradicted verdicts,
+ * and by agents to query verification status by entity, page, or failure type.
+ *
+ * Response types are inferred from the server route via Hono RPC type system.
  */
 
 import { apiRequest, type ApiResult } from './client.ts';
@@ -18,16 +21,17 @@ type RpcClient = ReturnType<typeof hc<SourceChecksRoute>>;
 export type VerdictsResponse = InferResponseType<RpcClient['verdicts']['$get'], 200>;
 export type VerdictEntry = VerdictsResponse['verdicts'][number];
 
+export type ByEntityResponse = InferResponseType<RpcClient['by-entity'][':entityId']['$get'], 200>;
+export type ByPageResponse = InferResponseType<RpcClient['by-page'][':pageSlug']['$get'], 200>;
+export type FailuresResponse = InferResponseType<RpcClient['failures']['$get'], 200>;
+export type StaleResponse = InferResponseType<RpcClient['stale']['$get'], 200>;
+
 // ---------------------------------------------------------------------------
 // API functions
 // ---------------------------------------------------------------------------
 
 /**
  * Fetch source-check verdicts filtered by verdict type.
- *
- * @param verdict - The verdict type to filter by (e.g., 'contradicted')
- * @param limit - Maximum number of verdicts to return (default: 200)
- * @returns ApiResult containing the verdicts array and total count
  */
 export async function getVerdictsByType(
   verdict: string,
@@ -40,25 +44,105 @@ export async function getVerdictsByType(
 }
 
 /**
+ * Fetch all verdicts for a given entity, including aggregate counts by verdict type.
+ */
+export async function getVerdictsByEntity(
+  entityId: string,
+  options: { limit?: number; offset?: number; verdict?: string } = {},
+): Promise<ApiResult<ByEntityResponse>> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.offset !== undefined) params.set('offset', String(options.offset));
+  if (options.verdict) params.set('verdict', options.verdict);
+  const qs = params.toString();
+  return apiRequest<ByEntityResponse>(
+    'GET',
+    `/api/source-checks/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/**
+ * Fetch all verdicts for records associated with a wiki page.
+ */
+export async function getVerdictsByPage(
+  pageSlug: string,
+  options: { limit?: number; offset?: number } = {},
+): Promise<ApiResult<ByPageResponse>> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.offset !== undefined) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<ByPageResponse>(
+    'GET',
+    `/api/source-checks/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/**
+ * Fetch verdicts with failure verdicts (contradicted, outdated, partial, unverifiable).
+ */
+export async function getFailures(
+  options: {
+    error_type?: string;
+    record_type?: string;
+    entity_id?: string;
+    limit?: number;
+    offset?: number;
+  } = {},
+): Promise<ApiResult<FailuresResponse>> {
+  const params = new URLSearchParams();
+  if (options.error_type) params.set('error_type', options.error_type);
+  if (options.record_type) params.set('record_type', options.record_type);
+  if (options.entity_id) params.set('entity_id', options.entity_id);
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.offset !== undefined) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<FailuresResponse>(
+    'GET',
+    `/api/source-checks/failures${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/**
+ * Fetch verdicts older than N days that need rechecking.
+ */
+export async function getStaleVerdicts(
+  options: {
+    days?: number;
+    record_type?: string;
+    entity_id?: string;
+    limit?: number;
+    offset?: number;
+  } = {},
+): Promise<ApiResult<StaleResponse>> {
+  const params = new URLSearchParams();
+  if (options.days !== undefined) params.set('days', String(options.days));
+  if (options.record_type) params.set('record_type', options.record_type);
+  if (options.entity_id) params.set('entity_id', options.entity_id);
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.offset !== undefined) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<StaleResponse>(
+    'GET',
+    `/api/source-checks/stale${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/**
  * Fetch all contradicted source-check verdicts and return the set of
  * entity IDs (stableIds) that have at least one contradicted verdict.
- *
- * This is a convenience wrapper for use by the auto-update pipeline.
- * Returns an empty set (not an error) if the wiki-server is unavailable,
- * following the best-effort pattern from error-handling.md.
  */
 export async function getContradictedEntityIds(): Promise<Set<string>> {
   const result = await getVerdictsByType('contradicted', 200);
 
   if (!result.ok) {
-    // Best-effort: wiki-server unavailable → proceed without filtering
     console.warn(`[source-checks] Failed to fetch contradicted verdicts: ${result.message}`);
     return new Set();
   }
 
   const { verdicts, total } = result.data;
   if (total > verdicts.length) {
-    console.warn(`[source-checks] Fetched ${verdicts.length}/${total} contradicted verdicts — some entities may not be filtered`);
+    console.warn(`[source-checks] Fetched ${verdicts.length}/${total} contradicted verdicts`);
   }
 
   const entityIds = new Set<string>();


### PR DESCRIPTION
## Summary

- Add 4 new GET endpoints to the source-checks route for querying verification status programmatically
- `GET /by-entity/:entityId` -- all verdicts for an entity with aggregate counts (confirmed, contradicted, etc.)
- `GET /by-page/:pageSlug` -- all verdicts for a wiki page (resolves slug to entity stableId via entities/wikiPages tables)
- `GET /failures` -- contradicted/outdated/unverifiable/partial verdicts, filterable by error_type, record_type, entity_id
- `GET /stale?days=90` -- verdicts older than N days needing recheck
- Add typed client functions in `crux/lib/wiki-server/source-checks.ts` using `InferResponseType` from Hono RPC
- All endpoints use Zod validation on query params, paginated results (limit/offset), and method-chaining for type inference

Closes #3665

## Test plan

- [x] 17 client tests verify URL construction, parameter encoding, and response handling
- [x] TypeScript compiles with no new errors (`npx tsc --noEmit` in wiki-server)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)