### PR TITLE
fix: add packages/ to worker Docker image

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -28,6 +28,9 @@ RUN echo 'export const X = 1;' > /tmp/test.ts && \
 # Copy crux source (worker + all transitive imports)
 COPY crux/ ./crux/
 
+# Copy shared packages (factbase, id-utils) — crux has runtime imports from these
+COPY packages/ ./packages/
+
 # NOTE: No apps/wiki-server/ files needed — all imports are type-only (erased by tsx)
 # NOTE: No content/, data/, apps/web/ needed — worker is stateless
 # NOTE: Only stateless handlers (claim-verification, ping) work in this image.


### PR DESCRIPTION
## Summary
- Resource-ingest jobs failing in prod with `Cannot find module '/repo/packages/factbase/src/ids.ts'`
- The worker Dockerfile only copies `crux/` but crux has runtime imports from `packages/factbase` and `packages/id-utils`
- Adding `COPY packages/ ./packages/` to `Dockerfile.worker`

## Test plan
- [x] Built Docker image locally, ran resource-ingest handler inside container — passes
- [x] Without fix: `FAIL - import error: Cannot find module '/repo/packages/factbase/src/ids.ts'`
- [x] With fix: `OK: completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker service build configuration to ensure all necessary shared dependencies are properly included and available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->