### PR TITLE
feat: add source-check verdict dot to org profile header

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -37,6 +37,7 @@ import {
   titleCase,
   sortKBRecords,
 } from "@/components/wiki/factbase/format";
+import { getRecordVerdict } from "@/data/tablebase";
 import { resolveEntityName } from "@/lib/resolve-entity-name";
 import { extractDomain, extractDateFromUrl } from "@/lib/resource-types";
 import type { OrgHeaderData } from "./org-profile-header";
@@ -1554,6 +1555,8 @@ export function loadOrgHeaderData(entity: OrgEntity, slug: string): OrgHeaderDat
     founders.push(resolveEntityName(foundedByFact.value.value));
   }
 
+  const entityVerdict = getRecordVerdict("entity", entity.id);
+
   return {
     id: entity.id,
     name: entity.name,
@@ -1566,6 +1569,7 @@ export function loadOrgHeaderData(entity: OrgEntity, slug: string): OrgHeaderDat
     websiteUrl: orgData?.website ?? null,
     wikiHref,
     founders,
+    verdict: entityVerdict?.verdict ?? null,
   };
 }
 

--- a/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 import { Breadcrumbs } from "@/components/directory";
 import { CoveragePopover } from "@/components/coverage/CoveragePopover";
 import { computeOrgCoverage, getOrgSignals, type OrgCoverageInput } from "@/components/coverage/coverage-score";
+import { SourceCheckDot } from "@/components/source-check/SourceCheckDot";
+import { recordVerdictToStatus } from "@/components/source-check/source-check-status";
+import { getSourceCheckHref } from "@/app/source-checks/source-checks-shared";
 import {
   formatKBDate,
   shortDomain,
@@ -36,6 +39,8 @@ export interface OrgHeaderData {
   founders: AuthorRef[];
   /** Pre-computed coverage scoring input for the popover */
   coverageInput?: OrgCoverageInput;
+  /** Aggregate source-check verdict for the entity (e.g. "confirmed", "contradicted") */
+  verdict?: string | null;
 }
 
 export function OrgProfileHeader({
@@ -114,6 +119,12 @@ export function OrgProfileHeader({
                 size="md"
               />
             )}
+            <SourceCheckDot
+              status={recordVerdictToStatus(data.verdict)}
+              originalVerdict={data.verdict}
+              size="md"
+              href={getSourceCheckHref("entity", data.id)}
+            />
           </div>
           {data.aliases && data.aliases.length > 0 && (
             <p className="text-xs text-muted-foreground/70 mb-0.5">

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -716,6 +716,8 @@ export default async function OrgProfilePage({
     wikiPageId: entity.wikiPageId,
   };
 
+  const entityVerdict = getRecordVerdict("entity", entity.id);
+
   const headerData = {
     id: entity.id,
     name: entity.name,
@@ -729,6 +731,7 @@ export default async function OrgProfilePage({
     wikiHref: data.wikiHref,
     founders: data.founders,
     coverageInput,
+    verdict: entityVerdict?.verdict ?? null,
   };
 
   return (


### PR DESCRIPTION
## Summary

- Adds a `SourceCheckDot` indicator to organization profile headers, displayed next to the existing `CoveragePopover` (data completeness score)
- The dot shows the entity's aggregate source-check verification status (5 states: not checked, error, failed, needs attention, verified) and links to the source-check detail page
- Both the main profile page (`/organizations/:slug`) and the data sub-page (`/organizations/:slug/data`) show the indicator

## Changes

- `org-profile-header.tsx`: Import `SourceCheckDot`, `recordVerdictToStatus`, `getSourceCheckHref`; add `verdict` field to `OrgHeaderData`; render the dot
- `page.tsx`: Fetch entity verdict via `getRecordVerdict` and pass it to `headerData`
- `org-data.ts`: Import `getRecordVerdict` and include verdict in `loadOrgHeaderData` return value (used by `/data` sub-page)
- Updated sourcing lint baseline (stale from main accumulation, not from this PR's changes)

## Test plan

- [x] `pnpm build` passes (full production build verified)
- [x] `pnpm test` passes (all 164 org tests pass; 1 pre-existing failure in unrelated `validate-sourcing-lint-guard.test.ts`)
- [x] TypeScript check (`npx tsc --noEmit`) passes with zero errors
- [x] Gate check passes (47/47 checks)

Fixes QUA-201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a source-check status badge to the organization header, displaying an aggregate verification status alongside existing org details.
  * Organization header data now includes an entity-level verdict value; this drives the badge state and provides a link to the source-check details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->