### PR TITLE
simplify: followup cleanups from code review

### DIFF
--- a/apps/web/src/components/political/campaign-finance.tsx
+++ b/apps/web/src/components/political/campaign-finance.tsx
@@ -17,15 +17,7 @@
 import { cn } from "@/lib/utils";
 import { safeHref, formatCompactCurrency } from "@/lib/format-compact";
 import type { CampaignFinanceRecord } from "./types";
-
-// ── Numeric parsing ─────────────────────────────────────────────────
-
-/** Convert a numeric value (number or string from PG) to number, returning 0 for null/invalid. */
-function toNum(value: number | string | null): number {
-  if (value == null) return 0;
-  const n = Number(value);
-  return isNaN(n) ? 0 : n;
-}
+import { toNum } from "./utils";
 
 // ── Funding breakdown ───────────────────────────────────────────────
 

--- a/apps/web/src/components/political/finance-cell.tsx
+++ b/apps/web/src/components/political/finance-cell.tsx
@@ -15,14 +15,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import type { CampaignFinanceRecord } from "./types";
-
-// ── Numeric parsing ─────────────────────────────────────────────────
-
-function toNum(value: number | string | null): number {
-  if (value == null) return 0;
-  const n = Number(value);
-  return isNaN(n) ? 0 : n;
-}
+import { toNum } from "./utils";
 
 // ── Funding segment colors ──────────────────────────────────────────
 

--- a/apps/web/src/components/political/utils.ts
+++ b/apps/web/src/components/political/utils.ts
@@ -1,0 +1,6 @@
+/** Convert a numeric value (number or string from PG) to number, returning 0 for null/invalid. */
+export function toNum(value: number | string | null): number {
+  if (value == null) return 0;
+  const n = Number(value);
+  return isNaN(n) ? 0 : n;
+}

--- a/apps/web/src/components/wiki/VerificationStatus.tsx
+++ b/apps/web/src/components/wiki/VerificationStatus.tsx
@@ -4,16 +4,10 @@ import { useState, useEffect } from "react";
 import { ShieldCheck, ChevronRight } from "lucide-react";
 import { cn } from "@lib/utils";
 import {
-  SOURCE_CHECK_VERDICT_STYLES,
   getSourceCheckVerdictStyle,
   type VerdictRow,
 } from "@/components/shared/verdict-styles";
 import { formatDateDeterministic } from "@lib/format";
-
-// ── Verdict styling (from shared module) ─────────────────────────────────
-
-const VERDICT_STYLES = SOURCE_CHECK_VERDICT_STYLES;
-const getVerdictStyle = getSourceCheckVerdictStyle;
 
 // ── Component ────────────────────────────────────────────────────────────
 
@@ -122,7 +116,7 @@ export function VerificationStatus({ entityId }: VerificationStatusProps) {
         {/* Verdict distribution */}
         <div className="px-4 py-2.5 flex items-center gap-3 flex-wrap">
           {sortedVerdicts.map(([verdict, count]) => {
-            const style = getVerdictStyle(verdict);
+            const style = getSourceCheckVerdictStyle(verdict);
             return (
               <span
                 key={verdict}
@@ -172,7 +166,7 @@ export function VerificationStatus({ entityId }: VerificationStatusProps) {
                 </thead>
                 <tbody>
                   {verdicts.map((v, i) => {
-                    const style = getVerdictStyle(v.verdict);
+                    const style = getSourceCheckVerdictStyle(v.verdict);
                     return (
                       <tr
                         key={`${v.recordType}:${v.recordId}:${v.fieldName ?? ""}:${i}`}

--- a/apps/web/src/data/tables/accident-risks.ts
+++ b/apps/web/src/data/tables/accident-risks.ts
@@ -100,26 +100,3 @@ export const riskCategories = [
   'Human-AI Interaction',
 ];
 
-// Abstraction level descriptions
-export const abstractionLevelDescriptions: Record<AbstractionLevel, string> = {
-  THEORETICAL: 'Foundational concepts and frameworks',
-  MECHANISM: 'How failures occur',
-  BEHAVIOR: 'Observable manifestations',
-  OUTCOME: 'Resulting states and scenarios',
-};
-
-// Get related risks for a given risk
-function getRelatedRisks(
-  riskId: string
-): { risk: AccidentRisk; relationship: RiskRelationship }[] {
-  const risk = accidentRisks.find((r) => r.id === riskId);
-  if (!risk) return [];
-
-  return risk.relatedRisks
-    .map((rel) => {
-      const relatedRisk = accidentRisks.find((r) => r.id === rel.riskId);
-      if (!relatedRisk) return null;
-      return { risk: relatedRisk, relationship: rel };
-    })
-    .filter((r): r is { risk: AccidentRisk; relationship: RiskRelationship } => r !== null);
-}

--- a/apps/web/src/data/tables/safety-approaches.ts
+++ b/apps/web/src/data/tables/safety-approaches.ts
@@ -4,16 +4,6 @@
 
 import safetyApproachesData from "./safety-approaches.json";
 
-export type RatingLevel =
-  | 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'NEGLIGIBLE'  // For safety uplift
-  | 'DOMINANT' | 'SIGNIFICANT' | 'SOME' | 'NEUTRAL' | 'TAX'  // For capability uplift
-  | 'HARMFUL' | 'UNCLEAR' | 'HELPFUL'  // For net effect
-  | 'NONE' | 'WEAK' | 'PARTIAL' | 'STRONG'  // For robustness
-  | 'NO' | 'UNLIKELY' | 'UNKNOWN' | 'MAYBE' | 'YES'  // For scalability
-  | 'NEGATIVE' | 'MODERATE' | 'CORE'  // For incentives
-  | 'EXPERIMENTAL' | 'WIDESPREAD' | 'UNIVERSAL'  // For adoption
-  | 'N/A' | '???';
-
 export interface RatedProperty {
   level: string;
   note: string;
@@ -118,7 +108,3 @@ export const CATEGORIES = [
   { id: 'theoretical', label: 'Theoretical & Research', color: '#6366f1' },
 ] as const;
 
-// Helper to get approaches by category
-export function getApproachesByCategory(category: string): SafetyApproach[] {
-  return SAFETY_APPROACHES.filter(a => a.category === category);
-}

--- a/crux/lib/political/sources/council-livable-world.ts
+++ b/crux/lib/political/sources/council-livable-world.ts
@@ -21,9 +21,7 @@
  * If scraping fails, realistic sample data is used.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { loadFixture } from "./load-fixture.ts";
 
 import type {
   ScorecardSource,
@@ -170,13 +168,12 @@ async function fetchCandidatesPage(): Promise<string | null> {
 function getSampleData(year: number): ScoreRecord[] {
   // Realistic sample data based on Council for a Livable World endorsements.
   // These are historically endorsed legislators known for arms control stances.
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const samples: Array<{
+  const samples = loadFixture<Array<{
     name: string;
     party: string;
     state: string;
     chamber: string;
-  }> = JSON.parse(readFileSync(join(dir, "fixtures/council-livable-world-sample.json"), "utf-8"));
+  }>>(import.meta.url, "fixtures/council-livable-world-sample.json");
 
   return samples.map((s) => ({
     id: generateScoreId(SCORER_ORG, s.name, year),

--- a/crux/lib/political/sources/fec.ts
+++ b/crux/lib/political/sources/fec.ts
@@ -13,10 +13,10 @@
  */
 
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { generateDeterministicId } from "../id-utils.ts";
+import { loadFixture } from "./load-fixture.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -342,8 +342,7 @@ function getSampleData(
   // Realistic sample data based on FEC filings for the given cycle.
   // Includes a mix of senators, representatives, and candidates that
   // overlap with politician entities in people.yaml.
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const sampleCandidates: Array<{
+  const sampleCandidates = loadFixture<Array<{
     name: string;
     fecId: string;
     party: string;
@@ -357,7 +356,7 @@ function getSampleData(
     pacContributions: number;
     smallDonorContributions: number;
     selfFunding: number;
-  }> = JSON.parse(readFileSync(join(dir, "fixtures/fec-sample.json"), "utf-8"));
+  }>>(import.meta.url, "fixtures/fec-sample.json");
 
   const today = new Date().toISOString().split("T")[0];
 

--- a/crux/lib/political/sources/humane-world.ts
+++ b/crux/lib/political/sources/humane-world.ts
@@ -14,9 +14,7 @@
  * If that fails, we use realistic sample data.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { loadFixture } from "./load-fixture.ts";
 
 import type {
   ScorecardSource,
@@ -177,14 +175,13 @@ function normalizeParty(p: string): string {
 function getSampleData(year: number): ScoreRecord[] {
   // Realistic sample data based on the 2025 Humane Scorecard "100+ Club"
   // and "Total Zeroes" lists.
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const samples: Array<{
+  const samples = loadFixture<Array<{
     name: string;
     party: string;
     state: string;
     score: number;
     notes: string;
-  }> = JSON.parse(readFileSync(join(dir, "fixtures/humane-world-sample.json"), "utf-8"));
+  }>>(import.meta.url, "fixtures/humane-world-sample.json");
 
   return samples.map((s) => ({
     id: generateScoreId(SCORER_ORG, s.name, year),

--- a/crux/lib/political/sources/lcv.ts
+++ b/crux/lib/political/sources/lcv.ts
@@ -12,9 +12,7 @@
  * back to realistic sample data so the pipeline works end-to-end.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { loadFixture } from "./load-fixture.ts";
 
 import type {
   ScorecardSource,
@@ -163,15 +161,14 @@ async function fetchLcvPage(year: number): Promise<string | null> {
 function getSampleData(year: number): ScoreRecord[] {
   // Realistic sample data based on actual LCV 2024 scores.
   // Used as fallback when the LCV website blocks scraping.
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const sampleLegislators: Array<{
+  const sampleLegislators = loadFixture<Array<{
     name: string;
     party: string;
     state: string;
     district: string | null;
     score: number;
     chamber: string;
-  }> = JSON.parse(readFileSync(join(dir, "fixtures/lcv-sample.json"), "utf-8"));
+  }>>(import.meta.url, "fixtures/lcv-sample.json");
 
   return sampleLegislators.map((l) => ({
     id: generateScoreId(SCORER_ORG, l.name, year),

--- a/crux/lib/political/sources/load-fixture.ts
+++ b/crux/lib/political/sources/load-fixture.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared fixture loading utility for scorecard/finance source modules.
+ *
+ * Resolves fixture paths relative to the calling module's `import.meta.url`
+ * (which must be passed in, since `import.meta.url` is module-specific).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Load and parse a JSON fixture file relative to the caller's directory.
+ *
+ * @param callerUrl - The calling module's `import.meta.url`
+ * @param filename  - Path relative to the caller's directory (e.g. "fixtures/lcv-sample.json")
+ */
+export function loadFixture<T>(callerUrl: string, filename: string): T {
+  const dir = dirname(fileURLToPath(callerUrl));
+  return JSON.parse(readFileSync(join(dir, filename), "utf-8")) as T;
+}


### PR DESCRIPTION
## Summary

Four small simplification fixes surfaced during code review of recent PRs:

1. **Remove unnecessary local aliases in VerificationStatus.tsx** — `SOURCE_CHECK_VERDICT_STYLES` was imported then aliased as `VERDICT_STYLES` (unused), and `getSourceCheckVerdictStyle` aliased as `getVerdictStyle`. Removed aliases, use imported names directly.

2. **Extract duplicated `toNum()` to shared utils** — Both `campaign-finance.tsx` and `finance-cell.tsx` had identical `toNum()` definitions. Extracted to `apps/web/src/components/political/utils.ts` and imported from both files.

3. **Extract shared `loadFixture` helper** — All 4 scorecard source files (`lcv.ts`, `humane-world.ts`, `council-livable-world.ts`, `fec.ts`) had duplicated `dirname`/`fileURLToPath`/`readFileSync`/`JSON.parse` boilerplate for loading fixture JSON. Extracted to `crux/lib/political/sources/load-fixture.ts` with a generic `loadFixture<T>(callerUrl, filename)` function.

4. **Remove dead code from table modules** — Removed `abstractionLevelDescriptions` (exported but never imported) and `getRelatedRisks` (private, never called) from `accident-risks.ts`. Removed `RatingLevel` type (exported but never referenced) and `getApproachesByCategory` (exported but never imported) from `safety-approaches.ts`.

## Test plan

- [x] `tsc --noEmit` passes clean
- [x] Net: 44 lines added, 85 removed (-41 lines)
- [x] Refactor-only — no behavioral changes