### PR TITLE
feat: auto-sync Linear issues on PR merge via native GitHub integration

### DIFF
--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -141,7 +141,7 @@ if [ -n "$LINEAR_ID" ] && [ -n "$PR_URL" ]; then
 fi
 ```
 
-Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` keeps this best-effort so a missing key doesn't abort the ship flow. Linear → Done happens automatically when the PR merges, via the release workflow.
+Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` keeps this best-effort so a missing key doesn't abort the ship flow. Linear → Done happens automatically when the PR merges, via Linear's native GitHub integration — **but only if** the branch name contains `qua-NNN` or the PR body contains `Fixes QUA-NNN`. `crux gh pr create` auto-injects the latter from the branch name, checklist metadata, and `--linear` flag.
 
 ## Step 6: Session log
 

--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -18,6 +18,8 @@ When the session is working on a tracked issue, encode the issue ID in the branc
 
 Both GitHub (`fix-NNN`) and Linear (`qua-NNN`) patterns are auto-detected by `crux sys agent-checklist init`. Linear detection also falls back to any bare `QUA-NNN` token in the task description, and can be overridden with `--linear=QUA-NNN`.
 
+**Linear branch naming is critical for auto-close.** Linear's GitHub integration auto-moves issues to Done on PR merge, but only if the branch name contains `qua-NNN`. If you name the branch `claude/tier0-data-integrity` instead of `claude/qua-155-tier0-data-integrity`, Linear won't link the PR and the issue stays open after merge. `agent-checklist init` warns about this. As a fallback, `crux gh pr create` auto-injects `Fixes QUA-NNN` into the PR body.
+
 ### CI-fix dedup check (when triggered by a CI failure, not a GitHub issue)
 
 Before creating a branch to fix a CI failure, check for existing fix attempts:

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -29,7 +29,7 @@ import { registerAgent, listActiveAgents } from '../lib/wiki-server/active-agent
 import { syncToMain } from '../lib/git.ts';
 import { commands as issuesCommands } from './issues.ts';
 import { commands as linearCommands } from './linear.ts';
-import { resolveLinearId } from '../lib/linear/parse-id.ts';
+import { resolveLinearId, parseLinearId } from '../lib/linear/parse-id.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -155,6 +155,19 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   if (!linearId) {
     const detected = resolveLinearId([branch, task]);
     if (detected) linearId = detected;
+  }
+
+  // Warn if Linear ID detected but branch name doesn't encode it.
+  // Linear's GitHub integration auto-moves issues on PR merge only when it can
+  // link the PR — which requires the branch name to contain the issue ID.
+  let linearBranchWarning = '';
+  if (linearId && !parseLinearId(branch)) {
+    const suggested = `claude/${linearId.toLowerCase()}-${task.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/,'').slice(0, 40)}`;
+    linearBranchWarning =
+      `\n${c.yellow}⚠ Branch "${branch}" does not contain the Linear ID ${linearId}.${c.reset}\n` +
+      `  Linear's GitHub integration won't auto-close the issue on PR merge.\n` +
+      `  ${c.dim}Suggested: git checkout -b ${suggested}${c.reset}\n` +
+      `  ${c.dim}Or: include "Fixes ${linearId}" in the PR description (done automatically by \`crux gh pr create\`).${c.reset}\n`;
   }
 
   const metadata: ChecklistMetadata = { task, branch, timestamp: new Date().toISOString(), issue, linearId };
@@ -294,6 +307,7 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   output += `  Items: ${status.totalItems}\n`;
   if (dbSynced) output += `  ${c.dim}Synced to wiki-server DB${c.reset}\n`;
   if (directoryWarning) output += directoryWarning;
+  if (linearBranchWarning) output += linearBranchWarning;
   if (issueStartOutput) output += `\n${issueStartOutput}`;
   if (linearStartOutput) output += `\n${linearStartOutput}`;
 

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeClosesSyntax, validateTestPlan, bigramSimilarity } from './pr.ts';
+import { normalizeClosesSyntax, validateTestPlan, bigramSimilarity, injectLinearRefs } from './pr.ts';
 
 describe('normalizeClosesSyntax', () => {
   it('rewrites comma-separated Closes to one-per-line', () => {
@@ -117,6 +117,67 @@ describe('validateTestPlan', () => {
     const result = validateTestPlan('');
     expect(result.status).toBe('block');
     expect(result.hasTestPlanSection).toBe(false);
+  });
+});
+
+describe('injectLinearRefs', () => {
+  it('injects from branch name', () => {
+    const result = injectLinearRefs('## Summary\nSome changes', 'claude/qua-184-linear-integration', undefined, null);
+    expect(result.injected).toEqual(['QUA-184']);
+    expect(result.body).toContain('Fixes QUA-184');
+  });
+
+  it('injects from explicit --linear flag', () => {
+    const result = injectLinearRefs('## Summary\nSome changes', 'claude/tier0-data-integrity', 'QUA-155', null);
+    expect(result.injected).toEqual(['QUA-155']);
+    expect(result.body).toContain('Fixes QUA-155');
+  });
+
+  it('injects multiple from comma-separated --linear flag', () => {
+    const result = injectLinearRefs('## Summary', 'claude/some-branch', 'QUA-155,QUA-151', null);
+    expect(result.injected).toEqual(['QUA-155', 'QUA-151']);
+    expect(result.body).toContain('Fixes QUA-155');
+    expect(result.body).toContain('Fixes QUA-151');
+  });
+
+  it('injects from checklist metadata', () => {
+    const result = injectLinearRefs('## Summary', 'claude/some-branch', undefined, 'QUA-110');
+    expect(result.injected).toEqual(['QUA-110']);
+    expect(result.body).toContain('Fixes QUA-110');
+  });
+
+  it('deduplicates across sources', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184', 'QUA-184');
+    expect(result.injected).toEqual(['QUA-184']);
+    expect(result.body.match(/Fixes QUA-184/g)?.length).toBe(1);
+  });
+
+  it('skips already-referenced IDs', () => {
+    const body = '## Summary\n\nFixes QUA-184';
+    const result = injectLinearRefs(body, 'claude/qua-184-fix', undefined, null);
+    expect(result.injected).toEqual([]);
+    expect(result.body).toBe(body);
+  });
+
+  it('skips Closes/Resolves variants too', () => {
+    const body = '## Summary\n\nCloses QUA-155\nResolves QUA-151';
+    const result = injectLinearRefs(body, 'claude/qua-155-fix', 'QUA-151', null);
+    expect(result.injected).toEqual([]);
+  });
+
+  it('returns original body when no IDs found', () => {
+    const body = '## Summary';
+    const result = injectLinearRefs(body, 'claude/some-feature', undefined, null);
+    expect(result.injected).toEqual([]);
+    expect(result.body).toBe(body);
+  });
+
+  it('combines branch + explicit + checklist IDs', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-155', 'QUA-110');
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155', 'QUA-110']);
+    expect(result.body).toContain('Fixes QUA-184');
+    expect(result.body).toContain('Fixes QUA-155');
+    expect(result.body).toContain('Fixes QUA-110');
   });
 });
 

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -19,6 +19,7 @@ import { currentBranch } from '../lib/session/session-checklist.ts';
 import { rebaseAllPrs } from '../lib/pr-rebase.ts';
 import { resolveAllConflicts } from '../lib/conflict-resolution.ts';
 import { parseDeployTasksFromBody } from '../lib/deploy-tasks/detect.ts';
+import { parseLinearId } from '../lib/linear/parse-id.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 
 // ── Test plan validation ─────────────────────────────────────────────────────
@@ -137,6 +138,47 @@ export function bigramSimilarity(a: string, b: string): number {
   }
 
   return intersection / (setA.size + setB.size - intersection);
+}
+
+/**
+ * Collect Linear IDs from branch name, explicit flag, and checklist metadata,
+ * then inject `Fixes QUA-NNN` lines into the PR body for any not already referenced.
+ * Linear's GitHub integration auto-moves issues to Done on PR merge when it sees these.
+ */
+export function injectLinearRefs(
+  body: string,
+  branch: string,
+  explicitLinear: string | undefined,
+  checklistLinearId: string | null,
+): { body: string; injected: string[] } {
+  const linearIds: string[] = [];
+
+  const branchLinearId = parseLinearId(branch);
+  if (branchLinearId) linearIds.push(branchLinearId);
+
+  if (explicitLinear) {
+    for (const token of explicitLinear.split(',')) {
+      const parsed = parseLinearId(token.trim());
+      if (parsed && !linearIds.includes(parsed)) linearIds.push(parsed);
+    }
+  }
+
+  if (checklistLinearId && !linearIds.includes(checklistLinearId)) {
+    linearIds.push(checklistLinearId);
+  }
+
+  const alreadyReferenced = new Set(
+    [...body.matchAll(/(?:Fixes|Closes|Resolves)\s+(QUA-\d+)/gi)].map(m => m[1].toUpperCase())
+  );
+  const toInject = linearIds.filter(id => !alreadyReferenced.has(id));
+
+  if (toInject.length === 0) return { body, injected: [] };
+
+  const refs = toInject.map(id => `Fixes ${id}`).join('\n');
+  return {
+    body: body.trimEnd() + '\n\n' + refs + '\n',
+    injected: toInject,
+  };
 }
 
 interface GitHubPR {
@@ -347,6 +389,24 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
       } else {
         log.info(testPlanResult.message);
       }
+    }
+  }
+
+  // ── Auto-inject Linear issue reference ──────────────────────────────────
+  if (body) {
+    let checklistLinearId: string | null = null;
+    try {
+      const checklist = readFileSync('.claude/wip-checklist.md', 'utf-8');
+      const match = checklist.match(/^> Linear: ([A-Z]+-\d+)/m);
+      if (match) checklistLinearId = match[1];
+    } catch {
+      // No checklist — skip
+    }
+
+    const result = injectLinearRefs(body, branch, options.linear as string | undefined, checklistLinearId);
+    if (result.injected.length > 0) {
+      body = result.body;
+      log.info(`Auto-injected Linear reference(s): ${result.injected.join(', ')}`);
     }
   }
 
@@ -974,6 +1034,8 @@ Options (create):
   --no-draft          Create as ready PR (default: draft).
   --allow-empty-body  Allow creating PR without a description (not recommended).
   --skip-test-plan    Skip test plan validation (not recommended).
+  --linear=QUA-NNN    Inject Linear issue references (comma-separated for epics: QUA-155,QUA-151).
+                      Auto-detected from branch name and .claude/wip-checklist.md if omitted.
   (stdin)             If --body and --body-file are absent and stdin is a pipe, body is read from stdin.
 
 Options (ready):


### PR DESCRIPTION
## Summary

Linear's GitHub integration is already installed and configured to auto-close issues on PR merge. But it wasn't working because branches used descriptive names (`claude/tier0-data-integrity`) instead of encoding the Linear ID (`claude/qua-155-tier0-data-integrity`), so Linear couldn't link the PR to the issue.

Three fixes:
- **Branch naming warning**: `agent-checklist init` now warns when it detects a Linear ID but the branch name doesn't contain it, with a suggested branch name
- **Auto-inject `Fixes QUA-NNN`**: `crux gh pr create` auto-detects Linear IDs from the branch name, checklist metadata, and new `--linear` flag, then injects `Fixes QUA-NNN` into the PR body as a fallback
- **Epic sub-issues**: New `--linear=QUA-155,QUA-151` flag on `crux gh pr create` for PRs that address multiple Linear issues

Also closed QUA-155 on Linear (was stale — all 4 Tier 0 bugs shipped via PR #4020 on 2026-04-08).

## Test plan
- [x] 9 new tests for `injectLinearRefs()` covering: branch-only, explicit-only, checklist-only, multi-ID, dedup, already-referenced, no-IDs, combined sources
- [x] All 32 PR tests pass (`pnpm vitest run crux/commands/pr.test.ts`)
- [x] All 51 Linear lib tests pass (`pnpm vitest run crux/lib/linear/`)
- [x] Zero TypeScript errors in changed files
- [x] Gate check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)