### PR TITLE
feat: add server-side scan endpoint and groundskeeper cron task (QUA-161)

### DIFF
--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -39,6 +39,7 @@ export interface Config {
     jobWorkerHealth: TaskConfig;
     autoUpdateEnqueue: AutoUpdateEnqueueConfig;
     jobFailureTriage: TaskConfig;
+    tablebaseScan: TaskConfig;
   };
 }
 
@@ -134,6 +135,11 @@ export function loadConfig(): Config {
         enabled: envBool("TASK_JOB_FAILURE_TRIAGE_ENABLED", true),
         schedule:
           process.env["TASK_JOB_FAILURE_TRIAGE_SCHEDULE"] ?? "0 */6 * * *", // every 6 hours
+      },
+      tablebaseScan: {
+        enabled: envBool("TASK_TABLEBASE_SCAN_ENABLED", true),
+        schedule:
+          process.env["TASK_TABLEBASE_SCAN_SCHEDULE"] ?? "0 5 * * *", // daily at 5am UTC
       },
     },
   };

--- a/apps/groundskeeper/src/incident-buffer.test.ts
+++ b/apps/groundskeeper/src/incident-buffer.test.ts
@@ -54,6 +54,7 @@ function makeConfig(): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -12,6 +12,7 @@ import { dataQualitySnapshot } from "./tasks/data-quality-snapshot.js";
 import { jobWorkerHealth } from "./tasks/job-worker-health.js";
 import { autoUpdateEnqueue } from "./tasks/auto-update-enqueue.js";
 import { jobFailureTriage } from "./tasks/job-failure-triage.js";
+import { tablebaseScan } from "./tasks/tablebase-scan.js";
 import { logger } from "./logger.js";
 
 const config = loadConfig();
@@ -59,6 +60,10 @@ logger.info({
     jobFailureTriage: {
       enabled: config.tasks.jobFailureTriage.enabled,
       schedule: config.tasks.jobFailureTriage.schedule,
+    },
+    tablebaseScan: {
+      enabled: config.tasks.tablebaseScan.enabled,
+      schedule: config.tasks.tablebaseScan.schedule,
     },
   },
 }, "Groundskeeper starting");
@@ -137,6 +142,14 @@ registerTask(
   config.tasks.jobFailureTriage.schedule,
   config.tasks.jobFailureTriage.enabled,
   () => jobFailureTriage(config)
+);
+
+registerTask(
+  config,
+  "tablebase-scan",
+  config.tasks.tablebaseScan.schedule,
+  config.tasks.tablebaseScan.enabled,
+  () => tablebaseScan(config)
 );
 
 // Register as an active agent (best-effort)

--- a/apps/groundskeeper/src/run-tracker.test.ts
+++ b/apps/groundskeeper/src/run-tracker.test.ts
@@ -33,6 +33,7 @@ function makeConfig(runLogPath: string): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -57,6 +57,7 @@ function makeConfig(): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/health-check.test.ts
+++ b/apps/groundskeeper/src/tasks/health-check.test.ts
@@ -85,6 +85,7 @@ function makeConfig(overrides?: Partial<Config>): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
     ...overrides,
   };

--- a/apps/groundskeeper/src/tasks/issue-responder.test.ts
+++ b/apps/groundskeeper/src/tasks/issue-responder.test.ts
@@ -102,6 +102,7 @@ function makeConfig(): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
+++ b/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
@@ -82,6 +82,7 @@ function makeConfig(): Config {
         maxPages: 5,
       },
       jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/session-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/session-sweep.test.ts
@@ -40,6 +40,7 @@ function makeConfig(): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -34,6 +34,7 @@ function makeConfig(keep = 100): Config {
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
+++ b/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Config } from "../config.js";
+import { tablebaseScan } from "./tablebase-scan.js";
+
+// Minimal config for testing
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    githubAppId: "test",
+    githubInstallationId: "test",
+    githubAppPrivateKey: "test",
+    githubRepo: "test/repo",
+    wikiServerUrl: "http://localhost:9999",
+    discordWebhookUrl: "http://localhost:9999/discord",
+    dailyRunCap: 20,
+    runLogPath: "/tmp/test-run-log.json",
+    circuitBreakerCooldownMs: 1800000,
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      issueResponder: { enabled: false, schedule: "*/15 * * * *" },
+      githubShadowbanCheck: {
+        enabled: true,
+        schedule: "0 9 * * *",
+        usernames: [],
+      },
+      snapshotRetention: {
+        enabled: true,
+        schedule: "0 3 * * *",
+        keep: 100,
+      },
+      sessionSweep: { enabled: true, schedule: "0 */4 * * *" },
+      dataQualitySnapshot: { enabled: true, schedule: "0 6 * * *" },
+      jobWorkerHealth: { enabled: true, schedule: "*/5 * * * *" },
+      autoUpdateEnqueue: {
+        enabled: true,
+        schedule: "0 6 * * *",
+        budget: 30,
+        maxPages: 5,
+      },
+      jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: true, schedule: "0 5 * * *" },
+    },
+    ...overrides,
+  };
+}
+
+describe("tablebaseScan task", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env["LONGTERMWIKI_SERVER_API_KEY"] = "test-api-key";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("returns success when wiki-server responds with valid scan data", async () => {
+    const mockResponse = {
+      scanRunId: "test-uuid-1234",
+      inserted: 42,
+      tables: 6,
+      recordTypes: ["grants", "personnel", "funding_rounds", "investments", "benchmark_results", "source_quality"],
+      avgCompleteness: 45.2,
+      scannedAt: "2026-04-11T05:00:00.000Z",
+    };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("42 rows");
+    expect(result.summary).toContain("6 tables");
+    expect(result.summary).toContain("avg 45.2%");
+  });
+
+  it("returns failure on HTTP error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("HTTP 500");
+  });
+
+  it("returns failure on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      new Error("Connection refused"),
+    );
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("Connection refused");
+  });
+
+  it("skips gracefully when API key is missing (non-prod)", async () => {
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
+    delete process.env["PROD_LONGTERMWIKI_SERVER_API_KEY"];
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("Skipped");
+  });
+
+  it("fails when API key is missing in prod mode", async () => {
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
+    delete process.env["PROD_LONGTERMWIKI_SERVER_API_KEY"];
+    process.env["WIKI_SERVER_ENV"] = "prod";
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("Missing");
+  });
+
+  it("returns failure on invalid response schema", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ unexpected: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await tablebaseScan(makeConfig());
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("Invalid scan response schema");
+  });
+});

--- a/apps/groundskeeper/src/tasks/tablebase-scan.ts
+++ b/apps/groundskeeper/src/tasks/tablebase-scan.ts
@@ -1,0 +1,100 @@
+import type { Config } from "../config.js";
+import { logger as rootLogger } from "../logger.js";
+
+const logger = rootLogger.child({ task: "tablebase-scan" });
+
+function getWikiServerApiKey(): string | undefined {
+  const prefix = process.env["WIKI_SERVER_ENV"] === "prod" ? "PROD_" : "";
+  return process.env[`${prefix}LONGTERMWIKI_SERVER_API_KEY`];
+}
+
+interface RunScanResponse {
+  scanRunId: string;
+  inserted: number;
+  tables: number;
+  recordTypes?: string[];
+  avgCompleteness?: number;
+  scannedAt?: string;
+  message?: string;
+}
+
+/**
+ * TableBase scan task: runs a server-side coverage scan and persists results.
+ *
+ * Calls POST /api/scanner-results/run on the wiki-server, which computes
+ * per-entity completeness metrics via SQL and inserts them into the
+ * tablebase_scanner_results table. Results feed the TableBase Coverage
+ * Dashboard (/internal/tablebase-coverage-dashboard).
+ *
+ * Runs nightly. Timeout is generous (3 minutes) because the scan touches
+ * multiple large tables (grants, personnel, investments, etc.).
+ */
+export async function tablebaseScan(
+  config: Config,
+): Promise<{ success: boolean; summary?: string }> {
+  const apiKey = getWikiServerApiKey();
+  if (!apiKey) {
+    const isProd = process.env["WIKI_SERVER_ENV"] === "prod";
+    const keyName = isProd
+      ? "PROD_LONGTERMWIKI_SERVER_API_KEY"
+      : "LONGTERMWIKI_SERVER_API_KEY";
+    const summary = `Missing ${keyName}`;
+    if (isProd) {
+      logger.error(`${summary} — scan not attempted.`);
+      return { success: false, summary };
+    }
+    logger.warn(`${summary} — skipping scan.`);
+    return { success: true, summary: `Skipped: ${summary}` };
+  }
+
+  const url = `${config.wikiServerUrl}/api/scanner-results/run`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(180_000), // 3 minute timeout for multi-table scan
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      logger.error({ status: res.status, body: text.slice(0, 200) }, "Scan failed");
+      return { success: false, summary: `HTTP ${res.status}: ${text.slice(0, 100)}` };
+    }
+
+    const data = (await res.json()) as RunScanResponse;
+
+    if (typeof data.inserted !== "number") {
+      logger.error({ body: data }, "Scan response schema mismatch");
+      return { success: false, summary: "Invalid scan response schema" };
+    }
+
+    const summary = [
+      `Scan ${data.scanRunId.slice(0, 8)}:`,
+      `${data.inserted} rows`,
+      `${data.tables} tables`,
+      data.avgCompleteness != null ? `avg ${data.avgCompleteness}%` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    logger.info(
+      {
+        scanRunId: data.scanRunId,
+        inserted: data.inserted,
+        tables: data.tables,
+        avgCompleteness: data.avgCompleteness,
+      },
+      summary,
+    );
+
+    return { success: true, summary };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ error: msg }, "Scan request failed");
+    return { success: false, summary: msg };
+  }
+}

--- a/apps/wiki-server/src/__tests__/scanner-results.test.ts
+++ b/apps/wiki-server/src/__tests__/scanner-results.test.ts
@@ -5,6 +5,8 @@
  *   1. POST /sync inserts items and returns count
  *   2. Schema validation rejects invalid payloads
  *   3. Empty batch rejected (min 1 item)
+ *   4. POST /run triggers server-side scan and persists results
+ *   5. GET /latest returns empty when no data
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -45,7 +47,58 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [{ count: insertedRows.length }];
   }
 
-  // SELECT for latest
+  // Entity queries for the /run endpoint
+  // organizations query
+  if (q.includes('"entities"') && q.includes("organization")) {
+    return [
+      { stable_id: "sid_org001", title: "TestOrg", entity_type: "organization" },
+    ];
+  }
+
+  // ai-model entities
+  if (q.includes('"entities"') && q.includes("ai-model")) {
+    return [
+      { stable_id: "sid_model001", title: "TestModel", entity_type: "ai-model" },
+    ];
+  }
+
+  // Grants grouped by org
+  if (q.includes('"grants"')) {
+    return [
+      { entity_id: "sid_org001", entity_name: "TestOrg", total: "3", linked: "2" },
+    ];
+  }
+
+  // Personnel grouped by org
+  if (q.includes('"personnel"')) {
+    return [
+      { entity_id: "sid_org001", entity_name: "TestOrg", total: "10" },
+    ];
+  }
+
+  // Funding rounds
+  if (q.includes('"funding_rounds"')) {
+    return [];
+  }
+
+  // Investments
+  if (q.includes('"investments"')) {
+    return [];
+  }
+
+  // Benchmark results
+  if (q.includes('"benchmark_results"')) {
+    return [
+      { entity_id: "sid_model001", entity_name: "TestModel", total: "5" },
+    ];
+  }
+
+  // Source check verdicts
+  if (q.includes('"source_check_verdicts"')) {
+    return [];
+  }
+
+  // SELECT for latest (generic select from tablebase_scanner_results)
   if (q.includes("select") && q.includes("from")) {
     return [];
   }
@@ -157,5 +210,23 @@ describe("scanner-results route", () => {
     expect(body.items).toEqual([]);
     expect(body.total).toBe(0);
     expect(body.scanRunId).toBeNull();
+  });
+
+  it("POST /run triggers server-side scan and returns summary", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/scanner-results/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scanRunId).toBeDefined();
+    expect(typeof body.scanRunId).toBe("string");
+    expect(body.scanRunId.length).toBeGreaterThan(0);
+    expect(typeof body.inserted).toBe("number");
+    expect(body.inserted).toBeGreaterThanOrEqual(0);
+    expect(typeof body.tables).toBe("number");
+    expect(body.scannedAt).toBeDefined();
   });
 });

--- a/apps/wiki-server/src/routes/tablebase/scanner-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/scanner-results.ts
@@ -1,8 +1,18 @@
+import { randomUUID } from "crypto";
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq, desc, count, sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { tablebaseScannerResults } from "../../schema.js";
+import {
+  tablebaseScannerResults,
+  entities,
+  grants,
+  personnel,
+  fundingRounds,
+  investments,
+  benchmarkResults,
+  sourceVerdicts,
+} from "../../schema.js";
 import { zv, clampedLimit } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
@@ -75,6 +85,257 @@ function formatRow(r: ScannerResultRow) {
     scannedAt: r.scannedAt.toISOString(),
     createdAt: r.createdAt.toISOString(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Server-side scan: compute coverage metrics via SQL
+// ---------------------------------------------------------------------------
+
+interface ScanRow {
+  entityId: string;
+  entityName: string;
+  entityType: string;
+  recordType: string;
+  totalRecords: number;
+  verifiedRecords: number;
+  completenessPct: number;
+  missingFields: string[];
+}
+
+/**
+ * Run a full server-side scan by querying PG directly.
+ *
+ * Returns one row per (entity, record_type) pair.
+ * Coverage heuristics match the crux/tablebase/scanner.ts logic:
+ *   - grants: % of grants with granteeId linked
+ *   - personnel: min(100, count * 5) — 20+ records = 100%
+ *   - funding_rounds: binary (has any = 100%, none = 0%)
+ *   - investments: binary
+ *   - benchmark_results: min(100, count * 10) — 10+ = 100%
+ *   - source_quality: 100 - unverifiable_count * 5 (capped at 0)
+ */
+async function runServerSideScan(): Promise<ScanRow[]> {
+  const db = getDrizzleDb();
+  const rows: ScanRow[] = [];
+
+  // 1. Grants — per org, completeness = % with grantee linked
+  const grantRows = await db.execute<{
+    entity_id: string;
+    entity_name: string;
+    total: string;
+    linked: string;
+  }>(sql`
+    SELECT
+      e.stable_id AS entity_id,
+      e.title AS entity_name,
+      COUNT(*)::int AS total,
+      COUNT(g.grantee_id)::int AS linked
+    FROM ${grants} g
+    JOIN ${entities} e ON e.stable_id = COALESCE(g.org_entity_id, g.organization_id)
+    GROUP BY e.stable_id, e.title
+    HAVING COUNT(*) > 0
+  `);
+
+  for (const r of grantRows) {
+    const total = Number(r.total);
+    const linked = Number(r.linked);
+    const pct = total > 0 ? Math.round((linked / total) * 100) : 100;
+    const missing: string[] = [];
+    if (linked < total) missing.push(`${total - linked} grants missing granteeId`);
+    rows.push({
+      entityId: r.entity_id,
+      entityName: r.entity_name,
+      entityType: "organization",
+      recordType: "grants",
+      totalRecords: total,
+      verifiedRecords: linked,
+      completenessPct: pct,
+      missingFields: missing,
+    });
+  }
+
+  // 2. Personnel — per org, completeness heuristic: min(100, count * 5)
+  const personnelRows = await db.execute<{
+    entity_id: string;
+    entity_name: string;
+    total: string;
+  }>(sql`
+    SELECT
+      e.stable_id AS entity_id,
+      e.title AS entity_name,
+      COUNT(*)::int AS total
+    FROM ${personnel} p
+    JOIN ${entities} e ON e.stable_id = COALESCE(p.org_entity_id, p.organization_id)
+    WHERE e.entity_type = 'organization'
+    GROUP BY e.stable_id, e.title
+  `);
+
+  // Also include orgs with zero personnel so we can flag them
+  const orgEntities = await db
+    .select({ stableId: entities.stableId, title: entities.title })
+    .from(entities)
+    .where(eq(entities.entityType, "organization"));
+
+  const personnelByOrg = new Map(
+    personnelRows.map((r) => [r.entity_id, Number(r.total)])
+  );
+
+  for (const org of orgEntities) {
+    const cnt = personnelByOrg.get(org.stableId) ?? 0;
+    const pct = Math.min(100, cnt * 5);
+    const missing: string[] = [];
+    if (cnt === 0) missing.push("no personnel records");
+    else if (cnt < 5) missing.push(`only ${cnt} personnel records — missing broader team`);
+    else if (cnt < 15) missing.push(`${cnt} personnel records — deeper coverage needed`);
+
+    rows.push({
+      entityId: org.stableId,
+      entityName: org.title,
+      entityType: "organization",
+      recordType: "personnel",
+      totalRecords: cnt,
+      verifiedRecords: cnt, // personnel don't have a separate "verified" concept
+      completenessPct: pct,
+      missingFields: missing,
+    });
+  }
+
+  // 3. Funding rounds — per org, binary completeness
+  const frRows = await db.execute<{
+    entity_id: string;
+    entity_name: string;
+    total: string;
+  }>(sql`
+    SELECT
+      e.stable_id AS entity_id,
+      e.title AS entity_name,
+      COUNT(*)::int AS total
+    FROM ${fundingRounds} fr
+    JOIN ${entities} e ON e.stable_id = COALESCE(fr.company_entity_id, fr.company_id)
+    GROUP BY e.stable_id, e.title
+  `);
+
+  const frByOrg = new Map(frRows.map((r) => [r.entity_id, Number(r.total)]));
+  for (const org of orgEntities) {
+    const cnt = frByOrg.get(org.stableId) ?? 0;
+    const missing: string[] = [];
+    if (cnt === 0) missing.push("no funding round data");
+    rows.push({
+      entityId: org.stableId,
+      entityName: org.title,
+      entityType: "organization",
+      recordType: "funding_rounds",
+      totalRecords: cnt,
+      verifiedRecords: cnt,
+      completenessPct: cnt > 0 ? 100 : 0,
+      missingFields: missing,
+    });
+  }
+
+  // 4. Investments — per org, binary completeness
+  const invRows = await db.execute<{
+    entity_id: string;
+    entity_name: string;
+    total: string;
+  }>(sql`
+    SELECT
+      e.stable_id AS entity_id,
+      e.title AS entity_name,
+      COUNT(*)::int AS total
+    FROM ${investments} i
+    JOIN ${entities} e ON e.stable_id = COALESCE(i.company_entity_id, i.company_id)
+    GROUP BY e.stable_id, e.title
+  `);
+
+  const invByOrg = new Map(invRows.map((r) => [r.entity_id, Number(r.total)]));
+  for (const org of orgEntities) {
+    const cnt = invByOrg.get(org.stableId) ?? 0;
+    const missing: string[] = [];
+    if (cnt === 0) missing.push("no investment records");
+    rows.push({
+      entityId: org.stableId,
+      entityName: org.title,
+      entityType: "organization",
+      recordType: "investments",
+      totalRecords: cnt,
+      verifiedRecords: cnt,
+      completenessPct: cnt > 0 ? 100 : 0,
+      missingFields: missing,
+    });
+  }
+
+  // 5. Benchmark results — per model, min(100, count * 10)
+  const brRows = await db.execute<{
+    entity_id: string;
+    entity_name: string;
+    total: string;
+  }>(sql`
+    SELECT
+      e.stable_id AS entity_id,
+      e.title AS entity_name,
+      COUNT(*)::int AS total
+    FROM ${benchmarkResults} br
+    JOIN ${entities} e ON e.stable_id = br.model_id
+    GROUP BY e.stable_id, e.title
+  `);
+
+  const modelEntities = await db
+    .select({ stableId: entities.stableId, title: entities.title })
+    .from(entities)
+    .where(eq(entities.entityType, "ai-model"));
+
+  const brByModel = new Map(brRows.map((r) => [r.entity_id, Number(r.total)]));
+  for (const model of modelEntities) {
+    const cnt = brByModel.get(model.stableId) ?? 0;
+    const pct = Math.min(100, cnt * 10);
+    const missing: string[] = [];
+    if (cnt === 0) missing.push("no benchmark results");
+    else if (cnt < 5) missing.push(`only ${cnt} benchmark results`);
+
+    rows.push({
+      entityId: model.stableId,
+      entityName: model.title,
+      entityType: "ai-model",
+      recordType: "benchmark_results",
+      totalRecords: cnt,
+      verifiedRecords: cnt,
+      completenessPct: pct,
+      missingFields: missing,
+    });
+  }
+
+  // 6. Source quality — unverifiable verdict counts per entity
+  const verdictRows = await db.execute<{
+    entity_id: string;
+    entity_display_name: string | null;
+    unverifiable_count: string;
+  }>(sql`
+    SELECT
+      v.entity_id,
+      v.entity_display_name,
+      COUNT(*)::int AS unverifiable_count
+    FROM ${sourceVerdicts} v
+    WHERE v.verdict = 'unverifiable' AND v.entity_id IS NOT NULL
+    GROUP BY v.entity_id, v.entity_display_name
+  `);
+
+  for (const r of verdictRows) {
+    if (!r.entity_id) continue;
+    const cnt = Number(r.unverifiable_count);
+    const pct = Math.max(0, 100 - cnt * 5);
+    rows.push({
+      entityId: r.entity_id,
+      entityName: r.entity_display_name ?? r.entity_id,
+      entityType: "organization", // best guess — source quality spans types
+      recordType: "source_quality",
+      totalRecords: cnt,
+      verifiedRecords: 0,
+      completenessPct: pct,
+      missingFields: [`${cnt} record(s) with unverifiable sources`],
+    });
+  }
+
+  return rows;
 }
 
 const scannerResultsApp = new Hono()
@@ -177,6 +438,56 @@ const scannerResultsApp = new Hono()
         totalRecordsSum: r.totalRecordsSum,
       })),
       entityTrends,
+    });
+  })
+  // POST /run — run a server-side scan, compute coverage via SQL, persist results
+  .post("/run", async (c) => {
+    const db = getDrizzleDb();
+    const scanRunId = randomUUID();
+    const now = new Date();
+
+    const scanRows = await runServerSideScan();
+
+    if (scanRows.length === 0) {
+      return c.json({ scanRunId, inserted: 0, tables: 0, message: "No entities found" });
+    }
+
+    // Insert in chunks to avoid exceeding PG parameter limit
+    const CHUNK_SIZE = 500;
+    let inserted = 0;
+    for (let i = 0; i < scanRows.length; i += CHUNK_SIZE) {
+      const chunk = scanRows.slice(i, i + CHUNK_SIZE);
+      await db.insert(tablebaseScannerResults).values(
+        chunk.map((row) => ({
+          scanRunId,
+          recordType: row.recordType,
+          entityId: row.entityId,
+          entityName: row.entityName,
+          entityType: row.entityType,
+          totalRecords: row.totalRecords,
+          verifiedRecords: row.verifiedRecords,
+          completenessPct: row.completenessPct,
+          missingFields: row.missingFields,
+          entityImportance: null, // server-side scan doesn't have page-rank data
+          scannedAt: now,
+        })),
+      );
+      inserted += chunk.length;
+    }
+
+    // Compute summary stats
+    const recordTypes = [...new Set(scanRows.map((r) => r.recordType))];
+    const avgCompleteness = scanRows.length > 0
+      ? Math.round(scanRows.reduce((s, r) => s + r.completenessPct, 0) / scanRows.length * 10) / 10
+      : 0;
+
+    return c.json({
+      scanRunId,
+      inserted,
+      tables: recordTypes.length,
+      recordTypes,
+      avgCompleteness,
+      scannedAt: now.toISOString(),
     });
   })
   // POST /sync — accepts batch scan results and upserts them


### PR DESCRIPTION
## Summary

- Add `POST /api/scanner-results/run` endpoint that computes per-entity TableBase coverage metrics via direct SQL queries (grants, personnel, funding rounds, investments, benchmark results, source quality) and persists results to the `tablebase_scanner_results` table
- Add nightly groundskeeper `tablebase-scan` cron task (daily at 5am UTC) that calls the new endpoint, feeding the TableBase Coverage Dashboard with fresh scan data automatically
- Coverage heuristics match the existing `crux/tablebase/scanner.ts` logic: grants use granteeId linkage %, personnel use `min(100, count*5)`, benchmark results use `min(100, count*10)`, etc.

## Changes

**Wiki-server** (`apps/wiki-server/src/routes/tablebase/scanner-results.ts`):
- Added `runServerSideScan()` function with 6 SQL-based scanners
- Added `POST /run` endpoint that runs the scan and persists results in a single request
- All existing endpoints (`GET /latest`, `GET /trends`, `POST /sync`, `POST /delete-batch`) unchanged

**Groundskeeper** (`apps/groundskeeper/`):
- New task: `src/tasks/tablebase-scan.ts` — calls `POST /api/scanner-results/run`
- Config: `tablebaseScan` task config with env vars `TASK_TABLEBASE_SCAN_ENABLED` and `TASK_TABLEBASE_SCAN_SCHEDULE`
- Registered in `src/index.ts`, default schedule: daily at 5am UTC
- Updated all existing test configs to include the new task field

**Tests**:
- 6 tests for the wiki-server endpoint (including `POST /run` test)
- 6 tests for the groundskeeper task (success, HTTP error, network error, missing API key, prod mode, invalid schema)

## Test plan

- [x] `npx vitest run` in `apps/wiki-server/` — 907 tests pass (45 files)
- [x] `npx vitest run` in `apps/groundskeeper/` — 146 tests pass (8 files, 2 pre-existing failures in disabled issue-responder)
- [x] `npx vitest run` in `apps/web/` — 1384 tests pass (79 files)
- [x] `pnpm build` — passes
- [x] Gate check — all 44 blocking checks pass

Fixes QUA-161