### PR TITLE
chore: increase weekly source-check budgets

### DIFF
--- a/.github/workflows/source-check-recheck.yml
+++ b/.github/workflows/source-check-recheck.yml
@@ -12,12 +12,12 @@ on:
       budget:
         description: 'Max budget in dollars'
         required: false
-        default: '5'
+        default: '15'
         type: string
       limit:
         description: 'Max items to recheck'
         required: false
-        default: '100'
+        default: '500'
         type: string
       record_type:
         description: 'Filter by record type (empty = all)'
@@ -53,8 +53,8 @@ jobs:
       PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
-      INPUT_BUDGET: ${{ inputs.budget || '5' }}
-      INPUT_LIMIT: ${{ inputs.limit || '100' }}
+      INPUT_BUDGET: ${{ inputs.budget || '15' }}
+      INPUT_LIMIT: ${{ inputs.limit || '500' }}
       INPUT_RECORD_TYPE: ${{ inputs.record_type }}
       INPUT_DRY_RUN: ${{ inputs.dry_run }}
 

--- a/.github/workflows/source-check.yml
+++ b/.github/workflows/source-check.yml
@@ -12,7 +12,7 @@ on:
       budget:
         description: 'Max budget in dollars'
         required: false
-        default: '15'
+        default: '30'
         type: string
       table:
         description: 'Table to check (personnel|grants|funding-rounds|all)'
@@ -52,7 +52,7 @@ jobs:
       PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
-      INPUT_BUDGET: ${{ inputs.budget || '15' }}
+      INPUT_BUDGET: ${{ inputs.budget || '30' }}
       INPUT_TABLE: ${{ inputs.table || 'all' }}
       INPUT_DRY_RUN: ${{ inputs.dry_run }}
 


### PR DESCRIPTION
## Summary
- Source-check weekly budget: $15 → $30 (~3000 items/week)
- Recheck weekly budget: $5 → $15, item limit 100 → 500
- Full coverage cycle every ~3 weeks instead of ~6

Part of QUA-91 / QUA-110.

## Test plan
- [ ] CI green
- [ ] Next Monday source-check run uses $30 budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)