### PR TITLE
B3 (narrowed): Unique index on policy_stakeholders natural key (epic #4017)

### DIFF
--- a/apps/wiki-server/drizzle/0168_policy_stakeholders_unique_key.sql
+++ b/apps/wiki-server/drizzle/0168_policy_stakeholders_unique_key.sql
@@ -1,0 +1,44 @@
+-- Epic #4017 Phase B3 (narrowed): Add unique index on policy_stakeholders
+-- natural key.
+--
+-- The original B3 PR (#4032) was closed because the grants and funding_rounds
+-- natural keys were wrong (name collisions across years). This migration only
+-- covers policy_stakeholders, where the natural key IS correct:
+-- (policy_entity_id, stakeholder_display_name, position) — all NOT NULL,
+-- genuinely unique per policy + stakeholder + position taken.
+--
+-- Pattern: ROW_NUMBER() dynamic dedup (keeps most-recently-updated row),
+-- then CREATE UNIQUE INDEX IF NOT EXISTS. Reference: migration 0108.
+
+-- ============================================================================
+-- Step 1: Deduplicate existing rows
+-- ============================================================================
+
+DELETE FROM policy_stakeholders
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY policy_entity_id, stakeholder_display_name, position
+        ORDER BY
+          (CASE WHEN stakeholder_entity_id IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN importance IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN reason IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN source IS NOT NULL THEN 1 ELSE 0 END
+           + CASE WHEN context IS NOT NULL THEN 1 ELSE 0 END
+          ) DESC,
+          updated_at DESC,
+          created_at DESC
+      ) AS rn
+    FROM policy_stakeholders
+  ) ranked
+  WHERE rn > 1
+);
+
+-- ============================================================================
+-- Step 2: Add unique index
+-- ============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_stakeholders_natural_key
+  ON policy_stakeholders (policy_entity_id, stakeholder_display_name, position);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1170,6 +1170,13 @@
       "when": 1783843200000,
       "tag": "0166_drop_source_resource_id",
       "breakpoints": true
+    },
+    {
+      "idx": 167,
+      "version": "7",
+      "when": 1783929600000,
+      "tag": "0168_policy_stakeholders_unique_key",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Narrowed B3 from epic #4017 — adds a unique index only for `policy_stakeholders`, where the natural key is correct. The original B3 PR (#4032) was closed because grants and funding_rounds had name-collision issues.

### Why policy_stakeholders is safe
- Natural key: `(policy_entity_id, stakeholder_display_name, position)`
- All 3 columns are NOT NULL
- The combination is genuinely unique: same stakeholder can't take the same position on the same policy twice
- No "placeholder name" issue like grants' "Grant to X"

### What's deferred
Grants and funding_rounds need a different approach — either including `date`/`grantee_id` in the key, or fixing the ID generation. Filed as a follow-up in the epic.

## Test plan
- [x] wiki-server typecheck: clean
- [x] wiki-server tests: 871 pass / 21 skipped
- [ ] CI green
- [ ] Post-deploy: verify index exists

Part of epic #4017 (Phase B — tighten the schema).
