### PR TITLE
fix: use sort=created for deploy-tasks GitHub API queries

### DIFF
--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -102,7 +102,7 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
   const prs = await githubApi<PrData[]>(
-    `/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=30`
+    `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
   );
 
   const pendingPrs: Array<{

--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -127,7 +127,7 @@ export async function fetchSubPrDeployTasks(): Promise<string[]> {
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
   const prs = await githubApi<SubPrData[]>(
-    `/repos/${REPO}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=50`
+    `/repos/${REPO}/pulls?state=closed&base=main&sort=created&direction=desc&per_page=50`
   );
 
   const tasks: string[] = [];


### PR DESCRIPTION
## Summary
- Changed `sort=updated` to `sort=created` in two GitHub API queries that fetch closed PRs for deploy-task detection
- `fetchSubPrDeployTasks` in `crux/commands/release.ts` and the `pending` command in `crux/commands/deploy-tasks.ts` were both affected
- `sort=updated` could miss PRs merged within the 14-day lookback window if they hadn't been recently touched, because other recently-updated PRs would push them past the `per_page` limit

## Test plan
- [x] Existing deploy-tasks tests pass (43/43)
- [x] All wiki-server and web tests pass

Closes #3784

🤖 Generated with [Claude Code](https://claude.com/claude-code)