### PR TITLE
fix: agent-reset discards unstaged changes before pulling main

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -51,10 +51,12 @@ pnpm crux gh pr-patrol stop
 
 ## Step 4: Clean up local artifacts
 
-Remove the WIP checklist and review marker:
+Remove untracked session artifacts and discard any unstaged changes (modified hooks, deleted markers, etc.):
 
 ```bash
-rm -f .claude/wip-checklist.md .claude/review-done .claude/wip-context.md
+rm -f .claude/wip-checklist.md .claude/wip-context.md
+git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/hooks/ 2>/dev/null || true
 ```
 
 ## Step 5: Session summary

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -160,10 +160,12 @@ Run `/agent-push-and-verify`.
 
 ## Step 9: Session close-out
 
-Clean up local session artifacts:
+Clean up session artifacts and discard any unstaged changes (modified hooks, deleted markers, etc.):
 
 ```bash
-rm -f .claude/wip-checklist.md .claude/review-done .claude/wip-context.md
+rm -f .claude/wip-checklist.md .claude/wip-context.md
+git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/hooks/ 2>/dev/null || true
 ```
 
 ## Step 10: Final report

--- a/crux/commands/agent-reset.ts
+++ b/crux/commands/agent-reset.ts
@@ -623,10 +623,23 @@ async function resetCommand(
     }
   }
 
-  // 4e. Pull latest main
+  // 4e. Discard unstaged changes (session leftovers like modified hooks, deleted markers)
+  if (git.isDirty) {
+    try {
+      exec('git checkout -- .');
+      output += `  ${c.green}✓${c.reset} Discarded unstaged changes\n`;
+      git.isDirty = false;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      output += `  ${c.red}✗ Failed to discard unstaged changes: ${msg}${c.reset}\n`;
+      hadErrors = true;
+    }
+  }
+
+  // 4f. Pull latest main
   if (git.behindMain > 0 || git.currentBranch !== 'main') {
     if (git.isDirty) {
-      output += `  ${c.yellow}⚠ Working tree is dirty — skipping checkout/pull. Commit or stash changes first.${c.reset}\n`;
+      output += `  ${c.yellow}⚠ Working tree still dirty — skipping checkout/pull${c.reset}\n`;
     } else {
       try {
         if (git.currentBranch !== 'main') {
@@ -683,7 +696,8 @@ Cleanup actions (with --kill):
   3. Delete stale .claude/wip-checklist.md
   4. Clear git stashes
   5. Delete local branches merged into main
-  6. Checkout main and pull latest
+  6. Discard unstaged changes (session leftovers)
+  7. Checkout main and pull latest
 
 Examples:
   crux sys agent-reset                   # Scan — show what's stale


### PR DESCRIPTION
## Summary

- `agent-reset --kill` now runs `git checkout -- .` to discard unstaged changes before checking out main, fixing the chicken-and-egg problem where dirty session leftovers (modified hooks, deleted `.claude/review-done`) prevented the checkout/pull step
- `/agent-end` and `/agent-ship` cleanup steps now use `git checkout` to restore tracked `.claude/` files instead of `rm -f`, which was leaving dirty deletions

## Test plan

- [ ] Run `agent-reset --kill` on a slot with unstaged `.claude/` changes — should discard them and successfully pull main
- [ ] Run `/agent-end` — should leave the working tree clean (no unstaged changes to `.claude/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)