### PR TITLE
Add 5 subsystem maps + DRYwall baseline to combat agent duplication

### DIFF
--- a/.claude/rules/entity-sync-pipeline.md
+++ b/.claude/rules/entity-sync-pipeline.md
@@ -1,0 +1,111 @@
+# Entity-Sync / TableBase Pipeline
+
+Subsystem map for the YAML → sync → PG pipeline and the tablebase route infrastructure. **Read this before writing a new sync endpoint, delete handler, or entity validation** — the shared helpers and factories are missed constantly.
+
+## Why this file exists
+
+The last 100 PRs had 18 rework incidents in this subsystem:
+- **PR #4059** broke `unnest()` array parameterization across 8 endpoints — `sqlInList` helper existed but wasn't used
+- **PR #4029** added `validateEntityRefs` calls to 8 endpoints that had silently been missing it
+- **PR #4045** fixed an entity slug reassignment race
+- **PR #4064** discovered **20+ tablebase routes had `/sync` but no `/delete-batch`** (systemic gap)
+- **PR #4067** created a shared delete-handler factory after grants/funding-programs had duplicated 33-line hand-written handlers. **PR #4072** then ripped out the duplicates
+- **PR #4000** consolidated duplicate personnel entity title queries
+
+The common failure: "I didn't know that helper/factory existed." This file is the helper/factory inventory.
+
+---
+
+## 1. Shared helpers (the things that get missed)
+
+All live in `apps/wiki-server/src/routes/shared/`:
+
+| Helper | File | Purpose | Missed in |
+|--------|------|---------|-----------|
+| `sqlInList()` | `query-helpers.ts:170` | Parameterized `IN (...)` for array values; wraps `unnest()` correctly | PR #4059 (8 endpoints) |
+| `validateEntityRefs()` | `validate-entity-refs.ts` | Batch FK check against `entities.id` and `entities.stable_id`; bypass-with-reason logging | PR #4029 (8 endpoints) |
+| `findMissingEntityRefs()` | `validate-entity-refs.ts` | Returns unresolved refs without throwing | — |
+| `shouldSkipEntityValidation()` | `validate-entity-refs.ts` | Migration-mode escape hatch | — |
+| `resolveEntityFKs()` | `resolve-entity-fks.ts` | Post-upsert: resolves raw FK columns (slug/stableId) → `entities.stable_id`, backfills display names | Only 5 routes use it |
+| `deleteBatchHandler()` | `delete-batch.ts` | **Factory for `/delete-batch` endpoints**. Deletes from domain table + `things` with FK-safe ordering. Options: `maxBatchSize`, `label`, `pkColumn`, `maxIdLength` | PR #4064 (6 routes still missing it) |
+| `upsertThingsInTx()` | `thing-sync.ts` | Upserts `things` records inside domain transaction; resolves entity titles for `search_vector` | — |
+
+**Before writing any delete endpoint**: use `deleteBatchHandler()`. Do not write a hand-rolled delete.
+**Before writing any array-parameter query**: use `sqlInList()`. Do not write raw `unnest()`.
+**Before any sync handler that takes entity refs**: call `validateEntityRefs()` first. Not calling it is a bug, not a style choice.
+
+## 2. Sync orchestrators (`crux/wiki-server/sync-*.ts`)
+
+Crux-side scripts that read YAML source and batch POST to wiki-server. All use `sync-common.ts` helpers.
+
+| Script | Source | Target endpoint |
+|--------|--------|-----------------|
+| `sync-entities.ts` | `data/entities/*.yaml` | `/api/entities/sync` |
+| `sync-facts.ts` | `packages/factbase/data/things/*.yaml` | `/api/facts/sync` |
+| `sync-things.ts` | derived | `/api/things/sync` |
+| `sync-pages.ts` | `content/docs/**/*.mdx` | `/api/pages/sync` |
+| `sync-sessions.ts` / `sync-session.ts` | session logs | `/api/sessions/*` |
+| `sync-assessments.ts` | assessments | `/api/assessments/sync` |
+| `sync-benchmarks.ts` | benchmark YAML | `/api/benchmarks/sync` |
+| `sync-auto-update-runs.ts` | auto-update logs | `/api/auto-update-runs/sync` |
+| `sync-common.ts` | **shared infra** | `batchSync<T>()`, `waitForHealthy()`, `fetchWithRetry()`, health-check + exponential backoff + consecutive-failure tracking |
+
+**Adding a new sync**: use `batchSync()` from `sync-common.ts`. Don't write your own batch loop.
+
+## 3. Tablebase route inventory (40 routes)
+
+All under `apps/wiki-server/src/routes/tablebase/`. Each route file is one PG table.
+
+**Routes with BOTH `/sync` and `/delete-batch`** (25 — the baseline):
+`grants`, `funding-rounds`, `investments`, `equity-positions`, `benchmarks`, `benchmark-results`, `funding-programs`, `entity-profile`, `entity-profile-descriptions`, `entity-assessments`, `entity-resources`, `entity-events`, `research-areas`, `political-votes`, `political-offices`, `political-scores`, `policy-stakeholders`, `prediction-markets`, `publications`, `secondary-market-prices`, `website-sources`, `division-personnel`, `divisions`, `campaign-finance`, `data-sources`
+
+**Read-only / utility routes** (no `/sync` or `/delete-batch` expected): `audit-log`, `ids`, `people`, `record-lookup`, `sourcing-schema`, `talent-flows`, `write-inline-verdicts`.
+
+**Routes still missing `/delete-batch` (PR #4064 gap)** (6):
+- `bluesky.ts`
+- `entities.ts`
+- `personnel.ts`
+- `platform-accounts.ts`
+- `political-races.ts`
+- `things.ts`
+
+If you're touching any of these, consider adding `deleteBatchHandler()` — it's a known gap. (Check first — one may have been added since this doc was written.)
+
+## 4. Natural keys / upsert conflict targets
+
+Most routes use `onConflictDoUpdate({ target: <table>.id, set: { ...excluded fields } })` with `id` as the natural key. Personnel may use composite `(personId, organizationId)`. **No shared upsert-builder factory yet** — each route hand-writes the `set:` clause. This is a candidate for a future `createUpsertHandler()` factory but doesn't exist today.
+
+`validate-tablebase-completeness.ts` is the gate check that flags missing `/sync`, `/delete-batch`, and validation calls.
+
+## 5. Concurrency / race patterns
+
+- **Slug reassignment** (PR #4045 safe pattern): bulk UPDATE to clear stale slugs, then upsert on `stableId`, **both inside the same transaction**. See `entities.ts:~930-960` for the reference implementation. Displaced slugs get title-derived fallback with `-displaced` suffix.
+- **ID allocation** (PR #4043): sequential, transaction-safe. Goes through wiki-server, not local.
+- **Advisory locks**: used in `wikibase/links.ts` and `operational/build-metrics.ts` for page-level concurrency. Tablebase routes rely on transaction ordering, not explicit advisory locks.
+
+## 6. Data flow (one diagram)
+
+```
+YAML source of truth           crux/wiki-server/sync-*.ts           apps/wiki-server/src/routes/tablebase/*.ts
+  data/entities/*.yaml     →   batchSync() via sync-common.ts   →   upsert → validateEntityRefs → resolveEntityFKs →
+  packages/factbase/                                                upsertThingsInTx
+    data/things/*.yaml
+                                                                              ↓
+                                                    PG (entities, grants, facts, things, ...)
+                                                                              ↓
+                                                   build-time: database.json + factbase-data.json
+                                                                              ↓
+                                                    apps/web reads the JSON, calls /api/* at runtime
+```
+
+## Adding functionality — checklist
+
+Before writing new sync/tablebase code:
+
+1. **Grep `deleteBatchHandler`, `validateEntityRefs`, `sqlInList`, `resolveEntityFKs`, `upsertThingsInTx`, `batchSync`** — use what exists.
+2. **New `/delete-batch` endpoint**: `deleteBatchHandler(table, "sourceTable")`. Do not hand-write.
+3. **New array param query**: `sqlInList()`. Do not write `unnest()` directly.
+4. **New sync handler accepting entity refs**: call `validateEntityRefs()` BEFORE upserting.
+5. **New route with entity FK columns**: call `resolveEntityFKs()` post-upsert to backfill display names.
+6. **New sync orchestrator**: extend `sync-common.ts::batchSync()`. Do not write your own fetch loop.
+7. **Run `validate-tablebase-completeness`** before PR — it catches missing sync/delete/validation.

--- a/.claude/rules/id-system.md
+++ b/.claude/rules/id-system.md
@@ -1,0 +1,108 @@
+# ID System
+
+Subsystem map for the wiki's ID schemes (`numericId`, `stableId`, slugs, legacy IDs). **Read this before allocating an ID, writing a new entity type, or adding an ID validator** — there are three distinct ID concepts and agents repeatedly conflate them.
+
+## Why this file exists
+
+Last 100 PRs had 21 ID-related rework incidents: regex bugs (#4065), allocation races (#4043), personnel ID regex (#3964), `sid_` prefix handling (#4008), string/number type confusion from `postgres.js` returning strings where Sets expected numbers. The failure mode is always the same: agent assumes ID system is simpler than it is, picks the wrong helper, or invents a new ID format.
+
+---
+
+## The three ID schemes (understand this before touching IDs)
+
+| Scheme | Example | Format | Who uses it | Storage |
+|--------|---------|--------|-------------|---------|
+| **numericId** | `E42`, `E1334` | `E<int>` | Wiki entities with their own pages | `entity_ids` PG table (sequence-allocated) |
+| **stableId** | `sid_1LcLlMGLbw` | `sid_` + 10 alphanumeric | FactBase entities + lightweight TableBase records (personnel, etc.) | `entities.stable_id`, FactBase YAML |
+| **tableId** | `g_abc123`, numeric PK | varies | Per-table primary keys (grants, investments, etc.) | Each tablebase table |
+| slug | `anthropic`, `geoffrey-hinton` | kebab-case | Human-readable, legacy, URL path | YAML filenames, `entities.id` |
+
+**Key rule**: `numericId` is ONLY for wiki entities that have their own pages (`/wiki/E42`). Only ~200-300 entities should have one. Everything else (personnel, authors, minor refs) gets a `stableId` only.
+
+## Tier 1: wiki entities (have a page)
+
+- **When**: organization with a wiki page, concept with a wiki page, major person with a bio page
+- **How to allocate**: `pnpm crux tb ids allocate <slug>`
+- **What you get**: a `numericId` (E-number) + a `stableId` (`sid_`)
+- **Result**: agent-allocated, written to `data/entities/*.yaml`, wiki page at `/wiki/E<N>`
+- **Backend**: `crux/commands/ids.ts` (CLI) → `crux/lib/wiki-server/ids.ts::allocateId()` → wiki-server `/api/ids/allocate` → PG `entity_ids` sequence
+
+## Tier 2: lightweight TableBase records (no page)
+
+- **When**: paper author, personnel row, minor person, directory-only record
+- **How to allocate**: `pnpm crux tb ensure-entities --type=person` or `crux tb create-entity`
+- **What you get**: a `stableId` only, NO `numericId`, NO wiki page
+- **Result**: row in `entities` PG table
+
+## Tier 3: per-table records
+
+- **When**: grant, investment, funding round, personnel record — PG-primary data
+- **How to allocate**: the sync handler creates the PK automatically; don't manually mint
+- **Format**: each table has its own PK convention
+
+## Core ID helpers — `@longterm-wiki/id-utils` (`packages/id-utils/src/index.ts`)
+
+| Export | Purpose |
+|--------|---------|
+| `SID_PREFIX = "sid_"` | The canonical prefix constant |
+| `isSid(s)` | Is this a `sid_`-prefixed stableId? |
+| `isAnySid(s)` | Broader: any stableId format (accepts legacy) |
+| `isDisplayableName(s)` | Inverse of `isSid` — safe to show to users? |
+| `stripSid(s)` | Remove `sid_` prefix |
+| `generateSid()` | Create a new `sid_<random10>` stableId |
+
+**Import path**: `import { isSid, SID_PREFIX } from "@longterm-wiki/id-utils"`.
+**Do not invent your own SID check** — always use `isSid()`.
+
+Currently imported by: `apps/wiki-server/src/routes/tablebase/{entities,record-lookup,personnel,entity-profile}.ts`, `apps/web/src/app/things/[id]/page.tsx`, `apps/web/src/components/wiki/factbase/ref-detection.ts`, `apps/web/src/lib/stable-id.ts`, `apps/wiki-server/src/routes/shared/{query-helpers,entity-ref}.ts`. If you need SID logic in a new file, import from here.
+
+## Core ID allocation — `crux/lib/wiki-server/ids.ts` (RPC client)
+
+| Export | Purpose |
+|--------|---------|
+| `allocateId(slug, description?)` | Allocate one ID (numericId + stableId) |
+| `allocateBatch(items)` | Allocate many atomically |
+| `allocateIds(slugs)` | Convenience wrapper |
+| `getIdBySlug(slug)` | Lookup existing |
+| `listIds()` | Enumerate |
+| `isConfigured()` | Is the wiki-server reachable? |
+
+**Never mint an ID manually.** Always call `allocateId()` — it handles concurrency, sequence allocation, and persists to PG + YAML.
+
+## Validation (run before PR)
+
+Four SID/ID validators in `crux/validate/`:
+
+| Validator | What it catches |
+|-----------|-----------------|
+| `validate-rendered-sid.ts` | `sid_` leaking into built HTML/JSON (user-visible) |
+| `validate-sid-display.ts` | `sid_` in display name columns (contacts, titles) |
+| `validate-factbase-stableid.ts` | FactBase entity IDs match the stableId format |
+| `validate-factbase-entity-ids.ts` | FactBase ↔ TableBase entity ID consistency (no duplicates, no orphans) |
+| `validate-kb-entity-slugs.ts` | FactBase refs have matching entity registry entries |
+
+`validate-gate.ts` runs all of these in blocking mode (see lines 500, 512, 648). If you touch IDs, run `pnpm crux w validate gate --fix` before PR.
+
+## Migration scripts (when you need them)
+
+Three historical migrations under `crux/scripts/`:
+- `migrate-kb-slugs-to-stableids.ts` — slug → sid_ conversion
+- `migrate-ref-slugs.ts` — bulk reference rewrite
+- `migrate-resource-hex-to-stableid.ts` — hex → sid_ conversion
+
+These are one-shot historical scripts. Do not run them unless you're migrating data; look at them for patterns when writing a new one-shot migration.
+
+## Known rough edges (don't re-discover)
+
+- **postgres.js returns BIGINT as string**, not number. `Set<number>` comparisons fail silently. Always normalize via `Number(id)` or `String(id)` depending on the target type. (Caught in PR #3964.)
+- **Two regex styles for stableIds** in the wild: `STABLE_ID_RE` (sid_ + 10-char) and a looser `[A-Za-z0-9_-]{10}` (legacy). Prefer the sid_-prefixed form.
+- **Allocation races** (PR #4043) — the server-side sequence is safe, but local YAML write-back can race if two agents allocate simultaneously. `allocateBatch()` is atomic; prefer it over multiple `allocateId()` calls.
+- **Layered architecture, not duplication**: `crux/commands/ids.ts` (CLI) → `crux/lib/wiki-server/ids.ts` (RPC client) → `packages/id-utils` (pure SID format helpers). This is intentional; don't "consolidate" it.
+
+## Adding functionality — checklist
+
+1. **Minting a new ID?** → `allocateId()`. Don't invent.
+2. **Checking if something is a SID?** → `isSid()` from `@longterm-wiki/id-utils`. Don't regex it yourself.
+3. **New entity type?** → decide Tier 1 (wiki page) vs Tier 2 (lightweight) before allocating.
+4. **New validator?** → grep existing `validate-*sid*.ts` and `validate-*entity-id*.ts` first.
+5. **Comparing IDs from PG?** → `Number()` or `String()` to normalize. Don't trust bigint types.

--- a/.claude/rules/source-check-system.md
+++ b/.claude/rules/source-check-system.md
@@ -1,0 +1,107 @@
+# Source-Check / Verdict / Coverage System
+
+Subsystem map for source-checking, verdict tracking, and entity coverage scoring. **Read this before proposing new verdict UI, coverage scores, or source-check endpoints** — most of the plumbing already exists.
+
+## Why this file exists
+
+Agents have repeatedly proposed "add a coverage/source-check score column to X" without realizing the components, APIs, and scoring functions already exist and are embedded on public pages. The naming doesn't follow "source-check" — look for "claims", "verdict", "coverage", "dot", "pipeline".
+
+---
+
+## 1. Database tables
+
+- `source_check_evidence` (schema.ts:1657) — per-source checks. 5 verdict types: `confirmed | contradicted | unverifiable | outdated | partial`. Links to `resourceId` and `sourceUrl`. Field-level granularity via `field_name` (NULL = row-level).
+- `source_check_verdicts` (schema.ts:1703) — aggregate verdict per `(record_type, record_id, COALESCE(field_name, ''))`. 6 states: adds `unchecked`. Derived from evidence rows.
+- **Migration**: `0127` unified the legacy `record_verifications` + `record_verdicts` + `factbase_resource_verifications` + `factbase_verdicts` into these two tables. Don't create new verdict tables.
+- `things.verdict` — removed. Verdicts now live only in `source_check_verdicts`.
+
+## 2. Wiki-server endpoints (`/api/source-checks/*`)
+
+All in `apps/wiki-server/src/routes/source-check/source-checks.ts`, mounted in `app.ts:203`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/verdicts` | Query verdicts by entity/record/verdict type |
+| GET | `/verdicts/:recordType/:recordId` | Single record's verdicts |
+| POST | `/verdicts` | Upsert aggregate verdicts |
+| POST | `/evidence` | Ingest per-source evidence |
+| GET | `/stale-evidence` | Checks needing rerun (model drift) |
+| GET | `/due-for-recheck` | Records needing rechecking |
+| GET | `/coverage` | Table coverage summary |
+| GET | `/coverage-matrix` | Record type × coverage cross-tab |
+| GET | `/verdict-matrix` | Record type × verdict cross-tab |
+| GET | `/entity-summary` | Entity-level stats |
+| GET | `/resolve-names` | recordIds → display names |
+
+**Frontend proxies** (`apps/web/src/app/api/*-proxy/`): `claims-by-entity-proxy`, `source-check-verdicts-proxy`, `source-check-coverage-proxy`, `source-check-names-proxy`, `source-check-detail`, `entity-profile-proxy`. Use these from server components; don't add new proxies without checking.
+
+## 3. React components (the critical section — the miss point)
+
+**Visual indicators** (already embedded in directory tables and profile pages):
+- `components/coverage/CoverageDots.tsx` — pie-chart 1-4 score indicator
+- `components/coverage/RecordStatusDots.tsx` — **CoverageDots + SourceCheckDot combined**. This is the thing agents keep missing.
+- `components/source-check/SourceCheckDot.tsx` — unified colored dot, 5 states: `not_run | error | failed | trouble | verified`
+- `components/source-check/FactSourceCheckDot.tsx` — fact variant
+- `components/wiki/VerdictBadge.tsx` — wiki citation verdict
+- `components/wiki/ReferenceCitationDot.tsx` — citation accuracy dot
+
+**Data display components:**
+- `components/entity/claims-pipeline-summary.tsx` — `ClaimsPipelineSummary`: fetches `/api/claims-by-entity-proxy`, renders pipeline flow (sources → claims → records)
+- `components/directory/EntityDbPage.tsx` — `EntityDbPage`: wrapper using EntityProfileViewer
+- `app/internal/entity-profile/entity-profile-viewer.tsx` — `EntityProfileViewer`: core database record browser, renders SourceCheckDot inline
+
+## 4. Coverage computation
+
+- `components/coverage/coverage-score.ts` — **12 entity-type scorers**, all return 1–4: `computeOrgCoverage`, `computePersonCoverage`, `computeAiModelCoverage`, `computeLegislationCoverage`, `computeProjectCoverage`, `computeBenchmarkCoverage`, `computeGrantCoverage`, `computeFundingProgramCoverage`, `computeFundingRoundCoverage`, `computeDivisionCoverage`, `computePublicationCoverage`, `computeGenericCoverage`. Also signal extractors: `getOrgSignals`, `getPersonSignals`, `getLegislationSignals`.
+- `data/entity-coverage.ts` — `getEntityDataDepth()`, `computeEntityCoverage()` (dispatches to type scorers), `getAllEntityCoverageScores()` (batch, for dashboards)
+- `data/page-coverage.ts` — `getPageCoverageItems()` (wiki page coverage from database.json)
+- `lib/coverage.ts` — `getRatioStatus(num, denom)` (≥75% green, >0 amber, 0 red), `getMetricStatus(actual, target)`
+
+**Adding coverage for a new entity type**: add a scorer in `coverage-score.ts` + dispatch it in `data/entity-coverage.ts::computeEntityCoverage()`. Don't create a parallel scoring system.
+
+## 5. Public surfaces already rendering source-check data
+
+- `/organizations/:slug` profile — RecordStatusDots in sub-section tables
+- `/organizations/:slug/data` — EntityDbPage → EntityProfileViewer
+- `/organizations` directory table — RecordStatusDots per row
+- `/people`, `/people/:slug/db`, similar pattern for persons
+- `/approaches`, `/benchmarks`, `/projects`, `/ai-models` directories — RecordStatusDots import in `*-table.tsx` files
+- Entity profile headers — ClaimsPipelineSummary
+
+If you're about to add a "show source-check status on X page", first grep for `RecordStatusDots` / `SourceCheckDot` / `CoverageDots` imports — it may already be there.
+
+## 6. Internal dashboards
+
+- **Source Checks** (E2200) — `/internal/entity-source-checks/` — main dashboard. Subcomponents: `action-queue.tsx`, `claims-viewer.tsx`, `coverage-bars.tsx`, `source-check-tabs.tsx`
+- **Source Check Coverage** — `/internal/source-check-coverage/` — loads `/api/source-checks/stats`, coverage-matrix, verdict-matrix
+- **Citation Accuracy** (E917) — `/internal/citation-accuracy/`
+- **Data Quality** (E2600) — `/internal/data-quality/`
+- **People Coverage** (E1099) — entity coverage scores for people
+
+## 7. Conventions
+
+- **Entity coverage scale**: 1=stub, 2=basic, 3=moderate, 4=comprehensive. Typical record is 2, not 3.
+- **Source-check verdict states** (6): `confirmed | contradicted | outdated | partial | unverifiable | unchecked`
+- **Citation verdict states** (5): `accurate | minor_issues | inaccurate | unsupported | not_verifiable`
+- **Unified display status** (5): `not_run | error | failed | trouble | verified`. Mapping in `recordVerdictToStatus()` / `factbaseVerdictToStatus()` at `source-check-status.ts:65-105`.
+- **Color scheme**: canonical source is `components/shared/verdict-styles.ts` — `SOURCE_CHECK_VERDICT_STYLES`, `CITATION_VERDICT_STYLES`, `CITATION_VERDICT_COLORS`, `SOURCE_CHECK_VERDICT_PRIORITY`, `CITATION_VERDICT_SEVERITY`. **Do not inline your own color map** — `source-check-coverage-content.tsx` did this at lines 51-67 and it's a known duplication.
+- **Checker model**: `claude-haiku-4-5-20251001` (source-checks.ts:66). Stale model → rerun flagged.
+- **Build-time vs runtime**: entity coverage is computed on-demand from database.json + FactBase KB. Source-check verdicts/evidence are runtime PG queries.
+
+## 8. Known rough edges (don't re-discover these)
+
+- `SourceCheckDot` accepts `href` but not all callers pass it — personnel/grants tables may not link through.
+- Two parallel scoring systems: entity coverage (type scorers) vs page coverage (database.json green/amber/red). No single "data completeness" score.
+- Per-field verdicts are stored (`source_check_verdicts.field_name`) but `EntityProfileViewer` aggregates by record, not field. Public tables don't show per-field granularity.
+- Color-map duplication: `source-check-coverage-content.tsx:51-67` redefines verdict colors independently of `verdict-styles.ts`.
+- Coverage ratio thresholds hardcoded at 75% in `lib/coverage.ts:17`.
+- No automatic entity-level verdict aggregation ("entity has contradicted info") — only per-record.
+
+## Adding new functionality — checklist
+
+Before proposing new work in this subsystem:
+
+1. **Grep `RecordStatusDots`, `SourceCheckDot`, `CoverageDots`, `computeXxxCoverage`** — the thing may already exist
+2. If adding a new entity type's coverage score: add scorer to `coverage-score.ts`, dispatch in `entity-coverage.ts`. Don't copy the pattern to a new file.
+3. If adding a new verdict type: update `source-check-status.ts` mapping AND `verdict-styles.ts` — both must stay in sync
+4. If adding a dashboard: use `/internal/entity-source-checks/` as the Pattern A reference; it has entity ID + redirect already wired

--- a/.claude/rules/three-bases-architecture.md
+++ b/.claude/rules/three-bases-architecture.md
@@ -1,0 +1,78 @@
+# Three Bases Architecture — Quick Reference
+
+Subsystem map for the TableBase / FactBase / WikiBase architecture. **Read this before adding a new data type, writing a new sync, or using the word "entity" in a commit message** — the naming is overloaded and agents repeatedly pick the wrong layer.
+
+**Canonical source**: the wiki page at `content/docs/internal/data-architecture.mdx` (E1334) has the full version with mermaid diagrams, table inventories, and migration history. This file is the *agent cheat-sheet* — read this first, follow the link if you need depth.
+
+---
+
+## The three layers
+
+| Base | What it stores | Source of truth | Access module |
+|------|----------------|-----------------|----------------|
+| **TableBase** | Typed relational records (entities, resources, publications, orgs) | `data/entities/*.yaml`, `data/resources/*.yaml` | `apps/web/src/data/tablebase.ts` |
+| **FactBase** | Structured triples with temporal data + provenance | `packages/factbase/data/things/*.yaml` | `apps/web/src/data/factbase.ts` |
+| **WikiBase** | Long-form MDX articles | `content/docs/**/*.mdx` | `Page` interface in `tablebase.ts` |
+
+PG has read mirrors of all three. YAML/MDX is authoritative; PG is queryable.
+
+## The word "entity" is overloaded — this bites agents constantly
+
+| Where you see it | What it means |
+|------------------|---------------|
+| `data/entities/*.yaml` | YAML catalog entry (slug-based ID like `anthropic`) |
+| `entities` PG table | Read mirror of the YAML catalog |
+| `packages/factbase/data/things/anthropic.yaml` | **FactBase** entity (10-char ID like `mK9pX3rQ7n`) |
+| `factbase.ts::getFactBaseEntity()` | Returns FactBase entity by slug OR 10-char ID |
+
+**Bridge**: `factbase-data.json` has a `slugToEntityId` map. If you're confused about which "entity" you hold, check: `sid_` prefix or 10 chars alphanumeric = FactBase; plain slug = TableBase.
+
+## The word "things" is also overloaded
+
+| Where you see it | What it means |
+|------------------|---------------|
+| `packages/factbase/data/things/` | **FactBase entity YAML files** (one per entity) |
+| `things` PG table | **Cross-base universal search index** — unrelated to the directory |
+
+The PG `things` table indexes items from ALL domains (entity, fact, grant, resource, personnel, etc.) for unified search. **It is not a FactBase concept**. `source_table` + `source_id` columns point back to the originating record.
+
+## The word "facts" is also overloaded
+
+| Where you see it | What it means |
+|------------------|---------------|
+| `packages/factbase/data/things/*.yaml` `facts:` blocks | **Authoritative** FactBase YAML facts |
+| `facts` PG table | Read mirror of FactBase YAML. Will become primary source once PG schema includes all Fact fields (`validEnd`, `currency`, etc.) |
+| `tablebase.ts::Fact` interface | Legacy bridge type for calc-engine, old components |
+
+> **Note**: The old `data/facts/*.yaml` directory has been **removed**. If you see a doc or comment referring to it, it's stale. Don't look for it.
+
+**Rule**: new structured facts go in FactBase YAML (`packages/factbase/data/things/*.yaml`). Period. Use `<FBF>` / `<FBFactValue>` / `<Calc>` in MDX.
+
+## Which base owns this file? Quick map
+
+| Module | Base |
+|--------|------|
+| `apps/web/src/data/tablebase.ts` | TableBase |
+| `apps/web/src/data/factbase.ts` | FactBase |
+| `apps/web/scripts/build-data.mjs` | ALL (compiles YAML + MDX → JSON + PG) |
+| `packages/factbase/` | FactBase core (serialization, types, YAML loading) |
+| `apps/wiki-server/src/schema.ts` | ALL PG schema |
+| `apps/wiki-server/src/routes/tablebase/` | TableBase mirror API |
+| `apps/wiki-server/src/routes/factbase/` | FactBase mirror API |
+| `apps/wiki-server/src/routes/wikibase/` | WikiBase mirror API |
+| `apps/wiki-server/src/routes/things.ts` | Cross-base universal index API |
+
+## When in doubt — the decision tree
+
+1. **Does it have numeric fields to aggregate, many-to-many relationships, or its own directory page?** → **PG-primary TableBase** table (grants, investments, benchmarks pattern). See `.claude/rules/entity-sync-pipeline.md`.
+2. **Is it a structured fact about an existing entity (revenue, CEO, headcount, valuation)?** → **FactBase** YAML (`packages/factbase/data/things/<entity>.yaml`).
+3. **Is it a lightweight catalog entry used as a link target (a concept, a risk, a minor person)?** → **YAML entity** in `data/entities/*.yaml`.
+4. **Is it long-form prose?** → **WikiBase** MDX in `content/docs/`.
+
+**Strongly prefer PG-primary tables for new features with dedicated UI.** YAML entities are for link targets, not data-rich records.
+
+## Read this too
+
+- Full architecture doc: `content/docs/internal/data-architecture.mdx` (E1334) — authoritative
+- Entity-sync plumbing: `.claude/rules/entity-sync-pipeline.md`
+- Source-check/verdicts: `.claude/rules/source-check-system.md`

--- a/.claude/rules/validation-gate-system.md
+++ b/.claude/rules/validation-gate-system.md
@@ -1,0 +1,177 @@
+# Validation & Gate System
+
+Subsystem map for the `crux/validate/` validator system, the gate check, and how checks are wired. **Read this before adding a new validator, changing gate behavior, or wondering "why didn't CI catch that?"**
+
+## Why this file exists
+
+There are **56 `validate-*.ts` files** in `crux/validate/` (plus ~20 test files and a handful of shared helpers). Gate logic is spread across `validate-gate.ts`, `validate-data.ts`, and `validate-daily.ts`. Agents adding a new check commonly:
+- Wire it into the wrong pipeline (daily instead of gate)
+- Miss the blocking-vs-advisory distinction
+- Duplicate existing validators (four separate `validate-factbase-*-refs.ts` files exist)
+- Write a validator without using the validator-first pattern from `.claude/rules/implementation-quality.md`
+
+---
+
+## The four pipelines
+
+| Command | Purpose | File | When it runs |
+|---------|---------|------|--------------|
+| `pnpm crux w validate gate` | **CI-blocking pre-PR check** | `validate-gate.ts` (1096 lines) | On every PR, before merge |
+| `pnpm crux w validate data` | Data-integrity subset | `validate-data.ts` (421 lines) | Called by gate + ad-hoc |
+| `pnpm crux w validate daily` | Slow/expensive checks | `validate-daily.ts` (513 lines) | Nightly CI |
+| `pnpm crux w validate unified` | Unified rule runner | `validate-unified.ts` (189 lines) | Fast content-only check |
+
+**Rule of thumb**: if the check must run on every PR, add it to gate. If it's slow/expensive, daily.
+
+## The gate orchestrator — `validate-gate.ts`
+
+### Structure
+
+- **`Step` interface** at line 157 — **subprocess-based, not function-based**:
+  ```ts
+  interface Step {
+    id: string;
+    name: string;
+    command: string;          // e.g. 'node' or 'npx'
+    args: string[];           // e.g. ['--import', 'tsx/esm', 'crux/validate/validate-my-check.ts']
+    cwd: string;              // where to run from
+    advisory?: boolean;       // true = failure reported but doesn't block
+    emitOutputInCi?: boolean; // print captured output in CI even on success
+    requiresServer?: boolean; // auto-advisory when wiki-server unreachable
+  }
+  ```
+  Note: the gate does NOT call an in-process `run()` function — each check is a **separate subprocess** spawned with `command` + `args`. This is what allows parallel execution without blocking the main process.
+- **Sequential steps** at top (ID allocation, build-data — other steps depend on these)
+- **`runSequential()`** (line 809), **`runParallel()`** (line 828) — the subprocess runners
+- **`gate-triage.ts`** — LLM optimization that predicts which checks can be skipped based on the diff, to reduce CI time. Fail-closed: on error, runs everything.
+
+### Adding a new check to the gate
+
+1. Write your validator as `crux/validate/validate-<name>.ts`. Make it runnable standalone: `npx tsx crux/validate/validate-<name>.ts` exits 0 on pass, non-zero on fail. Emit errors to stderr.
+2. Add an entry to the `parallelChecks` array in `validate-gate.ts`, grouped with similar checks:
+   ```ts
+   {
+     id: 'my-check',
+     name: 'My new check',
+     command: 'npx',
+     args: ['tsx', 'crux/validate/validate-my-check.ts'],
+     cwd: PROJECT_ROOT,
+     // advisory: true,  // uncomment for non-blocking
+   }
+   ```
+3. Decide blocking (default) vs `advisory: true`. New rules enforcing a freshly-applied pattern should be blocking so the pattern doesn't regress.
+4. Add a test file `crux/validate/validate-<name>.test.ts` — most validators have one.
+
+## The 50+ gate checks (reference, as of 2026-04)
+
+Selected from `validate-gate.ts::parallelChecks`. Line numbers in the file.
+
+### Content & syntax (blocking)
+- `Unified blocking rules` (242) — MDX syntax, frontmatter, wiki IDs, EntityLink, pipeline artifacts
+- `YAML schema` (253)
+- `Conflict marker detection` (345)
+- `MDX compilation smoke-test` (370, advisory)
+
+### Code quality (blocking)
+- `.returning() guard check` (279) — Drizzle writes must handle empty return
+- `Drizzle migration journal integrity` (286) — unique prefixes
+- `No untyped row casts in routes` (293) — blocks `(r: any)` in wiki-server
+- `No console.log in server code` (300)
+- `No inline limit clamping in routes (use clampedLimit)` (307)
+- `Prompt XML interpolation escaping` (314) — enforces `escapeXml()`
+- `Data-integrity anti-patterns` (321) — silent catch, `as any` in routes, `skipEntityValidation` without reason
+- `No inline apiRequest<{...}> types` (335, advisory) — enforces typed wiki-server clients
+
+### TypeScript (blocking/advisory)
+- `TypeScript type check — app` (260, blocking)
+- `TypeScript type check — crux` (267, advisory; baseline enforced separately)
+
+### FactBase / TableBase (blocking)
+- `FactBase lookups use stableIds (not slugs)` (328)
+- `FactBase entity coverage` (430) — every FactBase file has TableBase entry
+- `FactBase ↔ TableBase entity ID consistency` (439) — duplicates, stableId mismatches
+- `FactBase record ref resolution` (512)
+- `Soft FK entity reference validation` (521, advisory)
+- `Person reference validation` (696)
+
+### Entities / IDs (blocking)
+- `Entity reference integrity (KB records)` (419)
+- `KB entity slug validation` (448)
+- `YAML entity reference integrity` (457)
+- `Orphan entity detection (PG without YAML source)` (487)
+- `No sid_ values in display name columns` (500)
+- `Rendered SID check (no sid_ leaks in built data)` (706)
+- `Display name quality (no raw machine IDs in titles)` (666)
+
+### Temporal / numeric (blocking)
+- `Temporal invariant validation` (466)
+- `PG temporal consistency` (534)
+- `Numeric range validation (low ≤ high)` (558)
+- `Controlled vocabulary validation` (546)
+
+### Source-check / completeness (blocking)
+- `TableBase source-check coverage` (650)
+- `Tablebase route completeness` (676) — delete, things sync, entity ref validation
+- `Dot indicator position` (352) — SourceCheckDot / RecordStatusDots not in first column
+- `Display formatting quality` (686) — no `[object Object]`, no unescaped MDX in titles
+
+### Resources (blocking/advisory)
+- `Resource reference validation` (570, advisory)
+- `Resource data quality` (583)
+
+### Cross-base consistency (blocking)
+- `Cross-base consistency` (594) — WikiBase / TableBase / FactBase alignment
+- `Related entry type mismatches` (606)
+- `Component reference validation` (381)
+
+### Advisory-only
+- `Directory page data quality` (475)
+- `Cross-page numeric consistency` (616)
+- `Stale content detection` (628)
+- `Cross-page date consistency` (639)
+- `PR review status` (388)
+
+## Shared infrastructure in `crux/validate/`
+
+Non-validator files you should know exist before writing new helpers:
+
+- `types.ts` — shared `ValidatorResult` / `ValidatorOptions` types
+- `gate-triage.ts` (+ `.test.ts`) — LLM diff-based skip predictor, called from `validate-gate.ts`
+- `cross-entity-consistency.ts` — cross-file invariant helper
+- `check-staleness.ts` — staleness check utility
+- `to-rdjsonl.ts` — rdjsonl output formatter
+- `cross-check-people.ts` — person reference cross-check helper
+- `__tests__/` — test-only validators (e.g. `validate-manual-api-types.test.ts`, `validate-prompt-escaping.test.ts`)
+
+## The 56 validators (by concern)
+
+Grouped by what they check. **Before writing a new validator, grep this list.**
+
+- **Entity refs**: `entity-refs`, `entity-links`, `yaml-entity-refs`, `component-refs`, `internal-links`, `resource-refs`, `kb-entity-slugs`, `person-refs`, `soft-fks`
+- **FactBase**: `factbase-entities`, `factbase-entity-ids`, `factbase-stableid`, `factbase-record-refs`, `factbase-schema`
+- **IDs / SIDs**: `rendered-sid`, `sid-display`, `display-names`
+- **Schema / compile**: `yaml-schema`, `mdx-compile`, `pg-temporal`, `temporal`, `numeric-ranges`, `numeric-consistency`, `controlled-vocab`
+- **Code quality**: `no-console-log`, `returning-guard`, `untyped-rows`, `prompt-escaping`, `dangerous-patterns`, `drizzle-journal`, `manual-api-types`, `conflict-markers`
+- **Source-check**: `source-check-coverage`, `source-check-names`, `tablebase-completeness`, `dot-position`, `display-formatting`
+- **Content quality**: `review-marker`, `hallucination-risk`, `financials`, `cross-base`, `cross-page-dates`, `stale-content`, `related-entry-types`, `directory-pages`
+- **Infra**: `actions-yaml`, `inline-pagination`, `crux-tsc`
+- **Resources**: `resource-refs`, `resource-quality`, `orphan-entities`
+- **Data integrity**: `data`, `consistency`, `quality`, `daily`, `unified`
+
+## Validator-first pattern (read `.claude/rules/implementation-quality.md`)
+
+When applying a structural rule across >5 files, **write the validator first**, then fix violations using its output as the work queue. A validator is cheaper than trusting grep to find everything.
+
+Four complexity tiers:
+1. **Text pattern** (banned import, naming) → regex scan
+2. **Structural pattern** (component position in JSX) → line state machine (`validate-dot-position.ts`)
+3. **Cross-file invariant** (unique IDs, matching FKs) → load + check in memory (`validate-drizzle-journal.ts`)
+4. **Runtime check** (rendered output) → Playwright e2e (`e2e/render-audit.spec.ts`)
+
+## Adding functionality — checklist
+
+1. **Does a similar validator exist?** Grep the 80+ list above first.
+2. **Wire it into gate, not daily**, if it must run on every PR.
+3. **Blocking vs advisory**: blocking unless you have a documented reason (see `validate-gate.ts` comments on fail-open exceptions — e.g., `assign-ids`, `typecheck-crux`, `mdx-compile`, `gate-triage`).
+4. **Standalone-runnable**: `npx tsx crux/validate/validate-<name>.ts` should work.
+5. **Test file**: add `validate-<name>.test.ts` — most validators have one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,3 +184,13 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/implementation-quality.md` — Thoroughness, testing depth, self-review
 - `.claude/rules/auto-update-system.md` — Auto-update system
 - `.claude/rules/worktree-isolation-bug.md` — Known Claude Code worktree CWD bug (DO NOT USE `isolation: "worktree"`)
+
+## Subsystem Maps — Read BEFORE proposing work in these areas
+
+These are "mental model" maps. They list the components, endpoints, helpers, and conventions that already exist in each subsystem so agents don't re-implement things. **Read the relevant map at task-start, not after writing code.**
+
+- `.claude/rules/source-check-system.md` — Source-check, verdict, and coverage scoring (if touching verdict UI, coverage scores, or `/api/source-checks/*`)
+- `.claude/rules/entity-sync-pipeline.md` — TableBase sync infrastructure, shared helpers (`sqlInList`, `validateEntityRefs`, `deleteBatchHandler`, `resolveEntityFKs`)
+- `.claude/rules/three-bases-architecture.md` — TableBase/FactBase/WikiBase naming and which layer owns what
+- `.claude/rules/id-system.md` — `numericId` vs `stableId` vs `tableId`, allocation, validation
+- `.claude/rules/validation-gate-system.md` — `crux/validate/` 80+ validators, gate wiring, blocking vs advisory


### PR DESCRIPTION
## Summary

Adds five `.claude/rules/*-system.md` files that get auto-loaded into every Claude Code session. The goal: stop agents re-implementing things that already exist because they grepped for the wrong names or didn't know the subsystem's naming convention.

Reference incident: an agent recently tried to add a "source-check score column" to the organizations directory and missed that `ClaimsPipelineSummary`, `EntityDbPage`, `EntityProfileViewer`, `RecordStatusDots`, and `computeOrgCoverage` already existed. The fix that works isn't "search harder" — it's giving future agents a mental-model map of each subsystem at session start.

## Maps added

Each ~100–170 lines. All in `.claude/rules/`:

- **`source-check-system.md`** — source-check tables, 11 `/api/source-checks/*` endpoints, 6+ dot/verdict components, 12 `computeXxxCoverage()` scorers, 5 internal dashboards, known rough edges
- **`entity-sync-pipeline.md`** — shared helpers that keep getting missed: `sqlInList`, `validateEntityRefs`, `deleteBatchHandler`, `resolveEntityFKs`, `upsertThingsInTx`, `batchSync`. Includes the full inventory of which 25 tablebase routes have `/sync` + `/delete-batch` and which 6 still don't (PR #4064 gap)
- **`three-bases-architecture.md`** — cheat-sheet pointing to the canonical wiki page E1334. Summarizes the "entity/things/facts" naming overloads in a form agents can read in 30 seconds
- **`id-system.md`** — `numericId` (E-numbers) vs `stableId` (`sid_`) vs `tableId` tiers, allocation call chain, 5 SID validators, 3 migration scripts, known rough edges
- **`validation-gate-system.md`** — 56-validator inventory, the actual (subprocess-based) `Step` interface at `validate-gate.ts:157`, how `runParallel()` / `runSequential()` / `gate-triage.ts` fit together

`CLAUDE.md` gains a "Subsystem Maps" section pointing to all five.

## Methodology

Rather than guessing which subsystems need maps, I surveyed data from three angles:

1. **Last 100 PRs** — ranked subsystems by rework/duplication traffic. Top hits: IDs (21 incidents), entity-sync (18 incidents), source-check (15, being handled elsewhere), tablebase (13), verification (10)
2. **GitHub Discussions + agent-filed issues** — surfaced the "three bases" naming confusion (#2428, #2436, #2440, #3859, #4090), cache-vs-source drift, data-layer access-pattern confusion
3. **Codebase scan** — counted files per subsystem, looked for sprawl and multiple entry points

Each map was drafted from a focused Explore-agent audit, then **peer-reviewed by a second Explore agent**. Review findings corrected:

- Wrong line number in `app.ts:215` (actual: 203)
- Undercounted route list: missing `policy-stakeholders` + `publications` (23 → 25)
- Stale claim about `data/facts/` (the directory has been removed)
- **Wrong `Step` interface shape** in the gate map — originally described as function-based with `run()`, actually subprocess-based with `command/args/cwd/advisory`. Load-bearing correction
- Over-counted validator count (80+ → actual 56)

## DRYwall baseline scan

Ran `jscpd` (min-tokens 50, min-lines 5) across `crux/`, `apps/wiki-server/src/`, `apps/web/src/`, `packages/`. Results:

| Format | Files | Clones | Dup lines | Dup % |
|--------|-------|--------|-----------|-------|
| TypeScript | 981 | 687 | 7,989 | **3.53%** |
| TSX | 402 | 261 | 3,691 | **5.26%** |
| JavaScript | 347 | 20 | 865 | 2.31% |
| **Total** | **2,293** | **975** | **12,634** | **3.54%** |

**Top file offenders**:
- `apps/wiki-server/src/routes/tablebase/personnel.ts` — 29 clones, 321 dup-lines
- `crux/commands/people/enrich.ts` — 28 clones, 444 dup-lines
- `crux/commands/orgs.ts` — 24 clones, 410 dup-lines
- `apps/web/src/app/resources/resources-table.tsx` — 16 clones, 353 dup-lines

**Largest single clones**:
- 94 lines — `resources-table.tsx:456-549` ↔ `organizations/[slug]/resources-section.tsx:493-561`
- 93 lines — `grants-table.tsx:268-360` ↔ `research-areas-table.tsx:142-168`
- 89 lines — `crux/lib/valid-subcategories.ts` ↔ `apps/web/src/data/valid-subcategories.ts` (whole file)
- 78 lines — `factbase-entities-table.tsx:123-200` ↔ `factbase-facts-table.tsx:325-465`
- 58 lines — `crux/lib/rules/index.ts:122-179` ↔ `crux/lib/rules/index.ts:182-239` (self-duplication)

## Issues filed from this session

- **#4094** — Consolidate duplicate `formatValue` / `format*` helpers (5 files, 2 incompatible signatures)
- **#4100** — `valid-subcategories.ts` 89-line duplicate
- **#4101** — `crux/lib/rules/index.ts` duplicates ~56 rule names in two lists
- **Commented on #1254** (table factory consolidation, already open) with jscpd evidence

## Global tooling installed (not in this PR)

Per user request, installed globally to `~/.claude/`, affects all Claude Code sessions:

- **Serena MCP** — LSP-style semantic code search, activates next session
- **DRYwall plugin** v0.2.1 — jscpd-wrapped duplicate detection

## What this PR does NOT do

- Doesn't run the baseline fixes from DRYwall — issues filed for follow-up
- Doesn't consolidate the 6 format modules (#4094) — follow-up
- Doesn't address the 6 tablebase routes missing `/delete-batch` — referenced in the map, follow-up
- Doesn't add a jscpd gate check — high-signal dups will mostly be caught by the maps preventing new duplication

## Test plan

- [x] All 5 maps peer-reviewed by a second Explore agent; review findings applied
- [x] All file paths, line numbers, and exported names spot-verified
- [x] `CLAUDE.md` updated to reference all 5 new map files
- [x] `jscpd` baseline scan completed (12k dup-lines, 975 clones)
- [ ] Next session: agent should find the subsystem maps load into context and actually use them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
