### PR TITLE
feat: add SourceCheckDot to factbase entity and fact pages

### DIFF
--- a/apps/web/src/app/factbase/fact/[factId]/page.tsx
+++ b/apps/web/src/app/factbase/fact/[factId]/page.tsx
@@ -13,6 +13,7 @@ import { getResourceIdForFact } from "@/data/resource-fact-links";
 import type { Fact, Property } from "@longterm-wiki/factbase";
 import { formatKBFactValue, formatKBDate, shortDomain, isUrl } from "@/components/wiki/factbase/format";
 import { KVRow, KVTable, Dash } from "@/components/wiki/factbase/factbase-detail-shared";
+import { FactSourceCheckDot } from "@/components/verification/FactSourceCheckDot";
 
 // ── Rendering mode ───────────────────────────────────────────────────
 // Render on-demand to reduce build output size (~492 pages saved).
@@ -187,7 +188,8 @@ export default async function FactDetailPage({ params }: PageProps) {
       </nav>
 
       {/* Header */}
-      <h1 className="text-2xl font-bold mb-1">
+      <h1 className="text-2xl font-bold mb-1 inline-flex items-center gap-2">
+        <FactSourceCheckDot factId={factId} size="md" />
         <FactValueDisplay fact={fact} unit={property?.unit} display={property?.display} />
       </h1>
       <p className="text-sm text-muted-foreground mb-6">
@@ -267,9 +269,12 @@ export default async function FactDetailPage({ params }: PageProps) {
         </KVRow>
         <KVRow label="Notes">{fact.notes ?? <Dash />}</KVRow>
         <KVRow label="Verification">
-          <FactLink href={`/source-checks/fact/${factId}`}>
-            view source checks {"\u2192"}
-          </FactLink>
+          <span className="inline-flex items-center gap-2">
+            <FactSourceCheckDot factId={factId} size="md" />
+            <FactLink href={`/source-checks/fact/${factId}`}>
+              view source checks {"\u2192"}
+            </FactLink>
+          </span>
         </KVRow>
       </KVTable>
 
@@ -321,6 +326,7 @@ export default async function FactDetailPage({ params }: PageProps) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="pl-3 py-2 font-medium w-5"></th>
                   <th className="px-3 py-2 font-medium">As Of</th>
                   <th className="px-3 py-2 font-medium">Value</th>
                   <th className="px-3 py-2 font-medium">Source</th>
@@ -335,6 +341,9 @@ export default async function FactDetailPage({ params }: PageProps) {
                       key={f.id}
                       className={`border-t border-border ${isCurrent ? "bg-primary/5" : "[&:nth-child(even)]:bg-muted/30"}`}
                     >
+                      <td className="pl-3 py-1.5">
+                        <FactSourceCheckDot factId={f.id} size="md" />
+                      </td>
                       <td className="px-3 py-1.5">{formatKBDate(f.asOf)}</td>
                       <td className="px-3 py-1.5 font-mono">
                         <FactValueDisplay fact={f} unit={property?.unit} display={property?.display} />

--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -9,6 +9,7 @@ import {
   titleCase,
   isUrl,
 } from "@/components/wiki/factbase/format";
+import { FactSourceCheckDot } from "@/components/verification/FactSourceCheckDot";
 
 import type { VerdictRow } from "./entity-detail-shared";
 import { VerdictBadge } from "./entity-verdict";
@@ -121,7 +122,8 @@ export function CategoryFactSection({
           return (
             <details key={propertyId} id={propertyId} className="group scroll-mt-16">
               <summary className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-muted/30 text-sm select-none transition-colors">
-                <span className="font-semibold min-w-[10rem] text-foreground/90">
+                <span className="inline-flex items-center gap-1.5 font-semibold min-w-[10rem] text-foreground/90">
+                  <FactSourceCheckDot factId={latestFact.id} size="sm" />
                   {property?.name ?? propertyId}
                 </span>
                 <span className="flex-1 text-muted-foreground truncate font-mono text-[13px]">
@@ -152,6 +154,7 @@ export function CategoryFactSection({
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="text-xs text-muted-foreground border-b border-border">
+                      <th className="text-left py-1 pr-1 font-medium w-5"></th>
                       <th className="text-left py-1 pr-3 font-medium">As Of</th>
                       <th className="text-left py-1 pr-3 font-medium">Value</th>
                       <th className="text-left py-1 pr-3 font-medium">Source</th>
@@ -166,6 +169,9 @@ export function CategoryFactSection({
                       const verdict = verdicts.get(fact.id);
                       return (
                         <tr key={fact.id} id={fact.id} className="scroll-mt-16">
+                          <td className="py-1.5 pr-1">
+                            <FactSourceCheckDot factId={fact.id} size="md" />
+                          </td>
                           <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
                             {formatKBDate(fact.asOf)}
                           </td>


### PR DESCRIPTION
## Summary

- Adds `FactSourceCheckDot` to the FactBase entity page (`/factbase/entity/[entityId]`) in both the collapsed summary rows and expanded fact detail tables of the `CategoryFactSection` component
- Adds `FactSourceCheckDot` to the FactBase fact detail page (`/factbase/fact/[factId]`) in the header, verification row, and time series table
- Preserves all existing columns (Source, Verified) and the `VerificationSummary` overview -- the dot supplements rather than replaces existing displays

Follows up on PR #3870 which added `SourceCheckDot` to wiki page components (`FBF`, `FBEntitySidebar`, `FBFactTable`) but missed the dedicated FactBase pages.

Closes #3857

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (5009 tests)
- [ ] Visual check: `/factbase/entity/anthropic` shows dots next to fact property names and per-row in expanded tables
- [ ] Visual check: `/factbase/fact/<any-fact-id>` shows dot in header and verification row

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source verification indicators (visual dots) throughout the fact display interface to show verification status at a glance
  * Integrated check indicators alongside fact headers and within the verification section for improved transparency and quick reference
  * Introduced new verification status column to fact tables, enabling streamlined review of fact verification across the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->