### PR TITLE
feat: persist coverage scan results to PG

### DIFF
--- a/apps/wiki-server/drizzle/0171_create_coverage_scans.sql
+++ b/apps/wiki-server/drizzle/0171_create_coverage_scans.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS tablebase_coverage_scans (
+  id             SERIAL PRIMARY KEY,
+  entity_type    TEXT    NOT NULL,
+  entity_id      TEXT    NOT NULL,
+  coverage_score INTEGER NOT NULL CHECK (coverage_score BETWEEN 1 AND 4),
+  signals_filled INTEGER NOT NULL DEFAULT 0,
+  signals_total  INTEGER NOT NULL DEFAULT 0,
+  signals        JSONB   NOT NULL DEFAULT '{}',
+  scanned_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_coverage_scans_entity ON tablebase_coverage_scans (entity_id);
+CREATE INDEX IF NOT EXISTS idx_coverage_scans_type_score ON tablebase_coverage_scans (entity_type, coverage_score);
+CREATE INDEX IF NOT EXISTS idx_coverage_scans_scanned_at ON tablebase_coverage_scans (scanned_at);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1198,6 +1198,13 @@
       "when": 1784188800000,
       "tag": "0170_investments_display_name_dedup",
       "breakpoints": true
+    },
+    {
+      "idx": 171,
+      "version": "7",
+      "when": 1784275200000,
+      "tag": "0171_create_coverage_scans",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/coverage-scans.test.ts
+++ b/apps/wiki-server/src/__tests__/coverage-scans.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the coverage-scans sync handler configuration.
+ *
+ * Uses the same pattern as sync-factory.test.ts: tests the createSyncHandler
+ * factory with the coverage-scans-specific config (entityRefFields, naturalKey,
+ * conflictTarget) against a mocked DB using the `entities` table as a stand-in.
+ *
+ * Validates:
+ *   1. Happy path: sync valid items -> upserted count
+ *   2. FK-invalid: sync with nonexistent entityId -> 400
+ *   3. Natural key collision: duplicate entityId in batch -> 400
+ *   4. Schema validation: missing required fields -> 400
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { z } from "zod";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs: unnest + entities check ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- INSERT (upsert) ---
+  if (q.includes("insert into")) {
+    return [];
+  }
+
+  return [];
+}
+
+// Mock the db module
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createSyncHandler } = await import(
+  "../routes/tablebase/sync-factory.js"
+);
+// Use `entities` table as stand-in — same pattern as sync-factory.test.ts.
+// The actual Drizzle table columns are introspected at build time;
+// what matters for the test is the factory pipeline behavior.
+const { entities } = await import("../schema.js");
+
+// ---- Schemas (mirror from coverage-scans route) ----
+
+const SyncItemSchema = z.object({
+  id: z.string().optional(), // Satisfies factory TItem constraint
+  entityType: z.string().min(1).max(100),
+  entityId: z.string().min(1).max(200),
+  coverageScore: z.number().int().min(1).max(4),
+  signalsFilled: z.number().int().min(0).default(0),
+  signalsTotal: z.number().int().min(0).default(0),
+  signals: z.record(z.boolean()).default({}),
+  scannedAt: z.string().datetime().optional(),
+});
+
+type SyncItem = z.infer<typeof SyncItemSchema>;
+
+const SyncBatchSchema = z.object({
+  items: z.array(SyncItemSchema).min(1).max(2000),
+});
+
+// ---- Build test app with factory config matching the real route ----
+
+function buildApp() {
+  // Use type assertion on batchSchema to work around Zod .default() making
+  // input types optional while output types are required. The factory's
+  // ZodType constraint checks against the output shape.
+  const handler = createSyncHandler<SyncItem, typeof entities>({
+    name: "coverage-scans",
+    table: entities,
+    batchSchema: SyncBatchSchema as z.ZodType<{ items: SyncItem[] }>,
+    toRow: (item, now) => ({
+      id: item.entityId, // entities table expects id column
+      entityType: item.entityType,
+      coverageScore: item.coverageScore,
+      signalsFilled: item.signalsFilled,
+      signalsTotal: item.signalsTotal,
+      signals: item.signals,
+      scannedAt: item.scannedAt ? new Date(item.scannedAt) : now,
+      updatedAt: now,
+    }),
+    naturalKey: (item) => item.entityId,
+    naturalKeyError: "Duplicate entityId in batch",
+    entityRefFields: (items) => [
+      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+    ],
+  });
+  return new Hono().post("/sync", handler);
+}
+
+// ---------------------------------------------------------------------------
+
+describe("coverage-scans sync handler", () => {
+  beforeEach(() => {
+    resetStores();
+    // Seed with known entities (matched by stable_id)
+    entitiesStore.set("anthropic", {
+      id: "anthropic",
+      stable_id: "sid_abc1234567",
+      title: "Anthropic",
+    });
+    entitiesStore.set("openai", {
+      id: "openai",
+      stable_id: "sid_def7654321",
+      title: "OpenAI",
+    });
+  });
+
+  it("returns upserted count on valid sync", async () => {
+    const app = buildApp();
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          entityType: "organization",
+          entityId: "sid_abc1234567",
+          coverageScore: 3,
+          signalsFilled: 4,
+          signalsTotal: 7,
+          signals: { revenue: true, headcount: true, valuation: false },
+        },
+        {
+          entityType: "organization",
+          entityId: "sid_def7654321",
+          coverageScore: 2,
+          signalsFilled: 2,
+          signalsTotal: 7,
+          signals: { revenue: false, headcount: true },
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.upserted).toBe(2);
+  });
+
+  it("returns 400 when entityId does not exist", async () => {
+    const app = buildApp();
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          entityType: "organization",
+          entityId: "nonexistent_entity_id",
+          coverageScore: 2,
+          signalsFilled: 1,
+          signalsTotal: 5,
+          signals: {},
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("validation_error");
+  });
+
+  it("returns 400 on duplicate entityId in batch", async () => {
+    const app = buildApp();
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          entityType: "organization",
+          entityId: "sid_abc1234567",
+          coverageScore: 3,
+          signalsFilled: 4,
+          signalsTotal: 7,
+          signals: {},
+        },
+        {
+          entityType: "organization",
+          entityId: "sid_abc1234567",
+          coverageScore: 2,
+          signalsFilled: 2,
+          signalsTotal: 7,
+          signals: {},
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("Duplicate entityId in batch");
+  });
+
+  it("returns 400 on invalid schema (missing required fields)", async () => {
+    const app = buildApp();
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          entityType: "organization",
+          // missing entityId and coverageScore
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("validation_error");
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -33,6 +33,7 @@ import { blueskyRoute } from "./routes/tablebase/bluesky.js";
 import { talentFlowsRoute } from "./routes/tablebase/talent-flows.js";
 import { dataSourcesRoute } from "./routes/tablebase/data-sources.js";
 import { platformAccountsRoute } from "./routes/tablebase/platform-accounts.js";
+import { coverageScansRoute } from "./routes/tablebase/coverage-scans.js";
 
 // Unified source-check system (replaces legacy factbase + record source-checks)
 import { sourceChecksRoute } from "./routes/source-check/source-checks.js";
@@ -249,6 +250,7 @@ export function createApp() {
   app.route("/api/publications", publicationsRoute);
   app.route("/api/website-sources", websiteSourcesRoute);
   app.route("/api/entity-resources", entityResourcesRoute);
+  app.route("/api/coverage-scans", coverageScansRoute);
 
   // Aggregated entity profile (reads from all TableBase tables)
   app.route("/api/entity-profile", entityProfileRoute);

--- a/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
+++ b/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
@@ -1,12 +1,11 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, desc, count, sql } from "drizzle-orm";
+import { eq, desc, count } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { tablebaseCoverageScans } from "../../schema.js";
-import { zv, clampedLimit, parseJsonBody, validationError, invalidJsonError } from "../shared/utils.js";
+import { zv, clampedLimit } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
-import { validateEntityRefs } from "../shared/validate-entity-refs.js";
-import { logger } from "../../logger.js";
+import { createSyncHandler } from "./sync-factory.js";
 
 const MAX_PAGE_SIZE = 500;
 const MAX_BATCH_SIZE = 2000;
@@ -18,6 +17,7 @@ const ListQuery = z.object({
 });
 
 const SyncItemSchema = z.object({
+  id: z.string().optional(), // Satisfies factory TItem constraint; not stored — entityId is the natural key
   entityType: z.string().min(1).max(100),
   entityId: z.string().min(1).max(200),
   coverageScore: z.number().int().min(1).max(4),
@@ -30,6 +30,8 @@ const SyncItemSchema = z.object({
 const SyncBatchSchema = z.object({
   items: z.array(SyncItemSchema).min(1).max(MAX_BATCH_SIZE),
 });
+
+type SyncItem = z.infer<typeof SyncItemSchema>;
 
 interface CoverageScanRow {
   id: number;
@@ -71,47 +73,31 @@ const coverageScansApp = new Hono()
       .groupBy(tablebaseCoverageScans.entityType, tablebaseCoverageScans.coverageScore);
     return c.json({ stats: rows });
   })
-  .post("/sync", async (c) => {
-    const body = await parseJsonBody(c);
-    if (!body) return invalidJsonError(c);
-    const parsed = SyncBatchSchema.safeParse(body);
-    if (!parsed.success) return validationError(c, parsed.error.errors.map((e) => e.message).join("; "));
-    const { items } = parsed.data;
-    const now = new Date();
-    const db = getDrizzleDb();
-
-    // Check for duplicate entityIds in batch
-    const seen = new Set<string>();
-    for (const item of items) {
-      if (seen.has(item.entityId)) return validationError(c, `Duplicate entityId in batch: ${item.entityId}`);
-      seen.add(item.entityId);
-    }
-
-    // Validate entity references
-    const refError = await validateEntityRefs(c, db, [
-      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
-    ]);
-    if (refError) return refError;
-
-    const rows = items.map((item) => ({
-      entityType: item.entityType, entityId: item.entityId,
-      coverageScore: item.coverageScore, signalsFilled: item.signalsFilled,
-      signalsTotal: item.signalsTotal, signals: item.signals,
-      scannedAt: item.scannedAt ? new Date(item.scannedAt) : now, updatedAt: now,
-    }));
-
-    await db.insert(tablebaseCoverageScans).values(rows).onConflictDoUpdate({
-      target: tablebaseCoverageScans.entityId,
-      set: {
-        entityType: sql`excluded.entity_type`, coverageScore: sql`excluded.coverage_score`,
-        signalsFilled: sql`excluded.signals_filled`, signalsTotal: sql`excluded.signals_total`,
-        signals: sql`excluded.signals`, scannedAt: sql`excluded.scanned_at`, updatedAt: sql`excluded.updated_at`,
-      },
-    });
-    logger.info({ count: items.length }, "coverage-scans: synced");
-    return c.json({ upserted: items.length });
-  })
-  .post("/delete-batch", deleteBatchHandler(tablebaseCoverageScans, "coverage_scans"));
+  .post(
+    "/sync",
+    createSyncHandler<SyncItem, typeof tablebaseCoverageScans>({
+      name: "coverage-scans",
+      table: tablebaseCoverageScans,
+      batchSchema: SyncBatchSchema as z.ZodType<{ items: SyncItem[] }>,
+      toRow: (item, now) => ({
+        entityType: item.entityType,
+        entityId: item.entityId,
+        coverageScore: item.coverageScore,
+        signalsFilled: item.signalsFilled,
+        signalsTotal: item.signalsTotal,
+        signals: item.signals,
+        scannedAt: item.scannedAt ? new Date(item.scannedAt) : now,
+        updatedAt: now,
+      }),
+      conflictTarget: tablebaseCoverageScans.entityId,
+      naturalKey: (item) => item.entityId,
+      naturalKeyError: "Duplicate entityId in batch",
+      entityRefFields: (items) => [
+        { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+      ],
+    }),
+  )
+  .post("/delete-batch", deleteBatchHandler(tablebaseCoverageScans, null));
 
 export const coverageScansRoute = coverageScansApp;
 export type CoverageScansRoute = typeof coverageScansApp;

--- a/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
+++ b/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
@@ -1,0 +1,108 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, desc, count, sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { tablebaseCoverageScans } from "../../schema.js";
+import { zv, clampedLimit, parseJsonBody, validationError, invalidJsonError } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { logger } from "../../logger.js";
+
+const MAX_PAGE_SIZE = 500;
+const MAX_BATCH_SIZE = 2000;
+
+const ListQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
+  offset: z.coerce.number().int().min(0).default(0),
+  entityType: z.string().max(100).optional(),
+});
+
+const SyncItemSchema = z.object({
+  entityType: z.string().min(1).max(100),
+  entityId: z.string().min(1).max(200),
+  coverageScore: z.number().int().min(1).max(4),
+  signalsFilled: z.number().int().min(0).default(0),
+  signalsTotal: z.number().int().min(0).default(0),
+  signals: z.record(z.boolean()).default({}),
+  scannedAt: z.string().datetime().optional(),
+});
+
+const SyncBatchSchema = z.object({
+  items: z.array(SyncItemSchema).min(1).max(MAX_BATCH_SIZE),
+});
+
+interface CoverageScanRow {
+  id: number;
+  entityType: string;
+  entityId: string;
+  coverageScore: number;
+  signalsFilled: number;
+  signalsTotal: number;
+  signals: unknown;
+  scannedAt: Date;
+}
+
+function formatRow(r: CoverageScanRow) {
+  return {
+    id: r.id, entityType: r.entityType, entityId: r.entityId,
+    coverageScore: r.coverageScore, signalsFilled: r.signalsFilled,
+    signalsTotal: r.signalsTotal, signals: r.signals,
+    scannedAt: r.scannedAt.toISOString(),
+  };
+}
+
+// Hand-rolled sync handler because this table uses entityId as the upsert
+// key, not a standard `id` PK (factory requires { id?: string } items).
+const coverageScansApp = new Hono()
+  .get("/all", zv("query", ListQuery), async (c) => {
+    const { limit, offset, entityType } = c.req.valid("query");
+    const db = getDrizzleDb();
+    const where = entityType ? eq(tablebaseCoverageScans.entityType, entityType) : undefined;
+    const [rows, totalRows] = await Promise.all([
+      db.select().from(tablebaseCoverageScans).where(where)
+        .orderBy(desc(tablebaseCoverageScans.scannedAt)).limit(limit).offset(offset),
+      db.select({ count: count() }).from(tablebaseCoverageScans).where(where),
+    ]);
+    return c.json({ items: rows.map((r) => formatRow(r as CoverageScanRow)), total: totalRows[0]?.count ?? 0 });
+  })
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+    const rows = await db
+      .select({ entityType: tablebaseCoverageScans.entityType, coverageScore: tablebaseCoverageScans.coverageScore, count: count() })
+      .from(tablebaseCoverageScans)
+      .groupBy(tablebaseCoverageScans.entityType, tablebaseCoverageScans.coverageScore);
+    return c.json({ stats: rows });
+  })
+  .post("/sync", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+    const parsed = SyncBatchSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.errors.map((e) => e.message).join("; "));
+    const { items } = parsed.data;
+    const now = new Date();
+    const db = getDrizzleDb();
+    const seen = new Set<string>();
+    for (const item of items) {
+      if (seen.has(item.entityId)) return validationError(c, `Duplicate entityId in batch: ${item.entityId}`);
+      seen.add(item.entityId);
+    }
+    const rows = items.map((item) => ({
+      entityType: item.entityType, entityId: item.entityId,
+      coverageScore: item.coverageScore, signalsFilled: item.signalsFilled,
+      signalsTotal: item.signalsTotal, signals: item.signals,
+      scannedAt: item.scannedAt ? new Date(item.scannedAt) : now, updatedAt: now,
+    }));
+    await db.insert(tablebaseCoverageScans).values(rows).onConflictDoUpdate({
+      target: tablebaseCoverageScans.entityId,
+      set: {
+        entityType: sql`excluded.entity_type`, coverageScore: sql`excluded.coverage_score`,
+        signalsFilled: sql`excluded.signals_filled`, signalsTotal: sql`excluded.signals_total`,
+        signals: sql`excluded.signals`, scannedAt: sql`excluded.scanned_at`, updatedAt: sql`excluded.updated_at`,
+      },
+    });
+    logger.info({ count: items.length }, "coverage-scans: synced");
+    return c.json({ upserted: items.length });
+  })
+  .post("/delete-batch", deleteBatchHandler(tablebaseCoverageScans, "coverage_scans"));
+
+export const coverageScansRoute = coverageScansApp;
+export type CoverageScansRoute = typeof coverageScansApp;

--- a/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
+++ b/apps/wiki-server/src/routes/tablebase/coverage-scans.ts
@@ -5,6 +5,7 @@ import { getDrizzleDb } from "../../db.js";
 import { tablebaseCoverageScans } from "../../schema.js";
 import { zv, clampedLimit, parseJsonBody, validationError, invalidJsonError } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { logger } from "../../logger.js";
 
 const MAX_PAGE_SIZE = 500;
@@ -50,8 +51,6 @@ function formatRow(r: CoverageScanRow) {
   };
 }
 
-// Hand-rolled sync handler because this table uses entityId as the upsert
-// key, not a standard `id` PK (factory requires { id?: string } items).
 const coverageScansApp = new Hono()
   .get("/all", zv("query", ListQuery), async (c) => {
     const { limit, offset, entityType } = c.req.valid("query");
@@ -80,17 +79,27 @@ const coverageScansApp = new Hono()
     const { items } = parsed.data;
     const now = new Date();
     const db = getDrizzleDb();
+
+    // Check for duplicate entityIds in batch
     const seen = new Set<string>();
     for (const item of items) {
       if (seen.has(item.entityId)) return validationError(c, `Duplicate entityId in batch: ${item.entityId}`);
       seen.add(item.entityId);
     }
+
+    // Validate entity references
+    const refError = await validateEntityRefs(c, db, [
+      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+    ]);
+    if (refError) return refError;
+
     const rows = items.map((item) => ({
       entityType: item.entityType, entityId: item.entityId,
       coverageScore: item.coverageScore, signalsFilled: item.signalsFilled,
       signalsTotal: item.signalsTotal, signals: item.signals,
       scannedAt: item.scannedAt ? new Date(item.scannedAt) : now, updatedAt: now,
     }));
+
     await db.insert(tablebaseCoverageScans).values(rows).onConflictDoUpdate({
       target: tablebaseCoverageScans.entityId,
       set: {

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3899,3 +3899,26 @@ export const politicalVotes = pgTable(
     ),
   ]
 );
+
+// ── Coverage Scans ─────────────────────────────────────────────────
+
+export const tablebaseCoverageScans = pgTable(
+  "tablebase_coverage_scans",
+  {
+    id: serial("id").primaryKey(),
+    entityType: text("entity_type").notNull(),
+    entityId: text("entity_id").notNull(),
+    coverageScore: integer("coverage_score").notNull(),
+    signalsFilled: integer("signals_filled").notNull().default(0),
+    signalsTotal: integer("signals_total").notNull().default(0),
+    signals: jsonb("signals").notNull().default({}),
+    scannedAt: timestamp("scanned_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_coverage_scans_entity").on(table.entityId),
+    index("idx_coverage_scans_type_score").on(table.entityType, table.coverageScore),
+    index("idx_coverage_scans_scanned_at").on(table.scannedAt),
+  ],
+);

--- a/crux/wiki-server/sync-coverage-scans.ts
+++ b/crux/wiki-server/sync-coverage-scans.ts
@@ -61,9 +61,9 @@ function computeForEntity(entity: TypedEntity, facts: Map<string, Fact[]>, orgPe
     }
     case "ai-model": {
       const e = entity as Record<string, unknown>;
-      const i = { developer: (e.developer as string) ?? null, releaseDate: (e.releaseDate as string) ?? null, contextWindow: (e.contextWindow as number) ?? null, parameterCount: (e.parameterCount as string) ?? null, safetyLevel: (e.safetyLevel as string) ?? null, wikiId: entity.wikiId ?? null };
+      const i = { developer: (e.developer as string) ?? null, releaseDate: (e.releaseDate as string) ?? null, inputPrice: (e.inputPrice as number) ?? null, outputPrice: (e.outputPrice as number) ?? null, contextWindow: (e.contextWindow as number) ?? null, parameterCount: (e.parameterCount as string) ?? null, safetyLevel: (e.safetyLevel as string) ?? null, wikiId: entity.wikiId ?? null };
       score = computeAiModelCoverage(i);
-      signals = { pricing: i.contextWindow != null, contextWindow: i.contextWindow != null, parameterCount: !!i.parameterCount, safetyLevel: !!i.safetyLevel, wikiPage: !!i.wikiId }; break;
+      signals = { pricing: i.inputPrice != null || i.outputPrice != null, contextWindow: i.contextWindow != null, parameterCount: !!i.parameterCount, safetyLevel: !!i.safetyLevel, wikiPage: !!i.wikiId }; break;
     }
     case "policy": {
       const e = entity as Record<string, unknown>;
@@ -90,7 +90,7 @@ function computeForEntity(entity: TypedEntity, facts: Map<string, Fact[]>, orgPe
     }
   }
   const { filled, total } = countSignals(signals);
-  return { entityType: entity.entityType, entityId: entity.id, coverageScore: score, signalsFilled: filled, signalsTotal: total, signals, scannedAt: now };
+  return { entityType: entity.entityType, entityId: entity.stableId ?? entity.id, coverageScore: score, signalsFilled: filled, signalsTotal: total, signals, scannedAt: now };
 }
 
 async function main() {

--- a/crux/wiki-server/sync-coverage-scans.ts
+++ b/crux/wiki-server/sync-coverage-scans.ts
@@ -1,0 +1,131 @@
+/**
+ * Coverage Scan Sync — computes entity coverage scores and syncs to wiki-server.
+ * Usage: pnpm crux wiki-server sync-coverage-scans [--dry-run] [--batch-size=N]
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
+import { batchSync, waitForHealthy } from "./sync-common.ts";
+import {
+  computeOrgCoverage, computePersonCoverage, computeAiModelCoverage,
+  computeLegislationCoverage, computeProjectCoverage, computeBenchmarkCoverage,
+  computeGenericCoverage, type OrgCoverageInput, type PersonCoverageInput,
+} from "../../apps/web/src/components/coverage/coverage-score.ts";
+
+const PROJECT_ROOT = join(import.meta.dirname!, "../..");
+const DATABASE_JSON = join(PROJECT_ROOT, "apps/web/src/data/database.json");
+const FACTBASE_JSON = join(PROJECT_ROOT, "apps/web/src/data/factbase-data.json");
+
+interface TypedEntity { id: string; stableId?: string; title: string; entityType: string; description?: string; tags?: string[]; wikiId?: string; clusters?: string[]; [key: string]: unknown; }
+interface FactValue { type: string; value: unknown; }
+interface Fact { propertyId: string; value: FactValue; asOf?: string; }
+interface CoverageScanItem { entityType: string; entityId: string; coverageScore: number; signalsFilled: number; signalsTotal: number; signals: Record<string, boolean>; scannedAt: string; }
+
+function loadFactBase(): Map<string, Fact[]> {
+  try {
+    const raw = JSON.parse(readFileSync(FACTBASE_JSON, "utf-8"));
+    const map = new Map<string, Fact[]>();
+    if (raw.facts) for (const [id, facts] of Object.entries(raw.facts)) map.set(id, facts as Fact[]);
+    return map;
+  } catch { console.warn("  Warning: Could not load factbase-data.json"); return new Map(); }
+}
+
+function getLatestFact(facts: Map<string, Fact[]>, entityId: string, prop: string): Fact | null {
+  const ef = facts.get(entityId); if (!ef) return null;
+  const m = ef.filter((f) => f.propertyId === prop); if (!m.length) return null;
+  m.sort((a, b) => (b.asOf ?? "").localeCompare(a.asOf ?? "")); return m[0];
+}
+function kbNum(facts: Map<string, Fact[]>, id: string, p: string): number | null { const f = getLatestFact(facts, id, p); return f?.value.type === "number" ? f.value.value as number : null; }
+function kbText(facts: Map<string, Fact[]>, id: string, p: string): string | null { const f = getLatestFact(facts, id, p); return (f?.value.type === "text" || f?.value.type === "date") ? f.value.value as string : null; }
+function kbRef(facts: Map<string, Fact[]>, id: string, p: string): string | null { const f = getLatestFact(facts, id, p); return f?.value.type === "ref" ? f.value.value as string : null; }
+function fbNum(facts: Map<string, Fact[]>, e: TypedEntity, p: string) { return (e.stableId ? kbNum(facts, e.stableId, p) : null) ?? kbNum(facts, e.id, p); }
+function fbText(facts: Map<string, Fact[]>, e: TypedEntity, p: string) { return (e.stableId ? kbText(facts, e.stableId, p) : null) ?? kbText(facts, e.id, p); }
+function fbRef(facts: Map<string, Fact[]>, e: TypedEntity, p: string) { return (e.stableId ? kbRef(facts, e.stableId, p) : null) ?? kbRef(facts, e.id, p); }
+
+function countSignals(s: Record<string, boolean>) { const t = Object.keys(s).length; return { filled: Object.values(s).filter(Boolean).length, total: t }; }
+
+function computeForEntity(entity: TypedEntity, facts: Map<string, Fact[]>, orgPeople: Map<string, number>): CoverageScanItem {
+  const now = new Date().toISOString();
+  let score: number; let signals: Record<string, boolean>;
+  switch (entity.entityType) {
+    case "organization": {
+      const i: OrgCoverageInput = { revenueNum: fbNum(facts, entity, "revenue"), valuationNum: fbNum(facts, entity, "valuation"), headcount: fbNum(facts, entity, "headcount"), totalFundingNum: fbNum(facts, entity, "total-funding"), foundedDate: fbText(facts, entity, "founded-date"), peopleCount: orgPeople.get(entity.stableId ?? entity.id) ?? 0, wikiPageId: entity.wikiId ?? null };
+      score = computeOrgCoverage(i);
+      signals = { revenue: i.revenueNum != null, valuation: i.valuationNum != null, headcount: i.headcount != null, totalFunding: i.totalFundingNum != null, foundedDate: !!i.foundedDate, peopleTen: (i.peopleCount ?? 0) >= 10, wikiPage: !!i.wikiPageId }; break;
+    }
+    case "person": case "researcher": {
+      const i: PersonCoverageInput = { role: fbText(facts, entity, "role"), employerId: fbRef(facts, entity, "employed-by"), bornYear: fbNum(facts, entity, "born-year"), netWorthNum: fbNum(facts, entity, "net-worth"), wikiPageId: entity.wikiId ?? null };
+      score = computePersonCoverage(i);
+      signals = { role: !!i.role, employer: !!i.employerId, bornYear: i.bornYear != null, netWorth: i.netWorthNum != null, wikiPage: !!i.wikiPageId }; break;
+    }
+    case "ai-model": {
+      const e = entity as Record<string, unknown>;
+      const i = { developer: (e.developer as string) ?? null, releaseDate: (e.releaseDate as string) ?? null, contextWindow: (e.contextWindow as number) ?? null, parameterCount: (e.parameterCount as string) ?? null, safetyLevel: (e.safetyLevel as string) ?? null, wikiId: entity.wikiId ?? null };
+      score = computeAiModelCoverage(i);
+      signals = { pricing: i.contextWindow != null, contextWindow: i.contextWindow != null, parameterCount: !!i.parameterCount, safetyLevel: !!i.safetyLevel, wikiPage: !!i.wikiId }; break;
+    }
+    case "policy": {
+      const e = entity as Record<string, unknown>;
+      const i = { introduced: (e.introduced as string) ?? null, policyStatus: (e.policyStatus as string) ?? null, author: (e.author as string) ?? null, jurisdiction: (e.jurisdiction as string) ?? null, billNumber: (e.billNumber as string) ?? null, fullTextUrl: (e.fullTextUrl as string) ?? null, description: entity.description ?? null, tags: entity.tags, wikiId: entity.wikiId ?? null };
+      score = computeLegislationCoverage(i);
+      signals = { introduced: !!i.introduced, author: !!i.author, billNumber: !!i.billNumber, fullTextUrl: !!i.fullTextUrl, description: !!i.description, tags: (i.tags?.length ?? 0) >= 1, wikiPage: !!i.wikiId }; break;
+    }
+    case "project": {
+      const e = entity as Record<string, unknown>;
+      const i = { description: entity.description ?? null, status: (e.projectStatus as string) ?? null, website: (e.projectUrl as string) ?? null, orgName: (e.organization as string) ?? null, clusters: entity.clusters, wikiId: entity.wikiId ?? null };
+      score = computeProjectCoverage(i);
+      signals = { description: !!i.description, status: !!i.status, website: !!i.website, clusters: (i.clusters?.length ?? 0) >= 1, wikiPage: !!i.wikiId }; break;
+    }
+    case "benchmark": {
+      const e = entity as Record<string, unknown>;
+      const i = { category: (e.category as string) ?? null, scoringMethod: (e.scoringMethod as string) ?? null, maintainer: (e.maintainer as string) ?? null, description: entity.description ?? null, wikiId: entity.wikiId ?? null };
+      score = computeBenchmarkCoverage(i);
+      signals = { category: !!i.category, scoringMethod: !!i.scoringMethod, maintainer: !!i.maintainer, description: !!i.description, wikiPage: !!i.wikiId }; break;
+    }
+    default: {
+      const i = { description: entity.description ?? null, tags: entity.tags, wikiId: entity.wikiId ?? null };
+      score = computeGenericCoverage(i);
+      signals = { description: !!i.description, tags: (i.tags?.length ?? 0) >= 1, wikiPage: !!i.wikiId }; break;
+    }
+  }
+  const { filled, total } = countSignals(signals);
+  return { entityType: entity.entityType, entityId: entity.id, coverageScore: score, signalsFilled: filled, signalsTotal: total, signals, scannedAt: now };
+}
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || 200;
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+  if (!serverUrl) { console.error("Error: LONGTERMWIKI_SERVER_URL required"); process.exit(1); }
+  if (!apiKey) { console.error("Error: LONGTERMWIKI_SERVER_API_KEY required"); process.exit(1); }
+
+  console.log("Loading data...");
+  const db = JSON.parse(readFileSync(DATABASE_JSON, "utf-8"));
+  const entities: TypedEntity[] = db.typedEntities ?? [];
+  console.log("  " + entities.length + " entities loaded");
+  const facts = loadFactBase();
+  console.log("  " + facts.size + " FactBase entities loaded");
+
+  const orgPeople = new Map<string, number>();
+  for (const [, ef] of facts) for (const f of ef) if (f.propertyId === "employed-by" && f.value.type === "ref") { const o = f.value.value as string; orgPeople.set(o, (orgPeople.get(o) ?? 0) + 1); }
+
+  console.log("Computing coverage scores...");
+  const items = entities.map((e) => computeForEntity(e, facts, orgPeople));
+  const byScore = [0, 0, 0, 0, 0];
+  for (const item of items) byScore[item.coverageScore]++;
+  console.log("  Score distribution: 1=" + byScore[1] + ", 2=" + byScore[2] + ", 3=" + byScore[3] + ", 4=" + byScore[4]);
+
+  if (dryRun) { console.log("Dry run: would sync " + items.length + " coverage scans"); return; }
+
+  console.log("Syncing " + items.length + " coverage scans...");
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) { console.error("Server is not healthy, aborting"); process.exit(1); }
+  const result = await batchSync(serverUrl + "/api/coverage-scans/sync", items, batchSize, { bodyKey: "items", responseCountKey: "upserted", itemLabel: "coverage scans" });
+  console.log("\nDone: " + result.count + " synced, " + result.errors + " errors");
+  if (result.errors > 0) process.exit(1);
+}
+
+main().catch((err) => { console.error("Fatal error:", err); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds `tablebase_coverage_scans` PG table (migration 0170) to store per-entity coverage scores with signal breakdowns
- Adds `/api/coverage-scans` route with `/sync`, `/all`, `/stats`, `/delete-batch` endpoints
- Adds `crux/wiki-server/sync-coverage-scans.ts` script that computes scores using the existing type-specific scorers from `coverage-score.ts` + FactBase data, then syncs to the wiki-server

This is infrastructure for a future coverage dashboard (QUA-226). The sync script can be run manually or wired into a nightly cron.

### Usage
```bash
# Dry run — see score distribution without syncing
pnpm crux wiki-server sync-coverage-scans --dry-run

# Sync to wiki-server
WIKI_SERVER_ENV=prod pnpm crux wiki-server sync-coverage-scans
```

Fixes QUA-226

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Tablebase completeness validator passes (0 blocking)
- [x] Gate check passes
- [ ] Migration runs on deploy (creates table + indexes)
- [ ] Sync script produces expected score distribution in dry-run mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)