### PR TITLE
Complete FactBase source-check dots: remove source/verified columns, add dots to fact pages

### DIFF
--- a/apps/web/src/app/factbase/entity/[entityId]/page.tsx
+++ b/apps/web/src/app/factbase/entity/[entityId]/page.tsx
@@ -329,7 +329,6 @@ export default async function KBEntityPage({
                 categoryLabel={CATEGORY_LABELS[category] ?? titleCase(category)}
                 propertyIds={propertyIds}
                 factGroups={factGroups}
-                verdicts={verdicts}
               />
             );
           })}

--- a/apps/web/src/app/factbase/fact/[factId]/page.tsx
+++ b/apps/web/src/app/factbase/fact/[factId]/page.tsx
@@ -188,9 +188,9 @@ export default async function FactDetailPage({ params }: PageProps) {
       </nav>
 
       {/* Header */}
-      <h1 className="text-2xl font-bold mb-1 inline-flex items-center gap-2">
-        <FactSourceCheckDot factId={factId} size="md" />
+      <h1 className="text-2xl font-bold mb-1 flex items-center gap-2">
         <FactValueDisplay fact={fact} unit={property?.unit} display={property?.display} />
+        <FactSourceCheckDot factId={factId} sourceUrl={fact.source} size="md" />
       </h1>
       <p className="text-sm text-muted-foreground mb-6">
         <FactLink href={`/factbase/entity/${fact.subjectId}`}>{entityName}</FactLink>
@@ -270,7 +270,7 @@ export default async function FactDetailPage({ params }: PageProps) {
         <KVRow label="Notes">{fact.notes ?? <Dash />}</KVRow>
         <KVRow label="Verification">
           <span className="inline-flex items-center gap-2">
-            <FactSourceCheckDot factId={factId} size="md" />
+            <FactSourceCheckDot factId={factId} sourceUrl={fact.source} size="md" />
             <FactLink href={`/source-checks/fact/${factId}`}>
               view source checks {"\u2192"}
             </FactLink>
@@ -326,11 +326,11 @@ export default async function FactDetailPage({ params }: PageProps) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="pl-3 py-2 font-medium w-5"></th>
                   <th className="px-3 py-2 font-medium">As Of</th>
                   <th className="px-3 py-2 font-medium">Value</th>
                   <th className="px-3 py-2 font-medium">Source</th>
                   <th className="px-3 py-2 font-medium">Fact ID</th>
+                  <th className="px-3 py-2 font-medium w-5"></th>
                 </tr>
               </thead>
               <tbody>
@@ -341,9 +341,6 @@ export default async function FactDetailPage({ params }: PageProps) {
                       key={f.id}
                       className={`border-t border-border ${isCurrent ? "bg-primary/5" : "[&:nth-child(even)]:bg-muted/30"}`}
                     >
-                      <td className="pl-3 py-1.5">
-                        <FactSourceCheckDot factId={f.id} size="md" />
-                      </td>
                       <td className="px-3 py-1.5">{formatKBDate(f.asOf)}</td>
                       <td className="px-3 py-1.5 font-mono">
                         <FactValueDisplay fact={f} unit={property?.unit} display={property?.display} />
@@ -370,6 +367,9 @@ export default async function FactDetailPage({ params }: PageProps) {
                         ) : (
                           <FactLink href={`/factbase/fact/${f.id}`}>{f.id}</FactLink>
                         )}
+                      </td>
+                      <td className="px-3 py-1.5">
+                        <FactSourceCheckDot factId={f.id} sourceUrl={f.source} size="sm" />
                       </td>
                     </tr>
                   );

--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -11,8 +11,6 @@ import {
 } from "@/components/wiki/factbase/format";
 import { FactSourceCheckDot } from "@/components/verification/FactSourceCheckDot";
 
-import type { VerdictRow } from "./entity-detail-shared";
-import { VerdictBadge } from "./entity-verdict";
 import { SectionHeader } from "./entity-section-header";
 
 export function SourceCell({ fact }: { fact: Fact }) {
@@ -98,13 +96,11 @@ export function CategoryFactSection({
   categoryLabel,
   propertyIds,
   factGroups,
-  verdicts,
 }: {
   category: string;
   categoryLabel: string;
   propertyIds: string[];
   factGroups: Map<string, Fact[]>;
-  verdicts: Map<string, VerdictRow>;
 }) {
   return (
     <section className="mb-6">
@@ -123,7 +119,7 @@ export function CategoryFactSection({
             <details key={propertyId} id={propertyId} className="group scroll-mt-16">
               <summary className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-muted/30 text-sm select-none transition-colors">
                 <span className="inline-flex items-center gap-1.5 font-semibold min-w-[10rem] text-foreground/90">
-                  <FactSourceCheckDot factId={latestFact.id} size="sm" />
+                  <FactSourceCheckDot factId={latestFact.id} sourceUrl={latestFact.source} size="sm" />
                   {property?.name ?? propertyId}
                 </span>
                 <span className="flex-1 text-muted-foreground truncate font-mono text-[13px]">
@@ -154,24 +150,16 @@ export function CategoryFactSection({
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="text-xs text-muted-foreground border-b border-border">
-                      <th className="text-left py-1 pr-1 font-medium w-5"></th>
                       <th className="text-left py-1 pr-3 font-medium">As Of</th>
                       <th className="text-left py-1 pr-3 font-medium">Value</th>
-                      <th className="text-left py-1 pr-3 font-medium">Source</th>
-                      {verdicts.size > 0 && (
-                        <th className="text-left py-1 pr-3 font-medium">Verified</th>
-                      )}
-                      <th className="text-left py-1 font-medium">Fact ID</th>
+                      <th className="text-left py-1 pr-3 font-medium">Fact ID</th>
+                      <th className="text-left py-1 font-medium w-5"></th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-border/50">
                     {facts.map((fact) => {
-                      const verdict = verdicts.get(fact.id);
                       return (
                         <tr key={fact.id} id={fact.id} className="scroll-mt-16">
-                          <td className="py-1.5 pr-1">
-                            <FactSourceCheckDot factId={fact.id} size="md" />
-                          </td>
                           <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
                             {formatKBDate(fact.asOf)}
                           </td>
@@ -179,24 +167,15 @@ export function CategoryFactSection({
                             <FactValueDisplay fact={fact} property={property} />
                           </td>
                           <td className="py-1.5 pr-3">
-                            <SourceCell fact={fact} />
-                          </td>
-                          {verdicts.size > 0 && (
-                            <td className="py-1.5 pr-3">
-                              {verdict ? (
-                                <VerdictBadge verdict={verdict} />
-                              ) : (
-                                <span className="text-xs text-muted-foreground">&mdash;</span>
-                              )}
-                            </td>
-                          )}
-                          <td className="py-1.5">
                             <Link
                               href={`/factbase/fact/${fact.id}`}
                               className="text-blue-600 hover:underline dark:text-blue-400 font-mono text-xs"
                             >
                               {fact.id}
                             </Link>
+                          </td>
+                          <td className="py-1.5 pl-1">
+                            <FactSourceCheckDot factId={fact.id} sourceUrl={fact.source} size="md" />
                           </td>
                         </tr>
                       );

--- a/apps/web/src/components/verification/FactSourceCheckDot.tsx
+++ b/apps/web/src/components/verification/FactSourceCheckDot.tsx
@@ -10,10 +10,12 @@ import { factbaseVerdictToStatus } from "./source-check-status";
 
 export function FactSourceCheckDot({
   factId,
+  sourceUrl,
   size = "sm",
   className,
 }: {
   factId: string;
+  sourceUrl?: string | null;
   size?: "sm" | "md";
   className?: string;
 }) {
@@ -23,6 +25,7 @@ export function FactSourceCheckDot({
     <SourceCheckDot
       status={factbaseVerdictToStatus(verification)}
       originalVerdict={verification}
+      sourceUrl={sourceUrl}
       size={size}
       className={className}
     />


### PR DESCRIPTION
## Summary
- Remove redundant Source and Verified columns from FactBase category fact tables — the SourceCheckDot now carries this info in its tooltip
- Add `sourceUrl` prop to `FactSourceCheckDot` so tooltip shows the source domain
- Add SourceCheckDot to fact detail pages (header, verification section, time series table)
- Dot positioned as last column per design spec

Completes #3857

Closes #3857

## Changes
- `FactSourceCheckDot.tsx` — added optional `sourceUrl` prop, passed through to SourceCheckDot tooltip
- `entity-fact-display.tsx` — removed Source column (`SourceCell`), removed Verified column (`VerdictBadge`), removed `verdicts` prop; dot now last column with source URL
- `factbase/fact/[factId]/page.tsx` — dot in header, verification section, and time series table (last column)
- `factbase/entity/[entityId]/page.tsx` — removed `verdicts` prop from CategoryFactSection call

## Test plan
- [x] `pnpm build` passes
- [x] Gate check passes (42 checks)
- [x] Category fact tables show dots without Source/Verified text columns
- [x] Fact detail page shows dot in header and time series
- [ ] Visual spot-check on real org pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)