### PR TITLE
fix: replace unsafe as casts with Zod runtime validation

### DIFF
--- a/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
+++ b/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useRef, useEffect } from "react";
 import Link from "next/link";
+import { z } from "zod";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { useServerTable } from "@/hooks/use-server-table";
 import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
@@ -32,32 +33,38 @@ export interface GrantRow {
 
 // ── Server grant shape (from wiki-server API) ───────────────────────
 
-/** Structured entity reference from wiki-server API. */
-interface EntityRef {
-  entityId: string | null;
-  slug: string | null;
-  name: string | null;
-}
+const EntityRefSchema = z.object({
+  entityId: z.string().nullable(),
+  slug: z.string().nullable(),
+  name: z.string().nullable(),
+});
 
-interface ServerGrant {
-  id: string;
-  granteeId: string | null;
-  grantee: EntityRef;
-  name: string;
-  amount: number | null;
-  period: string | null;
-  date: string | null;
-  status: string | null;
-  source: string | null;
-  notes: string | null;
-  programId: string | null;
-  verification?: {
-    verdict: string;
-    confidence: number | null;
-    sourcesChecked: number;
-    checkedAt: string | null;
-  } | null;
-}
+const ServerGrantSchema = z.object({
+  id: z.string(),
+  granteeId: z.string().nullable(),
+  grantee: EntityRefSchema,
+  name: z.string(),
+  amount: z.number().nullable(),
+  period: z.string().nullable(),
+  date: z.string().nullable(),
+  status: z.string().nullable(),
+  source: z.string().nullable(),
+  notes: z.string().nullable(),
+  programId: z.string().nullable(),
+  verification: z.object({
+    verdict: z.string(),
+    confidence: z.number().nullable(),
+    sourcesChecked: z.number(),
+    checkedAt: z.string().nullable(),
+  }).nullable().optional(),
+});
+
+type ServerGrant = z.infer<typeof ServerGrantSchema>;
+
+const ServerGrantsResponseSchema = z.object({
+  grants: z.array(ServerGrantSchema).optional(),
+  total: z.number().optional(),
+});
 
 function formatSlug(slug: string): string {
   return slug
@@ -88,7 +95,12 @@ function serverGrantToRow(g: ServerGrant, orgSlug?: string): GrantRow {
 
 function makeTransform(orgSlug?: string) {
   return (json: unknown): { rows: GrantRow[]; total: number } => {
-    const data = json as { grants?: ServerGrant[]; total?: number };
+    const parsed = ServerGrantsResponseSchema.safeParse(json);
+    if (!parsed.success) {
+      console.warn("Grants API response schema mismatch:", parsed.error.message);
+      return { rows: [], total: 0 };
+    }
+    const data = parsed.data;
     return {
       rows: (data.grants ?? []).map((g) => serverGrantToRow(g, orgSlug)),
       total: data.total ?? 0,

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import Link from "next/link";
+import { z } from "zod";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { FilterChips } from "@/components/directory/FilterChips";
 import { PaginationControls } from "@/components/directory/PaginationControls";
@@ -91,22 +92,29 @@ export interface OrgStatDef {
 
 // ── Server response shape ──────────────────────────────────────────
 
-interface ServerOrg {
-  id: string;
-  wikiId: string | null;
-  stableId: string | null;
-  title: string;
-  description: string | null;
-  website: string | null;
-  revenueNum: number | null;
-  revenueDate: string | null;
-  valuationNum: number | null;
-  valuationDate: string | null;
-  headcount: number | null;
-  headcountDate: string | null;
-  totalFundingNum: number | null;
-  foundedDate: string | null;
-}
+const ServerOrgSchema = z.object({
+  id: z.string(),
+  wikiId: z.string().nullable(),
+  stableId: z.string().nullable().optional(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  website: z.string().nullable().optional(),
+  revenueNum: z.number().nullable(),
+  revenueDate: z.string().nullable(),
+  valuationNum: z.number().nullable(),
+  valuationDate: z.string().nullable(),
+  headcount: z.number().nullable(),
+  headcountDate: z.string().nullable(),
+  totalFundingNum: z.number().nullable(),
+  foundedDate: z.string().nullable(),
+});
+
+type ServerOrg = z.infer<typeof ServerOrgSchema>;
+
+const ServerOrgsResponseSchema = z.object({
+  organizations: z.array(ServerOrgSchema).optional(),
+  total: z.number().optional(),
+});
 
 // Map OrgSortKey to server sort field names.
 // orgType is not sortable server-side (not in DB).
@@ -123,7 +131,12 @@ const PAGE_SIZE = 50;
 
 // Stable module-level transform function — avoids re-renders
 function transformOrgsResponse(json: unknown): { rows: OrgRow[]; total: number } {
-  const data = json as { organizations?: ServerOrg[]; total?: number };
+  const parsed = ServerOrgsResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    console.warn("Organizations API response schema mismatch:", parsed.error.message);
+    return { rows: [], total: 0 };
+  }
+  const data = parsed.data;
   return {
     rows: (data.organizations ?? []).map((org) => ({
       id: org.id,

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback, useState } from "react";
 import Link from "next/link";
+import { z } from "zod";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { FilterChips } from "@/components/directory/FilterChips";
 import { PaginationControls } from "@/components/directory/PaginationControls";
@@ -44,18 +45,25 @@ export interface PersonRow {
 
 // ── Server person shape (from wiki-server API) ──────────────────────
 
-interface ServerPerson {
-  id: string;
-  slug: string;
-  name: string;
-  wikiId: string | null;
-  description: string | null;
-  role: string | null;
-  employerId: string | null;
-  employerName: string | null;
-  bornYear: number | null;
-  netWorth: number | null;
-}
+const ServerPersonSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  wikiId: z.string().nullable(),
+  description: z.string().nullable().optional(),
+  role: z.string().nullable(),
+  employerId: z.string().nullable(),
+  employerName: z.string().nullable(),
+  bornYear: z.number().nullable(),
+  netWorth: z.number().nullable(),
+});
+
+type ServerPerson = z.infer<typeof ServerPersonSchema>;
+
+const ServerPeopleResponseSchema = z.object({
+  items: z.array(ServerPersonSchema).optional(),
+  total: z.number().optional(),
+});
 
 function serverPersonToRow(p: ServerPerson): PersonRow {
   return {
@@ -83,7 +91,12 @@ function transformPeopleResponse(json: unknown): {
   rows: PersonRow[];
   total: number;
 } {
-  const data = json as { items?: ServerPerson[]; total?: number };
+  const parsed = ServerPeopleResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    console.warn("People API response schema mismatch:", parsed.error.message);
+    return { rows: [], total: 0 };
+  }
+  const data = parsed.data;
   return {
     rows: (data.items ?? []).map(serverPersonToRow),
     total: data.total ?? 0,


### PR DESCRIPTION
## Summary
- Replace `json as Type` casts in three table component transform functions with Zod `safeParse` runtime validation
- On schema mismatch, logs a `console.warn` with the Zod error message and returns empty results (graceful degradation) instead of silently producing `undefined` property accesses
- Adds Zod schemas (`ServerOrgSchema`, `ServerGrantSchema`, `ServerPersonSchema`) that mirror the existing TypeScript interfaces, then derives the types via `z.infer`

## Files changed
- `apps/web/src/app/organizations/organizations-table.tsx` — `transformOrgsResponse` now validates via `ServerOrgsResponseSchema`
- `apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx` — `makeTransform` now validates via `ServerGrantsResponseSchema`
- `apps/web/src/app/people/people-table.tsx` — `transformPeopleResponse` now validates via `ServerPeopleResponseSchema`

Closes #3492

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit` — no new errors in modified files)
- [ ] Organizations table loads correctly at `/organizations`
- [ ] Grants table loads on org detail pages (e.g., `/organizations/open-philanthropy`)
- [ ] People table loads at `/people`
- [ ] Schema mismatch produces a console warning (testable by temporarily adding an extra required field to the schema)

Generated with [Claude Code](https://claude.com/claude-code)