### PR TITLE
Make /agent-init programmatic: sync-to-main, auto-issue-start, inline checklist

### DIFF
--- a/.claude/commands/agent-init.md
+++ b/.claude/commands/agent-init.md
@@ -9,28 +9,32 @@ Initialize an agent checklist and establish working context.
 
 Run this at the start of a session, after understanding what the task is.
 
-## Step 1: Generate the checklist
+## Step 1: Run `crux sys agent-checklist init`
 
-Run `pnpm crux sys agent-checklist init` with the appropriate arguments:
+This single command does everything below in order:
 
-- **If working on a GitHub issue**: `pnpm crux sys agent-checklist init --issue=N` (auto-detects type from labels)
-- **If not on an issue**: `pnpm crux sys agent-checklist init "Task description" --type=X`
+1. **Syncs to main** — verifies the working tree is clean, switches to `main` if needed, and runs `git pull --ff-only origin main`. If the tree is dirty, it aborts and tells you what's uncommitted.
+2. Generates `.claude/wip-checklist.md` for the session type.
+3. Auto-marks `issue-tracking` as N/A when no `--issue` is given.
+4. **Signals start on the GitHub issue** (when `--issue=N` is given) — adds the `agent:working` label and posts the start comment. Best-effort: a GitHub failure does not fail init.
+5. Prints the full checklist so you can scan it.
 
-Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands`
+Pick the right invocation:
 
-If unsure about the type, `infrastructure` is the default.
+- **Working on a GitHub issue**: `pnpm crux sys agent-checklist init --issue=N` (auto-detects type from labels)
+- **Not on an issue**: `pnpm crux sys agent-checklist init "Task description" --type=X`
 
-## Step 2: Signal start on GitHub issue (if applicable)
+Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands` (default: `infrastructure`).
 
-If this session is working on a specific GitHub issue and `--issue` was used in step 1, also run:
+### Recovery cases
 
-```bash
-pnpm crux gh issues start <ISSUE_NUM>
-```
+- **Dirty working tree** → Stop. Ask the user whether to commit, stash, or discard. Do NOT bypass — the sync exists to keep sessions from accumulating cross-branch debris.
+- **Pull is non-fast-forward** → Local main has diverged. Surface the error to the user; don't try to force-pull.
+- **Intentionally continuing on the current branch** (e.g. resuming after a crash) → Re-run with `--no-sync`.
 
-## Step 3: Assemble research context (optional but recommended)
+## Step 2: Assemble research context (optional but recommended)
 
-For content sessions (editing a page or working with an entity), gather context upfront to avoid 5-15 separate file reads:
+For content sessions or any task tied to specific pages/entities/issues, gather context upfront to avoid 5-15 separate file reads:
 
 ```bash
 # Context for a specific page you'll be editing:
@@ -48,8 +52,8 @@ pnpm crux context for-topic "topic description"
 
 Output is saved to `.claude/wip-context.md`. Read it once — it contains page metadata, related pages, backlinks, citation health, entity YAML, and frontmatter.
 
-## Step 4: Present the checklist
+## Step 3: Highlight risky items
 
-Read `.claude/wip-checklist.md` and output it to the user. Highlight any items that seem particularly important or risky for this specific task.
+The init output already shows the full checklist. Briefly call out any items that look particularly important or risky for *this specific task* (e.g. "tests-written" matters more for a bugfix, "fix-escaping" matters for content edits, etc.). Don't re-paste the whole list — the user just saw it.
 
 Throughout the session, check items off in `.claude/wip-checklist.md` as they are completed. When done, run `/agent-ship` (if shipping a PR) or `/agent-end` (if not).

--- a/crux/commands/agent-checklist.test.ts
+++ b/crux/commands/agent-checklist.test.ts
@@ -54,14 +54,20 @@ describe('agent-checklist init', () => {
     vi.clearAllMocks();
   });
 
+  // Wrap `commands.init` so every test bypasses the real git/GitHub side
+  // effects (sync-to-main and auto-call to `gh issues start`). Tests that want
+  // to exercise those paths can call `commands.init` directly.
+  const initNoSideEffects = (args: string[], options: Record<string, unknown> = {}) =>
+    commands.init(args, { noSync: true, noIssueStart: true, ...options });
+
   it('returns usage error when no task description and no --issue', async () => {
-    const result = await commands.init([], {});
+    const result = await initNoSideEffects([], {});
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Usage');
   });
 
   it('creates checklist with --type=infrastructure', async () => {
-    const result = await commands.init(['Build new feature'], { type: 'infrastructure' });
+    const result = await initNoSideEffects(['Build new feature'], { type: 'infrastructure' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('checklist created');
     expect(result.output).toContain('infrastructure');
@@ -73,7 +79,7 @@ describe('agent-checklist init', () => {
   });
 
   it('creates checklist with --type=bugfix', async () => {
-    const result = await commands.init(['Fix scoring bug'], { type: 'bugfix' });
+    const result = await initNoSideEffects(['Fix scoring bug'], { type: 'bugfix' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
@@ -81,7 +87,7 @@ describe('agent-checklist init', () => {
   });
 
   it('creates checklist with --type=content', async () => {
-    const result = await commands.init(['Write AI safety page'], { type: 'content' });
+    const result = await initNoSideEffects(['Write AI safety page'], { type: 'content' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
@@ -91,7 +97,7 @@ describe('agent-checklist init', () => {
   });
 
   it('creates checklist with --type=commands', async () => {
-    const result = await commands.init(['Add session CLI'], { type: 'commands' });
+    const result = await initNoSideEffects(['Add session CLI'], { type: 'commands' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
@@ -100,7 +106,7 @@ describe('agent-checklist init', () => {
   });
 
   it('creates checklist with --type=refactor', async () => {
-    const result = await commands.init(['Refactor validation'], { type: 'refactor' });
+    const result = await initNoSideEffects(['Refactor validation'], { type: 'refactor' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
@@ -109,7 +115,7 @@ describe('agent-checklist init', () => {
   });
 
   it('rejects invalid --type', async () => {
-    const result = await commands.init(['Task'], { type: 'invalid' });
+    const result = await initNoSideEffects(['Task'], { type: 'invalid' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Invalid type');
     expect(result.output).toContain('content');
@@ -123,7 +129,7 @@ describe('agent-checklist init', () => {
       html_url: 'https://github.com/test/repo/issues/42',
     });
 
-    const result = await commands.init([], { issue: '42' });
+    const result = await initNoSideEffects([], { issue: '42' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('bugfix');
     expect(result.output).toContain('#42');
@@ -142,7 +148,7 @@ describe('agent-checklist init', () => {
       html_url: 'https://github.com/test/repo/issues/42',
     });
 
-    const result = await commands.init([], { issue: '42', type: 'infrastructure' });
+    const result = await initNoSideEffects([], { issue: '42', type: 'infrastructure' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
@@ -150,20 +156,20 @@ describe('agent-checklist init', () => {
   });
 
   it('rejects invalid issue number', async () => {
-    const result = await commands.init([], { issue: 'abc' });
+    const result = await initNoSideEffects([], { issue: 'abc' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Invalid issue number');
   });
 
   it('handles GitHub API failure gracefully', async () => {
     mockGithubApi.mockRejectedValueOnce(new Error('Not found'));
-    const result = await commands.init([], { issue: '999' });
+    const result = await initNoSideEffects([], { issue: '999' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Failed to fetch');
   });
 
   it('auto-marks issue-tracking as N/A with reason when no issue provided', async () => {
-    const result = await commands.init(['Build a feature'], { type: 'infrastructure' });
+    const result = await initNoSideEffects(['Build a feature'], { type: 'infrastructure' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('issue-tracking auto-marked N/A');
 
@@ -181,7 +187,7 @@ describe('agent-checklist init', () => {
       html_url: 'https://github.com/test/repo/issues/5',
     });
 
-    const result = await commands.init([], { issue: '5' });
+    const result = await initNoSideEffects([], { issue: '5' });
     expect(result.exitCode).toBe(0);
     expect(result.output).not.toContain('issue-tracking auto-marked N/A');
 
@@ -197,7 +203,7 @@ describe('agent-checklist init', () => {
       html_url: 'https://github.com/test/repo/issues/10',
     });
 
-    const result = await commands.init([], { issue: '10' });
+    const result = await initNoSideEffects([], { issue: '10' });
     expect(result.exitCode).toBe(0);
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -26,6 +26,8 @@ import {
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { upsertAgentSession, updateAgentSession, getAgentSessionByBranch } from '../lib/wiki-server/agent-sessions.ts';
 import { registerAgent, listActiveAgents } from '../lib/wiki-server/active-agents.ts';
+import { syncToMain } from '../lib/git.ts';
+import { commands as issuesCommands } from './issues.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -43,6 +45,11 @@ interface CommandOptions extends BaseOptions {
   type?: string;
   issue?: string;
   reason?: string;
+  /** Skip the sync-to-main step. Used by tests and by scripted callers that
+   *  intentionally want to start a session on the current branch. */
+  noSync?: boolean;
+  /** Skip the auto-call to `gh issues start <N>`. Used by tests. */
+  noIssueStart?: boolean;
 }
 
 interface GitHubIssueResponse {
@@ -109,6 +116,28 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
     return { output: `${c.red}Usage: crux sys agent-checklist init "Task" --type=X | --issue=N${c.reset}\n`, exitCode: 1 };
   }
 
+  // ── Sync to main ──────────────────────────────────────────────────────────
+  // Programmatic replacement for the old "Step 0: sync with main" instructions
+  // in /agent-init. Always runs unless explicitly opted out via --no-sync.
+  // If the working tree is dirty, this aborts BEFORE writing the checklist —
+  // the user must commit/stash/discard before retrying.
+  let syncOutput = '';
+  if (!options.noSync) {
+    const sync = syncToMain();
+    if (!sync.ok) {
+      return {
+        output:
+          `${c.red}✗ Failed to sync to main:${c.reset}\n${sync.error}\n\n` +
+          `${c.dim}If you intentionally want to start a session on the current branch ` +
+          `(e.g. continuing work after a crash), re-run with --no-sync.${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+    for (const step of sync.steps) {
+      syncOutput += `  ${c.dim}↻${c.reset} ${step}\n`;
+    }
+  }
+
   const branch = currentBranch();
   const worktree = PROJECT_ROOT;
   const metadata: ChecklistMetadata = { task, branch, timestamp: new Date().toISOString(), issue };
@@ -173,8 +202,41 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
     // Best-effort
   }
 
+  // ── Auto-call `gh issues start <N>` ───────────────────────────────────────
+  // Programmatic replacement for the old "Step 2: signal start on issue"
+  // instructions in /agent-init. Best-effort: failure here (e.g. GitHub down,
+  // wiki-server down, label conflict) does NOT fail the init — the local
+  // checklist is already on disk and that's the important state.
+  let issueStartOutput = '';
+  if (issue && !options.noIssueStart) {
+    try {
+      const startResult = await issuesCommands.start(
+        [String(issue)],
+        { ci: options.ci },
+      );
+      if (startResult.exitCode === 0) {
+        issueStartOutput = startResult.output;
+      } else {
+        issueStartOutput =
+          `${c.yellow}⚠ Auto-start of issue #${issue} returned non-zero exit:${c.reset}\n` +
+          startResult.output +
+          `${c.dim}(checklist created locally; you may want to run ` +
+          `\`crux gh issues start ${issue}\` manually)${c.reset}\n`;
+      }
+    } catch (e) {
+      issueStartOutput =
+        `${c.yellow}⚠ Could not signal start on issue #${issue}: ` +
+        `${e instanceof Error ? e.message : String(e)}${c.reset}\n` +
+        `${c.dim}(checklist created locally)${c.reset}\n`;
+    }
+  }
+
   const status = parseChecklist(markdown);
-  let output = `${c.green}✓${c.reset} Agent checklist created: ${c.cyan}.claude/wip-checklist.md${c.reset}\n`;
+  let output = '';
+  if (syncOutput) {
+    output += `${c.bold}Synced to main${c.reset}\n${syncOutput}\n`;
+  }
+  output += `${c.green}✓${c.reset} Agent checklist created: ${c.cyan}.claude/wip-checklist.md${c.reset}\n`;
   output += `  Type: ${c.bold}${type}${c.reset}\n`;
   output += `  Task: ${task}\n`;
   output += `  Branch: ${c.cyan}${branch}${c.reset}\n`;
@@ -184,9 +246,39 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   output += `  Items: ${status.totalItems}\n`;
   if (dbSynced) output += `  ${c.dim}Synced to wiki-server DB${c.reset}\n`;
   if (directoryWarning) output += directoryWarning;
-  output += `\n${c.dim}Run \`crux sys agent-checklist status\` to check progress.${c.reset}\n`;
+  if (issueStartOutput) output += `\n${issueStartOutput}`;
+
+  // Render the full checklist so callers don't need a separate `status` call.
+  output += `\n${renderChecklistItems(status, c)}`;
 
   return { output, exitCode: 0 };
+}
+
+/**
+ * Render the checklist items as colored text. Shared between `init` and `status`
+ * so they format identically.
+ */
+function renderChecklistItems(
+  s: ReturnType<typeof parseChecklist>,
+  c: ReturnType<typeof createLogger>['colors'],
+): string {
+  const pct = s.totalItems > 0 ? Math.round((s.totalChecked / s.totalItems) * 100) : 0;
+  const color = s.allPassing ? c.green : pct >= 50 ? c.yellow : c.red;
+  let output = `${c.bold}Session Checklist${c.reset} ${color}${s.totalChecked}/${s.totalItems} (${pct}%)${c.reset}\n\n`;
+
+  for (const item of s.items) {
+    const isAdvisory = CHECKLIST_ITEMS.find(ci => ci.id === item.id)?.priority === 'advisory';
+    const prefix = isAdvisory ? `${c.dim}(advisory)${c.reset} ` : '';
+    if (item.status === 'checked') output += `  ${c.green}[x]${c.reset} ${prefix}${item.label}\n`;
+    else if (item.status === 'na') output += `  ${c.dim}[~] ${prefix}${item.label} (N/A${item.naReason ? `: ${item.naReason}` : ''})${c.reset}\n`;
+    else output += `  ${c.red}[ ]${c.reset} ${prefix}${item.label}\n`;
+  }
+
+  if (s.decisions.length > 0) {
+    output += `\n${c.bold}Key Decisions (${s.decisions.length}):${c.reset}\n`;
+    for (const d of s.decisions) output += `  ${c.cyan}-${c.reset} ${d}\n`;
+  }
+  return output;
 }
 
 async function status(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -204,24 +296,7 @@ async function status(_args: string[], options: CommandOptions): Promise<Command
     return { output: JSON.stringify({ totalChecked: s.totalChecked, totalItems: s.totalItems, allPassing: s.allPassing, decisions: s.decisions }, null, 2), exitCode: 0 };
   }
 
-  const pct = s.totalItems > 0 ? Math.round((s.totalChecked / s.totalItems) * 100) : 0;
-  const color = s.allPassing ? c.green : pct >= 50 ? c.yellow : c.red;
-  let output = `${c.bold}Session Checklist${c.reset} ${color}${s.totalChecked}/${s.totalItems} (${pct}%)${c.reset}\n\n`;
-
-  for (const item of s.items) {
-    const isAdvisory = CHECKLIST_ITEMS.find(ci => ci.id === item.id)?.priority === 'advisory';
-    const prefix = isAdvisory ? `${c.dim}(advisory)${c.reset} ` : '';
-    if (item.status === 'checked') output += `  ${c.green}[x]${c.reset} ${prefix}${item.label}\n`;
-    else if (item.status === 'na') output += `  ${c.dim}[~] ${prefix}${item.label} (N/A${item.naReason ? `: ${item.naReason}` : ''})${c.reset}\n`;
-    else output += `  ${c.red}[ ]${c.reset} ${prefix}${item.label}\n`;
-  }
-
-  if (s.decisions.length > 0) {
-    output += `\n${c.bold}Key Decisions (${s.decisions.length}):${c.reset}\n`;
-    for (const d of s.decisions) output += `  ${c.cyan}-${c.reset} ${d}\n`;
-  }
-
-  return { output, exitCode: 0 };
+  return { output: renderChecklistItems(s, c), exitCode: 0 };
 }
 
 async function complete(_args: string[], options: CommandOptions): Promise<CommandResult> {

--- a/crux/lib/git.test.ts
+++ b/crux/lib/git.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { isValidBranchName } from './git.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+import { isValidBranchName, syncToMain } from './git.ts';
+
+const mockExecFileSync = vi.mocked(execFileSync);
 
 describe('isValidBranchName', () => {
   it('accepts typical branch names', () => {
@@ -28,5 +36,118 @@ describe('isValidBranchName', () => {
 
   it('accepts names at the boundary length', () => {
     expect(isValidBranchName('a'.repeat(255))).toBe(true);
+  });
+});
+
+// ── syncToMain ───────────────────────────────────────────────────────────────
+//
+// `syncToMain` orchestrates: rev-parse (current branch) → status → checkout? → pull.
+// Tests stub execFileSync per call to simulate each git invocation in order.
+
+/** Stub a sequence of git invocations. Each entry maps to one execFileSync call. */
+function stubGitCalls(
+  calls: Array<
+    | { ok: true; stdout: string }
+    | { ok: false; stderr: string; stdout?: string; status?: number }
+  >,
+) {
+  let i = 0;
+  mockExecFileSync.mockImplementation(((..._args: unknown[]) => {
+    const call = calls[i++];
+    if (!call) throw new Error(`syncToMain made more git calls than stubbed (${i})`);
+    if (call.ok) return call.stdout;
+    const err = new Error(call.stderr) as Error & {
+      status: number;
+      stdout: string;
+      stderr: string;
+    };
+    err.status = call.status ?? 1;
+    err.stdout = call.stdout ?? '';
+    err.stderr = call.stderr;
+    throw err;
+  }) as unknown as typeof execFileSync);
+}
+
+describe('syncToMain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('succeeds when already on main and pull is up to date', () => {
+    stubGitCalls([
+      { ok: true, stdout: 'main' },              // rev-parse --abbrev-ref HEAD
+      { ok: true, stdout: '' },                  // status --porcelain (clean)
+      { ok: true, stdout: 'Already up to date.' }, // pull --ff-only origin main
+    ]);
+
+    const result = syncToMain();
+    expect(result.ok).toBe(true);
+    expect(result.startBranch).toBe('main');
+    expect(result.switchedBranch).toBe(false);
+    expect(result.steps).toEqual([
+      'Already on main',
+      'Pulled main (already up to date)',
+    ]);
+  });
+
+  it('checks out main and pulls when starting on a feature branch', () => {
+    stubGitCalls([
+      { ok: true, stdout: 'claude/feature-x' }, // rev-parse
+      { ok: true, stdout: '' },                 // status
+      { ok: true, stdout: "Switched to branch 'main'" }, // checkout main
+      { ok: true, stdout: 'Updating abc..def\nFast-forward\n 1 file changed' }, // pull
+    ]);
+
+    const result = syncToMain();
+    expect(result.ok).toBe(true);
+    expect(result.startBranch).toBe('claude/feature-x');
+    expect(result.switchedBranch).toBe(true);
+    expect(result.steps[0]).toBe('Switched claude/feature-x → main');
+    expect(result.steps[1]).toMatch(/^Pulled main/);
+  });
+
+  it('aborts when working tree has uncommitted changes', () => {
+    stubGitCalls([
+      { ok: true, stdout: 'main' },
+      { ok: true, stdout: ' M apps/web/foo.tsx\n?? new-file.md' }, // dirty
+    ]);
+
+    const result = syncToMain();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Working tree is not clean');
+    expect(result.error).toContain('apps/web/foo.tsx');
+    expect(result.switchedBranch).toBe(false);
+    // Should NOT have called checkout or pull.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts when checkout main fails', () => {
+    stubGitCalls([
+      { ok: true, stdout: 'claude/feature-x' },
+      { ok: true, stdout: '' },
+      { ok: false, stderr: 'error: branch main not found' },
+    ]);
+
+    const result = syncToMain();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('git checkout main failed');
+    expect(result.error).toContain('branch main not found');
+    expect(result.switchedBranch).toBe(false);
+  });
+
+  it('aborts when pull is non-fast-forward', () => {
+    stubGitCalls([
+      { ok: true, stdout: 'main' },
+      { ok: true, stdout: '' },
+      {
+        ok: false,
+        stderr: 'fatal: Not possible to fast-forward, aborting.',
+      },
+    ]);
+
+    const result = syncToMain();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('git pull --ff-only origin main failed');
+    expect(result.error).toContain('fast-forward');
   });
 });

--- a/crux/lib/git.ts
+++ b/crux/lib/git.ts
@@ -256,3 +256,102 @@ export function hasChanges(): boolean {
   const unstaged = gitSafe('diff', '--quiet');
   return !staged.ok || !unstaged.ok;
 }
+
+// ── Sync to main ─────────────────────────────────────────────────────────────
+
+/**
+ * Result of attempting to sync the working tree to the latest origin/main.
+ *
+ * `ok=false` means no destructive action was taken — the caller should surface
+ * the error to the user instead of proceeding with stale state.
+ */
+export interface SyncToMainResult {
+  ok: boolean;
+  /** Human-readable steps that were performed (in order). */
+  steps: string[];
+  /** Error message if ok=false. */
+  error?: string;
+  /** True if we switched off another branch onto main. */
+  switchedBranch: boolean;
+  /** The branch we were on before syncing. */
+  startBranch: string;
+}
+
+/**
+ * Sync the working tree to the latest origin/main:
+ *
+ *   1. Verify the working tree is clean (no uncommitted or untracked files).
+ *      If dirty, abort without making any changes.
+ *   2. If not on main, run `git checkout main`.
+ *   3. Run `git pull --ff-only origin main`.
+ *
+ * Used by `crux sys agent-checklist init` so every new session starts from a
+ * fresh main, instead of inheriting whatever stale branch the slot happened
+ * to be on.
+ */
+export function syncToMain(): SyncToMainResult {
+  const startBranch = currentBranch();
+  const steps: string[] = [];
+
+  // Step 1: clean tree check (porcelain catches both modified and untracked).
+  const status = gitSafe('status', '--porcelain');
+  if (!status.ok) {
+    return {
+      ok: false,
+      steps,
+      error: `git status failed: ${status.stderr || status.output}`,
+      switchedBranch: false,
+      startBranch,
+    };
+  }
+  if (status.output.length > 0) {
+    return {
+      ok: false,
+      steps,
+      error:
+        `Working tree is not clean. Commit, stash, or discard before syncing:\n` +
+        status.output,
+      switchedBranch: false,
+      startBranch,
+    };
+  }
+
+  // Step 2: switch to main if needed.
+  let switchedBranch = false;
+  if (startBranch !== 'main') {
+    const checkout = gitSafe('checkout', 'main');
+    if (!checkout.ok) {
+      return {
+        ok: false,
+        steps,
+        error: `git checkout main failed: ${checkout.stderr || checkout.output}`,
+        switchedBranch: false,
+        startBranch,
+      };
+    }
+    switchedBranch = true;
+    steps.push(`Switched ${startBranch} → main`);
+  } else {
+    steps.push('Already on main');
+  }
+
+  // Step 3: pull (fast-forward only — diverged local main is a real problem).
+  const pull = gitSafe('pull', '--ff-only', 'origin', 'main');
+  if (!pull.ok) {
+    return {
+      ok: false,
+      steps,
+      error: `git pull --ff-only origin main failed: ${pull.stderr || pull.output}`,
+      switchedBranch,
+      startBranch,
+    };
+  }
+  if (pull.output.includes('Already up to date')) {
+    steps.push('Pulled main (already up to date)');
+  } else {
+    const summary = pull.output.split('\n').slice(-2)[0]?.trim() || 'updated';
+    steps.push(`Pulled main (${summary})`);
+  }
+
+  return { ok: true, steps, switchedBranch, startBranch };
+}


### PR DESCRIPTION
## Summary
- `crux sys agent-checklist init` now handles git sync (checkout main + pull), GitHub issue start signal, and full checklist rendering — replacing 3 manual LLM instruction steps in `/agent-init`
- New `syncToMain()` helper in `crux/lib/git.ts`: verifies clean tree, switches to main if needed, pulls `--ff-only`
- `--no-sync` and `--no-issue-start` flags for tests and crash-recovery scenarios
- `/agent-init.md` collapsed from 4 steps to 1 command + optional context assembly

## Test plan
- [x] 5 new unit tests for `syncToMain()` (dirty tree, branch switch, checkout fail, pull fail, happy path)
- [x] 27 existing agent-checklist tests pass with `initNoSideEffects()` wrapper
- [x] Smoke tested dirty-tree abort path (shows file list + escape hint)
- [x] Smoke tested `--no-sync` bypass (full checklist renders inline)
- [x] Gate checks pass (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)