### PR TITLE
Hide Published date column when venue has low date coverage

### DIFF
--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -96,6 +96,11 @@ export default async function PublicationDetailPage({ params }: PageProps) {
     };
   });
 
+  // Hide the Published column when fewer than 10% of resources have dates
+  const datesPopulated = resourceRows.filter((r) => r.publishedDate).length;
+  const showPublishedDate =
+    resourceRows.length === 0 || datesPopulated / resourceRows.length >= 0.1;
+
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
       {/* Back link */}
@@ -227,7 +232,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
             <FileText className="w-4 h-4 inline mr-1.5 -mt-0.5" />
             Resources ({resources.length})
           </h2>
-          <PublicationResourcesTable resources={resourceRows} />
+          <PublicationResourcesTable resources={resourceRows} showPublishedDate={showPublishedDate} />
         </section>
       )}
 

--- a/apps/web/src/app/publications/[id]/publication-resources-table.tsx
+++ b/apps/web/src/app/publications/[id]/publication-resources-table.tsx
@@ -152,10 +152,20 @@ function makeColumns(): ColumnDef<PublicationResourceRow>[] {
 
 export function PublicationResourcesTable({
   resources,
+  showPublishedDate = true,
 }: {
   resources: PublicationResourceRow[];
+  showPublishedDate?: boolean;
 }) {
-  const columns = useMemo(() => makeColumns(), []);
+  const columns = useMemo(() => {
+    const all = makeColumns();
+    if (!showPublishedDate) {
+      return all.filter(
+        (c) => (c as { accessorKey?: string }).accessorKey !== "publishedDate",
+      );
+    }
+    return all;
+  }, [showPublishedDate]);
 
   const [sorting, setSorting] = useState<SortingState>([
     { id: "citingPageCount", desc: true },


### PR DESCRIPTION
## Summary
- Hide the "Published" date column on publication venue detail pages when fewer than 10% of resources have dates populated
- Major venues (Anthropic 2%, OpenAI 1%, DeepMind 0%) showed a column of em-dashes — now the column is hidden entirely
- Venues with good date coverage (LessWrong 100%, arXiv 95%, RAND 59%) continue to show the column

## Details
The `published_date` field is populated for 17,075/22,373 resources overall (76%), but coverage is highly venue-dependent. Rather than enriching dates for all venues (which would require web scraping), this hides the column when it provides no value.

The 10% threshold cleanly separates venues with meaningful coverage (all ≥57%) from those with negligible coverage (all ≤3%).

Closes #3369

## Test plan
- [x] Build passes (`pnpm build` exits 0)
- [x] TypeScript check passes (no errors in changed files)
- [x] Gate check passes (5/5)
- [x] Manual verification: threshold correctly shows/hides column per venue
- [x] Backwards compatible: `showPublishedDate` defaults to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)