### PR TITLE
fix: add missing entity-coverage mock in entities-content test

### DIFF
--- a/apps/web/src/app/internal/__tests__/entities-content.test.tsx
+++ b/apps/web/src/app/internal/__tests__/entities-content.test.tsx
@@ -28,6 +28,10 @@ vi.mock("@lib/wiki-server", () => ({
   fetchDetailed: vi.fn(() => Promise.resolve({ ok: false, error: "mock" })),
 }));
 
+vi.mock("@/data/entity-coverage", () => ({
+  getEntityDataDepth: vi.fn(() => null),
+}));
+
 vi.mock("@/app/internal/entities/entities-data-table", () => ({
   EntitiesDataTable: () => null,
 }));


### PR DESCRIPTION
## Summary
- Adds missing `@/data/entity-coverage` mock to `entities-content.test.tsx`
- The test was failing because `entity-coverage.ts` imports `getTypedEntityById` from `@/data`, which wasn't included in the test's `@/data` mock
- Mocks the module directly since the test doesn't need real coverage calculations

## Test plan
- [x] All 6 tests in `entities-content.test.tsx` pass
- [x] Full test suite passes (5038 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by enhancing mocking dependencies for entities content component tests, strengthening test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->