### PR TITLE
fix: keep sid_ prefix in submit_records and eagerly init stableId cache

### DIFF
--- a/.tablebase-completed.txt
+++ b/.tablebase-completed.txt
@@ -196,3 +196,5 @@ EjKCxZe8Ej7b
 1dPyhnq0K7jn
 29KsT6wfq3Sw
 5AVLtXYjA_XD
+B2S5anCRGUTg
+hFas5DeN9R_l

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -290,7 +290,10 @@ async function handleCreateEntity(input: Record<string, unknown>): Promise<strin
 
   // Update caches so subsequent resolve/validate calls find this entity
   _entityMatcher = null; // Force re-build on next resolve
-  if (_knownStableIds) _knownStableIds.add(stableId); // Avoid stale-cache rejection in submit_records
+  // Eagerly initialize the stableId set so newly created entities are recognized
+  // by submit_records validation. Without this, batch-creating entities before
+  // the first submit_records leaves them missing from the set (it was null).
+  getKnownStableIds().add(stableId);
 
   return JSON.stringify({
     created: true,
@@ -418,7 +421,10 @@ async function handleSubmitRecords(
       if (isSid(val)) {
         const raw = stripSid(val);
         if (stableIdSet.has(raw) || stableIdSet.has(val)) {
-          record[field] = raw;
+          // Keep the sid_ prefix — entities.stable_id stores the prefixed form,
+          // and validateEntityRefs checks against it. Stripping causes lookup misses
+          // for newly created entities (see: Arcadia Impact enrichment failure 2026-04-07).
+          record[field] = val;
           continue;
         }
         invalidRefs.push(`${field}="${val}" — sid_-prefixed but ID not found in database. Use resolve_entity to get a valid ID.`);


### PR DESCRIPTION
## Summary
- `submit_records` was stripping the `sid_` prefix from entity reference fields before sending to the server (`record[field] = raw`). The `entities.stable_id` column stores the full `sid_`-prefixed form, so `validateEntityRefs` lookups failed for newly created entities.
- The `_knownStableIds` guard in `create_entity` used `if (_knownStableIds)` which skipped `add()` when the cache was `null` (before the first `submit_records` call). Fixed by calling `getKnownStableIds().add()` which eagerly initializes the set.

## Test plan
- [x] Manual verification: `pnpm crux tb enrich --max=3 --budget=5` — confirmed newly created entities accepted by `submit_records` (9 records submitted, 0 "Entity references not found" errors)
- [x] Existing gate checks pass (gate cached green for this commit)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where newly created entities were not properly recognized during subsequent validation operations.
  * Corrected reference field handling to preserve proper formatting during record submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->