### PR TITLE
fix: map unverifiable verdicts to red (failed)

### DIFF
--- a/apps/web/src/components/verification/source-check-status.ts
+++ b/apps/web/src/components/verification/source-check-status.ts
@@ -67,7 +67,7 @@ const RECORD_VERDICT_MAP: Record<string, SourceCheckStatus> = {
   contradicted: "failed",
   outdated: "trouble",
   partial: "trouble",
-  unverifiable: "trouble",
+  unverifiable: "failed",
 };
 
 /**
@@ -90,7 +90,7 @@ const FACTBASE_VERDICT_MAP: Record<string, SourceCheckStatus> = {
   minor_issues: "trouble",
   inaccurate: "failed",
   unsupported: "failed",
-  not_verifiable: "trouble",
+  not_verifiable: "failed",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Maps `unverifiable` (TableBase) and `not_verifiable` (FactBase) source-check verdicts from orange ("trouble") to red ("failed")
- "Unverifiable" means the source check couldn't verify the claim — that's a failure, not just a concern

Addresses item 17 of #3852.

## Test plan
- [x] `pnpm build` passes
- [ ] Visual: check /organizations/80000-hours?tab=people — unverifiable dots should now be red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verification status indicators updated: results previously shown as "trouble" for unverifiable/not verifiable cases now display as "failed" for both record and citation sources; null/unknown cases continue to display as "not_run".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->