### PR TITLE
feat: persist TableBase scanner results to PG (QUA-160 Phase 1)

### DIFF
--- a/apps/wiki-server/drizzle/0172_create_scanner_results.sql
+++ b/apps/wiki-server/drizzle/0172_create_scanner_results.sql
@@ -1,0 +1,25 @@
+-- Persist TableBase scanner results (per-entity, per-table completeness data).
+-- Different from tablebase_coverage_scans (entity-level 1-4 scores) — this stores
+-- the raw scanner output: record counts, completeness percentages, missing fields,
+-- grouped by scan_run_id for trend analysis.
+
+CREATE TABLE IF NOT EXISTS tablebase_scanner_results (
+  id             SERIAL PRIMARY KEY,
+  scan_run_id    TEXT         NOT NULL,
+  record_type    TEXT         NOT NULL,
+  entity_id      TEXT         NOT NULL,
+  entity_name    TEXT         NOT NULL,
+  entity_type    TEXT         NOT NULL,
+  total_records  INTEGER      NOT NULL DEFAULT 0,
+  verified_records INTEGER    NOT NULL DEFAULT 0,
+  completeness_pct REAL       NOT NULL DEFAULT 0,
+  missing_fields JSONB        NOT NULL DEFAULT '[]',
+  entity_importance REAL,
+  scanned_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scanner_results_run_id ON tablebase_scanner_results (scan_run_id);
+CREATE INDEX IF NOT EXISTS idx_scanner_results_entity ON tablebase_scanner_results (entity_id);
+CREATE INDEX IF NOT EXISTS idx_scanner_results_scanned_at ON tablebase_scanner_results (scanned_at);
+CREATE INDEX IF NOT EXISTS idx_scanner_results_type_entity ON tablebase_scanner_results (record_type, entity_id);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1205,6 +1205,13 @@
       "when": 1784275200000,
       "tag": "0171_create_coverage_scans",
       "breakpoints": true
+    },
+    {
+      "idx": 172,
+      "version": "7",
+      "when": 1784361600000,
+      "tag": "0172_create_scanner_results",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/scanner-results.test.ts
+++ b/apps/wiki-server/src/__tests__/scanner-results.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the scanner-results route.
+ *
+ * Validates:
+ *   1. POST /sync inserts items and returns count
+ *   2. Schema validation rejects invalid payloads
+ *   3. Empty batch rejected (min 1 item)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { z } from "zod";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- In-memory store ----
+
+let insertedRows: Record<string, unknown>[];
+
+function resetStores() {
+  insertedRows = [];
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // INSERT
+  if (q.includes("insert into")) {
+    // Track inserted rows (we don't need to parse individual rows)
+    insertedRows.push({ query: q, params });
+    return [];
+  }
+
+  // SELECT count
+  if (q.includes("count(")) {
+    return [{ count: insertedRows.length }];
+  }
+
+  // SELECT for latest
+  if (q.includes("select") && q.includes("from")) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { scannerResultsRoute } = await import(
+  "../routes/tablebase/scanner-results.js"
+);
+
+function buildApp() {
+  return new Hono().route("/api/scanner-results", scannerResultsRoute);
+}
+
+describe("scanner-results route", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("POST /sync inserts valid items and returns upserted count", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/scanner-results/sync", {
+      items: [
+        {
+          scanRunId: "test-run-001",
+          recordType: "personnel",
+          entityId: "sid_abc1234567",
+          entityName: "Anthropic",
+          entityType: "organization",
+          totalRecords: 15,
+          verifiedRecords: 11,
+          completenessPct: 73.3,
+          missingFields: ["deeper coverage needed"],
+          entityImportance: 85.5,
+        },
+        {
+          scanRunId: "test-run-001",
+          recordType: "grants",
+          entityId: "sid_def7654321",
+          entityName: "OpenAI",
+          entityType: "organization",
+          totalRecords: 0,
+          verifiedRecords: 0,
+          completenessPct: 0,
+          missingFields: ["no grant records"],
+          entityImportance: null,
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.upserted).toBe(2);
+  });
+
+  it("POST /sync rejects empty items array", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/scanner-results/sync", {
+      items: [],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /sync rejects missing required fields", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/scanner-results/sync", {
+      items: [
+        {
+          scanRunId: "test-run-001",
+          // missing recordType, entityId, etc.
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /sync rejects completenessPct out of range", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/scanner-results/sync", {
+      items: [
+        {
+          scanRunId: "test-run-001",
+          recordType: "personnel",
+          entityId: "sid_abc1234567",
+          entityName: "Test",
+          entityType: "organization",
+          totalRecords: 10,
+          verifiedRecords: 5,
+          completenessPct: 150, // out of range
+          missingFields: [],
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /latest returns empty when no data", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/scanner-results/latest");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.scanRunId).toBeNull();
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -34,6 +34,7 @@ import { talentFlowsRoute } from "./routes/tablebase/talent-flows.js";
 import { dataSourcesRoute } from "./routes/tablebase/data-sources.js";
 import { platformAccountsRoute } from "./routes/tablebase/platform-accounts.js";
 import { coverageScansRoute } from "./routes/tablebase/coverage-scans.js";
+import { scannerResultsRoute } from "./routes/tablebase/scanner-results.js";
 
 // Unified source-check system (replaces legacy factbase + record source-checks)
 import { sourceChecksRoute } from "./routes/source-check/source-checks.js";
@@ -251,6 +252,7 @@ export function createApp() {
   app.route("/api/website-sources", websiteSourcesRoute);
   app.route("/api/entity-resources", entityResourcesRoute);
   app.route("/api/coverage-scans", coverageScansRoute);
+  app.route("/api/scanner-results", scannerResultsRoute);
 
   // Aggregated entity profile (reads from all TableBase tables)
   app.route("/api/entity-profile", entityProfileRoute);

--- a/apps/wiki-server/src/routes/tablebase/scanner-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/scanner-results.ts
@@ -1,0 +1,216 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, desc, count, sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { tablebaseScannerResults } from "../../schema.js";
+import { zv, clampedLimit } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+
+const MAX_PAGE_SIZE = 500;
+const MAX_BATCH_SIZE = 5000;
+
+const LatestQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
+  offset: z.coerce.number().int().min(0).default(0),
+  recordType: z.string().max(100).optional(),
+  entityType: z.string().max(100).optional(),
+});
+
+const TrendsQuery = z.object({
+  entityId: z.string().max(200).optional(),
+  recordType: z.string().max(100).optional(),
+  limit: clampedLimit(50, 10),
+});
+
+const SyncItemSchema = z.object({
+  scanRunId: z.string().min(1).max(200),
+  recordType: z.string().min(1).max(100),
+  entityId: z.string().min(1).max(200),
+  entityName: z.string().min(1).max(500),
+  entityType: z.string().min(1).max(100),
+  totalRecords: z.number().int().min(0),
+  verifiedRecords: z.number().int().min(0).default(0),
+  completenessPct: z.number().min(0).max(100),
+  missingFields: z.array(z.string()).default([]),
+  entityImportance: z.number().nullable().optional(),
+  scannedAt: z.string().datetime().optional(),
+});
+
+const SyncBatchSchema = z.object({
+  items: z.array(SyncItemSchema).min(1).max(MAX_BATCH_SIZE),
+});
+
+type SyncItem = z.infer<typeof SyncItemSchema>;
+
+interface ScannerResultRow {
+  id: number;
+  scanRunId: string;
+  recordType: string;
+  entityId: string;
+  entityName: string;
+  entityType: string;
+  totalRecords: number;
+  verifiedRecords: number;
+  completenessPct: number;
+  missingFields: unknown;
+  entityImportance: number | null;
+  scannedAt: Date;
+  createdAt: Date;
+}
+
+function formatRow(r: ScannerResultRow) {
+  return {
+    id: r.id,
+    scanRunId: r.scanRunId,
+    recordType: r.recordType,
+    entityId: r.entityId,
+    entityName: r.entityName,
+    entityType: r.entityType,
+    totalRecords: r.totalRecords,
+    verifiedRecords: r.verifiedRecords,
+    completenessPct: r.completenessPct,
+    missingFields: r.missingFields,
+    entityImportance: r.entityImportance,
+    scannedAt: r.scannedAt.toISOString(),
+    createdAt: r.createdAt.toISOString(),
+  };
+}
+
+const scannerResultsApp = new Hono()
+  // GET /latest — returns the most recent scan run's results
+  .get("/latest", zv("query", LatestQuery), async (c) => {
+    const { limit, offset, recordType, entityType } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    // Find the most recent scan_run_id
+    const latestRun = await db
+      .select({ scanRunId: tablebaseScannerResults.scanRunId })
+      .from(tablebaseScannerResults)
+      .orderBy(desc(tablebaseScannerResults.scannedAt))
+      .limit(1);
+
+    if (latestRun.length === 0) {
+      return c.json({ items: [], total: 0, scanRunId: null });
+    }
+
+    const runId = latestRun[0].scanRunId;
+
+    // Apply optional filters
+    const conditions = [eq(tablebaseScannerResults.scanRunId, runId)];
+    if (recordType) conditions.push(eq(tablebaseScannerResults.recordType, recordType));
+    if (entityType) conditions.push(eq(tablebaseScannerResults.entityType, entityType));
+
+    const combinedWhere = conditions.length === 1
+      ? conditions[0]
+      : sql`${sql.join(conditions, sql` AND `)}`;
+
+    const [rows, totalRows] = await Promise.all([
+      db.select().from(tablebaseScannerResults).where(combinedWhere)
+        .orderBy(desc(tablebaseScannerResults.completenessPct))
+        .limit(limit).offset(offset),
+      db.select({ count: count() }).from(tablebaseScannerResults).where(combinedWhere),
+    ]);
+
+    return c.json({
+      items: rows.map((r) => formatRow(r as ScannerResultRow)),
+      total: totalRows[0]?.count ?? 0,
+      scanRunId: runId,
+    });
+  })
+  // GET /trends — scan results grouped by scan_run_id for trend analysis
+  .get("/trends", zv("query", TrendsQuery), async (c) => {
+    const { entityId, recordType, limit } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    // Get distinct scan runs ordered by recency
+    const runsQuery = db
+      .select({
+        scanRunId: tablebaseScannerResults.scanRunId,
+        scannedAt: sql<string>`MIN(${tablebaseScannerResults.scannedAt})`.as("scanned_at"),
+        totalItems: count(),
+        avgCompleteness: sql<number>`ROUND(AVG(${tablebaseScannerResults.completenessPct})::numeric, 1)`.as("avg_completeness"),
+        totalRecordsSum: sql<number>`SUM(${tablebaseScannerResults.totalRecords})`.as("total_records_sum"),
+      })
+      .from(tablebaseScannerResults)
+      .groupBy(tablebaseScannerResults.scanRunId)
+      .orderBy(desc(sql`MIN(${tablebaseScannerResults.scannedAt})`))
+      .limit(limit);
+
+    const runs = await runsQuery;
+
+    // If entityId or recordType filter is requested, also get per-run details for that filter
+    let entityTrends: Array<{ scanRunId: string; completenessPct: number; totalRecords: number; scannedAt: string }> = [];
+    if (entityId || recordType) {
+      const conditions = [];
+      if (entityId) conditions.push(eq(tablebaseScannerResults.entityId, entityId));
+      if (recordType) conditions.push(eq(tablebaseScannerResults.recordType, recordType));
+      const combinedWhere = conditions.length === 1
+        ? conditions[0]
+        : sql`${sql.join(conditions, sql` AND `)}`;
+
+      const details = await db
+        .select({
+          scanRunId: tablebaseScannerResults.scanRunId,
+          completenessPct: tablebaseScannerResults.completenessPct,
+          totalRecords: tablebaseScannerResults.totalRecords,
+          scannedAt: tablebaseScannerResults.scannedAt,
+        })
+        .from(tablebaseScannerResults)
+        .where(combinedWhere)
+        .orderBy(desc(tablebaseScannerResults.scannedAt));
+
+      entityTrends = details.map((d) => ({
+        scanRunId: d.scanRunId,
+        completenessPct: d.completenessPct,
+        totalRecords: d.totalRecords,
+        scannedAt: d.scannedAt.toISOString(),
+      }));
+    }
+
+    return c.json({
+      runs: runs.map((r) => ({
+        scanRunId: r.scanRunId,
+        scannedAt: r.scannedAt,
+        totalItems: r.totalItems,
+        avgCompleteness: r.avgCompleteness,
+        totalRecordsSum: r.totalRecordsSum,
+      })),
+      entityTrends,
+    });
+  })
+  // POST /sync — accepts batch scan results and upserts them
+  .post("/sync", zv("json", SyncBatchSchema), async (c) => {
+    const { items } = c.req.valid("json");
+    const db = getDrizzleDb();
+    const now = new Date();
+
+    const rows = items.map((item: SyncItem) => ({
+      scanRunId: item.scanRunId,
+      recordType: item.recordType,
+      entityId: item.entityId,
+      entityName: item.entityName,
+      entityType: item.entityType,
+      totalRecords: item.totalRecords,
+      verifiedRecords: item.verifiedRecords,
+      completenessPct: item.completenessPct,
+      missingFields: item.missingFields,
+      entityImportance: item.entityImportance ?? null,
+      scannedAt: item.scannedAt ? new Date(item.scannedAt) : now,
+    }));
+
+    // Insert in chunks to avoid exceeding PG parameter limit
+    const CHUNK_SIZE = 500;
+    let inserted = 0;
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE);
+      await db.insert(tablebaseScannerResults).values(chunk);
+      inserted += chunk.length;
+    }
+
+    return c.json({ upserted: inserted });
+  })
+  // POST /delete-batch — standard delete handler
+  .post("/delete-batch", deleteBatchHandler(tablebaseScannerResults, null));
+
+export const scannerResultsRoute = scannerResultsApp;
+export type ScannerResultsRoute = typeof scannerResultsApp;

--- a/apps/wiki-server/src/routes/tablebase/scanner-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/scanner-results.ts
@@ -5,6 +5,7 @@ import { getDrizzleDb } from "../../db.js";
 import { tablebaseScannerResults } from "../../schema.js";
 import { zv, clampedLimit } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 
 const MAX_PAGE_SIZE = 500;
 const MAX_BATCH_SIZE = 5000;
@@ -183,6 +184,12 @@ const scannerResultsApp = new Hono()
     const { items } = c.req.valid("json");
     const db = getDrizzleDb();
     const now = new Date();
+
+    // Validate entity FK references
+    const refError = await validateEntityRefs(c, db, [
+      { fieldName: "entityId", ids: items.map((i) => i.entityId) },
+    ]);
+    if (refError) return refError;
 
     const rows = items.map((item: SyncItem) => ({
       scanRunId: item.scanRunId,

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3922,3 +3922,30 @@ export const tablebaseCoverageScans = pgTable(
     index("idx_coverage_scans_scanned_at").on(table.scannedAt),
   ],
 );
+
+// ── Scanner Results ──────────────────────────────────────────────
+
+export const tablebaseScannerResults = pgTable(
+  "tablebase_scanner_results",
+  {
+    id: serial("id").primaryKey(),
+    scanRunId: text("scan_run_id").notNull(),
+    recordType: text("record_type").notNull(),
+    entityId: text("entity_id").notNull(),
+    entityName: text("entity_name").notNull(),
+    entityType: text("entity_type").notNull(),
+    totalRecords: integer("total_records").notNull().default(0),
+    verifiedRecords: integer("verified_records").notNull().default(0),
+    completenessPct: real("completeness_pct").notNull().default(0),
+    missingFields: jsonb("missing_fields").notNull().default([]),
+    entityImportance: real("entity_importance"),
+    scannedAt: timestamp("scanned_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_scanner_results_run_id").on(table.scanRunId),
+    index("idx_scanner_results_entity").on(table.entityId),
+    index("idx_scanner_results_scanned_at").on(table.scannedAt),
+    index("idx_scanner_results_type_entity").on(table.recordType, table.entityId),
+  ],
+);

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -53,6 +53,37 @@ interface CommandOptions extends BaseOptions {
   model?: string;
   source?: string;
   entity?: string;
+  persist?: boolean;
+}
+
+async function persistScanResults(scan: import('../tablebase/types.ts').ScanSummary): Promise<void> {
+  const { randomUUID } = await import('crypto');
+  const { transformScanToItems, syncScannerResults } = await import('../wiki-server/sync-scanner-results.ts');
+  const { getServerUrl } = await import('../lib/wiki-server/client.ts');
+  const { waitForHealthy } = await import('../wiki-server/sync-common.ts');
+
+  const serverUrl = getServerUrl();
+  if (!serverUrl) {
+    console.warn('[persist] LONGTERMWIKI_SERVER_URL not set, skipping persistence');
+    return;
+  }
+
+  const scanRunId = randomUUID();
+  const items = transformScanToItems(scan, scanRunId);
+  console.log(`\n[persist] Syncing ${items.length} scanner results (run: ${scanRunId})...`);
+
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.warn('[persist] Server is not healthy, skipping persistence');
+    return;
+  }
+
+  const result = await syncScannerResults(serverUrl, items);
+  if (result.errors > 0) {
+    console.warn(`[persist] Completed with ${result.errors} errors (${result.inserted} synced)`);
+  } else {
+    console.log(`[persist] Done: ${result.inserted} results synced`);
+  }
 }
 
 async function scanCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -67,10 +98,17 @@ async function scanCommand(_args: string[], options: CommandOptions): Promise<Co
     if (options.ci) {
       return { exitCode: 0, output: JSON.stringify(result, null, 2) };
     }
-    return { exitCode: 0, output: formatScanSummary({ tables: [result], timestamp: new Date().toISOString() }) };
+    const summary = { tables: [result], timestamp: new Date().toISOString() };
+    if (options.persist) {
+      await persistScanResults(summary);
+    }
+    return { exitCode: 0, output: formatScanSummary(summary) };
   }
 
   const scan = await runFullScan();
+  if (options.persist) {
+    await persistScanResults(scan);
+  }
   if (options.ci) {
     return { exitCode: 0, output: JSON.stringify(scan, null, 2) };
   }
@@ -1386,6 +1424,7 @@ Options:
   --apply                   For source-discover: also link discovered resources to records
   --v2                      For source-discover: use claims-first agent (extracts + submits claims)
   --claims-only             For source-discover --v2: submit claims but don't apply results
+  --persist                 Persist scan results to wiki-server (tablebase_scanner_results)
   --ci                      JSON output
 
 Modes:

--- a/crux/commands/wiki-server.ts
+++ b/crux/commands/wiki-server.ts
@@ -48,6 +48,16 @@ const SCRIPTS = {
     description: 'Sync page assessments (quality, importance, ratings) to wiki-server',
     passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
   },
+  'sync-coverage-scans': {
+    script: 'wiki-server/sync-coverage-scans.ts',
+    description: 'Compute entity coverage scores and sync to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
+  'sync-scanner-results': {
+    script: 'wiki-server/sync-scanner-results.ts',
+    description: 'Run full TableBase scan and persist results to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
   'snapshot-resources': {
     script: 'wiki-server/snapshot-resources.ts',
     description: 'Export PG resources to data/resources-snapshot.json',

--- a/crux/wiki-server/sync-scanner-results.test.ts
+++ b/crux/wiki-server/sync-scanner-results.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { transformScanToItems } from "./sync-scanner-results.ts";
+import type { ScanSummary } from "../tablebase/types.ts";
+
+describe("transformScanToItems", () => {
+  const sampleScan: ScanSummary = {
+    timestamp: "2026-04-10T12:00:00.000Z",
+    tables: [
+      {
+        table: "personnel",
+        totalEntities: 2,
+        entitiesWithRecords: 1,
+        totalRecords: 15,
+        avgCompleteness: 50,
+        profiles: [
+          {
+            entityId: "sid_abc1234567",
+            entityName: "Anthropic",
+            entityType: "organization",
+            table: "personnel",
+            totalRecords: 15,
+            completenessPercent: 75,
+            missingFields: ["deeper coverage needed"],
+            website: "https://anthropic.com",
+            entityImportance: 85.5,
+          },
+          {
+            entityId: "sid_def7654321",
+            entityName: "OpenAI",
+            entityType: "organization",
+            table: "personnel",
+            totalRecords: 0,
+            completenessPercent: 0,
+            missingFields: ["no personnel records"],
+            entityImportance: 90,
+          },
+        ],
+      },
+      {
+        table: "grants",
+        totalEntities: 1,
+        entitiesWithRecords: 1,
+        totalRecords: 10,
+        avgCompleteness: 80,
+        profiles: [
+          {
+            entityId: "sid_ghi9999999",
+            entityName: "Open Philanthropy",
+            entityType: "organization",
+            table: "grants",
+            totalRecords: 10,
+            completenessPercent: 80,
+            missingFields: ["2 grants missing granteeId"],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("produces one row per profile across all tables", () => {
+    const items = transformScanToItems(sampleScan, "test-run-uuid");
+    expect(items).toHaveLength(3);
+  });
+
+  it("assigns the scanRunId to all rows", () => {
+    const items = transformScanToItems(sampleScan, "run-123");
+    for (const item of items) {
+      expect(item.scanRunId).toBe("run-123");
+    }
+  });
+
+  it("maps TableProfile fields correctly", () => {
+    const items = transformScanToItems(sampleScan, "run-abc");
+    const anthropic = items.find((i) => i.entityId === "sid_abc1234567");
+    expect(anthropic).toBeDefined();
+    expect(anthropic!.recordType).toBe("personnel");
+    expect(anthropic!.entityName).toBe("Anthropic");
+    expect(anthropic!.entityType).toBe("organization");
+    expect(anthropic!.totalRecords).toBe(15);
+    expect(anthropic!.completenessPct).toBe(75);
+    expect(anthropic!.missingFields).toEqual(["deeper coverage needed"]);
+    expect(anthropic!.entityImportance).toBe(85.5);
+    expect(anthropic!.scannedAt).toBe("2026-04-10T12:00:00.000Z");
+  });
+
+  it("computes verifiedRecords from totalRecords and completeness", () => {
+    const items = transformScanToItems(sampleScan, "run-abc");
+    const anthropic = items.find((i) => i.entityId === "sid_abc1234567");
+    // 15 * 75 / 100 = 11.25, rounded to 11
+    expect(anthropic!.verifiedRecords).toBe(11);
+
+    const openai = items.find((i) => i.entityId === "sid_def7654321");
+    // 0 * 0 / 100 = 0
+    expect(openai!.verifiedRecords).toBe(0);
+
+    const openPhil = items.find((i) => i.entityId === "sid_ghi9999999");
+    // 10 * 80 / 100 = 8
+    expect(openPhil!.verifiedRecords).toBe(8);
+  });
+
+  it("handles null entityImportance", () => {
+    const items = transformScanToItems(sampleScan, "run-abc");
+    const openPhil = items.find((i) => i.entityId === "sid_ghi9999999");
+    expect(openPhil!.entityImportance).toBeNull();
+  });
+
+  it("returns empty array for scan with no profiles", () => {
+    const emptyScan: ScanSummary = {
+      timestamp: "2026-04-10T00:00:00Z",
+      tables: [
+        {
+          table: "investments",
+          totalEntities: 0,
+          entitiesWithRecords: 0,
+          totalRecords: 0,
+          avgCompleteness: 0,
+          profiles: [],
+        },
+      ],
+    };
+    const items = transformScanToItems(emptyScan, "empty-run");
+    expect(items).toHaveLength(0);
+  });
+});

--- a/crux/wiki-server/sync-scanner-results.ts
+++ b/crux/wiki-server/sync-scanner-results.ts
@@ -1,0 +1,154 @@
+/**
+ * Scanner Results Sync — runs a full TableBase scan and persists results to wiki-server.
+ *
+ * Transforms the scanner's TableProfile output into rows for the
+ * tablebase_scanner_results PG table, grouped under a single scan_run_id.
+ *
+ * Usage:
+ *   pnpm crux wiki-server sync-scanner-results [--dry-run] [--batch-size=N]
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL   - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { randomUUID } from "crypto";
+import { fileURLToPath } from "url";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
+import { batchSync, waitForHealthy } from "./sync-common.ts";
+import { runFullScan } from "../tablebase/scanner.ts";
+import type { ScanSummary, TableProfile } from "../tablebase/types.ts";
+
+interface ScannerResultItem {
+  scanRunId: string;
+  recordType: string;
+  entityId: string;
+  entityName: string;
+  entityType: string;
+  totalRecords: number;
+  verifiedRecords: number;
+  completenessPct: number;
+  missingFields: string[];
+  entityImportance: number | null;
+  scannedAt: string;
+}
+
+/**
+ * Transform a ScanSummary into flat rows for the scanner_results table.
+ * Each TableProfile becomes one row, all sharing the same scanRunId.
+ */
+export function transformScanToItems(
+  scan: ScanSummary,
+  scanRunId: string,
+): ScannerResultItem[] {
+  const items: ScannerResultItem[] = [];
+
+  for (const table of scan.tables) {
+    for (const profile of table.profiles) {
+      // Compute verified records as totalRecords * completeness / 100
+      const verifiedRecords = Math.round(
+        profile.totalRecords * profile.completenessPercent / 100,
+      );
+
+      items.push({
+        scanRunId,
+        recordType: table.table,
+        entityId: profile.entityId,
+        entityName: profile.entityName,
+        entityType: profile.entityType,
+        totalRecords: profile.totalRecords,
+        verifiedRecords,
+        completenessPct: profile.completenessPercent,
+        missingFields: profile.missingFields,
+        entityImportance: profile.entityImportance ?? null,
+        scannedAt: scan.timestamp,
+      });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Sync scanner results to the wiki-server.
+ * Exported for testing and for use by the --persist flag in the scan command.
+ */
+export async function syncScannerResults(
+  serverUrl: string,
+  items: ScannerResultItem[],
+  batchSize: number = 200,
+  options: { _sleep?: (ms: number) => Promise<void> } = {},
+): Promise<{ inserted: number; errors: number }> {
+  const result = await batchSync(
+    `${serverUrl}/api/scanner-results/sync`,
+    items,
+    batchSize,
+    {
+      bodyKey: "items",
+      responseCountKey: "upserted",
+      itemLabel: "scanner results",
+      _sleep: options._sleep,
+    },
+  );
+
+  return { inserted: result.count, errors: result.errors };
+}
+
+// --- CLI ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || 200;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error("Error: LONGTERMWIKI_SERVER_URL environment variable is required");
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error("Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  console.log("Running full TableBase scan...");
+  const scan = await runFullScan();
+  const scanRunId = randomUUID();
+  const items = transformScanToItems(scan, scanRunId);
+
+  console.log(`  Scan completed: ${scan.tables.length} tables, ${items.length} entity profiles`);
+  console.log(`  Scan run ID: ${scanRunId}`);
+
+  // Summary per table
+  for (const table of scan.tables) {
+    console.log(
+      `    ${table.table}: ${table.profiles.length} entities, ${table.totalRecords} records, avg ${table.avgCompleteness}% complete`,
+    );
+  }
+
+  if (dryRun) {
+    console.log(`\n[dry-run] Would sync ${items.length} scanner result rows`);
+    process.exit(0);
+  }
+
+  console.log(`\nSyncing ${items.length} scanner results to ${serverUrl}...`);
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error("Server is not healthy, aborting");
+    process.exit(1);
+  }
+
+  const result = await syncScannerResults(serverUrl, items, batchSize);
+  console.log(`\nDone: ${result.inserted} synced, ${result.errors} errors`);
+  if (result.errors > 0) process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a new `tablebase_scanner_results` PG table to persist per-entity, per-table scanner output (record counts, completeness percentages, missing fields) grouped by `scan_run_id` for trend analysis
- Creates wiki-server route at `/api/scanner-results` with POST /sync, GET /latest, GET /trends, and POST /delete-batch endpoints
- Adds crux sync script `sync-scanner-results.ts` that transforms `runFullScan()` output into rows for the new table
- Adds `--persist` flag to `crux tb scan` command for direct CLI integration
- Includes 11 tests (6 for transform logic, 5 for route validation)

This is separate from the existing `tablebase_coverage_scans` table (entity-level 1-4 scores with signals). Scanner results store the raw scanner output with actual record counts and field-level gaps, enabling historical trend tracking.

Fixes QUA-160

## Test plan

- [x] `npx vitest run crux/wiki-server/sync-scanner-results.test.ts` -- 6 tests pass
- [x] `npx vitest run apps/wiki-server/src/__tests__/scanner-results.test.ts` -- 5 tests pass
- [x] `npx vitest run apps/wiki-server/src/__tests__/coverage-scans.test.ts` -- 4 tests pass (no regression)
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` -- clean
- [x] Gate check passes (0 blocking issues; source-check-coverage failure is pre-existing on main)

## Note on pre-push gate

The `TableBase source-check coverage` validator fails locally due to pre-existing manifest files in `data/tablebase-manifests/` that use `verificationSummary` instead of the expected `sourceCheckSummary` field name. This is a pre-existing issue on main (same validator fails on `lw/main`) but GitHub Actions CI passes because it runs a different check subset.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>