### PR TITLE
refactor: migrate political component types to Hono RPC InferResponseType

### DIFF
--- a/apps/web/src/components/political/campaign-finance.tsx
+++ b/apps/web/src/components/political/campaign-finance.tsx
@@ -20,8 +20,8 @@ import type { CampaignFinanceRecord } from "./types";
 
 // ── Numeric parsing ─────────────────────────────────────────────────
 
-/** Parse a PG numeric string to number, returning 0 for null/invalid. */
-function toNum(value: string | null): number {
+/** Convert a numeric value (number or string from PG) to number, returning 0 for null/invalid. */
+function toNum(value: number | string | null): number {
   if (value == null) return 0;
   const n = Number(value);
   return isNaN(n) ? 0 : n;

--- a/apps/web/src/components/political/finance-cell.tsx
+++ b/apps/web/src/components/political/finance-cell.tsx
@@ -18,7 +18,7 @@ import type { CampaignFinanceRecord } from "./types";
 
 // ── Numeric parsing ─────────────────────────────────────────────────
 
-function toNum(value: string | null): number {
+function toNum(value: number | string | null): number {
   if (value == null) return 0;
   const n = Number(value);
   return isNaN(n) ? 0 : n;

--- a/apps/web/src/components/political/types.ts
+++ b/apps/web/src/components/political/types.ts
@@ -1,121 +1,51 @@
 /**
  * Shared types for political data components.
  *
- * These types mirror the response shapes from the wiki-server
- * political-scores and political-offices API endpoints.
+ * These types are inferred from the wiki-server Hono RPC route definitions
+ * via `InferResponseType<>`, ensuring the frontend stays in sync with the
+ * server response shapes at compile time.
  */
+
+import type {
+  RpcPoliticalScore,
+  RpcPoliticalScoresByEntityResult,
+  RpcPoliticalOffice,
+  RpcPoliticalOfficesByEntityResult,
+  RpcCampaignFinanceRecord,
+  RpcCampaignFinanceByEntityResult,
+  RpcPoliticalVoteRecord,
+  RpcPoliticalVotesByEntityResult,
+  RpcPoliticalVotesByLegislationResult,
+} from "@/lib/wiki-server";
 
 // ── Political Score ──────────────────────────────────────────────────
 
-export interface EntityRef {
-  entityId: string | null;
-  slug: string | null;
-  name: string | null;
-}
-
-export interface PoliticalScore {
-  id: string;
-  politicianEntityId: string;
-  politicianDisplayName: string | null;
-  politician: EntityRef;
-  scorerOrg: string;
-  scorerEntityId: string | null;
-  scorer: EntityRef;
-  score: number;
-  maxScore: number;
-  year: number;
-  scoreType: string | null;
-  sourceUrl: string | null;
-  notes: string | null;
-  syncedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface PoliticalScoresByEntityResponse {
-  scores: PoliticalScore[];
-  total: number;
-}
+export type PoliticalScore = RpcPoliticalScore;
+export type PoliticalScoresByEntityResponse = RpcPoliticalScoresByEntityResult;
 
 // ── Political Office ─────────────────────────────────────────────────
 
-export type OfficeStatus = "incumbent" | "candidate" | "former";
-
-export interface PoliticalOffice {
-  id: string;
-  politicianEntityId: string;
-  politicianDisplayName: string | null;
-  politician: EntityRef;
-  officeType: string;
-  jurisdiction: string;
-  district: string | null;
-  party: string | null;
-  status: string;
-  termStart: string | null;
-  termEnd: string | null;
-  sourceUrl: string | null;
-  notes: string | null;
-  syncedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface PoliticalOfficesByEntityResponse {
-  offices: PoliticalOffice[];
-  total: number;
-}
+export type PoliticalOffice = RpcPoliticalOffice;
+export type PoliticalOfficesByEntityResponse = RpcPoliticalOfficesByEntityResult;
 
 // ── Campaign Finance ────────────────────────────────────────────────
 
-export interface CampaignFinanceRecord {
-  id: string;
-  politicianEntityId: string;
-  politicianDisplayName: string | null;
-  cycle: number;
-  totalRaised: string | null;
-  totalSpent: string | null;
-  cashOnHand: string | null;
-  individualContributions: string | null;
-  pacContributions: string | null;
-  smallDonorContributions: string | null;
-  selfFunding: string | null;
-  party: string | null;
-  officeType: string | null;
-  state: string | null;
-  district: string | null;
-  sourceUrl: string | null;
-  dataAsOf: string | null;
-}
-
-export interface CampaignFinanceByEntityResponse {
-  records: CampaignFinanceRecord[];
-  total: number;
-}
+export type CampaignFinanceRecord = RpcCampaignFinanceRecord;
+export type CampaignFinanceByEntityResponse = RpcCampaignFinanceByEntityResult;
 
 // ── Political Vote Record ───────────────────────────────────────────
 
+export type PoliticalVoteRecord = RpcPoliticalVoteRecord;
+export type PoliticalVotesByEntityResponse = RpcPoliticalVotesByEntityResult;
+export type PoliticalVotesByLegislationResponse = RpcPoliticalVotesByLegislationResult;
+
+// ── UI-only types (not derived from server responses) ───────────────
+
+/** Possible vote values for display styling. */
 export type VoteValue = "yea" | "nay" | "abstain" | "not_voting" | "present";
 
-export interface PoliticalVoteRecord {
-  id: string;
-  politicianEntityId: string;
-  politicianDisplayName: string | null;
-  legislationEntityId: string | null;
-  legislationTitle: string | null;
-  vote: string;
-  voteDate: string | null;
-  chamber: string | null;
-  rollCallNumber: number | null;
-  congressNumber: number | null;
-  sourceUrl: string | null;
-}
+/** Possible office statuses for display styling. */
+export type OfficeStatus = "incumbent" | "candidate" | "former";
 
-export interface PoliticalVotesByEntityResponse {
-  votes: PoliticalVoteRecord[];
-  total: number;
-}
-
-export interface PoliticalVotesByLegislationResponse {
-  votes: PoliticalVoteRecord[];
-  total: number;
-}
+/** Entity reference shape (inferred from server via the score/office types). */
+export type EntityRef = PoliticalScore["politician"];

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -183,6 +183,10 @@ import type { DataQualityRoute } from "@wiki-server/data-quality-route";
 import type { TalentFlowsRoute } from "@wiki-server/talent-flows-route";
 import type { JobsRoute } from "@wiki-server/jobs-route";
 import type { DataSourcesRoute } from "@wiki-server/data-sources-route";
+import type { PoliticalScoresRoute } from "@wiki-server/political-scores-route";
+import type { PoliticalOfficesRoute } from "@wiki-server/political-offices-route";
+import type { PoliticalVotesRoute } from "@wiki-server/political-votes-route";
+import type { CampaignFinanceRoute } from "@wiki-server/campaign-finance-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -473,4 +477,55 @@ export type RpcDataSourceDetailResult = InferResponseType<DataSourcesClient[':id
 
 /** Inferred response type for GET /api/data-sources/:id/snapshots (used by detail page — PR 2) */
 export type RpcSnapshotListResult = InferResponseType<DataSourcesClient[':id']['snapshots']['$get'], 200>;
+
+// ============================================================================
+// Hono RPC client — Political Scores API
+// ============================================================================
+
+type PoliticalScoresClient = ReturnType<typeof hc<PoliticalScoresRoute>>;
+
+/** Inferred response type for GET /api/political-scores/by-entity/:entityId */
+export type RpcPoliticalScoresByEntityResult = InferResponseType<PoliticalScoresClient['by-entity'][':entityId']['$get'], 200>;
+
+/** A single political score row */
+export type RpcPoliticalScore = RpcPoliticalScoresByEntityResult['scores'][number];
+
+// ============================================================================
+// Hono RPC client — Political Offices API
+// ============================================================================
+
+type PoliticalOfficesClient = ReturnType<typeof hc<PoliticalOfficesRoute>>;
+
+/** Inferred response type for GET /api/political-offices/by-entity/:entityId */
+export type RpcPoliticalOfficesByEntityResult = InferResponseType<PoliticalOfficesClient['by-entity'][':entityId']['$get'], 200>;
+
+/** A single political office row */
+export type RpcPoliticalOffice = RpcPoliticalOfficesByEntityResult['offices'][number];
+
+// ============================================================================
+// Hono RPC client — Campaign Finance API
+// ============================================================================
+
+type CampaignFinanceClient = ReturnType<typeof hc<CampaignFinanceRoute>>;
+
+/** Inferred response type for GET /api/campaign-finance/by-entity/:entityId */
+export type RpcCampaignFinanceByEntityResult = InferResponseType<CampaignFinanceClient['by-entity'][':entityId']['$get'], 200>;
+
+/** A single campaign finance record */
+export type RpcCampaignFinanceRecord = RpcCampaignFinanceByEntityResult['records'][number];
+
+// ============================================================================
+// Hono RPC client — Political Votes API
+// ============================================================================
+
+type PoliticalVotesClient = ReturnType<typeof hc<PoliticalVotesRoute>>;
+
+/** Inferred response type for GET /api/political-votes/by-entity/:entityId */
+export type RpcPoliticalVotesByEntityResult = InferResponseType<PoliticalVotesClient['by-entity'][':entityId']['$get'], 200>;
+
+/** Inferred response type for GET /api/political-votes/by-legislation/:legislationId */
+export type RpcPoliticalVotesByLegislationResult = InferResponseType<PoliticalVotesClient['by-legislation'][':legislationId']['$get'], 200>;
+
+/** A single political vote record */
+export type RpcPoliticalVoteRecord = RpcPoliticalVotesByEntityResult['votes'][number];
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -34,7 +34,11 @@
       "@wiki-server/data-quality-route": ["../wiki-server/src/routes/operational/data-quality.ts"],
       "@wiki-server/talent-flows-route": ["../wiki-server/src/routes/tablebase/talent-flows.ts"],
       "@wiki-server/jobs-route": ["../wiki-server/src/routes/operational/jobs.ts"],
-      "@wiki-server/data-sources-route": ["../wiki-server/src/routes/tablebase/data-sources.ts"]
+      "@wiki-server/data-sources-route": ["../wiki-server/src/routes/tablebase/data-sources.ts"],
+      "@wiki-server/political-scores-route": ["../wiki-server/src/routes/tablebase/political-scores.ts"],
+      "@wiki-server/political-offices-route": ["../wiki-server/src/routes/tablebase/political-offices.ts"],
+      "@wiki-server/political-votes-route": ["../wiki-server/src/routes/tablebase/political-votes.ts"],
+      "@wiki-server/campaign-finance-route": ["../wiki-server/src/routes/tablebase/campaign-finance.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary

- Replace 121 lines of hand-written response interfaces in `apps/web/src/components/political/types.ts` with type aliases derived from wiki-server route types via `InferResponseType<>`
- Add RPC type definitions for political-scores, political-offices, campaign-finance, and political-votes routes to `apps/web/src/lib/wiki-server.ts`
- Add 4 new `@wiki-server/*-route` path aliases to `apps/web/tsconfig.json`
- Fix `CampaignFinanceRecord` type mismatch: the frontend had `string | null` for monetary amounts but the server's `formatRow()` returns `number | null` -- updated `toNum()` in `campaign-finance.tsx` and `finance-cell.tsx` to accept `number | string | null`

## Why

Hand-written response types drift silently from the server. The `CampaignFinanceRecord` type already had a real mismatch (string vs number amounts). With Hono RPC inference, the types are derived from the route handler at compile time, making drift impossible.

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify political components render correctly on a person page with political data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type definitions for political data to align with backend RPC specifications, improving code maintainability.
  * Enhanced numeric value handling to support more flexible data input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->