### PR TITLE
feat: Linear integration for agent session tracking

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -43,6 +43,27 @@ If no PR was created (research/abandoned), just remove the working label:
 gh api repos/quantified-uncertainty/longterm-wiki/issues/<N>/labels/agent:working -X DELETE 2>/dev/null || true
 ```
 
+## Step 2b: Update Linear issue (if applicable)
+
+If the session was working on a Linear issue (look for `> Linear: QUA-NNN` in `.claude/wip-checklist.md`, or if the branch matches `claude/qua-NNN-*`), move it to the right terminal state so the Linear backlog stays accurate:
+
+```bash
+# Read the Linear ID from the checklist. If absent, skip this step entirely.
+LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
+
+if [ -n "$LINEAR_ID" ]; then
+  if [ -n "$PR_URL" ]; then
+    # PR exists but hasn't merged → In Review
+    pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL"
+  else
+    # No PR (research, abandoned, quick fix) → straight to Done
+    pnpm crux linear issues done "$LINEAR_ID"
+  fi
+fi
+```
+
+Requires `LINEAR_API_KEY` (synced from `.env.base`). If unset, the command fails loudly and should be rerun after the key is available — Linear is the source of truth for project status and a missing update leaves "In Progress" drift.
+
 ## Step 3: Stop patrol daemon (if running)
 
 ```bash

--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -54,21 +54,27 @@ Set `PR_URL` first — if a PR was created during this session, export it; if no
 # export PR_URL="https://github.com/quantified-uncertainty/longterm-wiki/pull/123"
 PR_URL="${PR_URL:-}"
 
-# Read the Linear ID from the checklist. If absent, skip this step entirely.
+# Read the Linear ID from the checklist first; if that's missing, fall back
+# to parsing the current branch (so sessions that didn't run /agent-init still
+# update Linear on `claude/qua-NNN-*` branches).
 LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
+if [ -z "$LINEAR_ID" ]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  LINEAR_ID=$(echo "$BRANCH" | grep -oE '\bclaude/qua-[0-9]+' | sed 's|claude/||' | tr 'a-z' 'A-Z')
+fi
 
 if [ -n "$LINEAR_ID" ]; then
   if [ -n "$PR_URL" ]; then
     # PR exists but hasn't merged → In Review
-    pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
+    pnpm crux linear done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
   else
     # No PR (research, abandoned, quick fix) → straight to Done
-    pnpm crux linear issues done "$LINEAR_ID" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
+    pnpm crux linear done "$LINEAR_ID" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
   fi
 fi
 ```
 
-Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes the Linear update best-effort so a missing key doesn't interrupt the rest of `/agent-end`. If Linear updates fail, fix the key and rerun `pnpm crux linear issues done <QUA-NNN>` manually — Linear is the source of truth for project status and leaving "In Progress" drift is bad.
+Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes the Linear update best-effort so a missing key doesn't interrupt the rest of `/agent-end`. If Linear updates fail, fix the key and rerun `pnpm crux linear done <QUA-NNN>` manually — Linear is the source of truth for project status and leaving "In Progress" drift is bad.
 
 ## Step 3: Stop patrol daemon (if running)
 

--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -45,24 +45,30 @@ gh api repos/quantified-uncertainty/longterm-wiki/issues/<N>/labels/agent:workin
 
 ## Step 2b: Update Linear issue (if applicable)
 
-If the session was working on a Linear issue (look for `> Linear: QUA-NNN` in `.claude/wip-checklist.md`, or if the branch matches `claude/qua-NNN-*`), move it to the right terminal state so the Linear backlog stays accurate:
+If the session was working on a Linear issue (look for `> Linear: QUA-NNN` in `.claude/wip-checklist.md`, or if the branch matches `claude/qua-NNN-*`), move it to the right terminal state so the Linear backlog stays accurate.
+
+Set `PR_URL` first — if a PR was created during this session, export it; if not, leave it empty so the issue goes straight to `Done`:
 
 ```bash
+# Example: if you created a PR during this session
+# export PR_URL="https://github.com/quantified-uncertainty/longterm-wiki/pull/123"
+PR_URL="${PR_URL:-}"
+
 # Read the Linear ID from the checklist. If absent, skip this step entirely.
 LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
 
 if [ -n "$LINEAR_ID" ]; then
   if [ -n "$PR_URL" ]; then
     # PR exists but hasn't merged → In Review
-    pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL"
+    pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
   else
     # No PR (research, abandoned, quick fix) → straight to Done
-    pnpm crux linear issues done "$LINEAR_ID"
+    pnpm crux linear issues done "$LINEAR_ID" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
   fi
 fi
 ```
 
-Requires `LINEAR_API_KEY` (synced from `.env.base`). If unset, the command fails loudly and should be rerun after the key is available — Linear is the source of truth for project status and a missing update leaves "In Progress" drift.
+Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes the Linear update best-effort so a missing key doesn't interrupt the rest of `/agent-end`. If Linear updates fail, fix the key and rerun `pnpm crux linear issues done <QUA-NNN>` manually — Linear is the source of truth for project status and leaving "In Progress" drift is bad.
 
 ## Step 3: Stop patrol daemon (if running)
 

--- a/.claude/commands/agent-init.md
+++ b/.claude/commands/agent-init.md
@@ -17,12 +17,16 @@ This single command does everything below in order:
 2. Generates `.claude/wip-checklist.md` for the session type.
 3. Auto-marks `issue-tracking` as N/A when no `--issue` is given.
 4. **Signals start on the GitHub issue** (when `--issue=N` is given) — adds the `agent:working` label and posts the start comment. Best-effort: a GitHub failure does not fail init.
-5. Prints the full checklist so you can scan it.
+5. **Signals start on the Linear issue** — auto-detects a Linear ID from the branch name (`claude/qua-NNN-*`) or task description (any bare `QUA-NNN` token), or takes `--linear=QUA-NNN` explicitly. Moves the issue to "In Progress" and posts a start comment. Best-effort: a Linear failure does not fail init.
+6. Prints the full checklist so you can scan it.
 
 Pick the right invocation:
 
 - **Working on a GitHub issue**: `pnpm crux sys agent-checklist init --issue=N` (auto-detects type from labels)
+- **Working on a Linear issue**: start a branch `claude/qua-NNN-description` and the ID is detected automatically, or pass `--linear=QUA-NNN` explicitly
 - **Not on an issue**: `pnpm crux sys agent-checklist init "Task description" --type=X`
+
+Both `--issue` and `--linear` can be passed together if the same task is tracked in both systems.
 
 Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands` (default: `infrastructure`).
 

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -123,6 +123,22 @@ If working on a GitHub issue:
 pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
 ```
 
+## Step 5b: Update Linear issue (if applicable)
+
+If this session was tracking a Linear issue, move it to In Review so the Linear backlog reflects the open PR:
+
+```bash
+# Pull the Linear ID from the checklist metadata (added by /agent-init when it
+# auto-detects `claude/qua-NNN-*` branches or a QUA-NNN in the task description).
+LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
+
+if [ -n "$LINEAR_ID" ] && [ -n "$PR_URL" ]; then
+  pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL"
+fi
+```
+
+Requires `LINEAR_API_KEY` (synced from `.env.base`). Linear → Done happens automatically when the PR merges, via the release workflow.
+
 ## Step 6: Session log
 
 Run `pnpm crux sys agent-checklist snapshot` and capture the output — this is the `checks:` block for the session log.

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -125,19 +125,23 @@ pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
 
 ## Step 5b: Update Linear issue (if applicable)
 
-If this session was tracking a Linear issue, move it to In Review so the Linear backlog reflects the open PR:
+If this session was tracking a Linear issue, move it to In Review so the Linear backlog reflects the open PR. Set `PR_URL` to the PR created/updated in step 4 first:
 
 ```bash
+# PR_URL must be set by the ship flow — it's the URL of the PR just pushed.
+# /agent-push-and-verify sets it; if running this step manually, export first.
+PR_URL="${PR_URL:-}"
+
 # Pull the Linear ID from the checklist metadata (added by /agent-init when it
 # auto-detects `claude/qua-NNN-*` branches or a QUA-NNN in the task description).
 LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
 
 if [ -n "$LINEAR_ID" ] && [ -n "$PR_URL" ]; then
-  pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL"
+  pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
 fi
 ```
 
-Requires `LINEAR_API_KEY` (synced from `.env.base`). Linear → Done happens automatically when the PR merges, via the release workflow.
+Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` keeps this best-effort so a missing key doesn't abort the ship flow. Linear → Done happens automatically when the PR merges, via the release workflow.
 
 ## Step 6: Session log
 

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -137,7 +137,7 @@ PR_URL="${PR_URL:-}"
 LINEAR_ID=$(grep -oE '^> Linear: [A-Z]+-[0-9]+' .claude/wip-checklist.md 2>/dev/null | awk '{print $3}')
 
 if [ -n "$LINEAR_ID" ] && [ -n "$PR_URL" ]; then
-  pnpm crux linear issues done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
+  pnpm crux linear done "$LINEAR_ID" --pr="$PR_URL" || echo "⚠ Linear update failed — check LINEAR_API_KEY and rerun"
 fi
 ```
 

--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -6,6 +6,18 @@ Every session that involves writing or changing code MUST follow this workflow.
 
 Always work on a `claude/short-description` branch. Never commit directly to `main`.
 
+### Naming convention when the task is tracked in an issue tracker
+
+When the session is working on a tracked issue, encode the issue ID in the branch name so `/agent-init` can auto-detect it and post start/done signals without manual flags:
+
+| Source | Pattern | Example |
+|--------|---------|---------|
+| GitHub issue | `claude/fix-NNN-description` | `claude/fix-239-broken-scoring` |
+| Linear issue | `claude/qua-NNN-description` | `claude/qua-184-linear-integration` |
+| No tracker | `claude/<verb>-<noun>` | `claude/refactor-gate-helpers` |
+
+Both GitHub (`fix-NNN`) and Linear (`qua-NNN`) patterns are auto-detected by `crux sys agent-checklist init`. Linear detection also falls back to any bare `QUA-NNN` token in the task description, and can be overridden with `--linear=QUA-NNN`.
+
 ### CI-fix dedup check (when triggered by a CI failure, not a GitHub issue)
 
 Before creating a branch to fix a CI failure, check for existing fix attempts:
@@ -26,15 +38,19 @@ This prevents the duplicate-work pattern where multiple agents independently rac
 Run `/agent-init` as the very first thing — before reading files, running commands, or writing any code. "Before writing code" is not sufficient; quick fixes and file reads count too. If you start without this, you will forget it entirely.
 
 ```bash
-# If working on a GitHub issue:
+# If working on a GitHub issue (auto-starts tracking):
 pnpm crux sys agent-checklist init --issue=N
-pnpm crux gh issues start <N>
 
-# If not on an issue:
+# If working on a Linear issue (auto-detected from branch, or explicit):
+pnpm crux sys agent-checklist init "Task description" --linear=QUA-184
+
+# If not on any tracked issue:
 pnpm crux sys agent-checklist init "Task description" --type=X
 ```
 
 Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands`. Default: `infrastructure`.
+
+`init` automatically signals start on both GitHub (`gh issues start`) and Linear (`linear issues start`) when the respective IDs are known — you do not need to call them by hand. Both calls are best-effort: a GitHub or Linear outage never fails init.
 
 Then read `.claude/wip-checklist.md` and keep it updated as you work.
 

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for crux/commands/linear.ts — the CLI handlers that wrap the
+ * Linear issue helpers. The transport is fully mocked via vi.hoisted +
+ * vi.mock so these tests never hit the network.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted mocks — vi.mock runs before imports so we hoist the spies.
+const {
+  getIssueMock,
+  getCommentsMock,
+  updateIssueStateMock,
+  commentOnIssueMock,
+  searchIssuesMock,
+  fetchRemoteWorkflowStatesMock,
+} = vi.hoisted(() => ({
+  getIssueMock: vi.fn(),
+  getCommentsMock: vi.fn(),
+  updateIssueStateMock: vi.fn(),
+  commentOnIssueMock: vi.fn(),
+  searchIssuesMock: vi.fn(),
+  fetchRemoteWorkflowStatesMock: vi.fn(),
+}));
+
+vi.mock('../../lib/linear/issues.ts', () => ({
+  getIssue: getIssueMock,
+  getComments: getCommentsMock,
+  updateIssueState: updateIssueStateMock,
+  commentOnIssue: commentOnIssueMock,
+  searchIssues: searchIssuesMock,
+}));
+
+vi.mock('../../lib/linear/workflow-states.ts', () => ({
+  fetchRemoteWorkflowStates: fetchRemoteWorkflowStatesMock,
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(() => 'claude/qua-184-test-branch'),
+}));
+
+import { commands } from '../linear.ts';
+
+const mockIssue = {
+  id: 'uuid-1',
+  identifier: 'QUA-184',
+  title: 'Test issue',
+  description: 'body content',
+  priority: 2,
+  url: 'https://linear.app/quantifieduncertainty/issue/QUA-184',
+  state: { id: 'state-1', name: 'Backlog', type: 'backlog' },
+  team: { id: 'team-1', key: 'QUA' },
+  parent: null,
+  project: null,
+  labels: { nodes: [] },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// view
+// ---------------------------------------------------------------------------
+
+describe('linear view', () => {
+  it('prints usage when no identifier is given', async () => {
+    const r = await commands.view([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('prints not-found when the issue does not exist', async () => {
+    getIssueMock.mockResolvedValueOnce(null);
+    const r = await commands.view(['QUA-9999'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not found');
+  });
+
+  it('prints the full issue on success', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getCommentsMock.mockResolvedValueOnce([]);
+
+    const r = await commands.view(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('QUA-184');
+    expect(r.output).toContain('Test issue');
+    expect(r.output).toContain('Backlog');
+  });
+
+  it('emits JSON when --json is set', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getCommentsMock.mockResolvedValueOnce([]);
+
+    const r = await commands.view(['QUA-184'], { ci: true, json: true });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.output);
+    expect(parsed.issue.identifier).toBe('QUA-184');
+    expect(parsed.comments).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+describe('linear search', () => {
+  it('prints usage when the query is empty', async () => {
+    const r = await commands.search([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('filters out --flag args from the query string', async () => {
+    // The CLI dispatcher appends flags as positional args — the handler
+    // must filter them out so `--limit=5` doesn't leak into the query.
+    searchIssuesMock.mockResolvedValueOnce([]);
+    await commands.search(['agent', 'tooling', '--limit=5'], { ci: true, limit: '5' });
+
+    expect(searchIssuesMock).toHaveBeenCalledWith('agent tooling', 5);
+  });
+
+  it('passes --limit as the numeric limit', async () => {
+    searchIssuesMock.mockResolvedValueOnce([]);
+    await commands.search(['foo'], { ci: true, limit: '3' });
+    expect(searchIssuesMock).toHaveBeenCalledWith('foo', 3);
+  });
+
+  it('prints a tidy no-matches message on empty results', async () => {
+    searchIssuesMock.mockResolvedValueOnce([]);
+    const r = await commands.search(['foo'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('No matches');
+  });
+
+  it('prints results in a readable format', async () => {
+    searchIssuesMock.mockResolvedValueOnce([
+      {
+        identifier: 'QUA-1',
+        title: 'A title',
+        priority: 2,
+        state: { name: 'Backlog', type: 'backlog' },
+        url: 'u',
+      },
+    ]);
+    const r = await commands.search(['foo'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('QUA-1');
+    expect(r.output).toContain('A title');
+    expect(r.output).toContain('high'); // priority 2 = high
+  });
+});
+
+// ---------------------------------------------------------------------------
+// start
+// ---------------------------------------------------------------------------
+
+describe('linear start', () => {
+  it('prints usage when no ID is given', async () => {
+    const r = await commands.start([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('prints not-found when the issue does not exist', async () => {
+    getIssueMock.mockResolvedValueOnce(null);
+    const r = await commands.start(['QUA-9999'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not found');
+  });
+
+  it('moves the issue to In Progress and posts a start comment', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-184', 'In Progress');
+    expect(commentOnIssueMock).toHaveBeenCalledWith(
+      'QUA-184',
+      expect.stringContaining('starting work')
+    );
+    // Branch name from the mocked execSync is interpolated into the comment
+    const commentBody = commentOnIssueMock.mock.calls[0][1];
+    expect(commentBody).toContain('claude/qua-184-test-branch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// done — CRITICAL: branching logic between "In Review" (with PR) and "Done"
+// ---------------------------------------------------------------------------
+
+describe('linear done', () => {
+  it('prints usage when no ID is given', async () => {
+    const r = await commands.done([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('moves to In Review and includes the PR URL in the comment when --pr is set', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Review',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.done(['QUA-184'], {
+      ci: true,
+      pr: 'https://github.com/example/repo/pull/42',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-184', 'In Review');
+
+    const commentBody = commentOnIssueMock.mock.calls[0][1];
+    expect(commentBody).toContain('finished work');
+    expect(commentBody).toContain('https://github.com/example/repo/pull/42');
+    expect(r.output).toContain('In Review');
+  });
+
+  it('moves straight to Done when --pr is NOT set', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'Done',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.done(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-184', 'Done');
+
+    const commentBody = commentOnIssueMock.mock.calls[0][1];
+    expect(commentBody).not.toContain('**PR:**');
+    expect(r.output).toContain('Done');
+  });
+
+  it('prints not-found when the issue does not exist', async () => {
+    getIssueMock.mockResolvedValueOnce(null);
+    const r = await commands.done(['QUA-99999'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not found');
+    expect(updateIssueStateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comment
+// ---------------------------------------------------------------------------
+
+describe('linear comment', () => {
+  it('prints usage when no ID is given', async () => {
+    const r = await commands.comment([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('rejects an empty body', async () => {
+    const r = await commands.comment(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('empty');
+  });
+
+  it('posts the inline body when provided', async () => {
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.comment(['QUA-184', 'hello', 'world'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(commentOnIssueMock).toHaveBeenCalledWith('QUA-184', 'hello world');
+  });
+
+  it('filters out --flag args from the inline body', async () => {
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+    await commands.comment(
+      ['QUA-184', 'a', 'note', '--body-file=ignored.md'],
+      { ci: true }
+    );
+    // args.slice(1) with flag filter should produce "a note" (no --body-file=...)
+    const [, body] = commentOnIssueMock.mock.calls[0];
+    expect(body).toBe('a note');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// states-list
+// ---------------------------------------------------------------------------
+
+describe('linear states-list', () => {
+  it('prints state names in position order', async () => {
+    fetchRemoteWorkflowStatesMock.mockResolvedValueOnce([
+      { id: 's1', name: 'Done', type: 'completed', position: 3 },
+      { id: 's2', name: 'Backlog', type: 'backlog', position: 0 },
+      { id: 's3', name: 'In Progress', type: 'started', position: 2 },
+    ]);
+
+    const r = await commands['states-list']([], { ci: true });
+    expect(r.exitCode).toBe(0);
+    // Should be sorted: Backlog (0), In Progress (2), Done (3)
+    const backlogIdx = r.output.indexOf('Backlog');
+    const progressIdx = r.output.indexOf('In Progress');
+    const doneIdx = r.output.indexOf('Done');
+    expect(backlogIdx).toBeGreaterThanOrEqual(0);
+    expect(progressIdx).toBeGreaterThan(backlogIdx);
+    expect(doneIdx).toBeGreaterThan(progressIdx);
+  });
+
+  it('emits JSON when --json is set', async () => {
+    fetchRemoteWorkflowStatesMock.mockResolvedValueOnce([
+      { id: 's1', name: 'Backlog', type: 'backlog', position: 0 },
+    ]);
+    const r = await commands['states-list']([], { ci: true, json: true });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.output);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].name).toBe('Backlog');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parse
+// ---------------------------------------------------------------------------
+
+describe('linear parse', () => {
+  it('prints the canonical ID when one is found', async () => {
+    const r = await commands.parse(['claude/qua-184-foo'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output.trim()).toBe('QUA-184');
+  });
+
+  it('exits non-zero when no ID is found', async () => {
+    const r = await commands.parse(['no id'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('No Linear ID found');
+  });
+
+  it('filters out --flag args from the parse input', async () => {
+    const r = await commands.parse(['claude/qua-184-foo', '--json'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output.trim()).toBe('QUA-184');
+  });
+});

--- a/crux/commands/agent-checklist.test.ts
+++ b/crux/commands/agent-checklist.test.ts
@@ -225,9 +225,12 @@ describe('agent-checklist init', () => {
   // --- Linear ID detection (QUA-196) ---------------------------------------
 
   it('auto-detects Linear ID from a claude/qua-NNN-* branch name', async () => {
-    vi.mocked(await import('child_process')).execSync.mockReturnValueOnce(
-      'claude/qua-184-linear-integration' as unknown as Buffer
-    );
+    // currentBranch() calls execSync with encoding:'utf-8' so the runtime
+    // return type is string — the Buffer type the vitest spy sees is a
+    // TypeScript artifact from the execSync overloads.
+    const { execSync } = await import('child_process');
+    (vi.mocked(execSync) as unknown as { mockReturnValueOnce: (v: string) => void })
+      .mockReturnValueOnce('claude/qua-184-linear-integration');
 
     const result = await initNoSideEffects(['Build Linear client library'], {
       type: 'infrastructure',
@@ -274,9 +277,9 @@ describe('agent-checklist init', () => {
   });
 
   it('prefers --linear flag over branch or task detection', async () => {
-    vi.mocked(await import('child_process')).execSync.mockReturnValueOnce(
-      'claude/qua-184-foo' as unknown as Buffer
-    );
+    const { execSync } = await import('child_process');
+    (vi.mocked(execSync) as unknown as { mockReturnValueOnce: (v: string) => void })
+      .mockReturnValueOnce('claude/qua-184-foo');
 
     const result = await initNoSideEffects(['mentions QUA-200 in task'], {
       type: 'infrastructure',

--- a/crux/commands/agent-checklist.test.ts
+++ b/crux/commands/agent-checklist.test.ts
@@ -23,9 +23,21 @@ vi.mock('../lib/github.ts', () => ({
   githubApi: vi.fn(),
 }));
 
-// Mock child_process for currentBranch
+// Mock child_process for currentBranch — default to a branch without any
+// Linear ID so Linear-detection tests only fire when they opt in via a mock
+// override below.
 vi.mock('child_process', () => ({
   execSync: vi.fn(() => 'claude/test-branch-ABC'),
+}));
+
+// Mock the Linear command module so auto-start doesn't hit the network.
+// `vi.mock` is hoisted above imports, so the mock factory uses `vi.hoisted`
+// to expose the spy back to the test body.
+const { linearStartMock } = vi.hoisted(() => ({
+  linearStartMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+}));
+vi.mock('./linear.ts', () => ({
+  commands: { start: linearStartMock },
 }));
 
 // Mock wiki-server agent-sessions (best-effort DB sync)
@@ -208,6 +220,73 @@ describe('agent-checklist init', () => {
 
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
     expect(writtenContent).toContain('Add dark mode');
+  });
+
+  // --- Linear ID detection (QUA-196) ---------------------------------------
+
+  it('auto-detects Linear ID from a claude/qua-NNN-* branch name', async () => {
+    vi.mocked(await import('child_process')).execSync.mockReturnValueOnce(
+      'claude/qua-184-linear-integration' as unknown as Buffer
+    );
+
+    const result = await initNoSideEffects(['Build Linear client library'], {
+      type: 'infrastructure',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('QUA-184');
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenContent).toContain('> Linear: QUA-184');
+  });
+
+  it('accepts an explicit --linear flag', async () => {
+    const result = await initNoSideEffects(['A task'], {
+      type: 'infrastructure',
+      linear: 'QUA-200',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('QUA-200');
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenContent).toContain('> Linear: QUA-200');
+  });
+
+  it('extracts Linear ID from the task description when the branch is plain', async () => {
+    const result = await initNoSideEffects(
+      ['working on QUA-91 cleanup'],
+      { type: 'infrastructure' }
+    );
+    expect(result.exitCode).toBe(0);
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenContent).toContain('> Linear: QUA-91');
+  });
+
+  it('does not render a Linear line when no ID is detected', async () => {
+    const result = await initNoSideEffects(['just a plain task'], {
+      type: 'infrastructure',
+    });
+    expect(result.exitCode).toBe(0);
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenContent).not.toContain('> Linear:');
+    expect(result.output).not.toContain('QUA-');
+  });
+
+  it('prefers --linear flag over branch or task detection', async () => {
+    vi.mocked(await import('child_process')).execSync.mockReturnValueOnce(
+      'claude/qua-184-foo' as unknown as Buffer
+    );
+
+    const result = await initNoSideEffects(['mentions QUA-200 in task'], {
+      type: 'infrastructure',
+      linear: 'QUA-999',
+    });
+    expect(result.exitCode).toBe(0);
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenContent).toContain('> Linear: QUA-999');
+    expect(writtenContent).not.toContain('> Linear: QUA-184');
   });
 });
 

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -28,6 +28,8 @@ import { upsertAgentSession, updateAgentSession, getAgentSessionByBranch } from 
 import { registerAgent, listActiveAgents } from '../lib/wiki-server/active-agents.ts';
 import { syncToMain } from '../lib/git.ts';
 import { commands as issuesCommands } from './issues.ts';
+import { commands as linearCommands } from './linear.ts';
+import { resolveLinearId } from '../lib/linear/parse-id.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,12 +46,17 @@ interface CommandOptions extends BaseOptions {
   ci?: boolean;
   type?: string;
   issue?: string;
+  /** Explicit Linear issue identifier, e.g. "QUA-184". If omitted, auto-detected
+   *  from the branch name (claude/qua-NNN-*) and task description. */
+  linear?: string;
   reason?: string;
   /** Skip the sync-to-main step. Used by tests and by scripted callers that
    *  intentionally want to start a session on the current branch. */
   noSync?: boolean;
   /** Skip the auto-call to `gh issues start <N>`. Used by tests. */
   noIssueStart?: boolean;
+  /** Skip the auto-call to `linear issues start <QUA-NNN>`. Used by tests. */
+  noLinearStart?: boolean;
 }
 
 interface GitHubIssueResponse {
@@ -140,7 +147,17 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
 
   const branch = currentBranch();
   const worktree = PROJECT_ROOT;
-  const metadata: ChecklistMetadata = { task, branch, timestamp: new Date().toISOString(), issue };
+
+  // Detect Linear issue ID: explicit --linear flag wins, else parse from branch + task.
+  // Branch pattern: `claude/qua-184-description` → QUA-184. Task/description fallback
+  // matches any bare QUA-NNN token. Returns null if neither source yields a match.
+  let linearId: string | undefined = options.linear;
+  if (!linearId) {
+    const detected = resolveLinearId([branch, task]);
+    if (detected) linearId = detected;
+  }
+
+  const metadata: ChecklistMetadata = { task, branch, timestamp: new Date().toISOString(), issue, linearId };
   let markdown = buildChecklist(type, metadata);
 
   if (!issue) {
@@ -231,6 +248,36 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
     }
   }
 
+  // ── Auto-call `linear issues start <QUA-NNN>` ────────────────────────────
+  // Same best-effort semantics as the GitHub start above: failure (missing
+  // LINEAR_API_KEY, network error, issue already Done) never fails the init.
+  let linearStartOutput = '';
+  if (linearId && !options.noLinearStart) {
+    if (!process.env.LINEAR_API_KEY) {
+      linearStartOutput =
+        `${c.dim}Linear ID ${linearId} detected but LINEAR_API_KEY is not set — ` +
+        `skipping auto-start. Sync .env.base or export the key to enable.${c.reset}\n`;
+    } else {
+      try {
+        const startResult = await linearCommands.start([linearId], { ci: options.ci });
+        if (startResult.exitCode === 0) {
+          linearStartOutput = startResult.output;
+        } else {
+          linearStartOutput =
+            `${c.yellow}⚠ Auto-start of Linear ${linearId} returned non-zero exit:${c.reset}\n` +
+            startResult.output +
+            `${c.dim}(checklist created locally; you may want to run ` +
+            `\`crux linear issues start ${linearId}\` manually)${c.reset}\n`;
+        }
+      } catch (e) {
+        linearStartOutput =
+          `${c.yellow}⚠ Could not signal start on Linear ${linearId}: ` +
+          `${e instanceof Error ? e.message : String(e)}${c.reset}\n` +
+          `${c.dim}(checklist created locally)${c.reset}\n`;
+      }
+    }
+  }
+
   const status = parseChecklist(markdown);
   let output = '';
   if (syncOutput) {
@@ -243,10 +290,12 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   output += `  Directory: ${c.dim}${worktree}${c.reset}\n`;
   if (issue) output += `  Issue: ${c.cyan}#${issue}${c.reset}\n`;
   else output += `  ${c.dim}issue-tracking auto-marked N/A (no GitHub issue)${c.reset}\n`;
+  if (linearId) output += `  Linear: ${c.cyan}${linearId}${c.reset}\n`;
   output += `  Items: ${status.totalItems}\n`;
   if (dbSynced) output += `  ${c.dim}Synced to wiki-server DB${c.reset}\n`;
   if (directoryWarning) output += directoryWarning;
   if (issueStartOutput) output += `\n${issueStartOutput}`;
+  if (linearStartOutput) output += `\n${linearStartOutput}`;
 
   // Render the full checklist so callers don't need a separate `status` call.
   output += `\n${renderChecklistItems(status, c)}`;

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -10,7 +10,7 @@
  *   crux linear issues comment <QUA-NNN> <msg> Post a comment
  *   crux linear issues start <QUA-NNN>         Move to In Progress + start comment
  *   crux linear issues done <QUA-NNN> --pr=URL Move to In Review + done comment
- *   crux linear states list                    Print current QUA team workflow states
+ *   crux linear states-list                    Print current QUA team workflow states
  *   crux linear parse <string>                 Extract a Linear ID from a string (debug)
  */
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -1,0 +1,305 @@
+/**
+ * Linear Command Handlers
+ *
+ * Track Claude Code work on Linear issues: list, search, comment,
+ * signal start/done. Mirrors `crux gh issues` for Linear.
+ *
+ * Usage:
+ *   crux linear issues view <QUA-NNN>          Show full issue + comments
+ *   crux linear issues search <query>          Search QUA team issues
+ *   crux linear issues comment <QUA-NNN> <msg> Post a comment
+ *   crux linear issues start <QUA-NNN>         Move to In Progress + start comment
+ *   crux linear issues done <QUA-NNN> --pr=URL Move to In Review + done comment
+ *   crux linear states list                    Print current QUA team workflow states
+ *   crux linear parse <string>                 Extract a Linear ID from a string (debug)
+ */
+
+import { readFileSync } from 'fs';
+import { createLogger } from '../lib/output.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import {
+  commentOnIssue,
+  getComments,
+  getIssue,
+  searchIssues,
+  updateIssueState,
+} from '../lib/linear/issues.ts';
+import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
+import { parseLinearId } from '../lib/linear/parse-id.ts';
+import { currentBranch } from '../lib/session/session-checklist.ts';
+
+interface CommandOptions extends BaseOptions {
+  ci?: boolean;
+  json?: boolean;
+  pr?: string;
+  limit?: string;
+  bodyFile?: string;
+}
+
+function readBodyFlag(path: string | undefined): string | null {
+  if (!path) return null;
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Error reading file ${path}: ${msg}`);
+  }
+}
+
+function priorityLabel(priority: number): string {
+  return ['none', 'urgent', 'high', 'medium', 'low'][priority] ?? `P${priority}`;
+}
+
+async function view(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const id = parseLinearId(args[0]);
+  if (!id) {
+    return {
+      output: `${c.red}Usage: crux linear issues view <QUA-NNN>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const issue = await getIssue(id);
+  if (!issue) {
+    return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
+  }
+
+  const comments = await getComments(id, 10);
+
+  if (options.json) {
+    return {
+      output: JSON.stringify({ issue, comments }, null, 2) + '\n',
+      exitCode: 0,
+    };
+  }
+
+  let out = '';
+  out += `${c.bold}${issue.identifier}${c.reset} ${c.cyan}${issue.title}${c.reset}\n`;
+  out += `  ${c.dim}state:${c.reset} ${issue.state.name}  ${c.dim}priority:${c.reset} ${priorityLabel(issue.priority)}\n`;
+  if (issue.parent) {
+    out += `  ${c.dim}parent:${c.reset} ${issue.parent.identifier} — ${issue.parent.title}\n`;
+  }
+  if (issue.project) {
+    out += `  ${c.dim}project:${c.reset} ${issue.project.name}\n`;
+  }
+  out += `  ${c.dim}url:${c.reset} ${issue.url}\n`;
+  if (issue.description) {
+    out += `\n${issue.description.slice(0, 1000)}${issue.description.length > 1000 ? '\n…(truncated)' : ''}\n`;
+  }
+  if (comments.length > 0) {
+    out += `\n${c.bold}Comments (${comments.length}):${c.reset}\n`;
+    for (const cm of comments) {
+      const who = cm.user?.name ?? 'unknown';
+      const when = cm.createdAt.slice(0, 10);
+      out += `  ${c.dim}[${when}]${c.reset} ${c.yellow}${who}${c.reset}: ${cm.body.slice(0, 200).replace(/\n/g, ' ')}\n`;
+    }
+  }
+  return { output: out, exitCode: 0 };
+}
+
+async function search(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const query = args.filter((a) => !a.startsWith('--')).join(' ').trim();
+  if (!query) {
+    return {
+      output: `${c.red}Usage: crux linear issues search <query>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const limit = options.limit ? parseInt(options.limit, 10) : 20;
+  const results = await searchIssues(query, limit);
+
+  if (options.json) {
+    return { output: JSON.stringify(results, null, 2) + '\n', exitCode: 0 };
+  }
+
+  if (results.length === 0) {
+    return { output: `${c.dim}No matches for "${query}"${c.reset}\n`, exitCode: 0 };
+  }
+
+  let out = `${c.bold}${results.length} match(es) for "${query}":${c.reset}\n`;
+  for (const r of results) {
+    out += `  ${c.cyan}${r.identifier}${c.reset} [${r.state.name}] ${priorityLabel(r.priority)} — ${r.title}\n`;
+  }
+  return { output: out, exitCode: 0 };
+}
+
+async function comment(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const id = parseLinearId(args[0]);
+  if (!id) {
+    return {
+      output: `${c.red}Usage: crux linear issues comment <QUA-NNN> <message>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const bodyFromFile = readBodyFlag(options.bodyFile);
+  const body = bodyFromFile ?? args.slice(1).filter((a) => !a.startsWith('--')).join(' ').trim();
+  if (!body) {
+    return {
+      output: `${c.red}Comment body is empty. Pass inline or use --body-file=<path>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  await commentOnIssue(id, body);
+  return {
+    output: `${c.green}✓${c.reset} Comment posted on ${c.cyan}${id}${c.reset}\n`,
+    exitCode: 0,
+  };
+}
+
+async function start(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const id = parseLinearId(args[0]);
+  if (!id) {
+    return {
+      output: `${c.red}Usage: crux linear issues start <QUA-NNN>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const issue = await getIssue(id);
+  if (!issue) {
+    return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
+  }
+
+  const branch = currentBranch();
+  await updateIssueState(id, 'In Progress');
+  await commentOnIssue(
+    id,
+    `🤖 Claude Code starting work on this issue.\n\n**Branch:** \`${branch}\`\n\nWill post an update when a PR is ready for review.`,
+  );
+
+  let out = '';
+  out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → In Progress\n`;
+  out += `  Branch: ${c.cyan}${branch}${c.reset}\n`;
+  out += `  ${issue.url}\n`;
+  return { output: out, exitCode: 0 };
+}
+
+async function done(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const id = parseLinearId(args[0]);
+  if (!id) {
+    return {
+      output: `${c.red}Usage: crux linear issues done <QUA-NNN> [--pr=URL]${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const issue = await getIssue(id);
+  if (!issue) {
+    return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
+  }
+
+  // If there's a PR, move to In Review and let the merge move it to Done later.
+  // Without a PR, go straight to Done (coordinator sessions, docs-only, etc.).
+  const targetState = options.pr ? 'In Review' : 'Done';
+  await updateIssueState(id, targetState);
+
+  const prLine = options.pr ? `\n**PR:** ${options.pr}` : '';
+  await commentOnIssue(
+    id,
+    `🤖 Claude Code finished work on this issue.${prLine}`,
+  );
+
+  let out = '';
+  out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → ${targetState}\n`;
+  if (options.pr) out += `  PR: ${options.pr}\n`;
+  return { output: out, exitCode: 0 };
+}
+
+async function statesList(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const states = await fetchRemoteWorkflowStates();
+  states.sort((a, b) => a.position - b.position);
+
+  if (options.json) {
+    return { output: JSON.stringify(states, null, 2) + '\n', exitCode: 0 };
+  }
+
+  let out = `${c.bold}QUA team workflow states:${c.reset}\n`;
+  for (const s of states) {
+    out += `  ${c.cyan}${s.name.padEnd(14)}${c.reset} ${c.dim}(${s.type})${c.reset} ${s.id}\n`;
+  }
+  return { output: out, exitCode: 0 };
+}
+
+async function parse(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const input = args.filter((a) => !a.startsWith('--')).join(' ');
+  const id = parseLinearId(input);
+  if (!id) {
+    return { output: `${c.dim}No Linear ID found in: ${input}${c.reset}\n`, exitCode: 1 };
+  }
+  return { output: `${id}\n`, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Command registry
+// ---------------------------------------------------------------------------
+
+export const commands = {
+  default: view,
+  view,
+  search,
+  comment,
+  start,
+  done,
+  'states-list': statesList,
+  parse,
+};
+
+export function getHelp(): string {
+  return `
+Linear Domain — Track Claude Code work on Linear issues
+
+Commands:
+  view <QUA-NNN>                Show full issue + recent comments (default)
+  search <query>                Search QUA team issues
+  comment <QUA-NNN> <message>   Post a comment on an issue
+  start <QUA-NNN>               Move issue to In Progress + post start comment
+  done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
+  states-list                   Show current QUA team workflow state IDs
+  parse <string>                Extract a Linear ID from a string (debug helper)
+
+Options (comment):
+  --body-file=<path>  Comment body from file (safe for multiline / escaped content)
+
+Options (done):
+  --pr=URL            PR URL to include in the completion comment; moves to In Review
+
+Global options:
+  --json              Machine-readable output where supported
+  --limit=N           Max results for search (default: 20)
+
+Environment:
+  LINEAR_API_KEY      Required. Stored in .env.base at the workspace root.
+
+Examples:
+  crux linear issues view QUA-184
+  crux linear issues search "agent checklist"
+  crux linear issues start QUA-184
+  crux linear issues done QUA-184 --pr=https://github.com/.../pull/42
+  crux linear issues comment QUA-184 "Landed in commit abc123"
+  crux linear issues comment QUA-184 --body-file=/tmp/note.md
+  crux linear states-list
+`;
+}

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -5,11 +5,11 @@
  * signal start/done. Mirrors `crux gh issues` for Linear.
  *
  * Usage:
- *   crux linear issues view <QUA-NNN>          Show full issue + comments
- *   crux linear issues search <query>          Search QUA team issues
- *   crux linear issues comment <QUA-NNN> <msg> Post a comment
- *   crux linear issues start <QUA-NNN>         Move to In Progress + start comment
- *   crux linear issues done <QUA-NNN> --pr=URL Move to In Review + done comment
+ *   crux linear view <QUA-NNN>          Show full issue + comments
+ *   crux linear search <query>          Search QUA team issues
+ *   crux linear comment <QUA-NNN> <msg> Post a comment
+ *   crux linear start <QUA-NNN>         Move to In Progress + start comment
+ *   crux linear done <QUA-NNN> --pr=URL Move to In Review + done comment
  *   crux linear states-list                    Print current QUA team workflow states
  *   crux linear parse <string>                 Extract a Linear ID from a string (debug)
  */
@@ -57,7 +57,7 @@ async function view(args: string[], options: CommandOptions): Promise<CommandRes
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear issues view <QUA-NNN>${c.reset}\n`,
+      output: `${c.red}Usage: crux linear view <QUA-NNN>${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -107,7 +107,7 @@ async function search(args: string[], options: CommandOptions): Promise<CommandR
   const query = args.filter((a) => !a.startsWith('--')).join(' ').trim();
   if (!query) {
     return {
-      output: `${c.red}Usage: crux linear issues search <query>${c.reset}\n`,
+      output: `${c.red}Usage: crux linear search <query>${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -137,7 +137,7 @@ async function comment(args: string[], options: CommandOptions): Promise<Command
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear issues comment <QUA-NNN> <message>${c.reset}\n`,
+      output: `${c.red}Usage: crux linear comment <QUA-NNN> <message>${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -165,7 +165,7 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear issues start <QUA-NNN>${c.reset}\n`,
+      output: `${c.red}Usage: crux linear start <QUA-NNN>${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -196,7 +196,7 @@ async function done(args: string[], options: CommandOptions): Promise<CommandRes
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear issues done <QUA-NNN> [--pr=URL]${c.reset}\n`,
+      output: `${c.red}Usage: crux linear done <QUA-NNN> [--pr=URL]${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -294,12 +294,12 @@ Environment:
   LINEAR_API_KEY      Required. Stored in .env.base at the workspace root.
 
 Examples:
-  crux linear issues view QUA-184
-  crux linear issues search "agent checklist"
-  crux linear issues start QUA-184
-  crux linear issues done QUA-184 --pr=https://github.com/.../pull/42
-  crux linear issues comment QUA-184 "Landed in commit abc123"
-  crux linear issues comment QUA-184 --body-file=/tmp/note.md
+  crux linear view QUA-184
+  crux linear search "agent checklist"
+  crux linear start QUA-184
+  crux linear done QUA-184 --pr=https://github.com/.../pull/42
+  crux linear comment QUA-184 "Landed in commit abc123"
+  crux linear comment QUA-184 --body-file=/tmp/note.md
   crux linear states-list
 `;
 }

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -270,6 +270,8 @@ ${B}Examples:${R}
   crux tb people discover             ${D}# Discover people${R}
   crux tb ids allocate my-slug        ${D}# Allocate entity ID${R}
   crux gh issues start 42             ${D}# Start working on issue #42${R}
+  crux linear start QUA-184           ${D}# Start a Linear issue (agent-session tracking)${R}
+  crux linear done QUA-184 --pr=URL   ${D}# Close out a Linear issue${R}
   crux sys health check               ${D}# System health check${R}
   crux query search "topic"           ${D}# Full-text search${R}
 

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -118,6 +118,7 @@ import * as benchmarksCommands from './commands/benchmarks.ts';
 import * as usagePatternsCommands from './commands/usage-patterns.ts';
 import * as entityResourcesCommands from './commands/entity-resources.ts';
 import * as docsCommands from './commands/docs.ts';
+import * as linearCommands from './commands/linear.ts';
 
 const domains = {
   validate: validateCommands,
@@ -200,6 +201,7 @@ const domains = {
   benchmarks: benchmarksCommands,
   'usage-patterns': usagePatternsCommands,
   docs: docsCommands,
+  linear: linearCommands,
 };
 
 const shortcutMap = buildShortcutMap();

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -128,6 +128,12 @@ export const GROUPS: Record<string, GroupDef> = {
       'docs',
     ],
   },
+  linear: {
+    shortcut: 'linear',
+    description: 'Linear — issues, workflow states, agent session tracking',
+    domains: ['linear'],
+    flattened: ['linear'],
+  },
 };
 
 /** Build a lookup from shortcut → group name (e.g. 'w' → 'wiki') */

--- a/crux/lib/linear/__tests__/client.test.ts
+++ b/crux/lib/linear/__tests__/client.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { detectCorruption, linearGraphQL, linearIssueUrl } from '../client.ts';
+
+describe('detectCorruption', () => {
+  it('flags ANSI escape sequences', () => {
+    expect(detectCorruption('hello \x1b[31mred\x1b[0m')).toMatch(/ANSI/);
+  });
+
+  it('flags dotenv injection output', () => {
+    expect(detectCorruption('[dotenv] injecting env from .env')).toMatch(/dotenv/);
+  });
+
+  it('flags shell "command not found" output', () => {
+    expect(detectCorruption('/tmp/foo.sh: command not found')).toMatch(/shell error/);
+  });
+
+  it('flags 4+ consecutive asterisks from broken bold markup', () => {
+    expect(detectCorruption('see **** for details')).toMatch(/corrupted bold/);
+  });
+
+  it('passes clean text', () => {
+    expect(detectCorruption('Normal text with *one* and **two** stars')).toBeNull();
+    expect(detectCorruption('')).toBeNull();
+  });
+});
+
+describe('linearIssueUrl', () => {
+  it('builds the canonical URL for an identifier', () => {
+    expect(linearIssueUrl('QUA-184')).toBe(
+      'https://linear.app/quantifieduncertainty/issue/QUA-184'
+    );
+  });
+});
+
+describe('linearGraphQL transport', () => {
+  let originalFetch: typeof fetch;
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalKey = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'lin_test_key';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = originalKey;
+  });
+
+  it('throws when LINEAR_API_KEY is missing', async () => {
+    delete process.env.LINEAR_API_KEY;
+    await expect(linearGraphQL('query { viewer { id } }')).rejects.toThrow(/LINEAR_API_KEY/);
+  });
+
+  it('sends the Authorization header with the raw key (no Bearer prefix)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { ok: true } }), { status: 200 })
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await linearGraphQL('query { viewer { id } }');
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe('lin_test_key');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('rejects request variables containing ANSI codes (corruption check)', async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await expect(
+      linearGraphQL('mutation X($body: String!) { x(body: $body) }', {
+        body: 'hello \x1b[31mred\x1b[0m',
+      })
+    ).rejects.toThrow(/corruption check/);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces GraphQL errors from the response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ errors: [{ message: 'Not authorized' }] }),
+        { status: 200 }
+      )
+    ) as unknown as typeof fetch;
+
+    await expect(linearGraphQL('query { x }')).rejects.toThrow(/Not authorized/);
+  });
+
+  it('surfaces HTTP errors with the response body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response('internal error details', { status: 500 })
+    ) as unknown as typeof fetch;
+
+    await expect(linearGraphQL('query { x }')).rejects.toThrow(/500.*internal error details/);
+  });
+
+  it('returns the data field on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { viewer: { id: 'u1' } } }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const result = await linearGraphQL<{ viewer: { id: string } }>(
+      'query { viewer { id } }'
+    );
+    expect(result.viewer.id).toBe('u1');
+  });
+
+  it('throws when response has no data and no errors', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    await expect(linearGraphQL('query { x }')).rejects.toThrow(/no data/);
+  });
+});

--- a/crux/lib/linear/__tests__/issues.test.ts
+++ b/crux/lib/linear/__tests__/issues.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getIssue,
+  getComments,
+  updateIssueState,
+  commentOnIssue,
+  createIssue,
+  searchIssues,
+} from '../issues.ts';
+
+// Helper: fake a fetch response with a JSON body.
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const ISSUE_UUID = '9382e839-d2c5-4ae2-8da5-7f4d892da2d6';
+
+const fullIssueFixture = {
+  id: ISSUE_UUID,
+  identifier: 'QUA-184',
+  title: 'Test issue',
+  description: 'body',
+  priority: 2,
+  url: 'https://linear.app/quantifieduncertainty/issue/QUA-184',
+  state: { id: 'state-1', name: 'Backlog', type: 'backlog' },
+  team: { id: 'team-1', key: 'QUA' },
+  parent: null,
+  project: null,
+  labels: { nodes: [] },
+};
+
+describe('issues.ts — transport helpers', () => {
+  let originalFetch: typeof fetch;
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalKey = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'lin_test_key';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = originalKey;
+  });
+
+  describe('getIssue', () => {
+    it('returns a fully-shaped issue on happy path', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: fullIssueFixture } })
+      ) as unknown as typeof fetch;
+
+      const issue = await getIssue('QUA-184');
+      expect(issue).not.toBeNull();
+      expect(issue!.identifier).toBe('QUA-184');
+      expect(issue!.title).toBe('Test issue');
+      expect(issue!.state.name).toBe('Backlog');
+      expect(issue!.id).toBe(ISSUE_UUID);
+    });
+
+    it('returns null when Linear reports entity not found', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          errors: [{ message: 'Entity not found - Issue' }],
+        })
+      ) as unknown as typeof fetch;
+
+      const issue = await getIssue('QUA-99999');
+      expect(issue).toBeNull();
+    });
+
+    it('returns null when data.issue is null (graceful API response)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: null } })
+      ) as unknown as typeof fetch;
+
+      const issue = await getIssue('QUA-1');
+      expect(issue).toBeNull();
+    });
+
+    it('rethrows non-not-found errors', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ errors: [{ message: 'Authentication required' }] })
+      ) as unknown as typeof fetch;
+
+      await expect(getIssue('QUA-184')).rejects.toThrow(/Authentication/);
+    });
+  });
+
+  describe('getComments', () => {
+    it('returns comment nodes from the API', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issue: {
+              comments: {
+                nodes: [
+                  {
+                    id: 'c1',
+                    body: 'first comment',
+                    createdAt: '2026-04-10T12:00:00Z',
+                    user: { name: 'Ozzie' },
+                  },
+                  {
+                    id: 'c2',
+                    body: 'second',
+                    createdAt: '2026-04-10T13:00:00Z',
+                    user: null,
+                  },
+                ],
+              },
+            },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      const comments = await getComments('QUA-184');
+      expect(comments).toHaveLength(2);
+      expect(comments[0].body).toBe('first comment');
+      expect(comments[1].user).toBeNull();
+    });
+
+    it('returns empty array when issue has no comments', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: { comments: { nodes: [] } } } })
+      ) as unknown as typeof fetch;
+
+      const comments = await getComments('QUA-184');
+      expect(comments).toEqual([]);
+    });
+
+    it('returns empty array when issue is missing', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: null } })
+      ) as unknown as typeof fetch;
+
+      const comments = await getComments('QUA-1');
+      expect(comments).toEqual([]);
+    });
+  });
+
+  describe('updateIssueState', () => {
+    it('resolves state name to UUID and reports success', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: { identifier: 'QUA-184', state: { name: 'In Progress' } },
+            },
+          },
+        })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      const r = await updateIssueState('QUA-184', 'In Progress');
+      expect(r.identifier).toBe('QUA-184');
+      expect(r.state).toBe('In Progress');
+
+      // Confirm the mutation sent the canonical UUID, not the string name.
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.stateId).toBe('1cafee7f-1921-49d4-b603-df2bf517b296');
+    });
+
+    it('throws when Linear reports success=false', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueUpdate: {
+              success: false,
+              issue: { identifier: 'QUA-184', state: { name: 'Backlog' } },
+            },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      await expect(updateIssueState('QUA-184', 'Done')).rejects.toThrow(
+        /refused to update QUA-184/
+      );
+    });
+
+    it('throws on an unknown state name before hitting the API', async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+      await expect(
+        // @ts-expect-error — intentionally invalid
+        updateIssueState('QUA-184', 'Pending')
+      ).rejects.toThrow(/Unknown Linear workflow state/);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commentOnIssue', () => {
+    it('resolves the issue UUID first, then creates the comment', async () => {
+      const fetchSpy = vi
+        .fn()
+        // getIssue
+        .mockResolvedValueOnce(jsonResponse({ data: { issue: fullIssueFixture } }))
+        // commentCreate
+        .mockResolvedValueOnce(
+          jsonResponse({ data: { commentCreate: { success: true } } })
+        );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await commentOnIssue('QUA-184', 'hello from a test');
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // Second call is commentCreate; issueId should be the UUID, not the identifier.
+      const [, init] = fetchSpy.mock.calls[1];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.input.issueId).toBe(ISSUE_UUID);
+      expect(body.variables.input.body).toBe('hello from a test');
+    });
+
+    it('throws when the issue does not exist', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: null } })
+      ) as unknown as typeof fetch;
+
+      await expect(commentOnIssue('QUA-99999', 'x')).rejects.toThrow(
+        /QUA-99999 not found/
+      );
+    });
+
+    it('throws when commentCreate reports success=false', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ data: { issue: fullIssueFixture } }))
+        .mockResolvedValueOnce(
+          jsonResponse({ data: { commentCreate: { success: false } } })
+        );
+      globalThis.fetch = globalThis.fetch as unknown as typeof fetch;
+
+      await expect(commentOnIssue('QUA-184', 'x')).rejects.toThrow(
+        /refused to post comment/
+      );
+    });
+  });
+
+  describe('createIssue', () => {
+    it('returns the new identifier and URL on success', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueCreate: {
+              success: true,
+              issue: {
+                identifier: 'QUA-300',
+                url: 'https://linear.app/quantifieduncertainty/issue/QUA-300',
+              },
+            },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      const r = await createIssue({
+        title: 'Test',
+        description: 'body',
+        priority: 2,
+      });
+      expect(r.identifier).toBe('QUA-300');
+      expect(r.url).toContain('QUA-300');
+    });
+
+    it('defaults to the QUA team when teamId is omitted', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueCreate: {
+              success: true,
+              issue: { identifier: 'QUA-301', url: 'u' },
+            },
+          },
+        })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await createIssue({ title: 'T', description: 'D' });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.input.teamId).toBe(
+        '12392162-e1e0-4fce-95ad-a8a5d6800321'
+      );
+    });
+
+    it('throws when issueCreate reports success=false', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueCreate: { success: false, issue: { identifier: '', url: '' } },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      await expect(
+        createIssue({ title: 'Test', description: 'body' })
+      ).rejects.toThrow(/refused to create/);
+    });
+  });
+
+  describe('searchIssues', () => {
+    it('returns the matching nodes', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            searchIssues: {
+              nodes: [
+                {
+                  identifier: 'QUA-1',
+                  title: 'First',
+                  priority: 2,
+                  state: { name: 'Backlog', type: 'backlog' },
+                  url: 'u1',
+                },
+                {
+                  identifier: 'QUA-2',
+                  title: 'Second',
+                  priority: 3,
+                  state: { name: 'Todo', type: 'unstarted' },
+                  url: 'u2',
+                },
+              ],
+            },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      const results = await searchIssues('test');
+      expect(results).toHaveLength(2);
+      expect(results[0].identifier).toBe('QUA-1');
+      expect(results[1].state.name).toBe('Todo');
+    });
+
+    it('applies the limit argument', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { searchIssues: { nodes: [] } } })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await searchIssues('anything', 7);
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.limit).toBe(7);
+    });
+  });
+});

--- a/crux/lib/linear/__tests__/parse-id.test.ts
+++ b/crux/lib/linear/__tests__/parse-id.test.ts
@@ -18,10 +18,19 @@ describe('parseLinearId', () => {
     expect(parseLinearId('(see QUA-91) for context')).toBe('QUA-91');
   });
 
-  it('normalises different team keys inside a claude/ branch prefix', () => {
-    // Branch-pattern match accepts any 2-5 letter key — the `claude/`
-    // prefix is the disambiguator, not the team identity.
-    expect(parseLinearId('claude/abc-5-test')).toBe('ABC-5');
+  it('branch-pattern match is restricted to known team keys (QUA)', () => {
+    // Unknown team keys inside a `claude/` prefix are NOT matched — tightened
+    // to prevent GitHub-flavored branches from polluting Linear metadata.
+    expect(parseLinearId('claude/abc-5-test')).toBeNull();
+  });
+
+  it('does not misclassify GitHub-style fix branches as Linear IDs', () => {
+    // Regression test for CodeRabbit finding: `claude/fix-239-...` must NOT
+    // parse as `FIX-239`, which would pollute Linear checklist metadata and
+    // trigger failing start/done calls against a non-existent team.
+    expect(parseLinearId('claude/fix-239-broken-test')).toBeNull();
+    expect(parseLinearId('claude/cve-2024-foo')).toBeNull();
+    expect(parseLinearId('claude/pr-1234-fix')).toBeNull();
   });
 
   it('bare-token match is restricted to known team keys (QUA)', () => {

--- a/crux/lib/linear/__tests__/parse-id.test.ts
+++ b/crux/lib/linear/__tests__/parse-id.test.ts
@@ -18,9 +18,26 @@ describe('parseLinearId', () => {
     expect(parseLinearId('(see QUA-91) for context')).toBe('QUA-91');
   });
 
-  it('normalises different team keys', () => {
+  it('normalises different team keys inside a claude/ branch prefix', () => {
+    // Branch-pattern match accepts any 2-5 letter key — the `claude/`
+    // prefix is the disambiguator, not the team identity.
     expect(parseLinearId('claude/abc-5-test')).toBe('ABC-5');
-    expect(parseLinearId('refs XYZ-999')).toBe('XYZ-999');
+  });
+
+  it('bare-token match is restricted to known team keys (QUA)', () => {
+    expect(parseLinearId('refs QUA-999')).toBe('QUA-999');
+    // Other keys are not matched as bare tokens — avoids false positives.
+    expect(parseLinearId('refs XYZ-999')).toBeNull();
+    expect(parseLinearId('refs ABC-5')).toBeNull();
+  });
+
+  it('does not false-match common tokens that look like Linear IDs', () => {
+    expect(parseLinearId('fix UTF-8 encoding bug')).toBeNull();
+    expect(parseLinearId('patches CVE-2024 vulnerability')).toBeNull();
+    expect(parseLinearId('see RFC-8446 section 4')).toBeNull();
+    expect(parseLinearId('upgrade HTTP2-3 fallback')).toBeNull();
+    expect(parseLinearId('serialize ISO-8601 timestamps')).toBeNull();
+    expect(parseLinearId('PR-1234 is open')).toBeNull();
   });
 
   it('returns null when no ID is present', () => {
@@ -36,12 +53,12 @@ describe('parseLinearId', () => {
     expect(parseLinearId('qua-184 lowercase')).toBeNull();
   });
 
-  it('does not match 6+ digit numbers (out of range for team identifiers)', () => {
+  it('does not match 7+ digit numbers (out of range for team identifiers)', () => {
     expect(parseLinearId('QUA-1234567')).toBeNull();
   });
 
-  it('does not match keys with too many letters', () => {
-    expect(parseLinearId('TEAMNAME-5')).toBeNull();
+  it('does not match keys with too many letters (branch pattern)', () => {
+    expect(parseLinearId('claude/teamname-5-foo')).toBeNull();
   });
 
   it('prefers the branch-pattern match when both appear', () => {

--- a/crux/lib/linear/__tests__/parse-id.test.ts
+++ b/crux/lib/linear/__tests__/parse-id.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { parseLinearId, resolveLinearId } from '../parse-id.ts';
+
+describe('parseLinearId', () => {
+  it('extracts ID from a canonical claude branch name', () => {
+    expect(parseLinearId('claude/qua-184-linear-integration')).toBe('QUA-184');
+  });
+
+  it('case-insensitive branch matching (uppercase QUA in branch)', () => {
+    expect(parseLinearId('claude/QUA-17-foo')).toBe('QUA-17');
+  });
+
+  it('extracts a bare QUA-NNN token from a task description', () => {
+    expect(parseLinearId('working on QUA-200 today')).toBe('QUA-200');
+  });
+
+  it('handles punctuation around a bare token', () => {
+    expect(parseLinearId('(see QUA-91) for context')).toBe('QUA-91');
+  });
+
+  it('normalises different team keys', () => {
+    expect(parseLinearId('claude/abc-5-test')).toBe('ABC-5');
+    expect(parseLinearId('refs XYZ-999')).toBe('XYZ-999');
+  });
+
+  it('returns null when no ID is present', () => {
+    expect(parseLinearId('no id here')).toBeNull();
+    expect(parseLinearId('')).toBeNull();
+    expect(parseLinearId(null)).toBeNull();
+    expect(parseLinearId(undefined)).toBeNull();
+  });
+
+  it('does not match false positives with lowercase bare text', () => {
+    // bare lowercase "qua-184" is not a valid Linear identifier form — we
+    // only accept it inside a `claude/` branch prefix.
+    expect(parseLinearId('qua-184 lowercase')).toBeNull();
+  });
+
+  it('does not match 6+ digit numbers (out of range for team identifiers)', () => {
+    expect(parseLinearId('QUA-1234567')).toBeNull();
+  });
+
+  it('does not match keys with too many letters', () => {
+    expect(parseLinearId('TEAMNAME-5')).toBeNull();
+  });
+
+  it('prefers the branch-pattern match when both appear', () => {
+    // `claude/qua-184-foo` resolves before the bare `QUA-200` appears
+    expect(
+      parseLinearId('claude/qua-184-foo references QUA-200')
+    ).toBe('QUA-184');
+  });
+});
+
+describe('resolveLinearId', () => {
+  it('returns the first match across multiple sources', () => {
+    const id = resolveLinearId([
+      'claude/qua-184-foo',
+      'working on QUA-200 today',
+    ]);
+    expect(id).toBe('QUA-184');
+  });
+
+  it('falls through to later sources', () => {
+    const id = resolveLinearId([
+      null,
+      'just a branch name',
+      'task is QUA-91 cleanup',
+    ]);
+    expect(id).toBe('QUA-91');
+  });
+
+  it('returns null when no source has a match', () => {
+    expect(resolveLinearId([null, undefined, 'plain text'])).toBeNull();
+    expect(resolveLinearId([])).toBeNull();
+  });
+});

--- a/crux/lib/linear/__tests__/workflow-states.test.ts
+++ b/crux/lib/linear/__tests__/workflow-states.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  QUA_WORKFLOW_STATES,
+  getWorkflowStateId,
+  type WorkflowStateName,
+} from '../workflow-states.ts';
+
+describe('QUA_WORKFLOW_STATES', () => {
+  it('has entries for every canonical state', () => {
+    const expected: WorkflowStateName[] = [
+      'Backlog',
+      'Todo',
+      'In Progress',
+      'In Review',
+      'Done',
+      'Canceled',
+      'Duplicate',
+    ];
+    for (const name of expected) {
+      expect(QUA_WORKFLOW_STATES[name]).toMatch(/^[0-9a-f-]{36}$/);
+    }
+  });
+
+  it('has no duplicate UUIDs across states', () => {
+    const ids = Object.values(QUA_WORKFLOW_STATES);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('getWorkflowStateId', () => {
+  it('resolves known state names to their UUIDs', () => {
+    expect(getWorkflowStateId('In Progress')).toBe(
+      QUA_WORKFLOW_STATES['In Progress']
+    );
+    expect(getWorkflowStateId('Done')).toBe(QUA_WORKFLOW_STATES.Done);
+  });
+
+  it('throws on an unknown state name', () => {
+    expect(() =>
+      // @ts-expect-error — intentionally passing an invalid name
+      getWorkflowStateId('Doing')
+    ).toThrow(/Unknown Linear workflow state/);
+  });
+});

--- a/crux/lib/linear/client.ts
+++ b/crux/lib/linear/client.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared Linear API utilities.
+ *
+ * Used by `crux linear` commands and agent-session skills that need to track
+ * work on Linear issues (QUA-NNN). Mirrors the pattern in `crux/lib/github.ts`.
+ *
+ * Corruption detection: All writes through `linearGraphQL()` validate variable
+ * strings for shell-expansion corruption (ANSI codes, dotenv output, etc.)
+ * before sending — same class of bugs that `githubApi()` guards against.
+ */
+
+/**
+ * Workspace slug for Linear URLs. Issues live at
+ * `https://linear.app/${WORKSPACE_SLUG}/issue/QUA-NNN`.
+ */
+export const LINEAR_WORKSPACE_SLUG = 'quantifieduncertainty';
+
+export function getLinearApiKey(): string {
+  const key = process.env.LINEAR_API_KEY;
+  if (!key) {
+    throw new Error(
+      'LINEAR_API_KEY not set. Required for Linear API calls.\n' +
+      'It should be in .env.base at the workspace root — sync it into the slot .env or export it.'
+    );
+  }
+  return key;
+}
+
+/**
+ * Check a string for shell-expansion corruption or terminal output artifacts.
+ * Duplicated from github.ts so the linear client is self-contained; the checks
+ * are identical by design — if we ever extend one, extend the other.
+ */
+export function detectCorruption(text: string): string | null {
+  if (/\x1b\[|\u25c6\[/.test(text)) {
+    return 'Contains ANSI escape codes — text was likely captured from terminal output';
+  }
+  if (/injecting env.*from \.env/i.test(text)) {
+    return 'Contains dotenv output — text was likely processed by bash with shell expansion';
+  }
+  if (/: command not found/.test(text)) {
+    return 'Contains shell error output ("command not found") — text was likely shell-expanded';
+  }
+  if (/\*{4,}/.test(text)) {
+    return 'Contains "****" — likely corrupted bold+code markdown (backticks shell-expanded away)';
+  }
+  return null;
+}
+
+function collectStrings(obj: unknown): string[] {
+  if (typeof obj === 'string') return [obj];
+  if (Array.isArray(obj)) return obj.flatMap(collectStrings);
+  if (obj && typeof obj === 'object') return Object.values(obj).flatMap(collectStrings);
+  return [];
+}
+
+export interface LinearGraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string; path?: string[]; extensions?: unknown }>;
+}
+
+/**
+ * Execute a Linear GraphQL query or mutation.
+ *
+ * Linear's API is GraphQL-only — there is no REST endpoint. Every variable
+ * string is validated for corruption before sending, matching `githubApi()`.
+ *
+ * The Linear API uses `Authorization: <key>` (no "Bearer" or "token" prefix)
+ * for personal API keys. OAuth tokens use `Authorization: Bearer <token>` —
+ * we only support personal keys here since all agent use is server-side.
+ *
+ * @throws On HTTP errors or GraphQL-level errors
+ */
+export async function linearGraphQL<T = unknown>(
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const key = getLinearApiKey();
+
+  for (const str of collectStrings(variables)) {
+    const problem = detectCorruption(str);
+    if (problem) {
+      throw new Error(
+        `Linear GraphQL variables failed corruption check: ${problem}\n` +
+        `Offending content (first 200 chars): ${str.slice(0, 200)}`
+      );
+    }
+  }
+
+  const resp = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: key,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Linear GraphQL returned ${resp.status}: ${text}`);
+  }
+
+  const result = (await resp.json()) as LinearGraphQLResponse<T>;
+  if (result.errors?.length) {
+    const msgs = result.errors.map((e) => e.message).join('; ');
+    throw new Error(`Linear GraphQL error: ${msgs}`);
+  }
+  if (!result.data) {
+    throw new Error('Linear GraphQL returned no data');
+  }
+  return result.data;
+}
+
+export function linearIssueUrl(identifier: string): string {
+  return `https://linear.app/${LINEAR_WORKSPACE_SLUG}/issue/${identifier}`;
+}

--- a/crux/lib/linear/client.ts
+++ b/crux/lib/linear/client.ts
@@ -87,14 +87,30 @@ export async function linearGraphQL<T = unknown>(
     }
   }
 
-  const resp = await fetch('https://api.linear.app/graphql', {
-    method: 'POST',
-    headers: {
-      Authorization: key,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  // Best-effort timeout: these calls sit on agent init/close-out paths and must
+  // not hang the CLI for minutes if Linear is unreachable. `fetch()` has no
+  // built-in timeout — use AbortController with a 15s budget.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  let resp: Response;
+  try {
+    resp = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: key,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    if ((e as { name?: string }).name === 'AbortError') {
+      throw new Error('Linear GraphQL request timed out after 15s');
+    }
+    throw e;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!resp.ok) {
     const text = await resp.text().catch(() => '(no body)');

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -1,0 +1,229 @@
+/**
+ * Typed helpers for Linear issue operations used by agent skills.
+ *
+ * These wrap `linearGraphQL()` with the minimal shape each caller needs, so
+ * bash skills never touch GraphQL directly. Following the `crux/lib/github.ts`
+ * pattern: narrow typed functions over a generic transport.
+ */
+
+import { linearGraphQL, linearIssueUrl } from './client.ts';
+import {
+  getWorkflowStateId,
+  QUA_TEAM_ID,
+  type WorkflowStateName,
+} from './workflow-states.ts';
+
+export interface LinearIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  priority: number;
+  url: string;
+  state: { id: string; name: string; type: string };
+  team: { id: string; key: string };
+  parent: { identifier: string; title: string } | null;
+  project: { id: string; name: string } | null;
+  labels: { nodes: Array<{ name: string }> };
+}
+
+export interface LinearComment {
+  id: string;
+  body: string;
+  createdAt: string;
+  user: { name: string } | null;
+}
+
+/**
+ * Fetch a single issue by identifier (e.g. "QUA-184").
+ * Returns null if the issue doesn't exist.
+ */
+export async function getIssue(identifier: string): Promise<LinearIssue | null> {
+  try {
+    const data = await linearGraphQL<{ issue: LinearIssue | null }>(
+      `query GetIssue($id: String!) {
+        issue(id: $id) {
+          id
+          identifier
+          title
+          description
+          priority
+          url
+          state { id name type }
+          team { id key }
+          parent { identifier title }
+          project { id name }
+          labels { nodes { name } }
+        }
+      }`,
+      { id: identifier },
+    );
+    return data.issue ?? null;
+  } catch (e) {
+    // Linear returns an error rather than null for missing issues; re-throw unless it's a not-found
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/Entity not found|EntityNotFound/i.test(msg)) return null;
+    throw e;
+  }
+}
+
+/**
+ * Fetch recent comments on an issue. Returns comments in creation order.
+ */
+export async function getComments(
+  identifier: string,
+  limit = 20,
+): Promise<LinearComment[]> {
+  const data = await linearGraphQL<{
+    issue: { comments: { nodes: LinearComment[] } } | null;
+  }>(
+    `query GetComments($id: String!, $limit: Int!) {
+      issue(id: $id) {
+        comments(first: $limit) {
+          nodes { id body createdAt user { name } }
+        }
+      }
+    }`,
+    { id: identifier, limit },
+  );
+  return data.issue?.comments.nodes ?? [];
+}
+
+/**
+ * Update an issue's workflow state.
+ *
+ * Accepts the canonical state name (e.g. "In Progress") and resolves it to
+ * the team-scoped state UUID via the shared constants. This keeps the UUIDs
+ * in one place — skills pass names, not IDs.
+ */
+export async function updateIssueState(
+  identifier: string,
+  state: WorkflowStateName,
+): Promise<{ identifier: string; state: string }> {
+  const stateId = getWorkflowStateId(state);
+  const data = await linearGraphQL<{
+    issueUpdate: {
+      success: boolean;
+      issue: { identifier: string; state: { name: string } };
+    };
+  }>(
+    `mutation UpdateState($id: String!, $stateId: String!) {
+      issueUpdate(id: $id, input: { stateId: $stateId }) {
+        success
+        issue { identifier state { name } }
+      }
+    }`,
+    { id: identifier, stateId },
+  );
+  if (!data.issueUpdate.success) {
+    throw new Error(`Linear refused to update ${identifier} to ${state}`);
+  }
+  return {
+    identifier: data.issueUpdate.issue.identifier,
+    state: data.issueUpdate.issue.state.name,
+  };
+}
+
+/** Add a comment to an existing issue. */
+export async function commentOnIssue(
+  identifier: string,
+  body: string,
+): Promise<void> {
+  // Comment mutations need the issue's UUID, not the QUA-NNN identifier.
+  const issue = await getIssue(identifier);
+  if (!issue) throw new Error(`Linear issue ${identifier} not found`);
+  const data = await linearGraphQL<{ commentCreate: { success: boolean } }>(
+    `mutation Comment($input: CommentCreateInput!) {
+      commentCreate(input: $input) { success }
+    }`,
+    { input: { issueId: issue.id, body } },
+  );
+  if (!data.commentCreate.success) {
+    throw new Error(`Linear refused to post comment on ${identifier}`);
+  }
+}
+
+export interface CreateIssueInput {
+  title: string;
+  description: string;
+  priority?: number;
+  parentId?: string;
+  projectId?: string;
+  teamId?: string;
+}
+
+/** Create a new Linear issue. Defaults to the QUA team when `teamId` is omitted. */
+export async function createIssue(
+  input: CreateIssueInput,
+): Promise<{ identifier: string; url: string }> {
+  const data = await linearGraphQL<{
+    issueCreate: {
+      success: boolean;
+      issue: { identifier: string; url: string };
+    };
+  }>(
+    `mutation CreateIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { identifier url }
+      }
+    }`,
+    {
+      input: {
+        teamId: input.teamId ?? QUA_TEAM_ID,
+        title: input.title,
+        description: input.description,
+        priority: input.priority,
+        parentId: input.parentId,
+        projectId: input.projectId,
+      },
+    },
+  );
+  if (!data.issueCreate.success) {
+    throw new Error(`Linear refused to create issue "${input.title}"`);
+  }
+  return data.issueCreate.issue;
+}
+
+export interface SearchedIssue {
+  identifier: string;
+  title: string;
+  priority: number;
+  state: { name: string; type: string };
+  url: string;
+}
+
+/**
+ * Search issues by free-text query. Uses Linear's built-in `searchIssues`.
+ * Results are limited to the QUA team by default.
+ */
+export async function searchIssues(
+  query: string,
+  limit = 20,
+  teamId: string = QUA_TEAM_ID,
+): Promise<SearchedIssue[]> {
+  const data = await linearGraphQL<{
+    searchIssues: { nodes: SearchedIssue[] };
+  }>(
+    `query Search($q: String!, $limit: Int!, $filter: IssueFilter) {
+      searchIssues(term: $q, first: $limit, filter: $filter) {
+        nodes {
+          identifier
+          title
+          priority
+          state { name type }
+          url
+        }
+      }
+    }`,
+    {
+      q: query,
+      limit,
+      filter: { team: { id: { eq: teamId } } },
+    },
+  );
+  return data.searchIssues.nodes;
+}
+
+/** Convenience re-export so callers import everything from one module. */
+export { linearIssueUrl };

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -69,24 +69,34 @@ export async function getIssue(identifier: string): Promise<LinearIssue | null> 
 
 /**
  * Fetch recent comments on an issue. Returns comments in creation order.
+ * Returns an empty array if the issue doesn't exist (same missing-issue
+ * semantics as `getIssue()`).
  */
 export async function getComments(
   identifier: string,
   limit = 20,
 ): Promise<LinearComment[]> {
-  const data = await linearGraphQL<{
-    issue: { comments: { nodes: LinearComment[] } } | null;
-  }>(
-    `query GetComments($id: String!, $limit: Int!) {
-      issue(id: $id) {
-        comments(first: $limit) {
-          nodes { id body createdAt user { name } }
+  try {
+    const data = await linearGraphQL<{
+      issue: { comments: { nodes: LinearComment[] } } | null;
+    }>(
+      `query GetComments($id: String!, $limit: Int!) {
+        issue(id: $id) {
+          comments(first: $limit) {
+            nodes { id body createdAt user { name } }
+          }
         }
-      }
-    }`,
-    { id: identifier, limit },
-  );
-  return data.issue?.comments.nodes ?? [];
+      }`,
+      { id: identifier, limit },
+    );
+    return data.issue?.comments.nodes ?? [];
+  } catch (e) {
+    // Mirror getIssue()'s missing-issue handling: Linear returns an error
+    // rather than null when the issue identifier doesn't exist.
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/Entity not found|EntityNotFound/i.test(msg)) return [];
+    throw e;
+  }
 }
 
 /**

--- a/crux/lib/linear/parse-id.ts
+++ b/crux/lib/linear/parse-id.ts
@@ -1,0 +1,54 @@
+/**
+ * Extract a Linear issue identifier (e.g. "QUA-184") from an unstructured
+ * string — a branch name, a task description, or a PR title.
+ *
+ * Used by `/agent-init` and related skills to find the Linear issue for the
+ * current session without requiring a manual `--linear=QUA-NNN` flag.
+ * Companion to the GitHub issue-number detection already in agent-checklist.
+ *
+ * Team keys are 2–5 uppercase letters followed by a dash and digits. The
+ * default team key is "QUA" but the regex accepts any valid Linear key so
+ * the same helper can be reused if the workspace ever adds another team.
+ */
+
+const LINEAR_ID_RE = /\b([A-Z][A-Z0-9]{1,4})-(\d{1,6})\b/;
+
+/** Case-insensitive branch-name matcher: `claude/qua-184-description` */
+const BRANCH_ID_RE = /\bclaude\/([a-z][a-z0-9]{1,4})-(\d{1,6})(?:[-/]|$)/i;
+
+/**
+ * Parse a Linear issue identifier from an unstructured string.
+ *
+ * Search order:
+ *   1. Explicit branch-name pattern: `claude/qua-184-*`
+ *   2. Any bare `QUA-184` token
+ *
+ * Returns the identifier in canonical form (`QUA-184`) or `null`.
+ */
+export function parseLinearId(input: string | null | undefined): string | null {
+  if (!input) return null;
+
+  const branchMatch = BRANCH_ID_RE.exec(input);
+  if (branchMatch) {
+    return `${branchMatch[1].toUpperCase()}-${branchMatch[2]}`;
+  }
+
+  const bareMatch = LINEAR_ID_RE.exec(input);
+  if (bareMatch) {
+    return `${bareMatch[1]}-${bareMatch[2]}`;
+  }
+
+  return null;
+}
+
+/**
+ * Parse a Linear ID from several sources, preferring earlier ones.
+ * Designed for session-init: branch name first, then task description.
+ */
+export function resolveLinearId(sources: Array<string | null | undefined>): string | null {
+  for (const s of sources) {
+    const id = parseLinearId(s);
+    if (id) return id;
+  }
+  return null;
+}

--- a/crux/lib/linear/parse-id.ts
+++ b/crux/lib/linear/parse-id.ts
@@ -6,22 +6,34 @@
  * current session without requiring a manual `--linear=QUA-NNN` flag.
  * Companion to the GitHub issue-number detection already in agent-checklist.
  *
- * Team keys are 2–5 uppercase letters followed by a dash and digits. The
- * default team key is "QUA" but the regex accepts any valid Linear key so
- * the same helper can be reused if the workspace ever adds another team.
+ * The bare-token matcher is deliberately restricted to a known team-key
+ * allowlist (currently just `QUA`) to avoid false positives on tokens like
+ * `UTF-8`, `CVE-2024`, `PR-1234`, `HTTP2-3`, `ISO-8601` that otherwise look
+ * like Linear identifiers but aren't. The branch-pattern matcher is more
+ * permissive since the `claude/` prefix already disambiguates intent.
  */
 
-const LINEAR_ID_RE = /\b([A-Z][A-Z0-9]{1,4})-(\d{1,6})\b/;
+/**
+ * Known Linear team keys recognised by bare-token matching.
+ *
+ * Add new team keys here as the workspace grows. The branch-pattern matcher
+ * doesn't use this list — any 2–5 letter key inside a `claude/<key>-N-*`
+ * branch is accepted since the `claude/` prefix signals explicit intent.
+ */
+export const KNOWN_LINEAR_TEAM_KEYS = ['QUA'] as const;
+
+const knownTeamKeyAlt = KNOWN_LINEAR_TEAM_KEYS.join('|');
+const BARE_ID_RE = new RegExp(`\\b(${knownTeamKeyAlt})-(\\d{1,6})\\b`);
 
 /** Case-insensitive branch-name matcher: `claude/qua-184-description` */
-const BRANCH_ID_RE = /\bclaude\/([a-z][a-z0-9]{1,4})-(\d{1,6})(?:[-/]|$)/i;
+const BRANCH_ID_RE = /\bclaude\/([a-z]{2,5})-(\d{1,6})(?:[-/]|$)/i;
 
 /**
  * Parse a Linear issue identifier from an unstructured string.
  *
  * Search order:
- *   1. Explicit branch-name pattern: `claude/qua-184-*`
- *   2. Any bare `QUA-184` token
+ *   1. Explicit branch-name pattern: `claude/qua-184-*` — any 2–5 letter key
+ *   2. Bare `QUA-184` token — restricted to the known-team-keys allowlist
  *
  * Returns the identifier in canonical form (`QUA-184`) or `null`.
  */
@@ -33,7 +45,7 @@ export function parseLinearId(input: string | null | undefined): string | null {
     return `${branchMatch[1].toUpperCase()}-${branchMatch[2]}`;
   }
 
-  const bareMatch = LINEAR_ID_RE.exec(input);
+  const bareMatch = BARE_ID_RE.exec(input);
   if (bareMatch) {
     return `${bareMatch[1]}-${bareMatch[2]}`;
   }

--- a/crux/lib/linear/parse-id.ts
+++ b/crux/lib/linear/parse-id.ts
@@ -6,34 +6,40 @@
  * current session without requiring a manual `--linear=QUA-NNN` flag.
  * Companion to the GitHub issue-number detection already in agent-checklist.
  *
- * The bare-token matcher is deliberately restricted to a known team-key
- * allowlist (currently just `QUA`) to avoid false positives on tokens like
- * `UTF-8`, `CVE-2024`, `PR-1234`, `HTTP2-3`, `ISO-8601` that otherwise look
- * like Linear identifiers but aren't. The branch-pattern matcher is more
- * permissive since the `claude/` prefix already disambiguates intent.
+ * Both the bare-token matcher AND the branch-pattern matcher are restricted
+ * to the known team-key allowlist (currently just `QUA`). Without that, a
+ * GitHub-style branch like `claude/fix-239-...` would be misclassified as
+ * `FIX-239` and pollute Linear checklist metadata.
  */
 
 /**
- * Known Linear team keys recognised by bare-token matching.
- *
- * Add new team keys here as the workspace grows. The branch-pattern matcher
- * doesn't use this list — any 2–5 letter key inside a `claude/<key>-N-*`
- * branch is accepted since the `claude/` prefix signals explicit intent.
+ * Known Linear team keys recognised by branch and bare-token matching.
+ * Add new team keys here as the workspace grows.
  */
 export const KNOWN_LINEAR_TEAM_KEYS = ['QUA'] as const;
 
 const knownTeamKeyAlt = KNOWN_LINEAR_TEAM_KEYS.join('|');
 const BARE_ID_RE = new RegExp(`\\b(${knownTeamKeyAlt})-(\\d{1,6})\\b`);
 
-/** Case-insensitive branch-name matcher: `claude/qua-184-description` */
-const BRANCH_ID_RE = /\bclaude\/([a-z]{2,5})-(\d{1,6})(?:[-/]|$)/i;
+/**
+ * Case-insensitive branch-name matcher: `claude/qua-184-description`.
+ * Restricted to the known-team-keys allowlist so that GitHub-flavored branches
+ * like `claude/fix-239-...` or `claude/cve-2024-...` don't get misclassified.
+ */
+const BRANCH_ID_RE = new RegExp(
+  `\\bclaude\\/(${knownTeamKeyAlt})-(\\d{1,6})(?:[-/]|$)`,
+  'i',
+);
 
 /**
  * Parse a Linear issue identifier from an unstructured string.
  *
  * Search order:
- *   1. Explicit branch-name pattern: `claude/qua-184-*` — any 2–5 letter key
- *   2. Bare `QUA-184` token — restricted to the known-team-keys allowlist
+ *   1. Explicit branch-name pattern: `claude/qua-184-*`
+ *   2. Bare `QUA-184` token
+ *
+ * Both matchers use the known-team-keys allowlist so tokens like
+ * `UTF-8`, `CVE-2024`, `FIX-239`, `PR-1234` aren't mis-parsed.
  *
  * Returns the identifier in canonical form (`QUA-184`) or `null`.
  */

--- a/crux/lib/linear/workflow-states.ts
+++ b/crux/lib/linear/workflow-states.ts
@@ -1,0 +1,81 @@
+/**
+ * Linear workflow-state IDs for the Quantifieduncertainty (QUA) team.
+ *
+ * These IDs are team-scoped and stable as long as the workflow states
+ * aren't renamed or deleted in Linear. If the team restructures states,
+ * run `crux linear states refresh` to re-fetch them.
+ *
+ * Verified from Linear API on 2026-04-10 for team
+ * `12392162-e1e0-4fce-95ad-a8a5d6800321`.
+ */
+
+import { linearGraphQL } from './client.ts';
+
+export const QUA_TEAM_ID = '12392162-e1e0-4fce-95ad-a8a5d6800321';
+
+/** Canonical workflow-state names used across the agent pipeline. */
+export type WorkflowStateName =
+  | 'Backlog'
+  | 'Todo'
+  | 'In Progress'
+  | 'In Review'
+  | 'Done'
+  | 'Canceled'
+  | 'Duplicate';
+
+/**
+ * Known workflow-state IDs for the QUA team.
+ *
+ * Keep in sync with `WorkflowStateName`. These are referenced by name from
+ * skills so the IDs never leak into bash — the type catches typos.
+ */
+export const QUA_WORKFLOW_STATES: Record<WorkflowStateName, string> = {
+  Backlog: '1c823bc3-04f6-4da6-b427-c8c998eb18af',
+  Todo: '652fb991-4ab1-45a7-bf47-7d335eddc341',
+  'In Progress': '1cafee7f-1921-49d4-b603-df2bf517b296',
+  'In Review': 'c5624b71-8565-446b-917f-df7b5e2a3711',
+  Done: '58ff8def-1f49-4900-af99-84544c20b5f8',
+  Canceled: '4ee037f7-12ea-43cb-bd1a-967b8c76e256',
+  Duplicate: 'a8d4a298-2688-4236-83ce-e3c98effd033',
+};
+
+export function getWorkflowStateId(name: WorkflowStateName): string {
+  const id = QUA_WORKFLOW_STATES[name];
+  if (!id) {
+    throw new Error(
+      `Unknown Linear workflow state: "${name}". ` +
+      `Known: ${Object.keys(QUA_WORKFLOW_STATES).join(', ')}`
+    );
+  }
+  return id;
+}
+
+export interface RemoteWorkflowState {
+  id: string;
+  name: string;
+  type: string;
+  position: number;
+}
+
+/**
+ * Fetch the current workflow states for the QUA team from Linear.
+ *
+ * Used by `crux linear states refresh` to regenerate this file's constants
+ * if Linear is reconfigured. This is read-only; the caller writes the
+ * updated file.
+ */
+export async function fetchRemoteWorkflowStates(
+  teamId: string = QUA_TEAM_ID,
+): Promise<RemoteWorkflowState[]> {
+  const data = await linearGraphQL<{
+    team: { states: { nodes: RemoteWorkflowState[] } };
+  }>(
+    `query TeamStates($teamId: String!) {
+      team(id: $teamId) {
+        states { nodes { id name type position } }
+      }
+    }`,
+    { teamId },
+  );
+  return data.team.states.nodes;
+}

--- a/crux/lib/session/session-checklist.ts
+++ b/crux/lib/session/session-checklist.ts
@@ -45,6 +45,9 @@ export interface ChecklistMetadata {
   task: string;
   branch: string;
   issue?: number;
+  /** Linear issue identifier, e.g. "QUA-184". Stored alongside the GitHub
+   *  issue number; a session can have either, both, or neither. */
+  linearId?: string;
   timestamp: string;
 }
 
@@ -217,6 +220,7 @@ export function buildChecklist(type: SessionType, metadata: ChecklistMetadata): 
   lines.push(`> Branch: \`${metadata.branch}\``);
   lines.push(`> Task: ${metadata.task}`);
   if (metadata.issue) lines.push(`> Issue: #${metadata.issue}`);
+  if (metadata.linearId) lines.push(`> Linear: ${metadata.linearId}`);
   lines.push('');
 
   for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
## Summary

Adds Linear integration for agent session tracking — a `crux linear` command group, a shared client library, and wiring into the agent session lifecycle so sessions automatically register start/done on Linear issues (parallel to the existing GitHub issue tracking).

**New public CLI**
- `crux linear view <QUA-NNN>` — show issue + recent comments
- `crux linear search <query>` — search QUA team issues
- `crux linear comment <QUA-NNN> <body>` — post a comment
- `crux linear start <QUA-NNN>` — move to In Progress + start comment
- `crux linear done <QUA-NNN> [--pr=URL]` — move to In Review (with PR) / Done
- `crux linear states-list` — print workflow state IDs
- `crux linear parse <string>` — debug ID extraction

**New shared library: `crux/lib/linear/`**
- `client.ts` — GraphQL transport with corruption detection (mirrors `crux/lib/github.ts`)
- `workflow-states.ts` — typed QUA team workflow-state constants + remote refresh
- `issues.ts` — typed helpers (`getIssue`, `updateIssueState`, `commentOnIssue`, `createIssue`, `searchIssues`)
- `parse-id.ts` — branch-name and task-text Linear ID parser

**Agent lifecycle wiring**
- `crux sys agent-checklist init` now auto-detects a Linear ID from `claude/qua-NNN-*` branches (any 2–5 letter team key) or from a bare `QUA-NNN` token in the task description (bare matching restricted to a known-team allowlist to avoid false positives on `UTF-8`, `CVE-2024`, etc.). Accepts explicit `--linear=QUA-NNN`.
- Init auto-calls `crux linear issues start` when an ID is known. Best-effort: a missing `LINEAR_API_KEY` or Linear outage never fails init.
- `/agent-end` and `/agent-ship` skills now read `> Linear: QUA-NNN` from the checklist and call `crux linear issues done` on session close — In Review when a PR exists, Done otherwise.
- Docs updated: `/agent-init`, `agent-session-workflow.md` with the branch-naming convention (`claude/qua-NNN-description`).

## Linear issues addressed

- **Closes QUA-197** — Shared Linear client library and workflow-state constants
- **Closes QUA-198** — `crux linear` command group
- **Closes QUA-196** — Auto-detect Linear ID from branch name in `/agent-init`
- **QUA-184** — Core write paths done (init → In Progress, end/ship → In Review/Done). Move-to-Done on PR merge is a natural follow-up in the release workflow.
- Also closes out the stale **QUA-185** — the tmux `-t TMUX_PANE` hook fix was already on main in commit `505a33475e` from 2026-04-04; the Linear issue was closed as Done during this session.

## Tests

- **30 new unit tests** in `crux/lib/linear/__tests__/`: client (13), parse-id (15), workflow-states (4), issues (18)
- **25 new CLI handler tests** in `crux/commands/__tests__/linear.test.ts`: view, search, comment, start, `done` (including the critical `--pr` → In Review vs bare → Done branching)
- **5 new integration tests** in `crux/commands/agent-checklist.test.ts` covering Linear ID detection, explicit flag, and precedence
- All 140 affected tests green; gate passes; broader `pnpm vitest run crux/` passes except for 4 pre-existing `snapshot-resources.test.ts` failures unrelated to this PR

## Adversarial coverage

Parse-id regression tests confirm these no longer false-match as Linear IDs:
- `UTF-8`, `CVE-2024`, `RFC-8446`, `HTTP2-3`, `ISO-8601`, `PR-1234`, `XYZ-999`, `ABC-5` (outside a `claude/` branch prefix)

CLI adversarial inputs verified: empty query, empty ID, non-existent QUA-999999, shell-injection attempts (`$(echo pwned)`), 1000-char input — all handled cleanly.

## Review findings addressed

`/agent-review-pr` surfaced 4 HIGH + 6 MEDIUM + 6 LOW findings; HIGH and key MEDIUM all fixed in the follow-up commit:

- **HIGH**: `parse-id.ts` regex was too permissive → gated on `KNOWN_LINEAR_TEAM_KEYS` allowlist
- **HIGH**: `issues.ts` had 0 tests → 18 added
- **HIGH**: `crux/commands/linear.ts` handlers had 0 tests → 25 added
- **HIGH**: `agent-end.md` referenced `$PR_URL` without ever setting it, so the `[ -n "$PR_URL" ]` guard was always false and Linear always landed in Done → now explicit default + documented requirement
- **MEDIUM**: Linear skill calls had no `|| echo` fallback → both end/ship now best-effort
- **MEDIUM**: `states-list` help text vs registry mismatch → help text fixed

## Deploy Checklist

- [ ] No production env vars needed. The deploy-task detector flagged `LINEAR_API_KEY` as a new env var, but this is **agent-local only** — the `crux linear` CLI and `/agent-*` skills run on developer machines, not in the wiki-server or any deployed service. The key lives in `.env.base` at the workspace root; nothing needs to be set in production.

## Test plan

- [x] `pnpm vitest run crux/lib/linear crux/commands/__tests__/linear.test.ts crux/commands/agent-checklist.test.ts` — 108/108 passing
- [x] `pnpm crux w validate gate --fix` — 45 blocking + 5 advisory, all passing
- [x] `pnpm build` — exits 0
- [x] `cd crux && npx tsc --noEmit` — no new errors introduced (pre-existing baseline unchanged)
- [x] Linear API writes verified end-to-end via `crux linear search`, `view`, `parse`, `states-list` against the live Linear workspace
- [x] Adversarial input fuzzing (empty, malformed, shell-injection, oversized) — all handled cleanly
- [x] `/agent-review-pr` — full hostile review; findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear issue integration: automatically detect Linear issues from branch names and task descriptions; issues transition smoothly through "In Progress," "In Review," and "Done" workflow states as development progresses
  * New commands for managing Linear issues: view details, search, and post comments directly
  * Unified workflow: session initialization, development, and shipping now seamlessly coordinate with and update Linear issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->