### PR TITLE
fix: add entity ref mock to scanner-results test (unblock main CI)

### DIFF
--- a/apps/wiki-server/src/__tests__/scanner-results.test.ts
+++ b/apps/wiki-server/src/__tests__/scanner-results.test.ts
@@ -15,17 +15,27 @@ import { mockDbModule, postJson } from "./test-utils.js";
 // ---- In-memory store ----
 
 let insertedRows: Record<string, unknown>[];
+/** Known entity IDs — validateEntityRefs checks these exist */
+let knownEntityIds: Set<string>;
 
 function resetStores() {
   insertedRows = [];
+  // Pre-populate with the entity IDs used in test fixtures
+  knownEntityIds = new Set(["sid_abc1234567", "sid_def7654321"]);
 }
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
+  // validateEntityRefs: unnest + entities check
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => knownEntityIds.has(p as string))
+      .map((p) => ({ ref: p }));
+  }
+
   // INSERT
   if (q.includes("insert into")) {
-    // Track inserted rows (we don't need to parse individual rows)
     insertedRows.push({ query: q, params });
     return [];
   }


### PR DESCRIPTION
PR #4146 added validateEntityRefs to scanner-results sync but the test mock didn't handle entity lookup queries. Test entity IDs were rejected as non-existent, returning 400. Added knownEntityIds mock matching the sync-factory.test.ts pattern. 5/5 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test database capabilities to support additional validation patterns, improving test coverage and reliability of entity reference validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->