### PR TITLE
fix: correct broken crux command references in skill/config files

### DIFF
--- a/.claude/common-issues.md
+++ b/.claude/common-issues.md
@@ -164,7 +164,7 @@ When entity data contains slug reassignments (same slug pointing to a new stable
 
 **Root cause**: The sync endpoint tries to INSERT before cleaning up stale slug rows, or the unique constraint on slugs prevents the upsert pattern.
 
-**Prevention**: After any PR that modifies entity sync logic, run `pnpm crux tb sync` end-to-end with a test slug reassignment before merging. Consider adding an integration test for slug reassignment in `entities.ts`.
+**Prevention**: After any PR that modifies entity sync logic, run `pnpm crux sys wiki-server` end-to-end with a test slug reassignment before merging. Consider adding an integration test for slug reassignment in `entities.ts`.
 
 **Fix pattern when it happens**: Clear stale slug rows before the batch INSERT, or drop/re-add the unique constraint inside the transaction. See PRs #3096-#3105 for the progression of fixes.
 

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -48,7 +48,7 @@ Check for an existing PR patrol process:
 pgrep -f "pr-patrol" && echo "✓ PR patrol already running" || echo "✗ not running"
 ```
 
-If the user wants it started, follow the standard PR patrol startup procedure (typically `pnpm crux pr-patrol watch` from `lw/coord` or `lw/main`). Do NOT start it without user confirmation — PR patrol uses real LLM budget.
+If the user wants it started, follow the standard PR patrol startup procedure (typically `pnpm crux gh pr-patrol` from `lw/coord` or `lw/main`). Do NOT start it without user confirmation — PR patrol uses real LLM budget.
 
 ### Section 2: Pull latest
 


### PR DESCRIPTION
## Summary

- Audited all 100+ unique `pnpm crux` command references across `.claude/commands/`, `.claude/rules/`, `.claude/skills/`, `CLAUDE.md`, and `.claude/common-issues.md`
- Found and fixed 2 broken references in active config files:
  - `.claude/common-issues.md`: `pnpm crux tb sync` (nonexistent) replaced with `pnpm crux sys wiki-server`
  - `.claude/skills/admin-setup/SKILL.md`: `pnpm crux pr-patrol watch` (invalid subcommand) replaced with `pnpm crux gh pr-patrol`
- Additional stale references exist in `.claude/design/` docs (e.g., `crux statements`, `crux kb migrate`, `crux tables add-row`) but these are inactive design documents, not agent-loaded config

Fixes QUA-232

## Test plan
- [ ] Verified both replacement commands resolve: `pnpm crux sys wiki-server` and `pnpm crux gh pr-patrol`
- [ ] Confirmed all other referenced commands in active files work correctly
- [ ] Gate check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)