### PR TITLE
feat: improve things pages with shared directory components

### DIFF
--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRight,
   Layers,
 } from "lucide-react";
+import { Breadcrumbs } from "@/components/directory/Breadcrumbs";
 import { fetchDetailed } from "@/lib/wiki-server";
 import type { RpcSourceCheckDetailResult } from "@/lib/wiki-server";
 import {
@@ -216,9 +217,45 @@ function RecordValue({
     return <span className="text-sm">{value}</span>;
   }
 
-  // Arrays and objects — JSON fallback
+  // Arrays — check for stableId references first
+  if (Array.isArray(value)) {
+    const hasSids = value.some(
+      (v) => typeof v === "string" && isAnySid(v) && displayNames[v]
+    );
+    if (hasSids) {
+      return (
+        <span className="flex flex-wrap gap-1.5">
+          {value.map((item, i) => {
+            if (typeof item === "string" && isAnySid(item) && displayNames[item]) {
+              const dn = displayNames[item];
+              return (
+                <span key={`${item}-${i}`}>
+                  {i > 0 && <span className="text-muted-foreground">, </span>}
+                  <Link href={`/wiki/${dn.slug}`} className="text-primary hover:underline">
+                    {dn.title}
+                  </Link>
+                  <span className="text-xs text-muted-foreground ml-1">({dn.entityType})</span>
+                </span>
+              );
+            }
+            if (typeof item === "object" && item !== null) {
+              return <span key={`obj-${i}`} className="text-sm">{JSON.stringify(item)}</span>;
+            }
+            return <span key={`${item}-${i}`}>{String(item)}</span>;
+          })}
+        </span>
+      );
+    }
+  }
+
+  // Objects and non-stableId arrays — JSON fallback
   if (typeof value === "object") {
-    const json = JSON.stringify(value, null, 2);
+    let json: string;
+    try {
+      json = JSON.stringify(value, null, 2);
+    } catch {
+      json = "[Unable to serialize]";
+    }
     const display = json.length > 300 ? json.slice(0, 300) + "\u2026" : json;
     return (
       <pre className="text-xs bg-muted px-2 py-1 rounded overflow-x-auto max-w-full whitespace-pre-wrap">
@@ -407,6 +444,13 @@ export default async function ThingDetailPage({ params }: PageProps) {
 
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
+      <Breadcrumbs
+        items={[
+          { label: "Things", href: "/things" },
+          { label: thing.title },
+        ]}
+      />
+
       {/* Header */}
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-3">
@@ -444,14 +488,14 @@ export default async function ThingDetailPage({ params }: PageProps) {
         )}
         {thing.parentThingId && (
           <Link
-            href={`/wiki/E1929?q=${encodeURIComponent(thing.parentThingId)}`}
+            href={`/wiki/E1929?entity=${encodeURIComponent(thing.parentThingId)}`}
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
           >
             <Layers className="h-3.5 w-3.5" />
             View entity profile
           </Link>
         )}
-        {hasVerdicts && (
+        {VERDICT_SOURCE_TABLES.has(thing.sourceTable) && (
           <Link
             href={getSourceCheckHref(recordType, thing.sourceId)}
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
@@ -520,7 +564,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
       </section>
 
       {/* Source Check Verdicts */}
-      {hasVerdicts && (
+      {hasVerdicts ? (
         <section className="mb-8">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
             <span className="inline-flex items-center gap-1.5">
@@ -586,7 +630,28 @@ export default async function ThingDetailPage({ params }: PageProps) {
             </Link>
           </div>
         </section>
-      )}
+      ) : VERDICT_SOURCE_TABLES.has(thing.sourceTable) ? (
+        <section className="mb-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            <span className="inline-flex items-center gap-1.5">
+              <ShieldCheck className="h-4 w-4" />
+              Source Check
+            </span>
+          </h2>
+          <div className="rounded-lg border border-dashed border-border/60 p-4">
+            <p className="text-sm text-muted-foreground">
+              This record has not been source-checked yet.
+            </p>
+            <Link
+              href={getSourceCheckHref(recordType, thing.sourceId)}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mt-2"
+            >
+              View source check page
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+        </section>
+      ) : null}
 
       {/* Debug footer */}
       <details className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">

--- a/apps/web/src/app/things/page.tsx
+++ b/apps/web/src/app/things/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { fetchDetailed } from "@/lib/wiki-server";
+import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
 import { ThingsTable } from "./things-table";
+import { formatType } from "./types";
+import type { ThingRow, ThingsStatsResponse } from "./types";
 
 export const metadata: Metadata = {
   title: "Things",
@@ -14,30 +15,10 @@ export const revalidate = 300;
 
 const PAGE_SIZE = 50;
 
-interface ThingRow {
-  id: string;
-  thingType: string;
-  title: string;
-  parentThingId: string | null;
-  sourceTable: string;
-  sourceId: string;
-  entityType: string | null;
-  description: string | null;
-  href: string | null;
-  parentTitle: string | null;
-  updatedAt: string | null;
-}
-
 interface ThingsListResponse {
   results?: ThingRow[];
   things?: ThingRow[];
   total: number;
-}
-
-interface ThingsStatsResponse {
-  total: number;
-  byType: Record<string, number>;
-  byEntityType: Record<string, number>;
 }
 
 interface PageProps {
@@ -52,12 +33,23 @@ function getParam(
   return typeof val === "string" ? val : undefined;
 }
 
+/** Valid sort fields supported by the wiki-server API. */
+const VALID_SORT_FIELDS = new Set(["title", "updated_at", "created_at", "thing_type"]);
+
 export default async function ThingsPage({ searchParams }: PageProps) {
   const sp = await searchParams;
   const searchQuery = getParam(sp, "q") ?? "";
   const filterType = getParam(sp, "type") ?? "";
+
+  // Parse page (useDirectoryUrl stores as 1-indexed in URL)
   const pageNum = Math.max(1, parseInt(getParam(sp, "page") ?? "1", 10) || 1);
   const offset = (pageNum - 1) * PAGE_SIZE;
+
+  // Parse sort (useDirectoryUrl stores as "field:dir")
+  const sortParam = getParam(sp, "sort") ?? "updated_at:desc";
+  const [rawSortField, rawSortDir] = sortParam.split(":");
+  const sortField = VALID_SORT_FIELDS.has(rawSortField) ? rawSortField : "updated_at";
+  const sortDir = rawSortDir === "asc" ? "asc" : "desc";
 
   // Build list/search URL
   let listUrl: string;
@@ -67,8 +59,8 @@ export default async function ThingsPage({ searchParams }: PageProps) {
     listUrl = `/api/things/search?${params.toString()}`;
   } else {
     const params = new URLSearchParams({
-      sort: "updated_at",
-      order: "desc",
+      sort: sortField,
+      order: sortDir,
       limit: String(PAGE_SIZE),
       offset: String(offset),
     });
@@ -96,31 +88,19 @@ export default async function ThingsPage({ searchParams }: PageProps) {
     );
   }
 
-  // The list endpoint returns { things, total } while the search endpoint
-  // returns { results, total }. Normalize to a single shape.
   const listBody = listResult.data;
   const results = listBody.results ?? listBody.things ?? [];
   const total = listBody.total ?? results.length;
 
-  // Stats may fail independently — degrade gracefully.
-  // Use the list total as fallback so the header doesn't show "0 items total"
-  // while rows are visibly rendered.
   const stats: ThingsStatsResponse = statsResult.ok
     ? statsResult.data
     : { total, byType: {}, byEntityType: {} };
-  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  function buildUrl(overrides: { q?: string; type?: string; page?: number }) {
-    const params = new URLSearchParams();
-    const q = overrides.q ?? searchQuery;
-    const t = overrides.type ?? filterType;
-    const p = overrides.page ?? 1;
-    if (q) params.set("q", q);
-    if (t) params.set("type", t);
-    if (p > 1) params.set("page", String(p));
-    const qs = params.toString();
-    return `/things${qs ? `?${qs}` : ""}`;
-  }
+  // Top types for stat cards (top 3 by count)
+  const topTypes = Object.entries(stats.byType)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 3);
 
   return (
     <div className="max-w-[90rem] mx-auto px-6 py-8">
@@ -128,60 +108,34 @@ export default async function ThingsPage({ searchParams }: PageProps) {
       <div className="mb-6">
         <h1 className="text-3xl font-extrabold tracking-tight mb-2">Things</h1>
         <p className="text-muted-foreground text-sm max-w-2xl">
-          Universal index of all tracked items across the knowledge base.{" "}
-          <span className="tabular-nums">{stats.total.toLocaleString()}</span> items total.
+          Universal index of all tracked items across the knowledge base.
         </p>
       </div>
 
-      {/* Client component with search + type filter + table */}
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+        <ProfileStatCard
+          label="Total Things"
+          value={stats.total.toLocaleString()}
+        />
+        {topTypes.map(([type, count]) => (
+          <ProfileStatCard
+            key={type}
+            label={formatType(type)}
+            value={count.toLocaleString()}
+            href={`/things?type=${encodeURIComponent(type)}`}
+          />
+        ))}
+      </div>
+
+      {/* Client component with search + filters + sortable table + pagination */}
       <ThingsTable
         rows={results}
         total={total}
+        totalPages={totalPages}
         stats={stats}
-        currentQuery={searchQuery}
-        currentType={filterType}
-        currentPage={pageNum}
         pageSize={PAGE_SIZE}
       />
-
-      {/* Server-rendered pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between px-1 mt-4">
-          <span className="text-sm text-muted-foreground">
-            Showing {offset + 1}&ndash;{Math.min(offset + PAGE_SIZE, total)} of{" "}
-            {total.toLocaleString()}
-          </span>
-          <div className="flex items-center gap-1">
-            {pageNum > 1 ? (
-              <Link
-                href={buildUrl({ page: pageNum - 1 })}
-                className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 transition-colors"
-              >
-                <ChevronLeft className="h-3.5 w-3.5" /> Prev
-              </Link>
-            ) : (
-              <span className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground opacity-40 cursor-not-allowed">
-                <ChevronLeft className="h-3.5 w-3.5" /> Prev
-              </span>
-            )}
-            <span className="px-2 text-xs text-muted-foreground tabular-nums">
-              {pageNum} / {totalPages}
-            </span>
-            {pageNum < totalPages ? (
-              <Link
-                href={buildUrl({ page: pageNum + 1 })}
-                className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 transition-colors"
-              >
-                Next <ChevronRight className="h-3.5 w-3.5" />
-              </Link>
-            ) : (
-              <span className="inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs text-muted-foreground opacity-40 cursor-not-allowed">
-                Next <ChevronRight className="h-3.5 w-3.5" />
-              </span>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/app/things/things-table.tsx
+++ b/apps/web/src/app/things/things-table.tsx
@@ -1,44 +1,21 @@
 "use client";
 
-import { useCallback } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-interface ThingRow {
-  id: string;
-  thingType: string;
-  title: string;
-  parentThingId: string | null;
-  sourceTable: string;
-  sourceId: string;
-  entityType: string | null;
-  description: string | null;
-  href: string | null;
-  parentTitle: string | null;
-  updatedAt: string | null;
-}
-
-interface ThingsStatsResponse {
-  total: number;
-  byType: Record<string, number>;
-  byEntityType: Record<string, number>;
-}
+import { useDirectoryUrl } from "@/hooks/use-directory-url";
+import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
+import { PaginationControls } from "@/components/directory/PaginationControls";
+import { formatType } from "./types";
+import type { ThingRow, ThingsStatsResponse } from "./types";
 
 interface ThingsTableProps {
   rows: ThingRow[];
   total: number;
+  totalPages: number;
   stats: ThingsStatsResponse;
-  currentQuery: string;
-  currentType: string;
-  currentPage: number;
   pageSize: number;
-}
-
-/** Format a thingType value as a readable badge label. */
-function formatType(type: string): string {
-  return type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /** Format an ISO date string to a short date. */
@@ -62,45 +39,52 @@ const TYPE_COLORS: Record<string, string> = {
   resource: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
   grant: "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300",
   division: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  "funding-program": "bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300",
   funding_program: "bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300",
   personnel: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
 };
 
 const DEFAULT_TYPE_COLOR = "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400";
 
+type SortKey = "thing_type" | "title" | "updated_at";
+
 export function ThingsTable({
   rows,
   total,
+  totalPages,
   stats,
-  currentQuery,
-  currentType,
-  currentPage,
   pageSize,
 }: ThingsTableProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const url = useDirectoryUrl({
+    defaultSort: { field: "updated_at", dir: "desc" },
+    filters: ["type"],
+  });
 
-  const updateUrl = useCallback(
-    (updates: Record<string, string | null>) => {
-      const params = new URLSearchParams(searchParams.toString());
-      for (const [key, value] of Object.entries(updates)) {
-        if (value === null || value === "") {
-          params.delete(key);
-        } else {
-          params.set(key, value);
-        }
+  // Sort is ignored by the search API (results ranked by relevance),
+  // so we disable sort controls when a search query is active.
+  const isSearchActive = url.search.length > 0;
+  const VALID_SORT_KEYS = new Set<string>(["thing_type", "title", "updated_at"]);
+  const rawField = url.sort.field;
+  const sortKey: SortKey = VALID_SORT_KEYS.has(rawField) ? (rawField as SortKey) : "updated_at";
+  const sortDir = url.sort.dir;
+
+  const handleSort = (key: SortKey) => {
+    if (isSearchActive) return;
+    if (sortKey === key) {
+      if (sortDir === "asc") {
+        url.setSort({ field: key, dir: "desc" });
+      } else {
+        url.setSort({ field: "updated_at", dir: "desc" });
       }
-      // Reset page when filters change
-      const query = params.toString();
-      router.push(`/things${query ? `?${query}` : ""}`, { scroll: false });
-    },
-    [router, searchParams],
-  );
+    } else {
+      url.setSort({ field: key, dir: "asc" });
+    }
+  };
 
-  // Sort types by count descending, take top 8
+  // Build filter chip items from stats — all types, sorted by count
+  const typeFilter = url.filters.type ?? "all";
   const typeEntries = Object.entries(stats.byType)
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 8);
+    .sort(([, a], [, b]) => b - a);
 
   return (
     <div>
@@ -112,13 +96,8 @@ export function ThingsTable({
             type="text"
             placeholder="Search things..."
             aria-label="Search things"
-            defaultValue={currentQuery}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                const value = (e.target as HTMLInputElement).value;
-                updateUrl({ q: value || null, page: null });
-              }
-            }}
+            value={url.search}
+            onChange={(e) => url.setSearch(e.target.value)}
             className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40"
           />
         </div>
@@ -127,40 +106,18 @@ export function ThingsTable({
         </span>
       </div>
 
-      {/* Type filter badges */}
-      <div className="flex gap-1.5 flex-wrap mb-4">
-        <button
-          type="button"
-          onClick={() => updateUrl({ type: null, page: null })}
-          className={cn(
-            "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-            !currentType
-              ? "bg-foreground text-background"
-              : "bg-muted text-muted-foreground hover:bg-muted/80",
-          )}
-        >
-          All ({stats.total.toLocaleString()})
-        </button>
-        {typeEntries.map(([type, count]) => (
-          <button
-            key={type}
-            type="button"
-            onClick={() =>
-              updateUrl({
-                type: currentType === type ? null : type,
-                page: null,
-              })
-            }
-            className={cn(
-              "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-              currentType === type
-                ? "bg-foreground text-background"
-                : "bg-muted text-muted-foreground hover:bg-muted/80",
-            )}
-          >
-            {formatType(type)} ({count.toLocaleString()})
-          </button>
-        ))}
+      {/* Type filter chips */}
+      <div className="mb-4">
+        <FilterChips
+          items={typeEntries.map(([type, count]) => ({
+            key: type,
+            label: formatType(type),
+            count,
+          }))}
+          selected={typeFilter}
+          onSelect={(key) => url.setFilter("type", key)}
+          allCount={stats.total}
+        />
       </div>
 
       {/* Table */}
@@ -168,10 +125,42 @@ export function ThingsTable({
         <table className="w-full text-sm">
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border bg-muted">
-              <th className="py-2.5 px-3 text-left font-medium w-24">Type</th>
-              <th className="py-2.5 px-3 text-left font-medium">Title</th>
-              <th className="py-2.5 px-3 text-left font-medium w-48">Parent</th>
-              <th className="py-2.5 px-3 text-left font-medium w-32">Updated</th>
+              {isSearchActive ? (
+                <>
+                  <th className="py-2.5 px-3 text-left font-medium w-24">Type</th>
+                  <th className="py-2.5 px-3 text-left font-medium">Title</th>
+                  <th className="py-2.5 px-3 text-left font-medium w-48">Parent</th>
+                  <th className="py-2.5 px-3 text-left font-medium w-32">Updated</th>
+                </>
+              ) : (
+                <>
+                  <SortHeader
+                    label="Type"
+                    sortKey="thing_type"
+                    currentSort={sortKey}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                    className="text-left w-24"
+                  />
+                  <SortHeader
+                    label="Title"
+                    sortKey="title"
+                    currentSort={sortKey}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                    className="text-left"
+                  />
+                  <th className="py-2.5 px-3 text-left font-medium w-48">Parent</th>
+                  <SortHeader
+                    label="Updated"
+                    sortKey="updated_at"
+                    currentSort={sortKey}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                    className="text-left w-32"
+                  />
+                </>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
@@ -231,6 +220,19 @@ export function ThingsTable({
       {rows.length === 0 && (
         <div className="text-center py-12 text-muted-foreground">
           No things match your search.
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4">
+          <PaginationControls
+            page={url.page}
+            pageCount={totalPages}
+            totalItems={total}
+            pageSize={pageSize}
+            onPageChange={url.setPage}
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/app/things/types.ts
+++ b/apps/web/src/app/things/types.ts
@@ -1,0 +1,24 @@
+export interface ThingRow {
+  id: string;
+  thingType: string;
+  title: string;
+  parentThingId: string | null;
+  sourceTable: string;
+  sourceId: string;
+  entityType: string | null;
+  description: string | null;
+  href: string | null;
+  parentTitle: string | null;
+  updatedAt: string | null;
+}
+
+export interface ThingsStatsResponse {
+  total: number;
+  byType: Record<string, number>;
+  byEntityType: Record<string, number>;
+}
+
+/** Format a thingType value as a readable label (e.g. "funding-program" → "Funding Program"). */
+export function formatType(type: string): string {
+  return type.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -51,6 +51,7 @@ export const NAV_ITEMS: NavItem[] = [
       { href: "/publications", label: "Publications" },
       { href: "/source-checks", label: "Source Checks" },
       { href: "/data-sources", label: "Data Sources" },
+      { href: "/things", label: "Things" },
     ],
   },
   { href: "/factbase", label: "FactBase" },


### PR DESCRIPTION
## Summary

Upgrades the `/things` pages to match the quality level of other directory pages (organizations, grants, people):

- **Navigation**: Add `/things` to Sources dropdown in header nav
- **Detail page** (`/things/[id]`):
  - Add breadcrumbs (`Things / [title]`)
  - Show "not checked yet" message for records that support source-checking but have no verdicts (instead of silently hiding the section)
  - Fix entity profile link bug (`?q=` → `?entity=` param, matching what entity-profile-viewer expects)
  - Handle arrays of stableIds in RecordValue (render as entity links instead of raw JSON)
  - Add try-catch around JSON.stringify for circular reference safety
- **Listing page** (`/things`):
  - Add `ProfileStatCard` grid showing total + top 3 types
  - Adopt `SortHeader` for sortable Type, Title, Updated columns
  - Adopt `FilterChips` for type filter (shows all types with counts, not just top 8)
  - Adopt `PaginationControls` (with first/last/prev/next buttons)
  - Use `useDirectoryUrl` hook for URL state management (sort, search, filter, page all synced to URL)
  - Sort headers disabled during search (search API returns relevance-ranked results, ignoring sort)
- **Code quality**: Extract shared `ThingRow`, `ThingsStatsResponse`, `formatType` to `types.ts`

## Architecture note

Things has 10K+ rows so must stay server-paginated (unlike organizations which loads ~500 rows client-side). The approach is a hybrid: `useDirectoryUrl` manages URL state in the client component, and each state change triggers a Next.js server re-render that fetches new data from the wiki-server API.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm crux w fix escaping` — no issues
- [x] Review via `/agent-review-pr` — 8 findings, 5 fixed
- [ ] `/things` appears in Sources nav dropdown
- [ ] `/things` listing: stat cards render, sort headers work, FilterChips work, pagination works
- [ ] `/things/[id]`: breadcrumbs show, "not checked yet" appears for checkable records without verdicts
- [ ] Sort headers become plain headers during search (no misleading sort indicators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumbs navigation to thing detail pages
  * Added stat cards displaying total count and top 3 types on Things listing
  * Added Things link to Sources navigation menu

* **Improvements**
  * Related entities in arrays now render as clickable links with type badges
  * Enhanced error handling for unserializable data
  * Source Check section now displays helpful feedback when checks are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->