### PR TITLE
Fix source-fetcher auto-enqueue blind spot for brand-new URLs

### DIFF
--- a/crux/lib/source-check/source-fetcher.test.ts
+++ b/crux/lib/source-check/source-fetcher.test.ts
@@ -246,4 +246,45 @@ describe('fetchSourceContent self-healing ingest enqueue', () => {
     expect(result.errorMessage).toBe('Source content not in cache — enqueue failed');
     expect(result.ingestEnqueued).toBe(false);
   });
+
+  it('reports enqueue failure when suggestResourcesApi resolves with ok:false', async () => {
+    // Regression: suggestResourcesApi returns ApiResult (discriminated union) and
+    // never throws on API-level failures. A resolved { ok: false } must be
+    // treated the same as a rejected promise — otherwise ingestEnqueued would
+    // be silently true and the record would sit stuck forever.
+    vi.mocked(getCitationContentByUrl).mockResolvedValue({ ok: false, error: 'miss', message: 'no content' } as any);
+    vi.mocked(lookupResourceByUrl).mockResolvedValue({ ok: false, error: 'not_found', message: 'no row' } as any);
+    vi.mocked(suggestResourcesApi).mockResolvedValue({
+      ok: false,
+      error: 'server_error',
+      message: 'wiki-server down',
+    } as any);
+
+    const result = await fetchSourceContent('https://example.com/failing-ok-false');
+
+    expect(result.errorType).toBe('not_cached');
+    expect(result.errorMessage).toBe('Source content not in cache — enqueue failed');
+    expect(result.ingestEnqueued).toBe(false);
+  });
+
+  it('reports enqueue failure when createJob resolves with ok:false', async () => {
+    // Same class of bug on the resourceId branch: createJob returns ApiResult
+    // and a non-throwing failure must not be silently treated as success.
+    vi.mocked(getCitationContentByUrl).mockResolvedValue({ ok: false, error: 'miss', message: 'no content' } as any);
+    vi.mocked(lookupResourceByUrl).mockResolvedValue({
+      ok: true,
+      data: { id: 'res_1', url: 'https://example.com/failing-job', numericId: 1 },
+    } as any);
+    vi.mocked(createJob).mockResolvedValue({
+      ok: false,
+      error: 'server_error',
+      message: 'job queue rejected',
+    } as any);
+
+    const result = await fetchSourceContent('https://example.com/failing-job');
+
+    expect(result.errorType).toBe('not_cached');
+    expect(result.errorMessage).toBe('Source content not in cache — enqueue failed');
+    expect(result.ingestEnqueued).toBe(false);
+  });
 });

--- a/crux/lib/source-check/source-fetcher.test.ts
+++ b/crux/lib/source-check/source-fetcher.test.ts
@@ -1,8 +1,29 @@
 /**
  * Tests for source-fetcher.ts
  */
-import { describe, it, expect } from 'vitest';
-import { isPrivateHost, htmlToText } from './source-fetcher.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isPrivateHost, htmlToText, fetchSourceContent } from './source-fetcher.ts';
+
+// Mock wiki-server dependencies so fetchSourceContent runs offline.
+vi.mock('../wiki-server/citations.ts', () => ({
+  getCitationContentByUrl: vi.fn(),
+}));
+vi.mock('../wiki-server/resources.ts', () => ({
+  lookupResourceByUrl: vi.fn(),
+  suggestResourcesApi: vi.fn().mockResolvedValue({ ok: true, data: { results: [], batchId: 'test' } }),
+}));
+vi.mock('../wiki-server/jobs.ts', () => ({
+  createJob: vi.fn().mockResolvedValue({ ok: true, data: { id: 123 } }),
+}));
+vi.mock('../wayback.ts', () => ({
+  lookupWaybackSnapshot: vi.fn().mockResolvedValue(null),
+  fetchWaybackContent: vi.fn(),
+  formatWaybackTimestamp: vi.fn(),
+}));
+
+import { getCitationContentByUrl } from '../wiki-server/citations.ts';
+import { lookupResourceByUrl, suggestResourcesApi } from '../wiki-server/resources.ts';
+import { createJob } from '../wiki-server/jobs.ts';
 
 describe('isPrivateHost', () => {
   it('blocks localhost', () => {
@@ -159,5 +180,70 @@ describe('htmlToText', () => {
     const text = htmlToText(html);
     // <main> has < 200 chars, so falls back to full HTML
     expect(text).toContain('Full body content');
+  });
+});
+
+describe('fetchSourceContent self-healing ingest enqueue', () => {
+  beforeEach(() => {
+    vi.mocked(getCitationContentByUrl).mockReset();
+    vi.mocked(lookupResourceByUrl).mockReset();
+    vi.mocked(createJob).mockReset();
+    vi.mocked(suggestResourcesApi).mockReset();
+    vi.mocked(createJob).mockResolvedValue({ ok: true, data: { id: 123 } } as any);
+    vi.mocked(suggestResourcesApi).mockResolvedValue({ ok: true, data: { results: [], batchId: 'test' } } as any);
+  });
+
+  it('enqueues a resource-ingest job when resource row exists but content is missing', async () => {
+    vi.mocked(getCitationContentByUrl).mockResolvedValue({ ok: false, error: 'miss', message: 'no content' } as any);
+    vi.mocked(lookupResourceByUrl).mockResolvedValue({
+      ok: true,
+      data: { id: 'res-abc123', url: 'https://example.com/page', fetchStatus: null },
+    } as any);
+
+    const result = await fetchSourceContent('https://example.com/page');
+
+    expect(result.errorType).toBe('not_cached');
+    expect(result.errorMessage).toBe('Source content not in cache — resource-ingest job enqueued');
+    expect(result.ingestEnqueued).toBe(true);
+    // Should have used createJob (fast path) for existing resource
+    expect(vi.mocked(createJob)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'resource-ingest',
+        params: { resourceId: 'res-abc123', url: 'https://example.com/page' },
+        dedupKey: 'ingest:res-abc123',
+      }),
+    );
+    // Should NOT have called suggestResourcesApi when we already have a resource row
+    expect(vi.mocked(suggestResourcesApi)).not.toHaveBeenCalled();
+  });
+
+  it('registers via /suggest when URL has no resource row (the bug fix)', async () => {
+    vi.mocked(getCitationContentByUrl).mockResolvedValue({ ok: false, error: 'miss', message: 'no content' } as any);
+    // lookupResourceByUrl returns 404 / not found
+    vi.mocked(lookupResourceByUrl).mockResolvedValue({ ok: false, error: 'not_found', message: 'no row' } as any);
+
+    const result = await fetchSourceContent('https://brand-new-url.example.com/path');
+
+    expect(result.errorType).toBe('not_cached');
+    expect(result.errorMessage).toBe('Source content not in cache — resource-ingest job enqueued');
+    expect(result.ingestEnqueued).toBe(true);
+    // Should have used suggestResourcesApi (the new branch) — registers + enqueues in one shot
+    expect(vi.mocked(suggestResourcesApi)).toHaveBeenCalledWith({
+      urls: ['https://brand-new-url.example.com/path'],
+    });
+    // Should NOT have called createJob directly — /suggest does that server-side
+    expect(vi.mocked(createJob)).not.toHaveBeenCalled();
+  });
+
+  it('gracefully reports enqueue failure without throwing', async () => {
+    vi.mocked(getCitationContentByUrl).mockResolvedValue({ ok: false, error: 'miss', message: 'no content' } as any);
+    vi.mocked(lookupResourceByUrl).mockResolvedValue({ ok: false, error: 'not_found', message: 'no row' } as any);
+    vi.mocked(suggestResourcesApi).mockRejectedValue(new Error('network down'));
+
+    const result = await fetchSourceContent('https://example.com/failing');
+
+    expect(result.errorType).toBe('not_cached');
+    expect(result.errorMessage).toBe('Source content not in cache — enqueue failed');
+    expect(result.ingestEnqueued).toBe(false);
   });
 });

--- a/crux/lib/source-check/source-fetcher.ts
+++ b/crux/lib/source-check/source-fetcher.ts
@@ -209,16 +209,26 @@ export async function fetchSourceContent(
   // Fire-and-forget: don't block the caller or fail the source-check.
   let ingestEnqueued = false;
   try {
+    // `createJob` and `suggestResourcesApi` both return `Promise<ApiResult<...>>`
+    // (a discriminated union — they never throw on API-level failures). We must
+    // check `.ok` explicitly, otherwise a failing API call silently produces
+    // `ingestEnqueued = true` and the record sits stuck forever.
     if (resourceId) {
-      await createJob({
+      const jobResult = await createJob({
         type: 'resource-ingest',
         params: { resourceId, url },
         priority: 1, // Slightly elevated — source-check is actively waiting for this
         dedupKey: `ingest:${resourceId}`,
       });
+      if (!jobResult.ok) {
+        throw new Error(jobResult.message ?? 'createJob returned ok=false');
+      }
     } else {
       // Brand-new URL: register + enqueue via /suggest in one call.
-      await suggestResourcesApi({ urls: [url] });
+      const suggestResult = await suggestResourcesApi({ urls: [url] });
+      if (!suggestResult.ok) {
+        throw new Error(suggestResult.message ?? 'suggestResourcesApi returned ok=false');
+      }
     }
     ingestEnqueued = true;
     console.log(`${logPrefix} Auto-enqueued resource-ingest for ${url}`);

--- a/crux/lib/source-check/source-fetcher.ts
+++ b/crux/lib/source-check/source-fetcher.ts
@@ -24,7 +24,7 @@ import {
 import { isDeadFetchStatus } from './types.ts';
 import { getCitationContentByUrl } from '../wiki-server/citations.ts';
 import { createJob } from '../wiki-server/jobs.ts';
-import { lookupResourceByUrl } from '../wiki-server/resources.ts';
+import { lookupResourceByUrl, suggestResourcesApi } from '../wiki-server/resources.ts';
 import { lookupWaybackSnapshot, fetchWaybackContent, formatWaybackTimestamp } from '../wayback.ts';
 import { isPrivateHost } from '../url-utils.ts';
 import { htmlToText } from '../html-utils.ts';
@@ -196,22 +196,35 @@ export async function fetchSourceContent(
 
   // Auto-enqueue a resource-ingest job so the content gets fetched for next time
   // (self-healing pipeline, Discussion #3499 Issue H).
+  //
+  // Two cases:
+  //   1. resourceId exists → enqueue ingest job directly (fast path)
+  //   2. resourceId is null → URL has never been seen; call /api/resources/suggest
+  //      which hashIds the URL, inserts a bare resources row, and enqueues the
+  //      ingest job in one shot. Without this branch, records with brand-new
+  //      source URLs (common after manual curation or agentic source-discover)
+  //      stall forever — the error message said "run resource-ingest first" but
+  //      no self-healing actually happened. See milestone "Anthropic → 100% green".
+  //
   // Fire-and-forget: don't block the caller or fail the source-check.
   let ingestEnqueued = false;
-  if (resourceId) {
-    try {
+  try {
+    if (resourceId) {
       await createJob({
         type: 'resource-ingest',
         params: { resourceId, url },
         priority: 1, // Slightly elevated — source-check is actively waiting for this
         dedupKey: `ingest:${resourceId}`,
       });
-      ingestEnqueued = true;
-      console.log(`${logPrefix} Auto-enqueued resource-ingest for ${url}`);
-    } catch (e: unknown) {
-      // Best-effort — don't fail source-check if enqueue fails
-      console.warn(`${logPrefix} Failed to auto-enqueue ingest for ${url}: ${e instanceof Error ? e.message : String(e)}`);
+    } else {
+      // Brand-new URL: register + enqueue via /suggest in one call.
+      await suggestResourcesApi({ urls: [url] });
     }
+    ingestEnqueued = true;
+    console.log(`${logPrefix} Auto-enqueued resource-ingest for ${url}`);
+  } catch (e: unknown) {
+    // Best-effort — don't fail source-check if enqueue fails
+    console.warn(`${logPrefix} Failed to auto-enqueue ingest for ${url}: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   return {
@@ -219,7 +232,7 @@ export async function fetchSourceContent(
     errorType: 'not_cached',
     errorMessage: ingestEnqueued
       ? 'Source content not in cache — resource-ingest job enqueued'
-      : 'Source content not in cache — run resource-ingest first',
+      : 'Source content not in cache — enqueue failed',
     ingestEnqueued,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a blind spot in the source-check pipeline's self-healing auto-enqueue: when a record's source URL has no resource row yet (the common case after manual curation or agentic source discovery), no ingest job was queued. The error message said "run resource-ingest first" but no self-healing actually happened — records stalled indefinitely.

**Before**: `source-fetcher.ts:201` only ran `createJob` inside `if (resourceId)`. For URLs with no pre-existing resource row, the pipeline silently reported "not_cached" on every run.

**After**: when `resourceId` is null, call `suggestResourcesApi({ urls: [url] })` which hashIds the URL, inserts a bare resources row, and enqueues the ingest job in one shot. Reuses the existing `/api/resources/suggest` endpoint (see `apps/wiki-server/src/routes/wikibase/resources.ts:605`) rather than duplicating its logic.

## How it was discovered

While curating Anthropic personnel records, I updated 21 records with hand-picked authoritative sources (arXiv papers, Anthropic blog posts, personal sites, reputable press). The first orchestrator pass hit 11 `not_cached` errors. Of those:

- 5 URLs already had resource rows (from unrelated earlier work) → auto-enqueued, worker processed them in ~15 min, verified on next pass
- 6 URLs were brand-new → NOT auto-enqueued, pipeline frozen forever

`GET /api/resources/lookup?url=X` returned 404 for all 6. Manually calling `POST /api/resources/suggest` with the URL list completed ingest for all 6 in ~2 seconds (the worker is fast; the issue was that no job was ever queued).

Without this fix, QUA-210 (source-discover v2) would inherit the same bug at scale — every new URL proposed by the agent would stall.

## Changes

| File | Diff |
|---|---|
| `crux/lib/source-check/source-fetcher.ts` | Import `suggestResourcesApi`; new branch in the auto-enqueue block at line 201 that calls `suggestResourcesApi({ urls: [url] })` when `resourceId` is null. Expanded the code comment to explain both code paths. Updated the error message on the null-enqueue failure path from "run resource-ingest first" (misleading — there is no such CLI action) to "enqueue failed". |
| `crux/lib/source-check/source-fetcher.test.ts` | 3 new tests with vitest mocks for `getCitationContentByUrl`, `lookupResourceByUrl`, `suggestResourcesApi`, `createJob`, and wayback functions. Cover: (1) existing resource + missing content → createJob fast path, (2) missing resource → suggestResourcesApi bug-fix path, (3) enqueue failure → graceful degradation with `ingestEnqueued: false`. |

## Test plan

- [x] `pnpm vitest run crux/lib/source-check/source-fetcher.test.ts` — 28/28 tests pass (3 new + 25 existing)
- [x] Manual verification on prod: the 7 stuck Anthropic URLs were all resolved by calling `POST /api/resources/suggest` directly; worker processed them in ~2 seconds; next orchestrator pass verified them
- [x] No TypeScript errors introduced (pre-existing `apps/web` test errors in the base commit are unrelated)
- [ ] After merge: monitor next scheduled source-check run for any new `run resource-ingest first` errors (should be zero; the only remaining null-enqueue path is failure-to-call-suggest which logs and continues)

## Related

- **Closes #QUA-218** (filed in Linear during the investigation)
- Unblocks **QUA-210** (source-discover v2) — the new agentic pipeline must not inherit this blind spot
- Part of milestone "Anthropic → 100% green" — the curation that surfaced this bug pushed Anthropic personnel from 41% verified-or-better to 100% after the manual workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling when source content is missing: the system now attempts to register missing resources and enqueue ingestion automatically, and returns clearer error messages when enqueueing fails.

* **Tests**
  * Added comprehensive tests covering self-healing enqueue flows and failure scenarios to ensure predictable behavior when content is not cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->