### PR TITLE
fix: exclude unchecked from heatmap coverage numerator

### DIFF
--- a/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
+++ b/apps/web/src/app/internal/source-check-coverage/source-check-coverage-content.tsx
@@ -553,9 +553,14 @@ export async function SourceCheckCoverageContent() {
                       (s, v) => s + (row[v] ?? 0),
                       0
                     );
+                    // Coverage numerator excludes `unchecked` to match the
+                    // checked-coverage definition used elsewhere on the page.
+                    const checkedTotal = allVerdictTypes
+                      .filter((v) => v !== "unchecked")
+                      .reduce((s, v) => s + (row[v] ?? 0), 0);
                     const totalRecords = totalRecordsByType.get(rt);
                     const coveragePct = totalRecords != null && totalRecords > 0
-                      ? Math.round((rowTotal / totalRecords) * 100)
+                      ? Math.round((checkedTotal / totalRecords) * 100)
                       : null;
                     return (
                       <tr
@@ -602,8 +607,13 @@ export async function SourceCheckCoverageContent() {
                     const totalAllRecords = coverageMatrix.totals.totalRecords;
                     const totalAllVerdicts = Object.values(verdictMatrix.totals)
                       .reduce((s, c) => s + c, 0);
+                    // Coverage numerator excludes `unchecked` to match the
+                    // checked-coverage definition used elsewhere on the page.
+                    const totalCheckedVerdicts = allVerdictTypes
+                      .filter((v) => v !== "unchecked")
+                      .reduce((s, v) => s + (verdictMatrix.totals[v] ?? 0), 0);
                     const totalCoverage = totalAllRecords > 0
-                      ? Math.round((totalAllVerdicts / totalAllRecords) * 100)
+                      ? Math.round((totalCheckedVerdicts / totalAllRecords) * 100)
                       : null;
                     return (
                       <tr className="border-t-2 border-border/60 font-semibold">


### PR DESCRIPTION
## Summary

Follow-up to #4078 — addresses a CodeRabbit review comment.

The heatmap's Coverage % column was using `rowTotal` (sum of ALL verdict buckets including `unchecked`) as the numerator, which conflicts with the checked-coverage definition used in the Coverage Matrix above. When `unchecked > 0` this would inflate coverage.

Fix: compute `checkedTotal` excluding `unchecked` before dividing. Same fix applied to the footer Totals row.

## Test plan

- [x] TypeScript compiles
- [ ] Verify Coverage % values match between heatmap and coverage-matrix sections after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Coverage percentage calculations in the Verdict Heatmap to exclude unchecked verdicts from the numerator. This affects both per-record-type coverage and total coverage display, providing more accurate coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->