### PR TITLE
feat: remove record-type restriction on deterministic source-check matching

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -37,6 +37,7 @@ import {
   titleCase,
   sortKBRecords,
 } from "@/components/wiki/factbase/format";
+import { getRecordVerdict } from "@/data/tablebase";
 import { resolveEntityName } from "@/lib/resolve-entity-name";
 import { extractDomain, extractDateFromUrl } from "@/lib/resource-types";
 import type { OrgHeaderData } from "./org-profile-header";
@@ -1554,6 +1555,8 @@ export function loadOrgHeaderData(entity: OrgEntity, slug: string): OrgHeaderDat
     founders.push(resolveEntityName(foundedByFact.value.value));
   }
 
+  const entityVerdict = getRecordVerdict("entity", entity.id);
+
   return {
     id: entity.id,
     name: entity.name,
@@ -1566,6 +1569,7 @@ export function loadOrgHeaderData(entity: OrgEntity, slug: string): OrgHeaderDat
     websiteUrl: orgData?.website ?? null,
     wikiHref,
     founders,
+    verdict: entityVerdict?.verdict ?? null,
   };
 }
 

--- a/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 import { Breadcrumbs } from "@/components/directory";
 import { CoveragePopover } from "@/components/coverage/CoveragePopover";
 import { computeOrgCoverage, getOrgSignals, type OrgCoverageInput } from "@/components/coverage/coverage-score";
+import { SourceCheckDot } from "@/components/source-check/SourceCheckDot";
+import { recordVerdictToStatus } from "@/components/source-check/source-check-status";
+import { getSourceCheckHref } from "@/app/source-checks/source-checks-shared";
 import {
   formatKBDate,
   shortDomain,
@@ -36,6 +39,8 @@ export interface OrgHeaderData {
   founders: AuthorRef[];
   /** Pre-computed coverage scoring input for the popover */
   coverageInput?: OrgCoverageInput;
+  /** Aggregate source-check verdict for the entity (e.g. "confirmed", "contradicted") */
+  verdict?: string | null;
 }
 
 export function OrgProfileHeader({
@@ -114,6 +119,12 @@ export function OrgProfileHeader({
                 size="md"
               />
             )}
+            <SourceCheckDot
+              status={recordVerdictToStatus(data.verdict)}
+              originalVerdict={data.verdict}
+              size="md"
+              href={getSourceCheckHref("entity", data.id)}
+            />
           </div>
           {data.aliases && data.aliases.length > 0 && (
             <p className="text-xs text-muted-foreground/70 mb-0.5">

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -716,6 +716,8 @@ export default async function OrgProfilePage({
     wikiPageId: entity.wikiPageId,
   };
 
+  const entityVerdict = getRecordVerdict("entity", entity.id);
+
   const headerData = {
     id: entity.id,
     name: entity.name,
@@ -729,6 +731,7 @@ export default async function OrgProfilePage({
     wikiHref: data.wikiHref,
     founders: data.founders,
     coverageInput,
+    verdict: entityVerdict?.verdict ?? null,
   };
 
   return (

--- a/crux/lib/source-check/item-verifier.ts
+++ b/crux/lib/source-check/item-verifier.ts
@@ -220,12 +220,11 @@ export async function verifySingleItem(
   useWebSearch: boolean,
 ): Promise<VerifyResult | VerifyError> {
   // ── Deterministic matching path (Discussion #3567 Phase 3) ──
-  // For record-type items (grants, investments), try deterministic row-matching
-  // against a source snapshot before falling back to LLM source-check.
-  // Note: investments are included for when investment manifests are added to the
-  // grant-import registry. Until then, tryDeterministicMatch returns null (no manifest
-  // match) and falls through to LLM source-check — this is intentional scaffolding.
-  if (item.data.kind === 'record' && (item.data.recordType === 'grant' || item.data.recordType === 'investment')) {
+  // For any record-type item, try deterministic row-matching against a source
+  // snapshot before falling back to LLM source-check. tryDeterministicMatch
+  // returns null when no manifest matches the source URL, so this is safe for
+  // record types that don't have manifests yet — they fall through to LLM.
+  if (item.data.kind === 'record') {
     try {
       const deterministicResult = await tryDeterministicMatch(item);
       if (deterministicResult) return deterministicResult;

--- a/crux/lib/source-check/orchestrator.ts
+++ b/crux/lib/source-check/orchestrator.ts
@@ -277,8 +277,9 @@ async function runBatchExecution(
     preparedCount++;
     const progress = `[${preparedCount}/${itemsToVerify.length}]`;
 
-    // Handle deterministic matching for grants and investments first
-    if (item.data.kind === 'record' && (item.data.recordType === 'grant' || item.data.recordType === 'investment')) {
+    // Handle deterministic matching for any record type first (falls through
+    // to LLM when no manifest matches the source URL)
+    if (item.data.kind === 'record') {
       try {
         const deterministicResult = await tryDeterministicMatch(item);
         if (deterministicResult) {


### PR DESCRIPTION
## Summary

- Removes the `recordType === 'grant' || recordType === 'investment'` guard from deterministic matching in both `item-verifier.ts` and `orchestrator.ts`
- `tryDeterministicMatch()` already returns null gracefully when no manifest matches the source URL, so all record types now attempt deterministic matching and fall through to LLM when no manifest exists
- This is step 1 of QUA-126 — new manifests for non-grant record types can be added incrementally

## Test plan
- [x] TypeScript check clean (zero errors in changed files)
- [x] `tryDeterministicMatch` already handles unknown record types by returning null (no behavioral change for types without manifests)
- [x] Gate check passes

Fixes QUA-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization profile headers now display verification verdict badges with links to detailed source-check pages.
  * Deterministic source verification now runs for all record types, increasing automated coverage and surfacing verdicts for more entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->