### PR TITLE
feat: claims-first source-discover agent (--v2)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -1167,8 +1167,8 @@ async function sourceDiscoverCommand(args: string[], options: CommandOptions): P
   const apply = !!options.apply;
   const limit = options.limit ? parseInt(options.limit as string, 10) : 10;
   const entityOnly = !!(options as Record<string, unknown>).entityOnly;
-
-  const { discoverSources } = await import('../tablebase/source-discovery.ts');
+  const useV2 = !!(options as Record<string, unknown>).v2;
+  const claimsOnly = !!(options as Record<string, unknown>).claimsOnly;
 
   // Resolve entity name to ID if provided
   let entityId: string | undefined;
@@ -1180,6 +1180,69 @@ async function sourceDiscoverCommand(args: string[], options: CommandOptions): P
     entityId = match?.stableId || entityArg;
     entityName = match?.name || entityArg;
   }
+
+  // ── V2: Claims-first agent ──────────────────────────────────────────
+  if (useV2) {
+    if (!entityId) {
+      return { exitCode: 1, output: 'Error: --v2 requires an entity argument (e.g., crux tb source-discover anthropic --v2)' };
+    }
+
+    const { runSourceDiscoverAgent } = await import('../tablebase/source-discover-agent.ts');
+
+    const result = await runSourceDiscoverAgent({
+      entityId,
+      entityName,
+      limit,
+      dryRun: !apply && !claimsOnly,
+      apply,
+      claimsOnly,
+      budgetCap: options.budget ? parseFloat(options.budget) : 1.00,
+    });
+
+    if (options.ci) {
+      return { exitCode: 0, output: JSON.stringify(result, null, 2) };
+    }
+
+    // Format summary
+    const lines: string[] = [
+      `Entity: ${result.entityName} (${result.entityId})`,
+      `Unverifiable records: ${result.unverifiableCount} total, ${result.recordsProcessed} processed`,
+      `Sources: ${result.sourcesDiscovered} discovered, ${result.sourcesWithClaims} with claims`,
+      `Claims: ${result.claimsExtracted} extracted, ${result.claimsSubmitted} submitted`,
+      `Cost: $${result.cost.toFixed(4)}, Duration: ${Math.round(result.durationMs / 1000)}s`,
+    ];
+
+    if (result.batchId) {
+      lines.push(`Batch ID: ${result.batchId}`);
+    }
+
+    if (result.verificationStatus) {
+      const v = result.verificationStatus;
+      lines.push(`Verification: ${v.verified} verified, ${v.contradicted} contradicted, ${v.unverifiable} unverifiable, ${v.pending} pending${v.timedOut ? ' (timed out)' : ''}`);
+    }
+
+    if (result.sources.length > 0) {
+      lines.push('', 'Sources with claims:');
+      for (const s of result.sources) {
+        lines.push(`  ${s.title} (${s.claims.length} claims)`);
+        for (const c of s.claims.slice(0, 3)) {
+          lines.push(`    - ${c.claimText.slice(0, 100)}${c.claimText.length > 100 ? '...' : ''}`);
+        }
+        if (s.claims.length > 3) {
+          lines.push(`    ... and ${s.claims.length - 3} more`);
+        }
+      }
+    }
+
+    const mode = apply ? 'apply' : claimsOnly ? 'claims-only' : 'dry-run';
+    return {
+      exitCode: 0,
+      output: `[source-discover-agent v2] ${mode}\n${lines.join('\n')}`,
+    };
+  }
+
+  // ── V1: Legacy string-matching approach ─────────────────────────────
+  const { discoverSources } = await import('../tablebase/source-discovery.ts');
 
   const result = await discoverSources({ entityId, entityName, limit, dryRun, apply, entityOnly });
 
@@ -1328,6 +1391,8 @@ Options:
   --records-file=<path>     JSON file for submit command
   --skip-source-check       Skip source-check before submit (for testing)
   --apply                   For source-discover: also link discovered resources to records
+  --v2                      For source-discover: use claims-first agent (extracts + submits claims)
+  --claims-only             For source-discover --v2: submit claims but don't apply results
   --ci                      JSON output
 
 Modes:
@@ -1357,6 +1422,9 @@ Examples:
   crux tb tablebase source-discover anthropic --dry-run       # Preview source suggestions for Anthropic
   crux tb tablebase source-discover --limit=5 --budget=5     # Discover sources for top 5 entities
   crux tb tablebase source-discover anthropic --apply        # Discover + link sources to records
+  crux tb tablebase source-discover anthropic --v2           # Claims-first discovery (dry-run)
+  crux tb tablebase source-discover anthropic --v2 --apply   # Claims-first: extract + submit + verify
+  crux tb tablebase source-discover anthropic --v2 --claims-only  # Submit claims but don't apply
   crux tb tablebase normalize-ids                            # Dry-run: show slug-based IDs
   crux tb tablebase normalize-ids --apply                    # Fix slug-based IDs
   crux tb tablebase resolve "OpenAI"                       # Resolve name → stableId

--- a/crux/tablebase/claim-extractor.test.ts
+++ b/crux/tablebase/claim-extractor.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildExtractionPrompt,
+  parseClaimsResponse,
+  type UnverifiableRecord,
+} from './claim-extractor.ts';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const sampleRecords: UnverifiableRecord[] = [
+  {
+    recordType: 'personnel',
+    recordId: 'rec-001',
+    fieldName: 'title',
+    displayName: 'Personnel: Alice Smith at Anthropic (Research Scientist)',
+    reasoning: 'No source found for this role',
+    entityId: 'anthropic',
+  },
+  {
+    recordType: 'personnel',
+    recordId: 'rec-002',
+    fieldName: 'startDate',
+    displayName: 'Personnel: Bob Jones at Anthropic (VP Engineering)',
+    reasoning: 'Could not verify employment dates',
+    entityId: 'anthropic',
+  },
+  {
+    recordType: 'grant',
+    recordId: 'rec-003',
+    fieldName: null,
+    displayName: 'Grant: $5M from Open Philanthropy',
+    reasoning: 'Source URL is dead',
+    entityId: 'anthropic',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// buildExtractionPrompt
+// ---------------------------------------------------------------------------
+
+describe('buildExtractionPrompt', () => {
+  it('includes source content and URL', () => {
+    const prompt = buildExtractionPrompt(
+      'Alice Smith joined Anthropic as Research Scientist in 2024.',
+      'https://example.com/team',
+      sampleRecords,
+    );
+
+    expect(prompt).toContain('https://example.com/team');
+    expect(prompt).toContain('Alice Smith joined Anthropic');
+  });
+
+  it('includes all record IDs in the prompt', () => {
+    const prompt = buildExtractionPrompt(
+      'Some content',
+      'https://example.com',
+      sampleRecords,
+    );
+
+    expect(prompt).toContain('rec-001');
+    expect(prompt).toContain('rec-002');
+    expect(prompt).toContain('rec-003');
+  });
+
+  it('includes record type and displayName', () => {
+    const prompt = buildExtractionPrompt(
+      'Some content',
+      'https://example.com',
+      sampleRecords,
+    );
+
+    expect(prompt).toContain('type="personnel"');
+    expect(prompt).toContain('type="grant"');
+    expect(prompt).toContain('Alice Smith at Anthropic');
+  });
+
+  it('escapes XML-special characters in content', () => {
+    const prompt = buildExtractionPrompt(
+      'Revenue was <$100M & growing > 50%',
+      'https://example.com/report?q=a&b=c',
+      [sampleRecords[0]],
+    );
+
+    // Content should be escaped
+    expect(prompt).toContain('&lt;$100M');
+    expect(prompt).toContain('&amp; growing');
+    expect(prompt).toContain('&gt; 50%');
+    // URL in attribute should also be escaped
+    expect(prompt).toContain('q=a&amp;b=c');
+  });
+
+  it('truncates very long content', () => {
+    const longContent = 'x'.repeat(10_000);
+    const prompt = buildExtractionPrompt(
+      longContent,
+      'https://example.com',
+      [sampleRecords[0]],
+    );
+
+    expect(prompt).toContain('[... truncated]');
+    // The content portion should be capped (8000 chars + truncation marker)
+    expect(prompt.length).toBeLessThan(longContent.length + 2000);
+  });
+
+  it('handles records with null fields gracefully', () => {
+    const record: UnverifiableRecord = {
+      recordType: 'grant',
+      recordId: 'rec-100',
+      fieldName: null,
+      displayName: null,
+      reasoning: null,
+      entityId: null,
+    };
+
+    const prompt = buildExtractionPrompt('Some content', 'https://example.com', [record]);
+    expect(prompt).toContain('rec-100');
+    expect(prompt).toContain('type="grant"');
+    // Should not contain empty attributes
+    expect(prompt).not.toContain('displayName=""');
+  });
+
+  it('includes reasoning when present', () => {
+    const prompt = buildExtractionPrompt(
+      'Some content',
+      'https://example.com',
+      sampleRecords,
+    );
+
+    expect(prompt).toContain('<reasoning>No source found for this role</reasoning>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseClaimsResponse
+// ---------------------------------------------------------------------------
+
+describe('parseClaimsResponse', () => {
+  it('parses a valid JSON array response', () => {
+    const raw = JSON.stringify([
+      {
+        claimText: 'Alice Smith is a Research Scientist at Anthropic.',
+        targetField: 'title',
+        proposedValue: 'Research Scientist',
+        recordIds: ['rec-001'],
+      },
+      {
+        claimText: 'Bob Jones joined Anthropic in January 2023.',
+        targetField: 'startDate',
+        proposedValue: '2023-01',
+        recordIds: ['rec-002'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(2);
+
+    expect(claims[0].claimText).toBe('Alice Smith is a Research Scientist at Anthropic.');
+    expect(claims[0].targetField).toBe('title');
+    expect(claims[0].proposedValue).toBe('Research Scientist');
+    expect(claims[0].matchedRecordIds).toEqual(['rec-001']);
+
+    expect(claims[1].claimText).toBe('Bob Jones joined Anthropic in January 2023.');
+    expect(claims[1].targetField).toBe('startDate');
+    expect(claims[1].proposedValue).toBe('2023-01');
+    expect(claims[1].matchedRecordIds).toEqual(['rec-002']);
+  });
+
+  it('handles claims with null optional fields', () => {
+    const raw = JSON.stringify([
+      {
+        claimText: 'Anthropic received a $5M grant.',
+        targetField: null,
+        proposedValue: null,
+        recordIds: ['rec-003'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].targetField).toBeNull();
+    expect(claims[0].proposedValue).toBeNull();
+  });
+
+  it('handles claims with missing optional fields', () => {
+    const raw = JSON.stringify([
+      {
+        claimText: 'A factual claim.',
+        recordIds: ['rec-001'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].targetField).toBeNull();
+    expect(claims[0].proposedValue).toBeNull();
+  });
+
+  it('extracts JSON from markdown-fenced response', () => {
+    const raw = `Here are the claims I found:
+
+\`\`\`json
+[
+  {
+    "claimText": "Alice is a scientist.",
+    "targetField": "title",
+    "proposedValue": "scientist",
+    "recordIds": ["rec-001"]
+  }
+]
+\`\`\``;
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].claimText).toBe('Alice is a scientist.');
+  });
+
+  it('returns empty array for non-JSON response', () => {
+    const claims = parseClaimsResponse('I could not find any relevant claims in this source.');
+    expect(claims).toEqual([]);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    const claims = parseClaimsResponse('[{bad json}]');
+    expect(claims).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    const claims = parseClaimsResponse('');
+    expect(claims).toEqual([]);
+  });
+
+  it('skips invalid items but keeps valid ones (partial extraction)', () => {
+    // One valid, one missing required claimText
+    const raw = JSON.stringify([
+      {
+        claimText: 'Valid claim.',
+        recordIds: ['rec-001'],
+      },
+      {
+        targetField: 'title',
+        recordIds: ['rec-002'],
+        // Missing claimText — invalid
+      },
+      {
+        claimText: 'Another valid claim.',
+        recordIds: ['rec-003'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(2);
+    expect(claims[0].claimText).toBe('Valid claim.');
+    expect(claims[1].claimText).toBe('Another valid claim.');
+  });
+
+  it('skips items with empty recordIds', () => {
+    const raw = JSON.stringify([
+      {
+        claimText: 'Orphan claim with no records.',
+        recordIds: [],
+      },
+      {
+        claimText: 'Valid claim.',
+        recordIds: ['rec-001'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].claimText).toBe('Valid claim.');
+  });
+
+  it('handles claims referencing multiple records', () => {
+    const raw = JSON.stringify([
+      {
+        claimText: 'Anthropic team page lists both Alice and Bob.',
+        targetField: null,
+        proposedValue: null,
+        recordIds: ['rec-001', 'rec-002'],
+      },
+    ]);
+
+    const claims = parseClaimsResponse(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].matchedRecordIds).toEqual(['rec-001', 'rec-002']);
+  });
+});

--- a/crux/tablebase/claim-extractor.ts
+++ b/crux/tablebase/claim-extractor.ts
@@ -1,0 +1,225 @@
+/**
+ * Claim Extractor — Extract structured claims from source content.
+ *
+ * Takes fetched source content + a list of unverifiable records and uses
+ * Haiku to extract claims that could verify those records. Returns
+ * structured claims ready for proposeClaims().
+ *
+ * Part of the claims-first source-discover agent (QUA-210).
+ */
+
+import { z } from 'zod';
+import { createLlmClient, streamingCreate, extractText, MODELS } from '../lib/llm.ts';
+import { escapeXml } from '../lib/prompt-utils.ts';
+import { MODEL_PRICING } from '../lib/pricing.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UnverifiableRecord {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  displayName: string | null;
+  reasoning: string | null;
+  entityId: string | null;
+}
+
+export interface ExtractedClaim {
+  claimText: string;
+  targetField: string | null;
+  proposedValue: string | null;
+  /** Which record(s) this claim is relevant to */
+  matchedRecordIds: string[];
+}
+
+export interface ClaimExtractionResult {
+  claims: ExtractedClaim[];
+  cost: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema for LLM output validation
+// ---------------------------------------------------------------------------
+
+const LlmClaimSchema = z.object({
+  claimText: z.string().min(1),
+  targetField: z.string().nullable().optional(),
+  proposedValue: z.string().nullable().optional(),
+  recordIds: z.array(z.string()).min(1),
+});
+
+const LlmClaimsResponseSchema = z.array(LlmClaimSchema);
+
+// ---------------------------------------------------------------------------
+// Prompt builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the extraction prompt. Exported for testing.
+ */
+export function buildExtractionPrompt(
+  sourceContent: string,
+  sourceUrl: string,
+  records: UnverifiableRecord[],
+): string {
+  const maxContentLength = 8_000;
+  const truncatedContent = sourceContent.length > maxContentLength
+    ? sourceContent.slice(0, maxContentLength) + '\n[... truncated]'
+    : sourceContent;
+
+  const recordsXml = records.map(r => {
+    const displayPart = r.displayName ? ` displayName="${escapeXml(r.displayName)}"` : '';
+    const fieldPart = r.fieldName ? ` fieldName="${escapeXml(r.fieldName)}"` : '';
+    const reasoningPart = r.reasoning
+      ? `\n    <reasoning>${escapeXml(r.reasoning)}</reasoning>`
+      : '';
+    return `  <record id="${escapeXml(r.recordId)}" type="${escapeXml(r.recordType)}"${displayPart}${fieldPart}>${reasoningPart}\n  </record>`;
+  }).join('\n');
+
+  return `You are a structured data extraction assistant. Given a source document and a list of database records that need verification, extract factual claims from the source that could verify or update those records.
+
+<source url="${escapeXml(sourceUrl)}">
+${escapeXml(truncatedContent)}
+</source>
+
+<records_needing_verification>
+${recordsXml}
+</records_needing_verification>
+
+Instructions:
+- Extract ONLY claims that are explicitly stated in the source content.
+- Each claim must reference at least one record ID from the list above.
+- Include a proposedValue when the source states a concrete value (number, date, name, title).
+- Include targetField when you can identify which specific field the claim updates (e.g., "title", "startDate", "source").
+- Do NOT fabricate information not present in the source.
+- Return at most 20 claims.
+
+Return a JSON array of objects with these fields:
+- claimText (string): A clear factual statement from the source.
+- targetField (string | null): The database field this claim updates, if identifiable.
+- proposedValue (string | null): The concrete value from the source, if applicable.
+- recordIds (string[]): Which record IDs from the list this claim is relevant to.
+
+Return ONLY the JSON array. No prose, no markdown fences.`;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse LLM response into validated claims. Exported for testing.
+ */
+export function parseClaimsResponse(raw: string): ExtractedClaim[] {
+  // Try to extract a JSON array from the response
+  const jsonMatch = raw.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return [];
+  }
+
+  const result = LlmClaimsResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    // Try partial extraction: validate each item individually
+    if (!Array.isArray(parsed)) return [];
+    const claims: ExtractedClaim[] = [];
+    for (const item of parsed) {
+      const single = LlmClaimSchema.safeParse(item);
+      if (single.success) {
+        claims.push({
+          claimText: single.data.claimText,
+          targetField: single.data.targetField ?? null,
+          proposedValue: single.data.proposedValue ?? null,
+          matchedRecordIds: single.data.recordIds,
+        });
+      }
+    }
+    return claims;
+  }
+
+  return result.data.map(c => ({
+    claimText: c.claimText,
+    targetField: c.targetField ?? null,
+    proposedValue: c.proposedValue ?? null,
+    matchedRecordIds: c.recordIds,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Main extraction function
+// ---------------------------------------------------------------------------
+
+const HAIKU_PRICING = MODEL_PRICING['claude-haiku-4-5-20251001'];
+
+let _llmClient: ReturnType<typeof createLlmClient> | null = null;
+function getLlmClient() {
+  if (!_llmClient) _llmClient = createLlmClient();
+  return _llmClient;
+}
+
+/**
+ * Extract structured claims from source content using Haiku.
+ *
+ * @param sourceContent - The fetched text content of the source
+ * @param sourceUrl - The URL of the source (for context)
+ * @param records - Unverifiable records to match claims against
+ * @returns Extracted claims with cost info
+ */
+export async function extractClaims(
+  sourceContent: string,
+  sourceUrl: string,
+  records: UnverifiableRecord[],
+): Promise<ClaimExtractionResult> {
+  if (!sourceContent.trim() || records.length === 0) {
+    return { claims: [], cost: 0, inputTokens: 0, outputTokens: 0 };
+  }
+
+  const prompt = buildExtractionPrompt(sourceContent, sourceUrl, records);
+
+  let raw: string;
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  try {
+    const response = await streamingCreate(getLlmClient(), {
+      model: MODELS.haiku,
+      max_tokens: 2000,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    raw = extractText(response);
+    inputTokens = response.usage?.input_tokens ?? 0;
+    outputTokens = response.usage?.output_tokens ?? 0;
+  } catch (err: unknown) {
+    console.warn(
+      `[claim-extractor] Haiku call failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { claims: [], cost: 0, inputTokens: 0, outputTokens: 0 };
+  }
+
+  const cost =
+    (inputTokens / 1_000_000) * HAIKU_PRICING.inputPerM +
+    (outputTokens / 1_000_000) * HAIKU_PRICING.outputPerM;
+
+  const claims = parseClaimsResponse(raw);
+
+  // Filter claims to only reference valid record IDs from the input
+  const validRecordIds = new Set(records.map(r => r.recordId));
+  const filteredClaims = claims
+    .map(c => ({
+      ...c,
+      matchedRecordIds: c.matchedRecordIds.filter(id => validRecordIds.has(id)),
+    }))
+    .filter(c => c.matchedRecordIds.length > 0);
+
+  return { claims: filteredClaims, cost, inputTokens, outputTokens };
+}

--- a/crux/tablebase/source-discover-agent.ts
+++ b/crux/tablebase/source-discover-agent.ts
@@ -86,6 +86,9 @@ export interface AgentResult {
   cost: number;
   /** Duration in ms */
   durationMs: number;
+  /** Non-null when the run exited early — distinguishes "no unverifiable
+   *  records" from "research failed" or "no usable sources found". */
+  skipReason?: string;
 }
 
 export interface VerificationPollResult {
@@ -185,7 +188,7 @@ export async function runSourceDiscoverAgent(
 
   if (records.length === 0) {
     console.log(`[source-discover-agent] ${entityName}: no unverifiable records found.`);
-    return emptyResult(entityId, entityName, startMs);
+    return emptyResult(entityId, entityName, startMs, 'no unverifiable records');
   }
 
   // Log record type breakdown
@@ -223,7 +226,7 @@ export async function runSourceDiscoverAgent(
     console.warn(
       `[source-discover-agent] Research failed: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return emptyResult(entityId, entityName, startMs);
+    return emptyResult(entityId, entityName, startMs, `research failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   const fetchedSources = researchResult.sources.filter(s => s.content && s.content.length >= 50);
@@ -232,7 +235,7 @@ export async function runSourceDiscoverAgent(
   );
 
   if (fetchedSources.length === 0) {
-    return emptyResult(entityId, entityName, startMs);
+    return emptyResult(entityId, entityName, startMs, 'no sources with usable content (all < 50 chars)');
   }
 
   // ─── Step 3: Register resources ───────────────────────────────────
@@ -316,37 +319,48 @@ export async function runSourceDiscoverAgent(
       }
     }
 
-    // Submit claims for each target table
+    // Submit claims for each target table, batching at 100 (API limit).
+    // All batch IDs are collected so none are silently lost.
+    const allBatchIds: string[] = [];
+
     for (const [targetTable, claims] of claimsByTable) {
       if (claims.length === 0) continue;
 
-      // Cap at 100 per batch (API limit)
-      const batch = claims.slice(0, 100);
+      // Submit in 100-claim chunks instead of silently truncating
+      for (let offset = 0; offset < claims.length; offset += 100) {
+        const batch = claims.slice(offset, offset + 100);
 
-      try {
-        const result = await proposeClaims({
-          entityId,
-          targetTable,
-          claims: batch,
-        });
+        try {
+          const result = await proposeClaims({
+            entityId,
+            targetTable,
+            claims: batch,
+          });
 
-        if (result.ok) {
-          claimsSubmitted += batch.length;
-          // Use the last batch ID (if multiple tables, they get separate batches)
-          batchId = result.data.batchId;
-          console.log(
-            `[source-discover-agent] ${entityName}: submitted ${batch.length} claims for ${targetTable} (batch: ${batchId})`,
-          );
-        } else {
+          if (result.ok) {
+            claimsSubmitted += batch.length;
+            allBatchIds.push(result.data.batchId);
+            batchId = result.data.batchId; // keep last for polling
+            console.log(
+              `[source-discover-agent] ${entityName}: submitted ${batch.length}/${claims.length} claims for ${targetTable} (batch: ${batchId})`,
+            );
+          } else {
+            console.warn(
+              `[source-discover-agent] ${entityName}: claim submission failed for ${targetTable}: ${result.message}`,
+            );
+          }
+        } catch (err: unknown) {
           console.warn(
-            `[source-discover-agent] ${entityName}: claim submission failed for ${targetTable}: ${result.message}`,
+            `[source-discover-agent] ${entityName}: claim submission error for ${targetTable}: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
-      } catch (err: unknown) {
-        console.warn(
-          `[source-discover-agent] ${entityName}: claim submission error for ${targetTable}: ${err instanceof Error ? err.message : String(err)}`,
-        );
       }
+    }
+
+    if (allBatchIds.length > 1) {
+      console.log(
+        `[source-discover-agent] ${entityName}: ${allBatchIds.length} batches submitted: ${allBatchIds.join(', ')}`,
+      );
     }
   }
 
@@ -449,7 +463,12 @@ async function pollForVerification(
 // Helpers
 // ---------------------------------------------------------------------------
 
-function emptyResult(entityId: string, entityName: string, startMs: number): AgentResult {
+function emptyResult(
+  entityId: string,
+  entityName: string,
+  startMs: number,
+  skipReason?: string,
+): AgentResult {
   return {
     entityId,
     entityName,
@@ -464,5 +483,6 @@ function emptyResult(entityId: string, entityName: string, startMs: number): Age
     sources: [],
     cost: 0,
     durationMs: Date.now() - startMs,
+    ...(skipReason ? { skipReason } : {}),
   };
 }

--- a/crux/tablebase/source-discover-agent.ts
+++ b/crux/tablebase/source-discover-agent.ts
@@ -1,0 +1,468 @@
+/**
+ * Source Discover Agent V3 — Claims-first source discovery
+ *
+ * Replaces the string-matching approach in source-discovery.ts (V2) with a
+ * claims-first pipeline that:
+ *   1. Gets unverifiable records for an entity via getFailures()
+ *   2. Runs runResearch() to discover sources
+ *   3. Registers resources via suggestResources()
+ *   4. Extracts structured claims from fetched content via Haiku
+ *   5. Submits claims via proposeClaims()
+ *   6. Optionally polls for verification via getClaimStatus()
+ *
+ * All record types are handled from day one — the claim extraction prompt
+ * is type-agnostic. No string-matching heuristics.
+ *
+ * Part of QUA-210.
+ */
+
+import { runResearch } from '../lib/search/research-agent.ts';
+import type { ResearchResult } from '../lib/search/research-agent.ts';
+import { getFailures } from '../lib/wiki-server/source-checks.ts';
+import type { FailuresResponse } from '../lib/wiki-server/source-checks.ts';
+import { suggestResources } from '../lib/search/suggest-resources.ts';
+import { proposeClaims, getClaimStatus } from '../lib/wiki-server/claims.ts';
+import type { ProposeClaims } from '../../apps/wiki-server/src/api-types.ts';
+import { extractClaims } from './claim-extractor.ts';
+import type { UnverifiableRecord, ExtractedClaim } from './claim-extractor.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SourceDiscoverAgentOptions {
+  /** Entity slug or stableId */
+  entityId: string;
+  /** Human-readable entity name (for search queries) */
+  entityName?: string;
+  /** Max unverifiable records to process (default: 50) */
+  limit?: number;
+  /** Preview mode — discover sources and extract claims, but don't submit (default) */
+  dryRun?: boolean;
+  /** Submit claims to the claims pipeline for async verification */
+  apply?: boolean;
+  /** Submit claims but don't apply verified results to records */
+  claimsOnly?: boolean;
+  /** Record types to filter by (default: all) */
+  recordTypes?: string[];
+  /** Budget cap for research in USD (default: 1.00) */
+  budgetCap?: number;
+  /** Poll for claim verification status after submitting (default: false) */
+  pollVerification?: boolean;
+  /** Max seconds to poll for verification (default: 120) */
+  pollTimeoutSec?: number;
+}
+
+export interface SourceWithClaims {
+  url: string;
+  title: string;
+  contentLength: number;
+  claims: ExtractedClaim[];
+  resourceId?: string;
+}
+
+export interface AgentResult {
+  entityId: string;
+  entityName: string;
+  /** Total unverifiable records found */
+  unverifiableCount: number;
+  /** Records filtered by record type (if applicable) */
+  recordsProcessed: number;
+  /** Sources discovered via research agent */
+  sourcesDiscovered: number;
+  /** Sources that yielded at least one claim */
+  sourcesWithClaims: number;
+  /** Total claims extracted across all sources */
+  claimsExtracted: number;
+  /** Claims submitted to the pipeline (0 if dry-run) */
+  claimsSubmitted: number;
+  /** Batch ID from proposeClaims (null if dry-run) */
+  batchId: string | null;
+  /** Verification status if polling was enabled */
+  verificationStatus: VerificationPollResult | null;
+  /** Per-source breakdown */
+  sources: SourceWithClaims[];
+  /** Cost in USD */
+  cost: number;
+  /** Duration in ms */
+  durationMs: number;
+}
+
+export interface VerificationPollResult {
+  total: number;
+  verified: number;
+  contradicted: number;
+  unverifiable: number;
+  pending: number;
+  timedOut: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map a verdict row from the failures API to our internal type. */
+function toUnverifiableRecord(v: FailuresResponse['items'][number]): UnverifiableRecord {
+  return {
+    recordType: v.recordType,
+    recordId: v.recordId,
+    fieldName: v.fieldName ?? null,
+    displayName: v.displayName ?? null,
+    reasoning: v.reasoning ?? null,
+    entityId: v.entityId ?? null,
+  };
+}
+
+/**
+ * Build a search query from the entity name and record types.
+ * More specific queries yield better sources.
+ */
+function buildSearchQuery(entityName: string, records: UnverifiableRecord[]): string {
+  // Collect unique record types
+  const types = [...new Set(records.map(r => r.recordType))];
+
+  // Build a descriptive query
+  const typeParts: string[] = [];
+  for (const t of types) {
+    switch (t) {
+      case 'personnel': typeParts.push('team leadership staff employees'); break;
+      case 'grant': typeParts.push('grants funding awarded'); break;
+      case 'funding-round': typeParts.push('funding rounds investment raised'); break;
+      case 'investment': typeParts.push('investments portfolio'); break;
+      case 'division': typeParts.push('departments divisions teams'); break;
+      case 'publication': typeParts.push('research papers publications'); break;
+      case 'benchmark-result': typeParts.push('benchmark results performance'); break;
+      case 'entity-event': typeParts.push('events milestones announcements'); break;
+      default: typeParts.push(t.replace(/-/g, ' ')); break;
+    }
+  }
+
+  const typeString = typeParts.length > 0 ? ` ${typeParts.join(' ')}` : '';
+  return `${entityName}${typeString}`;
+}
+
+// ---------------------------------------------------------------------------
+// Core agent
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the claims-first source discovery agent for a single entity.
+ */
+export async function runSourceDiscoverAgent(
+  options: SourceDiscoverAgentOptions,
+): Promise<AgentResult> {
+  const startMs = Date.now();
+  let totalCost = 0;
+
+  const entityId = options.entityId;
+  const entityName = options.entityName || entityId;
+  const limit = options.limit ?? 50;
+  const budgetCap = options.budgetCap ?? 1.00;
+  const isDryRun = options.dryRun ?? (!options.apply && !options.claimsOnly);
+
+  // ─── Step 1: Get unverifiable records ─────────────────────────────
+  console.log(`[source-discover-agent] ${entityName}: fetching unverifiable records...`);
+
+  const failuresResult = await getFailures({
+    entity_id: entityId,
+    error_type: 'unverifiable',
+    limit,
+  });
+
+  if (!failuresResult.ok) {
+    throw new Error(
+      `[source-discover-agent] Failed to get failures for ${entityName}: ${failuresResult.message}`,
+    );
+  }
+
+  let records = failuresResult.data.items.map(toUnverifiableRecord);
+
+  // Filter by record type if specified
+  if (options.recordTypes && options.recordTypes.length > 0) {
+    const typeSet = new Set(options.recordTypes);
+    records = records.filter(r => typeSet.has(r.recordType));
+  }
+
+  if (records.length === 0) {
+    console.log(`[source-discover-agent] ${entityName}: no unverifiable records found.`);
+    return emptyResult(entityId, entityName, startMs);
+  }
+
+  // Log record type breakdown
+  const typeCounts = new Map<string, number>();
+  for (const r of records) {
+    typeCounts.set(r.recordType, (typeCounts.get(r.recordType) || 0) + 1);
+  }
+  const typeBreakdown = [...typeCounts.entries()].map(([t, c]) => `${t}=${c}`).join(', ');
+  console.log(
+    `[source-discover-agent] ${entityName}: ${records.length} unverifiable records (${typeBreakdown})`,
+  );
+
+  // ─── Step 2: Research — discover sources ──────────────────────────
+  console.log(`[source-discover-agent] ${entityName}: running research...`);
+
+  const searchQuery = buildSearchQuery(entityName, records);
+  let researchResult: ResearchResult;
+
+  try {
+    researchResult = await runResearch({
+      topic: searchQuery,
+      pageContext: { title: entityName, type: 'organization', entityId },
+      config: {
+        maxResultsPerSource: 5,
+        maxUrlsToFetch: 10,
+        extractFacts: false, // skip fact extraction — we extract claims instead
+        useGitHub: false,
+        useSemanticScholar: false,
+        useFederalRegister: false,
+      },
+      budgetCap,
+    });
+    totalCost += researchResult.metadata.totalCost;
+  } catch (err: unknown) {
+    console.warn(
+      `[source-discover-agent] Research failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return emptyResult(entityId, entityName, startMs);
+  }
+
+  const fetchedSources = researchResult.sources.filter(s => s.content && s.content.length >= 50);
+  console.log(
+    `[source-discover-agent] ${entityName}: ${researchResult.sources.length} sources fetched, ${fetchedSources.length} with content`,
+  );
+
+  if (fetchedSources.length === 0) {
+    return emptyResult(entityId, entityName, startMs);
+  }
+
+  // ─── Step 3: Register resources ───────────────────────────────────
+  const sourceUrls = fetchedSources.map(s => s.url);
+  const urlToResourceId = new Map<string, string>();
+
+  if (!isDryRun) {
+    try {
+      const registered = await suggestResources({ urls: sourceUrls, entityId });
+      for (const res of registered.resources) {
+        urlToResourceId.set(res.url, res.resourceId);
+      }
+      console.log(
+        `[source-discover-agent] ${entityName}: registered ${registered.resources.length} resources`,
+      );
+    } catch (err: unknown) {
+      console.warn(
+        `[source-discover-agent] Resource registration failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // ─── Step 4: Extract claims from each source ──────────────────────
+  console.log(`[source-discover-agent] ${entityName}: extracting claims from ${fetchedSources.length} sources...`);
+
+  const sourcesWithClaims: SourceWithClaims[] = [];
+  let totalClaimsExtracted = 0;
+
+  for (const source of fetchedSources) {
+    const content = source.content || '';
+    const extractionResult = await extractClaims(content, source.url, records);
+    totalCost += extractionResult.cost;
+
+    const sourceEntry: SourceWithClaims = {
+      url: source.url,
+      title: source.title || source.url,
+      contentLength: content.length,
+      claims: extractionResult.claims,
+      resourceId: urlToResourceId.get(source.url),
+    };
+
+    if (extractionResult.claims.length > 0) {
+      sourcesWithClaims.push(sourceEntry);
+      totalClaimsExtracted += extractionResult.claims.length;
+    }
+  }
+
+  console.log(
+    `[source-discover-agent] ${entityName}: extracted ${totalClaimsExtracted} claims from ${sourcesWithClaims.length}/${fetchedSources.length} sources`,
+  );
+
+  // ─── Step 5: Submit claims (if not dry-run) ───────────────────────
+  let claimsSubmitted = 0;
+  let batchId: string | null = null;
+
+  if (!isDryRun && totalClaimsExtracted > 0) {
+    // Build the claims payload — group by target table
+    const claimsByTable = new Map<string, ProposeClaims['claims']>();
+
+    for (const source of sourcesWithClaims) {
+      for (const claim of source.claims) {
+        // Determine target table from the matched records
+        for (const recordId of claim.matchedRecordIds) {
+          const record = records.find(r => r.recordId === recordId);
+          if (!record) continue;
+
+          const table = record.recordType;
+          if (!claimsByTable.has(table)) {
+            claimsByTable.set(table, []);
+          }
+
+          claimsByTable.get(table)!.push({
+            claimText: claim.claimText,
+            targetField: claim.targetField ?? undefined,
+            proposedValue: claim.proposedValue ?? undefined,
+            sourceUrl: source.url,
+            resourceId: source.resourceId,
+            agentEvidence: `Extracted from ${source.title} by source-discover-agent`,
+          });
+        }
+      }
+    }
+
+    // Submit claims for each target table
+    for (const [targetTable, claims] of claimsByTable) {
+      if (claims.length === 0) continue;
+
+      // Cap at 100 per batch (API limit)
+      const batch = claims.slice(0, 100);
+
+      try {
+        const result = await proposeClaims({
+          entityId,
+          targetTable,
+          claims: batch,
+        });
+
+        if (result.ok) {
+          claimsSubmitted += batch.length;
+          // Use the last batch ID (if multiple tables, they get separate batches)
+          batchId = result.data.batchId;
+          console.log(
+            `[source-discover-agent] ${entityName}: submitted ${batch.length} claims for ${targetTable} (batch: ${batchId})`,
+          );
+        } else {
+          console.warn(
+            `[source-discover-agent] ${entityName}: claim submission failed for ${targetTable}: ${result.message}`,
+          );
+        }
+      } catch (err: unknown) {
+        console.warn(
+          `[source-discover-agent] ${entityName}: claim submission error for ${targetTable}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  // ─── Step 6: Poll verification (if enabled) ───────────────────────
+  let verificationStatus: VerificationPollResult | null = null;
+
+  if (options.pollVerification && batchId) {
+    console.log(`[source-discover-agent] ${entityName}: polling verification status...`);
+    verificationStatus = await pollForVerification(
+      batchId,
+      options.pollTimeoutSec ?? 120,
+    );
+  }
+
+  // ─── Result ───────────────────────────────────────────────────────
+  const result: AgentResult = {
+    entityId,
+    entityName,
+    unverifiableCount: failuresResult.data.total,
+    recordsProcessed: records.length,
+    sourcesDiscovered: fetchedSources.length,
+    sourcesWithClaims: sourcesWithClaims.length,
+    claimsExtracted: totalClaimsExtracted,
+    claimsSubmitted,
+    batchId,
+    verificationStatus,
+    sources: sourcesWithClaims,
+    cost: totalCost,
+    durationMs: Date.now() - startMs,
+  };
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Verification polling
+// ---------------------------------------------------------------------------
+
+async function pollForVerification(
+  batchId: string,
+  timeoutSec: number,
+): Promise<VerificationPollResult> {
+  const startMs = Date.now();
+  const timeoutMs = timeoutSec * 1000;
+  const pollIntervalMs = 5_000;
+
+  while (Date.now() - startMs < timeoutMs) {
+    const statusResult = await getClaimStatus(batchId);
+    if (!statusResult.ok) {
+      console.warn(`[source-discover-agent] Status poll failed: ${statusResult.message}`);
+      // Wait and retry
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+
+    const data = statusResult.data;
+    const pending = data.claims.filter(
+      (c: { status: string }) => c.status === 'pending' || c.status === 'verifying',
+    ).length;
+
+    if (pending === 0) {
+      // All claims resolved
+      return {
+        total: data.claims.length,
+        verified: data.claims.filter((c: { status: string }) => c.status === 'verified').length,
+        contradicted: data.claims.filter((c: { status: string }) => c.status === 'contradicted').length,
+        unverifiable: data.claims.filter((c: { status: string }) => c.status === 'unverifiable').length,
+        pending: 0,
+        timedOut: false,
+      };
+    }
+
+    console.log(
+      `[source-discover-agent] Verification: ${data.claims.length - pending}/${data.claims.length} resolved, ${pending} pending...`,
+    );
+
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+
+  // Timed out — return partial status
+  const finalResult = await getClaimStatus(batchId);
+  if (!finalResult.ok) {
+    return { total: 0, verified: 0, contradicted: 0, unverifiable: 0, pending: 0, timedOut: true };
+  }
+
+  const claims = finalResult.data.claims;
+  return {
+    total: claims.length,
+    verified: claims.filter((c: { status: string }) => c.status === 'verified').length,
+    contradicted: claims.filter((c: { status: string }) => c.status === 'contradicted').length,
+    unverifiable: claims.filter((c: { status: string }) => c.status === 'unverifiable').length,
+    pending: claims.filter(
+      (c: { status: string }) => c.status === 'pending' || c.status === 'verifying',
+    ).length,
+    timedOut: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyResult(entityId: string, entityName: string, startMs: number): AgentResult {
+  return {
+    entityId,
+    entityName,
+    unverifiableCount: 0,
+    recordsProcessed: 0,
+    sourcesDiscovered: 0,
+    sourcesWithClaims: 0,
+    claimsExtracted: 0,
+    claimsSubmitted: 0,
+    batchId: null,
+    verificationStatus: null,
+    sources: [],
+    cost: 0,
+    durationMs: Date.now() - startMs,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a new claims-first source discovery pipeline activated via `--v2` flag on `crux tb source-discover`
- Replaces string-matching heuristics with LLM-powered claim extraction using Haiku
- Handles all record types from day one (personnel, grants, investments, etc.) -- not just personnel
- 6-step pipeline: get failures -> research sources -> register resources -> extract claims -> submit claims -> poll verification

## New files

- `crux/tablebase/claim-extractor.ts` (~225 lines) -- Haiku prompt builder + Zod-validated response parser with `escapeXml()` for prompt safety
- `crux/tablebase/source-discover-agent.ts` (~470 lines) -- orchestrator using existing `getFailures()`, `runResearch()`, `suggestResources()`, `proposeClaims()`, `getClaimStatus()`
- `crux/tablebase/claim-extractor.test.ts` (~290 lines) -- 17 tests covering prompt building, XML escaping, JSON parsing, partial extraction, adversarial inputs

## Modified files

- `crux/commands/tablebase.ts` -- adds `--v2`, `--claims-only` flags to `source-discover` command with formatted output

## Usage

```bash
# Dry-run (default): discover sources and extract claims, but don't submit
crux tb source-discover anthropic --v2

# Apply: extract claims and submit for async verification
crux tb source-discover anthropic --v2 --apply

# Claims-only: submit claims but don't apply verified results
crux tb source-discover anthropic --v2 --claims-only

# JSON output for scripting
crux tb source-discover anthropic --v2 --ci
```

Fixes QUA-210 (partial -- this is the `--v2` path, not the default yet)

## Test plan

- [x] 17 unit tests for claim extractor pass
- [x] TypeScript compiles cleanly (crux tsconfig)
- [x] Gate check passes (46/46 blocking checks)
- [ ] Manual test: run `crux tb source-discover <entity> --v2` against prod wiki-server

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--v2` flag enabling improved source discovery with claims-first extraction
  * Added `--claims-only` flag for dry-run modes without submitting claims
  * Enhanced output formatting with source counts, claim statistics, and cost information
  * Introduced claim verification polling capabilities

* **Tests**
  * Added comprehensive test coverage for claim extraction and response parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->