### PR TITLE
feat: entity-resources things dual-write, dashboard stats, backfill monitoring

### DIFF
--- a/apps/web/src/app/internal/entities/entities-content.tsx
+++ b/apps/web/src/app/internal/entities/entities-content.tsx
@@ -1,4 +1,4 @@
-import { getTypedEntities, getEntityHref, getPageById, getPageCoverageItems, getPageRankings, getIdRegistry } from "@/data";
+import { getTypedEntities, getEntityHref, getPageById, getPageCoverageItems, getPageRankings, getIdRegistry, getEntityResourceLinks } from "@/data";
 import { getEntityDataDepth } from "@/data/entity-coverage";
 import { fetchDetailed, type RpcEntitySummaryRow } from "@lib/wiki-server";
 import { EntitiesDataTable } from "./entities-data-table";
@@ -80,6 +80,8 @@ export async function EntitiesContent() {
     const rank = rankingById.get(e.id);
     const href = getEntityHref(e.id);
     const sc = scSummary.get(e.id);
+    const erLinks = e.stableId ? getEntityResourceLinks(e.stableId) : null;
+    const resourceLinkCount = erLinks ? erLinks.authored.length + erLinks.subject.length : 0;
 
     const quality = cov?.quality ?? rank?.quality ?? null;
     const readerImportance = cov?.readerImportance ?? rank?.readerImportance ?? null;
@@ -190,9 +192,11 @@ export async function EntitiesContent() {
       scAvgConfidence: sc?.avgConfidence ?? null,
       scAccuracyRate,
       scVerificationCoverage,
+      resourceLinkCount,
     };
   });
 
+  const withResourceLinks = rows.filter((r) => r.resourceLinkCount > 0).length;
   const withPages = rows.filter((r) => r.hasPage).length;
   const withImportance = rows.filter((r) => r.readerImportance != null).length;
   const withCoverage = rows.filter((r) => r.coverageScore != null).length;
@@ -209,7 +213,9 @@ export async function EntitiesContent() {
         <span className="font-medium text-foreground">{withCoverage}</span>{" "}
         have coverage data,{" "}
         <span className="font-medium text-foreground">{withVerification}</span>{" "}
-        have source-check verdicts. Use <strong>preset buttons</strong> to switch views.
+        have source-check verdicts,{" "}
+        <span className="font-medium text-foreground">{withResourceLinks}</span>{" "}
+        have resource links. Use <strong>preset buttons</strong> to switch views.
         The <strong>Verification</strong> preset shows source-check accuracy and coverage.
       </p>
       <EntitiesDataTable entities={rows} />

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -113,6 +113,8 @@ export interface UnifiedEntityRow {
   scAvgConfidence: number | null;
   scAccuracyRate: number | null;
   scVerificationCoverage: number | null;
+  // Entity-resource links
+  resourceLinkCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1030,6 +1032,17 @@ const columns: ColumnDef<UnifiedEntityRow>[] = [
           <span className={`text-[11px] tabular-nums font-medium ${color}`}>{pct}%</span>
         </div>
       );
+    },
+  },
+  // ── Entity-resource links ──
+  {
+    accessorKey: "resourceLinkCount",
+    sortUndefined: "last",
+    header: ({ column }) => <SortableHeader column={column} title="Entity-resource links (authored + subject)">Links</SortableHeader>,
+    cell: ({ row }) => {
+      const v = row.original.resourceLinkCount;
+      if (!v) return <Dash />;
+      return <span className="text-[11px] tabular-nums font-medium">{v}</span>;
     },
   },
 ];

--- a/apps/wiki-server/src/routes/operational/data-quality.ts
+++ b/apps/wiki-server/src/routes/operational/data-quality.ts
@@ -124,6 +124,26 @@ const dataQualityApp = new Hono()
       const pagesTotalRows = await db.select({ count: count() }).from(wikiPages);
       const pagesTotal = pagesTotalRows[0].count;
 
+      // 9. Entity-resources and sourceResourceId coverage
+      const entityResourceRows = (await db.execute(
+        sql`SELECT COUNT(*)::text AS cnt FROM entity_resources`
+      )) as Array<{ cnt: string }>;
+      const entityResourcesTotal = parseInt(entityResourceRows[0]?.cnt ?? "0", 10);
+
+      const sourceResourceCoverage: Record<string, { total: number; linked: number }> = {};
+      for (const table of ["personnel", "grants", "funding_rounds", "investments", "equity_positions"] as const) {
+        const totalRows = (await db.execute(
+          sql.raw(`SELECT COUNT(*)::text AS cnt FROM ${table} WHERE source IS NOT NULL AND source != ''`)
+        )) as Array<{ cnt: string }>;
+        const linkedRows = (await db.execute(
+          sql.raw(`SELECT COUNT(*)::text AS cnt FROM ${table} WHERE source_resource_id IS NOT NULL`)
+        )) as Array<{ cnt: string }>;
+        sourceResourceCoverage[table] = {
+          total: parseInt(totalRows[0]?.cnt ?? "0", 10),
+          linked: parseInt(linkedRows[0]?.cnt ?? "0", 10),
+        };
+      }
+
       // ---- Insert snapshot ----
       const [snapshot] = await db
         .insert(dataQualitySnapshots)
@@ -148,6 +168,10 @@ const dataQualityApp = new Hono()
           factbaseEntities,
           factbaseFacts,
           pagesTotal,
+          extra: {
+            entityResourcesTotal,
+            sourceResourceCoverage,
+          },
         })
         .returning();
 

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -2,12 +2,13 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { entityResources } from "../../schema.js";
+import { entityResources, resources } from "../../schema.js";
 import {
   parseJsonBody,
   validationError,
   invalidJsonError,
 } from "../shared/utils.js";
+import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 
 const SyncItemSchema = z.object({
   entityId: z.string().min(1).max(200),
@@ -84,20 +85,52 @@ const entityResourcesApp = new Hono()
     const { items } = parsed.data;
     const db = getDrizzleDb();
 
-    // OR-merge: boolean flags accumulate across seed passes (e.g., publisher + wiki_citation).
-    // inferenceSource uses COALESCE (first-writer-wins) — the initial source is preserved.
-    const upserted = await db
-      .insert(entityResources)
-      .values(items.map(toRow))
-      .onConflictDoUpdate({
-        target: [entityResources.entityId, entityResources.resourceId],
-        set: {
-          authoredByEntity: sql`EXCLUDED.authored_by_entity OR entity_resources.authored_by_entity`,
-          isSubject: sql`EXCLUDED.is_subject OR entity_resources.is_subject`,
-          inferenceSource: sql`COALESCE(EXCLUDED.inference_source, entity_resources.inference_source)`,
-        },
-      })
-      .returning({ id: entityResources.id });
+    const upserted = await db.transaction(async (tx) => {
+      // OR-merge: boolean flags accumulate across seed passes (e.g., publisher + wiki_citation).
+      // inferenceSource uses COALESCE (first-writer-wins) — the initial source is preserved.
+      const rows = await tx
+        .insert(entityResources)
+        .values(items.map(toRow))
+        .onConflictDoUpdate({
+          target: [entityResources.entityId, entityResources.resourceId],
+          set: {
+            authoredByEntity: sql`EXCLUDED.authored_by_entity OR entity_resources.authored_by_entity`,
+            isSubject: sql`EXCLUDED.is_subject OR entity_resources.is_subject`,
+            inferenceSource: sql`COALESCE(EXCLUDED.inference_source, entity_resources.inference_source)`,
+          },
+        })
+        .returning({ id: entityResources.id, entityId: entityResources.entityId, resourceId: entityResources.resourceId, authoredByEntity: entityResources.authoredByEntity, isSubject: entityResources.isSubject });
+
+      // Dual-write to things table for universal search/browse index
+      if (rows.length > 0) {
+        const resourceIds = [...new Set(rows.map((r) => r.resourceId))];
+        const entityIds = [...new Set(rows.map((r) => r.entityId))];
+
+        // Resolve resource titles and entity titles for search
+        const resourceRows = await tx
+          .select({ id: resources.id, title: resources.title, url: resources.url })
+          .from(resources)
+          .where(sql`${resources.id} IN (${sql.join(resourceIds.map(id => sql`${id}`), sql`, `)})`);
+        const resourceTitleMap = new Map(resourceRows.map((r) => [r.id, r.title ?? r.url ?? r.id]));
+
+        const entityTitleMap = await resolveEntityTitles(tx, entityIds);
+
+        await upsertThingsInTx(
+          tx,
+          rows.map((r) => ({
+            id: `er:${r.entityId}:${r.resourceId}`,
+            thingType: "entity-resource",
+            title: resourceTitleMap.get(r.resourceId) ?? r.resourceId,
+            sourceTable: "entity_resources",
+            sourceId: String(r.id),
+            description: r.authoredByEntity ? "authored" : r.isSubject ? "about" : null,
+            parentTitle: entityTitleMap.get(r.entityId) ?? r.entityId,
+          }))
+        );
+      }
+
+      return rows;
+    });
 
     return c.json({ total: upserted.length });
   })


### PR DESCRIPTION
## Summary

Observability and indexing improvements for the entity_resources system.

**1. Things table dual-write** — Entity-resources sync endpoint now writes to the `things` table within the same transaction. Each entity-resource link gets a things row with the resource title, entity parent title, and authored/subject description. Makes entity-resource links browsable at `/things`.

**2. Internal entities dashboard** — Added `resourceLinkCount` to the entities data table. Summary shows count of entities with resource links. New "Links" column sortable in the table.

**3. Data quality snapshot monitoring** — `POST /api/data-quality` now tracks:
  - `entityResourcesTotal` — total entity-resource links
  - `sourceResourceCoverage` — per-table (personnel, grants, funding_rounds, investments, equity_positions) counts of records with vs without `source_resource_id` linked

Both stored in the `extra` JSONB field (no migration needed).

**4. Backfill** — Cannot run from agent session (no psql/DB access). Run manually:
```bash
psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/backfill-source-resource-ids.sql
```

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (pre-existing snapshot failures only)
- [x] Wiki-server TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)