### PR TITLE
D1+D2+D5: Incident dedup race, ID allocation, deterministic YAML load (epic #4017)

### DIFF
--- a/apps/wiki-server/drizzle/0167_incident_dedup_unique.sql
+++ b/apps/wiki-server/drizzle/0167_incident_dedup_unique.sql
@@ -1,0 +1,17 @@
+-- Dedup existing open incidents: keep the earliest per (service, title),
+-- then add a partial unique index to prevent future duplicates.
+
+DELETE FROM service_health_incidents
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY service, title
+      ORDER BY detected_at, id  -- keep earliest; id as tiebreaker
+    ) AS rn
+    FROM service_health_incidents
+    WHERE status = 'open'
+  ) ranked WHERE rn > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_shi_open_service_title
+  ON service_health_incidents (service, title) WHERE status = 'open';

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1170,6 +1170,13 @@
       "when": 1783843200000,
       "tag": "0166_drop_source_resource_id",
       "breakpoints": true
+    },
+    {
+      "idx": 167,
+      "version": "7",
+      "when": 1783929600000,
+      "tag": "0167_incident_dedup_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/operational/monitoring.ts
+++ b/apps/wiki-server/src/routes/operational/monitoring.ts
@@ -86,6 +86,26 @@ interface AgentActivityRow {
   completed_this_week: number;
 }
 
+/** Map raw SQL snake_case row to camelCase for API consistency with Drizzle-returned rows. */
+function formatIncidentRow(row: Record<string, unknown>) {
+  return {
+    id: row.id as number,
+    service: row.service as string,
+    severity: row.severity as string,
+    status: row.status as string,
+    title: row.title as string,
+    detail: row.detail as string | null,
+    detectedAt: row.detected_at as string,
+    resolvedAt: row.resolved_at as string | null,
+    resolvedBy: row.resolved_by as string | null,
+    checkSource: row.check_source as string | null,
+    metadata: row.metadata as Record<string, unknown> | null,
+    githubIssueNumber: row.github_issue_number as number | null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}
+
 const monitoringApp = new Hono()
   // ---- GET /status — aggregated system health ----
   .get("/status", async (c) => {
@@ -346,57 +366,42 @@ const monitoringApp = new Hono()
     if (!parsed.success) return validationError(c, parsed.error.message);
 
     const d = parsed.data;
-    const db = getDrizzleDb();
+    const pgClient = getDb();
 
-    // Check for existing open incident for same service+title (dedup)
-    const existing = await db
-      .select({ id: serviceHealthIncidents.id })
-      .from(serviceHealthIncidents)
-      .where(
-        and(
-          eq(serviceHealthIncidents.service, d.service),
-          eq(serviceHealthIncidents.title, d.title),
-          eq(serviceHealthIncidents.status, "open")
-        )
-      )
-      .limit(1);
+    // Atomic upsert: INSERT or update existing open incident for same service+title.
+    // Uses the partial unique index idx_shi_open_service_title to avoid the TOCTOU
+    // race that existed in the previous SELECT-then-INSERT approach.
+    const rows = await pgClient.unsafe(
+      `INSERT INTO service_health_incidents
+         (service, severity, title, detail, check_source, metadata, github_issue_number)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (service, title) WHERE status = 'open'
+       DO UPDATE SET
+         detail = COALESCE($4, service_health_incidents.detail),
+         metadata = COALESCE($6, service_health_incidents.metadata),
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        d.service,
+        d.severity,
+        d.title,
+        d.detail ?? null,
+        d.checkSource ?? null,
+        d.metadata ? JSON.stringify(d.metadata) : null,
+        d.githubIssueNumber ?? null,
+      ]
+    );
 
-    if (existing.length > 0) {
-      // Update existing instead of creating duplicate
-      const updated = await db
-        .update(serviceHealthIncidents)
-        .set({
-          detail: d.detail ?? undefined,
-          metadata: d.metadata ?? undefined,
-          updatedAt: new Date(),
-        })
-        .where(eq(serviceHealthIncidents.id, existing[0].id))
-        .returning();
-      return c.json(firstOrThrow(updated, "incident dedup update"), 200);
+    if (rows.length === 0) {
+      return c.json({ error: "Failed to insert or update incident" }, 500);
     }
 
-    const inserted = await db
-      .insert(serviceHealthIncidents)
-      .values({
-        service: d.service,
-        severity: d.severity,
-        title: d.title,
-        detail: d.detail ?? null,
-        checkSource: d.checkSource ?? null,
-        metadata: d.metadata ?? null,
-        githubIssueNumber: d.githubIssueNumber ?? null,
-      })
-      .returning();
+    const row = rows[0] as Record<string, unknown>;
+    // Determine if this was an insert (created_at === updated_at) or a dedup update
+    const wasInsert =
+      String(row.created_at) === String(row.updated_at);
 
-    const incident = firstOrThrow(inserted, "incident insert");
-
-    // Note: Previously created a "monitoring-alert" job for critical incidents,
-    // but no job handler exists for this type — every such job permanently failed
-    // with "Unknown job type: monitoring-alert". Removed in #2193.
-    // The incident is already recorded in service_health_incidents and the
-    // groundskeeper handles alerting via GitHub issues and Discord.
-
-    return c.json(incident, 201);
+    return c.json(formatIncidentRow(row), wasInsert ? 201 : 200);
   })
 
   // ---- PATCH /incidents/:id — update/resolve ----

--- a/apps/wiki-server/src/routes/tablebase/ids.ts
+++ b/apps/wiki-server/src/routes/tablebase/ids.ts
@@ -102,17 +102,7 @@ const idsApp = new Hono()
     const { slug, description } = parsed.data;
     const db = getDrizzleDb();
 
-    // Check if slug already exists (avoids burning a sequence value on conflict)
-    const existing = await db
-      .select()
-      .from(entityIds)
-      .where(eq(entityIds.slug, slug));
-
-    if (existing.length > 0) {
-      return c.json(formatIdResponse(existing[0], false));
-    }
-
-    // Slug is new — allocate next sequence value + stable ID
+    // Try to allocate — if slug already exists, ON CONFLICT DO NOTHING returns []
     const inserted = await db
       .insert(entityIds)
       .values({
@@ -128,21 +118,21 @@ const idsApp = new Hono()
       return c.json(formatIdResponse(inserted[0], true), 201);
     }
 
-    // Race condition: another request inserted between our SELECT and INSERT.
-    // Re-fetch the existing row.
-    const raced = await db
+    // Slug already exists — return existing allocation
+    const [existing] = await db
       .select()
       .from(entityIds)
       .where(eq(entityIds.slug, slug));
 
-    if (raced.length === 0) {
+    if (!existing) {
+      // Should not happen — slug was just confirmed to exist via conflict
       return c.json(
-        { error: "internal_error", message: "Unexpected: slug not found after conflict" },
+        { error: "internal_error", message: "Race condition in ID allocation" },
         500
       );
     }
 
-    return c.json(formatIdResponse(raced[0], false));
+    return c.json(formatIdResponse(existing, false));
   })
 
   // ---- POST /allocate-batch ----
@@ -160,17 +150,7 @@ const idsApp = new Hono()
     // Run all allocations in a single transaction
     await db.transaction(async (tx) => {
       for (const item of items) {
-        // Check existence first to avoid burning sequence values
-        const existing = await tx
-          .select()
-          .from(entityIds)
-          .where(eq(entityIds.slug, item.slug));
-
-        if (existing.length > 0) {
-          results.push(formatIdResponse(existing[0], false));
-          continue;
-        }
-
+        // Try to allocate — if slug already exists, ON CONFLICT DO NOTHING returns []
         const inserted = await tx
           .insert(entityIds)
           .values({
@@ -185,14 +165,13 @@ const idsApp = new Hono()
         if (inserted.length > 0) {
           results.push(formatIdResponse(inserted[0], true));
         } else {
-          // Race condition: another request inserted between our SELECT and INSERT.
-          // Re-fetch the existing row.
-          const raced = await tx
+          // Slug already exists — return existing allocation
+          const [existing] = await tx
             .select()
             .from(entityIds)
             .where(eq(entityIds.slug, item.slug));
-          if (raced.length > 0) {
-            results.push(formatIdResponse(raced[0], false));
+          if (existing) {
+            results.push(formatIdResponse(existing, false));
           }
         }
       }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1400,6 +1400,9 @@ export const serviceHealthIncidents = pgTable(
     index("idx_shi_severity").on(table.severity),
     index("idx_shi_detected_at").on(table.detectedAt),
     index("idx_shi_service_status").on(table.service, table.status),
+    uniqueIndex("idx_shi_open_service_title")
+      .on(table.service, table.title)
+      .where(sql`status = 'open'`),
   ]
 );
 

--- a/packages/factbase/src/loader.ts
+++ b/packages/factbase/src/loader.ts
@@ -499,7 +499,7 @@ function parseFact(
 async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unknown }[]> {
   let entries: string[];
   try {
-    entries = await readdir(dir);
+    entries = (await readdir(dir)).sort();
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return []; // Directory doesn't exist — optional
@@ -535,7 +535,8 @@ async function discoverEntityFiles(
 ): Promise<{ name: string; parsed: unknown }[]> {
   let dirEntries: import("node:fs").Dirent[];
   try {
-    dirEntries = await readdir(thingsDir, { withFileTypes: true });
+    dirEntries = (await readdir(thingsDir, { withFileTypes: true }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return [];


### PR DESCRIPTION
## Summary

Phase D of epic #4017 — three quick concurrency and determinism fixes.

### D1: Incident dedup race (monitoring.ts)
TOCTOU race: two concurrent requests could both INSERT duplicate open incidents.
- **Migration 0167**: ROW_NUMBER() dedup + partial unique index `idx_shi_open_service_title ON (service, title) WHERE status = 'open'`
- **Handler rewrite**: atomic `INSERT ... ON CONFLICT ... DO UPDATE` using raw SQL

### D2: ID allocation simplification (ids.ts)
The SELECT→INSERT→re-SELECT pattern was redundant. INSERT-first with ON CONFLICT DO NOTHING handles races in one step.
- Reduces round-trips from 2-3 to 1-2
- Applied to both `/allocate` and `/allocate-batch`

### D5: Deterministic YAML load order (loader.ts)
`readdir()` returns filesystem-dependent order. Added `.sort()` in 2 places to make builds reproducible.

## Deploy checklist
- [ ] Verify migration 0167 applied (incident dedup + unique index)
- [ ] Verify no duplicate open incidents were created during the race window

## Test plan
- [x] wiki-server typecheck: clean
- [x] wiki-server tests: 871 pass / 21 skipped
- [x] pnpm build: succeeds
- [x] Drizzle journal validator: passes
- [ ] CI green

Part of epic #4017 (Phase D — concurrency and pipeline).
