### PR TITLE
Update page type terminology: KB Data -> FactBase

### DIFF
--- a/apps/web/src/app/factbase/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/factbase/entity/[entityId]/page.tsx
@@ -8,7 +8,7 @@ import {
   getKBAllRecordCollections,
   getKBProperty,
 } from "@/data/factbase";
-import { getEntityHref } from "@/data";
+import { getEntityHref, getDirectoryHref } from "@/data";
 import type { Fact, Property } from "@longterm-wiki/factbase";
 import { titleCase } from "@/components/wiki/factbase/format";
 
@@ -32,7 +32,7 @@ import {
 
 // ─── Rendering mode ──────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~724 pages x ~80KB each = ~56MB saved).
-// These are internal KB data pages with low traffic; SSG is unnecessary.
+// These are internal FactBase pages with low traffic; SSG is unnecessary.
 // Cache for 1 hour to avoid expensive re-renders from bot crawlers.
 export const revalidate = 3600;
 
@@ -53,7 +53,7 @@ export async function generateMetadata({
 
   const entity = getKBEntity(entityId);
   return {
-    title: entity ? `KB: ${entity.name}` : `KB: ${entityId}`,
+    title: entity ? `FactBase: ${entity.name}` : `FactBase: ${entityId}`,
     robots: { index: false },
   };
 }
@@ -177,9 +177,9 @@ export default async function KBEntityPage({
   );
   const totalCollections = Object.keys(itemCollections).length;
 
-  const wikiHref = entity.wikiId
-    ? `/wiki/${entity.wikiId}`
-    : getEntityHref(entityId);
+  // Separate profile (directory) and wiki page links
+  const profileHref = getDirectoryHref(entityId);
+  const wikiHref = entity.wikiId ? `/wiki/${entity.wikiId}` : null;
 
   // Hero stat properties for this entity type
   const heroProps = HERO_STAT_PROPERTIES[entity.type] ?? [];
@@ -214,12 +214,22 @@ export default async function KBEntityPage({
           </p>
         )}
         <div className="flex items-center gap-3 text-sm">
-          <Link
-            href={wikiHref}
-            className="inline-flex items-center gap-1 text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Wiki page &rarr;
-          </Link>
+          {profileHref && (
+            <Link
+              href={profileHref}
+              className="inline-flex items-center gap-1 text-primary hover:text-primary/80 font-medium transition-colors"
+            >
+              Profile page &rarr;
+            </Link>
+          )}
+          {wikiHref && (
+            <Link
+              href={wikiHref}
+              className="inline-flex items-center gap-1 text-primary hover:text-primary/80 font-medium transition-colors"
+            >
+              Wiki page &rarr;
+            </Link>
+          )}
           {verdicts.size > 0 && (
             <VerificationSummary verdicts={verdicts} totalFacts={structuredFacts.length} />
           )}

--- a/apps/web/src/app/factbase/factbase-entities-content.tsx
+++ b/apps/web/src/app/factbase/factbase-entities-content.tsx
@@ -68,7 +68,7 @@ export function FBEntityCoverageContent() {
   return (
     <>
       <p className="text-muted-foreground text-sm leading-relaxed mb-4">
-        {rows.length} entities with structured KB data (excluding
+        {rows.length} entities with structured FactBase data (excluding
         description-only entries). Sorted by fact count.
       </p>
       <FBEntitiesTable data={rows} />

--- a/apps/web/src/app/factbase/factbase-overview-content.tsx
+++ b/apps/web/src/app/factbase/factbase-overview-content.tsx
@@ -107,7 +107,7 @@ export function FBOverviewContent() {
   return (
     <>
       <p className="text-muted-foreground text-sm leading-relaxed mb-6">
-        The Knowledge Base (KB) stores structured, sourced facts about entities
+        The FactBase stores structured, sourced facts about entities
         tracked by this wiki. Each fact has a typed value, optional date stamp,
         and source attribution. This section lets you explore the full dataset.
       </p>
@@ -123,7 +123,7 @@ export function FBOverviewContent() {
           icon={Layers}
           label="Entities with Data"
           value={stats.entitiesWithStructuredData}
-          sublabel={`of ${stats.totalEntities} total KB entities`}
+          sublabel={`of ${stats.totalEntities} total FactBase entities`}
         />
         <StatCard
           icon={BarChart3}

--- a/apps/web/src/app/internal/people-coverage/people-coverage-content.tsx
+++ b/apps/web/src/app/internal/people-coverage/people-coverage-content.tsx
@@ -117,7 +117,7 @@ export function PeopleCoverageContent() {
     <>
       <p className="text-muted-foreground text-sm leading-relaxed">
         Data completeness overview for {total} person entities. Shows which
-        people have complete structured data across KB facts, expert positions,
+        people have complete structured data across FactBase facts, expert positions,
         wiki pages, and career history. Sorted by completeness (least complete
         first) to prioritize data gaps.
       </p>
@@ -131,7 +131,7 @@ export function PeopleCoverageContent() {
           value={`${withWikiPage} (${pct(withWikiPage)}%)`}
         />
         <StatCard
-          label="With KB Facts"
+          label="With FactBase Facts"
           value={`${withKBFacts} (${pct(withKBFacts)}%)`}
         />
       </div>
@@ -153,7 +153,7 @@ export function PeopleCoverageContent() {
           count={withCareerHistory}
           total={total}
         />
-        <MiniStat label="Has Any KB Facts" count={withKBFacts} total={total} />
+        <MiniStat label="Has Any FactBase Facts" count={withKBFacts} total={total} />
       </div>
 
       <PeopleCoverageTable data={rows} />

--- a/apps/web/src/app/internal/people-coverage/people-coverage-table.tsx
+++ b/apps/web/src/app/internal/people-coverage/people-coverage-table.tsx
@@ -95,7 +95,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
   {
     accessorKey: "hasRole",
     header: ({ column }) => (
-      <SortableHeader column={column} title="Has role in KB facts or entity data">
+      <SortableHeader column={column} title="Has role in FactBase facts or entity data">
         Role
       </SortableHeader>
     ),
@@ -108,7 +108,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
     header: ({ column }) => (
       <SortableHeader
         column={column}
-        title="Has employed-by in KB facts or affiliation in entity"
+        title="Has employed-by in FactBase facts or affiliation in entity"
       >
         Employer
       </SortableHeader>
@@ -120,7 +120,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
   {
     accessorKey: "hasBornYear",
     header: ({ column }) => (
-      <SortableHeader column={column} title="Has born-year KB fact">
+      <SortableHeader column={column} title="Has born-year FactBase fact">
         Born
       </SortableHeader>
     ),
@@ -131,7 +131,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
   {
     accessorKey: "hasNotableFor",
     header: ({ column }) => (
-      <SortableHeader column={column} title="Has notable-for KB fact">
+      <SortableHeader column={column} title="Has notable-for FactBase fact">
         Notable
       </SortableHeader>
     ),
@@ -169,7 +169,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
     header: ({ column }) => (
       <SortableHeader
         column={column}
-        title="Has 2+ employed-by KB facts (career history)"
+        title="Has 2+ employed-by FactBase facts (career history)"
       >
         Career
       </SortableHeader>
@@ -181,7 +181,7 @@ const columns: ColumnDef<PersonCoverageRow>[] = [
   {
     accessorKey: "kbFactCount",
     header: ({ column }) => (
-      <SortableHeader column={column} title="Total KB facts for this person">
+      <SortableHeader column={column} title="Total FactBase facts for this person">
         Facts
       </SortableHeader>
     ),

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -788,7 +788,7 @@ export default async function OrgProfilePage({
                 </Link>
               )}
               <Link href={`/factbase/entity/${entity.id}`} className="text-primary hover:text-primary/80 font-medium transition-colors">
-                KB data &rarr;
+                FactBase &rarr;
               </Link>
             </div>
 

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -454,7 +454,7 @@ export default async function PersonProfilePage({
               href={`/factbase/entity/${entity.id}`}
               className="text-primary hover:text-primary/80 font-medium transition-colors"
             >
-              KB data &rarr;
+              FactBase &rarr;
             </Link>
           </div>
         </div>

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -424,7 +424,7 @@ export default async function ProjectDetailPage({
                 href={`/factbase/entity/${entity.id}`}
                 className="text-xs text-primary hover:underline"
               >
-                KB data &rarr;
+                FactBase &rarr;
               </Link>
             </div>
           </section>

--- a/apps/web/src/components/directory/FactsSection.tsx
+++ b/apps/web/src/components/directory/FactsSection.tsx
@@ -247,7 +247,7 @@ export function FactsPanel({
           href={`/factbase/entity/${entityId}`}
           className="text-[11px] text-muted-foreground/60 hover:text-primary transition-colors"
         >
-          View all facts in KB explorer &rarr;
+          View all facts in FactBase &rarr;
         </Link>
       </div>
     </section>

--- a/apps/web/src/components/explore/ExploreGrid.tsx
+++ b/apps/web/src/components/explore/ExploreGrid.tsx
@@ -812,7 +812,7 @@ export function ExploreGrid({ initialItems, initialTotal, initialFacets, allItem
                 <option value="researchImportance">Research Importance</option>
                 <option value="tacticalValue">Tactical Value</option>
                 <option value="relevance">Relevance</option>
-                <option value="kbFacts">KB Facts</option>
+                <option value="kbFacts">FactBase Facts</option>
                 <option value="wordCount">Word Count</option>
                 <option value="title">Title (A-Z)</option>
               </select>

--- a/apps/web/src/components/explore/ExploreTable.tsx
+++ b/apps/web/src/components/explore/ExploreTable.tsx
@@ -109,7 +109,7 @@ function buildColumns(onSearchChange: (value: string) => void): ColumnDef<Explor
     {
       id: "kbData",
       accessorFn: (row) => (row.kbFactCount ?? 0) + (row.kbItemCount ?? 0),
-      header: ({ column }) => <SortableHeader column={column} title="Structured KB facts and items">KB</SortableHeader>,
+      header: ({ column }) => <SortableHeader column={column} title="Structured FactBase facts and items">FB</SortableHeader>,
       cell: ({ row }) => {
         const facts = row.original.kbFactCount ?? 0;
         const items = row.original.kbItemCount ?? 0;

--- a/apps/web/src/components/wiki/FBF.tsx
+++ b/apps/web/src/components/wiki/FBF.tsx
@@ -74,7 +74,7 @@ export function FBF({
           "inline px-1 py-0.5 bg-destructive/10 text-destructive text-sm rounded",
           className,
         )}
-        title={`Missing KB fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
+        title={`Missing FactBase fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
       >
         {children || `[missing: ${entity}.${property}]`}
       </span>

--- a/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
+++ b/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
@@ -751,7 +751,7 @@ function RecordCollectionSection({
             href={`/factbase/entity/${entityId}`}
             className="text-xs text-primary/60 hover:text-primary hover:underline transition-colors"
           >
-            View all {nonEmptyItems.length} {titleCase(collectionName).toLowerCase()} in full profile &rarr;
+            View all {nonEmptyItems.length} {titleCase(collectionName).toLowerCase()} in FactBase &rarr;
           </Link>
         </div>
       )}
@@ -863,7 +863,7 @@ export function FBAutoFacts({ entityId }: FBAutoFactsProps) {
             href={`/factbase/entity/${entityId}`}
             className="ml-auto text-xs text-primary/60 hover:text-primary hover:underline transition-colors"
           >
-            View full profile &rarr;
+            View in FactBase &rarr;
           </Link>
         </div>
 

--- a/apps/web/src/components/wiki/factbase/FBFactValue.tsx
+++ b/apps/web/src/components/wiki/factbase/FBFactValue.tsx
@@ -54,7 +54,7 @@ export function FBFactValue({
           "inline px-1 py-0.5 bg-destructive/10 text-destructive text-sm rounded",
           className,
         )}
-        title={`Missing KB fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
+        title={`Missing FactBase fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
       >
         [missing: {entity}.{property}]
       </span>

--- a/apps/web/src/components/wiki/factbase/FBRefLink.tsx
+++ b/apps/web/src/components/wiki/factbase/FBRefLink.tsx
@@ -44,7 +44,7 @@ export function FBRefLink({ id, label, className }: FBRefLinkProps) {
   return (
     <span
       className={cn("text-muted-foreground", className)}
-      title={`KB entity: ${id}`}
+      title={`FactBase entity: ${id}`}
     >
       {displayName}
     </span>

--- a/apps/web/src/lib/__tests__/fact-footnote-preprocessor.test.ts
+++ b/apps/web/src/lib/__tests__/fact-footnote-preprocessor.test.ts
@@ -108,7 +108,7 @@ describe("preprocessFactFootnotes", () => {
 
     const result = preprocessFactFootnotes(content, lookup);
 
-    expect(result.content).toContain("[^fact-f_empty]: KB fact f_empty");
+    expect(result.content).toContain("[^fact-f_empty]: FactBase fact f_empty");
     expect(result.resolvedFactIds.has("f_empty")).toBe(true);
   });
 
@@ -163,7 +163,7 @@ describe("preprocessFactFootnotes", () => {
     expect(result.content).not.toContain("[^fact:f_nonexistent]");
 
     // Should generate a warning footnote
-    expect(result.content).toContain("[^fact-f_nonexistent]: Fact f_nonexistent (not found in KB data)");
+    expect(result.content).toContain("[^fact-f_nonexistent]: Fact f_nonexistent (not found in FactBase)");
 
     expect(result.unresolvedFactIds.has("f_nonexistent")).toBe(true);
     expect(result.resolvedFactIds.size).toBe(0);
@@ -373,7 +373,7 @@ describe("buildFactFootnoteDefinition", () => {
     const fact = makeFact({ id: "f_nada" });
 
     const def = buildFactFootnoteDefinition(fact);
-    expect(def).toBe("KB fact f_nada");
+    expect(def).toBe("FactBase fact f_nada");
   });
 
   it("handles non-URL source text", () => {

--- a/apps/web/src/lib/__tests__/reference-preprocessor.test.ts
+++ b/apps/web/src/lib/__tests__/reference-preprocessor.test.ts
@@ -585,7 +585,7 @@ describe("preprocessReferences", () => {
       refData
     );
 
-    expect(result).toContain("[^1]: KB fact f_missing");
+    expect(result).toContain("[^1]: FactBase fact f_missing");
     expect(referenceMap.get(1)?.data).toBeNull();
     expect(referenceMap.get(1)?.kind).toBe("kb");
   });

--- a/apps/web/src/lib/fact-footnote-preprocessor.ts
+++ b/apps/web/src/lib/fact-footnote-preprocessor.ts
@@ -75,7 +75,7 @@ export function buildFactFootnoteDefinition(fact: Fact): string {
     parts.push(fact.notes);
   }
 
-  const text = parts.join(" \u2014 ") || `KB fact ${fact.id}`;
+  const text = parts.join(" \u2014 ") || `FactBase fact ${fact.id}`;
   return sanitizeFootnoteText(text);
 }
 
@@ -151,7 +151,7 @@ export function preprocessFactFootnotes(
       definitionText = buildFactFootnoteDefinition(fact);
     } else {
       unresolvedFactIds.add(factId);
-      definitionText = `Fact ${factId} (not found in KB data)`;
+      definitionText = `Fact ${factId} (not found in FactBase)`;
     }
 
     footnoteLines.push(`[^fact-${factId}]: ${definitionText}`);

--- a/apps/web/src/lib/reference-preprocessor.ts
+++ b/apps/web/src/lib/reference-preprocessor.ts
@@ -198,7 +198,7 @@ function buildKBFactFootnote(data: KBFactRefData): string {
     }
   }
   if (data.notes) parts.push(data.notes);
-  return sanitizeFootnoteText(parts.join(" \u2014 ") || `KB fact ${data.factId}`);
+  return sanitizeFootnoteText(parts.join(" \u2014 ") || `FactBase fact ${data.factId}`);
 }
 
 /**
@@ -296,7 +296,7 @@ export function preprocessReferences(
         data = kbData;
         definitionText = buildKBFactFootnote(kbData);
       } else {
-        definitionText = `KB fact ${factId}`;
+        definitionText = `FactBase fact ${factId}`;
       }
     } else {
       kind = "citation";

--- a/content/docs/factbase/entity-coverage.mdx
+++ b/content/docs/factbase/entity-coverage.mdx
@@ -1,7 +1,7 @@
 ---
 wikiId: E1022
 title: "Entity Coverage"
-description: "KB data coverage per entity - fact counts, properties, and source quality"
+description: "FactBase coverage per entity - fact counts, properties, and source quality"
 contentFormat: dashboard
 lastEdited: "2026-03-09"
 ---

--- a/content/docs/factbase/index.mdx
+++ b/content/docs/factbase/index.mdx
@@ -1,6 +1,6 @@
 ---
 wikiId: E1019
-title: "KB Data Overview"
+title: "FactBase Overview"
 description: "Structured data across wiki entities - facts, properties, and coverage statistics"
 contentFormat: dashboard
 lastEdited: "2026-03-09"


### PR DESCRIPTION
## Summary

Standardizes page type terminology across the UI to use consistent, descriptive names:

| URL pattern | New name |
|---|---|
| `/organizations/aclu` (directory pages) | **Profile page** |
| `/wiki/E123` (wiki articles) | **Wiki page** |
| `/factbase/entity/aclu` (structured data) | **FactBase page** |

- **Profile page headers** (orgs, people, projects): "KB data" link renamed to "FactBase"
- **FactBase entity page**: Single "Wiki page" link split into conditional "Profile page" (only shown when a directory page exists) and "Wiki page" (only shown when entity has a `wikiId`). Previously always showed a "Wiki page" link even when pointing to a profile/directory page.
- **FactBase overview**: "KB Data Overview" title -> "FactBase Overview"; "Knowledge Base (KB)" description -> "FactBase"
- **All user-visible "KB" labels**: Updated across explore tables, coverage dashboards, footnote fallback text, tooltips, and MDX descriptions (21 files total)
- **Tests**: Updated assertions to match new terminology strings

Closes #3859

## Test plan
- [x] `pnpm test` passes (4995 tests, 0 failures)
- [x] `pnpm build` succeeds
- [ ] Visually verify org profile page header shows "FactBase" link instead of "KB data"
- [ ] Visually verify FactBase entity page shows separate "Profile page" and "Wiki page" links
- [ ] Visually verify FactBase entity page hides "Wiki page" link for entities without wikiId

🤖 Generated with [Claude Code](https://claude.com/claude-code)