### PR TITLE
fix: resolve CI failure on main — sourcing lint guard (QUA-241)

### DIFF
--- a/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
+++ b/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
@@ -133,22 +133,22 @@ const entries: AutomationEntry[] = [
     file: "scheduled-maintenance.yml",
   },
   {
-    name: "Source-Check",
+    name: "Sourcing",
     type: "GHA (scheduled)",
     schedule: "Weekly Monday 04:00 UTC",
     description:
-      "Periodic source-checking of facts and records against cited URLs using Anthropic Batch API (50% cost discount).",
+      "Periodic sourcing verification of facts and records against cited URLs using Anthropic Batch API (50% cost discount).",
     status: "active",
-    file: "source-check.yml",
+    file: "sourcing.yml",
   },
   {
-    name: "Source-Check Recheck",
+    name: "Sourcing Recheck",
     type: "GHA (scheduled)",
     schedule: "Weekly Monday 08:00 UTC",
     description:
-      "Re-verifies stale source-check verdicts. Detects when previously-verified data becomes contradicted by updated sources.",
+      "Re-verifies stale sourcing verdicts. Detects when previously-verified data becomes contradicted by updated sources.",
     status: "active",
-    file: "source-check-recheck.yml",
+    file: "sourcing-recheck.yml",
   },
   {
     name: "Wiki Server Dead-Man-Switch",


### PR DESCRIPTION
## Summary

- The automation landscape content (PR #4158) used legacy "source-check" names for workflow files and descriptions
- The actual workflows were already renamed to `sourcing.yml` and `sourcing-recheck.yml`
- This caused the `validate-sourcing-lint-guard` ratchet to fail on main, breaking CI (total rose from 3 to 7)
- Updated the automation landscape entries to use the correct "sourcing" terminology

## Test plan

- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` passes (at baseline, 3 references)
- [x] `npx vitest run crux/validate/validate-sourcing-lint-guard.test.ts` — 14/14 tests pass
- [x] `pnpm build` passes

Fixes QUA-241
