### PR TITLE
fix: validate DEV_PORT is numeric before passing to lsof

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -56,7 +56,7 @@ Each slot uses its own port (`3010 + slot number`, e.g. `lw/a2` → 3012). Kill 
 ```bash
 # Read DEV_PORT from .env (set by the slot scaffolding); fall back to nothing.
 DEV_PORT=$(grep -m1 '^DEV_PORT=' .env 2>/dev/null | cut -d= -f2-)
-if [ -n "$DEV_PORT" ]; then
+if [ -n "$DEV_PORT" ] && [[ "$DEV_PORT" =~ ^[0-9]+$ ]]; then
   PIDS=$(lsof -ti:$DEV_PORT -sTCP:LISTEN 2>/dev/null)
   if [ -n "$PIDS" ]; then
     kill $PIDS 2>/dev/null


### PR DESCRIPTION
## Summary

Addresses a CodeRabbit Major review comment on PR #4024 that merged before the fix was applied. The `DEV_PORT` value read from `.env` in `.claude/commands/agent-end.md` was not validated as numeric before being passed to `lsof -ti:$DEV_PORT`. A malformed `.env` value (e.g., `DEV_PORT=abc` or `DEV_PORT=1234; evil`) could cause unexpected `lsof` behavior.

## Change

One-line fix in the documented kill-dev-server snippet:

```diff
-if [ -n "$DEV_PORT" ]; then
+if [ -n "$DEV_PORT" ] && [[ "$DEV_PORT" =~ ^[0-9]+$ ]]; then
```

## Test plan

- [x] Gate checks pass locally
- [ ] CI green

Follow-up to #4024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened development-server cleanup by validating the configured port is numeric before attempting to locate or stop processes. This reduces risk of running unsafe system commands when the port value is malformed and improves reliability of local dev server teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->