### PR TITLE
[maintenance] sweep 2026-04-06: close resolved issues, update audits

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -276,6 +276,9 @@ audits:
       - date: "2026-04-06"
         result: fail
         checked_by: "manual"
+      - date: "2026-04-06"
+        result: fail
+        checked_by: "manual"
   - id: model-freshness
     category: infrastructure
     description: "Claude model IDs in crux/lib/anthropic.ts are still the latest available versions"
@@ -300,6 +303,9 @@ audits:
         checked_by: "manual"
         notes: "All models current: opus-4-6, sonnet-4-6, haiku-4-5-20251001"
       - date: "2026-04-05"
+        result: pass
+        checked_by: "manual"
+      - date: "2026-04-06"
         result: pass
         checked_by: "manual"
   - id: audits-system-adoption


### PR DESCRIPTION
## Summary

- Closed #3927 (CI broken on main — verified CI is now green)
- Closed #3903 (Coverage dots Phase 1b — completed by PR #3912)
- Audit: model-freshness **PASS** (claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5 all current)
- Audit: gate-override-frequency **FAIL** (22% override rate vs 20% threshold, tracked in #3891)
- Verified no orphaned `agent:working` labels
- 3 stale issues (#1484, #1689, #1672) reviewed — all still valid backlog items

## Test plan
- [x] `pnpm crux w validate gate --fix` passes
- [x] Only `.claude/audits.yaml` changed (audit check timestamps)
