### PR TITLE
C5: Surface claim-linking failures in 5 batch sync responses (epic #4017)

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -280,6 +280,7 @@ const benchmarkResultsApp = new Hono()
 
     // Link verified claims to records (best-effort — records already committed)
     let claimsLinked = 0;
+    let claimLinkingError: string | null = null;
     if (allClaimIds.length > 0) {
       try {
         const rawDb = getDb();
@@ -291,11 +292,12 @@ const benchmarkResultsApp = new Hono()
         claimsLinked = linkResult.linked;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
         logger.warn({ error: msg }, "claim linking failed (records already committed)");
       }
     }
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked });
+    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
   });
 
 export const benchmarkResultsRoute = benchmarkResultsApp;

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -380,6 +380,7 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
 
     // Link verified claims to records (best-effort — records already committed)
     let claimsLinked = 0;
+    let claimLinkingError: string | null = null;
     if (allClaimIds.length > 0) {
       try {
         const rawDb = getDb();
@@ -391,11 +392,12 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
         claimsLinked = linkResult.linked;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
         logger.warn({ error: msg }, "claim linking failed (records already committed)");
       }
     }
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked });
+    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
   });
 
 // ---- Exports ----

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -751,6 +751,7 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
 
     // Link verified claims to records (best-effort — records already committed)
     let claimsLinked = 0;
+    let claimLinkingError: string | null = null;
     if (allClaimIds.length > 0) {
       try {
         const rawDb = getDb();
@@ -762,11 +763,12 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
         claimsLinked = linkResult.linked;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
         logger.warn({ error: msg }, "claim linking failed (records already committed)");
       }
     }
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked });
+    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
   })
 
   // ---- POST /delete-batch ----

--- a/apps/wiki-server/src/routes/tablebase/investments.ts
+++ b/apps/wiki-server/src/routes/tablebase/investments.ts
@@ -376,6 +376,7 @@ const investmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
 
     // Link verified claims to records (best-effort — records already committed)
     let claimsLinked = 0;
+    let claimLinkingError: string | null = null;
     if (allClaimIds.length > 0) {
       try {
         const rawDb = getDb();
@@ -387,11 +388,12 @@ const investmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
         claimsLinked = linkResult.linked;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
         logger.warn({ error: msg }, "claim linking failed (records already committed)");
       }
     }
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked });
+    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
   });
 
 // ---- Exports ----

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -538,6 +538,7 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
 
     // Link verified claims to records (best-effort — records already committed)
     let claimsLinked = 0;
+    let claimLinkingError: string | null = null;
     if (allClaimIds.length > 0) {
       try {
         const rawDb = getDb();
@@ -549,11 +550,12 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
         claimsLinked = linkResult.linked;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
         logger.warn({ error: msg }, "claim linking failed (records already committed)");
       }
     }
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked });
+    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
   })
 
   // ---- POST /delete ----


### PR DESCRIPTION
## Summary

Phase C5 of epic #4017 — surfaces claim-linking failures in 5 batch sync endpoint responses.

### Before
All 5 endpoints (grants, personnel, investments, benchmark-results, funding-rounds) return `claimsLinked: 0` on failure — identical to "no claims to link." Callers can't tell if linking crashed.

### After
Response includes optional `claimLinkingError: string` field when linking fails. Only present when non-null, so existing consumers are unaffected.

### Endpoints modified
- `POST /api/grants/sync`
- `POST /api/personnel/sync`
- `POST /api/investments/sync`
- `POST /api/benchmark-results/sync`
- `POST /api/funding-rounds/sync`

## Test plan
- [x] wiki-server typecheck: clean
- [x] wiki-server tests: 871 pass / 21 skipped
- [ ] CI green

Part of epic #4017 (Phase C — eliminate bypass paths).
