### PR TITLE
feat: coverage popover + search + dashboard (Waves 3-4)

### DIFF
--- a/apps/web/src/app/internal/entities/entities-content.tsx
+++ b/apps/web/src/app/internal/entities/entities-content.tsx
@@ -1,4 +1,5 @@
 import { getTypedEntities, getEntityHref, getPageById, getPageCoverageItems, getPageRankings, getIdRegistry } from "@/data";
+import { getEntityDataDepth } from "@/data/entity-coverage";
 import { fetchDetailed, type RpcEntitySummaryRow } from "@lib/wiki-server";
 import { EntitiesDataTable } from "./entities-data-table";
 import type { UnifiedEntityRow } from "./entities-data-table";
@@ -128,6 +129,7 @@ export async function EntitiesContent() {
       // Coverage
       coverageScore: cov?.score ?? null,
       coverageTotal: cov?.total ?? null,
+      dataDepth: getEntityDataDepth(e.id),
       // Risk
       riskLevel,
       riskScore: cov?.riskScore ?? null,

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -17,6 +17,7 @@ import {
 import { Search, Columns3, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
+import { CoverageDots } from "@/components/coverage/CoverageDots";
 
 // ---------------------------------------------------------------------------
 // Unified row type — merges entity metadata + page coverage + importance
@@ -51,6 +52,7 @@ export interface UnifiedEntityRow {
   // Coverage
   coverageScore: number | null;
   coverageTotal: number | null;
+  dataDepth: number | null;
   // Hallucination risk
   riskLevel: "low" | "medium" | "high" | null;
   riskScore: number | null;
@@ -421,6 +423,7 @@ const COLUMN_LABELS: Record<string, string> = {
   updateFrequency: "Update Freq (days)",
   // Coverage
   coverageScore: "Coverage Score",
+  dataDepth: "Data Depth",
   // Risk
   riskLevel: "Hallucination Risk",
   riskScore: "Risk Score",
@@ -651,6 +654,13 @@ const columns: ColumnDef<UnifiedEntityRow>[] = [
     accessorKey: "coverageScore",
     header: ({ column }) => <SortableHeader column={column} title="Coverage: passing items out of 13">Cov</SortableHeader>,
     cell: ({ row }) => <ScoreBadge score={row.original.coverageScore} total={row.original.coverageTotal} />,
+    sortUndefined: "last",
+  },
+  {
+    id: "dataDepth",
+    accessorKey: "dataDepth",
+    header: ({ column }) => <SortableHeader column={column} title="Entity data depth (1-4 from structured data scoring)">Depth</SortableHeader>,
+    cell: ({ row }) => row.original.dataDepth != null ? <CoverageDots score={row.original.dataDepth} /> : <span className="text-muted-foreground/30">&mdash;</span>,
     sortUndefined: "last",
   },
 
@@ -1045,7 +1055,7 @@ const PRESETS: Record<string, Preset> = {
   overview: {
     label: "Overview",
     description: "Key quality, risk, and status metrics for pages with content",
-    columns: ["title", "entityType", "quality", "readerImportance", "coverageScore", "riskLevel", "lastUpdated", "wordCount", "category"],
+    columns: ["title", "entityType", "quality", "readerImportance", "coverageScore", "dataDepth", "riskLevel", "lastUpdated", "wordCount", "category"],
     defaultSort: [{ id: "quality", desc: true }],
     filters: { pageFilter: "with" },
   },

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Breadcrumbs } from "@/components/directory";
+import { CoveragePopover } from "@/components/coverage/CoveragePopover";
+import { computeLegislationCoverage, getLegislationSignals } from "@/components/coverage/coverage-score";
 import { ProfileTabs, type ProfileTab } from "@/components/directory/ProfileTabs";
 import { RelatedPages } from "@/components/RelatedPages";
 import { FBAutoFacts } from "@/components/wiki/factbase/FBAutoFacts";
@@ -787,6 +789,26 @@ export default async function LegislationDetailPage({
                   {scope}
                 </span>
               )}
+              {(() => {
+                const covInput = {
+                  introduced,
+                  policyStatus: statusKey,
+                  author,
+                  jurisdiction,
+                  billNumber,
+                  fullTextUrl: entity.fullTextUrl,
+                  description: entity.description,
+                  tags: entity.tags,
+                  wikiId: entity.stableId,
+                };
+                return (
+                  <CoveragePopover
+                    score={computeLegislationCoverage(covInput)}
+                    signals={getLegislationSignals(covInput)}
+                    size="md"
+                  />
+                );
+              })()}
             </div>
             <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap mt-1">
               {jurisdiction && <span>{jurisdiction}</span>}

--- a/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { Breadcrumbs } from "@/components/directory";
+import { CoveragePopover } from "@/components/coverage/CoveragePopover";
+import { computeOrgCoverage, getOrgSignals, type OrgCoverageInput } from "@/components/coverage/coverage-score";
 import {
   formatKBDate,
   shortDomain,
@@ -32,6 +34,8 @@ export interface OrgHeaderData {
   websiteUrl: string | null;
   wikiHref: string | null;
   founders: AuthorRef[];
+  /** Pre-computed coverage scoring input for the popover */
+  coverageInput?: OrgCoverageInput;
 }
 
 export function OrgProfileHeader({
@@ -103,6 +107,13 @@ export function OrgProfileHeader({
                   {ORG_STATUS_LABELS[data.orgStatus] ?? data.orgStatus}
                 </span>
               )}
+            {data.coverageInput && (
+              <CoveragePopover
+                score={computeOrgCoverage(data.coverageInput)}
+                signals={getOrgSignals(data.coverageInput)}
+                size="md"
+              />
+            )}
           </div>
           {data.aliases && data.aliases.length > 0 && (
             <p className="text-xs text-muted-foreground/70 mb-0.5">

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -734,6 +734,21 @@ export default async function OrgProfilePage({
     });
   }
 
+  // Coverage scoring input for the header popover
+  const revFact = getKBLatest(entity.id, "revenue");
+  const valFact = getKBLatest(entity.id, "valuation");
+  const hcFact = getKBLatest(entity.id, "headcount");
+  const fundFact = getKBLatest(entity.id, "total-funding");
+  const coverageInput = {
+    revenueNum: revFact?.value.type === "number" ? revFact.value.value : null,
+    valuationNum: valFact?.value.type === "number" ? valFact.value.value : null,
+    headcount: hcFact?.value.type === "number" ? hcFact.value.value : null,
+    totalFundingNum: fundFact?.value.type === "number" ? fundFact.value.value : null,
+    foundedDate: data.foundedDateStr,
+    peopleCount: data.sortedPersons.length,
+    wikiPageId: entity.wikiPageId,
+  };
+
   const headerData = {
     id: entity.id,
     name: entity.name,
@@ -746,6 +761,7 @@ export default async function OrgProfilePage({
     websiteUrl: data.websiteUrl,
     wikiHref: data.wikiHref,
     founders: data.founders,
+    coverageInput,
   };
 
   return (

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { CoveragePopover } from "@/components/coverage/CoveragePopover";
+import { computePersonCoverage, getPersonSignals } from "@/components/coverage/coverage-score";
 import { resolveSlugAlias, getKBEntitySlug } from "@/data/factbase";
 import { isAnySid } from "@/lib/stable-id";
 import { titleToSlug } from "@/lib/slug-utils";
@@ -410,9 +412,30 @@ export default async function PersonProfilePage({
           {initials}
         </div>
         <div>
-          <h1 className="text-3xl font-extrabold tracking-tight mb-1">
-            {entity.name}
-          </h1>
+          <div className="flex items-center gap-3 mb-1">
+            <h1 className="text-3xl font-extrabold tracking-tight">
+              {entity.name}
+            </h1>
+            {(() => {
+              const covInput = {
+                role: roleFact?.value.type === "text" ? roleFact.value.value : null,
+                employerId: employedByFact?.value.type === "ref" ? employedByFact.value.value : null,
+                bornYear: bornYearFact?.value.type === "number" ? bornYearFact.value.value : null,
+                netWorthNum: netWorthFact?.value.type === "number" ? netWorthFact.value.value : null,
+                positionCount: positions.length,
+                publicationCount: publications.length,
+                careerHistoryCount: careerHistory.length,
+                wikiPageId: entity.wikiPageId,
+              };
+              return (
+                <CoveragePopover
+                  score={computePersonCoverage(covInput)}
+                  signals={getPersonSignals(covInput)}
+                  size="md"
+                />
+              );
+            })()}
+          </div>
           {entity.aliases && entity.aliases.length > 0 && (
             <p className="text-sm text-muted-foreground/70 mb-1">
               Also known as: {entity.aliases.join(", ")}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { SearchPageClient, type BrowseData } from "./search-client";
 import { getExploreItems } from "@data/explore";
+import { getAllEntityCoverageScores } from "@/data/entity-coverage";
 
 export const metadata: Metadata = {
   title: "Search | Longterm Wiki",
@@ -100,9 +101,19 @@ function buildBrowseData(): BrowseData {
 export default function SearchPage() {
   const browseData = buildBrowseData();
 
+  // Pre-compute coverage scores for directory-type entities only (server-side).
+  const directoryTypes = new Set(Object.keys(DIRECTORY_TYPES));
+  const coverageScores = getAllEntityCoverageScores();
+  const coverageMap: Record<string, number> = {};
+  for (const entry of coverageScores) {
+    if (directoryTypes.has(entry.entityType)) {
+      coverageMap[entry.id] = entry.score;
+    }
+  }
+
   return (
     <Suspense fallback={<SearchSkeleton />}>
-      <SearchPageClient browseData={browseData} />
+      <SearchPageClient browseData={browseData} coverageMap={coverageMap} />
     </Suspense>
   );
 }

--- a/apps/web/src/app/search/search-client.tsx
+++ b/apps/web/src/app/search/search-client.tsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   type LucideIcon,
 } from "lucide-react";
+import { CoverageDots } from "@/components/coverage/CoverageDots";
 
 // ── Browse data (passed from server component) ──────────────────────
 
@@ -230,7 +231,7 @@ function decodeEntities(text: string): string {
 
 // ── Component ────────────────────────────────────────────────────────
 
-export function SearchPageClient({ browseData }: { browseData: BrowseData }) {
+export function SearchPageClient({ browseData, coverageMap }: { browseData: BrowseData; coverageMap?: Record<string, number> }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
@@ -476,6 +477,7 @@ export function SearchPageClient({ browseData }: { browseData: BrowseData }) {
               query={query}
               showBadges={col.showBadges}
               selectedKey={selected >= 0 ? flatResults[selected]?.key : null}
+              coverageMap={coverageMap}
             />
           ))}
         </div>
@@ -507,6 +509,7 @@ function ResultColumnView({
   query,
   showBadges,
   selectedKey,
+  coverageMap,
 }: {
   title: string;
   icon: LucideIcon;
@@ -514,6 +517,7 @@ function ResultColumnView({
   query: string;
   showBadges: boolean;
   selectedKey: string | null;
+  coverageMap?: Record<string, number>;
 }) {
   return (
     <div className="min-w-0">
@@ -535,6 +539,7 @@ function ResultColumnView({
             query={query}
             showBadge={showBadges}
             isSelected={r.key === selectedKey}
+            coverageScore={coverageMap?.[r.key.split(":")[1]] ?? null}
           />
         ))}
       </div>
@@ -549,11 +554,13 @@ function ResultRow({
   query,
   showBadge,
   isSelected,
+  coverageScore,
 }: {
   result: UnifiedResult;
   query: string;
   showBadge: boolean;
   isSelected: boolean;
+  coverageScore: number | null;
 }) {
   const style = TYPE_STYLES[r.type] ?? FALLBACK_STYLE;
   const Icon = style.icon;
@@ -579,6 +586,9 @@ function ResultRow({
             <span className={`shrink-0 px-1.5 py-px text-[9px] font-semibold rounded ${style.badge}`}>
               {style.short}
             </span>
+          )}
+          {coverageScore != null && r.column === "entities" && (
+            <CoverageDots score={coverageScore} className="shrink-0 ml-0.5" />
           )}
           {isExternal && (
             <ExternalLink size={10} className="shrink-0 text-muted-foreground/25 mt-px" />

--- a/apps/web/src/components/coverage/CoveragePopover.tsx
+++ b/apps/web/src/components/coverage/CoveragePopover.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * CoveragePopover — Wraps CoverageDots with a click popover showing
+ * score breakdown and signal details.
+ */
+
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { CoverageDots } from "./CoverageDots";
+
+const SCORE_LABELS: Record<number, string> = {
+  1: "Stub",
+  2: "Basic",
+  3: "Moderate",
+  4: "Comprehensive",
+};
+
+interface CoveragePopoverProps {
+  /** Score from 1-4 */
+  score: number;
+  /** List of signals that contributed to the score */
+  signals?: string[];
+  /** Dot size */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function CoveragePopover({
+  score,
+  signals,
+  size = "sm",
+  className,
+}: CoveragePopoverProps) {
+  const clamped = Math.max(1, Math.min(4, Math.round(score)));
+  const label = SCORE_LABELS[clamped] ?? "Unknown";
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={`inline-flex cursor-default hover:opacity-80 transition-opacity ${className ?? ""}`}
+          aria-label={`Coverage: ${label} (${clamped}/4)`}
+        >
+          <CoverageDots score={score} size={size} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold text-foreground">
+              Coverage: {label}
+            </span>
+            <CoverageDots score={score} size="md" />
+          </div>
+
+          {signals && signals.length > 0 && (
+            <div className="border-t border-border/50 pt-2">
+              <p className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider mb-1">
+                Data signals detected
+              </p>
+              <ul className="space-y-0.5">
+                {signals.map((signal) => (
+                  <li
+                    key={signal}
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <span className="w-1 h-1 rounded-full bg-primary/70 shrink-0" />
+                    {signal}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p className="text-[10px] text-muted-foreground/50 border-t border-border/50 pt-1.5">
+            {clamped === 1
+              ? "This entity has minimal structured data."
+              : clamped === 4
+                ? "This entity has comprehensive structured data."
+                : signals && signals.length > 0
+                  ? `${signals.length} data signals detected.`
+                  : "This entity has partial structured data."}
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/coverage/coverage-score.ts
+++ b/apps/web/src/components/coverage/coverage-score.ts
@@ -356,3 +356,53 @@ export function computePublicationCoverage(row: PublicationCoverageInput): numbe
   if (signals >= 2) return 2;
   return 1;
 }
+
+// ── Signal extraction (for popover breakdown) ───────────────────────
+
+/** Extract human-readable signal names from an org entity. */
+export function getOrgSignals(row: OrgCoverageInput): string[] {
+  const signals: string[] = [];
+  if (row.revenueNum != null) signals.push("Revenue");
+  if (row.valuationNum != null) signals.push("Valuation");
+  if (row.headcount != null) signals.push("Headcount");
+  if (row.totalFundingNum != null) signals.push("Total funding");
+  if (row.foundedDate) signals.push("Founded date");
+  if (row.peopleCount != null && row.peopleCount >= 3) {
+    signals.push(`${row.peopleCount} people tracked`);
+    if (row.peopleCount >= 10) signals.push("10+ people (deep coverage)");
+  }
+  if (row.wikiPageId) signals.push("Wiki page");
+  return signals;
+}
+
+/** Extract human-readable signal names from a person entity. */
+export function getPersonSignals(row: PersonCoverageInput): string[] {
+  const signals: string[] = [];
+  if (row.role) signals.push("Role");
+  if (row.employerId) signals.push("Employer");
+  if (row.bornYear != null) signals.push("Birth year");
+  if (row.netWorthNum != null) signals.push("Net worth");
+  if ((row.careerHistoryCount ?? 0) >= 2) {
+    signals.push(`${row.careerHistoryCount} career entries`);
+    if ((row.careerHistoryCount ?? 0) >= 5) signals.push("5+ career entries (deep)");
+  }
+  if ((row.positionCount ?? 0) >= 1) signals.push(`${row.positionCount} positions`);
+  if ((row.publicationCount ?? 0) >= 1) signals.push(`${row.publicationCount} publications`);
+  if (row.wikiPageId) signals.push("Wiki page");
+  return signals;
+}
+
+/** Extract human-readable signal names from a legislation entity. */
+export function getLegislationSignals(row: LegislationCoverageInput): string[] {
+  const signals: string[] = [];
+  if (row.introduced) signals.push("Introduced date");
+  if (row.policyStatus) signals.push("Status");
+  if (row.author) signals.push("Author");
+  if (row.jurisdiction) signals.push("Jurisdiction");
+  if (row.billNumber) signals.push("Bill number");
+  if (row.fullTextUrl) signals.push("Full text link");
+  if (row.description) signals.push("Description");
+  if ((row.tags?.length ?? 0) >= 1) signals.push("Tags");
+  if (row.wikiId) signals.push("Wiki page");
+  return signals;
+}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { cn } from "@lib/utils";
+
+function Popover(props: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root {...props} />;
+}
+
+function PopoverTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return (
+    <PopoverPrimitive.Trigger
+      data-slot="popover-trigger"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-64 rounded-lg border border-border bg-card p-3 text-card-foreground shadow-md outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/apps/web/src/data/entity-coverage.ts
+++ b/apps/web/src/data/entity-coverage.ts
@@ -1,0 +1,150 @@
+/**
+ * Entity coverage data access layer.
+ *
+ * Computes coverage scores on-the-fly from entity data in database.json
+ * enriched with FactBase KB lookups for financial/relationship data.
+ */
+
+import { getTypedEntityById, getTypedEntities, type AnyEntity } from "@/data";
+import { getKBLatest, getKBEntities } from "@/data/factbase";
+import {
+  computeOrgCoverage,
+  computePersonCoverage,
+  computeAiModelCoverage,
+  computeLegislationCoverage,
+  computeProjectCoverage,
+  computeBenchmarkCoverage,
+  computeGenericCoverage,
+} from "@/components/coverage/coverage-score";
+
+/** Extract a numeric KB fact value, or null. */
+function kbNum(entityId: string, prop: string): number | null {
+  const fact = getKBLatest(entityId, prop);
+  return fact?.value.type === "number" ? fact.value.value : null;
+}
+
+/** Extract a text/date KB fact value, or null. */
+function kbText(entityId: string, prop: string): string | null {
+  const fact = getKBLatest(entityId, prop);
+  if (fact?.value.type === "text" || fact?.value.type === "date") return fact.value.value;
+  return null;
+}
+
+/** Lazy-computed reverse index: org stableId -> count of people employed there. */
+let _orgPeopleCount: Map<string, number> | null = null;
+function getOrgPeopleCount(orgStableId: string): number {
+  if (!_orgPeopleCount) {
+    _orgPeopleCount = new Map();
+    for (const person of getKBEntities().filter((e) => e.type === "person")) {
+      const fact = getKBLatest(person.id, "employed-by");
+      if (fact?.value.type === "ref") {
+        const orgId = fact.value.value;
+        _orgPeopleCount.set(orgId, (_orgPeopleCount.get(orgId) ?? 0) + 1);
+      }
+    }
+  }
+  return _orgPeopleCount.get(orgStableId) ?? 0;
+}
+
+/** Compute coverage score for any entity based on its type and available data. */
+export function getEntityDataDepth(entityId: string): number | null {
+  const entity = getTypedEntityById(entityId);
+  if (!entity) return null;
+  return computeEntityCoverage(entity);
+}
+
+/** Compute coverage for a typed entity. Dispatches to type-specific scorers. */
+function computeEntityCoverage(entity: AnyEntity): number {
+  const id = entity.id;
+  const type = entity.entityType;
+
+  switch (type) {
+    case "organization": {
+      const tbEntity = getTypedEntityById(id);
+      const stableId = tbEntity?.stableId;
+      return computeOrgCoverage({
+        revenueNum: kbNum(id, "revenue"),
+        valuationNum: kbNum(id, "valuation"),
+        headcount: kbNum(id, "headcount"),
+        totalFundingNum: kbNum(id, "total-funding"),
+        foundedDate: kbText(id, "founded-date"),
+        peopleCount: stableId ? getOrgPeopleCount(stableId) : 0,
+        wikiPageId: entity.wikiId ?? null,
+      });
+    }
+
+    case "person":
+    case "researcher":
+      return computePersonCoverage({
+        role: kbText(id, "role"),
+        employerId: (() => { const f = getKBLatest(id, "employed-by"); return f?.value.type === "ref" ? f.value.value : null; })(),
+        bornYear: kbNum(id, "born-year"),
+        netWorthNum: kbNum(id, "net-worth"),
+        wikiPageId: entity.wikiId ?? null,
+      });
+
+    case "ai-model":
+      return computeAiModelCoverage({
+        developer: (entity as any).developer ?? null,
+        releaseDate: (entity as any).releaseDate ?? null,
+        contextWindow: (entity as any).contextWindow ?? null,
+        parameterCount: (entity as any).parameterCount ?? null,
+        safetyLevel: (entity as any).safetyLevel ?? null,
+        wikiId: entity.wikiId ?? null,
+      });
+
+    case "policy":
+      return computeLegislationCoverage({
+        introduced: (entity as any).introduced ?? null,
+        policyStatus: (entity as any).policyStatus ?? null,
+        author: (entity as any).author ?? null,
+        jurisdiction: (entity as any).jurisdiction ?? null,
+        billNumber: (entity as any).billNumber ?? null,
+        fullTextUrl: (entity as any).fullTextUrl ?? null,
+        description: entity.description ?? null,
+        tags: entity.tags,
+        wikiId: entity.wikiId ?? null,
+      });
+
+    case "project":
+      return computeProjectCoverage({
+        description: entity.description ?? null,
+        status: (entity as any).projectStatus ?? null,
+        website: (entity as any).projectUrl ?? null,
+        orgName: (entity as any).organization ?? null,
+        clusters: entity.clusters,
+        wikiId: entity.wikiId ?? null,
+      });
+
+    case "benchmark":
+      return computeBenchmarkCoverage({
+        category: (entity as any).category ?? null,
+        scoringMethod: (entity as any).scoringMethod ?? null,
+        maintainer: (entity as any).maintainer ?? null,
+        description: entity.description ?? null,
+        wikiId: entity.wikiId ?? null,
+      });
+
+    default:
+      return computeGenericCoverage({
+        description: entity.description ?? null,
+        tags: entity.tags,
+        wikiId: entity.wikiId ?? null,
+      });
+  }
+}
+
+/** Get all entity coverage scores. Useful for dashboards and search. */
+export function getAllEntityCoverageScores(): Array<{
+  id: string;
+  title: string;
+  entityType: string;
+  score: number;
+}> {
+  return getTypedEntities().map((entity) => ({
+    id: entity.id,
+    title: entity.title,
+    entityType: entity.entityType,
+    score: computeEntityCoverage(entity),
+  }));
+}


### PR DESCRIPTION
## Summary

Waves 3-4 of Coverage Dots Everywhere (Discussion #3901). Builds on the merged PR #3912 which shipped the CoverageDots component, 12 scoring functions, and all 15 directory table integrations.

**Wave 3 — Entity headers with popover:**
- Radix-based Popover UI component
- CoveragePopover: click dots → score label + signal breakdown list
- Added to org header (via OrgProfileHeader), person header, legislation header
- Signal extractors: getOrgSignals, getPersonSignals, getLegislationSignals

**Wave 4a — Search results:**
- Pre-computed coverage map (directory types only) passed server→client
- CoverageDots inline in entity search results

**Wave 4b — Entities dashboard:**
- "Data Depth" column with CoverageDots in Entities & Pages dashboard (E908)
- Entity coverage data access layer with enriched KB lookups

## Test plan

- [x] `pnpm build` passes
- [ ] Visual: org header popover (click dots on /organizations/anthropic)
- [ ] Visual: person header popover (/people/dario-amodei)
- [ ] Visual: legislation header popover
- [ ] Visual: search results show dots for entity results
- [ ] Visual: Entities dashboard shows Data Depth column


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Data Coverage Scoring** – Added entity data coverage metrics displayed as visual indicators across entity listings, search results, and profile pages.

* **Coverage Information in Profiles** – Organization, person, and legislation profile pages now show coverage details with detected data signals in interactive popovers.

* **Entity Data Depth Column** – New "Data Depth" column in entity tables visualizes data completeness scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->