### PR TITLE
fix: update release tests to await async generateReleaseBody

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { categorizeCommit, groupCommits, generateReleaseBody } from './release.ts';
+
+// Mock deploy-tasks to avoid git calls (detectDeployTasks runs git diff)
+vi.mock('../lib/deploy-tasks/detect.ts', async () => {
+  const actual = await vi.importActual<typeof import('../lib/deploy-tasks/detect.ts')>(
+    '../lib/deploy-tasks/detect.ts'
+  );
+  return {
+    ...actual,
+    detectDeployTasks: vi.fn(() => ({ tasks: [] })),
+  };
+});
+
+// Mock github to avoid API calls (fetchSubPrDeployTasks calls githubApi)
+vi.mock('../lib/github.ts', () => ({
+  REPO: 'quantified-uncertainty/longterm-wiki',
+  githubApi: vi.fn(async () => []),
+}));
 
 // ── categorizeCommit ─────────────────────────────────────────────────────────
 
@@ -80,8 +97,12 @@ describe('groupCommits', () => {
 // ── generateReleaseBody ──────────────────────────────────────────────────────
 
 describe('generateReleaseBody', () => {
-  it('generates a basic release body', () => {
-    const body = generateReleaseBody({
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates a basic release body', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 5,
       behind: 0,
@@ -98,8 +119,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('[Full diff](https://github.com/org/repo/compare/production...main)');
   });
 
-  it('includes divergence warning when behind > 0', () => {
-    const body = generateReleaseBody({
+  it('includes divergence warning when behind > 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 2,
@@ -111,8 +132,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('**2 commits** not on main');
   });
 
-  it('omits divergence warning when behind = 0', () => {
-    const body = generateReleaseBody({
+  it('omits divergence warning when behind = 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 0,
@@ -123,8 +144,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('[!WARNING]');
   });
 
-  it('omits empty categories', () => {
-    const body = generateReleaseBody({
+  it('omits empty categories', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 1,
       behind: 0,
@@ -140,8 +161,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Other');
   });
 
-  it('handles empty subjects', () => {
-    const body = generateReleaseBody({
+  it('handles empty subjects', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 0,
       behind: 0,
@@ -154,8 +175,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Features');
   });
 
-  it('groups all conventional commit types correctly', () => {
-    const body = generateReleaseBody({
+  it('groups all conventional commit types correctly', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 6,
       behind: 0,


### PR DESCRIPTION
## Summary

- `generateReleaseBody` was made `async` in #3783 to support sub-PR deploy task aggregation, but the tests were not updated to `await` the returned Promise
- Tests were calling `generateReleaseBody({...})` synchronously, getting a `Promise` back, and then `.toContain()` assertions failed because a Promise is not a string
- Fix: add `vi.mock` for `detectDeployTasks` (avoids git calls) and `githubApi` (avoids API calls), then add `async/await` to the 5 affected test cases

Fixes CI failure from run #23966072766.