### PR TITLE
Fix remaining KB data references in frontier-ai-comparison

### DIFF
--- a/content/docs/knowledge-base/organizations/frontier-ai-comparison.mdx
+++ b/content/docs/knowledge-base/organizations/frontier-ai-comparison.mdx
@@ -49,7 +49,7 @@ The frontier AI landscape is consolidating around 5-6 major players, with the ra
 
 *Sources: [Sacra](https://sacra.com/c/anthropic/), [PitchBook](https://pitchbook.com/profiles/company/527294-17), [Bloomberg](https://www.bloomberg.com/news/articles/2026-01-21/anthropic-s-revenue-run-rate-tops-9-billion-as-vcs-pile-in)*
 
-#### Revenue Run-Rate (KB data)
+#### Revenue Run-Rate (FactBase)
 
 <FBCompareChart
   property="revenue"
@@ -63,7 +63,7 @@ The frontier AI landscape is consolidating around 5-6 major players, with the ra
   title="Revenue ARR — Frontier AI Labs"
 />
 
-#### Valuation (KB data)
+#### Valuation (FactBase)
 
 <FBCompareChart
   property="valuation"
@@ -78,7 +78,7 @@ The frontier AI landscape is consolidating around 5-6 major players, with the ra
   title="Latest Valuation — Frontier AI Labs"
 />
 
-#### Headcount (KB data)
+#### Headcount (FactBase)
 
 <FBCompareChart
   property="headcount"


### PR DESCRIPTION
## Summary
- Renames 3 remaining user-visible "KB data" section headers to "FactBase" in `frontier-ai-comparison.mdx`
- Follow-up to #3865 which renamed KB Data -> FactBase across 21 files but missed these MDX headings

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (4995 tests)
- [ ] Verify the frontier-ai-comparison page renders correctly with the new headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data source attribution labels in organization comparison sections. Revenue run-rate, valuation, and headcount metrics now explicitly reference FactBase, improving transparency and clarity regarding data origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->