### PR TITLE
B3: Add unique indexes on natural keys — grants, funding_rounds, policy_stakeholders (epic #4017)

### DIFF
--- a/apps/wiki-server/drizzle/0168_natural_key_uniqueness_phase2.sql
+++ b/apps/wiki-server/drizzle/0168_natural_key_uniqueness_phase2.sql
@@ -1,0 +1,116 @@
+-- Epic #4017 Phase B3: Add unique indexes on natural keys for grants,
+-- funding_rounds, and policy_stakeholders.
+--
+-- These tables use `id` as the upsert conflict target, which provides no
+-- natural-key deduplication. Concurrent or repeated syncs can create
+-- duplicate rows that the application thinks were prevented.
+--
+-- Pattern: ROW_NUMBER() dynamic dedup (keeps most-recently-updated row),
+-- then CREATE UNIQUE INDEX IF NOT EXISTS. Reference: migration 0108.
+--
+-- Tables are moderate size (grants ~2000, funding_rounds ~200,
+-- policy_stakeholders ~500) so ALTER TABLE is fast and doesn't need
+-- a manual migration.
+
+-- ============================================================================
+-- Step 1: Deduplicate existing rows
+-- ============================================================================
+
+-- Grants: deduplicate on (organization_id, name)
+-- Two grants are duplicates if they belong to the same org and share a name.
+-- Keep the row with the most non-null optional fields; break ties by updated_at.
+DELETE FROM grants
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY organization_id, name
+        ORDER BY
+          (CASE WHEN amount IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN period IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN status IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN notes IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN program_id IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN org_entity_id IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN grantee_entity_id IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM grants
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Funding rounds: deduplicate on (company_id, name)
+-- Two rounds are duplicates if they belong to the same company and share a name.
+DELETE FROM funding_rounds
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY company_id, name
+        ORDER BY
+          (CASE WHEN date IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN raised IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN valuation IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN instrument IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN lead_investor IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN notes IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN company_entity_id IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM funding_rounds
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Policy stakeholders: deduplicate on (policy_entity_id, stakeholder_display_name, position)
+-- A stakeholder record is logically unique per policy + stakeholder name + position.
+DELETE FROM policy_stakeholders
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY policy_entity_id, stakeholder_display_name, position
+        ORDER BY
+          (CASE WHEN stakeholder_entity_id IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN importance IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN reason IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN context IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM policy_stakeholders
+  ) ranked
+  WHERE rn > 1
+);
+
+-- ============================================================================
+-- Step 2: Add unique indexes
+-- ============================================================================
+
+-- Grants: unique on (organization_id, name)
+-- Both columns are NOT NULL, so no partial index needed.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_grants_natural_key
+  ON grants (organization_id, name);
+
+-- Funding rounds: unique on (company_id, name)
+-- Both columns are NOT NULL, so no partial index needed.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_funding_rounds_natural_key
+  ON funding_rounds (company_id, name);
+
+-- Policy stakeholders: unique on (policy_entity_id, stakeholder_display_name, position)
+-- All three columns are NOT NULL.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_stakeholders_natural_key
+  ON policy_stakeholders (policy_entity_id, stakeholder_display_name, position);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1170,6 +1170,13 @@
       "when": 1783843200000,
       "tag": "0166_drop_source_resource_id",
       "breakpoints": true
+    },
+    {
+      "idx": 167,
+      "version": "7",
+      "when": 1783929600000,
+      "tag": "0168_natural_key_uniqueness_phase2",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase B3 of epic #4017 — adds unique indexes on natural keys for 3 tables that were missing them. Concurrent or repeated syncs could create duplicate rows because all 3 use `id` as the upsert conflict target, not the natural key.

## Migration 0168

**Step 1 — Dynamic dedup** (ROW_NUMBER pattern per database-migrations.md):

| Table | Natural key | Dedup strategy |
|---|---|---|
| `grants` | `(organization_id, name)` | Keep row with most non-null fields, break ties by updated_at DESC |
| `funding_rounds` | `(company_id, name)` | Same |
| `policy_stakeholders` | `(policy_entity_id, stakeholder_display_name, position)` | Same |

**Step 2 — Unique indexes:**
- `uq_grants_natural_key ON grants (organization_id, name)`
- `uq_funding_rounds_natural_key ON funding_rounds (company_id, name)`
- `uq_policy_stakeholders_natural_key ON policy_stakeholders (policy_entity_id, stakeholder_display_name, position)`

All natural-key columns are NOT NULL — no partial indexes needed.

## What's already covered

| Table | Migration | Natural key |
|---|---|---|
| personnel | 0108 | (person_entity_id, org_entity_id, role_type, role) |
| investments | 0108 | (investor_entity_id, company_entity_id, round_name) |
| division_personnel | 0108 | (division_id, person_id) |
| funding_programs | 0143 | (org_id, name) |

## Design decisions

- **Sync handler conflict targets unchanged**: The `onConflictDoUpdate({ target: *.id })` pattern stays. ID-based upsert handles updates; the new unique index prevents duplicate inserts via separate transactions. Together they provide both natural-key uniqueness and ID-stable updates.
- **Dedup keeps the richest row**: The ROW_NUMBER ordering prefers rows with more non-null optional fields (more complete data), then newest by updated_at.

## Deploy checklist

- [ ] Verify migration 0168 applied — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] Verify indexes exist — `psql "$DATABASE_URL" -c "SELECT indexname FROM pg_indexes WHERE indexname LIKE 'uq_%_natural_key' ORDER BY indexname;"`
- [ ] If any existing duplicates violate the constraint, the migration's Step 1 dedup should have handled them. If the migration fails, check the error for which table has an unexpected duplicate pattern.

## Test plan
- [x] Drizzle journal validator: passes
- [x] wiki-server typecheck: clean
- [x] wiki-server tests: 871 pass / 21 skipped
- [x] pnpm build: succeeds
- [ ] CI green
- [ ] Post-deploy: verify indexes exist via psql

Part of epic #4017 (Phase B — tighten the schema).
