### PR TITLE
fix: correct Samotsvety website and CEPI founding date note

### DIFF
--- a/packages/factbase/data/things/coalition-for-epidemic-preparedness-innovations.yaml
+++ b/packages/factbase/data/things/coalition-for-epidemic-preparedness-innovations.yaml
@@ -13,7 +13,7 @@ facts:
     property: founded-date
     value: "2017-01"
     source: https://www.wikidata.org/wiki/Q27133033
-    notes: "Launched January 2017 at World Economic Forum in Davos (corrected from 2016-08). Wikidata lists Jan 2017 inception."
+    notes: "Launched January 2017 at World Economic Forum in Davos (corrected from 2016-08). Wikidata lists 30 August 2016 as inception (the incorporation date); we use the formal public launch date per cepi.net/cepi-officially-launched."
   - id: rNpP4ZtDoA
     property: headquarters
     value: Oslo

--- a/packages/factbase/data/things/samotsvety.yaml
+++ b/packages/factbase/data/things/samotsvety.yaml
@@ -21,9 +21,9 @@ facts:
     notes: From Wikidata Q4406987
   - id: sKYr07wHKQ
     property: website
-    value: http://www.samotsvety.ru/
-    source: https://www.wikidata.org/wiki/Q4406987
-    notes: "Corrected from samotsvetu.ru to samotsvety.ru per Wikidata official website listing"
+    value: https://samotsvety.org
+    source: https://samotsvety.org
+    notes: "Official website of Samotsvety Forecasting. Previous values (samotsvetu.ru, samotsvety.ru) were for the unrelated Russian pop band (Wikidata Q4406987)."
   - id: VLccWZ2UZw
     property: wikipedia-url
     value: https://en.wikipedia.org/wiki/Samotsvety


### PR DESCRIPTION
## Summary

Fixes two data accuracy issues found during review of PR #3716:

- **Samotsvety website**: Changed from `samotsvety.ru` to `samotsvety.org`. The `.ru` domain belongs to the Russian pop band "Samotsvety" (VIA, est. 1971), not the Samotsvety Forecasting group. The forecasting group's actual website is `samotsvety.org` (verified live -- self-describes as "a group of forecasters with a great track record").
- **CEPI founding date note**: The note incorrectly claimed "Wikidata lists Jan 2017 inception." Wikidata actually lists 30 August 2016 (the incorporation date). We keep `2017-01` as the value since that is the formal public launch date at Davos WEF, but the note now honestly represents both dates with source attribution.

Note: The broader issue that the Samotsvety FactBase entity pulls founded-date (1971), country (Russia), and Wikipedia URL from the Russian band's Wikidata entry (Q4406987) rather than the forecasting group is a pre-existing data quality issue beyond this fix's scope.

## Test plan

- [ ] Verify `samotsvety.org` resolves to the forecasting group's site
- [ ] Verify CEPI note accurately describes the Wikidata inception date
- [ ] No code changes -- data-only YAML edits

Generated with [Claude Code](https://claude.com/claude-code)