### PR TITLE
fix: use prod wiki-server URL for heartbeats in agent slots

### DIFF
--- a/.claude/hooks/heartbeat.sh
+++ b/.claude/hooks/heartbeat.sh
@@ -25,8 +25,18 @@ fi
 
 # Read agent ID and env vars
 AGENT_ID=$(cat "$AGENT_ID_FILE" 2>/dev/null || true)
-WIKI_SERVER_URL="${LONGTERMWIKI_SERVER_URL:-}"
-API_KEY="${LONGTERMWIKI_SERVER_API_KEY:-}"
+
+# Heartbeats always target the prod wiki-server (the active-agents dashboard
+# lives there). Agent slots don't run a local wiki-server, so the default
+# LONGTERMWIKI_SERVER_URL (localhost:311x) is unreachable. Use PROD_* vars
+# when available, falling back to the default vars for local-dev setups.
+if [ -n "${PROD_LONGTERMWIKI_SERVER_URL:-}" ]; then
+  WIKI_SERVER_URL="$PROD_LONGTERMWIKI_SERVER_URL"
+  API_KEY="${PROD_LONGTERMWIKI_SERVER_API_KEY:-${LONGTERMWIKI_SERVER_API_KEY:-}}"
+else
+  WIKI_SERVER_URL="${LONGTERMWIKI_SERVER_URL:-}"
+  API_KEY="${LONGTERMWIKI_SERVER_API_KEY:-}"
+fi
 
 # Validate inputs
 [[ "$AGENT_ID" =~ ^[0-9]+$ ]] || exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -99,7 +99,12 @@ fi
 
 # ─── 3. Wiki server connectivity ───────────────────────────────────────────────
 
-WIKI_SERVER_URL="${LONGTERMWIKI_SERVER_URL:-}"
+# Prefer PROD_* vars (agent slots don't run a local wiki-server)
+if [ -n "${PROD_LONGTERMWIKI_SERVER_URL:-}" ]; then
+  WIKI_SERVER_URL="$PROD_LONGTERMWIKI_SERVER_URL"
+else
+  WIKI_SERVER_URL="${LONGTERMWIKI_SERVER_URL:-}"
+fi
 if [ -z "$WIKI_SERVER_URL" ]; then
   CONTEXT_LINES+=("ℹ Wiki server: LONGTERMWIKI_SERVER_URL not set (crux query commands unavailable)")
 else
@@ -182,7 +187,12 @@ fi
 # Runs on every session start AND resume, keeping the heartbeat fresh.
 
 if [ -n "$WIKI_SERVER_URL" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "detached" ]; then
-  API_KEY="${LONGTERMWIKI_SERVER_API_KEY:-}"
+  # Use prod API key when targeting prod server
+  if [ -n "${PROD_LONGTERMWIKI_SERVER_API_KEY:-}" ]; then
+    API_KEY="$PROD_LONGTERMWIKI_SERVER_API_KEY"
+  else
+    API_KEY="${LONGTERMWIKI_SERVER_API_KEY:-}"
+  fi
   if [ -z "$API_KEY" ]; then
     CONTEXT_LINES+=("⚠ Active agent registration skipped: LONGTERMWIKI_SERVER_API_KEY not set")
   else


### PR DESCRIPTION
## Summary
- Fixes heartbeat and session-start hooks to use prod wiki-server URL in agent slots
- Slots don't run a local wiki-server, so heartbeats to localhost:3113 were failing silently

## Test plan
- [x] Build passes
- [x] All 5336 tests pass
- [x] Gate passes

Fixes QUA-222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated internal system configuration to support flexible selection of server credentials based on environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->