### PR TITLE
[maintenance] Fix auto-update false positive in wellness checks + audit updates

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -102,9 +102,9 @@ audits:
       Note: auto-update.yml intentionally disabled since PR #2592 — excluded from this check.
     frequency: weekly
     added: "2026-03-04"
-    last_checked: "2026-04-08"
+    last_checked: "2026-04-11"
     last_result: fail
-    last_result_note: "scheduled-maintenance.yml failed 2026-03-19 — Anthropic API credit balance too low"
+    last_result_note: "ci-pr-health failing (auto-update 100% failure rate triggers job queue check); scheduled-maintenance hit max turns (60)"
     history:
       - date: "2026-03-29"
         result: pass
@@ -132,6 +132,10 @@ audits:
         result: fail
         checked_by: "manual"
         notes: "ci-pr-health.yml failing 2026-04-07 (2 failures), scheduled-maintenance 2026-04-08 in progress (null result)"
+      - date: "2026-04-11"
+        result: fail
+        checked_by: "manual"
+        notes: "server-api-health OK, frontend-data-health OK, server-health-monitor OK. ci-pr-health failing (auto-update 100% failure flagged as job queue issue, #4107 open). scheduled-maintenance hit max turns (60) on 2026-04-10."
   - id: vercel-production-only
     category: infrastructure
     description: "Vercel ONLY builds the production branch — no builds for main, claude/*, issue branches, or PR previews"
@@ -255,6 +259,9 @@ audits:
       Target: <20% override rate on non-infrastructure PRs.
     frequency: monthly
     added: "2026-03-29"
+    last_checked: "2026-04-11"
+    last_result: pass
+    last_result_note: "10% (10/100 PRs) — well under 20% threshold"
     history:
       - date: "2026-03-30"
         result: pass
@@ -293,6 +300,10 @@ audits:
         result: pass
         checked_by: "manual"
         notes: "0 overrides out of 50 merged PRs in last 30 days (0%)"
+      - date: "2026-04-11"
+        result: pass
+        checked_by: "manual"
+        notes: "10% (10/100 PRs) — well under 20% threshold"
   - id: model-freshness
     category: infrastructure
     description: "Claude model IDs in crux/lib/anthropic.ts are still the latest available versions"
@@ -304,6 +315,9 @@ audits:
       4. Also check crux/lib/llm.ts for any hardcoded model references.
     frequency: monthly
     added: "2026-03-30"
+    last_checked: "2026-04-11"
+    last_result: pass
+    last_result_note: "haiku=claude-haiku-4-5-20251001, sonnet=claude-sonnet-4-6, opus=claude-opus-4-6. Current."
     history:
       - date: "2026-04-01"
         result: pass
@@ -326,6 +340,10 @@ audits:
         result: pass
         checked_by: "manual"
         notes: "haiku=claude-haiku-4-5-20251001, sonnet=claude-sonnet-4-6, opus=claude-opus-4-6. All match latest Claude 4.5/4.6 family per system context."
+      - date: "2026-04-11"
+        result: pass
+        checked_by: "manual"
+        notes: "haiku=claude-haiku-4-5-20251001, sonnet=claude-sonnet-4-6, opus=claude-opus-4-6. Current per system context."
   - id: audits-system-adoption
     category: process
     description: "This audits system itself is being used — items are checked on schedule, not abandoned"

--- a/crux/health/checks/job-queue.test.ts
+++ b/crux/health/checks/job-queue.test.ts
@@ -23,6 +23,7 @@ import {
   WARN_RATE_PCT,
   FAIL_PENDING,
   WARN_PENDING,
+  EXCLUDED_JOB_TYPES,
   type JobStatsResponse,
 } from './job-queue.ts';
 
@@ -296,6 +297,40 @@ describe('multiple job types', () => {
     expect(result.failures[0]).toMatch(/resource-ingest/);
     // ping should still show PASS
     expect(result.detail.some(l => l.includes('PASS') && l.includes('ping'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Excluded job types
+// ---------------------------------------------------------------------------
+
+describe('excluded job types', () => {
+  it('auto-update is excluded and does not trigger failure', () => {
+    const data: JobStatsResponse = {
+      totalJobs: 100,
+      byType: {
+        'auto-update': makeStats({
+          pending: 0,
+          failureRate: 1.0,
+          recentTotal: 50,
+          recentFailed: 50,
+        }),
+        'ping': makeStats({ pending: 0, failureRate: 0, recentTotal: 10, recentFailed: 0 }),
+      },
+    };
+
+    const result = evaluateJobStats(data);
+    expect(result.failures).toEqual([]);
+    expect(result.detail.some(l => l.includes('SKIP') && l.includes('auto-update'))).toBe(true);
+    expect(result.detail.some(l => l.includes('PASS') && l.includes('ping'))).toBe(true);
+  });
+
+  it('EXCLUDED_JOB_TYPES contains auto-update', () => {
+    expect(EXCLUDED_JOB_TYPES.has('auto-update')).toBe(true);
   });
 });
 

--- a/crux/health/checks/job-queue.ts
+++ b/crux/health/checks/job-queue.ts
@@ -42,6 +42,13 @@ export const FAIL_PENDING = 500;
 /** WARN tier: pending count above this is logged. */
 export const WARN_PENDING = 100;
 
+/**
+ * Job types excluded from health evaluation.
+ * auto-update is intentionally disabled (PR #2592) but still shows 100% failure
+ * rate in job stats, causing recurring false-positive wellness issues (#4086, #4068, #4107).
+ */
+export const EXCLUDED_JOB_TYPES = new Set(['auto-update']);
+
 // ---------------------------------------------------------------------------
 // Types (exported for tests)
 // ---------------------------------------------------------------------------
@@ -87,6 +94,10 @@ export function evaluateJobStats(data: JobStatsResponse): EvaluationResult {
   const byType = data.byType ?? {};
 
   for (const [jobType, stats] of Object.entries(byType)) {
+    if (EXCLUDED_JOB_TYPES.has(jobType)) {
+      detail.push(`SKIP  ${jobType}: excluded (intentionally disabled)`);
+      continue;
+    }
     const statusCounts = stats.byStatus ?? {};
     const pending = statusCounts['pending'] ?? 0;
     const running = statusCounts['running'] ?? 0;


### PR DESCRIPTION
## Summary
- Exclude `auto-update` from job-queue health evaluation — it's intentionally disabled (PR #2592) but was causing recurring false-positive wellness issues (#4086, #4068, #4107)
- Record 3 audit checks: gate-override-frequency (10%, pass), model-freshness (current, pass), scheduled-workflows (fail — filed #4138)
- Closed #3444 (verification dots confirmed on all 3 tables)
- Commented on #4107 explaining false positive

## Test plan
- [x] `job-queue.test.ts` — 17 tests pass including 2 new tests for excluded job types
- [x] Verified auto-update with 100% failure rate produces SKIP line, not FAIL

Closes #4107

🤖 Generated with [Claude Code](https://claude.com/claude-code)