### PR TITLE
feat: add numeric property matching to Wikidata matcher (headcount, revenue)

### DIFF
--- a/crux/lib/source-check/wikidata-matcher.test.ts
+++ b/crux/lib/source-check/wikidata-matcher.test.ts
@@ -127,6 +127,23 @@ function makeEntityRefClaim(pid: string, refQid: string, rank: string = 'normal'
   };
 }
 
+function makeQuantityClaim(pid: string, amount: number, unit?: string, rank: string = 'normal') {
+  return {
+    mainsnak: {
+      snaktype: 'value',
+      property: pid,
+      datavalue: {
+        type: 'quantity',
+        value: {
+          amount: amount >= 0 ? `+${amount}` : `${amount}`,
+          unit: unit ?? '1',
+        },
+      },
+    },
+    rank,
+  };
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe('extractQid', () => {
@@ -636,6 +653,95 @@ describe('tryWikidataMatch', () => {
       });
       const result = await tryWikidataMatch(item);
       // No English label -> can't compare -> return null -> LLM fallback
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── Quantity matching (P1128 headcount, P2139 revenue) ──
+
+  describe('headcount (P1128 quantity)', () => {
+    it('confirms matching headcount within tolerance', async () => {
+      setMockEntity('Q1000', makeWikidataEntity('Q1000', {
+        claims: { P1128: [makeQuantityClaim('P1128', 3200)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'headcount',
+        formattedValue: '3100',
+        source: 'https://www.wikidata.org/wiki/Q1000',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('confirmed');
+      expect(result!.confidence).toBe(0.95);
+    });
+
+    it('contradicts headcount outside tolerance', async () => {
+      setMockEntity('Q1001', makeWikidataEntity('Q1001', {
+        claims: { P1128: [makeQuantityClaim('P1128', 5000)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'headcount',
+        formattedValue: '2000',
+        source: 'https://www.wikidata.org/wiki/Q1001',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('contradicted');
+    });
+
+    it('returns unverifiable when P1128 missing', async () => {
+      setMockEntity('Q1002', makeWikidataEntity('Q1002', { claims: {} }));
+      const item = makeFactItem({
+        propertyName: 'headcount',
+        formattedValue: '1000',
+        source: 'https://www.wikidata.org/wiki/Q1002',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('unverifiable');
+    });
+  });
+
+  describe('revenue (P2139 quantity)', () => {
+    it('confirms matching revenue within 10% tolerance', async () => {
+      setMockEntity('Q1100', makeWikidataEntity('Q1100', {
+        claims: { P2139: [makeQuantityClaim('P2139', 6000000000)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: '$5,800,000,000',
+        source: 'https://www.wikidata.org/wiki/Q1100',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('confirmed');
+    });
+
+    it('contradicts revenue far outside tolerance', async () => {
+      setMockEntity('Q1101', makeWikidataEntity('Q1101', {
+        claims: { P2139: [makeQuantityClaim('P2139', 10000000000)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: '$1000000000',
+        source: 'https://www.wikidata.org/wiki/Q1101',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('contradicted');
+    });
+
+    it('returns null for unparseable fact value', async () => {
+      setMockEntity('Q1102', makeWikidataEntity('Q1102', {
+        claims: { P2139: [makeQuantityClaim('P2139', 5000000)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: 'approximately five billion',
+        source: 'https://www.wikidata.org/wiki/Q1102',
+      });
+      const result = await tryWikidataMatch(item);
+      // Can't parse "approximately five billion" as a number -> fall through to LLM
       expect(result).toBeNull();
     });
   });

--- a/crux/lib/source-check/wikidata-matcher.test.ts
+++ b/crux/lib/source-check/wikidata-matcher.test.ts
@@ -703,9 +703,12 @@ describe('tryWikidataMatch', () => {
   });
 
   describe('revenue (P2139 quantity)', () => {
-    it('confirms matching revenue within 10% tolerance', async () => {
+    const USD_UNIT = 'http://www.wikidata.org/entity/Q4917';
+    const EUR_UNIT = 'http://www.wikidata.org/entity/Q4916';
+
+    it('confirms matching USD revenue within 10% tolerance', async () => {
       setMockEntity('Q1100', makeWikidataEntity('Q1100', {
-        claims: { P2139: [makeQuantityClaim('P2139', 6000000000)] },
+        claims: { P2139: [makeQuantityClaim('P2139', 6000000000, USD_UNIT)] },
       }));
       const item = makeFactItem({
         propertyName: 'revenue',
@@ -717,9 +720,9 @@ describe('tryWikidataMatch', () => {
       expect(result!.verdict).toBe('confirmed');
     });
 
-    it('contradicts revenue far outside tolerance', async () => {
+    it('contradicts USD revenue far outside tolerance', async () => {
       setMockEntity('Q1101', makeWikidataEntity('Q1101', {
-        claims: { P2139: [makeQuantityClaim('P2139', 10000000000)] },
+        claims: { P2139: [makeQuantityClaim('P2139', 10000000000, USD_UNIT)] },
       }));
       const item = makeFactItem({
         propertyName: 'revenue',
@@ -733,7 +736,7 @@ describe('tryWikidataMatch', () => {
 
     it('returns null for unparseable fact value', async () => {
       setMockEntity('Q1102', makeWikidataEntity('Q1102', {
-        claims: { P2139: [makeQuantityClaim('P2139', 5000000)] },
+        claims: { P2139: [makeQuantityClaim('P2139', 5000000, USD_UNIT)] },
       }));
       const item = makeFactItem({
         propertyName: 'revenue',
@@ -743,6 +746,50 @@ describe('tryWikidataMatch', () => {
       const result = await tryWikidataMatch(item);
       // Can't parse "approximately five billion" as a number -> fall through to LLM
       expect(result).toBeNull();
+    });
+
+    it('rejects mixed-text numeric values like "$5.8 billion" (strict parse)', async () => {
+      setMockEntity('Q1103', makeWikidataEntity('Q1103', {
+        claims: { P2139: [makeQuantityClaim('P2139', 5800000000, USD_UNIT)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: '$5.8 billion',
+        source: 'https://www.wikidata.org/wiki/Q1103',
+      });
+      const result = await tryWikidataMatch(item);
+      // "$5.8 billion" after stripping -> "5.8billion", strict numeric regex rejects.
+      // Must fall through to LLM instead of partial-parsing as 5.8.
+      expect(result).toBeNull();
+    });
+
+    it('falls through to LLM when fact currency mismatches Wikidata unit', async () => {
+      // Wikidata claim is in EUR; fact is in USD. Same magnitude but different currency
+      // must NOT be confirmed — a cross-currency confirmation would be a false positive.
+      setMockEntity('Q1104', makeWikidataEntity('Q1104', {
+        claims: { P2139: [makeQuantityClaim('P2139', 6000000000, EUR_UNIT)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: '$6,000,000,000',
+        source: 'https://www.wikidata.org/wiki/Q1104',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).toBeNull();
+    });
+
+    it('confirms matching EUR revenue when both sides are EUR', async () => {
+      setMockEntity('Q1105', makeWikidataEntity('Q1105', {
+        claims: { P2139: [makeQuantityClaim('P2139', 6000000000, EUR_UNIT)] },
+      }));
+      const item = makeFactItem({
+        propertyName: 'revenue',
+        formattedValue: '€5,800,000,000',
+        source: 'https://www.wikidata.org/wiki/Q1105',
+      });
+      const result = await tryWikidataMatch(item);
+      expect(result).not.toBeNull();
+      expect(result!.verdict).toBe('confirmed');
     });
   });
 

--- a/crux/lib/source-check/wikidata-matcher.ts
+++ b/crux/lib/source-check/wikidata-matcher.ts
@@ -226,14 +226,41 @@ function getYearFromTime(claim: WikidataClaim): string | null {
 
 /**
  * Extract a numeric quantity from a claim's datavalue.
- * Wikidata quantities look like { amount: "+1234", unit: "http://..." }
+ * Wikidata quantities look like { amount: "+1234", unit: "http://www.wikidata.org/entity/Q4917" }
+ * for typed quantities (e.g. USD), or { amount: "+1234", unit: "1" } for dimensionless counts.
+ * Returns the amount alongside the unit QID (or null for dimensionless) so callers can
+ * enforce unit compatibility before comparing.
  */
-function getQuantityValue(claim: WikidataClaim): number | null {
+function getQuantityValue(
+  claim: WikidataClaim,
+): { amount: number; unit: string | null } | null {
   const dv = claim.mainsnak.datavalue;
   if (!dv || dv.type !== 'quantity') return null;
   const val = dv.value as { amount: string; unit?: string };
-  const num = parseFloat(val.amount);
-  return isNaN(num) ? null : num;
+  const amount = Number(val.amount);
+  if (!Number.isFinite(amount)) return null;
+  if (!val.unit || val.unit === '1') return { amount, unit: null };
+  const unitMatch = val.unit.match(/\/(Q\d+)$/);
+  return { amount, unit: unitMatch ? unitMatch[1] : val.unit };
+}
+
+/**
+ * Map currency symbols in a FactBase value to Wikidata currency QIDs.
+ * Only unambiguous symbols are included — "$" is treated as USD (the most common
+ * and the default used across the FactBase), "¥" is deliberately omitted because
+ * it's ambiguous between JPY and CNY.
+ */
+const CURRENCY_SYMBOL_TO_QID: Record<string, string> = {
+  $: 'Q4917', // United States dollar
+  '€': 'Q4916', // Euro
+  '£': 'Q25224', // Pound sterling
+};
+
+function detectCurrencyQid(factValue: string): string | null {
+  for (const [symbol, qid] of Object.entries(CURRENCY_SYMBOL_TO_QID)) {
+    if (factValue.includes(symbol)) return qid;
+  }
+  return null;
 }
 
 /**
@@ -561,25 +588,46 @@ function matchQuantity(
       `[wikidata-api] Property ${pid} missing from ${qid}`);
   }
 
-  // Parse the fact value as a number (strip currency symbols, commas, whitespace)
+  // Detect the fact's currency (if any) BEFORE stripping symbols, so we can
+  // enforce unit compatibility against Wikidata claims below.
+  const factCurrency = detectCurrencyQid(factValue);
+
+  // Parse the fact value as a number (strip currency symbols, commas, whitespace).
+  // Enforce a strict numeric match so values like "$5.8 billion" or "3100 employees"
+  // fall through to LLM verification instead of being silently partial-parsed.
   const cleanedFact = factValue.replace(/[$€£¥,\s]/g, '');
-  const factNum = parseFloat(cleanedFact);
-  if (isNaN(factNum)) return null; // Can't parse — fall through to LLM
+  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(cleanedFact)) {
+    return null; // Can't parse cleanly — fall through to LLM
+  }
+  const factNum = Number(cleanedFact);
 
+  // Only compare against claims whose unit matches the fact's currency
+  // (or both sides are dimensionless, e.g. for P1128 employee counts).
+  // Cross-currency comparisons like €6B vs $6B would otherwise produce
+  // false confirmations.
+  const compatibleClaims: Array<{ amount: number; unit: string | null }> = [];
   for (const claim of claims) {
-    const wdNum = getQuantityValue(claim);
-    if (wdNum == null) continue;
+    const wd = getQuantityValue(claim);
+    if (wd == null) continue;
+    if (wd.unit === factCurrency) compatibleClaims.push(wd);
+  }
 
-    // Compare with tolerance (e.g., 10% for revenue, 15% for headcount)
-    const ratio = Math.abs(factNum - wdNum) / Math.max(Math.abs(wdNum), 1);
+  if (compatibleClaims.length === 0) {
+    // No unit-compatible claim — fall through to LLM rather than risk a false
+    // contradiction across different currencies / units.
+    return null;
+  }
+
+  for (const wd of compatibleClaims) {
+    const ratio = Math.abs(factNum - wd.amount) / Math.max(Math.abs(wd.amount), 1);
     if (ratio <= tolerance) {
       return makeResult(item, 'confirmed', 0.95,
-        `Wikidata ${pid} (${propertyLabel(pid)}) = ${wdNum}`,
-        `[wikidata-api] FactBase value '${factValue}' (~${factNum}) matches Wikidata ${pid} = ${wdNum} (within ${(tolerance * 100).toFixed(0)}% tolerance)`);
+        `Wikidata ${pid} (${propertyLabel(pid)}) = ${wd.amount}`,
+        `[wikidata-api] FactBase value '${factValue}' (~${factNum}) matches Wikidata ${pid} = ${wd.amount} (within ${(tolerance * 100).toFixed(0)}% tolerance)`);
     }
   }
 
-  const wdValues = claims.map(c => getQuantityValue(c)).filter((v): v is number => v != null);
+  const wdValues = compatibleClaims.map(v => v.amount);
   return makeResult(item, 'contradicted', 0.90,
     `Wikidata ${pid} (${propertyLabel(pid)}) = ${wdValues.join(', ')}`,
     `[wikidata-api] FactBase value '${factValue}' (~${factNum}) does not match Wikidata ${pid} = ${wdValues.join(', ')}`);

--- a/crux/lib/source-check/wikidata-matcher.ts
+++ b/crux/lib/source-check/wikidata-matcher.ts
@@ -51,6 +51,7 @@ type MatchStrategy =
   | { type: 'date'; pid: string }
   | { type: 'year'; pid: string }
   | { type: 'entityRef'; pid: string; multiValued?: boolean }
+  | { type: 'quantity'; pid: string; tolerance?: number }
   | { type: 'skip' };
 
 // ── Property-to-PID map ─────────────────────────────────────────────
@@ -80,6 +81,8 @@ const PROPERTY_MAP: Record<string, MatchStrategy> = {
   'born-year': { type: 'year', pid: 'P569' },
   'ceo': { type: 'entityRef', pid: 'P169' },
   'parent-organization': { type: 'entityRef', pid: 'P749' },
+  'headcount': { type: 'quantity', pid: 'P1128', tolerance: 0.15 },
+  'revenue': { type: 'quantity', pid: 'P2139', tolerance: 0.10 },
   'description': { type: 'skip' },
 };
 
@@ -222,6 +225,18 @@ function getYearFromTime(claim: WikidataClaim): string | null {
 }
 
 /**
+ * Extract a numeric quantity from a claim's datavalue.
+ * Wikidata quantities look like { amount: "+1234", unit: "http://..." }
+ */
+function getQuantityValue(claim: WikidataClaim): number | null {
+  const dv = claim.mainsnak.datavalue;
+  if (!dv || dv.type !== 'quantity') return null;
+  const val = dv.value as { amount: string; unit?: string };
+  const num = parseFloat(val.amount);
+  return isNaN(num) ? null : num;
+}
+
+/**
  * Extract an entity reference QID from a claim.
  * Entity references have datavalue.type === 'wikibase-entityid'
  */
@@ -304,6 +319,8 @@ export async function tryWikidataMatch(item: VerifyItem): Promise<VerifyResult |
         return matchYear(item, entity, strategy.pid, factValue, qid);
       case 'entityRef':
         return await matchEntityRef(item, entity, strategy.pid, factValue, qid, !!strategy.multiValued);
+      case 'quantity':
+        return matchQuantity(item, entity, strategy.pid, factValue, qid, strategy.tolerance ?? 0.10);
     }
   } catch (e: unknown) {
     console.warn(`[wikidata-matcher] Match failed for ${item.id}: ${e instanceof Error ? e.message : String(e)}`);
@@ -529,6 +546,45 @@ async function matchEntityRef(
   }
 }
 
+function matchQuantity(
+  item: VerifyItem,
+  entity: WikidataEntity,
+  pid: string,
+  factValue: string,
+  qid: string,
+  tolerance: number,
+): VerifyResult | null {
+  const claims = getClaimsForProperty(entity, pid);
+  if (claims.length === 0) {
+    return makeResult(item, 'unverifiable', 0.80,
+      `Wikidata ${pid} not present on ${qid}`,
+      `[wikidata-api] Property ${pid} missing from ${qid}`);
+  }
+
+  // Parse the fact value as a number (strip currency symbols, commas, whitespace)
+  const cleanedFact = factValue.replace(/[$€£¥,\s]/g, '');
+  const factNum = parseFloat(cleanedFact);
+  if (isNaN(factNum)) return null; // Can't parse — fall through to LLM
+
+  for (const claim of claims) {
+    const wdNum = getQuantityValue(claim);
+    if (wdNum == null) continue;
+
+    // Compare with tolerance (e.g., 10% for revenue, 15% for headcount)
+    const ratio = Math.abs(factNum - wdNum) / Math.max(Math.abs(wdNum), 1);
+    if (ratio <= tolerance) {
+      return makeResult(item, 'confirmed', 0.95,
+        `Wikidata ${pid} (${propertyLabel(pid)}) = ${wdNum}`,
+        `[wikidata-api] FactBase value '${factValue}' (~${factNum}) matches Wikidata ${pid} = ${wdNum} (within ${(tolerance * 100).toFixed(0)}% tolerance)`);
+    }
+  }
+
+  const wdValues = claims.map(c => getQuantityValue(c)).filter((v): v is number => v != null);
+  return makeResult(item, 'contradicted', 0.90,
+    `Wikidata ${pid} (${propertyLabel(pid)}) = ${wdValues.join(', ')}`,
+    `[wikidata-api] FactBase value '${factValue}' (~${factNum}) does not match Wikidata ${pid} = ${wdValues.join(', ')}`);
+}
+
 // ── Utility ─────────────────────────────────────────────────────────
 
 /** Human-readable labels for common Wikidata properties */
@@ -543,6 +599,8 @@ const PID_LABELS: Record<string, string> = {
   P569: 'date of birth',
   P169: 'CEO',
   P749: 'parent organization',
+  P1128: 'employees',
+  P2139: 'revenue',
 };
 
 function propertyLabel(pid: string): string {


### PR DESCRIPTION
## Summary
- Adds `quantity` match strategy to the Wikidata deterministic matcher for numeric properties
- **Headcount** (P1128): 15% tolerance — catches approximate employee counts
- **Revenue** (P2139): 10% tolerance — matches revenue figures with rounding differences
- Parses Wikidata quantity values and compares numerically
- Strips currency symbols and commas from FactBase values before comparison
- Falls through to LLM for unparseable text values
- 7 new tests covering confirmed, contradicted, unverifiable, and unparseable cases

Cost: $0 per verification (API calls only, no LLM). Extends the pattern from QUA-92.

Closes QUA-93

## Test plan
- [x] 40 wikidata matcher tests pass (7 new + 33 existing)
- [x] All 5200+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic quantity-based matching for headcount and revenue against Wikidata quantities, with built-in tolerances and currency/unit compatibility checks; unparseable or unit-mismatched facts fall through for fallback handling.

* **Tests**
  * Expanded tests covering quantity scenarios (confirmed, contradicted, unverifiable) plus strict parsing and currency/unit edge cases; added helpers to build quantity claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->