### PR TITLE
fix: add argocd app sync to deploy workflow

### DIFF
--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -204,6 +204,16 @@ jobs:
             --server "${ARGOCD_SERVER}" \
             --grpc-web
 
+          # Trigger an explicit sync — the app uses Manual sync policy,
+          # so `app set` alone only queues the change without applying it.
+          # Without this, the deployment stays OutOfSync and the old pod
+          # continues serving traffic (caused deploy #3967 failure).
+          argocd app sync longterm-wiki-server \
+            --auth-token "${ARGOCD_AUTH_TOKEN}" \
+            --server "${ARGOCD_SERVER}" \
+            --grpc-web \
+            --timeout 300
+
           argocd app wait longterm-wiki-server \
             --health \
             --timeout 300 \


### PR DESCRIPTION
## Summary
- The deploy workflow was missing an explicit `argocd app sync` command between `argocd app set` and `argocd app wait --health`
- Since the ArgoCD app uses **Manual** sync policy, `app set` alone queues the parameter change without deploying it
- This caused deploy #3967 to fail — the new image was built and the tag was set, but the old pod continued serving traffic until a manual kubectl sync was triggered

## Changes
- Added `argocd app sync longterm-wiki-server` with 300s timeout between `app set` and `app wait --health`

## Test plan
- [ ] Next production deploy succeeds end-to-end without manual ArgoCD intervention
- [ ] The "Verify deployed SHA" step sees the new image tag and `Synced` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)