### PR TITLE
fix(tests): await generateReleaseBody calls after function became async

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { categorizeCommit, groupCommits, generateReleaseBody } from './release.ts';
+
+vi.mock('../lib/deploy-tasks/detect.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/deploy-tasks/detect.ts')>();
+  return {
+    ...actual,
+    detectDeployTasks: vi.fn(() => ({ tasks: [], filesAnalyzed: 0, rulesMatched: [] })),
+  };
+});
+
+vi.mock('../lib/github.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/github.ts')>();
+  return {
+    ...actual,
+    githubApi: vi.fn().mockResolvedValue([]),
+  };
+});
 
 // ── categorizeCommit ─────────────────────────────────────────────────────────
 
@@ -80,8 +96,8 @@ describe('groupCommits', () => {
 // ── generateReleaseBody ──────────────────────────────────────────────────────
 
 describe('generateReleaseBody', () => {
-  it('generates a basic release body', () => {
-    const body = generateReleaseBody({
+  it('generates a basic release body', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 5,
       behind: 0,
@@ -98,8 +114,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('[Full diff](https://github.com/org/repo/compare/production...main)');
   });
 
-  it('includes divergence warning when behind > 0', () => {
-    const body = generateReleaseBody({
+  it('includes divergence warning when behind > 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 2,
@@ -111,8 +127,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('**2 commits** not on main');
   });
 
-  it('omits divergence warning when behind = 0', () => {
-    const body = generateReleaseBody({
+  it('omits divergence warning when behind = 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 0,
@@ -123,8 +139,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('[!WARNING]');
   });
 
-  it('omits empty categories', () => {
-    const body = generateReleaseBody({
+  it('omits empty categories', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 1,
       behind: 0,
@@ -140,8 +156,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Other');
   });
 
-  it('handles empty subjects', () => {
-    const body = generateReleaseBody({
+  it('handles empty subjects', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 0,
       behind: 0,
@@ -154,8 +170,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Features');
   });
 
-  it('groups all conventional commit types correctly', () => {
-    const body = generateReleaseBody({
+  it('groups all conventional commit types correctly', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 6,
       behind: 0,


### PR DESCRIPTION
## Summary

- `generateReleaseBody` was made `async` in e895ece41 to support `fetchSubPrDeployTasks`, but the test callbacks were not updated to `await` the result
- This caused `body` to be a `Promise<string>` instead of a `string`, making all `toContain` assertions fail (they tested against `"[object Promise]"`)
- Fix: make the 6 `generateReleaseBody` test callbacks `async` and add `await`
- Also adds `vi.mock` for `detectDeployTasks` (prevents real git calls) and `githubApi` (prevents real network calls) so tests are deterministic

Fixes CI failure from run #23967237259.

## Test plan

- [x] All 15 tests in `crux/commands/release.test.ts` pass locally
- [x] Gate checks pass (all 33 CI-blocking checks green)
