### PR TITLE
B5: Add typed Zod schema for verificationConfig JSONB column (epic #4017)

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -37,11 +37,12 @@ const SyncDataSourceSchema = z.object({
   columnMapping: z.record(z.string()).nullable().optional(),
   sourceSchema: z.record(z.unknown()).nullable().optional(),
   // Issue #4017 B5: typed schema replaces z.record(z.unknown()). The shape
-  // is {strategy, matchFields, fuzzyFields} from grant-import manifests.
+  // is {strategy, matchFields, fuzzyFields, exactFields} from grant-import manifests.
   verificationConfig: z.object({
     strategy: z.string().max(100),
     matchFields: z.array(z.string().max(100)).optional(),
     fuzzyFields: z.array(z.string().max(100)).optional(),
+    exactFields: z.array(z.string().max(100)).optional(),
   }).passthrough().nullable().optional(),
   sourceStatus: z.enum(VALID_SOURCE_STATUSES).optional(),
 });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -831,11 +831,12 @@ export const resourceTabularSources = pgTable("resource_tabular_sources", {
   /** Frictionless-inspired field descriptions */
   sourceSchema: jsonb("source_schema").$type<Record<string, unknown>>(),
   /** { strategy, matchFields, fuzzyFields, exactFields } */
-  /** Source-check verification strategy. Shape: { strategy, matchFields?, fuzzyFields? }. Issue #4017 B5. */
+  /** Source-check verification strategy. Shape: { strategy, matchFields?, fuzzyFields?, exactFields? }. Issue #4017 B5. */
   verificationConfig: jsonb("verification_config").$type<{
     strategy: string;
     matchFields?: string[];
     fuzzyFields?: string[];
+    exactFields?: string[];
     [key: string]: unknown;
   }>(),
   /** active | archived | defunct */

--- a/crux/lib/wiki-server/data-sources.ts
+++ b/crux/lib/wiki-server/data-sources.ts
@@ -50,6 +50,7 @@ export interface SyncDataSourceInput {
     strategy: string;
     matchFields?: string[];
     fuzzyFields?: string[];
+    exactFields?: string[];
     [key: string]: unknown; // passthrough for future fields
   } | null;
   sourceStatus?: 'active' | 'archived' | 'defunct';


### PR DESCRIPTION
## Summary

Phase B5 of epic #4017 — replaces `z.record(z.unknown())` with a typed Zod schema for the `data_sources.verificationConfig` JSONB column.

**Shape**: `{ strategy: string, matchFields?: string[], fuzzyFields?: string[] }` — derived from the grant-import manifests which are the sole writers. Uses `.passthrough()` so future fields don't break validation.

## What's NOT in this PR (by design)

The remaining JSONB columns from the epic are deliberately flexible and should stay `z.record(z.unknown())`:

| Column | Why it stays untyped |
|---|---|
| `jobs.params/result` | Heterogeneous by design — varies by job type |
| `tablebase_audit_log.oldData/newData` | Arbitrary record snapshots for audit trail |
| `page_improve_runs.citationAudit/qualityMetrics` | Opaque LLM output |
| `active_agents.metadata` | Intentionally flexible agent state |
| `auto_update_runs.newPagesCreated` | TEXT field (not JSONB); write side already stores JSON; CSV fallback on read is for legacy data only |
| `claims.qualifiers` | Known shape (`Record<string, string>`) but no write-validated route exists yet |

## Test plan
- [x] wiki-server typecheck: clean
- [x] wiki-server tests: 871 pass / 21 skipped
- [x] pnpm build: succeeds
- [ ] CI green

Part of epic #4017 (Phase B — tighten the schema).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data source verification configuration with a more structured schema definition. Configuration now includes dedicated fields for verification strategy selection, match fields, fuzzy match fields, and exact match fields. Improved validation ensures configurations conform to the expected structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->