### PR TITLE
fix: batch API custom_id sanitization + server-side verification enforcement

### DIFF
--- a/apps/wiki-server/src/routes/shared/__tests__/verification-enforcement.test.ts
+++ b/apps/wiki-server/src/routes/shared/__tests__/verification-enforcement.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { enforceVerification } from '../verification-enforcement.js';
+
+// Helper to create a minimal Hono test context with query params
+function createTestApp(queryParams: Record<string, string> = {}) {
+  const app = new Hono();
+  app.post('/test', async (c) => {
+    const items = await c.req.json();
+    const error = enforceVerification(c, 'personnel', items);
+    if (error) return error;
+    return c.json({ ok: true });
+  });
+  return app;
+}
+
+function buildUrl(params: Record<string, string> = {}) {
+  const qs = new URLSearchParams(params).toString();
+  return qs ? `/test?${qs}` : '/test';
+}
+
+function makeRequest(app: Hono, items: unknown[], params: Record<string, string> = {}) {
+  return app.request(buildUrl(params), {
+    method: 'POST',
+    body: JSON.stringify(items),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('enforceVerification', () => {
+  it('allows records when no verification is required', async () => {
+    const app = createTestApp();
+    const res = await makeRequest(app, [{ id: '1' }, { id: '2' }]);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects unverified records when client sends requireVerification=true', async () => {
+    const app = createTestApp();
+    const res = await makeRequest(
+      app,
+      [{ id: '1' }, { id: '2', verification: { verdict: 'confirmed' } }],
+      { requireVerification: 'true' },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { message: string };
+    expect(body.message).toContain('1/2 records lack verification');
+  });
+
+  it('allows fully verified records when requireVerification=true', async () => {
+    const app = createTestApp();
+    const res = await makeRequest(
+      app,
+      [
+        { id: '1', verification: { verdict: 'confirmed' } },
+        { id: '2', verification: { verdict: 'partial' } },
+      ],
+      { requireVerification: 'true' },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('respects forceSkipVerification escape hatch', async () => {
+    const app = createTestApp();
+    const res = await makeRequest(
+      app,
+      [{ id: '1' }], // no verification
+      { requireVerification: 'true', forceSkipVerification: 'true', reason: 'migration backfill' },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('forceSkipVerification works without a reason', async () => {
+    const app = createTestApp();
+    const res = await makeRequest(
+      app,
+      [{ id: '1' }],
+      { requireVerification: 'true', forceSkipVerification: 'true' },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('error message includes table name', async () => {
+    const app = new Hono();
+    app.post('/test', async (c) => {
+      const items = await c.req.json();
+      const error = enforceVerification(c, 'grants', items);
+      if (error) return error;
+      return c.json({ ok: true });
+    });
+    const res = await makeRequest(app, [{ id: '1' }], { requireVerification: 'true' });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { message: string };
+    expect(body.message).toContain('pnpm crux tb verify grants');
+  });
+});

--- a/apps/wiki-server/src/routes/shared/verification-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/verification-enforcement.ts
@@ -1,0 +1,65 @@
+import type { Context } from "hono";
+import { logger as rootLogger } from "../../logger.js";
+import { validationError } from "./utils.js";
+
+const logger = rootLogger.child({ component: "verification-enforcement" });
+
+/**
+ * Server-side verification requirements — independent of client params.
+ *
+ * When a table is listed here as `true`, the sync endpoint requires every
+ * record to include inline verification data. This enforcement is server-side
+ * and cannot be bypassed by omitting query parameters.
+ *
+ * Rollout per Discussion #3875: tables are enabled here as they reach Phase 5.
+ */
+const VERIFICATION_REQUIRED: Record<string, boolean> = {
+  // Enable as tables reach Phase 5 hard enforcement:
+  // personnel: true,
+  // grants: true,
+};
+
+/**
+ * Enforce verification requirements for a sync endpoint.
+ *
+ * Checks both the server-side config (VERIFICATION_REQUIRED) and the legacy
+ * client-side `?requireVerification=true` query parameter. If either requests
+ * verification, all items must include verification data.
+ *
+ * Escape hatch: `?forceSkipVerification=true&reason=...` bypasses enforcement
+ * with an audit log entry. Use for migrations and backfills.
+ *
+ * @returns A 400 Response if enforcement fails, or null if OK (caller proceeds).
+ */
+export function enforceVerification(
+  c: Context,
+  tableName: string,
+  items: Array<{ verification?: unknown }>,
+): Response | null {
+  const serverRequired = VERIFICATION_REQUIRED[tableName] === true;
+  const clientRequired = c.req.query("requireVerification") === "true";
+
+  if (!serverRequired && !clientRequired) return null;
+
+  // Escape hatch for migrations/backfills
+  const forceSkip = c.req.query("forceSkipVerification");
+  if (forceSkip === "true") {
+    const reason = c.req.query("reason") || "no reason given";
+    logger.warn(
+      { table: tableName, itemCount: items.length, reason },
+      `Verification enforcement skipped via forceSkipVerification`,
+    );
+    return null;
+  }
+
+  const unverified = items.filter((i) => !i.verification);
+  if (unverified.length === 0) return null;
+
+  const source = serverRequired ? "server policy" : "client requireVerification param";
+  return validationError(
+    c,
+    `Verification required (${source}) but ${unverified.length}/${items.length} records lack verification. ` +
+    `Run \`pnpm crux tb verify ${tableName}\` before submitting, ` +
+    `or use ?forceSkipVerification=true&reason=... to bypass with audit logging.`,
+  );
+}

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -29,6 +29,7 @@ import { logAuditEntries } from "./audit-log.js";
 import { InlineVerificationSchema } from "./verification-schema.js";
 import { writeInlineVerdicts, logVerificationCoverage } from "./write-inline-verdicts.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
+import { enforceVerification } from "../shared/verification-enforcement.js";
 
 // ---- Constants ----
 
@@ -601,6 +602,11 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       }
       batchKeys.add(key);
     }
+
+    // Phase 5 (Discussion #3875): Verification enforcement — checks both server-side
+    // config and client ?requireVerification=true param. See verification-enforcement.ts.
+    const verificationError = enforceVerification(c, "grants", items);
+    if (verificationError) return verificationError;
 
     // Validate programId references (skip if skipEntityValidation is set)
     const skipValidation = c.req.query("skipEntityValidation") === "true";

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -28,6 +28,7 @@ import { logAuditEntries } from "./audit-log.js";
 import { InlineVerificationSchema } from "./verification-schema.js";
 import { writeInlineVerdicts, logVerificationCoverage } from "./write-inline-verdicts.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
+import { enforceVerification } from "../shared/verification-enforcement.js";
 import { sqlInList } from "../shared/query-helpers.js";
 
 // ---- Constants ----
@@ -355,19 +356,10 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
     const { items } = parsed.data;
     const db = getDrizzleDb();
 
-    // Phase 5 (Discussion #3875): Hard enforcement — require inline verification
-    // on every record when ?requireVerification=true is set. Agent sessions
-    // targeting hard-enforced tables must include verification data.
-    if (c.req.query("requireVerification") === "true") {
-      const unverified = items.filter((i) => !i.verification);
-      if (unverified.length > 0) {
-        return validationError(
-          c,
-          `requireVerification=true but ${unverified.length}/${items.length} records lack verification. ` +
-          `Run \`pnpm crux tb verify personnel\` before submitting, or remove ?requireVerification=true.`,
-        );
-      }
-    }
+    // Phase 5 (Discussion #3875): Verification enforcement — checks both server-side
+    // config and client ?requireVerification=true param. See verification-enforcement.ts.
+    const verificationError = enforceVerification(c, "personnel", items);
+    if (verificationError) return verificationError;
 
     // Check for natural key collisions within the batch itself.
     // Natural key: (personId, organizationId, role, roleType)

--- a/crux/lib/__tests__/anthropic-batch.test.ts
+++ b/crux/lib/__tests__/anthropic-batch.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeBatchCustomId } from '../anthropic-batch.ts';
+
+describe('sanitizeBatchCustomId', () => {
+  it('passes through valid IDs unchanged', () => {
+    expect(sanitizeBatchCustomId('verify-abc123')).toBe('verify-abc123');
+    expect(sanitizeBatchCustomId('hello_world-42')).toBe('hello_world-42');
+    expect(sanitizeBatchCustomId('A')).toBe('A');
+  });
+
+  it('replaces colons with underscores', () => {
+    expect(sanitizeBatchCustomId('verify-fact:f_abc123')).toBe('verify-fact_f_abc123');
+    expect(sanitizeBatchCustomId('verify-record:personnel:p-1')).toBe('verify-record_personnel_p-1');
+  });
+
+  it('replaces dots, slashes, and other special characters', () => {
+    expect(sanitizeBatchCustomId('https://example.com/path')).toBe('https___example_com_path');
+    expect(sanitizeBatchCustomId('file.name@host')).toBe('file_name_host');
+  });
+
+  it('truncates to 64 characters', () => {
+    const long = 'a'.repeat(100);
+    const result = sanitizeBatchCustomId(long);
+    expect(result).toHaveLength(64);
+    expect(result).toBe('a'.repeat(64));
+  });
+
+  it('truncates after sanitization', () => {
+    // Colons become underscores first, then truncation
+    const input = 'verify-' + 'a:b'.repeat(30);
+    const result = sanitizeBatchCustomId(input);
+    expect(result).toHaveLength(64);
+    expect(result).not.toContain(':');
+  });
+
+  it('throws on empty input', () => {
+    expect(() => sanitizeBatchCustomId('')).toThrow('Cannot sanitize empty');
+  });
+
+  it('throws on all-invalid characters', () => {
+    // All characters that would be replaced result in underscores, so this won't throw
+    // unless the string is empty. Let's verify underscore-only result is fine.
+    expect(sanitizeBatchCustomId(':::')).toBe('___');
+  });
+
+  it('preserves hyphens and underscores', () => {
+    expect(sanitizeBatchCustomId('my-id_123')).toBe('my-id_123');
+  });
+
+  it('handles realistic source-check IDs', () => {
+    // fact IDs
+    expect(sanitizeBatchCustomId('verify-fact:mK9pX3rQ7n')).toBe('verify-fact_mK9pX3rQ7n');
+    // record IDs with legacy format
+    expect(sanitizeBatchCustomId('verify-record:personnel:TFkU7FRiy-')).toBe('verify-record_personnel_TFkU7FRiy-');
+    // entity IDs (already valid)
+    expect(sanitizeBatchCustomId('verify-entity:sid_1LcLlMGLbw')).toBe('verify-entity_sid_1LcLlMGLbw');
+  });
+});

--- a/crux/lib/anthropic-batch.ts
+++ b/crux/lib/anthropic-batch.ts
@@ -33,6 +33,21 @@ export interface BatchRequest {
   params: Anthropic.Messages.MessageCreateParamsNonStreaming;
 }
 
+/** Anthropic Batch API custom_id constraint: [a-zA-Z0-9_-]{1,64} */
+const CUSTOM_ID_VALID = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * Sanitize a string for use as a Batch API custom_id.
+ * Replaces any character outside [a-zA-Z0-9_-] with underscore and truncates to 64 chars.
+ */
+export function sanitizeBatchCustomId(raw: string): string {
+  const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+  if (sanitized.length === 0) {
+    throw new Error(`Cannot sanitize empty or all-invalid custom_id: "${raw}"`);
+  }
+  return sanitized;
+}
+
 /**
  * Submit a batch of message creation requests to the Anthropic Batch API.
  *
@@ -53,6 +68,16 @@ export async function submitBatch(
   const ids = new Set(requests.map(r => r.customId));
   if (ids.size !== requests.length) {
     throw new Error('All customId values must be unique within a batch');
+  }
+
+  // Validate customId format — Anthropic requires [a-zA-Z0-9_-]{1,64}
+  const invalid = requests.filter(r => !CUSTOM_ID_VALID.test(r.customId));
+  if (invalid.length > 0) {
+    const examples = invalid.slice(0, 3).map(r => `"${r.customId}"`).join(', ');
+    throw new Error(
+      `${invalid.length} customId(s) contain invalid characters (must match [a-zA-Z0-9_-]{1,64}): ${examples}. ` +
+      `Use sanitizeBatchCustomId() to fix.`
+    );
   }
 
   const batchRequests: BatchCreateParams['requests'] = requests.map(r => ({

--- a/crux/lib/source-check/orchestrator.ts
+++ b/crux/lib/source-check/orchestrator.ts
@@ -7,7 +7,7 @@ import type { CommandResult } from '../command-types.ts';
 import { loadDatabase, loadPages } from '../content-types.ts';
 import { loadGraphFull } from '../factbase-loader.ts';
 import { createLlmClient } from '../llm.ts';
-import { submitBatch, pollBatch, getBatchResults, extractBatchResultText } from '../anthropic-batch.ts';
+import { submitBatch, pollBatch, getBatchResults, extractBatchResultText, sanitizeBatchCustomId } from '../anthropic-batch.ts';
 import type { BatchRequest } from '../anthropic-batch.ts';
 import { parseJsonResponse } from '../anthropic.ts';
 import { SOURCE_CHECK_CONSTANTS, LlmResponseSchema, validateVerdict } from './index.ts';
@@ -359,7 +359,7 @@ async function runBatchExecution(
         break;
     }
 
-    const customId = `verify-${item.id}`;
+    const customId = sanitizeBatchCustomId(`verify-${item.id}`);
     preparedSlots[index] = {
       request: {
         customId,

--- a/crux/resource-enrichment/batch-client.ts
+++ b/crux/resource-enrichment/batch-client.ts
@@ -22,6 +22,21 @@ export interface BatchRequest {
   };
 }
 
+/** Anthropic Batch API custom_id constraint: [a-zA-Z0-9_-]{1,64} */
+const CUSTOM_ID_VALID = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * Sanitize a string for use as a Batch API custom_id.
+ * Replaces any character outside [a-zA-Z0-9_-] with underscore and truncates to 64 chars.
+ */
+export function sanitizeBatchCustomId(raw: string): string {
+  const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+  if (sanitized.length === 0) {
+    throw new Error(`Cannot sanitize empty or all-invalid custom_id: "${raw}"`);
+  }
+  return sanitized;
+}
+
 export interface BatchStatus {
   id: string;
   type: 'message_batch';
@@ -59,6 +74,16 @@ function getAnthropicKey(): string {
  * Create a message batch. Returns the batch ID for polling.
  */
 export async function createBatch(requests: BatchRequest[]): Promise<string> {
+  // Validate custom_id format — Anthropic requires [a-zA-Z0-9_-]{1,64}
+  const invalid = requests.filter(r => !CUSTOM_ID_VALID.test(r.custom_id));
+  if (invalid.length > 0) {
+    const examples = invalid.slice(0, 3).map(r => `"${r.custom_id}"`).join(', ');
+    throw new Error(
+      `${invalid.length} custom_id(s) contain invalid characters (must match [a-zA-Z0-9_-]{1,64}): ${examples}. ` +
+      `Use sanitizeBatchCustomId() to fix.`
+    );
+  }
+
   const apiKey = getAnthropicKey();
 
   const response = await fetch(`${ANTHROPIC_API_BASE}/messages/batches`, {

--- a/crux/tablebase/source-check.ts
+++ b/crux/tablebase/source-check.ts
@@ -17,7 +17,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { createLlmClient, MODELS } from '../lib/llm.ts';
-import { submitBatch, pollBatch, getBatchResults, extractBatchResultText } from '../lib/anthropic-batch.ts';
+import { submitBatch, pollBatch, getBatchResults, extractBatchResultText, sanitizeBatchCustomId } from '../lib/anthropic-batch.ts';
 import type { BatchRequest } from '../lib/anthropic-batch.ts';
 import { getTableConfig } from './table-registry.ts';
 import { calculateCost } from '../lib/pricing.ts';
@@ -499,17 +499,22 @@ export async function runBatchVerification(
   // Build name map once for the entire batch
   const nameMap = buildStableIdNameMap();
 
-  // Build batch requests
-  const batchRequests: BatchRequest[] = records.map((rec) => ({
-    customId: `verify-${table}-${rec.id}`,
-    params: {
-      model,
-      max_tokens: 1024,
-      messages: [
-        { role: 'user' as const, content: buildVerificationPrompt(table, rec, nameMap) },
-      ],
-    },
-  }));
+  // Build batch requests + customId→recordId map (sanitization may mangle IDs)
+  const customIdToRecordId = new Map<string, string>();
+  const batchRequests: BatchRequest[] = records.map((rec) => {
+    const customId = sanitizeBatchCustomId(`verify-${table}-${rec.id}`);
+    customIdToRecordId.set(customId, String(rec.id));
+    return {
+      customId,
+      params: {
+        model,
+        max_tokens: 1024,
+        messages: [
+          { role: 'user' as const, content: buildVerificationPrompt(table, rec, nameMap) },
+        ],
+      },
+    };
+  });
 
   if (batchRequests.length === 0) {
     return { issues: [], cost: 0 };
@@ -522,7 +527,7 @@ export async function runBatchVerification(
   // Parse results
   let totalCost = 0;
   for (const [customId, result] of results) {
-    const recordId = customId.replace(`verify-${table}-`, '');
+    const recordId = customIdToRecordId.get(customId) ?? customId;
     const text = extractBatchResultText(result);
 
     if (result.result.type === 'succeeded') {


### PR DESCRIPTION
## Summary

- **Batch API custom_id fix**: Source-check IDs contain colons (`fact:xxx`, `record:personnel:xxx`) which violate Anthropic's Batch API `custom_id` constraint (`[a-zA-Z0-9_-]{1,64}`). Added `sanitizeBatchCustomId()` helper that replaces invalid characters with underscores. Applied to orchestrator.ts and source-check.ts (both use in-memory Maps for result lookup). Added validation in both `submitBatch()` and `createBatch()` across both batch clients to catch invalid IDs early.
- **Server-side verification enforcement (#3959)**: Extracted the client-side `?requireVerification=true` check from personnel.ts into a shared `verification-enforcement.ts` middleware. Applied to both personnel.ts and grants.ts. The middleware checks a server-side config (currently all disabled, ready for Phase 5 rollout) AND the legacy client param. Includes `?forceSkipVerification=true&reason=...` escape hatch with audit logging for migrations/backfills.

Closes #3959

## Test plan

- [x] 9 tests for `sanitizeBatchCustomId()` — colons, dots, slashes, truncation, empty input, realistic source-check IDs
- [x] 6 tests for `enforceVerification()` — no enforcement, client param, full verification, forceSkip with/without reason, table name in error
- [x] Full test suite passes (5044 tests)
- [x] Full production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)