### PR TITLE
fix: improve dot-position validator — detect RecordStatusDots, per-array column check, wire into gate

### DIFF
--- a/crux/commands/validate.ts
+++ b/crux/commands/validate.ts
@@ -161,6 +161,11 @@ const SCRIPTS = {
     description: 'Detect serialization bugs and unescaped MDX in entity data',
     passthrough: ['ci'],
   },
+  'dot-position': {
+    script: 'validate/validate-dot-position.ts',
+    description: 'Check that SourceCheckDot / RecordStatusDots are never the first column',
+    passthrough: [],
+  },
   'to-rdjsonl': {
     script: 'validate/to-rdjsonl.ts',
     description: 'Convert unified --ci JSON to Reviewdog rdjsonl (reads stdin)',

--- a/crux/validate/validate-dot-position.ts
+++ b/crux/validate/validate-dot-position.ts
@@ -1,16 +1,27 @@
 /**
- * Validate SourceCheckDot never appears as the first column in a table.
+ * Validate dot indicators never appear as the first column in a table.
+ *
+ * Detects both `SourceCheckDot` (direct) and `RecordStatusDots` (wrapper
+ * that renders SourceCheckDot internally).
  *
  * Checks two patterns:
- * 1. HTML tables: SourceCheckDot inside the first <td> of a <tr>
- * 2. TanStack columns: a column definition containing SourceCheckDot that
- *    appears before the first column with accessorKey "name" or "title"
+ * 1. HTML tables: dot component inside the first <td> of a <tr>
+ * 2. TanStack columns: within each ColumnDef array, a column containing a
+ *    dot component that appears before the first column with accessorKey
+ *    "name" or "title"
  *
  * Run: npx tsx crux/validate/validate-dot-position.ts
  */
 import { readFileSync, readdirSync } from "fs";
 import { join, relative } from "path";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
+
+/** Components that render status dots (SourceCheckDot or wrappers around it) */
+const DOT_COMPONENTS = ["SourceCheckDot", "RecordStatusDots"];
+
+function hasDotComponent(text: string): boolean {
+  return DOT_COMPONENTS.some((c) => text.includes(c));
+}
 
 interface Violation {
   file: string;
@@ -37,13 +48,13 @@ function collectTsx(dir: string): string[] {
 
 function checkFile(filePath: string): Violation[] {
   const content = readFileSync(filePath, "utf-8");
-  if (!content.includes("SourceCheckDot")) return [];
+  if (!hasDotComponent(content)) return [];
 
   const lines = content.split("\n");
   const violations: Violation[] = [];
   const rel = relative(PROJECT_ROOT, filePath);
 
-  // Pattern 1: HTML tables — check if first <td> in any <tr> contains SourceCheckDot
+  // Pattern 1: HTML tables — check if first <td> in any <tr> contains a dot component
   let inTr = false;
   let inFirstTd = false;
   let firstTdDone = false;
@@ -65,11 +76,12 @@ function checkFile(filePath: string): Violation[] {
       tdBuffer += "\n" + line;
     }
     if (inFirstTd && line.includes("</td")) {
-      if (tdBuffer.includes("SourceCheckDot")) {
+      if (hasDotComponent(tdBuffer)) {
+        const which = DOT_COMPONENTS.find((c) => tdBuffer.includes(c));
         violations.push({
           file: rel,
           line: tdStartLine + 1,
-          reason: "SourceCheckDot in first <td> of table row",
+          reason: `${which} in first <td> of table row`,
         });
       }
       inFirstTd = false;
@@ -84,41 +96,169 @@ function checkFile(filePath: string): Violation[] {
     }
   }
 
-  // Pattern 2: TanStack column arrays — SourceCheckDot column defined before name/title column.
-  // Only match inside column definition objects (look for `cell:` context, not import lines).
-  // A column def containing SourceCheckDot: line has SourceCheckDot AND is preceded by `id:` or `cell:` nearby.
-  let sourceCheckColLine = -1;
-  let nameColLine = -1;
+  // Pattern 2: TanStack column arrays — dot column defined before name/title column.
+  //
+  // Parse per-array: find each ColumnDef[] array (indicated by `: ColumnDef<` or
+  // `satisfies ColumnDef<` or `as ColumnDef<`), then extract the column objects
+  // within that array using brace-depth tracking. Check ordering within each array
+  // independently so unrelated arrays or imports don't cause false positives.
+  checkTanStackColumns(lines, rel, violations);
 
+  return violations;
+}
+
+/**
+ * Parse TanStack ColumnDef arrays and check that dot columns come after name/title columns.
+ *
+ * Strategy: find lines that start a ColumnDef array (type annotation followed by `[`),
+ * then track brace/bracket depth to extract individual column objects. Within each
+ * array, record whether a dot column appears before the first name/title column.
+ */
+function checkTanStackColumns(
+  lines: string[],
+  rel: string,
+  violations: Violation[]
+): void {
+  // Find the start of each ColumnDef array declaration
+  const arrayStarts: number[] = [];
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     // Skip import lines
     if (/^\s*import\s/.test(line)) continue;
+    // Match patterns like: `: ColumnDef<Foo>[] = [`, `satisfies ColumnDef<Foo>[]`,
+    // or a line with `ColumnDef<` followed by `[` on same or next line
+    if (/ColumnDef</.test(line) && !/import/.test(line)) {
+      // Find the opening `[` — could be on this line or the next
+      const bracketIdx = line.indexOf("[", line.indexOf("ColumnDef"));
+      if (bracketIdx !== -1) {
+        arrayStarts.push(i);
+      } else if (i + 1 < lines.length && lines[i + 1].trim().startsWith("[")) {
+        arrayStarts.push(i + 1);
+      }
+    }
+  }
 
-    // Find the first column cell/id that references SourceCheckDot
-    if (sourceCheckColLine === -1 && line.includes("SourceCheckDot") && !line.includes("import")) {
-      // Verify it's inside a column definition by checking surrounding lines for column-like patterns
-      const context = lines.slice(Math.max(0, i - 5), i + 1).join("\n");
-      if (/(?:cell:|id:|header:)/.test(context)) {
-        sourceCheckColLine = i;
+  for (const startLine of arrayStarts) {
+    checkSingleColumnArray(lines, startLine, rel, violations);
+  }
+}
+
+/**
+ * Check a single ColumnDef array starting at `startLine` for dot-before-name violations.
+ */
+function checkSingleColumnArray(
+  lines: string[],
+  startLine: number,
+  rel: string,
+  violations: Violation[]
+): void {
+  // Track bracket depth to find the end of the array
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let started = false;
+  let arrayEndLine = lines.length;
+
+  // Track columns: each top-level object `{ ... }` in the array is one column
+  let inColumn = false;
+  let columnStartLine = -1;
+  let columnBuffer = "";
+
+  // Per-array tracking
+  let firstDotColLine = -1;
+  let firstNameColLine = -1;
+  let dotComponentName = "";
+
+  for (let i = startLine; i < lines.length; i++) {
+    const line = lines[i];
+
+    for (const ch of line) {
+      if (ch === "[") {
+        bracketDepth++;
+        started = true;
+      }
+      if (ch === "]") {
+        bracketDepth--;
+        if (started && bracketDepth === 0) {
+          arrayEndLine = i;
+        }
+      }
+      if (ch === "{") {
+        braceDepth++;
+        // A top-level object inside the array (bracketDepth === 1, braceDepth === 1)
+        if (bracketDepth === 1 && braceDepth === 1 && !inColumn) {
+          inColumn = true;
+          columnStartLine = i;
+          columnBuffer = "";
+        }
+      }
+      if (ch === "}") {
+        braceDepth--;
+        if (bracketDepth === 1 && braceDepth === 0 && inColumn) {
+          // End of a column definition object
+          columnBuffer += "\n" + line;
+          analyzeColumn(
+            columnBuffer,
+            columnStartLine,
+            (line, name) => {
+              if (firstDotColLine === -1) {
+                firstDotColLine = line;
+                dotComponentName = name;
+              }
+            },
+            (line) => {
+              if (firstNameColLine === -1) {
+                firstNameColLine = line;
+              }
+            }
+          );
+          inColumn = false;
+          columnBuffer = "";
+          continue; // skip appending to buffer below
+        }
       }
     }
 
-    // Find column with name/title accessor
-    if (nameColLine === -1 && /accessorKey:\s*["'](name|title)["']/.test(line)) {
-      nameColLine = i;
+    if (inColumn) {
+      columnBuffer += "\n" + line;
     }
+
+    if (i === arrayEndLine) break;
   }
 
-  if (sourceCheckColLine !== -1 && nameColLine !== -1 && sourceCheckColLine < nameColLine) {
+  // Check: dot column before name/title column within this array
+  if (
+    firstDotColLine !== -1 &&
+    firstNameColLine !== -1 &&
+    firstDotColLine < firstNameColLine
+  ) {
     violations.push({
       file: rel,
-      line: sourceCheckColLine + 1,
-      reason: "SourceCheckDot column defined before name/title column in TanStack table",
+      line: firstDotColLine + 1,
+      reason: `${dotComponentName} column defined before name/title column in TanStack table`,
     });
   }
+}
 
-  return violations;
+/**
+ * Analyze a single column definition buffer for dot components and name/title accessor.
+ */
+function analyzeColumn(
+  buffer: string,
+  startLine: number,
+  onDot: (line: number, componentName: string) => void,
+  onName: (line: number) => void
+): void {
+  // Check if this column renders a dot component (in cell, not in imports)
+  for (const comp of DOT_COMPONENTS) {
+    if (buffer.includes(comp)) {
+      onDot(startLine, comp);
+      break;
+    }
+  }
+  // Check if this column has a name/title accessorKey
+  if (/accessorKey:\s*["'](name|title)["']/.test(buffer)) {
+    onName(startLine);
+  }
 }
 
 export function runCheck() {
@@ -130,9 +270,9 @@ export function runCheck() {
   const violations = allFiles.flatMap(checkFile);
 
   if (violations.length === 0) {
-    console.log("SourceCheckDot position check passed");
+    console.log("Dot-position check passed (SourceCheckDot / RecordStatusDots)");
   } else {
-    console.error(`SourceCheckDot position violations (${violations.length}):\n`);
+    console.error(`Dot-position violations (${violations.length}):\n`);
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line} — ${v.reason}`);
     }

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -341,6 +341,15 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'dot-position',
+    name: 'Dot indicator position (SourceCheckDot / RecordStatusDots not in first column)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-dot-position.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: dots in the first column confuse visual scanning. The validator
+    // checks both HTML <td> tables and TanStack ColumnDef arrays.
+  },
+  {
     id: 'actions-yaml',
     name: 'GitHub Actions workflow YAML (actionlint)',
     command: 'npx',


### PR DESCRIPTION
## Summary

Addresses three CodeRabbit review issues from #3954:

- **Detect RecordStatusDots alongside SourceCheckDot**: `RecordStatusDots` is a wrapper component that renders `SourceCheckDot` internally. The validator now uses a `DOT_COMPONENTS` list and `hasDotComponent()` helper to detect both.
- **Per-array TanStack column check**: Replaced the whole-file line-number comparison (which could be tripped by imports or unrelated JSX) with proper per-array parsing that finds each `ColumnDef[]` array, tracks brace/bracket depth to extract individual column objects, and checks ordering within each array independently.
- **Wired into the gate**: Registered the validator in `validate-gate.ts` as a blocking parallel step (`dot-position`) and in `crux/commands/validate.ts` so it can be run standalone via `pnpm crux w validate dot-position`.

## Test plan

- [x] Validator runs cleanly on the codebase: `npx tsx crux/validate/validate-dot-position.ts` passes
- [x] All 38 gate checks pass (including the new `dot-position` check)
- [x] Verified that `DOT_COMPONENTS` includes both `SourceCheckDot` and `RecordStatusDots`
- [x] Verified per-array parsing uses bracket/brace depth tracking
- [x] Verified registration in both `validate-gate.ts` and `crux/commands/validate.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added new validation check to enforce column positioning standards in data tables.
  * Enhanced CI pipeline with improved validation checks for code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->