### PR TITLE
fix: clamp all inline pagination limits instead of rejecting

### DIFF
--- a/apps/wiki-server/src/__tests__/pagination-query.test.ts
+++ b/apps/wiki-server/src/__tests__/pagination-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { paginationQuery } from "../routes/shared/utils.js";
+import { paginationQuery, clampedLimit } from "../routes/shared/utils.js";
+import { z } from "zod";
 
 describe("paginationQuery", () => {
   const schema = paginationQuery({ maxLimit: 200, defaultLimit: 50 });
@@ -54,5 +55,61 @@ describe("paginationQuery", () => {
     const defaultSchema = paginationQuery();
     const result = defaultSchema.parse({});
     expect(result.limit).toBe(50);
+  });
+});
+
+describe("clampedLimit", () => {
+  it("accepts limit within range", () => {
+    const schema = z.object({ limit: clampedLimit(200, 50) });
+    const result = schema.parse({ limit: "100" });
+    expect(result.limit).toBe(100);
+  });
+
+  it("uses default when not provided", () => {
+    const schema = z.object({ limit: clampedLimit(200, 50) });
+    const result = schema.parse({});
+    expect(result.limit).toBe(50);
+  });
+
+  it("clamps oversized limit instead of rejecting", () => {
+    const schema = z.object({ limit: clampedLimit(200, 50) });
+    const result = schema.parse({ limit: "500" });
+    expect(result.limit).toBe(200);
+  });
+
+  it("clamps limit exactly at max", () => {
+    const schema = z.object({ limit: clampedLimit(200, 50) });
+    const result = schema.parse({ limit: "200" });
+    expect(result.limit).toBe(200);
+  });
+
+  it("rejects limit below minimum (0)", () => {
+    const schema = z.object({ limit: clampedLimit(200, 50) });
+    expect(() => schema.parse({ limit: "0" })).toThrow();
+  });
+
+  it("works with different max limits", () => {
+    const schema = z.object({ limit: clampedLimit(50, 10) });
+    expect(schema.parse({ limit: "100" }).limit).toBe(50);
+    expect(schema.parse({}).limit).toBe(10);
+  });
+
+  it("works with .catch() chained after it", () => {
+    const schema = z.object({ limit: clampedLimit(500, 100).catch(100) });
+    // Non-numeric input gets caught and returns 100
+    const result = schema.parse({ limit: "not-a-number" });
+    expect(result.limit).toBe(100);
+    // Oversized input gets clamped
+    const result2 = schema.parse({ limit: "9999" });
+    expect(result2.limit).toBe(500);
+  });
+
+  it("paginationQuery uses clampedLimit internally", () => {
+    // Verify that paginationQuery and clampedLimit produce the same clamping behavior
+    const pq = paginationQuery({ maxLimit: 100, defaultLimit: 20 });
+    const cl = z.object({ limit: clampedLimit(100, 20), offset: z.coerce.number().int().min(0).default(0) });
+
+    expect(pq.parse({ limit: "500" }).limit).toBe(cl.parse({ limit: "500" }).limit);
+    expect(pq.parse({}).limit).toBe(cl.parse({}).limit);
   });
 });

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -11,6 +11,7 @@ import {
   invalidJsonError,
   dbError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { SyncFactsBatchSchema } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
@@ -23,29 +24,20 @@ const EXPORT_MAX_LIMIT = 50000;
 
 // ---- Query schemas ----
 
-/** Clamp limit to MAX_PAGE_SIZE instead of rejecting */
-const clampedLimit = (defaultVal: number) =>
-  z.coerce
-    .number()
-    .int()
-    .min(1)
-    .default(defaultVal)
-    .transform((v) => Math.min(v, MAX_PAGE_SIZE));
-
 const ByEntityQuery = z.object({
-  limit: clampedLimit(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   measure: z.string().max(100).optional(),
 });
 
 const TimeseriesQuery = z.object({
   measure: z.string().min(1).max(100),
-  limit: z.coerce.number().int().min(1).default(100).transform((v) => Math.min(v, 500)),
+  limit: clampedLimit(500, 100),
 });
 
 const StalenessQuery = z.object({
   olderThan: z.string().max(20).optional(), // e.g. "2025-01" — facts with asOf before this
-  limit: clampedLimit(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -9,6 +9,7 @@ import {
   invalidJsonError,
   firstOrThrow,
   escapeIlike,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   CreateAgentSessionSchema,
@@ -22,7 +23,7 @@ import { parseCostCents, parseDurationMinutes } from "./sessions.js";
 // ---- Query schemas ----
 
 const PageChangesQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(2000).default(500),
+  limit: clampedLimit(2000, 500),
   since: DateStringSchema.optional(),
 });
 

--- a/apps/wiki-server/src/routes/operational/artifacts.ts
+++ b/apps/wiki-server/src/routes/operational/artifacts.ts
@@ -10,6 +10,7 @@ import {
   invalidJsonError,
   notFoundError,
   paginationQuery,
+  clampedLimit,
 } from "../shared/utils.js";
 import { resolvePageIntId } from "../shared/page-id-helpers.js";
 
@@ -21,7 +22,7 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE, defaultLimit:
 
 const ByPageQuery = z.object({
   page_id: z.string().min(1).max(200),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(10),
+  limit: clampedLimit(MAX_PAGE_SIZE, 10),
 });
 
 // ---- Helpers ----

--- a/apps/wiki-server/src/routes/operational/auto-update-news.ts
+++ b/apps/wiki-server/src/routes/operational/auto-update-news.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   paginationQuery,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   AutoUpdateNewsItemSchema as SharedNewsItemSchema,
@@ -28,7 +29,7 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE, defaultLimit:
 
 const DashboardQuery = z.object({
   runs: z.coerce.number().int().min(1).max(50).default(10),
-  limit: z.coerce.number().int().min(1).max(500).default(200),
+  limit: clampedLimit(500, 200),
 });
 
 // ---- Helpers ----

--- a/apps/wiki-server/src/routes/operational/data-quality.ts
+++ b/apps/wiki-server/src/routes/operational/data-quality.ts
@@ -20,7 +20,7 @@ import {
   wikiPages,
   facts,
 } from "../../schema.js";
-import { zv } from "../shared/utils.js";
+import { zv, clampedLimit } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 
 // ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ import { logger } from "../../logger.js";
 // ---------------------------------------------------------------------------
 
 const HistoryQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  limit: clampedLimit(200, 50),
   offset: z.coerce.number().int().min(0).optional().default(0),
 });
 

--- a/apps/wiki-server/src/routes/operational/operations-log.ts
+++ b/apps/wiki-server/src/routes/operational/operations-log.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { desc } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { operationsLog } from "../../schema.js";
-import { zv } from "../shared/utils.js";
+import { zv, clampedLimit } from "../shared/utils.js";
 import { z } from "zod";
 
 const CreateOperationSchema = z.object({
@@ -13,11 +13,14 @@ const CreateOperationSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
 });
 
+const ListQuery = z.object({
+  limit: clampedLimit(200, 50),
+});
+
 const operationsLogApp = new Hono()
-  .get("/", async (c) => {
+  .get("/", zv("query", ListQuery), async (c) => {
     const db = getDrizzleDb();
-    const raw = parseInt(c.req.query("limit") ?? "50", 10);
-    const limit = Math.min(Math.max(Number.isNaN(raw) || raw < 1 ? 50 : raw, 1), 200);
+    const { limit } = c.req.valid("query");
 
     const rows = await db
       .select()

--- a/apps/wiki-server/src/routes/operational/sessions.ts
+++ b/apps/wiki-server/src/routes/operational/sessions.ts
@@ -4,7 +4,15 @@ import { eq, count, sql, desc, inArray, gte, like } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { logger as rootLogger } from "../../logger.js";
 import { sessions, sessionPages, wikiPages } from "../../schema.js";
-import { parseJsonBody, validationError, invalidJsonError, firstOrThrow, paginationQuery, dbError } from "../shared/utils.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+  firstOrThrow,
+  paginationQuery,
+  dbError,
+  clampedLimit,
+} from "../shared/utils.js";
 import {
   CreateSessionSchema as SharedCreateSessionSchema,
   CreateSessionBatchSchema,
@@ -76,7 +84,7 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE, defaultLimit:
 
 const PageChangesQuery = z.object({
   /** Maximum number of sessions to return. Defaults to 500. */
-  limit: z.coerce.number().int().min(1).max(2000).default(500),
+  limit: clampedLimit(2000, 500),
   /** Only include sessions on or after this date (YYYY-MM-DD). */
   since: DateStringSchema.optional(),
 });

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -6,6 +6,24 @@ import { logger as rootLogger } from "../../logger.js";
 const logger = rootLogger.child({ component: "db" });
 
 /**
+ * Create a clamped limit field for pagination schemas.
+ * Values above maxLimit are silently clamped (not rejected with 400)
+ * so clients requesting larger pages get the maximum allowed.
+ *
+ * Use this instead of `.max(N)` on limit fields — `.max()` rejects
+ * oversized values with a 400 error, which can cause retry storms
+ * when clients send large page sizes (see issue #3743).
+ */
+export function clampedLimit(maxLimit: number, defaultLimit: number) {
+  return z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(defaultLimit)
+    .transform((v) => Math.min(v, maxLimit));
+}
+
+/**
  * Create a PaginationQuery schema with configurable limits.
  * Each route can call this with its own defaults while sharing the base shape.
  * Values above maxLimit are clamped (not rejected) so clients requesting larger
@@ -17,12 +35,7 @@ export function paginationQuery(opts?: {
 }) {
   const { maxLimit = 200, defaultLimit = 50 } = opts ?? {};
   return z.object({
-    limit: z.coerce
-      .number()
-      .int()
-      .min(1)
-      .default(defaultLimit)
-      .transform((v) => Math.min(v, maxLimit)),
+    limit: clampedLimit(maxLimit, defaultLimit),
     offset: z.coerce.number().int().min(0).default(0),
   });
 }

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -35,6 +35,7 @@ import {
 } from "../../schema.js";
 import {
   zv,
+  clampedLimit,
   parseJsonBody,
   validationError,
   invalidJsonError,
@@ -101,12 +102,7 @@ const VerdictUpsertBody = z.object({
 });
 
 /** Limit field that clamps to MAX_PAGE_SIZE instead of rejecting */
-const clampedLimit = z.coerce
-  .number()
-  .int()
-  .min(1)
-  .default(50)
-  .transform((v) => Math.min(v, MAX_PAGE_SIZE));
+const defaultClampedLimit = clampedLimit(MAX_PAGE_SIZE, 50);
 
 const VerdictsQuery = z.object({
   record_type: z.string().max(50).optional(),
@@ -117,17 +113,17 @@ const VerdictsQuery = z.object({
     .transform((v) => v === "true")
     .optional(),
   q: z.string().max(500).optional(),
-  limit: clampedLimit,
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const EvidenceQuery = z.object({
-  limit: clampedLimit,
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const DueForRecheckQuery = z.object({
-  limit: clampedLimit,
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
   record_type: z.string().max(50).optional(),
   min_priority: z.coerce.number().optional(),
@@ -135,7 +131,7 @@ const DueForRecheckQuery = z.object({
 
 const StaleEvidenceQuery = z.object({
   record_type: z.string().max(50).optional(),
-  limit: clampedLimit,
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 
@@ -154,13 +150,13 @@ const ResolveNamesQuery = z.object({
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
   verdict: z.string().max(50).optional(),
 });
 
 const ByPageQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 
@@ -175,7 +171,7 @@ const FailuresQuery = z.object({
   error_type: z.string().max(50).optional(),
   record_type: z.string().max(50).optional(),
   entity_id: z.string().max(200).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 
@@ -183,7 +179,7 @@ const StaleQuery = z.object({
   days: z.coerce.number().int().min(1).max(3650).default(90),
   record_type: z.string().max(50).optional(),
   entity_id: z.string().max(200).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -9,6 +9,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
@@ -23,17 +24,17 @@ const MAX_PAGE_SIZE = 200;
 // ---- Query schemas ----
 
 const ByBenchmarkQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const ByModelQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/benchmarks.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmarks.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 
@@ -30,7 +31,7 @@ const VALID_CATEGORIES = [
 
 const AllQuery = z.object({
   category: z.enum(VALID_CATEGORIES).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/bluesky.ts
+++ b/apps/wiki-server/src/routes/tablebase/bluesky.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 
@@ -19,13 +20,13 @@ const BLUESKY_PUBLIC_API = "https://public.api.bsky.app/xrpc";
 // ---- Query schemas ----
 
 const AccountsQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   tag: z.string().optional(),
 });
 
 const PostsQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   accountDid: z.string().optional(),
   dateFrom: z.string().datetime({ message: "dateFrom must be an ISO-8601 datetime string" }).optional(),

--- a/apps/wiki-server/src/routes/tablebase/campaign-finance.ts
+++ b/apps/wiki-server/src/routes/tablebase/campaign-finance.ts
@@ -11,6 +11,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 
@@ -21,7 +22,7 @@ const MAX_PAGE_SIZE = 500;
 // ---- Query schemas ----
 
 const ListQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   cycle: z.coerce.number().int().optional(),
   state: z.string().max(5).optional(),

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -14,6 +14,7 @@ import {
   escapeIlike,
   dbError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   SyncEntitySchema as SharedSyncEntitySchema,
@@ -105,7 +106,7 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({
 
 const SearchQuery = z.object({
   q: z.string().min(1).max(500),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  limit: clampedLimit(100, 20),
 });
 
 // ---- Organizations query schema ----
@@ -113,7 +114,7 @@ const SearchQuery = z.object({
 const ORG_SORT_ALLOWED = ["name", "revenue", "valuation", "headcount", "totalFunding", "founded"] as const;
 
 const OrganizationsQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
   q: z.string().max(200).optional(),
   sort: z.string().max(50).optional(),

--- a/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -32,12 +33,12 @@ const VALID_ASSESSORS = [
 // ---- Schemas ----
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/entity-events.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-events.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -42,12 +43,12 @@ const VALID_SIGNIFICANCE = ["major", "moderate", "minor"] as const;
 // ---- Schemas ----
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   eventType: z.enum(VALID_EVENT_TYPES).optional(),
 });

--- a/apps/wiki-server/src/routes/tablebase/equity-positions.ts
+++ b/apps/wiki-server/src/routes/tablebase/equity-positions.ts
@@ -10,6 +10,7 @@ import {
   invalidJsonError,
   zv,
   parseRange,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
@@ -24,12 +25,12 @@ const MAX_PAGE_SIZE = 200;
 // ---- Query schemas ----
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -12,6 +12,7 @@ import {
   zv,
   parseRange,
   noDuplicateIds,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
@@ -29,12 +30,12 @@ const MAX_PAGE_SIZE = 200;
 // ---- Query schemas ----
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -18,6 +18,7 @@ import {
   invalidJsonError,
   zv,
   noDuplicateIds,
+  clampedLimit,
 } from "../shared/utils.js";
 import { parseSort, buildSearchCondition } from "../shared/query-helpers.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
@@ -38,7 +39,7 @@ const MAX_PAGE_SIZE = 200;
 const SORT_ALLOWED = ["amount", "date", "name", "recipient"] as const;
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
   q: z.string().max(200).optional(),
   sort: z.string().max(50).optional(),
@@ -49,7 +50,7 @@ const ByEntityQuery = z.object({
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/ids.ts
+++ b/apps/wiki-server/src/routes/tablebase/ids.ts
@@ -9,6 +9,7 @@ import {
   validationError,
   invalidJsonError,
   notFoundError,
+  clampedLimit,
 } from "../shared/utils.js";
 
 /**
@@ -83,7 +84,7 @@ const AllocateBatchSchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(1000).default(100),
+  limit: clampedLimit(1000, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/investments.ts
+++ b/apps/wiki-server/src/routes/tablebase/investments.ts
@@ -12,6 +12,7 @@ import {
   zv,
   parseRange,
   noDuplicateIds,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
@@ -29,12 +30,12 @@ const MAX_PAGE_SIZE = 200;
 // ---- Query schemas ----
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/people.ts
+++ b/apps/wiki-server/src/routes/tablebase/people.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { zv, escapeIlike } from "../shared/utils.js";
+import { zv, escapeIlike, clampedLimit } from "../shared/utils.js";
 import { parseSort, TRIGRAM_FALLBACK_THRESHOLD } from "../shared/query-helpers.js";
 import {
   buildPrefixTsquery,
@@ -25,7 +25,7 @@ const SORT_ALLOWED = [
 ] as const;
 
 const PeopleQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
   q: z.string().max(200).optional(),
   sort: z.string().max(50).optional(),

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -17,6 +17,7 @@ import {
   invalidJsonError,
   zv,
   noDuplicateIds,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
@@ -40,18 +41,18 @@ import { isSid } from "@longterm-wiki/id-utils";
 
 const ByEntityQuery = z.object({
   role_type: z.enum(VALID_ROLE_TYPES).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const ByPersonQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const AllQuery = z.object({
   role_type: z.enum(VALID_ROLE_TYPES).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+++ b/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
@@ -39,12 +40,12 @@ const SyncStakeholderBatchSchema = z.object({
 
 const ByPolicyQuery = z.object({
   position: z.enum(VALID_POSITIONS).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const ByStakeholderQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/political-offices.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-offices.ts
@@ -11,6 +11,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 
@@ -40,7 +41,7 @@ const VALID_PARTIES = [
 // ---- Query schemas ----
 
 const ListQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   politicianEntityId: z.string().max(200).optional(),
   officeType: z.string().max(100).optional(),

--- a/apps/wiki-server/src/routes/tablebase/political-races.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-races.ts
@@ -16,6 +16,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
@@ -56,7 +57,7 @@ const VALID_PAC_POSITIONS = ["support", "oppose"] as const;
 // ---- Query schemas ----
 
 const ListQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   status: z.string().max(50).optional(),
   level: z.string().max(50).optional(),
@@ -65,12 +66,12 @@ const ListQuery = z.object({
 });
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const CandidatesAllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(1000).default(1000),
+  limit: clampedLimit(1000, 1000),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/political-scores.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-scores.ts
@@ -11,6 +11,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 
@@ -34,7 +35,7 @@ const VALID_SCORE_TYPES = [
 // ---- Query schemas ----
 
 const ListQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   politicianEntityId: z.string().max(200).optional(),
   scorerOrg: z.string().max(100).optional(),

--- a/apps/wiki-server/src/routes/tablebase/political-votes.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-votes.ts
@@ -11,6 +11,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 
@@ -36,7 +37,7 @@ const VALID_CHAMBERS = [
 // ---- Query schemas ----
 
 const ListQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   chamber: z.string().max(50).optional(),
   vote: z.string().max(20).optional(),

--- a/apps/wiki-server/src/routes/tablebase/prediction-markets.ts
+++ b/apps/wiki-server/src/routes/tablebase/prediction-markets.ts
@@ -13,6 +13,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -41,7 +42,7 @@ const VALID_QUESTION_TYPES = [
 // ---- Query schemas ----
 
 const QuestionsQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   category: z.string().optional(),
@@ -52,7 +53,7 @@ const QuestionsQuery = z.object({
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   category: z.string().optional(),
@@ -63,7 +64,7 @@ const ByEntityQuery = z.object({
 });
 
 const TimeseriesQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(500),
+  limit: clampedLimit(MAX_PAGE_SIZE, 500),
 });
 
 // ---- Sync schemas ----

--- a/apps/wiki-server/src/routes/tablebase/publications.ts
+++ b/apps/wiki-server/src/routes/tablebase/publications.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -37,14 +38,14 @@ const VALID_PUBLICATION_TYPES = [
 // ---- Schemas ----
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   publicationType: z.enum(VALID_PUBLICATION_TYPES).optional(),
   flagshipOnly: z.coerce.boolean().optional(),
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   publicationType: z.enum(VALID_PUBLICATION_TYPES).optional(),
   flagshipOnly: z.coerce.boolean().optional(),

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import {
@@ -43,7 +44,7 @@ const VALID_STATUSES = [
 const AllQuery = z.object({
   cluster: z.string().max(50).optional(),
   status: z.string().max(50).optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
+++ b/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
@@ -9,6 +9,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
@@ -41,7 +42,7 @@ const VALID_PRICE_TYPES = [
 // ---- Query schemas ----
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   dateFrom: z.string().optional(),
@@ -49,7 +50,7 @@ const AllQuery = z.object({
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   dateFrom: z.string().optional(),
@@ -59,7 +60,7 @@ const ByEntityQuery = z.object({
 const TimeseriesQuery = z.object({
   platform: z.string().optional(),
   priceType: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(500),
+  limit: clampedLimit(MAX_PAGE_SIZE, 500),
 });
 
 // ---- Sync schema ----

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -20,6 +20,7 @@ import {
   parseJsonBody,
   invalidJsonError,
   escapeIlike,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   normalizeSearchQuery,
@@ -41,14 +42,14 @@ const ListQuery = z.object({
   parent_id: z.string().max(100).optional(),
   sort: z.enum(["title", "updated_at", "created_at", "thing_type"]).default("title"),
   order: z.enum(["asc", "desc"]).default("asc"),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
 const SearchQuery = z.object({
   q: z.string().min(1).max(500),
   thing_type: z.string().max(50).optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  limit: clampedLimit(100, 20),
 });
 
 const StatsQuery = z.object({

--- a/apps/wiki-server/src/routes/tablebase/website-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/website-sources.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 
 // ---- Constants ----
@@ -31,7 +32,7 @@ const VALID_PAGE_ROLES = [
 // ---- Schemas ----
 
 const AllQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(200),
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   enabled: z
     .enum(["true", "false"])
@@ -40,7 +41,7 @@ const AllQuery = z.object({
 });
 
 const ByEntityQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/apps/wiki-server/src/routes/wikibase/assessments.ts
+++ b/apps/wiki-server/src/routes/wikibase/assessments.ts
@@ -9,6 +9,7 @@ import {
   invalidJsonError,
   firstOrThrow,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   PageAssessmentSchema,
@@ -59,12 +60,12 @@ interface UniqueCountRow {
 
 const HistoryQuery = z.object({
   pageId: z.string().min(1).max(300),
-  limit: z.coerce.number().int().min(1).max(200).default(50),
+  limit: clampedLimit(200, 50),
   assessor: z.enum(VALID_ASSESSORS).optional(),
 });
 
 const LatestQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(1000).default(200),
+  limit: clampedLimit(1000, 200),
   offset: z.coerce.number().int().min(0).default(0),
   assessor: z.enum(VALID_ASSESSORS).optional(),
 });

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -11,6 +11,7 @@ import {
   dbError,
   paginationQuery,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   UpsertCitationQuoteSchema,
@@ -194,18 +195,18 @@ const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE, defaultLimit:
 // Query schemas for endpoints that accept only a limit param
 const QuotesLimitQuery = z.object({
   page_id: z.string().min(1, "page_id query parameter is required").max(500),
-  limit: z.coerce.number().int().min(1).max(500).default(100).catch(100),
+  limit: clampedLimit(500, 100).catch(100),
 });
 const TrendsLimitQuery = z.object({
   page_id: z.string().min(1).max(500).optional(),
-  limit: z.coerce.number().int().min(1).max(500).default(50).catch(50),
+  limit: clampedLimit(500, 50).catch(50),
 });
 const QuotesByUrlQuery = z.object({
   url: z.string().min(1, "url query parameter is required").max(2000),
-  limit: z.coerce.number().int().min(1).max(500).default(100).catch(100),
+  limit: clampedLimit(500, 100).catch(100),
 });
 const UnverifiedLimitQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(100).catch(100),
+  limit: clampedLimit(MAX_PAGE_SIZE, 100).catch(100),
 });
 const CleanupQuery = z.object({
   keep: z.coerce.number().int().min(1).max(1000).default(30).catch(30),

--- a/apps/wiki-server/src/routes/wikibase/explore.ts
+++ b/apps/wiki-server/src/routes/wikibase/explore.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { getDb } from "../../db.js";
-import { validationError } from "../shared/utils.js";
+import { validationError, clampedLimit } from "../shared/utils.js";
 import {
   buildPrefixTsquery,
   titleMatchBoostExpr,
@@ -48,7 +48,7 @@ interface FacetCountRow {
 // ---- Query Schema ----
 
 const ExploreQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(200).default(50),
+  limit: clampedLimit(200, 50),
   offset: z.coerce.number().int().min(0).default(0),
   search: z.string().max(500).optional(),
   entityType: z.string().max(100).optional(),

--- a/apps/wiki-server/src/routes/wikibase/hallucination-risk.ts
+++ b/apps/wiki-server/src/routes/wikibase/hallucination-risk.ts
@@ -8,6 +8,7 @@ import {
   validationError,
   invalidJsonError,
   firstOrThrow,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   RiskSnapshotSchema as SharedSnapshotSchema,
@@ -54,13 +55,13 @@ const BatchSchema = RiskSnapshotBatchSchema;
 
 const HistoryQuery = z.object({
   page_id: z.string().min(1).max(300),
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
 });
 
 const StatsQuery = z.object({});
 
 const LatestQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(50),
+  limit: clampedLimit(MAX_PAGE_SIZE, 50),
   offset: z.coerce.number().int().min(0).default(0),
   level: z.enum(VALID_LEVELS).optional(),
 });

--- a/apps/wiki-server/src/routes/wikibase/links.ts
+++ b/apps/wiki-server/src/routes/wikibase/links.ts
@@ -1,10 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { getDb, getDrizzleDb, beginTransaction } from "../../db.js";
-import {
-  validationError,
-  zv,
-} from "../shared/utils.js";
+import { validationError, zv, clampedLimit } from "../shared/utils.js";
 import { SyncLinksBatchSchema } from "../../api-types.js";
 import { resolvePageIntId } from "../shared/page-id-helpers.js";
 
@@ -73,11 +70,11 @@ const INVERSE_LABEL: Record<string, string> = {
 const SyncBatchSchema = SyncLinksBatchSchema;
 
 const BacklinksQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(200).default(50),
+  limit: clampedLimit(200, 50),
 });
 
 const RelatedQuery = z.object({
-  limit: z.coerce.number().int().min(1).max(50).default(MAX_RELATED),
+  limit: clampedLimit(50, MAX_RELATED),
 });
 
 // ---- Raw SQL row types ----

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -9,6 +9,7 @@ import {
   dbError,
   paginationQuery,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 import {
@@ -53,7 +54,7 @@ export const SyncBatchSchema = SyncPagesBatchSchema;
 
 const SearchQuery = z.object({
   q: z.string().min(1).max(500),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  limit: clampedLimit(100, 20),
 });
 
 const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -30,6 +30,7 @@ import {
   dbError,
   paginationQuery,
   zv,
+  clampedLimit,
 } from "../shared/utils.js";
 import {
   UpsertResourceSchema as SharedUpsertResourceSchema,
@@ -116,7 +117,7 @@ const UpsertBatchSchema = UpsertResourceBatchSchema;
 
 const SearchQuery = z.object({
   q: z.string().min(1).max(500),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  limit: clampedLimit(100, 20),
 });
 
 const PaginationQuery = paginationQuery({ maxLimit: MAX_PAGE_SIZE }).extend({


### PR DESCRIPTION
## Summary

Follow-up to #3756. The original PR fixed `paginationQuery()` to clamp oversized limits, but **67 inline schemas** across 42 route files still used `.max(N)` which rejects oversized values with 400 errors.

This was the root cause of issue #3743: the source-check orchestrator sent `limit=1000` to `/api/source-checks/verdicts`, got a 400, retried, and generated 3,861 duplicate verification attempts.

### Changes

- **`shared/utils.ts`**: New `clampedLimit(maxLimit, defaultLimit)` helper. `paginationQuery()` now delegates to it.
- **`source-checks.ts`** (most critical): All 8 query schemas now clamp instead of rejecting
- **37 other route files**: All `limit` fields switched from `.max(N)` to `clampedLimit(N, D)`
- **`facts.ts`**: Removed local `clampedLimit` helper, uses shared version
- **`operations-log.ts`**: Replaced manual `Math.min(Math.max(...))` with `zv` + `clampedLimit`
- **`pagination-query.test.ts`**: 8 new tests for the `clampedLimit()` helper

### Why clamp instead of reject?

`.max(N)` in Zod rejects with a validation error (400). For pagination limits, this is wrong because:
- Clients sending `limit=1000` just want "as many as possible" — returning 200 items satisfies that intent
- 400 errors trigger retry logic in HTTP clients, making the problem worse
- The server already has a maximum anyway — clamping is the natural behavior

Closes #3743

## Test plan

- [x] `pnpm test` — all 4841 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit` in both `wiki-server` and `web`)
- [x] No remaining `.max()` on `limit` fields in any route file
- [x] New tests verify clamping behavior, `.catch()` chaining, and consistency with `paginationQuery()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized pagination limit handling across API endpoints for consistent behavior.

* **Bug Fixes**
  * Unified pagination limit validation to clamp oversized requests instead of rejecting them, improving request resilience.

* **Tests**
  * Added comprehensive test coverage for pagination limit validation and clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->