### PR TITLE
Phase 0 audit: TableBase factory pre-flight + type-level test

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/sync-factory.test-d.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.test-d.ts
@@ -1,0 +1,197 @@
+/**
+ * Type-level test for the planned `createSyncHandler<T>()` factory.
+ *
+ * This test runs against a HAND-MOCKED factory signature, NOT a real
+ * implementation, so that we can verify Hono RPC type inference works
+ * BEFORE building the factory itself. This is the de-risking step from
+ * Phase 0 audit (issue #4089) — if `InferResponseType<>` cannot resolve
+ * through `createSyncHandler({...})`, the entire factory approach is
+ * blocked and we need to redesign.
+ *
+ * The test asserts:
+ * 1. `InferResponseType<route['sync']['$post'], 200>` resolves to a CONCRETE
+ *    object shape (not `any`, not `unknown`, not a wide union).
+ * 2. The shape contains the factory's standard fields: `upserted`, plus
+ *    the fields from any `extendResponse` callback.
+ * 3. Hono method-chaining (`.get(...).post(...)`) is preserved across the
+ *    factory call.
+ *
+ * If this test compiles, the factory design is type-safe and we can proceed.
+ * If it fails to compile, the factory must be redesigned (e.g., using a
+ * different return shape or a different composition pattern).
+ *
+ * Run via: `pnpm tsc --noEmit apps/wiki-server/src/routes/tablebase/sync-factory.test-d.ts`
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { InferResponseType } from "hono/client";
+import { hc } from "hono/client";
+
+// ---------------------------------------------------------------------------
+// MOCKED factory signature — this is what we plan to build in Phase 1.
+// The actual implementation goes in `sync-factory.ts`. This file mocks it
+// so we can verify type inference works BEFORE writing the implementation.
+// ---------------------------------------------------------------------------
+
+interface SyncConfig<TItem> {
+  name: string;
+  // ... other config fields will be added in Phase 1
+  toRow: (item: TItem) => Record<string, unknown>;
+}
+
+/**
+ * Mocked factory. The real implementation will:
+ *  1. Parse + validate the request body
+ *  2. Run the 7-phase pipeline
+ *  3. Return c.json({ upserted, verdictsWritten, claimsLinked })
+ *
+ * For type-inference purposes, we model only the return shape. The handler
+ * MUST be a plain async function `(c: Context) => Promise<Response>` with
+ * a specific JSON return type so that Hono RPC can infer it from the chain.
+ */
+function createSyncHandler<TItem>(_config: SyncConfig<TItem>) {
+  return async (c: Context) => {
+    // The real implementation will do work here. For type purposes, we
+    // need the inferred return type of c.json() to be a concrete shape,
+    // not a union widened by error paths.
+    return c.json({
+      upserted: 0 as number,
+      verdictsWritten: 0 as number,
+      claimsLinked: 0 as number,
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: A factory-built route preserves Hono method-chaining
+// ---------------------------------------------------------------------------
+
+interface MockGrantItem {
+  id: string;
+  organizationId: string;
+  name: string;
+  amount: number | null;
+}
+
+const grantsApp = new Hono()
+  .get("/stats", (c) => c.json({ total: 0 }))
+  .post(
+    "/sync",
+    createSyncHandler<MockGrantItem>({
+      name: "grants",
+      toRow: (item) => ({ ...item }),
+    }),
+  )
+  .get("/all", (c) => c.json({ grants: [] as MockGrantItem[] }));
+
+// If method-chaining broke, this `typeof grantsApp` would be the unmodified
+// `Hono` base type, not the chained variant. The fact that we can use it
+// below as a Hono route confirms chaining works through the factory call.
+type GrantsRoute = typeof grantsApp;
+
+// ---------------------------------------------------------------------------
+// Test 2: InferResponseType resolves the factory route to a concrete shape
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<GrantsRoute>>;
+
+// This is the critical assertion: the response type from the factory-built
+// /sync endpoint must resolve to the EXACT shape we returned from c.json,
+// not `any`, `unknown`, or a wide union.
+type SyncResponse = InferResponseType<RpcClient["sync"]["$post"], 200>;
+
+// Type assertion: SyncResponse must be assignable to this exact shape.
+// If the factory broke type inference, this assignment would fail at
+// compile time.
+const _expected: {
+  upserted: number;
+  verdictsWritten: number;
+  claimsLinked: number;
+} = null as unknown as SyncResponse; // as-any-ok: type-level test asserting RPC inference shape
+
+// Reverse direction: the expected shape must be assignable back to
+// SyncResponse. This catches the case where SyncResponse is `unknown` or
+// a wider type that accepts any object.
+const _reverse: SyncResponse = {
+  upserted: 1,
+  verdictsWritten: 2,
+  claimsLinked: 3,
+};
+
+// Negative test: this MUST fail to compile if uncommented. SyncResponse
+// should NOT accept arbitrary fields.
+//
+// const _wrong: SyncResponse = {
+//   upserted: 1,
+//   verdictsWritten: 2,
+//   claimsLinked: 3,
+//   nonExistentField: "should not compile",
+// };
+
+// ---------------------------------------------------------------------------
+// Test 3: The other endpoints in the chain are still inferable
+// ---------------------------------------------------------------------------
+
+type StatsResponse = InferResponseType<RpcClient["stats"]["$get"], 200>;
+type AllResponse = InferResponseType<RpcClient["all"]["$get"], 200>;
+
+const _stats: StatsResponse = { total: 0 };
+const _all: AllResponse = { grants: [] };
+
+// ---------------------------------------------------------------------------
+// Test 4: Multiple factory-built routes in one app (the production case)
+// ---------------------------------------------------------------------------
+
+interface MockPersonnelItem {
+  id: string;
+  personId: string;
+  organizationId: string;
+  role: string;
+}
+
+const personnelApp = new Hono()
+  .post(
+    "/sync",
+    createSyncHandler<MockPersonnelItem>({
+      name: "personnel",
+      toRow: (item) => ({ ...item }),
+    }),
+  );
+
+type PersonnelRoute = typeof personnelApp;
+type PersonnelRpc = ReturnType<typeof hc<PersonnelRoute>>;
+type PersonnelSync = InferResponseType<PersonnelRpc["sync"]["$post"], 200>;
+
+// Both routes should resolve to the SAME shape since they use the same
+// factory. (When we add `extendResponse`, this will diverge per-route.)
+const _personnel: PersonnelSync = {
+  upserted: 0,
+  verdictsWritten: 0,
+  claimsLinked: 0,
+};
+
+// Suppress unused warnings — these vars exist for type assertion side effects
+void _expected;
+void _reverse;
+void _stats;
+void _all;
+void _personnel;
+void grantsApp;
+void personnelApp;
+
+// ---------------------------------------------------------------------------
+// Phase 0 verdict
+// ---------------------------------------------------------------------------
+//
+// If `tsc --noEmit` passes on this file, the factory's type design is sound
+// and Phase 1 can proceed.
+//
+// If it fails, the factory needs a different return-type strategy. Likely
+// fixes (in order of preference):
+//   1. Make the handler return type explicit: `Promise<Response<{...}>>`
+//   2. Use Hono's `Context.json` overload that takes a typed payload first
+//   3. Wrap the factory output in a no-op identity function that fixes
+//      the inferred return type
+//   4. Fall back to extracting only `runPostSyncPipeline()` as a utility
+//      (Approach A in Discussion #4088), giving up on factory type inference


### PR DESCRIPTION
## Summary

Phase 0 audit for the [TableBase Sync Handler Factory plan](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4088). Resolves all 6 blocking technical gaps identified by the red team review BEFORE writing any factory code. Closes #4089.

The only committed file is `apps/wiki-server/src/routes/tablebase/sync-factory.test-d.ts` — a type-level test against a hand-mocked factory signature that verifies Hono RPC type inference (`InferResponseType<>`) survives a factory call. **The test compiles cleanly under full wiki-server `tsc --noEmit`, confirming Phase 1 design is unblocked.**

Full audit findings posted as a comment on #4089 and as a correction comment on #4088. Audit document saved locally at `.claude/snapshots/tablebase-factory-phase0.md` (gitignored per repo convention).

## Key audit findings

- **Route inventory corrected**: 27 routes have main `/sync` (not 30 as the plan said). 23 factory candidates after exclusions (not 25).
- **New permanent exclusions**: `bluesky.ts` (only `/sync/:did` external API), `data-sources.ts` (multi-table writes per call), `ids.ts` (`nextval()` semantics)
- **`audit-log.ts` is already batch-safe** — N+1 risk doesn't exist for current routes
- **Postgres parameter limit headroom**: campaignFinance (largest, 25 cols) has 13× headroom on default 200-row batches. Factory must still auto-chunk for safety.
- **Hook budget of 1 per route is achievable**: 4 routes need `preValidate`, 1 needs `postUpsert`, 4 need `conflictSet` overrides for COALESCE preservation
- **Hook rollback contract specified**: hooks receive `tx`, external side effects forbidden, throwing rolls back the entire sync
- **Type-level test passes**: `InferResponseType<>` resolves to exact `{ upserted; verdictsWritten; claimsLinked }` shape (not widened to `any`/`unknown`)
- **Negative test verified**: extra fields produce `error TS2353` as expected
- **Baseline LOC**: 14,160 total tablebase route LOC; ~8,500 in factory candidates; target reduction across Phases 1-3 is ~4,500 lines (53% of candidate routes)

## Pilot route selection for Phase 1 (corrected)

- Tier 1: `personnel.ts` (exercises `postUpsert` escape hatch + all 7 phases)
- Tier 2: `divisions.ts` (exercises phase-omission + `conflictSet` COALESCE override)
- Tier 3: `political-scores.ts` (simplest per-item loop; clean batch conversion)

## Test plan

- [x] `pnpm tsc --noEmit -p apps/wiki-server/tsconfig.json` passes (type-level test compiles)
- [x] Negative test (uncommented `nonExistentField`) verified to produce `error TS2353: Object literal may only specify known properties`
- [x] `pnpm crux w validate gate --scope=content` passes
- [x] No runtime code added — pure type-level test, zero production risk

Closes #4089

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added type declaration tests for sync-handler factory, validating type inference, handler chaining behavior, and response type assertions across multiple endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->