### PR TITLE
Backfill Claude model benchmark scores

### DIFF
--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -197,6 +197,27 @@
   modality:
     - text
     - image
+  benchmarks:
+    - name: MMLU
+      score: 79.0
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: HumanEval
+      score: 73.0
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: GPQA Diamond
+      score: 40.4
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: MATH
+      score: 40.5
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
   capabilities:
     - tool-use
   description: >-
@@ -233,6 +254,27 @@
   modality:
     - text
     - image
+  benchmarks:
+    - name: MMLU
+      score: 75.2
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: HumanEval
+      score: 75.9
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: GPQA Diamond
+      score: 33.3
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
+    - name: MATH
+      score: 38.9
+      unit: "%"
+      date: "2024-03"
+      source: "https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf"
   capabilities:
     - tool-use
   description: >-
@@ -315,6 +357,11 @@
     - name: TAU-bench
       score: 58.8
       unit: "%"
+    - name: SWE-bench Verified
+      score: 49.0
+      unit: "%"
+      date: "2024-10"
+      source: "https://www.anthropic.com/news/3-5-models-and-computer-use"
   capabilities:
     - tool-use
     - computer-use
@@ -576,6 +623,17 @@
   modality:
     - text
     - image
+  benchmarks:
+    - name: SWE-bench Verified
+      score: 74.5
+      unit: "%"
+      date: "2025-08"
+      source: "https://www.anthropic.com/news/claude-opus-4-1"
+    - name: GPQA Diamond
+      score: 81.0
+      unit: "%"
+      date: "2025-08"
+      source: "https://www.anthropic.com/news/claude-opus-4-1"
   capabilities:
     - tool-use
     - extended-thinking
@@ -624,6 +682,16 @@
     - name: OSWorld
       score: 61.4
       unit: "%"
+    - name: GPQA Diamond
+      score: 83.4
+      unit: "%"
+      date: "2025-09"
+      source: "https://www.anthropic.com/news/claude-sonnet-4-5"
+    - name: AIME 2025
+      score: 87.0
+      unit: "%"
+      date: "2025-09"
+      source: "https://www.anthropic.com/news/claude-sonnet-4-5"
   capabilities:
     - tool-use
     - extended-thinking
@@ -663,6 +731,12 @@
   modality:
     - text
     - image
+  benchmarks:
+    - name: SWE-bench Verified
+      score: 73.3
+      unit: "%"
+      date: "2025-10"
+      source: "https://assets.anthropic.com/m/99128ddd009bdcb/Claude-Haiku-4-5-System-Card.pdf"
   capabilities:
     - tool-use
     - extended-thinking


### PR DESCRIPTION
## Summary

Adds missing benchmark scores to Claude model entries in `data/entities/ai-models.yaml`, sourced from official Anthropic publications (model cards, blog posts, system cards).

### Models updated

| Model | Benchmarks added | Source |
|-------|-----------------|--------|
| Claude 3 Sonnet | MMLU (79.0%), HumanEval (73.0%), GPQA Diamond (40.4%), MATH (40.5%) | [Claude 3 Model Card](https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf) |
| Claude 3 Haiku | MMLU (75.2%), HumanEval (75.9%), GPQA Diamond (33.3%), MATH (38.9%) | [Claude 3 Model Card](https://www-cdn.anthropic.com/de8ba9b01c9ab7cbabf5c33b80b7bbc618857627/Model_Card_Claude_3.pdf) |
| Claude 3.5 Sonnet | SWE-bench Verified (49.0%) | [Oct 2024 announcement](https://www.anthropic.com/news/3-5-models-and-computer-use) |
| Claude Opus 4.1 | SWE-bench Verified (74.5%), GPQA Diamond (81.0%) | [Opus 4.1 announcement](https://www.anthropic.com/news/claude-opus-4-1) |
| Claude Sonnet 4.5 | GPQA Diamond (83.4%), AIME 2025 (87.0%) | [Sonnet 4.5 announcement](https://www.anthropic.com/news/claude-sonnet-4-5) |
| Claude Haiku 4.5 | SWE-bench Verified (73.3%) | [Haiku 4.5 System Card](https://assets.anthropic.com/m/99128ddd009bdcb/Claude-Haiku-4-5-System-Card.pdf) |

### Not included (no official published scores found)

- MMLU/MATH/HumanEval for Claude 4.x models — Anthropic shifted to reporting SWE-bench, GPQA, and AIME as primary benchmarks. Blog post comparison charts use images rather than text tables, making exact values unverifiable.
- SWE-bench for Claude 3 Sonnet and Claude 3 Haiku — benchmark didn't exist as a standard evaluation for these models.

All existing scores left unchanged. Only scores with verifiable source URLs from official Anthropic publications were added.

Fixes QUA-192

## Test plan

- [x] `pnpm crux w fix escaping` — no issues
- [x] `pnpm build-data:content` — 0 YAML parse errors, 1999 entities loaded
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks passed

Generated with [Claude Code](https://claude.com/claude-code)