### PR TITLE
Fix source-check evidence display and add render audit regression tests

### DIFF
--- a/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/source-checks/[recordType]/[recordId]/page.tsx
@@ -24,6 +24,21 @@ import { formatKBFactValue } from "@/components/wiki/factbase/format";
 export const revalidate = 3600;
 export const dynamicParams = true;
 
+/** Format a single JSON value for display in a key-value summary. */
+function formatJsonValue(v: unknown): string {
+  if (typeof v === "string") return v.length > 100 ? v.slice(0, 100) + "\u2026" : v;
+  if (typeof v === "number") return v.toLocaleString("en-US");
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (v === null) return "\u2014";
+  if (Array.isArray(v)) return `[${v.length} items]`;
+  if (typeof v === "object") {
+    const entries = Object.entries(v);
+    if (entries.length <= 3) return entries.map(([k, val]) => `${k}: ${formatJsonValue(val)}`).join(", ");
+    return `{${entries.length} fields}`;
+  }
+  return String(v);
+}
+
 /** Format an extractedValue for display. Detects JSON and renders key-value summary. */
 function FormatExtractedValue({ value }: { value: string }) {
   const trimmed = value.trim();
@@ -34,7 +49,7 @@ function FormatExtractedValue({ value }: { value: string }) {
       const parsed = JSON.parse(trimmed);
       if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
         const entries = Object.entries(parsed);
-        const shown = entries.slice(0, 3);
+        const shown = entries.slice(0, 5);
         const remaining = entries.length - shown.length;
         return (
           <span className="text-sm">
@@ -42,9 +57,7 @@ function FormatExtractedValue({ value }: { value: string }) {
               <span key={k}>
                 {i > 0 && ", "}
                 <span className="font-medium text-foreground/70">{k}:</span>{" "}
-                {typeof v === "string"
-                  ? (v.length > 100 ? v.slice(0, 100) + "\u2026" : v)
-                  : JSON.stringify(v)}
+                {formatJsonValue(v)}
               </span>
             ))}
             {remaining > 0 && (
@@ -54,8 +67,19 @@ function FormatExtractedValue({ value }: { value: string }) {
         );
       }
       if (Array.isArray(parsed)) {
-        const label = `[${parsed.length} items]`;
-        return <span className="text-sm text-muted-foreground">{label}</span>;
+        if (parsed.length === 0) return <span className="text-sm text-muted-foreground">[empty]</span>;
+        // Show first few items for simple arrays
+        if (parsed.every((item) => typeof item !== "object" || item === null)) {
+          const shown = parsed.slice(0, 5).map((item) => formatJsonValue(item));
+          const remaining = parsed.length - shown.length;
+          return (
+            <span className="text-sm">
+              {shown.join(", ")}
+              {remaining > 0 && <span className="text-muted-foreground"> (+{remaining} more)</span>}
+            </span>
+          );
+        }
+        return <span className="text-sm text-muted-foreground">[{parsed.length} items]</span>;
       }
     } catch {
       // Not valid JSON — fall through to truncation

--- a/apps/web/src/lib/__tests__/factbase-format.test.ts
+++ b/apps/web/src/lib/__tests__/factbase-format.test.ts
@@ -217,6 +217,43 @@ describe("formatKBFactValue", () => {
     });
   });
 
+  describe("render audit regression — no raw 10+ digit numbers", () => {
+    it("formats 15B without raw digits (Meta AI infra-investment)", () => {
+      const fact = makeFact("infrastructure-investment", { type: "number", value: 15_000_000_000 });
+      const result = formatKBFactValue(fact, "USD");
+      expect(result).toBe("$15 billion");
+      expect(result).not.toMatch(/\d{10,}/);
+    });
+
+    it("formats 13.5B without raw digits", () => {
+      const fact = makeFact("infrastructure-investment", { type: "number", value: 13_500_000_000 });
+      const result = formatKBFactValue(fact, "USD");
+      expect(result).toBe("$13.5 billion");
+      expect(result).not.toMatch(/\d{10,}/);
+    });
+
+    it("formats 380B without raw digits (Anthropic valuation)", () => {
+      const fact = makeFact("valuation", { type: "number", value: 380_000_000_000 });
+      const result = formatKBFactValue(fact, "USD");
+      expect(result).toBe("$380 billion");
+      expect(result).not.toMatch(/\d{10,}/);
+    });
+
+    it("formats large number without unit and produces no raw digits", () => {
+      const fact = makeFact("parent-revenue", { type: "number", value: 200_970_000_000 });
+      const result = formatKBFactValue(fact);
+      expect(result).not.toMatch(/\d{10,}/);
+      expect(result).toContain("billion");
+    });
+
+    it("formats number with 'users' unit", () => {
+      const fact = makeFact("user-count", { type: "number", value: 1_000_000_000 });
+      const result = formatKBFactValue(fact, "users");
+      expect(result).not.toMatch(/\d{10,}/);
+      expect(result).toContain("billion");
+    });
+  });
+
   describe("existing value types are unaffected", () => {
     it("formats boolean facts", () => {
       const fact = makeFact("some-bool", { type: "boolean", value: true });


### PR DESCRIPTION
## Summary
- Improve `FormatExtractedValue` on source-check detail pages: numbers get locale formatting instead of raw digits, nested objects get human-readable summaries, arrays show first items
- Add render audit regression tests for `formatKBFactValue` ensuring values like $15B, $13.5B, $380B never produce raw 10+ digit strings in formatted output
- All 1242 tests pass, build succeeds

Closes #3769

## Test plan
- [x] All 199 format-related tests pass (including 5 new regression tests)
- [x] Full test suite (1242 tests) passes
- [x] `pnpm build` succeeds
- [x] Gate check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)