### PR TITLE
feat: add per-field verdict writing to source-check pipeline

### DIFF
--- a/apps/wiki-server/src/__tests__/source-check-join.test.ts
+++ b/apps/wiki-server/src/__tests__/source-check-join.test.ts
@@ -48,13 +48,17 @@ const { fetchFieldVerdicts } = await import(
   "../routes/shared/source-check-join.js"
 );
 
+// Get the Drizzle instance from the mock to pass as db parameter
+const dbModule = await import("../db.js");
+const db = (dbModule as any).getDrizzleDb();
+
 // ---------------------------------------------------------------------------
 
 describe("fetchFieldVerdicts", () => {
   beforeEach(resetStores);
 
   it("returns empty map for empty recordIds", async () => {
-    const result = await fetchFieldVerdicts("grant", []);
+    const result = await fetchFieldVerdicts(db, "grant", []);
     expect(result.size).toBe(0);
   });
 
@@ -94,7 +98,7 @@ describe("fetchFieldVerdicts", () => {
       },
     ];
 
-    const result = await fetchFieldVerdicts("grant", ["g1", "g2"]);
+    const result = await fetchFieldVerdicts(db, "grant", ["g1", "g2"]);
 
     expect(result.size).toBe(2);
 
@@ -126,7 +130,7 @@ describe("fetchFieldVerdicts", () => {
       },
     ];
 
-    const result = await fetchFieldVerdicts("grant", ["g1"]);
+    const result = await fetchFieldVerdicts(db, "grant", ["g1"]);
     expect(result.size).toBe(0);
   });
 });

--- a/apps/wiki-server/src/__tests__/source-check-join.test.ts
+++ b/apps/wiki-server/src/__tests__/source-check-join.test.ts
@@ -27,11 +27,19 @@ function resetStores() {
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
-  // Handle Drizzle query builder SELECT from source_check_verdicts
+  // Handle Drizzle query builder SELECT from source_check_verdicts.
+  // Honor bound params so the test verifies that fetchFieldVerdicts actually
+  // filters by record_type and record_ids — not just field_name IS NOT NULL.
   if (q.includes("source_check_verdicts")) {
-    // Filter by record_type and field_name IS NOT NULL
+    // Extract the record_type param (first string param) and record_ids (remaining strings)
+    const stringParams = params.filter((p): p is string => typeof p === "string");
+    const recordType = stringParams.length > 0 ? stringParams[0] : null;
+    const recordIds = stringParams.length > 1 ? new Set(stringParams.slice(1)) : null;
+
     return verdictRows
       .filter((r) => r.field_name !== null)
+      .filter((r) => !recordType || r.record_type === recordType)
+      .filter((r) => !recordIds || recordIds.has(r.record_id))
       .sort((a, b) => {
         const cmp = a.record_id.localeCompare(b.record_id);
         if (cmp !== 0) return cmp;
@@ -95,6 +103,24 @@ describe("fetchFieldVerdicts", () => {
         verdict: "partial",
         confidence: 0.6,
         last_computed_at: new Date("2025-01-02"),
+      },
+      // Out-of-scope row: different record_type — mock filter must exclude it.
+      {
+        record_type: "investment",
+        record_id: "inv-1",
+        field_name: "amount",
+        verdict: "confirmed",
+        confidence: 0.9,
+        last_computed_at: new Date("2025-01-03"),
+      },
+      // Out-of-scope row: right type but not in the requested record_ids.
+      {
+        record_type: "grant",
+        record_id: "g99",
+        field_name: "amount",
+        verdict: "confirmed",
+        confidence: 0.85,
+        last_computed_at: new Date("2025-01-04"),
       },
     ];
 

--- a/apps/wiki-server/src/__tests__/source-check-join.test.ts
+++ b/apps/wiki-server/src/__tests__/source-check-join.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for source-check-join helpers — fetchFieldVerdicts.
+ *
+ * Uses a mock DB to verify that per-field verdicts are fetched and grouped correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDbModule, createQueryResult } from "./test-utils.js";
+
+// ---- In-memory verdict store ----
+
+interface MockVerdict {
+  record_type: string;
+  record_id: string;
+  field_name: string | null;
+  verdict: string;
+  confidence: number | null;
+  last_computed_at: Date | null;
+}
+
+let verdictRows: MockVerdict[];
+
+function resetStores() {
+  verdictRows = [];
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // Handle Drizzle query builder SELECT from source_check_verdicts
+  if (q.includes("source_check_verdicts")) {
+    // Filter by record_type and field_name IS NOT NULL
+    return verdictRows
+      .filter((r) => r.field_name !== null)
+      .sort((a, b) => {
+        const cmp = a.record_id.localeCompare(b.record_id);
+        if (cmp !== 0) return cmp;
+        return (a.field_name ?? "").localeCompare(b.field_name ?? "");
+      });
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { fetchFieldVerdicts } = await import(
+  "../routes/shared/source-check-join.js"
+);
+
+// ---------------------------------------------------------------------------
+
+describe("fetchFieldVerdicts", () => {
+  beforeEach(resetStores);
+
+  it("returns empty map for empty recordIds", async () => {
+    const result = await fetchFieldVerdicts("grant", []);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns per-field verdicts grouped by recordId", async () => {
+    verdictRows = [
+      {
+        record_type: "grant",
+        record_id: "g1",
+        field_name: null,
+        verdict: "confirmed",
+        confidence: 0.9,
+        last_computed_at: new Date("2025-01-01"),
+      },
+      {
+        record_type: "grant",
+        record_id: "g1",
+        field_name: "amount",
+        verdict: "confirmed",
+        confidence: 0.95,
+        last_computed_at: new Date("2025-01-01"),
+      },
+      {
+        record_type: "grant",
+        record_id: "g1",
+        field_name: "start_date",
+        verdict: "contradicted",
+        confidence: 0.8,
+        last_computed_at: new Date("2025-01-01"),
+      },
+      {
+        record_type: "grant",
+        record_id: "g2",
+        field_name: "amount",
+        verdict: "partial",
+        confidence: 0.6,
+        last_computed_at: new Date("2025-01-02"),
+      },
+    ];
+
+    const result = await fetchFieldVerdicts("grant", ["g1", "g2"]);
+
+    expect(result.size).toBe(2);
+
+    const g1Fields = result.get("g1");
+    expect(g1Fields).toBeDefined();
+    expect(g1Fields).toHaveLength(2);
+    expect(g1Fields![0].fieldName).toBe("amount");
+    expect(g1Fields![0].verdict).toBe("confirmed");
+    expect(g1Fields![0].confidence).toBe(0.95);
+    expect(g1Fields![1].fieldName).toBe("start_date");
+    expect(g1Fields![1].verdict).toBe("contradicted");
+
+    const g2Fields = result.get("g2");
+    expect(g2Fields).toBeDefined();
+    expect(g2Fields).toHaveLength(1);
+    expect(g2Fields![0].fieldName).toBe("amount");
+    expect(g2Fields![0].verdict).toBe("partial");
+  });
+
+  it("excludes row-level verdicts (field_name IS NULL)", async () => {
+    verdictRows = [
+      {
+        record_type: "grant",
+        record_id: "g1",
+        field_name: null,
+        verdict: "confirmed",
+        confidence: 0.9,
+        last_computed_at: new Date("2025-01-01"),
+      },
+    ];
+
+    const result = await fetchFieldVerdicts("grant", ["g1"]);
+    expect(result.size).toBe(0);
+  });
+});

--- a/apps/wiki-server/src/__tests__/write-inline-verdicts.test.ts
+++ b/apps/wiki-server/src/__tests__/write-inline-verdicts.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for writeInlineVerdicts — row-level and per-field verdict writing.
+ *
+ * Uses a mock DB with Drizzle ORM to test that:
+ *   1. Row-level verdicts are written for records with sourcing
+ *   2. Per-field verdicts are written when fieldVerdicts is present
+ *   3. Evidence rows are written when sourceUrl is present
+ *   4. Records without sourcing are skipped
+ *   5. Return counts are accurate
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDbModule } from "./test-utils.js";
+
+// ---- In-memory stores ----
+
+interface VerdictRow {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  verdict: string;
+  confidence: number | null;
+  reasoning: string;
+}
+
+interface EvidenceRow {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  sourceUrl: string;
+  verdict: string;
+  confidence: number | null;
+}
+
+let verdictStore: VerdictRow[];
+let evidenceStore: EvidenceRow[];
+
+function resetStores() {
+  verdictStore = [];
+  evidenceStore = [];
+}
+
+/**
+ * Parse verdict rows from the Drizzle tagged-template params.
+ *
+ * The SQL template for row-level verdicts (field_name = NULL literal) produces:
+ *   params = [recordType, recordId, entityId, verdict, confidence, reasoning]
+ * 
+ * The SQL template for field-level verdicts (field_name = $param) produces:
+ *   params = [recordType, recordId, fieldName, entityId, verdict, confidence, reasoning]
+ */
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- source_check_verdicts: INSERT (upsert) ---
+  if (q.includes("insert into source_check_verdicts")) {
+    // Detect if this is a field-level verdict (has fieldName param) or row-level (NULL literal).
+    // Row-level has 6 interpolated params; field-level has 7.
+    // The key difference: row-level has NULL literal for field_name (not a param),
+    // field-level has ${fieldName} as a param.
+    const isFieldLevel = params.length >= 7;
+    
+    const row: VerdictRow = isFieldLevel
+      ? {
+          recordType: params[0] as string,
+          recordId: params[1] as string,
+          fieldName: params[2] as string | null,
+          // params[3] = entityId (skipped)
+          verdict: params[4] as string,
+          confidence: params[5] as number | null,
+          reasoning: params[6] as string,
+        }
+      : {
+          recordType: params[0] as string,
+          recordId: params[1] as string,
+          fieldName: null,
+          // params[2] = entityId (skipped)
+          verdict: params[3] as string,
+          confidence: params[4] as number | null,
+          reasoning: params[5] as string,
+        };
+
+    // Simulate ON CONFLICT upsert
+    const conflictKey = `${row.recordType}:${row.recordId}:${row.fieldName ?? ""}`;
+    const existing = verdictStore.findIndex(
+      (v) =>
+        `${v.recordType}:${v.recordId}:${v.fieldName ?? ""}` === conflictKey,
+    );
+    if (existing >= 0) {
+      verdictStore[existing] = row;
+    } else {
+      verdictStore.push(row);
+    }
+    return [];
+  }
+
+  // --- source_check_evidence: INSERT (upsert) ---
+  // Params: [recordType, recordId, entityId, sourceUrl, verdict, confidence, evidence, checkerModel, ...]
+  // (field_name is NULL literal, not a param)
+  if (q.includes("insert into source_check_evidence")) {
+    const row: EvidenceRow = {
+      recordType: params[0] as string,
+      recordId: params[1] as string,
+      fieldName: null, // Always NULL for evidence rows
+      sourceUrl: params[3] as string,
+      verdict: params[4] as string,
+      confidence: params[5] as number | null,
+    };
+    evidenceStore.push(row);
+    return [];
+  }
+
+  return [];
+}
+
+// Mock the db module
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { writeInlineVerdicts } = await import(
+  "../routes/tablebase/write-inline-verdicts.js"
+);
+
+// Get the Drizzle instance from the mock (supports tx.execute())
+const dbModule = await import("../db.js");
+const drizzleDb = (dbModule as any).getDrizzleDb();
+
+// ---------------------------------------------------------------------------
+
+describe("writeInlineVerdicts", () => {
+  beforeEach(resetStores);
+
+  it("returns zero counts when no records have sourcing", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      { recordType: "grant", recordId: "g1" },
+      { recordType: "grant", recordId: "g2", sourcing: null },
+    ]);
+
+    expect(result).toEqual({ written: 0, fieldVerdictsWritten: 0 });
+    expect(verdictStore).toHaveLength(0);
+    expect(evidenceStore).toHaveLength(0);
+  });
+
+  it("writes a row-level verdict for a record with sourcing", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        entityId: "ent1",
+        sourcing: {
+          verdict: "confirmed",
+          confidence: 0.9,
+          evidence: "Found matching grant data",
+        },
+      },
+    ]);
+
+    expect(result.written).toBe(1);
+    expect(result.fieldVerdictsWritten).toBe(0);
+    expect(verdictStore).toHaveLength(1);
+    expect(verdictStore[0]).toMatchObject({
+      recordType: "grant",
+      recordId: "g1",
+      fieldName: null,
+      verdict: "confirmed",
+      confidence: 0.9,
+    });
+    expect(verdictStore[0].reasoning).toContain("Inline source-check: confirmed");
+    expect(verdictStore[0].reasoning).toContain("Found matching grant data");
+  });
+
+  it("writes per-field verdicts when fieldVerdicts is present", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        entityId: "ent1",
+        sourcing: {
+          verdict: "confirmed",
+          confidence: 0.9,
+          fieldVerdicts: {
+            amount: { verdict: "confirmed", confidence: 0.95 },
+            start_date: { verdict: "contradicted", confidence: 0.8 },
+            grantee_id: { verdict: "unverifiable" },
+          },
+        },
+      },
+    ]);
+
+    expect(result.written).toBe(1);
+    expect(result.fieldVerdictsWritten).toBe(3);
+    // 1 row-level + 3 field-level = 4 total verdict rows
+    expect(verdictStore).toHaveLength(4);
+
+    // Row-level verdict
+    const rowLevel = verdictStore.find((v) => v.fieldName === null);
+    expect(rowLevel).toBeDefined();
+    expect(rowLevel!.verdict).toBe("confirmed");
+
+    // Field-level verdicts
+    const amountVerdict = verdictStore.find((v) => v.fieldName === "amount");
+    expect(amountVerdict).toBeDefined();
+    expect(amountVerdict!.verdict).toBe("confirmed");
+    expect(amountVerdict!.confidence).toBe(0.95);
+    expect(amountVerdict!.reasoning).toContain("amount");
+
+    const dateVerdict = verdictStore.find(
+      (v) => v.fieldName === "start_date",
+    );
+    expect(dateVerdict).toBeDefined();
+    expect(dateVerdict!.verdict).toBe("contradicted");
+    expect(dateVerdict!.confidence).toBe(0.8);
+
+    const granteeVerdict = verdictStore.find(
+      (v) => v.fieldName === "grantee_id",
+    );
+    expect(granteeVerdict).toBeDefined();
+    expect(granteeVerdict!.verdict).toBe("unverifiable");
+    expect(granteeVerdict!.confidence).toBeNull();
+  });
+
+  it("writes evidence row only at row level (not per-field)", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourceUrl: "https://example.com/grants",
+        sourcing: {
+          verdict: "confirmed",
+          confidence: 0.9,
+          evidence: "Found it",
+          fieldVerdicts: {
+            amount: { verdict: "confirmed", confidence: 0.95 },
+          },
+        },
+      },
+    ]);
+
+    expect(result.written).toBe(1);
+    expect(result.fieldVerdictsWritten).toBe(1);
+    // Only 1 evidence row (row-level), not 2
+    expect(evidenceStore).toHaveLength(1);
+    expect(evidenceStore[0]).toMatchObject({
+      recordType: "grant",
+      recordId: "g1",
+      fieldName: null,
+      sourceUrl: "https://example.com/grants",
+      verdict: "confirmed",
+    });
+  });
+
+  it("skips evidence row when no sourceUrl", async () => {
+    await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourcing: { verdict: "confirmed" },
+      },
+    ]);
+
+    expect(evidenceStore).toHaveLength(0);
+  });
+
+  it("handles multiple records with mixed sourcing and field verdicts", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourcing: {
+          verdict: "confirmed",
+          fieldVerdicts: {
+            amount: { verdict: "confirmed", confidence: 1.0 },
+          },
+        },
+      },
+      {
+        recordType: "grant",
+        recordId: "g2",
+        sourcing: null,
+      },
+      {
+        recordType: "grant",
+        recordId: "g3",
+        sourcing: {
+          verdict: "partial",
+          fieldVerdicts: {
+            amount: { verdict: "confirmed" },
+            recipient: { verdict: "outdated" },
+          },
+        },
+      },
+    ]);
+
+    expect(result.written).toBe(2);
+    expect(result.fieldVerdictsWritten).toBe(3);
+    // 2 row-level + 3 field-level = 5
+    expect(verdictStore).toHaveLength(5);
+  });
+
+  it("handles empty fieldVerdicts object", async () => {
+    const result = await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourcing: {
+          verdict: "confirmed",
+          fieldVerdicts: {},
+        },
+      },
+    ]);
+
+    expect(result.written).toBe(1);
+    expect(result.fieldVerdictsWritten).toBe(0);
+    expect(verdictStore).toHaveLength(1);
+  });
+
+  it("upserts row-level verdict on conflict", async () => {
+    // First write
+    await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourcing: { verdict: "partial", confidence: 0.5 },
+      },
+    ]);
+    expect(verdictStore).toHaveLength(1);
+    expect(verdictStore[0].verdict).toBe("partial");
+
+    // Second write (same record) — should upsert
+    await writeInlineVerdicts(drizzleDb, [
+      {
+        recordType: "grant",
+        recordId: "g1",
+        sourcing: { verdict: "confirmed", confidence: 0.95 },
+      },
+    ]);
+    expect(verdictStore).toHaveLength(1);
+    expect(verdictStore[0].verdict).toBe("confirmed");
+    expect(verdictStore[0].confidence).toBe(0.95);
+  });
+});

--- a/apps/wiki-server/src/routes/shared/source-check-join.ts
+++ b/apps/wiki-server/src/routes/shared/source-check-join.ts
@@ -2,10 +2,10 @@
  * Shared helpers for LEFT JOINing source_check_verdicts into queries
  * and formatting the result into the API response shape.
  */
-import { and, eq, isNotNull, inArray, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, inArray } from "drizzle-orm";
 import type { Column } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { sourceVerdicts } from "../../schema.js";
-import { getDrizzleDb } from "../../db.js";
 
 /**
  * Build the LEFT JOIN condition for source_check_verdicts.
@@ -15,7 +15,7 @@ export function verdictJoinCondition(recordType: string, idColumn: Column) {
   return and(
     eq(sourceVerdicts.recordType, recordType),
     eq(sourceVerdicts.recordId, idColumn),
-    sql`${sourceVerdicts.fieldName} IS NULL`,
+    isNull(sourceVerdicts.fieldName),
   );
 }
 
@@ -64,14 +64,17 @@ export type FieldVerdictsByRecord = Map<string, FieldVerdictRow[]>;
  *
  * This is separate from the row-level verdict JOIN (which filters field_name IS NULL)
  * so that callers can render both the row-level verdict and per-field breakdowns.
+ *
+ * Accepts `db` as parameter to respect transaction boundaries.
+ * PR #4131 will replace this implementation with one using `sqlInList()`.
  */
 export async function fetchFieldVerdicts(
+  db: PostgresJsDatabase<any>,
   recordType: string,
   recordIds: string[],
 ): Promise<FieldVerdictsByRecord> {
   if (recordIds.length === 0) return new Map();
 
-  const db = getDrizzleDb();
   const rows = await db
     .select({
       recordId: sourceVerdicts.recordId,

--- a/apps/wiki-server/src/routes/shared/source-check-join.ts
+++ b/apps/wiki-server/src/routes/shared/source-check-join.ts
@@ -2,9 +2,10 @@
  * Shared helpers for LEFT JOINing source_check_verdicts into queries
  * and formatting the result into the API response shape.
  */
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNotNull, inArray, sql } from "drizzle-orm";
 import type { Column } from "drizzle-orm";
 import { sourceVerdicts } from "../../schema.js";
+import { getDrizzleDb } from "../../db.js";
 
 /**
  * Build the LEFT JOIN condition for source_check_verdicts.
@@ -43,4 +44,68 @@ export function formatSourcing(row: VerdictJoinFields) {
     sourcesChecked: row.sourcingSourcesChecked ?? 0,
     checkedAt: row.sourcingCheckedAt?.toISOString() ?? null,
   };
+}
+
+/** A single per-field verdict row from the database. */
+export interface FieldVerdictRow {
+  recordId: string;
+  fieldName: string;
+  verdict: string;
+  confidence: number | null;
+  lastComputedAt: Date | null;
+}
+
+/** Per-field verdicts grouped by recordId. */
+export type FieldVerdictsByRecord = Map<string, FieldVerdictRow[]>;
+
+/**
+ * Fetch per-field verdicts for a set of records.
+ * Returns verdicts where field_name IS NOT NULL, grouped by record_id.
+ *
+ * This is separate from the row-level verdict JOIN (which filters field_name IS NULL)
+ * so that callers can render both the row-level verdict and per-field breakdowns.
+ */
+export async function fetchFieldVerdicts(
+  recordType: string,
+  recordIds: string[],
+): Promise<FieldVerdictsByRecord> {
+  if (recordIds.length === 0) return new Map();
+
+  const db = getDrizzleDb();
+  const rows = await db
+    .select({
+      recordId: sourceVerdicts.recordId,
+      fieldName: sourceVerdicts.fieldName,
+      verdict: sourceVerdicts.verdict,
+      confidence: sourceVerdicts.confidence,
+      lastComputedAt: sourceVerdicts.lastComputedAt,
+    })
+    .from(sourceVerdicts)
+    .where(
+      and(
+        eq(sourceVerdicts.recordType, recordType),
+        inArray(sourceVerdicts.recordId, recordIds),
+        isNotNull(sourceVerdicts.fieldName),
+      ),
+    )
+    .orderBy(sourceVerdicts.recordId, sourceVerdicts.fieldName);
+
+  const result: FieldVerdictsByRecord = new Map();
+  for (const row of rows) {
+    const entry: FieldVerdictRow = {
+      recordId: row.recordId,
+      fieldName: row.fieldName!,
+      verdict: row.verdict,
+      confidence: row.confidence,
+      lastComputedAt: row.lastComputedAt,
+    };
+    const existing = result.get(row.recordId);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      result.set(row.recordId, [entry]);
+    }
+  }
+
+  return result;
 }

--- a/apps/wiki-server/src/routes/tablebase/sourcing-schema.ts
+++ b/apps/wiki-server/src/routes/tablebase/sourcing-schema.ts
@@ -1,22 +1,39 @@
 import { z } from "zod";
 
+/** Verdict enum shared between row-level and field-level verdicts. */
+export const VerdictEnum = z.enum([
+  "confirmed",
+  "contradicted",
+  "outdated",
+  "partial",
+  "unverifiable",
+]);
+
+/** Per-field verdict (e.g., for "amount", "start_date", "grantee_id"). */
+export const FieldVerdictSchema = z.object({
+  verdict: VerdictEnum,
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+export type FieldVerdict = z.infer<typeof FieldVerdictSchema>;
+
 /**
  * Optional source-check data that can be submitted alongside any TableBase record.
  * When present, a source_check_verdict is written atomically with the record.
  */
 export const InlineSourcingSchema = z.object({
-  verdict: z.enum([
-    "confirmed",
-    "contradicted",
-    "outdated",
-    "partial",
-    "unverifiable",
-  ]),
+  verdict: VerdictEnum,
   evidence: z.string().max(5000).optional(),
   confidence: z.number().min(0).max(1).optional(),
   sourceContentHash: z.string().max(100).optional(),
   checkedAt: z.string().datetime().optional(),
   checkedBy: z.string().max(100).optional(),
+  /**
+   * Per-field verdicts keyed by snake_case column name (e.g., "amount", "start_date").
+   * When present, additional source_check_verdicts rows are written with field_name set.
+   * The row-level verdict (field_name = NULL) is always written regardless.
+   */
+  fieldVerdicts: z.record(z.string(), FieldVerdictSchema).optional(),
 });
 
 export type InlineSourcing = z.infer<typeof InlineSourcingSchema>;

--- a/apps/wiki-server/src/routes/tablebase/sourcing-schema.ts
+++ b/apps/wiki-server/src/routes/tablebase/sourcing-schema.ts
@@ -33,7 +33,12 @@ export const InlineSourcingSchema = z.object({
    * When present, additional source_check_verdicts rows are written with field_name set.
    * The row-level verdict (field_name = NULL) is always written regardless.
    */
-  fieldVerdicts: z.record(z.string(), FieldVerdictSchema).optional(),
+  fieldVerdicts: z
+    .record(
+      z.string().regex(/^[a-z_][a-z0-9_]*$/).max(63),
+      FieldVerdictSchema,
+    )
+    .optional(),
 });
 
 export type InlineSourcing = z.infer<typeof InlineSourcingSchema>;

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -280,6 +280,7 @@ export interface SyncConfig<TItem, TTable extends PgTable> {
 export interface SyncResponse {
   upserted: number;
   verdictsWritten: number;
+  fieldVerdictsWritten: number;
   claimsLinked: number;
   claimLinkingError?: string;
 }
@@ -499,7 +500,7 @@ export function createSyncHandler<
     const chunkSize = computeChunkSize(columnCount);
 
     let upserted = 0;
-    let verdictsResult = { written: 0 };
+    let verdictsResult = { written: 0, fieldVerdictsWritten: 0 };
 
     const conflictTarget = config.conflictTarget ?? (table as unknown as { id: PgColumn }).id; // as-any-ok: PgTable generic doesn't expose column names; same pattern as deleteBatchHandler
     const conflictSet =
@@ -647,6 +648,7 @@ export function createSyncHandler<
     const response: SyncResponse = {
       upserted,
       verdictsWritten: verdictsResult.written,
+      fieldVerdictsWritten: verdictsResult.fieldVerdictsWritten,
       claimsLinked,
       ...(claimLinkingError ? { claimLinkingError } : {}),
     };

--- a/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
+++ b/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
@@ -21,6 +21,10 @@ type DbOrTx =
  * Uses the same upsert pattern as source-checks.ts verdict writes:
  *   - Verdicts keyed on (record_type, record_id, COALESCE(field_name, ''))
  *   - Evidence keyed on (record_type, record_id, COALESCE(source_url, ''), COALESCE(checker_model, ''))
+ *
+ * When `sourcing.fieldVerdicts` is present, additional per-field verdict rows
+ * are written alongside the row-level verdict. Evidence rows are only written
+ * at the row level (the evidence dedup index does not include field_name).
  */
 export async function writeInlineVerdicts(
   tx: DbOrTx,
@@ -31,14 +35,16 @@ export async function writeInlineVerdicts(
     sourceUrl?: string | null;
     sourcing?: InlineSourcing | null;
   }>
-): Promise<{ written: number }> {
+): Promise<{ written: number; fieldVerdictsWritten: number }> {
   const withSourcing = records.filter((r) => r.sourcing);
-  if (withSourcing.length === 0) return { written: 0 };
+  if (withSourcing.length === 0) return { written: 0, fieldVerdictsWritten: 0 };
+
+  let fieldVerdictsWritten = 0;
 
   for (const record of withSourcing) {
     const v = record.sourcing!;
 
-    // Upsert verdict — same conflict key as source-checks.ts
+    // Upsert row-level verdict (field_name = NULL) — same conflict key as source-checks.ts
     // Note: `reasoning` is the verdict-level summary (not raw evidence text).
     // Raw evidence goes in source_check_evidence.extracted_quote.
     const reasoning = v.evidence
@@ -75,7 +81,49 @@ export async function writeInlineVerdicts(
         updated_at = NOW()
     `);
 
-    // Also write evidence row if we have a source URL
+    // Write per-field verdicts if present
+    if (v.fieldVerdicts) {
+      for (const [fieldName, fv] of Object.entries(v.fieldVerdicts)) {
+        const fieldReasoning = `Inline field source-check: ${fieldName} = ${fv.verdict}`;
+        await tx.execute(sql`
+          INSERT INTO source_check_verdicts (
+            record_type, record_id, field_name, entity_id,
+            verdict, confidence, reasoning, sources_checked,
+            needs_recheck, next_check_due,
+            last_computed_at, created_at, updated_at
+          ) VALUES (
+            ${record.recordType},
+            ${record.recordId},
+            ${fieldName},
+            ${record.entityId ?? null},
+            ${fv.verdict},
+            ${fv.confidence ?? null},
+            ${fieldReasoning},
+            1,
+            false,
+            NOW() + INTERVAL '90 days',
+            NOW(), NOW(), NOW()
+          )
+          ON CONFLICT (record_type, record_id, COALESCE(field_name, ''))
+          DO UPDATE SET
+            verdict = EXCLUDED.verdict,
+            confidence = EXCLUDED.confidence,
+            reasoning = EXCLUDED.reasoning,
+            sources_checked = EXCLUDED.sources_checked,
+            needs_recheck = false,
+            next_check_due = NOW() + INTERVAL '90 days',
+            last_computed_at = NOW(),
+            updated_at = NOW()
+        `);
+        fieldVerdictsWritten++;
+      }
+    }
+
+    // Also write evidence row if we have a source URL.
+    // Note: evidence rows are only written at the row level (field_name = NULL).
+    // The evidence dedup index (idx_sce_dedup) does not include field_name,
+    // so per-field evidence rows would conflict. Per-field evidence can be
+    // added in a follow-up after the dedup index is extended.
     if (record.sourceUrl) {
       await tx.execute(sql`
         INSERT INTO source_check_evidence (
@@ -107,7 +155,7 @@ export async function writeInlineVerdicts(
     }
   }
 
-  return { written: withSourcing.length };
+  return { written: withSourcing.length, fieldVerdictsWritten };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extend `writeInlineVerdicts` to write per-field verdicts alongside row-level verdicts when `sourcing.fieldVerdicts` is present
- Add `FieldVerdictSchema` and `fieldVerdicts` field to `InlineSourcingSchema` (Zod schema)
- Add `fetchFieldVerdicts()` function to `source-check-join.ts` for reading per-field verdicts grouped by record ID
- Track `fieldVerdictsWritten` count in sync factory `SyncResponse`

## Design decisions

- Evidence rows remain row-level only (field_name = NULL) because the evidence dedup index (`idx_sce_dedup`) does not include `field_name`. Per-field evidence can be added in a follow-up after the index is extended.
- Backward compatible: existing sync routes only access `.written` from the return value, which is unchanged.
- No existing sync routes need modification in this PR — they will start writing per-field verdicts when they are updated to pass `fieldVerdicts` data.

## Test plan

- [x] 8 new tests for `writeInlineVerdicts`: row-level only, with field verdicts, mixed records, empty fieldVerdicts, upsert, evidence isolation
- [x] 3 new tests for `fetchFieldVerdicts`: empty input, grouped results, NULL field_name exclusion
- [x] Existing sync-factory tests pass (13 tests)
- [x] Full test suite passes (5334 tests, 0 failures)
- [x] TypeScript compiles cleanly (wiki-server + web)

Fixes QUA-203 (partial — step 1 of 3)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-field source verdicts, enabling sourcing confidence and verdict information to be assigned to individual data fields in addition to record-level verdicts
  * Enhanced verdict write response to separately track the count of field-level verdicts written

* **Tests**
  * Added comprehensive test coverage for field-level verdict retrieval and write operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->