### PR TITLE
review: move sid_ filter to data layer, tighten E2E assertions

### DIFF
--- a/apps/web/e2e/factbase.spec.ts
+++ b/apps/web/e2e/factbase.spec.ts
@@ -5,7 +5,8 @@ test.describe("FactBase pages", () => {
     // /factbase now renders the FactBase overview page directly
     const response = await page.goto("/factbase");
     expect(response?.status()).toBe(200);
-    await expect(page.locator("h1").first()).toBeVisible({ timeout: 10000 });
+    expect(page.url()).toMatch(/\/factbase$/);
+    await expect(page.locator("h1").first()).toContainText("FactBase", { timeout: 10000 });
   });
 
   test("/sources loads", async ({ page }) => {

--- a/apps/web/e2e/projects-events.spec.ts
+++ b/apps/web/e2e/projects-events.spec.ts
@@ -6,8 +6,8 @@ test.describe("Projects Directory", () => {
     await expect(page).toHaveTitle(/Projects/);
     await expect(page.locator("h1")).toContainText("Projects");
 
-    // Should have project rows in the table
-    const projectLinks = page.locator('a[href^="/projects/"]');
+    // Should have project rows in the main content area
+    const projectLinks = page.locator('main a[href^="/projects/"]');
     const linkCount = await projectLinks.count();
     expect(linkCount).toBeGreaterThan(5);
   });

--- a/apps/web/src/app/factbase/factbase-facts-content.tsx
+++ b/apps/web/src/app/factbase/factbase-facts-content.tsx
@@ -92,8 +92,6 @@ export function FBFactsExplorerContent() {
 
     for (const fact of facts) {
       if (fact.propertyId === "description") continue;
-      // Skip stale PG rows with malformed sid_-prefixed fact IDs (#3881)
-      if (fact.id.startsWith("sid_")) continue;
 
       const property = propertiesById.get(fact.propertyId);
 

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -23,6 +23,7 @@
 import fs from "fs";
 import path from "path";
 import { getIdRegistry, getTypedEntityByStableId, getTypedEntities } from "@/data/tablebase";
+import { isSid } from "@/lib/stable-id";
 import type { Fact, Property, Entity } from "@longterm-wiki/factbase";
 import type { SerializedKB } from "@longterm-wiki/factbase";
 
@@ -106,9 +107,10 @@ export function getFactBaseFacts(entity: string, property?: string): Fact[] {
 
   const key = resolveEntityKey(entity);
   const facts = fb.facts[key] ?? [];
-  const filtered = property
-    ? facts.filter((f) => f.propertyId === property)
-    : facts;
+  // Filter out stale PG rows with malformed sid_-prefixed fact IDs (#3881)
+  const filtered = facts.filter(
+    (f) => !isSid(f.id) && (!property || f.propertyId === property),
+  );
 
   return sortByAsOfDesc(filtered);
 }


### PR DESCRIPTION
## Summary

Follow-up to #3889 (already merged). Improvements identified during code review:

- **Move sid_ filter to data layer**: The `sid_`-prefixed fact ID guard was applied only in `factbase-facts-content.tsx`, but `getKBFacts()` is called by 20+ consumers. Moved the filter into `getFactBaseFacts()` in `factbase.ts` so all consumers are protected.
- **Tighten factbase assertion**: Added URL check (`/factbase$`) to catch accidental redirects, and `toContainText("FactBase")` on h1 to catch error pages.
- **Scope project links selector**: Changed `a[href^="/projects/"]` to `main a[href^="/projects/"]` to avoid counting nav/sidebar links.

## Test plan

- [x] `pnpm test` passes (237 pass, 1 pre-existing failure unrelated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fact filtering logic to properly display all relevant facts in FactBase that were previously excluded.

* **Tests**
  * Updated end-to-end tests to more accurately validate routing and content rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->