### PR TITLE
feat: dead link count in source-checks dashboard (Discussion #3558)

### DIFF
--- a/apps/web/src/app/source-checks/page.tsx
+++ b/apps/web/src/app/source-checks/page.tsx
@@ -239,6 +239,7 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
   const unverifiableCount = bv.unverifiable ?? 0;
   const uncheckedCount = bv.unchecked ?? 0;
   const hasIssuesCount = contradictedCount + outdatedCount + partialCount;
+  const deadLinkCount = filteredStats.dead_link_count ?? 0;
   const checkedCount = filteredStats.total - uncheckedCount;
   const accuracyDenom = confirmedCount + contradictedCount + outdatedCount;
   const accuracyRate =
@@ -319,6 +320,11 @@ export default async function SourceChecksPage({ searchParams }: PageProps) {
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {pctOfChecked(unverifiableCount)} of checked
+            {deadLinkCount > 0 && (
+              <span className="block text-[10px] mt-0.5">
+                incl. {deadLinkCount.toLocaleString()} dead links
+              </span>
+            )}
           </p>
         </div>
         <div className="rounded-lg border border-dashed border-border/60 p-4">

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -379,6 +379,18 @@ const sourceChecksApp = new Hono()
           )
         );
 
+      // Count dead link detections (evidence from dead-link-detector)
+      const deadLinkConditions = [
+        eq(sourceCheckEvidence.checkerModel, "dead-link-detector"),
+      ];
+      if (record_type) {
+        deadLinkConditions.push(eq(sourceCheckEvidence.recordType, record_type));
+      }
+      const [deadLinkRow] = await db
+        .select({ count: count() })
+        .from(sourceCheckEvidence)
+        .where(and(...deadLinkConditions));
+
       return c.json({
         total: statsRow.total,
         by_verdict: byVerdict,
@@ -387,6 +399,7 @@ const sourceChecksApp = new Hono()
         avg_confidence:
           Math.round(Number(statsRow.avgConfidence) * 100) / 100,
         stale_evidence_count: staleRow.count,
+        dead_link_count: deadLinkRow.count,
         current_checker_model: CURRENT_CHECKER_MODEL,
       });
     }


### PR DESCRIPTION
## Summary

Adds dead link visibility to the source-checks dashboard, continuing the work from Discussion #3558.

- **API**: New `dead_link_count` field in `/api/source-checks/stats` — counts evidence rows with `checkerModel='dead-link-detector'`
- **Dashboard**: "Can't Verify" card now shows "incl. N dead links" when dead links are detected, so users can distinguish dead URLs from other unverifiable causes

## Context

Discussion #3558 described 6 fixes. Status:
- Fix 1 (resource linking): Done (pre-existing)
- Fix 2 (headline stats): Done (PR #3681)
- Fix 3 (claims display): Done (PR #3681)
- Fix 4 (broken link detection): Done (PR #3681)
- **Fix 5 (unverifiable subcategories): This PR** — first step: dead link count
- Fix 6 (full dashboard restructure with tabs): Not started — larger UI work for a future session

Ref: Discussion #3558

## Test plan
- [ ] TypeScript compiles clean
- [ ] Stats endpoint returns `dead_link_count` field
- [ ] Dashboard shows dead link count under "Can't Verify" when > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)