### PR TITLE
fix: aggregate sub-PR deploy tasks into release PR body

### DIFF
--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -14,7 +14,11 @@ import { execFileSync } from 'child_process';
 import { createLogger } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
-import { detectDeployTasks, formatDeployTasksSection } from '../lib/deploy-tasks/detect.ts';
+import {
+  detectDeployTasks,
+  formatDeployTasksSection,
+  parseDeployTasksFromBody,
+} from '../lib/deploy-tasks/detect.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -102,16 +106,61 @@ export function groupCommits(subjects: string[]): Record<CommitCategory, string[
   return groups;
 }
 
+// ── Sub-PR deploy task aggregation ──────────────────────────────────────────
+
+interface SubPrData {
+  number: number;
+  title: string;
+  body: string | null;
+  merged_at: string | null;
+  base: { ref: string };
+}
+
+/**
+ * Fetch unchecked deploy tasks from PRs merged to main since the last release.
+ * These are tasks that individual PRs declared but that the file-diff detector
+ * wouldn't pick up (e.g., manually added tasks, env vars not yet in code).
+ */
+export async function fetchSubPrDeployTasks(): Promise<string[]> {
+  const lookbackDays = 14;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+
+  const prs = await githubApi<SubPrData[]>(
+    `/repos/${REPO}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=50`
+  );
+
+  const tasks: string[] = [];
+
+  for (const pr of prs) {
+    if (!pr.merged_at || !pr.body) continue;
+    if (new Date(pr.merged_at) < cutoff) continue;
+    // Skip release PRs (they target production, not main)
+    if (pr.base.ref !== 'main') continue;
+
+    const parsed = parseDeployTasksFromBody(pr.body);
+    if (!parsed || parsed.unchecked === 0) continue;
+
+    for (const item of parsed.items) {
+      if (!item.checked) {
+        tasks.push(`${item.text} _(from PR #${pr.number})_`);
+      }
+    }
+  }
+
+  return tasks;
+}
+
 /**
  * Generate a release PR body from commit data.
  */
-export function generateReleaseBody(opts: {
+export async function generateReleaseBody(opts: {
   date: string;
   ahead: number;
   behind: number;
   subjects: string[];
   repoSlug: string;
-}): string {
+}): Promise<string> {
   const { date, ahead, behind, subjects, repoSlug } = opts;
   const groups = groupCommits(subjects);
   const lines: string[] = [];
@@ -147,7 +196,19 @@ export function generateReleaseBody(opts: {
 
   // Detect deploy tasks from the diff
   const deployResult = detectDeployTasks('origin/production');
-  const deploySection = formatDeployTasksSection(deployResult.tasks);
+  const diffTasks = deployResult.tasks;
+
+  // Fetch unchecked deploy tasks from sub-PRs merged to main
+  let subPrTasks: string[] = [];
+  try {
+    subPrTasks = await fetchSubPrDeployTasks();
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`Warning: failed to fetch sub-PR deploy tasks: ${msg}`);
+  }
+
+  // Build the deploy checklist section
+  const deploySection = formatDeployTasksSection(diffTasks, subPrTasks);
   lines.push(deploySection);
   lines.push('');
 
@@ -232,7 +293,7 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
   // Generate changelog
   const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD in UTC
   const subjects = commitSubjects('origin/production', 'origin/main');
-  const body = generateReleaseBody({
+  const body = await generateReleaseBody({
     date,
     ahead,
     behind,

--- a/crux/lib/deploy-tasks/__tests__/detect.test.ts
+++ b/crux/lib/deploy-tasks/__tests__/detect.test.ts
@@ -418,6 +418,42 @@ describe('formatDeployTasksSection', () => {
     expect(section).not.toContain('- [x]');
   });
 
+  // 4b. Sub-PR tasks are included in output
+  it('includes sub-PR tasks alongside diff-detected tasks', () => {
+    const tasks: DeployTask[] = [
+      makeTask({ id: 'env-FOO', description: 'Set FOO in production', category: 'env' }),
+    ];
+    const subPrTasks = [
+      '`env` Set BAR in production _(from PR #100)_',
+      '`migration` Run fix-data.sql _(from PR #200)_',
+    ];
+
+    const section = formatDeployTasksSection(tasks, subPrTasks);
+    expect(section).toContain('- [ ] `env` Set FOO in production');
+    expect(section).toContain('- [ ] `env` Set BAR in production _(from PR #100)_');
+    expect(section).toContain('- [ ] `migration` Run fix-data.sql _(from PR #200)_');
+    expect(section).not.toContain('No deploy tasks required.');
+
+    const checkboxLines = section.split('\n').filter((l) => l.startsWith('- [ ]'));
+    expect(checkboxLines).toHaveLength(3);
+  });
+
+  // 4c. Sub-PR tasks alone (no diff-detected tasks)
+  it('shows sub-PR tasks even when no diff-detected tasks exist', () => {
+    const subPrTasks = ['`env` Set BAZ in production _(from PR #300)_'];
+
+    const section = formatDeployTasksSection([], subPrTasks);
+    expect(section).toContain('- [ ] `env` Set BAZ in production _(from PR #300)_');
+    expect(section).not.toContain('No deploy tasks required.');
+  });
+
+  // 4d. Empty diff tasks + empty sub-PR tasks shows "No deploy tasks required"
+  it('shows "No deploy tasks required" when both sources are empty', () => {
+    const section = formatDeployTasksSection([], []);
+    expect(section).toContain('No deploy tasks required.');
+    expect(section).not.toContain('- [ ]');
+  });
+
   // 5. Tasks with special characters in description
   it('formats tasks with special characters in description', () => {
     const tasks: DeployTask[] = [

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -491,13 +491,19 @@ export function parseDeployTasksFromBody(body: string): ParsedDeployTasks | null
 
 /**
  * Format deploy tasks into a markdown section for PR descriptions.
+ *
+ * @param tasks - Tasks auto-detected from the file diff
+ * @param subPrTasks - Pre-formatted task strings from sub-PRs (already include PR ref)
  */
-export function formatDeployTasksSection(tasks: DeployTask[]): string {
+export function formatDeployTasksSection(
+  tasks: DeployTask[],
+  subPrTasks: string[] = []
+): string {
   const lines: string[] = [];
   lines.push("## Deploy Checklist");
   lines.push("<!-- deploy-tasks:v1 -->");
 
-  if (tasks.length === 0) {
+  if (tasks.length === 0 && subPrTasks.length === 0) {
     lines.push("No deploy tasks required.");
   } else {
     for (const task of tasks) {
@@ -506,6 +512,9 @@ export function formatDeployTasksSection(tasks: DeployTask[]): string {
         line += ` — \`${task.verifyCommand}\``;
       }
       lines.push(line);
+    }
+    for (const task of subPrTasks) {
+      lines.push(`- [ ] ${task}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- `crux gh release create` now fetches unchecked deploy tasks from PRs merged to main (14-day lookback) and includes them in the release PR body
- Previously only file-diff pattern matching was used, silently dropping manually-added deploy tasks from sub-PRs
- `formatDeployTasksSection` now accepts an optional `subPrTasks` parameter (backwards-compatible)

## Changes
- `release.ts`: `generateReleaseBody` is now async; calls `fetchSubPrDeployTasks()` to collect unchecked tasks from merged sub-PRs via GitHub API
- `detect.ts`: `formatDeployTasksSection` accepts optional `subPrTasks: string[]` and renders them alongside diff-detected tasks
- 3 new tests covering sub-PR task inclusion, sub-PR-only tasks, and empty state

## Test plan
- [x] All 43 deploy-tasks tests pass (40 existing + 3 new)
- [x] Type-check clean on modified files
- [ ] CI green

Closes #3782

🤖 Generated with [Claude Code](https://claude.com/claude-code)