### PR TITLE
feat: add crux linear next/list for autonomous Linear issue picking

### DIFF
--- a/.claude/commands/agent-next-issue.md
+++ b/.claude/commands/agent-next-issue.md
@@ -1,34 +1,59 @@
 ---
-description: Pick up the next highest-priority GitHub issue and start working on it.
-argument-hint: "[issue-number]"
+description: Pick up the next highest-priority issue (GitHub or Linear) and start working on it.
+argument-hint: "[issue-number] [--source=github|linear]"
 effort: medium
 ---
 
 # Next Issue
 
-Pick up the next highest-priority GitHub issue and start working on it.
+Pick up the next highest-priority issue and start working on it. Supports both GitHub issues and Linear issues.
 
 ## Overview
 
-This command helps you start a focused session on the most important open issue. It fetches open issues, applies priority ordering, filters out issues already being worked on (`agent:working` label), and presents the top candidates for selection.
+This command helps you start a focused session on the most important open issue. It fetches open issues, applies priority ordering, filters out issues already being worked on, and presents the top candidates for selection.
 
 ## Phase 1: Fetch and rank open issues
+
+### Option A: GitHub issues (default)
 
 ```bash
 pnpm crux gh issues next
 ```
 
-This will output a ranked list of open issues — highest priority first — with their labels, age, and a brief description. The ranking uses:
+This outputs a ranked list of open GitHub issues — highest priority first — with their labels, age, and a brief description. The ranking uses:
 
 1. **Priority labels** — `P0` > `P1` > `P2` > `P3` > unlabeled
 2. **Issue age** — older issues rank slightly higher within the same tier
 3. **Excluded** — issues labeled `agent:working`, `wontfix`, or `on-hold`
 
+### Option B: Linear issues
+
+```bash
+pnpm crux linear next
+```
+
+This outputs a ranked list of ready Linear issues (Todo/Backlog states) from the QUA team. The ranking uses:
+
+1. **Linear priority** — urgent > high > medium > low > none
+2. **Labels** — `claude-ready`/`agent-ready` issues get a 1.5× boost
+3. **Issue age** — older issues rank slightly higher within the same tier
+4. **Excluded** — issues labeled `blocked`, `waiting`, `on-hold`, etc.
+
+### Choosing a source
+
+If the user specified `--source=linear` or asked for a Linear issue, use Option B. If `--source=github` or a GitHub issue, use Option A. If unspecified, **check both sources** and present the top candidate from each, then pick the higher-priority one.
+
+To see the full queue from either source:
+```bash
+pnpm crux gh issues list     # All open GitHub issues
+pnpm crux linear list         # All ready Linear issues
+```
+
 Review the list. If the top issue looks right, proceed. If not, pick a different one from the list and note why you skipped the top one.
 
 ## Phase 2: Signal start on the chosen issue
 
-Once you've chosen an issue, use the crux CLI to announce work:
+### For GitHub issues:
 
 ```bash
 pnpm crux gh issues start <ISSUE_NUM>
@@ -39,7 +64,20 @@ This will:
 2. Add the `agent:working` label to signal it's in flight
 3. Print a summary of the issue title and body for context
 
-**Output the issue title and key details** to your working context before starting implementation — this ensures you understand what's being asked.
+### For Linear issues:
+
+```bash
+pnpm crux linear start <QUA-NNN>
+```
+
+This will:
+1. Move the issue to "In Progress"
+2. Post a comment with the branch name
+
+**Important:** When working on a Linear issue, the branch name **must** contain the Linear ID for auto-close to work on merge:
+```bash
+git checkout -b claude/qua-NNN-description
+```
 
 ## Phase 3: Understand the issue
 
@@ -51,30 +89,48 @@ Read the issue carefully. If the body contains acceptance criteria or examples, 
 
 If the issue is ambiguous, look at context in the issue comments or related code before proceeding.
 
-## Phase 4: Implement
+## Phase 4: Initialize the session checklist
+
+Run `/agent-init` to set up the session tracking:
+
+```bash
+# GitHub issue:
+pnpm crux sys agent-checklist init --issue=N
+
+# Linear issue:
+pnpm crux sys agent-checklist init "Task description" --linear=QUA-NNN
+
+# Both (if the Linear issue maps to a GitHub issue):
+pnpm crux sys agent-checklist init --issue=N --linear=QUA-NNN
+```
+
+## Phase 5: Implement
 
 Work through the issue using the standard development workflow:
 
-1. Use TodoWrite to plan the implementation steps
-2. Make changes, following all relevant rules in `.claude/rules/`
-3. Run validation: `pnpm crux w validate gate`
-4. Create a session log entry
+1. Make changes, following all relevant rules in `.claude/rules/`
+2. Run validation: `pnpm crux w validate gate`
+3. Write tests for new logic
 
-## Phase 5: Ship and close the loop
+## Phase 6: Ship and close the loop
 
-After the work is done:
-
-```bash
-pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
-```
-
-Then run `/agent-push-and-verify` as usual.
+Run `/agent-ship` to push, monitor CI, and close the session. It automatically:
+- Updates GitHub issues (`crux gh issues done`)
+- Updates Linear issues (`crux linear done --pr=URL`)
+- Creates the session log
 
 ## Quick reference
 
 ```bash
-pnpm crux gh issues next              # Show next priority issue
-pnpm crux gh issues list              # List all open issues with priority order
+# GitHub
+pnpm crux gh issues next              # Show next priority GitHub issue
+pnpm crux gh issues list              # List all open GitHub issues
 pnpm crux gh issues start <N>         # Announce start + add agent:working label
 pnpm crux gh issues done <N> --pr=URL # Announce completion + remove label
+
+# Linear
+pnpm crux linear next                 # Show next priority Linear issue
+pnpm crux linear list                 # List all ready Linear issues
+pnpm crux linear start <QUA-NNN>      # Move to In Progress + post start comment
+pnpm crux linear done <QUA-NNN> --pr=URL  # Move to In Review + post done comment
 ```

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -21,6 +21,8 @@ import {
   commentOnIssue,
   getComments,
   getIssue,
+  listReadyIssues,
+  rankReadyIssues,
   searchIssues,
   updateIssueState,
 } from '../lib/linear/issues.ts';
@@ -253,6 +255,102 @@ async function parse(args: string[], options: CommandOptions): Promise<CommandRe
 }
 
 // ---------------------------------------------------------------------------
+// Next / List — agent dispatch helpers
+// ---------------------------------------------------------------------------
+
+async function list(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const limit = options.limit ? parseInt(options.limit, 10) : 50;
+  const issues = await listReadyIssues(limit);
+  const ranked = rankReadyIssues(issues);
+
+  if (options.json) {
+    return { output: JSON.stringify(ranked, null, 2) + '\n', exitCode: 0 };
+  }
+
+  if (ranked.length === 0) {
+    return { output: `${c.dim}No ready issues found (Todo/Backlog) in QUA team.${c.reset}\n`, exitCode: 0 };
+  }
+
+  let out = `${c.bold}${ranked.length} ready issue(s) in QUA team:${c.reset}\n\n`;
+  for (const r of ranked) {
+    const pri = priorityLabel(r.priority);
+    const blocked = r.blocked ? ` ${c.red}[blocked]${c.reset}` : '';
+    const assignee = r.assignee ? ` ${c.dim}(${r.assignee.name})${c.reset}` : '';
+    const state = r.state.name;
+    const labels = r.labels.nodes.map((l) => l.name).join(', ');
+    out += `  ${c.cyan}${r.identifier}${c.reset} [${state}] ${pri} (score: ${r.score})${blocked}${assignee}\n`;
+    out += `    ${r.title}\n`;
+    if (labels) out += `    ${c.dim}labels: ${labels}${c.reset}\n`;
+    out += '\n';
+  }
+  return { output: out, exitCode: 0 };
+}
+
+async function next(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const issues = await listReadyIssues(50);
+  const ranked = rankReadyIssues(issues);
+  const available = ranked.filter((i) => !i.blocked);
+
+  if (options.json) {
+    return { output: JSON.stringify(available[0] ?? null, null, 2) + '\n', exitCode: 0 };
+  }
+
+  if (available.length === 0) {
+    const blockedCount = ranked.filter((i) => i.blocked).length;
+    let out = `${c.yellow}No available issues.${c.reset}\n`;
+    if (ranked.length > 0) {
+      out += `  ${c.dim}${ranked.length} ready issue(s) found, but ${blockedCount} blocked.${c.reset}\n`;
+    } else {
+      out += `  ${c.dim}No issues in Todo/Backlog states.${c.reset}\n`;
+    }
+    return { output: out, exitCode: 1 };
+  }
+
+  const top = available[0];
+  const pri = priorityLabel(top.priority);
+  const labels = top.labels.nodes.map((l) => l.name).join(', ');
+
+  let out = '';
+  out += `${c.bold}Next issue:${c.reset}\n\n`;
+  out += `  ${c.bold}${c.cyan}${top.identifier}${c.reset} ${top.title}\n`;
+  out += `  ${c.dim}state:${c.reset} ${top.state.name}  ${c.dim}priority:${c.reset} ${pri}  ${c.dim}score:${c.reset} ${top.score}\n`;
+  out += `  ${c.dim}url:${c.reset} ${top.url}\n`;
+  if (labels) out += `  ${c.dim}labels:${c.reset} ${labels}\n`;
+  if (top.parent) out += `  ${c.dim}parent:${c.reset} ${top.parent.identifier} — ${top.parent.title}\n`;
+  if (top.project) out += `  ${c.dim}project:${c.reset} ${top.project.name}\n`;
+  if (top.assignee) out += `  ${c.dim}assignee:${c.reset} ${top.assignee.name}\n`;
+
+  if (top.description) {
+    const desc = top.description.slice(0, 600);
+    out += `\n${desc}${top.description.length > 600 ? '\n…(truncated)' : ''}\n`;
+  }
+
+  // Show the rest of the queue
+  const rest = available.slice(1, 4);
+  if (rest.length > 0) {
+    out += `\n${c.dim}Next in queue:${c.reset}\n`;
+    for (const r of rest) {
+      out += `  ${c.cyan}${r.identifier}${c.reset} ${priorityLabel(r.priority)} — ${r.title}\n`;
+    }
+  }
+
+  const blocked = ranked.filter((i) => i.blocked);
+  if (blocked.length > 0) {
+    out += `\n${c.dim}${blocked.length} blocked issue(s) skipped.${c.reset}\n`;
+  }
+
+  out += `\n${c.bold}To start:${c.reset} pnpm crux linear start ${top.identifier}\n`;
+
+  return { output: out, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
 // Command registry
 // ---------------------------------------------------------------------------
 
@@ -263,6 +361,8 @@ export const commands = {
   comment,
   start,
   done,
+  next,
+  list,
   'states-list': statesList,
   parse,
 };
@@ -272,6 +372,8 @@ export function getHelp(): string {
 Linear Domain — Track Claude Code work on Linear issues
 
 Commands:
+  next                          Pick the highest-priority ready issue (Todo/Backlog)
+  list                          List all ready issues ranked by priority
   view <QUA-NNN>                Show full issue + recent comments (default)
   search <query>                Search QUA team issues
   comment <QUA-NNN> <message>   Post a comment on an issue
@@ -288,12 +390,14 @@ Options (done):
 
 Global options:
   --json              Machine-readable output where supported
-  --limit=N           Max results for search (default: 20)
+  --limit=N           Max results for search/list (default: 20/50)
 
 Environment:
   LINEAR_API_KEY      Required. Stored in .env.base at the workspace root.
 
 Examples:
+  crux linear next                                           # Pick top issue
+  crux linear list                                           # See all ready issues
   crux linear view QUA-184
   crux linear search "agent checklist"
   crux linear start QUA-184

--- a/crux/lib/linear/__tests__/issues.test.ts
+++ b/crux/lib/linear/__tests__/issues.test.ts
@@ -6,6 +6,10 @@ import {
   commentOnIssue,
   createIssue,
   searchIssues,
+  scoreLinearIssue,
+  isLinearIssueBlocked,
+  rankReadyIssues,
+  type ReadyIssue,
 } from '../issues.ts';
 
 // Helper: fake a fetch response with a JSON body.
@@ -344,5 +348,164 @@ describe('issues.ts — transport helpers', () => {
       const body = JSON.parse((init as RequestInit).body as string);
       expect(body.variables.limit).toBe(7);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure scoring / ranking helpers (no API mocking needed)
+// ---------------------------------------------------------------------------
+
+function makeReadyIssue(overrides: Partial<ReadyIssue> = {}): ReadyIssue {
+  return {
+    id: 'id-1',
+    identifier: 'QUA-100',
+    title: 'Test issue',
+    description: null,
+    priority: 3, // medium
+    url: 'https://linear.app/quantifieduncertainty/issue/QUA-100',
+    createdAt: '2026-03-01T00:00:00Z',
+    updatedAt: '2026-03-01T00:00:00Z',
+    state: { name: 'Todo', type: 'unstarted' },
+    assignee: null,
+    labels: { nodes: [] },
+    parent: null,
+    project: null,
+    ...overrides,
+  };
+}
+
+describe('scoreLinearIssue', () => {
+  it('scores urgent higher than high higher than medium', () => {
+    const urgent = scoreLinearIssue(makeReadyIssue({ priority: 1 }));
+    const high = scoreLinearIssue(makeReadyIssue({ priority: 2 }));
+    const medium = scoreLinearIssue(makeReadyIssue({ priority: 3 }));
+    const low = scoreLinearIssue(makeReadyIssue({ priority: 4 }));
+    const none = scoreLinearIssue(makeReadyIssue({ priority: 0 }));
+
+    expect(urgent).toBeGreaterThan(high);
+    expect(high).toBeGreaterThan(medium);
+    expect(medium).toBeGreaterThan(low);
+    expect(low).toBeGreaterThan(none);
+  });
+
+  it('applies bug label bonus', () => {
+    const base = scoreLinearIssue(makeReadyIssue({ priority: 3 }));
+    const withBug = scoreLinearIssue(
+      makeReadyIssue({ priority: 3, labels: { nodes: [{ name: 'Bug' }] } }),
+    );
+    expect(withBug).toBe(base + 50);
+  });
+
+  it('applies agent-ready 1.5x multiplier', () => {
+    const base = scoreLinearIssue(makeReadyIssue({ priority: 2 }));
+    const ready = scoreLinearIssue(
+      makeReadyIssue({ priority: 2, labels: { nodes: [{ name: 'claude-ready' }] } }),
+    );
+    // 500 base → 500 * 1.5 = 750. Age/recency bonuses identical.
+    expect(ready).toBeGreaterThan(base);
+    expect(ready - base).toBeGreaterThanOrEqual(Math.round(500 * 0.5) - 1); // ~250
+  });
+
+  it('gives recency bonus for recently updated issues', () => {
+    const stale = scoreLinearIssue(
+      makeReadyIssue({ updatedAt: '2025-01-01T00:00:00Z' }),
+    );
+    const recent = scoreLinearIssue(
+      makeReadyIssue({ updatedAt: new Date().toISOString() }),
+    );
+    expect(recent).toBe(stale + 15);
+  });
+
+  it('gives age bonus capped at 10', () => {
+    const fresh = scoreLinearIssue(
+      makeReadyIssue({ createdAt: new Date().toISOString(), updatedAt: '2025-01-01T00:00:00Z' }),
+    );
+    const old = scoreLinearIssue(
+      makeReadyIssue({ createdAt: '2020-01-01T00:00:00Z', updatedAt: '2025-01-01T00:00:00Z' }),
+    );
+    // Old issue should have +10 (capped), fresh issue +0
+    expect(old - fresh).toBe(10);
+  });
+});
+
+describe('isLinearIssueBlocked', () => {
+  it('returns false for a clean issue', () => {
+    expect(isLinearIssueBlocked(makeReadyIssue())).toBe(false);
+  });
+
+  it('returns true for blocked label', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ labels: { nodes: [{ name: 'blocked' }] } })),
+    ).toBe(true);
+  });
+
+  it('returns true for waiting label', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ labels: { nodes: [{ name: 'waiting' }] } })),
+    ).toBe(true);
+  });
+
+  it('returns true when description says "blocked by"', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ description: 'This is blocked by QUA-50' })),
+    ).toBe(true);
+  });
+
+  it('returns true when description says "waiting for"', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ description: 'Waiting for upstream fix' })),
+    ).toBe(true);
+  });
+
+  it('returns true when description says "depends on"', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ description: 'Depends on QUA-222 shipping first' })),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated description content', () => {
+    expect(
+      isLinearIssueBlocked(makeReadyIssue({ description: 'This feature adds a new command' })),
+    ).toBe(false);
+  });
+});
+
+describe('rankReadyIssues', () => {
+  it('sorts by score descending', () => {
+    const issues = [
+      makeReadyIssue({ identifier: 'QUA-1', priority: 4 }), // low
+      makeReadyIssue({ identifier: 'QUA-2', priority: 1 }), // urgent
+      makeReadyIssue({ identifier: 'QUA-3', priority: 3 }), // medium
+    ];
+    const ranked = rankReadyIssues(issues);
+    expect(ranked[0].identifier).toBe('QUA-2'); // urgent first
+    expect(ranked[1].identifier).toBe('QUA-3'); // then medium
+    expect(ranked[2].identifier).toBe('QUA-1'); // then low
+  });
+
+  it('uses creation date as tiebreaker (oldest first)', () => {
+    const issues = [
+      makeReadyIssue({ identifier: 'QUA-NEW', priority: 3, createdAt: '2026-04-01T00:00:00Z' }),
+      makeReadyIssue({ identifier: 'QUA-OLD', priority: 3, createdAt: '2026-01-01T00:00:00Z' }),
+    ];
+    const ranked = rankReadyIssues(issues);
+    expect(ranked[0].identifier).toBe('QUA-OLD');
+    expect(ranked[1].identifier).toBe('QUA-NEW');
+  });
+
+  it('marks blocked issues correctly', () => {
+    const issues = [
+      makeReadyIssue({ identifier: 'QUA-OK' }),
+      makeReadyIssue({ identifier: 'QUA-BLOCKED', labels: { nodes: [{ name: 'blocked' }] } }),
+    ];
+    const ranked = rankReadyIssues(issues);
+    const ok = ranked.find((r) => r.identifier === 'QUA-OK');
+    const blocked = ranked.find((r) => r.identifier === 'QUA-BLOCKED');
+    expect(ok!.blocked).toBe(false);
+    expect(blocked!.blocked).toBe(true);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(rankReadyIssues([])).toEqual([]);
   });
 });

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -235,12 +235,12 @@ export async function searchIssues(
   return data.searchIssues.nodes;
 }
 
+// ---------------------------------------------------------------------------
+// List by state type (for triage/maintenance)
+// ---------------------------------------------------------------------------
+
 /**
  * Fetch issues filtered by workflow state type(s).
- *
- * Uses Linear's `issues` query with a filter, not the free-text `searchIssues`.
- * `stateTypes` maps to Linear's internal type enum: "backlog", "unstarted",
- * "started", "completed", "canceled".
  */
 export async function listIssuesByStateType(
   stateTypes: string[],
@@ -286,6 +286,161 @@ export interface LinearTriageIssue {
   parent: { identifier: string; title: string } | null;
   project: { name: string } | null;
   labels: { nodes: Array<{ name: string }> };
+}
+
+// ---------------------------------------------------------------------------
+// List ready issues (for "next issue" picking)
+// ---------------------------------------------------------------------------
+
+export interface ReadyIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  priority: number; // 0=none, 1=urgent, 2=high, 3=medium, 4=low
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  state: { name: string; type: string };
+  assignee: { name: string } | null;
+  labels: { nodes: Array<{ name: string }> };
+  parent: { identifier: string; title: string } | null;
+  project: { id: string; name: string } | null;
+}
+
+/**
+ * Fetch issues in "ready" states (Todo, Backlog) from the QUA team.
+ * Returns issues sorted by Linear's priority (urgent first), then by
+ * creation date (oldest first within the same priority).
+ *
+ * Excludes issues that are In Progress, In Review, Done, Canceled, or Duplicate.
+ */
+export async function listReadyIssues(
+  limit = 50,
+  teamId: string = QUA_TEAM_ID,
+): Promise<ReadyIssue[]> {
+  const data = await linearGraphQL<{
+    issues: { nodes: ReadyIssue[] };
+  }>(
+    `query ReadyIssues($limit: Int!, $filter: IssueFilter) {
+      issues(
+        first: $limit
+        filter: $filter
+        orderBy: createdAt
+      ) {
+        nodes {
+          id
+          identifier
+          title
+          description
+          priority
+          url
+          createdAt
+          updatedAt
+          state { name type }
+          assignee { name }
+          labels { nodes { name } }
+          parent { identifier title }
+          project { id name }
+        }
+      }
+    }`,
+    {
+      limit,
+      filter: {
+        team: { id: { eq: teamId } },
+        state: {
+          type: { in: ['backlog', 'unstarted'] }, // backlog = Backlog, unstarted = Todo
+        },
+      },
+    },
+  );
+  return data.issues.nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring (mirrors crux/lib/issues/scoring.ts patterns for Linear)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a Linear issue for agent dispatch ordering.
+ *
+ * Linear priorities: 1=urgent, 2=high, 3=medium, 4=low, 0=none.
+ * Higher score = should be worked on first.
+ */
+export function scoreLinearIssue(issue: ReadyIssue): number {
+  // Base score from Linear's built-in priority
+  const priorityScores: Record<number, number> = {
+    1: 1000, // urgent
+    2: 500,  // high
+    3: 200,  // medium
+    4: 100,  // low
+    0: 50,   // none
+  };
+  let score = priorityScores[issue.priority] ?? 50;
+
+  // Bug/fix bonus
+  const labelNames = issue.labels.nodes.map((l) => l.name.toLowerCase());
+  if (labelNames.some((l) => ['bug', 'defect', 'regression', 'fix', 'crash'].includes(l))) {
+    score += 50;
+  }
+
+  // Agent-ready label bonus (1.5x)
+  if (labelNames.some((l) => ['claude-ready', 'agent-ready', 'agent:ready'].includes(l))) {
+    score = Math.round(score * 1.5);
+  }
+
+  // Recency bonus: updated in last 7 days = someone cares
+  const updatedMs = Date.now() - new Date(issue.updatedAt).getTime();
+  if (updatedMs < 7 * 24 * 60 * 60 * 1000) {
+    score += 15;
+  }
+
+  // Age bonus: +1 per month, capped at +10 (prevent starvation)
+  const ageMs = Date.now() - new Date(issue.createdAt).getTime();
+  const ageMonths = Math.floor(ageMs / (30 * 24 * 60 * 60 * 1000));
+  score += Math.min(ageMonths, 10);
+
+  return score;
+}
+
+/** Labels that signal an issue should be skipped. */
+const SKIP_LABELS = new Set([
+  'wontfix', "won't fix", 'on-hold', 'invalid', 'duplicate',
+  'blocked', 'waiting', 'needs-info', 'needs-discussion',
+]);
+
+/**
+ * Check if a Linear issue should be skipped by the auto-picker.
+ */
+export function isLinearIssueBlocked(issue: ReadyIssue): boolean {
+  const labelNames = issue.labels.nodes.map((l) => l.name.toLowerCase());
+  if (labelNames.some((l) => SKIP_LABELS.has(l))) return true;
+
+  // Check description for blocking language
+  if (issue.description) {
+    if (/\bblocked by\b/i.test(issue.description)) return true;
+    if (/\bwaiting (for|on)\b/i.test(issue.description)) return true;
+    if (/\bdepends on\b/i.test(issue.description)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Rank ready issues: score descending, then oldest first as tiebreaker.
+ */
+export function rankReadyIssues(issues: ReadyIssue[]): Array<ReadyIssue & { score: number; blocked: boolean }> {
+  return issues
+    .map((issue) => ({
+      ...issue,
+      score: scoreLinearIssue(issue),
+      blocked: isLinearIssueBlocked(issue),
+    }))
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
 }
 
 /** Convenience re-export so callers import everything from one module. */


### PR DESCRIPTION
## Summary

- Adds `crux linear next` — picks the highest-priority unblocked Linear issue from the QUA team's Todo/Backlog states
- Adds `crux linear list` — shows all ready issues ranked by score with blocked/assignee indicators
- Updates `/agent-next-issue` skill to support both GitHub and Linear backlogs
- Adds scoring logic mirroring the GitHub issue scorer (priority-based, with bug/agent-ready/recency/age bonuses)

This enables fully autonomous agent sessions that start from Linear issues without human issue selection. An agent in any slot can now run `crux linear next` → `crux linear start QUA-NNN` → work → `/agent-ship`.

Closes #200 (if applicable — QUA-200 tracks this feature)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (5350 tests, 14 new)
- [x] `pnpm crux w validate gate --fix` — all 46 checks pass
- [x] TypeScript type check — no new errors
- [x] `crux linear next` returns correct top issue from live API
- [x] `crux linear list` shows ranked queue with blocked indicators
- [x] `crux linear next --json` returns machine-readable output
- [x] `crux linear --help` shows new commands
- [x] Unit tests cover scoring (priority ordering, bonuses), blocking (labels + description), ranking (sort + tiebreak)
- [x] Subagent code review — 0 critical/high findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linear issue integration with `next` and `list` commands for viewing and selecting top-priority issues
  * Implemented intelligent issue ranking based on priority levels, labels, recency, and age
  * Added detection for blocked/dependent issues
  
* **Documentation**
  * Updated workflow documentation to support both GitHub and Linear issue sources
  
* **Tests**
  * Added unit test coverage for issue ranking and blocking detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->