### PR TITLE
Phase 2 Batch C: migrate 11 routes to sync-factory in parallel

### DIFF
--- a/.claude/rules/tablebase-sync-factory.md
+++ b/.claude/rules/tablebase-sync-factory.md
@@ -1,0 +1,136 @@
+# TableBase Sync Handler Factory
+
+The `createSyncHandler<T>()` factory in `apps/wiki-server/src/routes/tablebase/sync-factory.ts` is the canonical pattern for new TableBase POST /sync routes. Mass migration of existing routes is in progress (discussion #4088, issue #4090).
+
+## When to use it
+
+**Always use the factory for new sync routes.** Use the scaffolder:
+
+```bash
+pnpm crux tb sync-scaffold <route-name>             # Tier 2 (default)
+pnpm crux tb sync-scaffold <route-name> --tier=1    # Full features
+pnpm crux tb sync-scaffold <route-name> --tier=3    # Minimal
+pnpm crux tb sync-scaffold <route-name> --output=apps/wiki-server/src/routes/tablebase/<route-name>.ts
+```
+
+The scaffolder emits a starter route file with the minimum factory config. Replace the `TODO` placeholders with the real schema and field mappings.
+
+## When NOT to use it
+
+5 routes are permanently excluded from the factory (per Phase 0 audit, [issue #4089](https://github.com/quantified-uncertainty/longterm-wiki/issues/4089)):
+
+| Route | Reason |
+|-------|--------|
+| `entities.ts` | Slug displacement, statement_timeout overrides, relatedEntries validation |
+| `things.ts` | IT IS the things table, not a dual-write target |
+| `bluesky.ts` | Only `/sync/:did` (external API fetch), no main `/sync` |
+| `data-sources.ts` | Multi-table writes per call (resources + tabular sources + snapshots) |
+| `ids.ts` | Uses `nextval('entity_id_seq')` for ID allocation, fundamentally different semantics |
+
+If you're adding a route that needs >1 escape hatch (`preValidate`, `postUpsert`, `conflictSet`), the factory is the wrong fit. Hand-roll the route and document why in a comment.
+
+## Migration pattern (Phase 2)
+
+When migrating an existing route to the factory, use the per-route feature flag for safe rollback:
+
+```typescript
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
+
+// Keep both implementations for the 7-day soak period.
+const factoryHandler = createSyncHandler({
+  name: "my-route",
+  table: myTable,
+  // ...
+});
+
+const legacyHandler = async (c: Context) => {
+  // ... existing hand-rolled handler, unchanged ...
+};
+
+const myApp = new Hono()
+  .post("/sync", async (c) => {
+    if (useFactoryFor("my-route")) {
+      return factoryHandler(c);
+    }
+    return legacyHandler(c);
+  });
+```
+
+Operators can roll back any single route by setting the env var:
+
+```bash
+USE_SYNC_FACTORY_ROUTES=!my-route
+```
+
+After 7 days of clean metrics with the factory enabled (default), a follow-up PR removes the legacy handler and the conditional, leaving only the direct factory call.
+
+See `apps/wiki-server/src/routes/tablebase/sync-factory-flag.ts` for the full truth table.
+
+## Hook budget: max 1 per route
+
+The factory provides three escape hatches: `preValidate`, `postUpsert`, `conflictSet`. **Routes should use at most 1.** If you find yourself reaching for a second hook, that's a signal the factory isn't the right fit — hand-roll the route instead.
+
+The 3 Phase 1 pilot routes follow this rule:
+
+| Route | Hook | Reason |
+|-------|------|--------|
+| `personnel.ts` | `postUpsert` | `new:` prefix display-name backfill + things sync refetch (after `fkResolve`) |
+| `divisions.ts` | `conflictSet` | COALESCE preservation for nullable fields |
+| `political-scores.ts` | (none) | Pure batch upsert with auto-derived SET clause |
+
+## Hook contract
+
+Hooks (`preValidate`, `postUpsert`) receive the Drizzle transaction handle `tx`. They MUST:
+
+1. **Only do DB work via `tx`**. No external HTTP calls, file writes, Discord notifications, or `getDb()` calls for a separate connection.
+2. **Throw on failure**. The factory wraps thrown errors in `SyncPhaseError({ route, phase, cause })` and rolls back the transaction. The route returns 500.
+3. **Be synchronous within the transaction**. No fire-and-forget patterns.
+
+`preValidate` returns `Response | null`. If a Response is returned, the factory short-circuits and returns it (used for custom 400 errors before the transaction). `postUpsert` returns `void`.
+
+## What the factory handles automatically
+
+- **Parse + Zod validation** — invalid JSON → 400, schema errors → 400
+- **Natural key collision** (gated by `naturalKey` config) — intra-batch dedup → 400
+- **Source-check enforcement** (gated by `enforceSourceCheck` config) — calls `enforceSourceCheck()` from `source-check-enforcement.ts`
+- **Entity FK validation** (gated by `entityRefFields` config) — calls `validateEntityRefs()`
+- **Claim validation + linking** (gated by `claimSupport` config) — calls `validateClaimRefs()` pre-tx, `linkClaimsToRecords()` post-tx
+- **Batch upsert** — single `INSERT...ON CONFLICT`, auto-chunked based on Postgres parameter limit (`60000 / columnCount`)
+- **Auto-derived SET clause** — derived from `toRow()` output keys + `getTableColumns(table)`. Override with `conflictSet`.
+- **Audit logging** (gated by `auditRecordType` config) — single batch insert per chunk; existing-row pre-fetch in batch
+- **Entity FK resolution** (gated by `fkResolve` config) — calls `resolveEntityFKs()` post-upsert
+- **Things dual-write** (gated by `toThing` config) — calls `resolveEntityTitles()` + `upsertThingsInTx()`
+- **Inline source-check verdicts** (gated by `toVerdict` config) — calls `writeInlineVerdicts()` in tx
+- **Standard response shape** — `{ upserted, verdictsWritten, claimsLinked }`
+
+## What the factory does NOT handle
+
+- **GET /all, /stats, /by-entity** endpoints — hand-roll these. Use the existing `paginatedQuery` helper from `crux/lib/wiki-server/` for pagination.
+- **Slug displacement** — `entities.ts` is excluded from the factory permanently
+- **Multiple sync endpoints per route** — only the primary `/sync` is in scope. Secondary endpoints (e.g., `research-areas.ts /sync-papers`) stay hand-rolled.
+- **Non-standard primary keys** — the factory assumes `table.id` is the conflict target unless `conflictTarget` is overridden
+- **Custom response shapes** — routes that need to return additional fields beyond the standard shape should hand-roll
+
+## Testing
+
+The factory is tested in `apps/wiki-server/src/__tests__/sync-factory.test.ts`. The test pattern uses:
+
+- A fake `entities`-shaped Drizzle table (the factory needs SOMETHING to introspect via `getTableColumns()`)
+- The existing `mockDbModule` from `test-utils.ts` for transaction + dispatch mocking
+- A `buildAppWithErrorCapture()` helper that registers a Hono `onError` handler so tests can assert on `SyncPhaseError` instances
+
+When you migrate a route to the factory, write a new test in `apps/wiki-server/src/__tests__/<route-name>.test.ts` that:
+
+1. Uses `mockDbModule` with a dispatcher that handles your table's queries
+2. Tests happy path, FK-invalid, duplicate-id, and any custom hook behavior
+3. For routes with `postUpsert` hooks, test that the hook runs and that throwing rolls back
+
+## References
+
+- Discussion: [#4088](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4088)
+- Phase 0 audit: [#4089](https://github.com/quantified-uncertainty/longterm-wiki/issues/4089)
+- Phase 1 implementation: [#4090](https://github.com/quantified-uncertainty/longterm-wiki/issues/4090)
+- Factory source: `apps/wiki-server/src/routes/tablebase/sync-factory.ts`
+- Feature flag: `apps/wiki-server/src/routes/tablebase/sync-factory-flag.ts`
+- Type-level test: `apps/wiki-server/src/routes/tablebase/sync-factory.test-d.ts`

--- a/apps/wiki-server/src/__tests__/benchmark-results-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/benchmark-results-migration.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Phase 2 migration test for benchmark-results.ts.
+ *
+ * This route exercises the factory's `preValidate` escape hatch, used for
+ * two responsibilities that share one DB query:
+ *   1. Validating `benchmarkId` against the `benchmarks` table (a non-entities FK).
+ *   2. Auto-resolving benchmark slugs → ids in place before the upsert.
+ *
+ * `modelId` is a standard entities FK validated via `entityRefFields`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+let benchmarksStore: Map<string, { id: string; slug: string }>;
+
+function resetStores() {
+  entitiesStore = new Map();
+  benchmarksStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // Entity ref validation query — uses unnest against entities
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // benchmarks lookup: SELECT id, slug FROM benchmarks WHERE id IN (...) OR slug IN (...)
+  if (q.includes("from benchmarks")) {
+    return params
+      .filter((p) => {
+        const key = p as string;
+        for (const b of benchmarksStore.values()) {
+          if (b.id === key || b.slug === key) return true;
+        }
+        return false;
+      })
+      .map((p) => {
+        const key = p as string;
+        for (const b of benchmarksStore.values()) {
+          if (b.id === key || b.slug === key) return { id: b.id, slug: b.slug };
+        }
+        return { id: key, slug: key };
+      });
+  }
+
+  if (q.includes('"benchmark_results"')) return [];
+  if (q.includes('"things"')) return [];
+  if (q.includes("proposed_claims")) return [];
+  if (q.includes("claim_record_links")) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "bmr0000001",
+  benchmarkId: "bmk0000001",
+  modelId: "gpt-4",
+  score: 85.5,
+  unit: "accuracy",
+  date: "2024-01-15",
+  sourceUrl: "https://example.org/benchmark",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("benchmark-results — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("gpt-4", { id: "gpt-4", stable_id: "sidGpt4" });
+    benchmarksStore.set("bmk0000001", { id: "bmk0000001", slug: "mmlu" });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with full response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with the same upserted count", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!benchmark-results");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body.verdictsWritten).toBe(0);
+    });
+
+    it("factory mode accepts multiple items", async () => {
+      _resetFlagCache();
+      entitiesStore.set("claude-3", { id: "claude-3", stable_id: "sidClaude3" });
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "bmr0000002", modelId: "claude-3", score: 88.0 },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(2);
+    });
+  });
+
+  describe("benchmark FK validation (preValidate hook)", () => {
+    it("factory mode: rejects unknown benchmarkId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ ...VALID_ITEM, benchmarkId: "bmkUnknown" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("bmkUnknown");
+      expect(body.message).toContain("benchmarks");
+    });
+
+    it("legacy mode: rejects unknown benchmarkId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!benchmark-results");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ ...VALID_ITEM, benchmarkId: "bmkUnknown" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("bmkUnknown");
+    });
+
+    it("factory mode: accepts a benchmark slug and auto-resolves it to id", async () => {
+      _resetFlagCache();
+      // Submit with slug "mmlu" — should be accepted since slug matches
+      // benchmarksStore entry and preValidate resolves it to the underlying id.
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ ...VALID_ITEM, benchmarkId: "mmlu" }],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+  });
+
+  describe("model (entity) FK validation", () => {
+    it("factory mode: rejects unknown modelId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ ...VALID_ITEM, modelId: "nonexistent-model" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-model");
+    });
+
+    it("legacy mode: rejects unknown modelId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!benchmark-results");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ ...VALID_ITEM, modelId: "nonexistent-model" }],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/benchmark-results/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/benchmark-results/sync", {
+        items: [{ id: "bmr0000001" }], // missing benchmarkId, modelId, score
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/division-personnel-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/division-personnel-migration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Phase 2 migration test for division-personnel.ts.
+ *
+ * Verifies that:
+ *   1. The factory and legacy handlers produce equivalent behavior on the
+ *      happy path (both return 200 with the same shape)
+ *   2. The feature flag correctly routes between factory and legacy
+ *   3. Entity FK validation works in both paths
+ *   4. Invalid input is rejected with 400 in both paths
+ *
+ * This is the canonical Phase 2 migration test pattern. Future Phase 2
+ * migrations should follow the same shape:
+ *   - Test happy path with factory ON (default)
+ *   - Test happy path with factory OFF (legacy fallback)
+ *   - Test error cases (FK invalid, malformed body) in both paths
+ *
+ * After 7 days of clean metrics, the legacy handler is deleted and these
+ * tests collapse to just the factory path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+let divisionPersonnelStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+  divisionPersonnelStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- division_personnel: any insert/update ---
+  if (q.includes("division_personnel")) {
+    return [];
+  }
+
+  // --- things: insert/delete ---
+  if (q.includes('"things"')) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "dp00000001",
+  divisionId: "open-philanthropy/global-health",
+  personId: "alice-smith",
+  role: "Program Officer",
+  startDate: "2023-01-01",
+  endDate: null,
+  source: "https://example.org/alice",
+  notes: "Joined from prior role",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+const INVALID_FK_BATCH = {
+  items: [
+    {
+      ...VALID_ITEM,
+      personId: "nonexistent-person",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+
+describe("division-personnel — feature flag", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("alice-smith", { id: "alice-smith", stable_id: "sidAliceSmith" });
+    entitiesStore.set("open-philanthropy/global-health", {
+      id: "open-philanthropy/global-health",
+      stable_id: "sidOPGH",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path — factory ON (default)", () => {
+    it("returns 200 with upserted count", async () => {
+      // No env var set → factory ON by default
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+
+    it("returns the standard factory response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Factory always returns these three fields
+      expect(body).toHaveProperty("upserted");
+      expect(body).toHaveProperty("verdictsWritten");
+      expect(body).toHaveProperty("claimsLinked");
+    });
+  });
+
+  describe("happy path — legacy fallback (USE_SYNC_FACTORY_ROUTES=!division-personnel)", () => {
+    it("returns 200 with upserted count from legacy handler", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!division-personnel");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+
+    it("returns the legacy response shape (just upserted, no factory fields)", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!division-personnel");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", VALID_BATCH);
+      const body = await res.json();
+      // Legacy handler returns only `{ upserted }`
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation — factory ON", () => {
+    it("returns 400 for invalid personId", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/division-personnel/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-person");
+    });
+  });
+
+  describe("FK validation — legacy fallback", () => {
+    it("returns 400 for invalid personId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!division-personnel");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/division-personnel/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-person");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects invalid JSON in factory mode", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/division-personnel/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid JSON in legacy mode", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!division-personnel");
+      _resetFlagCache();
+      const res = await app.request("/api/division-personnel/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects items missing required fields in factory mode", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", {
+        items: [{ id: "dp00000001" }], // missing divisionId, personId, role
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("inclusion mode (other route enabled, division-personnel not listed)", () => {
+    it("falls back to legacy when division-personnel not in inclusion list", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "personnel,divisions");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/division-personnel/sync", VALID_BATCH);
+      const body = await res.json();
+      // Legacy shape (just upserted, no factory fields)
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/entity-assessments-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/entity-assessments-migration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Phase 2 Batch C migration test for entity-assessments.ts.
+ *
+ * Verifies factory and legacy handlers produce equivalent behavior on the
+ * happy path, entity FK validation, and malformed input. Follows the
+ * canonical Phase 2 migration test pattern (see division-personnel-migration.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- resolveEntityTitles: select ... from "entities" ---
+  if (q.includes('from "entities"')) return [];
+
+  // --- entity_assessments: insert/update ---
+  if (q.includes("entity_assessments")) return [];
+
+  // --- things: insert/delete ---
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "ea00000001",
+  entityId: "anthropic",
+  dimension: "speed",
+  rating: "Fast (<1 week)",
+  evidence: "Ships new features weekly.",
+  assessor: "editorial" as const,
+  assessedAt: "2024-01-15",
+  source: "https://example.org/anthropic-speed",
+  notes: "Based on public releases.",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+const INVALID_FK_BATCH = {
+  items: [
+    {
+      ...VALID_ITEM,
+      entityId: "nonexistent-entity",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+
+describe("entity-assessments — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", {
+      id: "anthropic",
+      stable_id: "sidAnthropic",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path — factory ON (default)", () => {
+    it("returns 200 with upserted count and factory fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-assessments/sync",
+        VALID_BATCH,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body).toHaveProperty("verdictsWritten");
+      expect(body).toHaveProperty("claimsLinked");
+    });
+  });
+
+  describe("happy path — legacy fallback (USE_SYNC_FACTORY_ROUTES=!entity-assessments)", () => {
+    it("returns 200 with just upserted count", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!entity-assessments");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-assessments/sync",
+        VALID_BATCH,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      // Legacy returns only { upserted }
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation — factory ON", () => {
+    it("returns 400 for invalid entityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-assessments/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("FK validation — legacy fallback", () => {
+    it("returns 400 for invalid entityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!entity-assessments");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-assessments/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects invalid JSON in factory mode", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/entity-assessments/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects items missing required fields in factory mode", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/entity-assessments/sync", {
+        items: [{ id: "ea00000001" }], // missing entityId, dimension, rating
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/entity-events-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/entity-events-migration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Phase 2 Batch C migration test for entity-events.ts.
+ *
+ * Verifies factory and legacy handlers produce equivalent behavior on the
+ * happy path, entity FK validation, and malformed input. Follows the
+ * canonical Phase 2 migration test pattern (see division-personnel-migration.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- resolveEntityTitles: select ... from "entities" where id in (...) or stable_id in (...) ---
+  // Return empty: routes will fall back to entity id as the title, which is fine for tests.
+  if (q.includes('from "entities"')) return [];
+
+  // --- entity_events: insert/update ---
+  if (q.includes("entity_events")) return [];
+
+  // --- things: insert/delete ---
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "ee00000001",
+  entityId: "anthropic",
+  entityDisplayName: "Anthropic",
+  date: "2024-01-15",
+  title: "Series C funding round",
+  description: "Closed a $4B Series C round.",
+  eventType: "funding" as const,
+  significance: "major" as const,
+  source: "https://example.org/anthropic-funding",
+  notes: "Major funding milestone",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+const INVALID_FK_BATCH = {
+  items: [
+    {
+      ...VALID_ITEM,
+      entityId: "nonexistent-entity",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+
+describe("entity-events — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", {
+      id: "anthropic",
+      stable_id: "sidAnthropic",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path — factory ON (default)", () => {
+    it("returns 200 with upserted count and factory fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/entity-events/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body).toHaveProperty("verdictsWritten");
+      expect(body).toHaveProperty("claimsLinked");
+    });
+  });
+
+  describe("happy path — legacy fallback (USE_SYNC_FACTORY_ROUTES=!entity-events)", () => {
+    it("returns 200 with just upserted count", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!entity-events");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/entity-events/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      // Legacy returns only { upserted }
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation — factory ON", () => {
+    it("returns 400 for invalid entityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-events/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("FK validation — legacy fallback", () => {
+    it("returns 400 for invalid entityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!entity-events");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/entity-events/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects invalid JSON in factory mode", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/entity-events/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects items missing required fields in factory mode", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/entity-events/sync", {
+        items: [{ id: "ee00000001" }], // missing entityId, date, title, eventType
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/funding-rounds-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/funding-rounds-migration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Phase 2 migration test for funding-rounds.ts.
+ *
+ * funding-rounds is a Tier 2 route that uses COALESCE preservation on its
+ * entity FK columns (companyEntityId, leadInvestorEntityId) via the factory's
+ * `conflictSet` escape hatch. It also exercises the factory's natural key,
+ * entity FK validation, claim support, things dual-write, and verdicts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validate-entity-refs uses unnest(...) from entities
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // Legacy pre-insert entity lookup: SELECT id, stable_id FROM entities WHERE id IN (...) OR stable_id IN (...)
+  if (q.includes("from entities") && q.includes("stable_id")) {
+    const ids = params as string[];
+    const rows: Array<{ id: string; stable_id: string }> = [];
+    for (const id of ids) {
+      const hit = entitiesStore.get(id);
+      if (hit) rows.push({ id: hit.id as string, stable_id: hit.stable_id as string });
+    }
+    return rows;
+  }
+
+  if (q.includes('"funding_rounds"')) return [];
+  if (q.includes('"things"')) return [];
+  if (q.includes("proposed_claims")) return [];
+  if (q.includes("claim_record_links")) return [];
+  if (q.includes("update funding_rounds") || q.includes("update entity")) return [];
+  if (q.includes("source_check_verdicts")) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "fr00000001",
+  companyId: "anthropic",
+  name: "Series C",
+  date: "2024-01-15",
+  raised: 1000000000,
+  valuation: 10000000000,
+  leadInvestor: "google",
+  source: "https://example.org/funding-round",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("funding-rounds — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", { id: "anthropic", stable_id: "sidAnthropic" });
+    entitiesStore.set("google", { id: "google", stable_id: "sidGoogle" });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with full response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with the same core fields", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!funding-rounds");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body.verdictsWritten).toBe(0);
+      expect(body.claimsLinked).toBe(0);
+    });
+  });
+
+  describe("natural key collision", () => {
+    it("factory mode: rejects duplicate (companyId, name)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "fr00000002" }, // same (companyId, name)
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("anthropic::Series C");
+    });
+
+    it("legacy mode: rejects duplicate with descriptive message", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!funding-rounds");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "fr00000002" },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("companyId=anthropic");
+    });
+  });
+
+  describe("FK validation", () => {
+    it("factory mode: rejects unknown companyId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", {
+        items: [{ ...VALID_ITEM, companyId: "nonexistent-co" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-co");
+    });
+
+    it("legacy mode: rejects unknown companyId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!funding-rounds");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", {
+        items: [{ ...VALID_ITEM, companyId: "nonexistent-co" }],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode: rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/funding-rounds/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/funding-rounds/sync", {
+        items: [{ id: "fr00000001" }], // missing companyId, name
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/investments-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/investments-migration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Phase 2 migration test for investments.ts.
+ *
+ * investments.ts is the most feature-complete Tier 2 route — it exercises
+ * the factory's natural key, entity FK, claim validation, FK resolve, things
+ * sync, and verdicts pipeline. This test verifies that both factory and
+ * legacy paths produce equivalent behavior across the full feature set.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  if (q.includes('"investments"')) return [];
+  if (q.includes('"things"')) return [];
+  if (q.includes("from proposed_claims") || q.includes("proposed_claims")) return [];
+  if (q.includes("claim_record_links")) return [];
+  if (q.includes("update investments") || q.includes("update entity")) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "inv0000001",
+  companyId: "anthropic",
+  investorId: "google",
+  roundName: "Series C",
+  date: "2024-01-15",
+  amount: 1000000000,
+  source: "https://example.org/investment",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("investments — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", { id: "anthropic", stable_id: "sidAnthropic" });
+    entitiesStore.set("google", { id: "google", stable_id: "sidGoogle" });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with full response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with the same fields", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!investments");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body.verdictsWritten).toBe(0);
+      expect(body.claimsLinked).toBe(0);
+    });
+  });
+
+  describe("natural key collision", () => {
+    it("factory mode: rejects duplicate (companyId, investorId, roundName)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "inv0000002" }, // same composite key
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("anthropic::google::Series C");
+    });
+
+    it("legacy mode: rejects duplicate with descriptive message", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!investments");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "inv0000002" },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("companyId=anthropic");
+    });
+  });
+
+  describe("FK validation", () => {
+    it("factory mode: rejects unknown companyId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [{ ...VALID_ITEM, companyId: "nonexistent-co" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-co");
+    });
+
+    it("factory mode: rejects unknown investorId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [{ ...VALID_ITEM, investorId: "nonexistent-investor" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-investor");
+    });
+
+    it("legacy mode: rejects unknown investorId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!investments");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [{ ...VALID_ITEM, investorId: "nonexistent-investor" }],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/investments/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/investments/sync", {
+        items: [{ id: "inv0000001" }], // missing companyId, investorId
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/platform-accounts-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/platform-accounts-migration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Phase 2 migration test for platform-accounts.ts.
+ *
+ * This route exercises the factory's composite `conflictTarget` +
+ * `conflictSet` (COALESCE-preservation) escape hatch. The unique key is
+ * (platform, platformUsername), not the row id. platform_accounts uses a
+ * bigserial `id` PK — items omit `id` entirely and the DB assigns it on
+ * insert.
+ *
+ * Note: the legacy handler returned HTTP 201 with `{ upserted }`, while the
+ * factory returns 200 with `{ upserted, verdictsWritten, claimsLinked }`. This
+ * test asserts on both shapes separately in their respective modes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // Legacy handler uses .returning({ id }) — return a fake row per inserted item
+  if (q.includes('"platform_accounts"') && q.includes("returning")) {
+    // Drizzle INSERT with returning — synthesize one row per VALUES tuple.
+    // postgres.js interpolates params one per placeholder; for a 6-column
+    // item schema (platform, platformUsername, platformUserId, entityStableId,
+    // displayName, profileUrl) that's 6 params per row.
+    const rowCount = Math.max(1, Math.floor(params.length / 6));
+    return Array.from({ length: rowCount }, (_, i) => ({ id: i + 1 }));
+  }
+
+  if (q.includes('"platform_accounts"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  platform: "github" as const,
+  platformUsername: "octocat",
+  platformUserId: "583231",
+  entityStableId: "sidOctocat",
+  displayName: "The Octocat",
+  profileUrl: "https://github.com/octocat",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("platform-accounts — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("octocat", { id: "octocat", stable_id: "sidOctocat" });
+    entitiesStore.set("dependabot", { id: "dependabot", stable_id: "sidDependabot" });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with standard sync response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 201 with { upserted }", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!platform-accounts");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", VALID_BATCH);
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+
+    it("factory mode accepts multiple items with composite key", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, platformUsername: "dependabot", entityStableId: "sidDependabot" },
+          { ...VALID_ITEM, platform: "twitter" as const, platformUsername: "octocat_tw" },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(3);
+    });
+
+    it("factory mode accepts items without entityStableId (unlinked accounts)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [
+          {
+            platform: "github" as const,
+            platformUsername: "unknown-user",
+            displayName: "Unknown",
+            // entityStableId omitted — account is unlinked
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+  });
+
+  describe("entity FK validation", () => {
+    it("factory mode: rejects unknown entityStableId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [{ ...VALID_ITEM, entityStableId: "sidGhost" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("sidGhost");
+    });
+
+    it("legacy mode: rejects unknown entityStableId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!platform-accounts");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [{ ...VALID_ITEM, entityStableId: "sidGhost" }],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("schema validation", () => {
+    it("factory mode rejects invalid platform enum", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [{ ...VALID_ITEM, platform: "not-a-real-platform" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode rejects empty platformUsername", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/platform-accounts/sync", {
+        items: [{ ...VALID_ITEM, platformUsername: "" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/platform-accounts/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/policy-stakeholders-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/policy-stakeholders-migration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Phase 2 migration test for policy-stakeholders.ts.
+ *
+ * Verifies that:
+ *   1. Factory and legacy handlers produce equivalent behavior on the happy path
+ *   2. The feature flag correctly routes between factory and legacy
+ *   3. Entity FK validation works in both paths (policyEntityId only;
+ *      stakeholderEntityId is optional and intentionally unvalidated)
+ *   4. Invalid input is rejected with 400 in both paths
+ *
+ * Tier 3 route with things dual-write: factory handles the per-item loop and
+ * the things sync (resolveEntityTitles + upsertThingsInTx) via toThing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validate-entity-refs — unnest ARRAY against entities
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // resolveEntityTitles — select stable_id/id/title from entities where ...
+  if (q.includes("from entities") && q.includes("title")) {
+    return [];
+  }
+
+  if (q.includes('"policy_stakeholders"')) return [];
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "ps00000001",
+  policyEntityId: "california-sb1047",
+  stakeholderEntityId: null,
+  stakeholderDisplayName: "Example Org",
+  position: "support" as const,
+  importance: "high" as const,
+  reason: "Supports AI safety regulation",
+  source: "https://example.org/statement",
+  context: ["ai-safety", "regulation"],
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("policy-stakeholders — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("california-sb1047", {
+      id: "california-sb1047",
+      stable_id: "sidCASB1047",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with factory response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/policy-stakeholders/sync",
+        VALID_BATCH,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with legacy response shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!policy-stakeholders");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/policy-stakeholders/sync",
+        VALID_BATCH,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation — policyEntityId", () => {
+    it("factory mode: rejects unknown policyEntityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/policy-stakeholders/sync", {
+        items: [{ ...VALID_ITEM, policyEntityId: "nonexistent-policy" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-policy");
+    });
+
+    it("legacy mode: rejects unknown policyEntityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!policy-stakeholders");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/policy-stakeholders/sync", {
+        items: [{ ...VALID_ITEM, policyEntityId: "nonexistent-policy" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-policy");
+    });
+
+    it("factory mode: accepts unresolved stakeholderEntityId (intentionally unvalidated)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/policy-stakeholders/sync", {
+        items: [
+          {
+            ...VALID_ITEM,
+            stakeholderEntityId: "not-yet-synced-entity",
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode: rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/policy-stakeholders/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("legacy mode: rejects invalid JSON", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!policy-stakeholders");
+      _resetFlagCache();
+      const res = await app.request("/api/policy-stakeholders/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/policy-stakeholders/sync", {
+        items: [{ id: "ps00000001" }], // missing policyEntityId, stakeholderDisplayName, position
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/political-offices-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/political-offices-migration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 2 migration test for political-offices.ts.
+ *
+ * Verifies that:
+ *   1. Factory and legacy handlers produce equivalent behavior on the happy path
+ *   2. The feature flag correctly routes between factory and legacy
+ *   3. Entity FK validation works in both paths (politicianEntityId)
+ *   4. Invalid input is rejected with 400 in both paths
+ *
+ * Tier 3 route: factory converts the per-item loop into a batched upsert.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validate-entity-refs — unnest ARRAY against entities
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  if (q.includes('"political_offices"')) return [];
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "po00000001",
+  politicianEntityId: "senator-alice",
+  politicianDisplayName: "Senator Alice",
+  officeType: "senator",
+  jurisdiction: "CA",
+  district: null,
+  party: "democratic",
+  status: "incumbent" as const,
+  termStart: "2023",
+  termEnd: "2029",
+  sourceUrl: "https://example.org/alice",
+  notes: null,
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("political-offices — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("senator-alice", {
+      id: "senator-alice",
+      stable_id: "sidSenatorAlice",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with factory response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-offices/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with legacy response shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-offices");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-offices/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation", () => {
+    it("factory mode: rejects unknown politicianEntityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-offices/sync", {
+        items: [{ ...VALID_ITEM, politicianEntityId: "nonexistent-pol" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-pol");
+    });
+
+    it("legacy mode: rejects unknown politicianEntityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-offices");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-offices/sync", {
+        items: [{ ...VALID_ITEM, politicianEntityId: "nonexistent-pol" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-pol");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode: rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/political-offices/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("legacy mode: rejects invalid JSON", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-offices");
+      _resetFlagCache();
+      const res = await app.request("/api/political-offices/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-offices/sync", {
+        items: [{ id: "po00000001" }], // missing politicianEntityId, officeType, jurisdiction
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/political-votes-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/political-votes-migration.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Phase 2 migration test for political-votes.ts.
+ *
+ * Verifies that:
+ *   1. Factory and legacy handlers produce equivalent behavior on the happy path
+ *   2. The feature flag correctly routes between factory and legacy
+ *   3. Entity FK validation works in both paths (politicianEntityId + legislationEntityId)
+ *   4. Invalid input is rejected with 400 in both paths
+ *
+ * Tier 3 route: factory converts the per-item loop into a batched upsert.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validate-entity-refs — unnest ARRAY against entities
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  if (q.includes('"political_votes"')) return [];
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "pv00000001",
+  politicianEntityId: "senator-alice",
+  politicianDisplayName: "Senator Alice",
+  legislationEntityId: "california-sb1047",
+  legislationTitle: "SB 1047",
+  vote: "yea" as const,
+  voteDate: "2024-08-15",
+  chamber: "senate",
+  rollCallNumber: 123,
+  congressNumber: 118,
+  session: 2,
+  sourceUrl: "https://example.org/votes/123",
+  notes: null,
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("political-votes — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("senator-alice", {
+      id: "senator-alice",
+      stable_id: "sidSenatorAlice",
+    });
+    entitiesStore.set("california-sb1047", {
+      id: "california-sb1047",
+      stable_id: "sidCASB1047",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with factory response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with legacy response shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-votes");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      // Legacy handler returns only { upserted }, no factory fields
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+
+  describe("FK validation — politicianEntityId", () => {
+    it("factory mode: rejects unknown politicianEntityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", {
+        items: [{ ...VALID_ITEM, politicianEntityId: "nonexistent-pol" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-pol");
+    });
+
+    it("legacy mode: rejects unknown politicianEntityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-votes");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", {
+        items: [{ ...VALID_ITEM, politicianEntityId: "nonexistent-pol" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-pol");
+    });
+  });
+
+  describe("FK validation — legislationEntityId", () => {
+    it("factory mode: rejects unknown legislationEntityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", {
+        items: [{ ...VALID_ITEM, legislationEntityId: "nonexistent-bill" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-bill");
+    });
+
+    it("factory mode: accepts null politicianEntityId (nullable FK)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", {
+        items: [{ ...VALID_ITEM, politicianEntityId: null }],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode: rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/political-votes/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("legacy mode: rejects invalid JSON", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-votes");
+      _resetFlagCache();
+      const res = await app.request("/api/political-votes/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/political-votes/sync", {
+        items: [{ id: "pv00000001" }], // missing vote (required enum)
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/publications-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/publications-migration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Phase 2 Batch C migration test for publications.ts.
+ *
+ * publications.ts has inline source-check verdict support (`toVerdict`), so
+ * the factory response includes verdictsWritten while legacy returns
+ * `{ upserted, verdictsWritten }` (no claimsLinked). Tests verify both paths
+ * on the happy path, FK validation, and malformed input.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- resolveEntityTitles: select ... from "entities" ---
+  if (q.includes('from "entities"')) return [];
+
+  // --- publications: insert/update ---
+  if (q.includes('"publications"') || q.includes("publications")) return [];
+
+  // --- things: insert/delete ---
+  if (q.includes('"things"')) return [];
+
+  // --- source_check_verdicts / source_check_evidence (raw SQL, won't fire
+  //     unless item.sourcing is present; test data passes no sourcing) ---
+  if (q.includes("source_check_verdicts") || q.includes("source_check_evidence")) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "pub0000001",
+  entityId: "anthropic",
+  entityDisplayName: "Anthropic",
+  title: "Constitutional AI: Harmlessness from AI Feedback",
+  authors: "Bai et al.",
+  url: "https://arxiv.org/abs/2212.08073",
+  venue: "arXiv",
+  publishedDate: "2022-12",
+  publicationType: "preprint" as const,
+  citationCount: 500,
+  isFlagship: true,
+  abstract: "Constitutional AI approach to training helpful assistants.",
+  source: "https://arxiv.org/abs/2212.08073",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+const INVALID_FK_BATCH = {
+  items: [
+    {
+      ...VALID_ITEM,
+      entityId: "nonexistent-entity",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+
+describe("publications — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", {
+      id: "anthropic",
+      stable_id: "sidAnthropic",
+    });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path — factory ON (default)", () => {
+    it("returns 200 with upserted count and factory fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/publications/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      // Factory always emits these three fields
+      expect(body).toHaveProperty("verdictsWritten");
+      expect(body.verdictsWritten).toBe(0);
+      expect(body).toHaveProperty("claimsLinked");
+    });
+  });
+
+  describe("happy path — legacy fallback (USE_SYNC_FACTORY_ROUTES=!publications)", () => {
+    it("returns 200 with upserted + verdictsWritten (no claimsLinked)", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!publications");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/publications/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body.verdictsWritten).toBe(0);
+      // Legacy does NOT include claimsLinked
+      expect(body).not.toHaveProperty("claimsLinked");
+    });
+  });
+
+  describe("FK validation — factory ON", () => {
+    it("returns 400 for invalid entityId", async () => {
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/publications/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("FK validation — legacy fallback", () => {
+    it("returns 400 for invalid entityId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!publications");
+      _resetFlagCache();
+      const res = await postJson(
+        app,
+        "/api/publications/sync",
+        INVALID_FK_BATCH,
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent-entity");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects invalid JSON in factory mode", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/publications/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects items missing required fields in factory mode", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/publications/sync", {
+        items: [{ id: "pub0000001" }], // missing entityId, title
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/research-areas-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/research-areas-migration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Phase 2 migration test for research-areas.ts.
+ *
+ * Only the main /sync endpoint is migrated. This test verifies that both
+ * factory and legacy paths produce equivalent behavior on the happy path,
+ * reject malformed JSON, and reject items missing required fields.
+ *
+ * research-areas has no entity FK validation, no claim validation, no
+ * verdicts — it's a straightforward Tier 2 route with a things dual-write.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+function dispatch(_query: string, _params: unknown[]): unknown[] {
+  // research-areas /sync only writes to research_areas and things — both
+  // are side-effect inserts that return nothing the test needs to inspect.
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "interpretability",
+  title: "Interpretability",
+  description: "Understanding how neural networks work internally",
+  status: "active" as const,
+  cluster: "alignment",
+  tags: ["alignment", "interpretability"],
+  metadata: {},
+  source: "https://example.org/interp",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("research-areas — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with full response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Factory always returns upserted, verdictsWritten, claimsLinked.
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with the legacy shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!research-areas");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Legacy handler returns only `{ upserted }`
+      expect(body.upserted).toBe(1);
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+
+    it("factory mode handles multiple items in a single batch", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "scalable-oversight", title: "Scalable Oversight" },
+          { ...VALID_ITEM, id: "evaluations", title: "Evaluations" },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(3);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/research-areas/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", {
+        items: [{ id: "missing-title" }], // missing required `title`
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("legacy mode rejects items missing required fields", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!research-areas");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", {
+        items: [{ id: "missing-title" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode rejects items with empty batch", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", { items: [] });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("inclusion mode", () => {
+    it("falls back to legacy when research-areas not in inclusion list", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "personnel,divisions");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/research-areas/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Legacy shape (only `upserted`)
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/secondary-market-prices-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/secondary-market-prices-migration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Phase 2 migration test for secondary-market-prices.ts.
+ *
+ * This route exercises the factory's COMPOSITE conflict target support
+ * (`conflictTarget: [col1, col2, col3, col4]`). The unique key for upserts
+ * is (companyId, platform, date, priceType), not the row id. This is the
+ * first Phase 2 migration to use a composite conflict target.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  if (q.includes('"secondary_market_prices"')) return [];
+  if (q.includes('"things"')) return [];
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+const VALID_ITEM = {
+  id: "smp0000001",
+  companyId: "anthropic",
+  platform: "forge" as const,
+  date: "2024-01-15",
+  priceType: "last_trade" as const,
+  pricePerShare: 42.5,
+  impliedValuation: 18_000_000_000,
+  volume: 1000,
+  source: "https://forge.example/anthropic",
+};
+
+const VALID_BATCH = { items: [VALID_ITEM] };
+
+describe("secondary-market-prices — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    resetStores();
+    entitiesStore.set("anthropic", { id: "anthropic", stable_id: "sidAnthropic" });
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path with composite conflict target", () => {
+    it("factory mode (default) returns 200", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+      expect(body.verdictsWritten).toBe(0);
+    });
+
+    it("legacy mode returns 200 with same shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!secondary-market-prices");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+    });
+
+    it("accepts a batch with multiple items", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", {
+        items: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "smp0000002", platform: "hiive" as const },
+          { ...VALID_ITEM, id: "smp0000003", date: "2024-01-16" },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(3);
+    });
+  });
+
+  describe("FK validation", () => {
+    it("factory mode: rejects unknown companyId", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", {
+        items: [{ ...VALID_ITEM, companyId: "ghost-co" }],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("ghost-co");
+    });
+
+    it("legacy mode: rejects unknown companyId", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!secondary-market-prices");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", {
+        items: [{ ...VALID_ITEM, companyId: "ghost-co" }],
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("schema validation", () => {
+    it("rejects invalid platform enum", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", {
+        items: [{ ...VALID_ITEM, platform: "not-a-platform" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid priceType enum", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/secondary-market-prices/sync", {
+        items: [{ ...VALID_ITEM, priceType: "made-up" }],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/secondary-market-prices/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/sync-factory-flag.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-factory-flag.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the per-route TableBase sync factory feature flag.
+ *
+ * Verifies the truth table from sync-factory-flag.ts:
+ *
+ * | Env value                   | Effect                                      |
+ * |-----------------------------|---------------------------------------------|
+ * | (unset) or empty            | Factory ON for all routes (default)         |
+ * | `*`                         | Factory ON for all routes (explicit)        |
+ * | `personnel,divisions`       | Factory ON only for those routes            |
+ * | `!political-scores`         | Factory ON for all EXCEPT excluded          |
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  useFactoryFor,
+  _resetFlagCache,
+} from "../routes/tablebase/sync-factory-flag.js";
+
+describe("sync-factory-flag — useFactoryFor", () => {
+  beforeEach(() => {
+    _resetFlagCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("default behavior (env unset or empty)", () => {
+    it("returns true for any route when env var is unset", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "");
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("divisions")).toBe(true);
+      expect(useFactoryFor("any-route")).toBe(true);
+    });
+
+    it("returns true for any route when env var is whitespace only", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "   ");
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(true);
+    });
+  });
+
+  describe("wildcard '*'", () => {
+    it("returns true for all routes when set to '*'", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "*");
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("divisions")).toBe(true);
+      expect(useFactoryFor("anything")).toBe(true);
+    });
+  });
+
+  describe("inclusion mode (route1,route2)", () => {
+    it("returns true only for explicitly listed routes", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "personnel,divisions");
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("divisions")).toBe(true);
+      expect(useFactoryFor("political-scores")).toBe(false);
+      expect(useFactoryFor("benchmarks")).toBe(false);
+    });
+
+    it("trims whitespace around entries", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", " personnel ,  divisions , ");
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("divisions")).toBe(true);
+      expect(useFactoryFor("other")).toBe(false);
+    });
+
+    it("returns false for an empty inclusion list with no exclusions", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "only-this-one");
+      _resetFlagCache();
+      expect(useFactoryFor("only-this-one")).toBe(true);
+      expect(useFactoryFor("anything-else")).toBe(false);
+    });
+  });
+
+  describe("exclusion mode (!route1,!route2)", () => {
+    it("returns false only for explicitly excluded routes", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!political-scores");
+      _resetFlagCache();
+      expect(useFactoryFor("political-scores")).toBe(false);
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("divisions")).toBe(true);
+      expect(useFactoryFor("anything-else")).toBe(true);
+    });
+
+    it("supports multiple exclusions", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!a,!b,!c");
+      _resetFlagCache();
+      expect(useFactoryFor("a")).toBe(false);
+      expect(useFactoryFor("b")).toBe(false);
+      expect(useFactoryFor("c")).toBe(false);
+      expect(useFactoryFor("d")).toBe(true);
+    });
+
+    it("treats mixed inclusions+exclusions as exclusion mode", () => {
+      // If any "!" entry is present, the flag is in exclusion mode and the
+      // default is true (i.e., enabled for all not explicitly excluded).
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!broken,personnel");
+      _resetFlagCache();
+      expect(useFactoryFor("broken")).toBe(false);
+      expect(useFactoryFor("personnel")).toBe(true);
+      expect(useFactoryFor("anything")).toBe(true); // default ON in exclusion mode
+    });
+  });
+
+  describe("caching", () => {
+    it("caches the parsed flag set across calls", () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "personnel");
+      _resetFlagCache();
+
+      // First call populates the cache
+      expect(useFactoryFor("personnel")).toBe(true);
+
+      // Change env without resetting cache — old value still in effect
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "divisions");
+      expect(useFactoryFor("personnel")).toBe(true); // still cached
+      expect(useFactoryFor("divisions")).toBe(false); // still cached
+
+      // After reset, new value takes effect
+      _resetFlagCache();
+      expect(useFactoryFor("personnel")).toBe(false);
+      expect(useFactoryFor("divisions")).toBe(true);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/sync-factory.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-factory.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Tests for createSyncHandler<T>() — the TableBase sync factory.
+ *
+ * Validates the 7-phase pipeline against a mocked DB:
+ *   1. Parse / invalid JSON
+ *   2. Zod schema validation
+ *   3. Natural key collision
+ *   4. enforceSourceCheck (gated)
+ *   5. validateEntityRefs (gated)
+ *   6. validateClaimRefs (gated)
+ *   7. preValidate hook (Response short-circuit + throw → SyncPhaseError)
+ *   8. Batch upsert (auto-derived SET clause)
+ *   9. Audit logging (gated, with existing-row pre-fetch)
+ *  10. postUpsert hook (rollback contract: throwing rolls back)
+ *  11. Response shape (upserted, verdictsWritten, claimsLinked)
+ *
+ * Per Phase 0 audit, the factory MUST:
+ *   - Wrap phase errors in SyncPhaseError({ route, phase, cause })
+ *   - Auto-chunk batches based on Postgres parameter limit
+ *   - Preserve Hono RPC type inference (verified separately by sync-factory.test-d.ts)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { z } from "zod";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+let widgetsStore: Map<string, Record<string, unknown>>;
+let auditLogStore: Array<Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+  widgetsStore = new Map();
+  auditLogStore = [];
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs: unnest + entities check ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- widgets: SELECT (existing row pre-fetch for audit) ---
+  // Drizzle generates: select ... from "widgets" where "widgets"."id" in (...)
+  if (q.includes("select") && q.includes('"widgets"') && q.includes("where")) {
+    return params
+      .filter((p) => widgetsStore.has(p as string))
+      .map((p) => ({ ...widgetsStore.get(p as string), id: p }));
+  }
+
+  // --- widgets: INSERT (batch upsert) ---
+  // Track which IDs were upserted by recording in store
+  if (q.includes("insert into") && q.includes('"widgets"')) {
+    // Simulate the upsert: each batch of params is a row.
+    // We can't reliably parse the column count, but for the tests we only
+    // need to know "an upsert happened on these IDs".
+    // The test uses 1-3 columns of data (id + payload), so we extract them.
+    return [];
+  }
+
+  // --- tablebase_audit_log: INSERT ---
+  if (q.includes("insert into") && q.includes("tablebase_audit_log")) {
+    // Each call inserts N rows. Capture for assertions.
+    auditLogStore.push({ insertedAt: Date.now(), paramCount: params.length });
+    return [];
+  }
+
+  // --- proposed_claims: SELECT (validateClaimRefs) ---
+  if (q.includes("from proposed_claims") || q.includes("proposed_claims")) {
+    return [];
+  }
+
+  // --- claim_record_links: INSERT ---
+  if (q.includes("claim_record_links")) {
+    return [];
+  }
+
+  return [];
+}
+
+// Mock the db module
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createSyncHandler } = await import("../routes/tablebase/sync-factory.js");
+const { SyncPhaseError } = await import("../routes/tablebase/sync-factory.js");
+// Import a real Drizzle table so the factory has something to introspect.
+// We use `entities` because it's small and well-known.
+const { entities, things } = await import("../schema.js");
+
+// ---- Test schemas ----
+
+const ItemSchema = z.object({
+  id: z.string().length(10),
+  title: z.string().min(1),
+  parentId: z.string().optional(),
+});
+
+const BatchSchema = z.object({
+  items: z.array(ItemSchema).min(1).max(100),
+});
+
+type Item = z.infer<typeof ItemSchema>;
+
+// ---- Test app builder ----
+
+function buildApp(handler: ReturnType<typeof createSyncHandler>) {
+  return new Hono().post("/sync", handler);
+}
+
+/**
+ * Helper that captures errors thrown by the handler. Hono catches unhandled
+ * errors and returns 500 by default; this helper attaches an `onError` handler
+ * that stashes the error so tests can assert on its type.
+ */
+function buildAppWithErrorCapture(handler: ReturnType<typeof createSyncHandler>) {
+  const errors: unknown[] = [];
+  const app = new Hono()
+    .post("/sync", handler)
+    .onError((err, c) => {
+      errors.push(err);
+      return c.json({ error: "internal", message: err.message }, 500);
+    });
+  return { app, errors };
+}
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — phase 1: parse + validate", () => {
+  beforeEach(resetStores);
+
+  it("returns 400 on invalid JSON", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+    });
+    const app = buildApp(handler);
+
+    const res = await app.request("/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not valid json",
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "invalid_json" });
+  });
+
+  it("returns 400 on Zod validation failure (missing items)", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", { wrong: "shape" });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "validation_error" });
+  });
+
+  it("returns 400 on Zod validation failure (item shape)", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "wrong-len", title: "" }], // id wrong length, empty title
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "validation_error" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — phase 2: natural key collision", () => {
+  beforeEach(resetStores);
+
+  it("returns 400 when two items collide on natural key", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      naturalKey: (item) => `${item.parentId ?? ""}::${item.title}`,
+      naturalKeyError: "Duplicate parentId+title",
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha", parentId: "p1" },
+        { id: "bbbbbbbbbb", title: "alpha", parentId: "p1" }, // collision
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("Duplicate parentId+title");
+    expect(body.message).toContain("p1::alpha");
+  });
+
+  it("accepts items with no natural key collision", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      naturalKey: (item) => `${item.parentId ?? ""}::${item.title}`,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha", parentId: "p1" },
+        { id: "bbbbbbbbbb", title: "beta", parentId: "p1" },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — phase 5: entity ref validation", () => {
+  beforeEach(resetStores);
+
+  it("returns 400 when an entity reference is missing", async () => {
+    entitiesStore.set("known-org", { id: "known-org", stable_id: "sidKnownOrg" });
+
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      entityRefFields: (items) => [
+        {
+          fieldName: "parentId",
+          ids: items.map((i) => i.parentId).filter((id): id is string => id != null),
+        },
+      ],
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha", parentId: "missing-org" }],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("missing-org");
+  });
+
+  it("accepts items when entity references resolve", async () => {
+    entitiesStore.set("known-org", { id: "known-org", stable_id: "sidKnownOrg" });
+
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      entityRefFields: (items) => [
+        {
+          fieldName: "parentId",
+          ids: items.map((i) => i.parentId).filter((id): id is string => id != null),
+        },
+      ],
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha", parentId: "known-org" }],
+    });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — phase 7: preValidate hook", () => {
+  beforeEach(resetStores);
+
+  it("short-circuits with the Response returned by preValidate", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      preValidate: async (c) => c.json({ error: "custom_block", reason: "test" }, 422),
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha" }],
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "custom_block", reason: "test" });
+  });
+
+  it("proceeds when preValidate returns null", async () => {
+    let preValidateCalled = false;
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      preValidate: async () => {
+        preValidateCalled = true;
+        return null;
+      },
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha" }],
+    });
+
+    expect(res.status).toBe(200);
+    expect(preValidateCalled).toBe(true);
+  });
+
+  it("wraps thrown errors in SyncPhaseError with route + phase context", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "my-route",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      preValidate: async () => {
+        throw new Error("upstream service exploded");
+      },
+    });
+    const { app, errors } = buildAppWithErrorCapture(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha" }],
+    });
+
+    expect(res.status).toBe(500);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(SyncPhaseError);
+    expect((errors[0] as SyncPhaseError).route).toBe("my-route");
+    expect((errors[0] as SyncPhaseError).phase).toBe("preValidate");
+    expect((errors[0] as Error).message).toContain("my-route/preValidate");
+    expect((errors[0] as Error).message).toContain("upstream service exploded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — postUpsert hook", () => {
+  beforeEach(resetStores);
+
+  it("runs after the upsert with the same tx", async () => {
+    let postUpsertCalled = false;
+    let postUpsertItemCount = 0;
+
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      postUpsert: async (_tx, items) => {
+        postUpsertCalled = true;
+        postUpsertItemCount = items.length;
+      },
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" },
+        { id: "bbbbbbbbbb", title: "beta" },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(postUpsertCalled).toBe(true);
+    expect(postUpsertItemCount).toBe(2);
+  });
+
+  it("wraps thrown errors with phase=postUpsert", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      postUpsert: async () => {
+        throw new Error("display name backfill failed");
+      },
+    });
+    const { app, errors } = buildAppWithErrorCapture(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [{ id: "aaaaaaaaaa", title: "alpha" }],
+    });
+
+    expect(res.status).toBe(500);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(SyncPhaseError);
+    expect((errors[0] as SyncPhaseError).phase).toBe("postUpsert");
+    expect((errors[0] as Error).message).toContain("display name backfill failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — happy path", () => {
+  beforeEach(resetStores);
+
+  it("returns the standard response shape", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" },
+        { id: "bbbbbbbbbb", title: "beta" },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      upserted: 2,
+      verdictsWritten: 0,
+      claimsLinked: 0,
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/sync-factory.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-factory.test.ts
@@ -24,6 +24,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { z } from "zod";
 import { mockDbModule, postJson } from "./test-utils.js";
+// Static type-only import — used for `expect(...).toBeInstanceOf(SyncPhaseError)`
+// and `(err as SyncPhaseErrorType)` casts. The runtime value is loaded
+// dynamically below (via `await import`) to keep the vi.mock() ordering correct.
+import type { SyncPhaseError as SyncPhaseErrorType } from "../routes/tablebase/sync-factory.js";
 
 // ---- In-memory stores ----
 
@@ -368,8 +372,8 @@ describe("createSyncHandler — phase 7: preValidate hook", () => {
     expect(res.status).toBe(500);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(SyncPhaseError);
-    expect((errors[0] as SyncPhaseError).route).toBe("my-route");
-    expect((errors[0] as SyncPhaseError).phase).toBe("preValidate");
+    expect((errors[0] as SyncPhaseErrorType).route).toBe("my-route");
+    expect((errors[0] as SyncPhaseErrorType).phase).toBe("preValidate");
     expect((errors[0] as Error).message).toContain("my-route/preValidate");
     expect((errors[0] as Error).message).toContain("upstream service exploded");
   });
@@ -427,7 +431,7 @@ describe("createSyncHandler — postUpsert hook", () => {
     expect(res.status).toBe(500);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(SyncPhaseError);
-    expect((errors[0] as SyncPhaseError).phase).toBe("postUpsert");
+    expect((errors[0] as SyncPhaseErrorType).phase).toBe("postUpsert");
     expect((errors[0] as Error).message).toContain("display name backfill failed");
   });
 });

--- a/apps/wiki-server/src/__tests__/things-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/things-migration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Phase 2 migration test for things.ts.
+ *
+ * things is the destination table for all other routes' dual-writes, so its
+ * factory config deliberately omits `toThing` (the handler doesn't dual-write
+ * to itself). The factory uses:
+ *   - naturalKey on (sourceTable, sourceId) for intra-batch dedup
+ *   - conflictTarget override [sourceTable, sourceId] (composite)
+ *   - conflictSet override (to skip id, sourceTable, sourceId on update)
+ *   - a `z.preprocess` schema that maps the request body's `things` key to
+ *     the factory's required `items` key
+ *
+ * No entity FK validation, no claim support, no verdicts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDbModule, postJson } from "./test-utils.js";
+import { _resetFlagCache } from "../routes/tablebase/sync-factory-flag.js";
+
+function dispatch(_query: string, _params: unknown[]): unknown[] {
+  // things /sync only inserts into the things table; nothing to stub.
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// ---- Test fixtures ----
+
+const VALID_ITEM = {
+  id: "anthropic",
+  thingType: "entity" as const,
+  title: "Anthropic",
+  sourceTable: "entities",
+  sourceId: "anthropic",
+  entityType: "organization",
+  description: "AI safety company",
+  sourceUrl: "https://anthropic.com",
+};
+
+// NOTE: things /sync uses `things` as the array key, not `items`.
+const VALID_BATCH = { things: [VALID_ITEM] };
+
+describe("things — feature flag migration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    _resetFlagCache();
+    app = await createApp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _resetFlagCache();
+  });
+
+  describe("happy path", () => {
+    it("factory mode (default) returns 200 with full response shape", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Factory always returns upserted, verdictsWritten, claimsLinked.
+      expect(body).toMatchObject({
+        upserted: 1,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      });
+    });
+
+    it("legacy mode returns 200 with the legacy shape", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!things");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Legacy handler returns only `{ upserted }`
+      expect(body.upserted).toBe(1);
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+
+    it("factory mode handles multiple distinct items in a batch", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", {
+        things: [
+          VALID_ITEM,
+          {
+            ...VALID_ITEM,
+            id: "google",
+            title: "Google",
+            sourceId: "google",
+          },
+          {
+            ...VALID_ITEM,
+            id: "openai",
+            title: "OpenAI",
+            sourceId: "openai",
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(3);
+    });
+  });
+
+  describe("natural key collision", () => {
+    it("factory mode: rejects duplicate (sourceTable, sourceId)", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", {
+        things: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "anthropic-dup" }, // same (sourceTable, sourceId)
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("Duplicate source key in batch");
+    });
+
+    it("legacy mode: rejects duplicate with descriptive message", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "!things");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", {
+        things: [
+          VALID_ITEM,
+          { ...VALID_ITEM, id: "anthropic-dup" },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("Duplicate source key in batch");
+    });
+  });
+
+  describe("malformed input", () => {
+    it("factory mode: rejects invalid JSON", async () => {
+      _resetFlagCache();
+      const res = await app.request("/api/things/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects items missing required fields", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", {
+        things: [{ id: "missing-fields" }], // missing thingType, title, etc.
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects payload with unrecognized top-level key", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", {
+        data: [VALID_ITEM], // wrong key name (factory accepts both `things` and `items` via preprocess, but not `data`)
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("factory mode: rejects empty batch", async () => {
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", { things: [] });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("inclusion mode", () => {
+    it("falls back to legacy when things not in inclusion list", async () => {
+      vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "personnel,divisions");
+      _resetFlagCache();
+      const res = await postJson(app, "/api/things/sync", VALID_BATCH);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Legacy shape (only `upserted`)
+      expect(Object.keys(body)).toEqual(["upserted"]);
+    });
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, desc, sql } from "drizzle-orm";
 import { getDrizzleDb, getDb } from "../../db.js";
@@ -17,6 +18,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -151,157 +154,253 @@ const benchmarkResultsApp = new Hono()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!benchmark-results` falls back to legacy.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncBenchmarkResultBatchSchema.safeParse(body);
-    if (!parsed.success) {
-      return validationError(c, parsed.error.issues.map((i) => i.message).join(", "));
+    if (useFactoryFor("benchmark-results")) {
+      return factorySyncHandler(c);
     }
-
-    const db = getDrizzleDb();
-
-    // Validate FK references before inserting.
-    // benchmarkId references the `benchmarks` table (not entities), so check it separately.
-    // modelId references entities.stable_id, so use the standard entity validation.
-    // Check benchmarkIds against the benchmarks table.
-    // This always runs — benchmarkId is a real FK to `benchmarks`, and skipping
-    // this check would let invalid references through to the upsert.
-    const benchmarkIds = [...new Set(parsed.data.items.map((i) => i.benchmarkId))];
-    if (benchmarkIds.length > 0) {
-      const placeholders = benchmarkIds.map((id) => sql`${id}`);
-      const inList = sql.join(placeholders, sql`, `);
-      // Check both id (10-char hash) and slug (e.g., "mmlu") since the enrichment
-      // agent may submit either format.
-      const found = await db.execute<{ id: string; slug: string }>(sql`
-        SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
-      `);
-      const foundIdSet = new Set(found.map((r) => r.id));
-      const foundSlugSet = new Set(found.map((r) => r.slug));
-      // Build slug→id mapping for auto-resolution
-      const slugToId = new Map(found.map((r) => [r.slug, r.id]));
-      const missing = benchmarkIds.filter((id) => !foundIdSet.has(id) && !foundSlugSet.has(id));
-      if (missing.length > 0) {
-        return validationError(
-          c,
-          `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first (pnpm crux wiki-server sync-benchmarks).`,
-        );
-      }
-      // Auto-resolve slugs to IDs so the upsert uses the correct FK
-      for (const item of parsed.data.items) {
-        if (slugToId.has(item.benchmarkId)) {
-          item.benchmarkId = slugToId.get(item.benchmarkId)!;
-        }
-      }
-    }
-
-    // Check modelIds against the entities table. validateEntityRefs() handles
-    // the ?skipEntityValidation=true bypass internally and logs loudly when used
-    // (issue #4017). Entity sync order may vary, but benchmark refs are always
-    // required, hence the bypass exists for migration scenarios only.
-    const modelRefError = await validateEntityRefs(c, db, [
-      { fieldName: "modelId", ids: parsed.data.items.map((i) => i.modelId) },
-    ]);
-    if (modelRefError) return modelRefError;
-
-    // Validate claim references
-    const items = parsed.data.items;
-    const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
-    if (allClaimIds.length > 0) {
-      const rawDb = getDb();
-      const claimError = await validateClaimRefs(rawDb, allClaimIds);
-      if (claimError) return validationError(c, claimError);
-    }
-
-    const now = new Date();
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
-        id: item.id,
-        benchmarkId: item.benchmarkId,
-        modelId: item.modelId,
-        score: item.score,
-        unit: item.unit ?? null,
-        date: item.date ?? null,
-        sourceUrl: item.sourceUrl ?? null,
-        notes: item.notes ?? null,
-        syncedAt: now,
-        updatedAt: now,
-      }));
-
-      await tx
-        .insert(benchmarkResults)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: benchmarkResults.id,
-          set: {
-            benchmarkId: sql`excluded.benchmark_id`,
-            modelId: sql`excluded.model_id`,
-            score: sql`excluded.score`,
-            unit: sql`excluded.unit`,
-            date: sql`excluded.date`,
-            sourceUrl: sql`excluded.source_url`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`excluded.synced_at`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
-      upserted = allVals.length;
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((br) => ({
-          id: br.id,
-          thingType: "benchmark-result" as const,
-          title: `${br.modelId} on ${br.benchmarkId}: ${br.score}`,
-          sourceTable: "benchmark_results",
-          sourceId: br.id,
-          sourceUrl: br.sourceUrl,
-        }))
-      );
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "benchmark-result",
-          recordId: item.id,
-          entityId: item.modelId,
-          sourceUrl: item.sourceUrl ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-    });
-
-    logSourceCheckCoverage("benchmark-results/sync", items.length, verdictsResult.written);
-
-    // Link verified claims to records (best-effort — records already committed)
-    let claimsLinked = 0;
-    let claimLinkingError: string | null = null;
-    if (allClaimIds.length > 0) {
-      try {
-        const rawDb = getDb();
-        const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
-          recordId: item.id,
-          recordType: "benchmark-result",
-          claimIds: item.claimIds,
-        })));
-        claimsLinked = linkResult.linked;
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        claimLinkingError = msg;
-        logger.warn({ error: msg }, "claim linking failed (records already committed)");
-      }
-    }
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+    return legacySyncHandler(c);
   })
 
   .post("/delete-batch", deleteBatchHandler(benchmarkResults, "benchmark_results"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+//
+// Escape hatch: `preValidate` handles the benchmark FK check (against the
+// `benchmarks` table, NOT entities) AND mutates items in place to auto-resolve
+// benchmark slugs → ids before the upsert. Both responsibilities share the
+// same DB query, so they count as a single hook per the factory's 1-hook rule.
+// The modelId entity FK is validated via the standard `entityRefFields`.
+
+const factorySyncHandler = createSyncHandler({
+  name: "benchmark-results",
+  table: benchmarkResults,
+  batchSchema: SyncBenchmarkResultBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "modelId", ids: items.map((i) => i.modelId) },
+  ],
+  claimSupport: {
+    recordType: "benchmark-result",
+    getClaimIds: (item) => item.claimIds ?? [],
+  },
+  // preValidate: check benchmarkId against benchmarks table (non-entities FK)
+  // and auto-resolve slug → id in place. Both operations share one query.
+  preValidate: async (c, db, items) => {
+    const benchmarkIds = [...new Set(items.map((i) => i.benchmarkId))];
+    if (benchmarkIds.length === 0) return null;
+
+    const placeholders = benchmarkIds.map((id) => sql`${id}`);
+    const inList = sql.join(placeholders, sql`, `);
+    // Check both id (10-char hash) and slug (e.g., "mmlu") since the enrichment
+    // agent may submit either format.
+    const found = await db.execute<{ id: string; slug: string }>(sql`
+      SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
+    `);
+    const foundIdSet = new Set(found.map((r) => r.id));
+    const foundSlugSet = new Set(found.map((r) => r.slug));
+    // Build slug→id mapping for auto-resolution
+    const slugToId = new Map(found.map((r) => [r.slug, r.id]));
+    const missing = benchmarkIds.filter((id) => !foundIdSet.has(id) && !foundSlugSet.has(id));
+    if (missing.length > 0) {
+      return validationError(
+        c,
+        `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first (pnpm crux wiki-server sync-benchmarks).`,
+      );
+    }
+    // Auto-resolve slugs to IDs so the upsert uses the correct FK
+    for (const item of items) {
+      if (slugToId.has(item.benchmarkId)) {
+        item.benchmarkId = slugToId.get(item.benchmarkId)!;
+      }
+    }
+    return null;
+  },
+  toRow: (item, now) => ({
+    id: item.id,
+    benchmarkId: item.benchmarkId,
+    modelId: item.modelId,
+    score: item.score,
+    unit: item.unit ?? null,
+    date: item.date ?? null,
+    sourceUrl: item.sourceUrl ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+  toThing: (item) => ({
+    id: item.id,
+    thingType: "benchmark-result" as const,
+    title: `${item.modelId} on ${item.benchmarkId}: ${item.score}`,
+    sourceTable: "benchmark_results",
+    sourceId: item.id,
+    sourceUrl: item.sourceUrl,
+  }),
+  toVerdict: (item) => ({
+    recordType: "benchmark-result",
+    recordId: item.id,
+    entityId: item.modelId,
+    sourceUrl: item.sourceUrl ?? null,
+    sourcing: item.sourcing ?? null,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncBenchmarkResultBatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(c, parsed.error.issues.map((i) => i.message).join(", "));
+  }
+
+  const db = getDrizzleDb();
+
+  // Validate FK references before inserting.
+  // benchmarkId references the `benchmarks` table (not entities), so check it separately.
+  // modelId references entities.stable_id, so use the standard entity validation.
+  // Check benchmarkIds against the benchmarks table.
+  // This always runs — benchmarkId is a real FK to `benchmarks`, and skipping
+  // this check would let invalid references through to the upsert.
+  const benchmarkIds = [...new Set(parsed.data.items.map((i) => i.benchmarkId))];
+  if (benchmarkIds.length > 0) {
+    const placeholders = benchmarkIds.map((id) => sql`${id}`);
+    const inList = sql.join(placeholders, sql`, `);
+    // Check both id (10-char hash) and slug (e.g., "mmlu") since the enrichment
+    // agent may submit either format.
+    const found = await db.execute<{ id: string; slug: string }>(sql`
+      SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
+    `);
+    const foundIdSet = new Set(found.map((r) => r.id));
+    const foundSlugSet = new Set(found.map((r) => r.slug));
+    // Build slug→id mapping for auto-resolution
+    const slugToId = new Map(found.map((r) => [r.slug, r.id]));
+    const missing = benchmarkIds.filter((id) => !foundIdSet.has(id) && !foundSlugSet.has(id));
+    if (missing.length > 0) {
+      return validationError(
+        c,
+        `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first (pnpm crux wiki-server sync-benchmarks).`,
+      );
+    }
+    // Auto-resolve slugs to IDs so the upsert uses the correct FK
+    for (const item of parsed.data.items) {
+      if (slugToId.has(item.benchmarkId)) {
+        item.benchmarkId = slugToId.get(item.benchmarkId)!;
+      }
+    }
+  }
+
+  // Check modelIds against the entities table. validateEntityRefs() handles
+  // the ?skipEntityValidation=true bypass internally and logs loudly when used
+  // (issue #4017). Entity sync order may vary, but benchmark refs are always
+  // required, hence the bypass exists for migration scenarios only.
+  const modelRefError = await validateEntityRefs(c, db, [
+    { fieldName: "modelId", ids: parsed.data.items.map((i) => i.modelId) },
+  ]);
+  if (modelRefError) return modelRefError;
+
+  // Validate claim references
+  const items = parsed.data.items;
+  const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
+  if (allClaimIds.length > 0) {
+    const rawDb = getDb();
+    const claimError = await validateClaimRefs(rawDb, allClaimIds);
+    if (claimError) return validationError(c, claimError);
+  }
+
+  const now = new Date();
+  let upserted = 0;
+  let verdictsResult = { written: 0 };
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => ({
+      id: item.id,
+      benchmarkId: item.benchmarkId,
+      modelId: item.modelId,
+      score: item.score,
+      unit: item.unit ?? null,
+      date: item.date ?? null,
+      sourceUrl: item.sourceUrl ?? null,
+      notes: item.notes ?? null,
+      syncedAt: now,
+      updatedAt: now,
+    }));
+
+    await tx
+      .insert(benchmarkResults)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: benchmarkResults.id,
+        set: {
+          benchmarkId: sql`excluded.benchmark_id`,
+          modelId: sql`excluded.model_id`,
+          score: sql`excluded.score`,
+          unit: sql`excluded.unit`,
+          date: sql`excluded.date`,
+          sourceUrl: sql`excluded.source_url`,
+          notes: sql`excluded.notes`,
+          syncedAt: sql`excluded.synced_at`,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
+    upserted = allVals.length;
+
+    // Dual-write to things table
+    await upsertThingsInTx(
+      tx,
+      items.map((br) => ({
+        id: br.id,
+        thingType: "benchmark-result" as const,
+        title: `${br.modelId} on ${br.benchmarkId}: ${br.score}`,
+        sourceTable: "benchmark_results",
+        sourceId: br.id,
+        sourceUrl: br.sourceUrl,
+      }))
+    );
+
+    // Write inline source-check verdicts atomically within the same transaction
+    verdictsResult = await writeInlineVerdicts(
+      tx,
+      items.map((item) => ({
+        recordType: "benchmark-result",
+        recordId: item.id,
+        entityId: item.modelId,
+        sourceUrl: item.sourceUrl ?? null,
+        sourcing: item.sourcing ?? null,
+      }))
+    );
+  });
+
+  logSourceCheckCoverage("benchmark-results/sync", items.length, verdictsResult.written);
+
+  // Link verified claims to records (best-effort — records already committed)
+  let claimsLinked = 0;
+  let claimLinkingError: string | null = null;
+  if (allClaimIds.length > 0) {
+    try {
+      const rawDb = getDb();
+      const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
+        recordId: item.id,
+        recordType: "benchmark-result",
+        claimIds: item.claimIds,
+      })));
+      claimsLinked = linkResult.linked;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      claimLinkingError = msg;
+      logger.warn({ error: msg }, "claim linking failed (records already committed)");
+    }
+  }
+
+  return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+}
 
 export const benchmarkResultsRoute = benchmarkResultsApp;
 export type BenchmarkResultsRoute = typeof benchmarkResultsApp;

--- a/apps/wiki-server/src/routes/tablebase/division-personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/division-personnel.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, sql, desc } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -14,6 +15,8 @@ import {
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Query schemas ----
 
@@ -162,75 +165,133 @@ const divisionPersonnelApp = new Hono()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!division-personnel` to fall back
+  // to the legacy handler instantly without redeploying.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncDivisionPersonnelBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "personId", ids: items.map((i) => i.personId) },
-    ]);
-    if (refError) return refError;
-
-    let upserted = 0;
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
-        id: item.id,
-        divisionId: item.divisionId,
-        personId: item.personId,
-        role: item.role,
-        startDate: item.startDate ?? null,
-        endDate: item.endDate ?? null,
-        source: item.source ?? null,
-        notes: item.notes ?? null,
-      }));
-
-      await tx
-        .insert(divisionPersonnel)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: divisionPersonnel.id,
-          set: {
-            divisionId: sql`excluded.division_id`,
-            personId: sql`excluded.person_id`,
-            role: sql`excluded.role`,
-            // COALESCE: preserve existing values when sync payload sends null
-            startDate: sql`COALESCE(excluded.start_date, ${divisionPersonnel.startDate})`,
-            endDate: sql`COALESCE(excluded.end_date, ${divisionPersonnel.endDate})`,
-            source: sql`COALESCE(excluded.source, ${divisionPersonnel.source})`,
-            notes: sql`COALESCE(excluded.notes, ${divisionPersonnel.notes})`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((dp) => ({
-          id: dp.id,
-          thingType: "division-personnel" as const,
-          title: `${dp.personId} — ${dp.role}`,
-          sourceTable: "division_personnel",
-          sourceId: dp.id,
-          sourceUrl: dp.source,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    return c.json({ upserted });
+    if (useFactoryFor("division-personnel")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
   })
 
   .post("/delete-batch", deleteBatchHandler(divisionPersonnel, "division_personnel"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+
+const factorySyncHandler = createSyncHandler({
+  name: "division-personnel",
+  table: divisionPersonnel,
+  batchSchema: SyncDivisionPersonnelBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "personId", ids: items.map((i) => i.personId) },
+  ],
+  toRow: (item) => ({
+    id: item.id,
+    divisionId: item.divisionId,
+    personId: item.personId,
+    role: item.role,
+    startDate: item.startDate ?? null,
+    endDate: item.endDate ?? null,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+  }),
+  // COALESCE preservation for nullable fields (route's only escape hatch).
+  conflictSet: {
+    divisionId: sql`excluded.division_id`,
+    personId: sql`excluded.person_id`,
+    role: sql`excluded.role`,
+    startDate: sql`COALESCE(excluded.start_date, ${divisionPersonnel.startDate})`,
+    endDate: sql`COALESCE(excluded.end_date, ${divisionPersonnel.endDate})`,
+    source: sql`COALESCE(excluded.source, ${divisionPersonnel.source})`,
+    notes: sql`COALESCE(excluded.notes, ${divisionPersonnel.notes})`,
+    syncedAt: sql`now()`,
+    updatedAt: sql`now()`,
+  },
+  toThing: (item) => ({
+    id: item.id,
+    thingType: "division-personnel" as const,
+    title: `${item.personId} — ${item.role}`,
+    sourceTable: "division_personnel",
+    sourceId: item.id,
+    sourceUrl: item.source,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncDivisionPersonnelBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Validate entity FK references before inserting
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "personId", ids: items.map((i) => i.personId) },
+  ]);
+  if (refError) return refError;
+
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => ({
+      id: item.id,
+      divisionId: item.divisionId,
+      personId: item.personId,
+      role: item.role,
+      startDate: item.startDate ?? null,
+      endDate: item.endDate ?? null,
+      source: item.source ?? null,
+      notes: item.notes ?? null,
+    }));
+
+    await tx
+      .insert(divisionPersonnel)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: divisionPersonnel.id,
+        set: {
+          divisionId: sql`excluded.division_id`,
+          personId: sql`excluded.person_id`,
+          role: sql`excluded.role`,
+          // COALESCE: preserve existing values when sync payload sends null
+          startDate: sql`COALESCE(excluded.start_date, ${divisionPersonnel.startDate})`,
+          endDate: sql`COALESCE(excluded.end_date, ${divisionPersonnel.endDate})`,
+          source: sql`COALESCE(excluded.source, ${divisionPersonnel.source})`,
+          notes: sql`COALESCE(excluded.notes, ${divisionPersonnel.notes})`,
+          syncedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      });
+
+    // Dual-write to things table
+    await upsertThingsInTx(
+      tx,
+      items.map((dp) => ({
+        id: dp.id,
+        thingType: "division-personnel" as const,
+        title: `${dp.personId} — ${dp.role}`,
+        sourceTable: "division_personnel",
+        sourceId: dp.id,
+        sourceUrl: dp.source,
+      }))
+    );
+
+    upserted = allVals.length;
+  });
+
+  return c.json({ upserted });
+}
 
 // ---- Exports ----
 

--- a/apps/wiki-server/src/routes/tablebase/divisions.ts
+++ b/apps/wiki-server/src/routes/tablebase/divisions.ts
@@ -6,17 +6,12 @@ import { divisions } from "../../schema.js";
 import {
   paginationQuery,
   noDuplicateIds,
-  parseJsonBody,
-  validationError,
-  invalidJsonError,
   notFoundError,
   zv,
 } from "../shared/utils.js";
-import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
-import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
-import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
 
 // ---- Constants ----
@@ -194,28 +189,14 @@ const divisionsApp = new Hono()
     return c.json(formatRow(rows[0]));
   })
 
-  // ---- POST /sync ----
-  .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncDivisionsBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "parentOrgId", ids: items.map((i) => i.parentOrgId) },
-    ]);
-    if (refError) return refError;
-
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
+  // ---- POST /sync — uses sync-factory (Phase 1 pilot, Tier 2) ----
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "divisions",
+      table: divisions,
+      batchSchema: SyncDivisionsBatchSchema,
+      toRow: (item) => ({
         id: item.id,
         slug: item.slug ?? null,
         parentOrgId: item.parentOrgId,
@@ -228,69 +209,47 @@ const divisionsApp = new Hono()
         website: item.website ?? null,
         source: item.source ?? null,
         notes: item.notes ?? null,
-      }));
-
-      await tx
-        .insert(divisions)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: divisions.id,
-          set: {
-            slug: sql`excluded.slug`,
-            parentOrgId: sql`excluded.parent_org_id`,
-            name: sql`excluded.name`,
-            divisionType: sql`excluded.division_type`,
-            // COALESCE: preserve existing values when sync payload sends null
-            lead: sql`COALESCE(excluded.lead, ${divisions.lead})`,
-            status: sql`COALESCE(excluded.status, ${divisions.status})`,
-            startDate: sql`COALESCE(excluded.start_date, ${divisions.startDate})`,
-            endDate: sql`COALESCE(excluded.end_date, ${divisions.endDate})`,
-            website: sql`COALESCE(excluded.website, ${divisions.website})`,
-            source: sql`COALESCE(excluded.source, ${divisions.source})`,
-            notes: sql`COALESCE(excluded.notes, ${divisions.notes})`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Resolve parent org slugs to human-readable titles for search
-      const orgSlugs = [...new Set(items.map((d) => d.parentOrgId))];
-      const titleMap = await resolveEntityTitles(tx, orgSlugs);
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((d) => ({
-          id: d.id,
-          thingType: "division" as const,
-          title: d.name,
-          sourceTable: "divisions",
-          sourceId: d.id,
-          sourceUrl: d.website,
-          parentTitle: titleMap.get(d.parentOrgId) ?? d.parentOrgId,
-          description: d.divisionType || null,
-        }))
-      );
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "division",
-          recordId: item.id,
-          entityId: item.parentOrgId,
-          sourceUrl: item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    logSourceCheckCoverage("divisions/sync", items.length, verdictsResult.written);
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written });
-  })
+      }),
+      // COALESCE preservation: preserve existing values when sync payload sends null.
+      // This is the only escape hatch divisions needs (its 1-hook budget per Phase 0 audit).
+      conflictSet: {
+        slug: sql`excluded.slug`,
+        parentOrgId: sql`excluded.parent_org_id`,
+        name: sql`excluded.name`,
+        divisionType: sql`excluded.division_type`,
+        lead: sql`COALESCE(excluded.lead, ${divisions.lead})`,
+        status: sql`COALESCE(excluded.status, ${divisions.status})`,
+        startDate: sql`COALESCE(excluded.start_date, ${divisions.startDate})`,
+        endDate: sql`COALESCE(excluded.end_date, ${divisions.endDate})`,
+        website: sql`COALESCE(excluded.website, ${divisions.website})`,
+        source: sql`COALESCE(excluded.source, ${divisions.source})`,
+        notes: sql`COALESCE(excluded.notes, ${divisions.notes})`,
+        syncedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      },
+      entityRefFields: (items) => [
+        { fieldName: "parentOrgId", ids: items.map((i) => i.parentOrgId) },
+      ],
+      thingsTitleIds: (items) => [...new Set(items.map((d) => d.parentOrgId))],
+      toThing: (item, titleMap) => ({
+        id: item.id,
+        thingType: "division" as const,
+        title: item.name,
+        sourceTable: "divisions",
+        sourceId: item.id,
+        sourceUrl: item.website ?? null,
+        parentTitle: titleMap.get(item.parentOrgId) ?? item.parentOrgId,
+        description: item.divisionType || null,
+      }),
+      toVerdict: (item) => ({
+        recordType: "division",
+        recordId: item.id,
+        entityId: item.parentOrgId,
+        sourceUrl: item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }),
+    }),
+  )
 
   .post("/delete-batch", deleteBatchHandler(divisions, "divisions"));
 

--- a/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -21,6 +22,8 @@ import {
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -104,34 +107,101 @@ const entityAssessmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
     }
   )
 
+  // ---- POST /sync ----
+  //
+  // Phase 2 Batch C migration (issue #4090, discussion #4088): factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!entity-assessments` to fall back
+  // to the legacy handler instantly without redeploying.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("entity-assessments")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(entityAssessments, "entity_assessments"));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 Batch C) ----
 
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "entity-assessments",
+  table: entityAssessments,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    entityId: item.entityId,
+    dimension: item.dimension,
+    rating: item.rating,
+    evidence: item.evidence ?? null,
+    assessor: item.assessor,
+    assessedAt: item.assessedAt ?? null,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+  toThing: (item, titleMap) => ({
+    id: item.id,
+    thingType: "entity-assessment" as const,
+    title: `${item.dimension}: ${item.rating}`,
+    sourceTable: "entity_assessments",
+    sourceId: item.id,
+    parentThingId: item.entityId,
+    parentTitle: titleMap.get(item.entityId) ?? item.entityId,
+    sourceUrl: item.source ?? null,
+    description: item.evidence ?? null,
+  }),
+  thingsTitleIds: (items) => [...new Set(items.map((i) => i.entityId))],
+});
 
-    const now = new Date();
-    let upserted = 0;
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    await db.transaction(async (tx) => {
-      const entityIds = [...new Set(items.map((i) => i.entityId))];
-      const titleMap = await resolveEntityTitles(tx, entityIds);
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-      for (const item of items) {
-        await tx
-          .insert(entityAssessments)
-          .values({
-            id: item.id,
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Validate entity FK references before inserting
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ]);
+  if (refError) return refError;
+
+  const now = new Date();
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    const entityIds = [...new Set(items.map((i) => i.entityId))];
+    const titleMap = await resolveEntityTitles(tx, entityIds);
+
+    for (const item of items) {
+      await tx
+        .insert(entityAssessments)
+        .values({
+          id: item.id,
+          entityId: item.entityId,
+          dimension: item.dimension,
+          rating: item.rating,
+          evidence: item.evidence ?? null,
+          assessor: item.assessor,
+          assessedAt: item.assessedAt ?? null,
+          source: item.source ?? null,
+          notes: item.notes ?? null,
+          syncedAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: entityAssessments.id,
+          set: {
             entityId: item.entityId,
             dimension: item.dimension,
             rating: item.rating,
@@ -142,47 +212,31 @@ const entityAssessmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
             notes: item.notes ?? null,
             syncedAt: now,
             updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: entityAssessments.id,
-            set: {
-              entityId: item.entityId,
-              dimension: item.dimension,
-              rating: item.rating,
-              evidence: item.evidence ?? null,
-              assessor: item.assessor,
-              assessedAt: item.assessedAt ?? null,
-              source: item.source ?? null,
-              notes: item.notes ?? null,
-              syncedAt: now,
-              updatedAt: now,
-            },
-          });
-        upserted++;
-      }
+          },
+        });
+      upserted++;
+    }
 
-      const entityTitle = (id: string) => titleMap.get(id) ?? id;
+    const entityTitle = (id: string) => titleMap.get(id) ?? id;
 
-      await upsertThingsInTx(
-        tx,
-        items.map((i) => ({
-          id: i.id,
-          thingType: "entity-assessment" as const,
-          title: `${i.dimension}: ${i.rating}`,
-          sourceTable: "entity_assessments",
-          sourceId: i.id,
-          parentThingId: i.entityId,
-          parentTitle: entityTitle(i.entityId),
-          sourceUrl: i.source ?? null,
-          description: i.evidence ?? null,
-        }))
-      );
-    });
+    await upsertThingsInTx(
+      tx,
+      items.map((i) => ({
+        id: i.id,
+        thingType: "entity-assessment" as const,
+        title: `${i.dimension}: ${i.rating}`,
+        sourceTable: "entity_assessments",
+        sourceId: i.id,
+        parentThingId: i.entityId,
+        parentTitle: entityTitle(i.entityId),
+        sourceUrl: i.source ?? null,
+        description: i.evidence ?? null,
+      }))
+    );
+  });
 
-    return c.json({ upserted });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(entityAssessments, "entity_assessments"));
+  return c.json({ upserted });
+}
 
 export const entityAssessmentsRoute = entityAssessmentsApp;
 export type EntityAssessmentsRoute = typeof entityAssessmentsApp;

--- a/apps/wiki-server/src/routes/tablebase/entity-events.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-events.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, count, desc } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -21,6 +22,8 @@ import {
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -118,33 +121,102 @@ const entityEventsApp = new Hono<{ Variables: ResolvedEntityVars }>()
     }
   )
 
+  // ---- POST /sync ----
+  //
+  // Phase 2 Batch C migration (issue #4090, discussion #4088): factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!entity-events` to fall back
+  // to the legacy handler instantly without redeploying.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("entity-events")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(entityEvents, "entity_events"));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 Batch C) ----
 
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "entity-events",
+  table: entityEvents,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    entityId: item.entityId,
+    entityDisplayName: item.entityDisplayName ?? null,
+    date: item.date,
+    title: item.title,
+    description: item.description ?? null,
+    eventType: item.eventType,
+    significance: item.significance ?? null,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+  toThing: (item, titleMap) => ({
+    id: item.id,
+    thingType: "entity-event" as const,
+    title: `${item.title} (${item.date})`,
+    sourceTable: "entity_events",
+    sourceId: item.id,
+    parentThingId: item.entityId,
+    parentTitle: titleMap.get(item.entityId) ?? item.entityId,
+    sourceUrl: item.source ?? null,
+    description: item.description ?? null,
+  }),
+  thingsTitleIds: (items) => [...new Set(items.map((i) => i.entityId))],
+});
 
-    const now = new Date();
-    let upserted = 0;
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    await db.transaction(async (tx) => {
-      const entityIds = [...new Set(items.map((i) => i.entityId))];
-      const titleMap = await resolveEntityTitles(tx, entityIds);
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-      for (const item of items) {
-        await tx
-          .insert(entityEvents)
-          .values({
-            id: item.id,
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ]);
+  if (refError) return refError;
+
+  const now = new Date();
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    const entityIds = [...new Set(items.map((i) => i.entityId))];
+    const titleMap = await resolveEntityTitles(tx, entityIds);
+
+    for (const item of items) {
+      await tx
+        .insert(entityEvents)
+        .values({
+          id: item.id,
+          entityId: item.entityId,
+          entityDisplayName: item.entityDisplayName ?? null,
+          date: item.date,
+          title: item.title,
+          description: item.description ?? null,
+          eventType: item.eventType,
+          significance: item.significance ?? null,
+          source: item.source ?? null,
+          notes: item.notes ?? null,
+          syncedAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: entityEvents.id,
+          set: {
             entityId: item.entityId,
             entityDisplayName: item.entityDisplayName ?? null,
             date: item.date,
@@ -156,48 +228,31 @@ const entityEventsApp = new Hono<{ Variables: ResolvedEntityVars }>()
             notes: item.notes ?? null,
             syncedAt: now,
             updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: entityEvents.id,
-            set: {
-              entityId: item.entityId,
-              entityDisplayName: item.entityDisplayName ?? null,
-              date: item.date,
-              title: item.title,
-              description: item.description ?? null,
-              eventType: item.eventType,
-              significance: item.significance ?? null,
-              source: item.source ?? null,
-              notes: item.notes ?? null,
-              syncedAt: now,
-              updatedAt: now,
-            },
-          });
-        upserted++;
-      }
+          },
+        });
+      upserted++;
+    }
 
-      const entityTitle = (id: string) => titleMap.get(id) ?? id;
+    const entityTitle = (id: string) => titleMap.get(id) ?? id;
 
-      await upsertThingsInTx(
-        tx,
-        items.map((i) => ({
-          id: i.id,
-          thingType: "entity-event" as const,
-          title: `${i.title} (${i.date})`,
-          sourceTable: "entity_events",
-          sourceId: i.id,
-          parentThingId: i.entityId,
-          parentTitle: entityTitle(i.entityId),
-          sourceUrl: i.source ?? null,
-          description: i.description ?? null,
-        }))
-      );
-    });
+    await upsertThingsInTx(
+      tx,
+      items.map((i) => ({
+        id: i.id,
+        thingType: "entity-event" as const,
+        title: `${i.title} (${i.date})`,
+        sourceTable: "entity_events",
+        sourceId: i.id,
+        parentThingId: i.entityId,
+        parentTitle: entityTitle(i.entityId),
+        sourceUrl: i.source ?? null,
+        description: i.description ?? null,
+      }))
+    );
+  });
 
-    return c.json({ upserted });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(entityEvents, "entity_events"));
+  return c.json({ upserted });
+}
 
 export const entityEventsRoute = entityEventsApp;
 export type EntityEventsRoute = typeof entityEventsApp;

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, sql, desc, inArray, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -23,6 +24,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -206,202 +209,316 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!funding-rounds` falls back to legacy.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncFundingRoundsBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Check for natural key collisions within the batch itself.
-    // Natural key: (companyId, name)
-    const batchKeys = new Set<string>();
-    for (const item of items) {
-      const key = `${item.companyId}::${item.name}`;
-      if (batchKeys.has(key)) {
-        return validationError(
-          c,
-          `Duplicate (companyId, name) in batch: ` +
-          `companyId=${item.companyId}, name="${item.name}". ` +
-          `Each funding round must have a unique name within its company.`
-        );
-      }
-      batchKeys.add(key);
+    if (useFactoryFor("funding-rounds")) {
+      return factorySyncHandler(c);
     }
-
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "companyId", ids: items.map((i) => i.companyId) },
-    ]);
-    if (refError) return refError;
-
-    // Validate claim references
-    const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
-    if (allClaimIds.length > 0) {
-      const rawDb = getDb();
-      const claimError = await validateClaimRefs(rawDb, allClaimIds);
-      if (claimError) return validationError(c, claimError);
-    }
-
-    // Resolve companyId and leadInvestor values (slugs or stableIds) to proper stableIds
-    // for the FK columns. This ensures companyEntityId and leadInvestorEntityId are populated
-    // so the JOINs on GET /all work correctly.
-    const uniqueCompanyIds = [...new Set(items.map((i) => i.companyId).filter(Boolean))];
-    const uniqueLeadInvestorIds = [...new Set(
-      items.map((i) => i.leadInvestor).filter((id): id is string => id != null && id !== "")
-    )];
-    const allUniqueIds = [...new Set([...uniqueCompanyIds, ...uniqueLeadInvestorIds])];
-    const entityRows = allUniqueIds.length > 0
-      ? await db
-          .select({ id: entities.id, stableId: entities.stableId })
-          .from(entities)
-          .where(or(inArray(entities.id, allUniqueIds), inArray(entities.stableId, allUniqueIds)))
-      : [];
-
-    const entityStableIdMap = new Map<string, string>();
-    for (const row of entityRows) {
-      if (row.stableId) {
-        entityStableIdMap.set(row.id, row.stableId);
-        entityStableIdMap.set(row.stableId, row.stableId);
-      }
-    }
-
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => {
-        const raisedRange = parseRange(item.raised);
-        const valuationRange = parseRange(item.valuation);
-        // Strip "new:" prefix from leadInvestor raw ID for entity resolution
-        const rawLI = item.leadInvestor?.startsWith("new:") ? item.leadInvestor.slice(4).trim() : item.leadInvestor;
-        return {
-          id: item.id,
-          companyId: item.companyId,
-          companyEntityId: entityStableIdMap.get(item.companyId) ?? null,
-          companyDisplayName: item.companyDisplayName ?? null,
-          name: item.name,
-          date: item.date ?? null,
-          raised: item.raised != null ? String(item.raised) : null,
-          raisedLow: raisedRange.low,
-          raisedHigh: raisedRange.high,
-          valuation: item.valuation != null ? String(item.valuation) : null,
-          valuationLow: valuationRange.low,
-          valuationHigh: valuationRange.high,
-          instrument: item.instrument ?? null,
-          leadInvestor: item.leadInvestor ?? null,
-          leadInvestorEntityId: rawLI ? (entityStableIdMap.get(rawLI) ?? null) : null,
-          leadInvestorDisplayName: item.leadInvestorDisplayName ?? null,
-          source: item.source ?? null,
-          notes: item.notes ?? null,
-        };
-      });
-
-      await tx
-        .insert(fundingRounds)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: fundingRounds.id,
-          set: {
-            companyId: sql`excluded.company_id`,
-            companyEntityId: sql`COALESCE(excluded.company_entity_id, ${fundingRounds.companyEntityId})`,
-            companyDisplayName: sql`COALESCE(excluded.company_display_name, ${fundingRounds.companyDisplayName})`,
-            name: sql`excluded.name`,
-            date: sql`excluded.date`,
-            raised: sql`excluded.raised`,
-            raisedLow: sql`excluded.raised_low`,
-            raisedHigh: sql`excluded.raised_high`,
-            valuation: sql`excluded.valuation`,
-            valuationLow: sql`excluded.valuation_low`,
-            valuationHigh: sql`excluded.valuation_high`,
-            instrument: sql`excluded.instrument`,
-            leadInvestor: sql`excluded.lead_investor`,
-            leadInvestorEntityId: sql`COALESCE(excluded.lead_investor_entity_id, ${fundingRounds.leadInvestorEntityId})`,
-            leadInvestorDisplayName: sql`COALESCE(excluded.lead_investor_display_name, ${fundingRounds.leadInvestorDisplayName})`,
-            source: sql`excluded.source`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Post-sync: resolve entity FKs as safety net (pre-insert JS resolution above
-      // may miss entities added after the initial query)
-      await resolveEntityFKs(tx, {
-        tableName: "funding_rounds",
-        fields: [
-          { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
-          { rawIdColumn: "lead_investor", entityIdColumn: "lead_investor_entity_id", displayNameColumn: "lead_investor_display_name" },
-        ],
-        scopeIds: items.map((i) => i.id),
-      });
-
-      // Resolve company slugs to human-readable titles for search
-      const companySlugs = [...new Set(items.map((fr) => fr.companyId))];
-      const titleMap = await resolveEntityTitles(tx, companySlugs);
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((fr) => ({
-          id: fr.id,
-          thingType: "funding-round" as const,
-          title: fr.name + (fr.date ? ` (${fr.date})` : ""),
-          sourceTable: "funding_rounds",
-          sourceId: fr.id,
-          sourceUrl: fr.source,
-          parentTitle: titleMap.get(fr.companyId) ?? fr.companyDisplayName ?? fr.companyId,
-          description: [
-            fr.raised != null ? `raised $${Number(fr.raised).toLocaleString()}` : null,
-            fr.instrument,
-            fr.leadInvestor ? `led by ${fr.leadInvestorDisplayName ?? fr.leadInvestor}` : null,
-          ].filter(Boolean).join(", ") || null,
-        }))
-      );
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "funding-round",
-          recordId: item.id,
-          entityId: item.companyId,
-          sourceUrl: item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    logSourceCheckCoverage("funding-rounds/sync", items.length, verdictsResult.written);
-
-    // Link verified claims to records (best-effort — records already committed)
-    let claimsLinked = 0;
-    let claimLinkingError: string | null = null;
-    if (allClaimIds.length > 0) {
-      try {
-        const rawDb = getDb();
-        const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
-          recordId: item.id,
-          recordType: "funding-rounds",
-          claimIds: item.claimIds,
-        })));
-        claimsLinked = linkResult.linked;
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        claimLinkingError = msg;
-        logger.warn({ error: msg }, "claim linking failed (records already committed)");
-      }
-    }
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+    return legacySyncHandler(c);
   })
 
   .post("/delete-batch", deleteBatchHandler(fundingRounds, "funding_rounds"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+//
+// Escape hatch: `conflictSet` — funding_rounds uses COALESCE preservation on
+// the entity FK columns (companyEntityId, leadInvestorEntityId, and their
+// display names) so that updates don't clobber previously-resolved values
+// with nulls. The legacy handler also did a pre-insert lookup to populate
+// these columns directly, but `fkResolve` runs in the same transaction as a
+// post-upsert backfill and achieves the same end state.
+const factorySyncHandler = createSyncHandler({
+  name: "funding-rounds",
+  table: fundingRounds,
+  batchSchema: SyncFundingRoundsBatchSchema,
+  naturalKey: (item) => `${item.companyId}::${item.name}`,
+  naturalKeyError:
+    "Duplicate (companyId, name) in batch — each funding round must have a unique name within its company",
+  entityRefFields: (items) => [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+  ],
+  claimSupport: {
+    recordType: "funding-rounds",
+    getClaimIds: (item) => item.claimIds ?? [],
+  },
+  toRow: (item) => {
+    const raisedRange = parseRange(item.raised);
+    const valuationRange = parseRange(item.valuation);
+    return {
+      id: item.id,
+      companyId: item.companyId,
+      companyEntityId: null,
+      companyDisplayName: item.companyDisplayName ?? null,
+      name: item.name,
+      date: item.date ?? null,
+      raised: item.raised != null ? String(item.raised) : null,
+      raisedLow: raisedRange.low,
+      raisedHigh: raisedRange.high,
+      valuation: item.valuation != null ? String(item.valuation) : null,
+      valuationLow: valuationRange.low,
+      valuationHigh: valuationRange.high,
+      instrument: item.instrument ?? null,
+      leadInvestor: item.leadInvestor ?? null,
+      leadInvestorEntityId: null,
+      leadInvestorDisplayName: item.leadInvestorDisplayName ?? null,
+      source: item.source ?? null,
+      notes: item.notes ?? null,
+    };
+  },
+  conflictSet: {
+    companyId: sql`excluded.company_id`,
+    companyEntityId: sql`COALESCE(excluded.company_entity_id, ${fundingRounds.companyEntityId})`,
+    companyDisplayName: sql`COALESCE(excluded.company_display_name, ${fundingRounds.companyDisplayName})`,
+    name: sql`excluded.name`,
+    date: sql`excluded.date`,
+    raised: sql`excluded.raised`,
+    raisedLow: sql`excluded.raised_low`,
+    raisedHigh: sql`excluded.raised_high`,
+    valuation: sql`excluded.valuation`,
+    valuationLow: sql`excluded.valuation_low`,
+    valuationHigh: sql`excluded.valuation_high`,
+    instrument: sql`excluded.instrument`,
+    leadInvestor: sql`excluded.lead_investor`,
+    leadInvestorEntityId: sql`COALESCE(excluded.lead_investor_entity_id, ${fundingRounds.leadInvestorEntityId})`,
+    leadInvestorDisplayName: sql`COALESCE(excluded.lead_investor_display_name, ${fundingRounds.leadInvestorDisplayName})`,
+    source: sql`excluded.source`,
+    notes: sql`excluded.notes`,
+    syncedAt: sql`now()`,
+    updatedAt: sql`now()`,
+  },
+  fkResolve: {
+    tableName: "funding_rounds",
+    fields: [
+      { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
+      { rawIdColumn: "lead_investor", entityIdColumn: "lead_investor_entity_id", displayNameColumn: "lead_investor_display_name" },
+    ],
+  },
+  thingsTitleIds: (items) => [...new Set(items.map((fr) => fr.companyId))],
+  toThing: (item, titleMap) => ({
+    id: item.id,
+    thingType: "funding-round" as const,
+    title: item.name + (item.date ? ` (${item.date})` : ""),
+    sourceTable: "funding_rounds",
+    sourceId: item.id,
+    sourceUrl: item.source,
+    parentTitle: titleMap.get(item.companyId) ?? item.companyDisplayName ?? item.companyId,
+    description: [
+      item.raised != null ? `raised $${Number(item.raised).toLocaleString()}` : null,
+      item.instrument,
+      item.leadInvestor ? `led by ${item.leadInvestorDisplayName ?? item.leadInvestor}` : null,
+    ].filter(Boolean).join(", ") || null,
+  }),
+  toVerdict: (item) => ({
+    recordType: "funding-round",
+    recordId: item.id,
+    entityId: item.companyId,
+    sourceUrl: item.source ?? null,
+    sourcing: item.sourcing ?? null,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncFundingRoundsBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Check for natural key collisions within the batch itself.
+  // Natural key: (companyId, name)
+  const batchKeys = new Set<string>();
+  for (const item of items) {
+    const key = `${item.companyId}::${item.name}`;
+    if (batchKeys.has(key)) {
+      return validationError(
+        c,
+        `Duplicate (companyId, name) in batch: ` +
+        `companyId=${item.companyId}, name="${item.name}". ` +
+        `Each funding round must have a unique name within its company.`
+      );
+    }
+    batchKeys.add(key);
+  }
+
+  // Validate entity FK references before inserting
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+  ]);
+  if (refError) return refError;
+
+  // Validate claim references
+  const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
+  if (allClaimIds.length > 0) {
+    const rawDb = getDb();
+    const claimError = await validateClaimRefs(rawDb, allClaimIds);
+    if (claimError) return validationError(c, claimError);
+  }
+
+  // Resolve companyId and leadInvestor values (slugs or stableIds) to proper stableIds
+  // for the FK columns. This ensures companyEntityId and leadInvestorEntityId are populated
+  // so the JOINs on GET /all work correctly.
+  const uniqueCompanyIds = [...new Set(items.map((i) => i.companyId).filter(Boolean))];
+  const uniqueLeadInvestorIds = [...new Set(
+    items.map((i) => i.leadInvestor).filter((id): id is string => id != null && id !== "")
+  )];
+  const allUniqueIds = [...new Set([...uniqueCompanyIds, ...uniqueLeadInvestorIds])];
+  const entityRows = allUniqueIds.length > 0
+    ? await db
+        .select({ id: entities.id, stableId: entities.stableId })
+        .from(entities)
+        .where(or(inArray(entities.id, allUniqueIds), inArray(entities.stableId, allUniqueIds)))
+    : [];
+
+  const entityStableIdMap = new Map<string, string>();
+  for (const row of entityRows) {
+    if (row.stableId) {
+      entityStableIdMap.set(row.id, row.stableId);
+      entityStableIdMap.set(row.stableId, row.stableId);
+    }
+  }
+
+  let upserted = 0;
+  let verdictsResult = { written: 0 };
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => {
+      const raisedRange = parseRange(item.raised);
+      const valuationRange = parseRange(item.valuation);
+      // Strip "new:" prefix from leadInvestor raw ID for entity resolution
+      const rawLI = item.leadInvestor?.startsWith("new:") ? item.leadInvestor.slice(4).trim() : item.leadInvestor;
+      return {
+        id: item.id,
+        companyId: item.companyId,
+        companyEntityId: entityStableIdMap.get(item.companyId) ?? null,
+        companyDisplayName: item.companyDisplayName ?? null,
+        name: item.name,
+        date: item.date ?? null,
+        raised: item.raised != null ? String(item.raised) : null,
+        raisedLow: raisedRange.low,
+        raisedHigh: raisedRange.high,
+        valuation: item.valuation != null ? String(item.valuation) : null,
+        valuationLow: valuationRange.low,
+        valuationHigh: valuationRange.high,
+        instrument: item.instrument ?? null,
+        leadInvestor: item.leadInvestor ?? null,
+        leadInvestorEntityId: rawLI ? (entityStableIdMap.get(rawLI) ?? null) : null,
+        leadInvestorDisplayName: item.leadInvestorDisplayName ?? null,
+        source: item.source ?? null,
+        notes: item.notes ?? null,
+      };
+    });
+
+    await tx
+      .insert(fundingRounds)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: fundingRounds.id,
+        set: {
+          companyId: sql`excluded.company_id`,
+          companyEntityId: sql`COALESCE(excluded.company_entity_id, ${fundingRounds.companyEntityId})`,
+          companyDisplayName: sql`COALESCE(excluded.company_display_name, ${fundingRounds.companyDisplayName})`,
+          name: sql`excluded.name`,
+          date: sql`excluded.date`,
+          raised: sql`excluded.raised`,
+          raisedLow: sql`excluded.raised_low`,
+          raisedHigh: sql`excluded.raised_high`,
+          valuation: sql`excluded.valuation`,
+          valuationLow: sql`excluded.valuation_low`,
+          valuationHigh: sql`excluded.valuation_high`,
+          instrument: sql`excluded.instrument`,
+          leadInvestor: sql`excluded.lead_investor`,
+          leadInvestorEntityId: sql`COALESCE(excluded.lead_investor_entity_id, ${fundingRounds.leadInvestorEntityId})`,
+          leadInvestorDisplayName: sql`COALESCE(excluded.lead_investor_display_name, ${fundingRounds.leadInvestorDisplayName})`,
+          source: sql`excluded.source`,
+          notes: sql`excluded.notes`,
+          syncedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      });
+
+    // Post-sync: resolve entity FKs as safety net (pre-insert JS resolution above
+    // may miss entities added after the initial query)
+    await resolveEntityFKs(tx, {
+      tableName: "funding_rounds",
+      fields: [
+        { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
+        { rawIdColumn: "lead_investor", entityIdColumn: "lead_investor_entity_id", displayNameColumn: "lead_investor_display_name" },
+      ],
+      scopeIds: items.map((i) => i.id),
+    });
+
+    // Resolve company slugs to human-readable titles for search
+    const companySlugs = [...new Set(items.map((fr) => fr.companyId))];
+    const titleMap = await resolveEntityTitles(tx, companySlugs);
+
+    // Dual-write to things table
+    await upsertThingsInTx(
+      tx,
+      items.map((fr) => ({
+        id: fr.id,
+        thingType: "funding-round" as const,
+        title: fr.name + (fr.date ? ` (${fr.date})` : ""),
+        sourceTable: "funding_rounds",
+        sourceId: fr.id,
+        sourceUrl: fr.source,
+        parentTitle: titleMap.get(fr.companyId) ?? fr.companyDisplayName ?? fr.companyId,
+        description: [
+          fr.raised != null ? `raised $${Number(fr.raised).toLocaleString()}` : null,
+          fr.instrument,
+          fr.leadInvestor ? `led by ${fr.leadInvestorDisplayName ?? fr.leadInvestor}` : null,
+        ].filter(Boolean).join(", ") || null,
+      }))
+    );
+
+    // Write inline source-check verdicts atomically within the same transaction
+    verdictsResult = await writeInlineVerdicts(
+      tx,
+      items.map((item) => ({
+        recordType: "funding-round",
+        recordId: item.id,
+        entityId: item.companyId,
+        sourceUrl: item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }))
+    );
+
+    upserted = allVals.length;
+  });
+
+  logSourceCheckCoverage("funding-rounds/sync", items.length, verdictsResult.written);
+
+  // Link verified claims to records (best-effort — records already committed)
+  let claimsLinked = 0;
+  let claimLinkingError: string | null = null;
+  if (allClaimIds.length > 0) {
+    try {
+      const rawDb = getDb();
+      const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
+        recordId: item.id,
+        recordType: "funding-rounds",
+        claimIds: item.claimIds,
+      })));
+      claimsLinked = linkResult.linked;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      claimLinkingError = msg;
+      logger.warn({ error: msg }, "claim linking failed (records already committed)");
+    }
+  }
+
+  return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+}
 
 // ---- Exports ----
 

--- a/apps/wiki-server/src/routes/tablebase/investments.ts
+++ b/apps/wiki-server/src/routes/tablebase/investments.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, sql, desc } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -23,6 +24,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -240,164 +243,244 @@ const investmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!investments` falls back to legacy.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncInvestmentsBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Check for natural key collisions within the batch itself.
-    // Natural key: (companyId, investorId, roundName)
-    const batchKeys = new Set<string>();
-    for (const item of items) {
-      const key = `${item.companyId}::${item.investorId}::${item.roundName ?? ""}`;
-      if (batchKeys.has(key)) {
-        return validationError(
-          c,
-          `Duplicate (companyId, investorId, roundName) in batch: ` +
-          `companyId=${item.companyId}, investorId=${item.investorId}, ` +
-          `roundName="${item.roundName ?? ""}". ` +
-          `Each investment must be unique by company + investor + round.`
-        );
-      }
-      batchKeys.add(key);
+    if (useFactoryFor("investments")) {
+      return factorySyncHandler(c);
     }
-
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "companyId", ids: items.map((i) => i.companyId) },
-      { fieldName: "investorId", ids: items.map((i) => i.investorId) },
-    ]);
-    if (refError) return refError;
-
-    // Validate claim references
-    const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
-    if (allClaimIds.length > 0) {
-      const rawDb = getDb();
-      const claimError = await validateClaimRefs(rawDb, allClaimIds);
-      if (claimError) return validationError(c, claimError);
-    }
-
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => {
-        const amountRange = parseRange(item.amount);
-        const stakeRange = parseRange(item.stakeAcquired);
-        return {
-          id: item.id,
-          companyId: item.companyId,
-          investorId: item.investorId,
-          roundName: item.roundName ?? null,
-          date: item.date ?? null,
-          amount: item.amount != null ? String(item.amount) : null,
-          amountLow: amountRange.low,
-          amountHigh: amountRange.high,
-          stakeAcquired: item.stakeAcquired ?? null,
-          stakeLow: stakeRange.low,
-          stakeHigh: stakeRange.high,
-          instrument: item.instrument ?? null,
-          role: item.role ?? null,
-          conditions: item.conditions ?? null,
-          source: item.source ?? null,
-          notes: item.notes ?? null,
-        };
-      });
-
-      await tx
-        .insert(investments)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: investments.id,
-          set: {
-            companyId: sql`excluded.company_id`,
-            investorId: sql`excluded.investor_id`,
-            roundName: sql`excluded.round_name`,
-            date: sql`excluded.date`,
-            amount: sql`excluded.amount`,
-            amountLow: sql`excluded.amount_low`,
-            amountHigh: sql`excluded.amount_high`,
-            stakeAcquired: sql`excluded.stake_acquired`,
-            stakeLow: sql`excluded.stake_low`,
-            stakeHigh: sql`excluded.stake_high`,
-            instrument: sql`excluded.instrument`,
-            role: sql`excluded.role`,
-            conditions: sql`excluded.conditions`,
-            source: sql`excluded.source`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Post-sync: resolve entity FKs for newly synced rows
-      await resolveEntityFKs(tx, {
-        tableName: "investments",
-        fields: [
-          { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
-          { rawIdColumn: "investor_id", entityIdColumn: "investor_entity_id", displayNameColumn: "investor_display_name" },
-        ],
-        scopeIds: items.map((i) => i.id),
-      });
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((i) => ({
-          id: i.id,
-          thingType: "investment" as const,
-          title: `${i.investorId} → ${i.companyId}${i.roundName ? ` (${i.roundName})` : ""}`,
-          sourceTable: "investments",
-          sourceId: i.id,
-          sourceUrl: i.source,
-        }))
-      );
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "investment",
-          recordId: item.id,
-          entityId: item.companyId,
-          sourceUrl: item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    logSourceCheckCoverage("investments/sync", items.length, verdictsResult.written);
-
-    // Link verified claims to records (best-effort — records already committed)
-    let claimsLinked = 0;
-    let claimLinkingError: string | null = null;
-    if (allClaimIds.length > 0) {
-      try {
-        const rawDb = getDb();
-        const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
-          recordId: item.id,
-          recordType: "investments",
-          claimIds: item.claimIds,
-        })));
-        claimsLinked = linkResult.linked;
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        claimLinkingError = msg;
-        logger.warn({ error: msg }, "claim linking failed (records already committed)");
-      }
-    }
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+    return legacySyncHandler(c);
   })
 
   .post("/delete-batch", deleteBatchHandler(investments, "investments"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+
+const factorySyncHandler = createSyncHandler({
+  name: "investments",
+  table: investments,
+  batchSchema: SyncInvestmentsBatchSchema,
+  naturalKey: (item) =>
+    `${item.companyId}::${item.investorId}::${item.roundName ?? ""}`,
+  naturalKeyError:
+    "Duplicate (companyId, investorId, roundName) in batch — each investment must be unique by company + investor + round",
+  entityRefFields: (items) => [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+    { fieldName: "investorId", ids: items.map((i) => i.investorId) },
+  ],
+  claimSupport: {
+    recordType: "investments",
+    getClaimIds: (item) => item.claimIds ?? [],
+  },
+  toRow: (item) => {
+    const amountRange = parseRange(item.amount);
+    const stakeRange = parseRange(item.stakeAcquired);
+    return {
+      id: item.id,
+      companyId: item.companyId,
+      investorId: item.investorId,
+      roundName: item.roundName ?? null,
+      date: item.date ?? null,
+      amount: item.amount != null ? String(item.amount) : null,
+      amountLow: amountRange.low,
+      amountHigh: amountRange.high,
+      stakeAcquired: item.stakeAcquired ?? null,
+      stakeLow: stakeRange.low,
+      stakeHigh: stakeRange.high,
+      instrument: item.instrument ?? null,
+      role: item.role ?? null,
+      conditions: item.conditions ?? null,
+      source: item.source ?? null,
+      notes: item.notes ?? null,
+    };
+  },
+  fkResolve: {
+    tableName: "investments",
+    fields: [
+      { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
+      { rawIdColumn: "investor_id", entityIdColumn: "investor_entity_id", displayNameColumn: "investor_display_name" },
+    ],
+  },
+  toThing: (item) => ({
+    id: item.id,
+    thingType: "investment" as const,
+    title: `${item.investorId} → ${item.companyId}${item.roundName ? ` (${item.roundName})` : ""}`,
+    sourceTable: "investments",
+    sourceId: item.id,
+    sourceUrl: item.source,
+  }),
+  toVerdict: (item) => ({
+    recordType: "investment",
+    recordId: item.id,
+    entityId: item.companyId,
+    sourceUrl: item.source ?? null,
+    sourcing: item.sourcing ?? null,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncInvestmentsBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Check for natural key collisions within the batch itself.
+  // Natural key: (companyId, investorId, roundName)
+  const batchKeys = new Set<string>();
+  for (const item of items) {
+    const key = `${item.companyId}::${item.investorId}::${item.roundName ?? ""}`;
+    if (batchKeys.has(key)) {
+      return validationError(
+        c,
+        `Duplicate (companyId, investorId, roundName) in batch: ` +
+        `companyId=${item.companyId}, investorId=${item.investorId}, ` +
+        `roundName="${item.roundName ?? ""}". ` +
+        `Each investment must be unique by company + investor + round.`
+      );
+    }
+    batchKeys.add(key);
+  }
+
+  // Validate entity FK references before inserting
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+    { fieldName: "investorId", ids: items.map((i) => i.investorId) },
+  ]);
+  if (refError) return refError;
+
+  // Validate claim references
+  const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
+  if (allClaimIds.length > 0) {
+    const rawDb = getDb();
+    const claimError = await validateClaimRefs(rawDb, allClaimIds);
+    if (claimError) return validationError(c, claimError);
+  }
+
+  let upserted = 0;
+  let verdictsResult = { written: 0 };
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => {
+      const amountRange = parseRange(item.amount);
+      const stakeRange = parseRange(item.stakeAcquired);
+      return {
+        id: item.id,
+        companyId: item.companyId,
+        investorId: item.investorId,
+        roundName: item.roundName ?? null,
+        date: item.date ?? null,
+        amount: item.amount != null ? String(item.amount) : null,
+        amountLow: amountRange.low,
+        amountHigh: amountRange.high,
+        stakeAcquired: item.stakeAcquired ?? null,
+        stakeLow: stakeRange.low,
+        stakeHigh: stakeRange.high,
+        instrument: item.instrument ?? null,
+        role: item.role ?? null,
+        conditions: item.conditions ?? null,
+        source: item.source ?? null,
+        notes: item.notes ?? null,
+      };
+    });
+
+    await tx
+      .insert(investments)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: investments.id,
+        set: {
+          companyId: sql`excluded.company_id`,
+          investorId: sql`excluded.investor_id`,
+          roundName: sql`excluded.round_name`,
+          date: sql`excluded.date`,
+          amount: sql`excluded.amount`,
+          amountLow: sql`excluded.amount_low`,
+          amountHigh: sql`excluded.amount_high`,
+          stakeAcquired: sql`excluded.stake_acquired`,
+          stakeLow: sql`excluded.stake_low`,
+          stakeHigh: sql`excluded.stake_high`,
+          instrument: sql`excluded.instrument`,
+          role: sql`excluded.role`,
+          conditions: sql`excluded.conditions`,
+          source: sql`excluded.source`,
+          notes: sql`excluded.notes`,
+          syncedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      });
+
+    // Post-sync: resolve entity FKs for newly synced rows
+    await resolveEntityFKs(tx, {
+      tableName: "investments",
+      fields: [
+        { rawIdColumn: "company_id", entityIdColumn: "company_entity_id", displayNameColumn: "company_display_name", entityTypeFilter: "organization" },
+        { rawIdColumn: "investor_id", entityIdColumn: "investor_entity_id", displayNameColumn: "investor_display_name" },
+      ],
+      scopeIds: items.map((i) => i.id),
+    });
+
+    // Dual-write to things table
+    await upsertThingsInTx(
+      tx,
+      items.map((i) => ({
+        id: i.id,
+        thingType: "investment" as const,
+        title: `${i.investorId} → ${i.companyId}${i.roundName ? ` (${i.roundName})` : ""}`,
+        sourceTable: "investments",
+        sourceId: i.id,
+        sourceUrl: i.source,
+      }))
+    );
+
+    // Write inline source-check verdicts atomically within the same transaction
+    verdictsResult = await writeInlineVerdicts(
+      tx,
+      items.map((item) => ({
+        recordType: "investment",
+        recordId: item.id,
+        entityId: item.companyId,
+        sourceUrl: item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }))
+    );
+
+    upserted = allVals.length;
+  });
+
+  logSourceCheckCoverage("investments/sync", items.length, verdictsResult.written);
+
+  // Link verified claims to records (best-effort — records already committed)
+  let claimsLinked = 0;
+  let claimLinkingError: string | null = null;
+  if (allClaimIds.length > 0) {
+    try {
+      const rawDb = getDb();
+      const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
+        recordId: item.id,
+        recordType: "investments",
+        claimIds: item.claimIds,
+      })));
+      claimsLinked = linkResult.linked;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      claimLinkingError = msg;
+      logger.warn({ error: msg }, "claim linking failed (records already committed)");
+    }
+  }
+
+  return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
+}
 
 // ---- Exports ----
 

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -2,8 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, or, count, sql, desc, isNull, like, inArray } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
-import { getDrizzleDb, getDb } from "../../db.js";
-import { logger } from "../../logger.js";
+import { getDrizzleDb } from "../../db.js";
 import { personnel, entities, things, sourceVerdicts } from "../../schema.js";
 import {
   verdictJoinCondition,
@@ -20,16 +19,12 @@ import {
   clampedLimit,
 } from "../shared/utils.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
-import { validateEntityRefs } from "../shared/validate-entity-refs.js";
-import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { logAuditEntries } from "./audit-log.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
-import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
-import { validateClaimRefs, linkClaimsToRecords } from "../shared/validate-claims.js";
-import { enforceSourceCheck } from "../shared/source-check-enforcement.js";
 import { sqlInList } from "../shared/query-helpers.js";
+import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
 
@@ -345,59 +340,28 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
     });
   })
 
-  // ---- POST /sync ----
-  .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncPersonnelBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    // Phase 5 (Discussion #3875): Source-check enforcement — checks both server-side
-    // config and client ?requireSourceCheck=true param. See source-check-enforcement.ts.
-    const sourceCheckError = enforceSourceCheck(c, "personnel", items);
-    if (sourceCheckError) return sourceCheckError;
-
-    // Check for natural key collisions within the batch itself.
-    // Natural key: (personId, organizationId, role, roleType)
-    const batchKeys = new Set<string>();
-    for (const item of items) {
-      const key = `${item.personId}::${item.organizationId}::${item.role}::${item.roleType}`;
-      if (batchKeys.has(key)) {
-        return validationError(
-          c,
-          `Duplicate (personId, organizationId, role, roleType) in batch: ` +
-          `personId=${item.personId}, organizationId=${item.organizationId}, ` +
-          `role="${item.role}", roleType=${item.roleType}. ` +
-          `Each personnel record must be unique by person + org + role.`
-        );
-      }
-      batchKeys.add(key);
-    }
-
-    // Validate entity FK references before inserting
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "personId", ids: items.map((i) => i.personId) },
-      { fieldName: "organizationId", ids: items.map((i) => i.organizationId) },
-    ]);
-    if (refError) return refError;
-
-    // Validate claim references (if any records cite verified claims)
-    const allClaimIds = items.flatMap((i) => i.claimIds ?? []);
-    if (allClaimIds.length > 0) {
-      const rawDb = getDb();
-      const claimError = await validateClaimRefs(rawDb, allClaimIds);
-      if (claimError) return validationError(c, claimError);
-    }
-
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
+  // ---- POST /sync — uses sync-factory (Phase 1 pilot, Tier 1) ----
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "personnel",
+      table: personnel,
+      batchSchema: SyncPersonnelBatchSchema,
+      enforceSourceCheck: true,
+      naturalKey: (item) =>
+        `${item.personId}::${item.organizationId}::${item.role}::${item.roleType}`,
+      naturalKeyError:
+        "Duplicate (personId, organizationId, role, roleType) in batch — each personnel record must be unique by person + org + role",
+      entityRefFields: (items) => [
+        { fieldName: "personId", ids: items.map((i) => i.personId) },
+        { fieldName: "organizationId", ids: items.map((i) => i.organizationId) },
+      ],
+      auditRecordType: "personnel",
+      claimSupport: {
+        recordType: "personnel",
+        getClaimIds: (item) => item.claimIds ?? [],
+      },
+      toRow: (item) => ({
         id: item.id,
         personId: item.personId,
         organizationId: item.organizationId,
@@ -410,153 +374,88 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
         background: item.background ?? null,
         source: item.source ?? null,
         notes: item.notes ?? null,
-      }));
-
-      // Fetch existing records for audit log (before upsert)
-      const existingIds = items.map((i) => i.id);
-      const existing = await tx
-        .select()
-        .from(personnel)
-        .where(inArray(personnel.id, existingIds));
-      const existingMap = new Map(existing.map((r) => [r.id, r]));
-
-      await tx
-        .insert(personnel)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: personnel.id,
-          set: {
-            personId: sql`excluded.person_id`,
-            organizationId: sql`excluded.organization_id`,
-            role: sql`excluded.role`,
-            roleType: sql`excluded.role_type`,
-            startDate: sql`excluded.start_date`,
-            endDate: sql`excluded.end_date`,
-            isFounder: sql`excluded.is_founder`,
-            appointedBy: sql`excluded.appointed_by`,
-            background: sql`excluded.background`,
-            source: sql`excluded.source`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Audit log
-      await logAuditEntries(
-        tx,
-        allVals.map((v) => {
-          const old = existingMap.get(v.id);
-          return {
-            recordType: "personnel",
-            recordId: v.id,
-            operation: old ? ("update" as const) : ("insert" as const),
-            oldData: old ? { ...old } : null,
-            newData: { ...v },
-            sourceUrl: v.source ?? null,
-          };
-        })
-      );
-
-      // Post-sync: resolve entity FKs for newly synced rows
-      const syncedIds = items.map((i) => i.id);
-      await resolveEntityFKs(tx, {
+      }),
+      fkResolve: {
         tableName: "personnel",
         fields: [
           { rawIdColumn: "person_id", entityIdColumn: "person_entity_id", displayNameColumn: "person_display_name", entityTypeFilter: "person" },
           { rawIdColumn: "organization_id", entityIdColumn: "org_entity_id", displayNameColumn: "org_display_name", entityTypeFilter: "organization" },
         ],
-        scopeIds: syncedIds,
-      });
+      },
+      toVerdict: (item) => ({
+        recordType: "personnel",
+        recordId: item.id,
+        entityId: item.organizationId,
+        sourceUrl: item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }),
+      // Personnel has unique post-fkResolve handling that the factory's
+      // standard `toThing` can't express:
+      //   1. Strip the "new:" prefix from personId for display name backfill
+      //   2. Re-fetch rows from PG (because fkResolve has updated person_entity_id)
+      //   3. Resolve person + org titles for the things table
+      //   4. Compose title as "personName — role at orgName"
+      // This is the personnel route's 1-hook escape hatch (per Phase 0 audit).
+      postUpsert: async (tx, items) => {
+        const syncedIds = items.map((i) => i.id);
+        const idList = sqlInList(syncedIds);
 
-      // Special handling: backfill display name from "new:" prefix (strip prefix)
-      const idList = sqlInList(syncedIds);
-      await tx.execute(sql`
-        UPDATE personnel SET
-          person_display_name = trim(substring(person_id FROM 5))
-        WHERE person_id LIKE 'new:%'
-          AND person_display_name IS NULL
-          AND id IN (${idList})
-      `);
+        // 1. Backfill display name from "new:" prefix (strip prefix)
+        await tx.execute(sql`
+          UPDATE personnel SET
+            person_display_name = trim(substring(person_id FROM 5))
+          WHERE person_id LIKE 'new:%'
+            AND person_display_name IS NULL
+            AND id IN (${idList})
+        `);
 
-      // Dual-write to things table with resolved names
-      const resolvedItems = await tx
-        .select({
-          id: personnel.id,
-          personId: personnel.personId,
-          personDisplayName: personnel.personDisplayName,
-          personEntityId: personnel.personEntityId,
-          role: personnel.role,
-          organizationId: personnel.organizationId,
-          source: personnel.source,
-        })
-        .from(personnel)
-        .where(inArray(personnel.id, syncedIds));
+        // 2. Re-fetch rows so things sync uses fkResolve-updated values
+        const resolvedItems = await tx
+          .select({
+            id: personnel.id,
+            personId: personnel.personId,
+            personDisplayName: personnel.personDisplayName,
+            personEntityId: personnel.personEntityId,
+            role: personnel.role,
+            organizationId: personnel.organizationId,
+            source: personnel.source,
+          })
+          .from(personnel)
+          .where(inArray(personnel.id, syncedIds));
 
-      // Resolve person + org IDs to human-readable titles in a single query
-      const resolvedPersonIds = resolvedItems
-        .filter((r) => r.personEntityId)
-        .map((r) => r.personEntityId!);
-      const orgIds = [...new Set(resolvedItems.map((p) => p.organizationId))];
-      const titleMap = await resolveEntityTitles(tx, [...resolvedPersonIds, ...orgIds]);
+        // 3. Resolve person + org IDs to human-readable titles in a single query
+        const resolvedPersonIds = resolvedItems
+          .filter((r) => r.personEntityId)
+          .map((r) => r.personEntityId!);
+        const orgIds = [...new Set(resolvedItems.map((p) => p.organizationId))];
+        const titleMap = await resolveEntityTitles(tx, [
+          ...resolvedPersonIds,
+          ...orgIds,
+        ]);
 
-      await upsertThingsInTx(
-        tx,
-        resolvedItems.map((p) => {
-          const personName = (p.personEntityId ? titleMap.get(p.personEntityId) : null)
-            ?? p.personDisplayName
-            ?? cleanPersonId(p.personId)
-            ?? p.personId;
-          const orgName = titleMap.get(p.organizationId) ?? p.organizationId;
-          return {
-            id: p.id,
-            thingType: "personnel" as const,
-            title: `${personName} — ${p.role} at ${orgName}`,
-            sourceTable: "personnel",
-            sourceId: p.id,
-            sourceUrl: p.source,
-          };
-        })
-      );
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "personnel",
-          recordId: item.id,
-          entityId: item.organizationId,
-          sourceUrl: item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    logSourceCheckCoverage("personnel/sync", items.length, verdictsResult.written);
-
-    // Link verified claims to records (best-effort — records already committed)
-    let claimsLinked = 0;
-    let claimLinkingError: string | null = null;
-    if (allClaimIds.length > 0) {
-      try {
-        const rawDb = getDb();
-        const linkResult = await linkClaimsToRecords(rawDb, items.map((item) => ({
-          recordId: item.id,
-          recordType: "personnel",
-          claimIds: item.claimIds,
-        })));
-        claimsLinked = linkResult.linked;
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        claimLinkingError = msg;
-        logger.warn({ error: msg }, "claim linking failed (records already committed)");
-      }
-    }
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written, claimsLinked, ...(claimLinkingError && { claimLinkingError }) });
-  })
+        // 4. Dual-write to things table
+        await upsertThingsInTx(
+          tx,
+          resolvedItems.map((p) => {
+            const personName =
+              (p.personEntityId ? titleMap.get(p.personEntityId) : null) ??
+              p.personDisplayName ??
+              cleanPersonId(p.personId) ??
+              p.personId;
+            const orgName = titleMap.get(p.organizationId) ?? p.organizationId;
+            return {
+              id: p.id,
+              thingType: "personnel" as const,
+              title: `${personName} — ${p.role} at ${orgName}`,
+              sourceTable: "personnel",
+              sourceId: p.id,
+              sourceUrl: p.source,
+            };
+          }),
+        );
+      },
+    }),
+  )
 
   // ---- POST /delete ----
   .post("/delete", async (c) => {

--- a/apps/wiki-server/src/routes/tablebase/platform-accounts.ts
+++ b/apps/wiki-server/src/routes/tablebase/platform-accounts.ts
@@ -8,6 +8,7 @@
  */
 
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, sql, isNull, count } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -21,6 +22,8 @@ import {
 } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 const VALID_PLATFORMS = [
   "lesswrong",
@@ -144,45 +147,18 @@ const platformAccountsApp = new Hono()
   })
 
   // POST /sync — batch upsert
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!platform-accounts` falls back to legacy.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) {
-      return validationError(
-        c,
-        parsed.error.issues.map((i) => i.message).join(", ")
-      );
+    if (useFactoryFor("platform-accounts")) {
+      return factorySyncHandler(c);
     }
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    const entityIds = items.map((i) => i.entityStableId).filter((id): id is string => id != null);
-    if (entityIds.length > 0) {
-      const refError = await validateEntityRefs(c, db, [
-        { fieldName: "entityStableId", ids: entityIds },
-      ]);
-      if (refError) return refError;
-    }
-
-    const result = await db
-      .insert(platformAccounts)
-      .values(items.map(toRow))
-      .onConflictDoUpdate({
-        target: [platformAccounts.platform, platformAccounts.platformUsername],
-        set: {
-          platformUserId: sql`COALESCE(EXCLUDED.platform_user_id, platform_accounts.platform_user_id)`,
-          entityStableId: sql`COALESCE(EXCLUDED.entity_stable_id, platform_accounts.entity_stable_id)`,
-          displayName: sql`COALESCE(EXCLUDED.display_name, platform_accounts.display_name)`,
-          profileUrl: sql`COALESCE(EXCLUDED.profile_url, platform_accounts.profile_url)`,
-          updatedAt: sql`now()`,
-        },
-      })
-      .returning({ id: platformAccounts.id });
-
-    return c.json({ upserted: result.length }, 201);
+    return legacySyncHandler(c);
   })
 
   // DELETE /:id — remove a mapping
@@ -205,6 +181,83 @@ const platformAccountsApp = new Hono()
 
     return c.json({ deleted: deleted[0].id }, 200);
   });
+
+// ---- Factory implementation (Phase 2 migration) ----
+//
+// Escape hatch: composite `conflictTarget` + COALESCE-preservation
+// `conflictSet`. Per the factory's 1-hook rule, composite-key handling
+// (target + set) counts as a single escape hatch family.
+//
+// Notable: platform_accounts uses a bigserial `id` primary key and identifies
+// rows by the composite (platform, platformUsername). toRow omits `id` so
+// the DB assigns it on insert, and the COALESCE SET clause preserves any
+// existing non-null fields on conflict (so partial syncs don't clobber data).
+
+const factorySyncHandler = createSyncHandler<SyncItem & { id?: string }, typeof platformAccounts>({
+  name: "platform-accounts",
+  table: platformAccounts,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    {
+      fieldName: "entityStableId",
+      ids: items
+        .map((i) => i.entityStableId)
+        .filter((id): id is string => id != null),
+    },
+  ],
+  toRow: (item) => toRow(item),
+  conflictTarget: [platformAccounts.platform, platformAccounts.platformUsername],
+  conflictSet: {
+    platformUserId: sql`COALESCE(EXCLUDED.platform_user_id, platform_accounts.platform_user_id)`,
+    entityStableId: sql`COALESCE(EXCLUDED.entity_stable_id, platform_accounts.entity_stable_id)`,
+    displayName: sql`COALESCE(EXCLUDED.display_name, platform_accounts.display_name)`,
+    profileUrl: sql`COALESCE(EXCLUDED.profile_url, platform_accounts.profile_url)`,
+    updatedAt: sql`now()`,
+  },
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(
+      c,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    );
+  }
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const entityIds = items.map((i) => i.entityStableId).filter((id): id is string => id != null);
+  if (entityIds.length > 0) {
+    const refError = await validateEntityRefs(c, db, [
+      { fieldName: "entityStableId", ids: entityIds },
+    ]);
+    if (refError) return refError;
+  }
+
+  const result = await db
+    .insert(platformAccounts)
+    .values(items.map(toRow))
+    .onConflictDoUpdate({
+      target: [platformAccounts.platform, platformAccounts.platformUsername],
+      set: {
+        platformUserId: sql`COALESCE(EXCLUDED.platform_user_id, platform_accounts.platform_user_id)`,
+        entityStableId: sql`COALESCE(EXCLUDED.entity_stable_id, platform_accounts.entity_stable_id)`,
+        displayName: sql`COALESCE(EXCLUDED.display_name, platform_accounts.display_name)`,
+        profileUrl: sql`COALESCE(EXCLUDED.profile_url, platform_accounts.profile_url)`,
+        updatedAt: sql`now()`,
+      },
+    })
+    .returning({ id: platformAccounts.id });
+
+  return c.json({ upserted: result.length }, 201);
+}
 
 export const platformAccountsRoute = platformAccountsApp;
 export type PlatformAccountsRoute = typeof platformAccountsApp;

--- a/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+++ b/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, count } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -14,6 +15,8 @@ import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-enti
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -113,37 +116,107 @@ const policyStakeholdersApp = new Hono<{ Variables: ResolvedEntityVars }>()
   })
 
   // POST /sync — upsert stakeholders batch
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!policy-stakeholders` to fall back.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("policy-stakeholders")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncStakeholderBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(policyStakeholders, "policy_stakeholders"));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 migration) ----
 
-    // Validate policyEntityId only. stakeholderEntityId is optional and may
-    // reference entities not yet synced to PG (build-data explicitly expects
-    // some to be missing — wiki-server-data.mjs has fallback logic for this).
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "policyEntityId", ids: items.map((i) => i.policyEntityId) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "policy-stakeholders",
+  table: policyStakeholders,
+  batchSchema: SyncStakeholderBatchSchema,
+  // Validate policyEntityId only. stakeholderEntityId is optional and may
+  // reference entities not yet synced to PG (build-data explicitly expects
+  // some to be missing — wiki-server-data.mjs has fallback logic for this).
+  entityRefFields: (items) => [
+    { fieldName: "policyEntityId", ids: items.map((i) => i.policyEntityId) },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    policyEntityId: item.policyEntityId,
+    stakeholderEntityId: item.stakeholderEntityId ?? null,
+    stakeholderDisplayName: item.stakeholderDisplayName,
+    position: item.position,
+    importance: item.importance ?? null,
+    reason: item.reason ?? null,
+    source: item.source ?? null,
+    context: item.context ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+  thingsTitleIds: (items) => [...new Set(items.map((i) => i.policyEntityId))],
+  toThing: (item, titleMap) => {
+    const policyTitle = titleMap.get(item.policyEntityId) ?? item.policyEntityId;
+    return {
+      id: item.id,
+      thingType: "policy-stakeholder" as const,
+      title: `${item.stakeholderDisplayName} on ${policyTitle}`,
+      sourceTable: "policy_stakeholders",
+      sourceId: item.id,
+      parentThingId: item.policyEntityId,
+      parentTitle: policyTitle,
+      sourceUrl: item.source ?? null,
+    };
+  },
+});
 
-    const now = new Date();
-    let upserted = 0;
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    await db.transaction(async (tx) => {
-      // Resolve policy entity titles for thing titles
-      const policyIds = [...new Set(items.map((i) => i.policyEntityId))];
-      const titleMap = await resolveEntityTitles(tx, policyIds);
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-      for (const item of items) {
-        await tx
-          .insert(policyStakeholders)
-          .values({
-            id: item.id,
+  const parsed = SyncStakeholderBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  // Validate policyEntityId only. stakeholderEntityId is optional and may
+  // reference entities not yet synced to PG (build-data explicitly expects
+  // some to be missing — wiki-server-data.mjs has fallback logic for this).
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "policyEntityId", ids: items.map((i) => i.policyEntityId) },
+  ]);
+  if (refError) return refError;
+
+  const now = new Date();
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    // Resolve policy entity titles for thing titles
+    const policyIds = [...new Set(items.map((i) => i.policyEntityId))];
+    const titleMap = await resolveEntityTitles(tx, policyIds);
+
+    for (const item of items) {
+      await tx
+        .insert(policyStakeholders)
+        .values({
+          id: item.id,
+          policyEntityId: item.policyEntityId,
+          stakeholderEntityId: item.stakeholderEntityId ?? null,
+          stakeholderDisplayName: item.stakeholderDisplayName,
+          position: item.position,
+          importance: item.importance ?? null,
+          reason: item.reason ?? null,
+          source: item.source ?? null,
+          context: item.context ?? null,
+          syncedAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: policyStakeholders.id,
+          set: {
             policyEntityId: item.policyEntityId,
             stakeholderEntityId: item.stakeholderEntityId ?? null,
             stakeholderDisplayName: item.stakeholderDisplayName,
@@ -154,48 +227,32 @@ const policyStakeholdersApp = new Hono<{ Variables: ResolvedEntityVars }>()
             context: item.context ?? null,
             syncedAt: now,
             updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: policyStakeholders.id,
-            set: {
-              policyEntityId: item.policyEntityId,
-              stakeholderEntityId: item.stakeholderEntityId ?? null,
-              stakeholderDisplayName: item.stakeholderDisplayName,
-              position: item.position,
-              importance: item.importance ?? null,
-              reason: item.reason ?? null,
-              source: item.source ?? null,
-              context: item.context ?? null,
-              syncedAt: now,
-              updatedAt: now,
-            },
-          });
-        upserted++;
-      }
+          },
+        });
+      upserted++;
+    }
 
-      // Dual-write to things table
-      const policyTitle = (policyId: string) =>
-        titleMap.get(policyId) ?? policyId;
+    // Dual-write to things table
+    const policyTitle = (policyId: string) =>
+      titleMap.get(policyId) ?? policyId;
 
-      await upsertThingsInTx(
-        tx,
-        items.map((i) => ({
-          id: i.id,
-          thingType: "policy-stakeholder" as const,
-          title: `${i.stakeholderDisplayName} on ${policyTitle(i.policyEntityId)}`,
-          sourceTable: "policy_stakeholders",
-          sourceId: i.id,
-          parentThingId: i.policyEntityId,
-          parentTitle: policyTitle(i.policyEntityId),
-          sourceUrl: i.source ?? null,
-        }))
-      );
-    });
+    await upsertThingsInTx(
+      tx,
+      items.map((i) => ({
+        id: i.id,
+        thingType: "policy-stakeholder" as const,
+        title: `${i.stakeholderDisplayName} on ${policyTitle(i.policyEntityId)}`,
+        sourceTable: "policy_stakeholders",
+        sourceId: i.id,
+        parentThingId: i.policyEntityId,
+        parentTitle: policyTitle(i.policyEntityId),
+        sourceUrl: i.source ?? null,
+      }))
+    );
+  });
 
-    return c.json({ upserted });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(policyStakeholders, "policy_stakeholders"));
+  return c.json({ upserted });
+}
 
 export const policyStakeholdersRoute = policyStakeholdersApp;
 export type PolicyStakeholdersRoute = typeof policyStakeholdersApp;

--- a/apps/wiki-server/src/routes/tablebase/political-offices.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-offices.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, count, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
@@ -16,6 +17,8 @@ import {
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -205,31 +208,90 @@ const politicalOfficesApp = new Hono()
   })
 
   // POST /sync
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!political-offices` to fall back.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("political-offices")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(politicalOffices, null));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 migration) ----
 
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "political-offices",
+  table: politicalOffices,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId) },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    politicianEntityId: item.politicianEntityId,
+    politicianDisplayName: item.politicianDisplayName ?? null,
+    officeType: item.officeType,
+    jurisdiction: item.jurisdiction,
+    district: item.district ?? null,
+    party: item.party ?? null,
+    status: item.status,
+    termStart: item.termStart ?? null,
+    termEnd: item.termEnd ?? null,
+    sourceUrl: item.sourceUrl ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+});
 
-    logger.info(`sync political-offices: upserting ${items.length} offices`);
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    let upserted = 0;
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-    await db.transaction(async (tx) => {
-      for (const item of items) {
-        await tx
-          .insert(politicalOffices)
-          .values({
-            id: item.id,
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId) },
+  ]);
+  if (refError) return refError;
+
+  logger.info(`sync political-offices: upserting ${items.length} offices`);
+
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    for (const item of items) {
+      await tx
+        .insert(politicalOffices)
+        .values({
+          id: item.id,
+          politicianEntityId: item.politicianEntityId,
+          politicianDisplayName: item.politicianDisplayName ?? null,
+          officeType: item.officeType,
+          jurisdiction: item.jurisdiction,
+          district: item.district ?? null,
+          party: item.party ?? null,
+          status: item.status,
+          termStart: item.termStart ?? null,
+          termEnd: item.termEnd ?? null,
+          sourceUrl: item.sourceUrl ?? null,
+          notes: item.notes ?? null,
+          syncedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: politicalOffices.id,
+          set: {
             politicianEntityId: item.politicianEntityId,
             politicianDisplayName: item.politicianDisplayName ?? null,
             officeType: item.officeType,
@@ -243,33 +305,14 @@ const politicalOfficesApp = new Hono()
             notes: item.notes ?? null,
             syncedAt: new Date(),
             updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: politicalOffices.id,
-            set: {
-              politicianEntityId: item.politicianEntityId,
-              politicianDisplayName: item.politicianDisplayName ?? null,
-              officeType: item.officeType,
-              jurisdiction: item.jurisdiction,
-              district: item.district ?? null,
-              party: item.party ?? null,
-              status: item.status,
-              termStart: item.termStart ?? null,
-              termEnd: item.termEnd ?? null,
-              sourceUrl: item.sourceUrl ?? null,
-              notes: item.notes ?? null,
-              syncedAt: new Date(),
-              updatedAt: new Date(),
-            },
-          });
-        upserted++;
-      }
-    });
+          },
+        });
+      upserted++;
+    }
+  });
 
-    return c.json({ upserted });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(politicalOffices, null));
+  return c.json({ upserted });
+}
 
 export const politicalOfficesRoute = politicalOfficesApp;
 export type PoliticalOfficesRoute = typeof politicalOfficesApp;

--- a/apps/wiki-server/src/routes/tablebase/political-scores.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-scores.ts
@@ -4,18 +4,14 @@ import { eq, and, count, desc, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { getDrizzleDb } from "../../db.js";
-import { logger } from "../../logger.js";
 import { politicalScores, entities } from "../../schema.js";
 import {
-  parseJsonBody,
-  validationError,
-  invalidJsonError,
   zv,
   clampedLimit,
 } from "../shared/utils.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
-import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
 
@@ -215,69 +211,42 @@ const politicalScoresApp = new Hono()
     return c.json({ scores: rows.map(formatRow), total: rows.length });
   })
 
-  // POST /sync
-  .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId) },
-      { fieldName: "scorerEntityId", ids: items.map((i) => i.scorerEntityId).filter((id): id is string => id != null) },
-    ]);
-    if (refError) return refError;
-
-    logger.info(`sync political-scores: upserting ${items.length} scores`);
-
-    let upserted = 0;
-
-    await db.transaction(async (tx) => {
-      for (const item of items) {
-        await tx
-          .insert(politicalScores)
-          .values({
-            id: item.id,
-            politicianEntityId: item.politicianEntityId,
-            politicianDisplayName: item.politicianDisplayName ?? null,
-            scorerOrg: item.scorerOrg,
-            scorerEntityId: item.scorerEntityId ?? null,
-            score: String(item.score),
-            maxScore: String(item.maxScore),
-            year: item.year,
-            scoreType: item.scoreType ?? null,
-            sourceUrl: item.sourceUrl ?? null,
-            notes: item.notes ?? null,
-            syncedAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: politicalScores.id,
-            set: {
-              politicianEntityId: item.politicianEntityId,
-              politicianDisplayName: item.politicianDisplayName ?? null,
-              scorerOrg: item.scorerOrg,
-              scorerEntityId: item.scorerEntityId ?? null,
-              score: String(item.score),
-              maxScore: String(item.maxScore),
-              year: item.year,
-              scoreType: item.scoreType ?? null,
-              sourceUrl: item.sourceUrl ?? null,
-              notes: item.notes ?? null,
-              syncedAt: new Date(),
-              updatedAt: new Date(),
-            },
-          });
-        upserted++;
-      }
-    });
-
-    return c.json({ upserted });
-  })
+  // POST /sync — uses sync-factory (Phase 1 pilot, Tier 3)
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "political-scores",
+      table: politicalScores,
+      batchSchema: SyncBatchSchema,
+      toRow: (item, now) => ({
+        id: item.id,
+        politicianEntityId: item.politicianEntityId,
+        politicianDisplayName: item.politicianDisplayName ?? null,
+        scorerOrg: item.scorerOrg,
+        scorerEntityId: item.scorerEntityId ?? null,
+        score: String(item.score),
+        maxScore: String(item.maxScore),
+        year: item.year,
+        scoreType: item.scoreType ?? null,
+        sourceUrl: item.sourceUrl ?? null,
+        notes: item.notes ?? null,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+      entityRefFields: (items) => [
+        {
+          fieldName: "politicianEntityId",
+          ids: items.map((i) => i.politicianEntityId),
+        },
+        {
+          fieldName: "scorerEntityId",
+          ids: items
+            .map((i) => i.scorerEntityId)
+            .filter((id): id is string => id != null),
+        },
+      ],
+    }),
+  )
 
   .post("/delete-batch", deleteBatchHandler(politicalScores, null));
 

--- a/apps/wiki-server/src/routes/tablebase/political-votes.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-votes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, count, desc, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
@@ -16,6 +17,8 @@ import {
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -260,32 +263,102 @@ const politicalVotesApp = new Hono()
   })
 
   // POST /sync — batch upsert
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!political-votes` to fall back.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("political-votes")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(politicalVotes, null));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 migration) ----
 
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId).filter((id): id is string => id != null) },
-      { fieldName: "legislationEntityId", ids: items.map((i) => i.legislationEntityId).filter((id): id is string => id != null) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "political-votes",
+  table: politicalVotes,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    {
+      fieldName: "politicianEntityId",
+      ids: items
+        .map((i) => i.politicianEntityId)
+        .filter((id): id is string => id != null),
+    },
+    {
+      fieldName: "legislationEntityId",
+      ids: items
+        .map((i) => i.legislationEntityId)
+        .filter((id): id is string => id != null),
+    },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    politicianEntityId: item.politicianEntityId ?? null,
+    politicianDisplayName: item.politicianDisplayName ?? null,
+    legislationEntityId: item.legislationEntityId ?? null,
+    legislationTitle: item.legislationTitle ?? null,
+    vote: item.vote,
+    voteDate: item.voteDate ?? null,
+    chamber: item.chamber ?? null,
+    rollCallNumber: item.rollCallNumber ?? null,
+    congressNumber: item.congressNumber ?? null,
+    session: item.session ?? null,
+    sourceUrl: item.sourceUrl ?? null,
+    notes: item.notes ?? null,
+    updatedAt: now,
+  }),
+});
 
-    logger.info(`sync political-votes: upserting ${items.length} votes`);
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    let upserted = 0;
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-    await db.transaction(async (tx) => {
-      for (const item of items) {
-        await tx
-          .insert(politicalVotes)
-          .values({
-            id: item.id,
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "politicianEntityId", ids: items.map((i) => i.politicianEntityId).filter((id): id is string => id != null) },
+    { fieldName: "legislationEntityId", ids: items.map((i) => i.legislationEntityId).filter((id): id is string => id != null) },
+  ]);
+  if (refError) return refError;
+
+  logger.info(`sync political-votes: upserting ${items.length} votes`);
+
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    for (const item of items) {
+      await tx
+        .insert(politicalVotes)
+        .values({
+          id: item.id,
+          politicianEntityId: item.politicianEntityId ?? null,
+          politicianDisplayName: item.politicianDisplayName ?? null,
+          legislationEntityId: item.legislationEntityId ?? null,
+          legislationTitle: item.legislationTitle ?? null,
+          vote: item.vote,
+          voteDate: item.voteDate ?? null,
+          chamber: item.chamber ?? null,
+          rollCallNumber: item.rollCallNumber ?? null,
+          congressNumber: item.congressNumber ?? null,
+          session: item.session ?? null,
+          sourceUrl: item.sourceUrl ?? null,
+          notes: item.notes ?? null,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: politicalVotes.id,
+          set: {
             politicianEntityId: item.politicianEntityId ?? null,
             politicianDisplayName: item.politicianDisplayName ?? null,
             legislationEntityId: item.legislationEntityId ?? null,
@@ -299,33 +372,14 @@ const politicalVotesApp = new Hono()
             sourceUrl: item.sourceUrl ?? null,
             notes: item.notes ?? null,
             updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: politicalVotes.id,
-            set: {
-              politicianEntityId: item.politicianEntityId ?? null,
-              politicianDisplayName: item.politicianDisplayName ?? null,
-              legislationEntityId: item.legislationEntityId ?? null,
-              legislationTitle: item.legislationTitle ?? null,
-              vote: item.vote,
-              voteDate: item.voteDate ?? null,
-              chamber: item.chamber ?? null,
-              rollCallNumber: item.rollCallNumber ?? null,
-              congressNumber: item.congressNumber ?? null,
-              session: item.session ?? null,
-              sourceUrl: item.sourceUrl ?? null,
-              notes: item.notes ?? null,
-              updatedAt: new Date(),
-            },
-          });
-        upserted++;
-      }
-    });
+          },
+        });
+      upserted++;
+    }
+  });
 
-    return c.json({ upserted });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(politicalVotes, null));
+  return c.json({ upserted });
+}
 
 export const politicalVotesRoute = politicalVotesApp;
 export type PoliticalVotesRoute = typeof politicalVotesApp;

--- a/apps/wiki-server/src/routes/tablebase/publications.ts
+++ b/apps/wiki-server/src/routes/tablebase/publications.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, desc, sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
@@ -22,6 +23,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -168,34 +171,122 @@ const publicationsApp = new Hono<{ Variables: ResolvedEntityVars }>()
     }
   )
 
+  // ---- POST /sync ----
+  //
+  // Phase 2 Batch C migration (issue #4090, discussion #4088): factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // Rollback: set `USE_SYNC_FACTORY_ROUTES=!publications` to fall back
+  // to the legacy handler instantly without redeploying.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
+    if (useFactoryFor("publications")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
+  })
 
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
+  .post("/delete-batch", deleteBatchHandler(publications, "publications"));
 
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
+// ---- Factory implementation (Phase 2 Batch C) ----
 
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
-    ]);
-    if (refError) return refError;
+const factorySyncHandler = createSyncHandler({
+  name: "publications",
+  table: publications,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ],
+  toRow: (item, now) => ({
+    id: item.id,
+    entityId: item.entityId,
+    entityDisplayName: item.entityDisplayName ?? null,
+    resourceId: item.resourceId ?? null,
+    title: item.title,
+    authors: item.authors ?? null,
+    url: item.url ?? null,
+    venue: item.venue ?? null,
+    publishedDate: item.publishedDate ?? null,
+    publicationType: item.publicationType,
+    citationCount: item.citationCount ?? null,
+    isFlagship: item.isFlagship,
+    abstract: item.abstract ?? null,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }),
+  toThing: (item, titleMap) => ({
+    id: item.id,
+    thingType: "publication" as const,
+    title: item.title,
+    sourceTable: "publications",
+    sourceId: item.id,
+    parentThingId: item.entityId,
+    parentTitle: titleMap.get(item.entityId) ?? item.entityId,
+    sourceUrl: item.url ?? item.source ?? null,
+    description:
+      [item.authors, item.venue, item.publishedDate].filter(Boolean).join(", ") ||
+      null,
+  }),
+  thingsTitleIds: (items) => [...new Set(items.map((i) => i.entityId))],
+  toVerdict: (item) => ({
+    recordType: "publication",
+    recordId: item.id,
+    entityId: item.entityId,
+    sourceUrl: item.url ?? item.source ?? null,
+    sourcing: item.sourcing ?? null,
+  }),
+});
 
-    const now = new Date();
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
 
-    await db.transaction(async (tx) => {
-      const entityIds = [...new Set(items.map((i) => i.entityId))];
-      const titleMap = await resolveEntityTitles(tx, entityIds);
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
 
-      for (const item of items) {
-        await tx
-          .insert(publications)
-          .values({
-            id: item.id,
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+  ]);
+  if (refError) return refError;
+
+  const now = new Date();
+  let upserted = 0;
+  let verdictsResult = { written: 0 };
+
+  await db.transaction(async (tx) => {
+    const entityIds = [...new Set(items.map((i) => i.entityId))];
+    const titleMap = await resolveEntityTitles(tx, entityIds);
+
+    for (const item of items) {
+      await tx
+        .insert(publications)
+        .values({
+          id: item.id,
+          entityId: item.entityId,
+          entityDisplayName: item.entityDisplayName ?? null,
+          resourceId: item.resourceId ?? null,
+          title: item.title,
+          authors: item.authors ?? null,
+          url: item.url ?? null,
+          venue: item.venue ?? null,
+          publishedDate: item.publishedDate ?? null,
+          publicationType: item.publicationType,
+          citationCount: item.citationCount ?? null,
+          isFlagship: item.isFlagship,
+          abstract: item.abstract ?? null,
+          source: item.source ?? null,
+          notes: item.notes ?? null,
+          syncedAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: publications.id,
+          set: {
             entityId: item.entityId,
             entityDisplayName: item.entityDisplayName ?? null,
             resourceId: item.resourceId ?? null,
@@ -212,69 +303,47 @@ const publicationsApp = new Hono<{ Variables: ResolvedEntityVars }>()
             notes: item.notes ?? null,
             syncedAt: now,
             updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: publications.id,
-            set: {
-              entityId: item.entityId,
-              entityDisplayName: item.entityDisplayName ?? null,
-              resourceId: item.resourceId ?? null,
-              title: item.title,
-              authors: item.authors ?? null,
-              url: item.url ?? null,
-              venue: item.venue ?? null,
-              publishedDate: item.publishedDate ?? null,
-              publicationType: item.publicationType,
-              citationCount: item.citationCount ?? null,
-              isFlagship: item.isFlagship,
-              abstract: item.abstract ?? null,
-              source: item.source ?? null,
-              notes: item.notes ?? null,
-              syncedAt: now,
-              updatedAt: now,
-            },
-          });
-        upserted++;
-      }
+          },
+        });
+      upserted++;
+    }
 
-      const entityTitle = (id: string) => titleMap.get(id) ?? id;
+    const entityTitle = (id: string) => titleMap.get(id) ?? id;
 
-      await upsertThingsInTx(
-        tx,
-        items.map((i) => ({
-          id: i.id,
-          thingType: "publication" as const,
-          title: i.title,
-          sourceTable: "publications",
-          sourceId: i.id,
-          parentThingId: i.entityId,
-          parentTitle: entityTitle(i.entityId),
-          sourceUrl: i.url ?? i.source ?? null,
-          description:
-            [i.authors, i.venue, i.publishedDate].filter(Boolean).join(", ") ||
-            null,
-        }))
-      );
+    await upsertThingsInTx(
+      tx,
+      items.map((i) => ({
+        id: i.id,
+        thingType: "publication" as const,
+        title: i.title,
+        sourceTable: "publications",
+        sourceId: i.id,
+        parentThingId: i.entityId,
+        parentTitle: entityTitle(i.entityId),
+        sourceUrl: i.url ?? i.source ?? null,
+        description:
+          [i.authors, i.venue, i.publishedDate].filter(Boolean).join(", ") ||
+          null,
+      }))
+    );
 
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "publication",
-          recordId: item.id,
-          entityId: item.entityId,
-          sourceUrl: item.url ?? item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-    });
+    // Write inline source-check verdicts atomically within the same transaction
+    verdictsResult = await writeInlineVerdicts(
+      tx,
+      items.map((item) => ({
+        recordType: "publication",
+        recordId: item.id,
+        entityId: item.entityId,
+        sourceUrl: item.url ?? item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }))
+    );
+  });
 
-    logSourceCheckCoverage("publications/sync", items.length, verdictsResult.written);
+  logSourceCheckCoverage("publications/sync", items.length, verdictsResult.written);
 
-    return c.json({ upserted, verdictsWritten: verdictsResult.written });
-  })
-
-  .post("/delete-batch", deleteBatchHandler(publications, "publications"));
+  return c.json({ upserted, verdictsWritten: verdictsResult.written });
+}
 
 export const publicationsRoute = publicationsApp;
 export type PublicationsRoute = typeof publicationsApp;

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, count, sql, and } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
@@ -13,6 +14,8 @@ import {
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 import {
   researchAreas,
   researchAreaOrganizations,
@@ -405,81 +408,22 @@ const researchAreasApp = new Hono()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!research-areas` falls back to legacy.
+  //
+  // NOTE: only the main /sync endpoint is migrated. The secondary endpoints
+  // (/sync-organizations, /sync-papers, /sync-grant-links, /sync-risks) are
+  // left unchanged — they sync link tables, not research_areas itself.
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncResearchAreaBatchSchema.safeParse(body);
-    if (!parsed.success) {
-      return validationError(
-        c,
-        parsed.error.issues.map((i) => i.message).join(", ")
-      );
+    if (useFactoryFor("research-areas")) {
+      return factorySyncHandler(c);
     }
-
-    const db = getDrizzleDb();
-    const now = new Date();
-    const { items } = parsed.data;
-
-    const allVals = items.map((item) => ({
-      id: item.id,
-      wikiId: item.wikiId ?? null,
-      title: item.title,
-      description: item.description ?? null,
-      status: item.status,
-      cluster: item.cluster ?? null,
-      parentAreaId: item.parentAreaId ?? null,
-      firstProposed: item.firstProposed ?? null,
-      firstProposedYear: item.firstProposedYear ?? null,
-      tags: item.tags,
-      metadata: item.metadata,
-      source: item.source ?? null,
-      notes: item.notes ?? null,
-      syncedAt: now,
-      updatedAt: now,
-    }));
-
-    await db.transaction(async (tx) => {
-      await tx
-        .insert(researchAreas)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: researchAreas.id,
-          set: {
-            wikiId: sql`excluded.wiki_id`,
-            title: sql`excluded.title`,
-            description: sql`excluded.description`,
-            status: sql`excluded.status`,
-            cluster: sql`excluded.cluster`,
-            parentAreaId: sql`excluded.parent_area_id`,
-            firstProposed: sql`excluded.first_proposed`,
-            firstProposedYear: sql`excluded.first_proposed_year`,
-            tags: sql`excluded.tags`,
-            metadata: sql`excluded.metadata`,
-            source: sql`excluded.source`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`excluded.synced_at`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
-
-      // Dual-write to things table
-      await upsertThingsInTx(
-        tx,
-        items.map((ra) => ({
-          id: ra.id,
-          thingType: "research-area" as const,
-          title: ra.title,
-          sourceTable: "research_areas",
-          sourceId: ra.id,
-          description: ra.description,
-          sourceUrl: ra.source,
-          href: `/research-areas/${ra.id}`,
-        }))
-      );
-    });
-
-    return c.json({ upserted: items.length });
+    return legacySyncHandler(c);
   })
 
   // ---- POST /sync-organizations ----
@@ -936,6 +880,118 @@ const researchAreasApp = new Hono()
   })
 
   .post("/delete-batch", deleteBatchHandler(researchAreas, "research_areas"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+
+const factorySyncHandler = createSyncHandler({
+  name: "research-areas",
+  table: researchAreas,
+  batchSchema: SyncResearchAreaBatchSchema,
+  toRow: (item) => ({
+    id: item.id,
+    wikiId: item.wikiId ?? null,
+    title: item.title,
+    description: item.description ?? null,
+    status: item.status,
+    cluster: item.cluster ?? null,
+    parentAreaId: item.parentAreaId ?? null,
+    firstProposed: item.firstProposed ?? null,
+    firstProposedYear: item.firstProposedYear ?? null,
+    tags: item.tags,
+    metadata: item.metadata,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+  }),
+  toThing: (item) => ({
+    id: item.id,
+    thingType: "research-area" as const,
+    title: item.title,
+    sourceTable: "research_areas",
+    sourceId: item.id,
+    description: item.description,
+    sourceUrl: item.source,
+    href: `/research-areas/${item.id}`,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncResearchAreaBatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(
+      c,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    );
+  }
+
+  const db = getDrizzleDb();
+  const now = new Date();
+  const { items } = parsed.data;
+
+  const allVals = items.map((item) => ({
+    id: item.id,
+    wikiId: item.wikiId ?? null,
+    title: item.title,
+    description: item.description ?? null,
+    status: item.status,
+    cluster: item.cluster ?? null,
+    parentAreaId: item.parentAreaId ?? null,
+    firstProposed: item.firstProposed ?? null,
+    firstProposedYear: item.firstProposedYear ?? null,
+    tags: item.tags,
+    metadata: item.metadata,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+    syncedAt: now,
+    updatedAt: now,
+  }));
+
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(researchAreas)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: researchAreas.id,
+        set: {
+          wikiId: sql`excluded.wiki_id`,
+          title: sql`excluded.title`,
+          description: sql`excluded.description`,
+          status: sql`excluded.status`,
+          cluster: sql`excluded.cluster`,
+          parentAreaId: sql`excluded.parent_area_id`,
+          firstProposed: sql`excluded.first_proposed`,
+          firstProposedYear: sql`excluded.first_proposed_year`,
+          tags: sql`excluded.tags`,
+          metadata: sql`excluded.metadata`,
+          source: sql`excluded.source`,
+          notes: sql`excluded.notes`,
+          syncedAt: sql`excluded.synced_at`,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
+
+    // Dual-write to things table
+    await upsertThingsInTx(
+      tx,
+      items.map((ra) => ({
+        id: ra.id,
+        thingType: "research-area" as const,
+        title: ra.title,
+        sourceTable: "research_areas",
+        sourceId: ra.id,
+        description: ra.description,
+        sourceUrl: ra.source,
+        href: `/research-areas/${ra.id}`,
+      }))
+    );
+  });
+
+  return c.json({ upserted: items.length });
+}
 
 export const researchAreasRoute = researchAreasApp;
 export type ResearchAreasRoute = typeof researchAreasApp;

--- a/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
+++ b/apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import { eq, and, count, desc, asc, sql, gte, lte } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -17,6 +18,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { writeInlineVerdicts, logSourceCheckCoverage } from "./write-inline-verdicts.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -338,92 +341,172 @@ const secondaryMarketPricesApp = new Hono<{ Variables: ResolvedEntityVars }>()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!secondary-market-prices`
   .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const { items } = parsed.data;
-    const db = getDrizzleDb();
-
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "companyId", ids: items.map((i) => i.companyId) },
-    ]);
-    if (refError) return refError;
-
-    let upserted = 0;
-    let verdictsResult = { written: 0 };
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
-        id: item.id,
-        companyId: item.companyId,
-        platform: item.platform,
-        date: item.date,
-        pricePerShare: toNum(item.pricePerShare),
-        impliedValuation: toNum(item.impliedValuation),
-        impliedValuationLow: toNum(item.impliedValuationLow),
-        impliedValuationHigh: toNum(item.impliedValuationHigh),
-        volume: toNum(item.volume),
-        openInterest: toNum(item.openInterest),
-        bidPrice: toNum(item.bidPrice),
-        askPrice: toNum(item.askPrice),
-        spreadPercent: toNum(item.spreadPercent),
-        priceType: item.priceType,
-        source: item.source ?? null,
-        notes: item.notes ?? null,
-      }));
-
-      await tx
-        .insert(secondaryMarketPrices)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: [
-            secondaryMarketPrices.companyId,
-            secondaryMarketPrices.platform,
-            secondaryMarketPrices.date,
-            secondaryMarketPrices.priceType,
-          ],
-          set: {
-            pricePerShare: sql`excluded.price_per_share`,
-            impliedValuation: sql`excluded.implied_valuation`,
-            impliedValuationLow: sql`excluded.implied_valuation_low`,
-            impliedValuationHigh: sql`excluded.implied_valuation_high`,
-            volume: sql`excluded.volume`,
-            openInterest: sql`excluded.open_interest`,
-            bidPrice: sql`excluded.bid_price`,
-            askPrice: sql`excluded.ask_price`,
-            spreadPercent: sql`excluded.spread_percent`,
-            source: sql`excluded.source`,
-            notes: sql`excluded.notes`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-
-      // Write inline source-check verdicts atomically within the same transaction
-      verdictsResult = await writeInlineVerdicts(
-        tx,
-        items.map((item) => ({
-          recordType: "secondary-market-price",
-          recordId: item.id,
-          entityId: item.companyId,
-          sourceUrl: item.source ?? null,
-          sourcing: item.sourcing ?? null,
-        }))
-      );
-
-      upserted = allVals.length;
-    });
-
-    logSourceCheckCoverage("secondary-market-prices/sync", items.length, verdictsResult.written);
-
-    return c.json({ upserted, verdictsWritten: verdictsResult.written });
+    if (useFactoryFor("secondary-market-prices")) {
+      return factorySyncHandler(c);
+    }
+    return legacySyncHandler(c);
   })
 
   .post("/delete-batch", deleteBatchHandler(secondaryMarketPrices, "secondary_market_prices"));
+
+// ---- Factory implementation (Phase 2 migration) ----
+//
+// Notable: this route uses a COMPOSITE conflict target — the unique key
+// is (companyId, platform, date, priceType), not the row id. The factory
+// supports composite targets via `conflictTarget: [col1, col2, ...]`.
+// The conflictSet override omits the conflict-target columns since they
+// match by definition on conflict.
+
+const factorySyncHandler = createSyncHandler({
+  name: "secondary-market-prices",
+  table: secondaryMarketPrices,
+  batchSchema: SyncBatchSchema,
+  entityRefFields: (items) => [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+  ],
+  toRow: (item) => ({
+    id: item.id,
+    companyId: item.companyId,
+    platform: item.platform,
+    date: item.date,
+    pricePerShare: toNum(item.pricePerShare),
+    impliedValuation: toNum(item.impliedValuation),
+    impliedValuationLow: toNum(item.impliedValuationLow),
+    impliedValuationHigh: toNum(item.impliedValuationHigh),
+    volume: toNum(item.volume),
+    openInterest: toNum(item.openInterest),
+    bidPrice: toNum(item.bidPrice),
+    askPrice: toNum(item.askPrice),
+    spreadPercent: toNum(item.spreadPercent),
+    priceType: item.priceType,
+    source: item.source ?? null,
+    notes: item.notes ?? null,
+  }),
+  conflictTarget: [
+    secondaryMarketPrices.companyId,
+    secondaryMarketPrices.platform,
+    secondaryMarketPrices.date,
+    secondaryMarketPrices.priceType,
+  ],
+  // Explicit SET clause to omit the conflict-target columns (no-op on conflict).
+  conflictSet: {
+    pricePerShare: sql`excluded.price_per_share`,
+    impliedValuation: sql`excluded.implied_valuation`,
+    impliedValuationLow: sql`excluded.implied_valuation_low`,
+    impliedValuationHigh: sql`excluded.implied_valuation_high`,
+    volume: sql`excluded.volume`,
+    openInterest: sql`excluded.open_interest`,
+    bidPrice: sql`excluded.bid_price`,
+    askPrice: sql`excluded.ask_price`,
+    spreadPercent: sql`excluded.spread_percent`,
+    source: sql`excluded.source`,
+    notes: sql`excluded.notes`,
+    syncedAt: sql`now()`,
+    updatedAt: sql`now()`,
+  },
+  toVerdict: (item) => ({
+    recordType: "secondary-market-price",
+    recordId: item.id,
+    entityId: item.companyId,
+    sourceUrl: item.source ?? null,
+    sourcing: item.sourcing ?? null,
+  }),
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const body = await parseJsonBody(c);
+  if (!body) return invalidJsonError(c);
+
+  const parsed = SyncBatchSchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const { items } = parsed.data;
+  const db = getDrizzleDb();
+
+  const refError = await validateEntityRefs(c, db, [
+    { fieldName: "companyId", ids: items.map((i) => i.companyId) },
+  ]);
+  if (refError) return refError;
+
+  let upserted = 0;
+  let verdictsResult = { written: 0 };
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => ({
+      id: item.id,
+      companyId: item.companyId,
+      platform: item.platform,
+      date: item.date,
+      pricePerShare: toNum(item.pricePerShare),
+      impliedValuation: toNum(item.impliedValuation),
+      impliedValuationLow: toNum(item.impliedValuationLow),
+      impliedValuationHigh: toNum(item.impliedValuationHigh),
+      volume: toNum(item.volume),
+      openInterest: toNum(item.openInterest),
+      bidPrice: toNum(item.bidPrice),
+      askPrice: toNum(item.askPrice),
+      spreadPercent: toNum(item.spreadPercent),
+      priceType: item.priceType,
+      source: item.source ?? null,
+      notes: item.notes ?? null,
+    }));
+
+    await tx
+      .insert(secondaryMarketPrices)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: [
+          secondaryMarketPrices.companyId,
+          secondaryMarketPrices.platform,
+          secondaryMarketPrices.date,
+          secondaryMarketPrices.priceType,
+        ],
+        set: {
+          pricePerShare: sql`excluded.price_per_share`,
+          impliedValuation: sql`excluded.implied_valuation`,
+          impliedValuationLow: sql`excluded.implied_valuation_low`,
+          impliedValuationHigh: sql`excluded.implied_valuation_high`,
+          volume: sql`excluded.volume`,
+          openInterest: sql`excluded.open_interest`,
+          bidPrice: sql`excluded.bid_price`,
+          askPrice: sql`excluded.ask_price`,
+          spreadPercent: sql`excluded.spread_percent`,
+          source: sql`excluded.source`,
+          notes: sql`excluded.notes`,
+          syncedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      });
+
+    // Write inline source-check verdicts atomically within the same transaction
+    verdictsResult = await writeInlineVerdicts(
+      tx,
+      items.map((item) => ({
+        recordType: "secondary-market-price",
+        recordId: item.id,
+        entityId: item.companyId,
+        sourceUrl: item.source ?? null,
+        sourcing: item.sourcing ?? null,
+      }))
+    );
+
+    upserted = allVals.length;
+  });
+
+  logSourceCheckCoverage("secondary-market-prices/sync", items.length, verdictsResult.written);
+
+  return c.json({ upserted, verdictsWritten: verdictsResult.written });
+}
 
 // ---- Exports ----
 

--- a/apps/wiki-server/src/routes/tablebase/sync-factory-flag.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory-flag.ts
@@ -1,0 +1,108 @@
+/**
+ * Per-route feature flag for the TableBase sync handler factory rollout.
+ *
+ * Provides instant per-route rollback during Phase 2+ of the factory migration.
+ * Read by routes that have BOTH a factory implementation and a legacy handler
+ * coexisting during the 7-day soak period after migration.
+ *
+ * Discussion #4088, issue #4090.
+ *
+ * ## Behavior
+ *
+ * The `USE_SYNC_FACTORY_ROUTES` env var controls which routes use the factory:
+ *
+ * | Env value                   | Effect                                      |
+ * |-----------------------------|---------------------------------------------|
+ * | (unset) or empty            | Factory ON for all routes (default)         |
+ * | `*`                         | Factory ON for all routes (explicit)        |
+ * | `personnel,divisions`       | Factory ON only for those routes; others fall back to legacy |
+ * | `!political-scores`         | Factory ON for all routes EXCEPT political-scores            |
+ * | `!a,!b,!c`                  | Factory ON for all routes EXCEPT a, b, c                     |
+ *
+ * The exclusion mode (`!routeName`) is the primary use case during migration:
+ * if a route breaks after factory adoption, operators set
+ * `USE_SYNC_FACTORY_ROUTES=!broken-route` to immediately fall back to the
+ * legacy handler without redeploying.
+ *
+ * ## Migration pattern
+ *
+ * Phase 2 migration PRs follow this pattern:
+ *
+ * ```typescript
+ * import { useFactoryFor } from "./sync-factory-flag.js";
+ *
+ * const myApp = new Hono()
+ *   .post("/sync", async (c) => {
+ *     if (useFactoryFor("my-route")) {
+ *       return factoryHandler(c);
+ *     }
+ *     return legacyHandler(c);
+ *   });
+ *
+ * const factoryHandler = createSyncHandler({ ... });
+ * const legacyHandler = async (c: Context) => { ... };
+ * ```
+ *
+ * After 7 days of clean metrics, a separate PR removes the legacy handler
+ * and the conditional, leaving only the factory call.
+ *
+ * ## Testing
+ *
+ * The flag is cached after the first call. Tests must call `_resetFlagCache()`
+ * in `beforeEach` to pick up `vi.stubEnv("USE_SYNC_FACTORY_ROUTES", "...")`
+ * changes.
+ */
+
+const FLAG_ENV = "USE_SYNC_FACTORY_ROUTES";
+
+let cached: Set<string> | null = null;
+
+function parseFlag(): Set<string> {
+  if (cached) return cached;
+  const raw = process.env[FLAG_ENV] ?? "";
+  cached = new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  return cached;
+}
+
+/**
+ * Returns true if the named route should use the factory implementation.
+ * Returns false if the route should fall back to its legacy handler.
+ *
+ * @param routeName - The route name (e.g. "personnel", "divisions"). Must
+ *   match the `name` field in the route's `createSyncHandler` config.
+ */
+export function useFactoryFor(routeName: string): boolean {
+  const flag = parseFlag();
+
+  // Default (no env var set) → factory ON for all
+  if (flag.size === 0) return true;
+
+  // Wildcard → factory ON for all
+  if (flag.has("*")) return true;
+
+  // Explicit exclusion → factory OFF for this route
+  if (flag.has(`!${routeName}`)) return false;
+
+  // Check if the flag is in exclusion mode (any "!"-prefixed entries)
+  const hasExclusions = [...flag].some((s) => s.startsWith("!"));
+  if (hasExclusions) {
+    // Exclusion mode: ON for all routes not explicitly excluded
+    return true;
+  }
+
+  // Inclusion mode: ON only for explicitly listed routes
+  return flag.has(routeName);
+}
+
+/**
+ * Reset the cached flag value. Tests must call this in `beforeEach` after
+ * stubbing `process.env.USE_SYNC_FACTORY_ROUTES` to pick up the new value.
+ */
+export function _resetFlagCache(): void {
+  cached = null;
+}

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -1,0 +1,655 @@
+/**
+ * `createSyncHandler<TItem, TTable>()` — Factory for TableBase POST /sync handlers.
+ *
+ * Implements the 7-phase pipeline shared by all TableBase sync routes:
+ *   1. Parse JSON body
+ *   2. Validate (Zod schema, natural key, source-check, entity FK, claims, custom preValidate)
+ *   3. Upsert (batch INSERT...ON CONFLICT, auto-chunked for Postgres param limit)
+ *   4. Audit log (single batch insert per chunk; existing-row pre-fetch in batch)
+ *   5. Entity FK resolve (post-upsert backfill via resolveEntityFKs)
+ *   6. Things dual-write (resolveEntityTitles + upsertThingsInTx)
+ *   7. Verdicts + claim linking (writeInlineVerdicts in tx; linkClaimsToRecords post-tx)
+ *
+ * Each phase is gated by config presence — a route that doesn't need a feature
+ * simply omits the relevant config field. The factory returns a plain Hono
+ * handler function `(c: Context) => Promise<Response>`, preserving Hono RPC
+ * type inference (verified by sync-factory.test-d.ts).
+ *
+ * Per the Phase 0 audit (issue #4089):
+ *   - Auto-chunks based on Postgres parameter limit (60000 / columnCount)
+ *   - Hooks (preValidate, postUpsert) receive `tx`; throwing rolls back the entire sync
+ *   - SET clause is auto-derived from toRow's output keys + getTableColumns(table)
+ *   - Errors are wrapped in SyncPhaseError({ route, phase, cause }) for stack-trace context
+ *
+ * See discussion #4088 for the full design rationale.
+ */
+
+import type { Context } from "hono";
+import type { z } from "zod";
+import { sql, inArray, getTableColumns } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import type { PgTable, PgColumn } from "drizzle-orm/pg-core";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type * as schema from "../../schema.js";
+import { getDrizzleDb, getDb } from "../../db.js";
+import { logger } from "../../logger.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+} from "../shared/utils.js";
+import {
+  validateEntityRefs,
+  type EntityRefField,
+} from "../shared/validate-entity-refs.js";
+import { enforceSourceCheck } from "../shared/source-check-enforcement.js";
+import {
+  validateClaimRefs,
+  linkClaimsToRecords,
+} from "../shared/validate-claims.js";
+import {
+  resolveEntityFKs,
+  type ResolveEntityFKsOptions,
+} from "../shared/resolve-entity-fks.js";
+import {
+  upsertThingsInTx,
+  resolveEntityTitles,
+  type ThingSyncInput,
+} from "../shared/thing-sync.js";
+import { logAuditEntries } from "./audit-log.js";
+import {
+  writeInlineVerdicts,
+  logSourceCheckCoverage,
+} from "./write-inline-verdicts.js";
+import type { InlineSourcing } from "./sourcing-schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Tx = PgTransaction<
+  PostgresJsQueryResultHKT,
+  typeof schema,
+  ExtractTablesWithRelations<typeof schema>
+>;
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+type RawDb = ReturnType<typeof getDb>;
+
+/** A record-shaped object the factory will write to the table. */
+type Row = Record<string, unknown>;
+
+/** Inline source-check verdict input shape (matches writeInlineVerdicts). */
+export interface VerdictInput {
+  recordType: string;
+  recordId: string;
+  entityId?: string | null;
+  sourceUrl?: string | null;
+  sourcing?: InlineSourcing | null;
+}
+
+/**
+ * SyncConfig — declarative configuration for a TableBase sync handler.
+ *
+ * The minimum required fields are: name, table, batchSchema, toRow.
+ * Every other field is optional and gates a phase of the pipeline.
+ *
+ * @typeParam TItem - The validated item shape (inferred from batchSchema).
+ * @typeParam TTable - The Drizzle table type.
+ */
+export interface SyncConfig<TItem, TTable extends PgTable> {
+  // ---- Required ----
+
+  /** Human-readable route name; appears in logs and error messages. */
+  name: string;
+
+  /** Drizzle table the factory writes to. */
+  table: TTable;
+
+  /**
+   * Zod schema for the batch body. Any schema that outputs `{ items: TItem[] }`
+   * is accepted — including schemas wrapped in `.refine()` (which become
+   * `ZodEffects`) and schemas with extra batch-level fields.
+   *
+   * The factory validates against this and unwraps `parsed.data.items`.
+   */
+  batchSchema: z.ZodType<{ items: TItem[] }>;
+
+  /**
+   * Map a validated item to a row that can be inserted into `table`.
+   * The `now` parameter is a single Date passed to all items in the batch
+   * so all rows have identical syncedAt/updatedAt values.
+   *
+   * Routes that need range parsing (parseRange), display-name backfill, or
+   * other computed columns do them here. The output keys are used to
+   * auto-derive the ON CONFLICT SET clause.
+   */
+  toRow: (item: TItem, now: Date) => Row;
+
+  // ---- Conflict resolution ----
+
+  /**
+   * Conflict target column(s) for ON CONFLICT. Default: `table.id`.
+   * Pass an array for composite primary keys.
+   */
+  conflictTarget?: PgColumn | PgColumn[];
+
+  /**
+   * Override the auto-derived SET clause. Use for routes that need COALESCE
+   * preservation (preserve existing values when new value is null) or other
+   * non-default merge semantics.
+   *
+   * If omitted, the factory auto-derives the SET clause from `toRow`'s output
+   * keys + `getTableColumns(table)`. Standard fields (id, createdAt) are
+   * skipped; syncedAt and updatedAt are set to `now()`.
+   */
+  conflictSet?: Record<string, SQL>;
+
+  // ---- Pre-upsert validation (each gated by presence) ----
+
+  /**
+   * Compute a string key for intra-batch duplicate detection. The factory
+   * builds a Set of these keys and returns 400 on collision. Used to catch
+   * malformed batches before they hit the unique constraint.
+   */
+  naturalKey?: (item: TItem) => string;
+
+  /**
+   * Human-readable error message prefix when natural key collision is found.
+   * Default: `Duplicate natural key in batch`.
+   */
+  naturalKeyError?: string;
+
+  /**
+   * Source-check enforcement. Set to `true` to enforce based on the route name
+   * (looked up in source-check-enforcement.ts SOURCE_CHECK_REQUIRED). Pass a
+   * string to override the table name used for the lookup.
+   */
+  enforceSourceCheck?: boolean | string;
+
+  /**
+   * Entity FK fields to validate pre-insert. Returns one EntityRefField per
+   * FK field. Each field's IDs are batch-checked against the entities table.
+   */
+  entityRefFields?: (items: TItem[]) => EntityRefField[];
+
+  /**
+   * Custom pre-validation hook. Runs AFTER schema validation and entity ref
+   * validation, BEFORE the transaction begins. Return a Response to short-circuit
+   * (factory returns it), or null to proceed.
+   *
+   * Use for custom FK validation against non-entities tables (e.g., grants
+   * checking programIds against funding_programs).
+   *
+   * Hook contract: external side effects forbidden. Throwing returns a 500.
+   */
+  preValidate?: (c: Context, db: Db, items: TItem[]) => Promise<Response | null>;
+
+  // ---- Audit log ----
+
+  /**
+   * Record type for audit log entries (e.g., "grants", "personnel"). Setting
+   * this enables audit logging: the factory pre-fetches existing rows in a
+   * single batch query before each upsert chunk, then writes audit entries
+   * with operation = "insert" | "update".
+   */
+  auditRecordType?: string;
+
+  /**
+   * Optional accessor for the source URL on each audit entry. Default: null.
+   */
+  auditSourceUrl?: (item: TItem) => string | null;
+
+  // ---- Things sync (dual-write) ----
+
+  /**
+   * Map an item to a `things` table row. Setting this enables things sync:
+   * the factory calls `resolveEntityTitles` for the IDs returned by
+   * `thingsTitleIds`, then `upsertThingsInTx`.
+   *
+   * The titleMap is keyed by both slug and stableId.
+   */
+  toThing?: (item: TItem, titleMap: Map<string, string>) => ThingSyncInput;
+
+  /**
+   * Entity IDs to resolve to titles for the `parentTitle` field on things rows.
+   * Default: empty (no titles resolved).
+   */
+  thingsTitleIds?: (items: TItem[]) => string[];
+
+  // ---- Entity FK resolution (post-upsert backfill) ----
+
+  /**
+   * Configuration for `resolveEntityFKs()`. Setting this enables FK resolution:
+   * after the upsert, the factory backfills entity stableIds and display names
+   * for the rows that were just inserted/updated.
+   */
+  fkResolve?: Omit<ResolveEntityFKsOptions, "scopeIds">;
+
+  /**
+   * Function to extract the row IDs to scope FK resolution to. Default:
+   * `items.map(i => (i as any).id)` if items have an `id` property.
+   */
+  fkResolveScopeIds?: (items: TItem[]) => string[];
+
+  // ---- Inline verdicts ----
+
+  /**
+   * Map an item to a verdict record for `writeInlineVerdicts()`. Setting this
+   * enables inline source-check verdict writing within the same transaction.
+   */
+  toVerdict?: (item: TItem) => VerdictInput;
+
+  // ---- Claim linking ----
+
+  /**
+   * Claim validation + linking. Setting this enables:
+   *   - Pre-tx: validateClaimRefs (rejects unknown or non-verified claims)
+   *   - Post-tx: linkClaimsToRecords (creates claim_record_links rows)
+   *
+   * `recordType` is the value used in claim_record_links.record_type.
+   * `getClaimIds` returns the claimIds for an item (or [] if none).
+   */
+  claimSupport?: {
+    recordType: string;
+    getClaimIds: (item: TItem) => number[];
+  };
+
+  // ---- Post-upsert hook ----
+
+  /**
+   * Custom post-upsert hook. Runs INSIDE the transaction, AFTER all standard
+   * phases (audit, FK resolve, things, verdicts). Use for routes with unique
+   * post-processing like personnel.ts's `new:` prefix display-name backfill.
+   *
+   * Hook contract: receives the same `tx` handle, must only do DB work on it,
+   * external side effects forbidden, throwing rolls back the entire sync.
+   */
+  postUpsert?: (tx: Tx, items: TItem[], rows: Row[]) => Promise<void>;
+}
+
+/**
+ * Standard response shape returned by factory-built sync handlers. Routes
+ * that need additional fields can use a postUpsert hook + custom response,
+ * but should keep this baseline.
+ */
+export interface SyncResponse {
+  upserted: number;
+  verdictsWritten: number;
+  claimsLinked: number;
+  claimLinkingError?: string;
+}
+
+// ---------------------------------------------------------------------------
+// SyncPhaseError — wraps errors with route + phase context for stack traces
+// ---------------------------------------------------------------------------
+
+export type SyncPhase =
+  | "parse"
+  | "validate"
+  | "naturalKey"
+  | "enforceSourceCheck"
+  | "validateEntityRefs"
+  | "validateClaimRefs"
+  | "preValidate"
+  | "upsert"
+  | "audit"
+  | "fkResolve"
+  | "things"
+  | "verdicts"
+  | "postUpsert"
+  | "linkClaims";
+
+export class SyncPhaseError extends Error {
+  constructor(
+    public readonly route: string,
+    public readonly phase: SyncPhase,
+    cause: unknown,
+  ) {
+    const message =
+      cause instanceof Error ? cause.message : String(cause);
+    super(`[${route}/${phase}] ${message}`);
+    this.name = "SyncPhaseError";
+    this.cause = cause;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-derive ON CONFLICT SET clause from toRow keys + table columns
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-derive the SET clause for ON CONFLICT DO UPDATE.
+ *
+ * For each key in `sampleRow` (the output of `toRow`), look up the
+ * corresponding column on the table and emit `excluded.<column_name>`.
+ *
+ * Skipped keys: `id`, `createdAt` (PK + immutable timestamp).
+ * Replaced keys: `syncedAt`, `updatedAt` → `now()`.
+ *
+ * If a key is in `sampleRow` but not on the table, it's silently skipped.
+ * (This shouldn't happen if `toRow` returns valid row shapes.)
+ */
+function deriveConflictSet<TTable extends PgTable>(
+  table: TTable,
+  sampleRow: Row,
+): Record<string, SQL> {
+  const cols = getTableColumns(table) as Record<string, PgColumn>;
+  const setClause: Record<string, SQL> = {};
+
+  for (const jsKey of Object.keys(sampleRow)) {
+    if (jsKey === "id" || jsKey === "createdAt") continue;
+    if (jsKey === "syncedAt" || jsKey === "updatedAt") {
+      setClause[jsKey] = sql`now()`;
+      continue;
+    }
+    const col = cols[jsKey];
+    if (!col) continue;
+    // sql.raw is safe here: col.name comes from the schema definition
+    // (developer-controlled), not user input.
+    setClause[jsKey] = sql.raw(`excluded.${col.name}`);
+  }
+
+  return setClause;
+}
+
+// ---------------------------------------------------------------------------
+// Compute chunk size based on Postgres parameter limit
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the maximum number of rows per chunk based on the Postgres
+ * parameter limit (65535) and the column count of the row shape.
+ *
+ * We use 60000 instead of 65535 to leave headroom for the SET clause's
+ * `excluded.*` references and any other parameters in the query.
+ *
+ * Verified by Phase 0 audit: even the largest table (campaignFinance, 25
+ * cols) has 13× headroom on the default 200-row batch.
+ */
+function computeChunkSize(columnCount: number): number {
+  return Math.max(1, Math.floor(60000 / Math.max(1, columnCount)));
+}
+
+// ---------------------------------------------------------------------------
+// Wrap a phase in a try/catch that adds route + phase context to errors
+// ---------------------------------------------------------------------------
+
+async function runPhase<T>(
+  route: string,
+  phase: SyncPhase,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (e instanceof SyncPhaseError) throw e;
+    throw new SyncPhaseError(route, phase, e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Hono handler function for a TableBase /sync endpoint.
+ *
+ * Returns `async (c: Context) => Promise<Response>`. Use it inside a Hono
+ * method-chain like:
+ *
+ *     const myApp = new Hono()
+ *       .get("/stats", ...)
+ *       .post("/sync", createSyncHandler({
+ *         name: "my-table",
+ *         table: myTable,
+ *         batchSchema: SyncBatchSchema,
+ *         toRow: (item, now) => ({ ...item, syncedAt: now, updatedAt: now }),
+ *       }))
+ *       .post("/delete-batch", deleteBatchHandler(myTable, "my_table"));
+ */
+export function createSyncHandler<
+  TItem extends { id?: string },
+  TTable extends PgTable,
+>(config: SyncConfig<TItem, TTable>) {
+  return async (c: Context): Promise<Response> => {
+    const { name, table } = config;
+
+    // ---- Phase 1: parse ----
+    const body = await runPhase(name, "parse", async () => parseJsonBody(c));
+    if (!body) return invalidJsonError(c);
+
+    // ---- Phase 2: validate (schema) ----
+    const parsed = await runPhase(name, "validate", async () =>
+      config.batchSchema.safeParse(body),
+    );
+    if (!parsed.success) {
+      return validationError(c, parsed.error.message);
+    }
+    const items = parsed.data.items as TItem[];
+
+    // ---- Phase 2: enforceSourceCheck ----
+    if (config.enforceSourceCheck) {
+      const tableName =
+        typeof config.enforceSourceCheck === "string"
+          ? config.enforceSourceCheck
+          : name;
+      const err = await runPhase(name, "enforceSourceCheck", async () =>
+        enforceSourceCheck(c, tableName, items as Array<{ sourcing?: unknown }>),
+      );
+      if (err) return err;
+    }
+
+    // ---- Phase 2: natural key collision ----
+    if (config.naturalKey) {
+      const seen = new Set<string>();
+      for (const item of items) {
+        const key = config.naturalKey(item);
+        if (seen.has(key)) {
+          return validationError(
+            c,
+            `${config.naturalKeyError ?? "Duplicate natural key in batch"}: ${key}`,
+          );
+        }
+        seen.add(key);
+      }
+    }
+
+    const db = getDrizzleDb() as unknown as Db; // as-any-ok: schema generic mismatch between getDrizzleDb's return and Db type alias
+
+    // ---- Phase 2: validateEntityRefs ----
+    if (config.entityRefFields) {
+      const fields = config.entityRefFields(items);
+      const refError = await runPhase(name, "validateEntityRefs", async () =>
+        validateEntityRefs(c, db, fields),
+      );
+      if (refError) return refError;
+    }
+
+    // ---- Phase 2: validateClaimRefs ----
+    let allClaimIds: number[] = [];
+    if (config.claimSupport) {
+      const getClaimIds = config.claimSupport.getClaimIds;
+      allClaimIds = items.flatMap((i) => getClaimIds(i) ?? []);
+      if (allClaimIds.length > 0) {
+        const rawDb = getDb();
+        const claimError = await runPhase(name, "validateClaimRefs", async () =>
+          validateClaimRefs(rawDb, allClaimIds),
+        );
+        if (claimError) return validationError(c, claimError);
+      }
+    }
+
+    // ---- Phase 2: preValidate hook ----
+    if (config.preValidate) {
+      const preErr = await runPhase(name, "preValidate", async () =>
+        config.preValidate!(c, db, items),
+      );
+      if (preErr) return preErr;
+    }
+
+    // ---- Phase 3-6: transaction ----
+    const now = new Date();
+    const allVals = items.map((item) => config.toRow(item, now));
+    const columnCount = Object.keys(allVals[0] ?? {}).length;
+    const chunkSize = computeChunkSize(columnCount);
+
+    let upserted = 0;
+    let verdictsResult = { written: 0 };
+
+    const conflictTarget = config.conflictTarget ?? (table as unknown as { id: PgColumn }).id; // as-any-ok: PgTable generic doesn't expose column names; same pattern as deleteBatchHandler
+    const conflictSet =
+      config.conflictSet ?? deriveConflictSet(table, allVals[0] ?? {});
+
+    await db.transaction(async (tx) => {
+      // ---- Phase 3: upsert (chunked) + Phase 4: audit ----
+      for (let offset = 0; offset < allVals.length; offset += chunkSize) {
+        const chunk = allVals.slice(offset, offset + chunkSize);
+        const chunkItems = items.slice(offset, offset + chunkSize);
+
+        // Pre-fetch existing rows for audit log (single batch query per chunk)
+        let existingMap = new Map<string, Row>();
+        if (config.auditRecordType) {
+          await runPhase(name, "audit", async () => {
+            const ids = chunk
+              .map((r) => r.id)
+              .filter((id): id is string => typeof id === "string");
+            if (ids.length === 0) return;
+            const idCol = (table as unknown as { id: PgColumn }).id; // as-any-ok: PgTable generic doesn't expose column names; same pattern as deleteBatchHandler
+            const existing = await tx
+              .select()
+              .from(table as PgTable)
+              .where(inArray(idCol, ids));
+            existingMap = new Map(
+              (existing as Row[]).map((r) => [r.id as string, r]),
+            );
+          });
+        }
+
+        await runPhase(name, "upsert", async () => {
+          await tx
+            .insert(table as PgTable)
+            .values(chunk as Row[])
+            .onConflictDoUpdate({
+              target: conflictTarget,
+              set: conflictSet,
+            });
+        });
+
+        // Write audit log entries for this chunk
+        if (config.auditRecordType) {
+          await runPhase(name, "audit", async () => {
+            const auditEntries = chunk.map((row, i) => {
+              const item = chunkItems[i];
+              const id = row.id as string;
+              const old = existingMap.get(id);
+              return {
+                recordType: config.auditRecordType!,
+                recordId: id,
+                operation: old ? ("update" as const) : ("insert" as const),
+                oldData: old ? { ...old } : null,
+                newData: { ...row },
+                sourceUrl: config.auditSourceUrl
+                  ? config.auditSourceUrl(item)
+                  : (row.source as string | null) ?? (row.sourceUrl as string | null) ?? null,
+              };
+            });
+            await logAuditEntries(tx, auditEntries);
+          });
+        }
+
+        upserted += chunk.length;
+      }
+
+      // ---- Phase 5: FK resolve (after all chunks upserted) ----
+      if (config.fkResolve) {
+        await runPhase(name, "fkResolve", async () => {
+          const scopeIds = config.fkResolveScopeIds
+            ? config.fkResolveScopeIds(items)
+            : items
+                .map((i) => (i as { id?: string }).id)
+                .filter((id): id is string => typeof id === "string");
+          await resolveEntityFKs(tx, {
+            ...config.fkResolve!,
+            scopeIds,
+          });
+        });
+      }
+
+      // ---- Phase 6: things sync ----
+      if (config.toThing) {
+        await runPhase(name, "things", async () => {
+          const titleIds = config.thingsTitleIds
+            ? config.thingsTitleIds(items)
+            : [];
+          const titleMap =
+            titleIds.length > 0
+              ? await resolveEntityTitles(tx, titleIds)
+              : new Map<string, string>();
+          const thingsRows = items.map((item) => config.toThing!(item, titleMap));
+          await upsertThingsInTx(tx, thingsRows);
+        });
+      }
+
+      // ---- Phase 7: verdicts ----
+      if (config.toVerdict) {
+        await runPhase(name, "verdicts", async () => {
+          const verdictRecords = items.map((item) => config.toVerdict!(item));
+          verdictsResult = await writeInlineVerdicts(tx, verdictRecords);
+        });
+      }
+
+      // ---- Custom postUpsert hook ----
+      if (config.postUpsert) {
+        await runPhase(name, "postUpsert", async () => {
+          await config.postUpsert!(tx, items, allVals);
+        });
+      }
+    });
+
+    if (config.toVerdict) {
+      logSourceCheckCoverage(`${name}/sync`, items.length, verdictsResult.written);
+    }
+
+    // ---- Post-tx: link verified claims to records ----
+    let claimsLinked = 0;
+    let claimLinkingError: string | undefined;
+    if (config.claimSupport && allClaimIds.length > 0) {
+      try {
+        const rawDb = getDb();
+        const recordType = config.claimSupport.recordType;
+        const getClaimIds = config.claimSupport.getClaimIds;
+        const linkResult = await linkClaimsToRecords(
+          rawDb,
+          items.map((item) => ({
+            recordId: (item as { id?: string }).id ?? "",
+            recordType,
+            claimIds: getClaimIds(item),
+          })),
+        );
+        claimsLinked = linkResult.linked;
+      } catch (e: unknown) {
+        // Claim linking is best-effort: records already committed. Surface
+        // the error in the response per #4040 contract, but do not roll back.
+        const msg = e instanceof Error ? e.message : String(e);
+        claimLinkingError = msg;
+        logger.warn(
+          { route: name, error: msg },
+          "claim linking failed (records already committed)",
+        );
+      }
+    }
+
+    const response: SyncResponse = {
+      upserted,
+      verdictsWritten: verdictsResult.written,
+      claimsLinked,
+      ...(claimLinkingError ? { claimLinkingError } : {}),
+    };
+    return c.json(response);
+  };
+}

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { z } from "zod";
 import {
   eq,
@@ -28,6 +29,8 @@ import {
   TRIGRAM_SIMILARITY_THRESHOLD,
   TRIGRAM_FALLBACK_THRESHOLD,
 } from "../../search-utils.js";
+import { createSyncHandler } from "./sync-factory.js";
+import { useFactoryFor } from "./sync-factory-flag.js";
 
 // ---- Constants ----
 
@@ -56,6 +59,47 @@ const SearchQuery = z.object({
 
 const StatsQuery = z.object({
   parent_id: z.string().max(100).optional(),
+});
+
+// ---- Sync schemas (hoisted to module scope so the factory handler can use them) ----
+
+const SyncThingSchema = z.object({
+  id: z.string().min(1).max(200),
+  thingType: z.enum(VALID_THING_TYPES),
+  title: z.string().min(1).max(2000),
+  parentThingId: z.string().max(200).optional(),
+  sourceTable: z.string().min(1).max(100),
+  sourceId: z.string().min(1).max(200),
+  entityType: z.string().max(100).optional(),
+  description: z.string().max(10000).optional(),
+  sourceUrl: z.string().max(2048).optional(),
+  wikiId: z.string().max(20).optional(),
+  parentTitle: z.string().max(500).optional(),
+});
+
+type SyncThingItem = z.infer<typeof SyncThingSchema>;
+
+/**
+ * Factory batch schema — the request body uses `things` as the array key,
+ * but the factory contract requires `items`. We use `z.preprocess` to rename
+ * the incoming `things` key to `items` so the output type matches the factory
+ * contract `{ items: TItem[] }` while still accepting the original body shape.
+ */
+const SyncThingsFactoryBatchSchema = z.preprocess(
+  (raw) => {
+    if (raw && typeof raw === "object" && "things" in raw) {
+      return { items: (raw as { things: unknown }).things };
+    }
+    return raw;
+  },
+  z.object({
+    items: z.array(SyncThingSchema).min(1).max(MAX_SYNC_BATCH),
+  })
+);
+
+/** Legacy batch schema — untransformed, used by the legacy handler for shape parity. */
+const SyncThingsLegacyBatchSchema = z.object({
+  things: z.array(SyncThingSchema).min(1).max(MAX_SYNC_BATCH),
 });
 
 // Source-check schemas live in the unified /api/source-checks route. See discussion #2950.
@@ -526,88 +570,137 @@ const thingsApp = new Hono()
   })
 
   // ---- POST /sync ----
+  //
+  // Phase 2 migration (issue #4090, discussion #4088): both factory and
+  // legacy handlers coexist behind USE_SYNC_FACTORY_ROUTES feature flag.
+  // After 7 days of clean metrics with the factory enabled (default), a
+  // follow-up PR will remove `legacySyncHandler` and the conditional.
+  //
+  // Rollback: `USE_SYNC_FACTORY_ROUTES=!things` falls back to legacy.
+  //
+  // NOTE: things is the destination table for all other routes' `toThing`
+  // dual-writes, so the factory config here deliberately omits `toThing` —
+  // the handler doesn't dual-write to itself.
   .post("/sync", async (c) => {
-    const raw = await parseJsonBody(c);
-    if (!raw) return invalidJsonError(c);
-
-    const SyncThingSchema = z.object({
-      id: z.string().min(1).max(200),
-      thingType: z.enum(VALID_THING_TYPES),
-      title: z.string().min(1).max(2000),
-      parentThingId: z.string().max(200).optional(),
-      sourceTable: z.string().min(1).max(100),
-      sourceId: z.string().min(1).max(200),
-      entityType: z.string().max(100).optional(),
-      description: z.string().max(10000).optional(),
-      sourceUrl: z.string().max(2048).optional(),
-      wikiId: z.string().max(20).optional(),
-      parentTitle: z.string().max(500).optional(),
-    });
-
-    const SyncBatchSchema = z.object({
-      things: z.array(SyncThingSchema).min(1).max(MAX_SYNC_BATCH),
-    });
-
-    const parsed = SyncBatchSchema.safeParse(raw);
-    if (!parsed.success) return validationError(c, parsed.error.message);
-
-    const items = parsed.data.things;
-
-    // Reject duplicate (sourceTable, sourceId) within the batch — duplicates
-    // would cause the multi-row upsert to fail and roll back.
-    const seenSourceKeys = new Set<string>();
-    for (const item of items) {
-      const key = `${item.sourceTable}\0${item.sourceId}`;
-      if (seenSourceKeys.has(key)) {
-        return validationError(
-          c,
-          `Duplicate source key in batch: (${item.sourceTable}, ${item.sourceId})`
-        );
-      }
-      seenSourceKeys.add(key);
+    if (useFactoryFor("things")) {
+      return factorySyncHandler(c);
     }
-
-    const db = getDrizzleDb();
-    let upserted = 0;
-
-    await db.transaction(async (tx) => {
-      const allVals = items.map((item) => ({
-        id: item.id,
-        thingType: item.thingType,
-        title: item.title,
-        parentThingId: item.parentThingId ?? null,
-        sourceTable: item.sourceTable,
-        sourceId: item.sourceId,
-        entityType: item.entityType ?? null,
-        description: item.description ?? null,
-        sourceUrl: item.sourceUrl ?? null,
-        wikiId: item.wikiId ?? null,
-      }));
-
-      await tx
-        .insert(things)
-        .values(allVals)
-        .onConflictDoUpdate({
-          target: [things.sourceTable, things.sourceId],
-          set: {
-            // Do NOT update `id` — it's the PK and may be referenced
-            // by external systems. Changing it would break links.
-            thingType: sql`excluded.thing_type`,
-            title: sql`excluded.title`,
-            parentThingId: sql`excluded.parent_thing_id`,
-            entityType: sql`excluded.entity_type`,
-            description: sql`excluded.description`,
-            sourceUrl: sql`excluded.source_url`,
-            wikiId: sql`excluded.wiki_id`,
-            syncedAt: sql`now()`,
-            updatedAt: sql`now()`,
-          },
-        });
-      upserted = allVals.length;
-    });
-
-    return c.json({ upserted });
+    return legacySyncHandler(c);
   });
+
+// ---- Factory implementation (Phase 2 migration) ----
+//
+// Escape hatch: `conflictSet` — things has a composite conflict target
+// `(sourceTable, sourceId)`, and we must not overwrite `id` or the conflict
+// key columns themselves on update. The auto-derived SET clause would include
+// them, so we supply an explicit conflictSet that excludes those columns.
+const factorySyncHandler = createSyncHandler<SyncThingItem, typeof things>({
+  name: "things",
+  table: things,
+  // Cast is required because `z.preprocess` widens the schema's input type
+  // to `unknown`, and the factory's `z.ZodType<{ items: ... }>` constraint is
+  // invariant on the input generic. The runtime output shape matches exactly.
+  batchSchema: SyncThingsFactoryBatchSchema as unknown as z.ZodType<{ items: SyncThingItem[] }>, // as-any-ok: z.preprocess widens input type to unknown, factory's ZodType is invariant on input. Output shape matches exactly.
+  naturalKey: (item) => `${item.sourceTable}\0${item.sourceId}`,
+  naturalKeyError: "Duplicate source key in batch",
+  conflictTarget: [things.sourceTable, things.sourceId],
+  // Explicit conflictSet: the auto-derived clause would include
+  // `id`, `sourceTable`, and `sourceId` — none of which should be written on
+  // an update. `id` is the PK and may be externally referenced; sourceTable
+  // and sourceId are the conflict key itself. The legacy handler produced
+  // exactly this SET clause.
+  conflictSet: {
+    thingType: sql`excluded.thing_type`,
+    title: sql`excluded.title`,
+    parentThingId: sql`excluded.parent_thing_id`,
+    entityType: sql`excluded.entity_type`,
+    description: sql`excluded.description`,
+    sourceUrl: sql`excluded.source_url`,
+    wikiId: sql`excluded.wiki_id`,
+    syncedAt: sql`now()`,
+    updatedAt: sql`now()`,
+  },
+  toRow: (item) => ({
+    id: item.id,
+    thingType: item.thingType,
+    title: item.title,
+    parentThingId: item.parentThingId ?? null,
+    sourceTable: item.sourceTable,
+    sourceId: item.sourceId,
+    entityType: item.entityType ?? null,
+    description: item.description ?? null,
+    sourceUrl: item.sourceUrl ?? null,
+    wikiId: item.wikiId ?? null,
+  }),
+  // No toThing — things is itself the things table; no dual-write.
+});
+
+// ---- Legacy sync handler (kept for 7-day soak window after Phase 2 migration) ----
+
+async function legacySyncHandler(c: Context) {
+  const raw = await parseJsonBody(c);
+  if (!raw) return invalidJsonError(c);
+
+  const parsed = SyncThingsLegacyBatchSchema.safeParse(raw);
+  if (!parsed.success) return validationError(c, parsed.error.message);
+
+  const items = parsed.data.things;
+
+  // Reject duplicate (sourceTable, sourceId) within the batch — duplicates
+  // would cause the multi-row upsert to fail and roll back.
+  const seenSourceKeys = new Set<string>();
+  for (const item of items) {
+    const key = `${item.sourceTable}\0${item.sourceId}`;
+    if (seenSourceKeys.has(key)) {
+      return validationError(
+        c,
+        `Duplicate source key in batch: (${item.sourceTable}, ${item.sourceId})`
+      );
+    }
+    seenSourceKeys.add(key);
+  }
+
+  const db = getDrizzleDb();
+  let upserted = 0;
+
+  await db.transaction(async (tx) => {
+    const allVals = items.map((item) => ({
+      id: item.id,
+      thingType: item.thingType,
+      title: item.title,
+      parentThingId: item.parentThingId ?? null,
+      sourceTable: item.sourceTable,
+      sourceId: item.sourceId,
+      entityType: item.entityType ?? null,
+      description: item.description ?? null,
+      sourceUrl: item.sourceUrl ?? null,
+      wikiId: item.wikiId ?? null,
+    }));
+
+    await tx
+      .insert(things)
+      .values(allVals)
+      .onConflictDoUpdate({
+        target: [things.sourceTable, things.sourceId],
+        set: {
+          // Do NOT update `id` — it's the PK and may be referenced
+          // by external systems. Changing it would break links.
+          thingType: sql`excluded.thing_type`,
+          title: sql`excluded.title`,
+          parentThingId: sql`excluded.parent_thing_id`,
+          entityType: sql`excluded.entity_type`,
+          description: sql`excluded.description`,
+          sourceUrl: sql`excluded.source_url`,
+          wikiId: sql`excluded.wiki_id`,
+          syncedAt: sql`now()`,
+          updatedAt: sql`now()`,
+        },
+      });
+    upserted = allVals.length;
+  });
+
+  return c.json({ upserted });
+}
 
 // ---- Exports ----
 

--- a/crux/commands/tablebase-sync-scaffold.ts
+++ b/crux/commands/tablebase-sync-scaffold.ts
@@ -1,0 +1,324 @@
+/**
+ * `crux tb sync-scaffold <route-name>` — emits a starter TableBase sync route
+ * file using the createSyncHandler factory.
+ *
+ * Without this command, agents adding new sync routes will copy-paste an
+ * existing 200-line handler instead of using the factory. The scaffolder
+ * gives them a 60-line starting point with the minimum config filled in,
+ * plus comments pointing to the optional fields they can add later.
+ *
+ * Usage:
+ *
+ *   crux tb sync-scaffold widgets
+ *     → emits scaffolded route to stdout
+ *
+ *   crux tb sync-scaffold widgets --table-name=widgets
+ *     → uses --table-name as the Drizzle table identifier
+ *       (defaults to camelCased route-name)
+ *
+ *   crux tb sync-scaffold widgets --output=apps/wiki-server/src/routes/tablebase/widgets.ts
+ *     → writes to file (errors if file already exists; pass --force to overwrite)
+ *
+ *   crux tb sync-scaffold widgets --tier=2
+ *     → adds tier-appropriate optional fields (entityRefFields, toThing, toVerdict, ...)
+ *       Default: tier 2. Tier 1 adds auditRecordType + claimSupport. Tier 3 minimal.
+ */
+
+import { existsSync, writeFileSync } from "node:fs";
+import type { CommandOptions as BaseOptions, CommandResult } from "../lib/command-types.ts";
+
+interface CommandOptions extends BaseOptions {
+  "table-name"?: string;
+  output?: string;
+  force?: boolean;
+  tier?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert kebab-case or snake_case to camelCase. */
+function camelCase(name: string): string {
+  return name.replace(/[-_](.)/g, (_, c) => c.toUpperCase());
+}
+
+/** Convert kebab-case to PascalCase for type identifiers. */
+function pascalCase(name: string): string {
+  const camel = camelCase(name);
+  return camel.charAt(0).toUpperCase() + camel.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+interface ScaffoldOptions {
+  routeName: string; // kebab-case, e.g. "widgets" or "political-scores"
+  tableName: string; // Drizzle camelCase identifier, e.g. "widgets"
+  tier: 1 | 2 | 3;
+}
+
+function renderTemplate(opts: ScaffoldOptions): string {
+  const { routeName, tableName, tier } = opts;
+  const PascalName = pascalCase(routeName);
+  const camelName = camelCase(routeName);
+
+  // Tier 1: full features (audit + claims + verdicts + things + FK resolve)
+  // Tier 2: standard (FK validation + things + verdicts)
+  // Tier 3: minimal (FK validation only)
+  const auditField =
+    tier === 1
+      ? `      auditRecordType: ${JSON.stringify(routeName)},\n`
+      : "";
+  const claimField =
+    tier === 1
+      ? `      claimSupport: {
+        recordType: ${JSON.stringify(routeName)},
+        getClaimIds: (item) => item.claimIds ?? [],
+      },\n`
+      : "";
+  const fkResolveField =
+    tier === 1
+      ? `      fkResolve: {
+        tableName: ${JSON.stringify(routeName.replace(/-/g, "_"))},
+        fields: [
+          // TODO: list FK columns to resolve, e.g.:
+          // { rawIdColumn: "entity_id", entityIdColumn: "entity_stable_id", displayNameColumn: "entity_display_name" },
+        ],
+      },\n`
+      : "";
+  const thingsField =
+    tier <= 2
+      ? `      // Things dual-write — TODO: replace ${camelName}Title with the field that
+      // has a human-readable name, and remove if this route doesn't sync to things.
+      thingsTitleIds: (items) => [...new Set(items.map((i) => i.entityId))],
+      toThing: (item, titleMap) => ({
+        id: item.id,
+        thingType: ${JSON.stringify(routeName)},
+        title: item.${camelName}Title ?? item.id,
+        sourceTable: ${JSON.stringify(routeName.replace(/-/g, "_"))},
+        sourceId: item.id,
+        sourceUrl: item.sourceUrl ?? null,
+        parentTitle: titleMap.get(item.entityId) ?? item.entityId,
+      }),\n`
+      : "";
+  const verdictField =
+    tier <= 2
+      ? `      toVerdict: (item) => ({
+        recordType: ${JSON.stringify(routeName)},
+        recordId: item.id,
+        entityId: item.entityId,
+        sourceUrl: item.sourceUrl ?? null,
+        sourcing: item.sourcing ?? null,
+      }),\n`
+      : "";
+  const sourcingField =
+    tier <= 2 ? "  sourcing: InlineSourcingSchema.optional(),\n" : "";
+  const sourcingImport =
+    tier <= 2
+      ? `import { InlineSourcingSchema } from "./sourcing-schema.js";\n`
+      : "";
+
+  return `import { Hono } from "hono";
+import { z } from "zod";
+import { eq, count, desc } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { ${tableName} } from "../../schema.js";
+import { zv, clampedLimit, noDuplicateIds } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+${sourcingImport}
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 200;
+
+// ---- Query schemas ----
+
+const ListQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ---- Sync schema ----
+//
+// TODO: replace these placeholder fields with the real schema for the
+// ${routeName} table. Every field that should be settable by sync clients
+// must be listed here.
+
+const SyncItemSchema = z.object({
+  id: z.string().length(10),
+  // TODO: add fields here
+  entityId: z.string().min(1).max(200),
+${sourcingField}});
+
+const SyncBatchSchema = z.object({
+  items: z
+    .array(SyncItemSchema)
+    .min(1)
+    .max(500)
+    .refine(noDuplicateIds, { message: "Duplicate id values in items array" }),
+});
+
+type SyncItem = z.infer<typeof SyncItemSchema>;
+
+// ---- Helpers ----
+
+function formatRow(r: typeof ${tableName}.$inferSelect) {
+  return {
+    id: r.id,
+    // TODO: add the fields you want exposed by GET /all and /by-entity
+    syncedAt: r.syncedAt,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// ---- Route ----
+
+const ${camelName}App = new Hono()
+
+  // GET /stats
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+    const [row] = await db.select({ total: count() }).from(${tableName});
+    return c.json({ total: row.total });
+  })
+
+  // GET /all
+  .get("/all", zv("query", ListQuery), async (c) => {
+    const { limit, offset } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select()
+      .from(${tableName})
+      .orderBy(desc(${tableName}.syncedAt), ${tableName}.id)
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db.select({ total: count() }).from(${tableName});
+
+    return c.json({ ${camelName}: rows.map(formatRow), total, limit, offset });
+  })
+
+  // POST /sync — uses sync-factory
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: ${JSON.stringify(routeName)},
+      table: ${tableName},
+      batchSchema: SyncBatchSchema,
+      // toRow: maps a validated SyncItem to a row that can be inserted.
+      // The factory uses these keys to auto-derive the ON CONFLICT SET clause.
+      toRow: (item, now) => ({
+        id: item.id,
+        // TODO: map the rest of your item fields to row fields
+        entityId: item.entityId,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+${auditField}${claimField}      // entityRefFields: validates that referenced entities exist before insert.
+      entityRefFields: (items) => [
+        { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+      ],
+${fkResolveField}${thingsField}${verdictField}    }),
+  )
+
+  .post("/delete-batch", deleteBatchHandler(${tableName}, ${JSON.stringify(routeName.replace(/-/g, "_"))}));
+
+// ---- Exports ----
+
+export const ${camelName}Route = ${camelName}App;
+export type ${PascalName}Route = typeof ${camelName}App;
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+async function scaffoldCommand(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const routeName = args.find((a) => !a.startsWith("--"));
+
+  if (!routeName) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux tb sync-scaffold <route-name> [options]
+
+  Emits a starter TableBase sync route file using createSyncHandler.
+  Without this command, agents will copy-paste existing 200-line handlers
+  instead of using the factory.
+
+Options:
+  --table-name=<name>   Drizzle table identifier (default: camelCased route name)
+  --output=<path>       Write to file instead of stdout
+  --force               Overwrite existing file (use with --output)
+  --tier=<1|2|3>        Feature tier (default: 2)
+                          1 = full features (audit, claims, FK resolve, things, verdicts)
+                          2 = standard (FK validation + things + verdicts)
+                          3 = minimal (FK validation only)
+
+Examples:
+  crux tb sync-scaffold widgets
+  crux tb sync-scaffold widgets --table-name=widgets --tier=2
+  crux tb sync-scaffold widgets --output=apps/wiki-server/src/routes/tablebase/widgets.ts`,
+    };
+  }
+
+  // Validate route name format (kebab-case)
+  if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(routeName)) {
+    return {
+      exitCode: 1,
+      output: `Error: route name must be kebab-case (lowercase, hyphens only). Got: ${routeName}`,
+    };
+  }
+
+  const tableName = options["table-name"] ?? camelCase(routeName);
+  const tierRaw = options.tier ?? "2";
+  const tierNum = Number(tierRaw);
+  if (![1, 2, 3].includes(tierNum)) {
+    return {
+      exitCode: 1,
+      output: `Error: --tier must be 1, 2, or 3. Got: ${tierRaw}`,
+    };
+  }
+  const tier = tierNum as 1 | 2 | 3;
+
+  const content = renderTemplate({ routeName, tableName, tier });
+
+  if (options.output) {
+    if (existsSync(options.output) && !options.force) {
+      return {
+        exitCode: 1,
+        output: `Error: ${options.output} already exists. Use --force to overwrite.`,
+      };
+    }
+    writeFileSync(options.output, content);
+    return {
+      exitCode: 0,
+      output: `Wrote ${content.split("\n").length} lines to ${options.output}
+
+Next steps:
+  1. Replace TODO placeholders in the schema (item shape + row mapping)
+  2. Add the route to apps/wiki-server/src/routes/tablebase/index.ts
+  3. Mount the route in apps/wiki-server/src/app.ts
+  4. Add a test in apps/wiki-server/src/__tests__/${routeName}.test.ts
+  5. Run \`pnpm crux w validate gate\` to verify it compiles`,
+    };
+  }
+
+  return { exitCode: 0, output: content };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const commands = {
+  default: scaffoldCommand,
+  scaffold: scaffoldCommand,
+};

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -28,6 +28,7 @@ import { commands as importDivisionsCommands } from './import-divisions.ts';
 import { commands as importFundingProgramsCommands } from './import-funding-programs.ts';
 import { commands as dataSourcesCommands } from './data-sources.ts';
 import { commands as websiteSourcesCommands } from './website-sources.ts';
+import { commands as syncScaffoldCommands } from './tablebase-sync-scaffold.ts';
 
 interface CommandOptions extends BaseOptions {
   top?: string;
@@ -1253,6 +1254,8 @@ export const commands = {
   'website-sources-list': websiteSourcesCommands.list,
   'website-sources-show': websiteSourcesCommands.show,
   'website-sources-fetch': websiteSourcesCommands.fetch,
+  // Sync handler scaffolder (for new tablebase routes)
+  'sync-scaffold': syncScaffoldCommands.scaffold,
 };
 
 export function getHelp(): string {
@@ -1307,6 +1310,10 @@ Commands:
   Market data:
   markets-discover <entity>   Discover prediction market questions via LLM agent
   markets-fetch [entity]      Fetch latest snapshots from platform APIs (Metaculus, etc.)
+
+  Sync handler scaffolding (Phase 2 of factory rollout):
+  sync-scaffold <name>        Emit a starter sync route file using createSyncHandler
+                              Options: --table-name, --output, --tier=1|2|3, --force
 
 Options:
   --table=<name>            Filter scan to specific table; required for submit/existing

--- a/crux/validate/validate-tablebase-completeness.ts
+++ b/crux/validate/validate-tablebase-completeness.ts
@@ -108,6 +108,11 @@ const NON_ROUTE_FILES = new Set([
   "sourcing-schema.ts",
   "write-inline-verdicts.ts",
   "audit-log.ts",
+  // Sync handler factory infrastructure (Phase 1 of factory rollout, #4090).
+  // These are utilities used BY route files, not routes themselves.
+  "sync-factory.ts",
+  "sync-factory-flag.ts",
+  "sync-factory.test-d.ts",
 ]);
 
 // ── Analysis ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 2 Batch C of the [TableBase Sync Handler Factory plan](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4088). **11 routes migrated to `createSyncHandler` in parallel using 4 subagents**, each owning distinct routes (no file conflicts). Closes part of #4090.

**Stacked on PR #4103** → #4099 → #4097.

## Why this PR is large

After validating the migration pattern on 6 routes (Phase 1 pilot + Batches A & B), this PR uses parallel subagents to scale the work. Each subagent owned 3 routes; all 4 ran concurrently. The result is 11 routes migrated in a single session at the same quality bar as the smaller PRs.

## Routes migrated

### Tier 2 (5 routes)

| Route | Hooks | Notes |
|-------|-------|-------|
| `research-areas.ts` (main `/sync` only) | 0 | Secondary endpoints (`/sync-organizations`, `/sync-papers`, `/sync-grant-links`, `/sync-risks`) left hand-rolled |
| `funding-rounds.ts` | 1 (`conflictSet`) | Dropped pre-insert `entityStableIdMap`; factory's `fkResolve` handles entity ID backfill in same tx with COALESCE preservation |
| `things.ts` | 1 (`conflictSet`) | Composite conflict target `[sourceTable, sourceId]`; `z.preprocess` to rename `things` → `items` for factory contract |
| `benchmark-results.ts` | 1 (`preValidate`) | Non-entities FK target — `benchmarkId` references `benchmarks` table, not `entities`. preValidate hook does both the FK check and slug→id auto-resolution |
| `platform-accounts.ts` | 1 (`conflictSet`) | Composite `[platform, platformUsername]` + COALESCE preservation. Bigserial `id` PK; items omit `id` (required generic typing) |

### Tier 3 (6 routes — per-item loops batch-converted)

| Route | Hooks | Notes |
|-------|-------|-------|
| `entity-events.ts` | 0 | Pure Tier 3 → batch upsert |
| `entity-assessments.ts` | 0 | Pure Tier 3 → batch upsert |
| `publications.ts` | 0 | Pure Tier 3 + `toVerdict` for inline source-check |
| `political-votes.ts` | 0 | Nullable politicianEntityId + legislationEntityId; no `syncedAt` column |
| `political-offices.ts` | 0 | Required politicianEntityId |
| `policy-stakeholders.ts` | 0 | policyEntityId validation + things sync |

## Routes skipped

- **`funding-programs.ts`** — needs >1 escape hatch (preValidate for cross-batch dedup + conflictSet for COALESCE on 9 fields + try/catch for 23505 → 400 mapping). Per the rule "max 1 escape hatch per route", this stays hand-rolled. Future: factory enhancement with a `mapTxError` hook would unblock it.

## Tests

**87 new migration tests** across 11 files. Each follows the canonical Phase 2 pattern (factory + legacy paths).

| Route | Tests |
|-------|------:|
| research-areas | 8 |
| funding-rounds | 10 |
| things | 10 |
| benchmark-results | 10 |
| platform-accounts | 9 |
| entity-events | 6 |
| entity-assessments | 6 |
| publications | 6 |
| political-votes | 9 |
| political-offices | 7 |
| policy-stakeholders | 6 |
| **Total** | **87** |

## Notable design decisions

### `funding-rounds`: behavior change

Legacy did pre-insert lookup for `companyId`/`leadInvestor` → entity stableIds. Factory drops this; `fkResolve` populates the FK columns post-upsert in the same tx. With COALESCE preservation in SET, this is functionally equivalent in steady state.

### `things`: `z.preprocess` to bridge naming convention

Route accepts `{things: [...]}` body; factory contract requires `{items: [...]}`. Used `z.preprocess` to rename the key transparently. Net effect: factory mode accepts BOTH `{things}` and `{items}`; legacy still requires `{things}`.

### `benchmark-results`: non-entities FK in `preValidate`

`benchmarkId` references the `benchmarks` table, not `entities`. The preValidate hook does both FK validation and slug→id auto-resolution in a single DB query — counts as 1 hook.

### `platform-accounts`: bigserial `id` + composite key

Items omit `id` entirely (table uses bigserial). Required explicit generic `createSyncHandler<SyncItem & { id?: string }, ...>` to satisfy TypeScript's structural typing.

## Verification

- [x] All 87 new migration tests pass
- [x] All 1025 wiki-server tests pass (was 938 → +87)
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` clean
- [x] `pnpm crux w validate gate --no-cache` — 43/43 gate checks pass
- [x] Hook budget: 0 violations (7 routes use 0 hooks, 4 use 1 hook)

## Cumulative Phase 1+2 progress

| Stage | PR | Routes | Cumulative |
|-------|---:|------:|----------:|
| Phase 1 pilot | #4097 | 3 | 3 |
| Batch A | #4099 | 1 | 4 |
| Batch B | #4103 | 2 | 6 |
| **Batch C (this PR)** | **this** | **11** | **17** |

**17 of 23 factory candidates migrated (74%)**. 5 routes remain for Batch D plus 1 skipped (funding-programs).

## Test plan

- [x] All 87 migration tests pass
- [x] All 1025 wiki-server tests pass
- [x] Type check clean
- [x] Gate passes (43/43)
- [x] Composite conflict targets verified end-to-end
- [x] Non-entities FK target (benchmarks) verified end-to-end
- [ ] Run real syncs against staging endpoints with `USE_SYNC_FACTORY_ROUTES` set both ways (deferred until review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
