### PR TITLE
fix: claims pipeline bugs — validateClaimRefs + personnel ID regex

### DIFF
--- a/apps/wiki-server/src/routes/shared/validate-claims.ts
+++ b/apps/wiki-server/src/routes/shared/validate-claims.ts
@@ -53,13 +53,14 @@ export async function validateClaimRefs(
 
   const unique = [...new Set(claimIds)];
   const rows = await db<ClaimStatusRow[]>`
-    SELECT id, status, entity_id
+    SELECT id::int, status, entity_id
     FROM proposed_claims
     WHERE id = ANY(${unique})
   `;
 
   // Check for missing claims
-  const foundIds = new Set(rows.map((r) => r.id));
+  // Cast to Number because postgres.js may return bigserial as string
+  const foundIds = new Set(rows.map((r) => Number(r.id)));
   const missing = unique.filter((id) => !foundIds.has(id));
   if (missing.length > 0) {
     return `Claim IDs not found: ${missing.join(", ")}`;

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -59,7 +59,7 @@ const AllQuery = z.object({
 // ---- Sync schema ----
 
 const SyncPersonnelItemSchema = z.object({
-  id: z.string().regex(/^[A-Za-z0-9]{10}$/, "id must be 10 alphanumeric characters"),
+  id: z.string().regex(/^[A-Za-z0-9_-]{10}$/, "id must be 10 alphanumeric characters (hyphens and underscores allowed)"),
   personId: z.string().min(1).max(200),
   organizationId: z.string().min(1).max(200),
   role: z.string().min(1).max(500),


### PR DESCRIPTION
## Summary
- Fix `validateClaimRefs` returning "Claim IDs not found" for claims that exist — postgres.js returns `bigserial` as strings, but the Set comparison used JS numbers (`"166" !== 166`)
- Fix personnel sync rejecting legacy record IDs with hyphens/underscores (e.g., `TFkU7FRiy-`, `O8pTg-CfxX`) — regex was `[A-Za-z0-9]{10}`, now `[A-Za-z0-9_-]{10}`

Both bugs were found during end-to-end testing of the claims pipeline (Resources → Claims → Records) on production Anthropic data.

Closes #3960

## Test plan
- [x] 822 existing wiki-server tests pass
- [x] Build succeeds
- [x] Gate passes
- [x] Tested on production: proposed 23 claims about Anthropic, verified by claim-verification handler, submitted 6 personnel records with inline verdicts — all turned green on directory page
- [ ] After merge: verify `claimIds` parameter works on personnel sync (was blocked by the bigint bug)
- [ ] After merge: verify legacy ID records (Dario Amodei, Jack Clark, Chris Olah) can be updated via sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)