### PR TITLE
fix: only link record IDs when source-check verdict exists

### DIFF
--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -673,7 +673,7 @@ function ProfileSection({
                       const idStr = recordId ?? null;
                       if (!idStr) return <td className="px-2 py-2" />;
                       const display = idStr.length > 7 ? idStr.slice(0, 7) : idStr;
-                      return section.recordType ? (
+                      return section.recordType && verdict ? (
                         <td className="px-2 py-2 align-top">
                           <Link
                             href={`/source-checks/${encodeURIComponent(section.recordType)}/${encodeURIComponent(idStr)}`}
@@ -706,7 +706,7 @@ function ProfileSection({
                           status={verdict ? recordVerdictToStatus(verdict.verdict) : "not_run"}
                           originalVerdict={verdict?.verdict}
                           size="md"
-                          href={recordId ? `/source-checks/${encodeURIComponent(section.recordType)}/${encodeURIComponent(recordId)}` : undefined}
+                          href={verdict && recordId ? `/source-checks/${encodeURIComponent(section.recordType)}/${encodeURIComponent(recordId)}` : undefined}
                         />
                       </td>
                     )}


### PR DESCRIPTION
## Summary
- Record IDs in the entity profile data tables linked to `/source-checks/{type}/{id}` even for records without any source check, producing 404 pages
- Now IDs are only clickable when a verdict exists for that record
- Also guards the SourceCheckDot href the same way

2-line change in `entity-profile-viewer.tsx`.

## Test plan
- [x] Playwright verification: unchecked records show plain text IDs, checked records link correctly
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link visibility logic in entity profiles—links to source checks now display only when complete information is available, preventing broken navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->