### PR TITLE
fix(tests): await async generateReleaseBody in release tests

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { categorizeCommit, groupCommits, generateReleaseBody } from './release.ts';
+
+// Mock external dependencies so tests don't hit GitHub API or run git commands
+vi.mock('../lib/github.ts', () => ({
+  githubApi: vi.fn().mockResolvedValue([]),
+  REPO: 'org/repo',
+}));
+
+vi.mock('../lib/deploy-tasks/detect.ts', () => ({
+  detectDeployTasks: vi.fn().mockReturnValue({ tasks: [] }),
+  deduplicateSubPrTasks: vi.fn().mockReturnValue([]),
+  formatDeployTasksSection: vi.fn().mockReturnValue(''),
+  parseDeployTasksFromBody: vi.fn().mockReturnValue(null),
+}));
 
 // ── categorizeCommit ─────────────────────────────────────────────────────────
 
@@ -80,8 +93,8 @@ describe('groupCommits', () => {
 // ── generateReleaseBody ──────────────────────────────────────────────────────
 
 describe('generateReleaseBody', () => {
-  it('generates a basic release body', () => {
-    const body = generateReleaseBody({
+  it('generates a basic release body', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 5,
       behind: 0,
@@ -98,8 +111,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('[Full diff](https://github.com/org/repo/compare/production...main)');
   });
 
-  it('includes divergence warning when behind > 0', () => {
-    const body = generateReleaseBody({
+  it('includes divergence warning when behind > 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 2,
@@ -111,8 +124,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('**2 commits** not on main');
   });
 
-  it('omits divergence warning when behind = 0', () => {
-    const body = generateReleaseBody({
+  it('omits divergence warning when behind = 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 0,
@@ -123,8 +136,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('[!WARNING]');
   });
 
-  it('omits empty categories', () => {
-    const body = generateReleaseBody({
+  it('omits empty categories', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 1,
       behind: 0,
@@ -140,8 +153,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Other');
   });
 
-  it('handles empty subjects', () => {
-    const body = generateReleaseBody({
+  it('handles empty subjects', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 0,
       behind: 0,
@@ -154,8 +167,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Features');
   });
 
-  it('groups all conventional commit types correctly', () => {
-    const body = generateReleaseBody({
+  it('groups all conventional commit types correctly', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 6,
       behind: 0,


### PR DESCRIPTION
## Root cause

`generateReleaseBody` was made `async` in a recent commit (to call `fetchSubPrDeployTasks` via the GitHub API), but the tests in `commands/release.test.ts` were not updated to `await` it. This meant each `body` variable held a `Promise` object instead of a string, causing 5 assertions to fail with `expected [] to include '...'`.

## Fix

- Added `async`/`await` to the 6 `generateReleaseBody` test cases
- Added `vi.mock` for `../lib/github.ts` and `../lib/deploy-tasks/detect.ts` so tests don't hit the GitHub API or run git commands (which would time out locally and in environments with real tokens)

Fixes CI failure from run #23967237259.