### PR TITLE
docs: add Linear-GitHub integration rules doc

### DIFF
--- a/.claude/rules/linear-integration.md
+++ b/.claude/rules/linear-integration.md
@@ -1,0 +1,143 @@
+# Linear Integration
+
+Subsystem map for the Linear-GitHub integration: auto-close, branch naming, PR injection, and agent commands. **Read this before working on a Linear-tracked issue or touching `crux linear` / `crux gh pr create`** -- agents repeatedly miss the branch-naming requirement and Linear issues stay open after merge.
+
+## Why this file exists
+
+Linear's GitHub integration auto-moves issues to Done on PR merge, but **only when it can link the PR to the issue**. The linking requires either the branch name or PR body to contain the Linear ID. Agents who skip the `qua-NNN` branch pattern silently break auto-close, leaving stale "In Progress" issues in the backlog.
+
+---
+
+## 1. How auto-close works
+
+Linear's native GitHub integration (installed at the org level) watches for PR merges and moves linked issues to Done. Linking happens via two mechanisms:
+
+| Mechanism | Example | Reliability |
+|-----------|---------|-------------|
+| **Branch name** contains `qua-NNN` | `claude/qua-184-linear-integration` | Primary -- always works |
+| **PR body** contains `Fixes QUA-NNN` | `Fixes QUA-184` | Fallback -- injected automatically by `crux gh pr create` |
+
+Both are case-insensitive. `Closes QUA-NNN` and `Resolves QUA-NNN` also work.
+
+**If neither is present, the issue stays open after merge.** This is the #1 failure mode.
+
+## 2. Branch naming convention
+
+For Linear issues, encode the ID in the branch name:
+
+```
+claude/qua-NNN-short-description
+```
+
+Examples:
+- `claude/qua-184-linear-integration`
+- `claude/qua-233-linear-integration-doc`
+
+**Why the branch name matters most**: Linear's GitHub integration links PRs by branch name before it parses the PR body. The branch name is set once at session start and can't be forgotten. The PR body injection is a safety net, not the primary mechanism.
+
+`agent-checklist init` auto-detects `qua-NNN` from the branch name and warns if the branch doesn't contain the Linear ID:
+
+```
+Warning: Branch "claude/tier0-data-integrity" does not contain the Linear ID QUA-155.
+  Linear's GitHub integration won't auto-close the issue on PR merge.
+  Suggested: git checkout -b claude/qua-155-tier0-data-integrity
+```
+
+## 3. `crux gh pr create` auto-injection
+
+When creating a PR, `crux gh pr create` automatically injects `Fixes QUA-NNN` into the PR body. It collects Linear IDs from three sources (in priority order):
+
+1. **Branch name** -- parsed by `parseLinearId()` from `crux/lib/linear/parse-id.ts`
+2. **`--linear=QUA-NNN,QUA-NNN` flag** -- explicit, supports multiple IDs for epics
+3. **`.claude/wip-checklist.md` metadata** -- the `> Linear: QUA-NNN` line written by `agent-checklist init`
+
+IDs already referenced in the body (`Fixes`, `Closes`, `Resolves`) are skipped to avoid duplicates.
+
+**Always use `crux gh pr create`**, not raw `gh pr create`. The crux wrapper handles Linear injection, body corruption detection, and GitHub API validation. The agent-push-and-verify skill enforces this.
+
+## 4. Agent workflow state transitions
+
+The `crux linear` commands manage issue state through the agent session lifecycle:
+
+| Session phase | Command | Linear state | Who calls it |
+|---------------|---------|-------------|--------------|
+| Start | `crux linear start QUA-NNN` | In Progress | Auto-called by `agent-checklist init` |
+| Ship (PR exists) | `crux linear done QUA-NNN --pr=URL` | In Review | `/agent-ship` step 5b |
+| End (no PR) | `crux linear done QUA-NNN` | Done | `/agent-end` step 2b |
+| PR merges | *(automatic)* | Done | Linear's GitHub integration |
+
+**State flow**: Backlog/Todo --> In Progress --> In Review --> Done
+
+`crux linear done` behavior:
+- **With `--pr=URL`**: moves to "In Review" (the PR merge will move it to Done via Linear's integration)
+- **Without `--pr`**: moves straight to "Done" (for research, abandoned work, docs-only sessions)
+
+Note: `crux linear done` does NOT auto-detect open PRs on the current branch. If a PR exists, you must pass `--pr=URL` explicitly. The `/agent-ship` and `/agent-end` skills handle this automatically.
+
+## 5. Git automation rules (configured in Linear)
+
+Linear has built-in Git automation that triggers state changes independent of the `crux` commands:
+
+| Git event | Linear action |
+|-----------|---------------|
+| Branch created with `qua-NNN` | Issue moves to In Progress |
+| PR review requested | Issue moves to In Review |
+| PR merged | Issue moves to Done |
+
+These are configured in Linear's team settings (not in this repo). The `crux` commands duplicate some of these transitions intentionally -- belt-and-suspenders for cases where Linear's automation doesn't fire (e.g., branch created before Linear integration was installed, or PR body reference without branch name match).
+
+## 6. Available commands
+
+```bash
+# View and search
+crux linear view QUA-NNN              # Show full issue + recent comments
+crux linear search <query>            # Search QUA team issues
+crux linear parse <string>            # Extract Linear ID from a string (debug)
+
+# State management
+crux linear start QUA-NNN             # Move to In Progress + post start comment
+crux linear done QUA-NNN [--pr=URL]   # Move to In Review (with PR) or Done
+
+# Communication
+crux linear comment QUA-NNN <message>           # Post a comment
+crux linear comment QUA-NNN --body-file=<path>  # Comment from file (multiline-safe)
+
+# Admin
+crux linear states-list               # Show current QUA team workflow state IDs
+```
+
+**Environment**: requires `LINEAR_API_KEY` (synced from `.env.base` at the workspace root). All Linear calls are best-effort in the agent pipeline -- a missing key or network error never blocks `agent-checklist init` or `/agent-ship`.
+
+## 7. ID parsing -- `parseLinearId()`
+
+The parser in `crux/lib/linear/parse-id.ts` uses an allowlist of known team keys (currently just `QUA`) to avoid false positives:
+
+- `claude/qua-184-description` --> `QUA-184` (branch pattern)
+- `"Work on QUA-184"` --> `QUA-184` (bare token)
+- `claude/fix-239-broken-scoring` --> `null` (not a known team key)
+- `CVE-2024-12345` --> `null` (not a known team key)
+
+`resolveLinearId([branch, taskDescription])` tries multiple sources in order, returning the first match. Used by `agent-checklist init` for auto-detection.
+
+## 8. Common mistakes to avoid
+
+| Mistake | Consequence | Fix |
+|---------|------------|-----|
+| Branch `claude/tier0-data-integrity` instead of `claude/qua-155-tier0-data-integrity` | Linear issue stays open after merge | Always include `qua-NNN` in branch name |
+| Using raw `gh pr create` | No `Fixes QUA-NNN` injection, no corruption detection | Use `crux gh pr create` |
+| Calling `crux linear done QUA-NNN` without `--pr` when a PR exists | Issue goes to Done instead of In Review; skips the merge-triggered auto-close | Pass `--pr=URL` when shipping a PR |
+| Forgetting `LINEAR_API_KEY` | Silent skip of all Linear state updates | Sync `.env.base` or `export LINEAR_API_KEY=...` |
+| Manually moving issues in Linear UI during active agent session | Agent's `crux linear done` may override the manual state | Let the agent pipeline manage state |
+
+## 9. Key files
+
+| File | Purpose |
+|------|---------|
+| `crux/commands/linear.ts` | Command implementations (view, search, comment, start, done) |
+| `crux/lib/linear/client.ts` | GraphQL client with corruption detection, 15s timeout |
+| `crux/lib/linear/parse-id.ts` | `parseLinearId()`, `resolveLinearId()`, team key allowlist |
+| `crux/lib/linear/workflow-states.ts` | QUA team workflow state IDs, `getWorkflowStateId()` |
+| `crux/lib/linear/issues.ts` | `getIssue()`, `searchIssues()`, `commentOnIssue()`, `updateIssueState()` |
+| `crux/commands/pr.ts` | `injectLinearRefs()` -- auto-injection into PR bodies |
+| `.claude/commands/agent-ship.md` | Step 5b -- Linear done on ship |
+| `.claude/commands/agent-end.md` | Step 2b -- Linear done on end |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/implementation-quality.md` — Thoroughness, testing depth, self-review
 - `.claude/rules/auto-update-system.md` — Auto-update system
 - `.claude/rules/worktree-isolation-bug.md` — Known Claude Code worktree CWD bug (DO NOT USE `isolation: "worktree"`)
+- `.claude/rules/linear-integration.md` — Linear-GitHub integration, branch naming, auto-close, `crux linear` commands
 
 ## Subsystem Maps — Read BEFORE proposing work in these areas
 


### PR DESCRIPTION
## Summary
- New `.claude/rules/linear-integration.md` documenting the full Linear-GitHub integration
- Covers branch naming, auto-close mechanics, crux commands, common mistakes
- Wired into CLAUDE.md detailed guides list

## Test plan
- [x] Documentation only — no code changes

Fixes QUA-233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide documenting Linear–GitHub integration conventions, including branch naming requirements, automated issue closing behavior, PR linking methods, available commands, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->