### PR TITLE
fix: migration check retry + SHA verification sync gate

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -398,18 +398,28 @@ jobs:
           ACTUAL_TIMESTAMP=""
           APPLIED_COUNT=""
           MIGRATION_RESPONSE=""
+          MIGRATION_HTTP_STATUS=""
           for i in 1 2 3; do
-            MIGRATION_RESPONSE=$(curl -s \
+            MIGRATION_HTTP_STATUS=$(curl -s -o /tmp/migration-response.json -w '%{http_code}' \
               -H "Authorization: Bearer ${LONGTERMWIKI_SERVER_API_KEY}" \
               "${LONGTERMWIKI_SERVER_URL}/health/migrations" 2>&1 || true)
-            ACTUAL_TIMESTAMP=$(echo "$MIGRATION_RESPONSE" | jq -r '.latestCreatedAt // empty' 2>/dev/null || true)
-            APPLIED_COUNT=$(echo "$MIGRATION_RESPONSE" | jq -r '.appliedCount // empty' 2>/dev/null || true)
-            if [ -n "$ACTUAL_TIMESTAMP" ]; then break; fi
-            echo "Migration check attempt $i/3: endpoint not ready ($MIGRATION_RESPONSE)"
-            if [ "$i" -lt 3 ]; then sleep 10; fi
+            MIGRATION_RESPONSE=$(cat /tmp/migration-response.json 2>/dev/null || true)
+            if [ "$MIGRATION_HTTP_STATUS" = "200" ]; then
+              ACTUAL_TIMESTAMP=$(echo "$MIGRATION_RESPONSE" | jq -r '.latestCreatedAt // empty' 2>/dev/null || true)
+              APPLIED_COUNT=$(echo "$MIGRATION_RESPONSE" | jq -r '.appliedCount // empty' 2>/dev/null || true)
+              if [ -n "$ACTUAL_TIMESTAMP" ]; then break; fi
+              echo "::error::Migration check returned 200 but response has no latestCreatedAt: $MIGRATION_RESPONSE"
+              exit 1
+            elif [ "$MIGRATION_HTTP_STATUS" = "404" ]; then
+              echo "Migration check attempt $i/3: endpoint returned 404 (old pod during rolling deploy)"
+              if [ "$i" -lt 3 ]; then sleep 10; fi
+            else
+              echo "::error::Migration check failed with HTTP $MIGRATION_HTTP_STATUS: $MIGRATION_RESPONSE"
+              exit 1
+            fi
           done
           if [ -z "$ACTUAL_TIMESTAMP" ]; then
-            echo "::error::Migration check failed — could not query /health/migrations after 3 attempts: $MIGRATION_RESPONSE"
+            echo "::error::Migration check failed — /health/migrations returned 404 after 3 attempts (endpoint may not exist in this version)"
             exit 1
           fi
           if [ "$ACTUAL_TIMESTAMP" != "$EXPECTED_TIMESTAMP" ]; then


### PR DESCRIPTION
## Summary
- **ArgoCD wait**: add `--sync` flag so `argocd app wait` blocks until the new image is actually deployed, not just healthy (root cause of #3944 and #3955 failures)
- **SHA verification**: require sync status `Synced` in addition to image tag match (defense in depth)
- **Migration check**: retry 3x with 10s delay on 404, since the endpoint may not exist on old pods during rolling deploys

## Context
Deploys #3944 and #3955 both failed because `argocd app wait --health` returned immediately (old pod was healthy), then the smoke test ran against the old pod. The fix chain:
1. `--sync` on `argocd app wait` = the actual fix (wait for ArgoCD reconciliation)
2. `Synced` requirement on SHA verification = defense in depth  
3. Migration check retry = graceful handling of transient 404s

## Test plan
- [x] Root-caused from deploy logs: `argocd app wait` returned in 3s, old image still running, sync: OutOfSync
- [x] Verified `argocd app wait --sync --health` semantics: blocks until sync + healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)