### PR TITLE
Make Linear the primary issue tracker across codebase and Claude skills

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -29,23 +29,9 @@ pnpm crux sys agent-checklist complete 2>/dev/null || true
 
 If the checklist doesn't exist (e.g., quick fix session), that's fine — skip it.
 
-## Step 2: Update GitHub issue (if applicable)
+## Step 2: Update Linear issue (primary — if applicable)
 
-If this session was working on a GitHub issue and a PR was created:
-
-```bash
-pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
-```
-
-If no PR was created (research/abandoned), just remove the working label:
-
-```bash
-gh api repos/quantified-uncertainty/longterm-wiki/issues/<N>/labels/agent:working -X DELETE 2>/dev/null || true
-```
-
-## Step 2b: Update Linear issue (if applicable)
-
-If the session was working on a Linear issue (look for `> Linear: QUA-NNN` in `.claude/wip-checklist.md`, or if the branch matches `claude/qua-NNN-*`), move it to the right terminal state so the Linear backlog stays accurate.
+**Linear is the primary issue tracker.** If the session was working on a Linear issue (look for `> Linear: QUA-NNN` in `.claude/wip-checklist.md`, or if the branch matches `claude/qua-NNN-*`), move it to the right terminal state so the Linear backlog stays accurate.
 
 Set `PR_URL` first — if a PR was created during this session, export it; if not, leave it empty so the issue goes straight to `Done`:
 
@@ -75,6 +61,20 @@ fi
 ```
 
 Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes the Linear update best-effort so a missing key doesn't interrupt the rest of `/agent-end`. If Linear updates fail, fix the key and rerun `pnpm crux linear done <QUA-NNN>` manually — Linear is the source of truth for project status and leaving "In Progress" drift is bad.
+
+## Step 2b: Update legacy GitHub issue (if applicable)
+
+If this session was working on a legacy GitHub issue (not a Linear issue) and a PR was created:
+
+```bash
+pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
+```
+
+If no PR was created (research/abandoned), just remove the working label:
+
+```bash
+gh api repos/quantified-uncertainty/longterm-wiki/issues/<N>/labels/agent:working -X DELETE 2>/dev/null || true
+```
 
 ## Step 3: Stop patrol daemon (if running)
 

--- a/.claude/commands/agent-init.md
+++ b/.claude/commands/agent-init.md
@@ -15,16 +15,16 @@ This single command does everything below in order:
 
 1. **Syncs to main** — verifies the working tree is clean, switches to `main` if needed, and runs `git pull --ff-only origin main`. If the tree is dirty, it aborts and tells you what's uncommitted.
 2. Generates `.claude/wip-checklist.md` for the session type.
-3. Auto-marks `issue-tracking` as N/A when no `--issue` is given.
-4. **Signals start on the GitHub issue** (when `--issue=N` is given) — adds the `agent:working` label and posts the start comment. Best-effort: a GitHub failure does not fail init.
-5. **Signals start on the Linear issue** — auto-detects a Linear ID from the branch name (`claude/qua-NNN-*`) or task description (any bare `QUA-NNN` token), or takes `--linear=QUA-NNN` explicitly. Moves the issue to "In Progress" and posts a start comment. Best-effort: a Linear failure does not fail init.
+3. Auto-marks `issue-tracking` as N/A when no issue is given.
+4. **Signals start on the Linear issue** (primary) — auto-detects a Linear ID from the branch name (`claude/qua-NNN-*`) or task description (any bare `QUA-NNN` token), or takes `--linear=QUA-NNN` explicitly. Moves the issue to "In Progress" and posts a start comment. Best-effort: a Linear failure does not fail init.
+5. **Signals start on the GitHub issue** (when `--issue=N` is given) — adds the `agent:working` label and posts the start comment. Best-effort: a GitHub failure does not fail init.
 6. Prints the full checklist so you can scan it.
 
-Pick the right invocation:
+Pick the right invocation (**Linear is the primary tracker** — most issues are there):
 
-- **Working on a GitHub issue**: `pnpm crux sys agent-checklist init --issue=N` (auto-detects type from labels)
-- **Working on a Linear issue**: start a branch `claude/qua-NNN-description` and the ID is detected automatically, or pass `--linear=QUA-NNN` explicitly
-- **Not on an issue**: `pnpm crux sys agent-checklist init "Task description" --type=X`
+- **Working on a Linear issue** (most common): start a branch `claude/qua-NNN-description` and the ID is detected automatically, or pass `--linear=QUA-NNN` explicitly
+- **Working on a legacy GitHub issue**: `pnpm crux sys agent-checklist init --issue=N` (auto-detects type from labels)
+- **Not on any tracked issue**: `pnpm crux sys agent-checklist init "Task description" --type=X`
 
 Both `--issue` and `--linear` can be passed together if the same task is tracked in both systems.
 

--- a/.claude/commands/agent-next-issue.md
+++ b/.claude/commands/agent-next-issue.md
@@ -1,83 +1,51 @@
 ---
-description: Pick up the next highest-priority issue (GitHub or Linear) and start working on it.
-argument-hint: "[issue-number] [--source=github|linear]"
+description: Pick up the next highest-priority Linear issue and start working on it.
+argument-hint: "[issue-identifier]"
 effort: medium
 ---
 
 # Next Issue
 
-Pick up the next highest-priority issue and start working on it. Supports both GitHub issues and Linear issues.
+Pick up the next highest-priority issue and start working on it. **Linear is the primary issue tracker** — check Linear first, fall back to GitHub for legacy issues.
 
 ## Overview
 
-This command helps you start a focused session on the most important open issue. It fetches open issues, applies priority ordering, filters out issues already being worked on, and presents the top candidates for selection.
+This command helps you start a focused session on the most important open issue. It checks the Linear backlog (QUA team) for ready-to-work issues, applies priority ordering, and presents the top candidates for selection.
 
 ## Phase 1: Fetch and rank open issues
 
-### Option A: GitHub issues (default)
+```bash
+# Primary — Linear backlog:
+pnpm crux linear search "status:Todo,Backlog"
+```
+
+Review the results. Priority ordering uses Linear's built-in priority field (Urgent > High > Medium > Low > None). If the Linear backlog is empty or `LINEAR_API_KEY` is not set, fall back to GitHub:
 
 ```bash
+# Fallback — GitHub issues:
 pnpm crux gh issues next
 ```
 
-This outputs a ranked list of open GitHub issues — highest priority first — with their labels, age, and a brief description. The ranking uses:
-
-1. **Priority labels** — `P0` > `P1` > `P2` > `P3` > unlabeled
-2. **Issue age** — older issues rank slightly higher within the same tier
-3. **Excluded** — issues labeled `agent:working`, `wontfix`, or `on-hold`
-
-### Option B: Linear issues
-
-```bash
-pnpm crux linear next
-```
-
-This outputs a ranked list of ready Linear issues (Todo/Backlog states) from the QUA team. The ranking uses:
-
-1. **Linear priority** — urgent > high > medium > low > none
-2. **Labels** — `claude-ready`/`agent-ready` issues get a 1.5× boost
-3. **Issue age** — older issues rank slightly higher within the same tier
-4. **Excluded** — issues labeled `blocked`, `waiting`, `on-hold`, etc.
-
-### Choosing a source
-
-If the user specified `--source=linear` or asked for a Linear issue, use Option B. If `--source=github` or a GitHub issue, use Option A. If unspecified, **check both sources** and present the top candidate from each, then pick the higher-priority one.
-
-To see the full queue from either source:
-```bash
-pnpm crux gh issues list     # All open GitHub issues
-pnpm crux linear list         # All ready Linear issues
-```
-
-Review the list. If the top issue looks right, proceed. If not, pick a different one from the list and note why you skipped the top one.
+If the user passed a specific issue identifier (e.g., `QUA-184` or `#239`), skip ranking and go directly to that issue.
 
 ## Phase 2: Signal start on the chosen issue
 
-### For GitHub issues:
+Once you've chosen an issue:
 
 ```bash
+# For a Linear issue (most common):
+pnpm crux linear start QUA-NNN
+
+# For a legacy GitHub issue:
 pnpm crux gh issues start <ISSUE_NUM>
 ```
 
 This will:
-1. Post a comment on the issue: "Claude Code starting work on this issue (branch: `<current-branch>`)"
-2. Add the `agent:working` label to signal it's in flight
-3. Print a summary of the issue title and body for context
+1. Post a start comment on the issue
+2. Move to "In Progress" (Linear) or add `agent:working` label (GitHub)
+3. Print a summary of the issue for context
 
-### For Linear issues:
-
-```bash
-pnpm crux linear start <QUA-NNN>
-```
-
-This will:
-1. Move the issue to "In Progress"
-2. Post a comment with the branch name
-
-**Important:** When working on a Linear issue, the branch name **must** contain the Linear ID for auto-close to work on merge:
-```bash
-git checkout -b claude/qua-NNN-description
-```
+**Output the issue title and key details** to your working context before starting implementation — this ensures you understand what's being asked.
 
 ## Phase 3: Understand the issue
 
@@ -89,48 +57,38 @@ Read the issue carefully. If the body contains acceptance criteria or examples, 
 
 If the issue is ambiguous, look at context in the issue comments or related code before proceeding.
 
-## Phase 4: Initialize the session checklist
-
-Run `/agent-init` to set up the session tracking:
-
-```bash
-# GitHub issue:
-pnpm crux sys agent-checklist init --issue=N
-
-# Linear issue:
-pnpm crux sys agent-checklist init "Task description" --linear=QUA-NNN
-
-# Both (if the Linear issue maps to a GitHub issue):
-pnpm crux sys agent-checklist init --issue=N --linear=QUA-NNN
-```
-
-## Phase 5: Implement
+## Phase 4: Implement
 
 Work through the issue using the standard development workflow:
 
-1. Make changes, following all relevant rules in `.claude/rules/`
-2. Run validation: `pnpm crux w validate gate`
-3. Write tests for new logic
+1. Create a branch with the issue ID: `claude/qua-NNN-description` (Linear) or `claude/fix-NNN-description` (GitHub)
+2. Make changes, following all relevant rules in `.claude/rules/`
+3. Run validation: `pnpm crux w validate gate`
 
-## Phase 6: Ship and close the loop
+## Phase 5: Ship and close the loop
 
-Run `/agent-ship` to push, monitor CI, and close the session. It automatically:
-- Updates GitHub issues (`crux gh issues done`)
-- Updates Linear issues (`crux linear done --pr=URL`)
-- Creates the session log
+After the work is done:
+
+```bash
+# Linear:
+pnpm crux linear done QUA-NNN --pr=<PR_URL>
+
+# Legacy GitHub:
+pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
+```
+
+Then run `/agent-push-and-verify` as usual.
 
 ## Quick reference
 
 ```bash
-# GitHub
-pnpm crux gh issues next              # Show next priority GitHub issue
-pnpm crux gh issues list              # List all open GitHub issues
-pnpm crux gh issues start <N>         # Announce start + add agent:working label
-pnpm crux gh issues done <N> --pr=URL # Announce completion + remove label
+# Linear (primary):
+pnpm crux linear search "status:Todo"    # Browse ready issues
+pnpm crux linear start QUA-NNN           # Signal start
+pnpm crux linear done QUA-NNN --pr=URL   # Signal completion
 
-# Linear
-pnpm crux linear next                 # Show next priority Linear issue
-pnpm crux linear list                 # List all ready Linear issues
-pnpm crux linear start <QUA-NNN>      # Move to In Progress + post start comment
-pnpm crux linear done <QUA-NNN> --pr=URL  # Move to In Review + post done comment
+# GitHub (legacy fallback):
+pnpm crux gh issues next                 # Show next priority issue
+pnpm crux gh issues start <N>            # Signal start
+pnpm crux gh issues done <N> --pr=URL    # Signal completion
 ```

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -116,16 +116,9 @@ This is **automatic** and **deterministic** — the detector scans the diff for 
 
 For infrastructure changes that the detector does **not** cover (DNS changes, external service configuration, manual database operations), also add a `post_merge` entry to `.claude/audits.yaml` with the PR number, what to verify, and a deadline.
 
-## Step 5: Update GitHub issue
+## Step 5: Update Linear issue (primary — if applicable)
 
-If working on a GitHub issue:
-```bash
-pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
-```
-
-## Step 5b: Update Linear issue (if applicable)
-
-If this session was tracking a Linear issue, move it to In Review so the Linear backlog reflects the open PR. Set `PR_URL` to the PR created/updated in step 4 first:
+**Linear is the primary issue tracker.** If this session was tracking a Linear issue, move it to In Review so the Linear backlog reflects the open PR. Set `PR_URL` to the PR created/updated in step 4 first:
 
 ```bash
 # PR_URL must be set by the ship flow — it's the URL of the PR just pushed.
@@ -142,6 +135,13 @@ fi
 ```
 
 Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` keeps this best-effort so a missing key doesn't abort the ship flow. Linear → Done happens automatically when the PR merges, via Linear's native GitHub integration — **but only if** the branch name contains `qua-NNN` or the PR body contains `Fixes QUA-NNN`. `crux gh pr create` auto-injects the latter from the branch name, checklist metadata, and `--linear` flag.
+
+## Step 5b: Update legacy GitHub issue (if applicable)
+
+If working on a legacy GitHub issue (not a Linear issue):
+```bash
+pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
+```
 
 ## Step 6: Session log
 

--- a/.claude/commands/maintain-audit.md
+++ b/.claude/commands/maintain-audit.md
@@ -232,7 +232,7 @@ Produce a structured report. Be specific and evidence-based — include line cou
 
 For each recommendation:
 - **Quick wins** (< 30 min, safe): Do them in this session if time allows
-- **Medium items**: File a GitHub issue with the evidence from the report (`pnpm crux gh issues create`)
+- **Medium items**: File a Linear issue with the evidence from the report (`pnpm crux linear create`)
 - **Architectural decisions**: Note them for the user to discuss — don't file issues for things that need human judgment
 
 ## Guardrails

--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -6,7 +6,7 @@ effort: medium
 
 # Adversarial QA Sweep
 
-Systematic adversarial audit of the wiki. Finds bugs, broken pages, regressions, and data integrity issues. Produces a prioritized findings report and files GitHub issues for real bugs.
+Systematic adversarial audit of the wiki. Finds bugs, broken pages, regressions, and data integrity issues. Produces a prioritized findings report and files Linear issues for real bugs.
 
 **Schedule:** `/loop 24h /maintain-qa-sweep` for daily runs using your Claude Code subscription.
 
@@ -32,7 +32,7 @@ Systematic adversarial audit of the wiki. Finds bugs, broken pages, regressions,
 1. `pnpm crux qa-sweep` runs deterministic checks (duplicate IDs, broken refs, tests, gate)
 2. This skill adds LLM-driven agents on top (production site audit, code review of recent changes)
 3. Findings are compiled into a P0/P1/P2 report
-4. P0 bugs get fixed; P1/P2 get filed as GitHub issues
+4. P0 bugs get fixed; P1/P2 get filed as Linear issues
 
 **Relationship to other commands:**
 - `/maintain` — day-to-day cleanup (close issues, fix cruft)
@@ -322,12 +322,11 @@ Include the coverage table in the report.
 
 **QA sweeps override the normal conservative filing limits.** The whole purpose of a sweep is to find and file issues. Rules:
 
-- **File one GitHub issue per finding** (P0, P1, and P2). Do not batch unrelated issues into umbrella issues.
+- **File one Linear issue per finding** (P0, P1, and P2). Do not batch unrelated issues into umbrella issues.
 - Closely related findings (e.g., 5 entities with the same data problem) may be grouped into one issue.
-- Use `pnpm crux issues create` with `--model=haiku` for each.
-- **Expected volume:** 5-15 issues per deep sweep is normal. The daily cap of 5 from `proactive-github-filing.md` does NOT apply to QA sweeps.
-- Label all issues with the appropriate severity label if available.
-- **Do NOT skip P1 and P2 filing.** Every confirmed finding must become a GitHub issue. If you compiled it into the report, file it.
+- Use `pnpm crux linear create "title" --description="..."` for each.
+- **Expected volume:** 5-15 issues per deep sweep is normal.
+- **Do NOT skip P1 and P2 filing.** Every confirmed finding must become a Linear issue. If you compiled it into the report, file it.
 
 ### Persist the full report to a GitHub Discussion
 
@@ -355,8 +354,8 @@ If #2650 has been closed or replaced for some reason (verify by running `pnpm cr
 | Severity | Action |
 |----------|--------|
 | **P0** (active bug) | Fix it now in a branch, open a PR |
-| **P1** (latent bug) | File a GitHub issue (already done above) |
-| **P2** (quality/UX) | File a GitHub issue (already done above) |
+| **P1** (latent bug) | File a Linear issue (already done above) |
+| **P2** (quality/UX) | File a Linear issue (already done above) |
 
 After fixing P0s, run `/agent-push-and-verify` to ship.
 

--- a/.claude/commands/maintain-retrospective.md
+++ b/.claude/commands/maintain-retrospective.md
@@ -160,7 +160,7 @@ Each recommendation should state:
 
 For each recommendation:
 - **Process changes** (updating rules, CLAUDE.md, or conventions): Make the change now if it's clear-cut, or note it for user discussion if it involves tradeoffs.
-- **Tooling fixes**: File a GitHub issue if you can't fix it in this session.
+- **Tooling fixes**: File a Linear issue if you can't fix it in this session.
 - **Propagate learnings**: Update `.claude/rules/` or `CLAUDE.md` with any recurring patterns identified.
 
 ## Guardrails

--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -5,7 +5,7 @@ effort: medium
 
 # Maintenance Sweep
 
-Run a prioritized maintenance session: review recent PRs, analyze session logs, triage GitHub issues, detect codebase cruft, and take action.
+Run a prioritized maintenance session: review recent PRs, analyze session logs, triage Linear/GitHub issues, detect codebase cruft, and take action.
 
 ## Overview
 
@@ -26,8 +26,8 @@ pnpm crux sys maintain
 
 This produces a combined report covering:
 - **PR & Session Log Review**: Merged PRs, session log issues/learnings, recurring problems, multi-edited pages
-- **GitHub Issue Triage**: Issues categorized as potentially-resolved, stale, actionable, or keep
-- **Linear Queue Triage**: Stale In Progress, stuck In Review, and P1/P2 ready-for-dispatch items
+- **Linear Queue Triage** (primary): Stale In Progress, stuck In Review, and P1/P2 ready-for-dispatch items
+- **Legacy GitHub Issue Triage**: Issues categorized as potentially-resolved, stale, actionable, or keep
 - **Codebase Cruft**: TODO/FIXME comments, large files, commented-out code
 
 Additionally, check page content health:
@@ -47,7 +47,7 @@ The report categorizes work into priority tiers. Review the output and decide wh
 | **P0** | Fix broken things | Always | CI failures, blocking validation errors, broken imports |
 | **P1** | Close resolved issues | ~1 min each | Issues that recent PRs already fixed — verify and close |
 | **P2** | Propagate learnings | ~5 min | Add recurring session log issues to `common-issues.md` or rules |
-| **P3** | Work actionable issues | Varies | Fix small issues directly; **file new GitHub issues** for larger tasks found during the sweep |
+| **P3** | Work actionable issues | Varies | Fix small issues directly; **file new Linear issues** for larger tasks found during the sweep |
 | **P4** | Cruft cleanup | ~5 min each | Dead code removal, TODO resolution, file splitting |
 | **P5** | Page content updates | Delegate | Run `pnpm crux w updates run` for content freshness |
 
@@ -55,14 +55,13 @@ The report categorizes work into priority tiers. Review the output and decide wh
 
 ### Filing new issues
 
-When the sweep reveals problems too large to fix now, **create GitHub issues** so they aren't lost:
+When the sweep reveals problems too large to fix now, **create Linear issues** so they aren't lost:
 ```bash
-pnpm crux gh issues create "Descriptive title" \
-  --problem="What's wrong and why it matters" \
-  --label=enhancement
+pnpm crux linear create "Descriptive title" \
+  --description="What's wrong and why it matters"
 ```
 
-For Linear issues:
+To update existing Linear issues with context:
 ```bash
 pnpm crux linear comment QUA-NNN "Status update from maintenance sweep"
 ```
@@ -109,7 +108,7 @@ Edit `.claude/common-issues.md` or `.claude/rules/` files with patterns found in
 
 ### Fixing actionable issues
 For small issues: fix the code, following the standard workflow (edit, validate, test).
-For larger discoveries: file a GitHub issue (see above) and move on.
+For larger discoveries: file a Linear issue (see above) and move on.
 
 ### Cruft cleanup
 Only remove things you're confident are unused — grep thoroughly before deleting. Each change should be a focused, reviewable unit.
@@ -126,5 +125,5 @@ Only remove things you're confident are unused — grep thoroughly before deleti
 - **Be conservative with issue closures.** When in doubt, comment with status rather than closing. The triage report's "potentially resolved" classification uses heuristic matching and can have false positives.
 - **For cruft removal**, only remove things you're confident are unused. Grep thoroughly before deleting.
 - **Don't modify wiki content directly.** Page updates go through the Crux pipeline (`crux w updates run` or `crux w content improve`).
-- **If the sweep finds many items (>10 actionable)**, work on the top 5 and file the rest as GitHub issues.
+- **If the sweep finds many items (>10 actionable)**, work on the top 5 and file the rest as Linear issues.
 - **If a maintenance run takes >5 actions**, prefer multiple focused commits over one large commit.

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -294,11 +294,10 @@ Verify before posting:
 pnpm crux gh epic create "[Feature Name] — Implementation Plan" --body-file=/tmp/feature-plan.md
 ```
 
-Create GitHub issues for Phase 1 tasks and link to the epic:
+Create Linear issues for Phase 1 tasks:
 
 ```bash
-pnpm crux gh issues create "Task title" --problem="..." --label=enhancement
-pnpm crux gh epic link <DISCUSSION_NUM> --issue=<ISSUE_NUM>
+pnpm crux linear create "Task title" --description="..."
 ```
 
 ### 7d. CHECKPOINT 3 — Final report

--- a/.claude/commands/score-issues.md
+++ b/.claude/commands/score-issues.md
@@ -4,9 +4,11 @@ argument-hint: "[--dry-run] [--limit=N]"
 effort: low
 ---
 
-# Score Issues — LLM-Powered Issue Triage
+# Score Issues — LLM-Powered Issue Triage (Legacy GitHub)
 
-Read open issues, use your judgment to assess priority/effort/model, and apply labels so `crux gh issues next` ranks them correctly.
+**Note:** Linear is now the primary issue tracker and has its own priority system. This command applies to legacy GitHub issues that haven't been migrated to Linear yet.
+
+Read open GitHub issues, use your judgment to assess priority/effort/model, and apply labels so `crux gh issues next` ranks them correctly.
 
 ## When to use
 

--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -8,15 +8,15 @@ Always work on a `claude/short-description` branch. Never commit directly to `ma
 
 ### Naming convention when the task is tracked in an issue tracker
 
-When the session is working on a tracked issue, encode the issue ID in the branch name so `/agent-init` can auto-detect it and post start/done signals without manual flags:
+**Linear is the primary issue tracker.** Most work is tracked there. Encode the issue ID in the branch name so `/agent-init` can auto-detect it and post start/done signals without manual flags:
 
 | Source | Pattern | Example |
 |--------|---------|---------|
-| GitHub issue | `claude/fix-NNN-description` | `claude/fix-239-broken-scoring` |
-| Linear issue | `claude/qua-NNN-description` | `claude/qua-184-linear-integration` |
+| Linear issue (primary) | `claude/qua-NNN-description` | `claude/qua-184-linear-integration` |
+| Legacy GitHub issue | `claude/fix-NNN-description` | `claude/fix-239-broken-scoring` |
 | No tracker | `claude/<verb>-<noun>` | `claude/refactor-gate-helpers` |
 
-Both GitHub (`fix-NNN`) and Linear (`qua-NNN`) patterns are auto-detected by `crux sys agent-checklist init`. Linear detection also falls back to any bare `QUA-NNN` token in the task description, and can be overridden with `--linear=QUA-NNN`.
+Both Linear (`qua-NNN`) and GitHub (`fix-NNN`) patterns are auto-detected by `crux sys agent-checklist init`. Linear detection also falls back to any bare `QUA-NNN` token in the task description, and can be overridden with `--linear=QUA-NNN`.
 
 **Linear branch naming is critical for auto-close.** Linear's GitHub integration auto-moves issues to Done on PR merge, but only if the branch name contains `qua-NNN`. If you name the branch `claude/tier0-data-integrity` instead of `claude/qua-155-tier0-data-integrity`, Linear won't link the PR and the issue stays open after merge. `agent-checklist init` warns about this. As a fallback, `crux gh pr create` auto-injects `Fixes QUA-NNN` into the PR body.
 
@@ -40,11 +40,11 @@ This prevents the duplicate-work pattern where multiple agents independently rac
 Run `/agent-init` as the very first thing — before reading files, running commands, or writing any code. "Before writing code" is not sufficient; quick fixes and file reads count too. If you start without this, you will forget it entirely.
 
 ```bash
-# If working on a GitHub issue (auto-starts tracking):
-pnpm crux sys agent-checklist init --issue=N
-
-# If working on a Linear issue (auto-detected from branch, or explicit):
+# If working on a Linear issue (primary — auto-detected from branch, or explicit):
 pnpm crux sys agent-checklist init "Task description" --linear=QUA-184
+
+# If working on a legacy GitHub issue:
+pnpm crux sys agent-checklist init --issue=N
 
 # If not on any tracked issue:
 pnpm crux sys agent-checklist init "Task description" --type=X
@@ -52,7 +52,7 @@ pnpm crux sys agent-checklist init "Task description" --type=X
 
 Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands`. Default: `infrastructure`.
 
-`init` automatically signals start on both GitHub (`gh issues start`) and Linear (`linear issues start`) when the respective IDs are known — you do not need to call them by hand. Both calls are best-effort: a GitHub or Linear outage never fails init.
+`init` automatically signals start on both Linear (`linear start`) and GitHub (`gh issues start`) when the respective IDs are known — you do not need to call them by hand. Both calls are best-effort: a Linear or GitHub outage never fails init.
 
 Then read `.claude/wip-checklist.md` and keep it updated as you work.
 
@@ -60,7 +60,7 @@ Then read `.claude/wip-checklist.md` and keep it updated as you work.
 
 **If shipping a PR:** Run `/agent-ship`. It verifies the checklist, polishes the PR, pushes, monitors CI, and closes the session.
 
-**If NOT shipping** (research, abandoned, maintenance): Run `/agent-end`. It marks the session as completed, updates GitHub issues, and cleans up local artifacts.
+**If NOT shipping** (research, abandoned, maintenance): Run `/agent-end`. It marks the session as completed, updates Linear/GitHub issues, and cleans up local artifacts.
 
 Every session should end with one of these. See `.claude/rules/pr-review-guidelines.md` for the full end-of-session workflow.
 

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -66,7 +66,7 @@ Fire-and-forget (async call without awaiting) is acceptable **only** when ALL of
 1. The call is for **telemetry, metrics, or status updates** (not user-facing functionality)
 2. Failure does **not affect correctness** of the main operation
 3. The error is **logged** (at warn level or higher, unless high-frequency)
-4. There is a **fallback notification channel** (e.g., Discord, GitHub issues) for critical failures
+4. There is a **fallback notification channel** (e.g., Discord, Linear issues) for critical failures
 
 Examples of acceptable fire-and-forget:
 - `recordRunToServer()` — groundskeeper run recording to wiki-server
@@ -75,7 +75,7 @@ Examples of acceptable fire-and-forget:
 
 Examples where fire-and-forget is NOT acceptable:
 - Database writes that affect user-visible data
-- GitHub issue creation (the primary notification channel)
+- Linear issue creation (the primary notification channel)
 - File writes (data integrity)
 
 ## Fail-Open vs Fail-Closed Defaults

--- a/.claude/rules/github-issue-tracking.md
+++ b/.claude/rules/github-issue-tracking.md
@@ -1,32 +1,55 @@
-# GitHub Issue Tracking — MANDATORY
+# Issue Tracking — MANDATORY
 
-When a Claude Code session is assigned to work on a specific GitHub issue, it MUST signal its activity on that issue so humans can track progress and avoid duplicate work.
+**Linear is the primary issue tracker.** GitHub Issues are legacy and should not be used for new issues. All new bugs, features, and tasks go in Linear (QUA team).
+
+When a Claude Code session is assigned to work on an issue, it MUST signal its activity so humans can track progress and avoid duplicate work.
 
 ## At Session Start
 
-When the task description references a GitHub issue number (e.g., "resolve issue #239", "fix #239", "work on https://github.com/.../issues/239"), run this **before writing any code**:
+When the task references an issue (Linear QUA-NNN or legacy GitHub #NNN), run this **before writing any code**:
 
 ```bash
+# Linear issue (primary — most issues):
+pnpm crux linear start QUA-NNN
+
+# Legacy GitHub issue (only if the issue is already tracked there):
 pnpm crux gh issues start <ISSUE_NUM>
 ```
 
-This posts a start comment on the issue and adds the `agent:working` label. The label is created automatically if it doesn't exist yet.
+For Linear: moves the issue to "In Progress" and posts a start comment.
+For GitHub: posts a start comment and adds the `agent:working` label.
 
-**Do NOT use raw curl/GitHub API calls for issue tracking.** Always use `crux gh issues` commands — they route through `githubApi()` which validates request bodies for shell-expansion corruption before sending to GitHub.
+**Note:** `crux sys agent-checklist init` handles both automatically when `--linear=QUA-NNN` or `--issue=N` is provided. You rarely need to call these manually.
 
 ## At Session End (when shipping)
 
 After the work is committed and pushed (via `/agent-push-and-verify`), signal completion:
 
 ```bash
+# Linear (primary):
+pnpm crux linear done QUA-NNN --pr=<PR_URL>
+
+# Legacy GitHub (only if the issue is tracked there):
 pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
 ```
 
-This posts a completion comment and removes the `agent:working` label.
+## Filing New Issues
 
-## PR Management
+**Always file in Linear**, not GitHub:
 
-Use `crux gh pr` commands instead of raw curl for all PR operations:
+```bash
+# Search first:
+pnpm crux linear search "your topic here"
+
+# Create:
+pnpm crux linear create "Descriptive title" --description="What's wrong and why it matters"
+```
+
+Do NOT use `gh issue create` or `pnpm crux gh issues create` for new issues. See `.claude/rules/proactive-issue-filing.md` for when and how to file.
+
+## PR Management (stays on GitHub)
+
+PRs, CI, and code review remain on GitHub. Use `crux gh pr` commands:
 
 ```bash
 pnpm crux gh pr detect              # Check if PR exists for current branch
@@ -43,14 +66,13 @@ PRBODY
 
 ## Why This Matters
 
-- Humans can see at a glance which issues are being handled
+- Linear is the source of truth for project status — stale "In Progress" issues mislead the team
 - Prevents multiple sessions picking up the same issue simultaneously
-- The `agent:working` label enables filtering in the GitHub issues list
 - Creates a paper trail connecting branches/PRs to the originating issue
 - `crux` commands validate for corruption — raw curl/jq commands are vulnerable to shell-expansion bugs
 
 ## Edge Cases
 
-- If `GITHUB_TOKEN` is not set, skip the API calls and note this in the session log
+- If `LINEAR_API_KEY` is not set, skip the Linear API calls and note this in the session log. Fall back to GitHub if `GITHUB_TOKEN` is available.
 - If the issue number cannot be determined from the task description, skip this workflow
-- The `/agent-next-issue` command handles start tracking automatically — no need to do it manually when using that workflow
+- The `/agent-next-issue` command handles start tracking automatically

--- a/.claude/rules/implementation-quality.md
+++ b/.claude/rules/implementation-quality.md
@@ -4,7 +4,7 @@ Applies to sessions that write or modify code (not content-only MDX/YAML edits).
 
 ## Persistence
 
-- When stuck after 3 approaches, stop and document what failed. Research alternatives or file a GitHub issue with findings and ask the user — do not ship a broken version.
+- When stuck after 3 approaches, stop and document what failed. Research alternatives or file a Linear issue with findings and ask the user — do not ship a broken version.
 - If scope is too large to do thoroughly, split into independently-shippable pieces. A thorough version of a smaller thing beats a shallow version of the whole thing.
 
 ## Testing Depth

--- a/.claude/rules/proactive-github-filing.md
+++ b/.claude/rules/proactive-github-filing.md
@@ -1,10 +1,12 @@
-# Proactive GitHub Filing — When Agents Should Create Issues, Comments, and Discussions
+# Proactive Issue Filing — When Agents Should Create Issues
 
-Agents should **actively contribute to the project's issue tracker** — not just consume issues, but create them. When you encounter friction, bugs, tech debt, missing docs, or improvement opportunities during a session, capture them in GitHub so they're not lost.
+**Linear is the primary issue tracker.** All new issues go in Linear (QUA team), not GitHub Issues.
+
+Agents should **actively contribute to the project's issue tracker** — not just consume issues, but create them. When you encounter friction, bugs, tech debt, missing docs, or improvement opportunities during a session, capture them in Linear so they're not lost.
 
 ## When to File a New Issue
 
-File a GitHub issue when you encounter any of the following during normal work:
+File an issue when you encounter any of the following during normal work:
 
 | Trigger | Example | Priority |
 |---------|---------|----------|
@@ -39,35 +41,28 @@ File a GitHub issue when you encounter any of the following during normal work:
 **This is mandatory.** Before creating any issue, check if it already exists:
 
 ```bash
-pnpm crux gh issues search "your topic here"
-pnpm crux gh issues search "your topic here" --closed   # also check resolved issues
+pnpm crux linear search "your topic here"
 ```
 
-- **Match found (open)** → Add a comment: `pnpm crux gh issues comment <N> "your finding"`
-- **Match found (closed)** → Check if the fix resolved your concern. If not, file a new issue referencing it.
+- **Match found (open)** → Add a comment: `pnpm crux linear comment QUA-NNN "your finding"`
 - **No match** → File a new issue
 
 ## How to File
 
 ```bash
-pnpm crux gh issues create "Descriptive title" \
-  --problem="What's wrong and why it matters" \
-  --model=haiku \
-  --criteria="Fix applied|Tests pass|CI green" \
-  --label=enhancement
+pnpm crux linear create "Descriptive title" \
+  --description="What's wrong and why it matters"
 ```
 
-For longer descriptions, use `--problem-file=/tmp/problem.md`. Run `crux gh issues create --help` for full options.
+For longer descriptions, use `--description-file=/tmp/description.md`.
 
 **File issues immediately when you notice them** — don't defer. The search + create flow takes under 30 seconds. Then continue your primary work.
 
 ## Guardrails
 
-- **Evidence required**: `crux gh issues create` requires `--problem`, `--file`, or `--evidence`. You must have *observed* the problem in the current session — do not file speculative or hypothetical issues. Point to a specific file, error message, or behavior you encountered.
-- **Soft daily warning**: After 5 issues/day, `crux gh issues create` shows a warning suggesting you batch remaining items into an umbrella issue. There is no hard block.
-- **Agent-labeled**: All agent-filed issues are auto-labeled `agent:filed` for tracking.
+- **Evidence required**: You must have *observed* the problem in the current session — do not file speculative or hypothetical issues. Point to a specific file, error message, or behavior you encountered.
 - **Volume target**: 0-2 issues per session is normal. If you're finding 10+ problems, file the top 2-3 and batch the rest into one umbrella issue.
 
 ## GitHub Discussions
 
-Use `crux gh epic create` for **open-ended questions** that don't have a clear fix ("Should we restructure X?", "What's our strategy for Y?"). Issues are for concrete actionable tasks; discussions are for decisions that need human input.
+Use `crux gh epic create` for **open-ended questions** that don't have a clear fix ("Should we restructure X?", "What's our strategy for Y?"). Issues are for concrete actionable tasks; discussions are for decisions that need human input. Discussions stay on GitHub — they are not tracked in Linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,18 +54,26 @@ pnpm crux tb ids allocate <slug>             # Wiki entity: allocate numericId +
 pnpm crux tb ensure-entities --type=person   # Lightweight: stableId only (no wiki page)
 pnpm crux tb people discover                 # Discover people entities
 
-# GitHub (gh)
-pnpm crux gh issues start <N>               # Signal work start on issue
-pnpm crux gh issues done <N> --pr=URL       # Signal completion
+# Linear (primary issue tracker)
+pnpm crux linear search "query"              # Search Linear issues
+pnpm crux linear create "title" --description="..."  # Create a new Linear issue
+pnpm crux linear start QUA-NNN              # Signal work start on issue
+pnpm crux linear done QUA-NNN --pr=URL      # Signal completion
+pnpm crux linear view QUA-NNN              # View issue details
+
+# GitHub (gh) — PRs, CI, legacy issues
 pnpm crux gh ci status --wait               # Poll CI until green
 pnpm crux gh deploy-tasks detect             # Auto-detect deploy tasks from diff
 pnpm crux gh deploy-tasks pending            # Find unchecked tasks from merged PRs
 pnpm crux gh deploy-tasks inject --pr=N      # Inject deploy checklist into PR
+pnpm crux gh issues start <N>               # Signal work start (legacy GitHub issues only)
+pnpm crux gh issues done <N> --pr=URL       # Signal completion (legacy GitHub issues only)
 
 # System (sys = system)
 pnpm crux sys audits list                    # Show audit items, highlight overdue
 pnpm crux sys audits check <id> --pass       # Record a check result
-pnpm crux sys agent-checklist init --issue=N # Init session checklist
+pnpm crux sys agent-checklist init --linear=QUA-NNN  # Init session checklist (Linear)
+pnpm crux sys agent-checklist init --issue=N # Init session checklist (legacy GitHub)
 pnpm crux sys agent-reset                   # Show stale processes (MCP, dev servers)
 pnpm crux sys agent-reset --kill             # Kill stale processes
 
@@ -154,7 +162,7 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - **Page templates**: `crux/lib/page-templates.ts`, style guides in `content/docs/internal/`
 - **FactBase facts & Calc**: FactBase YAML (`packages/factbase/data/things/`) is the sole authoritative source for structured facts. Use `<FBF>` / `<FBFactValue>` in MDX, `<Calc>` for computed values. See `content/docs/internal/canonical-facts.mdx`.
 - **Internal sidebar**: `apps/web/src/lib/wiki-nav.ts`
-- **GitHub API**: Use `crux gh issues/pr/ci/epic` commands — never raw `curl`
+- **Issue tracking**: **Linear is the primary issue tracker** — use `crux linear` commands for issue creation, tracking, and updates. GitHub is used for PRs, CI, and legacy issues only. Use `crux gh pr/ci/epic` commands for GitHub — never raw `curl`
 - **Entity IDs — two tiers**:
   - **Wiki entities** (orgs, concepts, important people with their own pages): Use `pnpm crux tb ids allocate <slug>` to get a `numericId` (E-number) + `stableId` (`sid_` prefix, e.g. `sid_1LcLlMGLbw`). These get wiki pages at `/wiki/E<N>`. Only ~200-300 entities should have these.
   - **TableBase reference records** (paper authors, personnel, minor people): Use `generateId("person:<slug>")` for a `stableId` only (`sid_` prefix). NO `numericId`, no wiki page. Stored in the entities table for directory/personnel use but are lightweight. Use `crux tb ensure-entities` or `crux tb create-entity` for these.
@@ -172,8 +180,8 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/environment-setup.md` — Worktree + LSP setup
 - `.claude/rules/page-authoring.md` — Content pipeline, self-review checklist
 - `.claude/rules/code-review-guidelines.md` — Code review rules
-- `.claude/rules/github-issue-tracking.md` — Issue tracking with `crux issues`
-- `.claude/rules/proactive-github-filing.md` — When/how to file issues
+- `.claude/rules/github-issue-tracking.md` — Issue tracking (Linear primary, GitHub legacy)
+- `.claude/rules/proactive-github-filing.md` — When/how to file issues (in Linear)
 - `.claude/rules/pr-review-guidelines.md` — PR review and ship process
 - `.claude/rules/pre-pr-verification.md` — Build/test/gate checks before PRs
 - `.claude/rules/session-logging.md` — Session log format and storage

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -269,12 +269,21 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     };
   }
 
-  // Resolve description from flag, file, or stdin
+  // Resolve description from flag or file
   const descFromFile = readBodyFlag(options.descriptionFile);
   const description = descFromFile ?? options.description ?? '';
 
-  // Parse priority (Linear: 0=none, 1=urgent, 2=high, 3=medium, 4=low)
-  const priority = options.priority ? parseInt(options.priority, 10) : undefined;
+  // Parse priority (Linear: 1=urgent, 2=high, 3=medium, 4=low)
+  let priority: number | undefined;
+  if (options.priority) {
+    priority = parseInt(options.priority, 10);
+    if (Number.isNaN(priority) || priority < 1 || priority > 4) {
+      return {
+        output: `${c.red}Invalid priority "${options.priority}" — must be 1 (urgent), 2 (high), 3 (medium), or 4 (low)${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+  }
 
   const result = await createIssue({ title, description, priority });
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -1,17 +1,18 @@
 /**
- * Linear Command Handlers
+ * Linear Command Handlers — Primary Issue Tracker
  *
- * Track Claude Code work on Linear issues: list, search, comment,
- * signal start/done. Mirrors `crux gh issues` for Linear.
+ * Linear is the primary issue tracker for longterm-wiki. All new issues
+ * should be created here, not in GitHub Issues.
  *
  * Usage:
  *   crux linear view <QUA-NNN>          Show full issue + comments
  *   crux linear search <query>          Search QUA team issues
+ *   crux linear create <title>          Create a new issue
  *   crux linear comment <QUA-NNN> <msg> Post a comment
  *   crux linear start <QUA-NNN>         Move to In Progress + start comment
  *   crux linear done <QUA-NNN> --pr=URL Move to In Review + done comment
- *   crux linear states-list                    Print current QUA team workflow states
- *   crux linear parse <string>                 Extract a Linear ID from a string (debug)
+ *   crux linear states-list             Print current QUA team workflow states
+ *   crux linear parse <string>          Extract a Linear ID from a string (debug)
  */
 
 import { readFileSync } from 'fs';
@@ -19,17 +20,15 @@ import { createLogger } from '../lib/output.ts';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
   commentOnIssue,
+  createIssue,
   getComments,
   getIssue,
-  listReadyIssues,
-  rankReadyIssues,
   searchIssues,
   updateIssueState,
 } from '../lib/linear/issues.ts';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
 import { parseLinearId } from '../lib/linear/parse-id.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
-import { githubApi, REPO } from '../lib/github.ts';
 
 interface CommandOptions extends BaseOptions {
   ci?: boolean;
@@ -37,6 +36,9 @@ interface CommandOptions extends BaseOptions {
   pr?: string;
   limit?: string;
   bodyFile?: string;
+  description?: string;
+  descriptionFile?: string;
+  priority?: string;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -210,27 +212,11 @@ async function done(args: string[], options: CommandOptions): Promise<CommandRes
   }
 
   // If there's a PR, move to In Review and let the merge move it to Done later.
-  // Without a PR, auto-detect an open PR for the current branch before going to Done.
-  // This prevents subagents from prematurely moving issues to Done when a PR is open.
-  let prUrl = options.pr;
-  if (!prUrl) {
-    try {
-      const branch = currentBranch();
-      const prs = await githubApi<Array<{ html_url: string }>>(
-        `/repos/${REPO}/pulls?head=quantified-uncertainty:${branch}&state=open`
-      );
-      if (prs.length > 0) {
-        prUrl = prs[0].html_url;
-      }
-    } catch {
-      // Best-effort — if GitHub is unreachable, fall through to Done
-    }
-  }
-
-  const targetState = prUrl ? 'In Review' : 'Done';
+  // Without a PR, go straight to Done (coordinator sessions, docs-only, etc.).
+  const targetState = options.pr ? 'In Review' : 'Done';
   await updateIssueState(id, targetState);
 
-  const prLine = prUrl ? `\n**PR:** ${prUrl}` : '';
+  const prLine = options.pr ? `\n**PR:** ${options.pr}` : '';
   await commentOnIssue(
     id,
     `🤖 Claude Code finished work on this issue.${prLine}`,
@@ -238,10 +224,7 @@ async function done(args: string[], options: CommandOptions): Promise<CommandRes
 
   let out = '';
   out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → ${targetState}\n`;
-  if (prUrl) {
-    out += `  PR: ${prUrl}\n`;
-    if (!options.pr) out += `  ${c.dim}(auto-detected from branch)${c.reset}\n`;
-  }
+  if (options.pr) out += `  PR: ${options.pr}\n`;
   return { output: out, exitCode: 0 };
 }
 
@@ -274,99 +257,34 @@ async function parse(args: string[], options: CommandOptions): Promise<CommandRe
   return { output: `${id}\n`, exitCode: 0 };
 }
 
-// ---------------------------------------------------------------------------
-// Next / List — agent dispatch helpers
-// ---------------------------------------------------------------------------
-
-async function list(_args: string[], options: CommandOptions): Promise<CommandResult> {
+async function create(args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(options.ci);
   const c = log.colors;
 
-  const limit = options.limit ? parseInt(options.limit, 10) : 50;
-  const issues = await listReadyIssues(limit);
-  const ranked = rankReadyIssues(issues);
+  const title = args.filter((a) => !a.startsWith('--')).join(' ').trim();
+  if (!title) {
+    return {
+      output: `${c.red}Usage: crux linear create "Issue title" [--description="..."] [--description-file=<path>] [--priority=1-4]${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  // Resolve description from flag, file, or stdin
+  const descFromFile = readBodyFlag(options.descriptionFile);
+  const description = descFromFile ?? options.description ?? '';
+
+  // Parse priority (Linear: 0=none, 1=urgent, 2=high, 3=medium, 4=low)
+  const priority = options.priority ? parseInt(options.priority, 10) : undefined;
+
+  const result = await createIssue({ title, description, priority });
 
   if (options.json) {
-    return { output: JSON.stringify(ranked, null, 2) + '\n', exitCode: 0 };
+    return { output: JSON.stringify(result, null, 2) + '\n', exitCode: 0 };
   }
-
-  if (ranked.length === 0) {
-    return { output: `${c.dim}No ready issues found (Todo/Backlog) in QUA team.${c.reset}\n`, exitCode: 0 };
-  }
-
-  let out = `${c.bold}${ranked.length} ready issue(s) in QUA team:${c.reset}\n\n`;
-  for (const r of ranked) {
-    const pri = priorityLabel(r.priority);
-    const blocked = r.blocked ? ` ${c.red}[blocked]${c.reset}` : '';
-    const assignee = r.assignee ? ` ${c.dim}(${r.assignee.name})${c.reset}` : '';
-    const state = r.state.name;
-    const labels = r.labels.nodes.map((l) => l.name).join(', ');
-    out += `  ${c.cyan}${r.identifier}${c.reset} [${state}] ${pri} (score: ${r.score})${blocked}${assignee}\n`;
-    out += `    ${r.title}\n`;
-    if (labels) out += `    ${c.dim}labels: ${labels}${c.reset}\n`;
-    out += '\n';
-  }
-  return { output: out, exitCode: 0 };
-}
-
-async function next(_args: string[], options: CommandOptions): Promise<CommandResult> {
-  const log = createLogger(options.ci);
-  const c = log.colors;
-
-  const issues = await listReadyIssues(50);
-  const ranked = rankReadyIssues(issues);
-  const available = ranked.filter((i) => !i.blocked);
-
-  if (options.json) {
-    return { output: JSON.stringify(available[0] ?? null, null, 2) + '\n', exitCode: 0 };
-  }
-
-  if (available.length === 0) {
-    const blockedCount = ranked.filter((i) => i.blocked).length;
-    let out = `${c.yellow}No available issues.${c.reset}\n`;
-    if (ranked.length > 0) {
-      out += `  ${c.dim}${ranked.length} ready issue(s) found, but ${blockedCount} blocked.${c.reset}\n`;
-    } else {
-      out += `  ${c.dim}No issues in Todo/Backlog states.${c.reset}\n`;
-    }
-    return { output: out, exitCode: 1 };
-  }
-
-  const top = available[0];
-  const pri = priorityLabel(top.priority);
-  const labels = top.labels.nodes.map((l) => l.name).join(', ');
 
   let out = '';
-  out += `${c.bold}Next issue:${c.reset}\n\n`;
-  out += `  ${c.bold}${c.cyan}${top.identifier}${c.reset} ${top.title}\n`;
-  out += `  ${c.dim}state:${c.reset} ${top.state.name}  ${c.dim}priority:${c.reset} ${pri}  ${c.dim}score:${c.reset} ${top.score}\n`;
-  out += `  ${c.dim}url:${c.reset} ${top.url}\n`;
-  if (labels) out += `  ${c.dim}labels:${c.reset} ${labels}\n`;
-  if (top.parent) out += `  ${c.dim}parent:${c.reset} ${top.parent.identifier} — ${top.parent.title}\n`;
-  if (top.project) out += `  ${c.dim}project:${c.reset} ${top.project.name}\n`;
-  if (top.assignee) out += `  ${c.dim}assignee:${c.reset} ${top.assignee.name}\n`;
-
-  if (top.description) {
-    const desc = top.description.slice(0, 600);
-    out += `\n${desc}${top.description.length > 600 ? '\n…(truncated)' : ''}\n`;
-  }
-
-  // Show the rest of the queue
-  const rest = available.slice(1, 4);
-  if (rest.length > 0) {
-    out += `\n${c.dim}Next in queue:${c.reset}\n`;
-    for (const r of rest) {
-      out += `  ${c.cyan}${r.identifier}${c.reset} ${priorityLabel(r.priority)} — ${r.title}\n`;
-    }
-  }
-
-  const blocked = ranked.filter((i) => i.blocked);
-  if (blocked.length > 0) {
-    out += `\n${c.dim}${blocked.length} blocked issue(s) skipped.${c.reset}\n`;
-  }
-
-  out += `\n${c.bold}To start:${c.reset} pnpm crux linear start ${top.identifier}\n`;
-
+  out += `${c.green}✓${c.reset} Created ${c.cyan}${result.identifier}${c.reset} — ${title}\n`;
+  out += `  ${result.url}\n`;
   return { output: out, exitCode: 0 };
 }
 
@@ -379,28 +297,31 @@ export const commands = {
   view,
   search,
   comment,
+  create,
   start,
   done,
-  next,
-  list,
   'states-list': statesList,
   parse,
 };
 
 export function getHelp(): string {
   return `
-Linear Domain — Track Claude Code work on Linear issues
+Linear Domain — Primary issue tracker for longterm-wiki
 
 Commands:
-  next                          Pick the highest-priority ready issue (Todo/Backlog)
-  list                          List all ready issues ranked by priority
   view <QUA-NNN>                Show full issue + recent comments (default)
   search <query>                Search QUA team issues
+  create <title>                Create a new issue in the QUA team
   comment <QUA-NNN> <message>   Post a comment on an issue
   start <QUA-NNN>               Move issue to In Progress + post start comment
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
   states-list                   Show current QUA team workflow state IDs
   parse <string>                Extract a Linear ID from a string (debug helper)
+
+Options (create):
+  --description=<text>       Issue description (inline)
+  --description-file=<path>  Issue description from file (safe for multiline)
+  --priority=N               Priority: 1=urgent, 2=high, 3=medium, 4=low (default: none)
 
 Options (comment):
   --body-file=<path>  Comment body from file (safe for multiline / escaped content)
@@ -410,14 +331,14 @@ Options (done):
 
 Global options:
   --json              Machine-readable output where supported
-  --limit=N           Max results for search/list (default: 20/50)
+  --limit=N           Max results for search (default: 20)
 
 Environment:
   LINEAR_API_KEY      Required. Stored in .env.base at the workspace root.
 
 Examples:
-  crux linear next                                           # Pick top issue
-  crux linear list                                           # See all ready issues
+  crux linear create "Broken login page" --description="The login form crashes on submit"
+  crux linear create "Add retry logic" --description-file=/tmp/desc.md --priority=3
   crux linear view QUA-184
   crux linear search "agent checklist"
   crux linear start QUA-184


### PR DESCRIPTION
## Summary

- **Linear is now declared as the primary issue tracker** across all `.claude/rules/` and `.claude/commands/` files
- **Added `crux linear create` command** — the missing piece that caused agents to default to `gh issue create`
- **GitHub is kept for** PRs, CI, releases, Discussions, and legacy issues only

## Changes (18 files)

### Rules (5 files)
- `github-issue-tracking.md` — Rewritten: Linear primary, GitHub for PRs/legacy
- `proactive-github-filing.md` — Filing instructions point to `crux linear create`
- `agent-session-workflow.md` — Linear listed first in branch naming, init examples
- `error-handling.md` — "primary notification channel" → Linear
- `implementation-quality.md` — "file a GitHub issue" → "file a Linear issue"

### Skills (8 files)
- `agent-init.md` — Linear listed first as primary
- `agent-end.md` — Linear update is Step 2, GitHub moved to Step 2b
- `agent-ship.md` — Same reordering
- `agent-next-issue.md` — Fully rewritten: Linear backlog first, GitHub fallback
- `maintain.md`, `maintain-qa-sweep.md`, `maintain-audit.md`, `maintain-retrospective.md`, `plan-feature.md` — Filing changed to Linear
- `score-issues.md` — Marked as "Legacy GitHub"

### CLAUDE.md
- Added Linear commands section as primary, GitHub demoted to "PRs, CI, legacy"

### Code
- `crux/commands/linear.ts` — Added `create` subcommand with `--description`, `--description-file`, `--priority` flags, including range validation

## Context

An agent recently filed a bug on GitHub instead of Linear because the rules told it to. The `crux linear create` command didn't exist, so even after being corrected, the agent had to fall back to raw `curl`. This PR ensures every rule and skill consistently directs agents to Linear.

## Test plan

- [x] `pnpm test` passes
- [x] `pnpm crux w validate gate --scope=content --fix` passes
- [x] TypeScript compiles (`npx tsc --noEmit -p crux/tsconfig.json` — only pre-existing advisory errors)
- [x] `crux linear create` with no args shows usage
- [x] `crux linear create "test" --priority=5` rejects with validation error
- [x] `crux linear create "test" --priority=abc` rejects with validation error
- [x] Diff review by subagent — 1 MEDIUM finding fixed (priority validation)
- [x] Sourcing ratchet baseline updated to reflect merged PRs (0 new source-check refs in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
