### PR TITLE
fix: exempt release PRs from Protected Paths Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,8 +637,11 @@ jobs:
     # code for mandatory human review. Without the `gate:rules-ok` label,
     # the check fails so these changes cannot merge unnoticed.
     name: Protected Paths Check
+    # Release PRs (main → production) are exempt: individual PRs already
+    # went through protected-paths review before merging to main.
     if: >-
-      github.event_name == 'pull_request' && (
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref != 'production' && (
         github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
         github.event.label.name == 'gate:rules-ok'
       )


### PR DESCRIPTION
## Summary

- Release PRs (main -> production) now skip the Protected Paths Check automatically
- The check was failing on every release because release PRs accumulate protected-path changes from multiple already-reviewed PRs, requiring manual `gate:rules-ok` labeling each time
- Individual PRs still go through the protected-paths review when targeting `main` -- no security gap

## How it works

Added `github.event.pull_request.base.ref != 'production'` to the job's `if:` condition. When the PR base branch is `production` (i.e., a release PR), the job is skipped entirely. For PRs targeting `main`, behavior is unchanged.

## Test plan

- [ ] Verify CI passes on this PR (the workflow file itself is valid YAML and the condition is syntactically correct)
- [ ] On the next release PR (main -> production), confirm the Protected Paths Check is skipped or auto-passes
- [ ] Verify a normal PR to `main` that touches `.claude/rules/` still triggers the protected-paths gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved handling of pull requests targeting the production branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->