### PR TITLE
fix: drop 'Cumulative' from org funding chart legend

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-charts.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-charts.tsx
@@ -828,7 +828,7 @@ export function FundingTimelineChart({
         </div>
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-[2px] rounded-full" style={{ backgroundColor: cumulativeColor }} />
-          <span className="text-[10px] text-muted-foreground">Cumulative</span>
+          <span className="text-[10px] text-muted-foreground">Total</span>
         </div>
       </div>
     </ChartCard>


### PR DESCRIPTION
## Summary
- Changed the funding timeline chart legend label from "Cumulative" to "Total" on organization profile pages
- The tooltip already used "Total" — this makes the legend consistent with it

Closes #3854

## Test plan
- [ ] Visit an org page with funding data (e.g. `/organizations/aclu`) and verify the chart legend shows "Total" instead of "Cumulative"
- [ ] Verify the chart still renders correctly with the cumulative line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated legend label in the funding timeline chart for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->