### PR TITLE
feat: add verification dots to organizations and people directories

### DIFF
--- a/apps/web/src/app/organizations/org-sort.test.ts
+++ b/apps/web/src/app/organizations/org-sort.test.ts
@@ -25,6 +25,7 @@ function makeRow(overrides: Partial<OrgRow> = {}): OrgRow {
     foundedDate: null,
     peopleCount: null,
     completionScore: 1,
+    verdictString: null,
     searchText: "",
     ...overrides,
   };

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -12,7 +12,7 @@ import { toggleSort } from "@/lib/sort-utils";
 import { compareOrgRows } from "@/app/organizations/org-sort";
 import type { OrgSortKey } from "@/app/organizations/org-sort";
 import { ORG_TYPE_LABELS, ORG_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR } from "@/app/organizations/org-constants";
-import { CoverageDots } from "@/components/coverage/CoverageDots";
+import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
 import { useServerTable } from "@/hooks/use-server-table";
 import { formatCompactCurrency, formatCompactNumber as formatCompactNum } from "@/lib/format-compact";
@@ -45,6 +45,8 @@ export interface OrgRow {
   peopleCount: number | null;
   /** Completeness score 1-4 based on available data */
   completionScore: number;
+  /** Source-check verdict string (confirmed, contradicted, etc.) or null */
+  verdictString: string | null;
 
   /** Pre-computed lowercase text blob for full-text search across all fields */
   searchText: string;
@@ -92,6 +94,7 @@ const ServerOrgSchema = z.object({
   headcountDate: z.string().nullable(),
   totalFundingNum: z.number().nullable(),
   foundedDate: z.string().nullable(),
+  verdictString: z.string().nullable().optional(),
 });
 
 type ServerOrg = z.infer<typeof ServerOrgSchema>;
@@ -143,6 +146,7 @@ function transformOrgsResponse(json: unknown): { rows: OrgRow[]; total: number }
       foundedDate: org.foundedDate,
       peopleCount: null, // Not available from API
       completionScore: computeOrgCoverage(org),
+      verdictString: org.verdictString ?? null,
       searchText: "",
     })),
     total: data.total ?? 0,
@@ -585,7 +589,7 @@ export function OrganizationsTable({
                     {/* Completion Score */}
                     {visibleColumns.has("completionScore") && (
                       <td className="py-2.5 px-3 text-center">
-                        <CoverageDots score={row.completionScore} label={`Coverage: ${row.completionScore}/4`} />
+                        <RecordStatusDots coverageScore={row.completionScore} verdict={row.verdictString} />
                       </td>
                     )}
 

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getKBLatest, getKBFacts, getKBRecords, getKBEntities, resolveSlugAlias } from "@/data/factbase";
-import { getTypedEntityById } from "@/data/tablebase";
+import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { getTypedEntities, isOrganization, getPageById, type OrganizationEntity } from "@/data";
 import { resolveOrgBySlug } from "@/app/organizations/org-utils";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
@@ -204,6 +204,7 @@ async function loadFromApi(
 
       peopleCount: null, // Not available from API
       completionScore: computeOrgCoverage(org),
+      verdictString: getRecordVerdict("entity", org.id)?.verdict ?? null,
 
       searchText: searchParts.join(" ").toLowerCase(),
     };
@@ -254,6 +255,7 @@ async function loadFromApi(
 
       peopleCount: null,
       completionScore: computeOrgCoverage({ foundedDate }),
+      verdictString: getRecordVerdict("entity", org.id)?.verdict ?? null,
 
       searchText: searchParts.join(" ").toLowerCase(),
     });
@@ -341,6 +343,7 @@ function loadFromLocal(): OrgPageData {
         peopleCount,
         wikiPageId: org.wikiId && getPageById(org.id) ? org.wikiId : null,
       }),
+      verdictString: getRecordVerdict("entity", org.id)?.verdict ?? null,
 
       searchText: buildOrgSearchText(org, orgToEmployeeNames),
     };

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getKBLatest, getKBFacts, getKBRecords, getKBEntities, resolveSlugAlias } from "@/data/factbase";
-import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
-import { getTypedEntities, isOrganization, getPageById, type OrganizationEntity } from "@/data";
+import { getTypedEntities, isOrganization, getPageById, getTypedEntityById, getRecordVerdict, type OrganizationEntity } from "@/data";
 import { resolveOrgBySlug } from "@/app/organizations/org-utils";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
 import type { Fact, Property } from "@longterm-wiki/factbase";

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -1,11 +1,10 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getKBEntities, getKBLatest, getKBRecords, getKBFacts, getKBEntitySlug } from "@/data/factbase";
-import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import type { Fact } from "@longterm-wiki/factbase";
 import { ProfileStatCard } from "@/components/directory";
 import { PeopleTable, type PersonRow } from "./people-table";
-import { getTypedEntities, getPersonEntityById, isPerson } from "@/data";
+import { getTypedEntities, getPersonEntityById, isPerson, getTypedEntityById, getRecordVerdict } from "@/data";
 import { fetchDetailed } from "@lib/wiki-server";
 import { partitionPersonRows } from "./people-filter";
 import { isAnySid } from "@/lib/stable-id";

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getKBEntities, getKBLatest, getKBRecords, getKBFacts, getKBEntitySlug } from "@/data/factbase";
-import { getTypedEntityById } from "@/data/tablebase";
+import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import type { Fact } from "@longterm-wiki/factbase";
 import { ProfileStatCard } from "@/components/directory";
 import { PeopleTable, type PersonRow } from "./people-table";
@@ -129,6 +129,7 @@ function apiEntityToPersonRow(e: DirectoryEntity): PersonRow {
     topics,
     publicationCount,
     careerHistoryCount,
+    verdictString: getRecordVerdict("entity", entityId)?.verdict ?? null,
 
     searchText: searchParts.join(" ").toLowerCase(),
   };
@@ -245,6 +246,7 @@ function loadFromLocal(): PersonRow[] {
       topics,
       publicationCount: 0,
       careerHistoryCount: getLocalCareerCount(entity.id),
+      verdictString: getRecordVerdict("entity", entity.id)?.verdict ?? null,
       searchText: searchParts.join(" ").toLowerCase(),
     };
   });
@@ -285,6 +287,7 @@ function loadFromLocal(): PersonRow[] {
       topics: [],
       publicationCount: 0,
       careerHistoryCount: 0,
+      verdictString: getRecordVerdict("entity", tp.id)?.verdict ?? null,
       searchText: [tp.title, tp.description ?? ""].join(" ").toLowerCase(),
     });
   }

--- a/apps/web/src/app/people/people-filter.test.ts
+++ b/apps/web/src/app/people/people-filter.test.ts
@@ -20,6 +20,7 @@ function makeRow(overrides: Partial<PersonRow> = {}): PersonRow {
     topics: [],
     publicationCount: 0,
     careerHistoryCount: 0,
+    verdictString: null,
     searchText: "",
     ...overrides,
   };

--- a/apps/web/src/app/people/people-sort.test.ts
+++ b/apps/web/src/app/people/people-sort.test.ts
@@ -24,6 +24,7 @@ function makeRow(overrides: Partial<PersonRow> = {}): PersonRow {
     topics: [],
     publicationCount: 0,
     careerHistoryCount: 0,
+    verdictString: null,
     searchText: "",
     ...overrides,
   };

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -15,7 +15,7 @@ import { useServerTable } from "@/hooks/use-server-table";
 import { comparePersonRows } from "./people-sort";
 import type { PeopleSortKey } from "./people-sort";
 import { isPersonMeaningful } from "./people-filter";
-import { CoverageDots } from "@/components/coverage/CoverageDots";
+import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computePersonCoverage } from "@/components/coverage/coverage-score";
 
 export interface PersonRow {
@@ -41,6 +41,9 @@ export interface PersonRow {
   publicationCount: number;
   careerHistoryCount: number;
 
+  /** Source-check verdict string or null */
+  verdictString: string | null;
+
   /** Pre-computed lowercase text blob for full-text search across all fields */
   searchText: string;
 }
@@ -58,6 +61,7 @@ const ServerPersonSchema = z.object({
   employerName: z.string().nullable(),
   bornYear: z.number().nullable(),
   netWorth: z.number().nullable(),
+  verdictString: z.string().nullable().optional(),
 });
 
 type ServerPerson = z.infer<typeof ServerPersonSchema>;
@@ -84,6 +88,7 @@ function serverPersonToRow(p: ServerPerson): PersonRow {
     topics: [],
     publicationCount: 0,
     careerHistoryCount: 0,
+    verdictString: p.verdictString ?? null,
     searchText: "", // Not needed in server mode
   };
 }
@@ -663,7 +668,7 @@ export function PeopleTable({
                     )}
                     {/* Coverage */}
                     <td className="py-2.5 px-3 text-center">
-                      <CoverageDots score={computePersonCoverage(row)} />
+                      <RecordStatusDots coverageScore={computePersonCoverage(row)} verdict={row.verdictString} />
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- Swap `CoverageDots` → `RecordStatusDots` on the two remaining server-paginated directory pages (organizations, people)
- Both now show source-check verdict indicators alongside the existing coverage pie chart
- All simple directory pages (ai-models, benchmarks, legislation, publications, projects, approaches, events, grants, etc.) already had this — these were the last two holdouts
- Adds `verdictString` field to `OrgRow` and `PersonRow` interfaces + test fixtures

Relates to QUA-116, QUA-136

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (5200 tests)
- [x] TypeScript check passes (app)
- [x] Test fixtures updated for new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coverage indicators in Organizations and People tables now show record verdicts alongside completion scores.
  * Table row data now includes an optional verdict field so verdicts are available where present.
  * API handling updated to accept an optional verdict value from responses.

* **Tests**
  * Test helpers updated to initialize the verdict field for consistency with table row structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->