### PR TITLE
Standardize record status dots: always right, add coverage

### DIFF
--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
 import type { RecordVerdict } from "@/data/tablebase";
 import { titleCase } from "@/components/wiki/factbase/format";
 import {
@@ -194,6 +194,7 @@ export function DivisionsTable({
                 </th>
                 <th className="text-left py-2.5 px-3 font-medium">Type</th>
                 <th className="text-left py-2.5 px-3 font-medium">Status</th>
+                <RecordStatusHeader />
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -204,11 +205,6 @@ export function DivisionsTable({
                 >
                   <td className="py-2 px-3">
                     <span className="flex items-center gap-1.5">
-                      <RecordVerificationDot
-                        verdict={row.verdict?.verdict}
-                        variant="label"
-                        href={row.verdict?.verdict ? `/source-checks/division/${encodeURIComponent(row.key)}` : undefined}
-                      />
                       {row.href ? (
                         <Link
                           href={row.href}
@@ -258,6 +254,10 @@ export function DivisionsTable({
                       </span>
                     )}
                   </td>
+                  <RecordStatusCell
+                    verdict={row.verdict?.verdict}
+                    sourceCheckHref={row.verdict?.verdict ? `/source-checks/division/${encodeURIComponent(row.key)}` : undefined}
+                  />
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -3,7 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
+import { computeFundingProgramCoverage } from "@/components/verification/coverage-scoring";
 import type { RecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { compareFPRows, type SortDir } from "./funding-programs-sort";
@@ -348,6 +349,7 @@ export function FundingProgramsListTable({
                 onSort={handleSort}
                 className="text-center"
               />
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -359,11 +361,6 @@ export function FundingProgramsListTable({
                 {/* Name */}
                 <td className="py-2.5 px-3">
                   <span className="flex items-center gap-1.5">
-                    <RecordVerificationDot
-                      verdict={row.verdict?.verdict}
-                      variant="label"
-                      href={row.verdict?.verdict ? `/source-checks/funding-program/${encodeURIComponent(row.id)}` : undefined}
-                    />
                     <Link
                       href={`/funding-programs/${row.id}`}
                       className="font-medium text-foreground hover:text-primary transition-colors"
@@ -439,6 +436,11 @@ export function FundingProgramsListTable({
                   )}
                 </td>
 
+                <RecordStatusCell
+                  verdict={row.verdict?.verdict}
+                  sourceCheckHref={row.verdict?.verdict ? `/source-checks/funding-program/${encodeURIComponent(row.id)}` : undefined}
+                  coverageScore={computeFundingProgramCoverage(row)}
+                />
               </tr>
             ))}
           </tbody>

--- a/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
+++ b/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { PaginationControls } from "@/components/directory/PaginationControls";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
 import type { RecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { compareFundingRoundRows, type SortDir, type FundingRoundSortKey } from "./funding-rounds-sort";
@@ -44,12 +44,6 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
   const [sortKey, setSortKey] = useState<FundingRoundSortKey>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(0);
-
-  // Only show verification dots if any row has a real verdict
-  const hasAnyVerdict = useMemo(
-    () => rows.some((r) => r.verdict != null && r.verdict.verdict !== "unchecked"),
-    [rows],
-  );
 
   // Instrument filter options
   const instruments = useMemo(() => {
@@ -199,6 +193,7 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
               <SortHeader label="Instrument" sortKey="instrument" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Lead Investor" sortKey="leadInvestor" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-left" />
               <SortHeader label="Date" sortKey="date" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -209,9 +204,6 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
               >
                 <td className="py-2 px-3">
                   <span className="flex items-center gap-1.5">
-                    {hasAnyVerdict && (
-                      <RecordVerificationDot verdict={row.verdict?.verdict} variant="label" />
-                    )}
                     <Link
                       href={`/funding-rounds/${row.key}`}
                       className="font-medium text-foreground text-xs hover:text-primary transition-colors"
@@ -279,6 +271,10 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
                 <td className="py-2 px-3 text-center text-muted-foreground text-xs whitespace-nowrap">
                   {row.date ?? <span className="text-muted-foreground/40">{"\u2014"}</span>}
                 </td>
+                <RecordStatusCell
+                  verdict={row.verdict?.verdict}
+                  sourceCheckHref={row.verdict?.verdict ? `/source-checks/funding-round/${encodeURIComponent(row.key)}` : undefined}
+                />
               </tr>
             ))}
           </tbody>

--- a/apps/web/src/app/organizations/[slug]/divisions-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/divisions-section.tsx
@@ -9,7 +9,8 @@ import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedDivisionRecord } from "./org-data";
 import { getDivisionHref } from "@/app/divisions/[slug]/division-data";
 import { getRecordVerdict } from "@/data/tablebase";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
+import { computeDivisionCoverage } from "@/components/verification/coverage-scoring";
 
 type LeadMap = Map<string, { name: string; href: string | null }>;
 type MembersMap = Map<string, Array<{ name: string; href: string | null; role: string | null }>>;
@@ -101,10 +102,7 @@ function DivisionCard({
       className={`relative border border-border/50 border-l-[3px] ${accentBorder} rounded-md px-3 py-2 hover:bg-muted/40 hover:border-border transition-all group/card`}
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-foreground leading-tight min-w-0">
-          <RecordVerificationDot
-            verdict={getRecordVerdict("division", String(d.key))?.verdict}
-          />
+        <span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-foreground leading-tight min-w-0 flex-1">
           <span className="truncate">
             {divHref ? (
               <Link
@@ -118,6 +116,16 @@ function DivisionCard({
             )}
           </span>
         </span>
+        <RecordStatusCell
+          as="inline"
+          verdict={getRecordVerdict("division", String(d.key))?.verdict}
+          coverageScore={computeDivisionCoverage({
+            lead: leadDisplay ?? null,
+            totalAmount: null,
+            status: d.status ?? null,
+            startDate: d.startDate ?? null,
+          })}
+        />
         {divHref && (
           <svg
             aria-hidden="true"
@@ -228,6 +236,7 @@ export function DivisionsSection({
               )}
               <th scope="col" className="text-center py-2.5 px-3 font-medium">Status</th>
               <th scope="col" className="text-center py-2.5 px-3 font-medium">Since</th>
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -240,11 +249,6 @@ export function DivisionsSection({
                 <tr key={d.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-2.5 px-3">
                     <span className="font-medium text-foreground text-xs flex items-center gap-1.5">
-                      <RecordVerificationDot
-                        verdict={verdict?.verdict}
-                        variant="label"
-                        href={verdict?.verdict ? `/source-checks/division/${encodeURIComponent(String(d.key))}` : undefined}
-                      />
                       {(() => {
                         const href = getDivisionHref(d);
                         return href ? (
@@ -355,6 +359,16 @@ export function DivisionsSection({
                   <td className="py-2.5 px-3 text-center text-muted-foreground text-xs">
                     {d.startDate && formatKBDate(d.startDate)}
                   </td>
+                  <RecordStatusCell
+                    verdict={verdict?.verdict}
+                    sourceCheckHref={verdict?.verdict ? `/source-checks/division/${encodeURIComponent(String(d.key))}` : undefined}
+                    coverageScore={computeDivisionCoverage({
+                      lead: d.lead,
+                      totalAmount: stats?.totalAmount ?? null,
+                      status: d.status,
+                      startDate: d.startDate,
+                    })}
+                  />
                 </tr>
               );
             })}

--- a/apps/web/src/app/organizations/[slug]/equity-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/equity-section.tsx
@@ -6,7 +6,7 @@
  */
 import Link from "next/link";
 import { getRecordVerdict } from "@data/tablebase";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedEquityPositionRecord, ParsedInvestmentRecord, ParsedCharitablePledgeRecord, NumericOrRange } from "./org-data";
@@ -136,6 +136,7 @@ export function EquityPositionsSection({
               {hasPledges && (
                 <th scope="col" className="text-right py-2 px-3 font-medium">Pledge %</th>
               )}
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -164,11 +165,6 @@ export function EquityPositionsSection({
                           source
                         </a>
                       )}
-                      <RecordVerificationDot
-                        verdict={verdict?.verdict}
-                        variant="label"
-                        href={verdict?.verdict ? `/source-checks/equity-position/${encodeURIComponent(String(pos.key))}` : undefined}
-                      />
                     </div>
                     {pos.notes && (
                       <div className="text-[11px] text-muted-foreground/70 leading-tight mt-0.5">
@@ -200,6 +196,10 @@ export function EquityPositionsSection({
                       )}
                     </td>
                   )}
+                  <RecordStatusCell
+                    verdict={verdict?.verdict}
+                    sourceCheckHref={verdict?.verdict ? `/source-checks/equity-position/${encodeURIComponent(String(pos.key))}` : undefined}
+                  />
                 </tr>
               );
             })}
@@ -221,6 +221,7 @@ export function EquityPositionsSection({
                   </td>
                 )}
                 {hasPledges && <td />}
+                <td />
               </tr>
             </tfoot>
           )}

--- a/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
+++ b/apps/web/src/app/organizations/[slug]/interactive-grants-table.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { z } from "zod";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { useServerTable } from "@/hooks/use-server-table";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell } from "@/components/verification/RecordStatusCell";
+import { computeGrantCoverage } from "@/components/verification/coverage-scoring";
 
 // ── Serializable grant row (no JSX, no functions — pure JSON) ───────
 
@@ -129,7 +130,7 @@ type ColumnId =
   | "division"
   | "status"
   | "notes"
-  | "verified";
+  | "recordStatus";
 
 // Map column IDs to server sort field names
 const COLUMN_TO_SORT_FIELD: Partial<Record<ColumnId, string>> = {
@@ -150,13 +151,6 @@ interface ColumnDef {
 
 const ALL_COLUMNS: ColumnDef[] = [
   { id: "name", label: "Grant", defaultVisible: true, align: "left" },
-  {
-    id: "verified",
-    label: "\u2713",
-    defaultVisible: true,
-    align: "center",
-    onlyIfData: (rows) => rows.some((r) => r.verificationVerdict),
-  },
   {
     id: "recipient",
     label: "Recipient",
@@ -207,6 +201,12 @@ const ALL_COLUMNS: ColumnDef[] = [
     defaultVisible: false,
     align: "left",
     onlyIfData: (rows) => rows.some((r) => r.notes),
+  },
+  {
+    id: "recordStatus",
+    label: "",
+    defaultVisible: true,
+    align: "right",
   },
 ];
 
@@ -309,7 +309,7 @@ export function InteractiveGrantsTable({
         case "notes":
           cmp = (a.notes ?? "").localeCompare(b.notes ?? "");
           break;
-        case "verified":
+        case "recordStatus":
           cmp = (a.verificationVerdict ?? "").localeCompare(b.verificationVerdict ?? "");
           break;
       }
@@ -769,12 +769,18 @@ function CellContent({
           {grant.notes.replace(/\\n/g, "\n")}
         </span>
       ) : null;
-    case "verified":
+    case "recordStatus":
       return (
-        <RecordVerificationDot
+        <RecordStatusCell
+          as="inline"
           verdict={grant.verificationVerdict}
-          variant="label"
-          href={grant.sourceCheckHref}
+          sourceCheckHref={grant.sourceCheckHref}
+          coverageScore={computeGrantCoverage({
+            amount: grant.amount,
+            date: grant.date,
+            source: grant.source,
+            programName: grant.programName,
+          })}
         />
       );
     default:

--- a/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
+++ b/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
@@ -15,7 +15,7 @@ import {
   isUrl,
 } from "@/components/wiki/factbase/format";
 import { FBRecordCollection } from "@/components/wiki/factbase/FBRecordCollection";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
 import {
   SectionHeader,
   SourceLink,
@@ -50,6 +50,7 @@ export function FundingHistorySection({
               <th scope="col" className="py-2 px-3 text-right font-medium">Valuation</th>
               <th scope="col" className="py-2 px-3 text-left font-medium">Lead Investor</th>
               <th scope="col" className="py-2 px-3 text-left font-medium hidden lg:table-cell">Type</th>
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -66,15 +67,9 @@ export function FundingHistorySection({
               return (
                 <tr key={round.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-2 px-3 font-medium">
-                    <span className="inline-flex items-center gap-1.5">
-                      <RecordVerificationDot
-                        verdict={getRecordVerdict("funding-round", String(round.key))?.verdict}
-                        href={`/source-checks/funding-round/${encodeURIComponent(String(round.key))}`}
-                      />
-                      <Link href={`/funding-rounds/${round.key}`} className="text-foreground hover:text-primary transition-colors">
-                        {name}
-                      </Link>
-                    </span>
+                    <Link href={`/funding-rounds/${round.key}`} className="text-foreground hover:text-primary transition-colors">
+                      {name}
+                    </Link>
                   </td>
                   <td className="py-2 px-3 text-muted-foreground whitespace-nowrap">
                     {date ? formatKBDate(date) : "\u2014"}
@@ -99,6 +94,10 @@ export function FundingHistorySection({
                   <td className="py-2 px-3 hidden lg:table-cell">
                     {instrument && <Badge>{instrument}</Badge>}
                   </td>
+                  <RecordStatusCell
+                    verdict={getRecordVerdict("funding-round", String(round.key))?.verdict}
+                    sourceCheckHref={`/source-checks/funding-round/${encodeURIComponent(String(round.key))}`}
+                  />
                 </tr>
               );
             })}
@@ -129,6 +128,7 @@ export function InvestorParticipationSection({
               <th scope="col" className="py-2 px-3 text-left font-medium">Round</th>
               <th scope="col" className="py-2 px-3 text-right font-medium">Amount</th>
               <th scope="col" className="py-2 px-3 text-left font-medium">Date</th>
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -146,19 +146,13 @@ export function InvestorParticipationSection({
               return (
                 <tr key={inv.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-1.5 px-3">
-                    <span className="inline-flex items-center gap-1.5">
-                      <RecordVerificationDot
-                        verdict={getRecordVerdict("investment", String(inv.key))?.verdict}
-                        href={`/source-checks/investment/${encodeURIComponent(String(inv.key))}`}
-                      />
-                      {investorHref ? (
-                        <Link href={investorHref} className="font-medium text-foreground hover:text-primary transition-colors">
-                          {investorName}
-                        </Link>
-                      ) : (
-                        <span className="font-medium">{investorName}</span>
-                      )}
-                    </span>
+                    {investorHref ? (
+                      <Link href={investorHref} className="font-medium text-foreground hover:text-primary transition-colors">
+                        {investorName}
+                      </Link>
+                    ) : (
+                      <span className="font-medium">{investorName}</span>
+                    )}
                   </td>
                   <td className="py-1.5 px-3 text-muted-foreground">
                     {roundName ? (
@@ -175,6 +169,10 @@ export function InvestorParticipationSection({
                   <td className="py-1.5 px-3 text-muted-foreground whitespace-nowrap">
                     {date ? formatKBDate(date) : <span className="text-muted-foreground/40">{"\u2014"}</span>}
                   </td>
+                  <RecordStatusCell
+                    verdict={getRecordVerdict("investment", String(inv.key))?.verdict}
+                    sourceCheckHref={`/source-checks/investment/${encodeURIComponent(String(inv.key))}`}
+                  />
                 </tr>
               );
             })}

--- a/apps/web/src/app/organizations/[slug]/people-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/people-section.tsx
@@ -14,7 +14,8 @@ import {
 } from "@/lib/wiki-server";
 import { isSid } from "@/lib/stable-id";
 import { SectionHeader } from "./org-shared";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
+import { computePersonnelCoverage } from "@/components/verification/coverage-scoring";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -234,6 +235,7 @@ export function PeopleSection({
               <th scope="col" className="py-2 px-3 text-left font-medium">
                 Tenure
               </th>
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -258,11 +260,6 @@ export function PeopleSection({
                 >
                   <td className="py-1.5 px-3">
                     <span className="flex items-center gap-1.5">
-                      <RecordVerificationDot
-                        verdict={person.verificationVerdict}
-                        variant="label"
-                        href={person.sourceCheckHref}
-                      />
                       {href ? (
                         <Link
                           href={href}
@@ -291,6 +288,11 @@ export function PeopleSection({
                   <td className="py-1.5 px-3 text-muted-foreground whitespace-nowrap text-xs">
                     {tenure}
                   </td>
+                  <RecordStatusCell
+                    verdict={person.verificationVerdict}
+                    sourceCheckHref={person.sourceCheckHref}
+                    coverageScore={computePersonnelCoverage(person)}
+                  />
                 </tr>
               );
             })}

--- a/apps/web/src/app/organizations/[slug]/programs-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/programs-section.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import { titleCase } from "@/components/wiki/factbase/format";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { getRecordVerdict } from "@data/tablebase";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell, RecordStatusHeader } from "@/components/verification/RecordStatusCell";
+import { computeFundingProgramCoverage } from "@/components/verification/coverage-scoring";
 import { PROGRAM_TYPE_LABELS, PROGRAM_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR } from "@/app/organizations/org-constants";
 import { SectionHeader, safeHref } from "./org-shared";
 import type { ParsedFundingProgramRecord } from "./org-data";
@@ -38,6 +39,7 @@ export function FundingProgramsSection({
               <th scope="col" className="text-right py-2 px-3 font-medium">Budget</th>
               <th scope="col" className="text-center py-2 px-3 font-medium">Status</th>
               <th scope="col" className="text-center py-2 px-3 font-medium">Deadline</th>
+              <RecordStatusHeader />
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -64,11 +66,6 @@ export function FundingProgramsSection({
                         source
                       </a>
                     )}
-                    <RecordVerificationDot
-                      verdict={verdict?.verdict}
-                      variant="label"
-                      href={verdict?.verdict ? `/source-checks/funding-program/${encodeURIComponent(String(p.key))}` : undefined}
-                    />
                     {p.description && (
                       <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
                         {p.description}
@@ -107,6 +104,11 @@ export function FundingProgramsSection({
                   <td className="py-2 px-3 text-center text-muted-foreground text-xs">
                     {p.deadline ?? p.openDate ?? <span className="text-muted-foreground/40">{"\u2014"}</span>}
                   </td>
+                  <RecordStatusCell
+                    verdict={verdict?.verdict}
+                    sourceCheckHref={verdict?.verdict ? `/source-checks/funding-program/${encodeURIComponent(String(p.key))}` : undefined}
+                    coverageScore={computeFundingProgramCoverage(p)}
+                  />
                 </tr>
               );
             })}

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -14,6 +14,7 @@ import type { OrgSortKey } from "@/app/organizations/org-sort";
 import { ORG_TYPE_LABELS, ORG_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR, computeCompletionScore } from "@/app/organizations/org-constants";
 import { useServerTable } from "@/hooks/use-server-table";
 import { formatCompactCurrency, formatCompactNumber as formatCompactNum } from "@/lib/format-compact";
+import { CoverageDots } from "@/components/verification/RecordStatusCell";
 
 export interface OrgRow {
   id: string;
@@ -583,7 +584,7 @@ export function OrganizationsTable({
                     {/* Completion Score */}
                     {visibleColumns.has("completionScore") && (
                       <td className="py-2.5 px-3 text-center">
-                        <CompletionDots score={row.completionScore} ariaLabel={`Completeness: ${row.completionScore}/4`} />
+                        <CoverageDots score={row.completionScore} ariaLabel={`Completeness: ${row.completionScore}/4`} />
                       </td>
                     )}
 
@@ -684,21 +685,3 @@ export function OrganizationsTable({
   );
 }
 
-/** Renders 1-4 filled/empty dots for data completeness. */
-function CompletionDots({ score, ariaLabel }: { score: number; ariaLabel: string }) {
-  return (
-    <span className="inline-flex gap-0.5" role="img" aria-label={ariaLabel}>
-      {[1, 2, 3, 4].map((i) => (
-        <span
-          key={i}
-          aria-hidden="true"
-          className={`inline-block w-1.5 h-1.5 rounded-full ${
-            i <= score
-              ? "bg-primary/70"
-              : "bg-muted-foreground/20"
-          }`}
-        />
-      ))}
-    </span>
-  );
-}

--- a/apps/web/src/app/people/[slug]/career-history.tsx
+++ b/apps/web/src/app/people/[slug]/career-history.tsx
@@ -3,7 +3,7 @@ import { resolveEntityRef, formatDateRange } from "@/lib/directory-utils";
 import { getKBEntitySlug } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
 import { CurrentBadge, FounderBadge } from "@/components/directory";
-import { RecordVerificationDot } from "@/components/verification/RecordVerificationDot";
+import { RecordStatusCell } from "@/components/verification/RecordStatusCell";
 import type { CareerHistoryEntry } from "../people-utils";
 
 export function CareerHistory({
@@ -35,10 +35,10 @@ export function CareerHistory({
                 <span className="font-semibold text-sm">{entry.title}</span>
                 {isFounder && <FounderBadge />}
                 {isCurrent && <CurrentBadge />}
-                <RecordVerificationDot
+                <RecordStatusCell
+                  as="inline"
                   verdict={verdict?.verdict}
-                  variant="label"
-                  href={verdict?.verdict ? `/source-checks/personnel/${encodeURIComponent(String(entry.key))}` : undefined}
+                  sourceCheckHref={verdict?.verdict ? `/source-checks/personnel/${encodeURIComponent(String(entry.key))}` : undefined}
                 />
               </div>
               <div className="text-sm text-muted-foreground mt-0.5">

--- a/apps/web/src/components/verification/RecordStatusCell.tsx
+++ b/apps/web/src/components/verification/RecordStatusCell.tsx
@@ -1,0 +1,100 @@
+/**
+ * RecordStatusCell — Unified status indicator column for record tables.
+ *
+ * Combines two indicators in a narrow rightmost column:
+ * - Source-check dot (verification verdict)
+ * - Coverage dots (data completeness, 1-4 scale)
+ *
+ * Usage in HTML tables:
+ *   <th> header: add an empty <th> with sr-only "Status" text
+ *   <td> cell:   <RecordStatusCell verdict={...} coverageScore={3} />
+ *
+ * Usage in card/flex layouts:
+ *   <RecordStatusCell as="inline" verdict={...} />
+ */
+
+import { RecordVerificationDot } from "./RecordVerificationDot";
+
+// ── CoverageDots (shared, also used by organizations-table) ──────────
+
+export function CoverageDots({
+  score,
+  max = 4,
+  ariaLabel,
+}: {
+  score: number;
+  max?: number;
+  ariaLabel?: string;
+}) {
+  return (
+    <span
+      className="inline-flex gap-0.5"
+      role="img"
+      aria-label={ariaLabel ?? `Data completeness: ${score}/${max}`}
+    >
+      {Array.from({ length: max }, (_, i) => (
+        <span
+          key={i}
+          aria-hidden="true"
+          className={`inline-block w-1.5 h-1.5 rounded-full ${
+            i < score ? "bg-primary/70" : "bg-muted-foreground/20"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
+
+// ── RecordStatusCell ─────────────────────────────────────────────────
+
+interface RecordStatusCellProps {
+  /** Source-check verdict (null = not checked) */
+  verdict: string | null | undefined;
+  /** Link to source-check detail page */
+  sourceCheckHref?: string;
+  /** Coverage score 1-4 (omit to hide coverage dots) */
+  coverageScore?: number;
+  /** Render as <td> (for tables) or <span> (for card/flex layouts) */
+  as?: "td" | "inline";
+}
+
+export function RecordStatusCell({
+  verdict,
+  sourceCheckHref,
+  coverageScore,
+  as = "td",
+}: RecordStatusCellProps) {
+  const content = (
+    <span className={`inline-flex items-center gap-2 ${as === "inline" ? "ml-auto" : ""}`}>
+      {coverageScore != null && (
+        <CoverageDots score={coverageScore} />
+      )}
+      <RecordVerificationDot
+        verdict={verdict}
+        href={sourceCheckHref}
+        size="sm"
+      />
+    </span>
+  );
+
+  if (as === "td") {
+    return (
+      <td className="py-1.5 px-2 text-right">
+        {content}
+      </td>
+    );
+  }
+
+  return content;
+}
+
+// ── Table header helper ──────────────────────────────────────────────
+
+/** Empty <th> for the status column — use as the last header cell. */
+export function RecordStatusHeader({ className = "" }: { className?: string }) {
+  return (
+    <th scope="col" className={`py-2 px-2 w-16 ${className}`}>
+      <span className="sr-only">Status</span>
+    </th>
+  );
+}

--- a/apps/web/src/components/verification/coverage-scoring.ts
+++ b/apps/web/src/components/verification/coverage-scoring.ts
@@ -1,0 +1,70 @@
+/**
+ * Per-record-type coverage scoring — counts non-null optional fields
+ * and maps to a 1-4 score for display as CompletionDots.
+ *
+ * Each function accepts a minimal interface so callers only need
+ * to pass the fields they have available.
+ */
+
+/** Map a field count to a 1-4 score given the total number of scoreable fields. */
+function fieldCountToScore(filled: number, total: number): number {
+  if (total <= 0) return 1;
+  const ratio = filled / total;
+  if (ratio >= 0.75) return 4;
+  if (ratio >= 0.5) return 3;
+  if (ratio >= 0.25) return 2;
+  return 1;
+}
+
+function countPresent(...values: unknown[]): number {
+  return values.filter((v) => v != null && v !== "" && v !== false).length;
+}
+
+// ── Personnel ────────────────────────────────────────────────────────
+
+export function computePersonnelCoverage(entry: {
+  title?: string | null;
+  start?: string | null;
+  end?: string | null;
+  verificationVerdict?: string | null;
+}): number {
+  // Fields: role/title, start date, end date, has been source-checked
+  const filled = countPresent(entry.title, entry.start, entry.end, entry.verificationVerdict);
+  return fieldCountToScore(filled, 4);
+}
+
+// ── Grants ───────────────────────────────────────────────────────────
+
+export function computeGrantCoverage(grant: {
+  amount?: number | string | null;
+  date?: string | null;
+  source?: string | null;
+  programName?: string | null;
+}): number {
+  const filled = countPresent(grant.amount, grant.date, grant.source, grant.programName);
+  return fieldCountToScore(filled, 4);
+}
+
+// ── Divisions ────────────────────────────────────────────────────────
+
+export function computeDivisionCoverage(div: {
+  lead?: string | null;
+  totalAmount?: number | null;
+  status?: string | null;
+  startDate?: string | null;
+}): number {
+  const filled = countPresent(div.lead, div.totalAmount, div.status, div.startDate);
+  return fieldCountToScore(filled, 4);
+}
+
+// ── Funding Programs ─────────────────────────────────────────────────
+
+export function computeFundingProgramCoverage(prog: {
+  totalBudget?: number | string | null;
+  deadline?: string | null;
+  description?: string | null;
+  source?: string | null;
+}): number {
+  const filled = countPresent(prog.totalBudget, prog.deadline, prog.description, prog.source);
+  return fieldCountToScore(filled, 4);
+}


### PR DESCRIPTION
## Summary

- **Move source-check dots from inline-left to rightmost column** across all 12 record tables (people, divisions, programs, grants, investments, equity, funding rounds, career history)
- **Add coverage dots** (data completeness 1-4 scale) alongside source-check dots where records have meaningful variation: people, grants, divisions (org page), funding programs
- **Create unified `RecordStatusCell` component** that combines both indicators, with `as="td"` for tables and `as="inline"` for card layouts
- **Extract shared `CoverageDots`** from organizations-table local function to shared component

## Key changes

### New files
- `components/verification/RecordStatusCell.tsx` — unified component (source-check dot + optional coverage dots)
- `components/verification/coverage-scoring.ts` — per-record-type completeness scoring (personnel, grants, divisions, funding programs)

### Modified (13 files)
- `people-section.tsx`, `divisions-section.tsx`, `programs-section.tsx`, `main-content-sections.tsx`, `equity-section.tsx` — server-component tables: dot moved from name cell to last column
- `divisions-table.tsx`, `funding-programs-table.tsx`, `funding-rounds-table.tsx` — client tables: same migration
- `interactive-grants-table.tsx` — "verified" column moved from position 2 to last as "recordStatus"
- `career-history.tsx` — dot moved to right side of card layout
- `organizations-table.tsx` — local `CompletionDots` replaced with shared `CoverageDots` import

## Test plan

- [x] `pnpm build` passes
- [x] `tsc --noEmit` (production code) passes
- [x] Visual verification via Playwright: People tab shows dots on right
- [ ] Verify on Vercel preview: `/organizations/anthropic` (People, Funding, Divisions tabs)
- [ ] Verify: `/divisions`, `/funding-programs`, `/funding-rounds`
- [ ] Verify: `/people/dario-amodei` (career history)
- [ ] Verify: `/organizations` list (CompletionDots still works)

Discussion: #3930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
