### PR TITLE
fix: move resources table dots to right + add position validator

### DIFF
--- a/apps/web/src/app/organizations/[slug]/resources-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/resources-section.tsx
@@ -54,8 +54,6 @@ function computeColumnVisibility(
   };
 }
 
-// STANCE_COLORS imported from resource-constants
-
 function makeColumns(opts: {
   showDate: boolean;
   showPublication: boolean;

--- a/crux/validate/validate-dot-position.ts
+++ b/crux/validate/validate-dot-position.ts
@@ -8,7 +8,7 @@
  *
  * Run: npx tsx crux/validate/validate-dot-position.ts
  */
-import { readFileSync, readdirSync, statSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { join, relative } from "path";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 
@@ -21,17 +21,13 @@ interface Violation {
 function collectTsx(dir: string): string[] {
   const results: string[] = [];
   function walk(d: string) {
-    for (const entry of readdirSync(d)) {
-      const fullPath = join(d, entry);
-      try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          if (entry !== "node_modules" && entry !== "__tests__") walk(fullPath);
-        } else if (entry.endsWith(".tsx")) {
-          results.push(fullPath);
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules" && entry.name !== "__tests__") {
+          walk(join(d, entry.name));
         }
-      } catch {
-        // Permission errors or broken symlinks — skip silently
+      } else if (entry.name.endsWith(".tsx")) {
+        results.push(join(d, entry.name));
       }
     }
   }


### PR DESCRIPTION
## Summary

Fix the last remaining left-positioned source-check dot and add a validator to prevent regressions.

### Fix: resources/press table
The `resources-section.tsx` (Announcements/Press tabs on org pages) had `SourceCheckDot` as the **first column** before Title. Moved it to the rightmost column combined with `CoverageDots` via `RecordStatusDots`.

**Before:** `○ "AI Agents Market Report." Grand View Research...`
**After:** `"AI Agents Market Report." Grand View Research... ◐●`

### Prevention: gate validator
New `crux/validate/validate-dot-position.ts` — scans all `.tsx` files for `SourceCheckDot` appearing as the first column in tables (both HTML `<td>` patterns and TanStack column definition order). Exits non-zero on violations.

Run: `npx tsx crux/validate/validate-dot-position.ts`

## Test plan
- [x] `tsc --noEmit` passes
- [x] Validator passes (0 violations across 31 files using SourceCheckDot)
- [ ] Verify on Vercel: `/organizations/ai-revenue-sources?tab=press` — dots on right

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized resource verdict display to consolidate source check information within the coverage column.

* **Tests**
  * Added validation tooling for component positioning checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->