### PR TITLE
fix: source-check false positives from formatValue() rounding (QUA-240)

### DIFF
--- a/crux/lib/sourcing/format-for-prompt.test.ts
+++ b/crux/lib/sourcing/format-for-prompt.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the formatNumericForPrompt helper and the rounding false-positive
+ * prevention in source-check prompt builders.
+ *
+ * QUA-240: Source-check false positives from formatValue() rounding.
+ * The core issue: formatValue() rounds numbers for display (e.g., 1,234,000,000 → "$1.2B"),
+ * but the LLM then sees "$1.2B" as the claim and a source saying "$1.234 billion" and flags
+ * it as contradicted. The fix annotates raw numbers with human-readable equivalents.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatNumericForPrompt,
+  buildFactSourcingPrompt,
+  buildRecordSourcingPrompt,
+} from './item-verifier.ts';
+import type { FactItemData, RecordItemData } from './orchestrator-types.ts';
+import type { Fact, Entity as FBEntity } from '../../../packages/factbase/src/types.ts';
+
+// ── formatNumericForPrompt ─────────────────────────────────────────
+
+describe('formatNumericForPrompt', () => {
+  describe('billions', () => {
+    it('annotates billions with human-readable equivalent', () => {
+      const result = formatNumericForPrompt(1_234_000_000);
+      expect(result).toBe('1,234,000,000 (i.e. ~1.23 billion)');
+    });
+
+    it('handles exact billions', () => {
+      const result = formatNumericForPrompt(1_000_000_000);
+      expect(result).toBe('1,000,000,000 (i.e. ~1 billion)');
+    });
+
+    it('handles multi-billion values', () => {
+      const result = formatNumericForPrompt(19_000_000_000);
+      expect(result).toBe('19,000,000,000 (i.e. ~19 billion)');
+    });
+
+    it('preserves decimal precision for billions', () => {
+      const result = formatNumericForPrompt(2_500_000_000);
+      expect(result).toBe('2,500,000,000 (i.e. ~2.5 billion)');
+    });
+  });
+
+  describe('millions', () => {
+    it('annotates millions with human-readable equivalent', () => {
+      const result = formatNumericForPrompt(50_000_000);
+      expect(result).toBe('50,000,000 (i.e. ~50 million)');
+    });
+
+    it('handles exact millions', () => {
+      const result = formatNumericForPrompt(1_000_000);
+      expect(result).toBe('1,000,000 (i.e. ~1 million)');
+    });
+
+    it('preserves decimal precision for millions', () => {
+      const result = formatNumericForPrompt(115_576_357);
+      expect(result).toBe('115,576,357 (i.e. ~115.58 million)');
+    });
+  });
+
+  describe('trillions', () => {
+    it('annotates trillions with human-readable equivalent', () => {
+      const result = formatNumericForPrompt(1_500_000_000_000);
+      expect(result).toBe('1,500,000,000,000 (i.e. ~1.5 trillion)');
+    });
+  });
+
+  describe('small numbers (no annotation needed)', () => {
+    it('returns formatted number without annotation for small values', () => {
+      expect(formatNumericForPrompt(1500)).toBe('1,500');
+    });
+
+    it('returns plain number for very small values', () => {
+      expect(formatNumericForPrompt(42)).toBe('42');
+    });
+
+    it('returns zero as-is', () => {
+      expect(formatNumericForPrompt(0)).toBe('0');
+    });
+  });
+
+  describe('negative values', () => {
+    it('handles negative billions', () => {
+      const result = formatNumericForPrompt(-5_000_000_000);
+      expect(result).toBe('-5,000,000,000 (i.e. -~5 billion)');
+    });
+
+    it('handles negative millions', () => {
+      const result = formatNumericForPrompt(-850_000_000);
+      expect(result).toBe('-850,000,000 (i.e. -~850 million)');
+    });
+  });
+
+  describe('trailing zero trimming', () => {
+    it('trims trailing zeros from decimal annotations', () => {
+      // 5,000,000,000 → 5.00 billion → trimmed to "5"
+      const result = formatNumericForPrompt(5_000_000_000);
+      expect(result).toContain('~5 billion');
+      expect(result).not.toContain('5.00');
+    });
+
+    it('preserves meaningful decimals', () => {
+      // 1,230,000,000 → 1.23 billion
+      const result = formatNumericForPrompt(1_230_000_000);
+      expect(result).toContain('~1.23 billion');
+    });
+
+    it('trims single trailing zero', () => {
+      // 1,200,000,000 → 1.20 billion → trimmed to "1.2"
+      const result = formatNumericForPrompt(1_200_000_000);
+      expect(result).toContain('~1.2 billion');
+      expect(result).not.toContain('1.20');
+    });
+  });
+});
+
+// ── buildFactSourcingPrompt — rounding false positive prevention ────
+
+describe('buildFactSourcingPrompt — rounding annotation', () => {
+  function makeFactData(overrides: Partial<FactItemData> = {}): FactItemData {
+    return {
+      kind: 'fact',
+      entity: {
+        id: 'test123456',
+        type: 'organization',
+        name: 'Anthropic',
+        stableId: 'test123456',
+      } as FBEntity,
+      fact: {
+        id: 'f_test',
+        subjectId: 'test123456',
+        propertyId: 'revenue',
+        value: { type: 'number', value: 1_234_000_000 },
+        source: 'https://example.com/report',
+      } as Fact,
+      propertyName: 'Annual Revenue',
+      formattedValue: '$1.2B',
+      rawValue: '1234000000',
+      ...overrides,
+    };
+  }
+
+  it('includes human-readable annotation for large numeric raw values', () => {
+    const prompt = buildFactSourcingPrompt(makeFactData(), 'Source text here');
+    // Should contain the annotated raw value, not just the bare number
+    expect(prompt).toContain('1,234,000,000');
+    expect(prompt).toContain('~1.23 billion');
+  });
+
+  it('includes both the formatted display and the exact stored value', () => {
+    const prompt = buildFactSourcingPrompt(makeFactData(), 'Source text here');
+    expect(prompt).toContain('$1.2B');
+    expect(prompt).toContain('exact stored value:');
+  });
+
+  it('does not add raw suffix when rawValue matches formattedValue', () => {
+    const data = makeFactData({
+      formattedValue: '42',
+      rawValue: '42',
+    });
+    const prompt = buildFactSourcingPrompt(data, 'Source text');
+    // The claim line should NOT contain "exact stored value" when values match
+    const claimLine = prompt.split('\n').find(l => l.startsWith('Claim:'));
+    expect(claimLine).toBeDefined();
+    expect(claimLine).not.toContain('exact stored value');
+  });
+
+  it('shows plain raw value for small numbers', () => {
+    const data = makeFactData({
+      formattedValue: '$1,500',
+      rawValue: '1500',
+    });
+    const prompt = buildFactSourcingPrompt(data, 'Source text');
+    // The claim line should contain the raw value without billion/million annotation
+    const claimLine = prompt.split('\n').find(l => l.startsWith('Claim:'));
+    expect(claimLine).toBeDefined();
+    expect(claimLine).toContain('exact stored value: 1500');
+    expect(claimLine).not.toContain('billion');
+    expect(claimLine).not.toContain('million');
+  });
+});
+
+// ── buildRecordSourcingPrompt — monetary field annotation ──────────
+
+describe('buildRecordSourcingPrompt — monetary field annotation', () => {
+  function makeRecordData(
+    fields: Record<string, string | number | null>,
+    overrides: Partial<RecordItemData> = {},
+  ): RecordItemData {
+    return {
+      kind: 'record',
+      recordType: 'grant',
+      recordId: 'g_test',
+      fields,
+      ...overrides,
+    };
+  }
+
+  it('annotates large amount fields with human-readable equivalents', () => {
+    const data = makeRecordData({ amount: 1_234_000_000, grantee: 'MIRI' });
+    const prompt = buildRecordSourcingPrompt(data, 'Grant to MIRI', 'Source text');
+    expect(prompt).toContain('1,234,000,000');
+    expect(prompt).toContain('~1.23 billion');
+  });
+
+  it('annotates raised field in funding rounds', () => {
+    const data = makeRecordData(
+      { raised: 500_000_000, name: 'Series B' },
+      { recordType: 'funding-round' },
+    );
+    const prompt = buildRecordSourcingPrompt(data, 'Funding round', 'Source text');
+    expect(prompt).toContain('500,000,000');
+    expect(prompt).toContain('~500 million');
+  });
+
+  it('annotates valuation field', () => {
+    const data = makeRecordData(
+      { valuation: 18_000_000_000 },
+      { recordType: 'funding-round' },
+    );
+    const prompt = buildRecordSourcingPrompt(data, 'Funding round', 'Source text');
+    expect(prompt).toContain('18,000,000,000');
+    expect(prompt).toContain('~18 billion');
+  });
+
+  it('does not annotate non-monetary fields', () => {
+    const data = makeRecordData({ name: 'Test Grant', grantee: 'MIT' });
+    const prompt = buildRecordSourcingPrompt(data, 'Grant to MIT', 'Source text');
+    // String fields should appear as-is in the Key fields section
+    const fieldsSection = prompt.split('Key fields:\n')[1]?.split('\n\nSource text')[0] ?? '';
+    expect(fieldsSection).toContain('name: Test Grant');
+    expect(fieldsSection).toContain('grantee: MIT');
+    // The fields section itself should not have "i.e." annotations for non-monetary fields
+    expect(fieldsSection).not.toContain('i.e.');
+  });
+
+  it('does not annotate small monetary amounts', () => {
+    const data = makeRecordData({ amount: 5000, grantee: 'Lab' });
+    const prompt = buildRecordSourcingPrompt(data, 'Small grant', 'Source text');
+    // Small monetary amounts should not get the "i.e." annotation in the fields section
+    const fieldsSection = prompt.split('Key fields:\n')[1]?.split('\n\nSource text')[0] ?? '';
+    expect(fieldsSection).toContain('amount: 5000');
+    expect(fieldsSection).not.toContain('i.e.');
+  });
+
+  it('annotates impliedValuation field', () => {
+    const data = makeRecordData(
+      { impliedValuation: 61_000_000_000, company: 'Anthropic' },
+      { recordType: 'secondary-market-price' },
+    );
+    const prompt = buildRecordSourcingPrompt(data, 'Market price', 'Source text');
+    expect(prompt).toContain('61,000,000,000');
+    expect(prompt).toContain('~61 billion');
+  });
+});

--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -35,6 +35,56 @@ import type {
 
 const { PROMPT_CONTENT_LENGTH } = SOURCE_CHECK_CONSTANTS;
 
+// ── Numeric formatting for LLM prompts ─────────────────────────────
+
+/**
+ * Format a large number as a human-readable string for LLM prompts.
+ * The LLM needs to match "1234000000" against "$1.234 billion" in source text —
+ * showing just the raw number leads to false-positive contradictions.
+ *
+ * Examples:
+ *   formatNumericForPrompt(1234000000) → "1,234,000,000 (i.e. ~1.23 billion)"
+ *   formatNumericForPrompt(50000000)   → "50,000,000 (i.e. ~50 million)"
+ *   formatNumericForPrompt(1500)       → "1,500"
+ *   formatNumericForPrompt(42)         → "42"
+ */
+export function formatNumericForPrompt(value: number): string {
+  const formatted = value.toLocaleString('en-US');
+
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+
+  if (abs >= 1e12) {
+    const trillions = abs / 1e12;
+    return `${formatted} (i.e. ${sign}~${trimTrailingZero(trillions.toFixed(2))} trillion)`;
+  }
+  if (abs >= 1e9) {
+    const billions = abs / 1e9;
+    return `${formatted} (i.e. ${sign}~${trimTrailingZero(billions.toFixed(2))} billion)`;
+  }
+  if (abs >= 1e6) {
+    const millions = abs / 1e6;
+    return `${formatted} (i.e. ${sign}~${trimTrailingZero(millions.toFixed(2))} million)`;
+  }
+  return formatted;
+}
+
+/** Remove trailing zeros after decimal: "1.20" → "1.2", "1.00" → "1" */
+function trimTrailingZero(s: string): string {
+  if (!s.includes('.')) return s;
+  return s.replace(/\.?0+$/, '');
+}
+
+/**
+ * Known monetary field names used in record sourcing.
+ * When these fields contain numbers, we annotate them with human-readable equivalents
+ * in the LLM prompt to prevent rounding false positives.
+ */
+const MONETARY_FIELDS = new Set([
+  'amount', 'raised', 'valuation', 'budget', 'impliedValuation',
+  'pricePerShare', 'totalBudget',
+]);
+
 /** Cache parsed snapshots to avoid re-fetching and re-parsing per grant */
 export const snapshotCache = new Map<string, { rawContent: string; manifest: DataSourceManifest } | null>();
 
@@ -46,10 +96,18 @@ export function buildFactSourcingPrompt(
 ): string {
   const asOfStr = data.fact.asOf ? ` (as of ${data.fact.asOf})` : '';
   const notesStr = data.fact.notes ? `\nAdditional context: ${data.fact.notes}` : '';
-  // Include exact stored value when it differs from the display value to avoid rounding false positives
-  const rawSuffix = data.rawValue && data.rawValue !== data.formattedValue
-    ? ` (exact stored value: ${data.rawValue})`
-    : '';
+  // Include exact stored value when it differs from the display value to avoid rounding false positives.
+  // Format the raw value with human-readable annotation so the LLM can match it against source text
+  // (e.g., "1,234,000,000 (i.e. ~1.23 billion)" instead of just "1234000000").
+  let rawSuffix = '';
+  if (data.rawValue && data.rawValue !== data.formattedValue) {
+    const numericRaw = Number(data.rawValue);
+    if (Number.isFinite(numericRaw) && Math.abs(numericRaw) >= 1e6) {
+      rawSuffix = ` (exact stored value: ${formatNumericForPrompt(numericRaw)})`;
+    } else {
+      rawSuffix = ` (exact stored value: ${data.rawValue})`;
+    }
+  }
 
   return `You are a fact-checker. Given the source text below, verify this claim.
 
@@ -78,7 +136,15 @@ export function buildRecordSourcingPrompt(
 ): string {
   const fieldsStr = Object.entries(data.fields)
     .filter(([, v]) => v != null)
-    .map(([k, v]) => `  ${k}: ${v}`)
+    .map(([k, v]) => {
+      // Annotate large monetary fields with human-readable equivalents to prevent
+      // false-positive contradictions. Without this, the LLM sees "amount: 1234000000"
+      // and must figure out on its own that it equals "$1.234 billion" from the source.
+      if (typeof v === 'number' && MONETARY_FIELDS.has(k) && Math.abs(v) >= 1e6) {
+        return `  ${k}: ${formatNumericForPrompt(v)}`;
+      }
+      return `  ${k}: ${v}`;
+    })
     .join('\n');
 
   return `You are a fact-checker. Given the source text below, verify this structured data record.

--- a/crux/lib/sourcing/prompt-guidelines.ts
+++ b/crux/lib/sourcing/prompt-guidelines.ts
@@ -18,7 +18,8 @@ export const SOURCE_CHECK_FALSE_POSITIVE_GUIDELINES = `IMPORTANT — avoid these
 - **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
 - **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
 - **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
-- **Rounded display values**: The claim may show a rounded display format (e.g., "$19B") with an exact stored value in parentheses (e.g., "exact stored value: 19000000000"). Compare against the exact stored value, not the rounded display. "$19B" and "$19,000,000,000" and "19 billion" are all equivalent — use "confirmed".
+- **Rounded display values**: The claim may show a rounded display format (e.g., "$1.2B") with an exact stored value in parentheses (e.g., "exact stored value: 1,234,000,000 (i.e. ~1.23 billion)"). ALWAYS compare against the exact stored value, not the rounded display. The rounded display loses precision: "$1.2B" is the display version of "$1,234,000,000". If the source says "$1.234 billion" or "$1,234,000,000" and we display "$1.2B", that is "confirmed", NOT contradicted.
+- **Numeric format equivalence**: All of these represent the same value and should be treated as equivalent: "$1.234B", "$1.234 billion", "$1,234,000,000", "1234000000", "1.234e9". Differences in notation (compact vs. full, abbreviation vs. word, with vs. without commas) are NEVER contradictions.
 - **URL format**: "example.com", "https://www.example.com", and "http://example.com" all refer to the same website. Differences in protocol (http/https), "www" prefix, or trailing slashes are NOT contradictions — use "confirmed".
 - **Date precision**: "2016-08" and "30 August 2016" are equivalent. Month-level vs day-level dates for the same month are NOT contradictions — use "confirmed".
 - **Archive URLs**: A web.archive.org URL for a defunct/dissolved organization is intentional — not a contradiction with the original URL. Use "confirmed".
@@ -33,7 +34,7 @@ Reserve "contradicted" ONLY for cases where the source clearly and directly stat
  * Provides softer guidance on edge cases.
  */
 export const SOURCE_CHECK_ADDITIONAL_CONSIDERATIONS = `Other considerations:
-- Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B")
+- Numbers may be expressed differently (e.g., "1 billion" vs "1e9" vs "$1B" vs "1,000,000,000"). Rounding differences are expected — the claim may display a rounded value like "$1.2B" while the source says "$1.234 billion". If the exact stored value (shown in parentheses) matches the source, use "confirmed".
 - Names may differ slightly (abbreviations, legal names vs common names)
 - Dates may be approximate
 - If the source discusses the topic but the specific data point isn't mentioned, that's "unverifiable"


### PR DESCRIPTION
## Summary

Fixes false-positive "contradicted" verdicts in the source-check system caused by `formatValue()` rounding large numbers for display. When a stored value like `1,234,000,000` is displayed as `$1.2B`, the LLM checker would flag it as contradicted when the source says `$1.234 billion`.

Three-part fix:
- **New `formatNumericForPrompt()` helper** — annotates large raw numbers with human-readable equivalents (e.g., `"1,234,000,000 (i.e. ~1.23 billion)"`) so the LLM can match against source text
- **Enhanced fact and record prompts** — monetary values >= $1M now include human-readable annotations instead of bare numbers
- **Strengthened prompt guidelines** — explicit numeric format equivalence rules and clearer rounding tolerance instructions

## Test plan

- [x] 26 new tests covering `formatNumericForPrompt()`, fact prompt annotation, and record prompt annotation
- [x] All 366 sourcing tests pass
- [x] Full test suite (5444 tests) passes (1 pre-existing failure in sourcing lint guard baseline unrelated to this PR)
- [x] `pnpm build` passes
- [x] Gate checks pass

Fixes QUA-240