### PR TITLE
fix(tests): await async generateReleaseBody in release tests

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -80,8 +80,8 @@ describe('groupCommits', () => {
 // ── generateReleaseBody ──────────────────────────────────────────────────────
 
 describe('generateReleaseBody', () => {
-  it('generates a basic release body', () => {
-    const body = generateReleaseBody({
+  it('generates a basic release body', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 5,
       behind: 0,
@@ -98,8 +98,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('[Full diff](https://github.com/org/repo/compare/production...main)');
   });
 
-  it('includes divergence warning when behind > 0', () => {
-    const body = generateReleaseBody({
+  it('includes divergence warning when behind > 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 2,
@@ -111,8 +111,8 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('**2 commits** not on main');
   });
 
-  it('omits divergence warning when behind = 0', () => {
-    const body = generateReleaseBody({
+  it('omits divergence warning when behind = 0', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 3,
       behind: 0,
@@ -123,8 +123,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('[!WARNING]');
   });
 
-  it('omits empty categories', () => {
-    const body = generateReleaseBody({
+  it('omits empty categories', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 1,
       behind: 0,
@@ -140,8 +140,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Other');
   });
 
-  it('handles empty subjects', () => {
-    const body = generateReleaseBody({
+  it('handles empty subjects', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 0,
       behind: 0,
@@ -154,8 +154,8 @@ describe('generateReleaseBody', () => {
     expect(body).not.toContain('### Features');
   });
 
-  it('groups all conventional commit types correctly', () => {
-    const body = generateReleaseBody({
+  it('groups all conventional commit types correctly', async () => {
+    const body = await generateReleaseBody({
       date: '2026-03-04',
       ahead: 6,
       behind: 0,


### PR DESCRIPTION
## Summary

- `generateReleaseBody` was made `async` in e895ece41 to support fetching sub-PR deploy tasks, but the 5 `generateReleaseBody` test cases in `release.test.ts` were not updated to `await` the Promise
- All failing tests called the function synchronously, receiving a `Promise` instead of a string, causing every `.toContain()` assertion to fail with `expected [] to include ...`
- Fixed by adding `async` + `await` to all 6 `generateReleaseBody` test cases

Fixes CI failure from run [#23967237259](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/23967237259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test invocation patterns to ensure proper async operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->