### PR TITLE
fix: deduplicate release deploy tasks from diff and sub-PR sources

### DIFF
--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -15,6 +15,7 @@ import { createLogger } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 import {
+  deduplicateSubPrTasks,
   detectDeployTasks,
   formatDeployTasksSection,
   parseDeployTasksFromBody,
@@ -207,8 +208,11 @@ export async function generateReleaseBody(opts: {
     console.warn(`Warning: failed to fetch sub-PR deploy tasks: ${msg}`);
   }
 
+  // Deduplicate: drop sub-PR tasks that overlap with diff-detected tasks
+  const dedupedSubPrTasks = deduplicateSubPrTasks(diffTasks, subPrTasks);
+
   // Build the deploy checklist section
-  const deploySection = formatDeployTasksSection(diffTasks, subPrTasks);
+  const deploySection = formatDeployTasksSection(diffTasks, dedupedSubPrTasks);
   lines.push(deploySection);
   lines.push('');
 

--- a/crux/lib/deploy-tasks/__tests__/detect.test.ts
+++ b/crux/lib/deploy-tasks/__tests__/detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDeployTasksFromBody, formatDeployTasksSection } from '../detect.ts';
+import { deduplicateSubPrTasks, parseDeployTasksFromBody, formatDeployTasksSection } from '../detect.ts';
 import type { DeployTask } from '../types.ts';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -821,5 +821,205 @@ Generated with Claude Code`;
     const parsed = parseDeployTasksFromBody(newBody);
     expect(parsed).not.toBeNull();
     expect(parsed!.total).toBe(2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// deduplicateSubPrTasks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('deduplicateSubPrTasks', () => {
+  it('removes sub-PR task that matches a diff task by env var name', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-wayback-fallback-enabled',
+        description: 'Set env var WAYBACK_FALLBACK_ENABLED in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+    ];
+    const subPrTasks = [
+      '`env` Set env var WAYBACK_FALLBACK_ENABLED in production _(from PR #3780)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('removes sub-PR task that matches by "Set FOO in production" pattern', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-api-secret',
+        description: 'Set env var API_SECRET in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+    ];
+    const subPrTasks = [
+      '`env` Set API_SECRET in production _(from PR #100)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('removes sub-PR task that matches a diff task by migration number', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'migration-0060',
+        description: 'Verify migration 0060 applied on server start',
+        category: 'migration',
+        phase: 'post-deploy',
+        verifyCommand: 'psql "$DATABASE_URL" -c "SELECT 1"',
+      }),
+    ];
+    const subPrTasks = [
+      '`migration` Run migration 0060 after deploy _(from PR #200)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('removes sub-PR task that matches a diff task by workflow name', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'ci-auto-update',
+        description: 'Modified workflow "auto update" — verify it runs successfully after merge',
+        category: 'ci',
+        phase: 'post-deploy',
+        verifyCommand: 'gh run list --workflow="auto-update.yml" --limit=1',
+      }),
+    ];
+    const subPrTasks = [
+      '`ci` Check workflow "auto-update" passes _(from PR #300)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('removes sub-PR task when diff task description is a substring', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-foo',
+        description: 'Set env var FOO in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+    ];
+    const subPrTasks = [
+      'Set env var FOO in production (requires ops approval) _(from PR #400)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps sub-PR tasks that do not overlap with any diff task', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-foo',
+        description: 'Set env var FOO in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+    ];
+    const subPrTasks = [
+      '`env` Set BAR in production _(from PR #500)_',
+      '`migration` Run fix-data.sql manually _(from PR #501)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('BAR');
+    expect(result[1]).toContain('fix-data.sql');
+  });
+
+  it('keeps all sub-PR tasks when diff tasks are empty', () => {
+    const subPrTasks = [
+      '`env` Set BAR in production _(from PR #500)_',
+    ];
+
+    const result = deduplicateSubPrTasks([], subPrTasks);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual(subPrTasks);
+  });
+
+  it('returns empty array when sub-PR tasks are empty', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({ id: 'env-foo', description: 'Set FOO', category: 'env' }),
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles mixed duplicates and non-duplicates', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-api-key',
+        description: 'Set env var API_KEY in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+      makeTask({
+        id: 'migration-0070',
+        description: 'Verify migration 0070 applied on server start',
+        category: 'migration',
+        phase: 'post-deploy',
+      }),
+    ];
+    const subPrTasks = [
+      '`env` Set env var API_KEY in production _(from PR #600)_',  // duplicate
+      '`env` Set WEBHOOK_SECRET in production _(from PR #601)_',   // unique
+      '`migration` Verify migration 0070 applied _(from PR #602)_', // duplicate
+      '`config` Update vercel.json redirect rules _(from PR #603)_', // unique
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('WEBHOOK_SECRET');
+    expect(result[1]).toContain('vercel.json');
+  });
+
+  it('handles backtick-wrapped env var names in sub-PR tasks', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'env-my-var',
+        description: 'Set env var MY_VAR in production',
+        category: 'env',
+        phase: 'pre-merge',
+        automated: false,
+      }),
+    ];
+    const subPrTasks = [
+      '`env` Set `MY_VAR` in production _(from PR #700)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it('is case-insensitive for substring matching', () => {
+    const diffTasks: DeployTask[] = [
+      makeTask({
+        id: 'docker-change',
+        description: 'Docker configuration changed — verify container builds',
+        category: 'docker',
+        phase: 'post-deploy',
+      }),
+    ];
+    const subPrTasks = [
+      'docker configuration changed — verify container builds _(from PR #800)_',
+    ];
+
+    const result = deduplicateSubPrTasks(diffTasks, subPrTasks);
+    expect(result).toHaveLength(0);
   });
 });

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -444,6 +444,153 @@ function detectDockerChanges(files: ChangedFile[]): DeployTask[] {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Deduplication (sub-PR tasks vs diff-detected tasks)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a string for fuzzy matching: lowercase, strip backticks and
+ * markdown formatting, collapse whitespace.
+ */
+function normalizeForComparison(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/`/g, "")
+    .replace(/_\(from PR #\d+\)_/g, "") // strip sub-PR attribution
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract specific identifiers from a task string that can be used for
+ * exact dedup matching. Returns extracted keys by category.
+ *
+ * Operates on normalized text (backticks stripped, lowercased) so that
+ * formatting differences don't prevent matching.
+ */
+function extractTaskKeys(
+  rawText: string
+): { envVars: string[]; migrationNums: string[]; workflowNames: string[] } {
+  // Strip backticks and markdown formatting before extracting keys
+  const text = rawText.replace(/`/g, "");
+
+  const envVars: string[] = [];
+  const migrationNums: string[] = [];
+  const workflowNames: string[] = [];
+
+  // Env var names: "Set env var FOO_BAR" or "Set FOO_BAR in production"
+  const envPattern = /\benv\s+var\s+([A-Z_][A-Z0-9_]*)\b/gi;
+  let match;
+  while ((match = envPattern.exec(text)) !== null) {
+    envVars.push(match[1].toUpperCase());
+  }
+  // Also match "Set FOO_BAR in production" without "var"
+  const envPattern2 = /\bset\s+([A-Z_][A-Z0-9_]*)\s+in\s+production\b/gi;
+  while ((match = envPattern2.exec(text)) !== null) {
+    envVars.push(match[1].toUpperCase());
+  }
+
+  // Migration numbers: "migration 0060" or "migration-0060"
+  const migPattern = /\bmigration[\s-]+(\d+)/gi;
+  while ((match = migPattern.exec(text)) !== null) {
+    migrationNums.push(match[1]);
+  }
+
+  // Workflow names: workflow "name" or workflow name.yml
+  // Handle both quoted ("auto update") and unquoted (auto-update.yml) names.
+  // Normalize hyphens to spaces so "auto-update" matches "auto update".
+  const wfQuotedPattern = /\bworkflow\s+["']([^"']+)["']/gi;
+  while ((match = wfQuotedPattern.exec(text)) !== null) {
+    workflowNames.push(
+      match[1].toLowerCase().replace(/\.yml$/, "").replace(/-/g, " ")
+    );
+  }
+  const wfUnquotedPattern = /\bworkflow\s+([a-z0-9][\w.-]*)/gi;
+  while ((match = wfUnquotedPattern.exec(text)) !== null) {
+    workflowNames.push(
+      match[1].toLowerCase().replace(/\.yml$/, "").replace(/-/g, " ")
+    );
+  }
+
+  return { envVars, migrationNums, workflowNames };
+}
+
+/**
+ * Check whether a sub-PR task is a duplicate of any diff-detected task.
+ *
+ * Uses two strategies:
+ * 1. Key-based matching: extract env var names, migration numbers, workflow names
+ *    and check for overlap.
+ * 2. Substring matching: check if either task description is a substring of the
+ *    other (after normalization).
+ */
+function isSubPrTaskDuplicate(
+  subPrTask: string,
+  diffTasks: DeployTask[]
+): boolean {
+  const normalizedSubPr = normalizeForComparison(subPrTask);
+  const subPrKeys = extractTaskKeys(subPrTask);
+
+  for (const diffTask of diffTasks) {
+    const normalizedDiff = normalizeForComparison(diffTask.description);
+
+    // Strategy 1: Key-based matching
+    const diffKeys = extractTaskKeys(diffTask.description);
+
+    // Check env var overlap
+    if (subPrKeys.envVars.length > 0 && diffKeys.envVars.length > 0) {
+      for (const envVar of subPrKeys.envVars) {
+        if (diffKeys.envVars.includes(envVar)) return true;
+      }
+    }
+
+    // Check migration number overlap
+    if (
+      subPrKeys.migrationNums.length > 0 &&
+      diffKeys.migrationNums.length > 0
+    ) {
+      for (const migNum of subPrKeys.migrationNums) {
+        if (diffKeys.migrationNums.includes(migNum)) return true;
+      }
+    }
+
+    // Check workflow name overlap
+    if (
+      subPrKeys.workflowNames.length > 0 &&
+      diffKeys.workflowNames.length > 0
+    ) {
+      for (const wfName of subPrKeys.workflowNames) {
+        if (diffKeys.workflowNames.includes(wfName)) return true;
+      }
+    }
+
+    // Strategy 2: Substring matching on normalized descriptions
+    if (
+      normalizedSubPr.includes(normalizedDiff) ||
+      normalizedDiff.includes(normalizedSubPr)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Remove sub-PR tasks that duplicate diff-detected tasks.
+ *
+ * Diff-detected tasks are preferred because they are more structured (have
+ * category, phase, verify commands). Sub-PR tasks are free-text strings
+ * scraped from PR bodies.
+ */
+export function deduplicateSubPrTasks(
+  diffTasks: DeployTask[],
+  subPrTasks: string[]
+): string[] {
+  if (diffTasks.length === 0 || subPrTasks.length === 0) return subPrTasks;
+  return subPrTasks.filter((task) => !isSubPrTaskDuplicate(task, diffTasks));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // PR Body Parsing & Formatting (shared with CLI command and tests)
 // ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- After #3783, `crux gh release create` collects deploy tasks from two sources: file-diff pattern matching (`detectDeployTasks`) and sub-PR body scraping (`fetchSubPrDeployTasks`). If both sources detect the same task (e.g., both mention "Set env var FOO"), the release PR checklist shows the task twice.
- Add `deduplicateSubPrTasks()` in `crux/lib/deploy-tasks/detect.ts` that filters out sub-PR tasks overlapping with diff-detected tasks, using key-based matching (env var names, migration numbers, workflow names) and normalized substring matching.
- Call the dedup in `generateReleaseBody` in `crux/commands/release.ts` before passing tasks to `formatDeployTasksSection`.

Closes #3786

## Test plan

- [x] Added 11 tests for `deduplicateSubPrTasks` covering: env var dedup, migration number dedup, workflow name dedup, substring matching, backtick-wrapped names, case insensitivity, mixed duplicates/non-duplicates, empty inputs
- [x] All 54 deploy-tasks tests pass (`npx vitest run --config crux/vitest.config.ts crux/lib/deploy-tasks/`)
- [x] Existing tests for `parseDeployTasksFromBody` and `formatDeployTasksSection` unaffected

Generated with [Claude Code](https://claude.com/claude-code)