### PR TITLE
fix: allow parallel manual job-worker dispatches

### DIFF
--- a/.github/workflows/job-worker.yml
+++ b/.github/workflows/job-worker.yml
@@ -34,9 +34,11 @@ on:
         default: '1'
         type: string
 
-# Limit concurrent workers
+# Limit concurrent workers — use run_id so dispatched runs don't cancel each other.
+# Scheduled runs share a group (only 1 scheduled run at a time), but manual dispatches
+# each get their own group for parallel bulk processing.
 concurrency:
-  group: job-worker-${{ github.ref }}
+  group: job-worker-${{ github.event_name == 'schedule' && github.ref || github.run_id }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Summary

- GitHub Actions concurrency groups only allow 1 running + 1 pending per group. Manual `workflow_dispatch` runs were getting cancelled when multiple were dispatched for bulk resource-ingest processing.
- Changed the concurrency group key: scheduled runs still share a group (1 at a time), but manual dispatches each get their own group (keyed by `run_id`) enabling parallel processing.

## Test plan

- [x] Scheduled runs still deduplicate (same group key `job-worker-refs/heads/main`)
- [x] Manual dispatches get unique groups (e.g., `job-worker-12345`, `job-worker-12346`)
- [ ] Verify parallel dispatches both run concurrently after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized job scheduling behavior to allow manual workflow runs to execute in parallel while maintaining sequential execution for scheduled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->