### PR TITLE
fix: address CodeRabbit review comments from #3957

### DIFF
--- a/.claude/rules/pre-pr-verification.md
+++ b/.claude/rules/pre-pr-verification.md
@@ -54,7 +54,7 @@ const { chromium } = require('@playwright/test');
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
   await page.goto('http://localhost:3015/things', { waitUntil: 'networkidle' });
-  const text = await page.textContent('body');
+  const text = await page.textContent('body') ?? '';
   console.log('Page loaded, length:', text.length);
   // Check for error states:
   const errors = await page.locator('.text-red-600, .text-red-500').count();

--- a/apps/web/src/app/things/page.tsx
+++ b/apps/web/src/app/things/page.tsx
@@ -96,15 +96,18 @@ export default async function ThingsPage({ searchParams }: PageProps) {
     );
   }
 
-  // Stats may fail independently — degrade gracefully
-  const stats: ThingsStatsResponse = statsResult.ok
-    ? statsResult.data
-    : { total: 0, byType: {}, byEntityType: {} };
   // The list endpoint returns { things, total } while the search endpoint
   // returns { results, total }. Normalize to a single shape.
   const listBody = listResult.data;
   const results = listBody.results ?? listBody.things ?? [];
   const total = listBody.total ?? results.length;
+
+  // Stats may fail independently — degrade gracefully.
+  // Use the list total as fallback so the header doesn't show "0 items total"
+  // while rows are visibly rendered.
+  const stats: ThingsStatsResponse = statsResult.ok
+    ? statsResult.data
+    : { total, byType: {}, byEntityType: {} };
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   function buildUrl(overrides: { q?: string; type?: string; page?: number }) {


### PR DESCRIPTION
## Summary

Addresses two minor CodeRabbit review comments from PR #3957:

1. **Null guard for `page.textContent()`** (`.claude/rules/pre-pr-verification.md` line 57): `page.textContent('body')` can return `null`, so `text.length` would throw. Added `?? ''` fallback.

2. **Stats total fallback** (`apps/web/src/app/things/page.tsx` line 102): When the stats endpoint fails but the list endpoint succeeds, the header showed "0 items total" while rows were visibly rendered. Reordered code so the list `total` is computed first and used as fallback for the stats object.

## Test plan

- [x] Gate check passed (43/43 checks, full Next.js build)
- [ ] Verify `/things` page still renders correctly when stats are available
- [ ] Verify `/things` page degrades gracefully when stats fail (shows list count instead of 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)