### PR TITLE
feat: add /work-on-discussion and /score-issues skills

### DIFF
--- a/.claude/commands/score-issues.md
+++ b/.claude/commands/score-issues.md
@@ -1,0 +1,93 @@
+---
+description: Score open issues with LLM and apply priority/effort/model labels
+argument-hint: "[--dry-run] [--limit=N]"
+effort: low
+---
+
+# Score Issues — LLM-Powered Issue Triage
+
+Read open issues, use your judgment to assess priority/effort/model, and apply labels so `crux gh issues next` ranks them correctly.
+
+## When to use
+
+- After a batch of new issues are created (e.g., from discussion decomposition)
+- Periodically to re-triage the backlog
+- Before kicking off an autonomous execution loop
+
+## Step 1: Fetch issues needing scoring
+
+```bash
+pnpm crux gh issues list --json 2>&1
+```
+
+Parse the JSON output. Focus on issues that are **under-labeled** — they lack priority, size, or model labels. Skip issues that already have `priority:*` AND `size:*` AND `model:*` labels.
+
+If the user passed `--limit=N`, only process the top N under-labeled issues. Default: 20.
+
+## Step 2: Score each issue
+
+For each under-labeled issue, read the title and body and assess:
+
+### Priority (pick one)
+| Label | Criteria |
+|-------|----------|
+| `priority:high` | Data corruption, broken pages, pipeline failures, blocks other work |
+| `priority:medium` | Missing features with clear user impact, coverage gaps, UI bugs |
+| `priority:low` | Polish, nice-to-haves, speculative improvements, minor cleanup |
+
+### Size (pick one)
+| Label | Criteria |
+|-------|----------|
+| `size: S` | Single file, data fix, config change, <30 min agent session |
+| `size: M` | 2-5 files, new component or command, 30-90 min session |
+| `size: L` | Multiple systems, new pipeline, migration + code + UI, 2+ hours |
+
+### Model (pick one)
+| Label | Criteria |
+|-------|----------|
+| `model:haiku` | Data fixes, simple UI tweaks, label changes, config updates |
+| `model:sonnet` | Standard features, new components, moderate refactors |
+| `model:opus` | Architecture changes, complex multi-system work, design decisions |
+
+### Additional labels (apply if relevant)
+- `bug` — if it describes broken behavior (not just missing features)
+- `claude-ready` — if the issue is well-scoped with clear acceptance criteria and an agent could complete it without human clarification
+
+## Step 3: Apply labels
+
+For each issue, apply the labels via the GitHub API:
+
+```bash
+gh api repos/quantified-uncertainty/longterm-wiki/issues/NNNN/labels \
+  -X POST --input - <<< '{"labels":["priority:medium","size: S","model:haiku"]}'
+```
+
+**Rules:**
+- Never remove existing labels — only add missing ones
+- If `--dry-run` was passed, just print the proposed labels without applying them
+- Print a summary table as you go:
+
+```
+#3659  priority:high    size: S  model:haiku   claude-ready  Fix investment URLs (data bug)
+#3670  priority:low     size: S  model:sonnet               Surface abstract in resource cards
+#3653  priority:medium  size: M  model:sonnet  claude-ready  Benchmark scorecard visualization
+```
+
+## Step 4: Report
+
+After labeling, show the new ranking:
+
+```bash
+pnpm crux gh issues next --scores
+```
+
+This confirms the scoring system now has useful signal to work with.
+
+## Heuristics for good scoring
+
+- **Data corruption/integrity issues are always priority:high** — wrong URLs, fabricated IDs, broken FKs
+- **Pipeline improvements that save money or prevent bad data are priority:high** — dead link detection, verification gates
+- **UI improvements are usually priority:low to medium** — unless they fix broken/misleading displays
+- **Issues with clear acceptance criteria get `claude-ready`** — look for checkboxes, specific file paths, concrete "before/after"
+- **Issues that reference other issues as blockers should NOT get `claude-ready`** — check dependencies first
+- **Prefer `model:haiku` for anything that's mostly data manipulation or simple edits** — save Opus/Sonnet budget for complex work

--- a/.claude/commands/work-on-discussion.md
+++ b/.claude/commands/work-on-discussion.md
@@ -1,0 +1,136 @@
+---
+description: Bind to a GitHub Discussion and work through it as a sustained project session.
+argument-hint: "<discussion-number>"
+effort: high
+---
+
+# Work on Discussion — Sustained Project Session
+
+Bind this agent session to a GitHub Discussion and work through its plan systematically. The discussion is your anchor — stay on it until you finish a meaningful chunk or hit a blocker.
+
+This replaces the "pick next issue → do it → reset" pattern with "pick a project → build deep context → make real progress."
+
+## Step 1: Load the discussion
+
+```bash
+pnpm crux gh epic view <N>
+```
+
+Read the full discussion body and comments. Understand:
+- What is the **goal**?
+- What **phases/steps** are described?
+- What has **already been done** (check comments, linked issues, codebase)?
+
+## Step 2: Check for agent metadata
+
+Look for an HTML comment block at the top of the discussion body:
+
+```html
+<!-- agent-project
+priority: high | medium | low
+status: not-started | in-progress | blocked | done
+phases_total: N
+phases_done: N
+last_agent_session: YYYY-MM-DD
+blocker: (optional free text)
+-->
+```
+
+If it doesn't exist, that's fine — you'll add it at the end.
+
+## Step 3: Determine the next action
+
+Read the discussion plan and figure out what the **next concrete step** is. This requires judgment:
+
+1. **Scan the phases/plan** in the discussion body
+2. **Check what's already implemented** — read code, check git log, look for related PRs
+3. **Identify the first unfinished phase** that isn't blocked
+4. If the discussion doesn't have clear phases, write a plan as a comment and ask for confirmation
+
+The next action should be something you can **implement and ship in this session**. If a phase is too large, break it into a sub-step you can complete.
+
+## Step 4: Create a branch and init
+
+```bash
+git checkout -b claude/disc-<N>-<short-description>
+pnpm crux sys agent-checklist init "Discussion #<N>: <phase description>" --type=infrastructure
+```
+
+Post a comment on the discussion signaling you're starting:
+
+```bash
+pnpm crux gh epic comment <N> "Starting work on Phase X: <description>. Branch: claude/disc-<N>-..."
+```
+
+## Step 5: Implement
+
+Work through the current phase. As you go:
+
+- **Stay focused on this discussion's scope** — don't get pulled into tangential fixes
+- **If you discover something broken**, file an issue and note it, but keep working on the discussion
+- **If you need a human decision**, post a comment on the discussion explaining the tradeoff and what you'd recommend. Then move to the next phase you CAN do, or stop.
+- **If a phase turns out to be already done**, note it and move to the next one
+
+## Step 6: Ship and update
+
+When you've completed a meaningful chunk:
+
+1. **Ship the PR** with `/agent-ship` — reference the discussion in the PR body:
+   ```
+   Ref: Discussion #NNNN (Phase X)
+   ```
+
+2. **Post a progress comment** on the discussion:
+   ```bash
+   pnpm crux gh epic comment <N> "Completed Phase X: <what was done>. PR: #YYYY. Next: Phase X+1 (<description>)."
+   ```
+
+3. **Update the agent metadata** in the discussion body. Use `pnpm crux gh epic update <N>` to edit the body, adding or updating the HTML comment block:
+   ```html
+   <!-- agent-project
+   priority: medium
+   status: in-progress
+   phases_total: 5
+   phases_done: 3
+   last_agent_session: 2026-04-03
+   -->
+   ```
+
+4. **If there's more to do and you have capacity**, continue to the next phase in the same session. Don't reset — your context is valuable.
+
+5. **If you're done or blocked**, update status to `done` or `blocked` with a blocker description.
+
+## Step 7: Continue or hand off
+
+If the session ends mid-discussion:
+- The discussion comment trail shows exactly where you stopped
+- The metadata block shows phases_done vs phases_total
+- The next agent session picks up where you left off by reading the discussion + comments
+
+## How this differs from /agent-next-issue
+
+| | /agent-next-issue | /work-on-discussion |
+|---|---|---|
+| **Scope** | One atomic issue | Multi-phase project |
+| **Context** | Rebuilt each session | Compounds within session |
+| **Duration** | 15-60 min | Hours |
+| **Output** | One PR per issue | One or more PRs per session |
+| **Tracking** | Issue labels | Discussion comments + metadata |
+| **Issues** | Pre-existing | Created as needed during work |
+
+## Picking which discussion to work on
+
+If no discussion number was provided, pick one by checking:
+
+1. **Discussions with `status: in-progress`** — continue unfinished work first
+2. **Discussions with `priority: high`** — highest priority unstarted work
+3. **Discussions with the most phases remaining** — biggest bang for a session
+4. **Most recently active discussions** — momentum matters
+
+You can scan for the metadata block:
+```bash
+# List discussions and check for agent-project metadata
+pnpm crux gh epic list
+```
+
+Then read the top candidates and pick the one where you can make the most progress.


### PR DESCRIPTION
## Summary

Two new Claude Code skills for the discussion-first workflow (Discussion #3643):

- **`/work-on-discussion N`** — Binds an agent session to a GitHub Discussion and works through its phases as a sustained project. Context compounds over hours instead of resetting per-issue.
- **`/score-issues`** — LLM-assisted triage: reads open issues and applies priority/size/model labels so `crux gh issues next` ranks them meaningfully.

All 17 open discussions now have `<!-- agent-project -->` metadata blocks with priority, status, and phase tracking.

## Test plan
- [ ] Verify `/work-on-discussion` appears in skill list
- [ ] Verify `/score-issues` appears in skill list
- [ ] Run `/work-on-discussion 3558` in a test slot to confirm it loads the discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)