### PR TITLE
Fix factual errors in subsystem maps (follow-up to #4102)

### DIFF
--- a/.claude/rules/entity-sync-pipeline.md
+++ b/.claude/rules/entity-sync-pipeline.md
@@ -4,7 +4,7 @@ Subsystem map for the YAML → sync → PG pipeline and the tablebase route infr
 
 ## Why this file exists
 
-The last 100 PRs had 18 rework incidents in this subsystem:
+Recent rework incidents in this subsystem include:
 - **PR #4059** broke `unnest()` array parameterization across 8 endpoints — `sqlInList` helper existed but wasn't used
 - **PR #4029** added `validateEntityRefs` calls to 8 endpoints that had silently been missing it
 - **PR #4045** fixed an entity slug reassignment race
@@ -56,14 +56,16 @@ Crux-side scripts that read YAML source and batch POST to wiki-server. All use `
 
 All under `apps/wiki-server/src/routes/tablebase/`. Each route file is one PG table.
 
-**Routes with BOTH `/sync` and `/delete-batch`** (25 — the baseline):
-`grants`, `funding-rounds`, `investments`, `equity-positions`, `benchmarks`, `benchmark-results`, `funding-programs`, `entity-profile`, `entity-profile-descriptions`, `entity-assessments`, `entity-resources`, `entity-events`, `research-areas`, `political-votes`, `political-offices`, `political-scores`, `policy-stakeholders`, `prediction-markets`, `publications`, `secondary-market-prices`, `website-sources`, `division-personnel`, `divisions`, `campaign-finance`, `data-sources`
+**Routes with BOTH `/sync` and `/delete-batch`** (23 — the baseline):
+`grants`, `funding-rounds`, `investments`, `equity-positions`, `benchmarks`, `benchmark-results`, `funding-programs`, `entity-assessments`, `entity-resources`, `entity-events`, `research-areas`, `political-votes`, `political-offices`, `political-scores`, `policy-stakeholders`, `prediction-markets`, `publications`, `secondary-market-prices`, `website-sources`, `division-personnel`, `divisions`, `campaign-finance`, `data-sources`
 
-**Read-only / utility routes** (no `/sync` or `/delete-batch` expected): `audit-log`, `ids`, `people`, `record-lookup`, `sourcing-schema`, `talent-flows`, `write-inline-verdicts`.
+**Read-only / utility routes** (no `/sync` or `/delete-batch` expected): `audit-log`, `ids`, `index`, `people`, `record-lookup`, `sourcing-schema`, `sync-factory` (types only), `talent-flows`, `write-inline-verdicts`.
 
-**Routes still missing `/delete-batch` (PR #4064 gap)** (6):
+**Routes still missing `/delete-batch` (PR #4064 gap)** (8):
 - `bluesky.ts`
 - `entities.ts`
+- `entity-profile.ts`
+- `entity-profile-descriptions.ts`
 - `personnel.ts`
 - `platform-accounts.ts`
 - `political-races.ts`

--- a/.claude/rules/id-system.md
+++ b/.claude/rules/id-system.md
@@ -4,7 +4,7 @@ Subsystem map for the wiki's ID schemes (`numericId`, `stableId`, slugs, legacy 
 
 ## Why this file exists
 
-Last 100 PRs had 21 ID-related rework incidents: regex bugs (#4065), allocation races (#4043), personnel ID regex (#3964), `sid_` prefix handling (#4008), string/number type confusion from `postgres.js` returning strings where Sets expected numbers. The failure mode is always the same: agent assumes ID system is simpler than it is, picks the wrong helper, or invents a new ID format.
+Recent ID-related rework incidents: regex bugs (#4065), allocation races (#4043), personnel ID regex (#3964), `sid_` prefix handling (#4008), string/number type confusion from `postgres.js` returning strings where Sets expected numbers. The failure mode is always the same: agent assumes ID system is simpler than it is, picks the wrong helper, or invents a new ID format.
 
 ---
 
@@ -71,7 +71,7 @@ Currently imported by: `apps/wiki-server/src/routes/tablebase/{entities,record-l
 
 ## Validation (run before PR)
 
-Four SID/ID validators in `crux/validate/`:
+Five SID/ID validators in `crux/validate/`:
 
 | Validator | What it catches |
 |-----------|-----------------|
@@ -81,7 +81,7 @@ Four SID/ID validators in `crux/validate/`:
 | `validate-factbase-entity-ids.ts` | FactBase ↔ TableBase entity ID consistency (no duplicates, no orphans) |
 | `validate-kb-entity-slugs.ts` | FactBase refs have matching entity registry entries |
 
-`validate-gate.ts` runs all of these in blocking mode (see lines 500, 512, 648). If you touch IDs, run `pnpm crux w validate gate --fix` before PR.
+`validate-gate.ts` runs all of these in blocking mode (see the `factbase-stableid`, `factbase-entity-ids`, `kb-entity-slugs`, `sid-display`, and `rendered-sid` entries in `parallelChecks`). If you touch IDs, run `pnpm crux w validate gate --fix` before PR.
 
 ## Migration scripts (when you need them)
 

--- a/.claude/rules/source-check-system.md
+++ b/.claude/rules/source-check-system.md
@@ -55,7 +55,7 @@ All in `apps/wiki-server/src/routes/source-check/source-checks.ts`, mounted in `
 - `components/coverage/coverage-score.ts` — **12 entity-type scorers**, all return 1–4: `computeOrgCoverage`, `computePersonCoverage`, `computeAiModelCoverage`, `computeLegislationCoverage`, `computeProjectCoverage`, `computeBenchmarkCoverage`, `computeGrantCoverage`, `computeFundingProgramCoverage`, `computeFundingRoundCoverage`, `computeDivisionCoverage`, `computePublicationCoverage`, `computeGenericCoverage`. Also signal extractors: `getOrgSignals`, `getPersonSignals`, `getLegislationSignals`.
 - `data/entity-coverage.ts` — `getEntityDataDepth()`, `computeEntityCoverage()` (dispatches to type scorers), `getAllEntityCoverageScores()` (batch, for dashboards)
 - `data/page-coverage.ts` — `getPageCoverageItems()` (wiki page coverage from database.json)
-- `lib/coverage.ts` — `getRatioStatus(num, denom)` (≥75% green, >0 amber, 0 red), `getMetricStatus(actual, target)`
+- `apps/web/src/lib/coverage.ts` — `getRatioStatus(num, denom)` (≥75% green, >0 amber, 0 red), `getMetricStatus(actual, target)`
 
 **Adding coverage for a new entity type**: add a scorer in `coverage-score.ts` + dispatch it in `data/entity-coverage.ts::computeEntityCoverage()`. Don't create a parallel scoring system.
 
@@ -83,7 +83,7 @@ If you're about to add a "show source-check status on X page", first grep for `R
 - **Entity coverage scale**: 1=stub, 2=basic, 3=moderate, 4=comprehensive. Typical record is 2, not 3.
 - **Source-check verdict states** (6): `confirmed | contradicted | outdated | partial | unverifiable | unchecked`
 - **Citation verdict states** (5): `accurate | minor_issues | inaccurate | unsupported | not_verifiable`
-- **Unified display status** (5): `not_run | error | failed | trouble | verified`. Mapping in `recordVerdictToStatus()` / `factbaseVerdictToStatus()` at `source-check-status.ts:65-105`.
+- **Unified display status** (5): `not_run | error | failed | trouble | verified`. Mapping in `recordVerdictToStatus()` / `factbaseVerdictToStatus()` at `apps/web/src/components/source-check/source-check-status.ts`.
 - **Color scheme**: canonical source is `components/shared/verdict-styles.ts` — `SOURCE_CHECK_VERDICT_STYLES`, `CITATION_VERDICT_STYLES`, `CITATION_VERDICT_COLORS`, `SOURCE_CHECK_VERDICT_PRIORITY`, `CITATION_VERDICT_SEVERITY`. **Do not inline your own color map** — `source-check-coverage-content.tsx` did this at lines 51-67 and it's a known duplication.
 - **Checker model**: `claude-haiku-4-5-20251001` (source-checks.ts:66). Stale model → rerun flagged.
 - **Build-time vs runtime**: entity coverage is computed on-demand from database.json + FactBase KB. Source-check verdicts/evidence are runtime PG queries.
@@ -94,7 +94,7 @@ If you're about to add a "show source-check status on X page", first grep for `R
 - Two parallel scoring systems: entity coverage (type scorers) vs page coverage (database.json green/amber/red). No single "data completeness" score.
 - Per-field verdicts are stored (`source_check_verdicts.field_name`) but `EntityProfileViewer` aggregates by record, not field. Public tables don't show per-field granularity.
 - Color-map duplication: `source-check-coverage-content.tsx:51-67` redefines verdict colors independently of `verdict-styles.ts`.
-- Coverage ratio thresholds hardcoded at 75% in `lib/coverage.ts:17`.
+- Coverage ratio thresholds hardcoded at 75% in `apps/web/src/lib/coverage.ts::getRatioStatus`.
 - No automatic entity-level verdict aggregation ("entity has contradicted info") — only per-record.
 
 ## Adding new functionality — checklist

--- a/.claude/rules/validation-gate-system.md
+++ b/.claude/rules/validation-gate-system.md
@@ -170,7 +170,7 @@ Four complexity tiers:
 
 ## Adding functionality — checklist
 
-1. **Does a similar validator exist?** Grep the 80+ list above first.
+1. **Does a similar validator exist?** Grep the list above first.
 2. **Wire it into gate, not daily**, if it must run on every PR.
 3. **Blocking vs advisory**: blocking unless you have a documented reason (see `validate-gate.ts` comments on fail-open exceptions — e.g., `assign-ids`, `typecheck-crux`, `mdx-compile`, `gate-triage`).
 4. **Standalone-runnable**: `npx tsx crux/validate/validate-<name>.ts` should work.


### PR DESCRIPTION
## Summary

Follow-up to #4102 (merged as c5a4be9ac). Fixes 4 HIGH and 4 MEDIUM factual errors caught by `/agent-review-pr` after the original PR merged. Since these files are loaded into every Claude Code session as persistent context, factual errors teach agents false models and are high-priority to correct.

## Fixes

**HIGH:**

1. **`entity-sync-pipeline.md` — delete-batch route inventory wrong.** Claimed 25 routes have both `/sync` and `/delete-batch`; actual is 23. `entity-profile` and `entity-profile-descriptions` do NOT have `/delete-batch` endpoints (verified via grep). Moved them to the missing list, which is now 8 (not 6).

2. **`id-system.md` — "Four SID/ID validators" contradicted the table of 5.** Fixed to "Five".

3. **`id-system.md` — three fabricated gate line citations.** Cited lines 500, 512, 648 for the five SID validators. Actual name-lines in `validate-gate.ts` are 328 (factbase-stableid), 439 (factbase-entity-ids), 448 (kb-entity-slugs), 500 (sid-display), 706 (rendered-sid). Since line numbers drift when gate.ts is edited, replaced with `id:` references (`factbase-stableid`, `factbase-entity-ids`, etc.) which are stable.

4. (HIGH #4 was caught during review but was a variant of #3 — the "648" was past EOF in the old gate.ts.)

**MEDIUM:**

5. **`source-check-system.md`** — `lib/coverage.ts:17` cited for `getRatioStatus`, actual is line 12. `source-check-status.ts:65-105` range cited for `recordVerdictToStatus`/`factbaseVerdictToStatus`, actual positions are lines 77 and 100. Removed specific line/range anchors in favor of file+symbol references.

6. **`entity-sync-pipeline.md` and `id-system.md`** — "Last 100 PRs had N incidents" phrasing will rot as time passes. Reworded both to "Recent rework incidents include:". PR numbers (#4059, #4029, etc.) remain as historical anchors.

7. **`validation-gate-system.md`** — "Grep the 80+ list above first" contradicted the corrected "56 validators" header. Changed to "Grep the list".

## Methodology

The `/agent-review-pr` hostile-review subagent spotted these issues by reading the full diff and verifying every concrete claim (file paths, line numbers, counts, exported symbols) against the actual codebase. The review happened after the original PR merged (so fixes couldn't land as a pre-merge commit) — this PR is the follow-up.

One of the reviewer's "HIGH" findings was itself wrong: it claimed `runSequential()` was at line 820, but verification showed 809 is correct. That finding was dismissed.

## Test plan

- [x] All 4 HIGH findings verified by direct grep/read against the codebase before fixing
- [x] All 4 MEDIUM findings verified
- [x] Reviewer's own errors cross-checked and dismissed where wrong
- [x] No new line numbers introduced that could drift — anchors are now file+symbol wherever possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
