### PR TITLE
feat: add Records and Coverage columns to verdict heatmap

### DIFF
--- a/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
+++ b/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
@@ -401,11 +401,12 @@ export async function SourceCheckCoverageContent() {
               <tbody>
                 {coverageMatrix.tables.map((t) => {
                   const checked =
-                    t.verdicts.confirmed +
+                    t.checkedRecords ??
+                    (t.verdicts.confirmed +
                     t.verdicts.partial +
                     t.verdicts.unverifiable +
                     t.verdicts.contradicted +
-                    t.verdicts.outdated;
+                    t.verdicts.outdated);
                   return (
                     <tr
                       key={t.recordType}
@@ -470,7 +471,7 @@ export async function SourceCheckCoverageContent() {
       )}
 
       {/* ── (e) Verdict Heatmap ──────────────────────────────────────── */}
-      {Object.keys(verdictMatrix.matrix).length > 0 && (() => {
+      {(Object.keys(verdictMatrix.matrix).length > 0 || coverageMatrix.tables.length > 0) && (() => {
         const allVerdictTypes = [
           "confirmed",
           "partial",

--- a/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
+++ b/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
@@ -20,6 +20,7 @@ interface CoverageMatrixResult {
   tables: Array<{
     recordType: string;
     totalRecords: number;
+    checkedRecords?: number;
     verdicts: {
       confirmed: number;
       partial: number;
@@ -157,8 +158,12 @@ export async function SourceCheckCoverageContent() {
     ...verdictMatrixResult.data,
   };
 
-  const source = sourceCheckResult.source === "api" ? "api" as const : "local" as const;
-  const apiError = sourceCheckResult.apiError;
+  // Surface failures from any of the three endpoints in the banner
+  const allResults = [sourceCheckResult, coverageMatrixResult, verdictMatrixResult];
+  const source = allResults.every((r) => r.source === "api")
+    ? ("api" as const)
+    : ("local" as const);
+  const apiError = allResults.find((r) => r.apiError)?.apiError;
 
   // Local entity data for entity type counts
   const entities = getTypedEntities();
@@ -474,7 +479,12 @@ export async function SourceCheckCoverageContent() {
           "outdated",
           "unchecked",
         ];
-        const recordTypes = Object.keys(verdictMatrix.matrix).sort();
+        // Include all record types from coverage matrix (not just those with verdicts)
+        // so that zero-verdict types still appear in the heatmap
+        const recordTypes = Array.from(new Set([
+          ...coverageMatrix.tables.map((t) => t.recordType),
+          ...Object.keys(verdictMatrix.matrix),
+        ])).sort();
 
         // Build lookup from coverage matrix for total record counts per type
         const totalRecordsByType = new Map<string, number>();

--- a/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
+++ b/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
@@ -476,6 +476,12 @@ export async function SourceCheckCoverageContent() {
         ];
         const recordTypes = Object.keys(verdictMatrix.matrix).sort();
 
+        // Build lookup from coverage matrix for total record counts per type
+        const totalRecordsByType = new Map<string, number>();
+        for (const t of coverageMatrix.tables) {
+          totalRecordsByType.set(t.recordType, t.totalRecords);
+        }
+
         // Find max count for color intensity scaling
         let maxCount = 0;
         for (const rt of recordTypes) {
@@ -516,6 +522,7 @@ export async function SourceCheckCoverageContent() {
                 <thead>
                   <tr className="border-b border-border/60">
                     <th className="text-left py-2 px-3 font-medium">Record Type</th>
+                    <th className="text-right py-2 px-3 font-medium">Records</th>
                     {allVerdictTypes.map((v) => (
                       <th
                         key={v}
@@ -524,7 +531,8 @@ export async function SourceCheckCoverageContent() {
                         {v}
                       </th>
                     ))}
-                    <th className="text-right py-2 px-3 font-medium">Total</th>
+                    <th className="text-right py-2 px-3 font-medium">Verdicts</th>
+                    <th className="text-right py-2 px-3 font-medium">Coverage</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -534,12 +542,21 @@ export async function SourceCheckCoverageContent() {
                       (s, v) => s + (row[v] ?? 0),
                       0
                     );
+                    const totalRecords = totalRecordsByType.get(rt);
+                    const coveragePct = totalRecords != null && totalRecords > 0
+                      ? Math.round((rowTotal / totalRecords) * 100)
+                      : null;
                     return (
                       <tr
                         key={rt}
                         className="border-b border-border/30 hover:bg-muted/30"
                       >
                         <td className="py-2 px-3 font-medium">{rt}</td>
+                        <td className="text-right py-2 px-3 tabular-nums text-muted-foreground">
+                          {totalRecords != null ? totalRecords.toLocaleString() : (
+                            <span className="text-muted-foreground/50">—</span>
+                          )}
+                        </td>
                         {allVerdictTypes.map((v) => {
                           const val = row[v] ?? 0;
                           return (
@@ -557,27 +574,54 @@ export async function SourceCheckCoverageContent() {
                         <td className="text-right py-2 px-3 tabular-nums font-medium">
                           {rowTotal.toLocaleString()}
                         </td>
+                        <td className={`text-right py-2 px-3 tabular-nums font-medium ${
+                          coveragePct == null ? "text-muted-foreground/50"
+                            : coveragePct >= 80 ? "text-emerald-600"
+                            : coveragePct >= 40 ? "text-amber-600"
+                            : "text-red-600"
+                        }`}>
+                          {coveragePct != null ? `${coveragePct}%` : "—"}
+                        </td>
                       </tr>
                     );
                   })}
                 </tbody>
                 <tfoot>
-                  <tr className="border-t-2 border-border/60 font-semibold">
-                    <td className="py-2 px-3">Totals</td>
-                    {allVerdictTypes.map((v) => (
-                      <td
-                        key={v}
-                        className={`text-right py-2 px-3 tabular-nums ${VERDICT_COLORS[v] ?? ""}`}
-                      >
-                        {(verdictMatrix.totals[v] ?? 0).toLocaleString()}
-                      </td>
-                    ))}
-                    <td className="text-right py-2 px-3 tabular-nums">
-                      {Object.values(verdictMatrix.totals)
-                        .reduce((s, c) => s + c, 0)
-                        .toLocaleString()}
-                    </td>
-                  </tr>
+                  {(() => {
+                    const totalAllRecords = coverageMatrix.totals.totalRecords;
+                    const totalAllVerdicts = Object.values(verdictMatrix.totals)
+                      .reduce((s, c) => s + c, 0);
+                    const totalCoverage = totalAllRecords > 0
+                      ? Math.round((totalAllVerdicts / totalAllRecords) * 100)
+                      : null;
+                    return (
+                      <tr className="border-t-2 border-border/60 font-semibold">
+                        <td className="py-2 px-3">Totals</td>
+                        <td className="text-right py-2 px-3 tabular-nums">
+                          {totalAllRecords > 0 ? totalAllRecords.toLocaleString() : "—"}
+                        </td>
+                        {allVerdictTypes.map((v) => (
+                          <td
+                            key={v}
+                            className={`text-right py-2 px-3 tabular-nums ${VERDICT_COLORS[v] ?? ""}`}
+                          >
+                            {(verdictMatrix.totals[v] ?? 0).toLocaleString()}
+                          </td>
+                        ))}
+                        <td className="text-right py-2 px-3 tabular-nums">
+                          {totalAllVerdicts.toLocaleString()}
+                        </td>
+                        <td className={`text-right py-2 px-3 tabular-nums ${
+                          totalCoverage == null ? ""
+                            : totalCoverage >= 80 ? "text-emerald-600"
+                            : totalCoverage >= 40 ? "text-amber-600"
+                            : "text-red-600"
+                        }`}>
+                          {totalCoverage != null ? `${totalCoverage}%` : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })()}
                 </tfoot>
               </table>
             </div>

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -1831,21 +1831,71 @@ const sourceChecksApp = new Hono()
     }
 
     // 2. Verdict counts grouped by record_type and verdict
+    // 3. Distinct checked records per type
+    //
+    // Both queries filter out orphaned verdicts (verdict rows referencing records
+    // that have been deleted from their source table) by JOINing against a CTE
+    // of all live (record_type, record_id) pairs.
+    //
+    // Note: for 'fact' type, record_id stores fact_id (not the serial PK),
+    // and for 'citation' type, record_id stores citation_quotes.id::text.
+    const liveRecordsCte = sql`
+      live_records AS (
+        SELECT 'personnel' AS record_type, id::text AS record_id FROM personnel
+        UNION ALL
+        SELECT 'division', id::text FROM divisions
+        UNION ALL
+        SELECT 'grant', id::text FROM grants
+        UNION ALL
+        SELECT 'funding-round', id::text FROM funding_rounds
+        UNION ALL
+        SELECT 'investment', id::text FROM investments
+        UNION ALL
+        SELECT 'funding-program', id::text FROM funding_programs
+        UNION ALL
+        SELECT 'publication', id::text FROM publications
+        UNION ALL
+        SELECT 'secondary-market-price', id::text FROM secondary_market_prices
+        UNION ALL
+        SELECT 'equity-position', id::text FROM equity_positions
+        UNION ALL
+        SELECT 'entity-event', id::text FROM entity_events
+        UNION ALL
+        SELECT 'entity-assessment', id::text FROM entity_assessments
+        UNION ALL
+        SELECT 'benchmark-result', id::text FROM benchmark_results
+        UNION ALL
+        SELECT 'policy-stakeholder', id::text FROM policy_stakeholders
+        UNION ALL
+        SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
+        UNION ALL
+        SELECT 'wiki-page', id::text FROM wiki_pages
+        UNION ALL
+        SELECT 'fact', fact_id FROM facts
+      )
+    `;
+
     const verdictRows = (await db.execute(sql`
-      SELECT record_type, verdict, count(*)::int AS cnt
-      FROM source_check_verdicts
-      GROUP BY record_type, verdict
-      ORDER BY record_type, verdict
+      WITH ${liveRecordsCte}
+      SELECT v.record_type, v.verdict, count(*)::int AS cnt
+      FROM source_check_verdicts v
+      INNER JOIN live_records lr
+        ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      GROUP BY v.record_type, v.verdict
+      ORDER BY v.record_type, v.verdict
     `)) as Array<{ record_type: string; verdict: string; cnt: number }>;
 
-    // 3. Distinct checked records per type
-    // A record can have multiple verdict rows (one per fieldName), so coverage
-    // must be computed from COUNT(DISTINCT record_id) to avoid exceeding 100%.
+    // Coverage is based on distinct checked records, not verdict row counts.
+    // A record can have multiple verdict rows (one per fieldName), so we use
+    // COUNT(DISTINCT record_id) to avoid exceeding 100%.
     const checkedRows = (await db.execute(sql`
-      SELECT record_type, count(DISTINCT record_id)::int AS checked_records
-      FROM source_check_verdicts
-      WHERE verdict != 'unchecked'
-      GROUP BY record_type
+      WITH ${liveRecordsCte}
+      SELECT v.record_type, count(DISTINCT v.record_id)::int AS checked_records
+      FROM source_check_verdicts v
+      INNER JOIN live_records lr
+        ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      WHERE v.verdict != 'unchecked'
+      GROUP BY v.record_type
     `)) as Array<{ record_type: string; checked_records: number }>;
 
     const checkedByType: Record<string, number> = {};
@@ -1945,11 +1995,32 @@ const sourceChecksApp = new Hono()
   .get("/verdict-matrix", async (c) => {
     const db = getDrizzleDb();
 
+    // Exclude orphaned verdicts for deleted records (same CTE pattern as /coverage-matrix)
     const rows = (await db.execute(sql`
-      SELECT record_type, verdict, count(*)::int AS cnt
-      FROM source_check_verdicts
-      GROUP BY record_type, verdict
-      ORDER BY record_type, verdict
+      WITH live_records AS (
+        SELECT 'personnel' AS record_type, id::text AS record_id FROM personnel
+        UNION ALL SELECT 'division', id::text FROM divisions
+        UNION ALL SELECT 'grant', id::text FROM grants
+        UNION ALL SELECT 'funding-round', id::text FROM funding_rounds
+        UNION ALL SELECT 'investment', id::text FROM investments
+        UNION ALL SELECT 'funding-program', id::text FROM funding_programs
+        UNION ALL SELECT 'publication', id::text FROM publications
+        UNION ALL SELECT 'secondary-market-price', id::text FROM secondary_market_prices
+        UNION ALL SELECT 'equity-position', id::text FROM equity_positions
+        UNION ALL SELECT 'entity-event', id::text FROM entity_events
+        UNION ALL SELECT 'entity-assessment', id::text FROM entity_assessments
+        UNION ALL SELECT 'benchmark-result', id::text FROM benchmark_results
+        UNION ALL SELECT 'policy-stakeholder', id::text FROM policy_stakeholders
+        UNION ALL SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
+        UNION ALL SELECT 'wiki-page', id::text FROM wiki_pages
+        UNION ALL SELECT 'fact', fact_id FROM facts
+      )
+      SELECT v.record_type, v.verdict, count(*)::int AS cnt
+      FROM source_check_verdicts v
+      INNER JOIN live_records lr
+        ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      GROUP BY v.record_type, v.verdict
+      ORDER BY v.record_type, v.verdict
     `)) as Array<{ record_type: string; verdict: string; cnt: number }>;
 
     // Build the matrix: { recordType: { verdict: count } }

--- a/apps/wiki-server/src/routes/source-check/source-checks.ts
+++ b/apps/wiki-server/src/routes/source-check/source-checks.ts
@@ -1815,6 +1815,8 @@ const sourceChecksApp = new Hono()
       UNION ALL
       SELECT 'policy-stakeholder', count(*)::int FROM policy_stakeholders
       UNION ALL
+      SELECT 'citation', count(*)::int FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
+      UNION ALL
       SELECT 'wiki-page', count(*)::int FROM wiki_pages
       UNION ALL
       SELECT 'fact', count(DISTINCT fact_id)::int FROM facts
@@ -1836,6 +1838,21 @@ const sourceChecksApp = new Hono()
       ORDER BY record_type, verdict
     `)) as Array<{ record_type: string; verdict: string; cnt: number }>;
 
+    // 3. Distinct checked records per type
+    // A record can have multiple verdict rows (one per fieldName), so coverage
+    // must be computed from COUNT(DISTINCT record_id) to avoid exceeding 100%.
+    const checkedRows = (await db.execute(sql`
+      SELECT record_type, count(DISTINCT record_id)::int AS checked_records
+      FROM source_check_verdicts
+      WHERE verdict != 'unchecked'
+      GROUP BY record_type
+    `)) as Array<{ record_type: string; checked_records: number }>;
+
+    const checkedByType: Record<string, number> = {};
+    for (const row of checkedRows) {
+      checkedByType[row.record_type] = row.checked_records;
+    }
+
     // Build per-type verdict maps
     const verdictsByType: Record<string, Record<string, number>> = {};
     for (const row of verdictRows) {
@@ -1845,13 +1862,14 @@ const sourceChecksApp = new Hono()
       verdictsByType[row.record_type][row.verdict] = row.cnt;
     }
 
-    // 3. Merge into tables array
+    // 4. Merge into tables array
     const allTypes = new Set([
       ...Object.keys(totalsByType),
       ...Object.keys(verdictsByType),
     ]);
 
     let grandTotalRecords = 0;
+    let grandCheckedRecords = 0;
     let grandTotalVerdicts = 0;
     let grandConfirmed = 0;
 
@@ -1859,6 +1877,7 @@ const sourceChecksApp = new Hono()
       .map((recordType) => {
         const totalRecords = totalsByType[recordType] ?? 0;
         const verdicts = verdictsByType[recordType] ?? {};
+        const checkedRecords = checkedByType[recordType] ?? 0;
 
         const confirmed = verdicts["confirmed"] ?? 0;
         const partial = verdicts["partial"] ?? 0;
@@ -1869,11 +1888,11 @@ const sourceChecksApp = new Hono()
 
         const totalVerdicts =
           confirmed + partial + unverifiable + contradicted + outdated + unchecked;
-        const checkedVerdicts = totalVerdicts - unchecked;
 
+        // Coverage is based on distinct checked records, not verdict row counts
         const coveragePercent =
           totalRecords > 0
-            ? Math.round((checkedVerdicts / totalRecords) * 1000) / 10
+            ? Math.round((checkedRecords / totalRecords) * 1000) / 10
             : 0;
         const greenPercent =
           totalVerdicts > 0
@@ -1881,12 +1900,14 @@ const sourceChecksApp = new Hono()
             : 0;
 
         grandTotalRecords += totalRecords;
+        grandCheckedRecords += checkedRecords;
         grandTotalVerdicts += totalVerdicts;
         grandConfirmed += confirmed;
 
         return {
           recordType,
           totalRecords,
+          checkedRecords,
           verdicts: {
             confirmed,
             partial,
@@ -1901,9 +1922,6 @@ const sourceChecksApp = new Hono()
       })
       .sort((a, b) => b.totalRecords - a.totalRecords);
 
-    const grandChecked = grandTotalVerdicts -
-      tables.reduce((s, t) => s + t.verdicts.unchecked, 0);
-
     return c.json({
       tables,
       totals: {
@@ -1915,7 +1933,7 @@ const sourceChecksApp = new Hono()
             : 0,
         coveragePercent:
           grandTotalRecords > 0
-            ? Math.round((grandChecked / grandTotalRecords) * 1000) / 10
+            ? Math.round((grandCheckedRecords / grandTotalRecords) * 1000) / 10
             : 0,
       },
     });


### PR DESCRIPTION
## Summary

- Add **Records** column to the verdict heatmap showing total records in the database for each record type (from coverage-matrix API)
- Add **Coverage %** column with color-coded thresholds (green ≥80%, amber ≥40%, red <40%)
- Rename "Total" column to "Verdicts" for clarity

Previously the heatmap only showed verdict counts, making it look like there were e.g. only 10 investments or 24 funding programs — when those are just the source-checked count, not the total.

## Test plan

- [ ] TypeScript compiles (`npx tsc --noEmit` passed locally)
- [ ] Dashboard renders with new columns showing Records, Verdicts, and Coverage %
- [ ] Record types without coverage-matrix data show "—" gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verdict Heatmap table now displays separate "Verdicts," "Coverage," and "Records" columns for improved clarity.
  * Coverage percentages are now computed and displayed for each record type.
  * Coverage values are color-coded by threshold (green ≥80%, amber ≥40%, red <40%) for quick visual assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->