### PR TITLE
fix: prevent patrol from creating duplicate main-branch fix PRs

### DIFF
--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -276,6 +276,7 @@ async function runCheckCycle(
   logHeader(`Check cycle #${cycleCount}`);
 
   // 0a. Check if a tracked main-branch fix PR has been merged
+  let skipMainFix = false;
   const trackedFix = getTrackedMainFixPr();
   if (trackedFix) {
     try {
@@ -290,16 +291,19 @@ async function runCheckCycle(
         log(`${cl.yellow}⚠ Main branch fix PR #${trackedFix.prNumber} closed without merging${cl.reset}`);
         clearTrackedMainFixPr();
       } else {
-        log(`  ${cl.dim}Tracked fix PR #${trackedFix.prNumber} still open — waiting for merge${cl.reset}`);
+        log(`  ${cl.dim}Tracked fix PR #${trackedFix.prNumber} still open — skipping main branch fix${cl.reset}`);
+        skipMainFix = true;
       }
     } catch (e) {
       log(`  ${cl.yellow}Warning: could not check tracked fix PR: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
     }
   }
 
-  // 0b. Check main branch CI first — highest priority
+  // 0b. Check main branch CI first — highest priority (skip if fix PR already open)
   const mainStatus = await daemonCheckMainBranch(config);
-  if (mainStatus.isRed) {
+  if (mainStatus.isRed && skipMainFix) {
+    log(`${cl.yellow}⚠ Main branch CI is red but fix PR #${trackedFix!.prNumber} already open — skipping${cl.reset}`);
+  } else if (mainStatus.isRed) {
     log(`${cl.red}Main branch CI is red${cl.reset} — prioritizing fix over PR queue`);
     await fixMainBranch(mainStatus, config);
     appendJsonl(JSONL_FILE_INTERNAL, {


### PR DESCRIPTION
## Summary

- When the patrol daemon detects main branch CI is red, it spawns a Claude agent to fix it and tracks the resulting PR
- Bug: after creating the fix PR, subsequent cycles checked if the tracked PR was merged/closed, but if it was still open, they logged "waiting for merge" and **fell through** to the main-is-red check, creating another fix PR
- This caused 6 duplicate PRs (#3796-#3808) all fixing the same `generateReleaseBody` async/await issue
- Fix: set a `skipMainFix` flag when the tracked PR is still open, skip the `fixMainBranch()` call

Closes #3796

## Test plan

- [x] `tsc --noEmit` passes
- [x] Logic review: the `skipMainFix` flag prevents re-entering `fixMainBranch()` when a tracked fix PR is still open
- [x] Closed 6 duplicate PRs and deleted their branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the daemon's main-branch fix handling to prevent redundant fix PR creation when a fix attempt is already in progress. The daemon now properly tracks open main-branch fix PRs and skips initiating new fixes until the current one is resolved, improving overall fix coordination and preventing conflicting change attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->