### PR TITLE
feat: remove heuristic fallback, drop keyPublications, add sourceResourceId FKs (Phase 4)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -25,16 +25,12 @@ import {
   isOrganization,
   isPerson,
   isAiModel,
-  getAllResources,
-  getResourcesForPage,
   getResourceById,
   getResourceCredibility,
   getResourcePublication,
   getPagesForResource,
-  getLiteraturePapers,
   getEntityResourceLinks,
   type Resource,
-  type LiteraturePaper,
 } from "@/data";
 import {
   formatKBNumber,
@@ -876,18 +872,13 @@ function normalizeRow(r: Resource, orgName: string): OrgResourceRow | null {
  *  - aboutOrg: external resources cited on the org's wiki page
  */
 function getOrgResources(
-  orgSlug: string,
   orgName: string,
-  websiteUrl: string | null,
   entityStableId?: string,
-  /** Grant source URLs to exclude from aboutOrg (press tab) */
-  grantSourceUrls?: Set<string>,
 ): {
   publications: OrgResourceRow[];
   announcements: OrgResourceRow[];
   aboutOrg: OrgResourceRow[];
 } {
-  // Try entity_resources first (explicit relational data)
   if (entityStableId) {
     const links = getEntityResourceLinks(entityStableId);
     if (links && (links.authored.length > 0 || links.subject.length > 0)) {
@@ -895,8 +886,8 @@ function getOrgResources(
     }
   }
 
-  // Fallback: heuristic domain-matching (until entity_resources is seeded)
-  return getOrgResourcesFromHeuristics(orgSlug, orgName, websiteUrl, grantSourceUrls);
+  // Entity not in entity_resources — return empty
+  return { publications: [], announcements: [], aboutOrg: [] };
 }
 
 /** Use entity_resources links to split resources into publications/announcements/press */
@@ -912,6 +903,7 @@ function getOrgResourcesFromLinks(
   const publications: OrgResourceRow[] = [];
   const announcements: OrgResourceRow[] = [];
   const aboutOrg: OrgResourceRow[] = [];
+  const RESEARCH_PUB_TYPES = new Set(["preprint_server", "academic_journal", "think_tank", "academic"]);
 
   // Authored resources → split into publications vs announcements by publication type
   for (const rid of links.authored) {
@@ -921,7 +913,7 @@ function getOrgResourcesFromLinks(
     if (!row) continue;
 
     const pub = getResourcePublication(r);
-    const isResearch = pub?.type === "preprint_server" || pub?.type === "academic_journal"
+    const isResearch = (pub?.type && RESEARCH_PUB_TYPES.has(pub.type))
       || r.type === "paper" || isResearchUrl(r.url);
     if (isResearch) {
       publications.push(row);
@@ -953,92 +945,6 @@ function getOrgResourcesFromLinks(
     publications: publications.sort(sortByDate),
     announcements: announcements.sort(sortByDate),
     aboutOrg: aboutOrg.sort(sortByDate),
-  };
-}
-
-/** Legacy heuristic: domain-matching + URL path sniffing (fallback until entity_resources seeded) */
-function getOrgResourcesFromHeuristics(
-  orgSlug: string,
-  orgName: string,
-  websiteUrl: string | null,
-  grantSourceUrls?: Set<string>,
-): {
-  publications: OrgResourceRow[];
-  announcements: OrgResourceRow[];
-  aboutOrg: OrgResourceRow[];
-} {
-  const allResources = getAllResources();
-
-  // Determine the org's domain(s) for matching
-  const orgDomains = new Set<string>();
-  if (websiteUrl) {
-    const d = extractDomain(websiteUrl);
-    if (d) orgDomains.add(d);
-  }
-
-  // Split org resources into publications vs announcements
-  const publicationsMap = new Map<string, OrgResourceRow>();
-  const announcementsMap = new Map<string, OrgResourceRow>();
-  const allOrgIds = new Set<string>();
-  // Track URLs and titles to deduplicate entries
-  const seenUrls = new Set<string>();
-  const seenTitles = new Set<string>();
-
-  if (orgDomains.size > 0) {
-    for (const r of allResources) {
-      const rDomain = extractDomain(r.url);
-      if (!rDomain || !orgDomains.has(rDomain)) continue;
-      const row = normalizeRow(r, orgName);
-      if (!row) continue;
-
-      // Deduplicate by normalized URL (strip trailing slash + fragment)
-      const normUrl = r.url.replace(/[#?].*$/, "").replace(/\/$/, "").toLowerCase();
-      if (seenUrls.has(normUrl)) continue;
-      seenUrls.add(normUrl);
-
-      // Deduplicate by title (case-insensitive) — keep first seen
-      const normTitle = row.title.toLowerCase().trim();
-      if (seenTitles.has(normTitle)) continue;
-      seenTitles.add(normTitle);
-
-      allOrgIds.add(r.id);
-
-      if (isResearchUrl(r.url) || r.type === "paper") {
-        publicationsMap.set(r.id, row);
-      } else {
-        announcementsMap.set(r.id, row);
-      }
-    }
-  }
-
-  // Resources cited on the org's wiki page (ABOUT the org, external only)
-  const pageResourceIds = getResourcesForPage(orgSlug);
-  const aboutOrgMap = new Map<string, OrgResourceRow>();
-  for (const rid of pageResourceIds) {
-    if (allOrgIds.has(rid)) continue;
-    const r = getResourceById(rid);
-    if (!r) continue;
-    // Exclude resources whose URL matches a grant source (these are grant records, not press)
-    if (grantSourceUrls?.has(r.url.replace(/[#?].*$/, "").replace(/\/$/, "").toLowerCase())) continue;
-    const row = normalizeRow(r, orgName);
-    if (!row) continue;
-    aboutOrgMap.set(rid, row);
-  }
-
-  // Sort all by date (newest first), dateless items last, then by title
-  const sortByDate = (a: OrgResourceRow, b: OrgResourceRow) => {
-    const da = a.publishedDate;
-    const db = b.publishedDate;
-    if (da && !db) return -1;
-    if (!da && db) return 1;
-    if (da && db && da !== db) return db.localeCompare(da);
-    return (a.title ?? "").localeCompare(b.title ?? "");
-  };
-
-  return {
-    publications: [...publicationsMap.values()].sort(sortByDate),
-    announcements: [...announcementsMap.values()].sort(sortByDate),
-    aboutOrg: [...aboutOrgMap.values()].sort(sortByDate),
   };
 }
 
@@ -1451,21 +1357,12 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     founders.push(resolved);
   }
 
-  // ── Resources ──
-  // Collect grant source URLs to exclude from press/resources tab
-  const grantSourceUrls = new Set<string>();
-  for (const g of grantsMade) {
-    if (g.source) grantSourceUrls.add(g.source.replace(/[#?].*$/, "").replace(/\/$/, "").toLowerCase());
-  }
-  for (const g of grantsReceived) {
-    if (g.source) grantSourceUrls.add(g.source.replace(/[#?].*$/, "").replace(/\/$/, "").toLowerCase());
-  }
-
+  // ── Resources (from entity_resources join table) ──
   const {
     publications: resourcePublications,
     announcements: resourceAnnouncements,
     aboutOrg: resourcesAboutOrg,
-  } = getOrgResources(slug, entity.name, websiteUrl, typedEntity?.stableId, grantSourceUrls);
+  } = getOrgResources(entity.name, typedEntity?.stableId);
 
   // ── Key Publications (from literature.yaml) ──
   const orgMatchNames = new Set<string>([
@@ -1474,13 +1371,6 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     entity.id.toLowerCase(),
     ...(entity.aliases?.map((a) => a.toLowerCase()) ?? []),
   ]);
-  const keyPublications: LiteraturePaper[] = getLiteraturePapers()
-    .filter((p) => {
-      if (!p.organization) return false;
-      return orgMatchNames.has(p.organization.toLowerCase());
-    })
-    .sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
-
   // ── Model benchmark data ──
   const modelBenchmarks = new Map<string, Array<{ name: string; score: number; unit?: string }>>();
   for (const model of orgModels) {
@@ -1625,7 +1515,6 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     resourcePublications,
     resourceAnnouncements,
     resourcesAboutOrg,
-    keyPublications,
     modelBenchmarks,
     divisionLeadResolved,
     divisionMembers,

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -40,7 +40,6 @@ import {
 import {
   loadOrgPageData,
   resolveOrgEntity,
-  resolveAuthor,
   HERO_STATS,
   ORG_TYPE_LABELS,
   ORG_TYPE_COLORS,
@@ -49,7 +48,6 @@ import {
   ORG_STATUS_COLORS,
   type OrgEntity,
 } from "./org-data";
-import type { AuthorRef } from "./org-data";
 
 // Section components
 
@@ -60,7 +58,6 @@ import { AiModelsSection } from "./ai-models-section";
 import { PolicyPositionsSection, getOrgPolicyPositions } from "./policy-positions-section";
 
 // Section components — publications
-import { KeyPublicationsSection } from "./publications-section";
 
 // Section components — grants (main content column)
 import { GrantsSection } from "./grants-section";
@@ -533,49 +530,19 @@ export default async function OrgProfilePage({
   const announcementVerdicts = buildResourceVerdicts(data.resourceAnnouncements);
   const pressVerdicts = buildResourceVerdicts(data.resourcesAboutOrg);
 
-  // ── Publications tab (research papers + literature papers, deduplicated) ──
-  // Deduplicate key publications that already appear in the resources table (by title match)
-  const resourcePubTitles = new Set(
-    data.resourcePublications.map((r) => r.title.toLowerCase().trim()),
-  );
-  const dedupedKeyPubs = data.keyPublications.filter(
-    (p) => !resourcePubTitles.has(p.title.toLowerCase().trim()),
-  );
-
-  // Build resolved author map for key publications author linking
-  const keyPubAuthorMap = new Map<string, AuthorRef>();
-  for (const pub of dedupedKeyPubs) {
-    for (const name of pub.authors) {
-      if (!keyPubAuthorMap.has(name)) {
-        keyPubAuthorMap.set(name, resolveAuthor(name));
-      }
-    }
-  }
-
-  const hasPublications = data.resourcePublications.length > 0 || dedupedKeyPubs.length > 0;
-  if (hasPublications) {
-    const pubCount = data.resourcePublications.length + dedupedKeyPubs.length;
+  // ── Publications tab (research papers from entity_resources) ──
+  if (data.resourcePublications.length > 0) {
     tabs.push({
       id: "publications",
       label: "Publications",
-      count: pubCount,
+      count: data.resourcePublications.length,
       content: (
-        <div className="space-y-8">
-          {data.resourcePublications.length > 0 && (
-            <OrgResourcesSection
-              resources={data.resourcePublications}
-              title="Research & Technical Papers"
-              emptyMessage=""
-              verdicts={pubVerdicts}
-            />
-          )}
-          {dedupedKeyPubs.length > 0 && (
-            <KeyPublicationsSection
-              publications={dedupedKeyPubs}
-              resolvedAuthors={keyPubAuthorMap}
-            />
-          )}
-        </div>
+        <OrgResourcesSection
+          resources={data.resourcePublications}
+          title="Research & Technical Papers"
+          emptyMessage=""
+          verdicts={pubVerdicts}
+        />
       ),
     });
   }

--- a/apps/wiki-server/drizzle/0165_add_source_resource_id.sql
+++ b/apps/wiki-server/drizzle/0165_add_source_resource_id.sql
@@ -1,0 +1,24 @@
+-- Add source_resource_id FK to tables with plain-text source URL columns.
+-- This enables linking record sources to the resources table for rich metadata,
+-- verification, and dead-link tracking. The existing source text column is kept
+-- for backward compatibility during transition.
+ALTER TABLE personnel
+  ADD COLUMN IF NOT EXISTS source_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL;
+
+ALTER TABLE grants
+  ADD COLUMN IF NOT EXISTS source_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL;
+
+ALTER TABLE funding_rounds
+  ADD COLUMN IF NOT EXISTS source_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL;
+
+ALTER TABLE investments
+  ADD COLUMN IF NOT EXISTS source_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL;
+
+ALTER TABLE equity_positions
+  ADD COLUMN IF NOT EXISTS source_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_personnel_source_resource ON personnel (source_resource_id);
+CREATE INDEX IF NOT EXISTS idx_grants_source_resource ON grants (source_resource_id);
+CREATE INDEX IF NOT EXISTS idx_funding_rounds_source_resource ON funding_rounds (source_resource_id);
+CREATE INDEX IF NOT EXISTS idx_investments_source_resource ON investments (source_resource_id);
+CREATE INDEX IF NOT EXISTS idx_equity_positions_source_resource ON equity_positions (source_resource_id);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1156,6 +1156,13 @@
       "when": 1783670400000,
       "tag": "0164_drop_entity_recommended_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 165,
+      "version": "7",
+      "when": 1783756800000,
+      "tag": "0165_add_source_resource_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1799,6 +1799,7 @@ export const personnel = pgTable(
     appointedBy: text("appointed_by"), // board-seats only
     background: text("background"), // board-seats only
     source: text("source"), // URL confirming the role
+    sourceResourceId: text("source_resource_id").references(() => resources.id, { onDelete: "set null" }),
     notes: text("notes"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
@@ -1858,6 +1859,7 @@ export const grants = pgTable(
     date: text("date"), // announcement/start date (YYYY-MM)
     status: text("status"), // active | completed | winding-down
     source: text("source"), // URL to announcement or report
+    sourceResourceId: text("source_resource_id").references(() => resources.id, { onDelete: "set null" }),
     notes: text("notes"),
     programId: text("program_id").references(
       () => fundingPrograms.id,
@@ -1926,6 +1928,7 @@ export const fundingRounds = pgTable(
     /** Display name fallback when lead investor doesn't have an entity. */
     leadInvestorDisplayName: text("lead_investor_display_name"),
     source: text("source"), // URL to announcement
+    sourceResourceId: text("source_resource_id").references(() => resources.id, { onDelete: "set null" }),
     notes: text("notes"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
@@ -1983,6 +1986,7 @@ export const investments = pgTable(
     role: text("role"), // lead | participant | founder
     conditions: text("conditions"), // investment conditions
     source: text("source"), // URL to source
+    sourceResourceId: text("source_resource_id").references(() => resources.id, { onDelete: "set null" }),
     notes: text("notes"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
@@ -2037,6 +2041,7 @@ export const equityPositions = pgTable(
     stakeLow: numeric("stake_low"), // parsed low bound of stake
     stakeHigh: numeric("stake_high"), // parsed high bound of stake
     source: text("source"), // URL to source
+    sourceResourceId: text("source_resource_id").references(() => resources.id, { onDelete: "set null" }),
     notes: text("notes"),
     asOf: text("as_of"), // when this position was valid from (YYYY or YYYY-MM)
     validEnd: text("valid_end"), // when this position expired


### PR DESCRIPTION
## Summary

Phase 4 of entity-resources cleanup. Depends on #3936 (merged), #3943 (merged), #3951.

**1. Removed heuristic fallback** — Deleted `getOrgResourcesFromHeuristics()` and associated dead code (~85 lines). Org pages now use `entity_resources` exclusively (4,182 rows seeded in production). Entities without entity_resources data get empty tabs rather than heuristic guesses.

**2. Improved publication type detection** — Added `think_tank` and `academic` to `RESEARCH_PUB_TYPES` for better Publications vs Announcements splitting.

**3. Removed keyPublications** — Dropped `literature.yaml` loading and `KeyPublicationsSection` from org pages. The Publications tab now shows only entity_resources-linked research papers. Literature papers can be added to entity_resources via the seed command in the future.

**4. Added `sourceResourceId` FK columns** — New nullable `source_resource_id TEXT REFERENCES resources(id)` on personnel, grants, funding_rounds, investments, equity_positions (migration 0165). Enables linking record-level source URLs to the resources table for rich metadata, verification, and dead-link tracking. Existing `source` text column kept for backward compatibility.

> **Depends on:** #3951 — merge that first.

## Net impact
- 5 files changed, +51 / -159 lines
- ~85 lines of heuristic code deleted from org-data.ts

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Wiki-server TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)