### PR TITLE
D4: Build pipeline fail-closed — abort on YAML errors, surface wiki-server failures (epic #4017)

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -60,6 +60,8 @@ import {
   fetchEntityResourceLinks,
   buildPageReferenceIndex,
   getWikiServerWarningCount,
+  getSkippedDataSources,
+  setFullBuildMode,
 } from './lib/wiki-server-data.mjs';
 import {
   buildPagesRegistry,
@@ -93,6 +95,9 @@ const CONTENT_ONLY = SCOPE === 'content';
 
 if (CONTENT_ONLY) {
   console.log('⚡ Running in content-only scope (skipping git dates, block IR, redundancy, server sync, LLM files)\n');
+} else {
+  // In full build mode, wiki-server failures produce louder warnings
+  setFullBuildMode(true);
 }
 
 const OUTPUT_FILE = join(OUTPUT_DIR, 'database.json');
@@ -1219,6 +1224,16 @@ async function main() {
   }
 
   // =========================================================================
+  // PRE-WRITE SAFETY CHECK — abort before writing if data is corrupt
+  // =========================================================================
+  const totalYamlErrors = yamlParseErrorCount + getPagesBuilderYamlErrors();
+  if (totalYamlErrors > 0) {
+    console.error(`\n❌ Build aborted: ${totalYamlErrors} YAML parse error(s) found. Fix them before building.`);
+    console.error('database.json was NOT written — the previous version is preserved.');
+    process.exit(1);
+  }
+
+  // =========================================================================
   // WRITE OUTPUT FILES
   // =========================================================================
   const { databaseForOutput, strippedFields } = writeMainOutputFiles({ database, outputFile: OUTPUT_FILE });
@@ -1297,7 +1312,8 @@ async function main() {
   // ==========================================================================
   // BUILD HEALTH REPORT
   // ==========================================================================
-  const totalYamlErrors = yamlParseErrorCount + getPagesBuilderYamlErrors();
+  // Note: YAML errors are already checked before writing output files above.
+  // If we reach this point, totalYamlErrors is guaranteed to be 0.
   const totalWikiServerWarnings = getWikiServerWarningCount();
 
   console.log('\n--- Build Health ---');
@@ -1306,14 +1322,16 @@ async function main() {
   console.log(`  YAML parse errors:        ${totalYamlErrors}`);
   console.log(`  Wiki-server warnings:     ${totalWikiServerWarnings}`);
 
-  if (totalYamlErrors > 0) {
-    console.error(`\nFATAL: ${totalYamlErrors} YAML parse error(s) occurred. The output data is incomplete.`);
-    console.error('Fix the malformed YAML files listed above and re-run build-data.');
-    process.exit(1);
-  }
-
-  if (totalWikiServerWarnings > 0) {
-    console.warn(`\nNote: ${totalWikiServerWarnings} wiki-server API call(s) failed (non-fatal). Some dashboard data may be missing.`);
+  if (totalWikiServerWarnings > 0 && !CONTENT_ONLY) {
+    const skipped = getSkippedDataSources();
+    console.warn(`\n⚠️  ${totalWikiServerWarnings} wiki-server API call(s) failed during FULL build.`);
+    console.warn('   database.json was written but is missing data from:');
+    for (const source of skipped) {
+      console.warn(`     - ${source}`);
+    }
+    console.warn('   If this is CI, the build output is incomplete — investigate wiki-server availability.');
+  } else if (totalWikiServerWarnings > 0) {
+    console.warn(`\nNote: ${totalWikiServerWarnings} wiki-server API call(s) failed (expected in content-only mode).`);
   }
 }
 

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -31,19 +31,47 @@ function isBareMachineId(s) {
 // Counts actual API failures (not "URL not set" which is expected for local dev).
 // ---------------------------------------------------------------------------
 let wikiServerWarningCount = 0;
+/** Tracks which data sources were skipped due to wiki-server failures. */
+const skippedDataSources = [];
+
+/**
+ * When true, wiki-server failures produce loud console.error messages.
+ * Set via setFullBuildMode() — should be true for full (CI) builds,
+ * false for --scope=content (local dev).
+ */
+let fullBuildMode = false;
+
+/**
+ * Signal that this is a full build (not content-only).
+ * Wiki-server failures will produce louder warnings in full mode.
+ */
+export function setFullBuildMode(enabled) {
+  fullBuildMode = enabled;
+}
 
 /** Return the number of wiki-server API warnings encountered by this module. */
 export function getWikiServerWarningCount() {
   return wikiServerWarningCount;
 }
 
+/** Return the list of data sources that were skipped due to wiki-server failures. */
+export function getSkippedDataSources() {
+  return [...skippedDataSources];
+}
+
 /**
  * Log a wiki-server API failure and increment the warning counter.
- * These are non-fatal: the build continues with fallback data.
+ * In full build mode, uses console.error for visibility.
+ * In content-only mode, uses console.log (expected behavior).
  */
 function logWikiServerWarning(context, reason) {
-  console.log(`  ${context}: skipped (${reason})`);
+  skippedDataSources.push(context);
   wikiServerWarningCount++;
+  if (fullBuildMode) {
+    console.error(`  ⚠️  ${context}: FAILED (${reason}) — data will be missing from output`);
+  } else {
+    console.log(`  ${context}: skipped (${reason})`);
+  }
 }
 
 /** Build headers for wiki-server API requests, including auth if configured. */


### PR DESCRIPTION
## Summary

Phase D4 of epic #4017 — makes the build pipeline fail-closed.

### Fix 1: YAML error check before writeMainOutputFiles
Previously database.json was written first, then YAML errors checked. Now aborts with exit(1) BEFORE writing if any YAML parse errors occurred, preserving the previous valid database.json.

### Fix 2: Wiki-server failures are mode-aware
- **Full mode (CI)**: Prominent console.error warnings + BUILD HEALTH REPORT lists skipped data sources
- **Content-only mode (local dev)**: Quiet logging, no behavior change

Does NOT exit(1) on wiki-server failures yet — that would break local dev. A follow-up could add `--strict` for CI.

## Test plan
- [x] wiki-server typecheck: clean
- [x] pnpm build: succeeds (content-only mode, wiki-server not running)
- [ ] CI green (full mode with wiki-server available)

Part of epic #4017 (Phase D — concurrency and pipeline).
