### PR TITLE
skills: fix discussion lifecycle bugs causing duplicate/orphaned discussions

### DIFF
--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -331,14 +331,11 @@ Include the coverage table in the report.
 
 ### Persist the full report to a GitHub Discussion
 
-After filing issues, post the **complete** Phase 3 report as a comment on Discussion #2650 (QA Sweep Reports).
+After filing issues, post the **complete** Phase 3 report as a comment on **Discussion #2650** (the canonical "QA Sweep Reports" archive). Always use #2650 — do **not** create a new discussion. Past attempts to "find or create" the discussion produced duplicates (#3220, #3724) which were closed in favor of #2650.
 
 ```bash
-# First run: create the discussion
-pnpm crux epic create "QA Sweep Reports" --body="Archive of /maintain-qa-sweep findings. Each comment is one sweep run."
-
-# Every run: post the report as a comment
-pnpm crux epic comment <DISCUSSION_NUMBER> "$(cat <<'REPORT'
+# Always post to #2650 — do not create a new discussion
+pnpm crux gh epic comment 2650 "$(cat <<'REPORT'
 ## QA Sweep — [DATE]
 ### Focus: [focus] | Depth: [depth]
 [Full report here — copy the entire Phase 3 output]
@@ -351,7 +348,7 @@ REPORT
 )"
 ```
 
-**To find the discussion number:** Search for "QA Sweep Reports" in discussions, or check the QA sweep discussion number stored in `.claude/memory/` if a previous sweep saved it. If no discussion exists yet, create one.
+If #2650 has been closed or replaced for some reason (verify by running `pnpm crux gh epic view 2650`), stop and ask the user — do **not** silently create a new discussion.
 
 ### Fix P0s
 

--- a/.claude/commands/update-discussion.md
+++ b/.claude/commands/update-discussion.md
@@ -103,6 +103,13 @@ mutation {
 
 If the discussion body has an `<!-- agent-project -->` metadata block, update `last_agent_session` to today's date and adjust `phases_done` if applicable.
 
+**If `phases_done == phases_total` (or `status: done`) after your update, close the discussion.** Open discussions with all phases done accumulate as ambient noise that future cleanup sweeps have to triage. Run:
+
+```bash
+pnpm crux gh epic comment <N> "All phases complete. Closing per status update."
+pnpm crux gh epic close <N>
+```
+
 ## What this is NOT
 
 - This is not `/work-on-discussion` — you are **reporting**, not implementing

--- a/.claude/commands/work-on-discussion.md
+++ b/.claude/commands/work-on-discussion.md
@@ -100,6 +100,13 @@ When you've completed a meaningful chunk:
 
 5. **If you're done or blocked**, update status to `done` or `blocked` with a blocker description.
 
+6. **Auto-close when complete.** If after this session `phases_done == phases_total` (or `status: done`), close the discussion explicitly. Open discussions with all phases done accumulate as ambient noise that future sweeps have to clean up. Run:
+   ```bash
+   pnpm crux gh epic comment <N> "All phases complete. Closing — see PR #YYYY for the final shipping piece."
+   pnpm crux gh epic close <N>
+   ```
+   Use `--reason=outdated` only if the plan was abandoned rather than completed; default `resolved` is correct for "all phases shipped". This is a hard rule, not a judgment call: if `phases_done == phases_total`, close.
+
 ## Step 7: Continue or hand off
 
 If the session ends mid-discussion:


### PR DESCRIPTION
## Summary

Two recurring patterns surfaced in the 2026-04-08 discussions review:

**1. `/maintain-qa-sweep` was creating duplicate "QA Sweep Reports" discussions.** The skill said "post on #2650" but provided a fallback that created a new discussion if the agent couldn't find #2650 (e.g., wasn't recorded in `.claude/memory/`). Result: #3220 and #3724 were both spawned as duplicates and had to be closed manually. This is a recurring issue — every fresh agent that runs the skill misses the #2650 hint and creates a new one.

   **Fix:** hardcode #2650 in the skill, remove the "create new" path, and instruct the skill to stop and ask if #2650 is unavailable for some reason.

**2. `/work-on-discussion` and `/update-discussion` never close discussions when all phases are done.** The agent-project frontmatter has `phases_done` and `phases_total` fields, and the skills update them as work progresses, but neither skill closes the discussion when `phases_done == phases_total`. Result: discussions like #3768 sit open with `status: complete, phases_done: 6/6` indefinitely, accumulating as ambient noise that future cleanup sweeps have to triage.

   **Fix:** add an explicit "close when complete" step to both skills.

## Context

Found while doing a deep review of the last 2 weeks of GitHub Discussions. Closed 10 superseded discussions manually as part of the same review. These two skill bugs are the upstream causes of much of that cleanup work — fixing them prevents future duplication.

## Files changed

- `.claude/commands/maintain-qa-sweep.md` — hardcode #2650, remove "create new" path
- `.claude/commands/work-on-discussion.md` — close when `phases_done == phases_total`
- `.claude/commands/update-discussion.md` — same close-when-complete instruction

## Test plan

- [ ] Skills are markdown instructions only — no automated test path. Verify by reading the diffs.
- [ ] Next `/maintain-qa-sweep` run should append to #2650 instead of creating a new discussion.
- [ ] Next `/work-on-discussion` or `/update-discussion` session that completes a project should close the discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)