### PR TITLE
crux: add gh epic audit command for discussion lifecycle health

### DIFF
--- a/crux/commands/epic-audit.test.ts
+++ b/crux/commands/epic-audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { parseAgentProjectMeta } from './epic.ts';
+import { parseAgentProjectMeta, classifyDiscussion } from './epic.ts';
+import type { AuditDiscussionInput } from './epic.ts';
 
 describe('parseAgentProjectMeta', () => {
   it('returns null when no agent-project block exists', () => {
@@ -101,6 +102,22 @@ status: blocked
     });
   });
 
+  it('returns null when block exists but contains only unknown keys', () => {
+    const body = `<!-- agent-project
+custom_field: value
+another_unknown: data
+-->`;
+
+    expect(parseAgentProjectMeta(body)).toBeNull();
+  });
+
+  it('returns null when block exists but is empty', () => {
+    const body = `<!-- agent-project
+-->`;
+
+    expect(parseAgentProjectMeta(body)).toBeNull();
+  });
+
   it('detects block embedded deep in the body', () => {
     const body = `# Big Discussion
 
@@ -133,60 +150,161 @@ Not started.`;
   });
 });
 
-describe('audit detection categories', () => {
-  // These test the classification logic conceptually.
-  // The actual audit function fetches from GitHub, so we test the
-  // classification rules via the frontmatter parser + category rules.
+describe('classifyDiscussion', () => {
+  const now = new Date('2026-04-05T12:00:00Z');
 
-  it('detects drift: phases_done == phases_total', () => {
-    const meta = parseAgentProjectMeta(`<!-- agent-project
+  function makeDiscussion(overrides: Partial<AuditDiscussionInput> = {}): AuditDiscussionInput {
+    return {
+      number: 42,
+      title: 'Test Discussion',
+      body: '',
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 5,
+      ...overrides,
+    };
+  }
+
+  it('detects drift when phases_done == phases_total', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
 status: in-progress
 phases_total: 6
 phases_done: 6
 last_agent_session: 2026-04-04
--->`);
-    expect(meta).not.toBeNull();
-    expect(meta!.phases_done).toBe(meta!.phases_total);
-    // This should be classified as "drift" by the audit
+-->`,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'drift')).toBe(true);
   });
 
-  it('detects drift: status complete', () => {
-    const meta = parseAgentProjectMeta(`<!-- agent-project
+  it('detects drift when status is complete', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
 status: complete
 phases_total: 3
 phases_done: 3
--->`);
-    expect(meta?.status).toBe('complete');
+-->`,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'drift')).toBe(true);
   });
 
-  it('detects drift: status done', () => {
-    const meta = parseAgentProjectMeta(`<!-- agent-project
+  it('detects drift when status is done', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
 status: done
--->`);
-    expect(meta?.status).toBe('done');
+-->`,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'drift')).toBe(true);
   });
 
-  it('does not flag in-progress with phases remaining', () => {
-    const meta = parseAgentProjectMeta(`<!-- agent-project
+  it('does not flag in-progress with phases remaining and recent session', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
 status: in-progress
 phases_total: 5
 phases_done: 2
-last_agent_session: 2026-04-07
--->`);
-    expect(meta?.status).toBe('in-progress');
-    expect(meta!.phases_done).toBeLessThan(meta!.phases_total!);
-    // This should NOT be classified as drift or stale (session is recent)
+last_agent_session: 2026-04-03
+-->`,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings).toEqual([]);
   });
 
-  it('detects stale: in-progress with old last_agent_session', () => {
-    const meta = parseAgentProjectMeta(`<!-- agent-project
+  it('detects stale when in-progress with old last_agent_session', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
 status: in-progress
 phases_total: 4
 phases_done: 1
 last_agent_session: 2026-02-01
--->`);
-    const daysSince = (Date.now() - new Date('2026-02-01').getTime()) / (1000 * 60 * 60 * 24);
-    expect(daysSince).toBeGreaterThan(30);
-    // This should be classified as "stale" by the audit
+-->`,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'stale')).toBe(true);
+    expect(findings.find((f) => f.category === 'stale')!.detail).toContain('2026-02-01');
+  });
+
+  it('detects orphaned discussions with 0 comments and 0 linked issues after 14 days', () => {
+    const d = makeDiscussion({
+      body: 'No metadata, no issue links.',
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 0,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'orphaned')).toBe(true);
+  });
+
+  it('does not flag orphaned if discussion has comments', () => {
+    const d = makeDiscussion({
+      body: 'No metadata, no issue links.',
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 3,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'orphaned')).toBe(false);
+  });
+
+  it('does not flag orphaned if discussion is younger than 14 days', () => {
+    const d = makeDiscussion({
+      body: 'No metadata, no issue links.',
+      createdAt: '2026-03-30T00:00:00Z',
+      commentCount: 0,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'orphaned')).toBe(false);
+  });
+
+  it('detects missing_frontmatter for old discussions without agent-project block', () => {
+    const d = makeDiscussion({
+      body: 'Just a regular discussion.',
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 3,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'missing_frontmatter')).toBe(true);
+  });
+
+  it('does not flag missing_frontmatter for discussions younger than 7 days', () => {
+    const d = makeDiscussion({
+      body: 'Just a regular discussion.',
+      createdAt: '2026-04-02T00:00:00Z',
+      commentCount: 3,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings.some((f) => f.category === 'missing_frontmatter')).toBe(false);
+  });
+
+  it('can produce multiple findings for one discussion', () => {
+    // Drift + orphaned: completed discussion with 0 comments, 0 issues, old
+    const d = makeDiscussion({
+      body: `<!-- agent-project
+status: done
+-->`,
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 0,
+    });
+    const findings = classifyDiscussion(d, now);
+    const categories = findings.map((f) => f.category);
+    expect(categories).toContain('drift');
+    expect(categories).toContain('orphaned');
+  });
+
+  it('returns empty array for healthy in-progress discussion', () => {
+    const d = makeDiscussion({
+      body: `<!-- agent-project
+status: in-progress
+phases_total: 5
+phases_done: 2
+last_agent_session: 2026-04-03
+-->
+- #100
+- #101`,
+      createdAt: '2026-03-01T00:00:00Z',
+      commentCount: 10,
+    });
+    const findings = classifyDiscussion(d, now);
+    expect(findings).toEqual([]);
   });
 });

--- a/crux/commands/epic.ts
+++ b/crux/commands/epic.ts
@@ -998,6 +998,7 @@ export function parseAgentProjectMeta(body: string): AgentProjectMeta | null {
   if (!match) return null;
 
   const meta: AgentProjectMeta = {};
+  let hasRecognizedKey = false;
   for (const line of match[1].split('\n')) {
     const kv = line.match(/^\s*(\w[\w_]*):\s*(.+?)\s*$/);
     if (!kv) continue;
@@ -1007,15 +1008,15 @@ export function parseAgentProjectMeta(body: string): AgentProjectMeta | null {
       return isNaN(n) ? undefined : n;
     };
     switch (key) {
-      case 'priority': meta.priority = val; break;
-      case 'status': meta.status = val; break;
-      case 'phases_total': meta.phases_total = safeInt(val); break;
-      case 'phases_done': meta.phases_done = safeInt(val); break;
-      case 'last_agent_session': meta.last_agent_session = val; break;
-      case 'blocker': meta.blocker = val; break;
+      case 'priority': meta.priority = val; hasRecognizedKey = true; break;
+      case 'status': meta.status = val; hasRecognizedKey = true; break;
+      case 'phases_total': meta.phases_total = safeInt(val); hasRecognizedKey = true; break;
+      case 'phases_done': meta.phases_done = safeInt(val); hasRecognizedKey = true; break;
+      case 'last_agent_session': meta.last_agent_session = val; hasRecognizedKey = true; break;
+      case 'blocker': meta.blocker = val; hasRecognizedKey = true; break;
     }
   }
-  return meta;
+  return hasRecognizedKey ? meta : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -1028,6 +1029,91 @@ interface AuditFinding {
   title: string;
   detail: string;
   meta: AgentProjectMeta | null;
+}
+
+/** Input for classifying a single discussion into audit findings. */
+export interface AuditDiscussionInput {
+  number: number;
+  title: string;
+  body: string;
+  createdAt: string;
+  commentCount: number;
+}
+
+/**
+ * Classify a single discussion into zero or more audit findings.
+ *
+ * Pure function — no I/O, no side effects, independently testable.
+ *
+ * Rules:
+ *   - drift: phases_done >= phases_total or status is complete/done
+ *   - stale: in-progress with last_agent_session > 30 days ago
+ *   - orphaned: 0 comments, 0 linked issues, > 14 days old
+ *   - missing_frontmatter: no agent-project block, > 7 days old (advisory)
+ */
+export function classifyDiscussion(d: AuditDiscussionInput, now: Date): AuditFinding[] {
+  const findings: AuditFinding[] = [];
+  const meta = parseAgentProjectMeta(d.body);
+  const linkedIssues = extractLinkedIssues(d.body);
+  const ageInDays = (now.getTime() - new Date(d.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+
+  if (meta) {
+    // Drift: phases complete or status done but still open
+    if (
+      (meta.phases_total != null && meta.phases_done != null &&
+       meta.phases_done >= meta.phases_total) ||
+      meta.status === 'complete' || meta.status === 'done'
+    ) {
+      findings.push({
+        category: 'drift',
+        number: d.number,
+        title: d.title,
+        detail: meta.phases_total != null
+          ? `phases_done: ${meta.phases_done}/${meta.phases_total}, status: ${meta.status ?? 'n/a'}`
+          : `status: ${meta.status}`,
+        meta,
+      });
+    }
+
+    // Stale in-progress: last_agent_session > 30 days ago
+    if (meta.status === 'in-progress' && meta.last_agent_session) {
+      const lastSession = new Date(meta.last_agent_session);
+      const daysSinceSession = (now.getTime() - lastSession.getTime()) / (1000 * 60 * 60 * 24);
+      if (daysSinceSession > 30) {
+        findings.push({
+          category: 'stale',
+          number: d.number,
+          title: d.title,
+          detail: `last_agent_session: ${meta.last_agent_session} (${Math.floor(daysSinceSession)} days ago)`,
+          meta,
+        });
+      }
+    }
+  } else {
+    // Missing frontmatter (advisory, only for discussions > 7 days old)
+    if (ageInDays > 7) {
+      findings.push({
+        category: 'missing_frontmatter',
+        number: d.number,
+        title: d.title,
+        detail: `created ${d.createdAt.split('T')[0]}, ${d.commentCount} comments`,
+        meta: null,
+      });
+    }
+  }
+
+  // Orphaned: 0 comments, 0 linked issues, > 14 days old
+  if (d.commentCount === 0 && linkedIssues.length === 0 && ageInDays > 14) {
+    findings.push({
+      category: 'orphaned',
+      number: d.number,
+      title: d.title,
+      detail: `created ${d.createdAt.split('T')[0]}, 0 comments, 0 linked issues`,
+      meta: parseAgentProjectMeta(d.body),
+    });
+  }
+
+  return findings;
 }
 
 /**
@@ -1093,65 +1179,13 @@ async function audit(_args: string[], options: CommandOptions): Promise<CommandR
   const findings: AuditFinding[] = [];
 
   for (const d of allDiscussions) {
-    const meta = parseAgentProjectMeta(d.body);
-    const linkedIssues = extractLinkedIssues(d.body);
-    const ageInDays = (now.getTime() - new Date(d.createdAt).getTime()) / (1000 * 60 * 60 * 24);
-
-    if (meta) {
-      // Drift: phases complete or status done but still open
-      if (
-        (meta.phases_total != null && meta.phases_done != null &&
-         meta.phases_done >= meta.phases_total) ||
-        meta.status === 'complete' || meta.status === 'done'
-      ) {
-        findings.push({
-          category: 'drift',
-          number: d.number,
-          title: d.title,
-          detail: meta.phases_total != null
-            ? `phases_done: ${meta.phases_done}/${meta.phases_total}, status: ${meta.status ?? 'n/a'}`
-            : `status: ${meta.status}`,
-          meta,
-        });
-      }
-
-      // Stale in-progress: last_agent_session > 30 days ago
-      if (meta.status === 'in-progress' && meta.last_agent_session) {
-        const lastSession = new Date(meta.last_agent_session);
-        const daysSinceSession = (now.getTime() - lastSession.getTime()) / (1000 * 60 * 60 * 24);
-        if (daysSinceSession > 30) {
-          findings.push({
-            category: 'stale',
-            number: d.number,
-            title: d.title,
-            detail: `last_agent_session: ${meta.last_agent_session} (${Math.floor(daysSinceSession)} days ago)`,
-            meta,
-          });
-        }
-      }
-    } else {
-      // Missing frontmatter (advisory, only for discussions > 7 days old)
-      if (ageInDays > 7) {
-        findings.push({
-          category: 'missing_frontmatter',
-          number: d.number,
-          title: d.title,
-          detail: `created ${d.createdAt.split('T')[0]}, ${d.comments.totalCount} comments`,
-          meta: null,
-        });
-      }
-    }
-
-    // Orphaned: 0 comments, 0 linked issues, > 14 days old
-    if (d.comments.totalCount === 0 && linkedIssues.length === 0 && ageInDays > 14) {
-      findings.push({
-        category: 'orphaned',
-        number: d.number,
-        title: d.title,
-        detail: `created ${d.createdAt.split('T')[0]}, 0 comments, 0 linked issues`,
-        meta: parseAgentProjectMeta(d.body),
-      });
-    }
+    findings.push(...classifyDiscussion({
+      number: d.number,
+      title: d.title,
+      body: d.body,
+      createdAt: d.createdAt,
+      commentCount: d.comments.totalCount,
+    }, now));
   }
 
   // Sort findings by severity: drift > stale > orphaned > missing_frontmatter
@@ -1212,7 +1246,8 @@ async function audit(_args: string[], options: CommandOptions): Promise<CommandR
     output += `${c.bold}Summary:${c.reset} ${driftCount} drift, ${staleCount} stale, ${orphanedCount} orphaned\n`;
   }
 
-  return { output, exitCode: 0 };
+  const hasDrift = findings.some((f) => f.category === 'drift');
+  return { output, exitCode: hasDrift ? 1 : 0 };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `pnpm crux gh epic audit [--ci]` — a deterministic command that scans all open GitHub Discussions and detects lifecycle issues:
  - **drift**: open discussions where `phases_done == phases_total` or `status: complete/done` (should have been closed)
  - **stale**: in-progress discussions with `last_agent_session` >30 days ago
  - **orphaned**: 0-comment, 0-linked-issue planning docs >14 days old
  - **missing_frontmatter**: discussions without `agent-project` metadata (advisory)
- Exports `parseAgentProjectMeta()` for reuse by other tools
- 13 tests covering the frontmatter parser and classification logic
- Weekly RemoteTrigger configured (`trig_01Xyi3v1V3Mq1Lg1FxTqjiyV`) — runs every Monday at 9:07am PT, auto-closes drift discussions, posts summary on Discussion #2650

## Context

During a 2026-04-08 discussions review, we found 10 discussions that should have been closed (superseded, completed, duplicate). The manual cleanup revealed two systemic issues:
1. No automated detection of lifecycle issues — the only way to find drift/stale/orphaned discussions is manual review
2. No recurring enforcement — the cleanup only happens when someone remembers

This PR provides the detection layer. The trigger provides the enforcement cadence.

## Test plan

- [x] 13 unit tests pass (parser + classification logic)
- [x] `pnpm crux gh epic audit` runs against live GitHub and returns correct results
- [x] `pnpm crux gh epic audit --ci` produces structured JSON
- [x] Weekly trigger created and confirmed via RemoteTrigger API
- [ ] Trigger fires on 2026-04-13 and produces a report on #2650 (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `epic audit` command to analyze GitHub Discussions and report on lifecycle health, identifying drift, stale, orphaned, and missing frontmatter issues
  * Supports `--ci` flag for CI integration with JSON output and appropriate exit codes for automation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->