### PR TITLE
fix: aggregate policy-stakeholder verdicts for legislation dots (QUA-116)

### DIFF
--- a/apps/web/src/app/legislation/page.tsx
+++ b/apps/web/src/app/legislation/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTypedEntities, isPolicy } from "@/data";
-import { getRecordVerdict } from "@/data/tablebase";
+import { getAggregatePolicyVerdict } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
 import { LegislationTable, type LegislationRow } from "./legislation-table";
 import { normalizeStatus } from "./legislation-constants";
@@ -87,6 +87,18 @@ interface StatDef {
 
 const VALID_SCOPES = new Set(["state", "federal", "international", "national"]);
 
+interface ApiStakeholderLite {
+  name?: string;
+}
+
+function extractStakeholderNames(meta: Record<string, unknown>): string[] {
+  const raw = meta.stakeholders;
+  if (!Array.isArray(raw)) return [];
+  return (raw as ApiStakeholderLite[])
+    .map((s) => (typeof s?.name === "string" ? s.name : null))
+    .filter((n): n is string => n !== null && n.length > 0);
+}
+
 function apiEntityToRow(e: DirectoryEntity): LegislationRow {
   const meta = e.metadata ?? {};
   const policyStatus = (meta.policyStatus as string | undefined) ?? null;
@@ -120,7 +132,7 @@ function apiEntityToRow(e: DirectoryEntity): LegislationRow {
     lastActionDate: lastActionInfo?.date ?? null,
     description: e.description ?? null,
     tags: e.tags ?? [],
-    verdictString: getRecordVerdict("policy", e.id)?.verdict ?? null,
+    verdictString: getAggregatePolicyVerdict(e.stableId, extractStakeholderNames(meta)),
   };
 }
 
@@ -169,7 +181,10 @@ function loadFromLocal(): LegislationPageData {
       lastActionDate: lastActionInfo?.date ?? null,
       description: entity.description ?? null,
       tags: entity.tags,
-      verdictString: getRecordVerdict("policy", entity.id)?.verdict ?? null,
+      verdictString: getAggregatePolicyVerdict(
+        entity.stableId,
+        entity.stakeholders.map((s) => s.name),
+      ),
     };
   });
 

--- a/apps/web/src/app/legislation/page.tsx
+++ b/apps/web/src/app/legislation/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTypedEntities, isPolicy } from "@/data";
-import { getAggregatePolicyVerdict } from "@/data/tablebase";
+import { aggregateRecordVerdicts, getPolicyStakeholderId } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
 import { LegislationTable, type LegislationRow } from "./legislation-table";
 import { normalizeStatus } from "./legislation-constants";
@@ -91,6 +91,24 @@ interface ApiStakeholderLite {
   name?: string;
 }
 
+/**
+ * Resolve the given stakeholder display names to PG stakeholder record IDs
+ * for a specific policy entity. Missing/unresolvable entries are dropped.
+ * Policy-specific — stakeholder rows are keyed by (policyStableId, displayName).
+ */
+function resolvePolicyStakeholderIds(
+  policyStableId: string | null | undefined,
+  names: readonly string[],
+): string[] {
+  if (!policyStableId) return [];
+  const ids: string[] = [];
+  for (const name of names) {
+    const id = getPolicyStakeholderId(policyStableId, name);
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
 function extractStakeholderNames(meta: Record<string, unknown>): string[] {
   const raw = meta.stakeholders;
   if (!Array.isArray(raw)) return [];
@@ -132,7 +150,10 @@ function apiEntityToRow(e: DirectoryEntity): LegislationRow {
     lastActionDate: lastActionInfo?.date ?? null,
     description: e.description ?? null,
     tags: e.tags ?? [],
-    verdictString: getAggregatePolicyVerdict(e.stableId, extractStakeholderNames(meta)),
+    verdictString: aggregateRecordVerdicts(
+      "policy-stakeholder",
+      resolvePolicyStakeholderIds(e.stableId, extractStakeholderNames(meta)),
+    ),
   };
 }
 
@@ -181,9 +202,12 @@ function loadFromLocal(): LegislationPageData {
       lastActionDate: lastActionInfo?.date ?? null,
       description: entity.description ?? null,
       tags: entity.tags,
-      verdictString: getAggregatePolicyVerdict(
-        entity.stableId,
-        entity.stakeholders.map((s) => s.name),
+      verdictString: aggregateRecordVerdicts(
+        "policy-stakeholder",
+        resolvePolicyStakeholderIds(
+          entity.stableId,
+          entity.stakeholders.map((s) => s.name),
+        ),
       ),
     };
   });

--- a/apps/web/src/app/races/page.tsx
+++ b/apps/web/src/app/races/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { fetchFromWikiServer } from "@/lib/wiki-server";
-import { getRecordVerdict } from "@/data/tablebase";
+import { getRecordVerdict, pickWorstVerdict } from "@/data/tablebase";
 import { ProfileStatCard } from "@/components/directory";
 import { RACE_LEVEL_LABELS } from "./races-constants";
 import { RacesTable, type RaceRow, type CandidateRow } from "./races-table";
@@ -63,22 +63,32 @@ export default async function RacesPage() {
   }
 
   const races = racesData?.races ?? [];
-  const raceRows: RaceRow[] = races.map((race) => ({
-    id: race.id,
-    name: race.name,
-    raceType: race.raceType,
-    party: race.party,
-    level: race.level,
-    state: race.state,
-    district: race.district,
-    electionDate: race.electionDate,
-    status: race.status,
-    outcome: race.outcome,
-    outcomeDetails: race.outcomeDetails,
-    aiAngle: race.aiAngle,
-    candidates: candidatesByRace.get(race.id) ?? [],
-    verdictString: getRecordVerdict("race", String(race.id))?.verdict ?? null,
-  }));
+  const raceRows: RaceRow[] = races.map((race) => {
+    const candidates = candidatesByRace.get(race.id) ?? [];
+    return {
+      id: race.id,
+      name: race.name,
+      raceType: race.raceType,
+      party: race.party,
+      level: race.level,
+      state: race.state,
+      district: race.district,
+      electionDate: race.electionDate,
+      status: race.status,
+      outcome: race.outcome,
+      outcomeDetails: race.outcomeDetails,
+      aiAngle: race.aiAngle,
+      candidates,
+      // Source-check doesn't verify the `race` record type yet (QUA-214);
+      // roll up the worst candidate verdict so the row dot surfaces any
+      // known issues instead of always rendering as unchecked.
+      verdictString: pickWorstVerdict(
+        candidates
+          .map((c) => c.verdictString)
+          .filter((v): v is string => v !== null),
+      ),
+    };
+  });
 
   const raceStats = stats?.races ?? { total: 0, upcoming: 0, active: 0, resolved: 0 };
   const candidateStats = stats?.candidates ?? { total: 0 };

--- a/apps/web/src/data/__tests__/aggregate-policy-verdict.test.ts
+++ b/apps/web/src/data/__tests__/aggregate-policy-verdict.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { pickWorstPolicyVerdict } from "../tablebase";
+
+describe("pickWorstPolicyVerdict", () => {
+  it("returns null for an empty list", () => {
+    expect(pickWorstPolicyVerdict([])).toBeNull();
+  });
+
+  it("returns null when no verdicts are known", () => {
+    expect(pickWorstPolicyVerdict(["unknown", "mystery"])).toBeNull();
+  });
+
+  it("passes through a single confirmed verdict", () => {
+    expect(pickWorstPolicyVerdict(["confirmed"])).toBe("confirmed");
+  });
+
+  it("ranks contradicted above everything else", () => {
+    expect(
+      pickWorstPolicyVerdict([
+        "confirmed",
+        "contradicted",
+        "partial",
+        "unverifiable",
+      ]),
+    ).toBe("contradicted");
+  });
+
+  it("ranks unverifiable above outdated, partial, confirmed", () => {
+    expect(
+      pickWorstPolicyVerdict(["confirmed", "partial", "unverifiable", "outdated"]),
+    ).toBe("unverifiable");
+  });
+
+  it("ranks outdated above partial and confirmed", () => {
+    expect(pickWorstPolicyVerdict(["confirmed", "partial", "outdated"])).toBe(
+      "outdated",
+    );
+  });
+
+  it("ranks partial above confirmed", () => {
+    expect(pickWorstPolicyVerdict(["confirmed", "partial", "confirmed"])).toBe(
+      "partial",
+    );
+  });
+
+  it("returns confirmed when all verdicts are confirmed", () => {
+    expect(
+      pickWorstPolicyVerdict(["confirmed", "confirmed", "confirmed"]),
+    ).toBe("confirmed");
+  });
+
+  it("ignores unknown strings mixed with known ones", () => {
+    expect(
+      pickWorstPolicyVerdict(["mystery", "confirmed", "garbage"]),
+    ).toBe("confirmed");
+  });
+
+  it("returns the worst even when the worst appears last", () => {
+    expect(
+      pickWorstPolicyVerdict(["confirmed", "confirmed", "contradicted"]),
+    ).toBe("contradicted");
+  });
+});

--- a/apps/web/src/data/__tests__/verdict-aggregation.test.ts
+++ b/apps/web/src/data/__tests__/verdict-aggregation.test.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { pickWorstPolicyVerdict } from "../tablebase";
+import { pickWorstVerdict } from "../tablebase";
 
-describe("pickWorstPolicyVerdict", () => {
+describe("pickWorstVerdict", () => {
   it("returns null for an empty list", () => {
-    expect(pickWorstPolicyVerdict([])).toBeNull();
+    expect(pickWorstVerdict([])).toBeNull();
   });
 
   it("returns null when no verdicts are known", () => {
-    expect(pickWorstPolicyVerdict(["unknown", "mystery"])).toBeNull();
+    expect(pickWorstVerdict(["unknown", "mystery"])).toBeNull();
   });
 
   it("passes through a single confirmed verdict", () => {
-    expect(pickWorstPolicyVerdict(["confirmed"])).toBe("confirmed");
+    expect(pickWorstVerdict(["confirmed"])).toBe("confirmed");
   });
 
   it("ranks contradicted above everything else", () => {
     expect(
-      pickWorstPolicyVerdict([
+      pickWorstVerdict([
         "confirmed",
         "contradicted",
         "partial",
@@ -27,37 +27,43 @@ describe("pickWorstPolicyVerdict", () => {
 
   it("ranks unverifiable above outdated, partial, confirmed", () => {
     expect(
-      pickWorstPolicyVerdict(["confirmed", "partial", "unverifiable", "outdated"]),
+      pickWorstVerdict(["confirmed", "partial", "unverifiable", "outdated"]),
     ).toBe("unverifiable");
   });
 
   it("ranks outdated above partial and confirmed", () => {
-    expect(pickWorstPolicyVerdict(["confirmed", "partial", "outdated"])).toBe(
+    expect(pickWorstVerdict(["confirmed", "partial", "outdated"])).toBe(
       "outdated",
     );
   });
 
   it("ranks partial above confirmed", () => {
-    expect(pickWorstPolicyVerdict(["confirmed", "partial", "confirmed"])).toBe(
+    expect(pickWorstVerdict(["confirmed", "partial", "confirmed"])).toBe(
       "partial",
     );
   });
 
   it("returns confirmed when all verdicts are confirmed", () => {
     expect(
-      pickWorstPolicyVerdict(["confirmed", "confirmed", "confirmed"]),
+      pickWorstVerdict(["confirmed", "confirmed", "confirmed"]),
     ).toBe("confirmed");
   });
 
   it("ignores unknown strings mixed with known ones", () => {
     expect(
-      pickWorstPolicyVerdict(["mystery", "confirmed", "garbage"]),
+      pickWorstVerdict(["mystery", "confirmed", "garbage"]),
     ).toBe("confirmed");
   });
 
   it("returns the worst even when the worst appears last", () => {
     expect(
-      pickWorstPolicyVerdict(["confirmed", "confirmed", "contradicted"]),
+      pickWorstVerdict(["confirmed", "confirmed", "contradicted"]),
     ).toBe("contradicted");
+  });
+
+  it("returns null for an empty list containing a bare null equivalent", () => {
+    // Defensive: the severity ladder doesn't include "unchecked" or empty
+    // strings, so they should be ignored.
+    expect(pickWorstVerdict(["unchecked", "", "confirmed"])).toBe("confirmed");
   });
 });

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1132,10 +1132,14 @@ export function getPolicyStakeholderId(
   return map[`${policyEntityStableId}:${stakeholderDisplayName}`] ?? null;
 }
 
-// Severity order for rolling up per-stakeholder verdicts to a policy-level dot.
-// Lower index = worse. Mirrors the display mapping in source-check-status.ts
-// (contradicted/unverifiable → failed; outdated/partial → trouble; confirmed → verified).
-const POLICY_VERDICT_SEVERITY = [
+// Severity order for source-check record verdicts. Lower index = worse.
+// Mirrors the display mapping in source-check-status.ts:
+//   contradicted/unverifiable → failed (red)
+//   outdated/partial          → trouble (orange)
+//   confirmed                 → verified (green)
+// Any verdict string not in this list (including 'unchecked' or unknown
+// values) is treated as "no data" and excluded from aggregation.
+const VERDICT_SEVERITY = [
   "contradicted",
   "unverifiable",
   "outdated",
@@ -1145,43 +1149,40 @@ const POLICY_VERDICT_SEVERITY = [
 
 /**
  * Pick the worst-case verdict from a list of verdict strings, ignoring any
- * values not in the known severity ladder. Exported for unit tests.
+ * values not in the known severity ladder. Pure function — exported for unit
+ * tests and for any caller that has already resolved a list of verdicts.
  */
-export function pickWorstPolicyVerdict(
+export function pickWorstVerdict(
   verdicts: readonly string[],
 ): string | null {
   let worstIdx = -1;
   for (const v of verdicts) {
-    const idx = POLICY_VERDICT_SEVERITY.indexOf(
-      v as (typeof POLICY_VERDICT_SEVERITY)[number],
-    );
+    const idx = VERDICT_SEVERITY.indexOf(v as (typeof VERDICT_SEVERITY)[number]);
     if (idx === -1) continue;
     if (worstIdx === -1 || idx < worstIdx) worstIdx = idx;
   }
-  return worstIdx === -1 ? null : POLICY_VERDICT_SEVERITY[worstIdx];
+  return worstIdx === -1 ? null : VERDICT_SEVERITY[worstIdx];
 }
 
 /**
- * Aggregate source-check verdicts for a policy by rolling up its stakeholders'
- * `policy-stakeholder` verdicts to a single worst-case verdict string.
+ * Roll up per-child source-check verdicts to a single worst-case verdict
+ * string. Generic across any parent→child relationship (e.g. policy→stakeholder,
+ * org→personnel, publication→citation). Callers are responsible for resolving
+ * their domain-specific name→id mapping before calling this.
  *
- * Policies don't have their own source-check verdict type — only stakeholders do.
- * Returns null if the policy has no stableId, no stakeholders, or none of the
- * stakeholders have a verdict yet.
+ * Returns null if `recordIds` is empty or none of the ids have a verdict.
  */
-export function getAggregatePolicyVerdict(
-  policyStableId: string | null | undefined,
-  stakeholderNames: readonly string[],
+export function aggregateRecordVerdicts(
+  recordType: string,
+  recordIds: readonly string[],
 ): string | null {
-  if (!policyStableId || stakeholderNames.length === 0) return null;
+  if (recordIds.length === 0) return null;
   const verdicts: string[] = [];
-  for (const name of stakeholderNames) {
-    const stakeholderId = getPolicyStakeholderId(policyStableId, name);
-    if (!stakeholderId) continue;
-    const v = getRecordVerdict("policy-stakeholder", stakeholderId);
+  for (const id of recordIds) {
+    const v = getRecordVerdict(recordType, id);
     if (v) verdicts.push(v.verdict);
   }
-  return pickWorstPolicyVerdict(verdicts);
+  return pickWorstVerdict(verdicts);
 }
 
 // Re-export loadYaml for use in domain modules

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1132,6 +1132,58 @@ export function getPolicyStakeholderId(
   return map[`${policyEntityStableId}:${stakeholderDisplayName}`] ?? null;
 }
 
+// Severity order for rolling up per-stakeholder verdicts to a policy-level dot.
+// Lower index = worse. Mirrors the display mapping in source-check-status.ts
+// (contradicted/unverifiable → failed; outdated/partial → trouble; confirmed → verified).
+const POLICY_VERDICT_SEVERITY = [
+  "contradicted",
+  "unverifiable",
+  "outdated",
+  "partial",
+  "confirmed",
+] as const;
+
+/**
+ * Pick the worst-case verdict from a list of verdict strings, ignoring any
+ * values not in the known severity ladder. Exported for unit tests.
+ */
+export function pickWorstPolicyVerdict(
+  verdicts: readonly string[],
+): string | null {
+  let worstIdx = -1;
+  for (const v of verdicts) {
+    const idx = POLICY_VERDICT_SEVERITY.indexOf(
+      v as (typeof POLICY_VERDICT_SEVERITY)[number],
+    );
+    if (idx === -1) continue;
+    if (worstIdx === -1 || idx < worstIdx) worstIdx = idx;
+  }
+  return worstIdx === -1 ? null : POLICY_VERDICT_SEVERITY[worstIdx];
+}
+
+/**
+ * Aggregate source-check verdicts for a policy by rolling up its stakeholders'
+ * `policy-stakeholder` verdicts to a single worst-case verdict string.
+ *
+ * Policies don't have their own source-check verdict type — only stakeholders do.
+ * Returns null if the policy has no stableId, no stakeholders, or none of the
+ * stakeholders have a verdict yet.
+ */
+export function getAggregatePolicyVerdict(
+  policyStableId: string | null | undefined,
+  stakeholderNames: readonly string[],
+): string | null {
+  if (!policyStableId || stakeholderNames.length === 0) return null;
+  const verdicts: string[] = [];
+  for (const name of stakeholderNames) {
+    const stakeholderId = getPolicyStakeholderId(policyStableId, name);
+    if (!stakeholderId) continue;
+    const v = getRecordVerdict("policy-stakeholder", stakeholderId);
+    if (v) verdicts.push(v.verdict);
+  }
+  return pickWorstPolicyVerdict(verdicts);
+}
+
 // Re-export loadYaml for use in domain modules
 export { loadYaml };
 // Re-export wiki-server helpers

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1170,6 +1170,11 @@ export function pickWorstVerdict(
  * org→personnel, publication→citation). Callers are responsible for resolving
  * their domain-specific name→id mapping before calling this.
  *
+ * This is a workaround for parent record types that lack their own
+ * source-check coverage yet (QUA-214). When coverage lands, call sites should
+ * prefer the parent's own verdict and/or combine it with the aggregated
+ * children via pickWorstVerdict.
+ *
  * Returns null if `recordIds` is empty or none of the ids have a verdict.
  */
 export function aggregateRecordVerdicts(


### PR DESCRIPTION
## Summary

The `/legislation` directory was rendering every policy's source-check dot as "unchecked" despite 162 `policy-stakeholder` verdicts existing in prod. Root cause: both code paths called `getRecordVerdict("policy", id)`, but source-check never produces verdicts for the `policy` record type — only for `policy-stakeholder`.

This adds a `getAggregatePolicyVerdict(stableId, stakeholderNames)` helper that rolls up the per-stakeholder verdicts to a single worst-case policy-level verdict, using the severity ladder:

```
contradicted > unverifiable > outdated > partial > confirmed
```

Wired into both the API path (`metadata.stakeholders` from `/api/entities/directory`) and the local-YAML fallback path.

## Why this shape

- A policy's "verification health" is inherently a roll-up of its stakeholders' claims — there is no canonical single source to check for a policy as a whole.
- Severity ladder matches the existing display mapping in `source-check-status.ts` (`contradicted`/`unverifiable` → failed/red; `outdated`/`partial` → trouble/orange; `confirmed` → verified/green).
- Pure aggregation logic extracted into `pickWorstPolicyVerdict()` for direct unit testing; the stateful `getAggregatePolicyVerdict()` wrapper handles the lookups.

## Test plan

- [x] `pickWorstPolicyVerdict` — 10 unit tests covering empty lists, single verdicts, all 4 priority rankings, unknown-string skipping, and worst-last ordering
- [x] `pnpm test` (apps/web) — all 1380 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm crux w validate gate --fix --scope=content` — clean
- [x] Data flow verified against prod: 38/38 policies have `metadata.stakeholders` with `name` fields in the directory API response; 162 `policy-stakeholder` verdicts exist (108 confirmed, 54 unverifiable); `policyStakeholderIds` map bridges names → PG IDs as expected.
- [ ] Visual: once deployed, `/legislation` should show green dots on policies where all stakeholder claims are confirmed, and orange/red on policies with any `unverifiable` or `contradicted` stakeholder.

## Linear

QUA-116 — found during research pass that most Tier-1 directories (grants, publications, ai-models, benchmarks, projects, approaches, events, legislation) already use `RecordStatusDots`. Only legislation had a real bug. The other 6 directories render all-unchecked dots because source-check hasn't produced verdicts for those record types yet — that's coverage-expansion work (QUA-64, QUA-65), not a dots rendering issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced policy verdict calculation to aggregate verdicts from multiple stakeholders with severity-based ranking.

* **Tests**
  * Added comprehensive test coverage for verdict aggregation logic, validating severity ranking across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->