### PR TITLE
fix: add 'fact' to VALID_RECORD_TYPES (unblock fact verdict storage)

### DIFF
--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -49,6 +49,7 @@ export const VALID_RECORD_TYPES = [
   "secondary-market-price",
   "citation",
   "wiki-page",
+  "fact",
 ] as const;
 
 export type RecordType = (typeof VALID_RECORD_TYPES)[number];


### PR DESCRIPTION
## Summary

- Add `"fact"` to `VALID_RECORD_TYPES` in `api-types.ts`
- The source-check orchestrator sends `recordType: "fact"` when storing FactBase fact verdicts, but `"fact"` was missing from the Zod-validated record types list
- The server rejected every fact verdict write with `bad_request`, silently preventing all fact verdicts from being stored via the orchestrator pipeline
- The 1,912 existing fact verdicts were stored through the legacy citation-based path (`kb-fact-source-check.json` build-time matching), which bypasses this validation

**Impact**: Unblocks Phase 4 of the source-check all-green plan — without this fix, running `verify-orchestrate --type=fact` produces verdicts but can't persist them.

## Test plan
- [x] Wiki-server TypeScript passes
- [x] Wiki-server tests pass (908 passed)

Fixes QUA-245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "fact" as a new record type in the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->