### PR TITLE
fix: overlay hooks from main/ to prevent old branches reverting tmux fixes

### DIFF
--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -123,19 +123,20 @@ function overlayHooks(lwDir: string, slotDir: string): boolean {
 
   if (!existsSync(mainHooksDir)) return false;
 
+  // Only these two hooks contain tmux rename logic that needs the -t $TMUX_PANE fix
   const hookFiles = ['session-start.sh', 'heartbeat.sh'];
   let copied = false;
 
+  mkdirSync(slotHooksDir, { recursive: true });
   for (const file of hookFiles) {
     const src = join(mainHooksDir, file);
     const dst = join(slotHooksDir, file);
     if (!existsSync(src)) continue;
 
-    mkdirSync(slotHooksDir, { recursive: true });
     try {
       copyFileSync(src, dst);
       copied = true;
-    } catch { /* permission error or similar */ }
+    } catch { /* permission error — slot hooks stay as-is */ }
   }
 
   return copied;
@@ -159,7 +160,7 @@ function listTmuxWindows(): TmuxWindowInfo[] {
     return raw.split('\n').filter(Boolean).map((line) => {
       const parts = line.split('|||');
       return { index: parts[0] || '', cwd: parts[1] || '', name: parts[2] || '' };
-    });
+    }).filter((w) => /^\d+$/.test(w.index) && w.cwd);
   } catch {
     return [];
   }
@@ -476,9 +477,10 @@ async function open(args: string[], _options: CommandOptions): Promise<CommandRe
 
   // Check if a window for this slot already exists — match by pane CWD, not window name
   // (window names get renamed to A${slot}:${branch} by hooks, so exact name match fails)
+  // Use startsWith to handle cases where the user cd'd into a subdirectory
   const windows = listTmuxWindows();
   for (const win of windows) {
-    if (win.cwd === slotDir) {
+    if (win.cwd === slotDir || win.cwd.startsWith(slotDir + '/')) {
       try {
         execSync(`tmux select-window -t "${win.index}"`, { stdio: 'inherit' });
         return { exitCode: 0, output: `Switched to existing tmux window for slot a${slot}` };


### PR DESCRIPTION
## Summary

Third and final fix for the tmux tab naming saga. The root cause of recurring breakage: **hooks are tracked in git**, so checking out any branch that predates the `-t $TMUX_PANE` fix reverts the hooks to the broken version, and sessions start renaming random tabs again.

**Changes:**
- `ws refresh` now copies `session-start.sh` + `heartbeat.sh` from `main/` to all slots after resetting
- `ws open` overlays hooks before creating the tmux window/starting Claude
- `fix-tabs` now labels the coordinator window (`lw/`) as `LW` instead of ignoring it

**Defense in depth — all vectors now covered:**

| Vector | Defense |
|--------|---------|
| Hook renames wrong window | `-t $TMUX_PANE` (PR #3843) |
| Old branch restores old hooks | Hook overlay from `main/` on refresh + open (this PR) |
| Stale names after slot reset | `renameTmuxWindows()` in refresh (PR #3839) |
| Coordinator window mislabeled | `fix-tabs` handles `lw/` → `LW` (this PR) |
| Manual fix needed | `ws fix-tabs` command (PR #3839) |
| Delimiter bug in fix-tabs | `|||` instead of `\t` (PR #3843) |

Closes #3835

## Test plan

- [x] `pnpm crux agent-workspace fix-tabs` correctly labels coordinator as LW
- [x] Hook overlay copies latest files to slots
- [x] Build passes
- [x] Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
