### PR TITLE
fix: em-dash literal text in things detail page

### DIFF
--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -121,7 +121,7 @@ function formatTimestamp(ts: string | null): string {
 }
 
 function ChildrenSummary({ count, byType }: { count: number; byType: Record<string, number> }) {
-  if (count === 0) return <span className="text-muted-foreground">\u2014</span>;
+  if (count === 0) return <span className="text-muted-foreground">{"\u2014"}</span>;
 
   const entries = Object.entries(byType).sort(([, a], [, b]) => b - a);
   return (


### PR DESCRIPTION
One-line fix: `\u2014` between JSX tags renders as literal text, not a unicode em-dash. Wrap in `{"\u2014"}` expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)