### PR TITLE
fix(ci): serialize sync-content jobs to prevent rate limit collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,11 @@ jobs:
     # Sync wiki page content to wiki-server after build succeeds on main.
     needs: [ci]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Serialize syncs so concurrent pushes don't saturate the wiki-server rate limiter.
+    # cancel-in-progress: true drops stale queued runs — the latest state always subsumes them.
+    concurrency:
+      group: sync-content-main
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

When multiple PRs merge in quick succession, multiple `sync-content` CI jobs start concurrently. All of them try to write 700+ pages to the wiki-server at the same time, saturating its rate limiter (HTTP 429 responses). After 3 consecutive batch failures, each sync job aborts.

This caused the CI failures in run [#23959108337](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/23959108337) and [#23959118503](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/23959118503).

## Fix

Add a job-level `concurrency` group to `sync-content` so only one instance runs at a time. `cancel-in-progress: true` means if a newer sync is queued while an older one is running, the older one gets cancelled in favour of the newer one — this is correct since the latest state subsumes all previous states.

## Verification

- The most recent run ([#23959135563](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/23959135563)) succeeded with `sync-content` passing — confirming the issue was transient concurrent rate limiting, not a code bug
- The fix is a 5-line YAML change with no logic changes