### PR TITLE
fix: self-healing .agent-slot — post-checkout hook + session/heartbeat repair

### DIFF
--- a/.claude/hooks/heartbeat.sh
+++ b/.claude/hooks/heartbeat.sh
@@ -41,8 +41,18 @@ if curl -s --max-time 3 \
   -d '{}' >/dev/null 2>&1; then
   touch "$HEARTBEAT_FILE"
 
-  # Update tmux window with current branch + PR info
+  # Self-heal .agent-slot if missing (git operations on stale branches delete it)
+  # See: https://github.com/quantified-uncertainty/longterm-wiki/discussions/3779
   AGENT_SLOT_FILE="$REPO_ROOT/.agent-slot"
+  DIR_NAME=$(basename "$REPO_ROOT")
+  if [[ "$DIR_NAME" =~ ^a([0-9]+)$ ]]; then
+    SLOT_FROM_DIR="${BASH_REMATCH[1]}"
+    CURRENT_SLOT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+    if [ "$CURRENT_SLOT" != "$SLOT_FROM_DIR" ]; then
+      echo "$SLOT_FROM_DIR" > "$AGENT_SLOT_FILE"
+    fi
+  fi
+
   if [ -f "$AGENT_SLOT_FILE" ] && command -v tmux >/dev/null 2>&1 && [ -n "${TMUX:-}" ]; then
     SLOT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null || true)
     CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo "?")

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -143,14 +143,33 @@ if [ -n "$ISSUE_NUM" ]; then
   CONTEXT_LINES+=("→ Remember to run: pnpm crux gh issues start ${ISSUE_NUM}")
 fi
 
-# ─── 5b. Tmux window naming from agent slot ───────────────────────────────────
+# ─── 5b. Self-heal .agent-slot + Tmux window naming ──────────────────────────
+# .agent-slot gets deleted by git operations on stale branches that still track it.
+# See: https://github.com/quantified-uncertainty/longterm-wiki/discussions/3779
+# Self-heal: derive slot number from directory name (a7 → 7) and recreate if missing/wrong.
 AGENT_SLOT_FILE="$REPO_ROOT/.agent-slot"
-if [ -f "$AGENT_SLOT_FILE" ] && command -v tmux >/dev/null 2>&1 && [ -n "${TMUX:-}" ]; then
-  SLOT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null || true)
-  if [ -n "$SLOT" ]; then
-    tmux rename-window "A${SLOT}:${BRANCH}" 2>/dev/null || true
-    CONTEXT_LINES+=("Tmux: window renamed to A${SLOT}:${BRANCH}")
+DIR_NAME=$(basename "$REPO_ROOT")
+SLOT_FROM_DIR=""
+if [[ "$DIR_NAME" =~ ^a([0-9]+)$ ]]; then
+  SLOT_FROM_DIR="${BASH_REMATCH[1]}"
+fi
+
+if [ -n "$SLOT_FROM_DIR" ]; then
+  CURRENT_SLOT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+  if [ "$CURRENT_SLOT" != "$SLOT_FROM_DIR" ]; then
+    echo "$SLOT_FROM_DIR" > "$AGENT_SLOT_FILE"
+    if [ -z "$CURRENT_SLOT" ]; then
+      WARNINGS+=(".agent-slot was missing — recreated with value ${SLOT_FROM_DIR} (self-healed from dir name)")
+    else
+      WARNINGS+=(".agent-slot had wrong value '${CURRENT_SLOT}' — fixed to ${SLOT_FROM_DIR} (self-healed from dir name)")
+    fi
   fi
+fi
+
+SLOT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+if [ -n "$SLOT" ] && command -v tmux >/dev/null 2>&1 && [ -n "${TMUX:-}" ]; then
+  tmux rename-window "A${SLOT}:${BRANCH}" 2>/dev/null || true
+  CONTEXT_LINES+=("Tmux: window renamed to A${SLOT}:${BRANCH}")
 fi
 
 # ─── 6. Active agent registration/heartbeat ──────────────────────────────────────

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Post-checkout hook — repairs .agent-slot after branch switches.
+#
+# .agent-slot gets deleted when checking out branches that predate the
+# April 2026 fix that untracked it from git. This hook recreates it
+# immediately from the directory name.
+#
+# See: https://github.com/quantified-uncertainty/longterm-wiki/discussions/3779
+#
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+
+DIR_NAME=$(basename "$REPO_ROOT")
+AGENT_SLOT_FILE="$REPO_ROOT/.agent-slot"
+
+# Only applies to agent slot directories (a1, a2, ..., a20)
+if [[ "$DIR_NAME" =~ ^a([0-9]+)$ ]]; then
+  EXPECTED="${BASH_REMATCH[1]}"
+  CURRENT=$(cat "$AGENT_SLOT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+  if [ "$CURRENT" != "$EXPECTED" ]; then
+    echo "$EXPECTED" > "$AGENT_SLOT_FILE"
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds `post-checkout` git hook that recreates `.agent-slot` immediately after every `git checkout`/`git switch` — this is the exact moment git deletes the file
- Adds self-healing to `session-start.sh` — repairs `.agent-slot` on every Claude session start/resume with a warning
- Adds self-healing to `heartbeat.sh` — repairs `.agent-slot` every 10 min during active sessions

All three derive the slot number from the directory name (`a7` → `7`), which is the ground truth that can never be corrupted by git.

## Root cause

`.agent-slot` was accidentally committed to git on March 13, removed/re-committed 7+ times, and finally properly untracked on April 1-2. But **268+ remote branches still have it tracked**. Any `git checkout` crossing one of these stale branches silently deletes the file.

Full investigation and repair log: https://github.com/quantified-uncertainty/longterm-wiki/discussions/3779

## Test plan

- [x] Syntax checked all three shell scripts (`bash -n`)
- [x] Tested `post-checkout` hook: deleted `.agent-slot`, ran hook, verified it recreated with correct value
- [x] Tested session-start self-healing: set `.agent-slot` to wrong value (`8`), verified hook corrects to `7`
- [x] Traced through the deletion scenario step-by-step to confirm `post-checkout` fires at the right moment

🤖 Generated with [Claude Code](https://claude.com/claude-code)