### PR TITLE
Restructure Policy nav: add Politicians + Races, move Funding to Entities

### DIFF
--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -25,6 +25,7 @@ export const NAV_ITEMS: NavItem[] = [
       { href: "/people", label: "People" },
       { href: "/ai-models", label: "AI Models" },
       { href: "/projects", label: "Projects" },
+      { href: "/funding-programs", label: "Funding Programs" },
     ],
   },
   {
@@ -39,8 +40,8 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Policy",
     items: [
       { href: "/legislation", label: "Legislation" },
-      // /races hidden from nav — page is empty (0 entries). Re-add when data exists.
-      { href: "/funding-programs", label: "Funding" },
+      { href: "/politicians", label: "Politicians" },
+      { href: "/races", label: "Races" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Move **Funding Programs** from Policy → Entities (it's about funding sources, not governance)
- Add **Politicians** (92 entries) and **Races** (45 entries) to Policy tab
- Remove stale comment claiming /races has 0 entries (confirmed 45 on prod via Playwright)

Addresses item 14 from #3852.

## Test plan
- [x] `pnpm build` passes
- [x] Verified nav renders correctly on local server (screenshots taken)
- [x] Confirmed /races and /politicians have real data on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)