### PR TITLE
crux: add deploy-tasks verify subcommand

### DIFF
--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -8,12 +8,16 @@
  *   crux gh deploy-tasks detect             Detect deploy tasks from current branch diff
  *   crux gh deploy-tasks pending            Find unchecked tasks from recently merged PRs
  *   crux gh deploy-tasks inject             Output deploy tasks section (or update a PR)
+ *   crux gh deploy-tasks verify             Run embedded verify commands for unchecked tasks
  */
+
+import { spawnSync } from 'child_process';
 
 import { createLogger } from '../lib/output.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 import {
   detectDeployTasks,
+  extractVerifyCommand,
   parseDeployTasksFromBody,
   formatDeployTasksSection,
 } from '../lib/deploy-tasks/detect.ts';
@@ -163,6 +167,185 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
   return { output: lines.join('\n').trimEnd() + '\n', exitCode: 0 };
 }
 
+// ── verify ──────────────────────────────────────────────────────────────────
+
+interface VerifyResult {
+  pr: number;
+  prTitle: string;
+  task: string;
+  command: string | null;
+  status: 'pass' | 'fail' | 'skip';
+  exitCode?: number;
+  output?: string;
+}
+
+/**
+ * Run a shell command via `bash -c` with a timeout. Captures combined stdout +
+ * stderr (truncated to keep output reviewable). Returns exit code 124 on
+ * timeout, mirroring GNU coreutils' `timeout` exit convention.
+ */
+function runVerifyCommand(
+  command: string,
+  timeoutMs: number
+): { exitCode: number; output: string } {
+  const result = spawnSync('bash', ['-c', command], {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 1024 * 1024, // 1MB cap
+  });
+
+  // spawnSync sets `signal` on timeout (typically SIGTERM); the docs are
+  // explicit that exit code is null in that case.
+  if (result.signal) {
+    return {
+      exitCode: 124,
+      output: `[timeout after ${timeoutMs}ms] ${result.stdout ?? ''}${result.stderr ?? ''}`.trim(),
+    };
+  }
+  // spawnSync.error fires for things like ENOENT (bash missing) — surface it.
+  if (result.error) {
+    return { exitCode: 1, output: `[spawn error] ${result.error.message}` };
+  }
+  const combined = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  // Truncate to keep terminal output reviewable. Full output stays in JSON mode.
+  const truncated =
+    combined.length > 500 ? combined.slice(0, 500) + '\n... [truncated]' : combined;
+  return { exitCode: result.status ?? 1, output: truncated };
+}
+
+async function verify(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+  const lookbackDays = Number(options.days) || 14;
+  const dryRun = Boolean(options.dryRun ?? options['dry-run']);
+  const timeoutMs = Number(options.timeout) || 30_000;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+
+  const prs = await githubApi<PrData[]>(
+    `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
+  );
+
+  const results: VerifyResult[] = [];
+
+  for (const pr of prs) {
+    if (!pr.merged_at) continue;
+    if (new Date(pr.merged_at) < cutoff) continue;
+    if (!pr.body) continue;
+
+    const parsed = parseDeployTasksFromBody(pr.body);
+    if (!parsed || parsed.unchecked === 0) continue;
+
+    for (const item of parsed.items) {
+      if (item.checked) continue;
+
+      const command = extractVerifyCommand(item.text);
+      if (!command) {
+        results.push({
+          pr: pr.number,
+          prTitle: pr.title,
+          task: item.text,
+          command: null,
+          status: 'skip',
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        results.push({
+          pr: pr.number,
+          prTitle: pr.title,
+          task: item.text,
+          command,
+          status: 'skip',
+          output: '[dry-run]',
+        });
+        continue;
+      }
+
+      const { exitCode, output } = runVerifyCommand(command, timeoutMs);
+      results.push({
+        pr: pr.number,
+        prTitle: pr.title,
+        task: item.text,
+        command,
+        status: exitCode === 0 ? 'pass' : 'fail',
+        exitCode,
+        output,
+      });
+    }
+  }
+
+  const passed = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  const skipped = results.filter((r) => r.status === 'skip').length;
+
+  if (options.ci) {
+    return {
+      output:
+        JSON.stringify(
+          { results, summary: { passed, failed, skipped, total: results.length } },
+          null,
+          2
+        ) + '\n',
+      exitCode: failed > 0 ? 1 : 0,
+    };
+  }
+
+  if (results.length === 0) {
+    return {
+      output: `${c.green}No pending deploy tasks to verify.${c.reset}\n`,
+      exitCode: 0,
+    };
+  }
+
+  // Group by PR for human-readable output
+  const byPr = new Map<number, VerifyResult[]>();
+  for (const r of results) {
+    if (!byPr.has(r.pr)) byPr.set(r.pr, []);
+    byPr.get(r.pr)!.push(r);
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `${c.bold}Deploy Tasks Verification${c.reset}${dryRun ? ' (dry-run)' : ''}\n`
+  );
+
+  for (const [prNum, prResults] of byPr) {
+    const title = prResults[0].prTitle;
+    lines.push(`${c.cyan}PR #${prNum}${c.reset} ${c.dim}"${title}"${c.reset}`);
+    for (const r of prResults) {
+      let badge: string;
+      if (r.status === 'pass') badge = `${c.green}PASS${c.reset}`;
+      else if (r.status === 'fail') badge = `${c.red}FAIL${c.reset}`;
+      else badge = `${c.yellow}SKIP${c.reset}`;
+      lines.push(`  ${badge}  ${r.task}`);
+      if (r.status === 'fail' && r.output) {
+        // Indent failure output for readability
+        const indented = r.output
+          .split('\n')
+          .map((l) => `        ${c.dim}${l}${c.reset}`)
+          .join('\n');
+        lines.push(`        ${c.dim}exit=${r.exitCode}${c.reset}`);
+        lines.push(indented);
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push(
+    `${c.bold}Summary:${c.reset} ${c.green}${passed} passed${c.reset}, ${
+      failed > 0 ? c.red : c.dim
+    }${failed} failed${c.reset}, ${c.dim}${skipped} skipped${c.reset}`
+  );
+
+  return {
+    output: lines.join('\n').trimEnd() + '\n',
+    exitCode: failed > 0 ? 1 : 0,
+  };
+}
+
 // ── inject ──────────────────────────────────────────────────────────────────
 
 async function inject(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -233,6 +416,7 @@ export const commands = {
   detect,
   pending,
   inject,
+  verify,
 };
 
 export function getHelp(): string {
@@ -242,6 +426,7 @@ Commands:
   detect                Detect deploy tasks from current branch diff.
   pending               Find unchecked deploy tasks from recently merged PRs.
   inject                Inject deploy tasks section into a PR description.
+  verify                Run embedded verify commands for unchecked deploy tasks.
 
 Options (detect):
   --base=<ref>          Base ref for diff (default: origin/main).
@@ -255,8 +440,20 @@ Options (inject):
   --pr=N                Update PR #N's description (otherwise prints to stdout).
   --base=<ref>          Base ref for diff (default: origin/main).
 
+Options (verify):
+  --days=N              Lookback window in days (default: 14).
+  --timeout=N           Per-command timeout in milliseconds (default: 30000).
+  --dry-run             Print commands without executing them.
+  --ci                  JSON output.
+
+Environment for verify:
+  Tasks may reference shell variables like \$DATABASE_URL, \$WIKI_SERVER_URL.
+  Set these in the calling shell — verify inherits the parent environment.
+
 Examples:
   pnpm crux gh deploy-tasks detect                # Show tasks for current branch
   pnpm crux gh deploy-tasks pending               # Show unchecked tasks from recent PRs
-  pnpm crux gh deploy-tasks inject --pr=3270      # Add tasks section to PR #3270`;
+  pnpm crux gh deploy-tasks inject --pr=3270      # Add tasks section to PR #3270
+  pnpm crux gh deploy-tasks verify                # Run verify commands for pending tasks
+  pnpm crux gh deploy-tasks verify --dry-run      # Show what would run`;
 }

--- a/crux/lib/deploy-tasks/__tests__/detect.test.ts
+++ b/crux/lib/deploy-tasks/__tests__/detect.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { deduplicateSubPrTasks, parseDeployTasksFromBody, formatDeployTasksSection, preserveCheckedState } from '../detect.ts';
+import {
+  deduplicateSubPrTasks,
+  extractVerifyCommand,
+  parseDeployTasksFromBody,
+  formatDeployTasksSection,
+  preserveCheckedState,
+} from '../detect.ts';
 import type { DeployTask } from '../types.ts';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1288,5 +1294,89 @@ describe('preserveCheckedState', () => {
     const parsed = parseDeployTasksFromBody(result);
     expect(parsed).not.toBeNull();
     expect(parsed!.items[0]).toEqual({ text: taskText, checked: true });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// extractVerifyCommand
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('extractVerifyCommand', () => {
+  it('extracts a simple curl verify command', () => {
+    const text =
+      '`schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`';
+    expect(extractVerifyCommand(text)).toBe(
+      'curl -sf "$WIKI_SERVER_URL/health" | jq .'
+    );
+  });
+
+  it('extracts a psql verify command with embedded quotes and SQL', () => {
+    const text =
+      '`migration` Verify migration 0166 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`';
+    expect(extractVerifyCommand(text)).toBe(
+      'psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"'
+    );
+  });
+
+  it('strips trailing sub-PR attribution before extracting', () => {
+    const text =
+      '`migration` Verify migration 0159 applied on server start — `psql "$DATABASE_URL" -c "SELECT 1;"` _(from PR #3936)_';
+    expect(extractVerifyCommand(text)).toBe(
+      'psql "$DATABASE_URL" -c "SELECT 1;"'
+    );
+  });
+
+  it('returns null when there is no embedded command', () => {
+    const text = '`manual-migration` Run manual migration script: foo.sql';
+    expect(extractVerifyCommand(text)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractVerifyCommand('')).toBeNull();
+  });
+
+  it('handles description that itself contains an em-dash', () => {
+    // The description has its own em-dash; the LAST `— `cmd`` segment is the command.
+    const text =
+      '`ci` Modified workflow "ci" — verify it runs successfully after merge — `gh run list --workflow="ci.yml" --limit=1`';
+    expect(extractVerifyCommand(text)).toBe(
+      'gh run list --workflow="ci.yml" --limit=1'
+    );
+  });
+
+  it('round-trips: formatDeployTasksSection output is parseable by extractVerifyCommand', () => {
+    // The interesting overlap: format produces task lines; parser reads them.
+    // If either side drifts (em-dash vs hyphen, backtick escaping), this breaks.
+    const tasks: DeployTask[] = [
+      makeTask({
+        id: 'm1',
+        category: 'migration',
+        description: 'Verify migration 0200 applied on server start',
+        verifyCommand: 'psql "$DATABASE_URL" -c "SELECT 1;"',
+      }),
+      makeTask({
+        id: 's1',
+        category: 'schema',
+        description: 'Drizzle schema changed',
+        verifyCommand: 'curl -sf "$WIKI_SERVER_URL/health"',
+      }),
+      makeTask({
+        id: 'r1',
+        category: 'route',
+        description: 'No-command task',
+        // no verifyCommand
+      }),
+    ];
+    const section = formatDeployTasksSection(tasks);
+    const parsed = parseDeployTasksFromBody(`<!-- deploy-tasks:v1 -->${section.split('<!-- deploy-tasks:v1 -->')[1]}`);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.items).toHaveLength(3);
+    expect(extractVerifyCommand(parsed!.items[0].text)).toBe(
+      'psql "$DATABASE_URL" -c "SELECT 1;"'
+    );
+    expect(extractVerifyCommand(parsed!.items[1].text)).toBe(
+      'curl -sf "$WIKI_SERVER_URL/health"'
+    );
+    expect(extractVerifyCommand(parsed!.items[2].text)).toBeNull();
   });
 });

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -602,6 +602,29 @@ export interface ParsedDeployTasks {
 }
 
 /**
+ * Extract the verification shell command embedded in a deploy task text line.
+ *
+ * Tasks formatted by `formatDeployTasksSection` look like:
+ *   `category` Description goes here — `verify command`
+ *
+ * Sub-PR tasks may have a trailing attribution suffix:
+ *   `category` Description — `verify command` _(from PR #1234)_
+ *
+ * Returns the command string (without backticks) or null if no embedded command
+ * is found. Uses an em-dash (U+2014) as the command separator since that's what
+ * `formatDeployTasksSection` writes.
+ */
+export function extractVerifyCommand(text: string): string | null {
+  // Strip trailing sub-PR attribution before matching
+  const cleaned = text.replace(/\s*_\(from PR #\d+\)_\s*$/, "").trim();
+  // Match the LAST `— \`...\`` segment so descriptions containing em-dashes work.
+  // Backticks inside the command itself are not supported (deploy task formatter
+  // doesn't produce them).
+  const match = cleaned.match(/—\s+`([^`]+)`\s*$/);
+  return match ? match[1] : null;
+}
+
+/**
  * Parse deploy tasks from a PR body. Returns null if no deploy tasks section found.
  */
 export function parseDeployTasksFromBody(body: string): ParsedDeployTasks | null {


### PR DESCRIPTION
## Summary

The `/deploy` skill has been telling operators to run `pnpm crux gh deploy-tasks verify` as part of mandatory post-deploy verification, but the subcommand never existed — only `detect`, `pending`, and `inject` were implemented. This PR adds it.

`verify` iterates over unchecked deploy tasks from recently merged PRs, extracts the embedded shell command from each task line (the `` — `command` `` segment that `formatDeployTasksSection` writes), and runs it via `bash -c` with a configurable timeout.

```
$ WIKI_SERVER_URL=https://wiki-server.k8s.quantifieduncertainty.org \
    pnpm crux gh deploy-tasks verify --days=2

PR #4018 "release: 2026-04-08"
  PASS  schema  Drizzle schema changed — verify wiki-server redeployed
  PASS  ci      Modified workflow "ci" — verify it runs successfully
  FAIL  route   New API route "source-check-enforcement" added — false positive
        exit=22  (curl 404)
  SKIP  manual-migration  Run manual migration script: ...

Summary: 11 passed, 14 failed, 3 skipped
```

## Behaviour

- Walks the same recent merged PRs as `pending`, with the same `--days` lookback (default 14).
- For each unchecked task, parses out the trailing `` — `command` `` segment (also strips `_(from PR #N)_` sub-PR attribution).
- Runs each command via `bash -c`, with per-command timeout (default 30s) and 1MB output cap.
- Reports `PASS` (exit 0), `FAIL` (non-zero exit, with truncated stderr+stdout), or `SKIP` (no embedded command).
- Process exit code is 1 if any command failed — so CI / the `/deploy` skill can gate on it.
- `--dry-run` prints what would run without executing. `--ci` emits JSON.
- Tasks reference shell variables like `$DATABASE_URL` and `$WIKI_SERVER_URL`; verify inherits the parent shell environment, so the caller is responsible for setting them. Documented in `--help`.

## Why this design

- **Read-only over network**: verify never patches PR bodies. Marking tasks as checked is left to a human or future enhancement — most failures during a real /deploy turn out to be detector false positives (e.g., `routes/shared/source-check-enforcement.ts` is detected as a "new API route" but is actually a helper module), so auto-checking would mask those.
- **Sequential execution**: simple, predictable ordering; per-command timeout protects against hangs. Most pending sets are <30 tasks so parallelism isn't worth the complexity.
- **Trust merged-PR commands**: the commands run came from PR bodies of already-merged PRs (so they passed code review). I considered an allowlist of command prefixes (`curl`, `gh`, `psql`, `pnpm`) but it would block legitimate one-off verifiers. `--dry-run` is the safety hatch.

## Testing

- 6 new unit tests for `extractVerifyCommand` covering: simple curl, complex psql with embedded quotes/SQL, sub-PR attribution stripping, no-command-present, empty string, descriptions containing their own em-dashes, and a round-trip test that runs `formatDeployTasksSection` output back through the parser (catches drift between formatter and extractor).
- Manually exercised against today's release PR #4018.
- Full deploy-tasks test file: 73 tests pass (was 67).
- `pnpm test` (apps/web): 1370 pass, no regressions.
- `crux` test suite: 5 pre-existing failures in `snapshot-resources.test.ts` and `auto-update/ci-*` tests (also flagged as unrelated baseline in #4009's PR description).
- `cd crux && tsc --noEmit`: 131 pre-existing errors, 0 new errors in deploy-tasks files (verified by `git checkout HEAD~1 -- deploy-tasks` then re-running).

Closes #4022

## Test plan
- [x] `extractVerifyCommand` round-trips with `formatDeployTasksSection`
- [x] Sub-PR attribution `_(from PR #N)_` is stripped before command extraction
- [x] Tasks with no embedded command are reported as SKIP (not FAIL)
- [x] `--dry-run` does not execute commands
- [x] Command exit code surfaces as exit 1 from the CLI (gates `/deploy`)
- [x] Manually verified against release PR #4018
