### PR TITLE
feat: TableBase Coverage Dashboard (Pattern A)

### DIFF
--- a/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
@@ -194,6 +194,7 @@ export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
           <input
             type="text"
             placeholder="Search entities..."
+            aria-label="Search entities by name"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full rounded-md border border-border bg-background pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -202,6 +203,7 @@ export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
+          aria-label="Filter by entity type"
           className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         >
           <option value="all">All types ({data.length})</option>

--- a/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+import { DataTable } from "@/components/ui/data-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CoverageRow {
+  entityId: string;
+  entityType: string;
+  title: string;
+  coverageScore: number;
+  signalsFilled: number;
+  signalsTotal: number;
+  signals: Record<string, boolean>;
+  scannedAt: string;
+  href: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function scoreBadgeClass(score: number): string {
+  switch (score) {
+    case 1:
+      return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300";
+    case 2:
+      return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300";
+    case 3:
+      return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300";
+    case 4:
+      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300";
+    default:
+      return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
+  }
+}
+
+function scoreLabel(score: number): string {
+  switch (score) {
+    case 1:
+      return "Stub";
+    case 2:
+      return "Basic";
+    case 3:
+      return "Moderate";
+    case 4:
+      return "Comprehensive";
+    default:
+      return "Unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+const columns: ColumnDef<CoverageRow>[] = [
+  {
+    accessorKey: "title",
+    header: ({ column }) => <SortableHeader column={column}>Entity</SortableHeader>,
+    cell: ({ row }) => {
+      const href = row.original.href;
+      return href ? (
+        <a href={href} className="text-blue-600 hover:underline dark:text-blue-400">
+          {row.original.title}
+        </a>
+      ) : (
+        <span>{row.original.title}</span>
+      );
+    },
+    size: 280,
+  },
+  {
+    accessorKey: "entityType",
+    header: ({ column }) => <SortableHeader column={column}>Type</SortableHeader>,
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">{row.original.entityType}</span>
+    ),
+    size: 120,
+  },
+  {
+    accessorKey: "coverageScore",
+    header: ({ column }) => <SortableHeader column={column}>Score</SortableHeader>,
+    cell: ({ row }) => {
+      const score = row.original.coverageScore;
+      return (
+        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${scoreBadgeClass(score)}`}>
+          {score} - {scoreLabel(score)}
+        </span>
+      );
+    },
+    size: 140,
+  },
+  {
+    accessorKey: "signalsFilled",
+    header: ({ column }) => <SortableHeader column={column}>Signals</SortableHeader>,
+    cell: ({ row }) => (
+      <span className="tabular-nums text-sm">
+        {row.original.signalsFilled}/{row.original.signalsTotal}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    id: "missingSignals",
+    header: "Missing",
+    cell: ({ row }) => {
+      const missing = Object.entries(row.original.signals)
+        .filter(([, v]) => !v)
+        .map(([k]) => k);
+      if (missing.length === 0) return <span className="text-xs text-muted-foreground">-</span>;
+      return (
+        <span className="text-xs text-muted-foreground">
+          {missing.join(", ")}
+        </span>
+      );
+    },
+    size: 200,
+  },
+  {
+    accessorKey: "scannedAt",
+    header: ({ column }) => <SortableHeader column={column}>Scanned</SortableHeader>,
+    cell: ({ row }) => {
+      const d = new Date(row.original.scannedAt);
+      return (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {d.toLocaleDateString()}
+        </span>
+      );
+    },
+    size: 100,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface CoverageTableProps {
+  data: CoverageRow[];
+  entityTypes: string[];
+}
+
+export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "coverageScore", desc: false },
+  ]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+
+  const filtered = useMemo(() => {
+    let rows = data;
+    if (typeFilter !== "all") {
+      rows = rows.filter((r) => r.entityType === typeFilter);
+    }
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.title.toLowerCase().includes(q) ||
+          r.entityId.toLowerCase().includes(q)
+      );
+    }
+    return rows;
+  }, [data, typeFilter, searchQuery]);
+
+  const table = useReactTable({
+    data: filtered,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search entities..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full rounded-md border border-border bg-background pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="all">All types ({data.length})</option>
+          {entityTypes.map((t) => (
+            <option key={t} value={t}>
+              {t} ({data.filter((r) => r.entityType === t).length})
+            </option>
+          ))}
+        </select>
+        <span className="text-xs text-muted-foreground">
+          {filtered.length} entities
+        </span>
+      </div>
+
+      <DataTable table={table} />
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/tablebase-coverage/page.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function TablebaseCoveragePage() {
+  redirect("/wiki/E2211");
+}

--- a/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
@@ -4,8 +4,7 @@ import {
   type FetchResult,
 } from "@lib/wiki-server";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
-import { getTypedEntityById } from "@data/tablebase";
-import { getEntityHref } from "@/data/entity-nav";
+import { getTypedEntityById, getEntityHref } from "@/data";
 import { CoverageTable, type CoverageRow } from "./coverage-table";
 
 // ── Types (match the wiki-server coverage-scans route response shapes) ──
@@ -53,16 +52,17 @@ async function loadFromApi(): Promise<FetchResult<DashboardData>> {
     }),
   ]);
 
-  if (!allResult.ok) return allResult;
-  if (!statsResult.ok) return statsResult;
+  // Degrade gracefully: show whatever data we got rather than failing the
+  // whole dashboard because one endpoint is down.
+  const items = allResult.ok ? allResult.data.items : [];
+  const stats = statsResult.ok ? statsResult.data.stats : [];
 
-  return {
-    ok: true,
-    data: {
-      items: allResult.data.items,
-      stats: statsResult.data.stats,
-    },
-  };
+  if (!allResult.ok && !statsResult.ok) {
+    // Both failed — bubble up the first error
+    return allResult;
+  }
+
+  return { ok: true, data: { items, stats } };
 }
 
 function emptyFallback(): DashboardData {

--- a/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
@@ -1,0 +1,275 @@
+import {
+  fetchDetailed,
+  withApiFallback,
+  type FetchResult,
+} from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { getTypedEntityById } from "@data/tablebase";
+import { getEntityHref } from "@/data/entity-nav";
+import { CoverageTable, type CoverageRow } from "./coverage-table";
+
+// ── Types (match the wiki-server coverage-scans route response shapes) ──
+
+interface CoverageScanItem {
+  id: number;
+  entityType: string;
+  entityId: string;
+  coverageScore: number;
+  signalsFilled: number;
+  signalsTotal: number;
+  signals: Record<string, boolean>;
+  scannedAt: string;
+}
+
+interface AllResponse {
+  items: CoverageScanItem[];
+  total: number;
+}
+
+interface StatRow {
+  entityType: string;
+  coverageScore: number;
+  count: number;
+}
+
+interface StatsResponse {
+  stats: StatRow[];
+}
+
+interface DashboardData {
+  items: CoverageScanItem[];
+  stats: StatRow[];
+}
+
+// ── Data Loading ────────────────────────────────────────────────────
+
+async function loadFromApi(): Promise<FetchResult<DashboardData>> {
+  const [allResult, statsResult] = await Promise.all([
+    fetchDetailed<AllResponse>("/api/coverage-scans/all?limit=500", {
+      revalidate: 60,
+    }),
+    fetchDetailed<StatsResponse>("/api/coverage-scans/stats", {
+      revalidate: 60,
+    }),
+  ]);
+
+  if (!allResult.ok) return allResult;
+  if (!statsResult.ok) return statsResult;
+
+  return {
+    ok: true,
+    data: {
+      items: allResult.data.items,
+      stats: statsResult.data.stats,
+    },
+  };
+}
+
+function emptyFallback(): DashboardData {
+  return { items: [], stats: [] };
+}
+
+// ── Stats computation ────────────────────────────────────────────────
+
+interface TypeStats {
+  entityType: string;
+  total: number;
+  byScore: Record<number, number>;
+  avgScore: number;
+}
+
+function computeTypeStats(stats: StatRow[]): TypeStats[] {
+  const byType = new Map<string, { total: number; byScore: Record<number, number>; sum: number }>();
+
+  for (const row of stats) {
+    const existing = byType.get(row.entityType) ?? { total: 0, byScore: {}, sum: 0 };
+    existing.total += row.count;
+    existing.byScore[row.coverageScore] = (existing.byScore[row.coverageScore] ?? 0) + row.count;
+    existing.sum += row.coverageScore * row.count;
+    byType.set(row.entityType, existing);
+  }
+
+  const result: TypeStats[] = [];
+  for (const [entityType, data] of byType) {
+    result.push({
+      entityType,
+      total: data.total,
+      byScore: data.byScore,
+      avgScore: data.total > 0 ? Math.round((data.sum / data.total) * 100) / 100 : 0,
+    });
+  }
+
+  result.sort((a, b) => b.total - a.total);
+  return result;
+}
+
+// ── Coverage Bar ────────────────────────────────────────────────────
+
+const SCORE_COLORS: Record<number, string> = {
+  1: "bg-red-500 dark:bg-red-600",
+  2: "bg-amber-400 dark:bg-amber-500",
+  3: "bg-blue-500 dark:bg-blue-500",
+  4: "bg-emerald-500 dark:bg-emerald-500",
+};
+
+const SCORE_LABELS: Record<number, string> = {
+  1: "Stub",
+  2: "Basic",
+  3: "Moderate",
+  4: "Comprehensive",
+};
+
+function CoverageBar({ stats }: { stats: TypeStats }) {
+  const { total, byScore } = stats;
+  if (total === 0) return null;
+
+  return (
+    <div className="flex h-5 w-full rounded-md overflow-hidden">
+      {[1, 2, 3, 4].map((score) => {
+        const count = byScore[score] ?? 0;
+        if (count === 0) return null;
+        const pct = (count / total) * 100;
+        return (
+          <div
+            key={score}
+            className={`${SCORE_COLORS[score]} flex items-center justify-center text-[10px] font-medium text-white`}
+            style={{ width: `${pct}%` }}
+            title={`${SCORE_LABELS[score]}: ${count} (${pct.toFixed(1)}%)`}
+          >
+            {pct >= 8 ? count : ""}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Content Component ────────────────────────────────────────────────
+
+export async function TablebaseCoverageContent() {
+  const { data, source, apiError } = await withApiFallback(
+    loadFromApi,
+    emptyFallback,
+  );
+
+  const { items, stats } = data;
+  const typeStats = computeTypeStats(stats);
+
+  // Compute global summary
+  const totalEntities = typeStats.reduce((s, t) => s + t.total, 0);
+  const globalByScore: Record<number, number> = {};
+  for (const ts of typeStats) {
+    for (const [score, count] of Object.entries(ts.byScore)) {
+      globalByScore[Number(score)] = (globalByScore[Number(score)] ?? 0) + count;
+    }
+  }
+  const globalSum = typeStats.reduce((s, t) => s + t.avgScore * t.total, 0);
+  const avgScore = totalEntities > 0 ? Math.round((globalSum / totalEntities) * 100) / 100 : 0;
+
+  // Transform items for enrichment queue table
+  const rows: CoverageRow[] = items.map((item) => {
+    const entity = getTypedEntityById(item.entityId);
+    return {
+      entityId: item.entityId,
+      entityType: item.entityType,
+      title: entity?.title ?? item.entityId,
+      coverageScore: item.coverageScore,
+      signalsFilled: item.signalsFilled,
+      signalsTotal: item.signalsTotal,
+      signals: (item.signals ?? {}) as Record<string, boolean>,
+      scannedAt: item.scannedAt,
+      href: getEntityHref(item.entityId),
+    };
+  });
+
+  const entityTypes = [...new Set(rows.map((r) => r.entityType))].sort();
+
+  return (
+    <>
+      <DataSourceBanner source={source} apiError={apiError} />
+
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Coverage scores for {totalEntities.toLocaleString()} entities across{" "}
+        {typeStats.length} entity types. Scores range from 1 (stub) to 4
+        (comprehensive). Use the enrichment queue below to find entities that
+        need more data.
+      </p>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
+        <StatCard label="Entities Scanned" value={totalEntities.toLocaleString()} />
+        <StatCard label="Average Score" value={avgScore.toFixed(2)} />
+        <StatCard label="Stub (Score 1)" value={(globalByScore[1] ?? 0).toLocaleString()} />
+        <StatCard label="Comprehensive (4)" value={(globalByScore[4] ?? 0).toLocaleString()} />
+      </div>
+
+      {/* Score distribution legend */}
+      <div className="flex flex-wrap gap-4 mb-6">
+        {[1, 2, 3, 4].map((score) => (
+          <div key={score} className="flex items-center gap-1.5">
+            <div className={`h-3 w-3 rounded-sm ${SCORE_COLORS[score]}`} />
+            <span className="text-xs text-muted-foreground">
+              {score} - {SCORE_LABELS[score]} ({(globalByScore[score] ?? 0).toLocaleString()})
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Coverage by entity type */}
+      {typeStats.length > 0 && (
+        <div className="my-6">
+          <h2 className="text-lg font-semibold mb-3">Coverage by Entity Type</h2>
+          <div className="space-y-3">
+            {typeStats.map((ts) => (
+              <div key={ts.entityType}>
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium">{ts.entityType}</span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {ts.total} entities, avg {ts.avgScore.toFixed(2)}
+                  </span>
+                </div>
+                <CoverageBar stats={ts} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Enrichment queue */}
+      {rows.length > 0 && (
+        <div className="my-6">
+          <h2 className="text-lg font-semibold mb-1">Enrichment Queue</h2>
+          <p className="text-sm text-muted-foreground mb-3">
+            Entities ranked by lowest coverage score. Use this to prioritize data
+            enrichment work.
+          </p>
+          <CoverageTable data={rows} entityTypes={entityTypes} />
+        </div>
+      )}
+
+      {totalEntities === 0 && (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground my-6">
+          <p className="text-lg font-medium mb-2">No coverage scans yet</p>
+          <p className="text-sm">
+            Run{" "}
+            <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+              pnpm crux wiki-server sync-coverage-scans
+            </code>{" "}
+            to compute and sync coverage scores.
+          </p>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── Helper Components ────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -80,6 +80,7 @@ import { DataQualityContent } from "@/app/internal/data-quality/data-quality-con
 import { TalentFlowsContent } from "@/app/internal/talent-flows/talent-flows-content";
 import { JobsDashboardContent } from "@/app/internal/jobs/jobs-content";
 import { DataSourcesContent } from "@/app/data-sources/data-sources-content";
+import { TablebaseCoverageContent } from "@/app/internal/tablebase-coverage/tablebase-coverage-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -242,6 +243,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   TalentFlowsContent,
   JobsDashboardContent,
   DataSourcesContent,
+  TablebaseCoverageContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -286,6 +286,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Funding Programs", href: internalHref("funding-programs-dashboard") },
         { label: "Talent Flows", href: internalHref("talent-flows-dashboard") },
         { label: "Jobs", href: internalHref("jobs-dashboard") },
+        { label: "Coverage", href: internalHref("tablebase-coverage-dashboard") },
       ],
     },
     {

--- a/content/docs/internal/tablebase-coverage-dashboard.mdx
+++ b/content/docs/internal/tablebase-coverage-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2211
+title: "TableBase Coverage Dashboard"
+description: "Entity data coverage scores and enrichment queue"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-10"
+---
+
+<TablebaseCoverageContent />


### PR DESCRIPTION
## Summary
- New internal dashboard at `/internal/tablebase-coverage/` (E2211) visualizing entity coverage scores from the `tablebase_coverage_scans` table (added in PR #4125)
- Shows summary stats (total entities, average score, score distribution), coverage bars per entity type, and a searchable/sortable enrichment queue
- Follows Pattern A: MDX stub + content component + redirect page + sidebar entry

## Details
- **Entity ID**: E2211 (allocated via `crux tb ids allocate`)
- **API endpoints**: Fetches from `/api/coverage-scans/all` and `/api/coverage-scans/stats` (defined in PR #4125)
- **Enrichment queue**: Client-side DataTable with search, type filter, and columns for entity, type, score badge, signals filled/total, missing signals, and scan date
- **Graceful fallback**: Shows empty state with instructions when no coverage scans exist or when wiki-server is unreachable

Fixes QUA-227

> Note: This dashboard depends on PR #4125 (QUA-226) which adds the `tablebase_coverage_scans` table and sync route. The dashboard will show "No coverage scans yet" until that PR merges and `sync-coverage-scans` is run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched the TableBase Coverage Dashboard: summary statistics, score distribution visuals by entity type, and an interactive enrichment queue table with search, sorting, type filter, coverage-score badges, missing-signals display, and scanned-date.
* **Navigation**
  * Added a top-level "Coverage" entry in internal navigation for quick access.
* **Documentation**
  * Added an internal docs page that embeds the new Coverage Dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->