### PR TITLE
simplify: use getSourceCheckHref(), add sr-only label, remove comment

### DIFF
--- a/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
+++ b/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
@@ -9,6 +9,7 @@
 import Link from "next/link";
 import type { KBRecordEntry } from "@/data/factbase";
 import { getRecordVerdict } from "@data/tablebase";
+import { getSourceCheckHref } from "@/app/source-checks/source-checks-shared";
 import {
   formatKBDate,
   titleCase,
@@ -69,7 +70,7 @@ export function FundingHistorySection({
                     <span className="inline-flex items-center gap-1.5">
                       <RecordVerificationDot
                         verdict={getRecordVerdict("funding-round", String(round.key))?.verdict}
-                        href={`/source-checks/funding-round/${encodeURIComponent(String(round.key))}`}
+                        href={getSourceCheckHref("funding-round", String(round.key))}
                       />
                       <Link href={`/funding-rounds/${round.key}`} className="text-foreground hover:text-primary transition-colors">
                         {name}
@@ -149,7 +150,7 @@ export function InvestorParticipationSection({
                     <span className="inline-flex items-center gap-1.5">
                       <RecordVerificationDot
                         verdict={getRecordVerdict("investment", String(inv.key))?.verdict}
-                        href={`/source-checks/investment/${encodeURIComponent(String(inv.key))}`}
+                        href={getSourceCheckHref("investment", String(inv.key))}
                       />
                       {investorHref ? (
                         <Link href={investorHref} className="font-medium text-foreground hover:text-primary transition-colors">

--- a/apps/web/src/components/wiki/FBF.tsx
+++ b/apps/web/src/components/wiki/FBF.tsx
@@ -178,7 +178,6 @@ export function FBF({
           </span>
         )}
 
-        {/* Verification status */}
         <FactVerificationDot factId={fact.id} showLabel className="mt-1" />
 
         {/* Fact detail link */}

--- a/apps/web/src/components/wiki/factbase/FBFactTable.tsx
+++ b/apps/web/src/components/wiki/factbase/FBFactTable.tsx
@@ -68,7 +68,7 @@ export function FBFactTable({ entity, property, title, includeExpired }: FBFactT
             <TableRow>
               <TableHead scope="col">Date</TableHead>
               <TableHead scope="col">Value</TableHead>
-              <TableHead scope="col" className="w-8"></TableHead>
+              <TableHead scope="col" className="w-8"><span className="sr-only">Verification</span></TableHead>
               <TableHead scope="col">Source</TableHead>
               <TableHead scope="col">Notes</TableHead>
             </TableRow>


### PR DESCRIPTION
## Summary

Follow-up simplification from PR #3816 (verification dots Phase 1), applying code review findings:

- Replace inline `/source-checks/...` URL construction with existing `getSourceCheckHref()` utility from `source-checks-shared.tsx` (DRY)
- Add `<span className="sr-only">Verification</span>` to empty `<TableHead>` in FBFactTable for screen reader accessibility
- Remove redundant `{/* Verification status */}` comment in FBF.tsx

3 files, 4 lines changed. No behavior changes.

## Test plan

- [x] TypeScript compiles cleanly
- [x] Tests pass (1164/1164)
- [x] Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added accessible labels to verification column headers to improve screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->