### PR TITLE
feat: update TableBase coverage dashboard to use scanner-results API

### DIFF
--- a/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
@@ -18,12 +18,14 @@ import { SortableHeader } from "@/components/ui/sortable-header";
 
 export interface CoverageRow {
   entityId: string;
+  entityName: string;
   entityType: string;
-  title: string;
-  coverageScore: number;
-  signalsFilled: number;
-  signalsTotal: number;
-  signals: Record<string, boolean>;
+  recordType: string;
+  totalRecords: number;
+  verifiedRecords: number;
+  completenessPct: number;
+  missingFields: string[];
+  entityImportance: number | null;
   scannedAt: string;
   href: string | null;
 }
@@ -32,34 +34,14 @@ export interface CoverageRow {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function scoreBadgeClass(score: number): string {
-  switch (score) {
-    case 1:
-      return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300";
-    case 2:
-      return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300";
-    case 3:
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300";
-    case 4:
-      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300";
-    default:
-      return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
-  }
-}
-
-function scoreLabel(score: number): string {
-  switch (score) {
-    case 1:
-      return "Stub";
-    case 2:
-      return "Basic";
-    case 3:
-      return "Moderate";
-    case 4:
-      return "Comprehensive";
-    default:
-      return "Unknown";
-  }
+function completenessBadgeClass(pct: number): string {
+  if (pct >= 75)
+    return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300";
+  if (pct >= 50)
+    return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300";
+  if (pct >= 25)
+    return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300";
+  return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300";
 }
 
 // ---------------------------------------------------------------------------
@@ -68,62 +50,81 @@ function scoreLabel(score: number): string {
 
 const columns: ColumnDef<CoverageRow>[] = [
   {
-    accessorKey: "title",
+    accessorKey: "entityName",
     header: ({ column }) => <SortableHeader column={column}>Entity</SortableHeader>,
     cell: ({ row }) => {
       const href = row.original.href;
       return href ? (
         <a href={href} className="text-blue-600 hover:underline dark:text-blue-400">
-          {row.original.title}
+          {row.original.entityName}
         </a>
       ) : (
-        <span>{row.original.title}</span>
+        <span>{row.original.entityName}</span>
       );
     },
-    size: 280,
+    size: 240,
+  },
+  {
+    accessorKey: "recordType",
+    header: ({ column }) => <SortableHeader column={column}>Record Type</SortableHeader>,
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">{row.original.recordType}</span>
+    ),
+    size: 130,
   },
   {
     accessorKey: "entityType",
-    header: ({ column }) => <SortableHeader column={column}>Type</SortableHeader>,
+    header: ({ column }) => <SortableHeader column={column}>Entity Type</SortableHeader>,
     cell: ({ row }) => (
       <span className="text-xs text-muted-foreground">{row.original.entityType}</span>
     ),
-    size: 120,
+    size: 110,
   },
   {
-    accessorKey: "coverageScore",
-    header: ({ column }) => <SortableHeader column={column}>Score</SortableHeader>,
+    accessorKey: "completenessPct",
+    header: ({ column }) => <SortableHeader column={column}>Completeness</SortableHeader>,
     cell: ({ row }) => {
-      const score = row.original.coverageScore;
+      const pct = row.original.completenessPct;
       return (
-        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${scoreBadgeClass(score)}`}>
-          {score} - {scoreLabel(score)}
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${completenessBadgeClass(pct)}`}
+        >
+          {pct}%
         </span>
       );
     },
-    size: 140,
+    size: 120,
   },
   {
-    accessorKey: "signalsFilled",
-    header: ({ column }) => <SortableHeader column={column}>Signals</SortableHeader>,
+    accessorKey: "totalRecords",
+    header: ({ column }) => <SortableHeader column={column}>Records</SortableHeader>,
     cell: ({ row }) => (
       <span className="tabular-nums text-sm">
-        {row.original.signalsFilled}/{row.original.signalsTotal}
+        {row.original.totalRecords.toLocaleString()}
       </span>
     ),
     size: 90,
   },
   {
-    id: "missingSignals",
-    header: "Missing",
+    accessorKey: "verifiedRecords",
+    header: ({ column }) => <SortableHeader column={column}>Verified</SortableHeader>,
+    cell: ({ row }) => (
+      <span className="tabular-nums text-sm">
+        {row.original.verifiedRecords.toLocaleString()}
+      </span>
+    ),
+    size: 90,
+  },
+  {
+    id: "missingFields",
+    header: "Missing Fields",
     cell: ({ row }) => {
-      const missing = Object.entries(row.original.signals)
-        .filter(([, v]) => !v)
-        .map(([k]) => k);
-      if (missing.length === 0) return <span className="text-xs text-muted-foreground">-</span>;
+      const missing = row.original.missingFields;
+      if (!missing || missing.length === 0)
+        return <span className="text-xs text-muted-foreground">-</span>;
       return (
-        <span className="text-xs text-muted-foreground">
-          {missing.join(", ")}
+        <span className="text-xs text-muted-foreground" title={missing.join(", ")}>
+          {missing.length <= 3 ? missing.join(", ") : `${missing.slice(0, 3).join(", ")} +${missing.length - 3}`}
         </span>
       );
     },
@@ -150,31 +151,36 @@ const columns: ColumnDef<CoverageRow>[] = [
 
 interface CoverageTableProps {
   data: CoverageRow[];
+  recordTypes: string[];
   entityTypes: string[];
 }
 
-export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
+export function CoverageTable({ data, recordTypes, entityTypes }: CoverageTableProps) {
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "coverageScore", desc: false },
+    { id: "completenessPct", desc: false },
   ]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [recordTypeFilter, setRecordTypeFilter] = useState<string>("all");
+  const [entityTypeFilter, setEntityTypeFilter] = useState<string>("all");
 
   const filtered = useMemo(() => {
     let rows = data;
-    if (typeFilter !== "all") {
-      rows = rows.filter((r) => r.entityType === typeFilter);
+    if (recordTypeFilter !== "all") {
+      rows = rows.filter((r) => r.recordType === recordTypeFilter);
+    }
+    if (entityTypeFilter !== "all") {
+      rows = rows.filter((r) => r.entityType === entityTypeFilter);
     }
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
       rows = rows.filter(
         (r) =>
-          r.title.toLowerCase().includes(q) ||
+          r.entityName.toLowerCase().includes(q) ||
           r.entityId.toLowerCase().includes(q)
       );
     }
     return rows;
-  }, [data, typeFilter, searchQuery]);
+  }, [data, recordTypeFilter, entityTypeFilter, searchQuery]);
 
   const table = useReactTable({
     data: filtered,
@@ -201,12 +207,25 @@ export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
           />
         </div>
         <select
-          value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value)}
+          value={recordTypeFilter}
+          onChange={(e) => setRecordTypeFilter(e.target.value)}
+          aria-label="Filter by record type"
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="all">All record types ({data.length})</option>
+          {recordTypes.map((t) => (
+            <option key={t} value={t}>
+              {t} ({data.filter((r) => r.recordType === t).length})
+            </option>
+          ))}
+        </select>
+        <select
+          value={entityTypeFilter}
+          onChange={(e) => setEntityTypeFilter(e.target.value)}
           aria-label="Filter by entity type"
           className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          <option value="all">All types ({data.length})</option>
+          <option value="all">All entity types</option>
           {entityTypes.map((t) => (
             <option key={t} value={t}>
               {t} ({data.filter((r) => r.entityType === t).length})
@@ -214,7 +233,7 @@ export function CoverageTable({ data, entityTypes }: CoverageTableProps) {
           ))}
         </select>
         <span className="text-xs text-muted-foreground">
-          {filtered.length} entities
+          {filtered.length} results
         </span>
       </div>
 

--- a/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
@@ -4,143 +4,206 @@ import {
   type FetchResult,
 } from "@lib/wiki-server";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
-import { getTypedEntityById, getEntityHref } from "@/data";
+import { getEntityHref } from "@/data";
 import { CoverageTable, type CoverageRow } from "./coverage-table";
 
-// ── Types (match the wiki-server coverage-scans route response shapes) ──
+// ── Types (match the wiki-server scanner-results route response shapes) ──
 
-interface CoverageScanItem {
+interface ScannerResultItem {
   id: number;
-  entityType: string;
+  scanRunId: string;
+  recordType: string;
   entityId: string;
-  coverageScore: number;
-  signalsFilled: number;
-  signalsTotal: number;
-  signals: Record<string, boolean>;
-  scannedAt: string;
-}
-
-interface AllResponse {
-  items: CoverageScanItem[];
-  total: number;
-}
-
-interface StatRow {
+  entityName: string;
   entityType: string;
-  coverageScore: number;
-  count: number;
+  totalRecords: number;
+  verifiedRecords: number;
+  completenessPct: number;
+  missingFields: string[];
+  entityImportance: number | null;
+  scannedAt: string;
+  createdAt: string;
 }
 
-interface StatsResponse {
-  stats: StatRow[];
+interface LatestResponse {
+  items: ScannerResultItem[];
+  total: number;
+  scanRunId: string | null;
+}
+
+interface TrendRun {
+  scanRunId: string;
+  scannedAt: string;
+  totalItems: number;
+  avgCompleteness: number;
+  totalRecordsSum: number;
+}
+
+interface TrendsResponse {
+  runs: TrendRun[];
+  entityTrends: Array<{
+    scanRunId: string;
+    completenessPct: number;
+    totalRecords: number;
+    scannedAt: string;
+  }>;
 }
 
 interface DashboardData {
-  items: CoverageScanItem[];
-  stats: StatRow[];
+  items: ScannerResultItem[];
+  total: number;
+  scanRunId: string | null;
+  trendRuns: TrendRun[];
 }
 
 // ── Data Loading ────────────────────────────────────────────────────
 
 async function loadFromApi(): Promise<FetchResult<DashboardData>> {
-  const [allResult, statsResult] = await Promise.all([
-    fetchDetailed<AllResponse>("/api/coverage-scans/all?limit=500", {
+  const [latestResult, trendsResult] = await Promise.all([
+    fetchDetailed<LatestResponse>("/api/scanner-results/latest?limit=500", {
       revalidate: 60,
     }),
-    fetchDetailed<StatsResponse>("/api/coverage-scans/stats", {
+    fetchDetailed<TrendsResponse>("/api/scanner-results/trends?limit=10", {
       revalidate: 60,
     }),
   ]);
 
-  // Degrade gracefully: show whatever data we got rather than failing the
-  // whole dashboard because one endpoint is down.
-  const items = allResult.ok ? allResult.data.items : [];
-  const stats = statsResult.ok ? statsResult.data.stats : [];
+  const items = latestResult.ok ? latestResult.data.items : [];
+  const total = latestResult.ok ? latestResult.data.total : 0;
+  const scanRunId = latestResult.ok ? latestResult.data.scanRunId : null;
+  const trendRuns = trendsResult.ok ? trendsResult.data.runs : [];
 
-  if (!allResult.ok && !statsResult.ok) {
-    // Both failed — bubble up the first error
-    return allResult;
+  if (!latestResult.ok && !trendsResult.ok) {
+    return latestResult;
   }
 
-  return { ok: true, data: { items, stats } };
+  return { ok: true, data: { items, total, scanRunId, trendRuns } };
 }
 
 function emptyFallback(): DashboardData {
-  return { items: [], stats: [] };
+  return { items: [], total: 0, scanRunId: null, trendRuns: [] };
 }
 
 // ── Stats computation ────────────────────────────────────────────────
 
-interface TypeStats {
-  entityType: string;
-  total: number;
-  byScore: Record<number, number>;
-  avgScore: number;
+interface RecordTypeStats {
+  recordType: string;
+  entityCount: number;
+  totalRecords: number;
+  avgCompleteness: number;
+  /** Count of entities by completeness tier */
+  byTier: { stub: number; basic: number; moderate: number; comprehensive: number };
 }
 
-function computeTypeStats(stats: StatRow[]): TypeStats[] {
-  const byType = new Map<string, { total: number; byScore: Record<number, number>; sum: number }>();
+function completenessTier(pct: number): "stub" | "basic" | "moderate" | "comprehensive" {
+  if (pct >= 75) return "comprehensive";
+  if (pct >= 50) return "moderate";
+  if (pct >= 25) return "basic";
+  return "stub";
+}
 
-  for (const row of stats) {
-    const existing = byType.get(row.entityType) ?? { total: 0, byScore: {}, sum: 0 };
-    existing.total += row.count;
-    existing.byScore[row.coverageScore] = (existing.byScore[row.coverageScore] ?? 0) + row.count;
-    existing.sum += row.coverageScore * row.count;
-    byType.set(row.entityType, existing);
+function computeRecordTypeStats(items: ScannerResultItem[]): RecordTypeStats[] {
+  const byType = new Map<string, {
+    entityCount: number;
+    totalRecords: number;
+    completenessSum: number;
+    byTier: { stub: number; basic: number; moderate: number; comprehensive: number };
+  }>();
+
+  for (const item of items) {
+    const existing = byType.get(item.recordType) ?? {
+      entityCount: 0,
+      totalRecords: 0,
+      completenessSum: 0,
+      byTier: { stub: 0, basic: 0, moderate: 0, comprehensive: 0 },
+    };
+    existing.entityCount += 1;
+    existing.totalRecords += item.totalRecords;
+    existing.completenessSum += item.completenessPct;
+    existing.byTier[completenessTier(item.completenessPct)] += 1;
+    byType.set(item.recordType, existing);
   }
 
-  const result: TypeStats[] = [];
-  for (const [entityType, data] of byType) {
+  const result: RecordTypeStats[] = [];
+  for (const [recordType, data] of byType) {
     result.push({
-      entityType,
-      total: data.total,
-      byScore: data.byScore,
-      avgScore: data.total > 0 ? Math.round((data.sum / data.total) * 100) / 100 : 0,
+      recordType,
+      entityCount: data.entityCount,
+      totalRecords: data.totalRecords,
+      avgCompleteness: data.entityCount > 0
+        ? Math.round((data.completenessSum / data.entityCount) * 10) / 10
+        : 0,
+      byTier: data.byTier,
     });
   }
 
-  result.sort((a, b) => b.total - a.total);
+  result.sort((a, b) => b.entityCount - a.entityCount);
   return result;
 }
 
-// ── Coverage Bar ────────────────────────────────────────────────────
+// ── Completeness Bar ────────────────────────────────────────────────
 
-const SCORE_COLORS: Record<number, string> = {
-  1: "bg-red-500 dark:bg-red-600",
-  2: "bg-amber-400 dark:bg-amber-500",
-  3: "bg-blue-500 dark:bg-blue-500",
-  4: "bg-emerald-500 dark:bg-emerald-500",
+const TIER_COLORS: Record<string, string> = {
+  stub: "bg-red-500 dark:bg-red-600",
+  basic: "bg-amber-400 dark:bg-amber-500",
+  moderate: "bg-blue-500 dark:bg-blue-500",
+  comprehensive: "bg-emerald-500 dark:bg-emerald-500",
 };
 
-const SCORE_LABELS: Record<number, string> = {
-  1: "Stub",
-  2: "Basic",
-  3: "Moderate",
-  4: "Comprehensive",
+const TIER_LABELS: Record<string, string> = {
+  stub: "<25%",
+  basic: "25-49%",
+  moderate: "50-74%",
+  comprehensive: "75%+",
 };
 
-function CoverageBar({ stats }: { stats: TypeStats }) {
-  const { total, byScore } = stats;
-  if (total === 0) return null;
+function CompletenessBar({ stats }: { stats: RecordTypeStats }) {
+  const { entityCount, byTier } = stats;
+  if (entityCount === 0) return null;
+
+  const tiers = ["stub", "basic", "moderate", "comprehensive"] as const;
 
   return (
     <div className="flex h-5 w-full rounded-md overflow-hidden">
-      {[1, 2, 3, 4].map((score) => {
-        const count = byScore[score] ?? 0;
+      {tiers.map((tier) => {
+        const count = byTier[tier];
         if (count === 0) return null;
-        const pct = (count / total) * 100;
         return (
           <div
-            key={score}
-            className={`${SCORE_COLORS[score]} flex items-center justify-center text-[10px] font-medium text-white`}
-            style={{ width: `${pct}%` }}
-            title={`${SCORE_LABELS[score]}: ${count} (${pct.toFixed(1)}%)`}
+            key={tier}
+            className={`${TIER_COLORS[tier]} flex items-center justify-center text-[10px] font-medium text-white`}
+            style={{ width: `${(count / entityCount) * 100}%` }}
+            title={`${TIER_LABELS[tier]}: ${count} entities (${((count / entityCount) * 100).toFixed(1)}%)`}
           >
-            {pct >= 8 ? count : ""}
+            {(count / entityCount) * 100 >= 8 ? count : ""}
           </div>
         );
       })}
     </div>
+  );
+}
+
+// ── Trend Indicator ────────────────────────────────────────────────
+
+function TrendIndicator({ runs }: { runs: TrendRun[] }) {
+  if (runs.length < 2) return null;
+
+  const latest = runs[0];
+  const previous = runs[1];
+  const diff = latest.avgCompleteness - previous.avgCompleteness;
+
+  if (Math.abs(diff) < 0.5) {
+    return <span className="text-xs text-muted-foreground">flat</span>;
+  }
+
+  return diff > 0 ? (
+    <span className="text-xs text-emerald-600 dark:text-emerald-400">
+      +{diff.toFixed(1)}%
+    </span>
+  ) : (
+    <span className="text-xs text-red-600 dark:text-red-400">
+      {diff.toFixed(1)}%
+    </span>
   );
 }
 
@@ -152,36 +215,33 @@ export async function TablebaseCoverageContent() {
     emptyFallback,
   );
 
-  const { items, stats } = data;
-  const typeStats = computeTypeStats(stats);
+  const { items, scanRunId, trendRuns } = data;
+  const typeStats = computeRecordTypeStats(items);
 
   // Compute global summary
-  const totalEntities = typeStats.reduce((s, t) => s + t.total, 0);
-  const globalByScore: Record<number, number> = {};
-  for (const ts of typeStats) {
-    for (const [score, count] of Object.entries(ts.byScore)) {
-      globalByScore[Number(score)] = (globalByScore[Number(score)] ?? 0) + count;
-    }
-  }
-  const globalSum = typeStats.reduce((s, t) => s + t.avgScore * t.total, 0);
-  const avgScore = totalEntities > 0 ? Math.round((globalSum / totalEntities) * 100) / 100 : 0;
+  const totalEntities = items.length;
+  const globalAvgCompleteness = totalEntities > 0
+    ? Math.round(items.reduce((s, i) => s + i.completenessPct, 0) / totalEntities * 10) / 10
+    : 0;
+  const totalRecords = items.reduce((s, i) => s + i.totalRecords, 0);
+  const totalVerified = items.reduce((s, i) => s + i.verifiedRecords, 0);
 
   // Transform items for enrichment queue table
-  const rows: CoverageRow[] = items.map((item) => {
-    const entity = getTypedEntityById(item.entityId);
-    return {
-      entityId: item.entityId,
-      entityType: item.entityType,
-      title: entity?.title ?? item.entityId,
-      coverageScore: item.coverageScore,
-      signalsFilled: item.signalsFilled,
-      signalsTotal: item.signalsTotal,
-      signals: (item.signals ?? {}) as Record<string, boolean>,
-      scannedAt: item.scannedAt,
-      href: getEntityHref(item.entityId),
-    };
-  });
+  const rows: CoverageRow[] = items.map((item) => ({
+    entityId: item.entityId,
+    entityName: item.entityName,
+    entityType: item.entityType,
+    recordType: item.recordType,
+    totalRecords: item.totalRecords,
+    verifiedRecords: item.verifiedRecords,
+    completenessPct: item.completenessPct,
+    missingFields: item.missingFields,
+    entityImportance: item.entityImportance,
+    scannedAt: item.scannedAt,
+    href: getEntityHref(item.entityId),
+  }));
 
+  const recordTypes = [...new Set(rows.map((r) => r.recordType))].sort();
   const entityTypes = [...new Set(rows.map((r) => r.entityType))].sort();
 
   return (
@@ -189,48 +249,101 @@ export async function TablebaseCoverageContent() {
       <DataSourceBanner source={source} apiError={apiError} />
 
       <p className="text-muted-foreground text-sm leading-relaxed">
-        Coverage scores for {totalEntities.toLocaleString()} entities across{" "}
-        {typeStats.length} entity types. Scores range from 1 (stub) to 4
-        (comprehensive). Use the enrichment queue below to find entities that
-        need more data.
+        Coverage analysis for {totalEntities.toLocaleString()} entity-record-type
+        pairs across {typeStats.length} record types, from scan run{" "}
+        <code className="text-xs bg-muted px-1 py-0.5 rounded">
+          {scanRunId ?? "none"}
+        </code>
+        . Use the enrichment queue below to prioritize data enrichment.
       </p>
 
       {/* Summary stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 my-6">
         <StatCard label="Entities Scanned" value={totalEntities.toLocaleString()} />
-        <StatCard label="Average Score" value={avgScore.toFixed(2)} />
-        <StatCard label="Stub (Score 1)" value={(globalByScore[1] ?? 0).toLocaleString()} />
-        <StatCard label="Comprehensive (4)" value={(globalByScore[4] ?? 0).toLocaleString()} />
+        <StatCard label="Avg Completeness" value={`${globalAvgCompleteness}%`}>
+          <TrendIndicator runs={trendRuns} />
+        </StatCard>
+        <StatCard label="Total Records" value={totalRecords.toLocaleString()} />
+        <StatCard label="Verified Records" value={totalVerified.toLocaleString()} />
+        <StatCard label="Record Types" value={typeStats.length.toLocaleString()} />
       </div>
 
-      {/* Score distribution legend */}
+      {/* Completeness tier legend */}
       <div className="flex flex-wrap gap-4 mb-6">
-        {[1, 2, 3, 4].map((score) => (
-          <div key={score} className="flex items-center gap-1.5">
-            <div className={`h-3 w-3 rounded-sm ${SCORE_COLORS[score]}`} />
-            <span className="text-xs text-muted-foreground">
-              {score} - {SCORE_LABELS[score]} ({(globalByScore[score] ?? 0).toLocaleString()})
-            </span>
-          </div>
-        ))}
+        {(["stub", "basic", "moderate", "comprehensive"] as const).map((tier) => {
+          const count = items.filter((i) => completenessTier(i.completenessPct) === tier).length;
+          return (
+            <div key={tier} className="flex items-center gap-1.5">
+              <div className={`h-3 w-3 rounded-sm ${TIER_COLORS[tier]}`} />
+              <span className="text-xs text-muted-foreground">
+                {TIER_LABELS[tier]} ({count.toLocaleString()})
+              </span>
+            </div>
+          );
+        })}
       </div>
 
-      {/* Coverage by entity type */}
+      {/* Coverage by record type */}
       {typeStats.length > 0 && (
         <div className="my-6">
-          <h2 className="text-lg font-semibold mb-3">Coverage by Entity Type</h2>
+          <h2 className="text-lg font-semibold mb-3">Coverage by Record Type</h2>
           <div className="space-y-3">
             {typeStats.map((ts) => (
-              <div key={ts.entityType}>
+              <div key={ts.recordType}>
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium">{ts.entityType}</span>
+                  <span className="text-sm font-medium">{ts.recordType}</span>
                   <span className="text-xs text-muted-foreground tabular-nums">
-                    {ts.total} entities, avg {ts.avgScore.toFixed(2)}
+                    {ts.entityCount} entities, {ts.totalRecords.toLocaleString()} records, avg {ts.avgCompleteness}%
                   </span>
                 </div>
-                <CoverageBar stats={ts} />
+                <CompletenessBar stats={ts} />
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Scan history (trends) */}
+      {trendRuns.length > 0 && (
+        <div className="my-6">
+          <h2 className="text-lg font-semibold mb-3">Scan History</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left">
+                  <th className="py-2 pr-4 font-medium">Scan Run</th>
+                  <th className="py-2 pr-4 font-medium">Date</th>
+                  <th className="py-2 pr-4 font-medium text-right">Items</th>
+                  <th className="py-2 pr-4 font-medium text-right">Avg Completeness</th>
+                  <th className="py-2 font-medium text-right">Total Records</th>
+                </tr>
+              </thead>
+              <tbody>
+                {trendRuns.map((run) => (
+                  <tr key={run.scanRunId} className="border-b border-border/50">
+                    <td className="py-2 pr-4">
+                      <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                        {run.scanRunId.length > 20
+                          ? `${run.scanRunId.slice(0, 20)}...`
+                          : run.scanRunId}
+                      </code>
+                    </td>
+                    <td className="py-2 pr-4 text-muted-foreground tabular-nums">
+                      {new Date(run.scannedAt).toLocaleDateString()}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {run.totalItems.toLocaleString()}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {run.avgCompleteness}%
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {run.totalRecordsSum.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       )}
@@ -240,22 +353,26 @@ export async function TablebaseCoverageContent() {
         <div className="my-6">
           <h2 className="text-lg font-semibold mb-1">Enrichment Queue</h2>
           <p className="text-sm text-muted-foreground mb-3">
-            Entities ranked by lowest coverage score. Use this to prioritize data
+            Entities ranked by lowest completeness. Use this to prioritize data
             enrichment work.
           </p>
-          <CoverageTable data={rows} entityTypes={entityTypes} />
+          <CoverageTable
+            data={rows}
+            recordTypes={recordTypes}
+            entityTypes={entityTypes}
+          />
         </div>
       )}
 
       {totalEntities === 0 && (
         <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground my-6">
-          <p className="text-lg font-medium mb-2">No coverage scans yet</p>
+          <p className="text-lg font-medium mb-2">No scanner results yet</p>
           <p className="text-sm">
             Run{" "}
             <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-              pnpm crux wiki-server sync-coverage-scans
+              pnpm crux tb scan --persist
             </code>{" "}
-            to compute and sync coverage scores.
+            to compute and persist coverage data.
           </p>
         </div>
       )}
@@ -265,11 +382,22 @@ export async function TablebaseCoverageContent() {
 
 // ── Helper Components ────────────────────────────────────────────────
 
-function StatCard({ label, value }: { label: string; value: string }) {
+function StatCard({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value: string;
+  children?: React.ReactNode;
+}) {
   return (
     <div className="rounded-lg border border-border/60 p-4">
       <p className="text-xs text-muted-foreground mb-1">{label}</p>
-      <p className="text-2xl font-bold tabular-nums">{value}</p>
+      <div className="flex items-baseline gap-2">
+        <p className="text-2xl font-bold tabular-nums">{value}</p>
+        {children}
+      </div>
     </div>
   );
 }

--- a/content/docs/internal/tablebase-coverage-dashboard.mdx
+++ b/content/docs/internal/tablebase-coverage-dashboard.mdx
@@ -1,10 +1,12 @@
 ---
 wikiId: E2211
 title: "TableBase Coverage Dashboard"
-description: "Entity data coverage scores and enrichment queue"
+description: "Coverage trends and enrichment priority queue for TableBase scanner results"
 subcategory: dashboards
 contentFormat: dashboard
-lastEdited: "2026-04-10"
+lastEdited: "2026-04-11"
 ---
+
+Coverage analysis from `pnpm crux tb scan --persist`. Each row represents one entity-record-type pair showing completeness percentage, total records, and missing fields. Use the enrichment queue to find entities that need more data.
 
 <TablebaseCoverageContent />


### PR DESCRIPTION
## Summary

- Rewires the TableBase Coverage Dashboard (E2211) from the old `coverage-scans` endpoints to the Phase 1 `scanner-results` API (`/api/scanner-results/latest` and `/api/scanner-results/trends`)
- Dashboard now shows completeness percentages, record counts, verified records, missing fields, and scan history trends
- Adds record-type and entity-type dual filters to the enrichment queue table
- Includes trend indicator (up/down/flat) comparing latest vs previous scan run

Part of QUA-160 Phase 2.

## Test plan

- [x] `pnpm build` passes
- [x] All 43 gate checks pass
- [x] MDX escaping and markdown fixes verified clean

Generated with [Claude Code](https://claude.com/claude-code)