### PR TITLE
fix: await generateReleaseBody in tests (broke in #3783)

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -80,8 +80,8 @@ describe('groupCommits', () => {
 // ── generateReleaseBody ──────────────────────────────────────────────────────
 
 describe('generateReleaseBody', () => {
-  it('generates a basic release body', () => {
-    const body = generateReleaseBody({
+  it('generates a basic release body', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 5,
       behind: 0,
@@ -98,8 +98,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('[Full diff](https://github.com/org/repo/compare/production...main)');
   });
 
-  it('includes divergence warning when behind > 0', () => {
-    const body = generateReleaseBody({
+  it('includes divergence warning when behind > 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 2,
@@ -111,8 +111,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('**2 commits** not on main');
   });
 
-  it('omits divergence warning when behind = 0', () => {
-    const body = generateReleaseBody({
+  it('omits divergence warning when behind = 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 0,
@@ -123,8 +123,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('[!WARNING]');
   });
 
-  it('omits empty categories', () => {
-    const body = generateReleaseBody({
+  it('omits empty categories', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 1,
       behind: 0,
@@ -140,8 +140,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Other');
   });
 
-  it('handles empty subjects', () => {
-    const body = generateReleaseBody({
+  it('handles empty subjects', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 0,
       behind: 0,
@@ -154,8 +154,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Features');
   });
 
-  it('groups all conventional commit types correctly', () => {
-    const body = generateReleaseBody({
+  it('groups all conventional commit types correctly', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 6,
       behind: 0,


### PR DESCRIPTION
## Summary

- `generateReleaseBody` was made `async` in #3783 to support sub-PR deploy task aggregation
- The 5 failing `generateReleaseBody` test cases were not updated to `await` the result
- Tests were asserting on `Promise` objects instead of resolved strings, causing all 5 to fail

## Root cause

```
AssertionError: expected [] to include '## Release 2026-03-04'
```

`[]` is how Vitest serializes an unawaited Promise when checking `.toContain()`. All test callbacks in `generateReleaseBody` describe block were synchronous — they called the now-async function but didn't await it.

## Fix

Made all 5 failing test callbacks `async` and added `await` before `generateReleaseBody(...)` calls.

Fixes CI failure from run #23966072766.